### PR TITLE
fix(deployer,cli): apply deploy env context to preflight via unified build metadata

### DIFF
--- a/.changeset/modern-items-study.md
+++ b/.changeset/modern-items-study.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed a false-positive LOCAL_STORAGE_PATH preflight error that flagged storage paths like `file:./data.db` that don't exist in your project. The deploy bundler's local-storage detector now excludes everything under `.mastra/.build/` (deployer-generated intermediate chunks), not just `@mastra__*` shim files. Those chunks can carry JSDoc examples from library code (for example `LibSQLStore({ url: 'file:./data.db' })` from `@mastra/core`), which previously blocked `mastra server deploy` and forced `--skip-preflight` even though the user's code had no local storage paths. Local storage paths in your own source files are still detected.

--- a/.changeset/some-taxes-push.md
+++ b/.changeset/some-taxes-push.md
@@ -1,0 +1,11 @@
+---
+'mastra': patch
+---
+
+Fixed `mastra deploy` preflight blocking deploys that are actually fine:
+
+**Env-guarded storage fallbacks** — code like `process.env.TURSO_DATABASE_URL || "file:./.mastra-demo.db"` no longer hard-errors when the environment variable is provided for the deploy. If the variable is missing from your env file you still get an error, and if no env file is available you get a warning instead.
+
+**Library env-var false positives** — the missing environment variable check now only looks at variables your own code references, so variables read by bundled Mastra packages (like `AUTO_BLOCK_EXTERNAL_PROVIDERS`) no longer show up as warnings. They are listed as info instead.
+
+These deploys previously required `--skip-preflight` to get through.

--- a/.changeset/some-taxes-push.md
+++ b/.changeset/some-taxes-push.md
@@ -8,4 +8,8 @@ Fixed `mastra deploy` preflight blocking deploys that are actually fine:
 
 **Library env-var false positives** — the missing environment variable check now only looks at variables your own code references, so variables read by bundled Mastra packages (like `AUTO_BLOCK_EXTERNAL_PROVIDERS`) no longer show up as warnings. They are listed as info instead.
 
+**Platform-stored env vars** — `mastra deploy` and `mastra server deploy` preflight now merge the env vars already stored on the target environment / server project under your local env file (local wins, mirroring the platform's deploy-time merge). Vars stored only on the platform no longer trigger `MISSING_ENV_VAR` or `LOCAL_STORAGE_PATH` alarms.
+
+**Platform-injected guards** — storage fallbacks guarded by variables the platform sets automatically (like `MASTRA_STORAGE_URL` on Mastra Cloud) are trusted and never flagged.
+
 These deploys previously required `--skip-preflight` to get through.

--- a/.changeset/tricky-geckos-lead.md
+++ b/.changeset/tricky-geckos-lead.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed deploy preflight false positives for env-guarded storage fallbacks. The build now records when a local storage path like `file:./.mastra-demo.db` is only used as a fallback behind an environment variable (for example `process.env.TURSO_DATABASE_URL || "file:./.mastra-demo.db"`), and which environment variables your own code reads, so the deploy preflight can tell dead fallbacks and library-internal variables apart from real problems.
+
+Also fixed another source of false `LOCAL_STORAGE_PATH` errors: dependencies installed via symlinks (pnpm `link:`/`file:`) resolve to paths outside `node_modules` and are no longer treated as your code.

--- a/packages/cli/src/commands/actions/lint-project.test.ts
+++ b/packages/cli/src/commands/actions/lint-project.test.ts
@@ -125,19 +125,20 @@ describe('lintProject', () => {
     expect(parsed.issues[0]).toMatchObject({ code: 'MISSING_ENV_VAR', scope: 'bundle' });
   });
 
-  it('exits 1 when no env file is resolvable for preflight', async () => {
-    writeBundle(`export default {};`);
+  it('runs preflight without an env file, reporting warnings instead of failing', async () => {
+    // Env vars may live on the platform (e.g. CI without a checked-in .env),
+    // so a missing env file must not hard-fail — issues soften to warnings.
+    writeBundle(`const x = process.env.MY_MISSING_VAR; export default x;`);
 
-    await expect(lintProject({ root: tmpDir, preflight: true, skipBuild: true, json: true })).rejects.toThrow(
-      'process.exit(1)',
-    );
+    await expect(lintProject({ root: tmpDir, preflight: true, skipBuild: true, json: true })).resolves.toBeUndefined();
 
     const calls = stdoutSpy.mock.calls.map((c: unknown[]) => String(c[0]));
     const jsonOutput = calls.find((c: string) => c.trim().startsWith('{'));
     expect(jsonOutput).toBeDefined();
     const parsed = JSON.parse(jsonOutput!);
-    expect(parsed.ok).toBe(false);
-    expect(parsed.error).toContain('No env file found');
+    expect(parsed.ok).toBe(true);
+    expect(parsed.warningCount).toBeGreaterThan(0);
+    expect(parsed.issues[0]).toMatchObject({ code: 'MISSING_ENV_VAR', scope: 'bundle' });
   });
 
   it('emits project-phase issues as structured JSON', async () => {

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -253,6 +253,52 @@ describe('preflightBuildOutput', () => {
       expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
     });
 
+    it('suppresses guarded paths when the var is a platform-managed injection (managedEnvVarNames)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(
+        tmpDir,
+        {},
+        { hasEnvFile: true, managedEnvVarNames: ['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'] },
+      );
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+
+    it('suppresses MISSING_ENV_VAR for platform-managed vars (managedEnvVarNames)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ userEnvRefs: ['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'] });
+
+      const issues = await preflightBuildOutput(
+        tmpDir,
+        {},
+        { hasEnvFile: true, managedEnvVarNames: ['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'] },
+      );
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
+    it('hard-errors on guarded misses when managedEnvVarNames is present (complete env picture)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      // Field present but the guard var is not managed, provided, or stored —
+      // the picture is complete even without a local env file.
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: false, managedEnvVarNames: [] });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.severity).toBe('error');
+      expect(issue?.message).toContain('TURSO_DATABASE_URL is not set');
+    });
+
+    it('warns (not errors) on guarded misses when platform context lacks managedEnvVarNames (older platform)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true, managedEnvVarNames: null });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.severity).toBe('warning');
+      expect(issue?.message).toContain('cannot verify whether the platform injects it');
+    });
+
     it('still errors on unguarded local paths', async () => {
       writeBundle(`export {};`);
       writeMetadata({

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 
-import { preflightBuildOutput, printPreflightIssues } from './deploy-preflight.js';
+import { mergePreflightEnvVars, preflightBuildOutput, printPreflightIssues } from './deploy-preflight.js';
 import type { PreflightIssue } from './deploy-preflight.js';
 
 vi.mock('@clack/prompts', () => ({
@@ -225,6 +225,34 @@ describe('preflightBuildOutput', () => {
       expect(issue?.message).toContain('cannot verify TURSO_DATABASE_URL is set on the platform');
     });
 
+    it('suppresses paths guarded by platform-provided vars (e.g. MASTRA_STORAGE_URL) without an env entry', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({
+        localPaths: [{ ...guardedDetection, guardedBy: 'MASTRA_STORAGE_URL' }],
+      });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+
+    it('suppresses guarded paths when the var is present only in platform-stored env vars', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const merged = mergePreflightEnvVars({ TURSO_DATABASE_URL: 'libsql://stored.turso.io' }, {});
+      const issues = await preflightBuildOutput(tmpDir, merged, { hasEnvFile: true });
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+
+    it('suppresses MISSING_ENV_VAR for vars present only in platform-stored env vars', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ userEnvRefs: ['OPENAI_API_KEY'] });
+
+      const merged = mergePreflightEnvVars({ OPENAI_API_KEY: 'sk-stored' }, {});
+      const issues = await preflightBuildOutput(tmpDir, merged, { hasEnvFile: true });
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
     it('still errors on unguarded local paths', async () => {
       writeBundle(`export {};`);
       writeMetadata({
@@ -305,6 +333,31 @@ describe('preflightBuildOutput', () => {
     const issues = await preflightBuildOutput(tmpDir, {});
     const missing = issues.find(i => i.code === 'MISSING_ENV_VAR');
     expect(missing?.message).toContain('SECRET_KEY');
+  });
+});
+
+describe('mergePreflightEnvVars', () => {
+  it('keeps vars present only in the stored environment', () => {
+    expect(mergePreflightEnvVars({ TURSO_DATABASE_URL: 'libsql://stored.turso.io' }, {})).toEqual({
+      TURSO_DATABASE_URL: 'libsql://stored.turso.io',
+    });
+  });
+
+  it('lets local env file values win over stored values (mirrors platform merge)', () => {
+    expect(mergePreflightEnvVars({ API_KEY: 'stored' }, { API_KEY: 'local' })).toEqual({ API_KEY: 'local' });
+  });
+
+  it('lets a blank local value override a stored value (platform request-wins semantics)', () => {
+    expect(
+      mergePreflightEnvVars({ TURSO_DATABASE_URL: 'libsql://stored.turso.io' }, { TURSO_DATABASE_URL: '' }),
+    ).toEqual({
+      TURSO_DATABASE_URL: '',
+    });
+  });
+
+  it('tolerates absent stored env (older platform responses)', () => {
+    expect(mergePreflightEnvVars(undefined, { A: '1' })).toEqual({ A: '1' });
+    expect(mergePreflightEnvVars(null, { A: '1' })).toEqual({ A: '1' });
   });
 });
 

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -193,6 +193,16 @@ describe('preflightBuildOutput', () => {
       expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
     });
 
+    it('treats an empty-string guard value as missing (runtime || still takes the fallback)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, { TURSO_DATABASE_URL: '' }, { hasEnvFile: true });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.severity).toBe('error');
+      expect(issue?.message).toContain('TURSO_DATABASE_URL is not set');
+    });
+
     it('errors with an actionable message when the guarding var is missing and an env file is present', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [guardedDetection] });

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -97,6 +97,12 @@ describe('preflightBuildOutput', () => {
       const missing = issues.find(i => i.code === 'MISSING_ENV_VAR');
       expect(missing?.message).toContain('STRIPE_KEY');
     });
+
+    it('does not flag AUTO_BLOCK_EXTERNAL_PROVIDERS (read by bundled @mastra/server)', async () => {
+      writeBundle(`const f = process.env.AUTO_BLOCK_EXTERNAL_PROVIDERS;`);
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
   });
 
   describe('LOCAL_STORAGE_PATH', () => {
@@ -153,6 +159,130 @@ describe('preflightBuildOutput', () => {
       writePreflightMetadata([]);
       const issues = await preflightBuildOutput(tmpDir, {});
       expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+  });
+
+  describe('unified preflight-metadata.json', () => {
+    function writeLegacyMetadata(detections: Array<{ value: string; hint: string; module: string }>) {
+      writeFileSync(join(tmpDir, '.mastra', 'output', 'preflight-local-paths.json'), JSON.stringify(detections));
+    }
+
+    function writeMetadata(metadata: {
+      version?: number;
+      localPaths?: Array<{ value: string; hint: string; module: string; guardedBy?: string }>;
+      userEnvRefs?: string[];
+    }) {
+      writeFileSync(
+        join(tmpDir, '.mastra', 'output', 'preflight-metadata.json'),
+        JSON.stringify({ version: 1, localPaths: [], userEnvRefs: [], ...metadata }),
+      );
+    }
+
+    const guardedDetection = {
+      value: 'file:./.mastra-demo.db',
+      hint: 'LibSQL/SQLite file path relative to the build host',
+      module: 'src/constants.ts',
+      guardedBy: 'TURSO_DATABASE_URL',
+    };
+
+    it('suppresses env-guarded local paths when the guarding var is in the deploy env', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, { TURSO_DATABASE_URL: 'libsql://x.turso.io' });
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+
+    it('errors with an actionable message when the guarding var is missing and an env file is present', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.severity).toBe('error');
+      expect(issue?.message).toContain('file:./.mastra-demo.db will be used at runtime');
+      expect(issue?.message).toContain('TURSO_DATABASE_URL is not set');
+      expect(issue?.fix).toContain('TURSO_DATABASE_URL');
+    });
+
+    it('warns (not errors) when the guarding var is missing but the CLI has no env file', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: false });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.severity).toBe('warning');
+      expect(issue?.message).toContain('cannot verify TURSO_DATABASE_URL is set on the platform');
+    });
+
+    it('still errors on unguarded local paths', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({
+        localPaths: [{ value: 'file:./mastra.db', hint: 'LibSQL/SQLite file path', module: 'src/mastra/index.ts' }],
+      });
+
+      const issues = await preflightBuildOutput(tmpDir, { TURSO_DATABASE_URL: 'libsql://x.turso.io' });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.severity).toBe('error');
+      expect(issue?.message).toContain('file:./mastra.db');
+    });
+
+    it('prefers metadata localPaths over the legacy preflight-local-paths.json', async () => {
+      writeBundle(`export {};`);
+      // Legacy file says error; unified metadata knows the path is guarded.
+      writeLegacyMetadata([{ value: 'file:./.mastra-demo.db', hint: 'x', module: 'src/constants.ts' }]);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, { TURSO_DATABASE_URL: 'libsql://x.turso.io' });
+      expect(issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+    });
+
+    it('scopes MISSING_ENV_VAR to userEnvRefs — library-only refs in the bundle do not warn', async () => {
+      writeBundle(`const libFlag = process.env.SOME_LIBRARY_ONLY_FLAG;`);
+      writeMetadata({ userEnvRefs: [] });
+
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
+    it('still warns for user-referenced env vars missing from the deploy env', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ userEnvRefs: ['OPENAI_API_KEY', 'TURSO_DATABASE_URL'] });
+
+      const issues = await preflightBuildOutput(tmpDir, { TURSO_DATABASE_URL: 'libsql://x.turso.io' });
+      const missing = issues.find(i => i.code === 'MISSING_ENV_VAR');
+      expect(missing?.severity).toBe('warning');
+      expect(missing?.message).toContain('OPENAI_API_KEY');
+      expect(missing?.message).not.toContain('TURSO_DATABASE_URL');
+    });
+
+    it('applies the allowlist to userEnvRefs too', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ userEnvRefs: ['PORT', 'MASTRA_API_TOKEN'] });
+
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')).toBeUndefined();
+    });
+
+    it('falls back to bundle-wide scan + legacy file when metadata is absent (regression guard)', async () => {
+      writeBundle(`const k = process.env.ANTHROPIC_API_KEY;`);
+      writeLegacyMetadata([{ value: 'file:./mastra.db', hint: 'x', module: 'src/mastra/index.ts' }]);
+
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')?.message).toContain('ANTHROPIC_API_KEY');
+      const storage = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(storage?.severity).toBe('error');
+    });
+
+    it('ignores malformed metadata (wrong version) and falls back', async () => {
+      writeBundle(`const k = process.env.ANTHROPIC_API_KEY;`);
+      writeFileSync(
+        join(tmpDir, '.mastra', 'output', 'preflight-metadata.json'),
+        JSON.stringify({ version: 99, nonsense: true }),
+      );
+
+      const issues = await preflightBuildOutput(tmpDir, {});
+      expect(issues.find(i => i.code === 'MISSING_ENV_VAR')?.message).toContain('ANTHROPIC_API_KEY');
     });
   });
 

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -165,6 +165,20 @@ export async function preflightBuildOutput(
   return issues;
 }
 
