### PR TITLE
Document stricter React agent best practices

### DIFF
--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -7,7 +7,7 @@ description: React performance optimization guidelines from Mastra Engineering. 
 
 ## Overview
 
-Routing and priority guide for React performance and quality, containing 22 rules across 9 categories. Rule files hold the detailed explanations, examples, review smells, and impact metrics.
+Routing and priority guide for React performance and quality, containing 25 rules across 9 categories. Rule files hold the detailed explanations, examples, review smells, and impact metrics.
 
 ## When to Apply
 
@@ -61,6 +61,8 @@ Rules are prioritized by impact:
 - Apply `startTransition` for non-urgent updates (`rerender-transitions`)
 - Minimize `useEffect` function calls (`rerender-useeffect-function-calls`)
 - Never reset state with `useEffect`; lift the discriminant and remount the branch (`rerender-no-useeffect-state-reset`)
+- Never add `useMemo` or `useCallback`; leave memoization decisions to developers with profiler evidence (`rerender-no-usememo-usecallback`)
+- Never call `setState` during render or inside `useEffect`; derive during render or move state ownership to an intermediate component (`rerender-no-setstate-in-render-or-effect`)
 
 **Component Structure:**
 
@@ -79,6 +81,7 @@ Rules are prioritized by impact:
 **Type Safety:**
 
 - No `as` type assertions anywhere — production **or tests**; narrow with real type guards, query generics (`querySelector<T>`, `getByRole<T>`), typed fixture factories, or `implements` on mocks. `as const` is the only allowed form. Do not replace a cast with a domain-type predicate that only checks `typeof value === 'object'`; call that an `isRecord` helper or validate the fields used (`types-no-type-assertions`)
+- Use `undefined` and optional `?` for absence, not `null`; convert external `null` at boundaries with `?? undefined` (`types-no-null`)
 
 ### Rendering Patterns
 
@@ -113,9 +116,9 @@ grep -l "Tanstack" references/rules/
 - `async-*` - Waterfall elimination (1 rule)
 - `bundle-*` - Bundle size optimization (2 rules)
 - `client-*` - Client-side data fetching (1 rule)
-- `rerender-*` - Re-render optimization (4 rules)
+- `rerender-*` - Re-render optimization (6 rules)
 - `rendering-*` - DOM rendering performance (2 rules)
 - `js-*` - JavaScript micro-optimizations (3 rules)
-- `types-*` - Type-safety / no-`as`-cast rules (1 rule)
+- `types-*` - Type-safety / no-`as`-cast and no-`null` rules (2 rules)
 - `structure-*` - Component/hook structure (6 rules)
 - `testing-*` - BDD tests + mock-only-the-network policy + no className implementation-mirror assertions (2 rules)

--- a/.claude/skills/react-best-practices/references/react-best-practices-reference.md
+++ b/.claude/skills/react-best-practices/references/react-best-practices-reference.md
@@ -4,7 +4,7 @@
 Mastra Engineering
 January 2026
 
-This catalog is an index for React performance and quality guidance used by agents and LLMs. It contains 22 rules across 9 categories, prioritized by impact. The canonical guidance — detailed explanations, incorrect vs. correct examples, review smells, and impact metrics — lives in `references/rules/*.md`.
+This catalog is an index for React performance and quality guidance used by agents and LLMs. It contains 25 rules across 9 categories, prioritized by impact. The canonical guidance — detailed explanations, incorrect vs. correct examples, review smells, and impact metrics — lives in `references/rules/*.md`.
 
 ## How to Use This Catalog
 
@@ -19,12 +19,12 @@ This catalog is an index for React performance and quality guidance used by agen
 | 1        | Eliminating Waterfalls    | CRITICAL                      | 1          |
 | 2        | Bundle Size Optimization  | CRITICAL                      | 2          |
 | 3        | Client-Side Data Fetching | MEDIUM-HIGH                   | 1          |
-| 4        | Re-render Optimization    | MEDIUM                        | 4          |
+| 4        | Re-render Optimization    | MEDIUM                        | 6          |
 | 5        | Rendering Performance     | MEDIUM                        | 2          |
 | 6        | JavaScript Performance    | LOW-MEDIUM                    | 3          |
 | 7        | Component Structure       | MEDIUM-HIGH (maintainability) | 6          |
 | 8        | Testing                   | MEDIUM-HIGH (correctness)     | 2          |
-| 9        | Type Safety               | HIGH                          | 1          |
+| 9        | Type Safety               | HIGH                          | 2          |
 
 ## Category Focus
 
