### PR TITLE
docs: Port design tokens & adjust slight visuals

### DIFF
--- a/docs/custom.css
+++ b/docs/custom.css
@@ -559,10 +559,6 @@ html {
   margin-bottom: 0;
 }
 
-[data-theme='dark'] .navbar {
-  border-bottom-color: var(--border);
-}
-
 .navbar__link {
   font-weight: 500;
 }

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -502,14 +502,21 @@ html {
   height: auto;
   padding-inline: 0;
   padding-block: 0;
-  border-bottom: 1px solid var(--border);
-  box-shadow: 0 0 37.7px 0 #eaeaea;
+  /* Render the bottom hairline via box-shadow instead of border-bottom so it
+     doesn't add 1px to the navbar's occupied height. The navbar height is
+     driven by --ifm-navbar-height (47px), and a real border would push the
+     layout to 48px, desyncing the sidebar's sticky offset and causing a 1px
+     scroll jump. The second layer is the soft drop shadow. */
+  box-shadow:
+    0 1px 0 0 var(--border),
+    0 0 37.7px 0 #eaeaea;
   background-color: var(--ifm-navbar-background-color);
 }
 
 [data-theme='dark'] .theme-layout-navbar {
-  border-bottom-color: var(--border);
-  box-shadow: 0 8px 60px 0 rgba(2, 2, 2, 0.5);
+  box-shadow:
+    0 1px 0 0 var(--border),
+    0 8px 60px 0 rgba(2, 2, 2, 0.5);
 }
 
 .theme-layout-navbar a {

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -231,6 +231,248 @@
   --ifm-menu-color-active: var(--mastra-text-primary);
 }
 
