### PR TITLE
test(core): add unit tests for processor-workflow guard and prompt content helpers

### DIFF
--- a/packages/core/src/agent/message-list/prompt/data-content.test.ts
+++ b/packages/core/src/agent/message-list/prompt/data-content.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Tests for packages/core/src/agent/message-list/prompt/data-content.ts
+ *
+ * `convertDataContentToBase64String` is a pure function with no I/O. It
+ * fans out on the runtime type of its input (string passthrough,
+ * ArrayBuffer, or Uint8Array/Buffer), so coverage exercises each branch
+ * plus the documented edge cases (empty input, Buffer-is-a-Uint8Array).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { convertDataContentToBase64String } from './data-content';
+
+describe('convertDataContentToBase64String', () => {
+  it('returns a string input unchanged (no re-encoding)', () => {
+    expect(convertDataContentToBase64String('already-base64==')).toBe('already-base64==');
+  });
+
+  it('returns an empty string input unchanged', () => {
+    expect(convertDataContentToBase64String('')).toBe('');
+  });
+
+  it('encodes a Uint8Array to a base64 string', () => {
+    const bytes = new Uint8Array([104, 101, 108, 108, 111]); // "hello"
+
+    expect(convertDataContentToBase64String(bytes)).toBe('aGVsbG8=');
+  });
+
+  it('encodes an ArrayBuffer to a base64 string', () => {
+    const buffer = new Uint8Array([104, 101, 108, 108, 111]).buffer; // "hello"
+
+    expect(convertDataContentToBase64String(buffer)).toBe('aGVsbG8=');
+  });
+
+  it('produces the same base64 output for equivalent Uint8Array and ArrayBuffer input', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const buffer = bytes.buffer;
+
+    expect(convertDataContentToBase64String(bytes)).toBe(convertDataContentToBase64String(buffer));
+  });
+
+  it('encodes an empty Uint8Array to an empty base64 string', () => {
+    expect(convertDataContentToBase64String(new Uint8Array([]))).toBe('');
+  });
+
+  it('encodes an empty ArrayBuffer to an empty base64 string', () => {
+    expect(convertDataContentToBase64String(new ArrayBuffer(0))).toBe('');
+  });
+
+  it('encodes a Node.js Buffer via the Uint8Array branch (Buffer is a Uint8Array subclass)', () => {
+    const buf = Buffer.from('hello', 'utf-8');
+
+    expect(convertDataContentToBase64String(buf)).toBe('aGVsbG8=');
+  });
+
+  it('round-trips arbitrary binary bytes (including 0x00 and 0xff) correctly', () => {
+    const bytes = new Uint8Array([0, 255, 128, 64, 1]);
+    const encoded = convertDataContentToBase64String(bytes);
+    const decoded = Buffer.from(encoded, 'base64');
+
+    expect(Array.from(decoded)).toEqual(Array.from(bytes));
+  });
+});