@@ -67,8 +67,10 @@ This catalog is an index for React performance and quality guidance used by agen
 | ----------------------------------- | ------------------------------------------------------------------ | ----------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
 | `rerender-lazy-state-init`          | Use Lazy State Initialization                                      | MEDIUM      | Pass expensive initial values to `useState` as a lazy initializer function.                         | `references/rules/rerender-lazy-state-init.md`          |
 | `rerender-transitions`              | Use Transitions for Non-Urgent Updates                             | MEDIUM      | Mark frequent, non-urgent updates as transitions to keep the UI responsive.                         | `references/rules/rerender-transitions.md`              |
-| `rerender-useeffect-function-calls` | useEffectEvent when using functions in useEffect                   | MEDIUM      | Use `useEffectEvent` for functions called from effects instead of overusing `useCallback`.          | `references/rules/rerender-useeffect-function-calls.md` |
-| `rerender-no-useeffect-state-reset` | Never Reset State with useEffect — Remount via Component Hierarchy | MEDIUM-HIGH | Remount stateful branches when upstream identity changes instead of resetting state in `useEffect`. | `references/rules/rerender-no-useeffect-state-reset.md` |
+| `rerender-useeffect-function-calls`          | useEffectEvent when using functions in useEffect                   | MEDIUM      | Use `useEffectEvent` for functions called from effects instead of overusing `useCallback`.          | `references/rules/rerender-useeffect-function-calls.md`          |
+| `rerender-no-useeffect-state-reset`          | Never Reset State with useEffect — Remount via Component Hierarchy | MEDIUM-HIGH | Remount stateful branches when upstream identity changes instead of resetting state in `useEffect`. | `references/rules/rerender-no-useeffect-state-reset.md`          |
+| `rerender-no-usememo-usecallback`            | Do Not Add useMemo or useCallback                                  | MEDIUM      | Never introduce `useMemo` or `useCallback`; leave memoization decisions to developers with profiler evidence. | `references/rules/rerender-no-usememo-usecallback.md`            |
+| `rerender-no-setstate-in-render-or-effect`   | Do Not setState During Render or Effects                           | MEDIUM-HIGH | Derive values during render or move state ownership to an intermediate component instead of syncing with setters. | `references/rules/rerender-no-setstate-in-render-or-effect.md`   |
 
 ### 5. Rendering Performance
 
@@ -108,6 +110,7 @@ This catalog is an index for React performance and quality guidance used by agen
 | Rule                       | Title                                     | Impact | Summary                                                                                                                | Canonical file                                 |
 | -------------------------- | ----------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------- |
 | `types-no-type-assertions` | No `as` Type Assertions (Including Tests) | HIGH   | Never use `as` casts (production or tests); narrow with real guards, query generics, typed factories, or `implements`. | `references/rules/types-no-type-assertions.md` |
+| `types-no-null`            | Use undefined for Absence, Not null       | HIGH   | Model absence with optional `?`/`undefined`; convert external `null` at boundaries and keep internal types null-free. | `references/rules/types-no-null.md`            |
 
 ## External References
 

