### PR TITLE
fix(relevance): extract numeric score from prose-wrapped LLM output

### DIFF
--- a/packages/core/src/relevance/mastra-agent/index.test.ts
+++ b/packages/core/src/relevance/mastra-agent/index.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// LLMs frequently wrap the requested numeric score in prose (e.g. "The relevance
+// score is 0.42.") even when instructed to output only a number. The old
+// implementation returned parseFloat(response), which yields NaN for any
+// non-bare-numeric payload. That NaN silently corrupts downstream ranking
+// (weights.semantic * NaN === NaN) with no error. This test pins the corrected
+// extraction behavior.
+const mockGenerate = vi.fn().mockResolvedValue({ text: '0.87' });
+
+vi.mock('../../agent', () => ({
+  Agent: class {
+    async getModel() {
+      return { specificationVersion: 'v3' };
+    }
+    async generate() {
+      return mockGenerate();
+    }
+  },
+  isSupportedLanguageModel: () => true,
+}));
+
+import { MastraAgentRelevanceScorer } from './index';
+
+describe('MastraAgentRelevanceScorer.getRelevanceScore', () => {
+  it('returns the numeric score when the model emits a bare number', async () => {
+    mockGenerate.mockResolvedValue({ text: '0.87' });
+    const scorer = new MastraAgentRelevanceScorer('test', {} as any);
+    const score = await scorer.getRelevanceScore('query', 'text');
+    expect(Number.isNaN(score)).toBe(false);
+    expect(score).toBe(0.87);
+  });
+
+  it('extracts the number when the model wraps it in prose (regression for NaN)', async () => {
+    mockGenerate.mockResolvedValue({ text: 'The relevance score is 0.42.' });
+    const scorer = new MastraAgentRelevanceScorer('test', {} as any);
+    const score = await scorer.getRelevanceScore('query', 'text');
+    expect(Number.isNaN(score)).toBe(false);
+    expect(score).toBe(0.42);
+  });
+
+  it('falls back to 0 (not NaN) when no number is present in the output', async () => {
+    mockGenerate.mockResolvedValue({ text: 'unable to determine a score' });
+    const scorer = new MastraAgentRelevanceScorer('test', {} as any);
+    const score = await scorer.getRelevanceScore('query', 'text');
+    expect(Number.isNaN(score)).toBe(false);
+    expect(score).toBe(0);
+  });
+});

--- a/packages/core/src/relevance/mastra-agent/index.ts
+++ b/packages/core/src/relevance/mastra-agent/index.ts
@@ -38,6 +38,7 @@ Always return just the number, no explanation.`,
       const responseText = await this.agent.generateLegacy(prompt);
       response = responseText.text;
     }
-    return parseFloat(response);
+    const match = response.match(/-?\d+(?:\.\d+)?/);
+    return match ? parseFloat(match[0]) : 0;
   }
 }

--- a/packages/rag/src/rerank/relevance/mastra-agent/index.ts
+++ b/packages/rag/src/rerank/relevance/mastra-agent/index.ts
@@ -37,6 +37,7 @@ Always return just the number, no explanation.`,
       response = await this.agent.generateLegacy(prompt);
     }
 
-    return parseFloat(response.text);
+    const match = response.text.match(/-?\d+(?:\.\d+)?/);
+    return match ? parseFloat(match[0]) : 0;
   }
 }


### PR DESCRIPTION
## Summary
`getRelevanceScore` returned `parseFloat(response)`, which yields `NaN` whenever the model wraps the requested numeric score in prose (e.g. `"The relevance score is 0.42."`) — extremely common even with "output only a number" instructions.

## Impact
That `NaN` silently corrupts the rerank score (`weights.semantic * NaN === NaN`), so `rerank` returns results in an arbitrary order — no exception, no warning, just silently wrong rankings a real user hits in production RAG.

## Fix
Extract the first numeric match with a regex; fall back to `0` when no number is present. Applied to both `packages/core` (canonical export) and `packages/rag` (the copy `rerank` actually uses).

## Test
Added `packages/core/src/relevance/mastra-agent/index.test.ts` with three cases: bare number, prose-wrapped number (regression for NaN), and no-number fallback. FAILS before the fix (2 of 3 fail with `Number.isNaN`), PASSES after (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change makes the app read the number from the model’s answer more carefully. If the model says something like “The score is 0.42,” it now finds the `0.42` instead of getting confused and returning a broken value.

## Summary
- Updated `getRelevanceScore` to extract the first numeric value from the LLM response with a regex instead of parsing the whole string.
- Added a safe fallback to `0` when no number is present.
- Applied the fix in both `packages/core` and `packages/rag` so the shared logic stays consistent.
- Added tests covering:
  - a plain numeric response
  - a number wrapped in prose
  - a response with no number

<!-- end of auto-generated comment: release notes by coderabbit.ai -->