### PR TITLE
test(core): add trailing assistant guard coverage

### DIFF
--- a/packages/core/src/processors/trailing-assistant-guard.test.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+
+import type { MastraDBMessage } from '../agent/message-list';
+import { isMaybeClaude46, TrailingAssistantGuard } from './trailing-assistant-guard';
+import type { ProcessInputStepArgs } from './index';
+
+const createMessage = (role: 'user' | 'assistant', text: string): MastraDBMessage => ({
+  id: `${role}-${text}`,
+  role,
+  content: {
+    format: 2,
+    parts: [{ type: 'text', text }],
+  },
+  createdAt: new Date(),
+  threadId: 'test-thread',
+});
+
+const makeArgs = (
+  overrides: Pick<Partial<ProcessInputStepArgs>, 'messages' | 'structuredOutput'> = {},
+): ProcessInputStepArgs =>
+  ({
+    messages: overrides.messages ?? [createMessage('assistant', 'draft response')],
+    structuredOutput:
+      'structuredOutput' in overrides ? overrides.structuredOutput : { schema: z.object({ answer: z.string() }) },
+  }) as ProcessInputStepArgs;
+
+describe('isMaybeClaude46', () => {
+  it('detects Claude 4.6 string model configs from Anthropic providers', () => {
+    expect(isMaybeClaude46('anthropic/claude-opus-4-6')).toBe(true);
+    expect(isMaybeClaude46('anthropic/claude-sonnet-4.6')).toBe(true);
+  });
+
+  it('rejects non-Claude 4.6 string model configs', () => {
+    expect(isMaybeClaude46('anthropic/claude-sonnet-4-5')).toBe(false);
+    expect(isMaybeClaude46('openai/claude-opus-4-6')).toBe(false);
+  });
+
+  it('detects Claude 4.6 language model objects', () => {
+    expect(isMaybeClaude46({ provider: 'anthropic', modelId: 'claude-opus-4-6' })).toBe(true);
+    expect(isMaybeClaude46({ provider: 'anthropic.messages', modelId: 'claude-sonnet-4.6' })).toBe(true);
+  });
+
+  it('rejects non-Claude 4.6 language model objects', () => {
+    expect(isMaybeClaude46({ provider: 'anthropic', modelId: 'claude-sonnet-4-5' })).toBe(false);
+    expect(isMaybeClaude46({ provider: 'openai', modelId: 'claude-opus-4-6' })).toBe(false);
+  });
+
+  it('treats dynamic model functions and unknown shapes as possibly Claude 4.6', () => {
+    expect(isMaybeClaude46(() => 'anthropic/claude-opus-4-6')).toBe(true);
+    expect(isMaybeClaude46({})).toBe(true);
+    expect(isMaybeClaude46(undefined)).toBe(true);
+  });
+
+  it('detects Claude 4.6 inside fallback arrays', () => {
+    expect(
+      isMaybeClaude46([{ model: 'openai/gpt-5' }, { model: { provider: 'anthropic', modelId: 'claude-sonnet-4.6' } }]),
+    ).toBe(true);
+  });
+
+  it('rejects fallback arrays without a Claude 4.6 candidate', () => {
+    expect(
+      isMaybeClaude46([{ model: 'openai/gpt-5' }, { model: { provider: 'anthropic', modelId: 'claude-sonnet-4-5' } }]),
+    ).toBe(false);
+  });
+});
+
+describe('TrailingAssistantGuard', () => {
+  it('has the expected id and name', () => {
+    const guard = new TrailingAssistantGuard();
+
+    expect(guard.id).toBe('trailing-assistant-guard');
+    expect(guard.name).toBe('Trailing Assistant Guard');
+  });
+
+  it('appends a user continuation message when native structured output follows an assistant message', () => {
+    const guard = new TrailingAssistantGuard();
+    const messages = [createMessage('user', 'question'), createMessage('assistant', 'draft response')];
+
+    const result = guard.processInputStep(makeArgs({ messages }));
+
+    expect(result?.messages).toHaveLength(3);
+    expect(result?.messages?.slice(0, 2)).toEqual(messages);
+    expect(result?.messages?.[2]).toMatchObject({
+      role: 'user',
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'Generate the structured response.' }],
+      },
+    });
+    expect(result?.messages?.[2]?.id).toEqual(expect.any(String));
+    expect(result?.messages?.[2]?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('does not append a message when structured output has no schema', () => {
+    const guard = new TrailingAssistantGuard();
+
+    const result = guard.processInputStep(makeArgs({ structuredOutput: undefined }));
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not append a message when structured output uses a separate model', () => {
+    const guard = new TrailingAssistantGuard();
+
+    const result = guard.processInputStep(
+      makeArgs({
+        structuredOutput: {
+          schema: z.object({ answer: z.string() }),
+          model: 'anthropic/claude-opus-4-6',
+        },
+      }),
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not append a message when JSON prompt injection is enabled', () => {
+    const guard = new TrailingAssistantGuard();
+
+    const result = guard.processInputStep(
+      makeArgs({
+        structuredOutput: {
+          schema: z.object({ answer: z.string() }),
+          jsonPromptInjection: true,
+        },
+      }),
+    );
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not append a message when the last message is not from the assistant', () => {
+    const guard = new TrailingAssistantGuard();
+
+    const result = guard.processInputStep(makeArgs({ messages: [createMessage('user', 'question')] }));
+
+    expect(result).toBeUndefined();
+  });
+
+  it('does not append a message when there are no messages', () => {
+    const guard = new TrailingAssistantGuard();
+
+    const result = guard.processInputStep(makeArgs({ messages: [] }));
+
+    expect(result).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- add focused coverage for Claude 4.6 detection across string, language-model object, dynamic, unknown, and fallback configurations
- verify that `TrailingAssistantGuard` only appends its continuation message for native structured output after an assistant message
- assert the exact appended message shape and preserve the original message sequence using real `MastraDBMessage` fixtures and a Zod schema

Fixes #18951.

## Why

`trailing-assistant-guard.ts` currently has no dedicated unit tests. These cases protect both the conservative model-detection behavior and the structured-output gating conditions that determine whether the guard mutates the input message list.

## Validation

- `../../node_modules/.bin/vitest --config /dev/null run src/processors/trailing-assistant-guard.test.ts` (14 tests passed)
- `../../node_modules/.bin/eslint src/processors/trailing-assistant-guard.test.ts`
- `../../node_modules/.bin/prettier --check src/processors/trailing-assistant-guard.test.ts`
- `git diff --check`

## Notes

The package-wide `tsc --noEmit` check could not complete in the filtered local install because several internal workspace packages were not built/resolvable (for example `@internal/ai-sdk-v4` and `@mastra/schema-compat`). The focused Vitest run type-checked and executed this test file successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This adds tests for a “helper” that decides when to add one more message at the end of a conversation. The tests make sure it only does that in the right cases, so the app behaves correctly with different model setups.

### Summary
- Added Vitest coverage for `isMaybeClaude46` across:
  - string model configs
  - language model objects
  - function/dynamic configs
  - fallback arrays
  - unknown shapes and non-Claude 4.6 cases
- Added `TrailingAssistantGuard` tests for:
  - public `id` and `name`
  - appending a continuation user message after an assistant message when native structured output is enabled
  - preserving the original message sequence
  - skipping the append when structured output is missing, `jsonPromptInjection` is enabled, the model doesn’t match, the last message is not from the assistant, or there are no messages
- Uses real `MastraDBMessage` fixtures and a Zod schema to verify the exact appended message shape

<!-- end of auto-generated comment: release notes by coderabbit.ai -->