### PR TITLE
test(schema-compat): fix 'successful' typo in e2e test descriptions

### DIFF
--- a/.changeset/fix-schema-compat-successful-typo.md
+++ b/.changeset/fix-schema-compat-successful-typo.md
@@ -1,0 +1,5 @@
+---
+'@mastra/schema-compat': patch
+---
+
+test(schema-compat): fix 'successful' typo in provider e2e test descriptions

--- a/packages/schema-compat/src/provider-compats/__snapshots__/anthropic.e2e.test.ts.snap
+++ b/packages/schema-compat/src/provider-compats/__snapshots__/anthropic.e2e.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Anthropic e2e test > should be succesful with structured_output 1`] = `
+exports[`Anthropic e2e test > should be successful with structured_output 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
@@ -318,7 +318,7 @@ constraints: a valid uuid",
 }
 `;
 
-exports[`Anthropic e2e test > should be succesful with structured_output 2`] = `
+exports[`Anthropic e2e test > should be successful with structured_output 2`] = `
 {
   "value": {
     "actualData": 2024-01-20T16:45:00.000Z,

--- a/packages/schema-compat/src/provider-compats/__snapshots__/google.e2e.test.ts.snap
+++ b/packages/schema-compat/src/provider-compats/__snapshots__/google.e2e.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Google e2e test > should be succesful with structured_output 1`] = `
+exports[`Google e2e test > should be successful with structured_output 1`] = `
 {
   "properties": {
     "actualData": {
@@ -368,7 +368,7 @@ constraints: a valid uuid",
 }
 `;
 
-exports[`Google e2e test > should be succesful with structured_output 2`] = `
+exports[`Google e2e test > should be successful with structured_output 2`] = `
 {
   "value": {
     "actualData": 2023-01-01T00:00:00.000Z,

--- a/packages/schema-compat/src/provider-compats/__snapshots__/openai-reasoning.e2e.test.ts.snap
+++ b/packages/schema-compat/src/provider-compats/__snapshots__/openai-reasoning.e2e.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`OpenAI reasoning e2e test > should be succesful with structured_output 1`] = `
+exports[`OpenAI reasoning e2e test > should be successful with structured_output 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
@@ -326,7 +326,7 @@ constraints: a valid uuid",
 }
 `;
 
-exports[`OpenAI reasoning e2e test > should be succesful with structured_output 2`] = `
+exports[`OpenAI reasoning e2e test > should be successful with structured_output 2`] = `
 {
   "value": {
     "actualData": 2026-03-27T00:00:00.000Z,

--- a/packages/schema-compat/src/provider-compats/__snapshots__/openai.e2e.test.ts.snap
+++ b/packages/schema-compat/src/provider-compats/__snapshots__/openai.e2e.test.ts.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`OpenAI e2e test > should be succesful with structured_output 1`] = `
+exports[`OpenAI e2e test > should be successful with structured_output 1`] = `
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "additionalProperties": false,
@@ -326,7 +326,7 @@ constraints: a valid uuid",
 }
 `;
 
-exports[`OpenAI e2e test > should be succesful with structured_output 2`] = `
+exports[`OpenAI e2e test > should be successful with structured_output 2`] = `
 {
   "value": {
     "actualData": 2024-06-10T10:00:00.000Z,

--- a/packages/schema-compat/src/provider-compats/anthropic.e2e.test.ts
+++ b/packages/schema-compat/src/provider-compats/anthropic.e2e.test.ts
@@ -140,7 +140,7 @@ describe('Anthropic e2e test', () => {
   beforeAll(() => mock.start());
   afterAll(() => mock.saveAndStop());
 
-  it('should be succesful with structured_output', { timeout: 40_000 }, async () => {
+  it('should be successful with structured_output', { timeout: 40_000 }, async () => {
     const schema = z.object(allSchemas);
 
     const model = anthropic('claude-sonnet-4-0');

--- a/packages/schema-compat/src/provider-compats/google.e2e.test.ts
+++ b/packages/schema-compat/src/provider-compats/google.e2e.test.ts
@@ -165,7 +165,7 @@ describe('Google e2e test', () => {
   beforeAll(() => mock.start());
   afterAll(() => mock.saveAndStop());
 
-  it('should be succesful with structured_output', { timeout: 60000 }, async () => {
+  it('should be successful with structured_output', { timeout: 60000 }, async () => {
     const schema = z.object(allSchemas);
 
     const model = google('gemini-3.1-pro-preview');

--- a/packages/schema-compat/src/provider-compats/openai-reasoning.e2e.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai-reasoning.e2e.test.ts
@@ -144,7 +144,7 @@ describe('OpenAI reasoning e2e test', () => {
   beforeAll(() => mock.start());
   afterAll(() => mock.saveAndStop());
 
-  it('should be succesful with structured_output', { timeout: 60_000 }, async () => {
+  it('should be successful with structured_output', { timeout: 60_000 }, async () => {
     const schema = z.object(allSchemas);
 
     const model = openai('o4-mini');

--- a/packages/schema-compat/src/provider-compats/openai.e2e.test.ts
+++ b/packages/schema-compat/src/provider-compats/openai.e2e.test.ts
@@ -141,7 +141,7 @@ describe('OpenAI e2e test', () => {
   beforeAll(() => mock.start());
   afterAll(() => mock.saveAndStop());
 
-  it('should be succesful with structured_output', { timeout: 10000 }, async () => {
+  it('should be successful with structured_output', { timeout: 10000 }, async () => {
     const schema = z.object(allSchemas);
 
     const model = openai('gpt-4.1');


### PR DESCRIPTION
## Description

This PR fixes a minor typo (`succesful` -> `successful`) in the end-to-end test descriptions across the `@mastra/schema-compat` package. 

It updates the following files and their corresponding snapshots:
- `anthropic.e2e.test.ts`
- `google.e2e.test.ts`
- `openai.e2e.test.ts`
- `openai-reasoning.e2e.test.ts`

## Related issue(s)

Fixes #19166

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR fixes a spelling mistake in a few test names so they read correctly as “successful” instead of “succesful.” It doesn’t change how the tests work, just how they’re labeled.

## Summary
- Corrected the typo in `@mastra/schema-compat` provider e2e test descriptions.
- Updated the affected test files:
  - `packages/schema-compat/src/provider-compats/anthropic.e2e.test.ts`
  - `packages/schema-compat/src/provider-compats/google.e2e.test.ts`
  - `packages/schema-compat/src/provider-compats/openai.e2e.test.ts`
  - `packages/schema-compat/src/provider-compats/openai-reasoning.e2e.test.ts`
- Updated the matching snapshot/changeset-related entry to reflect the wording fix.
- No functional behavior changed; this is a typo-only test update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->