### PR TITLE
docs(channels): improve Slack setup guide

### DIFF
--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -41,7 +41,7 @@ import { createSlackAdapter } from '@chat-adapter/slack'
 export const yourAgent = new Agent({
   id: 'your-agent',
   name: 'Your Agent',
-  instructions: 'You are a helpful support assistant.',
+  instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
   channels: {
     adapters: {
@@ -213,7 +213,7 @@ import { waitUntil } from '@vercel/functions'
 export const yourAgent = new Agent({
   id: 'your-agent',
   name: 'Your Agent',
-  instructions: 'You are a helpful support assistant.',
+  instructions: 'You are a helpful assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
   channels: {
     adapters: {
@@ -235,6 +235,7 @@ Configure a shared pub/sub backed by Redis Streams on the `Mastra` instance so l
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
 import { RedisStreamsPubSub } from '@mastra/redis-streams'
+import { yourAgent } from './agents/your-agent'
 
 export const mastra = new Mastra({
   agents: { yourAgent },

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -9,7 +9,7 @@ packages:
 
 **Added in:** `@mastra/core@1.22.0`
 
-Channels connect agents to messaging and collaboration platforms like Slack, Microsoft Teams, Discord, Telegram, WhatsApp, GitHub, and Linear. When a user sends a message or comment on a platform, the agent receives it, processes it through the normal agent pipeline, and streams the response back to the conversation.
+Channels connect agents to messaging and collaboration platforms like Slack, Microsoft Teams, Discord, Telegram, WhatsApp, GitHub, and Linear. When a user sends a message or comment on a platform, the agent receives it, processes it through the normal agent pipeline, and streams the response back to the conversation. Mastra uses [Chat SDK](https://chat-sdk.dev/) for this channel layer.
 
 Start with the page for your platform:
 
@@ -19,7 +19,7 @@ Start with the page for your platform:
 - [Telegram](/docs/capabilities/channels/telegram)
 - [WhatsApp](/docs/capabilities/channels/whatsapp)
 
-Mastra channels work with compatible [Chat SDK](https://chat-sdk.dev/adapters) adapters beyond the platforms listed here. The [More](/docs/capabilities/channels/other-adapters) page lists additional adapters and explains how the same Mastra-side pattern applies.
+[More](/docs/capabilities/channels/other-adapters) lists additional platforms. Mastra channels work with compatible [Chat SDK adapters](https://chat-sdk.dev/adapters) beyond the platforms listed here, and the same Mastra configuration pattern applies across adapters.
 
 ## When to use channels
 
@@ -32,15 +32,15 @@ Use channels when an agent needs to:
 
 ## Configure an agent
 
-Configure channels directly on your agent using adapters from the Chat SDK. The example below uses Slack, but other adapters follow the same shape: import the adapter factory, add it to `channels.adapters`, and use the adapter key in the generated webhook route.
+Channels use Chat SDK adapters and follow the same Mastra-side pattern: create a channel adapter and add it to the agent.
 
-```typescript title="src/mastra/agents/support-agent.ts"
+```typescript title="src/mastra/agents/your-agent.ts"
 import { Agent } from '@mastra/core/agent'
 import { createSlackAdapter } from '@chat-adapter/slack'
 
-export const supportAgent = new Agent({
-  id: 'support-agent',
-  name: 'Support Agent',
+export const yourAgent = new Agent({
+  id: 'your-agent',
+  name: 'Your Agent',
   instructions: 'You are a helpful support assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
   channels: {
@@ -51,52 +51,52 @@ export const supportAgent = new Agent({
 })
 ```
 
-Register the agent in your Mastra instance with storage so channel state persists across restarts:
+:::note
+
+Channel adapters require provider-specific environment variables for credentials and request verification, such as bot tokens, signing secrets, app IDs, and webhook verification tokens. Check the guide for your platform or the [Chat SDK adapter catalog](https://chat-sdk.dev/adapters) for the exact variable names.
+
+:::
+
+We recommend configuring [storage](/docs/storage/overview) for channels. Storage lets Mastra persist channel state, thread subscriptions, tool approvals, and memory across restarts:
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
 import { LibSQLStore } from '@mastra/libsql'
-import { supportAgent } from './agents/support-agent'
+import { yourAgent } from './agents/your-agent'
 
 export const mastra = new Mastra({
-  agents: { supportAgent },
+  agents: { yourAgent },
   storage: new LibSQLStore({
     url: process.env.DATABASE_URL,
   }),
 })
 ```
 
-Each Chat SDK adapter documents the environment variables it reads by default, such as bot tokens, signing secrets, app IDs, and webhook verification tokens. Use the page for your platform in this section, or the [Chat SDK adapter catalog](https://chat-sdk.dev/adapters), to find the exact variable names.
-
 ## Webhook routes
 
-Platforms send channel activity to Mastra through webhooks. A webhook is an HTTP endpoint that the platform calls when something happens, such as a new message, a mention, or a user selecting "Approve" on an interactive tool approval card.
+Platforms send channel activity to Mastra through webhooks. A webhook is an HTTP endpoint that the platform calls when something happens, such as a new message, a mention, or a user selecting "Approve" on an interactive tool approval card. This is how your agent receives a new message, starts processing it, and responds in the same channel.
 
-Mastra generates a webhook route for each configured adapter:
-
-```text
-/api/agents/{agentId}/channels/{platform}/webhook
-```
-
-For example, a Slack adapter on an agent with the `support-agent` ID uses:
+Mastra registers a webhook route for each configured adapter and handles the request for you:
 
 ```text
-/api/agents/support-agent/channels/slack/webhook
+/api/agents/<AGENT_ID>/channels/<PLATFORM>/webhook
 ```
 
-Point the platform's webhook, event, or interactions URL to this path. The Chat SDK adapter verifies the incoming request, normalizes the event, and passes it to the agent.
+For example, a Slack adapter on an agent with the `your-agent` ID uses:
 
-During local development, platform webhooks need a public URL to reach your local server. Use a tunnel like [cloudflared](https://github.com/cloudflare/cloudflared) or [ngrok](https://ngrok.com/) to expose `localhost:4111`:
+```text
+/api/agents/your-agent/channels/slack/webhook
+```
+
+Point the platform's webhook, event, or interactions URL to this path. Follow the guide for your platform or the [Chat SDK docs](https://chat-sdk.dev/adapters).
+
+During local development, platform webhooks need a public URL to reach your local server. Use a tunnel like [cloudflared](https://github.com/cloudflare/cloudflared) or [ngrok](https://ngrok.com/) to expose your server, `localhost:4111` by default:
 
 ```bash npm2yarn
 npx cloudflared tunnel --url http://localhost:4111
 ```
 
-```bash
-ngrok http 4111
-```
-
-Use the generated public URL as the base URL for webhook paths, for example `https://abc123.trycloudflare.com/api/agents/support-agent/channels/slack/webhook`.
+Use the generated public URL as the base URL for webhook paths, for example `https://abc123.trycloudflare.com/api/agents/your-agent/channels/slack/webhook`.
 
 :::note
 
@@ -205,14 +205,14 @@ A channel webhook returns a `200` response right away, then the agent runs in th
 
 On Vercel, pass `waitUntil` from `@vercel/functions`:
 
-```typescript title="src/mastra/agents/support-agent.ts"
+```typescript title="src/mastra/agents/your-agent.ts"
 import { Agent } from '@mastra/core/agent'
 import { createSlackAdapter } from '@chat-adapter/slack'
 import { waitUntil } from '@vercel/functions'
 
-export const supportAgent = new Agent({
-  id: 'support-agent',
-  name: 'Support Agent',
+export const yourAgent = new Agent({
+  id: 'your-agent',
+  name: 'Your Agent',
   instructions: 'You are a helpful support assistant.',
   model: '__GATEWAY_OPENAI_MODEL__',
   channels: {
@@ -237,7 +237,7 @@ import { Mastra } from '@mastra/core'
 import { RedisStreamsPubSub } from '@mastra/redis-streams'
 
 export const mastra = new Mastra({
-  agents: { supportAgent },
+  agents: { yourAgent },
   pubsub: new RedisStreamsPubSub({
     url: process.env.REDIS_URL,
     keyPrefix: 'mastra:my-app',
@@ -247,9 +247,6 @@ export const mastra = new Mastra({
 
 Vercel's managed Redis integration and Upstash Redis both work well. For more on when a distributed pub/sub is needed, see the [PubSub guide](/docs/server/pubsub) and the [`RedisStreamsPubSub` reference](/reference/pubsub/redis-streams).
 
-## Next steps
+## Related
 
-- [Slack](/docs/capabilities/channels/slack)
-- [Microsoft Teams](/docs/capabilities/channels/teams)
-- [More](/docs/capabilities/channels/other-adapters)
 - [Channels reference](/reference/agents/channels)

--- a/docs/src/content/en/docs/capabilities/channels/slack.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/slack.mdx
@@ -1,15 +1,15 @@
 ---
 title: "Slack | Channels"
-description: "Configure a Mastra agent to receive Slack messages and mentions through a channel adapter."
+description: "Configure a Mastra agent to respond in Slack channels and direct messages through a channel adapter."
 packages:
   - "@mastra/core"
 ---
 
 # Slack
 
-Slack channels let a Mastra agent receive channel mentions and thread replies from Slack. Use the Slack adapter when you create and configure the Slack app yourself.
+Add your agent to Slack so people can message it in shared channel threads or direct messages. When someone sends a message, Mastra runs your agent through the normal agent pipeline and streams the response back to Slack. The Slack adapter handles Slack AI indicators and interactive cards for you.
 
-## Install the adapter
+## Installation
 
 Install the Slack adapter from the Chat SDK:
 
@@ -17,18 +17,16 @@ Install the Slack adapter from the Chat SDK:
 npm install @chat-adapter/slack
 ```
 
-## Agent configuration
-
 Add `createSlackAdapter()` to the agent's `channels.adapters` object:
 
-```typescript title="src/mastra/agents/slack-agent.ts"
+```typescript title="src/mastra/agents/your-agent.ts"
 import { Agent } from '@mastra/core/agent'
 import { createSlackAdapter } from '@chat-adapter/slack'
 
-export const slackAgent = new Agent({
-  id: 'slack-agent',
-  name: 'Slack Agent',
-  instructions: 'Answer questions, help with tasks, and have natural conversations in Slack.',
+export const yourAgent = new Agent({
+  id: 'your-agent',
+  name: 'Your Agent',
+  instructions: 'Help people plan tasks, answer questions, and coordinate work in Slack.',
   model: '__GATEWAY_ANTHROPIC_MODEL_OPUS__',
   channels: {
     adapters: {
@@ -38,86 +36,133 @@ export const slackAgent = new Agent({
 })
 ```
 
-The `channels` property tells Mastra to generate a webhook endpoint for the Slack adapter. The adapter handles Slack event verification, request signature validation, and message formatting.
+## Create a Slack app
 
-Register the agent on the Mastra instance:
+To connect your agent, create a Slack app in the workspace where you want it to run. The Slack app controls how your agent appears in Slack, what it can do, and which events it receives.
 
-```typescript title="src/mastra/index.ts"
-import { Mastra } from '@mastra/core'
-import { slackAgent } from './agents/slack-agent'
+This guide uses a [manifest](https://docs.slack.dev/app-manifests/configuring-apps-with-app-manifests/#creating_manifests): a configuration file that creates the Slack app settings for you. This is the fastest path when you are adding your agent to your own workspace. It doesn't cover the platform OAuth flow where other workspaces install your agent.
 
-export const mastra = new Mastra({
-  agents: { slackAgent },
-})
+Create the Slack app from a manifest:
+
+1. Open [api.slack.com/apps](https://api.slack.com/apps).
+1. Select **Create an app**.
+1. Select **From a manifest**.
+1. Choose the workspace where the agent should run.
+1. Paste this manifest, then select **Create**:
+
+```yaml
+display_information:
+  name: mastra-agent
+features:
+  app_home:
+    home_tab_enabled: false
+    messages_tab_enabled: true
+    messages_tab_read_only_enabled: false
+  bot_user:
+    display_name: mastra-agent
+    always_online: true
+oauth_config:
+  scopes:
+    bot:
+      - im:write
+      - app_mentions:read
+      - channels:history
+      - channels:read
+      - chat:write
+      - users:read
+      - im:read
+      - im:history
+  pkce_enabled: false
+settings:
+  event_subscriptions:
+    request_url: https://<YOUR-PUBLIC-URL>/api/agents/<YOUR-AGENT-ID>/channels/slack/webhook
+    bot_events:
+      - app_mention
+      - message.channels
+      - message.im
+  interactivity:
+    is_enabled: true
+    request_url: https://<YOUR-PUBLIC-URL>/api/agents/<YOUR-AGENT-ID>/channels/slack/webhook
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false
+  is_mcp_enabled: false
 ```
 
-## Slack app settings
+This manifest configures:
 
-Create a Slack app at [api.slack.com/apps](https://api.slack.com/apps). Select **Create New App** > **From scratch**, then choose the workspace where the agent should run.
+- `display_information.name` and `features.bot_user.display_name`: Set your agent's name in Slack. You can update it at any time; remember to reinstall the app after changing names or permissions.
+- `app_home.messages_tab_enabled` and `app_home.messages_tab_read_only_enabled`: Enable direct messages from the Slack app's **Messages** tab.
+- `always_online`: Shows the Slack bot user as always available.
+- `oauth_config.scopes.bot`: Grants the bot permission to post messages, read channel messages where it is present, read mentions, read and write direct messages, and look up users.
+- `event_subscriptions`: Tells Slack which message events to send to the webhook.
+- `interactivity`: Enables interactive cards and tells Slack where to send card actions.
 
-In **OAuth & Permissions**, add these **Bot Token Scopes**:
+After the app is created, open **Install App**, select **Install to Workspace**, and approve the requested scopes.
 
-- `app_mentions:read`
-- `channels:history`
-- `channels:read`
-- `chat:write`
-- `users:read`
+## Set Slack credentials
 
-Install the app to the workspace from **OAuth & Permissions**, then copy the **Bot User OAuth Token**. In **Basic Information** > **App Credentials**, copy the **Signing Secret**.
+Set the Slack credentials in Mastra so it can verify Slack requests and send messages back to Slack.
 
-Keep **Socket Mode** turned off under **Settings** > **Socket Mode**. The Slack adapter receives events through HTTP webhooks.
+In the Slack app settings, copy these values:
 
-## Environment variables
+- **Basic Information** > **App Credentials** > **Signing Secret**
+- **OAuth & Permissions** > **Bot User OAuth Token**
 
-The adapter reads Slack credentials from these environment variables by default:
+Set them in your Mastra environment:
 
 ```bash title=".env"
 SLACK_SIGNING_SECRET=your-signing-secret
 SLACK_BOT_TOKEN=xoxb-your-bot-token
 ```
 
-For additional adapter options, see the [Chat SDK Slack adapter docs](https://chat-sdk.dev/adapters/official/slack).
+Mastra reads these environment variables automatically.
 
-## Webhook URL
+## Configure the webhook route
 
-Mastra generates the Slack webhook route from the agent ID and adapter key:
+Slack sends channel activity to Mastra through webhooks. A webhook is an HTTP endpoint Slack calls when something happens, such as a new message, a mention, or a user selecting an interactive card.
 
-```text
-/api/agents/slack-agent/channels/slack/webhook
-```
-
-Use your public Mastra server URL as the base URL:
+Mastra automatically registers a Slack webhook route for your agent:
 
 ```text
-https://your-app.example.com/api/agents/slack-agent/channels/slack/webhook
+/api/agents/<YOUR-AGENT-ID>/channels/slack/webhook
 ```
 
-For local development, expose the Mastra dev server with a tunnel:
+Build the webhook URL from your public Mastra server URL and the generated route:
+
+```text
+https://<YOUR-PUBLIC-URL>/api/agents/<YOUR-AGENT-ID>/channels/slack/webhook
+```
+
+Slack can't send events to `localhost`. For local development, keep the Mastra dev server running and expose `http://localhost:4111` with a tunnel before you save the request URL in Slack.
+
+Use a tunnel such as `cloudflared` or `ngrok` for local development:
 
 ```bash npm2yarn
 npx cloudflared tunnel --url http://localhost:4111
 ```
 
-Use the generated tunnel URL as the base URL while developing:
+Use the generated tunnel host as `<YOUR-PUBLIC-URL>`, for example:
 
 ```text
-https://<your-tunnel-url>/api/agents/slack-agent/channels/slack/webhook
+https://abc123.trycloudflare.com/api/agents/your-agent/channels/slack/webhook
 ```
 
-In the Slack app settings, open **Event Subscriptions**, turn **Enable Events** on, and set **Request URL** to the webhook URL. Slack sends a verification request to the route.
+Update the request URLs in Slack:
 
-## Event subscriptions
+1. In the Slack app settings, open **Event Subscriptions**.
+1. Replace **Request URL** with the final webhook URL.
+1. Select **Save Changes**.
+1. Open **Interactivity & Shortcuts**.
+1. Replace **Request URL** with the same webhook URL.
+1. Select **Save Changes**.
+1. If Slack asks you to reinstall the app, open **OAuth & Permissions** and select **Reinstall to Workspace**.
 
-Under **Subscribe to bot events**, add these events:
+## Try it in Slack
 
-- `app_mention`: Delivers messages that mention the bot in channels.
-- `message.channels`: Delivers channel messages for conversations where the bot is present.
+Open a direct message with the Slack bot user and send a message. Direct messages work because the manifest includes the `message.im` event and `im:*` scopes.
 
-Select **Save Changes** after updating events. Slack requires the app to be reinstalled after event subscription changes. Open **OAuth & Permissions** and select **Reinstall to Workspace**.
-
-## Slack behavior
-
-Invite the bot to a channel before using channel mentions:
+To use the agent in a channel, invite the Slack bot user first:
 
 ```text
 /invite @your-bot-name
@@ -133,7 +178,7 @@ The agent responds in the thread. Response content depends on the model, instruc
 
 ## Production deployment
 
-When you deploy the Mastra server, update the Slack app's **Request URL** to the production webhook URL. The tunnel URL used for local development is temporary and changes when the tunnel restarts.
+When you deploy the Mastra server, update both request URLs in the Slack app settings to the production webhook URL. The tunnel URL used for local development is temporary and changes when the tunnel restarts.
 
 Channels on serverless platforms may need `waitUntil` and shared pub/sub configuration so background responses and thread leases work across short-lived instances. See [serverless deployment](/docs/capabilities/channels/overview#serverless-deployment) in the channels overview.
 


### PR DESCRIPTION
## Summary
- Clarifies how channels use Chat SDK adapters.
- Expands Slack setup with manifest, credentials, webhook URLs, and DM/channel usage.
- Updates webhook examples to use generic agent placeholders.

## Testing
- Not run; docs-only change. Commit hook ran lint-staged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes the Slack + Mastra setup steps easier by showing exactly what to configure (Slack app manifest, secrets, and webhook URLs). It also explains that Mastra connects chat features using Chat SDK adapters, so the right adapter credentials and configuration are the key pieces.

## Summary
- Updated the Channels overview docs to clarify that channel functionality is built on Chat SDK adapters, and that the same Mastra-side configuration pattern applies across compatible adapters.
- Refreshed “Configure an agent” examples to use `yourAgent`, and added guidance that channel adapters require provider-specific credential + request-verification environment variables.
- Added recommended storage setup guidance for persisting channel/thread/tool-related state.
- Reworked “Webhook routes” documentation:
  - Updated/cleaned up webhook route description and examples (using `your-agent`).
  - Removed a standalone `ngrok` command example, keeping the `cloudflared` tunnel example for local development.
- Updated serverless deployment examples (Vercel `waitUntil`) and shared Redis Streams pub/sub configuration to reference `yourAgent`.
- Changed navigation from “Next steps” to a “Related” section linking to the Channels reference.
- Rewrote the Slack setup guide into an end-to-end flow:
  - Added a “Create a Slack app” section with a manifest snippet and explanations of key configured fields.
  - Added explicit steps to set `SLACK_SIGNING_SECRET` and `SLACK_BOT_TOKEN`.
  - Expanded webhook route setup, including how to form the public webhook URL and local tunneling.
  - Clarified that you must update **both** Slack “request URLs” (events and interactivity) to the final webhook URL for both local testing and production.
  - Kept/updated “Try it in Slack” guidance for DMs and channel usage prerequisites.

## Testing
- No testing was run beyond the lint-staged commit hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->