--- a/packages/core/src/agent/message-list/prompt/invalid-content-error.test.ts
+++ b/packages/core/src/agent/message-list/prompt/invalid-content-error.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for packages/core/src/agent/message-list/prompt/invalid-content-error.ts
+ *
+ * `InvalidDataContentError` is a small error subclass with no I/O. Coverage
+ * focuses on its documented contract: the default message format, the
+ * marker-based `isInstance` type guard (as opposed to `instanceof`), and
+ * that constructor overrides (message/cause) are respected.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { InvalidDataContentError } from './invalid-content-error';
+
+describe('InvalidDataContentError', () => {
+  it('is an instance of Error', () => {
+    const error = new InvalidDataContentError({ content: 123 });
+
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it('stores the provided content', () => {
+    const content = new Uint8Array([1, 2, 3]);
+    const error = new InvalidDataContentError({ content });
+
+    expect(error.content).toBe(content);
+  });
+
+  it('builds a default message that includes the typeof the invalid content', () => {
+    const error = new InvalidDataContentError({ content: 42 });
+
+    expect(error.message).toBe(
+      'Invalid data content. Expected a base64 string, Uint8Array, ArrayBuffer, or Buffer, but got number.',
+    );
+  });
+
+  it('reflects the actual typeof for different invalid content types in the default message', () => {
+    expect(new InvalidDataContentError({ content: {} }).message).toContain('got object');
+    expect(new InvalidDataContentError({ content: true }).message).toContain('got boolean');
+    expect(new InvalidDataContentError({ content: undefined }).message).toContain('got undefined');
+  });
+
+  it('uses a custom message when one is provided instead of the default', () => {
+    const error = new InvalidDataContentError({ content: 'x', message: 'totally custom message' });
+
+    expect(error.message).toBe('totally custom message');
+  });
+
+  it('carries the provided cause', () => {
+    const cause = new Error('root cause');
+    const error = new InvalidDataContentError({ content: 'x', cause });
+
+    expect(error.cause).toBe(cause);
+  });
+
+  it('recognizes an error constructed by this class via isInstance', () => {
+    const error = new InvalidDataContentError({ content: 'x' });
+
+    expect(InvalidDataContentError.isInstance(error)).toBe(true);
+  });
+
+  it('does not recognize a plain Error via isInstance', () => {
+    expect(InvalidDataContentError.isInstance(new Error('nope'))).toBe(false);
+  });
+
+  it('does not recognize non-error values via isInstance', () => {
+    expect(InvalidDataContentError.isInstance('a string')).toBe(false);
+    expect(InvalidDataContentError.isInstance(null)).toBe(false);
+    expect(InvalidDataContentError.isInstance(undefined)).toBe(false);
+    expect(InvalidDataContentError.isInstance({})).toBe(false);
+  });
+
+  it('survives a JSON-like round trip check via its own marker rather than instanceof across realms', () => {
+    // isInstance is marker-based specifically so it still works for errors
+    // that fail a plain `instanceof` check (e.g. crossing a bundler/realm
+    // boundary). We can't easily simulate a second realm here, but we can
+    // assert the marker property itself is present and truthy.
+    const error = new InvalidDataContentError({ content: 'x' });
+    const marker = Symbol.for('vercel.ai.error.AI_InvalidDataContentError');
+
+    expect((error as unknown as Record<symbol, unknown>)[marker]).toBe(true);
+  });
+});

--- a/packages/core/src/processors/is-processor-workflow.test.ts
+++ b/packages/core/src/processors/is-processor-workflow.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Tests for packages/core/src/processors/is-processor-workflow.ts
+ *
+ * `isProcessorWorkflow` is a pure type guard with no I/O and no async
+ * behaviour. Coverage focuses on the documented contract: it must match
+ * workflow-shaped objects (id/inputSchema/outputSchema/execute) while
+ * explicitly excluding anything that also looks like a processor (which
+ * has process*-prefixed methods).
+ */
+import { describe, expect, it } from 'vitest';
+
+import { isProcessorWorkflow } from './is-processor-workflow';
+
+function buildWorkflowLike(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'my-workflow',
+    inputSchema: {},
+    outputSchema: {},
+    execute: () => {},
+    ...overrides,
+  };
+}
+
+describe('isProcessorWorkflow', () => {
+  it('returns true for a minimal object matching the workflow shape', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike())).toBe(true);
+  });
+
+  it('returns false when id is missing', () => {
+    const obj = buildWorkflowLike();
+    delete (obj as any).id;
+
+    expect(isProcessorWorkflow(obj)).toBe(false);
+  });
+
+  it('returns false when id is present but not a string', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ id: 123 }))).toBe(false);
+  });
+
+  it('returns false when inputSchema is missing', () => {
+    const obj = buildWorkflowLike();
+    delete (obj as any).inputSchema;
+
+    expect(isProcessorWorkflow(obj)).toBe(false);
+  });
+
+  it('returns false when outputSchema is missing', () => {
+    const obj = buildWorkflowLike();
+    delete (obj as any).outputSchema;
+
+    expect(isProcessorWorkflow(obj)).toBe(false);
+  });
+
+  it('returns false when execute is missing', () => {
+    const obj = buildWorkflowLike();
+    delete (obj as any).execute;
+
+    expect(isProcessorWorkflow(obj)).toBe(false);
+  });
+
+  it('returns false when execute is present but not a function', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ execute: 'not-a-function' }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processInput method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processInput: () => {} }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processInputStep method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processInputStep: () => {} }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processOutputStream method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processOutputStream: () => {} }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processOutputResult method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processOutputResult: () => {} }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processOutputStep method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processOutputStep: () => {} }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processLLMRequest method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processLLMRequest: () => {} }))).toBe(false);
+  });
+
+  it('returns false when the object also has a processAPIError method', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ processAPIError: () => {} }))).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(isProcessorWorkflow(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(isProcessorWorkflow(undefined)).toBe(false);
+  });
+
+  it('returns false for primitive values', () => {
+    expect(isProcessorWorkflow('a string')).toBe(false);
+    expect(isProcessorWorkflow(42)).toBe(false);
+    expect(isProcessorWorkflow(true)).toBe(false);
+  });
+
+  it('returns false for an empty object', () => {
+    expect(isProcessorWorkflow({})).toBe(false);
+  });
+
+  it('returns false for an array (even with matching keys as indices)', () => {
+    expect(isProcessorWorkflow([])).toBe(false);
+  });
+
+  it('ignores extra unrelated properties on an otherwise-valid workflow', () => {
+    expect(isProcessorWorkflow(buildWorkflowLike({ description: 'does a thing', retryConfig: { attempts: 3 } }))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds unit test coverage for three previously-untested pure modules:

- `processors/is-processor-workflow.ts` — `isProcessorWorkflow`
- `agent/message-list/prompt/invalid-content-error.ts` — `InvalidDataContentError`
- `agent/message-list/prompt/data-content.ts` — `convertDataContentToBase64String`

## Why

- `isProcessorWorkflow` is a type guard used to tell a real `Workflow` apart from a `Processor` (this repo's own doc comment notes it's factored out specifically to avoid ESM init-time cycles from the processors barrel). Its correctness hinges entirely on excluding every `process*`-prefixed method — tests pin down each of the 7 documented exclusions (`processInput`, `processInputStep`, `processOutputStream`, `processOutputResult`, `processOutputStep`, `processLLMRequest`, `processAPIError`) individually, plus the required-field and non-object negative cases.
- `InvalidDataContentError` uses a `Symbol.for(...)` marker-based `isInstance` check instead of `instanceof` specifically so it still works across bundler/realm boundaries — that's exactly the kind of non-obvious design choice worth locking in with a test, along with the default-message `typeof` interpolation and the message/cause override paths.
- `convertDataContentToBase64String` fans out on 3 different runtime input shapes (string / ArrayBuffer / Uint8Array). Tests cover all three branches, empty-input edge cases for each, that `Buffer` correctly falls through the `Uint8Array` branch, and a full binary round-trip (0x00/0xff bytes) to catch any future encoding regression.

## Coverage

39 test cases across 3 files: happy paths, all documented branch/exclusion conditions, and null/undefined/primitive/empty edge cases.

## Testing

- `npx vitest run` on all three new files: **39/39 passing**
- `npx eslint` on all three new files: clean
- No production code changed; test-only PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds tests for three small helper pieces of code so we can be more sure they work the way we expect. It checks how they recognize valid workflows, how a custom error behaves, and how different kinds of data get turned into base64 text.

### Summary
- Added coverage for `isProcessorWorkflow`, including valid workflow shapes, missing/invalid required fields, non-objects, and `process*` method exclusions.
- Added coverage for `InvalidDataContentError`, including default/custom messages, `cause`, stored content, and marker-based instance detection.
- Added coverage for `convertDataContentToBase64String`, including string passthrough, empty input handling, `ArrayBuffer`, `Uint8Array`/`Buffer`, and binary round-trip behavior.
- No production code changes.
- 39 new test cases across 3 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->