--- a/.claude/skills/react-best-practices/references/rules/rerender-no-setstate-in-render-or-effect.md
+++ b/.claude/skills/react-best-practices/references/rules/rerender-no-setstate-in-render-or-effect.md
@@ -1,0 +1,98 @@
+---
+title: Do Not setState During Render or Effects
+impact: MEDIUM-HIGH
+impactDescription: avoids render loops, double renders, stale flashes, and misplaced state ownership
+tags: rerender, state, useEffect, render, ownership
+---
+
+## Do Not setState During Render or Effects
+
+Never call a state setter during the render body. It can cause render loops, extra synchronous renders, and hard-to-review control flow.
+
+Also avoid using `useEffect` as a data-flow mechanism to push derived state after render. Effects run after paint, so the UI first renders stale or incomplete state, then renders again after the effect updates it.
+
+Both smells usually mean state lives in the wrong component. Fix the ownership boundary: create an intermediate component that owns the state transitions, then pass direct props to children so they can compute their output during render with no synchronization step.
+
+**Incorrect (setState during render):**
+
+```tsx
+function ProductPicker({ productId }: { productId: string }) {
+  const [selectedId, setSelectedId] = useState(productId);
+
+  if (selectedId !== productId) {
+    setSelectedId(productId);
+  }
+
+  return <ProductDetails productId={selectedId} />;
+}
+```
+
+**Incorrect (effect derives state from props):**
+
+```tsx
+function ProductList({ items, query }: ProductListProps) {
+  const [filteredItems, setFilteredItems] = useState<Product[]>([]);
+
+  useEffect(() => {
+    setFilteredItems(filterProducts(items, query));
+  }, [items, query]);
+
+  return <Products items={filteredItems} />;
+}
+```
+
+**Correct (derive during render):**
+
+```tsx
+function ProductList({ items, query }: ProductListProps) {
+  const filteredItems = filterProducts(items, query);
+
+  return <Products items={filteredItems} />;
+}
+```
+
+**Correct (intermediate owner handles state transitions):**
+
+```tsx
+function ProductPage({ productId }: { productId: string }) {
+  return <ProductSelectionBoundary productId={productId} />;
+}
+
+function ProductSelectionBoundary({ productId }: { productId: string }) {
+  const [selectedTab, setSelectedTab] = useState<ProductTab>('overview');
+
+  return (
+    <ProductDetails
+      productId={productId}
+      selectedTab={selectedTab}
+      onSelectedTabChange={setSelectedTab}
+    />
+  );
+}
+
+function ProductDetails({
+  productId,
+  selectedTab,
+  onSelectedTabChange,
+}: ProductDetailsProps) {
+  const visibleSections = getVisibleSections(productId, selectedTab);
+
+  return (
+    <ProductSections
+      sections={visibleSections}
+      selectedTab={selectedTab}
+      onSelectedTabChange={onSelectedTabChange}
+    />
+  );
+}
+```
+
+For the narrower case where local state must reset when an upstream identity changes, prefer remounting the stateful branch through hierarchy or `key`; see `rerender-no-useeffect-state-reset`.
+
+## Review Smells
+
+- Any `setX(...)` call directly in the component body.
+- `useEffect(() => setX(...), [...])` where `x` can be computed from props or state during render.
+- State whose only purpose is to mirror props.
+- A child receiving stale props for one render and being corrected by an effect.
+- Effects used to coordinate ownership between parent and child components.

--- a/.claude/skills/react-best-practices/references/rules/rerender-no-usememo-usecallback.md
+++ b/.claude/skills/react-best-practices/references/rules/rerender-no-usememo-usecallback.md
@@ -1,0 +1,71 @@
+---
+title: Do Not Add useMemo or useCallback
+impact: MEDIUM
+impactDescription: avoids agent-owned memoization decisions, dependency bugs, and stale closures
+tags: rerender, useMemo, useCallback, memoization, closures
+---
+
+## Do Not Add useMemo or useCallback
+
+Agents must not introduce `useMemo` or `useCallback`. Memoization is an optimization decision that belongs to the developer with profiler evidence and workload context. It has real costs: dependency-array bugs, stale closures, more complex reviews, and readability loss. The payoff is workload-dependent, so code generation should not guess.
+
+**Incorrect (memoization added by default):**
+
+```tsx
+function ProductList({ products, query }: ProductListProps) {
+  const visibleProducts = useMemo(
+    () => products.filter(product => product.name.includes(query)),
+    [products, query],
+  );
+
+  const handleSelect = useCallback((product: Product) => {
+    trackSelection(product.id);
+  }, []);
+
+  return <Products products={visibleProducts} onSelect={handleSelect} />;
+}
+```
+
+**Correct (derive directly during render):**
+
+```tsx
+function ProductList({ products, query }: ProductListProps) {
+  const visibleProducts = products.filter(product => product.name.includes(query));
+
+  function handleSelect(product: Product) {
+    trackSelection(product.id);
+  }
+
+  return <Products products={visibleProducts} onSelect={handleSelect} />;
+}
+```
+
+If a function is only needed from an effect, use `useEffectEvent` rather than `useCallback`; see `rerender-useeffect-function-calls`.
+
+```tsx
+function ProductTracker({ product }: { product: Product }) {
+  const trackView = useEffectEvent(() => {
+    analytics.track('product_viewed', { id: product.id });
+  });
+
+  useEffect(() => {
+    trackView();
+  }, [product.id]);
+}
+```
+
+If initialization is genuinely expensive and only needed once per mount, use lazy `useState`; see `rerender-lazy-state-init`.
+
+```tsx
+const [initialIndex] = useState(() => findInitialIndex(items));
+```
+
+If a subtree re-renders too much, restructure ownership and composition instead of masking it with memoization. Put state closer to where it changes, split unrelated responsibilities, and pass stable domain values rather than broad parent-owned objects.
+
+## Review Smells
+
+- New imports of `useMemo` or `useCallback`.
+- Memoization added because a linter or agent expected stable identities.
+- Dependency arrays that duplicate the body of a derived calculation.
+- `useCallback` used only to satisfy a `useEffect` dependency; prefer `useEffectEvent`.
+- Memoization used to compensate for a component owning too much unrelated state.

