### PR TITLE
feat(mastracode): add permission pattern allowlist

### DIFF
--- a/.changeset/permission-pattern-allowlist.md
+++ b/.changeset/permission-pattern-allowlist.md
@@ -1,0 +1,23 @@
+---
+'@mastra/core': minor
+'mastracode': patch
+---
+
+Added permission pattern allowlist as an alternative to full YOLO mode. Commands matching allow patterns auto-approve, deny patterns auto-block, and everything else prompts as usual.
+
+**Why**
+
+YOLO mode is all-or-nothing. Prompting for every safe command pushes users toward full YOLO, which also approves destructive commands. A per-pattern allowlist gives YOLO ergonomics for routine operations while preserving approval gates for dangerous commands.
+
+**@mastra/core:** Added `PermissionPatternRule` type and optional `patterns` field to `PermissionRules`. `resolveToolApproval` now accepts tool args and matches them against glob patterns. Deny patterns are checked before allow patterns.
+
+**mastracode:** Added `permissions` settings block with `allow`/`deny` arrays. The `/permissions` command displays active pattern rules.
+
+```json
+{
+  "permissions": {
+    "allow": ["Bash(git status*)", "Bash(git diff*)", "Bash(echo*)"],
+    "deny": ["Bash(rm -rf*)", "Bash(git push --force*)"]
+  }
+}
+```

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -71,7 +71,7 @@ import {
   resolveOmRoleModel,
   saveSettings,
 } from './onboarding/settings.js';
-import { getToolCategory } from './permissions.js';
+import { getToolCategory, parsePermissionPatterns } from './permissions.js';
 import { PluginManager } from './plugins/manager.js';
 import { PlanRejectionAbortProcessor } from './processors/plan-rejection-abort.js';
 import { createAmazonBedrockGateway } from './providers/amazon-bedrock-gateway.js';
@@ -760,6 +760,15 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     globalInitialState.yolo = globalSettings.preferences.yolo;
   }
   globalInitialState.thinkingLevel = globalSettings.preferences.thinkingLevel;
