### PR TITLE
fix(redis-streams,core): survive Redis connection drops, implement clearTopic, add opt-in stream TTL

### DIFF
--- a/.changeset/caching-pubsub-forward-cleartopic.md
+++ b/.changeset/caching-pubsub-forward-cleartopic.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+**Fixed** — `CachingPubSub.clearTopic` now forwards to the wrapped transport. Because the durable-agent runtime wraps every pubsub in `CachingPubSub`, clearing a topic previously dropped only the in-memory cache and never told a persistent backend (e.g. Redis Streams) to delete its stream — so finished runs' streams leaked. It now also calls `clearTopic` on the inner transport when the inner implements it.

--- a/.changeset/four-files-sell.md
+++ b/.changeset/four-files-sell.md
@@ -1,0 +1,21 @@
+---
+'@mastra/redis-streams': minor
+---
+
+Make `RedisStreamsPubSub` survive Redis connection drops, and add topic cleanup to bound memory.
+
+**Fixed** — a dropped Redis connection (restart, failover, idle reset) no longer wedges the client. The clients were missing the `'error'` listener node-redis requires, so a socket drop threw an uncaughtException and left the client unable to reconnect, hanging every later publish. It now reconnects on its own. The read loop also recovers when a stream's consumer group disappears, instead of retrying forever.
+
+**Added** — `clearTopic(topic)` deletes a topic's stream so finished runs release their memory instead of accumulating. The durable-agent runtime calls it during cleanup.
+
+**Added** — an opt-in `streamIdleTtlMs` option puts a rolling time-to-live on each stream. Active streams keep refreshing it and never expire mid-flight; abandoned ones (e.g. a crashed run) are removed after they go quiet.
+
+```ts
+const pubsub = new RedisStreamsPubSub({
+  url: 'redis://localhost:6379',
+  streamIdleTtlMs: 24 * 60 * 60 * 1000, // remove streams idle for 24h
+});
+
+// free a finished topic's stream immediately
+await pubsub.clearTopic('workflow.events.run-123');
+```

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -79,7 +79,7 @@ export const mastra = new Mastra({
     name: 'streamIdleTtlMs',
     type: 'number',
     description:
-      'Idle expiry in milliseconds: a sliding TTL refreshed on every write (publish, nack retry, group re-creation). Each write resets it, so an actively-used stream never expires mid-flight; a stream left idle for the full duration is deleted by Redis automatically. This is a backstop, not the primary cleanup — `clearTopic` handles normal end-of-lifecycle deletion; this only bounds memory for streams that never reach a `clearTopic` call (e.g. a crashed run). Must be a non-negative integer. Defaults to 0 (disabled).',
+      'Idle expiry in milliseconds: a sliding TTL refreshed on every write (publish, nack retry, group re-creation). Each write resets it, so an actively-written stream never expires mid-flight; a stream left idle for the full duration is deleted by Redis automatically. Note that only writes refresh the TTL — a consumer slowly draining a backlog does not — so set it well above the longest expected gap between writes on a live topic. This is a backstop, not the primary cleanup — `clearTopic` handles normal end-of-lifecycle deletion; this only bounds memory for streams that never reach a `clearTopic` call (e.g. a crashed run). Must be a non-negative integer. Defaults to 0 (disabled).',
     isOptional: true,
     defaultValue: '0',
   },
@@ -152,7 +152,9 @@ await pubsub.flush()
 
 ### `clearTopic(topic)`
 
-Deletes a topic's stream and every consumer group on it, freeing the memory a finished topic would otherwise hold. The durable-agent runtime calls this automatically when a run's cleanup fires; call it yourself only once nothing will read the topic again. It's best-effort and never throws — failures are logged. A subscriber still attached when the stream is deleted recovers on its own but misses the deleted entries.
+Deletes a topic's stream and every consumer group on it, freeing the memory a finished topic would otherwise hold. The durable-agent runtime calls this automatically when a run's cleanup fires; call it yourself only once nothing will read the topic again. It's best-effort and never throws — failures are logged at warn level. A subscriber still attached when the stream is deleted recovers on its own but misses the deleted entries.
+
+Automatic cleanup requires `@mastra/core` and `@mastra/redis-streams` versions that both support `clearTopic`: the runtime routes the call through its caching layer, so upgrade the two packages together to get end-of-run stream deletion.
 
 ```typescript
 await pubsub.clearTopic('workflow.events.run-123')

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -76,6 +76,14 @@ export const mastra = new Mastra({
     defaultValue: '10000',
   },
   {
+    name: 'streamIdleTtlMs',
+    type: 'number',
+    description:
+      'Idle expiry in milliseconds: a sliding TTL refreshed on every write (publish, nack retry, group re-creation). Each write resets it, so an actively-used stream never expires mid-flight; a stream left idle for the full duration is deleted by Redis automatically. This is a backstop, not the primary cleanup — `clearTopic` handles normal end-of-lifecycle deletion; this only bounds memory for streams that never reach a `clearTopic` call (e.g. a crashed run). Must be a non-negative integer. Defaults to 0 (disabled).',
+    isOptional: true,
+    defaultValue: '0',
+  },
+  {
     name: 'reclaimIntervalMs',
     type: 'number',
     description:
@@ -140,6 +148,14 @@ Waits for in-flight publishes to complete.
 
 ```typescript
 await pubsub.flush()
+```
+
+### `clearTopic(topic)`
+
+Deletes a topic's stream and every consumer group on it, freeing the memory a finished topic would otherwise hold. The durable-agent runtime calls this automatically when a run's cleanup fires; call it yourself only once nothing will read the topic again. It's best-effort and never throws — failures are logged. A subscriber still attached when the stream is deleted recovers on its own but misses the deleted entries.
+
+```typescript
+await pubsub.clearTopic('workflow.events.run-123')
 ```
 
 ### `close()`

--- a/packages/core/src/events/caching-pubsub.test.ts
+++ b/packages/core/src/events/caching-pubsub.test.ts
@@ -439,6 +439,30 @@ describe('CachingPubSub', () => {
       expect(history1).toHaveLength(0);
       expect(history2).toHaveLength(1);
     });
+
+    it('forwards clearTopic to an inner transport that implements it', async () => {
+      // A persistent inner (e.g. Redis Streams) must be told to delete its
+      // underlying stream — otherwise wrapping it in CachingPubSub turns
+      // clearTopic into a cache-only no-op and the inner storage leaks.
+      class ClearableInner extends PubSub {
+        clearTopic = vi.fn(async (_topic: string) => {});
+        async publish(): Promise<void> {}
+        async subscribe(): Promise<void> {}
+        async unsubscribe(): Promise<void> {}
+        async flush(): Promise<void> {}
+      }
+      const inner = new ClearableInner();
+      const wrapped = new CachingPubSub(inner, cache);
+
+      await wrapped.clearTopic('some-topic');
+
+      expect(inner.clearTopic).toHaveBeenCalledWith('some-topic');
+    });
+
+    it('does not throw when the inner transport has no clearTopic', async () => {
+      // EventEmitterPubSub has no clearTopic; the probe must skip it cleanly.
+      await expect(cachingPubsub.clearTopic('no-inner-hook')).resolves.toBeUndefined();
+    });
   });
 
   describe('flush', () => {

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -307,14 +307,24 @@ export class CachingPubSub extends PubSub {
   }
 
   /**
-   * Clear cached events for a specific topic.
-   * Call this when a stream completes to free memory.
-   * Also clears the index counter.
+   * Clear cached events for a specific topic (and the index counter), and
+   * forward the clear to the inner transport.
+   *
+   * Call this when a stream completes to free memory. The forward matters for
+   * persistent inner transports (e.g. Redis Streams): without it, wrapping a
+   * pubsub in `CachingPubSub` silently turns `clearTopic` into a cache-only
+   * no-op and the inner stream leaks forever. The hook is optional on the
+   * `PubSub` contract, so probe for it before calling.
    */
   async clearTopic(topic: string): Promise<void> {
     const cacheKey = this.getCacheKey(topic);
     const counterKey = this.getCounterKey(topic);
-    await Promise.all([this.cache.delete(cacheKey), this.cache.delete(counterKey)]);
+    const inner = this.inner as PubSub & { clearTopic?: (topic: string) => Promise<void> };
+    await Promise.all([
+      this.cache.delete(cacheKey),
+      this.cache.delete(counterKey),
+      typeof inner.clearTopic === 'function' ? inner.clearTopic(topic) : undefined,
+    ]);
   }
 
   /**

--- a/pubsub/redis-streams/src/connection-and-cleanup.test.ts
+++ b/pubsub/redis-streams/src/connection-and-cleanup.test.ts
@@ -4,7 +4,7 @@ import type { Event, EventCallback } from '@mastra/core/events';
 import { createClient } from 'redis';
 import type { RedisClientType } from 'redis';
 import { afterEach, describe, expect, it } from 'vitest';
-import { REDIS_URL } from '../test-fixtures/harness';
+import { getFreePort, REDIS_URL } from '../test-fixtures/harness';
 import { RedisStreamsPubSub } from './index';
 
 function makeEvent(overrides: Partial<Omit<Event, 'id' | 'createdAt'>> = {}): Omit<Event, 'id' | 'createdAt'> {
@@ -171,17 +171,19 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
   });
 
   describe('streamIdleTtlMs', () => {
-    it('stamps a rolling TTL on the stream key when configured', async () => {
+    it('stamps a rolling TTL on the stream key when configured (atomically with the write)', async () => {
       const ps = createPubSub({ streamIdleTtlMs: 60_000 });
       const topic = `ttl-${randomUUID()}`;
       await ps.publish(topic, makeEvent());
 
       const inspector = await createInspector();
-      // The PEXPIRE is fire-and-forget after the publish; poll briefly.
-      await expect
-        .poll(async () => await inspector.pTTL(`mastra:topic:${topic}`), { timeout: 3000 })
-        .toBeGreaterThan(0);
+      // No polling: XADD and PEXPIRE run in one MULTI, so the TTL must already
+      // be set the moment publish() resolves. A detached PEXPIRE could fail or
+      // be skipped (process exit) after the XADD — and on the topic's *last*
+      // write there is no next write to self-heal, leaving an immortal stream
+      // despite the TTL.
       const pttl = await inspector.pTTL(`mastra:topic:${topic}`);
+      expect(pttl).toBeGreaterThan(0);
       expect(pttl).toBeLessThanOrEqual(60_000);
     }, 15_000);
 
@@ -243,6 +245,62 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
       // (otherwise it would linger forever).
       await ps.clearTopic(topic);
       await expect.poll(async () => await inspector.pTTL(streamKey), { timeout: 5000 }).toBeGreaterThan(0);
+    }, 15_000);
+
+    it('tolerates same-group subscribers racing to recreate a deleted stream (BUSYGROUP in MULTI)', async () => {
+      // Two subscribers in one consumer group: deleting the stream sends both
+      // read loops into NOGROUP recovery, so the loser's XGROUP CREATE hits
+      // BUSYGROUP — which, inside the recovery MULTI, surfaces as a
+      // MultiErrorReply whose message does NOT contain "BUSYGROUP" (it lives in
+      // err.replies). Recovery must treat that as success: no error logged, TTL
+      // still applied, delivery resumed.
+      const logged: string[] = [];
+      const logger = {
+        debug: (msg: unknown) => logged.push(String(msg)),
+        warn: (msg: unknown) => logged.push(String(msg)),
+      };
+      const ps1 = createPubSub({ streamIdleTtlMs: 60_000, logger });
+      const ps2 = createPubSub({ streamIdleTtlMs: 60_000, logger });
+      const topic = `busygroup-${randomUUID()}`;
+      const group = 'workers';
+      const received: number[] = [];
+      const cb: EventCallback = (event, ack) => {
+        received.push((event.data as { n: number }).n);
+        void ack?.();
+      };
+      await ps1.subscribe(topic, cb, { group });
+      await ps2.subscribe(topic, cb, { group });
+
+      await ps1.publish(topic, makeEvent({ data: { n: 1 } }));
+      await expect.poll(() => received, { timeout: 5000 }).toContain(1);
+
+      const inspector = await createInspector();
+      const streamKey = `mastra:topic:${topic}`;
+      await ps1.clearTopic(topic);
+
+      // Both loops recover; the recreated stream carries a TTL and delivery works.
+      await expect.poll(async () => await inspector.pTTL(streamKey), { timeout: 5000 }).toBeGreaterThan(0);
+      await ps1.publish(topic, makeEvent({ data: { n: 2 } }));
+      await expect.poll(() => received, { timeout: 5000 }).toContain(2);
+      expect(logged.filter(m => m.includes('re-create failed'))).toEqual([]);
+    }, 20_000);
+  });
+
+  describe('failure observability', () => {
+    it('logs clearTopic failures at warn level instead of swallowing them silently', async () => {
+      // Point at a port nobody listens on, with reconnection disabled so the
+      // lazy connect fails fast. clearTopic must still resolve (callers invoke
+      // it fire-and-forget) but the failure has to surface at warn — a failed
+      // delete means the memory leak clearTopic exists to prevent is recurring.
+      const port = await getFreePort();
+      const warns: string[] = [];
+      const ps = new RedisStreamsPubSub({
+        url: `redis://127.0.0.1:${port}`,
+        redisOptions: { socket: { reconnectStrategy: false } },
+        logger: { warn: (msg: unknown) => warns.push(String(msg)) },
+      });
+      await expect(ps.clearTopic('some-topic')).resolves.toBeUndefined();
+      expect(warns.some(m => m.includes('clearTopic failed'))).toBe(true);
     }, 15_000);
   });
 });

