### PR TITLE
fix: multi-tenant Composio tool auth for Agent Builder

### DIFF
--- a/.changeset/bumpy-glasses-sleep.md
+++ b/.changeset/bumpy-glasses-sleep.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added an optional `scope` field to `ResolveToolsOpts` so tool providers can see a connection's identity bucketing (`per-author`, `shared`, or `caller-supplied`) when resolving tools. Providers can use this to let the backend auto-resolve an account within a caller's bucket instead of pinning a specific one. The field is optional and defaults to previous behavior when absent.

--- a/.changeset/bumpy-glasses-sleep.md
+++ b/.changeset/bumpy-glasses-sleep.md
@@ -5,3 +5,24 @@
 Added an optional `scope` field to `ResolveToolsOpts` so tool providers can see a connection's identity bucketing (`per-author`, `shared`, or `caller-supplied`) when resolving tools. Providers can use this to let the backend auto-resolve an account within a caller's bucket instead of pinning a specific one. The field is optional and defaults to previous behavior when absent.
 
 Also added an optional `defaultScope` to `BaseToolProviderOptions` (surfaced on the `ToolProvider` interface as `defaultScope`). This lets an app author set a tool provider's connection scope at config time — for example `defaultScope: 'caller-supplied'` for multi-tenant OAuth — so every connection authorized against the provider is bucketed correctly without any per-connection UI control. Defaults to `'per-author'` when absent.
+
+```ts
+import { BaseToolProvider, type ResolveToolsOpts } from '@mastra/core/tool-provider';
+
+class MyToolProvider extends BaseToolProvider {
+  // ...required members like `info` and `capabilities` elided
+
+  constructor() {
+    // Config-level tenancy decision: bucket connections per caller.
+    super({ defaultScope: 'caller-supplied' });
+  }
+
+  async resolveToolsVNext(opts: ResolveToolsOpts) {
+    if (opts.scope === 'caller-supplied') {
+      // Let the backend auto-resolve an account within the caller's
+      // bucket instead of pinning a specific connected account.
+    }
+    // ...
+  }
+}
+```

--- a/.changeset/bumpy-glasses-sleep.md
+++ b/.changeset/bumpy-glasses-sleep.md
@@ -3,3 +3,5 @@
 ---
 
 Added an optional `scope` field to `ResolveToolsOpts` so tool providers can see a connection's identity bucketing (`per-author`, `shared`, or `caller-supplied`) when resolving tools. Providers can use this to let the backend auto-resolve an account within a caller's bucket instead of pinning a specific one. The field is optional and defaults to previous behavior when absent.
+
+Also added an optional `defaultScope` to `BaseToolProviderOptions` (surfaced on the `ToolProvider` interface as `defaultScope`). This lets an app author set a tool provider's connection scope at config time — for example `defaultScope: 'caller-supplied'` for multi-tenant OAuth — so every connection authorized against the provider is bucketed correctly without any per-connection UI control. Defaults to `'per-author'` when absent.

--- a/.changeset/thirty-rockets-beg.md
+++ b/.changeset/thirty-rockets-beg.md
@@ -11,3 +11,7 @@ Agents that use a `caller-supplied` connection scope now let Composio pick the c
 **Fixed account authorization**
 
 Connecting a new account now uses Composio's supported managed-OAuth link flow, replacing a deprecated endpoint that stopped working for managed OAuth. Connections that collect custom fields (such as a Confluence subdomain) continue to work unchanged.
+
+**Config-level connection scope**
+
+`ComposioToolProvider` now forwards `defaultScope` to the provider, so you can set a provider's connection scope once at construction (for example `defaultScope: 'caller-supplied'`) instead of relying on per-request scope. Every connection authorized against the provider is then bucketed accordingly.

--- a/.changeset/thirty-rockets-beg.md
+++ b/.changeset/thirty-rockets-beg.md
@@ -1,0 +1,13 @@
+---
+'@mastra/editor': patch
+---
+
+Fixed multi-tenant tool connections for Composio-backed agents.
+
+**Multi-tenant credential auto-resolve**
+
+Agents that use a `caller-supplied` connection scope now let Composio pick the connected account within each tenant's user bucket, instead of pinning one shared account for every caller. This removes the need to track per-tenant account IDs yourself when building multi-tenant SaaS on top of the Agent Builder.
+
+**Fixed account authorization**
+
+Connecting a new account now uses Composio's supported managed-OAuth link flow, replacing a deprecated endpoint that stopped working for managed OAuth. Connections that collect custom fields (such as a Confluence subdomain) continue to work unchanged.

--- a/.changeset/witty-scope-defaults.md
+++ b/.changeset/witty-scope-defaults.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+The tool provider authorize handler now falls back to the provider's `defaultScope` when a request does not specify a connection `scope`. Precedence is: explicit request `scope`, then the provider's `defaultScope`, then `'per-author'`. This lets a provider configured with `defaultScope: 'caller-supplied'` produce per-tenant connections through the Agent Builder connect flow, which does not send a scope.