+  const permPatterns = parsePermissionPatterns(globalSettings.permissions);
+  if (permPatterns.length > 0) {
+    (globalInitialState as any).permissionRules = {
+      categories: {},
+      tools: {},
+      ...(globalInitialState as any).permissionRules,
+      patterns: permPatterns,
+    };
+  }
   if (config?.omScope) {
     globalInitialState.omScope = config.omScope;
   }

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -246,6 +246,13 @@ export interface GlobalSettings {
   signals: SignalSettings;
   // Cloud observability configuration (per-resource project IDs; tokens stored in auth.json)
   observability: ObservabilitySettings;
+  // Permission allowlist/denylist patterns for fine-grained tool approval
+  permissions: PermissionSettings;
+}
+
+export interface PermissionSettings {
+  allow?: string[];
+  deny?: string[];
 }
 
 export interface SignalSettings {
@@ -332,6 +339,7 @@ const DEFAULTS: GlobalSettings = {
   voice: { enabled: false, engine: defaultVoiceEngine(), provider: DEFAULT_STT_PROVIDER },
   signals: { unixSocketPubSub: false, experimentalGithubSignals: false },
   observability: { resources: {}, localTracing: false },
+  permissions: {},
 };
 
 const THINKING_LEVEL_VALUES: ThinkingLevelSetting[] = ['off', 'low', 'medium', 'high', 'xhigh'];
@@ -587,6 +595,19 @@ function parseObservabilitySettings(raw: unknown): ObservabilitySettings {
   return { resources, localTracing };
 }
 
+function parsePermissionSettings(raw: unknown): PermissionSettings {
+  if (!raw || typeof raw !== 'object') return {};
+  const obj = raw as Record<string, unknown>;
+  const result: PermissionSettings = {};
+  if (Array.isArray(obj.allow)) {
+    result.allow = obj.allow.filter((v): v is string => typeof v === 'string');
+  }
+  if (Array.isArray(obj.deny)) {
+    result.deny = obj.deny.filter((v): v is string => typeof v === 'string');
+  }
+  return result;
+}
+
 /**
  * One-time migration: move model-related data from auth.json to settings.json.
  * Reads `_modelRanks`, `_modeModelId_*`, `_subagentModelId*` from auth.json,
@@ -633,6 +654,7 @@ function migrateFromAuth(settingsPath: string): boolean {
         voice: parseVoiceSettings(raw.voice),
         signals: parseSignalSettings(raw.signals),
         observability: parseObservabilitySettings(raw.observability),
+        permissions: parsePermissionSettings(raw.permissions),
       };
       applyQuietModePreferenceRollout(settings, raw.onboarding);
     } catch {
@@ -756,6 +778,7 @@ export function loadSettings(filePath: string = getSettingsPath()): GlobalSettin
       voice: parseVoiceSettings(raw.voice),
       signals: parseSignalSettings(raw.signals),
       observability: parseObservabilitySettings(raw.observability),
+      permissions: parsePermissionSettings(raw.permissions),
     };
 
     // Migrate legacy omModelId → omModelOverride

--- a/mastracode/sdk/src/permissions.test.ts
+++ b/mastracode/sdk/src/permissions.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import { parsePatternEntry, parsePermissionPatterns } from './permissions.js';
+
+describe('parsePatternEntry', () => {
+  it('parses Bash(git status*) into execute_command pattern', () => {
+    const rule = parsePatternEntry('Bash(git status*)', 'allow');
+    expect(rule.toolName).toBe('execute_command');
+    expect(rule.pattern).toBe('git status*');
+    expect(rule.policy).toBe('allow');
+  });
+
+  it('parses Read(*.ts) into view pattern', () => {
+    const rule = parsePatternEntry('Read(*.ts)', 'allow');
+    expect(rule.toolName).toBe('view');
+    expect(rule.pattern).toBe('*.ts');
+    expect(rule.policy).toBe('allow');
+  });
+
+  it('parses bare tool name as wildcard pattern', () => {
+    const rule = parsePatternEntry('Bash', 'deny');
+    expect(rule.toolName).toBe('execute_command');
+    expect(rule.pattern).toBe('*');
+    expect(rule.policy).toBe('deny');
+  });
+
+  it('passes unknown tool names through as-is', () => {
+    const rule = parsePatternEntry('my_custom_tool(some_arg*)', 'allow');
+    expect(rule.toolName).toBe('my_custom_tool');
+    expect(rule.pattern).toBe('some_arg*');
+    expect(rule.policy).toBe('allow');
+  });
+});
+
+describe('parsePermissionPatterns', () => {
+  it('returns empty array for undefined config', () => {
+    expect(parsePermissionPatterns(undefined)).toEqual([]);
+  });
+
+  it('returns empty array for empty config', () => {
+    expect(parsePermissionPatterns({})).toEqual([]);
+  });
+
+  it('parses allow entries', () => {
+    const rules = parsePermissionPatterns({ allow: ['Bash(git status*)'] });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].policy).toBe('allow');
+    expect(rules[0].pattern).toBe('git status*');
+  });
+
+  it('parses deny entries', () => {
+    const rules = parsePermissionPatterns({ deny: ['Bash(rm -rf*)'] });
+    expect(rules).toHaveLength(1);
+    expect(rules[0].policy).toBe('deny');
+    expect(rules[0].pattern).toBe('rm -rf*');
+  });
+
+  it('parses mixed allow and deny', () => {
+    const rules = parsePermissionPatterns({
+      allow: ['Bash(git status*)', 'Bash(pnpm check-types*)'],
+      deny: ['Bash(rm -rf*)'],
+    });
+    expect(rules).toHaveLength(3);
+    // deny rules come first in the array
+    expect(rules[0].policy).toBe('deny');
+    expect(rules[1].policy).toBe('allow');
+    expect(rules[2].policy).toBe('allow');
+  });
+});

--- a/mastracode/sdk/src/permissions.ts
+++ b/mastracode/sdk/src/permissions.ts
@@ -6,6 +6,8 @@
  * Session-scoped grants let the user approve a category once per session.
  */
 
+import type { PermissionPatternRule } from '@mastra/core/agent-controller';
+
 import { MC_TOOLS } from './tool-names.js';
 
 // ---------------------------------------------------------------------------
@@ -198,4 +200,45 @@ export function resolveApproval(
 
   // 5. Default policy for category
   return DEFAULT_POLICIES[category] ?? 'ask';
+}
+
+// ---------------------------------------------------------------------------
+// Pattern rule parsing
+// ---------------------------------------------------------------------------
+
+const TOOL_ALIASES: Record<string, string> = {
+  Bash: MC_TOOLS.EXECUTE_COMMAND,
+  Edit: MC_TOOLS.STRING_REPLACE_LSP,
+  Write: MC_TOOLS.WRITE_FILE,
+  Read: MC_TOOLS.VIEW,
+  Grep: MC_TOOLS.SEARCH_CONTENT,
+  Glob: MC_TOOLS.FIND_FILES,
+};
+
+/** Parse "Bash(git status*)" into a PermissionPatternRule. Bare names get wildcard pattern. */
+export function parsePatternEntry(entry: string, policy: PermissionPolicy): PermissionPatternRule {
+  const match = entry.match(/^([A-Za-z_-]+)\((.+)\)$/);
+  if (match && match[1] && match[2]) {
+    const alias = match[1];
+    const pattern = match[2];
+    const toolName = TOOL_ALIASES[alias] ?? alias;
+    return { toolName, pattern, policy };
+  }
+  const toolName = TOOL_ALIASES[entry] ?? entry;
+  return { toolName, pattern: '*', policy };
+}
+
+/** Parse the `permissions` block from settings into PermissionPatternRule[]. */
+export function parsePermissionPatterns(
+  config: { allow?: string[]; deny?: string[] } | undefined,
+): PermissionPatternRule[] {
+  if (!config) return [];
+  const rules: PermissionPatternRule[] = [];
+  for (const entry of config.deny ?? []) {
+    rules.push(parsePatternEntry(entry, 'deny'));
+  }
+  for (const entry of config.allow ?? []) {
+    rules.push(parsePatternEntry(entry, 'allow'));
+  }
+  return rules;
 }

--- a/mastracode/sdk/src/schema.ts
+++ b/mastracode/sdk/src/schema.ts
@@ -122,6 +122,7 @@ export const stateSchema = z.object({
       categories: z.record(z.string(), z.enum(['allow', 'ask', 'deny'])).default({}),
       tools: z.record(z.string(), z.enum(['allow', 'ask', 'deny'])).default({}),
     })
+    .passthrough()
     .default({ categories: {}, tools: {} }),
   // Smart editing mode — use AST-based analysis for code edits
   smartEditing: z.boolean().default(true),

--- a/mastracode/tui/src/tui/commands/permissions.ts
+++ b/mastracode/tui/src/tui/commands/permissions.ts
@@ -55,6 +55,25 @@ async function showPermissions(ctx: SlashCommandContext): Promise<void> {
     }
   }
 