+/* ==================================================================== */
+/* Ported design tokens from @mastra/docusaurus-theme                    */
+/* These make the new theme's CSS variables available here so plugins    */
+/* (Algolia, Kapa chat, Shiki) can be ported without redefining tokens.  */
+/* New variables only — existing ifm / mastra-text values above are      */
+/* intentionally left untouched. Font vars are remapped to the fonts     */
+/* this repo actually ships (Inter / Geist Mono).                        */
+/* ==================================================================== */
+
+/* Palette: raw dark values */
+:root {
+  --mastra-color-dark-surface-bg: #020202;
+  --mastra-color-dark-surface-antigrid: #0d0d0d;
+  --mastra-color-dark-surface-elevation-sm: #171717;
+  --mastra-color-dark-surface-elevation-lg: #141414;
+  --mastra-color-dark-surface-hover: #262626;
+
+  --mastra-color-dark-border-antigrid: #191919;
+  --mastra-color-dark-border-elevation: #1a1a1a;
+
+  --mastra-color-dark-main-white: #f0f0f0;
+  --mastra-color-dark-special-gray: #cccccc;
+  --mastra-color-dark-main-gray: #939393;
+  --mastra-color-dark-dark-gray: #424242;
+
+  --mastra-color-dark-green: #72ff70;
+  --mastra-color-dark-orange: #ffa94b;
+  --mastra-color-dark-pink: #ff69cc;
+  --mastra-color-dark-purple: #be96ff;
+  --mastra-color-dark-blue: #6ccdfb;
+  --mastra-color-dark-red: #ff4758;
+  --mastra-color-dark-yellow: #e7e67b;
+
+  /* Palette: raw light values */
+  --mastra-color-light-surface-bg: #f8f8f8;
+  --mastra-color-light-surface-antigrid: #f4f4f4;
+  --mastra-color-light-surface-elevation-sm: #ebebeb;
+  --mastra-color-light-surface-elevation-lg: #f0f0f0;
+  --mastra-color-light-surface-hover: #e6e6e6;
+
+  --mastra-color-light-border-antigrid: #e5e2e2;
+  --mastra-color-light-border-elevation: #dfdfdf;
+
+  --mastra-color-light-main-white: #0f0f0f;
+  --mastra-color-light-special-gray: #272727;
+  --mastra-color-light-main-gray: #4b4b4b;
+  --mastra-color-light-dark-gray: #424242;
+
+  --mastra-color-light-green: #028300;
+  --mastra-color-light-orange: #9d5200;
+  --mastra-color-light-pink: #dd48ad;
+  --mastra-color-light-purple: #8c45ff;
+  --mastra-color-light-blue: #238db9;
+  --mastra-color-light-red: #f43c4f;
+  --mastra-color-light-yellow: #8a8806;
+
+  /* Themed aliases (light default, dark override below) */
+  --mastra-color-surface-bg: var(--mastra-color-light-surface-bg);
+  --mastra-color-surface-antigrid: var(--mastra-color-light-surface-antigrid);
+  --mastra-color-surface-elevation-sm: var(--mastra-color-light-surface-elevation-sm);
+  --mastra-color-surface-elevation-lg: var(--mastra-color-light-surface-elevation-lg);
+  --mastra-color-surface-hover: var(--mastra-color-light-surface-hover);
+
+  --mastra-color-border-antigrid: var(--mastra-color-light-border-antigrid);
+  --mastra-color-border-elevation: var(--mastra-color-light-border-elevation);
+
+  --mastra-shadow-dropdown: 0 4px 54px 0 rgba(0, 0, 0, 0.12);
+
+  --mastra-color-main-white: var(--mastra-color-light-main-white);
+  --mastra-color-special-gray: var(--mastra-color-light-special-gray);
+  --mastra-color-main-gray: var(--mastra-color-light-main-gray);
+  --mastra-color-dark-gray: var(--mastra-color-light-dark-gray);
+
+  --mastra-color-green: var(--mastra-color-light-green);
+  --mastra-color-orange: var(--mastra-color-light-orange);
+  --mastra-color-pink: var(--mastra-color-light-pink);
+  --mastra-color-purple: var(--mastra-color-light-purple);
+  --mastra-color-blue: var(--mastra-color-light-blue);
+  --mastra-color-red: var(--mastra-color-light-red);
+  --mastra-color-yellow: var(--mastra-color-light-yellow);
+
+  /* Sizings — radius + spacing */
+  --mastra-radius: 1.875rem;
+  --mastra-radius-sm: 1.25rem;
+  --mastra-radius-md: 2rem;
+  --mastra-radius-lg: 2.625rem;
+  --mastra-radius-elevation: 1rem;
+
+  --mastra-spacing: 0.25rem;
+
+  --mastra-button-padding-vertical: 0.375rem;
+  --mastra-button-padding-horizontal: 0.625rem;
+
+  /* Fonts — remapped to the fonts this repo ships */
+  --mastra-font-sans: var(--font-sans);
+  --mastra-font-heading: var(--font-sans);
+  --mastra-font-mono: var(--font-mono);
+  --mastra-font-mono-weight: 550;
+  --mastra-font-feature-settings: 'ss01', 'ss02';
+
+  /* Heading sizes */
+  --mastra-text-h1: 2.5rem;
+  --mastra-text-h1-leading: 110%;
+  --mastra-text-h1-weight: 520;
+  --mastra-text-h1-tracking: 0.015em;
+
+  --mastra-text-h2: 2rem;
+  --mastra-text-h2-leading: 110%;
+  --mastra-text-h2-weight: 520;
+  --mastra-text-h2-tracking: 0.015em;
+
+  --mastra-text-h3: 1.5rem;
+  --mastra-text-h3-leading: 110%;
+  --mastra-text-h3-weight: 520;
+  --mastra-text-h3-tracking: 0.015em;
+
+  --mastra-text-h4: 1.25rem;
+  --mastra-text-h4-leading: 110%;
+  --mastra-text-h4-weight: 520;
+  --mastra-text-h4-tracking: 0.015em;
+
+  /* Body sizes */
+  --mastra-text-body: 1rem;
+  --mastra-text-body-lg: 1.125rem;
+  --mastra-text-body-leading: 1.6;
+
+  --mastra-text-body-sm: 0.9375rem;
+  --mastra-text-body-sm-lg: 1.0625rem;
+
+  /* Plugin: Algolia search */
+  --algolia-bg: var(--mastra-color-surface-antigrid);
+  --algolia-bg-selected: var(--mastra-color-surface-elevation-sm);
+  --algolia-border: var(--mastra-color-border-elevation);
+  --algolia-text-primary: var(--ifm-color-content);
+  --algolia-text-secondary: var(--mastra-color-main-gray);
+  --algolia-text-icon: var(--ifm-color-emphasis-600);
+  --algolia-highlight: var(--ifm-color-primary);
+  --algolia-caret: var(--ifm-color-primary);
+
+  /* Plugin: Kapa chat */
+  --chat-bg-primary: var(--mastra-color-surface-bg);
+  --chat-bg-secondary: var(--mastra-color-surface-elevation-sm);
+  --chat-bg-elevated: var(--mastra-color-surface-elevation-lg);
+  --chat-bg-input: var(--mastra-color-surface-hover);
+  --chat-text-primary: var(--mastra-color-main-white);
+  --chat-text-muted: var(--mastra-color-main-gray);
+  --chat-accent-primary: var(--mastra-color-green);
+  --chat-border: var(--mastra-color-border-elevation);
+  --chat-feedback-positive: var(--mastra-color-green);
+  --chat-feedback-negative: var(--mastra-color-red);
+
+  --doc-chat-sidebar-width: clamp(20rem, 25vw, 34rem);
+  --doc-chat-sidebar-outer-gap: 1rem;
+  --doc-chat-sidebar-inner-gap: 0.6rem;
+
+  /* Shiki syntax highlighter */
+  --shiki-foreground: var(--mastra-color-main-white);
+  --shiki-background: var(--mastra-color-surface-antigrid);
+  --shiki-token-constant: var(--mastra-color-main-white);
+  --shiki-token-string: var(--mastra-color-green);
+  --shiki-token-string-expression: var(--mastra-color-green);
+  --shiki-token-comment: var(--mastra-color-main-gray);
+  --shiki-token-keyword: var(--mastra-color-orange);
+  --shiki-token-parameter: var(--mastra-color-main-white);
+  --shiki-token-function: var(--mastra-color-red);
+  --shiki-token-import: var(--mastra-color-red);
+  --shiki-token-punctuation: var(--mastra-color-purple);
+  --shiki-token-link: var(--mastra-color-main-white);
+
+  @media (min-width: 40rem) {
+    --mastra-radius: 2.625rem;
+    --mastra-radius-lg: 3.875rem;
+    --mastra-radius-elevation: 1.3125rem;
+  }
+}
+
+/* Themed aliases + plugin overrides for dark mode */
+[data-theme='dark'] {
+  --mastra-color-surface-bg: var(--mastra-color-dark-surface-bg);
+  --mastra-color-surface-antigrid: var(--mastra-color-dark-surface-antigrid);
+  --mastra-color-surface-elevation-sm: var(--mastra-color-dark-surface-elevation-sm);
+  --mastra-color-surface-elevation-lg: var(--mastra-color-dark-surface-elevation-lg);
+  --mastra-color-surface-hover: var(--mastra-color-dark-surface-hover);
+
+  --mastra-color-border-antigrid: var(--mastra-color-dark-border-antigrid);
+  --mastra-color-border-elevation: var(--mastra-color-dark-border-elevation);
+
+  --mastra-shadow-dropdown: 0 4px 54px 0 rgba(0, 0, 0, 0.8);
+
+  --mastra-color-main-white: var(--mastra-color-dark-main-white);
+  --mastra-color-special-gray: var(--mastra-color-dark-special-gray);
+  --mastra-color-main-gray: var(--mastra-color-dark-main-gray);
+  --mastra-color-dark-gray: var(--mastra-color-dark-dark-gray);
+
+  --mastra-color-green: var(--mastra-color-dark-green);
+  --mastra-color-orange: var(--mastra-color-dark-orange);
+  --mastra-color-pink: var(--mastra-color-dark-pink);
+  --mastra-color-purple: var(--mastra-color-dark-purple);
+  --mastra-color-blue: var(--mastra-color-dark-blue);
+  --mastra-color-red: var(--mastra-color-dark-red);
+  --mastra-color-yellow: var(--mastra-color-dark-yellow);
+
+  --mastra-font-mono-weight: 500;
+
+  /* Algolia (dark overrides) */
+  --algolia-text-icon: var(--ifm-color-emphasis-500);
+
+  /* Kapa chat (dark overrides) */
+  --kapa-text-icon: var(--ifm-color-emphasis-500);
+  --kapa-bg-user: var(--ifm-color-emphasis-200);
+  --kapa-bg-ai: var(--ifm-color-emphasis-100);
+}
+
+/* Tailwind @theme mappings for the ported palette + radius */
+@theme {
+  --color-mastra-surface-bg: var(--mastra-color-surface-bg);
+  --color-mastra-surface-antigrid: var(--mastra-color-surface-antigrid);
+  --color-mastra-surface-elevation-sm: var(--mastra-color-surface-elevation-sm);
+  --color-mastra-surface-elevation-lg: var(--mastra-color-surface-elevation-lg);
+  --color-mastra-surface-hover: var(--mastra-color-surface-hover);
+
+  --color-mastra-border-antigrid: var(--mastra-color-border-antigrid);
+  --color-mastra-border-elevation: var(--mastra-color-border-elevation);
+
+  --color-mastra-main-white: var(--mastra-color-main-white);
+  --color-mastra-special-gray: var(--mastra-color-special-gray);
+  --color-mastra-main-gray: var(--mastra-color-main-gray);
+  --color-mastra-dark-gray: var(--mastra-color-dark-gray);
+
+  --color-mastra-green: var(--mastra-color-green);
+  --color-mastra-orange: var(--mastra-color-orange);
+  --color-mastra-pink: var(--mastra-color-pink);
+  --color-mastra-purple: var(--mastra-color-purple);
+  --color-mastra-blue: var(--mastra-color-blue);
+  --color-mastra-red: var(--mastra-color-red);
+  --color-mastra-yellow: var(--mastra-color-yellow);
+
+  --radius-mastra: var(--mastra-radius);
+  --radius-mastra-lg: var(--mastra-radius-lg);
+  --radius-mastra-elevation: var(--mastra-radius-elevation);
+}
+
 body,
 html {
   overscroll-behavior: none;
@@ -260,9 +502,14 @@ html {
   height: auto;
   padding-inline: 0;
   padding-block: 0;
-  border-bottom: transparent;
-  box-shadow: none;
+  border-bottom: 2px solid var(--border);
+  box-shadow: 0 0 37.7px 0 #eaeaea;
   background-color: var(--ifm-navbar-background-color);
+}
+
+[data-theme='dark'] .theme-layout-navbar {
+  border-bottom-color: var(--border);
+  box-shadow: 0 8px 60px 0 rgba(2, 2, 2, 0.5);
 }
 
 .theme-layout-navbar a {
@@ -1010,7 +1257,9 @@ article p {
 
   /* ==================== SIDEBAR ==================== */
   .theme-doc-sidebar-container {
-    border-right: 0.5px solid var(--border);
+    border-right: 2px solid var(--border);
+    /* Allow the inverse corner to overflow past the sidebar's right edge */
+    clip-path: none;
   }
 
   [data-theme='dark'] .theme-doc-sidebar-container {
@@ -1370,7 +1619,7 @@ article p {
 
   .theme-doc-sidebar-container.theme-doc-sidebar-container {
     padding-inline-start: 0rem;
-    border-right: var(--border-sm) solid var(--border);
+    border-right: 2px solid var(--border);
   }
 
   [class*='sidebar']:has(> .menu) {

--- a/docs/custom.css
+++ b/docs/custom.css
@@ -502,7 +502,7 @@ html {
   height: auto;
   padding-inline: 0;
   padding-block: 0;
-  border-bottom: 2px solid var(--border);
+  border-bottom: 1px solid var(--border);
   box-shadow: 0 0 37.7px 0 #eaeaea;
   background-color: var(--ifm-navbar-background-color);
 }
@@ -553,7 +553,7 @@ html {
 }
 
 [data-theme='dark'] .navbar {
-  border-bottom-color: var(--mastra-border);
+  border-bottom-color: var(--border);
 }
 
 .navbar__link {
@@ -1257,9 +1257,7 @@ article p {
 
   /* ==================== SIDEBAR ==================== */
   .theme-doc-sidebar-container {
-    border-right: 2px solid var(--border);
-    /* Allow the inverse corner to overflow past the sidebar's right edge */
-    clip-path: none;
+    border-right: 1px solid var(--border);
   }
 
   [data-theme='dark'] .theme-doc-sidebar-container {
@@ -1619,7 +1617,11 @@ article p {
 
   .theme-doc-sidebar-container.theme-doc-sidebar-container {
     padding-inline-start: 0rem;
-    border-right: 2px solid var(--border);
+    border-right: 1px solid var(--border);
+    /* Docusaurus's sidebar container module sets clip-path: inset(0), which
+       clips the inverse corner that intentionally overflows the right edge.
+       Override it here with matching-or-higher specificity. */
+    clip-path: none;
   }
 
   [class*='sidebar']:has(> .menu) {

--- a/docs/src/theme/DocSidebar/Desktop/InverseCorner.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/InverseCorner.tsx
@@ -25,19 +25,21 @@ export interface InverseCornerProps {
 /**
  * Fill path for a concave top-right corner in a 1×1 viewBox.
  *
- * Arc goes from (1,i) to (i,1), then closes through the (0,0) corner.
- * Straight edges overshoot by `o` to bleed over the parent's border.
+ * The arc runs corner-to-corner, from the box's top-right (1,0) to its
+ * bottom-left (0,1), then closes back through the (0,0) corner. The straight
+ * edges overshoot by `O` so the fill bleeds over the parent's borders and
+ * leaves no gap.
  */
-const O = 0.05
-const I = 0.03
-const FILL_PATH = `M ${1 + O} ${I} A 1 1 0 0 0 ${I} ${1 + O} L ${-O} ${1 + O} L ${-O} ${-O} L ${1 + O} ${-O} Z`
+const O = 0.1
+const FILL_PATH = `M 1 0 A 1 1 0 0 0 0 1 L ${-O} 1 L ${-O} ${-O} L 1 ${-O} Z`
 
 /**
- * Arc-only path for stroke rendering. Endpoints are inset by `I` so the arc
- * doesn't start flush at the edge, creating a smoother transition into the
- * parent's straight border.
+ * Arc-only path for stroke rendering. The arc spans the full quarter circle,
+ * from the top edge (1,0) to the left edge (0,1), so its endpoints land
+ * exactly on the parent's navbar-bottom and sidebar-right borders. Position
+ * the SVG so this stroke overlaps those borders (see the consumer).
  */
-const ARC_PATH = `M 1 ${I} A 1 1 0 0 0 ${I} 1`
+const ARC_PATH = `M 1 0 A 1 1 0 0 0 0 1`
 
 /**
  * Renders an "inverse border-radius" — a concave quarter-circle at the
@@ -64,6 +66,7 @@ export function InverseCorner({
         position: 'absolute',
         display: 'block',
         pointerEvents: 'none',
+        overflow: 'visible',
         bottom: '100%',
         right: 0,
         width: size,

--- a/docs/src/theme/DocSidebar/Desktop/InverseCorner.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/InverseCorner.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties } from 'react'
+
+export interface InverseCornerProps {
+  /**
+   * CSS value for the corner radius, e.g. "12px" or "var(--radius)".
+   * Sets both width and height of the SVG.
+   */
+  size: string
+  /**
+   * Fill color — should match the parent's background.
+   */
+  fill?: string
+  /**
+   * Optional border/stroke color.
+   */
+  borderColor?: string
+  /**
+   * Border width in pixels.
+   */
+  borderWidth?: number
+  className?: string
+  style?: CSSProperties
+}
+
+/**
+ * Fill path for a concave top-right corner in a 1×1 viewBox.
+ *
+ * Arc goes from (1,i) to (i,1), then closes through the (0,0) corner.
+ * Straight edges overshoot by `o` to bleed over the parent's border.
+ */
+const O = 0.05
+const I = 0.03
+const FILL_PATH = `M ${1 + O} ${I} A 1 1 0 0 0 ${I} ${1 + O} L ${-O} ${1 + O} L ${-O} ${-O} L ${1 + O} ${-O} Z`
+
+/**
+ * Arc-only path for stroke rendering. Endpoints are inset by `I` so the arc
+ * doesn't start flush at the edge, creating a smoother transition into the
+ * parent's straight border.
+ */
+const ARC_PATH = `M 1 ${I} A 1 1 0 0 0 ${I} 1`
+
+/**
+ * Renders an "inverse border-radius" — a concave quarter-circle at the
+ * top-right that makes a div appear to extend outward with a smooth curve.
+ *
+ * Place this inside a `position: relative` parent. The SVG is absolutely
+ * positioned above the parent's top-right edge, extending outward.
+ */
+export function InverseCorner({
+  size,
+  fill = 'currentColor',
+  borderColor,
+  borderWidth = 1,
+  className,
+  style,
+}: InverseCornerProps) {
+  return (
+    <svg
+      viewBox="0 0 1 1"
+      preserveAspectRatio="none"
+      aria-hidden="true"
+      className={className}
+      style={{
+        position: 'absolute',
+        display: 'block',
+        pointerEvents: 'none',
+        bottom: '100%',
+        right: 0,
+        width: size,
+        height: size,
+        ...style,
+      }}
+    >
+      <path d={FILL_PATH} fill={fill} stroke="none" />
+      {borderColor && (
+        <path
+          d={ARC_PATH}
+          fill="none"
+          stroke={borderColor}
+          strokeWidth={borderWidth}
+          vectorEffect="non-scaling-stroke"
+        />
+      )}
+    </svg>
+  )
+}

--- a/docs/src/theme/DocSidebar/Desktop/InverseCorner.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/InverseCorner.tsx
@@ -43,10 +43,11 @@ const ARC_PATH = `M 1 0 A 1 1 0 0 0 0 1`
 
 /**
  * Renders an "inverse border-radius" — a concave quarter-circle at the
- * top-right that makes a div appear to extend outward with a smooth curve.
+ * top-right that makes a surface appear to extend outward with a smooth curve.
  *
- * Place this inside a `position: relative` parent. The SVG is absolutely
- * positioned above the parent's top-right edge, extending outward.
+ * The SVG is positioned (absolute by default) at its top-right edge. Pass a
+ * `style` to override the positioning — the consumer pins it at the
+ * navbar/sidebar junction (see DocSidebar/Desktop).
  */
 export function InverseCorner({
   size,

--- a/docs/src/theme/DocSidebar/Desktop/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/index.tsx
@@ -10,6 +10,7 @@ import { ThemeSwitcher } from '@site/src/components/theme-switcher'
 
 import styles from './styles.module.css'
 import VersionControl from '@site/src/components/version-control'
+import { InverseCorner } from './InverseCorner'
 
 function DocSidebarDesktop({ path, sidebar, onCollapse, isHidden }: Props) {
   const {
@@ -26,6 +27,18 @@ function DocSidebarDesktop({ path, sidebar, onCollapse, isHidden }: Props) {
         isHidden && styles.sidebarHidden,
       )}
     >
+      <InverseCorner
+        size="12px"
+        fill="var(--ifm-background-color)"
+        borderColor="var(--border)"
+        borderWidth={2}
+        style={{
+          bottom: 'auto',
+          top: 'var(--ifm-navbar-height)',
+          right: -2,
+          transform: 'translateX(100%)',
+        }}
+      />
       <div className="my-4 mr-[7px] mb-2">
         <VersionControl />
       </div>

--- a/docs/src/theme/DocSidebar/Desktop/index.tsx
+++ b/docs/src/theme/DocSidebar/Desktop/index.tsx
@@ -28,15 +28,17 @@ function DocSidebarDesktop({ path, sidebar, onCollapse, isHidden }: Props) {
       )}
     >
       <InverseCorner
-        size="12px"
-        fill="var(--ifm-background-color)"
+        size="24px"
+        fill="var(--ifm-navbar-background-color)"
         borderColor="var(--border)"
-        borderWidth={2}
+        borderWidth={1}
         style={{
+          position: 'fixed',
           bottom: 'auto',
+          right: 'auto',
           top: 'var(--ifm-navbar-height)',
-          right: -2,
-          transform: 'translateX(100%)',
+          left: 'var(--doc-sidebar-width)',
+          transform: 'translate(-0.5px, -0.5px)',
         }}
       />
       <div className="my-4 mr-[7px] mb-2">

--- a/docs/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/styles.module.css
@@ -5,6 +5,7 @@
     height: 100%;
     padding-top: var(--ifm-navbar-height);
     width: var(--doc-sidebar-width);
+    position: relative;
   }
 
   .sidebarWithHideableNavbar {

--- a/docs/src/theme/DocSidebar/Desktop/styles.module.css
+++ b/docs/src/theme/DocSidebar/Desktop/styles.module.css
@@ -5,7 +5,6 @@
     height: 100%;
     padding-top: var(--ifm-navbar-height);
     width: var(--doc-sidebar-width);
-    position: relative;
   }
 
   .sidebarWithHideableNavbar {

--- a/docs/src/theme/Navbar/index.tsx
+++ b/docs/src/theme/Navbar/index.tsx
@@ -9,7 +9,7 @@ import { TabSwitcher } from './tab-switcher'
 
 function NavbarContentDesktop() {
   return (
-    <div className="@container mx-auto flex h-(--ifm-navbar-height) w-full items-center justify-between border-b-[0.5px] border-(--border-subtle) px-4">
+    <div className="@container mx-auto flex h-(--ifm-navbar-height) w-full items-center justify-between px-4">
       <div className="flex items-center gap-2">
         <Link href="/docs" aria-label="mastra.ai, Back to docs homepage">
           <Logo />


### PR DESCRIPTION
## Summary

Aligns the docs site's navbar (toolbar) and sidebar chrome with the newer Docusaurus theme, and makes that theme's design tokens available here so upcoming plugin ports (Algolia search, Kapa chat, Shiki) have the CSS variables they expect.

## Visual changes

- **Navbar hairline + drop shadow** — a 1px bottom hairline plus a soft drop shadow below the navbar, in both light and dark mode. The hairline is drawn as a `box-shadow` layer rather than a `border-bottom` so it stays purely visual and does not add to the navbar's height (see "Why box-shadow" below).
- **Sidebar right border** — a matching 1px right border on the sidebar, so the navbar bottom and sidebar right read as one continuous 1px frame.
- **Inverse concave corner** — a smooth curved corner where the top-right of the sidebar meets the navbar, blending the two surfaces. Implemented as a small swizzle-local `InverseCorner` SVG component rendered from the existing `DocSidebar/Desktop` swizzle. It is `position: fixed` and pinned to the navbar/sidebar junction so it stays aligned with the fixed navbar while the sidebar content scrolls underneath.

## Why box-shadow for the navbar hairline

The navbar's height is driven by `--ifm-navbar-height` (47px), and the rest of the layout (the sidebar's sticky offset, the sidebar aside's negative top margin) assumes that value. A real `border-bottom` added 1px to the navbar's occupied height, pushing it to 48px and desyncing the sidebar by 1px — the sidebar visibly jumped up as soon as the page started scrolling. Rendering the hairline as a `box-shadow` keeps the navbar at exactly 47px, so there is no jump.

## Design tokens

Ported the newer theme's tokens as **new variables only** — no existing color values were changed:

- Full `--mastra-color-*` palette (raw light/dark values plus themed aliases with dark overrides)
- Radius/spacing scale and `--mastra-shadow-dropdown`
- Plugin-scoped vars: `--algolia-*`, `--chat-*` (Kapa), `--doc-chat-*`
- `--shiki-*` syntax highlighter tokens
- Tailwind `@theme` mappings (`--color-mastra-*`, `--radius-mastra*`)
- Font/typography vars, with font families remapped to the fonts this repo actually ships (Inter / Geist Mono) rather than the reference theme's unbundled fonts

These tokens are staged for the follow-up plugin ports and are not consumed by any rule yet.

## Test plan

- Prettier passes on all changed files.
- Manual verification in the running `pnpm dev` server (per `docs/AGENTS.md`, no production build during work), light and dark mode:
  - Navbar shows a soft drop shadow plus a 1px bottom hairline; navbar height stays 47px.
  - Sidebar has a matching 1px right border, forming a continuous frame with the navbar.
  - The top-right sidebar corner shows a smooth concave curve into the navbar, with the border stroke continuing around the arc.
  - Scrolling the docs page does not shift the sidebar or corner — no 1px jump (regression this PR fixes).
  - Corner isn't clipped and doesn't block pointer events; mobile/tablet layout is unaffected (desktop-only rules).

`mastra-docs` is a private package, so no changeset is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update makes the docs site look more like the newer design by smoothing out the top of the sidebar, adding a subtle navbar shadow, and lining up the sidebar and navbar edges better. It also brings over a set of design tokens so the docs package can use the newer theme’s colors, spacing, fonts, and syntax highlighting settings without changing the existing color palette.

### What changed
- Ported the newer theme’s design tokens into `docs/custom.css`
  - added light/dark palette variables and themed aliases
  - added radius, spacing, shadow, font, and typography tokens
  - added Tailwind `@theme` mappings
  - added plugin-scoped variables for Algolia, Kapa/chat, doc chat, and Shiki
- Updated navbar styling
  - replaced the bottom border treatment with a `box-shadow` hairline/shadow so the navbar stays at 47px
- Updated sidebar styling
  - added a 1px right border to match the navbar frame
  - disabled the upstream sidebar `clip-path` behavior so the corner treatment can work cleanly
- Added a new `InverseCorner` SVG component for the concave top-right sidebar corner
- Rendered that inverse-corner component in the desktop sidebar
- Removed the navbar’s old bottom border classes

### Notes
- No existing color values were changed; this only adds new token variables.
- No changeset was included because `mastra-docs` is private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->