### PR TITLE
fix: pin @opencode-ai/plugin to prevent pnpm trust downgrade

### DIFF
--- a/integrations/opencode/package.json
+++ b/integrations/opencode/package.json
@@ -57,7 +57,7 @@
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",
-    "@opencode-ai/plugin": "^1.2.27",
+    "@opencode-ai/plugin": "1.14.48",
     "@opencode-ai/sdk": "^1.17.4",
     "tsup": "^8.5.1",
     "typescript": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2067,7 +2067,7 @@ importers:
         specifier: workspace:*
         version: link:../../packages/_types-builder
       '@opencode-ai/plugin':
-        specifier: ^1.2.27
+        specifier: 1.14.48
         version: 1.14.48
       '@opencode-ai/sdk':
         specifier: ^1.17.4

--- a/renovate.json
+++ b/renovate.json
@@ -422,6 +422,11 @@
       "matchDepTypes": ["dependencies", "devDependencies"]
     },
     {
+      "description": "Disable @opencode-ai/plugin updates. Newer plugin versions pull effect@4.0.0-beta.83, which pnpm rejects as a trust downgrade under trustPolicy: no-downgrade. The plugin is exact-pinned to 1.14.48 (effect@4.0.0-beta.59) until upstream publishes a version that does not trigger ERR_PNPM_TRUST_DOWNGRADE.",
+      "matchPackageNames": ["@opencode-ai/plugin"],
+      "enabled": false
+    },
+    {
       "groupName": "OpenCode",
       "commitMessageTopic": "OpenCode",
       "matchFileNames": ["+(package.json)", "**/package.json"],


### PR DESCRIPTION
Renovate PR #19080 was failing because newer @opencode-ai/plugin versions pull in effect@4.0.0-beta.83, which pnpm 11 rejects under the workspace's trustPolicy: no-downgrade setting.

This pins @opencode-ai/plugin to 1.14.48 (which resolves effect@4.0.0-beta.59, already trusted) and tells Renovate to skip plugin updates until upstream ships a version that doesn't trigger the trust downgrade. No new trust exceptions are added — the existing policy stays strict.

```diff
- "@opencode-ai/plugin": "^1.2.27"
+ "@opencode-ai/plugin": "1.14.48"
```

The broader @opencode-ai/* Renovate group is untouched, so @opencode-ai/sdk and other OpenCode packages continue to get minor/patch updates normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change keeps one tool version locked to a safe older release so updates don’t break the project’s security/trust checks. It also tells Renovate to stop trying to update that one package for now, while leaving other package updates alone.

## Summary
- Pinned `@opencode-ai/plugin` in `integrations/opencode/package.json` to `1.14.48`.
- Added a Renovate `packageRules` entry to disable updates for `@opencode-ai/plugin` until a compatible upstream release is available.
- Left the workspace trust policy unchanged and did not add any new trust exceptions.
- Regenerated the lockfile only to reflect the specifier change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->