--- a/pubsub/redis-streams/src/connection-and-cleanup.test.ts
+++ b/pubsub/redis-streams/src/connection-and-cleanup.test.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from 'node:crypto';
+import net from 'node:net';
+import type { Event, EventCallback } from '@mastra/core/events';
+import { createClient } from 'redis';
+import type { RedisClientType } from 'redis';
+import { afterEach, describe, expect, it } from 'vitest';
+import { REDIS_URL } from '../test-fixtures/harness';
+import { RedisStreamsPubSub } from './index';
+
+function makeEvent(overrides: Partial<Omit<Event, 'id' | 'createdAt'>> = {}): Omit<Event, 'id' | 'createdAt'> {
+  return {
+    type: 'test',
+    data: {},
+    runId: 'run-1',
+    ...overrides,
+  };
+}
+
+/**
+ * TCP proxy in front of Redis whose live connections we can sever on demand,
+ * simulating a server-side drop (Redis restart / OOM-kill / idle reset) that
+ * the client did not initiate.
+ */
+function makeSeverableProxy(targetUrl: string) {
+  const parsed = new URL(targetUrl);
+  const hostname = parsed.hostname;
+  // A portless redis:// URL yields port === '' → Number('') === 0; fall back to
+  // the Redis default so the proxy dials the real server, not port 0.
+  const upstreamPort = Number(parsed.port) || 6379;
+  const sockets = new Set<net.Socket>();
+  const server = net.createServer(client => {
+    const upstream = net.connect(upstreamPort, hostname);
+    sockets.add(client);
+    sockets.add(upstream);
+    client.on('close', () => sockets.delete(client));
+    upstream.on('close', () => sockets.delete(upstream));
+    client.on('error', () => {});
+    upstream.on('error', () => {});
+    client.pipe(upstream);
+    upstream.pipe(client);
+  });
+  const listening = new Promise<number>(resolve => {
+    server.listen(0, '127.0.0.1', () => resolve((server.address() as net.AddressInfo).port));
+  });
+  return {
+    listening,
+    sever() {
+      for (const s of sockets) s.destroy();
+      sockets.clear();
+    },
+    close() {
+      this.sever();
+      return new Promise<void>(r => server.close(() => r()));
+    },
+  };
+}
+
+describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
+  let pubsubs: RedisStreamsPubSub[] = [];
+  let inspectors: RedisClientType[] = [];
+
+  function createPubSub(config: ConstructorParameters<typeof RedisStreamsPubSub>[0] = {}): RedisStreamsPubSub {
+    const ps = new RedisStreamsPubSub({ url: REDIS_URL, blockMs: 200, ...config });
+    pubsubs.push(ps);
+    return ps;
+  }
+
+  async function createInspector(): Promise<RedisClientType> {
+    const client = createClient({ url: REDIS_URL }) as RedisClientType;
+    client.on('error', () => {});
+    await client.connect();
+    inspectors.push(client);
+    return client;
+  }
+
+  afterEach(async () => {
+    await Promise.allSettled(pubsubs.map(ps => ps.close()));
+    pubsubs = [];
+    await Promise.allSettled(inspectors.map(c => c.destroy()));
+    inspectors = [];
+  });
+
+  describe('connection drops', () => {
+    it('survives a server-side socket close: no unhandled error, publish recovers', async () => {
+      const proxy = makeSeverableProxy(REDIS_URL);
+      const unhandled: unknown[] = [];
+      const onUncaught = (err: unknown) => unhandled.push(err);
+      process.on('uncaughtException', onUncaught);
+
+      // Not registered with createPubSub(): this instance must close while the
+      // proxy is still up (a client stranded behind a dead proxy retries its
+      // reconnect forever, so a later close() would hang the afterEach hook).
+      let ps: RedisStreamsPubSub | undefined;
+      try {
+        const port = await proxy.listening;
+        ps = new RedisStreamsPubSub({ url: `redis://127.0.0.1:${port}`, blockMs: 200 });
+        const topic = `sever-${randomUUID()}`;
+        const received: Event[] = [];
+        const cb: EventCallback = (event, ack) => {
+          received.push(event);
+          void ack?.();
+        };
+        await ps.subscribe(topic, cb);
+
+        await ps.publish(topic, makeEvent({ data: { n: 1 } }));
+        await expect.poll(() => received.length, { timeout: 5000 }).toBe(1);
+
+        // Drop every live connection out from under the client, as a Redis
+        // restart would. node-redis reconnects on its own — but only if an
+        // 'error' listener exists; without one this test hangs on the next
+        // publish and records an uncaughtException.
+        proxy.sever();
+        await new Promise(r => setTimeout(r, 300));
+
+        const outcome = await Promise.race([
+          ps.publish(topic, makeEvent({ data: { n: 2 } })).then(() => 'resolved' as const),
+          new Promise<'hung'>(r => setTimeout(() => r('hung'), 8000)),
+        ]);
+        expect(outcome).toBe('resolved');
+        await expect.poll(() => received.length, { timeout: 5000 }).toBe(2);
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('uncaughtException', onUncaught);
+        // Order matters: close the pubsub while the proxy still forwards, THEN
+        // tear the proxy down (see the note on `ps` above).
+        if (ps) await ps.close().catch(() => {});
+        await proxy.close();
+      }
+    }, 30_000);
+  });
+
+  describe('clearTopic', () => {
+    it('deletes the topic stream so finished runs release their memory', async () => {
+      const ps = createPubSub();
+      const topic = `clear-${randomUUID()}`;
+      await ps.publish(topic, makeEvent());
+      await ps.publish(topic, makeEvent());
+
+      const inspector = await createInspector();
+      const streamKey = `mastra:topic:${topic}`;
+      expect(await inspector.exists(streamKey)).toBe(1);
+
+      await ps.clearTopic(topic);
+      expect(await inspector.exists(streamKey)).toBe(0);
+    }, 15_000);
+
+    it('is a no-op for a topic that was never published to', async () => {
+      const ps = createPubSub();
+      await expect(ps.clearTopic(`never-${randomUUID()}`)).resolves.toBeUndefined();
+    }, 15_000);
+
+    it('lets a still-attached subscriber recover after the stream is deleted', async () => {
+      const ps = createPubSub();
+      const topic = `clear-live-${randomUUID()}`;
+      const received: string[] = [];
+      await ps.subscribe(topic, (event, ack) => {
+        received.push((event.data as { n: number }).n.toString());
+        void ack?.();
+      });
+
+      await ps.publish(topic, makeEvent({ data: { n: 1 } }));
+      await expect.poll(() => received, { timeout: 5000 }).toContain('1');
+
+      // Delete the stream (and its consumer group) out from under the live
+      // reader, then publish again. Without NOGROUP recovery in the read loop
+      // the subscriber would be permanently deaf; with it, delivery resumes.
+      await ps.clearTopic(topic);
+      await ps.publish(topic, makeEvent({ data: { n: 2 } }));
+      await expect.poll(() => received, { timeout: 5000 }).toContain('2');
+    }, 20_000);
+  });
+
+  describe('streamIdleTtlMs', () => {
+    it('stamps a rolling TTL on the stream key when configured', async () => {
+      const ps = createPubSub({ streamIdleTtlMs: 60_000 });
+      const topic = `ttl-${randomUUID()}`;
+      await ps.publish(topic, makeEvent());
+
+      const inspector = await createInspector();
+      // The PEXPIRE is fire-and-forget after the publish; poll briefly.
+      await expect
+        .poll(async () => await inspector.pTTL(`mastra:topic:${topic}`), { timeout: 3000 })
+        .toBeGreaterThan(0);
+      const pttl = await inspector.pTTL(`mastra:topic:${topic}`);
+      expect(pttl).toBeLessThanOrEqual(60_000);
+    }, 15_000);
+
+    it('leaves streams persistent by default', async () => {
+      const ps = createPubSub();
+      const topic = `nottl-${randomUUID()}`;
+      await ps.publish(topic, makeEvent());
+
+      const inspector = await createInspector();
+      // -1 = key exists with no TTL.
+      expect(await inspector.pTTL(`mastra:topic:${topic}`)).toBe(-1);
+    }, 15_000);
+
+    it('rejects an invalid streamIdleTtlMs (negative, NaN, Infinity, or non-integer)', () => {
+      // Redis PEXPIRE requires an integer; a bad value would otherwise fail
+      // silently on every publish and leave streams unbounded.
+      for (const bad of [-1, NaN, Infinity, 1000.5]) {
+        expect(() => new RedisStreamsPubSub({ url: REDIS_URL, streamIdleTtlMs: bad })).toThrow(/streamIdleTtlMs/);
+      }
+    });
+
+    it('refreshes the TTL on a nack retry republish', async () => {
+      const ps = createPubSub({ streamIdleTtlMs: 60_000, maxDeliveryAttempts: 3 });
+      const topic = `ttl-nack-${randomUUID()}`;
+      const inspector = await createInspector();
+      const streamKey = `mastra:topic:${topic}`;
+
+      let attempts = 0;
+      await ps.subscribe(topic, (_event, ack, nack) => {
+        attempts += 1;
+        if (attempts === 1) {
+          // Force the TTL down to simulate a retry landing near the end of the
+          // original window, then nack so it is republished.
+          void inspector.pExpire(streamKey, 1000).then(() => nack?.());
+        } else {
+          void ack?.();
+        }
+      });
+
+      await ps.publish(topic, makeEvent());
+      await expect.poll(() => attempts, { timeout: 5000 }).toBeGreaterThanOrEqual(2);
+
+      // The republish must have refreshed the TTL well above the forced 1000ms.
+      await expect.poll(async () => await inspector.pTTL(streamKey), { timeout: 3000 }).toBeGreaterThan(5000);
+    }, 15_000);
+
+    it('reapplies the TTL when the read loop recreates a deleted stream (no publish)', async () => {
+      const ps = createPubSub({ streamIdleTtlMs: 60_000 });
+      const topic = `ttl-recreate-${randomUUID()}`;
+      const inspector = await createInspector();
+      const streamKey = `mastra:topic:${topic}`;
+
+      await ps.subscribe(topic, (_event, ack) => void ack?.());
+      await ps.publish(topic, makeEvent());
+      await expect.poll(async () => await inspector.exists(streamKey), { timeout: 5000 }).toBe(1);
+
+      // Delete the stream; the read loop recreates the group via MKSTREAM. With
+      // no publish afterwards, the recreated empty stream must still carry a TTL
+      // (otherwise it would linger forever).
+      await ps.clearTopic(topic);
+      await expect.poll(async () => await inspector.pTTL(streamKey), { timeout: 5000 }).toBeGreaterThan(0);
+    }, 15_000);
+  });
+});