+  if (rules.patterns && rules.patterns.length > 0) {
+    lines.push('');
+    lines.push('Pattern Rules (from settings.json):');
+    const allowPatterns = rules.patterns.filter(r => r.policy === 'allow');
+    const denyPatterns = rules.patterns.filter(r => r.policy === 'deny');
+    if (allowPatterns.length > 0) {
+      lines.push('  Allow:');
+      for (const r of allowPatterns) {
+        lines.push(`    ${r.toolName}(${r.pattern})`);
+      }
+    }
+    if (denyPatterns.length > 0) {
+      lines.push('  Deny:');
+      for (const r of denyPatterns) {
+        lines.push(`    ${r.toolName}(${r.pattern})`);
+      }
+    }
+  }
+
   if (grants.categories.length > 0 || grants.tools.length > 0) {
     lines.push('');
     lines.push('Session Grants (reset on restart):');
@@ -70,6 +89,9 @@ async function showPermissions(ctx: SlashCommandContext): Promise<void> {
   lines.push('Commands:');
   lines.push('  /permissions set <category> <allow|ask|deny>');
   lines.push('  /yolo — toggle auto-approve all tools');
+  lines.push('');
+  lines.push('Pattern rules are configured in ~/.mastracode/settings.json:');
+  lines.push('  { "permissions": { "allow": ["Bash(git status*)"], "deny": ["Bash(rm -rf*)"] } }');
 
   ctx.showInfo(lines.join('\n'));
 }

--- a/packages/core/src/agent-controller/index.ts
+++ b/packages/core/src/agent-controller/index.ts
@@ -48,6 +48,7 @@ export type {
   OMBufferedStatus,
   OMProgressState,
   OMStatus,
+  PermissionPatternRule,
   PermissionPolicy,
   PermissionRules,
   ToolCategory,

--- a/packages/core/src/agent-controller/session-permissions.test.ts
+++ b/packages/core/src/agent-controller/session-permissions.test.ts
@@ -157,5 +157,20 @@ describe('session.permissions', () => {
 
       expect(session.resolveToolApproval('execute_command')).toBe('ask');
     });
+
+    it('deny patterns override YOLO mode', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        yolo: true,
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [{ toolName: 'execute_command', pattern: 'rm -rf*', policy: 'deny' }],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('execute_command', { command: 'rm -rf /' })).toBe('deny');
+      expect(session.resolveToolApproval('execute_command', { command: 'echo hello' })).toBe('allow');
+    });
   });
 });