+/**
+ * Mirror the platform's deploy-time env merge: local/request env vars are
+ * applied over the vars already stored on the target environment or server
+ * project (request wins). Preflight should see this merged picture so vars
+ * stored only on the platform don't produce false MISSING_ENV_VAR /
+ * LOCAL_STORAGE_PATH alarms.
+ */
+export function mergePreflightEnvVars(
+  stored: Record<string, string> | null | undefined,
+  local: Record<string, string>,
+): Record<string, string> {
+  return { ...stored, ...local };
+}
+
 export type PreflightOutcome = 'ok' | 'blocked' | 'cancelled';
 
 /**
@@ -277,14 +291,18 @@ function checkMissingEnvVars(source: string, envVars: Record<string, string>): P
   return checkEnvVarNames([...referenced], envVars);
 }
 
+/** Env vars the platform/runtime sets automatically at deploy time. */
+function isPlatformProvidedEnvVar(name: string): boolean {
+  return ENV_VAR_ALLOWLIST_EXACT.has(name) || ENV_VAR_ALLOWLIST_PREFIXES.some(prefix => name.startsWith(prefix));
+}
+
 function checkEnvVarNames(referenced: Iterable<string>, envVars: Record<string, string>): PreflightIssue[] {
   const provided = new Set(Object.keys(envVars));
   const missing: string[] = [];
 
   for (const name of new Set(referenced)) {
     if (provided.has(name)) continue;
-    if (ENV_VAR_ALLOWLIST_EXACT.has(name)) continue;
-    if (ENV_VAR_ALLOWLIST_PREFIXES.some(prefix => name.startsWith(prefix))) continue;
+    if (isPlatformProvidedEnvVar(name)) continue;
     missing.push(name);
   }
 
@@ -362,17 +380,29 @@ async function checkLocalStoragePaths(
       continue;
     }
 
+    // Guards on vars the platform/runtime sets automatically (e.g.
+    // MASTRA_STORAGE_URL on Mastra Cloud) are trusted the same way the
+    // missing-env-var check trusts them — the guard is satisfied at runtime
+    // even though the var never appears in a local env file.
+    if (isPlatformProvidedEnvVar(d.guardedBy)) continue;
+
     // The literal is a dead fallback when the guarding env var is set in the
     // deploy environment. An empty value doesn't count: `process.env.X || 'file:...'`
     // still takes the fallback at runtime when X is blank.
     if (envVars[d.guardedBy]) continue;
 
+    // TODO(managed-env-names): managed databases attached via the platform
+    // inject vars (e.g. TURSO_DATABASE_URL) directly onto the runtime service,
+    // invisible to the CLI — this error is a false positive for them today
+    // (--skip-preflight is the workaround). Once the platform exposes
+    // `managedEnvVarNames` on the environment/project response, merge those
+    // names into the provided set so the error never fires for injected guards.
     if (hasEnvFile) {
       issues.push({
         code: 'LOCAL_STORAGE_PATH',
         severity: 'error',
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-        fix: `Set ${d.guardedBy} in your env file, or remove the local fallback.`,
+        fix: `Set ${d.guardedBy} in your env file, or remove the local fallback. If the platform injects it (e.g. a managed database), re-run with --skip-preflight.`,
       });
     } else {
       issues.push({

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -126,9 +126,23 @@ export async function preflightBuildOutput(
      * every caller except the unified deploy always reads an env file.
      */
     hasEnvFile?: boolean;
+    /**
+     * Env var names the platform injects at deploy time (e.g. TURSO_DATABASE_URL
+     * from an attached managed database) — names only, values are platform-side
+     * secrets. Three states:
+     * - `string[]` — platform env context fetched and the field was present:
+     *   the env picture is complete, so guarded local paths whose var is
+     *   neither provided nor managed are trustworthy hard errors.
+     * - `null` — platform env context fetched but the field was absent (older
+     *   platform, or an endpoint that doesn't expose names): the picture is
+     *   incomplete, so guarded misses soften to warnings.
+     * - `undefined` — no platform context at all (lint, studio deploy):
+     *   severity falls back to `hasEnvFile`.
+     */
+    managedEnvVarNames?: string[] | null;
   } = {},
 ): Promise<PreflightIssue[]> {
-  const { hasEnvFile = true } = options;
+  const { hasEnvFile = true, managedEnvVarNames } = options;
   const outputDir = join(targetDir, '.mastra', 'output');
   const entryPath = join(outputDir, 'index.mjs');
 
@@ -149,18 +163,18 @@ export async function preflightBuildOutput(
   if (metadata) {
     // User modules' env refs were captured structurally at build time, so
     // library-only refs inside the bundle never produce warnings.
-    issues.push(...checkEnvVarNames(metadata.userEnvRefs, envVars));
+    issues.push(...checkEnvVarNames(metadata.userEnvRefs, envVars, managedEnvVarNames));
   } else {
     const bundleSources = await readBundleSources(outputDir);
     const combinedSource = bundleSources.join('\n');
-    issues.push(...checkMissingEnvVars(combinedSource, envVars));
+    issues.push(...checkMissingEnvVars(combinedSource, envVars, managedEnvVarNames));
   }
 
   // LOCAL_STORAGE_PATH — read from bundler-generated metadata.  The Rollup
   // plugin `mastra-local-storage-detector` runs during bundling and only
   // reports paths from user modules (not node_modules) that survived
   // tree-shaking, so library examples are structurally excluded.
-  issues.push(...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile)));
+  issues.push(...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile, managedEnvVarNames)));
 
   return issues;
 }
@@ -279,7 +293,11 @@ const PROCESS_ENV_BRACKET_REGEX = /\bprocess\.env\[['"]([A-Z_][A-Z0-9_]*)['"]\]/
  * Fallback for builds without `preflight-metadata.json`: regex-scan the whole
  * bundle (user + library code) for `process.env.X` references.
  */
-function checkMissingEnvVars(source: string, envVars: Record<string, string>): PreflightIssue[] {
+function checkMissingEnvVars(
+  source: string,
+  envVars: Record<string, string>,
+  managedEnvVarNames?: string[] | null,
+): PreflightIssue[] {
   const referenced = new Set<string>();
   for (const match of source.matchAll(PROCESS_ENV_REGEX)) {
     referenced.add(match[1]!);
@@ -288,7 +306,7 @@ function checkMissingEnvVars(source: string, envVars: Record<string, string>): P
     referenced.add(match[1]!);
   }
 
-  return checkEnvVarNames([...referenced], envVars);
+  return checkEnvVarNames([...referenced], envVars, managedEnvVarNames);
 }
 
 /** Env vars the platform/runtime sets automatically at deploy time. */
@@ -296,12 +314,18 @@ function isPlatformProvidedEnvVar(name: string): boolean {
   return ENV_VAR_ALLOWLIST_EXACT.has(name) || ENV_VAR_ALLOWLIST_PREFIXES.some(prefix => name.startsWith(prefix));
 }
 
-function checkEnvVarNames(referenced: Iterable<string>, envVars: Record<string, string>): PreflightIssue[] {
+function checkEnvVarNames(
+  referenced: Iterable<string>,
+  envVars: Record<string, string>,
+  managedEnvVarNames?: string[] | null,
+): PreflightIssue[] {
   const provided = new Set(Object.keys(envVars));
+  const managed = new Set(managedEnvVarNames ?? []);
   const missing: string[] = [];
 
   for (const name of new Set(referenced)) {
     if (provided.has(name)) continue;
+    if (managed.has(name)) continue;
     if (isPlatformProvidedEnvVar(name)) continue;
     missing.push(name);
   }
@@ -352,6 +376,7 @@ async function checkLocalStoragePaths(
   metadata: PreflightMetadata | null,
   envVars: Record<string, string>,
   hasEnvFile: boolean,
+  managedEnvVarNames?: string[] | null,
 ): Promise<PreflightIssue[]> {
   let detections: LocalStorageDetection[];
   if (metadata) {
@@ -391,13 +416,36 @@ async function checkLocalStoragePaths(
     // still takes the fallback at runtime when X is blank.
     if (envVars[d.guardedBy]) continue;
 
-    // TODO(managed-env-names): managed databases attached via the platform
-    // inject vars (e.g. TURSO_DATABASE_URL) directly onto the runtime service,
-    // invisible to the CLI — this error is a false positive for them today
-    // (--skip-preflight is the workaround). Once the platform exposes
-    // `managedEnvVarNames` on the environment/project response, merge those
-    // names into the provided set so the error never fires for injected guards.
-    if (hasEnvFile) {
+    // Managed platform resources (e.g. an attached Turso database) inject
+    // their vars at deploy time; the platform exposes the names so preflight
+    // knows the guard is satisfied even though the value is invisible here.
+    if (managedEnvVarNames?.includes(d.guardedBy)) continue;
+
+    if (managedEnvVarNames !== undefined) {
+      if (managedEnvVarNames === null) {
+        // Platform context was fetched but didn't expose managed names (older
+        // platform, or the server-project env endpoint which doesn't carry
+        // them yet) — the env picture is incomplete, so don't hard-block.
+        // TODO(managed-env-names): once every platform env endpoint exposes
+        // managedEnvVarNames, drop this branch and always hard-error.
+        issues.push({
+          code: 'LOCAL_STORAGE_PATH',
+          severity: 'warning',
+          message: `${truncate(d.value, 80)} will be used at runtime unless ${d.guardedBy} is set — cannot verify whether the platform injects it (${d.hint})`,
+          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars. If a managed database injects it, you can ignore this.`,
+        });
+      } else {
+        // Full env picture: local env file + stored vars + managed names.
+        // The guard var is genuinely absent, so the local fallback WILL be
+        // used at runtime — trustworthy hard error.
+        issues.push({
+          code: 'LOCAL_STORAGE_PATH',
+          severity: 'error',
+          message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
+          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or attach a managed database that provides it.`,
+        });
+      }
+    } else if (hasEnvFile) {
       issues.push({
         code: 'LOCAL_STORAGE_PATH',
         severity: 'error',

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -50,6 +50,7 @@ const ENV_VAR_ALLOWLIST_EXACT = new Set([
   'FORCE_COLOR',
   'EXPERIMENTAL_FEATURES',
   'SKILLS_BASE_DIR',
+  'AUTO_BLOCK_EXTERNAL_PROVIDERS',
 ]);
 
 /**
@@ -75,10 +76,31 @@ interface LocalStorageDetection {
   value: string;
   hint: string;
   module: string;
+  /**
+   * Env var that guards this literal at runtime (the literal is the fallback
+   * arm of a `process.env.X || literal` expression). Only present in
+   * `preflight-metadata.json` — the legacy file never carries it.
+   */
+  guardedBy?: string;
 }
 
-/** Name of the metadata file the Rollup plugin emits into the output dir. */
+/**
+ * Unified metadata emitted by newer deployers as `preflight-metadata.json`.
+ * `userEnvRefs` lists the env vars referenced from *user* modules only, so
+ * the missing-env-var check doesn't warn about vars read by bundled library
+ * code the project never references.
+ */
+interface PreflightMetadata {
+  version: number;
+  localPaths: LocalStorageDetection[];
+  userEnvRefs: string[];
+}
+
+/** Legacy metadata file emitted by older deployers (and still emitted by newer ones). */
 const LOCAL_PATHS_METADATA_FILE = 'preflight-local-paths.json';
+
+/** Unified metadata file emitted by newer deployers. */
+const PREFLIGHT_METADATA_FILE = 'preflight-metadata.json';
 
 /* ------------------------------------------------------------------ */
 /*  Public API                                                        */
@@ -95,7 +117,18 @@ const LOCAL_PATHS_METADATA_FILE = 'preflight-local-paths.json';
 export async function preflightBuildOutput(
   targetDir: string,
   envVars: Record<string, string>,
+  options: {
+    /**
+     * Whether the CLI has the full env picture for this deploy (an explicit
+     * `--env-file` or an ambient `.env*` file). When false, env vars may be
+     * stored on the platform and invisible to the CLI, so env-guarded local
+     * paths are surfaced as warnings instead of errors. Defaults to true —
+     * every caller except the unified deploy always reads an env file.
+     */
+    hasEnvFile?: boolean;
+  } = {},
 ): Promise<PreflightIssue[]> {
+  const { hasEnvFile = true } = options;
   const outputDir = join(targetDir, '.mastra', 'output');
   const entryPath = join(outputDir, 'index.mjs');
 
@@ -107,18 +140,27 @@ export async function preflightBuildOutput(
     return [];
   }
 
-  const bundleSources = await readBundleSources(outputDir);
-  const combinedSource = bundleSources.join('\n');
+  // Unified metadata from newer deployers. Absent for stale builds or older
+  // deployers — each check falls back to its previous behavior.
+  const metadata = await readPreflightMetadata(outputDir);
 
   const issues: PreflightIssue[] = [];
 
-  issues.push(...checkMissingEnvVars(combinedSource, envVars));
+  if (metadata) {
+    // User modules' env refs were captured structurally at build time, so
+    // library-only refs inside the bundle never produce warnings.
+    issues.push(...checkEnvVarNames(metadata.userEnvRefs, envVars));
+  } else {
+    const bundleSources = await readBundleSources(outputDir);
+    const combinedSource = bundleSources.join('\n');
+    issues.push(...checkMissingEnvVars(combinedSource, envVars));
+  }
 
   // LOCAL_STORAGE_PATH — read from bundler-generated metadata.  The Rollup
   // plugin `mastra-local-storage-detector` runs during bundling and only
   // reports paths from user modules (not node_modules) that survived
   // tree-shaking, so library examples are structurally excluded.
-  issues.push(...(await checkLocalStoragePaths(outputDir)));
+  issues.push(...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile)));
 
   return issues;
 }
@@ -219,6 +261,10 @@ async function collectMjsFiles(dir: string): Promise<string[]> {
 const PROCESS_ENV_REGEX = /\bprocess\.env\.([A-Z_][A-Z0-9_]*)\b/g;
 const PROCESS_ENV_BRACKET_REGEX = /\bprocess\.env\[['"]([A-Z_][A-Z0-9_]*)['"]\]/g;
 
+/**
+ * Fallback for builds without `preflight-metadata.json`: regex-scan the whole
+ * bundle (user + library code) for `process.env.X` references.
+ */
 function checkMissingEnvVars(source: string, envVars: Record<string, string>): PreflightIssue[] {
   const referenced = new Set<string>();
   for (const match of source.matchAll(PROCESS_ENV_REGEX)) {
@@ -228,10 +274,14 @@ function checkMissingEnvVars(source: string, envVars: Record<string, string>): P
     referenced.add(match[1]!);
   }
 
+  return checkEnvVarNames([...referenced], envVars);
+}
+
+function checkEnvVarNames(referenced: Iterable<string>, envVars: Record<string, string>): PreflightIssue[] {
   const provided = new Set(Object.keys(envVars));
   const missing: string[] = [];
 
-  for (const name of referenced) {
+  for (const name of new Set(referenced)) {
     if (provided.has(name)) continue;
     if (ENV_VAR_ALLOWLIST_EXACT.has(name)) continue;
     if (ENV_VAR_ALLOWLIST_PREFIXES.some(prefix => name.startsWith(prefix))) continue;
@@ -256,29 +306,84 @@ function checkMissingEnvVars(source: string, envVars: Record<string, string>): P
 /* ------------------------------------------------------------------ */
 
 /**
- * Read detections written by the `mastra-local-storage-detector` Rollup
- * plugin.  If the metadata file is absent (e.g. older build, or the plugin
- * wasn't active) the check is silently skipped — no false positives.
+ * Read the unified `preflight-metadata.json` emitted by newer deployers.
+ * Returns null when absent or malformed (stale build / older deployer).
  */
-async function checkLocalStoragePaths(outputDir: string): Promise<PreflightIssue[]> {
-  const metadataPath = join(outputDir, LOCAL_PATHS_METADATA_FILE);
-
-  let detections: LocalStorageDetection[];
+async function readPreflightMetadata(outputDir: string): Promise<PreflightMetadata | null> {
   try {
-    const raw = await readFile(metadataPath, 'utf-8');
-    detections = JSON.parse(raw) as LocalStorageDetection[];
+    const raw = await readFile(join(outputDir, PREFLIGHT_METADATA_FILE), 'utf-8');
+    const parsed = JSON.parse(raw) as PreflightMetadata;
+    if (parsed.version !== 1 || !Array.isArray(parsed.localPaths) || !Array.isArray(parsed.userEnvRefs)) {
+      return null;
+    }
+    return parsed;
   } catch {
-    return [];
+    return null;
+  }
+}
+
+/**
+ * Check detections written by the `mastra-local-storage-detector` Rollup
+ * plugin.  Prefers the unified metadata (which carries `guardedBy` env
+ * context); falls back to the legacy `preflight-local-paths.json`.  If both
+ * are absent (e.g. older build, or the plugin wasn't active) the check is
+ * silently skipped — no false positives.
+ */
+async function checkLocalStoragePaths(
+  outputDir: string,
+  metadata: PreflightMetadata | null,
+  envVars: Record<string, string>,
+  hasEnvFile: boolean,
+): Promise<PreflightIssue[]> {
+  let detections: LocalStorageDetection[];
+  if (metadata) {
+    detections = metadata.localPaths;
+  } else {
+    try {
+      const raw = await readFile(join(outputDir, LOCAL_PATHS_METADATA_FILE), 'utf-8');
+      detections = JSON.parse(raw) as LocalStorageDetection[];
+    } catch {
+      return [];
+    }
   }
 
   if (!Array.isArray(detections) || detections.length === 0) return [];
 
-  return detections.map(d => ({
-    code: 'LOCAL_STORAGE_PATH' as const,
-    severity: 'error' as const,
-    message: `Build contains a host-local storage URL: ${truncate(d.value, 80)} (${d.hint})`,
-    fix: `Replace it with a hosted URL (e.g. a Turso \`libsql://...\` URL or a public Postgres connection string) and store it in your env file.`,
-  }));
+  const issues: PreflightIssue[] = [];
+
+  for (const d of detections) {
+    if (!d.guardedBy) {
+      issues.push({
+        code: 'LOCAL_STORAGE_PATH',
+        severity: 'error',
+        message: `Build contains a host-local storage URL: ${truncate(d.value, 80)} (${d.hint})`,
+        fix: `Replace it with a hosted URL (e.g. a Turso \`libsql://...\` URL or a public Postgres connection string) and store it in your env file.`,
+      });
+      continue;
+    }
+
+    // The literal is a dead fallback when the guarding env var is set in the
+    // deploy environment.
+    if (d.guardedBy in envVars) continue;
+
+    if (hasEnvFile) {
+      issues.push({
+        code: 'LOCAL_STORAGE_PATH',
+        severity: 'error',
+        message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
+        fix: `Set ${d.guardedBy} in your env file, or remove the local fallback.`,
+      });
+    } else {
+      issues.push({
+        code: 'LOCAL_STORAGE_PATH',
+        severity: 'warning',
+        message: `${truncate(d.value, 80)} will be used at runtime unless ${d.guardedBy} is set — cannot verify ${d.guardedBy} is set on the platform (${d.hint})`,
+        fix: `Ensure ${d.guardedBy} is set in the target environment, or pass --env-file so preflight can verify it locally.`,
+      });
+    }
+  }
+
+  return issues;
 }
 
 /* ------------------------------------------------------------------ */

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -363,8 +363,9 @@ async function checkLocalStoragePaths(
     }
 
     // The literal is a dead fallback when the guarding env var is set in the
-    // deploy environment.
-    if (d.guardedBy in envVars) continue;
+    // deploy environment. An empty value doesn't count: `process.env.X || 'file:...'`
+    // still takes the fallback at runtime when X is blank.
+    if (envVars[d.guardedBy]) continue;
 
     if (hasEnvFile) {
       issues.push({

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -800,7 +800,13 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
   // stored vars (request wins), so platform-stored vars don't false-alarm.
   if (!skipPreflight) {
     const preflightEnv = mergePreflightEnvVars(environment.envVars, envVars);
-    const issues = await preflightBuildOutput(targetDir, preflightEnv, { hasEnvFile: hasAmbientEnvFile });
+    const issues = await preflightBuildOutput(targetDir, preflightEnv, {
+      hasEnvFile: hasAmbientEnvFile,
+      // Managed resources (e.g. attached databases) inject vars at deploy
+      // time; the platform exposes their names on the environment. Absent
+      // field = older platform = incomplete env picture (soften to warnings).
+      managedEnvVarNames: environment.managedEnvVarNames ?? null,
+    });
     const outcome = await printPreflightIssues(issues, { autoAccept });
     if (outcome === 'blocked') {
       p.cancel('Deploy blocked by preflight errors.');

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -26,7 +26,7 @@ import { checkBuildStaleness } from '../../utils/source-hash.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_PLATFORM_API_URL, MASTRA_STUDIO_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
-import { preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
+import { mergePreflightEnvVars, preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
 import { fetchEnvironments, fetchProjects, createEnvironment } from '../env/platform-api.js';
 import type { Environment } from '../env/platform-api.js';
 import { getDeployEnvFiles, loadDeployEnvFromDotenv, readEnvVars, getMastraVersion } from '../studio/deploy.js';
@@ -795,9 +795,12 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
     }
   }
 
-  // Pre-upload validation
+  // Pre-upload validation. Preflight sees the same env picture the platform
+  // applies at deploy time: request env vars merged over the environment's
+  // stored vars (request wins), so platform-stored vars don't false-alarm.
   if (!skipPreflight) {
-    const issues = await preflightBuildOutput(targetDir, envVars, { hasEnvFile: hasAmbientEnvFile });
+    const preflightEnv = mergePreflightEnvVars(environment.envVars, envVars);
+    const issues = await preflightBuildOutput(targetDir, preflightEnv, { hasEnvFile: hasAmbientEnvFile });
     const outcome = await printPreflightIssues(issues, { autoAccept });
     if (outcome === 'blocked') {
       p.cancel('Deploy blocked by preflight errors.');

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -797,7 +797,7 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
 
   // Pre-upload validation
   if (!skipPreflight) {
-    const issues = await preflightBuildOutput(targetDir, envVars);
+    const issues = await preflightBuildOutput(targetDir, envVars, { hasEnvFile: hasAmbientEnvFile });
     const outcome = await printPreflightIssues(issues, { autoAccept });
     if (outcome === 'blocked') {
       p.cancel('Deploy blocked by preflight errors.');

--- a/packages/cli/src/commands/env/platform-api.ts
+++ b/packages/cli/src/commands/env/platform-api.ts
@@ -19,6 +19,12 @@ export interface Environment {
   customServerUrl: string | null;
   observabilityProjectId: string | null;
   envVars: Record<string, string> | null;
+  /**
+   * Names of env vars injected at deploy time by managed platform resources
+   * (e.g. an attached Turso database). Names only — values are secrets.
+   * Absent on platforms that predate the field.
+   */
+  managedEnvVarNames?: string[];
   createdAt: string;
   updatedAt: string;
 }

--- a/packages/cli/src/commands/lint/index.test.ts
+++ b/packages/cli/src/commands/lint/index.test.ts
@@ -1,0 +1,79 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+
+import { lint } from './index.js';
+
+vi.mock('@clack/prompts', () => ({
+  log: { warn: vi.fn(), error: vi.fn(), step: vi.fn(), success: vi.fn() },
+  confirm: vi.fn(),
+  select: vi.fn(),
+  isCancel: (v: unknown) => v === Symbol.for('clack.cancel'),
+}));
+
+vi.mock('@mastra/deployer', () => ({
+  getDeployer: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('../../utils/run-build.js', () => ({
+  runBuild: vi.fn(),
+}));
+
+describe('lint --preflight env file handling', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'mastra-lint-preflight-test-'));
+    mkdirSync(join(tmpDir, '.mastra', 'output'), { recursive: true });
+    // No @mastra/core on purpose: the resulting project error short-circuits
+    // the deployer lint step so the test exercises only the preflight path.
+    writeFileSync(join(tmpDir, 'package.json'), JSON.stringify({ name: 'test', dependencies: {} }));
+    writeFileSync(join(tmpDir, '.mastra', 'output', 'index.mjs'), `export {};`);
+    writeFileSync(
+      join(tmpDir, '.mastra', 'output', 'preflight-metadata.json'),
+      JSON.stringify({
+        version: 1,
+        localPaths: [
+          {
+            value: 'file:./.mastra-demo.db',
+            hint: 'LibSQL/SQLite file path relative to the build host',
+            module: 'src/constants.ts',
+            guardedBy: 'TURSO_DATABASE_URL',
+          },
+        ],
+        userEnvRefs: ['TURSO_DATABASE_URL'],
+      }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('warns (not errors) on env-guarded local paths when no env file exists', async () => {
+    const result = await lint({ root: tmpDir, preflight: true, skipBuild: true, json: true });
+
+    const issue = result.issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+    expect(issue?.severity).toBe('warning');
+    expect(issue?.message).toContain('cannot verify TURSO_DATABASE_URL is set on the platform');
+  });
+
+  it('errors on env-guarded local paths when an env file exists without the guarding var', async () => {
+    writeFileSync(join(tmpDir, '.env'), 'OPENAI_API_KEY=sk-test\n');
+
+    const result = await lint({ root: tmpDir, preflight: true, skipBuild: true, json: true });
+
+    const issue = result.issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+    expect(issue?.severity).toBe('error');
+    expect(issue?.message).toContain('TURSO_DATABASE_URL is not set');
+  });
+
+  it('reports no local-path issue when the env file sets the guarding var', async () => {
+    writeFileSync(join(tmpDir, '.env'), 'TURSO_DATABASE_URL=libsql://x.turso.io\n');
+
+    const result = await lint({ root: tmpDir, preflight: true, skipBuild: true, json: true });
+
+    expect(result.issues.find(i => i.code === 'LOCAL_STORAGE_PATH')).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/lint/index.ts
+++ b/packages/cli/src/commands/lint/index.ts
@@ -9,7 +9,7 @@ import { runBuild } from '../../utils/run-build.js';
 import { BuildBundler } from '../build/BuildBundler.js';
 import { preflightBuildOutput } from '../deploy-preflight.js';
 import type { PreflightIssue } from '../deploy-preflight.js';
-import { readEnvVars } from '../studio/deploy.js';
+import { getDeployEnvFiles, readEnvVars } from '../studio/deploy.js';
 import { rules } from './rules/index.js';
 import type { LintContext, LintIssue, LintIssueCode } from './rules/types.js';
 
@@ -140,11 +140,17 @@ export async function lint(options: LintOptions): Promise<LintResult> {
         await runBuild(rootDir, { debug: options.debug });
       }
 
-      const envVars = await readEnvVars(rootDir, {
-        envFile: options.envFile,
-        autoAccept: options.json ?? false,
-      });
-      const preflightIssues = await preflightBuildOutput(rootDir, envVars);
+      // Only claim the full env picture when there's an explicit --env-file or
+      // an ambient .env* file. Without one (e.g. CI), env vars may live on the
+      // platform, so env-guarded issues should warn instead of error.
+      const hasEnvFile = Boolean(options.envFile) || (await getDeployEnvFiles(rootDir)).length > 0;
+      const envVars = hasEnvFile
+        ? await readEnvVars(rootDir, {
+            envFile: options.envFile,
+            autoAccept: options.json ?? false,
+          })
+        : {};
+      const preflightIssues = await preflightBuildOutput(rootDir, envVars, { hasEnvFile });
       issues.push(...preflightIssues.map(toLintIssue));
     }
 

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -500,7 +500,13 @@ async function runServerDeploy(dir: string | undefined, opts: ServerDeployOption
       // Stored env unavailable (older platform, network hiccup) — preflight
       // proceeds with the local env picture only.
     }
-    const issues = await preflightBuildOutput(targetDir, mergePreflightEnvVars(storedEnvVars, envVars));
+    // `managedEnvVarNames: null` — the server-project env endpoint doesn't
+    // expose managed-database var names yet, so the env picture is incomplete
+    // and guarded local paths soften to warnings instead of hard errors.
+    // TODO(managed-env-names): pass real names once the endpoint exposes them.
+    const issues = await preflightBuildOutput(targetDir, mergePreflightEnvVars(storedEnvVars, envVars), {
+      managedEnvVarNames: null,
+    });
     const outcome = await printPreflightIssues(issues, { autoAccept });
     if (outcome === 'blocked') {
       p.cancel('Deploy blocked by preflight errors.');

--- a/packages/cli/src/commands/server/deploy.ts
+++ b/packages/cli/src/commands/server/deploy.ts
@@ -14,9 +14,15 @@ import { checkBuildStaleness } from '../../utils/source-hash.js';
 import { fetchOrgs } from '../auth/api.js';
 import { MASTRA_STUDIO_URL, MASTRA_PLATFORM_API_URL } from '../auth/client.js';
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
-import { preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
+import { mergePreflightEnvVars, preflightBuildOutput, printPreflightIssues } from '../deploy-preflight.js';
 import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
-import { fetchServerProjects, createServerProject, uploadServerDeploy, pollServerDeploy } from './platform-api.js';
+import {
+  fetchServerProjects,
+  createServerProject,
+  uploadServerDeploy,
+  pollServerDeploy,
+  getServerProjectEnv,
+} from './platform-api.js';
 
 /* ------------------------------------------------------------------ */
 /*  Helpers                                                           */
@@ -483,8 +489,18 @@ async function runServerDeploy(dir: string | undefined, opts: ServerDeployOption
   }
 
   // Pre-upload validation — catch USER-attributable errors before zipping/shipping.
+  // Preflight sees the same env picture the platform applies at deploy time:
+  // uploaded env vars merged over the project's stored vars (upload wins), so
+  // vars stored only on the platform don't false-alarm.
   if (!skipPreflight) {
-    const issues = await preflightBuildOutput(targetDir, envVars);
+    let storedEnvVars: Record<string, string> | undefined;
+    try {
+      storedEnvVars = await getServerProjectEnv(token, orgId, projectId);
+    } catch {
+      // Stored env unavailable (older platform, network hiccup) — preflight
+      // proceeds with the local env picture only.
+    }
+    const issues = await preflightBuildOutput(targetDir, mergePreflightEnvVars(storedEnvVars, envVars));
     const outcome = await printPreflightIssues(issues, { autoAccept });
     if (outcome === 'blocked') {
       p.cancel('Deploy blocked by preflight errors.');

--- a/packages/cli/src/commands/studio/deploy.ts
+++ b/packages/cli/src/commands/studio/deploy.ts
@@ -562,6 +562,10 @@ async function runStudioDeploy(dir: string | undefined, opts: StudioDeployOption
   }
 
   // Pre-upload validation — catch USER-attributable errors before zipping/shipping.
+  // Unlike `mastra deploy` / `mastra server deploy`, the studio platform API has
+  // no endpoint to read stored env vars, so preflight only sees the local env
+  // file. Platform-provided vars (MASTRA_*, etc.) are still trusted via the
+  // preflight allowlist.
   if (!skipPreflight) {
     const issues = await preflightBuildOutput(targetDir, envVars);
     const outcome = await printPreflightIssues(issues, { autoAccept });

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -153,7 +153,7 @@ export async function getInputOptions(
       // },
       // },
       json(),
-      localStorageDetector(),
+      localStorageDetector(workspaceRoot || projectRoot),
       removeDeployer(entryFile, { sourcemap }),
       // treeshake unused imports
       esbuild({

--- a/packages/deployer/src/build/plugins/local-storage-detector.test.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.test.ts
@@ -64,17 +64,20 @@ describe('localStorageDetector', () => {
     expect(detections).toHaveLength(0);
   });
 
-  it('ignores deployer .mastra/.build shim files for @mastra/* packages', () => {
+  it('ignores all deployer .mastra/.build shim files', () => {
     // Reproduces the false positive triggered when a user sets a `bundler:` field
     // in `new Mastra({...})`, which causes the optimizer to pre-bundle
-    // `@mastra/core` into `.mastra/.build/@mastra__core__*.mjs` shims. These
-    // shims preserve JSDoc examples like `url: 'file:./data.db'`.
+    // dependencies into `.mastra/.build/*.mjs` shims. These shims preserve
+    // JSDoc examples like `url: 'file:./data.db'`. Non-@mastra shims (e.g.
+    // `@ag-ui__mastra.mjs`) can carry the same JSDoc, so the whole directory
+    // must be excluded.
     const plugin = getPlugin();
     plugin.transform(
       `const example = "storage: new LibSQLStore({ url: 'file:./data.db' })";`,
       '/project/.mastra/.build/@mastra__core__mastra.mjs',
     );
     plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@mastra__core.mjs');
+    plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@ag-ui__mastra.mjs');
 
     const emitted: Array<{ fileName: string; source: string }> = [];
     const ctx = {
@@ -91,6 +94,7 @@ describe('localStorageDetector', () => {
           modules: {
             '/project/.mastra/.build/@mastra__core__mastra.mjs': { renderedLength: 5000 },
             '/project/.mastra/.build/@mastra__core.mjs': { renderedLength: 5000 },
+            '/project/.mastra/.build/@ag-ui__mastra.mjs': { renderedLength: 5000 },
           },
         },
       },

--- a/packages/deployer/src/build/plugins/local-storage-detector.test.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.test.ts
@@ -1,224 +1,180 @@
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rollup } from 'rollup';
 import type { Plugin } from 'rollup';
+import { parseAst } from 'rollup/parseAst';
 import { describe, expect, it } from 'vitest';
 import { localStorageDetector } from './local-storage-detector';
+import type { LocalStorageDetection, PreflightMetadata } from './local-storage-detector';
 
-describe('localStorageDetector', () => {
-  function getPlugin(): Plugin & { transform: Function; generateBundle: Function } {
-    return localStorageDetector() as Plugin & { transform: Function; generateBundle: Function };
+/**
+ * Drives the plugin the way Rollup does: `transform` for each module (with a
+ * `this.parse` context, like Rollup provides), then `generateBundle` with a
+ * chunk whose `modules` map controls tree-shaking (`renderedLength`).
+ */
+function runPlugin(
+  modules: Array<{ id: string; code: string; renderedLength?: number }>,
+  rootDir?: string,
+): {
+  metadata: PreflightMetadata;
+  legacy: LocalStorageDetection[];
+  emitted: Array<{ fileName: string; source: string }>;
+} {
+  const plugin = localStorageDetector(rootDir) as Plugin & { transform: Function; generateBundle: Function };
+
+  const transformCtx = { parse: (code: string) => parseAst(code) };
+  for (const { id, code } of modules) {
+    plugin.transform.call(transformCtx, code, id);
   }
 
+  const emitted: Array<{ fileName: string; source: string }> = [];
+  const generateCtx = {
+    emitFile(file: { fileName: string; source: string }) {
+      emitted.push(file);
+    },
+  };
+  const chunkModules: Record<string, { renderedLength: number }> = {};
+  for (const { id, renderedLength } of modules) {
+    chunkModules[id] = { renderedLength: renderedLength ?? 100 };
+  }
+  plugin.generateBundle.call(generateCtx, {}, { 'index.mjs': { type: 'chunk', modules: chunkModules } });
+
+  const metadataFile = emitted.find(f => f.fileName === 'preflight-metadata.json');
+  const legacyFile = emitted.find(f => f.fileName === 'preflight-local-paths.json');
+  if (!metadataFile || !legacyFile) throw new Error('expected both metadata assets to be emitted');
+
+  return {
+    metadata: JSON.parse(metadataFile.source),
+    legacy: JSON.parse(legacyFile.source),
+    emitted,
+  };
+}
+
+describe('localStorageDetector', () => {
   it('collects file: paths from user modules', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const url = 'file:./mastra.db';`, '/project/src/mastra/index.ts');
+    const { metadata, legacy } = runPlugin([
+      { id: '/project/src/mastra/index.ts', code: `const url = 'file:./mastra.db';` },
+    ]);
 
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
-      {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/mastra/index.ts': { renderedLength: 100 },
-          },
-        },
-      },
-    );
-
-    expect(emitted).toHaveLength(1);
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(1);
-    expect(detections[0].value).toBe('file:./mastra.db');
-    expect(detections[0].module).toBe('/project/src/mastra/index.ts');
+    expect(metadata.localPaths).toHaveLength(1);
+    expect(metadata.localPaths[0]!.value).toBe('file:./mastra.db');
+    expect(metadata.localPaths[0]!.module).toBe('/project/src/mastra/index.ts');
+    expect(metadata.localPaths[0]!.guardedBy).toBeUndefined();
+    expect(legacy).toHaveLength(1);
   });
 
   it('ignores modules from node_modules', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const url = 'file:./mastra.db';`, '/project/node_modules/@mastra/agent-builder/dist/defaults.js');
-
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
+    const { metadata, legacy } = runPlugin([
       {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/node_modules/@mastra/agent-builder/dist/defaults.js': { renderedLength: 200 },
-          },
-        },
+        id: '/project/node_modules/@mastra/agent-builder/dist/defaults.js',
+        code: `const url = 'file:./mastra.db';`,
+        renderedLength: 200,
       },
-    );
+    ]);
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(0);
+    expect(metadata.localPaths).toHaveLength(0);
+    expect(legacy).toHaveLength(0);
   });
 
-  it('ignores all deployer .mastra/.build shim files', () => {
-    // Reproduces the false positive triggered when a user sets a `bundler:` field
-    // in `new Mastra({...})`, which causes the optimizer to pre-bundle
-    // dependencies into `.mastra/.build/*.mjs` shims. These shims preserve
-    // JSDoc examples like `url: 'file:./data.db'`. Non-@mastra shims (e.g.
-    // `@ag-ui__mastra.mjs`) can carry the same JSDoc, so the whole directory
-    // must be excluded.
-    const plugin = getPlugin();
-    plugin.transform(
-      `const example = "storage: new LibSQLStore({ url: 'file:./data.db' })";`,
-      '/project/.mastra/.build/@mastra__core__mastra.mjs',
-    );
-    plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@mastra__core.mjs');
-    plugin.transform(`const example = "url: 'file:./data.db'";`, '/project/.mastra/.build/@ag-ui__mastra.mjs');
-
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
+  it('ignores deployer .mastra/.build pre-bundled dependency files', () => {
+    // Reproduces the false positive triggered when the optimizer pre-bundles
+    // `@mastra/core` into `.mastra/.build/@mastra__core__*.mjs` shims and
+    // shared `chunk-*.mjs` files. These preserve JSDoc examples like
+    // `url: 'file:./data.db'`.
+    const { metadata } = runPlugin([
       {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/.mastra/.build/@mastra__core__mastra.mjs': { renderedLength: 5000 },
-            '/project/.mastra/.build/@mastra__core.mjs': { renderedLength: 5000 },
-            '/project/.mastra/.build/@ag-ui__mastra.mjs': { renderedLength: 5000 },
-          },
-        },
+        id: '/project/.mastra/.build/@mastra__core__mastra.mjs',
+        code: `const example = "storage: new LibSQLStore({ url: 'file:./data.db' })";`,
+        renderedLength: 5000,
       },
+      {
+        id: '/project/.mastra/.build/@mastra__core.mjs',
+        code: `const example = "url: 'file:./data.db'";`,
+        renderedLength: 5000,
+      },
+      {
+        id: '/project/.mastra/.build/@ag-ui__mastra.mjs',
+        code: `const example = "url: 'file:./data.db'";`,
+        renderedLength: 5000,
+      },
+      {
+        id: '/project/.mastra/.build/chunk-2TLN5H7J.mjs',
+        code: `const example = "new LibSQLStore({ id: 'mastra-storage', url: 'file:./data.db' })";`,
+        renderedLength: 5000,
+      },
+    ]);
+
+    expect(metadata.localPaths).toHaveLength(0);
+  });
+
+  it('ignores symlinked dependencies outside the project root (pnpm link:)', () => {
+    // pnpm `link:`/`file:` deps resolve through the symlink to a real path
+    // that never contains `node_modules` — e.g. a linked @mastra/server dist
+    // whose JSDoc examples mention `file:./mastra.db`. Anything outside the
+    // project root is library code.
+    const { metadata } = runPlugin(
+      [
+        {
+          id: '/home/dev/worktrees/mastra/packages/server/dist/dist-JNS5ZLN3.js',
+          code: `const example = "url: 'file:./mastra.db'"; const flag = process.env.AUTO_BLOCK_EXTERNAL_PROVIDERS;`,
+          renderedLength: 5000,
+        },
+        {
+          id: '/project/src/mastra/index.ts',
+          code: `const url = 'file:./user.db'; const key = process.env.USER_KEY;`,
+          renderedLength: 500,
+        },
+      ],
+      '/project',
     );
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(0);
+    expect(metadata.localPaths).toHaveLength(1);
+    expect(metadata.localPaths[0]!.value).toBe('file:./user.db');
+    expect(metadata.userEnvRefs).toEqual(['USER_KEY']);
   });
 
   it('excludes tree-shaken modules (renderedLength === 0)', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const url = 'file:./mastra.db';`, '/project/src/unused.ts');
-
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
+    const { metadata } = runPlugin([
       {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/unused.ts': { renderedLength: 0 },
-          },
-        },
+        id: '/project/src/unused.ts',
+        code: `const url = 'file:./mastra.db'; const key = process.env.UNUSED_KEY;`,
+        renderedLength: 0,
       },
-    );
+    ]);
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(0);
+    expect(metadata.localPaths).toHaveLength(0);
+    expect(metadata.userEnvRefs).toHaveLength(0);
   });
 
   it('deduplicates identical value+hint pairs across modules', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const url = 'file:./mastra.db';`, '/project/src/a.ts');
-    plugin.transform(`const url = 'file:./mastra.db';`, '/project/src/b.ts');
+    const { metadata } = runPlugin([
+      { id: '/project/src/a.ts', code: `const url = 'file:./mastra.db';`, renderedLength: 50 },
+      { id: '/project/src/b.ts', code: `const url = 'file:./mastra.db';`, renderedLength: 50 },
+    ]);
 
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
-      {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/a.ts': { renderedLength: 50 },
-            '/project/src/b.ts': { renderedLength: 50 },
-          },
-        },
-      },
-    );
-
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(1);
+    expect(metadata.localPaths).toHaveLength(1);
   });
 
   it('detects localhost connection strings', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const pg = 'postgresql://user:pass@localhost:5432/db';`, '/project/src/db.ts');
+    const { metadata } = runPlugin([
+      { id: '/project/src/db.ts', code: `const pg = 'postgresql://user:pass@localhost:5432/db';`, renderedLength: 80 },
+    ]);
 
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
-      {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/db.ts': { renderedLength: 80 },
-          },
-        },
-      },
-    );
-
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(1);
-    expect(detections[0].hint).toBe('localhost in a connection string');
+    expect(metadata.localPaths).toHaveLength(1);
+    expect(metadata.localPaths[0]!.hint).toBe('localhost in a connection string');
   });
 
   it('detects 127.0.0.1 connection strings', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const r = 'redis://127.0.0.1:6379';`, '/project/src/cache.ts');
+    const { metadata } = runPlugin([
+      { id: '/project/src/cache.ts', code: `const r = 'redis://127.0.0.1:6379';`, renderedLength: 60 },
+    ]);
 
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
-      {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/cache.ts': { renderedLength: 60 },
-          },
-        },
-      },
-    );
-
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(1);
-    expect(detections[0].hint).toBe('127.0.0.1 in a connection string');
+    expect(metadata.localPaths).toHaveLength(1);
+    expect(metadata.localPaths[0]!.hint).toBe('127.0.0.1 in a connection string');
   });
 
   it('reproduces original bug fix: agent-builder prompt templates are excluded', () => {
-    const plugin = getPlugin();
-
     // Exact content from packages/agent-builder/src/defaults.ts and prompts.ts
     const agentBuilderDefaults = `
       const defaults = {
@@ -230,131 +186,230 @@ describe('localStorageDetector', () => {
       const example = "storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' })";
     `;
 
-    // These come from node_modules — plugin should ignore them
-    plugin.transform(agentBuilderDefaults, '/project/node_modules/@mastra/agent-builder/dist/defaults.js');
-    plugin.transform(
-      agentBuilderPrompts,
-      '/project/node_modules/@mastra/agent-builder/dist/workflows/workflow-builder/prompts.js',
-    );
-
-    // User code has NO local paths
-    plugin.transform(`export const mastra = new Mastra({});`, '/project/src/mastra/index.ts');
-
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
+    const { metadata } = runPlugin([
+      // These come from node_modules — plugin should ignore them
       {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/node_modules/@mastra/agent-builder/dist/defaults.js': { renderedLength: 500 },
-            '/project/node_modules/@mastra/agent-builder/dist/workflows/workflow-builder/prompts.js': {
-              renderedLength: 300,
-            },
-            '/project/src/mastra/index.ts': { renderedLength: 100 },
-          },
-        },
+        id: '/project/node_modules/@mastra/agent-builder/dist/defaults.js',
+        code: agentBuilderDefaults,
+        renderedLength: 500,
       },
-    );
+      {
+        id: '/project/node_modules/@mastra/agent-builder/dist/workflows/workflow-builder/prompts.js',
+        code: agentBuilderPrompts,
+        renderedLength: 300,
+      },
+      // User code has NO local paths
+      { id: '/project/src/mastra/index.ts', code: `export const mastra = new Mastra({});` },
+    ]);
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(0);
+    expect(metadata.localPaths).toHaveLength(0);
   });
 
   it('flags user code but not library code in the same bundle', () => {
-    const plugin = getPlugin();
-
-    // Library: has local path but in node_modules
-    plugin.transform(`const url = 'file:./mastra.db';`, '/project/node_modules/@mastra/agent-builder/dist/defaults.js');
-    // User: also has a local path — this SHOULD be flagged
-    plugin.transform(`const db = 'file:./my-app.db';`, '/project/src/mastra/index.ts');
-
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
+    const { metadata } = runPlugin([
+      // Library: has local path but in node_modules
       {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/node_modules/@mastra/agent-builder/dist/defaults.js': { renderedLength: 200 },
-            '/project/src/mastra/index.ts': { renderedLength: 100 },
-          },
-        },
+        id: '/project/node_modules/@mastra/agent-builder/dist/defaults.js',
+        code: `const url = 'file:./mastra.db';`,
+        renderedLength: 200,
       },
-    );
+      // User: also has a local path — this SHOULD be flagged
+      { id: '/project/src/mastra/index.ts', code: `const db = 'file:./my-app.db';` },
+    ]);
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(1);
-    expect(detections[0].value).toBe('file:./my-app.db');
-    expect(detections[0].module).toBe('/project/src/mastra/index.ts');
+    expect(metadata.localPaths).toHaveLength(1);
+    expect(metadata.localPaths[0]!.value).toBe('file:./my-app.db');
+    expect(metadata.localPaths[0]!.module).toBe('/project/src/mastra/index.ts');
   });
 
   it('does not flag hosted URLs (turso, remote postgres)', () => {
-    const plugin = getPlugin();
-    plugin.transform(
-      `const url = 'libsql://my-db-acme.turso.io'; const pg = 'postgresql://user:pass@db.render.com:5432/app';`,
-      '/project/src/db.ts',
-    );
-
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
+    const { metadata } = runPlugin([
       {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/db.ts': { renderedLength: 100 },
-          },
-        },
+        id: '/project/src/db.ts',
+        code: `const url = 'libsql://my-db-acme.turso.io'; const pg = 'postgresql://user:pass@db.render.com:5432/app';`,
       },
-    );
+    ]);
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(0);
+    expect(metadata.localPaths).toHaveLength(0);
   });
 
-  it('emits empty array when no detections found', () => {
-    const plugin = getPlugin();
-    plugin.transform(`const x = 'hello world';`, '/project/src/clean.ts');
+  it('emits empty arrays when nothing is found', () => {
+    const { metadata, legacy } = runPlugin([
+      { id: '/project/src/clean.ts', code: `const x = 'hello world';`, renderedLength: 30 },
+    ]);
 
-    const emitted: Array<{ fileName: string; source: string }> = [];
-    const ctx = {
-      emitFile(file: { fileName: string; source: string }) {
-        emitted.push(file);
-      },
-    };
-    plugin.generateBundle.call(
-      ctx,
-      {},
-      {
-        'index.mjs': {
-          type: 'chunk',
-          modules: {
-            '/project/src/clean.ts': { renderedLength: 30 },
-          },
+    expect(metadata).toEqual({ version: 1, localPaths: [], userEnvRefs: [] });
+    expect(legacy).toHaveLength(0);
+  });
+
+  describe('guardedBy detection', () => {
+    it('records guardedBy for `process.env.X || literal`', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/src/constants.ts',
+          code: `const url = process.env.TURSO_DATABASE_URL || "file:./.mastra-demo.db";`,
         },
-      },
-    );
+      ]);
 
-    const detections = JSON.parse(emitted[0]!.source);
-    expect(detections).toHaveLength(0);
+      expect(metadata.localPaths).toHaveLength(1);
+      expect(metadata.localPaths[0]!.value).toBe('file:./.mastra-demo.db');
+      expect(metadata.localPaths[0]!.guardedBy).toBe('TURSO_DATABASE_URL');
+    });
+
+    it('records guardedBy for `process.env.X ?? literal`', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/src/constants.ts',
+          code: `const url = process.env.TURSO_DATABASE_URL ?? "file:./.mastra-demo.db";`,
+        },
+      ]);
+
+      expect(metadata.localPaths[0]!.guardedBy).toBe('TURSO_DATABASE_URL');
+    });
+
+    it('records guardedBy for bracket-notation env reads', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/src/constants.ts',
+          code: `const url = process.env["TURSO_DATABASE_URL"] || "file:./.mastra-demo.db";`,
+        },
+      ]);
+
+      expect(metadata.localPaths[0]!.guardedBy).toBe('TURSO_DATABASE_URL');
+    });
+
+    it('records guardedBy for chained fallbacks (`a || b || literal`)', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/src/constants.ts',
+          code: `const url = process.env.TURSO_DATABASE_URL || process.env.DATABASE_URL || "file:./.mastra-demo.db";`,
+        },
+      ]);
+
+      expect(metadata.localPaths[0]!.guardedBy).toBe('TURSO_DATABASE_URL');
+    });
+
+    it('does not record guardedBy for a bare literal', () => {
+      const { metadata } = runPlugin([{ id: '/project/src/db.ts', code: `const url = "file:./a.db";` }]);
+
+      expect(metadata.localPaths).toHaveLength(1);
+      expect(metadata.localPaths[0]!.guardedBy).toBeUndefined();
+    });
+
+    it('does not record guardedBy when the same value also appears unguarded', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/src/db.ts',
+          code: `const a = process.env.TURSO_DATABASE_URL || "file:./a.db"; const b = "file:./a.db";`,
+        },
+      ]);
+
+      expect(metadata.localPaths).toHaveLength(1);
+      expect(metadata.localPaths[0]!.guardedBy).toBeUndefined();
+    });
+
+    it('falls back to unguarded detection when the module fails to parse', () => {
+      const { metadata } = runPlugin([
+        { id: '/project/src/broken.ts', code: `const url = 'file:./a.db'; this is not { valid js` },
+      ]);
+
+      expect(metadata.localPaths).toHaveLength(1);
+      expect(metadata.localPaths[0]!.guardedBy).toBeUndefined();
+    });
+  });
+
+  describe('userEnvRefs collection', () => {
+    it('collects process.env reads from user modules (dot and bracket notation)', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/src/mastra/index.ts',
+          code: `const a = process.env.TURSO_DATABASE_URL; const b = process.env['OPENAI_API_KEY'];`,
+        },
+      ]);
+
+      expect(metadata.userEnvRefs).toEqual(['OPENAI_API_KEY', 'TURSO_DATABASE_URL']);
+    });
+
+    it('excludes env reads from node_modules and .mastra/.build files', () => {
+      const { metadata } = runPlugin([
+        {
+          id: '/project/node_modules/@mastra/server/dist/handlers/agents.js',
+          code: `const flag = process.env.AUTO_BLOCK_EXTERNAL_PROVIDERS;`,
+          renderedLength: 400,
+        },
+        {
+          id: '/project/.mastra/.build/@mastra__core.mjs',
+          code: `const flag = process.env.LIB_INTERNAL_FLAG;`,
+          renderedLength: 400,
+        },
+        {
+          id: '/project/.mastra/.build/telemetry-config.mjs',
+          code: `const t = process.env.OTHER_BUILD_FLAG;`,
+          renderedLength: 400,
+        },
+        { id: '/project/src/mastra/index.ts', code: `const key = process.env.OPENAI_API_KEY;` },
+      ]);
+
+      expect(metadata.userEnvRefs).toEqual(['OPENAI_API_KEY']);
+    });
+  });
+
+  it('produces correct metadata through a real Rollup build (end-to-end)', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'local-storage-detector-e2e-'));
+    try {
+      // Shaped like esbuild-transpiled user output — the plugin runs
+      // post-esbuild in the deployer's chain.
+      writeFileSync(
+        join(dir, 'entry.mjs'),
+        `const url = process.env.TURSO_DATABASE_URL || "file:./.mastra-demo.db";\n` +
+          `const key = process.env.OPENAI_API_KEY;\n` +
+          `const bare = "file:./other.db";\n` +
+          `export default { url, key, bare };\n`,
+      );
+
+      const bundle = await rollup({
+        input: join(dir, 'entry.mjs'),
+        plugins: [localStorageDetector()],
+        logLevel: 'silent',
+      });
+      await bundle.write({ dir: join(dir, 'out'), format: 'esm' });
+      await bundle.close();
+
+      const metadata: PreflightMetadata = JSON.parse(
+        readFileSync(join(dir, 'out', 'preflight-metadata.json'), 'utf-8'),
+      );
+      expect(metadata.version).toBe(1);
+      expect(metadata.userEnvRefs).toEqual(['OPENAI_API_KEY', 'TURSO_DATABASE_URL']);
+      expect(metadata.localPaths).toEqual([
+        expect.objectContaining({ value: 'file:./.mastra-demo.db', guardedBy: 'TURSO_DATABASE_URL' }),
+        expect.objectContaining({ value: 'file:./other.db' }),
+      ]);
+      expect(metadata.localPaths[1]!.guardedBy).toBeUndefined();
+
+      const legacy: LocalStorageDetection[] = JSON.parse(
+        readFileSync(join(dir, 'out', 'preflight-local-paths.json'), 'utf-8'),
+      );
+      expect(legacy.map(d => d.value)).toEqual(['file:./.mastra-demo.db', 'file:./other.db']);
+      expect(Object.keys(legacy[0]!)).toEqual(['value', 'hint', 'module']);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the legacy preflight-local-paths.json shape unchanged (no guardedBy)', () => {
+    const { legacy } = runPlugin([
+      {
+        id: '/project/src/constants.ts',
+        code: `const url = process.env.TURSO_DATABASE_URL || "file:./.mastra-demo.db";`,
+      },
+    ]);
+
+    expect(legacy).toEqual([
+      {
+        value: 'file:./.mastra-demo.db',
+        hint: 'LibSQL/SQLite file path relative to the build host',
+        module: '/project/src/constants.ts',
+      },
+    ]);
   });
 });

--- a/packages/deployer/src/build/plugins/local-storage-detector.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.ts
@@ -27,19 +27,21 @@ export interface LocalStorageDetection {
 
 /**
  * Matches the deployer's own intermediate dependency shims emitted under
- * `.mastra/.build/` (e.g. `@mastra__core.mjs`, `@mastra__core__mastra.mjs`).
+ * `.mastra/.build/` (e.g. `@mastra__core.mjs`, `@ag-ui__mastra.mjs`).
  * These pre-bundled chunks preserve JSDoc examples from the original library
  * source (e.g. `LibSQLStore({ url: 'file:./data.db' })`) which would otherwise
- * trip the host-local detector even though they're not user code.
+ * trip the host-local detector even though they're not user code. Everything
+ * in this directory is deployer-generated dependency output, never user
+ * source, so the whole directory is excluded.
  */
-const MASTRA_SHIM_PATH = /[\\/]\.mastra[\\/]\.build[\\/]@mastra__/;
+const MASTRA_BUILD_DIR = /[\\/]\.mastra[\\/]\.build[\\/]/;
 
 /**
  * Rollup plugin that detects host-local storage URLs (e.g. `file:./mastra.db`,
  * `postgres://localhost`) in **user source modules** during bundling.
  *
  * Only modules outside `node_modules` (and the deployer's own
- * `.mastra/.build/@mastra__*` shim files) are inspected, so library code
+ * `.mastra/.build/` shim files) are inspected, so library code
  * (like Agent Builder prompt templates or JSDoc examples in `@mastra/core`)
  * is naturally excluded.  Tree-shaken modules are excluded via
  * `generateBundle` — only modules that actually contribute rendered code to
@@ -56,7 +58,7 @@ export function localStorageDetector(): Plugin {
 
     transform(_code, id) {
       if (id.includes('node_modules')) return null;
-      if (MASTRA_SHIM_PATH.test(id)) return null;
+      if (MASTRA_BUILD_DIR.test(id)) return null;
 
       const matches: Array<{ value: string; hint: string }> = [];
       for (const { pattern, hint } of LOCAL_HOST_PATTERNS) {

--- a/packages/deployer/src/build/plugins/local-storage-detector.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.ts
@@ -197,7 +197,12 @@ function findGuardedValues(ast: AstNode, values: Set<string>): Map<string, strin
 export function localStorageDetector(rootDir?: string): Plugin {
   const userModuleMatches = new Map<string, ModuleMatch[]>();
   const userModuleEnvRefs = new Map<string, Set<string>>();
-  const normalizedRoot = rootDir ? rootDir.replace(/\\/g, '/').replace(/\/+$/, '') + '/' : undefined;
+  let normalizedRoot: string | undefined;
+  if (rootDir) {
+    let root = rootDir.replace(/\\/g, '/');
+    while (root.endsWith('/')) root = root.slice(0, -1);
+    normalizedRoot = root + '/';
+  }
 
   return {
     name: 'mastra-local-storage-detector',

--- a/packages/deployer/src/build/plugins/local-storage-detector.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.ts
@@ -57,6 +57,10 @@ const PROCESS_ENV_DOT = /\bprocess\.env\.([A-Z_][A-Z0-9_]*)\b/g;
 const PROCESS_ENV_BRACKET = /\bprocess\.env\[['"]([A-Z_][A-Z0-9_]*)['"]\]/g;
 
 /** Names of the metadata assets emitted into the output dir. */
+// TODO(preflight-metadata): stop emitting the legacy file in the next minor
+// after @mastra/deployer 1.50 — every CLI released alongside 1.50+ reads
+// preflight-metadata.json. Also remove the legacy fallback in the CLI's
+// deploy-preflight.ts at the same time.
 const LEGACY_LOCAL_PATHS_FILE = 'preflight-local-paths.json';
 const PREFLIGHT_METADATA_FILE = 'preflight-metadata.json';
 

--- a/packages/deployer/src/build/plugins/local-storage-detector.ts
+++ b/packages/deployer/src/build/plugins/local-storage-detector.ts
@@ -23,35 +23,177 @@ export interface LocalStorageDetection {
   value: string;
   hint: string;
   module: string;
+  /**
+   * Name of the env var that guards this literal at runtime, when the
+   * literal is the fallback arm of a `process.env.X || literal` (or `??`)
+   * expression. The CLI preflight uses this to suppress or soften the
+   * error when the guarding var is present in the deploy env.
+   */
+  guardedBy?: string;
 }
 
 /**
- * Matches the deployer's own intermediate dependency shims emitted under
- * `.mastra/.build/` (e.g. `@mastra__core.mjs`, `@ag-ui__mastra.mjs`).
- * These pre-bundled chunks preserve JSDoc examples from the original library
- * source (e.g. `LibSQLStore({ url: 'file:./data.db' })`) which would otherwise
- * trip the host-local detector even though they're not user code. Everything
- * in this directory is deployer-generated dependency output, never user
- * source, so the whole directory is excluded.
+ * Unified preflight metadata emitted as `preflight-metadata.json`.
+ * Superset of the legacy `preflight-local-paths.json` (which stays emitted
+ * for one release so older CLIs keep working with newer deployers).
+ */
+export interface PreflightMetadata {
+  version: 1;
+  localPaths: LocalStorageDetection[];
+  userEnvRefs: string[];
+}
+
+/**
+ * Everything under `.mastra/.build/` is deployer-generated pre-bundled
+ * dependency code (`@mastra__*.mjs` shims and their shared `chunk-*.mjs`
+ * files), never user-authored. These preserve JSDoc examples from the
+ * original library source (e.g. `LibSQLStore({ url: 'file:./data.db' })`)
+ * which would otherwise trip the host-local detector, and their env var
+ * reads are library refs that must not count as user references.
  */
 const MASTRA_BUILD_DIR = /[\\/]\.mastra[\\/]\.build[\\/]/;
 
+const PROCESS_ENV_DOT = /\bprocess\.env\.([A-Z_][A-Z0-9_]*)\b/g;
+const PROCESS_ENV_BRACKET = /\bprocess\.env\[['"]([A-Z_][A-Z0-9_]*)['"]\]/g;
+
+/** Names of the metadata assets emitted into the output dir. */
+const LEGACY_LOCAL_PATHS_FILE = 'preflight-local-paths.json';
+const PREFLIGHT_METADATA_FILE = 'preflight-metadata.json';
+
+interface ModuleMatch {
+  value: string;
+  hint: string;
+  guardedBy?: string;
+}
+
+function collectEnvRefs(code: string): Set<string> {
+  const refs = new Set<string>();
+  for (const m of code.matchAll(PROCESS_ENV_DOT)) refs.add(m[1]!);
+  for (const m of code.matchAll(PROCESS_ENV_BRACKET)) refs.add(m[1]!);
+  return refs;
+}
+
+/* ------------------------------------------------------------------ */
+/*  AST guard analysis                                                */
+/* ------------------------------------------------------------------ */
+
+interface AstNode {
+  type: string;
+  [key: string]: unknown;
+}
+
+function isAstNode(v: unknown): v is AstNode {
+  return typeof v === 'object' && v !== null && typeof (v as AstNode).type === 'string';
+}
+
+function walkAst(node: AstNode, visit: (node: AstNode) => void): void {
+  visit(node);
+  for (const value of Object.values(node)) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        if (isAstNode(item)) walkAst(item, visit);
+      }
+    } else if (isAstNode(value)) {
+      walkAst(value, visit);
+    }
+  }
+}
+
+/** Find the first `process.env.X` / `process.env['X']` read inside an expression. */
+function findFirstEnvRef(node: AstNode): string | undefined {
+  let found: string | undefined;
+  walkAst(node, n => {
+    if (found !== undefined) return;
+    if (n.type !== 'MemberExpression') return;
+    const object = n.object as AstNode | undefined;
+    if (
+      !object ||
+      object.type !== 'MemberExpression' ||
+      (object.object as AstNode | undefined)?.type !== 'Identifier' ||
+      ((object.object as AstNode).name as string) !== 'process' ||
+      (object.property as AstNode | undefined)?.type !== 'Identifier' ||
+      ((object.property as AstNode).name as string) !== 'env'
+    ) {
+      return;
+    }
+    const property = n.property as AstNode | undefined;
+    if (property?.type === 'Identifier' && !n.computed) {
+      found = property.name as string;
+    } else if (property?.type === 'Literal' && typeof property.value === 'string') {
+      found = property.value;
+    }
+  });
+  return found;
+}
+
+/**
+ * Parse a module and figure out, for each detected local-path value, whether
+ * every string literal containing it is the fallback arm of a
+ * `process.env.X || <literal>` / `??` expression. Returns a map from
+ * detected value to guarding env var name. Values with any unguarded
+ * occurrence (or inconsistent guards) are absent — the CLI then errors as
+ * before, which is the safe default.
+ */
+function findGuardedValues(ast: AstNode, values: Set<string>): Map<string, string> {
+  const stringLiterals: AstNode[] = [];
+  const guardedLiterals = new Map<AstNode, string>();
+
+  walkAst(ast, node => {
+    if (node.type === 'Literal' && typeof node.value === 'string') {
+      stringLiterals.push(node);
+      return;
+    }
+    if (node.type === 'LogicalExpression' && (node.operator === '||' || node.operator === '??')) {
+      const right = node.right as AstNode | undefined;
+      if (right?.type === 'Literal' && typeof right.value === 'string') {
+        const envName = findFirstEnvRef(node.left as AstNode);
+        if (envName) guardedLiterals.set(right, envName);
+      }
+    }
+  });
+
+  const result = new Map<string, string>();
+  for (const value of values) {
+    const containing = stringLiterals.filter(lit => (lit.value as string).includes(value));
+    if (containing.length === 0) continue;
+    const guards = containing.map(lit => guardedLiterals.get(lit));
+    const first = guards[0];
+    if (first !== undefined && guards.every(g => g === first)) {
+      result.set(value, first);
+    }
+  }
+  return result;
+}
+
 /**
  * Rollup plugin that detects host-local storage URLs (e.g. `file:./mastra.db`,
- * `postgres://localhost`) in **user source modules** during bundling.
+ * `postgres://localhost`) in **user source modules** during bundling, and
+ * collects the env vars user code reads via `process.env.X`.
  *
  * Only modules outside `node_modules` (and the deployer's own
- * `.mastra/.build/` shim files) are inspected, so library code
+ * `.mastra/.build/` pre-bundled files) are inspected, so library code
  * (like Agent Builder prompt templates or JSDoc examples in `@mastra/core`)
- * is naturally excluded.  Tree-shaken modules are excluded via
+ * is naturally excluded.  When `rootDir` is given, modules outside it are
+ * also excluded — symlinked dependencies (pnpm `link:`/`file:`) resolve to
+ * real paths that never contain `node_modules`.  Tree-shaken modules are
+ * excluded via
  * `generateBundle` — only modules that actually contribute rendered code to
  * the output are reported.
  *
- * Detected paths are emitted as `preflight-local-paths.json` in the output
- * directory for the CLI preflight check to consume.
+ * When a detected literal is the fallback arm of a `process.env.X || literal`
+ * expression, `guardedBy: "X"` is recorded so the CLI preflight can apply
+ * deploy-time env context instead of hard-erroring on a dead fallback.
+ *
+ * Two assets are emitted into the output directory for the CLI preflight:
+ * - `preflight-metadata.json` — unified metadata (local paths + user env refs)
+ * - `preflight-local-paths.json` — legacy shape, kept for one release so an
+ *   older globally-installed CLI paired with a newer project-local deployer
+ *   doesn't lose the LOCAL_STORAGE_PATH check.
  */