--- a/pubsub/redis-streams/src/index.ts
+++ b/pubsub/redis-streams/src/index.ts
@@ -28,6 +28,20 @@ export interface RedisStreamsPubSubConfig {
    */
   maxStreamLength?: number;
   /**
+   * Idle expiry (in ms): a sliding TTL refreshed on every write to the stream
+   * (publish, nack retry, group re-creation). Each write resets it, so an
+   * actively-used stream never expires mid-flight; a stream left idle for the
+   * full duration is deleted by Redis automatically.
+   *
+   * This is a BACKSTOP, not the primary cleanup. Normal cleanup is explicit:
+   * `clearTopic` deletes a topic's stream the moment its lifecycle ends. This
+   * option only bounds memory for streams that never reach a `clearTopic` call
+   * — e.g. a run that crashed before cleanup — so they don't linger forever.
+   *
+   * Defaults to 0 (disabled) to preserve existing behavior.
+   */
+  streamIdleTtlMs?: number;
+  /**
    * How often (in ms) each subscription runs XAUTOCLAIM to recover messages
    * that an earlier consumer in the group read but never acked. Defaults to
    * 30_000 ms. Set to 0 to disable.
@@ -69,6 +83,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
   #keyPrefix: string;
   #blockMs: number;
   #maxStreamLength: number;
+  #streamIdleTtlMs: number;
   #reclaimIntervalMs: number;
   #reclaimIdleMs: number;
   #maxDeliveryAttempts: number;
@@ -92,9 +107,20 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     const url = options.url ?? options.redisOptions?.url ?? 'redis://localhost:6379';
     this.#connectOptions = { ...options.redisOptions, url };
     this.#writeClient = createClient(this.#connectOptions) as RedisClientType;
+    this.#logger = options.logger;
+    this.#attachErrorLogger(this.#writeClient, 'write');
     this.#keyPrefix = options.keyPrefix ?? 'mastra:topic';
     this.#blockMs = options.blockMs ?? 1000;
     this.#maxStreamLength = options.maxStreamLength ?? 10_000;
+    const ttl = options.streamIdleTtlMs ?? 0;
+    // Must be a non-negative integer: node-redis serializes the PEXPIRE arg with
+    // toString(), and Redis rejects a non-integer/Infinity ('value is not an
+    // integer or out of range') — which the fire-and-forget publish path only
+    // logs at debug, so a bad value would silently disable expiry.
+    if (!Number.isInteger(ttl) || ttl < 0) {
+      throw new Error(`redis-streams: streamIdleTtlMs must be a non-negative integer (milliseconds), got ${ttl}`);
+    }
+    this.#streamIdleTtlMs = ttl;
     this.#reclaimIntervalMs = options.reclaimIntervalMs ?? 30_000;
     this.#reclaimIdleMs = options.reclaimIdleMs ?? 60_000;
     const cap = options.maxDeliveryAttempts ?? 5;
@@ -108,7 +134,33 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     } else {
       this.#maxDeliveryAttempts = cap;
     }
-    this.#logger = options.logger;
+  }
+
+  /**
+   * Attach the `'error'` listener node-redis requires on every client. Without
+   * one, a mid-life socket close makes the client emit an unhandled `'error'`,
+   * which (per EventEmitter semantics) throws from inside RedisSocket's error
+   * handler BEFORE the built-in reconnect is scheduled — the process gets an
+   * uncaughtException and the client is left permanently un-reconnected
+   * (isOpen=true, isReady=false), hanging every subsequent command. Merely
+   * having a listener lets node-redis's own reconnect run.
+   *
+   * Logged at warn so operators can see connection churn, throttled to one line
+   * per 30s per client: node-redis re-emits `'error'` roughly every 500ms while
+   * a server is unreachable, and with one reader client per subscription an
+   * outage would otherwise flood the logs with thousands of identical lines.
+   */
+  #attachErrorLogger(client: RedisClientType, role: 'write' | 'read', extra: Record<string, unknown> = {}): void {
+    let lastWarnAt = 0;
+    client.on('error', err => {
+      const now = Date.now();
+      if (now - lastWarnAt < 30_000) return;
+      lastWarnAt = now;
+      this.#logger?.warn?.(`redis-streams: ${role} client connection error (node-redis will reconnect)`, {
+        ...extra,
+        err: err instanceof Error ? err.message : err,
+      });
+    });
   }
 
   #subKey(topic: string, cb: EventCallback): string {
