### PR TITLE
fix(core): persist messages when lastMessages is false (write-only memory)

### DIFF
--- a/.changeset/memory-write-only-persistence.md
+++ b/.changeset/memory-write-only-persistence.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': patch
+---
+
+Fix: `lastMessages: false` no longer disables message persistence (enables write-only memory)
+
+`MessageHistory` handles both recall (input) and saving (output). Previously it was
+registered on the output side only when `lastMessages` was truthy, so `lastMessages: false`
+silently dropped the save — a thread was created but no messages were persisted. This
+contradicted the documented semantics ("To prevent saving new messages, use the `readOnly`
+option instead") and made a one-way / write-only memory impossible.
+
+The save (output) processor is now registered independent of `lastMessages`; recall stays
+gated on `lastMessages` (input side), and saving is disabled via `readOnly` (checked at
+execution). `lastMessages: false` therefore acts as a write-only memory: no recalled history
+is injected into the prompt, but each turn is still persisted. The missing-storage-adapter
+guard is preserved. Fixes #19149.

--- a/packages/core/src/memory/memory.ts
+++ b/packages/core/src/memory/memory.ts
@@ -916,33 +916,38 @@ https://mastra.ai/en/docs/memory/overview`,
       }
     }
 
+    // Message persistence (save) is registered independent of `lastMessages`.
+    // `lastMessages` gates recall on the input side only (see getInputProcessors);
+    // saving is on by default and is disabled via `readOnly` (checked at execution
+    // in MessageHistory.processOutputResult), matching the documented semantics:
+    // "To prevent saving new messages, use the readOnly option instead."
+    // This lets `lastMessages: false` act as a write-only memory — no recalled
+    // history is injected into the prompt, but each turn is still persisted.
     const lastMessages = effectiveConfig.lastMessages;
-    if (lastMessages) {
-      if (!memoryStore)
-        throw new MastraError({
-          category: 'USER',
-          domain: ErrorDomain.STORAGE,
-          id: 'MESSAGE_HISTORY_MISSING_STORAGE_ADAPTER',
-          text: 'Using Mastra Memory message history requires a storage adapter but no attached adapter was detected.',
-        });
+    if (!memoryStore)
+      throw new MastraError({
+        category: 'USER',
+        domain: ErrorDomain.STORAGE,
+        id: 'MESSAGE_HISTORY_MISSING_STORAGE_ADAPTER',
+        text: 'Using Mastra Memory message history requires a storage adapter but no attached adapter was detected.',
+      });
 
-      // Check if user already manually added MessageHistory
-      const hasMessageHistory = configuredProcessors.some(p => !isProcessorWorkflow(p) && p.id === 'message-history');
+    // Check if user already manually added MessageHistory
+    const hasMessageHistory = configuredProcessors.some(p => !isProcessorWorkflow(p) && p.id === 'message-history');
 
-      // Check if ObservationalMemory is present (via processor or config) - it handles its own message saving
-      const hasObservationalMemory =
-        configuredProcessors.some(p => !isProcessorWorkflow(p) && p.id === 'observational-memory') ||
-        isObservationalMemoryEnabled(effectiveConfig.observationalMemory);
+    // Check if ObservationalMemory is present (via processor or config) - it handles its own message saving
+    const hasObservationalMemory =
+      configuredProcessors.some(p => !isProcessorWorkflow(p) && p.id === 'observational-memory') ||
+      isObservationalMemoryEnabled(effectiveConfig.observationalMemory);
 
-      // Skip MessageHistory output processor if ObservationalMemory handles message saving
-      if (!hasMessageHistory && !hasObservationalMemory) {
-        processors.push(
-          new MessageHistory({
-            storage: memoryStore,
-            lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
-          }),
-        );
-      }
+    // Skip MessageHistory output processor if ObservationalMemory handles message saving
+    if (!hasMessageHistory && !hasObservationalMemory) {
+      processors.push(
+        new MessageHistory({
+          storage: memoryStore,
+          lastMessages: typeof lastMessages === 'number' ? lastMessages : undefined,
+        }),
+      );
     }
 
     // Return only the auto-generated processors (not the configured ones)

--- a/packages/core/src/memory/write-only-persistence.test.ts
+++ b/packages/core/src/memory/write-only-persistence.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Write-only memory: `lastMessages: false` must still persist turns.
+ *
+ * `lastMessages` gates recall on the input side only; saving is on by default and
+ * is disabled via `readOnly`, per the documented semantics ("To prevent saving new
+ * messages, use the readOnly option instead"). This lets `lastMessages: false` act
+ * as a one-way / write-only mirror: no recalled history is injected into the prompt,
+ * but each turn is still persisted.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { MastraStorage, MemoryStorage } from '../storage';
+
+import { MockMemory } from './mock';
+
+describe('MastraMemory write-only persistence (lastMessages: false)', () => {
+  let mockStorage: MastraStorage;
+  let mockMemoryStore: MemoryStorage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockMemoryStore = {
+      getThreadById: vi.fn().mockResolvedValue(null),
+      saveThread: vi.fn().mockImplementation(({ thread }) => Promise.resolve(thread)),
+      listMessages: vi.fn().mockResolvedValue({ messages: [] }),
+      getMessages: vi.fn().mockResolvedValue([]),
+      saveMessages: vi.fn().mockResolvedValue({ messages: [] }),
+    } as unknown as MemoryStorage;
+
+    mockStorage = {
+      getStore: vi.fn().mockResolvedValue(mockMemoryStore),
+      init: vi.fn().mockResolvedValue(undefined),
+    } as unknown as MastraStorage;
+  });
+
+  const makeMemory = (storage: MastraStorage) =>
+    new MockMemory({ storage: storage as any, enableMessageHistory: false, options: { lastMessages: false } });
+
+  it('registers the message-history save processor even when lastMessages is false', async () => {
+    const memory = makeMemory(mockStorage);
+    const output = await memory.getOutputProcessors();
+    expect(output.some(p => p.id === 'message-history')).toBe(true);
+  });
+
+  it('does not register recall (input message-history) when lastMessages is false', async () => {
+    const memory = makeMemory(mockStorage);
+    const input = await memory.getInputProcessors();
+    expect(input.some(p => p.id === 'message-history')).toBe(false);
+  });
+
+  it('still requires a storage adapter to save (throws MESSAGE_HISTORY_MISSING_STORAGE_ADAPTER)', async () => {
+    const noStore = {
+      getStore: vi.fn().mockResolvedValue(undefined),
+      init: vi.fn().mockResolvedValue(undefined),
+    } as unknown as MastraStorage;
+    const memory = makeMemory(noStore);
+    await expect(memory.getOutputProcessors()).rejects.toThrow(/storage adapter/i);
+  });
+});


