### PR TITLE
test(core): fix 'netwwork' typo in agent-network e2e test description

### DIFF
--- a/.changeset/happy-radios-jam.md
+++ b/.changeset/happy-radios-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed typo in agent-network e2e test description

--- a/packages/core/src/agent/agent-network.e2e.test.ts
+++ b/packages/core/src/agent/agent-network.e2e.test.ts
@@ -566,7 +566,7 @@ describe.skip('Agent - network', () => {
     expect(titleGenerationAttempted).toBe(false);
   });
 
-  it('Should not generate title when generateTitle:false is passed in netwwork options', async () => {
+  it('Should not generate title when generateTitle:false is passed in network options', async () => {
     let titleGenerationAttempted = false;
 
     const memoryWithoutTitleGen = new MockMemory();


### PR DESCRIPTION
## Description

This PR fixes a minor typo (`netwwork` -> `network`) in the test description for the `agent-network.e2e.test.ts` file.

## Related issue(s)

Fixes #19161

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