@@ -128,6 +180,28 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
 
   #streamKey(topic: string): string {
     return `${this.#keyPrefix}:${topic}`;
+  }
+
+  /**
+   * Refresh a stream's rolling TTL (no-op when `streamIdleTtlMs` is disabled).
+   *
+   * Must be called after EVERY write that keeps a topic alive — the initial
+   * publish, a `nack` retry republish, and a group re-creation — so the "an
+   * active stream never expires mid-flight" guarantee actually holds. If only
+   * one of those paths refreshed the TTL, a stream still being retried or a
+   * just-recreated stream could expire under a live consumer.
+   *
+   * Fire-and-forget: a missed refresh self-heals on the next write and must
+   * not add latency or a failure mode to the caller.
+   */
+  #refreshTtl(streamKey: string): void {
+    if (this.#streamIdleTtlMs <= 0) return;
+    this.#writeClient.pExpire(streamKey, this.#streamIdleTtlMs).catch((err: unknown) => {
+      this.#logger?.debug?.('redis-streams: PEXPIRE failed', {
+        streamKey,
+        err: err instanceof Error ? err.message : err,
+      });
+    });
   }
 
   async publish(
@@ -182,6 +256,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     } finally {
       this.#pendingPublishes.delete(promise);
     }
+    this.#refreshTtl(this.#streamKey(topic));
   }
 
   async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
@@ -226,6 +301,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     // Each subscription gets a dedicated reader connection because XREADGROUP
     // with BLOCK > 0 holds the connection until a message arrives.
     const readClient = createClient(this.#connectOptions) as RedisClientType;
+    this.#attachErrorLogger(readClient, 'read', { topic });
     await readClient.connect();
 
     const sub: Subscription = {
@@ -343,6 +419,36 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     // Wait for any in-flight publishes to settle.
     if (this.#pendingPublishes.size > 0) {
       await Promise.allSettled([...this.#pendingPublishes]);
+    }
+  }
+
+  /**
+   * Delete a topic's stream, and with it every consumer group on that stream.
+   * This is the Redis implementation of the optional `clearTopic` hook that
+   * consumers (e.g. `DurableAgent`) call to free a topic once its lifecycle is
+   * over — without it, a persistent backend accumulates every finished run's
+   * stream until Redis exhausts its memory.
+   *
+   * Because it removes events for ALL consumers and destroys their groups, only
+   * call it once nothing will read the topic again. A subscriber still attached
+   * when the stream is deleted recovers on its own (the read loop recreates the
+   * group on NOGROUP) but will have missed the deleted entries.
+   *
+   * Best-effort and non-throwing: callers commonly invoke this fire-and-forget
+   * (`void clearTopic(...)`), so a rejection would surface as an
+   * unhandledRejection. Failures are swallowed and logged; the `streamIdleTtlMs`
+   * backstop (when configured) reclaims anything a failed delete leaves behind.
+   */
+  async clearTopic(topic: string): Promise<void> {
+    if (this.#closed) return;
+    try {
+      await this.#ensureWriterConnected();
+      await this.#writeClient.del(this.#streamKey(topic));
+    } catch (err) {
+      this.#logger?.debug?.('redis-streams: clearTopic failed', {
+        topic,
+        err: err instanceof Error ? err.message : err,
+      });
     }
   }
 
@@ -494,12 +600,39 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
         });
       } catch (err) {
         if (sub.stopped) return;
-        this.#logger?.debug?.('redis-streams: xReadGroup failed', {
-          topic: sub.topic,
-          group: sub.group,
-          err: err instanceof Error ? err.message : err,
-        });
-        // Connection error or similar — pause briefly then retry.
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('NOGROUP')) {
+          // The stream or its consumer group was deleted out from under us
+          // (clearTopic, a streamIdleTtlMs expiry, or an external FLUSH). XREADGROUP
+          // returns NOGROUP immediately, ignoring BLOCK, so without recovery
+          // this loop busy-retries forever and the subscriber goes permanently
+          // deaf — a later publish recreates the stream but not the group.
+          // Recreate the group (anchored at '0', matching subscribe()) so
+          // delivery resumes.
+          try {
+            await this.#writeClient.xGroupCreate(sub.streamKey, sub.group, '0', { MKSTREAM: true });
+            this.#logger?.debug?.('redis-streams: recreated consumer group after NOGROUP', {
+              topic: sub.topic,
+              group: sub.group,
+            });
+          } catch (recreateErr) {
+            const rmsg = recreateErr instanceof Error ? recreateErr.message : String(recreateErr);
+            if (!rmsg.includes('BUSYGROUP')) {
+              this.#logger?.debug?.('redis-streams: consumer group re-create failed', { topic: sub.topic, err: rmsg });
+            }
+          }
+          // MKSTREAM just recreated an (empty) stream key. Reapply the TTL so an
+          // abandoned-but-recreated topic still expires instead of lingering
+          // forever when no further publish arrives (a no-op if TTL disabled).
+          this.#refreshTtl(sub.streamKey);
+        } else {
+          this.#logger?.debug?.('redis-streams: xReadGroup failed', {
+            topic: sub.topic,
+            group: sub.group,
+            err: msg,
+          });
+        }
+        // Pause briefly then retry (with the group recreated, if it was NOGROUP).
         await new Promise(r => setTimeout(r, 100));
         continue;
       }
@@ -592,6 +725,11 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
       };
       try {
         await this.#writeClient.xAdd(sub.streamKey, '*', { event: JSON.stringify(next) });
+        // A nack republish is a write that keeps this stream in use, so it must
+        // refresh the TTL too — otherwise a retry near the end of the original
+        // window inherits the old expiry and the stream can be deleted while the
+        // retry is still being processed.
+        this.#refreshTtl(sub.streamKey);
       } catch (err) {
         this.#logger?.warn?.('redis-streams: nack republish failed; leaving original pending for reclaim', {
           topic: sub.topic,

--- a/pubsub/redis-streams/src/index.ts
+++ b/pubsub/redis-streams/src/index.ts
@@ -5,6 +5,20 @@ import { createClient } from 'redis';
 import type { RedisClientOptions, RedisClientType } from 'redis';
 
 /**
+ * Flatten an error into searchable text. node-redis MULTI failures throw a
+ * `MultiErrorReply` whose own message is just "N commands failed…" — the real
+ * per-command errors (e.g. BUSYGROUP) live in `err.replies`, so those are
+ * folded in too.
+ */
+function errorText(err: unknown): string {
+  const parts: string[] = [err instanceof Error ? err.message : String(err)];
+  if (err instanceof Error && 'replies' in err && Array.isArray((err as { replies?: unknown[] }).replies)) {
+    parts.push(...(err as { replies: unknown[] }).replies.map(r => String(r)));
+  }
+  return parts.join('; ');
+}
+
+/**
  * Mastra PubSub backed by Redis Streams.
  *
  * - Each topic maps to a Redis stream key `<prefix>:<topic>`.
@@ -115,8 +129,9 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     const ttl = options.streamIdleTtlMs ?? 0;
     // Must be a non-negative integer: node-redis serializes the PEXPIRE arg with
     // toString(), and Redis rejects a non-integer/Infinity ('value is not an
-    // integer or out of range') — which the fire-and-forget publish path only
-    // logs at debug, so a bad value would silently disable expiry.
+    // integer or out of range'). Without this guard a bad value would poison
+    // every publish MULTI and be silently swallowed on the nack/recovery
+    // paths, so fail fast at construction instead.
     if (!Number.isInteger(ttl) || ttl < 0) {
       throw new Error(`redis-streams: streamIdleTtlMs must be a non-negative integer (milliseconds), got ${ttl}`);
     }
@@ -182,28 +197,6 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     return `${this.#keyPrefix}:${topic}`;
   }
 
-  /**
-   * Refresh a stream's rolling TTL (no-op when `streamIdleTtlMs` is disabled).
-   *
-   * Must be called after EVERY write that keeps a topic alive — the initial
-   * publish, a `nack` retry republish, and a group re-creation — so the "an
-   * active stream never expires mid-flight" guarantee actually holds. If only
-   * one of those paths refreshed the TTL, a stream still being retried or a
-   * just-recreated stream could expire under a live consumer.
-   *
-   * Fire-and-forget: a missed refresh self-heals on the next write and must
-   * not add latency or a failure mode to the caller.
-   */
-  #refreshTtl(streamKey: string): void {
-    if (this.#streamIdleTtlMs <= 0) return;
-    this.#writeClient.pExpire(streamKey, this.#streamIdleTtlMs).catch((err: unknown) => {
-      this.#logger?.debug?.('redis-streams: PEXPIRE failed', {
-        streamKey,
-        err: err instanceof Error ? err.message : err,
-      });
-    });
-  }
-
   async publish(
     topic: string,
     event: Omit<Event, 'id' | 'createdAt'>,
@@ -244,19 +237,37 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
         threshold: this.#maxStreamLength,
       };
     }
-    const promise = this.#writeClient.xAdd(
-      this.#streamKey(topic),
-      '*',
-      { event: JSON.stringify(payload) },
-      xaddOptions,
-    );
+    const streamKey = this.#streamKey(topic);
+    // When a TTL is configured the write and its PEXPIRE run in one MULTI
+    // transaction. A detached PEXPIRE could fail or be skipped (process exit)
+    // after a successful XADD — and on the *last* write before a topic is
+    // abandoned there is no "next write" to self-heal, leaving an immortal
+    // stream despite the TTL. Atomicity closes that window.
+    const promise =
+      this.#streamIdleTtlMs > 0
+        ? this.#writeClient
+            .multi()
+            .xAdd(streamKey, '*', { event: JSON.stringify(payload) }, xaddOptions)
+            .pExpire(streamKey, this.#streamIdleTtlMs)
+            .exec()
+            .then(replies => {
+              // XADD in the same transaction guarantees the key exists, so
+              // PEXPIRE must reply 1; anything else means the TTL backstop is
+              // not actually armed for this stream.
+              if (Number(replies[1]) !== 1) {
+                this.#logger?.warn?.('redis-streams: PEXPIRE inside publish MULTI did not apply', {
+                  streamKey,
+                  reply: String(replies[1]),
+                });
+              }
+            })
+        : this.#writeClient.xAdd(streamKey, '*', { event: JSON.stringify(payload) }, xaddOptions);
     this.#pendingPublishes.add(promise);
     try {
       await promise;
     } finally {
       this.#pendingPublishes.delete(promise);
     }
-    this.#refreshTtl(this.#streamKey(topic));
   }
 
   async subscribe(topic: string, cb: EventCallback, options?: SubscribeOptions): Promise<void> {
@@ -445,7 +456,9 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
       await this.#ensureWriterConnected();
       await this.#writeClient.del(this.#streamKey(topic));
     } catch (err) {
-      this.#logger?.debug?.('redis-streams: clearTopic failed', {
+      // warn, not debug: a failed delete means the memory leak clearTopic
+      // exists to prevent is silently recurring for this topic.
+      this.#logger?.warn?.('redis-streams: clearTopic failed', {
         topic,
         err: err instanceof Error ? err.message : err,
       });
@@ -610,21 +623,34 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
           // Recreate the group (anchored at '0', matching subscribe()) so
           // delivery resumes.
           try {
-            await this.#writeClient.xGroupCreate(sub.streamKey, sub.group, '0', { MKSTREAM: true });
+            if (this.#streamIdleTtlMs > 0) {
+              // MKSTREAM recreates an (empty) stream key, so the TTL must be
+              // stamped in the same MULTI — a detached PEXPIRE that fails or is
+              // skipped would leave an abandoned-but-recreated topic lingering
+              // forever with no further write to self-heal it. Note that when
+              // the group already exists (a sibling won the race), exec()
+              // throws a MultiErrorReply whose message does NOT contain
+              // "BUSYGROUP" — it lives in err.replies — while the PEXPIRE in
+              // the same transaction still applies, so the TTL is refreshed
+              // even on that path.
+              await this.#writeClient
+                .multi()
+                .xGroupCreate(sub.streamKey, sub.group, '0', { MKSTREAM: true })
+                .pExpire(sub.streamKey, this.#streamIdleTtlMs)
+                .exec();
+            } else {
+              await this.#writeClient.xGroupCreate(sub.streamKey, sub.group, '0', { MKSTREAM: true });
+            }
             this.#logger?.debug?.('redis-streams: recreated consumer group after NOGROUP', {
               topic: sub.topic,
               group: sub.group,
             });
           } catch (recreateErr) {
-            const rmsg = recreateErr instanceof Error ? recreateErr.message : String(recreateErr);
+            const rmsg = errorText(recreateErr);
             if (!rmsg.includes('BUSYGROUP')) {
               this.#logger?.debug?.('redis-streams: consumer group re-create failed', { topic: sub.topic, err: rmsg });
             }
           }
-          // MKSTREAM just recreated an (empty) stream key. Reapply the TTL so an
-          // abandoned-but-recreated topic still expires instead of lingering
-          // forever when no further publish arrives (a no-op if TTL disabled).
-          this.#refreshTtl(sub.streamKey);
         } else {
           this.#logger?.debug?.('redis-streams: xReadGroup failed', {
             topic: sub.topic,
@@ -724,12 +750,21 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
         deliveryAttempt: attempt + 1,
       };
       try {
-        await this.#writeClient.xAdd(sub.streamKey, '*', { event: JSON.stringify(next) });
-        // A nack republish is a write that keeps this stream in use, so it must
-        // refresh the TTL too — otherwise a retry near the end of the original
-        // window inherits the old expiry and the stream can be deleted while the
-        // retry is still being processed.
-        this.#refreshTtl(sub.streamKey);
+        if (this.#streamIdleTtlMs > 0) {
+          // A nack republish is a write that keeps this stream in use, so it
+          // must refresh the TTL too — otherwise a retry near the end of the
+          // original window inherits the old expiry and the stream can be
+          // deleted while the retry is still being processed. Same MULTI as
+          // the write for the same reason as publish(): the republish may be
+          // the stream's final write.
+          await this.#writeClient
+            .multi()
+            .xAdd(sub.streamKey, '*', { event: JSON.stringify(next) })
+            .pExpire(sub.streamKey, this.#streamIdleTtlMs)
+            .exec();
+        } else {
+          await this.#writeClient.xAdd(sub.streamKey, '*', { event: JSON.stringify(next) });
+        }
       } catch (err) {
         this.#logger?.warn?.('redis-streams: nack republish failed; leaving original pending for reclaim', {
           topic: sub.topic,


### PR DESCRIPTION
## Description

A dropped Redis connection (server restart, failover, OOM-kill, idle reset) permanently breaks `RedisStreamsPubSub`. The clients are created without the `'error'` listener node-redis requires, so a socket drop throws an `uncaughtException` ("Socket closed unexpectedly") from inside the socket error handler *before* the built-in reconnect is scheduled, and leaves the client a zombie (`isOpen=true`, `isReady=false`) that hangs every later `publish`. Since the pubsub is usually a process-lifetime singleton shared by all runs, one drop breaks every subsequent run until the process restarts. This took down our production deployment when Redis was briefly OOM-killed. Attaching the listener is what lets node-redis's own reconnect run:

```ts
// before: one Redis restart → publish() hangs forever + uncaughtException
// after:  reconnects in ~1s and the offline-queued publishes flush
this.#writeClient.on('error', err => { /* logged, throttled */ });
```

While fixing that I found a second issue: finished runs' streams are never deleted on Redis. `DurableAgent#clearPubsubTopic` probes the pubsub for an optional `clearTopic` at cleanup, but `RedisStreamsPubSub` didn't implement it, so on Redis the cleanup silently no-oped and every finished run's stream stayed resident (we measured 538MB across 14 run streams in a week, which is what OOM-killed our Redis). This PR implements `clearTopic` as a stream delete. It also fixes a related core bug: `CachingPubSub.clearTopic` never forwarded to the wrapped transport, and since `DurableAgent` wraps every pubsub in `CachingPubSub`, the new `clearTopic` would otherwise be unreachable in the default wiring — so clearing a topic dropped only the in-memory cache and the Redis stream still leaked.

Two smaller pieces round it out. The read loop now recovers when a stream's consumer group disappears (deletion, expiry, or `FLUSH`) instead of retrying `NOGROUP` forever and going permanently deaf. And there's a new opt-in `streamIdleTtlMs` — a sliding TTL refreshed on every write (publish, nack retry, group re-creation), so a stream whose lifecycle never reaches an explicit `clearTopic` (a crashed run) still expires after it goes idle; an actively-used stream keeps resetting it and never expires mid-flight. It's a backstop — `clearTopic` is the primary, precise cleanup. Defaults to off.

```ts
new RedisStreamsPubSub({
  url: 'redis://localhost:6379',
  streamIdleTtlMs: 24 * 60 * 60 * 1000, // remove streams idle for 24h
})
await pubsub.clearTopic('workflow.events.run-123')
```

`clearTopic` is best-effort and non-throwing (the runtime calls it fire-and-forget, so a rejection would become an unhandledRejection), the error log is throttled so an outage doesn't flood the logs, and `streamIdleTtlMs` is validated as a non-negative integer since Redis rejects a non-integer and the fire-and-forget path would only log that at debug. Tests cover a severable-proxy connection drop recovering with no uncaughtException, `clearTopic` freeing memory and a live subscriber recovering after deletion, TTL stamping/refresh (including on nack retry and group re-creation) and invalid-value rejection, and `CachingPubSub` forwarding.

Note on the two packages: the leak fix is end-to-end only when both changes ship together — `Redi reachable in the default wiring only via the `@mastra/core` `CachingPubSub` forwarding, so a user
on the new `@mastra/redis-streams` but an older `@mastra/core` still gets the connection-drop fix@mastra/core` is a peer dependency here (`>=1.0.0 <2.0.0`), so I've left the range as-is rather
than tightening it — happy to bump the floor to the released core version if you'd prefer to enfo

## Related issue(s)

Fixes #19122
Partially addresses #19123 — this PR fixes the `agent.stream.<runId>` leak end-to-end and adds the opt-in `streamIdleTtlMs` backstop, but `workflow.events.v2.<runId>` topics still have no explicit cleanup hook in the evented workflow engine (tracked as a follow-up).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes Redis-based messaging less “fragile” and easier to clean up. If Redis disconnects or a stream/consumer-group goes missing, the system can recover instead of getting stuck, and it can optionally delete streams that have been idle for too long.

## Summary
- Improved Redis Streams reliability by handling node-redis socket errors so `RedisStreamsPubSub` can reconnect and continue after connection interruptions.
- Added `clearTopic(topic)` for Redis Streams to delete the topic’s stream (and related consumer-group data) as a best-effort, non-throwing cleanup operation; ensured `CachingPubSub.clearTopic` forwards to the wrapped transport so durable/persistent backends actually clean up.
- Enhanced consumer-group recovery for missing/deleted/expired streams with capped exponential backoff and safer recreation behavior to avoid unwanted `MKSTREAM` during `NOGROUP` scenarios.
- Added opt-in `streamIdleTtlMs` to apply a sliding idle TTL to stream keys; validates the option as a non-negative integer and updates TTL atomically alongside writes (including publish, nack republish, and group recreation when needed).
- Extended/updated docs and added tests covering connection recovery, cleanup forwarding and failure observability, TTL behavior/validation, and transactional/retry/recovery edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