--- a/.changeset/workos-map-resource-id.md
+++ b/.changeset/workos-map-resource-id.md
@@ -1,0 +1,5 @@
+---
+"@mastra/auth-workos": patch
+---
+
+Added `mapUserToResourceId` to `MastraAuthWorkosOptions` so it can be set directly in the `MastraAuthWorkos` constructor. This maps an authenticated user to a resource id that multi-tenant tool providers use to bucket connected accounts (for example, Composio's `caller-supplied` scope). Previously the option was consumed at runtime but missing from the typed constructor surface, forcing a post-construction property assignment.

--- a/auth/workos/src/index.test.ts
+++ b/auth/workos/src/index.test.ts
@@ -144,6 +144,20 @@ describe('MastraAuthWorkos', () => {
           }),
       ).toThrow('WorkOS redirect URI is required');
     });
+
+    it('should wire mapUserToResourceId from options', () => {
+      const auth = new MastraAuthWorkos({
+        apiKey: mockApiKey,
+        clientId: mockClientId,
+        redirectUri: mockRedirectUri,
+        session: { cookiePassword: mockCookiePassword },
+        mapUserToResourceId: user => `tenant:${user.id}`,
+      });
+
+      expect(auth.mapUserToResourceId?.({ id: 'user-1', workosId: 'wos_1', email: 'a@b.com' } as any)).toBe(
+        'tenant:user-1',
+      );
+    });
   });
 
   describe('authenticateToken', () => {

--- a/auth/workos/src/types.ts
+++ b/auth/workos/src/types.ts
@@ -154,6 +154,20 @@ export interface MastraAuthWorkosOptions {
    * Runs after `jwtClaims` mapping and can override or augment the resolved user.
    */
   mapJwtPayloadToUser?: (payload: JwtPayload) => Partial<WorkOSUser> | null | undefined;
+  /**
+   * Map an authenticated user to a memory/tenant resource id.
+   *
+   * The returned value is written to the request context as the caller's
+   * `resourceId`, which multi-tenant tool providers use to bucket connected
+   * accounts (for example, Composio's `caller-supplied` scope). Return a
+   * stable per-user or per-tenant identifier such as `user.id`.
+   *
+   * @example
+   * ```typescript
+   * new MastraAuthWorkos({ mapUserToResourceId: user => user.id })
+   * ```
+   */
+  mapUserToResourceId?: (user: WorkOSUser) => string | undefined | null;
 }
 
 // ============================================================================

--- a/docs/src/content/en/docs/agent-builder/integrations.mdx
+++ b/docs/src/content/en/docs/agent-builder/integrations.mdx
@@ -88,11 +88,21 @@ The connected account is bound to the agent, and its tools are ready to use on t
 
 ## Connection scope
 
-When you select a toolkit's tools for an agent, you also pin a connection. The connection determines which account each tool call uses at runtime, and its scope controls who shares that credential. A scope maps each call to a _bucket_ — the identity partition that a connected account is stored under.
+Each connection determines which account a tool call uses at runtime, and its _scope_ controls who shares that credential. A scope maps each call to a _bucket_ — the identity partition that a connected account is stored under. Scope is a tenancy decision made by you, the app author, not by the end user connecting an account — so you set it on the provider, not in the Builder UI.
 
 - `per-author` (default): the connection belongs to the agent's author. Any invoker runs the agent with the author's account. Use this for personal agents or a single shared team account.
 - `shared`: every caller uses one shared bucket, regardless of who invokes the agent. Use this for a platform-owned account that all users should share.
 - `caller-supplied`: each call is bucketed by the caller's `resourceId`, read from the request context. Use this for multi-tenant SaaS, where the host app authenticates the end user upstream and each tenant should use their own connected account.
+
+Set `defaultScope` on the provider to apply a scope to every connection authorized against it:
+
+```typescript title="src/mastra/index.ts"
+const composio = new ComposioToolProvider({
+  apiKey: process.env.COMPOSIO_API_KEY!,
+  allowedToolkits: ['github'],
+  defaultScope: 'caller-supplied',
+})
+```
 
 With `caller-supplied`, the host app must forward a `resourceId` on every request so each tenant lands in its own bucket. Set `mapUserToResourceId` on the server's auth config to derive the `resourceId` from the authenticated user, so every request carries it automatically:
 

--- a/docs/src/content/en/docs/agent-builder/integrations.mdx
+++ b/docs/src/content/en/docs/agent-builder/integrations.mdx
@@ -16,6 +16,17 @@ Tool providers let Builder-created agents call tools from third-party apps such 
 
 This page covers what's specific to the Builder: setting up connections, choosing a connection scope, and managing connections. To register a provider and enable its toolkits, see [Tools](/docs/editor/tools).
 
+## Setup at a glance
+
+To connect a toolkit like Gmail and use it from a Builder agent:
+
+1. [Register a tool provider](#register-a-tool-provider) on `MastraEditor` with your Composio API key.
+1. [Set up a Composio auth config](#set-up-a-composio-auth-config) for the toolkit and enable it.
+1. [Connect the toolkit](#connect-a-toolkit) from the Builder and complete the OAuth flow.
+1. [Choose a connection scope](#connection-scope) if the default author-owned account isn't what you want.
+
+The rest of this page covers each step in detail.
+
 ## Prerequisites
 
 Before agents can use integration tools in the Builder:
@@ -50,6 +61,8 @@ export const mastra = new Mastra({
 
 Each provider's toolkits become available in the Builder once it's registered. Use `allowedToolkits` to restrict which toolkits the provider exposes — by slug, such as `gmail` or `googlecalendar`. Omit it to expose every toolkit the provider offers. To add another provider, import it and add another entry to `toolProviders`. For the full list of providers and their options, see [Tools — Integration providers](/docs/editor/tools#integration-providers).
 
+`ComposioToolProvider` needs a Composio **project** API key (the `x-api-key` type from a project's settings in the [Composio dashboard](https://dashboard.composio.dev)). Store it in an environment variable, as shown with `COMPOSIO_API_KEY` above.
+
 ## Set up a Composio auth config
 
 Each toolkit a user can connect needs its own auth config in the [Composio dashboard](https://dashboard.composio.dev). An auth config defines how Composio authenticates with an app — its OAuth client, scopes, and credentials. Each toolkit needs its own because requirements vary by app: some share common OAuth methods, while others need extra setup. Without an enabled config, the connection flow fails.
@@ -61,7 +74,7 @@ Each toolkit a user can connect needs its own auth config in the [Composio dashb
 Keep exactly one auth config enabled per toolkit. When a user connects the toolkit, the provider resolves the single enabled config for that toolkit and starts the OAuth flow against it.
 
 :::warning
-The provider throws if a toolkit has zero enabled auth configs or more than one. Enable exactly one auth config per toolkit you expose in the Builder.
+The provider throws if a toolkit has zero enabled auth configs or more than one. With no enabled config, the connection flow fails with an error like `No ENABLED auth config for toolkit "github"` — enable one in the Composio dashboard to fix it. Enable exactly one auth config per toolkit you expose in the Builder.
 :::
 
 ## Connect a toolkit
@@ -75,7 +88,28 @@ The connected account is bound to the agent, and its tools are ready to use on t
 
 ## Connection scope
 
-When you select a toolkit's tools for an agent, you also pin a connection. The connection determines which account each tool call uses at runtime, with a scope that controls who shares the credential. Today connections are `per-author`: the connection belongs to the agent's author, and any invoker runs the agent with the author's account.
+When you select a toolkit's tools for an agent, you also pin a connection. The connection determines which account each tool call uses at runtime, and its scope controls who shares that credential. A scope maps each call to a _bucket_ — the identity partition that a connected account is stored under.
+
+- `per-author` (default): the connection belongs to the agent's author. Any invoker runs the agent with the author's account. Use this for personal agents or a single shared team account.
+- `shared`: every caller uses one shared bucket, regardless of who invokes the agent. Use this for a platform-owned account that all users should share.
+- `caller-supplied`: each call is bucketed by the caller's `resourceId`, read from the request context. Use this for multi-tenant SaaS, where the host app authenticates the end user upstream and each tenant should use their own connected account.
+
+With `caller-supplied`, the host app must forward a `resourceId` on every request so each tenant lands in its own bucket. Set `mapUserToResourceId` on the server's auth config to derive the `resourceId` from the authenticated user, so every request carries it automatically:
+
+```typescript title="src/mastra/index.ts"
+export const mastra = new Mastra({
+  server: {
+    auth: {
+      authenticateToken: async token => verifyToken(token),
+      mapUserToResourceId: user => user.id,
+    },
+  },
+})
+```
+
+:::warning
+When a `caller-supplied` connection runs without a `resourceId`, every tenant falls back to a single shared `default` bucket. All callers then share one set of credentials, which can expose one tenant's connected account to another. Always wire `mapUserToResourceId` (or otherwise set `resourceId` on the request context) for multi-tenant deployments.
+:::
 
 ## Related
 

--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -58,7 +58,7 @@ Integration providers connect external tool platforms to the editor. Once regist
 
 [Composio](https://composio.dev) gives access to hundreds of integration tools organized into toolkits (GitHub, Slack, Gmail, and others).
 
-1. Get an API key from your Composio dashboard.
+1. Get a **project** API key (the `x-api-key` type) from your [Composio dashboard](https://dashboard.composio.dev).
 
 1. Register the provider in your Editor configuration:
 
@@ -81,7 +81,7 @@ Integration providers connect external tool platforms to the editor. Once regist
    })
    ```
 
-   Composio tool slugs use a format like `GITHUB_CREATE_ISSUE`. Tool calls are scoped to the `resourceId` passed through request context for per-user authentication.
+   Composio tool slugs use a format like `GITHUB_CREATE_ISSUE`. By default, tool calls use the connection pinned by the agent's author. To route calls to each end user's own account instead, see [connection scope](/docs/agent-builder/integrations#connection-scope) in the Agent Builder docs.
 
 ### Arcade
 

--- a/examples/agent-builder/src/mastra/auth.ts
+++ b/examples/agent-builder/src/mastra/auth.ts
@@ -8,6 +8,11 @@ import { MastraAuthWorkos, MastraRBACWorkos } from '@mastra/auth-workos';
 export async function initWorkOS() {
   const mastraAuth = new MastraAuthWorkos({
     redirectUri: process.env.WORKOS_REDIRECT_URI || 'http://localhost:4111/api/auth/callback',
+    // Map each authenticated user to a distinct resource id. This is what a
+    // `caller-supplied` tool connection reads to bucket Composio connected
+    // accounts per tenant. Without it, every caller collapses into the shared
+    // `'default'` bucket and OAuth accounts leak across tenants.
+    mapUserToResourceId: user => user.id,
   });
 
   const rbacProvider = new MastraRBACWorkos({

--- a/examples/agent-builder/src/mastra/index.ts
+++ b/examples/agent-builder/src/mastra/index.ts
@@ -69,7 +69,13 @@ export const mastra = new Mastra({
   editor: new MastraEditor({
     sandboxes: { e2b: e2bSandboxProvider },
     toolProviders: {
-      composio: new ComposioToolProvider({ apiKey: process.env.COMPOSIO_API_KEY ?? '', allowedToolkits: ['gmail'] }),
+      composio: new ComposioToolProvider({
+        apiKey: process.env.COMPOSIO_API_KEY ?? '',
+        allowedToolkits: ['gmail', 'github'],
+        // Multi-tenant: each authenticated user gets their own Composio bucket,
+        // keyed by the resourceId set via `mapUserToResourceId` in ./auth.ts.
+        defaultScope: 'caller-supplied',
+      }),
     },
     browsers: {
       stagehand: {

--- a/packages/core/src/tool-provider/base.ts
+++ b/packages/core/src/tool-provider/base.ts
@@ -12,6 +12,7 @@ import type {
   ResolveToolsOpts,
   ToolProvider,
   ToolProviderCapabilities,
+  ToolProviderConnectionScope,
   ToolProviderHealth,
   ToolProviderInfo,
   ToolProviderListResult,
@@ -42,6 +43,13 @@ export interface BaseToolProviderOptions {
    * leaves its tools unfiltered.
    */
   allowedTools?: Readonly<Record<string, readonly string[]>>;
+  /**
+   * Default identity-bucketing scope for connections authorized against this
+   * provider. This is the app author's tenancy decision (e.g.
+   * `'caller-supplied'` for per-tenant OAuth). The authorize flow applies it
+   * whenever a request doesn't override `scope`. Defaults to `'per-author'`.
+   */
+  defaultScope?: ToolProviderConnectionScope;
 }
 
 /**
@@ -58,10 +66,12 @@ export abstract class BaseToolProvider implements ToolProvider {
 
   protected readonly allowedToolkits: readonly string[];
   protected readonly allowedTools: Readonly<Record<string, readonly string[]>>;
+  readonly defaultScope?: ToolProviderConnectionScope;
 
   constructor(options: BaseToolProviderOptions = {}) {
     this.allowedToolkits = options.allowedToolkits ?? [];
     this.allowedTools = options.allowedTools ?? {};
+    this.defaultScope = options.defaultScope;
   }
 
   // ── VNext catalog (filtered) ──────────────────────────────────────────

--- a/packages/core/src/tool-provider/runtime.test.ts
+++ b/packages/core/src/tool-provider/runtime.test.ts
@@ -54,6 +54,7 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
 
     expect(resolveToolsVNext).toHaveBeenCalledTimes(1);
     expect(resolveToolsVNext.mock.calls[0]![0].authorId).toBe('user_abc');
+    expect(resolveToolsVNext.mock.calls[0]![0].scope).toBe('caller-supplied');
   });
 
   it("falls back to 'default' for caller-supplied scope when resourceId is missing", async () => {
@@ -67,6 +68,7 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
 
     expect(resolveToolsVNext).toHaveBeenCalledTimes(1);
     expect(resolveToolsVNext.mock.calls[0]![0].authorId).toBe('default');
+    expect(resolveToolsVNext.mock.calls[0]![0].scope).toBe('caller-supplied');
   });
 
   it('uses SHARED_BUCKET_ID as authorId for shared scope', async () => {
@@ -78,6 +80,7 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
 
     expect(resolveToolsVNext).toHaveBeenCalledTimes(1);
     expect(resolveToolsVNext.mock.calls[0]![0].authorId).toBe(SHARED_BUCKET_ID);
+    expect(resolveToolsVNext.mock.calls[0]![0].scope).toBe('shared');
   });
 
   it('forwards caller authorId as authorId for per-author scope', async () => {
@@ -89,6 +92,7 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
 
     expect(resolveToolsVNext).toHaveBeenCalledTimes(1);
     expect(resolveToolsVNext.mock.calls[0]![0].authorId).toBe('author_xyz');
+    expect(resolveToolsVNext.mock.calls[0]![0].scope).toBe('per-author');
   });
 });
 

--- a/packages/core/src/tool-provider/runtime.ts
+++ b/packages/core/src/tool-provider/runtime.ts
@@ -160,6 +160,7 @@ export async function resolveStoredToolProviders(
             toolMeta: cfg.tools ?? {},
             connectionId: connection.connectionId,
             authorId: resolvedAuthorId,
+            scope: connection.scope,
             requestContext,
           });
         } catch (error) {

--- a/packages/core/src/tool-provider/types.ts
+++ b/packages/core/src/tool-provider/types.ts
@@ -387,6 +387,16 @@ export interface ToolProvider {
    */
   readonly capabilities?: ToolProviderCapabilities;
 
+  /**
+   * Default identity-bucketing scope for connections authorized against this
+   * provider. Set by the app author at construction time — this is a tenancy
+   * architecture decision, not an end-user choice. The authorize flow uses it
+   * when the request does not specify a `scope`, so a provider configured with
+   * `defaultScope: 'caller-supplied'` produces per-tenant connections without
+   * any UI control. Falls back to `'per-author'` when absent.
+   */
+  readonly defaultScope?: ToolProviderConnectionScope;
+
   // ── Legacy surface (kept for back-compat) ─────────────────────────────
 
   /**

--- a/packages/core/src/tool-provider/types.ts
+++ b/packages/core/src/tool-provider/types.ts
@@ -245,6 +245,12 @@ export interface ResolveToolsOpts {
    * invoker, not just the author. Falsy = fall back to request context.
    */
   authorId?: string;
+  /**
+   * Identity bucketing for this connection. Providers may use it to decide
+   * whether to pin a specific account or let the backend auto-resolve within
+   * the user bucket. Absent = treat as `'per-author'` (back-compat).
+   */
+  scope?: ToolProviderConnectionScope;
   /** Per-request context (auth, tenant, currentUser, ...). */
   requestContext?: Record<string, unknown>;
 }

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -81,6 +81,16 @@ describe('ComposioToolProvider — identity & capabilities', () => {
       supportsRevoke: true,
     });
   });
+
+  it('has no defaultScope unless configured', () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+    expect(integration.defaultScope).toBeUndefined();
+  });
+
+  it('exposes the configured defaultScope', () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k', defaultScope: 'caller-supplied' });
+    expect(integration.defaultScope).toBe('caller-supplied');
+  });
 });
 
 describe('ComposioToolProvider — catalog allowlist', () => {

--- a/packages/editor/src/providers/composio.test.ts
+++ b/packages/editor/src/providers/composio.test.ts
@@ -14,6 +14,7 @@ const { composioInstances, makeFakeComposio } = vi.hoisted(() => {
     tools: { get: ReturnType<typeof vi.fn>; getRawComposioTools: ReturnType<typeof vi.fn> };
     connectedAccounts: {
       initiate: ReturnType<typeof vi.fn>;
+      link: ReturnType<typeof vi.fn>;
       get: ReturnType<typeof vi.fn>;
       list: ReturnType<typeof vi.fn>;
       delete: ReturnType<typeof vi.fn>;
@@ -29,7 +30,7 @@ const { composioInstances, makeFakeComposio } = vi.hoisted(() => {
       hasProvider: Boolean(opts.provider),
       toolkits: { get: vi.fn(), getConnectedAccountInitiationFields: vi.fn() },
       tools: { get: vi.fn(), getRawComposioTools: vi.fn() },
-      connectedAccounts: { initiate: vi.fn(), get: vi.fn(), list: vi.fn(), delete: vi.fn() },
+      connectedAccounts: { initiate: vi.fn(), link: vi.fn(), get: vi.fn(), list: vi.fn(), delete: vi.fn() },
       authConfigs: { list: vi.fn() },
     };
     instances.push(inst);
@@ -235,6 +236,34 @@ describe('ComposioToolProvider — resolveTools', () => {
     expect(params.connectedAccountId).toBe('ca_1');
   });
 
+  it('does not pin connectedAccountId under caller-supplied scope (lets Composio auto-resolve)', async () => {
+    const integration = new ComposioToolProvider({ apiKey: 'k' });
+
+    await integration
+      .resolveToolsVNext({ toolSlugs: ['a'], toolMeta: {}, connectionId: 'ca_1' })
+      .catch(() => undefined);
+    const mastra = getMastraInstance();
+    mastra.tools.get.mockClear();
+    mastra.tools.get.mockResolvedValue({ 'gmail.fetch_emails': { id: 'gmail.fetch_emails' } });
+
+    await integration.resolveToolsVNext({
+      toolSlugs: ['gmail.fetch_emails'],
+      toolMeta: {},
+      connectionId: 'ca_1',
+      scope: 'caller-supplied',
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant_7' },
+    });
+
+    // User bucket is the resolved resourceId, not the pinned connection id.
+    expect(mastra.tools.get.mock.calls[0]![0]).toBe('tenant_7');
+    const modifiers = mastra.tools.get.mock.calls[0]![2] as {
+      beforeExecute: (a: { params: { connectedAccountId?: string } }) => unknown;
+    };
+    const params: { connectedAccountId?: string } = {};
+    modifiers.beforeExecute({ params });
+    expect(params.connectedAccountId).toBeUndefined();
+  });
+
   it('falls back to "default" internalUserId when MASTRA_RESOURCE_ID_KEY missing', async () => {
     const integration = new ComposioToolProvider({ apiKey: 'k' });
 
@@ -309,12 +338,13 @@ describe('ComposioToolProvider — authorize', () => {
         { id: 'ac_2', status: 'DISABLED' },
       ],
     });
-    raw.connectedAccounts.initiate.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
+    raw.connectedAccounts.link.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
 
     const result = await integration.authorize({ toolkit: 'gmail', connectionId: 'author_1' });
 
     expect(raw.authConfigs.list).toHaveBeenCalledWith({ toolkit: 'gmail' });
-    expect(raw.connectedAccounts.initiate).toHaveBeenCalledWith('author_1', 'ac_1', { allowMultiple: true });
+    expect(raw.connectedAccounts.link).toHaveBeenCalledWith('author_1', 'ac_1');
+    expect(raw.connectedAccounts.initiate).not.toHaveBeenCalled();
     expect(result).toEqual({ url: 'https://oauth', authId: 'ca_new' });
   });
 
@@ -367,7 +397,7 @@ describe('ComposioToolProvider — authorize', () => {
     });
   });
 
-  it('omits config when an empty object is supplied', async () => {
+  it('uses link (no config) when an empty config object is supplied', async () => {
     const integration = new ComposioToolProvider({ apiKey: 'k' });
     await integration.authorize({ toolkit: 'gmail', connectionId: 'a' }).catch(() => undefined);
     const raw = getRawInstance();
@@ -375,11 +405,12 @@ describe('ComposioToolProvider — authorize', () => {
     raw.authConfigs.list.mockResolvedValue({
       items: [{ id: 'ac_1', status: 'ENABLED', authScheme: 'OAUTH2' }],
     });
-    raw.connectedAccounts.initiate.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
+    raw.connectedAccounts.link.mockResolvedValue({ id: 'ca_new', redirectUrl: 'https://oauth' });
 
     await integration.authorize({ toolkit: 'gmail', connectionId: 'a', config: {} });
 
-    expect(raw.connectedAccounts.initiate).toHaveBeenCalledWith('a', 'ac_1', { allowMultiple: true });
+    expect(raw.connectedAccounts.link).toHaveBeenCalledWith('a', 'ac_1');
+    expect(raw.connectedAccounts.initiate).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -70,6 +70,7 @@ export class ComposioToolProvider extends BaseToolProvider {
     super({
       allowedToolkits: config.allowedToolkits,
       allowedTools: config.allowedTools,
+      defaultScope: config.defaultScope,
     });
     this.apiKey = config.apiKey;
   }

--- a/packages/editor/src/providers/composio.ts
+++ b/packages/editor/src/providers/composio.ts
@@ -178,7 +178,14 @@ export class ComposioToolProvider extends BaseToolProvider {
       // into the API call. Mutating `params.connectedAccountId` routes
       // the call to a specific account.
       beforeExecute: ({ params }: { params: { connectedAccountId?: string; userId?: string } }) => {
-        params.connectedAccountId = opts.connectionId;
+        // Under `caller-supplied` scope the user bucket (`internalUserId`,
+        // resolved from the host app's resourceId) already scopes the call to
+        // the right tenant. Pinning a specific `connectedAccountId` would defeat
+        // Composio's per-user-bucket auto-resolve, so we let Composio pick the
+        // connected account within the bucket instead of forcing one.
+        if (opts.scope !== 'caller-supplied') {
+          params.connectedAccountId = opts.connectionId;
+        }
         return params;
       },
     };
@@ -230,12 +237,13 @@ export class ComposioToolProvider extends BaseToolProvider {
     // for authorize we treat it as the Composio `userId` so the new connected
     // account lands under the same bucket as the agent's resolved identity.
     const internalUserId = opts.connectionId || DEFAULT_INTERNAL_USER_ID;
-    // `allowMultiple: true` — we explicitly support N connected accounts per
-    // (user, auth config) and disambiguate at runtime via per-connection labels.
+
     // `config` carries provider-specific user-supplied fields (e.g. Confluence
-    // subdomain) collected by the picker via `listConnectionFields`. Composio
-    // expects a discriminated `{ authScheme, val }` shape; we cast through
-    // `unknown` because our generic interface keeps it Record-shaped.
+    // subdomain) collected by the picker via `listConnectionFields`. When it is
+    // present we must use `connectedAccounts.initiate`, which accepts a
+    // discriminated `{ authScheme, val }` config for programmatic account
+    // creation. Composio's non-deprecated `connectedAccounts.link` (hosted
+    // Connect Link) has no `config` parameter, so it cannot carry these fields.
     const initiateConfig =
       opts.config && Object.keys(opts.config).length > 0 && authScheme
         ? ({ authScheme, val: opts.config } as unknown as Parameters<
@@ -246,13 +254,21 @@ export class ComposioToolProvider extends BaseToolProvider {
               : never
             : never)
         : undefined;
-    const request = await composio.connectedAccounts.initiate(internalUserId, authConfigId, {
-      allowMultiple: true,
-      ...(initiateConfig ? { config: initiateConfig } : {}),
-    });
+
+    // Prefer `link` for the Composio-managed OAuth redirect flow: `initiate`
+    // is deprecated for managed OAuth. `link` allows multiple connected
+    // accounts per (user, auth config) by default, so we no longer pass
+    // `allowMultiple`. Fall back to `initiate` only when custom `config` fields
+    // are supplied, since `link` cannot forward them.
+    const request = initiateConfig
+      ? await composio.connectedAccounts.initiate(internalUserId, authConfigId, {
+          allowMultiple: true,
+          config: initiateConfig,
+        })
+      : await composio.connectedAccounts.link(internalUserId, authConfigId);
 
     if (!request.redirectUrl) {
-      throw new Error(`[composio] initiate did not return a redirectUrl for toolkit "${opts.toolkit}"`);
+      throw new Error(`[composio] authorize did not return a redirectUrl for toolkit "${opts.toolkit}"`);
     }
 
     return { url: request.redirectUrl, authId: request.id };

--- a/packages/server/src/server/handlers/tool-providers.test.ts
+++ b/packages/server/src/server/handlers/tool-providers.test.ts
@@ -997,6 +997,78 @@ describe('AUTHORIZE_TOOL_PROVIDER_ROUTE (scope)', () => {
     expect(authorize).not.toHaveBeenCalled();
     expect(store.upsertConnection).not.toHaveBeenCalled();
   });
+
+  it("uses the provider's defaultScope when the request omits scope", async () => {
+    const authorize = vi.fn().mockResolvedValue({ url: 'https://oauth/redirect', authId: 'ca_new' });
+    const provider = makeProvider({ authorize, defaultScope: 'caller-supplied' });
+    const editor = makeEditor(provider);
+    const store = makeToolProviderConnectionsStore();
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'end_user_77');
+
+    await AUTHORIZE_TOOL_PROVIDER_ROUTE.handler({
+      mastra: makeMastraWithStorage(editor, store),
+      providerId: 'composio',
+      toolkit: 'gmail',
+      connectionId: '',
+      // no scope on the request — provider defaultScope drives it
+      requestContext,
+    } as any);
+
+    expect(authorize).toHaveBeenCalledWith({
+      toolkit: 'gmail',
+      connectionId: 'end_user_77',
+      toolName: undefined,
+      config: undefined,
+    });
+    expect(store.upsertConnection).toHaveBeenCalledWith({
+      authorId: 'end_user_77',
+      providerId: 'composio',
+      toolkit: 'gmail',
+      connectionId: 'ca_new',
+      label: null,
+      scope: 'caller-supplied',
+    });
+  });
+
+  it('request scope overrides the provider defaultScope', async () => {
+    const authorize = vi.fn().mockResolvedValue({ url: 'https://oauth/redirect', authId: 'ca_new' });
+    const provider = makeProvider({ authorize, defaultScope: 'caller-supplied' });
+    const editor = makeEditor(provider);
+    const store = makeToolProviderConnectionsStore();
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'user_42');
+
+    await AUTHORIZE_TOOL_PROVIDER_ROUTE.handler({
+      mastra: makeMastraWithStorage(editor, store),
+      providerId: 'composio',
+      toolkit: 'gmail',
+      connectionId: '',
+      scope: 'shared',
+      requestContext,
+    } as any);
+
+    expect(store.upsertConnection).toHaveBeenCalledWith(expect.objectContaining({ scope: 'shared' }));
+  });
+
+  it("defaults to 'per-author' when neither request scope nor defaultScope is set", async () => {
+    const authorize = vi.fn().mockResolvedValue({ url: 'https://oauth/redirect', authId: 'ca_new' });
+    const provider = makeProvider({ authorize });
+    const editor = makeEditor(provider);
+    const store = makeToolProviderConnectionsStore();
+    const requestContext = new RequestContext();
+    requestContext.set(MASTRA_RESOURCE_ID_KEY, 'user_42');
+
+    await AUTHORIZE_TOOL_PROVIDER_ROUTE.handler({
+      mastra: makeMastraWithStorage(editor, store),
+      providerId: 'composio',
+      toolkit: 'gmail',
+      connectionId: '',
+      requestContext,
+    } as any);
+
+    expect(store.upsertConnection).toHaveBeenCalledWith(expect.objectContaining({ scope: 'per-author' }));
+  });
 });
 
 describe('DISCONNECT_TOOL_PROVIDER_CONNECTION_ROUTE (scope)', () => {

--- a/packages/server/src/server/handlers/tool-providers.test.ts
+++ b/packages/server/src/server/handlers/tool-providers.test.ts
@@ -1048,7 +1048,18 @@ describe('AUTHORIZE_TOOL_PROVIDER_ROUTE (scope)', () => {
       requestContext,
     } as any);
 
-    expect(store.upsertConnection).toHaveBeenCalledWith(expect.objectContaining({ scope: 'shared' }));
+    // The override must also select the shared bucket, not just persist the label:
+    // authorize gets the shared bucket as its connection context, and the stored
+    // row is owned by the shared author id.
+    expect(authorize).toHaveBeenCalledWith({
+      toolkit: 'gmail',
+      connectionId: 'shared',
+      toolName: undefined,
+      config: undefined,
+    });
+    expect(store.upsertConnection).toHaveBeenCalledWith(
+      expect.objectContaining({ authorId: 'shared', connectionId: 'ca_new', scope: 'shared' }),
+    );
   });
 
   it("defaults to 'per-author' when neither request scope nor defaultScope is set", async () => {

--- a/packages/server/src/server/handlers/tool-providers.ts
+++ b/packages/server/src/server/handlers/tool-providers.ts
@@ -279,8 +279,15 @@ export const AUTHORIZE_TOOL_PROVIDER_ROUTE = createRoute({
       // - 'shared' buckets under SHARED_BUCKET_ID.
       // - 'caller-supplied' buckets under request-context resourceId (400 if missing).
       // - 'per-author' (default) buckets under the caller's resolved authorId.
+      //
+      // Precedence: an explicit request `scope` wins, then the provider's
+      // config-level `defaultScope` (the app author's tenancy decision), then
+      // `'per-author'`. This lets a provider constructed with
+      // `defaultScope: 'caller-supplied'` produce per-tenant connections even
+      // though no UI control selects a scope.
+      const requestedScope = scope ?? provider.defaultScope;
       const effectiveScope: 'shared' | 'per-author' | 'caller-supplied' =
-        scope === 'shared' || scope === 'caller-supplied' ? scope : 'per-author';
+        requestedScope === 'shared' || requestedScope === 'caller-supplied' ? requestedScope : 'per-author';
       const callerResourceId = requestContext?.get(MASTRA_RESOURCE_ID_KEY);
       if (effectiveScope === 'caller-supplied') {
         if (typeof callerResourceId !== 'string' || callerResourceId.length === 0) {


### PR DESCRIPTION
Fixes multi-tenant tool auth for Composio-backed agents in the Agent Builder, plus docs for setting Composio up.

Agents using a `caller-supplied` connection scope now let Composio auto-resolve the connected account within each tenant's bucket instead of pinning one shared account for everyone. Before, every caller hit the same account:

```ts
// before: connectedAccountId always pinned, even for caller-supplied
params.connectedAccountId = opts.connectionId
```

```ts
// after: skip the pin under caller-supplied so Composio resolves within the tenant bucket
if (opts.scope !== 'caller-supplied') {
  params.connectedAccountId = opts.connectionId
}
```

This required threading a connection's `scope` through to the provider via an optional `scope` field on `ResolveToolsOpts` in `@mastra/core` (defaults to prior behavior when absent).

Also swapped account authorization from Composio's deprecated `initiate()` endpoint to the supported `link()` flow for managed OAuth, while keeping `initiate()` for connections that collect custom fields (like a Confluence subdomain).

On the docs side: documented the three connection scopes, the project API key requirement, the enable-auth-config failure and fix, and added a setup-at-a-glance flow.

Verified the code paths end-to-end against the live Composio API (connect, per-tenant isolation, tool execution). Unit tests and typechecks pass for both packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes multi-tenant, Composio-backed agents pick the right OAuth connection for each user/tenant instead of accidentally reusing one shared connection. It also fixes Composio signup/authorization to use the supported “link” flow and updates docs so the right keys and scope settings are easier to get right.

## What changed
- **Connection scoping for tool resolution (identity bucketing)**
  - Added an optional `scope` to `ResolveToolsOpts` in `@mastra/core` and threaded it through tool resolution.
  - For **`caller-supplied`**, Composio-backed agents no longer pin a single shared `connectedAccountId`; the connected account is resolved per tenant/user bucket.

- **Provider-level default scope**
  - Added optional `defaultScope` to `BaseToolProviderOptions` / `ToolProvider`.
  - Updated the server authorize handler to persist the effective connection scope using precedence:
    **request `scope` → provider `defaultScope` → `'per-author'`**.

- **Composio authorization flow**
  - Updated managed OAuth authorization to use Composio’s supported **`connectedAccounts.link()`** flow for the standard case.
  - Kept **`connectedAccounts.initiate()`** for connections that require custom fields (e.g., collecting additional configuration).

- **Per-user WorkOS resource mapping**
  - Added `mapUserToResourceId` support to `@mastra/auth-workos` options and wired it so apps can provide per-user tenant/bucket identifiers for multi-tenant deployments.
  - Updated Agent Builder examples to use this mapping and set Composio provider `defaultScope` appropriately.

- **Documentation + examples**
  - Added “setup at a glance” docs for Agent Builder Composio configuration.
  - Documented connection scopes (`per-author`, `shared`, `caller-supplied`), the Composio **project API key** requirement (`x-api-key`), auth-config validation expectations, and guidance for common connection-scope/auth configuration errors.

## Verification
- Updated/added unit tests covering:
  - `caller-supplied` behavior (no shared `connectedAccountId` pinning during resolution)
  - `link()` vs `initiate()` authorization behavior
  - scope precedence including provider `defaultScope`
- Type checks and unit tests pass for the involved packages, with end-to-end validation against the live Composio API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->