### PR TITLE
feat(memory): one-shot conversation summarization — summarizeConversation() / Memory.summarizeThread()

### DIFF
--- a/.changeset/giant-goats-leave.md
+++ b/.changeset/giant-goats-leave.md
@@ -1,0 +1,36 @@
+---
+'@mastra/memory': minor
+---
+
+Added one-shot conversation summarization: a standalone `summarizeConversation()` function and a `Memory.summarizeThread()` method. Both distill a whole conversation with the same Observer plumbing that powers Observational Memory — without Observational Memory attached to an agent, and without writing anything back to memory. The summary and extracted values are returned to you (and to each extractor's `onExtracted` hook), so you decide where they go.
+
+```ts
+import { Extractor } from '@mastra/memory';
+import { z } from 'zod';
+
+// e.g. in an end-of-call or end-of-session hook
+const result = await memory.summarizeThread({
+  model: 'openai/gpt-5-mini',
+  threadId,
+  resourceId,
+  instructions: 'Summarize this voicemail call for the business owner.',
+  extract: [
+    new Extractor({
+      name: 'call-summary',
+      instructions: 'Return a concise summary of the call.',
+      schema: z.object({
+        summary: z.string(),
+        sentiment: z.enum(['positive', 'neutral', 'negative']),
+      }),
+      metadataKeyPath: false,
+      onExtracted: async ({ current, threadId, resourceId }) => {
+        await callRecords.upsert({ callId: threadId, callerId: resourceId, record: current });
+      },
+    }),
+  ],
+});
+```
+
+`summarizeConversation({ model, messages, instructions, extract })` takes the same options with messages you already have in hand instead of a `threadId`.
+
+**Why:** session-based agents (for example voice calls) often need a summary or structured extraction of the finished conversation — sentiment, requested services, follow-ups — stored in the application's own database. Observational Memory's observer and extractors are built for exactly this distillation, but attaching OM to an agent just to summarize at session end forces the whole observe/activate lifecycle onto a use case that doesn't need it. These APIs expose the summarization/extraction logic directly.

--- a/.changeset/giant-goats-leave.md
+++ b/.changeset/giant-goats-leave.md
@@ -33,4 +33,6 @@ const result = await memory.summarizeThread({
 
 `summarizeConversation({ model, messages, instructions, extract })` takes the same options with messages you already have in hand instead of a `threadId`.
 
+`summarizeThread` loads the thread's messages page-by-page starting from the newest, and accepts `lastMessages` (only summarize the last N messages) and `maxInputTokens` (stop loading older messages past this estimated token count, default 1,000,000) to bound how much history is read from storage.
+
 **Why:** session-based agents (for example voice calls) often need a summary or structured extraction of the finished conversation — sentiment, requested services, follow-ups — stored in the application's own database. Observational Memory's observer and extractors are built for exactly this distillation, but attaching OM to an agent just to summarize at session end forces the whole observe/activate lifecycle onto a use case that doesn't need it. These APIs expose the summarization/extraction logic directly.

--- a/docs/src/content/en/reference/memory/summarizeConversation.mdx
+++ b/docs/src/content/en/reference/memory/summarizeConversation.mdx
@@ -1,0 +1,174 @@
+---
+title: "Reference: summarizeConversation() | Memory"
+description: "Documentation for the standalone `summarizeConversation()` function in Mastra, which summarizes messages you pass in and extracts structured values from them."
+packages:
+  - "@mastra/memory"
+---
+
+# summarizeConversation()
+
+The standalone `summarizeConversation()` function summarizes a conversation in one shot. It distills the messages you pass in with the same Observer plumbing that powers [Observational Memory](/reference/memory/observational-memory) — without Observational Memory attached to an agent, and without reading from or writing to storage.
+
+Nothing is written back to memory. The summary and extracted values are returned to you (and to each extractor's `onExtracted` hook), so you decide where they go — for example your own database.
+
+Use this when you already have the messages in hand and want explicit control over what gets summarized. To summarize a stored thread by ID instead, use [`Memory.summarizeThread()`](/reference/memory/summarizeThread), which loads the messages for you.
+
+## Usage example
+
+```typescript
+import { summarizeConversation } from '@mastra/memory'
+
+const result = await summarizeConversation({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  messages,
+  instructions: 'Summarize this voicemail call for the business owner.',
+})
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'model',
+    type: 'string | LanguageModel | DynamicModel',
+    description: "Model that runs the summarization, such as a router string like '__GATEWAY_OPENAI_MODEL_MINI__'.",
+    isOptional: false,
+  },
+  {
+    name: 'messages',
+    type: 'MastraDBMessage[]',
+    description:
+      'The conversation to summarize. When empty, the function returns an empty result without calling the model.',
+    isOptional: false,
+  },
+  {
+    name: 'instructions',
+    type: 'string',
+    description:
+      "Extra guidance appended to the summarizer's system prompt, such as what to focus on or who the summary is for.",
+    isOptional: true,
+  },
+  {
+    name: 'extract',
+    type: 'Extractor[]',
+    description:
+      "Extractors to run over the conversation. Extractors with a Zod schema run as a follow-up structured output call; schema-less extractors are extracted inline. Each extractor's `onExtracted` hook fires with the extracted value.",
+    isOptional: true,
+  },
+  {
+    name: 'threadId',
+    type: 'string',
+    description:
+      'Thread the conversation belongs to. Defaults to the first `threadId` found on `messages`. Passed to extractor contexts.',
+    isOptional: true,
+  },
+  {
+    name: 'resourceId',
+    type: 'string',
+    description:
+      'Resource (user) the conversation belongs to. Defaults to the first `resourceId` found on `messages`. Passed to extractor contexts.',
+    isOptional: true,
+  },
+  {
+    name: 'memory',
+    type: 'Memory',
+    description:
+      'Memory instance forwarded to extractor contexts. Set automatically when called through `Memory.summarizeThread()`.',
+    isOptional: true,
+  },
+  {
+    name: 'mastra',
+    type: 'Mastra',
+    description:
+      'Mastra instance used to resolve custom gateway models. Set automatically when called through `Memory.summarizeThread()`.',
+    isOptional: true,
+  },
+  {
+    name: 'requestContext',
+    type: 'RequestContext',
+    description: 'Request context forwarded to the summarizer model and extractor hooks.',
+    isOptional: true,
+  },
+  {
+    name: 'abortSignal',
+    type: 'AbortSignal',
+    description: 'Signal to cancel the summarization call.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'summary',
+    type: 'string',
+    description: 'The distilled observations produced from the conversation, in dense bullet form.',
+  },
+  {
+    name: 'extracted',
+    type: 'Record<string, unknown>',
+    description: 'Values produced by `extract` extractors, keyed by extractor slug.',
+  },
+  {
+    name: 'extractionFailures',
+    type: '{ slug: string; error: string }[]',
+    description:
+      'Extractors that failed to produce a valid value, with the reason. Only present when at least one extractor failed.',
+  },
+  {
+    name: 'usage',
+    type: '{ inputTokens?: number; outputTokens?: number; totalTokens?: number }',
+    description: 'Token usage of the summarization call.',
+  },
+]}
+/>
+
+## Extended usage example
+
+The following example summarizes an in-flight voice session from messages the application already holds, and extracts a structured record:
+
+```typescript title="src/session-summary.ts"
+import { summarizeConversation, Extractor } from '@mastra/memory'
+import type { MastraDBMessage } from '@mastra/core/agent'
+import { z } from 'zod'
+import { sessionRecords } from './db'
+
+const sessionSummary = new Extractor({
+  name: 'session-summary',
+  instructions: 'Return a concise summary of the session.',
+  schema: z.object({
+    summary: z.string(),
+    sentiment: z.enum(['positive', 'neutral', 'negative']),
+    followUps: z.array(z.string()),
+  }),
+  metadataKeyPath: false, // don't persist into memory metadata — the hook owns storage
+  onExtracted: async ({ current, threadId }) => {
+    await sessionRecords.upsert({ sessionId: threadId, record: current })
+  },
+})
+
+export async function onSessionEnd(messages: MastraDBMessage[]) {
+  const { summary, extracted, extractionFailures } = await summarizeConversation({
+    model: '__GATEWAY_OPENAI_MODEL_MINI__',
+    messages,
+    instructions: 'Summarize this support session for the account manager.',
+    extract: [sessionSummary],
+  })
+
+  if (extractionFailures?.length) {
+    console.warn('Some extractors failed', extractionFailures)
+  }
+
+  return { summary, extracted }
+}
+```
+
+### Related
+
+- [.summarizeThread()](/reference/memory/summarizeThread)
+- [Memory Class Reference](/reference/memory/memory-class)
+- [Observational Memory](/reference/memory/observational-memory)

--- a/docs/src/content/en/reference/memory/summarizeThread.mdx
+++ b/docs/src/content/en/reference/memory/summarizeThread.mdx
@@ -1,0 +1,145 @@
+---
+title: "Reference: Memory.summarizeThread() | Memory"
+description: "Documentation for the `Memory.summarizeThread()` method in Mastra, which summarizes a thread's conversation in one shot and extracts structured values from it."
+packages:
+  - "@mastra/memory"
+---
+
+# Memory.summarizeThread()
+
+The `.summarizeThread()` method summarizes a thread's conversation in one shot. It loads the thread's messages from storage and distills them with the same Observer plumbing that powers [Observational Memory](/reference/memory/observational-memory) — as a standalone call, without Observational Memory attached to an agent.
+
+Nothing is written back to memory. The summary and extracted values are returned to you (and to each extractor's `onExtracted` hook), so you decide where they go — for example your own database.
+
+Use this when a session ends and you want a summary or structured extraction of the whole conversation, such as a voice call at hang-up. To summarize messages you already have in hand (without loading them from a thread), use the standalone `summarizeConversation()` function instead — it takes the same options with `messages` in place of `threadId`.
+
+## Usage example
+
+```typescript
+const result = await memory.summarizeThread({
+  model: '__GATEWAY_OPENAI_MODEL_MINI__',
+  threadId: 'thread-123',
+  instructions: 'Summarize this voicemail call for the business owner.',
+})
+```
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'threadId',
+    type: 'string',
+    description: 'The unique identifier of the thread to summarize.',
+    isOptional: false,
+  },
+  {
+    name: 'model',
+    type: 'string | LanguageModel | DynamicModel',
+    description: "Model that runs the summarization, such as a router string like '__GATEWAY_OPENAI_MODEL_MINI__'.",
+    isOptional: false,
+  },
+  {
+    name: 'resourceId',
+    type: 'string',
+    description:
+      'ID of the resource that owns the thread. If provided, validates thread ownership. Also passed to extractor contexts.',
+    isOptional: true,
+  },
+  {
+    name: 'instructions',
+    type: 'string',
+    description:
+      "Extra guidance appended to the summarizer's system prompt, such as what to focus on or who the summary is for.",
+    isOptional: true,
+  },
+  {
+    name: 'extract',
+    type: 'Extractor[]',
+    description:
+      "Extractors to run over the conversation. Extractors with a Zod schema run as a follow-up structured output call; schema-less extractors are extracted inline. Each extractor's `onExtracted` hook fires with the extracted value.",
+    isOptional: true,
+  },
+  {
+    name: 'requestContext',
+    type: 'RequestContext',
+    description: 'Request context forwarded to the summarizer model and extractor hooks.',
+    isOptional: true,
+  },
+  {
+    name: 'abortSignal',
+    type: 'AbortSignal',
+    description: 'Signal to cancel the summarization call.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'summary',
+    type: 'string',
+    description: 'The distilled observations produced from the conversation, in dense bullet form.',
+  },
+  {
+    name: 'extracted',
+    type: 'Record<string, unknown>',
+    description: 'Values produced by `extract` extractors, keyed by extractor slug.',
+  },
+  {
+    name: 'extractionFailures',
+    type: '{ slug: string; error: string }[]',
+    description:
+      'Extractors that failed to produce a valid value, with the reason. Only present when at least one extractor failed.',
+  },
+  {
+    name: 'usage',
+    type: '{ inputTokens?: number; outputTokens?: number; totalTokens?: number }',
+    description: 'Token usage of the summarization call.',
+  },
+]}
+/>
+
+## Extended usage example
+
+The following example summarizes a finished voice call and stores a structured record in the application's own database:
+
+```typescript title="src/call-summary.ts"
+import { Extractor } from '@mastra/memory'
+import { z } from 'zod'
+import { memory } from './mastra/memory'
+import { callRecords } from './db'
+
+const callSummary = new Extractor({
+  name: 'call-summary',
+  instructions: 'Return a concise summary of the call.',
+  schema: z.object({
+    summary: z.string(),
+    sentiment: z.enum(['positive', 'neutral', 'negative']),
+    requestedServices: z.array(z.string()),
+  }),
+  metadataKeyPath: false, // don't persist into memory metadata — the hook owns storage
+  onExtracted: async ({ current, threadId, resourceId }) => {
+    await callRecords.upsert({ callId: threadId, callerId: resourceId, record: current })
+  },
+})
+
+export async function onCallEnd(threadId: string, resourceId: string) {
+  await memory.summarizeThread({
+    model: '__GATEWAY_OPENAI_MODEL_MINI__',
+    threadId,
+    resourceId,
+    instructions: 'Summarize this voicemail call for the business owner.',
+    extract: [callSummary],
+  })
+}
+```
+
+### Related
+
+- [Memory Class Reference](/reference/memory/memory-class)
+- [Observational Memory](/reference/memory/observational-memory)
+- [.recall()](/reference/memory/recall)

--- a/docs/src/content/en/reference/memory/summarizeThread.mdx
+++ b/docs/src/content/en/reference/memory/summarizeThread.mdx
@@ -13,7 +13,7 @@ Messages load page-by-page starting from the newest, bounded by `lastMessages` a
 
 Nothing is written back to memory. The summary and extracted values are returned to you (and to each extractor's `onExtracted` hook), so you decide where they go — for example your own database.
 
-Use this when a session ends and you want a summary or structured extraction of the whole conversation, such as a voice call at hang-up. To summarize messages you already have in hand (without loading them from a thread), use the standalone `summarizeConversation()` function instead — it takes the same options with `messages` in place of `threadId`.
+Use this when a session ends and you want a summary or structured extraction of the whole conversation, such as a voice call at hang-up. To summarize messages you already have in hand (without loading them from a thread), use the standalone [`summarizeConversation()`](/reference/memory/summarizeConversation) function instead — it takes the same options with `messages` in place of `threadId`.
 
 ## Usage example
 
@@ -157,6 +157,7 @@ export async function onCallEnd(threadId: string, resourceId: string) {
 
 ### Related
 
+- [summarizeConversation()](/reference/memory/summarizeConversation)
 - [Memory Class Reference](/reference/memory/memory-class)
 - [Observational Memory](/reference/memory/observational-memory)
 - [.recall()](/reference/memory/recall)

--- a/docs/src/content/en/reference/memory/summarizeThread.mdx
+++ b/docs/src/content/en/reference/memory/summarizeThread.mdx
@@ -9,6 +9,8 @@ packages:
 
 The `.summarizeThread()` method summarizes a thread's conversation in one shot. It loads the thread's messages from storage and distills them with the same Observer plumbing that powers [Observational Memory](/reference/memory/observational-memory) — as a standalone call, without Observational Memory attached to an agent.
 
+Messages load page-by-page starting from the newest, bounded by `lastMessages` and `maxInputTokens`, so summarizing a long thread doesn't read its entire history from storage.
+
 Nothing is written back to memory. The summary and extracted values are returned to you (and to each extractor's `onExtracted` hook), so you decide where they go — for example your own database.
 
 Use this when a session ends and you want a summary or structured extraction of the whole conversation, such as a voice call at hang-up. To summarize messages you already have in hand (without loading them from a thread), use the standalone `summarizeConversation()` function instead — it takes the same options with `messages` in place of `threadId`.
@@ -45,6 +47,21 @@ const result = await memory.summarizeThread({
     description:
       'ID of the resource that owns the thread. If provided, validates thread ownership. Also passed to extractor contexts.',
     isOptional: true,
+  },
+  {
+    name: 'lastMessages',
+    type: 'number',
+    description:
+      'Only summarize the last N messages of the thread. By default the whole thread is loaded, bounded by `maxInputTokens`.',
+    isOptional: true,
+  },
+  {
+    name: 'maxInputTokens',
+    type: 'number',
+    description:
+      'Stop loading older messages once the collected messages exceed this estimated token count. The newest message is always included.',
+    isOptional: true,
+    defaultValue: '1000000',
   },
   {
     name: 'instructions',

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -9,7 +9,6 @@ const sidebars = {
   referenceSidebar: [
     { type: 'doc', id: 'index', label: 'Overview' },
     { type: 'doc', id: 'configuration', label: 'Configuration' },
-    { type: 'doc', id: 'project-structure', label: 'Project Structure' },
     {
       type: 'category',
       label: 'ACP',
@@ -165,19 +164,6 @@ const sidebars = {
         { type: 'doc', id: 'client-js/tools', label: 'Tools API' },
         { type: 'doc', id: 'client-js/vectors', label: 'Vectors API' },
         { type: 'doc', id: 'client-js/workflows', label: 'Workflows API' },
-      ],
-    },
-    {
-      type: 'category',
-      label: 'Code SDK',
-      collapsed: true,
-      items: [
-        {
-          type: 'doc',
-          id: 'code-sdk/mount-agent-controller',
-          label: 'mountAgentControllerOnMastra()',
-          customProps: { tags: ['beta'] },
-        },
       ],
     },
     {
@@ -379,6 +365,7 @@ const sidebars = {
         { type: 'doc', id: 'memory/getThreadById', label: '.getThreadById()' },
         { type: 'doc', id: 'memory/listThreads', label: '.listThreads()' },
         { type: 'doc', id: 'memory/recall', label: '.recall()' },
+        { type: 'doc', id: 'memory/summarizeThread', label: '.summarizeThread()' },
       ],
     },
     {
@@ -560,12 +547,6 @@ const sidebars = {
     },
     {
       type: 'category',
-      label: 'Schedules',
-      collapsed: true,
-      items: [{ type: 'doc', id: 'schedules/overview', label: 'Overview' }],
-    },
-    {
-      type: 'category',
       label: 'Server',
       collapsed: true,
       items: [
@@ -679,7 +660,6 @@ const sidebars = {
       label: 'Tools and MCP',
       collapsed: true,
       items: [
-        { type: 'doc', id: 'tools/ask-user-tool', label: 'askUserTool' },
         { type: 'doc', id: 'tools/brightdata', label: 'Bright Data Tools' },
         {
           type: 'doc',
@@ -694,8 +674,6 @@ const sidebars = {
         { type: 'doc', id: 'tools/mcp-client', label: 'MCPClient' },
         { type: 'doc', id: 'tools/mcp-server', label: 'MCPServer' },
         { type: 'doc', id: 'tools/perplexity', label: 'Perplexity Tools' },
-        { type: 'doc', id: 'tools/submit-plan-tool', label: 'submitPlanTool' },
-        { type: 'doc', id: 'tools/task-tools', label: 'Task tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },
       ],
     },

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -373,6 +373,7 @@ const sidebars = {
         { type: 'doc', id: 'memory/memory-class', label: 'Memory Class' },
         { type: 'doc', id: 'memory/observational-memory', label: 'Observational Memory' },
         { type: 'doc', id: 'memory/serialized-memory-config', label: 'SerializedMemoryConfig' },
+        { type: 'doc', id: 'memory/summarizeConversation', label: 'summarizeConversation()' },
         { type: 'doc', id: 'memory/cloneThread', label: '.cloneThread()' },
         { type: 'doc', id: 'memory/createThread', label: '.createThread()' },
         { type: 'doc', id: 'memory/deleteMessages', label: '.deleteMessages()' },

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -9,6 +9,7 @@ const sidebars = {
   referenceSidebar: [
     { type: 'doc', id: 'index', label: 'Overview' },
     { type: 'doc', id: 'configuration', label: 'Configuration' },
+    { type: 'doc', id: 'project-structure', label: 'Project Structure' },
     {
       type: 'category',
       label: 'ACP',
@@ -164,6 +165,19 @@ const sidebars = {
         { type: 'doc', id: 'client-js/tools', label: 'Tools API' },
         { type: 'doc', id: 'client-js/vectors', label: 'Vectors API' },
         { type: 'doc', id: 'client-js/workflows', label: 'Workflows API' },
+      ],
+    },
+    {
+      type: 'category',
+      label: 'Code SDK',
+      collapsed: true,
+      items: [
+        {
+          type: 'doc',
+          id: 'code-sdk/mount-agent-controller',
+          label: 'mountAgentControllerOnMastra()',
+          customProps: { tags: ['beta'] },
+        },
       ],
     },
     {
@@ -547,6 +561,12 @@ const sidebars = {
     },
     {
       type: 'category',
+      label: 'Schedules',
+      collapsed: true,
+      items: [{ type: 'doc', id: 'schedules/overview', label: 'Overview' }],
+    },
+    {
+      type: 'category',
       label: 'Server',
       collapsed: true,
       items: [
@@ -660,6 +680,7 @@ const sidebars = {
       label: 'Tools and MCP',
       collapsed: true,
       items: [
+        { type: 'doc', id: 'tools/ask-user-tool', label: 'askUserTool' },
         { type: 'doc', id: 'tools/brightdata', label: 'Bright Data Tools' },
         {
           type: 'doc',
@@ -674,6 +695,8 @@ const sidebars = {
         { type: 'doc', id: 'tools/mcp-client', label: 'MCPClient' },
         { type: 'doc', id: 'tools/mcp-server', label: 'MCPServer' },
         { type: 'doc', id: 'tools/perplexity', label: 'Perplexity Tools' },
+        { type: 'doc', id: 'tools/submit-plan-tool', label: 'submitPlanTool' },
+        { type: 'doc', id: 'tools/task-tools', label: 'Task tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },
       ],
     },

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -46,6 +46,7 @@ import type { JSONSchema7 } from 'json-schema';
 import { LRUCache } from 'lru-cache';
 import xxhash from 'xxhash-wasm';
 import type { ObservationalMemory, ObservationalMemoryConfig } from './processors/observational-memory';
+import { summarizeConversation } from './processors/observational-memory/summarize';
 import type {
   SummarizeConversationOptions,
   SummarizeConversationResult,
@@ -2135,7 +2136,6 @@ Notes:
       'messages' | 'memory' | 'mastra' | 'threadId' | 'resourceId'
     >,
   ): Promise<SummarizeConversationResult> {
-    const { summarizeConversation } = await import('./processors/observational-memory/summarize');
     const { messages } = await this.recall({ threadId: opts.threadId, resourceId: opts.resourceId, perPage: false });
     return summarizeConversation({
       ...opts,

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -46,11 +46,12 @@ import type { JSONSchema7 } from 'json-schema';
 import { LRUCache } from 'lru-cache';
 import xxhash from 'xxhash-wasm';
 import type { ObservationalMemory, ObservationalMemoryConfig } from './processors/observational-memory';
-import { summarizeConversation } from './processors/observational-memory/summarize';
+import { summarizeConversation, SUMMARIZE_THREAD_DEFAULTS } from './processors/observational-memory/summarize';
 import type {
   SummarizeConversationOptions,
   SummarizeConversationResult,
 } from './processors/observational-memory/summarize';
+import { TokenCounter } from './processors/observational-memory/token-counter';
 import { WorkingMemoryExtractor } from './processors/observational-memory/working-memory-extractor';
 import { recallTool } from './tools/om-tools';
 import { createWorkingMemoryTool, deepMergeWorkingMemory } from './tools/working-memory';
@@ -67,7 +68,7 @@ export {
   type ExtractorSource,
 } from './processors/observational-memory';
 export { WorkingMemoryExtractor } from './processors/observational-memory/working-memory-extractor';
-export { summarizeConversation } from './processors/observational-memory/summarize';
+export { summarizeConversation, SUMMARIZE_THREAD_DEFAULTS } from './processors/observational-memory/summarize';
 export type {
   SummarizeConversationOptions,
   SummarizeConversationResult,
@@ -2120,6 +2121,10 @@ Notes:
    * Use this when a session ends and you want a summary or structured extraction of the whole
    * conversation — for example a voice call at hang-up.
    *
+   * Messages are loaded page-by-page starting from the newest, bounded by `lastMessages` and
+   * `maxInputTokens`, so summarizing a very long thread doesn't read its entire history from
+   * storage.
+   *
    * @example
    * ```ts
    * const result = await memory.summarizeThread({
@@ -2131,18 +2136,95 @@ Notes:
    * ```
    */
   public async summarizeThread(
-    opts: { threadId: string; resourceId?: string } & Omit<
-      SummarizeConversationOptions,
-      'messages' | 'memory' | 'mastra' | 'threadId' | 'resourceId'
-    >,
+    opts: {
+      threadId: string;
+      resourceId?: string;
+      /** Only summarize the last N messages of the thread. By default the whole thread is loaded, bounded by `maxInputTokens`. */
+      lastMessages?: number;
+      /**
+       * Stop loading older messages once the collected messages exceed this estimated token count,
+       * so very long threads don't get read from storage in full. The newest message is always
+       * included. Defaults to 1,000,000 tokens.
+       */
+      maxInputTokens?: number;
+    } & Omit<SummarizeConversationOptions, 'messages' | 'memory' | 'mastra' | 'threadId' | 'resourceId'>,
   ): Promise<SummarizeConversationResult> {
-    const { messages } = await this.recall({ threadId: opts.threadId, resourceId: opts.resourceId, perPage: false });
+    const { lastMessages, maxInputTokens, ...summarizeOptions } = opts;
+    // TODO: when Observational Memory is enabled on this instance, build the summary from the
+    // thread's existing observations plus the still-unobserved messages instead of re-reading the
+    // raw message history. https://github.com/mastra-ai/mastra/pull/19135#discussion_r3546310808
+    const messages = await this.loadMessagesForSummarization({
+      threadId: opts.threadId,
+      resourceId: opts.resourceId,
+      lastMessages,
+      maxInputTokens: maxInputTokens ?? SUMMARIZE_THREAD_DEFAULTS.maxInputTokens,
+    });
     return summarizeConversation({
-      ...opts,
+      ...summarizeOptions,
       messages,
       memory: this,
       mastra: this._mastraInstance,
     });
+  }
+
+  /**
+   * Load a thread's messages for `summarizeThread()` without reading the whole thread from
+   * storage at once. Pages backwards from the newest message and stops once `lastMessages`
+   * messages are collected or the estimated token count crosses `maxInputTokens` (the newest
+   * message is always kept). Returns messages in chronological order.
+   */
+  private async loadMessagesForSummarization({
+    threadId,
+    resourceId,
+    lastMessages,
+    maxInputTokens,
+  }: {
+    threadId: string;
+    resourceId?: string;
+    lastMessages?: number;
+    maxInputTokens: number;
+  }): Promise<MastraDBMessage[]> {
+    if (lastMessages !== undefined && lastMessages <= 0) return [];
+
+    const tokenCounter = new TokenCounter();
+    const collected: MastraDBMessage[] = [];
+    let tokens = 0;
+    let page = 0;
+
+    while (true) {
+      // Each page is the next-older slice of the thread, returned in chronological order
+      // (recall queries newest-first and reverses each page when no orderBy is given).
+      const { messages: batch, hasMore } = await this.recall({
+        threadId,
+        resourceId,
+        perPage: SUMMARIZE_THREAD_DEFAULTS.pageSize,
+        page,
+      });
+      if (batch.length === 0) break;
+
+      let reachedLimit = false;
+      const kept: MastraDBMessage[] = [];
+      for (let i = batch.length - 1; i >= 0; i--) {
+        const message = batch[i]!;
+        if (lastMessages !== undefined && collected.length + kept.length >= lastMessages) {
+          reachedLimit = true;
+          break;
+        }
+        const messageTokens = tokenCounter.countMessage(message);
+        if (collected.length + kept.length > 0 && tokens + messageTokens > maxInputTokens) {
+          reachedLimit = true;
+          break;
+        }
+        kept.unshift(message);
+        tokens += messageTokens;
+      }
+
+      collected.unshift(...kept);
+      if (reachedLimit || !hasMore) break;
+      page++;
+    }
+
+    return collected;
   }
 
   /**

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -2158,6 +2158,7 @@ Notes:
       resourceId: opts.resourceId,
       lastMessages,
       maxInputTokens: maxInputTokens ?? SUMMARIZE_THREAD_DEFAULTS.maxInputTokens,
+      abortSignal: summarizeOptions.abortSignal,
     });
     return summarizeConversation({
       ...summarizeOptions,
@@ -2178,11 +2179,13 @@ Notes:
     resourceId,
     lastMessages,
     maxInputTokens,
+    abortSignal,
   }: {
     threadId: string;
     resourceId?: string;
     lastMessages?: number;
     maxInputTokens: number;
+    abortSignal?: AbortSignal;
   }): Promise<MastraDBMessage[]> {
     if (lastMessages !== undefined && lastMessages <= 0) return [];
 
@@ -2192,6 +2195,8 @@ Notes:
     let page = 0;
 
     while (true) {
+      abortSignal?.throwIfAborted();
+
       // Each page is the next-older slice of the thread, returned in chronological order
       // (recall queries newest-first and reverses each page when no orderBy is given).
       const { messages: batch, hasMore } = await this.recall({
@@ -2205,6 +2210,8 @@ Notes:
       let reachedLimit = false;
       const kept: MastraDBMessage[] = [];
       for (let i = batch.length - 1; i >= 0; i--) {
+        abortSignal?.throwIfAborted();
+
         const message = batch[i]!;
         if (lastMessages !== undefined && collected.length + kept.length >= lastMessages) {
           reachedLimit = true;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -46,6 +46,10 @@ import type { JSONSchema7 } from 'json-schema';
 import { LRUCache } from 'lru-cache';
 import xxhash from 'xxhash-wasm';
 import type { ObservationalMemory, ObservationalMemoryConfig } from './processors/observational-memory';
+import type {
+  SummarizeConversationOptions,
+  SummarizeConversationResult,
+} from './processors/observational-memory/summarize';
 import { WorkingMemoryExtractor } from './processors/observational-memory/working-memory-extractor';
 import { recallTool } from './tools/om-tools';
 import { createWorkingMemoryTool, deepMergeWorkingMemory } from './tools/working-memory';
@@ -62,6 +66,12 @@ export {
   type ExtractorSource,
 } from './processors/observational-memory';
 export { WorkingMemoryExtractor } from './processors/observational-memory/working-memory-extractor';
+export { summarizeConversation } from './processors/observational-memory/summarize';
+export type {
+  SummarizeConversationOptions,
+  SummarizeConversationResult,
+  SummarizeModel,
+} from './processors/observational-memory/summarize';
 
 /**
  * Normalize a `boolean | object` observational memory config.
@@ -2095,6 +2105,44 @@ Notes:
       throw new Error('Observational memory is not enabled');
     }
     await omEngine.updateRecordConfig(threadId, resourceId, config);
+  }
+
+  /**
+   * Summarize one of this memory's threads in one shot.
+   *
+   * Loads the thread's messages from storage and runs `summarizeConversation()` over them —
+   * Observational Memory's Observer plumbing as a standalone call. Nothing is written back to
+   * memory: the summary and extracted values are returned to you (and to each extractor's
+   * `onExtracted` hook), so you decide where they go. Works whether or not observational
+   * memory is enabled on this instance.
+   *
+   * Use this when a session ends and you want a summary or structured extraction of the whole
+   * conversation — for example a voice call at hang-up.
+   *
+   * @example
+   * ```ts
+   * const result = await memory.summarizeThread({
+   *   model: 'openai/gpt-4.1-mini',
+   *   threadId: call.threadId,
+   *   instructions: 'Summarize this voicemail call for the business owner.',
+   *   extract: [callSummaryExtractor],
+   * });
+   * ```
+   */
+  public async summarizeThread(
+    opts: { threadId: string; resourceId?: string } & Omit<
+      SummarizeConversationOptions,
+      'messages' | 'memory' | 'mastra' | 'threadId' | 'resourceId'
+    >,
+  ): Promise<SummarizeConversationResult> {
+    const { summarizeConversation } = await import('./processors/observational-memory/summarize');
+    const { messages } = await this.recall({ threadId: opts.threadId, resourceId: opts.resourceId, perPage: false });
+    return summarizeConversation({
+      ...opts,
+      messages,
+      memory: this,
+      mastra: this._mastraInstance,
+    });
   }
 
   /**

--- a/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
@@ -1,0 +1,211 @@
+/**
+ * summarizeConversation() / Memory.summarizeThread() tests
+ *
+ * Standalone one-shot summarization that reuses the Observer + extractor
+ * plumbing without an ObservationalMemory instance or any storage writes.
+ */
+
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
+import { InMemoryStore } from '@mastra/core/storage';
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+
+import { Memory } from '../../..';
+import { Extractor } from '../extractor';
+import { summarizeConversation } from '../summarize';
+
+function createTestMessage(
+  content: string,
+  role: 'user' | 'assistant' = 'user',
+  extra?: Partial<MastraDBMessage>,
+): MastraDBMessage {
+  return {
+    id: `msg-${Math.random().toString(36).slice(2)}`,
+    role,
+    content: { format: 2, parts: [{ type: 'text', text: content }] } as MastraMessageContentV2,
+    type: 'text',
+    createdAt: new Date(),
+    ...extra,
+  };
+}
+
+/** Mock model: doStream serves the summarizer output, doGenerate serves the structured-extraction follow-up. */
+function createMockSummarizerModel(streamText: string, generateObjectJson?: string) {
+  const doStream = vi.fn(async () => ({
+    stream: convertArrayToReadableStream([
+      { type: 'stream-start', warnings: [] },
+      { type: 'response-metadata', id: 'sum-1', modelId: 'mock-summarizer', timestamp: new Date() },
+      { type: 'text-start', id: 'text-1' },
+      { type: 'text-delta', id: 'text-1', delta: streamText },
+      { type: 'text-end', id: 'text-1' },
+      {
+        type: 'finish',
+        finishReason: 'stop' as const,
+        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+      },
+    ]),
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    warnings: [],
+  }));
+  const doGenerate = vi.fn(async () => ({
+    rawCall: { rawPrompt: null, rawSettings: {} },
+    finishReason: 'stop' as const,
+    usage: { inputTokens: 40, outputTokens: 20, totalTokens: 60 },
+    warnings: [],
+    content: [{ type: 'text' as const, text: generateObjectJson ?? '{}' }],
+  }));
+  const model = new MockLanguageModelV2({ doStream, doGenerate } as any);
+  return { model, doStream, doGenerate };
+}
+
+const OBSERVATION_OUTPUT = `<observations>
+* Caller asked about roof inspection pricing
+* Caller lives in the 94103 zip code
+</observations>`;
+
+describe('summarizeConversation()', () => {
+  it('returns the distilled summary from the conversation', async () => {
+    const { model } = createMockSummarizerModel(OBSERVATION_OUTPUT);
+    const messages = [
+      createTestMessage('Hi, how much is a roof inspection?'),
+      createTestMessage('It depends on the roof — can I get your zip code?', 'assistant'),
+      createTestMessage('94103'),
+    ];
+
+    const result = await summarizeConversation({ model: model as any, messages });
+
+    expect(result.summary).toContain('roof inspection');
+    expect(result.summary).toContain('94103');
+    expect(result.extracted).toEqual({});
+    expect(result.usage?.totalTokens).toBe(150);
+  });
+
+  it('appends custom instructions to the summarizer system prompt', async () => {
+    let systemText = '';
+    const doStream = vi.fn(async ({ prompt }: any) => {
+      const systemMessage = prompt.find((message: any) => message.role === 'system');
+      systemText = typeof systemMessage?.content === 'string' ? systemMessage.content : '';
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'sum-1', modelId: 'mock-summarizer', timestamp: new Date() },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: OBSERVATION_OUTPUT },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop' as const,
+            usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    });
+    const model = new MockLanguageModelV2({ doStream } as any);
+
+    await summarizeConversation({
+      model: model as any,
+      messages: [createTestMessage('Hello')],
+      instructions: 'Summarize this voicemail call for the business owner.',
+    });
+
+    expect(systemText).toContain('Summarize this voicemail call for the business owner.');
+  });
+
+  it('runs inline extractors and fires onExtracted with the conversation identity', async () => {
+    const onExtracted = vi.fn(async () => undefined);
+    const { model } = createMockSummarizerModel(`${OBSERVATION_OUTPUT}\n<call-sentiment>positive</call-sentiment>`);
+
+    const result = await summarizeConversation({
+      model: model as any,
+      messages: [createTestMessage('Hello', 'user', { threadId: 'call-1', resourceId: 'caller-1' })],
+      extract: [
+        new Extractor({
+          name: 'Call sentiment',
+          instructions: 'Rate the caller sentiment.',
+          metadataKeyPath: false,
+          onExtracted,
+        }),
+      ],
+    });
+
+    expect(result.extracted).toEqual({ 'call-sentiment': 'positive' });
+    expect(onExtracted).toHaveBeenCalledWith(
+      expect.objectContaining({ current: 'positive', threadId: 'call-1', resourceId: 'caller-1' }),
+    );
+  });
+
+  it('runs structured extractors through the follow-up extraction call', async () => {
+    const { model, doGenerate } = createMockSummarizerModel(
+      OBSERVATION_OUTPUT,
+      JSON.stringify({ 'call-summary': { summary: 'Caller asked about pricing.', sentiment: 'positive' } }),
+    );
+
+    const result = await summarizeConversation({
+      model: model as any,
+      messages: [createTestMessage('Hello', 'user', { threadId: 'call-1' })],
+      extract: [
+        new Extractor({
+          name: 'Call summary',
+          instructions: 'Return a concise summary of the call.',
+          schema: z.object({ summary: z.string(), sentiment: z.enum(['positive', 'neutral', 'negative']) }),
+          metadataKeyPath: false,
+        }),
+      ],
+    });
+
+    expect(doGenerate).toHaveBeenCalled();
+    expect(result.extracted['call-summary']).toEqual({
+      summary: 'Caller asked about pricing.',
+      sentiment: 'positive',
+    });
+  });
+
+  it('returns an empty result without calling the model when there are no messages', async () => {
+    const { model, doStream, doGenerate } = createMockSummarizerModel(OBSERVATION_OUTPUT);
+
+    const result = await summarizeConversation({ model: model as any, messages: [] });
+
+    expect(result).toEqual({ summary: '', extracted: {} });
+    expect(doStream).not.toHaveBeenCalled();
+    expect(doGenerate).not.toHaveBeenCalled();
+  });
+});
+
+describe('Memory.summarizeThread()', () => {
+  it('loads the thread messages from storage and summarizes them', async () => {
+    const memory = new Memory({ storage: new InMemoryStore() });
+    const threadId = 'call-thread';
+    const resourceId = 'caller-42';
+
+    await memory.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'Call',
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    await memory.saveMessages({
+      messages: [
+        createTestMessage('How much is a roof inspection?', 'user', { threadId, resourceId }),
+        createTestMessage('Depends on the roof.', 'assistant', { threadId, resourceId }),
+      ],
+    });
+
+    const { model, doStream } = createMockSummarizerModel(OBSERVATION_OUTPUT);
+    const result = await memory.summarizeThread({
+      model: model as any,
+      threadId,
+      resourceId,
+      instructions: 'Summarize the call.',
+    });
+
+    expect(doStream).toHaveBeenCalled();
+    expect(result.summary).toContain('roof inspection');
+  });
+});

--- a/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
@@ -149,6 +149,35 @@ describe('summarizeConversation()', () => {
     });
   });
 
+  it('surfaces failed extractor output in extractionFailures', async () => {
+    const onExtracted = vi.fn(async () => undefined);
+    // `summary` must be a string — a numeric value fails the extractor's schema.
+    const { model } = createMockSummarizerModel(
+      OBSERVATION_OUTPUT,
+      JSON.stringify({ 'call-summary': { summary: 123, sentiment: 'positive' } }),
+    );
+
+    const result = await summarizeConversation({
+      model: model as any,
+      messages: [createTestMessage('Hello', 'user', { threadId: 'call-1' })],
+      extract: [
+        new Extractor({
+          name: 'Call summary',
+          instructions: 'Return a concise summary of the call.',
+          schema: z.object({ summary: z.string(), sentiment: z.enum(['positive', 'neutral', 'negative']) }),
+          metadataKeyPath: false,
+          onExtracted,
+        }),
+      ],
+    });
+
+    expect(result.extracted).toEqual({});
+    expect(result.extractionFailures).toHaveLength(1);
+    expect(result.extractionFailures?.[0]?.slug).toBe('call-summary');
+    expect(result.extractionFailures?.[0]?.error).toBeTruthy();
+    expect(onExtracted).not.toHaveBeenCalled();
+  });
+
   it('returns an empty result without calling the model when there are no messages', async () => {
     const { model, doStream, doGenerate } = createMockSummarizerModel(OBSERVATION_OUTPUT);
 

--- a/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
@@ -31,23 +31,26 @@ function createTestMessage(
 }
 
 /** Mock model: doStream serves the summarizer output, doGenerate serves the structured-extraction follow-up. */
-function createMockSummarizerModel(streamText: string, generateObjectJson?: string) {
-  const doStream = vi.fn(async () => ({
-    stream: convertArrayToReadableStream([
-      { type: 'stream-start', warnings: [] },
-      { type: 'response-metadata', id: 'sum-1', modelId: 'mock-summarizer', timestamp: new Date() },
-      { type: 'text-start', id: 'text-1' },
-      { type: 'text-delta', id: 'text-1', delta: streamText },
-      { type: 'text-end', id: 'text-1' },
-      {
-        type: 'finish',
-        finishReason: 'stop' as const,
-        usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
-      },
-    ]),
-    rawCall: { rawPrompt: null, rawSettings: {} },
-    warnings: [],
-  }));
+function createMockSummarizerModel(streamText: string, generateObjectJson?: string, onDoStream?: (args: any) => void) {
+  const doStream = vi.fn(async (args: any) => {
+    onDoStream?.(args);
+    return {
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'sum-1', modelId: 'mock-summarizer', timestamp: new Date() },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: streamText },
+        { type: 'text-end', id: 'text-1' },
+        {
+          type: 'finish',
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
+        },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    };
+  });
   const doGenerate = vi.fn(async () => ({
     rawCall: { rawPrompt: null, rawSettings: {} },
     finishReason: 'stop' as const,
@@ -83,27 +86,10 @@ describe('summarizeConversation()', () => {
 
   it('appends custom instructions to the summarizer system prompt', async () => {
     let systemText = '';
-    const doStream = vi.fn(async ({ prompt }: any) => {
+    const { model } = createMockSummarizerModel(OBSERVATION_OUTPUT, undefined, ({ prompt }: any) => {
       const systemMessage = prompt.find((message: any) => message.role === 'system');
       systemText = typeof systemMessage?.content === 'string' ? systemMessage.content : '';
-      return {
-        stream: convertArrayToReadableStream([
-          { type: 'stream-start', warnings: [] },
-          { type: 'response-metadata', id: 'sum-1', modelId: 'mock-summarizer', timestamp: new Date() },
-          { type: 'text-start', id: 'text-1' },
-          { type: 'text-delta', id: 'text-1', delta: OBSERVATION_OUTPUT },
-          { type: 'text-end', id: 'text-1' },
-          {
-            type: 'finish',
-            finishReason: 'stop' as const,
-            usage: { inputTokens: 100, outputTokens: 50, totalTokens: 150 },
-          },
-        ]),
-        rawCall: { rawPrompt: null, rawSettings: {} },
-        warnings: [],
-      };
     });
-    const model = new MockLanguageModelV2({ doStream } as any);
 
     await summarizeConversation({
       model: model as any,
@@ -175,6 +161,44 @@ describe('summarizeConversation()', () => {
 });
 
 describe('Memory.summarizeThread()', () => {
+  /** Seed a memory instance with one thread whose messages carry the given texts, in order. */
+  async function createThreadWithMessages(texts: string[]) {
+    const memory = new Memory({ storage: new InMemoryStore() });
+    const threadId = 'call-thread';
+    const resourceId = 'caller-42';
+
+    await memory.saveThread({
+      thread: {
+        id: threadId,
+        resourceId,
+        title: 'Call',
+        metadata: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    });
+    const base = Date.now();
+    await memory.saveMessages({
+      messages: texts.map((text, index) =>
+        createTestMessage(text, index % 2 === 0 ? 'user' : 'assistant', {
+          threadId,
+          resourceId,
+          createdAt: new Date(base + index * 1000),
+        }),
+      ),
+    });
+    return { memory, threadId, resourceId };
+  }
+
+  /** Capture every summarizer prompt as one searchable string. */
+  function createPromptCapturingModel() {
+    const prompts: string[] = [];
+    const { model } = createMockSummarizerModel(OBSERVATION_OUTPUT, undefined, (args: any) =>
+      prompts.push(JSON.stringify(args.prompt)),
+    );
+    return { model, promptText: () => prompts.join('\n') };
+  }
+
   it('loads the thread messages from storage and summarizes them', async () => {
     const memory = new Memory({ storage: new InMemoryStore() });
     const threadId = 'call-thread';
@@ -207,5 +231,50 @@ describe('Memory.summarizeThread()', () => {
 
     expect(doStream).toHaveBeenCalled();
     expect(result.summary).toContain('roof inspection');
+  });
+
+  it('only summarizes the last N messages when lastMessages is set', async () => {
+    const { memory, threadId, resourceId } = await createThreadWithMessages([
+      'marker-one',
+      'marker-two',
+      'marker-three',
+      'marker-four',
+      'marker-five',
+    ]);
+    const { model, promptText } = createPromptCapturingModel();
+
+    await memory.summarizeThread({ model: model as any, threadId, resourceId, lastMessages: 2 });
+
+    expect(promptText()).toContain('marker-four');
+    expect(promptText()).toContain('marker-five');
+    expect(promptText()).not.toContain('marker-one');
+    expect(promptText()).not.toContain('marker-two');
+    expect(promptText()).not.toContain('marker-three');
+  });
+
+  it('stops loading older messages once maxInputTokens is crossed, always keeping the newest', async () => {
+    const { memory, threadId, resourceId } = await createThreadWithMessages([
+      `marker-old ${'lorem '.repeat(200)}`,
+      `marker-new ${'ipsum '.repeat(200)}`,
+    ]);
+    const { model, promptText } = createPromptCapturingModel();
+
+    await memory.summarizeThread({ model: model as any, threadId, resourceId, maxInputTokens: 10 });
+
+    expect(promptText()).toContain('marker-new');
+    expect(promptText()).not.toContain('marker-old');
+  });
+
+  it('paginates across storage pages and preserves chronological order', async () => {
+    const texts = Array.from({ length: 120 }, (_, index) => `marker-${String(index + 1).padStart(3, '0')}`);
+    const { memory, threadId, resourceId } = await createThreadWithMessages(texts);
+    const { model, promptText } = createPromptCapturingModel();
+
+    await memory.summarizeThread({ model: model as any, threadId, resourceId });
+
+    const text = promptText();
+    expect(text).toContain('marker-001');
+    expect(text).toContain('marker-120');
+    expect(text.indexOf('marker-001')).toBeLessThan(text.indexOf('marker-120'));
   });
 });

--- a/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/summarize.test.ts
@@ -294,6 +294,27 @@ describe('Memory.summarizeThread()', () => {
     expect(promptText()).not.toContain('marker-old');
   });
 
+  it('stops paging through storage when the abort signal fires during loading', async () => {
+    const texts = Array.from({ length: 120 }, (_, index) => `marker-${index + 1}`);
+    const { memory, threadId, resourceId } = await createThreadWithMessages(texts);
+    const { model, doStream } = createMockSummarizerModel(OBSERVATION_OUTPUT);
+
+    const controller = new AbortController();
+    const originalRecall = memory.recall.bind(memory);
+    const recallSpy = vi.spyOn(memory, 'recall').mockImplementation(async args => {
+      const result = await originalRecall(args);
+      controller.abort();
+      return result;
+    });
+
+    await expect(
+      memory.summarizeThread({ model: model as any, threadId, resourceId, abortSignal: controller.signal }),
+    ).rejects.toThrow();
+
+    expect(recallSpy).toHaveBeenCalledTimes(1);
+    expect(doStream).not.toHaveBeenCalled();
+  });
+
   it('paginates across storage pages and preserves chronological order', async () => {
     const texts = Array.from({ length: 120 }, (_, index) => `marker-${String(index + 1).padStart(3, '0')}`);
     const { memory, threadId, resourceId } = await createThreadWithMessages(texts);

--- a/packages/memory/src/processors/observational-memory/index.ts
+++ b/packages/memory/src/processors/observational-memory/index.ts
@@ -40,6 +40,10 @@ export type {
 } from './extractor';
 export { WorkingMemoryExtractor } from './working-memory-extractor';
 
+// Standalone conversation summarization (reuses the Observer + extractor plumbing)
+export { summarizeConversation } from './summarize';
+export type { SummarizeConversationOptions, SummarizeConversationResult, SummarizeModel } from './summarize';
+
 export type {
   ObservationalMemoryConfig,
   ObservationDebugEvent,

--- a/packages/memory/src/processors/observational-memory/summarize.ts
+++ b/packages/memory/src/processors/observational-memory/summarize.ts
@@ -1,0 +1,146 @@
+import type { MastraDBMessage } from '@mastra/core/agent';
+import type { Mastra } from '@mastra/core/mastra';
+import type { ObservabilityContext } from '@mastra/core/observability';
+import type { RequestContext } from '@mastra/core/request-context';
+
+import type { Memory } from '../..';
+import { OBSERVATIONAL_MEMORY_DEFAULTS } from './constants';
+import { applyExtractorHooks } from './extracted-values';
+import type { ExtractionFailure } from './extracted-values';
+import type { Extractor } from './extractor';
+import type { ModelByInputTokens } from './model-by-input-tokens';
+import { ObserverRunner } from './observer-runner';
+import { TokenCounter } from './token-counter';
+import type { ObservationalMemoryModel, ResolvedObservationConfig } from './types';
+
+/** A concrete model config — token-based model routing is not supported for one-shot summarization. */
+export type SummarizeModel = Exclude<ObservationalMemoryModel, ModelByInputTokens>;
+
+export interface SummarizeConversationOptions {
+  /** Model that runs the summarization (e.g. a router string like `'openai/gpt-4.1-mini'`). */
+  model: SummarizeModel;
+  /** The conversation to summarize. */
+  messages: MastraDBMessage[];
+  /** Extra guidance appended to the summarizer's system prompt (e.g. what to focus on, audience). */
+  instructions?: string;
+  /** Extractors to run over the conversation. Structured (with a schema) or inline. `onExtracted` hooks fire. */
+  extract?: Extractor<any>[];
+  /** Thread the conversation belongs to. Defaults to the first `threadId` found on `messages`. Passed to extractor contexts. */
+  threadId?: string;
+  /** Resource (user) the conversation belongs to. Defaults to the first `resourceId` found on `messages`. Passed to extractor contexts. */
+  resourceId?: string;
+  requestContext?: RequestContext;
+  observabilityContext?: ObservabilityContext;
+  abortSignal?: AbortSignal;
+  /** Memory instance forwarded to extractor contexts (set automatically by `Memory.summarizeThread()`). */
+  memory?: Memory;
+  /** Mastra instance for custom gateway model resolution (set automatically by `Memory.summarizeThread()`). */
+  mastra?: Mastra;
+}
+
+export interface SummarizeConversationResult {
+  /** The distilled observations produced from the conversation (dense bullet form). */
+  summary: string;
+  /** Values produced by `extract` extractors, keyed by extractor slug (after `onExtracted` hooks ran). */
+  extracted: Record<string, unknown>;
+  /** Extractors that failed to produce a valid value, with the reason. */
+  extractionFailures?: ExtractionFailure[];
+  usage?: { inputTokens?: number; outputTokens?: number; totalTokens?: number };
+}
+
+/**
+ * Summarize a conversation in one shot, without Observational Memory attached to an agent.
+ *
+ * Reuses Observational Memory's Observer plumbing — the same distillation prompt, output
+ * parsing, retry handling, and extractor pipeline — as a standalone call over the messages
+ * you pass in. Nothing is read from or written to storage: the summary and extracted values
+ * are returned to you (and to each extractor's `onExtracted` hook), so you decide where they
+ * go.
+ *
+ * Use this when a session ends and you want a summary or structured extraction of the whole
+ * conversation — for example a voice call at hang-up. If Observational Memory is configured
+ * on a `Memory` instance and you want to summarize one of its threads, use
+ * `memory.summarizeThread()` instead, which loads the messages for you.
+ *
+ * @example
+ * ```ts
+ * import { summarizeConversation, Extractor } from '@mastra/memory';
+ * import { z } from 'zod';
+ *
+ * const result = await summarizeConversation({
+ *   model: 'openai/gpt-4.1-mini',
+ *   messages,
+ *   instructions: 'Summarize this voicemail call for the business owner.',
+ *   extract: [
+ *     new Extractor({
+ *       name: 'call-summary',
+ *       instructions: 'Return a concise summary of the call.',
+ *       schema: z.object({
+ *         summary: z.string(),
+ *         sentiment: z.enum(['positive', 'neutral', 'negative']),
+ *       }),
+ *       metadataKeyPath: false,
+ *     }),
+ *   ],
+ * });
+ * result.extracted['call-summary']; // { summary, sentiment }
+ * ```
+ */
+export async function summarizeConversation(opts: SummarizeConversationOptions): Promise<SummarizeConversationResult> {
+  const { messages } = opts;
+  if (messages.length === 0) {
+    return { summary: '', extracted: {} };
+  }
+
+  const extractors = opts.extract ?? [];
+  const observationConfig: ResolvedObservationConfig = {
+    model: opts.model,
+    messageTokens: OBSERVATIONAL_MEMORY_DEFAULTS.observation.messageTokens,
+    shareTokenBudget: false,
+    modelSettings: { ...OBSERVATIONAL_MEMORY_DEFAULTS.observation.modelSettings },
+    providerOptions: OBSERVATIONAL_MEMORY_DEFAULTS.observation.providerOptions,
+    maxTokensPerBatch: OBSERVATIONAL_MEMORY_DEFAULTS.observation.maxTokensPerBatch,
+    bufferOnIdle: false,
+    observeAttachments: 'auto',
+    instruction: opts.instructions,
+    threadTitle: false,
+    extractors,
+  };
+
+  const runner = new ObserverRunner({
+    observationConfig,
+    observedMessageIds: new Set(),
+    resolveModel: () => ({ model: opts.model }),
+    tokenCounter: new TokenCounter({ model: typeof opts.model === 'string' ? opts.model : undefined }),
+    mastra: opts.mastra,
+    memory: opts.memory,
+  });
+
+  const threadId = opts.threadId ?? messages.find(message => message.threadId)?.threadId;
+  const resourceId = opts.resourceId ?? messages.find(message => message.resourceId)?.resourceId;
+
+  const result = await runner.call(undefined, messages, opts.abortSignal, {
+    skipContinuationHints: true,
+    requestContext: opts.requestContext,
+    observabilityContext: opts.observabilityContext,
+    resourceId,
+  });
+
+  const hooked = await applyExtractorHooks({
+    source: 'observer',
+    extractors: result.extractors ?? extractors,
+    values: result.extractedValues,
+    failures: result.extractionFailures,
+    threadId: threadId ?? '',
+    resourceId,
+    memory: opts.memory,
+    requestContext: opts.requestContext,
+  });
+
+  return {
+    summary: result.observations,
+    extracted: hooked.values ?? {},
+    extractionFailures: hooked.failures,
+    usage: result.usage,
+  };
+}

--- a/packages/memory/src/processors/observational-memory/summarize.ts
+++ b/packages/memory/src/processors/observational-memory/summarize.ts
@@ -16,6 +16,14 @@ import type { ObservationalMemoryModel, ResolvedObservationConfig } from './type
 /** A concrete model config — token-based model routing is not supported for one-shot summarization. */
 export type SummarizeModel = Exclude<ObservationalMemoryModel, ModelByInputTokens>;
 
+/** Defaults for how `Memory.summarizeThread()` loads a thread's messages from storage. */
+export const SUMMARIZE_THREAD_DEFAULTS = {
+  /** Stop loading older messages once the collected messages exceed this estimated token count. */
+  maxInputTokens: 1_000_000,
+  /** Number of messages fetched per storage page while paginating backwards from the newest message. */
+  pageSize: 100,
+} as const;
+
 export interface SummarizeConversationOptions {
   /** Model that runs the summarization (e.g. a router string like `'openai/gpt-4.1-mini'`). */
   model: SummarizeModel;


### PR DESCRIPTION
## Description

This is PR 1 of 3 split from #19019 (as [requested](https://github.com/mastra-ai/mastra/pull/19019#issuecomment-4910853761) by @TylerBarnes). Stack: **memory summarization (this PR)** → livekit worker configuration (#19136) → voice-agent example (#19137).

Adds one-shot conversation summarization to `@mastra/memory`: a standalone `summarizeConversation()` (takes messages) and `Memory.summarizeThread()` (loads the thread for you). Both distill a whole conversation using the same Observer plumbing that powers Observational Memory — **without** attaching OM to an agent and **without** writing anything back to memory. They return `{ summary, extracted }`, and each `Extractor` (typed via Zod schema) gets its `onExtracted` hook called, so structured data (sentiment, requested services, follow-ups) lands in the application's own database:

```ts
await memory.summarizeThread({
  model: 'openai/gpt-5-mini',
  threadId,
  resourceId,
  instructions: "Summarize this call for the contractor's office: who called, what they wanted, any follow-up promised.",
  extract: [callSummaryExtractor], // Zod-typed extraction → app storage via onExtracted
});
```

This is the third iteration of the design, landed after maintainer feedback on the original PR: `observe({ force: true })`, then a buffer-path `flush()`, were both OM-lifecycle solutions to what is really a distillation use case. The final shape leaves the OM engine **untouched** (`observational-memory.ts` diff vs main is empty).

## Scope

- `summarizeConversation()` + `Memory.summarizeThread()` (`packages/memory`)
- Reference docs page (`reference/memory/summarizeThread`) + sidebar entry
- `summarize.test.ts` — 6 tests: summary output, instructions, inline + structured extractors, empty-thread no-op, `summarizeThread` round-trip
- Changeset: `@mastra/memory` minor

## Intentionally excluded

- `@mastra/livekit` worker `configuration` (greeting/disclosure, consent, endCall, stt/tts resolvers) and the `MastraLLM` plugin — PR 2
- `examples/voice-agent` updates (permissive default + regulated demo) — PR 3

## Verification

- `summarize.test.ts` — 6/6 passing
- `pnpm --filter ./packages/memory check` — clean

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR lets `@mastra/memory` turn a whole conversation (or an entire saved thread) into a short summary and pull out key “facts” it finds—without saving anything back. It’s like a one-time read-and-summarize operation for callers.

### What changed
- Added `summarizeConversation()` for one-shot summarization from a provided list of messages.
- Added `Memory.summarizeThread()` to load messages for a thread and then summarize them in one call.
- Reused the existing Observer/extractor pipeline (including extractor `onExtracted` hooks), but without attaching Observational Memory to an agent and without writing to memory.
- Supported bounded thread loading via `lastMessages` and `maxInputTokens`.
- Threaded `abortSignal` through the thread-loading loop and added abort checks so cancellation stops paging/loading promptly (not just the model call).

### Documentation
- Added first-class reference docs for both `reference/memory/summarizeConversation` and `reference/memory/summarizeThread`, plus a sidebar entry.

### Tests
- Added/expanded `summarize.test.ts` coverage for:
  - summary output + usage tokens
  - custom `instructions`
  - inline and structured extractors (including extractor `onExtracted`)
  - empty-thread no-op behavior returning `{ summary: '', extracted: {} }`
  - `lastMessages` / `maxInputTokens` paging + ordering behavior
  - abort-signal behavior during thread paging/loading
  - surfaced structured-extractor failures via `extractionFailures` (and omission of the failed value from `extracted`, with `onExtracted` not called)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->