--- a/packages/core/src/agent-controller/session-permissions.test.ts
+++ b/packages/core/src/agent-controller/session-permissions.test.ts
@@ -72,4 +72,90 @@ describe('session.permissions', () => {
     expect(rules.categories.execute).toBe('deny');
     expect(rules.tools.fetch).toBe('allow');
   });
+
+  describe('pattern-based approval', () => {
+    it('allows a command matching an allow pattern', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [{ toolName: 'execute_command', pattern: 'git status*', policy: 'allow' }],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('execute_command', { command: 'git status' })).toBe('allow');
+      expect(session.resolveToolApproval('execute_command', { command: 'git status --short' })).toBe('allow');
+    });
+
+    it('denies a command matching a deny pattern', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [{ toolName: 'execute_command', pattern: 'rm -rf*', policy: 'deny' }],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('execute_command', { command: 'rm -rf /' })).toBe('deny');
+    });
+
+    it('deny patterns take precedence over allow patterns', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [
+            { toolName: 'execute_command', pattern: 'git*', policy: 'allow' },
+            { toolName: 'execute_command', pattern: 'git push --force*', policy: 'deny' },
+          ],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('execute_command', { command: 'git status' })).toBe('allow');
+      expect(session.resolveToolApproval('execute_command', { command: 'git push --force origin main' })).toBe('deny');
+    });
+
+    it('falls through to ask when no pattern matches', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [{ toolName: 'execute_command', pattern: 'git*', policy: 'allow' }],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('execute_command', { command: 'rm -rf /' })).toBe('ask');
+    });
+
+    it('matches file_path arg for file tools', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [{ toolName: 'write_file', pattern: '*.test.ts', policy: 'allow' }],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('write_file', { file_path: 'foo.test.ts' })).toBe('allow');
+      expect(session.resolveToolApproval('write_file', { file_path: 'foo.ts' })).toBe('ask');
+    });
+
+    it('skips pattern matching when no args provided', async () => {
+      const { session } = await createSession(storage);
+      await session.state.set({
+        permissionRules: {
+          categories: {},
+          tools: {},
+          patterns: [{ toolName: 'execute_command', pattern: 'git*', policy: 'allow' }],
+        },
+      } as any);
+
+      expect(session.resolveToolApproval('execute_command')).toBe('ask');
+    });
+  });
 });

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -313,7 +313,7 @@ export class SessionRunEngine {
           ? approvalTransform.transformed
           : getDisplayTransform(chunk.metadata, 'input-available', chunk.payload.args);
 
-        const policy = this.#session.resolveToolApproval(toolName);
+        const policy = this.#session.resolveToolApproval(toolName, chunk.payload.args);
 
         if (policy === 'allow') {
           await this.#session.approveToolCall({ toolCallId, requestContext });

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -55,10 +55,19 @@ function extractPrimaryArg(_toolName: string, args: unknown): string | undefined
   return undefined;
 }
 
-/** Simple glob matching: `*` matches any sequence of characters. */
+/** Simple glob matching: `*` matches any sequence of characters. Linear-time, no regex. */
 function globMatch(input: string, pattern: string): boolean {
-  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
-  return new RegExp(`^${escaped}$`).test(input);
+  const segments = pattern.split('*');
+  if (segments.length === 1) return input === pattern;
+  if (!input.startsWith(segments[0])) return false;
+  let pos = segments[0].length;
+  for (let i = 1; i < segments.length; i++) {
+    const seg = segments[i];
+    const idx = input.indexOf(seg, pos);
+    if (idx === -1) return false;
+    pos = idx + seg.length;
+  }
+  return segments[segments.length - 1] === '' || pos === input.length;
 }
 
 /**
@@ -2855,19 +2864,28 @@ export class Session<TState = unknown> {
     const toolPolicy = rules.tools[toolName];
     if (toolPolicy === 'deny') return 'deny';
 
+    // Deny patterns are a hard safety floor — checked before YOLO.
+    if (rules.patterns?.length && args) {
+      const argStr = extractPrimaryArg(toolName, args);
+      if (argStr !== undefined) {
+        const denyMatch = rules.patterns.find(
+          r => r.policy === 'deny' && (r.toolName === toolName || r.toolName === '*') && globMatch(argStr, r.pattern),
+        );
+        if (denyMatch) return 'deny';
+      }
+    }
+
     if (state.yolo === true) return 'allow';
 
     if (toolPolicy) return toolPolicy;
 
+    // Allow patterns (non-deny) checked after YOLO.
     if (rules.patterns?.length && args) {
       const argStr = extractPrimaryArg(toolName, args);
       if (argStr !== undefined) {
-        const matchingPatterns = rules.patterns.filter(
-          r => (r.toolName === toolName || r.toolName === '*') && globMatch(argStr, r.pattern),
+        const allowMatch = rules.patterns.find(
+          r => r.policy === 'allow' && (r.toolName === toolName || r.toolName === '*') && globMatch(argStr, r.pattern),
         );
-        const denyMatch = matchingPatterns.find(r => r.policy === 'deny');
-        if (denyMatch) return 'deny';
-        const allowMatch = matchingPatterns.find(r => r.policy === 'allow');
         if (allowMatch) return 'allow';
       }
     }

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -41,6 +41,26 @@ import type {
   ToolCategory,
 } from './types';
 
+// ---------------------------------------------------------------------------
+// Permission pattern matching helpers
+// ---------------------------------------------------------------------------
+
+/** Extract the primary argument string from a tool call for pattern matching. */
+function extractPrimaryArg(_toolName: string, args: unknown): string | undefined {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) return undefined;
+  const record = args as Record<string, unknown>;
+  if (typeof record['command'] === 'string') return record['command'];
+  if (typeof record['file_path'] === 'string') return record['file_path'];
+  if (typeof record['path'] === 'string') return record['path'];
+  return undefined;
+}
+
+/** Simple glob matching: `*` matches any sequence of characters. */
+function globMatch(input: string, pattern: string): boolean {
+  const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+  return new RegExp(`^${escaped}$`).test(input);
+}
+
 /**
  * Minimal persistence surface the Session uses to read and write per-thread
  * settings (mode id, per-mode model id, …). The AgentController backs this with thread
@@ -2824,11 +2844,11 @@ export class Session<TState = unknown> {
 
   /**
    * Resolve the effective approval policy for a tool: explicit per-tool deny
-   * wins, then session-wide yolo, then an explicit per-tool policy, then a
-   * session-scoped grant, then the tool's category grant/policy, falling back to
-   * "ask". Pure session state plus the injected category resolver.
+   * wins, then session-wide yolo, then an explicit per-tool policy, then
+   * pattern rules (matched against tool args), then a session-scoped grant,
+   * then the tool's category grant/policy, falling back to "ask".
    */
