### PR TITLE
test(core): add unit tests for message-list cache and utils helpers

### DIFF
--- a/packages/core/src/agent/message-list/cache/stable-stringify.test.ts
+++ b/packages/core/src/agent/message-list/cache/stable-stringify.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for packages/core/src/agent/message-list/cache/stable-stringify.ts
+ *
+ * `stableStringify` is a pure function with no I/O and no async behaviour.
+ * The behaviour under test is the deterministic-key-order guarantee that
+ * makes it safe to use for cache-key generation, as described in the
+ * function's own doc comment.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { stableStringify } from './stable-stringify';
+
+describe('stableStringify', () => {
+  it('produces identical output regardless of key insertion order', () => {
+    const a = { a: 1, b: 2 };
+    const b = { b: 2, a: 1 };
+
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it('sorts keys alphabetically at the top level', () => {
+    const result = stableStringify({ z: 1, a: 2, m: 3 });
+
+    expect(result).toBe('{"a":2,"m":3,"z":1}');
+  });
+
+  it('sorts keys at every nested level, not just the top level', () => {
+    const nested = { outer2: 1, outer1: { innerB: 1, innerA: 2 } };
+
+    expect(stableStringify(nested)).toBe('{"outer1":{"innerA":2,"innerB":1},"outer2":1}');
+  });
+
+  it('produces identical output for deeply nested objects with different key orders', () => {
+    const a = { x: { y: { c: 1, b: 2, a: 3 } } };
+    const b = { x: { y: { a: 3, c: 1, b: 2 } } };
+
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it('preserves array element order (arrays are not sorted)', () => {
+    const value = [3, 1, 2];
+
+    expect(stableStringify(value)).toBe('[3,1,2]');
+  });
+
+  it('sorts object keys within array elements', () => {
+    const value = [{ b: 1, a: 2 }];
+
+    expect(stableStringify(value)).toBe('[{"a":2,"b":1}]');
+  });
+
+  it('does not treat arrays as plain objects to be key-sorted', () => {
+    // Guards against a regression where the replacer's `Array.isArray` guard
+    // is dropped and arrays get converted into sorted-key objects.
+    const value = { list: [10, 20, 30] };
+
+    expect(stableStringify(value)).toBe('{"list":[10,20,30]}');
+  });
+
+  it('handles primitive values the same way JSON.stringify does', () => {
+    expect(stableStringify('hello')).toBe('"hello"');
+    expect(stableStringify(42)).toBe('42');
+    expect(stableStringify(true)).toBe('true');
+    expect(stableStringify(null)).toBe('null');
+  });
+
+  it('returns undefined (as a JS value) for undefined input, matching JSON.stringify', () => {
+    expect(stableStringify(undefined)).toBe(undefined);
+  });
+
+  it('drops keys whose value is undefined, matching JSON.stringify', () => {
+    const value = { a: 1, b: undefined };
+
+    expect(stableStringify(value)).toBe('{"a":1}');
+  });
+
+  it('handles empty objects and empty arrays', () => {
+    expect(stableStringify({})).toBe('{}');
+    expect(stableStringify([])).toBe('[]');
+  });
+
+  it('produces the same key order for objects built via different assignment sequences', () => {
+    const built1: Record<string, number> = {};
+    built1.charlie = 3;
+    built1.alpha = 1;
+    built1.bravo = 2;
+
+    const built2: Record<string, number> = {};
+    built2.alpha = 1;
+    built2.bravo = 2;
+    built2.charlie = 3;
+
+    expect(stableStringify(built1)).toBe(stableStringify(built2));
+    expect(stableStringify(built1)).toBe('{"alpha":1,"bravo":2,"charlie":3}');
+  });
+
+  it('is stable for realistic data-* message part payloads regardless of source column ordering', () => {
+    // Simulates the PostgreSQL jsonb-vs-text-column scenario from the doc
+    // comment: functionally identical data survives storage/restore with a
+    // different key order, but must hash to the same cache key.
+    const fromJsonbColumn = { type: 'data-status', data: { status: 'complete', id: 'abc-123' } };
+    const fromTextColumn = { data: { id: 'abc-123', status: 'complete' }, type: 'data-status' };
+
+    expect(stableStringify(fromJsonbColumn)).toBe(stableStringify(fromTextColumn));
+  });
+
+  it('treats null and object-with-null-prototype-like values without throwing', () => {
+    const value = { a: null, b: { c: null } };
+
+    expect(() => stableStringify(value)).not.toThrow();
+    expect(stableStringify(value)).toBe('{"a":null,"b":{"c":null}}');
+  });
+});

--- a/packages/core/src/agent/message-list/utils/response-item-metadata.test.ts
+++ b/packages/core/src/agent/message-list/utils/response-item-metadata.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for packages/core/src/agent/message-list/utils/response-item-metadata.ts
+ *
+ * These are pure functions over `providerMetadata` objects with no I/O and
+ * no async behaviour. Coverage focuses on the documented edge cases: the
+ * Azure/OpenAI namespace-collision merge, provider-key formatting, and
+ * empty/missing metadata handling.
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  getResponseProviderItemId,
+  getResponseProviderItemIds,
+  getResponseProviderItemKey,
+  getResponseProviderItemKeys,
+} from './response-item-metadata';
+
+describe('getResponseProviderItemIds', () => {
+  it('returns an empty array when providerMetadata is undefined', () => {
+    expect(getResponseProviderItemIds(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array when providerMetadata is an empty object', () => {
+    expect(getResponseProviderItemIds({})).toEqual([]);
+  });
+
+  it('extracts a single openai item id', () => {
+    const metadata = { openai: { itemId: 'resp_openai_1' } };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([{ provider: 'openai', itemId: 'resp_openai_1' }]);
+  });
+
+  it('extracts a single azure item id', () => {
+    const metadata = { azure: { itemId: 'resp_azure_1' } };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([{ provider: 'azure', itemId: 'resp_azure_1' }]);
+  });
+
+  it('collapses azure and openai into a single entry when their item ids match', () => {
+    const metadata = { azure: { itemId: 'same-id' }, openai: { itemId: 'same-id' } };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([{ provider: 'azure', itemId: 'same-id' }]);
+  });
+
+  it('returns both entries, in provider-list order (openai before azure), when item ids differ', () => {
+    const metadata = { azure: { itemId: 'azure-id' }, openai: { itemId: 'openai-id' } };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([
+      { provider: 'openai', itemId: 'openai-id' },
+      { provider: 'azure', itemId: 'azure-id' },
+    ]);
+  });
+
+  it('ignores non-string itemId values', () => {
+    const metadata = { openai: { itemId: 123 } };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([]);
+  });
+
+  it('ignores providers outside the known provider list', () => {
+    const metadata = { anthropic: { itemId: 'resp_anthropic_1' } };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([]);
+  });
+
+  it('ignores a provider namespace with a missing itemId', () => {
+    const metadata = { openai: {} };
+
+    expect(getResponseProviderItemIds(metadata)).toEqual([]);
+  });
+});
+
+describe('getResponseProviderItemId', () => {
+  it('returns the first matching provider/item pair (openai, per provider-list order)', () => {
+    const metadata = { azure: { itemId: 'azure-id' }, openai: { itemId: 'openai-id' } };
+
+    expect(getResponseProviderItemId(metadata)).toEqual({ provider: 'openai', itemId: 'openai-id' });
+  });
+
+  it('returns undefined when there is no matching provider metadata', () => {
+    expect(getResponseProviderItemId(undefined)).toBeUndefined();
+    expect(getResponseProviderItemId({})).toBeUndefined();
+  });
+});
+
+describe('getResponseProviderItemKey', () => {
+  it('formats the key as "<provider>:<itemId>"', () => {
+    const metadata = { openai: { itemId: 'abc123' } };
+
+    expect(getResponseProviderItemKey(metadata)).toBe('openai:abc123');
+  });
+
+  it('returns undefined when there is no item id to key on', () => {
+    expect(getResponseProviderItemKey(undefined)).toBeUndefined();
+    expect(getResponseProviderItemKey({})).toBeUndefined();
+  });
+
+  it('keeps azure and openai keys distinct even for coincidentally equal ids', () => {
+    // Namespace must remain in the key so matching Azure/OpenAI ids from two
+    // *different* logical items never collide when compared independently.
+    const azureKey = getResponseProviderItemKey({ azure: { itemId: 'shared-id' } });
+    const openaiKey = getResponseProviderItemKey({ openai: { itemId: 'shared-id' } });
+
+    expect(azureKey).toBe('azure:shared-id');
+    expect(openaiKey).toBe('openai:shared-id');
+    expect(azureKey).not.toBe(openaiKey);
+  });
+});
+
+describe('getResponseProviderItemKeys', () => {
+  it('formats keys for every extracted provider/item pair, in provider-list order', () => {
+    const metadata = { azure: { itemId: 'azure-id' }, openai: { itemId: 'openai-id' } };
+
+    expect(getResponseProviderItemKeys(metadata)).toEqual(['openai:openai-id', 'azure:azure-id']);
+  });
+
+  it('returns an empty array when there is nothing to key', () => {
+    expect(getResponseProviderItemKeys(undefined)).toEqual([]);
+  });
+
+  it('returns a single collapsed key when azure and openai share an item id', () => {
+    const metadata = { azure: { itemId: 'same-id' }, openai: { itemId: 'same-id' } };
+
+    expect(getResponseProviderItemKeys(metadata)).toEqual(['azure:same-id']);
+  });
+});

--- a/packages/core/src/agent/message-list/utils/stamp-part.test.ts
+++ b/packages/core/src/agent/message-list/utils/stamp-part.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for packages/core/src/agent/message-list/utils/stamp-part.ts
+ *
+ * `stampPart` and `stampMessageParts` are small pure(-ish) helpers that
+ * assign a `createdAt` timestamp to message parts. The only non-determinism
+ * is `Date.now()`, which is mocked to keep assertions exact.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest';
+
+import type { MastraDBMessage, MastraMessagePart } from '../state/types';
+import { stampMessageParts, stampPart } from './stamp-part';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('stampPart', () => {
+  it('assigns the current time when createdAt is undefined', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+
+    const part = { type: 'text', text: 'hello' } as unknown as MastraMessagePart;
+    const result = stampPart(part);
+
+    expect(result.createdAt).toBe(1_700_000_000_000);
+  });
+
+  it('assigns the current time when createdAt is null', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+
+    const part = { type: 'text', text: 'hello', createdAt: null } as unknown as MastraMessagePart;
+    const result = stampPart(part);
+
+    expect(result.createdAt).toBe(1_700_000_000_000);
+  });
+
+  it('does not overwrite an existing createdAt value', () => {
+    const part = { type: 'text', text: 'hello', createdAt: 123 } as unknown as MastraMessagePart;
+    const result = stampPart(part);
+
+    expect(result.createdAt).toBe(123);
+  });
+
+  it('preserves createdAt of 0 (falsy but not nullish)', () => {
+    const part = { type: 'text', text: 'hello', createdAt: 0 } as unknown as MastraMessagePart;
+    const result = stampPart(part);
+
+    expect(result.createdAt).toBe(0);
+  });
+
+  it('mutates and returns the same object reference', () => {
+    const part = { type: 'text', text: 'hello' } as unknown as MastraMessagePart;
+    const result = stampPart(part);
+
+    expect(result).toBe(part);
+  });
+
+  it('leaves other fields on the part untouched', () => {
+    const part = { type: 'text', text: 'hello', foo: 'bar' } as unknown as MastraMessagePart;
+    const result = stampPart(part);
+
+    expect(result.text).toBe('hello');
+    expect((result as any).foo).toBe('bar');
+  });
+});
+
+describe('stampMessageParts', () => {
+  function buildMessage(parts: unknown[]): MastraDBMessage {
+    return {
+      content: { parts },
+    } as unknown as MastraDBMessage;
+  }
+
+  it('returns the message unchanged when source is "memory"', () => {
+    const message = buildMessage([{ type: 'text', text: 'hi' }]);
+    const result = stampMessageParts(message, 'memory');
+
+    expect(result).toBe(message);
+    expect((result.content.parts[0] as any).createdAt).toBeUndefined();
+  });
+
+  it('stamps all parts without an existing createdAt when source is not "memory"', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+
+    const message = buildMessage([
+      { type: 'text', text: 'a' },
+      { type: 'text', text: 'b' },
+    ]);
+    const result = stampMessageParts(message, 'response');
+
+    expect((result.content.parts[0] as any).createdAt).toBe(1_700_000_000_000);
+    expect((result.content.parts[1] as any).createdAt).toBe(1_700_000_000_000);
+  });
+
+  it('does not overwrite parts that already have createdAt', () => {
+    const message = buildMessage([{ type: 'text', text: 'a', createdAt: 42 }]);
+    const result = stampMessageParts(message, 'input');
+
+    expect((result.content.parts[0] as any).createdAt).toBe(42);
+  });
+
+  it('returns the message unchanged when parts is not an array', () => {
+    const message = { content: { parts: undefined } } as unknown as MastraDBMessage;
+    const result = stampMessageParts(message, 'input');
+
+    expect(result).toBe(message);
+  });
+
+  it('handles an empty parts array without throwing', () => {
+    const message = buildMessage([]);
+    const result = stampMessageParts(message, 'system');
+
+    expect(result.content.parts).toEqual([]);
+  });
+
+  it('stamps parts for every non-memory source value', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+
+    const sources: Array<'response' | 'input' | 'system' | 'context'> = ['response', 'input', 'system', 'context'];
+
+    for (const source of sources) {
+      const message = buildMessage([{ type: 'text', text: 'x' }]);
+      const result = stampMessageParts(message, source);
+      expect((result.content.parts[0] as any).createdAt).toBe(1_700_000_000_000);
+    }
+  });
+});

--- a/packages/core/src/agent/message-list/utils/tool-name.test.ts
+++ b/packages/core/src/agent/message-list/utils/tool-name.test.ts
@@ -1,0 +1,70 @@
+/**
+ * Tests for packages/core/src/agent/message-list/utils/tool-name.ts
+ *
+ * `sanitizeToolName` is a pure function with no I/O and no async behaviour.
+ * It guards against unsafe/unexpected tool-name values before they are used
+ * downstream (e.g. as identifiers in provider-specific tool-call payloads).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { FALLBACK_TOOL_NAME, sanitizeToolName } from './tool-name';
+
+describe('sanitizeToolName', () => {
+  it('returns the input unchanged when it only contains allowed characters', () => {
+    expect(sanitizeToolName('getWeather')).toBe('getWeather');
+    expect(sanitizeToolName('get_weather')).toBe('get_weather');
+    expect(sanitizeToolName('get-weather')).toBe('get-weather');
+    expect(sanitizeToolName('getWeather123')).toBe('getWeather123');
+  });
+
+  it('accepts a name made purely of digits', () => {
+    expect(sanitizeToolName('12345')).toBe('12345');
+  });
+
+  it('accepts a name made purely of underscores and hyphens', () => {
+    expect(sanitizeToolName('___')).toBe('___');
+    expect(sanitizeToolName('---')).toBe('---');
+  });
+
+  it('falls back for names containing spaces', () => {
+    expect(sanitizeToolName('get weather')).toBe(FALLBACK_TOOL_NAME);
+  });
+
+  it('falls back for names containing dots', () => {
+    expect(sanitizeToolName('weather.get')).toBe(FALLBACK_TOOL_NAME);
+  });
+
+  it('falls back for names containing special/unsafe characters', () => {
+    expect(sanitizeToolName('get<weather>')).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName('weather;DROP TABLE')).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName('weather/forecast')).toBe(FALLBACK_TOOL_NAME);
+  });
+
+  it('falls back for an empty string', () => {
+    expect(sanitizeToolName('')).toBe(FALLBACK_TOOL_NAME);
+  });
+
+  it('falls back for non-string inputs', () => {
+    expect(sanitizeToolName(undefined)).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName(null)).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName(123)).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName({})).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName([])).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName(true)).toBe(FALLBACK_TOOL_NAME);
+  });
+
+  it('falls back for unicode/emoji tool names', () => {
+    expect(sanitizeToolName('☃️toolName')).toBe(FALLBACK_TOOL_NAME);
+    expect(sanitizeToolName('工具名')).toBe(FALLBACK_TOOL_NAME);
+  });
+
+  it('is case sensitive but accepts both cases', () => {
+    expect(sanitizeToolName('GetWeather')).toBe('GetWeather');
+    expect(sanitizeToolName('GETWEATHER')).toBe('GETWEATHER');
+    expect(sanitizeToolName('getweather')).toBe('getweather');
+  });
+
+  it('exposes FALLBACK_TOOL_NAME as the documented sentinel value', () => {
+    expect(FALLBACK_TOOL_NAME).toBe('unknown_tool');
+  });
+});


### PR DESCRIPTION
Fixes #19087

## What

Adds unit test coverage for four small, previously-untested pure helper modules under `packages/core/src/agent/message-list/`:

- `cache/stable-stringify.ts` — `stableStringify`
- `utils/stamp-part.ts` — `stampPart`, `stampMessageParts`
- `utils/tool-name.ts` — `sanitizeToolName`
- `utils/response-item-metadata.ts` — `getResponseProviderItemId(s)`, `getResponseProviderItemKey(s)`

All four are pure functions with no I/O, so the tests require no mocking beyond faking `Date.now()` for the `stamp-part` timestamp assertions.

## Why

These modules had no direct test file even though they sit on paths that matter for correctness:

- `stableStringify` is explicitly documented as critical for cache-key generation across storage backends that normalize JSON key order differently (jsonb vs text columns) — an untested regression here would silently break cache dedup.
- `stampPart`/`stampMessageParts` control whether/when message parts get a `createdAt` timestamp, including a `'memory'` source short-circuit and a falsy-but-valid `createdAt = 0` edge case that's easy to break with a naive falsy check.
- `sanitizeToolName` is a security-relevant allow-list guard for tool names; tests pin down the exact fallback behavior for unsafe/unicode input.
- `response-item-metadata` helpers implement a specific azure/openai namespace-collision merge rule that's non-obvious from a quick read and worth locking in with tests.

## Coverage

54 test cases across 4 files, covering: happy paths, documented edge cases from source comments, falsy-vs-nullish distinctions, empty/undefined inputs, and the provider-collision merge behavior.

## Testing

- `npx vitest run` on all four new files: **54/54 passing**
- `npx eslint` on all four new files: clean
- No production code changed; test-only PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds tests for a few small helper functions that do important “housekeeping” work, like keeping cache keys consistent, adding timestamps, cleaning up tool names, and matching response metadata. These tests help make sure the helpers keep behaving the same way over time, especially in edge cases.

## Summary
- Added Vitest coverage for `stableStringify` to verify deterministic object serialization, stable nested key ordering, array handling, `undefined`/`null` behavior, and realistic payload cases.
- Added tests for `stampPart` and `stampMessageParts` to confirm timestamp stamping rules, `memory` source behavior, preservation of existing timestamps (including `0`), and safe handling of missing/empty parts.
- Added tests for `sanitizeToolName` to validate allowed names, fallback behavior for invalid or non-string inputs, and the fallback sentinel value.
- Added tests for response-item metadata helpers to verify provider/item ID extraction, Azure/OpenAI collision merging rules, key formatting, and ordering behavior.

No production code was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
