### PR TITLE
docs(mongodb): add MongoDB and VoyageAI to memory, RAG, embeddings, and reference

### DIFF
--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -6,8 +6,12 @@ packages:
   - "@mastra/fastembed"
   - "@mastra/libsql"
   - "@mastra/memory"
+  - "@mastra/mongodb"
   - "@mastra/pg"
 ---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
 
 # Semantic recall
 
@@ -35,33 +39,69 @@ After getting a response from the LLM, all new messages (user, assistant, and to
 
 Semantic recall is disabled by default. To enable it, set `semanticRecall: true` in `options` and provide a `vector` store and `embedder`:
 
-```typescript title="src/mastra/agents/index.ts"
-import { Agent } from '@mastra/core/agent'
-import { Memory } from '@mastra/memory'
-import { LibSQLStore, LibSQLVector } from '@mastra/libsql'
-import { ModelRouterEmbeddingModel } from '@mastra/core/llm'
+<Tabs>
+  <TabItem value="libsql" label="LibSQL" default>
+    ```typescript title="src/mastra/agents/index.ts"
+    import { Agent } from '@mastra/core/agent'
+    import { Memory } from '@mastra/memory'
+    import { LibSQLStore, LibSQLVector } from '@mastra/libsql'
+    import { ModelRouterEmbeddingModel } from '@mastra/core/llm'
 
-const agent = new Agent({
-  id: 'support-agent',
-  name: 'SupportAgent',
-  instructions: 'You are a helpful support agent.',
-  model: '__GATEWAY_OPENAI_MODEL__',
-  memory: new Memory({
-    storage: new LibSQLStore({
-      id: 'agent-storage',
-      url: 'file:./local.db',
-    }),
-    vector: new LibSQLVector({
-      id: 'agent-vector',
-      url: 'file:./local.db',
-    }),
-    embedder: new ModelRouterEmbeddingModel('openai/text-embedding-3-small'),
-    options: {
-      semanticRecall: true,
-    },
-  }),
-})
-```
+    const agent = new Agent({
+      id: 'support-agent',
+      name: 'SupportAgent',
+      instructions: 'You are a helpful support agent.',
+      model: '__GATEWAY_OPENAI_MODEL__',
+      memory: new Memory({
+        storage: new LibSQLStore({
+          id: 'agent-storage',
+          url: 'file:./local.db',
+        }),
+        vector: new LibSQLVector({
+          id: 'agent-vector',
+          url: 'file:./local.db',
+        }),
+        embedder: new ModelRouterEmbeddingModel('openai/text-embedding-3-small'),
+        options: {
+          semanticRecall: true,
+        },
+      }),
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="mongodb" label="MongoDB">
+    ```typescript title="src/mastra/agents/index.ts"
+    import { Agent } from '@mastra/core/agent'
+    import { Memory } from '@mastra/memory'
+    import { MongoDBStore, MongoDBVector } from '@mastra/mongodb'
+    import { ModelRouterEmbeddingModel } from '@mastra/core/llm'
+
+    const agent = new Agent({
+      id: 'support-agent',
+      name: 'SupportAgent',
+      instructions: 'You are a helpful support agent.',
+      model: '__GATEWAY_OPENAI_MODEL__',
+      memory: new Memory({
+        storage: new MongoDBStore({
+          id: 'agent-storage',
+          uri: process.env.MONGODB_URI,
+          dbName: process.env.MONGODB_DB_NAME,
+        }),
+        vector: new MongoDBVector({
+          id: 'agent-vector',
+          uri: process.env.MONGODB_URI,
+          dbName: process.env.MONGODB_DB_NAME,
+        }),
+        embedder: new ModelRouterEmbeddingModel('openai/text-embedding-3-small'),
+        options: {
+          semanticRecall: true,
+        },
+      }),
+    })
+    ```
+  </TabItem>
+</Tabs>
 
 ## Using the `recall()` method
 
@@ -161,7 +201,7 @@ const agent = new Agent({
 
 :::note
 
-`scope: 'resource'` is supported by the LibSQL, PostgreSQL, and Upstash storage adapters.
+`scope: 'resource'` is supported by the LibSQL, PostgreSQL, MongoDB, and Upstash storage adapters.
 
 :::
 

--- a/docs/src/content/en/docs/memory/storage.mdx
+++ b/docs/src/content/en/docs/memory/storage.mdx
@@ -5,6 +5,7 @@ packages:
   - "@mastra/core"
   - "@mastra/libsql"
   - "@mastra/memory"
+  - "@mastra/mongodb"
   - "@mastra/pg"
   - "@mastra/pinecone"
 ---
@@ -71,21 +72,44 @@ Storage can be configured at the instance level (shared by all agents) or at the
 
 Add storage to your Mastra instance so all agents, workflows, observability traces, and scores share the same storage backend:
 
-```typescript title="src/mastra/index.ts"
-import { Mastra } from '@mastra/core'
-import { PostgresStore } from '@mastra/pg'
+<Tabs>
+  <TabItem value="postgresql" label="PostgreSQL">
+    ```typescript title="src/mastra/index.ts"
+    import { Mastra } from '@mastra/core'
+    import { PostgresStore } from '@mastra/pg'
 
-export const mastra = new Mastra({
-  storage: new PostgresStore({
-    id: 'mastra-storage',
-    connectionString: process.env.DATABASE_URL,
-  }),
-})
+    export const mastra = new Mastra({
+      storage: new PostgresStore({
+        id: 'mastra-storage',
+        connectionString: process.env.DATABASE_URL,
+      }),
+    })
 
-// Both agents inherit storage from the Mastra instance above
-const agent1 = new Agent({ id: 'agent-1', memory: new Memory() })
-const agent2 = new Agent({ id: 'agent-2', memory: new Memory() })
-```
+    // Both agents inherit storage from the Mastra instance above
+    const agent1 = new Agent({ id: 'agent-1', memory: new Memory() })
+    const agent2 = new Agent({ id: 'agent-2', memory: new Memory() })
+    ```
+  </TabItem>
+
+  <TabItem value="mongodb" label="MongoDB">
+    ```typescript title="src/mastra/index.ts"
+    import { Mastra } from '@mastra/core'
+    import { MongoDBStore } from '@mastra/mongodb'
+
+    export const mastra = new Mastra({
+      storage: new MongoDBStore({
+        id: 'mastra-storage',
+        uri: process.env.MONGODB_URI,
+        dbName: process.env.MONGODB_DB_NAME,
+      }),
+    })
+
+    // Both agents inherit storage from the Mastra instance above
+    const agent1 = new Agent({ id: 'agent-1', memory: new Memory() })
+    const agent2 = new Agent({ id: 'agent-2', memory: new Memory() })
+    ```
+  </TabItem>
+</Tabs>
 
 This is useful when all primitives share the same storage backend and have similar performance, scaling, and operational requirements.
 
@@ -93,29 +117,63 @@ This is useful when all primitives share the same storage backend and have simil
 
 [Composite storage](/reference/storage/composite) is an alternative way to configure instance-level storage. Use `MastraCompositeStore` to route `memory` and any other [supported domains](/reference/storage/composite#storage-domains) to different storage providers.
 
-```typescript title="src/mastra/index.ts"
-import { Mastra } from '@mastra/core'
-import { MastraCompositeStore } from '@mastra/core/storage'
-import { MemoryLibSQL } from '@mastra/libsql'
-import { WorkflowsPG } from '@mastra/pg'
-import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
+<Tabs>
+  <TabItem value="libsql-pg" label="LibSQL + PostgreSQL">
+    ```typescript title="src/mastra/index.ts"
+    import { Mastra } from '@mastra/core'
+    import { MastraCompositeStore } from '@mastra/core/storage'
+    import { MemoryLibSQL } from '@mastra/libsql'
+    import { WorkflowsPG } from '@mastra/pg'
+    import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
 
-export const mastra = new Mastra({
-  storage: new MastraCompositeStore({
-    id: 'composite',
-    domains: {
-      // highlight-next-line
-      memory: new MemoryLibSQL({ url: 'file:./memory.db' }),
-      workflows: new WorkflowsPG({ connectionString: process.env.DATABASE_URL }),
-      observability: new ObservabilityStorageClickhouse({
-        url: process.env.CLICKHOUSE_URL,
-        username: process.env.CLICKHOUSE_USERNAME,
-        password: process.env.CLICKHOUSE_PASSWORD,
+    export const mastra = new Mastra({
+      storage: new MastraCompositeStore({
+        id: 'composite',
+        domains: {
+          // highlight-next-line
+          memory: new MemoryLibSQL({ url: 'file:./memory.db' }),
+          workflows: new WorkflowsPG({ connectionString: process.env.DATABASE_URL }),
+          observability: new ObservabilityStorageClickhouse({
+            url: process.env.CLICKHOUSE_URL,
+            username: process.env.CLICKHOUSE_USERNAME,
+            password: process.env.CLICKHOUSE_PASSWORD,
+          }),
+        },
       }),
-    },
-  }),
-})
-```
+    })
+    ```
+  </TabItem>
+
+  <TabItem value="mongodb-mixed" label="MongoDB + Others">
+    ```typescript title="src/mastra/index.ts"
+    import { Mastra } from '@mastra/core'
+    import { MastraCompositeStore } from '@mastra/core/storage'
+    import { MemoryStorageMongoDB, WorkflowsStorageMongoDB } from '@mastra/mongodb'
+    import { ObservabilityStorageClickhouse } from '@mastra/clickhouse'
+
+    export const mastra = new Mastra({
+      storage: new MastraCompositeStore({
+        id: 'composite',
+        domains: {
+          memory: new MemoryStorageMongoDB({
+            uri: process.env.MONGODB_URI,
+            dbName: 'mastra_memory',
+          }),
+          workflows: new WorkflowsStorageMongoDB({
+            uri: process.env.MONGODB_URI,
+            dbName: 'mastra_workflows',
+          }),
+          observability: new ObservabilityStorageClickhouse({
+            url: process.env.CLICKHOUSE_URL,
+            username: process.env.CLICKHOUSE_USERNAME,
+            password: process.env.CLICKHOUSE_PASSWORD,
+          }),
+        },
+      }),
+    })
+    ```
+  </TabItem>
+</Tabs>
 
 This is useful when different types of data have different performance or operational requirements, such as low-latency storage for memory, durable storage for workflows, and high-throughput storage for observability.
 

--- a/docs/src/content/en/docs/rag/vector-databases.mdx
+++ b/docs/src/content/en/docs/rag/vector-databases.mdx
@@ -16,6 +16,7 @@ packages:
   - "@mastra/s3vectors"
   - "@mastra/upstash"
   - "@mastra/vectorize"
+  - "@mastra/voyageai"
 ---
 
 import Tabs from "@theme/Tabs";
@@ -35,7 +36,7 @@ After generating embeddings, you need to store them in a database that supports 
     const store = new MongoDBVector({
       id: 'mongodb-vector',
       uri: process.env.MONGODB_URI,
-      dbName: process.env.MONGODB_DATABASE,
+      dbName: process.env.MONGODB_DB_NAME,
     })
     await store.createIndex({
       indexName: 'myCollection',
@@ -48,9 +49,13 @@ After generating embeddings, you need to store them in a database that supports 
     })
     ```
 