### PR DESCRIPTION
Fixes #19149

## Summary

`Memory`'s `MessageHistory` processor handles both **recall** (input side) and **saving** (output side). The save/output processor was registered only inside `if (lastMessages) { … }` in `getOutputProcessors`, so setting **`lastMessages: false` silently disabled message persistence** — a thread row is created, but no messages are ever written.

This contradicts the documented semantics in `reference-memory-memory-class.md`:

> **`lastMessages`** … Set to `false` to disable loading conversation history into context. **To prevent saving new messages, use the `readOnly` option instead.**
>
> **`readOnly`** … prevents memory from saving new messages …

i.e. `lastMessages` is meant to gate **recall**, and `readOnly` is meant to gate **saving** — but in practice `lastMessages: false` disabled both.

## Why it matters (use case)

A **one-way / write-only memory mirror**: persist each turn into Mastra Memory (for Studio thread inspection, datasets/experiments from real conversations, replay-as-evals, Observational Memory) **without** injecting recalled history into the prompt — because the app already owns its own conversation context and recall would double the prompt.

Today that's impossible:
- `lastMessages: false` → no recall **and** no save,
- any truthy `lastMessages` → injects recalled history,
- `readOnly: true` → the inverse (recall, but no save).

There is no "save without recall".

## Fix

In `getOutputProcessors`, register the `MessageHistory` (save) processor **independent of `lastMessages`**. Recall stays gated on `lastMessages` in `getInputProcessors`, and saving remains disabled via `readOnly` (already checked at execution in `MessageHistory.processOutputResult`). The missing-storage-adapter guard is preserved.

Result: `lastMessages: false` now behaves as a write-only memory — no recalled history injected, turns still persisted — matching the documented semantics.

## Repro (before this PR)

```ts
const memory = new Memory({ storage, options: { lastMessages: false, semanticRecall: false } });
const agent = new Agent({ /* … */ model, memory });
await agent.stream('hello', { memory: { thread: 't1', resource: 'r1' } });
// thread 't1' is created, but mastra_messages stays empty.
// With lastMessages: 20, the same turn persists 2 messages (user + assistant).
```

## Behavior change

`getOutputProcessors` now throws `MESSAGE_HISTORY_MISSING_STORAGE_ADAPTER` when memory is attached without a storage adapter regardless of `lastMessages` (saving is on by default and requires a store). Previously this only threw when `lastMessages` was truthy. Properly-configured memory always has a store, so this surfaces genuine misconfigurations rather than silently no-op'ing the save.

## Test

Adds `packages/core/src/memory/write-only-persistence.test.ts`: with `lastMessages: false`, `getOutputProcessors` registers the `message-history` (save) processor while `getInputProcessors` does not (recall stays off), and the missing-storage-adapter guard still throws.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change fixes memory so turning off “remember recent messages” no longer stops it from saving new ones. In other words, `lastMessages: false` now means “don’t load old chat into the prompt,” while `readOnly` still means “don’t save anything.”

## Summary
- Made `MessageHistory` output registration independent of `lastMessages`, so writes still happen when recall is disabled.
- Kept input-side history recall gated by `lastMessages`, preserving the no-history-in-prompt behavior.
- Preserved the missing storage adapter guard for cases where saving is expected.
- Added regression coverage for:
  - output persistence still being enabled with `lastMessages: false`
  - input recall staying disabled
  - missing storage adapter still throwing as expected
- Updated the changeset to document the write-only memory behavior fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->