### PR TITLE
docs(agent-controller): clarify session get-or-create by resourceId

### DIFF
--- a/docs/src/content/en/docs/agent-controller/session.mdx
+++ b/docs/src/content/en/docs/agent-controller/session.mdx
@@ -13,7 +13,7 @@ A [`Session`](/reference/agent-controller/session) holds the live state of an Ag
 
 The Session is the live state of a single user's interaction with the AgentController. It answers "what is true right now": who the session belongs to, which thread is currently bound, which mode and model are selected, what the user has approved, what's queued or running, the application state, and the snapshot to render. A session has one active thread at a time but can list, switch between, and clone many threads over its lifetime. Anything that describes the current state lives here; the AgentController owns the shared infrastructure every session runs on.
 
-Because each session has its own identity and state, one AgentController can serve many users at once — each backed by its own Session — without one session's mode, grants, or active thread leaking into another.
+Because each session has its own identity and state, one AgentController can serve many users at once — each with a different `resourceId` backed by its own Session — without one session's mode, grants, or active thread leaking into another. Calling `createSession` with the same `resourceId` returns the existing session (get-or-create), so a resource always resumes its own session.
 
 The rest of this page walks through the Session's state. Each part is a focused sub-object on `agentController.session`:
 

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -442,7 +442,7 @@ await agentController.init()
 
 Create a new, fully-wired `Session` and bring it online. The session starts in the default mode with the seeded model, connects to the AgentController's shared machinery (agent, storage/lock, config catalog), and has a current thread (the most recent thread for the resource, or a freshly created one). Call `init()` once before creating sessions so shared storage is ready.
 
-The AgentController owns no session of its own — every consumer creates its own session and drives all work through it. In a server or multiplayer setting, each request, thread, or user gets its own session, isolated from every other: independent event bus, mode, model, state, and current thread.
+The AgentController owns no session of its own — every consumer creates its own session and drives all work through it. A `resourceId` maps to exactly one session per AgentController (get-or-create): calling `createSession` with the same `resourceId` returns the existing session, so reconnects resume rather than fork the conversation. Different `resourceId`s produce independent sessions with isolated event bus, mode, model, state, and current thread. Use `session.thread.create()` and `session.thread.switch()` to manage multiple conversations within one session.
 
 `id` and `ownerId` are required — they mirror `SessionRecord.id` and `SessionRecord.ownerId` and are stable for the life of the session. `resourceId` is optional and defaults to `config.resourceId` then `config.id`.
 


### PR DESCRIPTION
## Description

Clarifies that `AgentController.createSession()` uses get-or-create semantics keyed by `resourceId` — calling it twice with the same `resourceId` returns the same session. The previous wording implied each call produces an independent session regardless of `resourceId`, which confused users into thinking multiple isolated sessions could share a resource scope.

- Updated `createSession` reference docs to explain the 1:1 `resourceId`→session mapping and point users to `session.thread.create()` / `session.thread.switch()` for multiple conversations
- Updated the Session guide to qualify that independent sessions require different `resourceId`s

## Related Issue(s)

Fixes #18934

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update makes the docs clearer about how sessions work: if you use the same `resourceId`, you get the same session back instead of a new one. It also explains that if you want separate conversations or isolated sessions, you need to use different `resourceId`s.

## Summary
- Clarified `AgentController.createSession()` as a get-or-create API keyed by `resourceId`.
- Explained that one `resourceId` maps to one live session per controller instance, and repeated calls reuse that session.
- Pointed users to `session.thread.create()` and `session.thread.switch()` for handling multiple conversations within a session.
- Updated the Session guide to state that independent sessions require different `resourceId`s.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->