### PR TITLE
fix(core): exempt memory-sourced messages from the resourceId guard in inputToMastraDBMessage

### DIFF
--- a/.changeset/loud-owls-listen.md
+++ b/.changeset/loud-owls-listen.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Exempt memory-sourced messages from the resourceId guard in inputToMastraDBMessage, matching the existing threadId exemption. Memory messages can carry a system resourceId (e.g. observational-memory continuation messages arrive with the observer's resourceId), and the mismatch previously threw inside input processing and hard-aborted the turn.

--- a/packages/core/src/agent/message-list/conversion/input-converter.test.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { MastraDBMessage } from '../state/types';
 import type { InputConversionContext } from './input-converter';
-import { hydrateMastraDBMessageFields } from './input-converter';
+import { hydrateMastraDBMessageFields, inputToMastraDBMessage } from './input-converter';
 
 describe('hydrateMastraDBMessageFields', () => {
   it('backfills resourceId when the message already has a threadId', () => {
@@ -31,5 +31,57 @@ describe('hydrateMastraDBMessageFields', () => {
     expect(result.resourceId).toBe('resource-1');
     expect(context.newMessageId).not.toHaveBeenCalled();
     expect(context.generateCreatedAt).not.toHaveBeenCalled();
+  });
+});
+
+describe('inputToMastraDBMessage', () => {
+  const makeContext = () =>
+    ({
+      memoryInfo: {
+        threadId: 'thread-1',
+        resourceId: 'resource-1',
+      },
+      newMessageId: vi.fn(() => 'generated-id'),
+      generateCreatedAt: vi.fn(() => new Date('2026-01-02T00:00:00.000Z')),
+      dbMessages: [],
+    }) satisfies InputConversionContext;
+
+  const makeMessage = (overrides: Partial<MastraDBMessage>) =>
+    ({
+      id: 'msg-1',
+      role: 'user',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      content: {
+        format: 2,
+        parts: [{ type: 'text', text: 'hello' }],
+      },
+      ...overrides,
+    }) as MastraDBMessage;
+
+  it('accepts memory-sourced messages whose resourceId differs from the conversation resource', () => {
+    // Memory messages can carry a system resourceId — e.g. observational-memory
+    // continuation messages arrive with the observer's own resourceId. The
+    // threadId guard already exempts `memory`; the resourceId guard must too,
+    // or a compaction mid-run throws inside input processing and aborts the turn.
+    const message = makeMessage({
+      threadId: 'other-thread',
+      resourceId: 'structured-observer',
+    });
+
+    expect(() => inputToMastraDBMessage(message, 'memory', makeContext())).not.toThrow();
+  });
+
+  it('still rejects non-memory messages with a mismatched resourceId', () => {
+    const message = makeMessage({ resourceId: 'someone-else' });
+
+    expect(() => inputToMastraDBMessage(message, 'user', makeContext())).toThrow(/wrong resourceId/);
+  });
+
+  it('still rejects non-memory messages with a mismatched threadId', () => {
+    const message = makeMessage({ threadId: 'other-thread' });
+
+    expect(() => inputToMastraDBMessage(message, 'user', makeContext())).toThrow(/wrong threadId/);
   });
 });

--- a/packages/core/src/agent/message-list/conversion/input-converter.ts
+++ b/packages/core/src/agent/message-list/conversion/input-converter.ts
@@ -46,8 +46,10 @@ export function inputToMastraDBMessage(
     );
   }
 
-  // Validate resourceId matches
+  // Validate resourceId matches (except for memory messages, which can carry a
+  // system resourceId — e.g. observational-memory continuation messages)
   if (
+    messageSource !== `memory` &&
     `resourceId` in message &&
     message.resourceId &&
     context.memoryInfo?.resourceId &&


### PR DESCRIPTION
Fixes #19152

## Bug

`inputToMastraDBMessage` (`packages/core/src/agent/message-list/conversion/input-converter.ts`) has two symmetry-broken guards:

- The **threadId** guard is exempted for memory-sourced messages, with a comment explaining why: *"except for memory messages which can come from other threads"*.
- The **resourceId** guard directly below has **no such exemption**.

## How it bites

With observational memory enabled, a heavy compaction injects a `messageSource === 'memory'` continuation message that carries the observer's own resourceId (`structured-observer`), not the conversation's resourceId. The resourceId guard then throws **synchronously inside input processing**:

```
Received input message with wrong resourceId. Input structured-observer, expected <user resource>
```

...which hard-aborts the turn after tools have already executed: the stream emits the tool activity, then dies before the answer. From the user's view the agent "did the work and never answered". Reproduces deterministically by forcing OM compaction (low observation threshold) on a busy thread — full repro in #19152.

## Fix

One line (plus the mirrored comment): apply the same `messageSource !== 'memory'` exemption the threadId guard already has. Memory-sourced messages are runtime-generated context, not user input — exactly the rationale the threadId comment gives.

Includes regression tests (memory bypass + still-enforced non-memory threadId/resourceId mismatches) and a `@mastra/core` patch changeset.

## Notes

- We currently ship this exact change as a pnpm patch against `@mastra/core` in production and have verified it live: forced compaction, zero stream errors, turn completes.
- Supersedes #19146 (auto-closed for a missing linked issue before review).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops the app from getting confused when a message comes from memory and has a different `resourceId` than the current conversation. Memory messages are now treated the same way as the existing `threadId` exception, so the turn can keep going instead of failing after work has already started.

### What changed
- Fixed `inputToMastraDBMessage` so `memory`-sourced messages skip the `resourceId` ownership check.
- Kept normal validation in place for non-memory messages, including `resourceId` and `threadId` mismatches.
- Added regression tests covering:
  - memory messages being allowed through with mismatched `resourceId`
  - non-memory messages still being rejected when IDs don’t match
- Added a patch changeset for `@mastra/core`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->