-  resolveToolApproval(toolName: string): PermissionPolicy {
+  resolveToolApproval(toolName: string, args?: unknown): PermissionPolicy {
     const state = this.state.get() as Record<string, unknown>;
     const rules = this.permissions.getRules();
 
@@ -2838,6 +2858,19 @@ export class Session<TState = unknown> {
     if (state.yolo === true) return 'allow';
 
     if (toolPolicy) return toolPolicy;
+
+    if (rules.patterns?.length && args) {
+      const argStr = extractPrimaryArg(toolName, args);
+      if (argStr !== undefined) {
+        const matchingPatterns = rules.patterns.filter(
+          r => (r.toolName === toolName || r.toolName === '*') && globMatch(argStr, r.pattern),
+        );
+        const denyMatch = matchingPatterns.find(r => r.policy === 'deny');
+        if (denyMatch) return 'deny';
+        const allowMatch = matchingPatterns.find(r => r.policy === 'allow');
+        if (allowMatch) return 'allow';
+      }
+    }
 
     if (this.hasToolGrant(toolName)) return 'allow';
 

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -391,6 +391,13 @@ export type ToolCategory = 'read' | 'edit' | 'execute' | 'mcp' | 'other';
  */
 export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 
+/** A pattern-based permission rule that matches tool arguments using glob-style wildcards. */
+export interface PermissionPatternRule {
+  toolName: string;
+  pattern: string;
+  policy: PermissionPolicy;
+}
+
 /**
  * Permission rules for controlling tool approval behavior.
  * Per-tool overrides take precedence over category policies.
@@ -398,6 +405,7 @@ export type PermissionPolicy = 'allow' | 'ask' | 'deny';
 export interface PermissionRules {
   categories: Partial<Record<ToolCategory, PermissionPolicy>>;
   tools: Partial<Record<string, PermissionPolicy>>;
+  patterns?: PermissionPatternRule[];
 }
 
 // =============================================================================

--- a/packages/core/src/harness/index.ts
+++ b/packages/core/src/harness/index.ts
@@ -70,6 +70,7 @@ export type {
   OMBufferedStatus,
   OMProgressState,
   OMStatus,
+  PermissionPatternRule,
   PermissionPolicy,
   PermissionRules,
   ToolCategory,


### PR DESCRIPTION
## Description

Added a permission pattern allowlist as a middle ground between prompt-every-time and full YOLO mode. Users can configure glob patterns in settings.json to auto-approve safe commands (e.g. `git status`, `echo`) and auto-deny dangerous ones (e.g. `rm -rf`), while everything else prompts as usual.

- Added `PermissionPatternRule` type and optional `patterns` field to `PermissionRules` in `@mastra/core`
- Modified `resolveToolApproval` to accept tool args and match against glob patterns (deny checked before allow)
- Added `extractPrimaryArg` helper to extract the matchable argument (`command` for shell tools, `file_path`/`path` for file tools)
- Added `parsePermissionPatterns` and `parsePatternEntry` to parse settings format `"Bash(git status*)"` into pattern rules
- Added `PermissionSettings` to `GlobalSettings` with `allow`/`deny` string arrays
- Added `.passthrough()` to the `permissionRules` zod schema so `patterns` survives validation
- Updated `/permissions` TUI command to display active pattern rules
- Added 6 tests for pattern-based approval in `@mastra/core` and 9 tests for pattern parsing in `mastracode`
- 
<img width="1196" height="576" alt="image" src="https://github.com/user-attachments/assets/e8de34ba-77f3-4cf9-a9ed-d6ad3abf8a70" />

## Related Issue(s)

Fixes #18174

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR