### PR TITLE
test(core): add unit tests for state serialization and processor send-signal helpers

### DIFF
--- a/packages/core/src/agent/message-list/state/serialization.test.ts
+++ b/packages/core/src/agent/message-list/state/serialization.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Tests for packages/core/src/agent/message-list/state/serialization.ts
+ *
+ * These are pure functions with no I/O beyond `Date`/ISO-string conversion.
+ * Coverage focuses on round-trip correctness and that non-`createdAt`
+ * fields pass through both directions unchanged.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { deserializeMessage, deserializeMessages, serializeMessage, serializeMessages } from './serialization';
+import type { MastraDBMessage } from './types';
+
+function buildMessage(overrides: Partial<MastraDBMessage> = {}): MastraDBMessage {
+  return {
+    id: 'msg-1',
+    threadId: 'thread-1',
+    resourceId: 'resource-1',
+    role: 'user',
+    content: { format: 2, parts: [{ type: 'text', text: 'hello' }] },
+    createdAt: new Date('2026-01-15T10:30:00.000Z'),
+    ...overrides,
+  } as unknown as MastraDBMessage;
+}
+
+describe('serializeMessage', () => {
+  it('converts createdAt from a Date to an ISO string', () => {
+    const message = buildMessage({ createdAt: new Date('2026-01-15T10:30:00.000Z') });
+
+    expect(serializeMessage(message).createdAt).toBe('2026-01-15T10:30:00.000Z');
+  });
+
+  it('passes through every other field unchanged', () => {
+    const message = buildMessage();
+    const result = serializeMessage(message);
+
+    expect(result.id).toBe(message.id);
+    expect(result.threadId).toBe(message.threadId);
+    expect(result.resourceId).toBe(message.resourceId);
+    expect(result.role).toBe(message.role);
+    expect(result.content).toEqual(message.content);
+  });
+
+  it('does not mutate the original message object', () => {
+    const message = buildMessage({ createdAt: new Date('2026-01-15T10:30:00.000Z') });
+    serializeMessage(message);
+
+    expect(message.createdAt).toBeInstanceOf(Date);
+    expect(message.createdAt.toISOString()).toBe('2026-01-15T10:30:00.000Z');
+  });
+});
+
+describe('deserializeMessage', () => {
+  it('converts createdAt from an ISO string back to a Date', () => {
+    const serialized = { ...buildMessage(), createdAt: '2026-01-15T10:30:00.000Z' };
+    const result = deserializeMessage(serialized);
+
+    expect(result.createdAt).toBeInstanceOf(Date);
+    expect(result.createdAt.toISOString()).toBe('2026-01-15T10:30:00.000Z');
+  });
+
+  it('passes through every other field unchanged', () => {
+    const serialized = { ...buildMessage(), createdAt: '2026-01-15T10:30:00.000Z' };
+    const result = deserializeMessage(serialized);
+
+    expect(result.id).toBe(serialized.id);
+    expect(result.threadId).toBe(serialized.threadId);
+    expect(result.resourceId).toBe(serialized.resourceId);
+    expect(result.role).toBe(serialized.role);
+    expect(result.content).toEqual(serialized.content);
+  });
+});
+
+describe('serializeMessage / deserializeMessage round-trip', () => {
+  it('preserves the exact instant through a full serialize -> deserialize cycle', () => {
+    const original = buildMessage({ createdAt: new Date('2026-01-15T10:30:00.123Z') });
+    const roundTripped = deserializeMessage(serializeMessage(original));
+
+    expect(roundTripped.createdAt.getTime()).toBe(original.createdAt.getTime());
+  });
+
+  it('preserves millisecond precision', () => {
+    const original = buildMessage({ createdAt: new Date(1_768_472_345_678) });
+    const roundTripped = deserializeMessage(serializeMessage(original));
+
+    expect(roundTripped.createdAt.getTime()).toBe(1_768_472_345_678);
+  });
+});
+
+describe('serializeMessages', () => {
+  it('maps serializeMessage over every element', () => {
+    const messages = [
+      buildMessage({ id: 'a', createdAt: new Date('2026-01-01T00:00:00.000Z') }),
+      buildMessage({ id: 'b', createdAt: new Date('2026-01-02T00:00:00.000Z') }),
+    ];
+    const result = serializeMessages(messages);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ ...messages[0], createdAt: '2026-01-01T00:00:00.000Z' });
+    expect(result[1]).toEqual({ ...messages[1], createdAt: '2026-01-02T00:00:00.000Z' });
+  });
+
+  it('returns an empty array for an empty input array', () => {
+    expect(serializeMessages([])).toEqual([]);
+  });
+});
+
+describe('deserializeMessages', () => {
+  it('maps deserializeMessage over every element', () => {
+    const serialized = [
+      { ...buildMessage({ id: 'a' }), createdAt: '2026-01-01T00:00:00.000Z' },
+      { ...buildMessage({ id: 'b' }), createdAt: '2026-01-02T00:00:00.000Z' },
+    ];
+    const result = deserializeMessages(serialized);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe('a');
+    expect(result[0].createdAt.toISOString()).toBe('2026-01-01T00:00:00.000Z');
+    expect(result[1].id).toBe('b');
+    expect(result[1].createdAt.toISOString()).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  it('returns an empty array for an empty input array', () => {
+    expect(deserializeMessages([])).toEqual([]);
+  });
+});

--- a/packages/core/src/processors/send-signal.test.ts
+++ b/packages/core/src/processors/send-signal.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for packages/core/src/processors/send-signal.ts
+ *
+ * `createProcessorSendSignal` is a factory whose returned function
+ * orchestrates calls across `createSignal`, a `MessageList`, and an
+ * optional `ProcessorStreamWriter`. `createSignal` is mocked so the tests
+ * focus purely on the orchestration logic in this file.
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import type { AgentSignalInput, CreatedAgentSignal } from '../agent/signals';
+import { createProcessorSendSignal } from './send-signal';
+
+const { createSignalMock } = vi.hoisted(() => ({
+  createSignalMock: vi.fn(),
+}));
+
+vi.mock('../agent/signals', () => ({
+  createSignal: createSignalMock,
+}));
+
+function buildCreatedSignal(overrides: Partial<CreatedAgentSignal> = {}): CreatedAgentSignal {
+  return {
+    id: 'signal-1',
+    type: 'progress',
+    toDataPart: vi.fn(() => ({ type: 'data-signal', data: { id: 'signal-1' } })),
+    ...overrides,
+  } as unknown as CreatedAgentSignal;
+}
+
+function buildMessageList(addSignalReturn: CreatedAgentSignal) {
+  return {
+    markResponseMessageBoundary: vi.fn(),
+    addSignal: vi.fn(() => addSignalReturn),
+  };
+}
+
+beforeEach(() => {
+  createSignalMock.mockReset();
+});
+
+describe('createProcessorSendSignal', () => {
+  it('calls createSignal with the provided signal input', async () => {
+    const created = buildCreatedSignal();
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+    const input: AgentSignalInput = { type: 'progress' } as AgentSignalInput;
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any });
+    await sendSignal(input);
+
+    expect(createSignalMock).toHaveBeenCalledWith(input);
+  });
+
+  it('marks a response message boundary before adding the signal', async () => {
+    const created = buildCreatedSignal();
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+    const callOrder: string[] = [];
+    messageList.markResponseMessageBoundary.mockImplementation(() => callOrder.push('boundary'));
+    messageList.addSignal.mockImplementation(() => {
+      callOrder.push('addSignal');
+      return created;
+    });
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any });
+    await sendSignal({ type: 'progress' } as AgentSignalInput);
+
+    expect(callOrder).toEqual(['boundary', 'addSignal']);
+  });
+
+  it('adds the created signal to the message list', async () => {
+    const created = buildCreatedSignal();
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any });
+    await sendSignal({ type: 'progress' } as AgentSignalInput);
+
+    expect(messageList.addSignal).toHaveBeenCalledWith(created);
+  });
+
+  it('resolves with the signal returned by messageList.addSignal', async () => {
+    const created = buildCreatedSignal();
+    const returnedFromList = buildCreatedSignal({ id: 'signal-from-list' });
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(returnedFromList);
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any });
+    const result = await sendSignal({ type: 'progress' } as AgentSignalInput);
+
+    expect(result).toBe(returnedFromList);
+  });
+
+  it('calls rotateResponseMessageId when provided', async () => {
+    const created = buildCreatedSignal();
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+    const rotateResponseMessageId = vi.fn(() => 'new-id');
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any, rotateResponseMessageId });
+    await sendSignal({ type: 'progress' } as AgentSignalInput);
+
+    expect(rotateResponseMessageId).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when rotateResponseMessageId is omitted', async () => {
+    const created = buildCreatedSignal();
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any });
+
+    await expect(sendSignal({ type: 'progress' } as AgentSignalInput)).resolves.toBeDefined();
+  });
+
+  it('calls writer.custom with the toDataPart() output when a writer is provided', async () => {
+    const dataPart = { type: 'data-signal', data: { id: 'signal-1' } };
+    const created = buildCreatedSignal({ toDataPart: vi.fn(() => dataPart) } as any);
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+    const writer = { custom: vi.fn() };
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any, writer: writer as any });
+    await sendSignal({ type: 'progress' } as AgentSignalInput);
+
+    expect(writer.custom).toHaveBeenCalledWith(dataPart);
+  });
+
+  it('does not throw when writer is omitted', async () => {
+    const created = buildCreatedSignal();
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any });
+
+    await expect(sendSignal({ type: 'progress' } as AgentSignalInput)).resolves.toBeDefined();
+  });
+
+  it('awaits writer.custom before resolving', async () => {
+    const dataPart = { type: 'data-signal', data: {} };
+    const created = buildCreatedSignal({ toDataPart: vi.fn(() => dataPart) } as any);
+    createSignalMock.mockReturnValue(created);
+    const messageList = buildMessageList(created);
+
+    let writerResolved = false;
+    const writer = {
+      custom: vi.fn(
+        () =>
+          new Promise<void>(resolve => {
+            setTimeout(() => {
+              writerResolved = true;
+              resolve();
+            }, 0);
+          }),
+      ),
+    };
+
+    const sendSignal = createProcessorSendSignal({ messageList: messageList as any, writer: writer as any });
+    await sendSignal({ type: 'progress' } as AgentSignalInput);
+
+    expect(writerResolved).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes #19093
Fixes #19099

## What

Adds unit test coverage for two previously untested modules:

- `agent/message-list/state/serialization.ts` — `serializeMessage`, `deserializeMessage`, `serializeMessages`, `deserializeMessages`
- `processors/send-signal.ts` — `createProcessorSendSignal`

## Why + overlap check

Before writing these, I grepped every `*.test.ts` in `packages/core/src` (including `e2e`/`integration` suites) for references to both modules and confirmed **zero existing coverage, direct or indirect**, of either. This PR follows up on #19089/#19090, which a maintainer correctly closed as redundant with existing e2e coverage — these two were deliberately chosen to avoid that.

- `serialization.ts` is a pure `Date`<->ISO-string converter used when persisting/restoring durable message-list state; a bug here would silently corrupt timestamps on restore.
- `send-signal.ts`'s `createProcessorSendSignal` orchestrates `createSignal` + `MessageList` + an optional stream `writer`; the call-order and optional-argument handling wasn't previously pinned down anywhere.

## Coverage

20 test cases across 2 files: Date/ISO round-trip (incl. millisecond precision) and field pass-through for serialization; full orchestration contract (call order, optional args, resolved value, awaited writer) for send-signal, with `createSignal` mocked so the tests isolate this file's own logic.

## Testing

- `npx vitest run` on both new files: **20/20 passing**, re-verified against latest `main`
- `npx eslint` on both new files: clean
- No production code changed; test-only PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR adds tests to make sure two important helper pieces keep working the way they should. One checks that saved messages can be safely turned into text and back without losing their date, and the other checks that processor signals are sent in the right order and still work even when some optional parts aren’t there.

## Summary
- Added direct Vitest coverage for `packages/core/src/agent/message-list/state/serialization.ts`
  - verifies `createdAt` converts between `Date` and ISO string correctly
  - covers round-trip preservation of the original instant
  - confirms other message fields stay unchanged
  - checks array helpers for empty and multi-item inputs
- Added direct Vitest coverage for `packages/core/src/processors/send-signal.ts`
  - verifies `markResponseMessageBoundary()` runs before `addSignal()`
  - verifies `addSignal()` returns the resolved value
  - covers optional `rotateResponseMessageId` behavior when provided or omitted
  - covers optional writer behavior, including awaiting `writer.custom(...)` when present
- No production code changes were made

<!-- end of auto-generated comment: release notes by coderabbit.ai -->