### PR TITLE
refactor(mastracode): split chat session startup

### DIFF
--- a/.changeset/chat-session-startup-gate.md
+++ b/.changeset/chat-session-startup-gate.md
@@ -1,0 +1,5 @@
+---
+'mastracode-web': patch
+---
+
+Improved Mastra Code chat startup by showing clear connecting and error states before loading the session.

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -45,11 +45,13 @@ export const queryKeys = {
     agentControllerId: string | undefined,
     resourceId: string | undefined,
     threadId: string | undefined,
+    syncEpoch?: number,
   ) =>
     [
       ...queryKeys.agentControllerSession(agentControllerId, resourceId),
       'threads',
       threadId ?? null,
       'messages',
+      syncEpoch ?? 0,
     ] as const,
 } as const;

--- a/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
@@ -197,14 +197,11 @@ describe('MastraCode sidebar auth actions', () => {
 });
 
 describe('MastraCode empty thread state', () => {
-  it('given a project with no messages, when the app renders, then the Mastra Code wordmark hero appears', async () => {
+  it('given a project with no messages, when the app renders, then the empty-thread project summary appears', async () => {
     renderSeededApp();
 
-    expect(await screen.findByText('Ready for new conversation')).toBeInTheDocument();
-    const wordmark = screen.getByLabelText('Mastra Code');
-    expect(wordmark).toBeInTheDocument();
-    // The hero sits inside the transcript scroller, which centers empty content vertically.
-    expect(wordmark.closest('.place-items-center')).not.toBeNull();
+    await waitFor(() => expect(screen.getByText('Ready for new conversation')).toBeInTheDocument());
+    expect(screen.queryByText('Loading messages')).not.toBeInTheDocument();
   });
 });
 

--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList.tsx
@@ -12,6 +12,7 @@ import type { Project } from '../../workspaces';
 import { useActiveProjectContext } from '../../workspaces';
 import type { ChatSessionApi } from '../context/ChatSessionProvider';
 import { useChatSession } from '../context/ChatSessionProvider';
+import { useThreadMessages } from '../context/ChatThreadMessages';
 import {
   useClearAgentControllerGoalMutation,
   usePauseAgentControllerGoalMutation,
@@ -36,7 +37,8 @@ const emptyThreadClass = 'w-full max-w-[80ch] px-7 text-left font-mono text-sm l
 export function ChatMessageList() {
   const { baseUrl } = useApiConfig();
   const { activeProject, resourceId, sessionEnabled } = useActiveProjectContext();
-  const { transcript, status, showWorkingIndicator, messagesPending, resolvePrompt } = useChatSession();
+  const { transcript, status, showWorkingIndicator, resolvePrompt } = useChatSession();
+  const { messagesPending } = useThreadMessages();
   const { threadRef, showScrollDown, scrollToBottom } = useTranscriptScroll(transcript);
   const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
   const approveMutation = useApproveAgentControllerToolMutation(hookArgs);
@@ -75,7 +77,7 @@ export function ChatMessageList() {
         activeProject={activeProject}
         transcript={transcript}
         showWorkingIndicator={showWorkingIndicator}
-        messagesPending={messagesPending || status === 'connecting'}
+        messagesPending={messagesPending}
         threadRef={threadRef}
         onApprove={onApprove}
         onRespond={onRespond}

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatMessageList.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatMessageList.msw.test.tsx
@@ -107,15 +107,17 @@ describe('ChatMessageList', () => {
     useAgentControllerHandlers();
     renderMessageList();
 
-    await waitFor(() => expect(screen.getByText('Ready for new conversation')).toBeInTheDocument());
-    expect(screen.getByText('Project')).toBeInTheDocument();
-    expect(screen.getByText('MastraCode Test')).toBeInTheDocument();
-    expect(screen.getByText('Resource ID')).toBeInTheDocument();
-    expect(screen.getByText(RESOURCE_ID)).toBeInTheDocument();
-    expect(screen.getByText('Branch')).toBeInTheDocument();
-    expect(screen.getByText('main')).toBeInTheDocument();
-    expect(screen.getByText('Workspace')).toBeInTheDocument();
-    expect(screen.getByText('/tmp/mastracode-test')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('Ready for new conversation')).toBeInTheDocument();
+      expect(screen.getByText('Project')).toBeInTheDocument();
+      expect(screen.getByText('MastraCode Test')).toBeInTheDocument();
+      expect(screen.getByText('Resource ID')).toBeInTheDocument();
+      expect(screen.getByText(RESOURCE_ID)).toBeInTheDocument();
+      expect(screen.getByText('Branch')).toBeInTheDocument();
+      expect(screen.getByText('main')).toBeInTheDocument();
+      expect(screen.getByText('Workspace')).toBeInTheDocument();
+      expect(screen.getByText('/tmp/mastracode-test')).toBeInTheDocument();
+    });
   });
 
   it('given streamed assistant text, then it renders the transcript entry', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/ThreadList.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/ThreadList.msw.test.tsx
@@ -197,8 +197,9 @@ describe('ThreadList', () => {
     useAgentControllerHandlers([threadOne, threadTwo]);
     renderThreadList();
 
+    await screen.findByText('Second thread');
     await userEvent.click(screen.getByRole('button', { name: 'open sidebar' }));
-    await userEvent.click(await screen.findByText('Second thread'));
+    await userEvent.click(screen.getByText('Second thread'));
 
     await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/threads/thread-two'));
     expect(screen.getByTestId('sidebar-open')).toHaveTextContent('no');

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionGate.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionGate.tsx
@@ -48,9 +48,20 @@ export function ChatConnectionGate({ children, resourceId, projectPath, sessionE
     return connection.status === 'error' ? <ConnectionErrorState /> : <ConnectionLoadingState />;
   }
 
+  const initialThreadId = eventHandlerRef.current
+    ? connection.state.threadId
+    : (connection.createdThreadId ?? connection.state.threadId);
+  const runtimeKey = [
+    'connected',
+    connection.stateUpdatedAt,
+    connection.state.threadId ?? '',
+    connection.state.modeId ?? '',
+    connection.state.modelId ?? '',
+  ].join(':');
+
   return (
     <ChatSessionRuntime
-      key="connected"
+      key={runtimeKey}
       resourceId={resourceId}
       sessionEnabled={sessionEnabled}
       status={connection.status}
@@ -58,7 +69,7 @@ export function ChatConnectionGate({ children, resourceId, projectPath, sessionE
       eventHandlerRef={eventHandlerRef}
       state={connection.state}
       stateUpdatedAt={connection.stateUpdatedAt}
-      createdThreadId={connection.createdThreadId}
+      initialThreadId={initialThreadId}
     >
       {children}
     </ChatSessionRuntime>

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionGate.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionGate.tsx
@@ -1,0 +1,88 @@
+import type { AgentControllerEvent } from '@mastra/client-js';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { useRef } from 'react';
+import type { ReactNode } from 'react';
+
+import { useApiConfig } from '../../../../../shared/api/config';
+import { Wordmark } from '../../../ui';
+import { useAgentControllerConnection } from '../hooks/useAgentControllerConnection';
+import { AGENT_CONTROLLER_ID } from '../services/constants';
+import { ChatSessionRuntime } from './ChatSessionRuntime';
+
+interface ChatConnectionGateProps {
+  children: ReactNode;
+  resourceId: string;
+  projectPath?: string;
+  sessionEnabled: boolean;
+}
+
+export function ChatConnectionGate({ children, resourceId, projectPath, sessionEnabled }: ChatConnectionGateProps) {
+  const { baseUrl } = useApiConfig();
+  const eventHandlerRef = useRef<((event: AgentControllerEvent) => void) | null>(null);
+  const connection = useAgentControllerConnection({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceId,
+    projectPath,
+    baseUrl,
+    enabled: sessionEnabled,
+    onEvent: event => eventHandlerRef.current?.(event),
+  });
+
+  if (!sessionEnabled) {
+    return (
+      <ChatSessionRuntime
+        key="dormant"
+        resourceId={resourceId}
+        sessionEnabled={sessionEnabled}
+        status="connecting"
+        modes={[]}
+        eventHandlerRef={eventHandlerRef}
+      >
+        {children}
+      </ChatSessionRuntime>
+    );
+  }
+
+  if (!connection.state) {
+    return connection.status === 'error' ? <ConnectionErrorState /> : <ConnectionLoadingState />;
+  }
+
+  return (
+    <ChatSessionRuntime
+      key="connected"
+      resourceId={resourceId}
+      sessionEnabled={sessionEnabled}
+      status={connection.status}
+      modes={connection.modes}
+      eventHandlerRef={eventHandlerRef}
+      state={connection.state}
+      stateUpdatedAt={connection.stateUpdatedAt}
+      createdThreadId={connection.createdThreadId}
+    >
+      {children}
+    </ChatSessionRuntime>
+  );
+}
+
+function ConnectionLoadingState() {
+  return (
+    <div role="status" aria-live="polite" className="flex min-h-0 flex-1 flex-col items-center justify-center gap-4 p-6">
+      <Wordmark className="h-8" />
+      <div className="flex items-center gap-2 font-mono text-sm text-icon3">
+        <Spinner className="size-4" />
+        <span>Connecting to agent…</span>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionErrorState() {
+  return (
+    <div className="flex min-h-0 flex-1 items-center justify-center p-6">
+      <div role="alert" className="w-full max-w-120">
+        <Notice variant="destructive">Disconnected. Check the server and reload to reconnect.</Notice>
+      </div>
+    </div>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -1,25 +1,20 @@
-import { useQueryClient } from '@tanstack/react-query';
-import { createContext, useContext, useEffect, useEffectEvent, useRef } from 'react';
+import { createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
 
-import { useApiConfig } from '../../../../../shared/api/config';
-import { queryKeys } from '../../../../../shared/api/keys';
 // Deep imports (not the workspaces barrel): the barrel re-exports components
 // that consume this chat context, so importing it here would create a cycle.
 import { useActiveProjectContext } from '../../workspaces/context/ActiveProjectProvider';
 import { deriveProjectPath } from '../../workspaces/hooks/useWorkspaces';
 import { useAgentControllerConnection } from '../hooks/useAgentControllerConnection';
 import type { ConnectionStatus } from '../hooks/useAgentControllerConnection';
-import { useAgentControllerThreadMessages } from '../hooks/useAgentControllerThreadMessages';
 import { useAgentControllerTranscript } from '../hooks/useAgentControllerTranscript';
-import { AGENT_CONTROLLER_ID } from '../services/constants';
 import type { TranscriptState } from '../services/transcript';
+import { ChatConnectionGate } from './ChatConnectionGate';
 
 export interface ChatSessionApi {
   transcript: TranscriptState;
   status: ConnectionStatus;
   modes: ReturnType<typeof useAgentControllerConnection>['modes'];
-  messagesPending: boolean;
   busy: boolean;
   showWorkingIndicator: boolean;
   localUser: (text: string, steer?: boolean) => void;
@@ -36,136 +31,22 @@ export interface ChatSessionApi {
   pushNotice: (text: string, level?: 'info' | 'error') => void;
 }
 
-const ChatSessionContext = createContext<ChatSessionApi | null>(null);
+export const ChatSessionContext = createContext<ChatSessionApi | null>(null);
 
 export function ChatSessionProvider({ children }: { children: ReactNode }) {
   const { activeProject, resourceId, sessionEnabled } = useActiveProjectContext();
   const projectPath = deriveProjectPath(activeProject);
 
   return (
-    <ChatSessionBoundary
+    <ChatConnectionGate
       key={`${resourceId}:${projectPath ?? ''}`}
       resourceId={resourceId}
       projectPath={projectPath}
       sessionEnabled={sessionEnabled}
     >
       {children}
-    </ChatSessionBoundary>
+    </ChatConnectionGate>
   );
-}
-
-function ChatSessionBoundary({
-  children,
-  resourceId,
-  projectPath,
-  sessionEnabled,
-}: {
-  children: ReactNode;
-  resourceId: string;
-  projectPath?: string;
-  sessionEnabled: boolean;
-}) {
-  const queryClient = useQueryClient();
-  const { baseUrl } = useApiConfig();
-  const firstSyncAtRef = useRef(0);
-
-  const {
-    transcript,
-    hydrateMessages,
-    reset,
-    resetDormant,
-    resetHydration,
-    resetCurrentThread,
-    syncState,
-    onEvent,
-    localUser,
-    resolvePrompt,
-    pushNotice,
-  } = useAgentControllerTranscript();
-
-  const messagesQuery = useAgentControllerThreadMessages({
-    agentControllerId: AGENT_CONTROLLER_ID,
-    resourceId,
-    threadId: transcript.threadId,
-    baseUrl,
-    enabled: sessionEnabled,
-  });
-
-  const onMessagesData = useEffectEvent((data: typeof messagesQuery.data) => {
-    hydrateMessages(data);
-  });
-
-  useEffect(() => {
-    onMessagesData(messagesQuery.data);
-  }, [messagesQuery.data]);
-
-  const connection = useAgentControllerConnection({
-    agentControllerId: AGENT_CONTROLLER_ID,
-    resourceId,
-    projectPath,
-    baseUrl,
-    enabled: sessionEnabled,
-    onEvent,
-  });
-
-  const onConnectionStateSynced = useEffectEvent(() => {
-    if (!connection.state || !connection.stateUpdatedAt) return;
-    const isFirst = firstSyncAtRef.current === 0;
-    firstSyncAtRef.current = connection.stateUpdatedAt;
-    resetHydration();
-    queryClient.removeQueries({
-      queryKey: queryKeys.agentControllerThreadMessages(AGENT_CONTROLLER_ID, resourceId, connection.state.threadId),
-    });
-    reset(
-      connection.state,
-      isFirst ? (connection.createdThreadId ?? connection.state.threadId) : connection.state.threadId,
-    );
-  });
-
-  useEffect(() => {
-    if (!connection.state || !connection.stateUpdatedAt) return;
-    onConnectionStateSynced();
-  }, [connection.state, connection.stateUpdatedAt]);
-
-  const onSessionDisabled = useEffectEvent(resetDormant);
-
-  useEffect(() => {
-    if (sessionEnabled) return;
-    onSessionDisabled();
-  }, [sessionEnabled]);
-
-  const busy = transcript.running || transcript.pending;
-  const lastEntry = transcript.entries[transcript.entries.length - 1];
-  const lastEntryHasText =
-    lastEntry?.kind === 'message' &&
-    lastEntry.message.role === 'assistant' &&
-    lastEntry.message.content.parts.some(part => part.type === 'text' && part.text.trim().length > 0);
-  const showWorkingIndicator =
-    busy &&
-    !(
-      lastEntry?.kind === 'message' &&
-      lastEntry.message.role === 'assistant' &&
-      lastEntry.streaming &&
-      lastEntryHasText
-    );
-
-  const value: ChatSessionApi = {
-    transcript,
-    status: connection.status,
-    modes: connection.modes,
-    messagesPending: Boolean(transcript.threadId) && messagesQuery.isPending,
-    busy,
-    showWorkingIndicator,
-    localUser,
-    resetHydration,
-    resetCurrentThread,
-    syncState,
-    reset,
-    resolvePrompt,
-    pushNotice,
-  };
-
-  return <ChatSessionContext.Provider value={value}>{children}</ChatSessionContext.Provider>;
 }
 
 export function useChatSession(): ChatSessionApi {

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionRuntime.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionRuntime.tsx
@@ -1,5 +1,5 @@
 import type { AgentControllerEvent, AgentControllerMessage } from '@mastra/client-js';
-import { useState } from 'react';
+import { useEffect, useEffectEvent } from 'react';
 import type { ReactNode, RefObject } from 'react';
 
 import { useApiConfig } from '../../../../../shared/api/config';
@@ -26,7 +26,7 @@ interface ChatSessionRuntimeProps {
   eventHandlerRef: RefObject<((event: AgentControllerEvent) => void) | null>;
   state?: SessionStateSnapshot;
   stateUpdatedAt?: number;
-  createdThreadId?: string;
+  initialThreadId?: string;
 }
 
 export function ChatSessionRuntime({
@@ -38,7 +38,7 @@ export function ChatSessionRuntime({
   eventHandlerRef,
   state,
   stateUpdatedAt,
-  createdThreadId,
+  initialThreadId,
 }: ChatSessionRuntimeProps) {
   const { baseUrl } = useApiConfig();
   const {
@@ -56,40 +56,10 @@ export function ChatSessionRuntime({
     // First sync: the gate only mounts the connected runtime once session
     // state exists, so the reducer initializes from it directly — preferring
     // the freshly created thread over whatever the server was last on.
-    state ? { state, threadId: createdThreadId ?? state.threadId } : undefined,
+    state ? { state, threadId: initialThreadId ?? state.threadId } : undefined,
   );
 
   eventHandlerRef.current = onEvent;
-
-  // Subsequent syncs (poll refresh, reconnect after an SSE drop): adjust
-  // state during render instead of in an effect. React re-renders with the
-  // reset transcript before committing, so no stale frame is ever painted.
-  const [prevStateUpdatedAt, setPrevStateUpdatedAt] = useState(stateUpdatedAt);
-  if (stateUpdatedAt !== prevStateUpdatedAt) {
-    setPrevStateUpdatedAt(stateUpdatedAt);
-    if (state && stateUpdatedAt) reset(state, state.threadId);
-  }
-
-  // Thread history for the transcript's current thread. `syncEpoch` in the
-  // query key makes every re-sync fetch fresh history (replacing the old
-  // imperative queryClient eviction).
-  const messagesQuery = useAgentControllerThreadMessages({
-    agentControllerId: AGENT_CONTROLLER_ID,
-    resourceId,
-    threadId: transcript.threadId,
-    baseUrl,
-    enabled: sessionEnabled,
-    syncEpoch: stateUpdatedAt,
-  });
-
-  // Fold fetched history into the transcript at render time. The reducer's
-  // hydrateMessages action is guarded (once per thread, empty idle transcript
-  // only), so this dispatch is idempotent.
-  const [prevMessages, setPrevMessages] = useState<AgentControllerMessage[] | undefined>(undefined);
-  if (messagesQuery.data !== prevMessages) {
-    setPrevMessages(messagesQuery.data);
-    hydrateMessages(messagesQuery.data);
-  }
 
   const { busy, showWorkingIndicator } = deriveRunIndicators(transcript);
 
@@ -110,9 +80,54 @@ export function ChatSessionRuntime({
 
   return (
     <ChatSessionContext.Provider value={value}>
-      <ChatThreadMessagesProvider messagesPending={Boolean(transcript.threadId) && messagesQuery.isPending}>
+      <ThreadMessagesHydrator
+        resourceId={resourceId}
+        sessionEnabled={sessionEnabled}
+        threadId={transcript.threadId}
+        baseUrl={baseUrl}
+        syncEpoch={stateUpdatedAt}
+        onMessages={hydrateMessages}
+      >
         {children}
-      </ChatThreadMessagesProvider>
+      </ThreadMessagesHydrator>
     </ChatSessionContext.Provider>
+  );
+}
+
+function ThreadMessagesHydrator({
+  children,
+  resourceId,
+  sessionEnabled,
+  threadId,
+  baseUrl,
+  syncEpoch,
+  onMessages,
+}: {
+  children: ReactNode;
+  resourceId: string;
+  sessionEnabled: boolean;
+  threadId?: string;
+  baseUrl?: string;
+  syncEpoch?: number;
+  onMessages: (messages?: AgentControllerMessage[]) => void;
+}) {
+  const messagesQuery = useAgentControllerThreadMessages({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceId,
+    threadId,
+    baseUrl,
+    enabled: sessionEnabled,
+    syncEpoch,
+  });
+  const handleMessages = useEffectEvent(onMessages);
+
+  useEffect(() => {
+    handleMessages(messagesQuery.data);
+  }, [messagesQuery.data]);
+
+  return (
+    <ChatThreadMessagesProvider messagesPending={Boolean(threadId) && messagesQuery.isPending}>
+      {children}
+    </ChatThreadMessagesProvider>
   );
 }

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionRuntime.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionRuntime.tsx
@@ -1,0 +1,118 @@
+import type { AgentControllerEvent, AgentControllerMessage } from '@mastra/client-js';
+import { useState } from 'react';
+import type { ReactNode, RefObject } from 'react';
+
+import { useApiConfig } from '../../../../../shared/api/config';
+import type { ConnectionStatus } from '../hooks/useAgentControllerConnection';
+import { useAgentControllerThreadMessages } from '../hooks/useAgentControllerThreadMessages';
+import { useAgentControllerTranscript } from '../hooks/useAgentControllerTranscript';
+import type { TranscriptInit } from '../hooks/useAgentControllerTranscript';
+import { AGENT_CONTROLLER_ID } from '../services/constants';
+import { deriveRunIndicators } from '../services/transcript';
+import { ChatSessionContext } from './ChatSessionProvider';
+import type { ChatSessionApi } from './ChatSessionProvider';
+import { ChatThreadMessagesProvider } from './ChatThreadMessages';
+
+type SessionStateSnapshot = TranscriptInit['state'];
+
+type ChatMode = ChatSessionApi['modes'][number];
+
+interface ChatSessionRuntimeProps {
+  children: ReactNode;
+  resourceId: string;
+  sessionEnabled: boolean;
+  status: ConnectionStatus;
+  modes: ChatMode[];
+  eventHandlerRef: RefObject<((event: AgentControllerEvent) => void) | null>;
+  state?: SessionStateSnapshot;
+  stateUpdatedAt?: number;
+  createdThreadId?: string;
+}
+
+export function ChatSessionRuntime({
+  children,
+  resourceId,
+  sessionEnabled,
+  status,
+  modes,
+  eventHandlerRef,
+  state,
+  stateUpdatedAt,
+  createdThreadId,
+}: ChatSessionRuntimeProps) {
+  const { baseUrl } = useApiConfig();
+  const {
+    transcript,
+    hydrateMessages,
+    reset,
+    resetHydration,
+    resetCurrentThread,
+    syncState,
+    onEvent,
+    localUser,
+    resolvePrompt,
+    pushNotice,
+  } = useAgentControllerTranscript(
+    // First sync: the gate only mounts the connected runtime once session
+    // state exists, so the reducer initializes from it directly — preferring
+    // the freshly created thread over whatever the server was last on.
+    state ? { state, threadId: createdThreadId ?? state.threadId } : undefined,
+  );
+
+  eventHandlerRef.current = onEvent;
+
+  // Subsequent syncs (poll refresh, reconnect after an SSE drop): adjust
+  // state during render instead of in an effect. React re-renders with the
+  // reset transcript before committing, so no stale frame is ever painted.
+  const [prevStateUpdatedAt, setPrevStateUpdatedAt] = useState(stateUpdatedAt);
+  if (stateUpdatedAt !== prevStateUpdatedAt) {
+    setPrevStateUpdatedAt(stateUpdatedAt);
+    if (state && stateUpdatedAt) reset(state, state.threadId);
+  }
+
+  // Thread history for the transcript's current thread. `syncEpoch` in the
+  // query key makes every re-sync fetch fresh history (replacing the old
+  // imperative queryClient eviction).
+  const messagesQuery = useAgentControllerThreadMessages({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceId,
+    threadId: transcript.threadId,
+    baseUrl,
+    enabled: sessionEnabled,
+    syncEpoch: stateUpdatedAt,
+  });
+
+  // Fold fetched history into the transcript at render time. The reducer's
+  // hydrateMessages action is guarded (once per thread, empty idle transcript
+  // only), so this dispatch is idempotent.
+  const [prevMessages, setPrevMessages] = useState<AgentControllerMessage[] | undefined>(undefined);
+  if (messagesQuery.data !== prevMessages) {
+    setPrevMessages(messagesQuery.data);
+    hydrateMessages(messagesQuery.data);
+  }
+
+  const { busy, showWorkingIndicator } = deriveRunIndicators(transcript);
+
+  const value: ChatSessionApi = {
+    transcript,
+    status,
+    modes,
+    busy,
+    showWorkingIndicator,
+    localUser,
+    resetHydration,
+    resetCurrentThread,
+    syncState,
+    reset,
+    resolvePrompt,
+    pushNotice,
+  };
+
+  return (
+    <ChatSessionContext.Provider value={value}>
+      <ChatThreadMessagesProvider messagesPending={Boolean(transcript.threadId) && messagesQuery.isPending}>
+        {children}
+      </ChatThreadMessagesProvider>
+    </ChatSessionContext.Provider>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatThreadMessages.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatThreadMessages.tsx
@@ -1,0 +1,31 @@
+import { createContext, useContext } from 'react';
+import type { ReactNode } from 'react';
+
+interface ChatThreadMessagesValue {
+  messagesPending: boolean;
+}
+
+const ChatThreadMessagesContext = createContext<ChatThreadMessagesValue | null>(null);
+
+/**
+ * Exposes the thread-history fetch status to the message list without routing
+ * it through `ChatSessionApi` — only the transcript panel cares about the
+ * loading skeleton, so it gets its own context seam.
+ */
+export function ChatThreadMessagesProvider({
+  children,
+  messagesPending,
+}: {
+  children: ReactNode;
+  messagesPending: boolean;
+}) {
+  return (
+    <ChatThreadMessagesContext.Provider value={{ messagesPending }}>{children}</ChatThreadMessagesContext.Provider>
+  );
+}
+
+export function useThreadMessages(): ChatThreadMessagesValue {
+  const ctx = useContext(ChatThreadMessagesContext);
+  if (!ctx) throw new Error('useThreadMessages must be used within a ChatThreadMessagesProvider');
+  return ctx;
+}

--- a/mastracode/web/src/web/ui/domains/chat/context/__tests__/ChatSessionProvider.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/__tests__/ChatSessionProvider.msw.test.tsx
@@ -6,7 +6,7 @@
  * props again. Driven end-to-end: real fetch/SSE transport, MSW at the
  * network boundary.
  */
-import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
+import type { AgentControllerEvent, AgentControllerMessage, AgentControllerSessionState } from '@mastra/client-js';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -17,6 +17,7 @@ import { renderWithProviders, TEST_BASE_URL } from '../../../../../../../e2e/web
 import type { Project } from '../../../workspaces';
 import { ActiveProjectProvider, useActiveProjectContext } from '../../../workspaces';
 import { ChatSessionProvider, useChatSession } from '../ChatSessionProvider';
+import { useThreadMessages } from '../ChatThreadMessages';
 
 const API = `${TEST_BASE_URL}/api/agent-controller/code`;
 const RESOURCE_ID = 'resource-test';
@@ -125,6 +126,11 @@ function Probe() {
   );
 }
 
+function MessagesProbe() {
+  const { messagesPending } = useThreadMessages();
+  return <span data-testid="messages-pending">{messagesPending ? 'yes' : 'no'}</span>;
+}
+
 function renderProbe() {
   return renderWithProviders(
     <ActiveProjectProvider>
@@ -136,6 +142,69 @@ function renderProbe() {
 }
 
 describe('ChatSessionProvider', () => {
+  it('given the first state request is still pending, then it shows the connection loading state without mounting children', async () => {
+    seedProject();
+    useAgentControllerHandlers();
+    server.use(http.get(SESSION, () => new Promise<Response>(() => {})));
+
+    renderProbe();
+
+    expect(screen.getByText('Connecting to agent…')).toBeInTheDocument();
+    expect(screen.queryByTestId('status')).not.toBeInTheDocument();
+  });
+
+  it('given the initial session create fails, then it shows the connection error state without mounting children', async () => {
+    seedProject();
+    useAgentControllerHandlers();
+    server.use(http.post(`${API}/sessions`, () => HttpResponse.json({ error: 'nope' }, { status: 500 })));
+
+    renderProbe();
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('Disconnected. Check the server and reload to reconnect.'),
+    );
+    expect(screen.queryByTestId('status')).not.toBeInTheDocument();
+  });
+
+  it('given a dormant project without a resource id, then children still render with a connecting session', async () => {
+    const dormantProject: Project = { ...project, id: 'project-dormant', resourceId: undefined };
+    seedProject([dormantProject], dormantProject);
+    server.use(http.get(`${TEST_BASE_URL}/web/project/resolve`, () => HttpResponse.json({ error: 'missing' }, { status: 404 })));
+
+    renderProbe();
+
+    expect(screen.getByTestId('status')).toHaveTextContent('connecting');
+    expect(screen.getByTestId('thread-id')).toHaveTextContent('(none)');
+  });
+
+  it('given thread messages are still loading, then the loader exposes pending until the transcript hydrates', async () => {
+    let resolveMessages: (messages: AgentControllerMessage[]) => void = () => {};
+    seedProject();
+    useAgentControllerHandlers();
+    server.use(
+      http.get(`${SESSION}/threads/${THREAD_ID}/messages`, () =>
+        new Promise<Response>(resolve => {
+          resolveMessages = messages => resolve(HttpResponse.json({ messages }));
+        }),
+      ),
+    );
+
+    renderWithProviders(
+      <ActiveProjectProvider>
+        <ChatSessionProvider>
+          <Probe />
+          <MessagesProbe />
+        </ChatSessionProvider>
+      </ActiveProjectProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('messages-pending')).toHaveTextContent('yes'));
+    resolveMessages([{ id: 'hydrated-message', role: 'user', content: [{ type: 'text', text: 'hydrated' }] }]);
+
+    await waitFor(() => expect(screen.getByTestId('messages-pending')).toHaveTextContent('no'));
+    await waitFor(() => expect(screen.getByTestId('entries-count')).toHaveTextContent('1'));
+  });
+
   it('given a seeded project, when the session connects, then it binds the session to the workspace path before ready', async () => {
     const requests: string[] = [];
     seedProject();

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreadMessages.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreadMessages.ts
@@ -9,6 +9,12 @@ interface UseAgentControllerThreadMessagesArgs {
   threadId?: string;
   baseUrl?: string;
   enabled?: boolean;
+  /**
+   * Session sync epoch (`dataUpdatedAt` of the sync query). Part of the query
+   * key so every re-sync (e.g. after an SSE drop) fetches fresh history
+   * instead of reusing a cache that may predate the disconnect.
+   */
+  syncEpoch?: number;
 }
 
 export function useAgentControllerThreadMessages({
@@ -17,11 +23,12 @@ export function useAgentControllerThreadMessages({
   threadId,
   baseUrl = '',
   enabled = true,
+  syncEpoch,
 }: UseAgentControllerThreadMessagesArgs) {
   const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
 
   return useQuery({
-    queryKey: queryKeys.agentControllerThreadMessages(agentControllerId, resourceId, threadId),
+    queryKey: queryKeys.agentControllerThreadMessages(agentControllerId, resourceId, threadId, syncEpoch),
     queryFn: () => session!.listMessages(threadId!),
     enabled: enabled && Boolean(session) && Boolean(threadId),
     refetchOnWindowFocus: false,

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerTranscript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerTranscript.ts
@@ -1,8 +1,8 @@
 import type { AgentControllerEvent, AgentControllerMessage, AgentControllerOMProgress } from '@mastra/client-js';
-import { useReducer, useRef } from 'react';
+import { useReducer } from 'react';
 
 import { initialTranscript, transcriptReducer } from '../services/transcript';
-import type { TranscriptState, UsageSnapshot } from '../services/transcript';
+import type { UsageSnapshot } from '../services/transcript';
 
 interface SessionStateSnapshot {
   modeId?: string;
@@ -12,24 +12,32 @@ interface SessionStateSnapshot {
   tokenUsage?: UsageSnapshot;
 }
 
-export function useAgentControllerTranscript() {
-  const [transcript, dispatch] = useReducer(transcriptReducer, initialTranscript);
-  const transcriptRef = useRef<TranscriptState>(transcript);
-  const hydratedThreadRef = useRef<string | undefined>(undefined);
-  transcriptRef.current = transcript;
+export interface TranscriptInit {
+  state: SessionStateSnapshot;
+  threadId?: string;
+}
+
+export function useAgentControllerTranscript(init?: TranscriptInit) {
+  const [transcript, dispatch] = useReducer(transcriptReducer, init, initArg =>
+    initArg
+      ? transcriptReducer(initialTranscript, {
+          type: 'reset',
+          modeId: initArg.state.modeId,
+          modelId: initArg.state.modelId,
+          threadId: initArg.threadId ?? initArg.state.threadId,
+          omProgress: initArg.state.omProgress,
+          usage: initArg.state.tokenUsage,
+        })
+      : initialTranscript,
+  );
 
   const hydrateMessages = (messages?: AgentControllerMessage[]) => {
-    const current = transcriptRef.current;
-    const threadId = current.threadId;
-    if (!threadId || !messages) return;
-    if (hydratedThreadRef.current === threadId) return;
-    if (current.running || current.pending || current.entries.length > 0) return;
-    hydratedThreadRef.current = threadId;
-    dispatch({ type: 'hydrateMessages', messages, threadId });
+    if (!messages) return;
+    dispatch({ type: 'hydrateMessages', messages });
   };
 
   const resetHydration = () => {
-    hydratedThreadRef.current = undefined;
+    dispatch({ type: 'resetHydration' });
   };
 
   const reset = (state?: SessionStateSnapshot, threadId?: string) => {
@@ -44,8 +52,7 @@ export function useAgentControllerTranscript() {
   };
 
   const resetCurrentThread = (threadId?: string) => {
-    const prev = transcriptRef.current;
-    dispatch({ type: 'reset', threadId, modeId: prev.modeId, modelId: prev.modelId });
+    dispatch({ type: 'resetThread', threadId });
   };
 
   const syncState = (state: SessionStateSnapshot) => {
@@ -74,14 +81,8 @@ export function useAgentControllerTranscript() {
     dispatch({ type: 'localNotice', text, level });
   };
 
-  const resetDormant = () => {
-    hydratedThreadRef.current = undefined;
-    dispatch({ type: 'reset' });
-  };
-
   return {
     transcript,
-    transcriptRef,
     hydrateMessages,
     resetHydration,
     reset,
@@ -91,6 +92,5 @@ export function useAgentControllerTranscript() {
     localUser,
     resolvePrompt,
     pushNotice,
-    resetDormant,
   };
 }

--- a/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -1,7 +1,7 @@
 import type { AgentControllerMessage } from '@mastra/client-js';
 import { describe, expect, it } from 'vitest';
 
-import { initialTranscript, transcriptReducer } from '../transcript';
+import { deriveRunIndicators, initialTranscript, transcriptReducer } from '../transcript';
 
 type MessageEntryFixture = {
   kind: 'message';
@@ -17,6 +17,86 @@ function isMessageEntry(entry: unknown): entry is MessageEntryFixture {
     typeof entry === 'object' && entry !== null && 'kind' in entry && entry.kind === 'message' && 'message' in entry
   );
 }
+
+describe('deriveRunIndicators', () => {
+  it('marks an idle transcript as not busy', () => {
+    expect(deriveRunIndicators(initialTranscript)).toEqual({ busy: false, showWorkingIndicator: false });
+  });
+
+  it('shows the working indicator while a run has no assistant text yet', () => {
+    const state = transcriptReducer(initialTranscript, { type: 'event', event: { type: 'agent_start' } });
+
+    expect(deriveRunIndicators(state)).toEqual({ busy: true, showWorkingIndicator: true });
+  });
+
+  it('hides the working indicator while streaming assistant text', () => {
+    const running = transcriptReducer(initialTranscript, { type: 'event', event: { type: 'agent_start' } });
+    const state = transcriptReducer(running, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: { id: 'assistant-1', role: 'assistant', content: [{ type: 'text', text: 'Streaming text' }] },
+      },
+    });
+
+    expect(deriveRunIndicators(state)).toEqual({ busy: true, showWorkingIndicator: false });
+  });
+});
+
+describe('transcript reducer history hydration', () => {
+  const messages: AgentControllerMessage[] = [{ id: 'user-1', role: 'user', content: [{ type: 'text', text: 'Hi' }] }];
+
+  function threadState(threadId = 'thread-1') {
+    return transcriptReducer(initialTranscript, { type: 'reset', threadId });
+  }
+
+  it('hydrates an empty idle transcript at most once per thread', () => {
+    const hydrated = transcriptReducer(threadState(), { type: 'hydrateMessages', messages });
+
+    expect(hydrated.entries).toHaveLength(1);
+    expect(hydrated.hydratedThreadId).toBe('thread-1');
+    // Re-dispatching with fresh data is a no-op — same state reference, so a
+    // render-phase dispatch cannot loop.
+    expect(transcriptReducer(hydrated, { type: 'hydrateMessages', messages: [] })).toBe(hydrated);
+  });
+
+  it('ignores hydration without a thread or into a busy/non-empty transcript', () => {
+    expect(transcriptReducer(initialTranscript, { type: 'hydrateMessages', messages })).toBe(initialTranscript);
+
+    const running = transcriptReducer(threadState(), { type: 'event', event: { type: 'agent_start' } });
+    expect(transcriptReducer(running, { type: 'hydrateMessages', messages })).toBe(running);
+
+    const withEntry = transcriptReducer(threadState(), { type: 'localNotice', level: 'info', text: 'hello' });
+    expect(transcriptReducer(withEntry, { type: 'hydrateMessages', messages })).toBe(withEntry);
+  });
+
+  it('re-arms hydration via resetHydration and reset', () => {
+    const hydrated = transcriptReducer(threadState(), { type: 'hydrateMessages', messages });
+
+    const rearmed = transcriptReducer(hydrated, { type: 'resetHydration' });
+    expect(rearmed.hydratedThreadId).toBeUndefined();
+
+    const resetState = transcriptReducer(hydrated, { type: 'reset', threadId: 'thread-2' });
+    expect(resetState.hydratedThreadId).toBeUndefined();
+    expect(resetState.entries).toEqual([]);
+  });
+
+  it('resets to a new thread while preserving mode and model', () => {
+    const configured = transcriptReducer(initialTranscript, {
+      type: 'reset',
+      threadId: 'thread-1',
+      modeId: 'build',
+      modelId: 'anthropic/claude-4.5-sonnet',
+    });
+
+    const switched = transcriptReducer(configured, { type: 'resetThread', threadId: 'thread-2' });
+
+    expect(switched.threadId).toBe('thread-2');
+    expect(switched.modeId).toBe('build');
+    expect(switched.modelId).toBe('anthropic/claude-4.5-sonnet');
+    expect(switched.entries).toEqual([]);
+  });
+});
 
 describe('transcript reducer message entries', () => {
   it('hydrates controller messages as ordered MastraDBMessage entries', () => {

--- a/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
@@ -174,6 +174,12 @@ export interface TranscriptState {
   /** Current tokens/sec throughput (0 when idle). */
   tokensPerSec: number;
   /**
+   * @internal Thread whose persisted history has been folded into `entries`.
+   * Guards `hydrateMessages` so hydration applies at most once per thread and
+   * stays idempotent when dispatched during render.
+   */
+  hydratedThreadId?: string;
+  /**
    * @internal Timestamp (ms) of the first streamed content delta of the current
    * step — i.e. when decoding actually began. Used to measure tokens/sec over
    * decode time only, excluding TTFT and tool-execution gaps between steps.
@@ -192,6 +198,23 @@ export const initialTranscript: TranscriptState = {
   tokensPerSec: 0,
   _decodeStartedAt: 0,
 };
+
+export function deriveRunIndicators(transcript: TranscriptState): {
+  busy: boolean;
+  showWorkingIndicator: boolean;
+} {
+  const busy = transcript.running || transcript.pending;
+  const lastEntry = transcript.entries[transcript.entries.length - 1];
+  const lastEntryHasText =
+    lastEntry?.kind === 'message' &&
+    lastEntry.message.role === 'assistant' &&
+    lastEntry.message.content.parts.some(part => part.type === 'text' && part.text.trim().length > 0);
+  const showWorkingIndicator =
+    busy &&
+    !(lastEntry?.kind === 'message' && lastEntry.message.role === 'assistant' && lastEntry.streaming && lastEntryHasText);
+
+  return { busy, showWorkingIndicator };
+}
 
 let noticeSeq = 0;
 
@@ -220,13 +243,21 @@ type Action =
   | {
       /**
        * Fold persisted messages into the timeline while keeping all live state
-       * (mode/model/usage/goal/OM). Used by the query-driven history hydration,
-       * which can resolve after live stream events have already arrived —
-       * entries the history doesn't know about (matched by id) are preserved.
+       * (mode/model/usage/goal/OM). Applies at most once per thread and only
+       * into an empty, idle transcript — otherwise it is a no-op, which makes
+       * it safe to dispatch during render.
        */
       type: 'hydrateMessages';
       messages: AgentControllerMessage[];
-      threadId: string;
+    }
+  | {
+      /** Re-arm history hydration for the current thread. */
+      type: 'resetHydration';
+    }
+  | {
+      /** Reset to a new thread, preserving the session's mode/model selection. */
+      type: 'resetThread';
+      threadId?: string;
     }
   | {
       /**
@@ -256,11 +287,15 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
     case 'hydrate':
       return hydrate(action.messages, action.modeId, action.modelId, action.threadId, action.omProgress, action.usage);
     case 'hydrateMessages': {
-      const hydrated = hydrateEntries(action.messages);
-      const known = new Set(hydrated.map(entry => entry.id));
-      const liveExtras = state.entries.filter(entry => !known.has(entry.id));
-      return { ...state, threadId: action.threadId, entries: [...hydrated, ...liveExtras] };
+      const threadId = state.threadId;
+      if (!threadId || state.hydratedThreadId === threadId) return state;
+      if (state.running || state.pending || state.entries.length > 0) return state;
+      return { ...state, hydratedThreadId: threadId, entries: hydrateEntries(action.messages) };
     }
+    case 'resetHydration':
+      return state.hydratedThreadId === undefined ? state : { ...state, hydratedThreadId: undefined };
+    case 'resetThread':
+      return { ...initialTranscript, threadId: action.threadId, modeId: state.modeId, modelId: state.modelId };
     case 'syncState':
       return {
         ...state,


### PR DESCRIPTION
## Summary

Splits the Mastra Code chat session startup path into explicit connection and runtime layers. The chat surface now shows dedicated initial connecting/error states before mounting the active transcript runtime, while resolved sessions keep the existing reconnect notice behavior inside the transcript.

The runtime owns transcript state and uses reducer-owned hydration guards plus sync-epoch keyed message queries, so thread history hydration and reconnect refreshes no longer depend on imperative session-boundary effects.

## Test plan

- `pnpm exec vitest run src/web/ui/domains/chat --config e2e/web-ui/vitest.config.ts --reporter=dot --bail 1`
- `pnpm exec vitest run --config e2e/web-ui/vitest.config.ts --reporter=dot`
- `pnpm run check`
- `pnpm test -- --reporter=dot`

Note: local commands completed with the existing Node engine warning because this environment is on Node `v22.14.0` while `mastracode/web` declares `>=22.19.0`.