### PR TITLE
fix(core): preserve tool payload transform in loop

### DIFF
--- a/.changeset/loose-pillows-unite.md
+++ b/.changeset/loose-pillows-unite.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool payload transforms so non-durable agent streams apply configured transform policies.

--- a/packages/core/src/loop/loop-internal.test.ts
+++ b/packages/core/src/loop/loop-internal.test.ts
@@ -1,0 +1,43 @@
+import { ReadableStream } from 'node:stream/web';
+import { describe, expect, it, vi } from 'vitest';
+import { MessageList } from '../agent/message-list';
+import type { LoopRun } from './types';
+
+let capturedLoopRun: LoopRun | undefined;
+
+vi.mock('./workflows/stream', () => ({
+  workflowLoopStream: (loopRun: LoopRun) => {
+    capturedLoopRun = loopRun;
+    return new ReadableStream({ start: controller => controller.close() });
+  },
+}));
+
+const { loop } = await import('./loop');
+
+describe('loop internal bootstrap', () => {
+  it('preserves tool payload transform while rebuilding _internal', () => {
+    const toolPayloadTransform = {
+      targets: ['display'],
+      transformToolPayload: vi.fn(),
+    };
+
+    loop({
+      agentId: 'test-agent',
+      messageList: new MessageList(),
+      models: [
+        {
+          model: {
+            modelId: 'test-model',
+            provider: 'test-provider',
+            specificationVersion: 'v2',
+          },
+        } as any,
+      ],
+      _internal: {
+        toolPayloadTransform: toolPayloadTransform as any,
+      },
+    });
+
+    expect(capturedLoopRun?._internal?.toolPayloadTransform).toBe(toolPayloadTransform);
+  });
+});

--- a/packages/core/src/loop/loop.ts
+++ b/packages/core/src/loop/loop.ts
@@ -71,6 +71,7 @@ export function loop<Tools extends ToolSet = ToolSet, OUTPUT = undefined>({
     backgroundTaskManager: _internal?.backgroundTaskManager,
     agentBackgroundConfig: _internal?.agentBackgroundConfig,
     backgroundTaskManagerConfig: _internal?.backgroundTaskManagerConfig,
+    toolPayloadTransform: _internal?.toolPayloadTransform,
     skipBgTaskWait: _internal?.skipBgTaskWait,
     drainPendingSignals: _internal?.drainPendingSignals,
     initialSignalEchoes: _internal?.initialSignalEchoes ? [..._internal.initialSignalEchoes] : undefined,


### PR DESCRIPTION
Fixes #19102.

This preserves `toolPayloadTransform` when `loop()` rebuilds the internal stream bootstrap bag before passing it to the evented workflow loop. Without this field, the run scope hydration path never receives the configured transform policy, so non-durable agent streams silently skip display/transcript tool payload transforms.

I added a focused regression test for the `loop()` reconstruction path and included a patch changeset for `@mastra/core`.

Validation run:
- `pnpm build:core`
- `pnpm --filter ./packages/core exec vitest run src/loop/loop-internal.test.ts`
- `pnpm --filter ./packages/core exec vitest run src/loop/loop-internal.test.ts src/loop/run-scope-helpers.test.ts`
- `pnpm --filter ./packages/core exec eslint src/loop/loop.ts src/loop/loop-internal.test.ts`
- `pnpm --filter ./packages/core check`
- `pnpm prettier --check packages/core/src/loop/loop.ts packages/core/src/loop/loop-internal.test.ts .changeset/loose-pillows-unite.md`
- `pnpm lint-staged --quiet`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes a bug where a “how to format tool messages” setting was getting lost while a stream was being rebuilt. Now that setting is kept, so tool calls and results show up correctly in non-durable agent streams.

## Summary
- Preserved `_internal.toolPayloadTransform` when `loop()` rebuilds its internal stream bootstrap data.
- Ensured the transform policy flows through `workflowLoopProps._internal` into `hydrateRunScopeFromInternal`, matching the expected hydration behavior.
- Added a regression test covering the `loop()` reconstruction path to verify the transform reference is retained.
- Included a patch changeset for `@mastra/core`.
- Validation was run across build, tests, linting, type checks, formatting, and lint-staged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->