-    <h3>Using MongoDB Atlas Vector search</h3>
+    <h3>Using MongoDB Atlas Vector Search</h3>
 
     For detailed setup instructions and best practices, see the [official MongoDB Atlas Vector Search documentation](https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-overview/?utm_campaign=devrel\&utm_source=third-party-content\&utm_medium=cta\&utm_content=mastra-docs).
+
+    <h3>Using VoyageAI with MongoDB</h3>
+
+    MongoDB works seamlessly with VoyageAI's embedding models, which are optimized for retrieval tasks. For complete examples and specialized models, see the [VoyageAI embeddings documentation](/models/embeddings#voyageai) and [MongoDB vector reference](/reference/vectors/mongodb).
   </TabItem>
 
   <TabItem value="pg-vector" label="PgVector">
@@ -384,6 +389,7 @@ The dimension size must match the output dimension of your chosen embedding mode
 
 - `OpenAI text-embedding-3-small`: 1536 dimensions (or custom, e.g., 256)
 - `Cohere embed-multilingual-v3`: 1024 dimensions
+- `VoyageAI voyage-3.5`: 1024 dimensions (or custom: 256, 512, 1024, 2048)
 - `Google gemini-embedding-001`: 768 dimensions (or custom)
 
 :::warning

--- a/docs/src/content/en/models/embeddings.mdx
+++ b/docs/src/content/en/models/embeddings.mdx
@@ -52,12 +52,15 @@ npm install @mastra/voyageai
 
 **Available models:**
 
-- `voyage-3.5` - 1024 dimensions (default), supports 256-2048 dimensions
-- `voyage-3-large` - 1024 dimensions (default), supports 256-2048 dimensions, higher quality
-- `voyage-code-3` - 1024 dimensions, optimized for code
-- `voyage-4` - 1024 dimensions, highest throughput (320k batch tokens)
-- `voyage-4-large` - 1024 dimensions (120k batch tokens)
-- `voyage-4-lite` - 1024 dimensions (1M batch tokens)
+- `voyage-4-large` - 1024 dimensions (default), supports 256-2048 dimensions, best general-purpose and multilingual retrieval quality (120k max tokens per batch)
+- `voyage-4` - 1024 dimensions (default), supports 256-2048 dimensions, optimized for general-purpose and multilingual retrieval (320k max tokens per batch)
+- `voyage-4-lite` - 1024 dimensions (default), supports 256-2048 dimensions, optimized for latency and cost (1M max tokens per batch)
+- `voyage-code-3` - 1024 dimensions (default), supports 256-2048 dimensions, optimized for code retrieval
+- `voyage-finance-2` - 1024 dimensions, optimized for finance retrieval and RAG
+- `voyage-law-2` - 1024 dimensions, optimized for legal retrieval and RAG (16k context)
+- `voyage-3-large` - 1024 dimensions (default), supports 256-2048 dimensions (previous generation)
+- `voyage-3.5` - 1024 dimensions (default), supports 256-2048 dimensions (previous generation)
+- `voyage-3.5-lite` - 1024 dimensions (default), supports 256-2048 dimensions, optimized for latency and cost (previous generation)
 - `voyage-multimodal-3.5` - 1024 dimensions, supports text + images
 
 ```typescript
@@ -68,7 +71,7 @@ const { embeddings } = await voyage.doEmbed({
   values: ["Hello world"],
 });
 
-// Use specific model
+// Use specific model (voyage-3-large)
 const largeEmbeddings = await voyage.large.doEmbed({
   values: ["More complex content"],
 });

--- a/docs/src/content/en/models/embeddings.mdx
+++ b/docs/src/content/en/models/embeddings.mdx
@@ -42,17 +42,113 @@ const embedder = new ModelRouterEmbeddingModel("openai/text-embedding-3-small");
 const embedder = new ModelRouterEmbeddingModel("google/gemini-embedding-001");
 ```
 
+### VoyageAI
+
+VoyageAI provides specialized embedding models optimized for retrieval tasks. These models are available as standalone packages:
+
+```bash npm2yarn
+npm install @mastra/voyageai
+```
+
+**Available models:**
+
+- `voyage-3.5` - 1024 dimensions (default), supports 256-2048 dimensions
+- `voyage-3-large` - 1024 dimensions (default), supports 256-2048 dimensions, higher quality
+- `voyage-code-3` - 1024 dimensions, optimized for code
+- `voyage-4` - 1024 dimensions, highest throughput (320k batch tokens)
+- `voyage-4-large` - 1024 dimensions (120k batch tokens)
+- `voyage-4-lite` - 1024 dimensions (1M batch tokens)
+- `voyage-multimodal-3.5` - 1024 dimensions, supports text + images
+
+```typescript
+import { voyage, voyageEmbedding } from "@mastra/voyageai";
+
+// Use default model (voyage-3.5)
+const { embeddings } = await voyage.doEmbed({
+  values: ["Hello world"],
+});
+
+// Use specific model
+const largeEmbeddings = await voyage.large.doEmbed({
+  values: ["More complex content"],
+});
+
+// Custom configuration
+const customModel = voyageEmbedding({
+  model: "voyage-3.5",
+  inputType: "query", // or 'document'
+  outputDimension: 512, // 256, 512, 1024, or 2048
+});
+
+const { embeddings: customEmbeddings } = await customModel.doEmbed({
+  values: ["Custom configuration example"],
+});
+```
+
+**VoyageAI with MongoDB:**
+
+VoyageAI works seamlessly with MongoDB Atlas Vector Search:
+
+```typescript
+import { voyage } from "@mastra/voyageai";
+import { MongoDBVector } from "@mastra/mongodb";
+
+const mongoVector = new MongoDBVector({
+  id: "mongodb-vector",
+  uri: process.env.MONGODB_URI,
+  dbName: process.env.MONGODB_DB_NAME,
+});
+
+// Create index matching VoyageAI dimensions
+await mongoVector.createIndex({
+  indexName: "documents",
+  dimension: 1024, // voyage-3.5 default
+});
+
+// Generate and store embeddings
+const { embeddings } = await voyage.doEmbed({
+  values: chunks.map((chunk) => chunk.text),
+});
+
+await mongoVector.upsert({
+  indexName: "documents",
+  vectors: embeddings,
+  metadata: chunks.map((chunk) => ({ text: chunk.text })),
+});
+```
+
+**Multimodal embeddings (text + images):**
+
+```typescript
+import { voyage } from "@mastra/voyageai";
+
+const { embeddings } = await voyage.multimodal.doEmbed({
+  values: [
+    {
+      content: [
+        { type: "text", text: "Product description" },
+        { type: "image_url", image_url: "https://example.com/image.jpg" },
+      ],
+    },
+  ],
+});
+```
+
+For more details, see the [MongoDB + VoyageAI integration guide](/reference/vectors/mongodb#vector-embeddings-with-voyageai).
+
 ## Authentication
 
 The model router automatically detects API keys from environment variables:
 
 - **OpenAI**: `OPENAI_API_KEY`
 - **Google**: `GOOGLE_API_KEY` (falls back to `GOOGLE_GENERATIVE_AI_API_KEY`)
+- **VoyageAI**: `VOYAGE_API_KEY`
 
 ```bash
 # .env
 OPENAI_API_KEY=sk-...
 GOOGLE_API_KEY=...
+VOYAGE_API_KEY=pa-...
 ```
 
 ## Custom Providers

--- a/docs/src/content/en/reference/storage/mongodb.mdx
+++ b/docs/src/content/en/reference/storage/mongodb.mdx
@@ -19,7 +19,7 @@ npm install @mastra/mongodb@latest
 
 ## Usage
 
-Ensure you have a MongoDB Atlas Local (via Docker) or MongoDB Atlas Cloud instance with Atlas Search enabled. MongoDB 7.0+ is recommended.
+Ensure you have a [MongoDB Atlas Local (via Docker)](https://www.mongodb.com/docs/atlas/cli/current/atlas-cli-deploy-docker/) or [MongoDB Atlas Cloud](https://www.mongodb.com/docs/atlas/cli/current/atlas-cli-getting-started/) instance with Atlas Search enabled. MongoDB 7.0+ is recommended.
 
 ```typescript
 import { MongoDBStore } from '@mastra/mongodb'
@@ -27,7 +27,7 @@ import { MongoDBStore } from '@mastra/mongodb'
 const storage = new MongoDBStore({
   id: 'mongodb-storage',
   uri: process.env.MONGODB_URI,
-  dbName: process.env.MONGODB_DATABASE,
+  dbName: process.env.MONGODB_DB_NAME,
 })
 ```
 
@@ -48,12 +48,6 @@ const storage = new MongoDBStore({
     isOptional: false,
   },
   {
-    name: 'url',
-    type: 'string',
-    description: 'Deprecated. Use uri instead. MongoDB connection string (supported for backward compatibility).',
-    isOptional: true,
-  },
-  {
     name: 'dbName',
     type: 'string',
     description: 'The name of the database you want the storage to use.',
@@ -62,15 +56,40 @@ const storage = new MongoDBStore({
   {
     name: 'options',
     type: 'MongoClientOptions',
-    description: 'MongoDB client options for advanced configuration (SSL, connection pooling, etc.).',
+    description:
+      'MongoDB client options for advanced configuration (SSL, connection pooling, etc.). See [Connection Options](https://www.mongodb.com/docs/drivers/node/current/fundamentals/connection/connection-options/)',
+    isOptional: true,
+  },
+  {
+    name: 'disableInit',
+    type: 'boolean',
+    description:
+      'When true, automatic initialization (collection creation) is disabled. Useful for CI/CD pipelines where you want to run migrations explicitly. You must call storage.init() manually when this is true.',
+    isOptional: true,
+  },
+  {
+    name: 'skipDefaultIndexes',
+    type: 'boolean',
+    description:
+      'When true, default indexes will not be created during initialization. Useful when managing indexes separately or using only custom indexes.',
+    isOptional: true,
+  },
+  {
+    name: 'indexes',
+    type: 'MongoDBIndexConfig[]',
+    description:
+      'Custom indexes to create during initialization. Each index must specify a collection, keys, and optional index options. See [Indexes](https://www.mongodb.com/docs/manual/indexes/)',
+    isOptional: true,
+  },
+  {
+    name: 'connectorHandler',
+    type: 'ConnectorHandler',
+    description:
+      'Custom connection handler for advanced connection management. Alternative to providing uri/dbName directly.',
     isOptional: true,
   },
 ]}
 />
-
-:::note[Deprecation Notice]
-The `url` parameter is deprecated but still supported for backward compatibility. Please use `uri` instead in all new code.
-:::
 
 ## Constructor examples
 
@@ -98,6 +117,26 @@ const store2 = new MongoDBStore({
     socketTimeoutMS: 45000,
   },
 })
+
+// With custom indexes
+const store3 = new MongoDBStore({
+  id: 'mongodb-storage-03',
+  uri: 'mongodb+srv://user:password@cluster.mongodb.net',
+  dbName: 'mastra_storage',
+  indexes: [
+    { collection: 'mastra_threads', keys: { 'metadata.type': 1 } },
+    { collection: 'mastra_messages', keys: { 'metadata.status': 1 }, options: { sparse: true } },
+  ],
+})
+
+// For CI/CD with explicit initialization
+const store4 = new MongoDBStore({
+  id: 'mongodb-storage-04',
+  uri: 'mongodb+srv://user:password@cluster.mongodb.net',
+  dbName: 'mastra_storage',
+  disableInit: true, // Disable auto-init
+})
+await store4.init() // Call init explicitly
 ```
 
 ## Additional notes
@@ -128,7 +167,7 @@ import { MongoDBStore } from '@mastra/mongodb'
 const storage = new MongoDBStore({
   id: 'mongodb-storage',
   uri: process.env.MONGODB_URI,
-  dbName: process.env.MONGODB_DATABASE,
+  dbName: process.env.MONGODB_DB_NAME,
 })
 
 const mastra = new Mastra({
@@ -144,7 +183,7 @@ import { MongoDBStore } from '@mastra/mongodb'
 const storage = new MongoDBStore({
   id: 'mongodb-storage',
   uri: process.env.MONGODB_URI,
-  dbName: process.env.MONGODB_DATABASE,
+  dbName: process.env.MONGODB_DB_NAME,
 })
 
 // Required when using storage directly
@@ -159,57 +198,28 @@ const thread = await memoryStore?.getThreadById({ threadId: '...' })
 If `init()` isn't called, collections won't be created and storage operations will fail silently or throw errors.
 :::
 
-## Vector search capabilities
+### Connection Management
 
-MongoDB storage includes built-in vector search capabilities for AI applications:
-
-### Vector Index Creation
+The `close()` method closes the MongoDB client connection. Call this when shutting down your application:
 
 ```typescript
-import { MongoDBVector } from '@mastra/mongodb'
+import { MongoDBStore } from '@mastra/mongodb'
 
-const vectorStore = new MongoDBVector({
-  id: 'mongodb-vector',
+const storage = new MongoDBStore({
+  id: 'mongodb-storage',
   uri: process.env.MONGODB_URI,
-  dbName: process.env.MONGODB_DATABASE,
+  dbName: process.env.MONGODB_DB_NAME,
 })
 
-// Create a vector index for embeddings
-await vectorStore.createIndex({
-  indexName: 'document_embeddings',
-  dimension: 1536,
-})
+// Use storage...
+
+// Clean up on shutdown
+await storage.close()
 ```
 
-### Vector Operations
+## Vector search capabilities
 
-```typescript prettier:false
-// Store vectors with metadata
-await vectorStore.upsert({
-  indexName: "document_embeddings",
-  vectors: [
-    {
-      id: "doc-1",
-      values: [0.1, 0.2, 0.3, ...], // 1536-dimensional vector
-      metadata: {
-        title: "Document Title",
-        category: "technical",
-        source: "api-docs",
-      },
-    },
-  ],
-});
-
-// Similarity search
-const results = await vectorStore.query({
-  indexName: "document_embeddings",
-  vector: queryEmbedding,
-  topK: 5,
-  filter: {
-    category: "technical",
-  },
-});
-```
+MongoDB storage includes built-in vector search capabilities for AI applications. For detailed vector operations including index creation, upserting embeddings, similarity search, and metadata filtering, see the [MongoDB vector reference](/reference/vectors/mongodb).
 
 ## Usage example
 
@@ -230,6 +240,7 @@ export const mongodbAgent = new Agent({
   model: '__GATEWAY_OPENAI_MODEL__',
   memory: new Memory({
     storage: new MongoDBStore({
+      id: 'mongodb-storage',
       uri: process.env.MONGODB_URI!,
       dbName: process.env.MONGODB_DB_NAME!,
     }),

--- a/docs/src/content/en/reference/storage/mongodb.mdx
+++ b/docs/src/content/en/reference/storage/mongodb.mdx
@@ -48,6 +48,12 @@ const storage = new MongoDBStore({
     isOptional: false,
   },
   {
+    name: 'url',
+    type: 'string',
+    description: 'Deprecated. Use `uri` instead. MongoDB connection string (supported for backward compatibility).',
+    isOptional: true,
+  },
+  {
     name: 'dbName',
     type: 'string',
     description: 'The name of the database you want the storage to use.',
@@ -90,6 +96,10 @@ const storage = new MongoDBStore({
   },
 ]}
 />
+
+:::note[Deprecation Notice]
+The `url` parameter is deprecated but still supported for backward compatibility. Please use `uri` instead in all new code.
+:::
 
 ## Constructor examples
 

--- a/docs/src/content/en/reference/storage/retention.mdx
+++ b/docs/src/content/en/reference/storage/retention.mdx
@@ -281,7 +281,7 @@ const storage = new MongoDBStore({
     },
     // Spans expire after 7 days
     {
-      collection: 'mastra_traces',
+      collection: 'mastra_ai_spans',
       keys: { startedAt: 1 },
       options: { expireAfterSeconds: 7 * 24 * 60 * 60 }, // 7 days
     },

--- a/docs/src/content/en/reference/storage/retention.mdx
+++ b/docs/src/content/en/reference/storage/retention.mdx
@@ -233,11 +233,73 @@ async function retentionTick() {
 
 You can also cancel a long-running prune with an `AbortSignal` — the loop stops between batches and returns partial results with `done: false`, so the next run resumes cleanly.
 
+## MongoDB TTL indexes (alternative to prune)
+
+MongoDB offers native [TTL (Time-To-Live) indexes](https://www.mongodb.com/docs/manual/core/index-ttl/) that automatically delete expired documents without requiring manual `prune()` calls. This is a database-level feature that runs as a background thread.
+
+:::note[When to use TTL vs prune()]
+
+**Use MongoDB TTL indexes when:**
+
+- You want automated, zero-maintenance deletion
+- Your retention periods are fixed (e.g., "always 30 days")
+- You prefer database-native solutions
+
+**Use `prune()` when:**
+
+- You need fine-grained control over deletion timing
+- You want to cap deletion rate during business hours
+- You need resumable, cancellable cleanup operations
+- You're using composite storage with multiple databases
+
+Both approaches are valid. TTL is simpler; `prune()` gives more control.
+:::
+
+### Setting up TTL indexes on MongoDB
+
+TTL indexes work on date fields. MongoDB checks the index every 60 seconds and deletes documents where the date field + TTL duration \< current time.
+
+```typescript
+import { MongoDBStore } from '@mastra/mongodb'
+
+const storage = new MongoDBStore({
+  id: 'mongodb-storage',
+  uri: process.env.MONGODB_URI!,
+  dbName: process.env.MONGODB_DB_NAME!,
+  indexes: [
+    // Messages expire after 30 days
+    {
+      collection: 'mastra_messages',
+      keys: { createdAt: 1 },
+      options: { expireAfterSeconds: 30 * 24 * 60 * 60 }, // 30 days
+    },
+    // Threads expire after 90 days
+    {
+      collection: 'mastra_threads',
+      keys: { createdAt: 1 },
+      options: { expireAfterSeconds: 90 * 24 * 60 * 60 }, // 90 days
+    },
+    // Spans expire after 7 days
+    {
+      collection: 'mastra_traces',
+      keys: { startedAt: 1 },
+      options: { expireAfterSeconds: 7 * 24 * 60 * 60 }, // 7 days
+    },
+  ],
+})
+```
+
+:::tip
+TTL indexes delete documents shortly after they expire (background thread runs every \~60 seconds), but the exact timing is not guaranteed. For precise, immediate cleanup, use `prune()` instead.
+:::
+
 ## Reclaiming disk
 
 `prune()` deletes rows but does not shrink the database file. On SQLite/libSQL the freed pages go on a freelist and are reused by future writes, so the file stops growing — for most users this alone solves the unbounded-growth problem.
 
 Handing that free space back to the OS is a separate concern that Mastra does not manage. If you specifically need to shrink the file, run the underlying database's compaction (for example `VACUUM` on self-hosted libSQL) yourself, in a maintenance window — a full `VACUUM` locks the file and needs roughly twice the file size in free disk. On PostgreSQL, autovacuum reclaims dead tuples for reuse automatically; a manual `VACUUM FULL` is only needed if you must return disk to the OS.
+
+For MongoDB, deleted documents are reused by future insertions. To reclaim disk space, run [`db.runCommand({ compact: "collection_name" })`](https://www.mongodb.com/docs/manual/reference/command/compact/) during a maintenance window.
 
 :::note[libSQL and Turso]
 [Turso Cloud](/reference/storage/libsql) manages storage compaction for you, so there's nothing to reclaim manually. This applies only to self-hosted libSQL files.

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -6,6 +6,7 @@ packages:
   - "@mastra/fastembed"
   - "@mastra/memory"
   - "@mastra/mongodb"
+  - "@mastra/voyageai"
 ---
 
 # MongoDB vector store
@@ -26,7 +27,7 @@ import { MongoDBVector } from '@mastra/mongodb'
 const store = new MongoDBVector({
   id: 'mongodb-vector',
   uri: process.env.MONGODB_URI,
-  dbName: process.env.MONGODB_DATABASE,
+  dbName: process.env.MONGODB_DB_NAME,
 })
 ```
 
@@ -40,7 +41,7 @@ import { MongoDBVector } from '@mastra/mongodb'
 const store = new MongoDBVector({
   id: 'mongodb-vector',
   uri: process.env.MONGODB_URI,
-  dbName: process.env.MONGODB_DATABASE,
+  dbName: process.env.MONGODB_DB_NAME,
   embeddingFieldPath: 'text.contentEmbedding', // Store embeddings at text.contentEmbedding
 })
 ```
@@ -83,6 +84,14 @@ const store = new MongoDBVector({
 
 ## Methods
 
+### `connect()`
+
+Establishes connection to the MongoDB server. This is called automatically on first use, but can be called explicitly if needed.
+
+```typescript
+await store.connect()
+```
+
 ### `createIndex()`
 
 Creates a new vector index (collection) in MongoDB.
@@ -105,6 +114,34 @@ Creates a new vector index (collection) in MongoDB.
     isOptional: true,
     defaultValue: 'cosine',
     description: 'Distance metric for similarity search',
+  },
+]}
+/>
+
+### `waitForIndexReady()`
+
+Waits for an index to become ready after creation. Useful when you need to ensure an index is ready before performing operations.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'indexName',
+    type: 'string',
+    description: 'Name of the index to wait for',
+  },
+  {
+    name: 'timeoutMs',
+    type: 'number',
+    isOptional: true,
+    defaultValue: '60000',
+    description: 'Maximum time to wait in milliseconds',
+  },
+  {
+    name: 'checkIntervalMs',
+    type: 'number',
+    isOptional: true,
+    defaultValue: '2000',
+    description: 'Interval between status checks in milliseconds',
   },
 ]}
 />
@@ -136,6 +173,12 @@ Adds or updates vectors and their metadata in the collection.
     type: 'string[]',
     isOptional: true,
     description: 'Optional vector IDs (auto-generated if not provided)',
+  },
+  {
+    name: 'documents',
+    type: 'string[]',
+    isOptional: true,
+    description: 'Optional document text content to store alongside vectors',
   },
 ]}
 />
@@ -181,6 +224,14 @@ Searches for similar vectors with optional metadata filtering.
     isOptional: true,
     defaultValue: 'false',
     description: 'Whether to include vector data in results',
+  },
+  {
+    name: 'numCandidates',
+    type: 'number',
+    isOptional: true,
+    defaultValue: '20 * topK (capped at 10000)',
+    description:
+      'Number of candidates the HNSW graph considers before selecting top-K results. Higher values improve recall at the cost of latency. See: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/',
   },
 ]}
 />
@@ -372,7 +423,7 @@ Embeddings are numeric vectors used by memory's `semanticRecall` to retrieve rel
 
 :::note
 
-You must use a deployment hosted on MongoDB Atlas to successfully use the MongoDB Vector database.
+MongoDB Atlas Vector Search is recommended for production use. For self-hosted deployments, Vector Search is available with [MongoDB Enterprise Server](https://www.mongodb.com/docs/atlas/architecture/current/solutions-library/search-enterprise-server/).
 
 :::
 
@@ -421,6 +472,53 @@ export const mongodbAgent = new Agent({
 })
 ```
 
+### Vector embeddings with VoyageAI
+
+VoyageAI provides specialized embedding models optimized for retrieval tasks. VoyageAI is also integrated with MongoDB Atlas for multimodal embeddings.
+
+```bash npm2yarn
+npm install @mastra/voyageai@latest
+```
+
+Basic usage example:
+
+```typescript title="src/mastra/agents/example-mongodb-voyageai-agent.ts"
+import { Memory } from '@mastra/memory'
+import { Agent } from '@mastra/core/agent'
+import { MongoDBStore, MongoDBVector } from '@mastra/mongodb'
+import { voyage } from '@mastra/voyageai'
+
+export const mongodbVoyageAgent = new Agent({
+  id: 'mongodb-voyage-agent',
+  name: 'MongoDB VoyageAI Agent',
+  instructions: 'You are an AI agent with semantic recall powered by VoyageAI and MongoDB.',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  memory: new Memory({
+    storage: new MongoDBStore({
+      id: 'mongodb-storage',
+      uri: process.env.MONGODB_URI!,
+      dbName: process.env.MONGODB_DB_NAME!,
+    }),
+    vector: new MongoDBVector({
+      id: 'mongodb-vector',
+      uri: process.env.MONGODB_URI!,
+      dbName: process.env.MONGODB_DB_NAME!,
+    }),
+    embedder: voyage, // VoyageAI's default model (voyage-3.5, 1024 dimensions)
+    options: {
+      lastMessages: 10,
+      semanticRecall: {
+        topK: 5,
+        messageRange: 2,
+      },
+    },
+  }),
+})
+```
+
+For comprehensive VoyageAI embedding examples including specialized models, multimodal embeddings, and retrieval optimization, see the [VoyageAI embeddings documentation](/models/embeddings#voyageai).
+
 ## Related
 
 - [Metadata Filters](../rag/metadata-filters)
+- [VoyageAI Embeddings Documentation](/models/embeddings#voyageai)

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -423,7 +423,7 @@ Embeddings are numeric vectors used by memory's `semanticRecall` to retrieve rel
 
 :::note
 
-MongoDB Atlas Vector Search is recommended for production use. For self-hosted deployments, Vector Search is available with [MongoDB Enterprise Server](https://www.mongodb.com/docs/atlas/architecture/current/solutions-library/search-enterprise-server/).
+MongoDB Atlas Vector Search is recommended for production use. For self-hosted deployments, Vector Search is available with [local Atlas deployments via the Atlas CLI](https://www.mongodb.com/docs/atlas/cli/current/atlas-cli-deploy-local/).
 
 :::
 


### PR DESCRIPTION
## Description

Comprehensive sync of MongoDB integration documentation to match the current implementation in `@mastra/mongodb`. This PR addresses documentation gaps identified during a MongoDB docs audit, including missing API parameters, inconsistent code examples, missing representation across documentation sections, and lack of VoyageAI integration examples.

## Related issue(s)

n/a

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---

## Summary

1. **API Documentation Sync** - Synced MongoDB storage and vector store reference docs with implementation
2. **Representation Improvements** - Added MongoDB examples across memory documentation
4. **VoyageAI Integration** - Added comprehensive VoyageAI + MongoDB integration examples

## Documentation changes

| Route                                              | Section                                   | Gap Type             | Change                                                                                                                | File                            |
| -------------------------------------------------- | ----------------------------------------- | -------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------- |
| `/docs/memory/semantic-recall`                     | Semantic Recall                           | Representation       | Added MongoDB tab                                                                                                     | `semantic-recall.mdx`           |
| `/docs/memory/storage`                             | Composite Storage                         | Representation       | Added MongoDB tab                                                                                                     | `storage.mdx`                   |
| `/docs/memory/storage`                             | Instance-level Storage                    | Representation       | Added MongoDB tab                                                                                                     | `storage.mdx`                   |
| `/docs/rag/chunking-and-embedding`                 | Chunking & Embedding                      | Representation       | Added VoyageAI + MongoDB                                                                                              | `chunking-and-embedding.mdx`    |
| `/docs/rag/vector-databases`                       | Vector Databases                          | Representation       | Enhanced MongoDB tab                                                                                                  | `vector-databases.mdx`          |
| `/models/embeddings`                               | Embeddings Models                         | Representation       | Added VoyageAI section                                                                                                | `embeddings.mdx`                |
| `/models/embeddings`                               | VoyageAI Multimodal Models                | Feature Missing      | Added multimodal embedding example in VoyageAI section; links to vector reference for full integration                | `embeddings.mdx`                |
| `/models/embeddings`                               | VoyageAI › Available models               | Wrong setup info     | Corrected `voyage-3-large` default dimension from 1536 to 1024; fixed voyage-4 series descriptions (removed incorrect "highest throughput" claim, added accurate official descriptions and max batch token limits); added flexible dimension support (256–2048) to voyage-4 series and voyage-code-3; marked voyage-3.x models as previous generation | `embeddings.mdx`                |
| `/models/embeddings`                               | VoyageAI › Available models               | Missing content      | Added missing models: `voyage-3.5-lite`, `voyage-finance-2`, `voyage-law-2`; reordered list to show current voyage-4 series first | `embeddings.mdx`                |
| `/models/embeddings`                               | VoyageAI › Code example                   | Misleading code      | Added comment clarifying `voyage.large` maps to `voyage-3-large` (previous generation)                                | `embeddings.mdx`                |
| `/reference/storage/retention`                     | MongoDB TTL indexes › Code example         | Wrong collection name | Fixed span collection name from `mastra_traces` to `mastra_ai_spans` (actual `TABLE_SPANS` constant)                  | `retention.mdx`                 |
| `/reference/storage/mongodb`                       | Additional notes                          | Missing API          | Added Connection Management section documenting `close()`                                                             | `mongodb.mdx`                   |
| `/reference/storage/mongodb`                       | Parameters                                | Missing API          | Added `connectorHandler` parameter                                                                                    | `mongodb.mdx`                   |
| `/reference/storage/mongodb`                       | Parameters                                | Missing API          | Added `disableInit` with CI/CD usage example                                                                          | `mongodb.mdx`                   |
| `/reference/storage/mongodb`                       | Parameters                                | Missing API          | Added `indexes` with custom index example                                                                             | `mongodb.mdx`                   |
| `/reference/storage/mongodb`                       | Parameters                                | Missing API          | Added `skipDefaultIndexes` parameter                                                                                  | `mongodb.mdx`                   |
| `/reference/storage/mongodb`                       | Usage example › Adding memory to an agent | Outdated API example | Fixed agent example missing required `id` parameter                                                                   | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | Methods                                   | Missing API          | Added `waitForIndexReady()` with full parameter table                                                                 | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | Methods › `query()`                       | Missing API          | Added `numCandidates` with HNSW performance note                                                                      | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | Methods › `upsert()`                      | Missing API          | Added `documents` to parameter table                                                                                  | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | Methods › `waitForIndexReady()`           | Outdated API example | Corrected `checkIntervalMs` default from 1000ms to 2000ms                                                             | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | numCandidates (HNSW tuning)               | Feature Missing      | Added `numCandidates` parameter to `query()` with HNSW context                                                        | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | Vector Search                             | Feature Missing      | Added `connect()`, `waitForIndexReady()`, `documents` param, and FastEmbed usage example                              | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`                       | Self-hosted deployment note               | Wrong info           | Fixed self-hosted link from MongoDB Enterprise Server to Atlas CLI local deployments                                  | `mongodb.mdx`                   |
| `/reference/vectors/mongodb`, `/models/embeddings` | VoyageAI Integration                      | Feature Missing      | Added VoyageAI section with agent usage example; added VoyageAI+MongoDB section with standalone example               | `mongodb.mdx`, `embeddings.mdx` |
| Multiple                                           | Multiple sections                         | Wrong setup info     | Standardized env var names from `MONGODB_DATABASE` to `MONGODB_DB_NAME` across all files                              | Multiple                        |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR updates the docs so they match how MongoDB and VoyageAI actually work now. It adds missing examples, fixes outdated names and settings, and shows people how to use the newer features correctly.

## Summary
- Expanded MongoDB coverage across memory, storage, RAG, and vector reference docs.
- Added MongoDB examples for semantic recall, storage setups, retention/TTL indexes, and vector search.
- Updated environment variable names to `MONGODB_DB_NAME` across examples and guidance.
- Added and refreshed `MongoDBStore` / `MongoDBVector` API docs, including `close()`, `connect()`, `waitForIndexReady()`, `documents`, and `numCandidates`.
- Added VoyageAI documentation and examples for embeddings, RAG, and MongoDB vector usage.
- Updated supported VoyageAI models, dimensions, limits, and multimodal embedding examples.
- Refined MongoDB deployment and maintenance guidance, including Atlas Vector Search and compaction notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->