### PR TITLE
docs: update video links

### DIFF
--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -7,17 +7,19 @@ packages:
   - "@mastra/libsql"
 ---
 
-import YouTube from "@site/src/components/YouTube-player";
-
 # Agent Builder overview
 
 :::note
 The Agent Builder is part of the Mastra Enterprise Edition. Production deployments require a valid EE license. [Contact sales](https://mastra.ai/contact) for more information.
 :::
 
-<YouTube id="AbdgIu4Z07I" />
-
 The Agent Builder lets you build, configure, and operate Mastra agents all within the UI. It runs inside your Mastra server, persists everything to `Mastra.storage`, and supports multi-tenant agent workflows with RBAC and channel integrations.
+
+:::tip[📹 Watch]
+
+Watch [Mastra Agent Builder overview](https://www.youtube.com/watch?v=AbdgIu4Z07I) to see how teams create and configure agents from the UI.
+
+:::
 
 - [**Configuration**](/docs/agent-builder/configuration): Toggle UI sections and pin admin-controlled defaults for every new agent.
 - [**Model policy**](/docs/agent-builder/model-policy): Restrict which providers and models the Builder exposes, and pin a default.
@@ -100,3 +102,4 @@ Omitting the `builder` field has the same effect.
 - [Configuration](/docs/agent-builder/configuration): Toggle Builder surfaces and pin defaults for new agents.
 - [Access control](/docs/agent-builder/access-control): Gate the Builder with authentication and role-based access control.
 - [Deploying](/docs/agent-builder/deploying): Replace local development primitives with production-ready storage, filesystems, and sandboxes.
+- 📹 [Mastra Agent Builder workshop](https://www.youtube.com/watch?v=p2p_wb-rUPg\&t=666s)

--- a/docs/src/content/en/docs/agent-controller/overview.mdx
+++ b/docs/src/content/en/docs/agent-controller/overview.mdx
@@ -142,3 +142,4 @@ Your app sends commands — send a message, switch mode, approve a tool call —
 - [Subagents](/docs/agent-controller/subagents): Delegate focused subtasks
 - [Tool approvals and permissions](/docs/agent-controller/tool-approvals): Human-in-the-loop gating
 - [API reference](/reference/agent-controller/agent-controller-class): Full constructor and method docs
+- 📹 [Mastra AgentController harness workshop](https://www.youtube.com/watch?v=tV1pSleP-LM)

--- a/docs/src/content/en/docs/agents/a2a.mdx
+++ b/docs/src/content/en/docs/agents/a2a.mdx
@@ -269,3 +269,4 @@ Use this hook to enforce expected providers, expected endpoints, certificate-bou
 - [JavaScript client agents reference](/reference/client-js/agents)
 - [A2A core concepts](https://a2a-protocol.org/latest/topics/key-concepts/)
 - [A2A discovery guide](https://a2a-protocol.org/latest/topics/agent-discovery/)
+- 📹 [Agent-to-agent with Mastra workshop](https://www.youtube.com/watch?v=LQDzyNGm-aw)

--- a/docs/src/content/en/docs/agents/guardrails.mdx
+++ b/docs/src/content/en/docs/agents/guardrails.mdx
@@ -426,3 +426,4 @@ outputProcessors: [
 - [Processors](/docs/agents/processors): How processors work, execution order, custom processors, and retry mechanism
 - [`Processor` Interface](/reference/processors/processor-interface): API reference for the `Processor` interface
 - [Memory Processors](/docs/memory/memory-processors): Processors for message history, semantic recall, and working memory
+- 📹 [Mastra processors and guardrails workshop](https://www.youtube.com/watch?v=4Vpp7xQYvl0)

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -21,9 +21,9 @@ Agents use LLMs and tools to solve open-ended tasks. They reason about goals, de
 
 Use agents when the task is open-ended and the steps aren't known in advance. An agent decides which tools to call, how many times to loop, and when to stop. You provide the goal and constraints instead of defining each step. For predetermined, multi-step processes with explicit control flow, use [workflows](/docs/workflows/overview) instead.
 
-:::tip
+:::tip[📹 Watch]
 
-Watch an introduction to agents, and how they compare to workflows on [YouTube (7 minutes)](https://youtu.be/0jg2g3sNvgw).
+Watch [Mastra agent quickstart](https://www.youtube.com/watch?v=G8tXjcseNjg) for a short walkthrough of creating and testing a Mastra agent.
 
 :::
 

--- a/docs/src/content/en/docs/agents/supervisor-agents.mdx
+++ b/docs/src/content/en/docs/agents/supervisor-agents.mdx
@@ -449,3 +449,4 @@ Version overrides propagate automatically through delegation. See [Subagent vers
 - [Agent approval](./agent-approval)
 - [Memory in multi-agent systems](/docs/memory/overview#memory-in-multi-agent-systems)
 - [Concept: Multi-agent systems](/guides/concepts/multi-agent-systems)
+- 📹 [Mastra supervisor agents workshop](https://www.youtube.com/watch?v=FNb2fL9WhQg\&t=1872s)

--- a/docs/src/content/en/docs/browser/overview.mdx
+++ b/docs/src/content/en/docs/browser/overview.mdx
@@ -142,3 +142,4 @@ const browser = new AgentBrowser({
 - [Browser recording (alpha)](/docs/browser/recording)
 - [BrowserViewer](/docs/browser/browser-viewer)
 - [MastraBrowser reference](/reference/browser/mastra-browser)
+- 📹 [Mastra browser capabilities workshop](https://www.youtube.com/watch?v=E9KFsZEnQO8\&t=5s)

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -251,3 +251,4 @@ Vercel's managed Redis integration and Upstash Redis both work well. For more on
 ## Related
 
 - [Channels reference](/reference/agents/channels)
+- 📹 [Mastra channels workshop](https://www.youtube.com/watch?v=E9KFsZEnQO8\&t=5s)

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -7,8 +7,6 @@ packages:
   - "@mastra/client-js"
 ---
 
-import { VideoPlayer } from "@site/src/components/video-player";
-
 # Editor overview
 
 The editor is a CMS-style system that separates agent configuration from code. Subject-matter experts, prompt engineers, and product teams can iterate on agents directly while developers keep the codebase stable.
@@ -97,8 +95,6 @@ The code source uses the Git history of each per-agent JSON file as its version 
 This means versions and rollbacks are managed through Git rather than through draft and publish actions.
 
 ## Studio
-
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1775596827/editor-overview_obqupx.mp4" />
 
 Go to the **Agents** tab in Studio and select an agent to edit. Select the **Editor** tab. You'll be taken to the editor interface, where you can modify the agent's instructions, tools, and variables.
 

--- a/docs/src/content/en/docs/evals/datasets/overview.mdx
+++ b/docs/src/content/en/docs/evals/datasets/overview.mdx
@@ -222,3 +222,4 @@ Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list o
 - [Scorers overview](/docs/evals/overview)
 - [DatasetsManager reference](/reference/datasets/datasets-manager)
 - [Dataset reference](/reference/datasets/dataset)
+- 📹 [Mastra evals, datasets, and experiments workshop](https://www.youtube.com/watch?v=Vla5LfmOOrM)

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -335,6 +335,12 @@ console.log(experiment.startedAt)
 console.log(experiment.completedAt)
 ```
 
+:::tip[📹 Watch]
+
+Watch [Mastra datasets and experiments workflow](https://www.youtube.com/watch?v=R6pjAdGhxhQ) to see how datasets and experiments help improve reliability.
+
+:::
+
 ### Item-level results
 
 ```typescript

--- a/docs/src/content/en/docs/evals/overview.mdx
+++ b/docs/src/content/en/docs/evals/overview.mdx
@@ -14,6 +14,12 @@ Scorers are automated tests that evaluate Agents outputs using model-graded, rul
 
 Scorers can be run in the cloud, capturing real-time results. But scorers can also be part of your CI/CD pipeline, allowing you to test and monitor your agents over time.
 
+:::tip[📹 Watch]
+
+Watch [Mastra evals overview](https://www.youtube.com/watch?v=12WN6u2DrBk) for an introduction to evals and how to reason about agent quality.
+
+:::
+
 ## Types of scorers
 
 Mastra provides different kinds of scorers, each serving a specific purpose. Here are some common types:
@@ -133,3 +139,4 @@ Once registered, you can score traces interactively within Studio under the **Ob
 - Learn how to create your own scorers in the [Creating Custom Scorers](/docs/evals/custom-scorers) guide
 - Explore built-in scorers in the [Built-in Scorers](/docs/evals/built-in-scorers) section
 - Test scorers with [Studio](/docs/studio/overview)
+- 📹 [Mastra evals workshop](https://www.youtube.com/watch?v=OHOZ5PgPj5M\&t=3578s)

--- a/docs/src/content/en/docs/getting-started/build-with-ai.mdx
+++ b/docs/src/content/en/docs/getting-started/build-with-ai.mdx
@@ -5,8 +5,6 @@ packages:
   - "@mastra/mcp-docs-server"
 ---
 
-import YouTube from "@site/src/components/YouTube-player";
-
 # Build with AI
 
 AI agents may not have up-to-date knowledge about Mastra's APIs, patterns, and best practices. These resources give your AI tools direct access to current Mastra documentation, enabling them to generate accurate code and help you build faster.

--- a/docs/src/content/en/docs/long-running-agents/signals.mdx
+++ b/docs/src/content/en/docs/long-running-agents/signals.mdx
@@ -20,6 +20,12 @@ Signals are a way to interact with an agent through a thread. Instead of startin
 
 Use message APIs for user-authored input. Use `sendSignal()` for lower-level system context, such as background task notifications, policy reminders, or processor-generated context.
 
+:::tip[📹 Watch]
+
+Watch [Mastra signals overview](https://www.youtube.com/watch?v=7It2y89TVP4) to see how signals wake and steer long-running agents.
+
+:::
+
 ## When to use signals
 
 Use signals when an agent thread needs new input or context outside the original `stream()` call. Signals are useful when users send follow-up messages while a run is active, when background systems need to add context to a thread, or when external events should wake, update, or notify the agent.
@@ -455,3 +461,4 @@ Use heartbeats together with client-side reconnect logic. Heartbeats reduce idle
 - [`client.getAgent().subscribeToThread()`](/reference/client-js/agents#subscribetothread)
 - [`client.getAgent().sendToolApproval()`](/reference/client-js/agents#sendtoolapproval)
 - [`RedisStreamsPubSub`](/reference/pubsub/redis-streams)
+- 📹 [Mastra signals workshop](https://www.youtube.com/watch?v=KLg6uFKz9aw\&t=3020s)

--- a/docs/src/content/en/docs/mastra-platform/observability.mdx
+++ b/docs/src/content/en/docs/mastra-platform/observability.mdx
@@ -72,3 +72,7 @@ npx mastra api trace list
 ```
 
 For observability commands, the CLI targets the hosted observability API and can infer credentials from your project environment. See the [`mastra api` CLI reference](/reference/cli/mastra#mastra-api) for available observability commands, filtering, pagination, credential resolution, and direct `curl` examples.
+
+## Related
+
+- 📹 [Mastra observability and Studio workshop](https://www.youtube.com/watch?v=dKO_a3RPra0)

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -739,3 +739,4 @@ In practical terms, OM replaces both working memory and message history, and has
 - [Message History](/docs/memory/message-history)
 - [Memory Processors](/docs/memory/memory-processors)
 - [Mastra Code](https://code.mastra.ai/): A coding agent using Observational Memory
+- 📹 [Mastra processors and Observational Memory workshop](https://www.youtube.com/watch?v=4Vpp7xQYvl0)

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -25,6 +25,12 @@ If the combined memory exceeds the model's context limit, [memory processors](/d
 
 Memory results will be stored in one or more of your configured [storage providers](/docs/storage/overview).
 
+:::tip[📹 Watch]
+
+Watch [Mastra memory concepts](https://www.youtube.com/watch?v=18iIHQtIPmc) for a conceptual overview of the memory layers agents can use.
+
+:::
+
 ## When to use memory
 
 Use memory when your agent needs to maintain multi-turn conversations that reference prior exchanges, recall user preferences or facts from earlier in a session, or build context over time within a conversation thread. Skip memory for single-turn requests where each interaction is independent.

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -17,12 +17,6 @@ import TabItem from "@theme/TabItem";
 
 If you ask your friend what they did last weekend, they will search in their memory for events associated with "last weekend" and then tell you what they did. That's sort of like how semantic recall works in Mastra.
 
-:::tip[Watch 📹]
-
-What semantic recall is, how it works, and how to configure it in Mastra → [YouTube (5 minutes)](https://youtu.be/UVZtK8cK8xQ)
-
-:::
-
 ## How semantic recall works
 
 Semantic recall is RAG-based search that helps agents maintain context across longer interactions when messages are no longer within [recent message history](./message-history).

--- a/docs/src/content/en/docs/memory/semantic-recall.mdx
+++ b/docs/src/content/en/docs/memory/semantic-recall.mdx
@@ -17,6 +17,12 @@ import TabItem from "@theme/TabItem";
 
 If you ask your friend what they did last weekend, they will search in their memory for events associated with "last weekend" and then tell you what they did. That's sort of like how semantic recall works in Mastra.
 
+:::tip[📹 Watch]
+
+Watch [Mastra semantic recall](https://www.youtube.com/watch?v=UVZtK8cK8xQ\&pp=ygUVbWFzdHJhIHdvcmtpbmcgbWVtb3J5) to see how agents retrieve relevant messages from past conversations.
+
+:::
+
 ## How semantic recall works
 
 Semantic recall is RAG-based search that helps agents maintain context across longer interactions when messages are no longer within [recent message history](./message-history).

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -10,8 +10,6 @@ packages:
   - "@mastra/upstash"
 ---
 
-import YouTube from "@site/src/components/YouTube-player";
-
 # Working Memory
 
 While [message history](/docs/memory/message-history) and [semantic recall](./semantic-recall) help agents remember conversations, working memory allows them to maintain persistent information about users across interactions.
@@ -55,9 +53,7 @@ const agent = new Agent({
 
 ## How it works
 
-Working memory is a block of Markdown text that the agent is able to update over time to store continuously relevant information:
-
-<YouTube id="UMy_JHLf1n8" />
+Working memory is a block of Markdown text that the agent is able to update over time to store continuously relevant information.
 
 ## Memory persistence scopes
 

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -20,6 +20,12 @@ This is useful for maintaining ongoing state that's always relevant and should a
 
 If you use [Observational Memory](/docs/memory/observational-memory), `observationalMemory.observation.manageWorkingMemory` lets OM update working memory for the agent.
 
+:::tip[📹 Watch]
+
+Watch [Mastra working memory](https://www.youtube.com/watch?v=UMy_JHLf1n8\&pp=ygUVbWFzdHJhIHdvcmtpbmcgbWVtb3J5) to see how agents keep persistent user context available across interactions.
+
+:::
+
 Working memory can persist at two different scopes:
 
 - **Resource-scoped** (default): Memory persists across all conversation threads for the same user

--- a/docs/src/content/en/docs/studio/observability.mdx
+++ b/docs/src/content/en/docs/studio/observability.mdx
@@ -6,8 +6,6 @@ packages:
   - "@mastra/observability"
 ---
 
-import { VideoPlayer } from "@site/src/components/video-player";
-
 # Studio observability
 
 Studio includes these observability views:
@@ -93,8 +91,6 @@ When you run an agent or workflow, the Observability tab displays traces that hi
 Tracing filters out low-level framework details so your traces stay focused and readable. Visit the [tracing overview](/docs/observability/tracing/overview) for more details.
 
 To export a trace, select **Download trace JSON** in the trace panel header. This saves the entire trace as a `trace-<id>.json` file, with every span and its full input, output, metadata, and attributes. Use it to share a trace, attach it to a bug report, or build an evaluation dataset offline.
-
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668518/observability_qmwbao.mp4" />
 
 ## Logs
 

--- a/docs/src/content/en/docs/studio/overview.mdx
+++ b/docs/src/content/en/docs/studio/overview.mdx
@@ -5,14 +5,9 @@ packages:
   - "@mastra/core"
 ---
 
-import YouTube from "@site/src/components/YouTube-player";
-import { VideoPlayer } from "@site/src/components/video-player";
-
 # Studio
 
 Studio provides an interactive UI for building, testing, and managing your agents, workflows, and tools. Run it locally during development, add [authentication](/docs/studio/auth), or [deploy it](/docs/studio/deployment) to production so your team can manage agents, monitor performance, and gain insights through built-in observability.
-
-<YouTube id="ojGu6Bi4wYk" />
 
 ## Start Studio
 
@@ -39,8 +34,6 @@ When you're ready to share Studio with your team, you can deploy it to productio
 
 Chat with your agent directly, dynamically switch [models](/models), and tweak settings like temperature and top-p to understand how they affect the output.
 
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668516/agent_f8sq1u.mp4" />
-
 When you interact with your agent, you can follow each step of its reasoning, view tool call outputs, and [observe](#observability) traces and logs to see how responses are generated. You can also attach [scorers](#scorers) to measure and compare response quality over time.
 
 While an agent response is streaming, you can send a follow-up message in the same thread. Studio shows the message as pending until the stream confirms it, then continues the response below that follow-up. Other Studio tabs that have the same thread open can observe the active stream.
@@ -51,15 +44,11 @@ Use [Editor](/docs/editor/overview) to let non-technical team members iterate on
 
 Visualize your workflow as a graph and run it step by step with a custom input. During execution, the interface updates in real time to show the active step and the path taken.
 
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668517/workflows_o4dmvm.mp4" />
-
 When running a workflow, you can also view detailed traces showing tool calls, raw JSON outputs, and any errors that might have occurred along the way.
 
 ### Processors
 
 View the input and output processors attached to each agent. The agent detail panel lists every processor by name and type, so you can verify your guardrails, token limiters, and custom processors are wired up correctly before testing.
-
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668517/processors_ka0lov.mp4" />
 
 See [processors](/docs/agents/processors) and [guardrails](/docs/agents/guardrails) for configuration details.
 
@@ -67,13 +56,9 @@ See [processors](/docs/agents/processors) and [guardrails](/docs/agents/guardrai
 
 List the MCP servers attached to your Mastra instance and explore their available tools.
 
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668515/mcp_rynloj.mp4" />
-
 ### Tools
 
 Run tools on their own to observe behavior and test them before assigning them to an agent. If something goes wrong, re-run a tool in isolation to debug the issue.
-
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668515/tools_ab07x7.mp4" />
 
 ### Workspaces
 
@@ -93,13 +78,9 @@ See [request context](/docs/server/request-context) for configuration details.
 
 The Scorers tab displays the results of your agent's scorers as they run. When messages pass through your agent, the defined scorers evaluate each output asynchronously and render their results here. This allows you to understand how your scorers respond to different interactions, compare performance across test cases, and identify areas for improvement.
 
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668517/scorers_wc9wjk.mp4" />
-
 ### Datasets
 
 Create and manage collections of test cases to evaluate your agents and workflows. Import items from CSV or JSON, define input and ground-truth schemas, and pin to specific versions so you can reproduce experiments exactly. Run experiments with [scorers](/docs/evals/overview) to compare quality across prompts, models, or code changes.
-
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1773668515/datasets_p35u2v.mp4" />
 
 See [datasets overview](/docs/evals/datasets/overview) for the full API and versioning details.
 
@@ -121,8 +102,6 @@ Configure the connection between Studio and your Mastra server. The settings pag
 - **API prefix**: Optional path prefix for all API requests (defaults to `/api`).
 - **Custom headers**: Add key-value pairs sent with every request, useful for authentication tokens or routing headers.
 - **Theme**: Switch between dark, light, or system theme.
-
-<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1774964365/settings_wp3gax.mp4" />
 
 ## Code configuration
 

--- a/docs/src/content/en/docs/studio/overview.mdx
+++ b/docs/src/content/en/docs/studio/overview.mdx
@@ -9,6 +9,12 @@ packages:
 
 Studio provides an interactive UI for building, testing, and managing your agents, workflows, and tools. Run it locally during development, add [authentication](/docs/studio/auth), or [deploy it](/docs/studio/deployment) to production so your team can manage agents, monitor performance, and gain insights through built-in observability.
 
+:::tip[📹 Watch]
+
+Watch [Mastra Studio overview](https://youtu.be/ojGu6Bi4wYk) for a short walkthrough of building, testing, and managing agents in Studio.
+
+:::
+
 ## Start Studio
 
 If you created your application with `create mastra`, start the development server using the `dev` script. You can also run it directly with `mastra dev`.

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -106,12 +106,6 @@ export const testWorkflow = createWorkflow({
   .commit()
 ```
 
-:::tip[📹 Watch]
-
-How to run steps in parallel and optimize your Mastra workflow → [YouTube (3 minutes)](https://youtu.be/GQJxve5Hki4)
-
-:::
-
 ### Output structure
 
 When steps run in parallel, the output is an object where each key is the step's `id` and the value is that step's output. This allows you to access each parallel step's result independently.

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -18,12 +18,6 @@ Workflows let you define complex sequences of tasks using clear, structured step
 
 Use workflows for tasks that are clearly defined upfront and involve multiple steps with a specific execution order. They give you fine-grained control over how data flows and transforms between steps, and which primitives are called at each stage.
 
-:::tip
-
-Watch an introduction to workflows, and how they compare to agents on [YouTube (7 minutes)](https://youtu.be/0jg2g3sNvgw).
-
-:::
-
 ## Core principles
 
 Mastra workflows operate using these principles:
@@ -591,3 +585,4 @@ For a closer look at workflows, see our [Workflow Guide](/guides/guide/ai-recrui
 - [Control Flow](/docs/workflows/control-flow)
 - [Suspend and Resume](/docs/workflows/suspend-and-resume)
 - [Error Handling](/docs/workflows/error-handling)
+- 📹 [Agentic workflows with Mastra workshop](https://www.youtube.com/watch?v=HGt8pVPpX9g)

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -421,3 +421,4 @@ External providers may perform additional setup like establishing connections or
 - [Skills](/docs/workspace/skills)
 - [Search and indexing](/docs/workspace/search)
 - [Workspace class reference](/reference/workspace/workspace-class)
+- 📹 [Introduction to Mastra Workspaces workshop](https://www.youtube.com/watch?v=QcQLiYlJuNQ)

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -20,6 +20,12 @@ A sandbox provider executes commands in a controlled environment:
 - **Timeouts**: Prevent long-running commands from hanging
 - **Isolation**: Optional OS-level sandboxing for security
 
+:::tip[📹 Watch]
+
+Watch [Mastra remote sandboxes overview](https://www.youtube.com/watch?v=Ix2X-sjVXjw) to see how remote sandboxes give agents an isolated computer to work in.
+
+:::
+
 ## Supported providers
 
 - [`LocalSandbox`](/reference/workspace/local-sandbox): Executes commands on the local machine

--- a/docs/src/content/en/guides/getting-started/quickstart.mdx
+++ b/docs/src/content/en/guides/getting-started/quickstart.mdx
@@ -5,7 +5,6 @@ description: Get started with Mastra using the create mastra CLI to build a serv
 
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
-import { VideoPlayer } from "@site/src/components/video-player";
 import QuickstartPrompt from "@site/src/content/en/docs/getting-started/_partial-quickstart-prompt.mdx";
 
 # Mastra Quickstart
@@ -19,6 +18,12 @@ The `create mastra` CLI command is the quickest way to get started. It walks you
 If you need more control over the setup, see the [manual installation guide](/docs/getting-started/manual-install). You can also use [`mastra init`](/reference/cli/mastra#mastra-init) for existing projects.
 
 <QuickstartPrompt />
+
+:::tip[📹 Watch]
+
+Watch [Mastra AI agent course](https://www.youtube.com/watch?v=lCmf_qrGfGA) for a guided introduction to building agents with Mastra.
+
+:::
 
 ## Before you begin
 
@@ -54,11 +59,7 @@ You can use [flags](/reference/cli/create-mastra#cli-flags) with `create mastra`
 
 Once setup is complete, follow the instructions in your terminal to start the Mastra dev server, then open Studio at [localhost:4111](http://localhost:4111).
 
-Try asking about the weather. If your API key is set up correctly, you'll get a response:
-
-<VideoPlayer
-  src="https://res.cloudinary.com/mastra-assets/video/upload/v1751406022/local-dev-agents-playground_100_m3begx.mp4"
-/>
+Try asking about the weather. If your API key is set up correctly, you'll get a response in Studio.
 
 [Studio](/docs/studio/overview) lets you rapidly build and prototype agents without needing to build a UI. Once you're ready, you can integrate your Mastra agent into your app using the guides below.
 

--- a/docs/src/content/en/guides/guide/chef-michel.mdx
+++ b/docs/src/content/en/guides/guide/chef-michel.mdx
@@ -5,15 +5,12 @@ description: Guide on creating a Chef Assistant agent in Mastra to help users co
 
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
-import YouTube from "@site/src/components/YouTube-player";
 
 # How to build an AI chef assistant
 
 In this guide, you'll create a "Chef Assistant" agent that helps users cook meals with available ingredients.
 
 You'll learn how to create the agent and register it with Mastra. Next, you'll interact with the agent through your terminal and get to know different response formats. Lastly, you'll access the agent through Mastra's local API endpoints.
-
-<YouTube id="_tZhOqHCrF0" />
 
 ## Prerequisites
 

--- a/docs/src/content/en/guides/guide/stock-agent.mdx
+++ b/docs/src/content/en/guides/guide/stock-agent.mdx
@@ -5,13 +5,10 @@ description: Guide on creating a stock agent in Mastra to fetch the last day's c
 
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
-import YouTube from "@site/src/components/YouTube-player";
 
 # Building an AI stock agent
 
 In this guide, you're going to create an agent that fetches the last day's closing stock price for a given symbol. You'll learn how to create a tool, add it to an agent, and use the agent to fetch stock prices.
-
-<YouTube id="rIaZ4l7y9wo" />
 
 ## Prerequisites
 

--- a/docs/src/pages/kitchen-sink.mdx
+++ b/docs/src/pages/kitchen-sink.mdx
@@ -10,7 +10,6 @@ import TabItem from '@theme/TabItem';
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
 import { CardGrid, CardGridItem } from "@site/src/components/cards/card-grid";
-import YouTube from "@site/src/components/YouTube-player";
 import { ReferenceCards } from "@site/src/components/ReferenceCards";
 
 # Kitchen Sink
@@ -222,10 +221,6 @@ Some **content** with _Markdown_ `syntax`. Check [this `api`](#).
     </div>
   </CardGridItem>
 </CardGrid>
-
-## YouTube
-
-<YouTube id="1qnmnRICX50" />
 
 ## Reference Cards
 


### PR DESCRIPTION
## Summary
- Removed non-homepage embedded videos from docs while keeping the homepage embed.
- Replaced selected embedded videos with docs-style Watch callouts that link to current YouTube videos.
- Added workshop links to existing related/next-step sections without adding standalone resource sections.

## Testing
- pnpm run format
- pnpm validate
- pnpm lint:remark
- git diff --check -- docs/src/content/en/docs docs/src/content/en/guides docs/src/pages/kitchen-sink.mdx

## Notes
- No changeset because this is docs-only.
- pnpm lint:prose currently fails locally with `E100 [lintMDX] Runtime error` because `mdx2vast` is not found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR cleans up the documentation by replacing embedded videos on most pages with simple “Watch”/workshop links. The homepage video stays embedded, but the rest of the docs pages become lighter and easier to scan.

### What changed
- Removed embedded YouTube/video player components from multiple non-homepage MDX docs pages.
- Replaced selected embeds with Docusaurus-style `:::tip[📹 Watch]` callouts linking to the same YouTube videos.
- Added additional YouTube links (workshops) into existing **Related** / **Next steps** sections instead of creating new resource sections.
- In some places, removed the prior “Watch” tip entirely (e.g., control-flow docs) so the page flows directly into the next section.
- Kept the homepage embed behavior intact.
- Docs-only change; no changeset added.

### Testing
- Formatting
- Validation
- Remark linting
- Diff checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->