### PR TITLE
fix(memory): mark data-om-status part transient so it is not persisted

### DIFF
--- a/.changeset/om-status-transient.md
+++ b/.changeset/om-status-transient.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed Observational Memory writing `data-om-status` snapshots into persisted message history. The status part (a window-usage snapshot meant only for polling UIs) was emitted without the `transient` flag that every other OM lifecycle marker sets, so the stream writer persisted each snapshot as a standalone assistant message. On long-running threads this crowded real conversation turns out of paginated history reads. The status part is now marked transient and is no longer persisted. Fixes #18869.

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -7377,6 +7377,66 @@ describe('Locking Behavior', () => {
   });
 });
 
+describe('data-om-status transient flag (regression for #18869)', () => {
+  const makeCapturingWriter = () => {
+    const customCalls: any[] = [];
+    const writer = {
+      custom: async (part: any) => {
+        customCalls.push(part);
+      },
+      write: async () => {},
+      close: async () => {},
+    } as any;
+    return { writer, customCalls };
+  };
+
+  it('emits data-om-status with transient: true so the OutputWriter does not persist it', async () => {
+    const storage = createInMemoryStorage();
+    const threadId = 'om-status-transient-thread';
+    const resourceId = 'om-status-transient-resource';
+
+    const om = new ObservationalMemory({
+      storage,
+      scope: 'thread',
+      observation: {
+        messageTokens: 100000,
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }) as any,
+      },
+      reflection: {
+        observationTokens: 40000,
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }) as any,
+      },
+    });
+
+    const record = await storage.initializeObservationalMemory({
+      threadId,
+      resourceId,
+      scope: 'thread',
+      config: {},
+    });
+
+    const { writer, customCalls } = makeCapturingWriter();
+
+    await om.emitProgress({
+      record,
+      pendingTokens: 10,
+      threshold: 100,
+      effectiveObservationTokensThreshold: 100,
+      currentObservationTokens: 0,
+      writer,
+      stepNumber: 0,
+      threadId,
+      resourceId,
+    });
+
+    const statusParts = customCalls.filter(part => part?.type === 'data-om-status');
+    expect(statusParts).toHaveLength(1);
+    // Without transient: true the OutputWriter persists each status snapshot as a
+    // standalone assistant message (#18869). Every sibling OM marker sets this flag.
+    expect(statusParts[0].transient).toBe(true);
+  });
+});
+
 describe('Reflection with Thread Attribution', () => {
   it('should create a new record after reflection', async () => {
     const storage = createInMemoryStorage();

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -2664,7 +2664,8 @@ ${formattedMessages}
       omDebug(
         `[OM:status] step=${stepNumber} msgs=${pendingTokens}/${threshold} obs=${currentObservationTokens}/${effectiveObservationTokensThreshold} gen=${record.generationCount}`,
       );
-      await writer.custom(statusPart).catch(() => {});
+      // Stream OM lifecycle markers as transient so the OutputWriter does not persist standalone data-only messages; the status snapshot is ephemeral (polling UIs only) and has no durable intent.
+      await writer.custom({ ...statusPart, transient: true }).catch(() => {});
     }
   }
 


### PR DESCRIPTION
## What

`data-om-status` Observational Memory parts were being persisted into message history. This adds the `transient: true` flag to the status emit so the `OutputWriter` stops writing each snapshot as a standalone assistant message.

Fixes #18869.

## Why

`data-om-status` is broken because the emit omits `transient`. Every OM lifecycle marker is streamed with `transient: true` so the `OutputWriter` doesn't persist it as a standalone data-only message, except the status snapshot. In `observational-memory.ts`, the three sibling markers all set it:

```ts
void writer.custom({ ...startMarker, transient: true }).catch(() => {});
```
but the status emit did not:
```ts
await writer.custom(statusPart).catch(() => {});   // ← no transient flag
```

The core persistence gate writes any non-transient data-* chunk as an assistant message, so each status snapshot became a durable row. data-om-status is a window-usage snapshot for polling UIs. It has no persistMarkerToStorage call and is explicitly non-rendered in channels, so it was never meant to persist. On long-running threads this crowds real conversation turns out of paginated listMessages reads.

## How
One-line change matching the sibling markers:

```ts
- await writer.custom(statusPart).catch(() => {});
+ await writer.custom({ ...statusPart, transient: true }).catch(() => {});
```

## Testing
Added a regression test: `data-om-status transient flag (regression for #18869)` in `observational-memory.test.ts`. It calls `emitProgress` with a capturing writer and asserts the emitted `data-om-status` part carries `transient: true`.

- Fails on main (without the fix `transient` is `undefined`), passes with this change.
- Full OM suite green: 453 passed.

```
node_modules/.bin/vitest run packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts -t "transient flag"
```

## Impact / regression risk
Scoped to the OM status emit only. The snapshot is still streamed to clients (polling UIs unaffected). It's just no longer written to storage, matching every other OM marker. No change for any other data part.

## Deviations
I commented on the issue first before opening this. Prior PR [#18922](https://github.com/mastra-ai/mastra/issues/18922) shipped the same one-line fix but was self-closed by its author without a regression test. This PR adds that missing test so the fix lands with coverage. I'd happy to defer if @bkidy or @aryanbarde80 would rather take it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR stops Observational Memory “status update” snapshots from being saved into the chat’s stored message history. They still stream to the UI as they happen, but they won’t show up later as fake assistant messages.

## What changed
- Updated `emitProgress` so `data-om-status` snapshots are emitted with `transient: true`.
- Added a regression test asserting that the emitted `data-om-status` part includes `transient: true` (fix for `#18869`), ensuring `OutputWriter` won’t persist these snapshots.

## Why
- `data-om-status` is ephemeral UI/polling state (a window-usage snapshot), not durable conversation content.
- Without `transient: true`, these snapshots polluted persisted message history and displaced real conversation turns in paginated reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->