--- a/.claude/skills/react-best-practices/references/rules/types-no-null.md
+++ b/.claude/skills/react-best-practices/references/rules/types-no-null.md
@@ -1,0 +1,90 @@
+---
+title: Use undefined for Absence, Not null
+impact: HIGH
+impactDescription: simpler types, fewer impossible states, and less defensive null checking
+tags: types, null, undefined, optional, boundaries
+---
+
+## Use undefined for Absence, Not null
+
+Model missing values as `undefined`, not `null`. In TypeScript code, optional props, params, and fields should use `?` or `| undefined`; they should not use `| null`. `null` should almost never appear inside the codebase.
+
+External systems may still emit `null` — REST payloads, database rows, or third-party APIs. Convert those values at the boundary with `?? undefined` and keep internal types null-free. Do not let `null` propagate inward.
+
+**Incorrect (null leaks through the component API):**
+
+```tsx
+type UserCardProps = {
+  user: User | null;
+};
+
+function UserCard({ user }: UserCardProps) {
+  if (user === null) return null;
+
+  return <span>{user.name}</span>;
+}
+```
+
+**Correct (absence is optional/undefined):**
+
+```tsx
+type UserCardProps = {
+  user?: User;
+};
+
+function UserCard({ user }: UserCardProps) {
+  if (!user) return null;
+
+  return <span>{user.name}</span>;
+}
+```
+
+**Incorrect (state starts as null):**
+
+```tsx
+const [selectedUser, setSelectedUser] = useState<User | null>(null);
+```
+
+**Correct (state starts as undefined):**
+
+```tsx
+const [selectedUser, setSelectedUser] = useState<User | undefined>();
+```
+
+**Correct (convert null at the boundary):**
+
+```ts
+type ApiUser = {
+  id: string;
+  avatarUrl: string | null;
+};
+
+type User = {
+  id: string;
+  avatarUrl?: string;
+};
+
+function fromApiUser(user: ApiUser): User {
+  return {
+    id: user.id,
+    avatarUrl: user.avatarUrl ?? undefined,
+  };
+}
+```
+
+`.find()` already returns `undefined`; do not wrap that result in `null`.
+
+```ts
+const selectedUser = users.find(user => user.id === selectedUserId);
+```
+
+Legitimate exceptions are narrow boundary cases: an external API requires `null`, a database column distinguishes `null` from missing, or React rendering uses `return null` to render nothing. Keep those cases local and explicit.
+
+## Review Smells
+
+- `| null` in props, hook params, domain types, or component state.
+- `useState<T | null>(null)`.
+- `=== null` / `!== null` checks outside boundary adapters.
+- Returning or storing `null` because a lookup did not find anything.
+- Passing `null` through multiple layers instead of converting once with `?? undefined`.
+- `null` literals outside boundary adapters, third-party API requirements, DB-specific semantics, or React `return null`.


### PR DESCRIPTION
## Summary
- Add React best-practices rules for modeling absence with undefined instead of null
- Add guidance that agents should not introduce useMemo or useCallback by default
- Add guidance to avoid setState during render or effects by fixing state ownership
- Update the skill entrypoint and rule catalog counts/indexes

## Test plan
- Verified docs diff with git diff --check
- Confirmed the three new rule slugs are indexed in SKILL.md and the rule catalog
- Skipped build/typecheck as requested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR teaches the React agent to prefer safer defaults: use `undefined` for “missing” values, avoid adding memoization unless there’s a real reason, and fix where state lives instead of forcing updates during render or effects. It also updates the skill docs and rule catalog so the new guidance is counted and indexed correctly.

## Summary
- Added a new rule to model absence with `undefined`/optional fields instead of `null`, with boundary conversion guidance for external `null` values.
- Added a new rule discouraging default use of `useMemo` and `useCallback`.
- Added a new rule against calling `setState` during render or inside effects, favoring state ownership fixes instead.
- Updated the `react-best-practices` skill entrypoint and catalog index to reflect 25 total rules and the new category counts/indexes.
- Added the new rule slugs to the skill docs and rule catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->