### PR TITLE
docs(memory): clarify lastMessages false behavior

### DIFF
--- a/docs/src/content/en/reference/memory/memory-class.mdx
+++ b/docs/src/content/en/reference/memory/memory-class.mdx
@@ -74,7 +74,7 @@ To enable `workingMemory` on an agent, you’ll need a storage provider configur
             name: 'lastMessages',
             type: 'number | false',
             description:
-              'Number of most recent messages to include in context. Set to `false` to disable loading conversation history into context. Use `Number.MAX_SAFE_INTEGER` to retrieve all messages with no limit. To prevent saving new messages, use the `readOnly` option instead.',
+              'Number of most recent messages to include in context. Set to `false` to disable the message history feature entirely (messages are not loaded into context or saved). Use `Number.MAX_SAFE_INTEGER` to retrieve all messages with no limit. To load messages without saving new ones, use the `readOnly` option.',
             isOptional: true,
             defaultValue: '10',
           },

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -73,7 +73,8 @@ new MastraEditor({
           {
             name: 'lastMessages',
             type: 'number | false',
-            description: 'Number of recent messages to include in context, or `false` to disable message history entirely (messages are not loaded or saved).',
+            description:
+              'Number of recent messages to include in context, or `false` to disable message history entirely (messages are not loaded or saved).',
             isOptional: true,
           },
           {

--- a/docs/src/content/en/reference/memory/serialized-memory-config.mdx
+++ b/docs/src/content/en/reference/memory/serialized-memory-config.mdx
@@ -73,7 +73,7 @@ new MastraEditor({
           {
             name: 'lastMessages',
             type: 'number | false',
-            description: 'Number of recent messages to include in context, or `false` to disable.',
+            description: 'Number of recent messages to include in context, or `false` to disable message history entirely (messages are not loaded or saved).',
             isOptional: true,
           },
           {


### PR DESCRIPTION
## Description

Fixes misleading `lastMessages` documentation that implied `false` only disables loading messages into context while still saving them. The actual behavior (confirmed by maintainer in #19148) is that `lastMessages: false` disables message history entirely — no loading and no saving.

- Updated `lastMessages` description in `memory-class.mdx` to clarify that `false` disables the message history feature entirely (messages are not loaded into context or saved)
- Updated `lastMessages` description in `serialized-memory-config.mdx` with the same clarification
- Reworded `readOnly` cross-reference from "to prevent saving" to "to load messages without saving new ones"

## Related Issue(s)

Fixes #19149

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This update fixes the docs so they match how memory actually works. It explains that setting `lastMessages: false` turns off message history completely, so messages won’t be loaded into the chat or saved for later.

## Summary
- Clarified `lastMessages` in `memory-class.mdx` to say `false` disables message history entirely.
- Reworded the `readOnly` reference to explain it’s for loading messages without saving new ones.
- Updated `serialized-memory-config.mdx` for the same `lastMessages` docs wording/formatting change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->