-export function localStorageDetector(): Plugin {
-  const userModuleMatches = new Map<string, Array<{ value: string; hint: string }>>();
+export function localStorageDetector(rootDir?: string): Plugin {
+  const userModuleMatches = new Map<string, ModuleMatch[]>();
+  const userModuleEnvRefs = new Map<string, Set<string>>();
+  const normalizedRoot = rootDir ? rootDir.replace(/\\/g, '/').replace(/\/+$/, '') + '/' : undefined;
 
   return {
     name: 'mastra-local-storage-detector',
@@ -59,8 +201,17 @@ export function localStorageDetector(): Plugin {
     transform(_code, id) {
       if (id.includes('node_modules')) return null;
       if (MASTRA_BUILD_DIR.test(id)) return null;
+      // Modules outside the project/workspace root are dependencies resolved
+      // through symlinks (pnpm `link:`, `file:`, monorepo dev setups) whose
+      // real path escapes `node_modules` — library code, not user code.
+      if (normalizedRoot && !id.replace(/\\/g, '/').startsWith(normalizedRoot)) return null;
 
-      const matches: Array<{ value: string; hint: string }> = [];
+      const refs = collectEnvRefs(_code);
+      if (refs.size > 0) {
+        userModuleEnvRefs.set(id, refs);
+      }
+
+      const matches: ModuleMatch[] = [];
       for (const { pattern, hint } of LOCAL_HOST_PATTERNS) {
         const re = new RegExp(pattern.source, pattern.flags.includes('g') ? pattern.flags : pattern.flags + 'g');
         for (const m of _code.matchAll(re)) {
@@ -69,6 +220,20 @@ export function localStorageDetector(): Plugin {
       }
 
       if (matches.length > 0) {
+        // Best-effort structural pass: a parse failure (or a non-Rollup test
+        // context without `this.parse`) simply means no `guardedBy`, which
+        // preserves the previous always-error behavior.
+        try {
+          const ast = this.parse(_code) as unknown as AstNode;
+          const guarded = findGuardedValues(ast, new Set(matches.map(m => m.value)));
+          for (const match of matches) {
+            const guardedBy = guarded.get(match.value);
+            if (guardedBy) match.guardedBy = guardedBy;
+          }
+        } catch {
+          // ignore — fall back to unguarded detections
+        }
+
         userModuleMatches.set(id, matches);
       }
 
@@ -78,6 +243,7 @@ export function localStorageDetector(): Plugin {
     generateBundle(_, bundle) {
       const detections: LocalStorageDetection[] = [];
       const seen = new Set<string>();
+      const userEnvRefs = new Set<string>();
 
       for (const chunk of Object.values(bundle)) {
         if (chunk.type !== 'chunk') continue;
@@ -85,23 +251,40 @@ export function localStorageDetector(): Plugin {
         for (const [moduleId, moduleInfo] of Object.entries(chunk.modules)) {
           if (moduleInfo.renderedLength === 0) continue;
 
+          for (const ref of userModuleEnvRefs.get(moduleId) ?? []) {
+            userEnvRefs.add(ref);
+          }
+
           const matches = userModuleMatches.get(moduleId);
           if (!matches) continue;
 
-          for (const { value, hint } of matches) {
+          for (const { value, hint, guardedBy } of matches) {
             const key = `${hint}::${value}`;
             if (seen.has(key)) continue;
             seen.add(key);
 
-            detections.push({ value, hint, module: moduleId });
+            detections.push({ value, hint, module: moduleId, ...(guardedBy ? { guardedBy } : {}) });
           }
         }
       }
 
+      const metadata: PreflightMetadata = {
+        version: 1,
+        localPaths: detections,
+        userEnvRefs: [...userEnvRefs].sort(),
+      };
+
       this.emitFile({
         type: 'asset',
-        fileName: 'preflight-local-paths.json',
-        source: JSON.stringify(detections),
+        fileName: PREFLIGHT_METADATA_FILE,
+        source: JSON.stringify(metadata),
+      });
+
+      // Legacy asset — shape unchanged (no `guardedBy`) for older CLIs.
+      this.emitFile({
+        type: 'asset',
+        fileName: LEGACY_LOCAL_PATHS_FILE,
+        source: JSON.stringify(detections.map(({ value, hint, module }) => ({ value, hint, module }))),
       });
     },
   };


### PR DESCRIPTION
## Summary

Deploy preflight checks currently see only text, not code structure, and have no deploy-time env context. That produces false positives that force users to deploy with `--skip-preflight`:

- **Env-guarded storage fallbacks**: `process.env.TURSO_DATABASE_URL || "file:./.mastra-demo.db"` hard-errors with `LOCAL_STORAGE_PATH` even though the fallback is dead code in production when the env var is set.
- **Library env-var false positives**: `MISSING_ENV_VAR` regex-scans the entire bundle, so env vars read only by bundled Mastra packages (e.g. `AUTO_BLOCK_EXTERNAL_PROVIDERS` from `@mastra/server`) are flagged even when the project never references them.
- **Bundler-intermediate false positives**: pre-bundled dependency chunks under `.mastra/.build/` carry JSDoc examples like `file:./data.db` and were flagged as user code (previously #19066, folded into this PR).

This PR splits the problem into build-time structure capture and deploy-time env context:

**@mastra/deployer** — the local-storage detector plugin now emits a unified `preflight-metadata.json`:
- An AST pass records `guardedBy: "X"` when a detected local path literal is the fallback arm of a `process.env.X || literal` (or `??`) expression
- `userEnvRefs` lists env vars read by user code only (excludes `node_modules`, everything under `.mastra/.build/`, and symlinked dependencies that resolve outside the project root)
- The legacy `preflight-local-paths.json` stays emitted for one release so older CLIs keep working with newer deployers

**mastra CLI** — the preflight applies the deploy env to that metadata:
- Guarded path + env var provided → no issue
- Guarded path + var missing from the env file → error with an actionable message
- Guarded path + no env file available → warning instead of a hard error
- Unguarded paths → error (unchanged)
- `MISSING_ENV_VAR` warnings scoped to `userEnvRefs`; library-only refs listed at info level
- Builds without the new metadata behave exactly as before (regression-guarded)

Supersedes #19066.

## Test plan

- [x] Plugin unit tests (23): `guardedBy` with `||`/`??`, bare paths, `userEnvRefs` exclusions (node_modules, `.mastra/.build/`, symlinked deps), tree-shaken modules, both metadata assets, plus a real-Rollup end-to-end test
- [x] CLI unit tests (28): all guarded/unguarded × env-present/missing/no-env-file combinations, `userEnvRefs` scoping, metadata-absent regression guard
- [x] Full package suites: deployer 521/521, cli 565/565
- [x] Real E2E in ui-dojo: with `TURSO_DATABASE_URL` in the env file, `mastra lint --preflight` reports no `LOCAL_STORAGE_PATH`/`MISSING_ENV_VAR` issues (no `--skip-preflight` needed); without it, a precise error explains the fallback will be used at runtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
ELI5: Mastra’s deploy/lint “preflight” checks used to raise warnings/errors about local files/paths and env vars even when those values were only optional backups (or when the platform already had the real env values). This PR makes Mastra record how those fallbacks/env vars are actually used during the build, then uses your deploy/lint-time env context to decide when the complaints are actionable.

### Summary
- Added unified deployer preflight metadata output (`preflight-metadata.json`) that records:
  - detected `LOCAL_STORAGE_PATH` candidates
  - `guardedBy` info for local-path fallbacks used behind `process.env.X || <literal>` and `process.env.X ?? <literal>` (falls back to unguarded detection when AST parsing fails)
  - `userEnvRefs`: env vars read by *project (user) code only* (including `process.env["..."]` / bracket access), used to scope missing-env validation
- Kept backward compatibility by still emitting legacy `preflight-local-paths.json` for one release; the CLI prefers unified metadata when available and falls back to legacy only when needed (and older builds keep prior behavior).
- Updated CLI deploy preflight to use deploy-time env context when interpreting guarded paths:
  - guarded local paths are suppressed when the guarding env var is present in the merged env context
  - if an env file exists but the guarding env var is missing → guarded local paths error
  - if no env file is available → guarded local paths warn instead of erroring
  - unguarded local paths still error
  - `MISSING_ENV_VAR` checks are now scoped to `userEnvRefs` (library/platform-only env refs are downgraded to info, not treated the same way)
  - wired `hasEnvFile` through deploy preflight so severity changes based on whether local env context is available
- Applied the same env-merging/`hasEnvFile` logic to `lint --preflight` (only claiming the full env picture when `--env-file` or ambient `.env*` exists).
- Updated server deploy preflight to merge platform/server stored env vars with locally selected env vars before running preflight checks.
- Reduced local-storage false positives by improving build-time detection:
  - exclude *all* deployer intermediates under `.mastra/.build/` (not just specific shim files)
  - ignore symlinked dependency paths that resolve outside the project root
  - tighter module filtering/deduping and build-time AST analysis to decide whether a fallback is truly guarded
<!-- end of auto-generated comment: release notes by coderabbit.ai -->