### PR TITLE
fix(deployer): stub externalized packages only when they break validation

### DIFF
--- a/.changeset/fix-externals-array-validation.md
+++ b/.changeset/fix-externals-array-validation.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` failing when a package listed in `bundler.externals` (array form) has a dependency that throws while loading — for example an older CommonJS module that touches an API removed in a newer Node version (such as `buffer.SlowBuffer` on Node 26). Packages you externalize are no longer executed during the build's validation step, so adding the package to `bundler.externals` now resolves the failure as the error message suggests.

--- a/.changeset/fix-externals-array-validation.md
+++ b/.changeset/fix-externals-array-validation.md
@@ -1,0 +1,7 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` failing on a package you already listed in `bundler.externals`, and stopped externalized packages from breaking builds that used to work.
+
+A package you externalize is installed where you deploy, not bundled, so the build no longer fails when it cannot be loaded during the build itself — an older CommonJS module that throws on a newer Node, or a package that isn't installed in your build environment. Externalized packages your code uses as it loads (`dotenv.config()`, `Sentry.init()`, a client created at module scope) keep working. Both `externals: ['pkg']` and `externals: true` are covered.

--- a/e2e-tests/monorepo/monorepo.test.ts
+++ b/e2e-tests/monorepo/monorepo.test.ts
@@ -776,6 +776,136 @@ export const environmentRoute = registerApiRoute('/environment', {
     );
   });
 
+  describe.sequential('externalized package validation', () => {
+    let isolatedFixturePath: string;
+    let originalMastraConfig: string;
+    const mastraConfigPath = () => join(isolatedFixturePath, 'apps', 'custom', 'src', 'mastra', 'index.ts');
+
+    /**
+     * Writes a package straight into the app's `node_modules` and declares it as a dependency.
+     *
+     * These packages exist to be *externalized*, so they cannot be workspace packages — the
+     * deployer always bundles those. Installing them by hand also keeps them out of the local
+     * registry and lets each one be exactly the shape the case needs.
+     */
+    async function installExternalPackage(name: string, indexJs: string) {
+      const version = '1.0.0';
+      const packageDir = join(isolatedFixturePath, 'apps', 'custom', 'node_modules', name);
+      await mkdir(packageDir, { recursive: true });
+      await writeFile(
+        join(packageDir, 'package.json'),
+        JSON.stringify({ name, version, type: 'module', main: 'index.js', exports: { '.': './index.js' } }, null, 2),
+      );
+      await writeFile(join(packageDir, 'index.js'), indexJs);
+
+      const appPackageJsonPath = join(isolatedFixturePath, 'apps', 'custom', 'package.json');
+      const appPackageJson = JSON.parse(await readFile(appPackageJsonPath, 'utf-8'));
+      appPackageJson.dependencies[name] = version;
+      await writeFile(appPackageJsonPath, JSON.stringify(appPackageJson, null, 2));
+    }
+
+    async function build() {
+      await removeOutputDir(isolatedFixturePath);
+      return execa(pkgManager, ['build'], {
+        cwd: join(isolatedFixturePath, 'apps', 'custom'),
+        env: process.env,
+        reject: false,
+      });
+    }
+
+    beforeAll(async () => {
+      isolatedFixturePath = await mkdtemp(join(tmpdir(), `mastra-monorepo-externals-test-${pkgManager}-`));
+      await setupMonorepo(isolatedFixturePath, pkgManager);
+
+      const corePath = join(isolatedFixturePath, 'apps', 'custom', 'node_modules', '@mastra', 'core', 'dist');
+      await mkdir(join(corePath, 'runtime-context'), { recursive: true });
+      await writeFile(
+        join(corePath, 'runtime-context', 'index.js'),
+        `export { RequestContext as RuntimeContext } from '../request-context/index.js';`,
+      );
+
+      // Healthy, ordinary library — the shape of `dotenv.config()` or `Sentry.init()`: it works,
+      // and bundled code calls it while the module evaluates.
+      await installExternalPackage(
+        'eager-init-external',
+        [
+          'function init(name) {',
+          "  if (typeof name !== 'string') {",
+          "    throw new TypeError('eager-init-external: init() needs a name');",
+          '  }',
+          '  return name;',
+          '}',
+          '',
+          'export default { init };',
+          '',
+        ].join('\n'),
+      );
+
+      // Mirrors the #18626 report, where `buffer-equal-constant-time` reads `buffer.SlowBuffer` —
+      // removed in Node 26 — and throws the moment it is evaluated. Thrown unconditionally so the
+      // case does not depend on which Node version CI happens to run.
+      await installExternalPackage(
+        'hostile-external',
+        "throw new TypeError('hostile-external: SlowBuffer is not a function');\n",
+      );
+
+      originalMastraConfig = await readFile(mastraConfigPath(), 'utf-8');
+    }, timeout);
+
+    afterAll(async () => {
+      await rm(isolatedFixturePath, { recursive: true, force: true });
+    });
+
+    it(
+      'builds when bundled code uses an externalized package while the module evaluates',
+      async () => {
+        await writeFile(
+          mastraConfigPath(),
+          originalMastraConfig
+            .replace(
+              "import 'nodemailer';",
+              "import 'nodemailer';\nimport eagerInit from 'eager-init-external';\n\neagerInit.init('monorepo-e2e');",
+            )
+            .replace(/externals:\s*\[[^\]]*\]/, "externals: ['bcrypt', 'eager-init-external']"),
+        );
+
+        const result = await build();
+        const output = `${result.stdout}\n${result.stderr}`;
+
+        // Stubbing externals up front hands this chunk `export default {}`, so the call at module
+        // scope fails and takes a build with it that has nothing wrong with it.
+        expect(output).not.toContain('eagerInit.init is not a function');
+        expect(result.exitCode).toBe(0);
+
+        const packageJson = JSON.parse(
+          await readFile(join(isolatedFixturePath, 'apps', 'custom', '.mastra', 'output', 'package.json'), 'utf-8'),
+        );
+        expect(packageJson.dependencies).toHaveProperty('eager-init-external');
+      },
+      timeout,
+    );
+
+    it(
+      'builds when an externalized package throws while it loads under externals: true',
+      async () => {
+        await writeFile(
+          mastraConfigPath(),
+          originalMastraConfig
+            .replace("import 'nodemailer';", "import 'nodemailer';\nimport 'hostile-external';")
+            .replace(/externals:\s*\[[^\]]*\]/, 'externals: true'),
+        );
+
+        const result = await build();
+        const output = `${result.stdout}\n${result.stderr}`;
+
+        // The package is installed where the app runs, not where it is built, so a throw during
+        // validation says nothing about the bundle and must not end the build.
+        expect(output).not.toContain('hostile-external: SlowBuffer is not a function');
+        expect(result.exitCode).toBe(0);
+      },
+      timeout,
+    );
+  });
   describe.sequential('pnpm build approvals', () => {
     it(
       'reports blocked native build scripts as a user configuration error',

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -416,3 +416,116 @@ describe('npm alias dependencies', () => {
     });
   }, 15000);
 });
+
+describe('externals array excludes packages from the validation pass (issue #18626)', () => {
+  // Builds a workspace whose entry imports a bundled workspace package, which in turn
+  // imports `throws-on-load` — a transitive dependency that throws a TypeError as soon as
+  // it is evaluated. This mirrors an old CommonJS module that touches an API removed in a
+  // newer Node version (e.g. `buffer.SlowBuffer` on Node 26): the bundler keeps the
+  // dependency external, but the post-bundle validation pass dynamically imports each
+  // bundled chunk and used to execute the real module even after the user externalized it.
+  async function setupThrowingTransitiveDep(prefix: string) {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, prefix));
+    tempDirs.push(tempDir);
+
+    const appDir = join(tempDir, 'apps', 'app');
+    const workspacePackageDir = join(tempDir, 'packages', 'workspace-package');
+    const throwingPackageDir = join(workspacePackageDir, 'node_modules', 'throws-on-load');
+    const entryFile = join(appDir, 'index.ts');
+    const outputDir = join(appDir, '.mastra', '.build');
+
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(appDir, 'node_modules', '@internal'), { recursive: true });
+    await mkdir(throwingPackageDir, { recursive: true });
+    await mkdir(join(workspacePackageDir, 'src'), { recursive: true });
+
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test-workspace', version: '1.0.0' }));
+    await writeFile(join(tempDir, 'pnpm-workspace.yaml'), `packages:\n  - apps/*\n  - packages/*\n`);
+    await writeFile(join(appDir, 'package.json'), JSON.stringify({ name: 'app', version: '1.0.0', type: 'module' }));
+    await writeFile(
+      join(workspacePackageDir, 'package.json'),
+      JSON.stringify({
+        name: '@internal/workspace-package',
+        version: '1.0.0',
+        type: 'module',
+        main: './src/index.js',
+        dependencies: { 'throws-on-load': '1.0.0' },
+      }),
+    );
+    // Throws a TypeError at module-evaluation time (like requiring a removed Node API).
+    await writeFile(
+      join(throwingPackageDir, 'package.json'),
+      JSON.stringify({ name: 'throws-on-load', version: '1.0.0', type: 'module', main: './index.js' }),
+    );
+    await writeFile(
+      join(throwingPackageDir, 'index.js'),
+      `const removedApi = undefined;\nexport const value = removedApi.prototype;\n`,
+    );
+    await writeFile(
+      join(workspacePackageDir, 'src', 'index.js'),
+      `import { value } from 'throws-on-load';\nexport const workspaceValue = value;\n`,
+    );
+    await symlink(workspacePackageDir, join(appDir, 'node_modules', '@internal', 'workspace-package'));
+    await writeFile(
+      entryFile,
+      `import { workspaceValue } from '@internal/workspace-package';\nexport const value = workspaceValue;\n`,
+    );
+
+    return { entryFile, outputDir, projectRoot: appDir, tempDir };
+  }
+
+  it('fails to build when the throwing transitive dependency is not externalized', async () => {
+    const { entryFile, outputDir, projectRoot, tempDir } = await setupThrowingTransitiveDep(
+      'mastra-externals-throw-repro-',
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      await expect(
+        analyzeBundle(
+          [entryFile],
+          entryFile,
+          {
+            outputDir,
+            projectRoot,
+            platform: 'node',
+            bundlerOptions: { externals: [], enableSourcemap: false },
+          },
+          noopLogger,
+        ),
+      ).rejects.toThrow(/throws-on-load/);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }, 20000);
+
+  it('does not execute a package listed in bundler.externals during validation', async () => {
+    const { entryFile, outputDir, projectRoot, tempDir } = await setupThrowingTransitiveDep(
+      'mastra-externals-throw-fixed-',
+    );
+
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      // Listing the throwing dependency in `bundler.externals` keeps it out of the bundle
+      // AND stubs it during validation, so the build completes instead of crashing.
+      await expect(
+        analyzeBundle(
+          [entryFile],
+          entryFile,
+          {
+            outputDir,
+            projectRoot,
+            platform: 'node',
+            bundlerOptions: { externals: ['throws-on-load'], enableSourcemap: false },
+          },
+          noopLogger,
+        ),
+      ).resolves.toBeDefined();
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }, 20000);
+});

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -543,3 +543,211 @@ describe('Software Factory project type detection', () => {
     expect(result.projectType).toBeUndefined();
   });
 });
+
+describe('externalized packages and the validation pass (issues #18626, #16626)', () => {
+  /**
+   * Builds a workspace whose entry imports a bundled workspace package, which in turn imports
+   * an externalizable dependency that is executed at module-evaluation time.
+   *
+   * `dependencySource` decides whether that dependency is hostile (throws while loading, like an
+   * old CommonJS module touching an API removed in a newer Node) or perfectly healthy.
+   */
+  async function setupWorkspaceWithLoadTimeDependency(
+    prefix: string,
+    { dependencySource, consumerSource }: { dependencySource: string; consumerSource: string },
+  ) {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, prefix));
+    tempDirs.push(tempDir);
+
+    const appDir = join(tempDir, 'apps', 'app');
+    const workspacePackageDir = join(tempDir, 'packages', 'workspace-package');
+    const dependencyDir = join(workspacePackageDir, 'node_modules', 'load-time-dependency');
+    const entryFile = join(appDir, 'index.ts');
+    const outputDir = join(appDir, '.mastra', '.build');
+
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(appDir, 'node_modules', '@internal'), { recursive: true });
+    await mkdir(dependencyDir, { recursive: true });
+    await mkdir(join(workspacePackageDir, 'src'), { recursive: true });
+
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test-workspace', version: '1.0.0' }));
+    await writeFile(join(tempDir, 'pnpm-workspace.yaml'), `packages:\n  - apps/*\n  - packages/*\n`);
+    await writeFile(join(appDir, 'package.json'), JSON.stringify({ name: 'app', version: '1.0.0', type: 'module' }));
+    await writeFile(
+      join(workspacePackageDir, 'package.json'),
+      JSON.stringify({
+        name: '@internal/workspace-package',
+        version: '1.0.0',
+        type: 'module',
+        main: './src/index.js',
+        dependencies: { 'load-time-dependency': '1.0.0' },
+      }),
+    );
+    await writeFile(
+      join(dependencyDir, 'package.json'),
+      JSON.stringify({ name: 'load-time-dependency', version: '1.0.0', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(dependencyDir, 'index.js'), dependencySource);
+    await writeFile(join(workspacePackageDir, 'src', 'index.js'), consumerSource);
+    await symlink(workspacePackageDir, join(appDir, 'node_modules', '@internal', 'workspace-package'));
+    await writeFile(
+      entryFile,
+      `import { workspaceValue } from '@internal/workspace-package';\nexport const value = workspaceValue;\n`,
+    );
+
+    return { entryFile, outputDir, projectRoot: appDir, tempDir };
+  }
+
+  // Throws a TypeError while loading, the way `buffer-equal-constant-time` does on Node 26 when
+  // it reads `buffer.SlowBuffer.prototype` and `SlowBuffer` is gone.
+  const throwsOnLoad = `const removedApi = undefined;\nexport const value = removedApi.prototype;\n`;
+  const importsValue = `import { value } from 'load-time-dependency';\nexport const workspaceValue = value;\n`;
+
+  // A perfectly ordinary package that is *used* at module-evaluation time — `dotenv.config()`,
+  // `Sentry.init()`, a top-level client construction. Stubbing this one out breaks the build.
+  const healthyOnLoad = `export function init() {\n  return 'ok';\n}\nexport default { init };\n`;
+  const callsInit = `import ext from 'load-time-dependency';\nexport const workspaceValue = ext.init();\n`;
+
+  async function build(
+    { entryFile, outputDir, projectRoot, tempDir }: Awaited<ReturnType<typeof setupWorkspaceWithLoadTimeDependency>>,
+    externals: boolean | string[],
+  ) {
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      return await analyzeBundle(
+        [entryFile],
+        entryFile,
+        {
+          outputDir,
+          projectRoot,
+          platform: 'node',
+          bundlerOptions: { externals, enableSourcemap: false },
+        },
+        noopLogger,
+      );
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }
+
+  it('fails the build when a dependency that throws while loading is not externalized', async () => {
+    const workspace = await setupWorkspaceWithLoadTimeDependency('mastra-externals-throw-repro-', {
+      dependencySource: throwsOnLoad,
+      consumerSource: importsValue,
+    });
+
+    await expect(build(workspace, [])).rejects.toThrow(/load-time-dependency/);
+  }, 20000);
+
+  it('builds when a dependency that throws while loading is listed in bundler.externals', async () => {
+    const workspace = await setupWorkspaceWithLoadTimeDependency('mastra-externals-throw-array-', {
+      dependencySource: throwsOnLoad,
+      consumerSource: importsValue,
+    });
+
+    await expect(build(workspace, ['load-time-dependency'])).resolves.toBeDefined();
+  }, 20000);
+
+  it('builds when a dependency that throws while loading is covered by externals: true', async () => {
+    const workspace = await setupWorkspaceWithLoadTimeDependency('mastra-externals-throw-preset-', {
+      dependencySource: throwsOnLoad,
+      consumerSource: importsValue,
+    });
+
+    await expect(build(workspace, true)).resolves.toBeDefined();
+  }, 20000);
+
+  it('still builds when a healthy externalized package is used at module-evaluation time', async () => {
+    const workspace = await setupWorkspaceWithLoadTimeDependency('mastra-externals-healthy-array-', {
+      dependencySource: healthyOnLoad,
+      consumerSource: callsInit,
+    });
+
+    await expect(build(workspace, ['load-time-dependency'])).resolves.toBeDefined();
+  }, 20000);
+
+  it('still builds when a healthy package used at module-evaluation time is covered by externals: true', async () => {
+    const workspace = await setupWorkspaceWithLoadTimeDependency('mastra-externals-healthy-preset-', {
+      dependencySource: healthyOnLoad,
+      consumerSource: callsInit,
+    });
+
+    await expect(build(workspace, true)).resolves.toBeDefined();
+  }, 20000);
+
+  /**
+   * The real shape of #18626: the package the user externalizes is the one they depend on
+   * (`jsonwebtoken`), while the package that actually throws is buried under it
+   * (`jsonwebtoken -> jws -> jwa -> buffer-equal-constant-time`). The thrower is the only package
+   * in the stack, so blame has to travel up the nested `node_modules` path to reach the external.
+   */
+  async function setupWorkspaceWithThrowingTransitiveDependency(prefix: string) {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, prefix));
+    tempDirs.push(tempDir);
+
+    const appDir = join(tempDir, 'apps', 'app');
+    const workspacePackageDir = join(tempDir, 'packages', 'workspace-package');
+    const rootDependencyDir = join(workspacePackageDir, 'node_modules', 'external-root');
+    const throwingDependencyDir = join(rootDependencyDir, 'node_modules', 'buried-thrower');
+    const entryFile = join(appDir, 'index.ts');
+    const outputDir = join(appDir, '.mastra', '.build');
+
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(join(appDir, 'node_modules', '@internal'), { recursive: true });
+    await mkdir(throwingDependencyDir, { recursive: true });
+    await mkdir(join(workspacePackageDir, 'src'), { recursive: true });
+
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test-workspace', version: '1.0.0' }));
+    await writeFile(join(tempDir, 'pnpm-workspace.yaml'), `packages:\n  - apps/*\n  - packages/*\n`);
+    await writeFile(join(appDir, 'package.json'), JSON.stringify({ name: 'app', version: '1.0.0', type: 'module' }));
+    await writeFile(
+      join(workspacePackageDir, 'package.json'),
+      JSON.stringify({
+        name: '@internal/workspace-package',
+        version: '1.0.0',
+        type: 'module',
+        main: './src/index.js',
+        dependencies: { 'external-root': '1.0.0' },
+      }),
+    );
+    await writeFile(
+      join(rootDependencyDir, 'package.json'),
+      JSON.stringify({
+        name: 'external-root',
+        version: '1.0.0',
+        type: 'module',
+        main: './index.js',
+        dependencies: { 'buried-thrower': '1.0.0' },
+      }),
+    );
+    await writeFile(
+      join(throwingDependencyDir, 'package.json'),
+      JSON.stringify({ name: 'buried-thrower', version: '1.0.0', type: 'module', main: './index.js' }),
+    );
+    await writeFile(join(throwingDependencyDir, 'index.js'), throwsOnLoad);
+    await writeFile(
+      join(rootDependencyDir, 'index.js'),
+      `import { value } from 'buried-thrower';\nexport const rootValue = value;\n`,
+    );
+    await writeFile(
+      join(workspacePackageDir, 'src', 'index.js'),
+      `import { rootValue } from 'external-root';\nexport const workspaceValue = rootValue;\n`,
+    );
+    await symlink(workspacePackageDir, join(appDir, 'node_modules', '@internal', 'workspace-package'));
+    await writeFile(
+      entryFile,
+      `import { workspaceValue } from '@internal/workspace-package';\nexport const value = workspaceValue;\n`,
+    );
+
+    return { entryFile, outputDir, projectRoot: appDir, tempDir };
+  }
+
+  it('builds when the externalized package is the parent of the one that throws', async () => {
+    const workspace = await setupWorkspaceWithThrowingTransitiveDependency('mastra-externals-transitive-array-');
+
+    await expect(build(workspace, ['external-root'])).resolves.toBeDefined();
+  }, 20000);
+});

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -2,7 +2,8 @@ import { access, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { noopLogger } from '@mastra/core/logger';
-import { afterEach, describe, expect, it } from 'vitest';
+import type { IMastraLogger } from '@mastra/core/logger';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { analyzeBundle } from './analyze';
 import { slash } from './utils';
 
@@ -612,6 +613,7 @@ describe('externalized packages and the validation pass (issues #18626, #16626)'
   async function build(
     { entryFile, outputDir, projectRoot, tempDir }: Awaited<ReturnType<typeof setupWorkspaceWithLoadTimeDependency>>,
     externals: boolean | string[],
+    logger: IMastraLogger = noopLogger,
   ) {
     const originalCwd = process.cwd();
     process.chdir(tempDir);
@@ -625,7 +627,7 @@ describe('externalized packages and the validation pass (issues #18626, #16626)'
           platform: 'node',
           bundlerOptions: { externals, enableSourcemap: false },
         },
-        noopLogger,
+        logger,
       );
     } finally {
       process.chdir(originalCwd);
@@ -747,7 +749,17 @@ describe('externalized packages and the validation pass (issues #18626, #16626)'
 
   it('builds when the externalized package is the parent of the one that throws', async () => {
     const workspace = await setupWorkspaceWithThrowingTransitiveDependency('mastra-externals-transitive-array-');
+    const logger = { ...noopLogger, warn: vi.fn() } as IMastraLogger;
 
-    await expect(build(workspace, ['external-root'])).resolves.toBeDefined();
+    await expect(build(workspace, ['external-root'], logger)).resolves.toBeDefined();
+
+    // Blame lands on `external-root`, not on `buried-thrower`. The consumer uses a named import
+    // of it, which the bare stub cannot satisfy, so the retry is inconclusive and says so.
+    const skipped = vi
+      .mocked(logger.warn)
+      .mock.calls.filter(([message]) => String(message).startsWith('Skipped validating'));
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]![0]).toContain('"external-root"');
+    expect(skipped[0]![0]).not.toContain('buried-thrower');
   }, 20000);
 });

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -288,6 +288,7 @@ async function validateOutput(
     projectRoot,
     workspaceMap,
     depsVersionInfo,
+    userExternals,
   }: {
     output: (OutputChunk | OutputAsset)[];
     reverseVirtualReferenceMap: Map<string, string>;
@@ -296,6 +297,7 @@ async function validateOutput(
     projectRoot: string;
     workspaceMap: Map<string, WorkspacePackageInfo>;
     depsVersionInfo: Map<string, ExternalDependencyInfo>;
+    userExternals: string[];
   },
   logger: IMastraLogger,
 ) {
@@ -357,7 +359,12 @@ async function validateOutput(
       moduleResolveMapLocation: join(outputDir, 'module-resolve-map.json'),
       logger,
       workspaceMap,
-      stubbedExternals: [...GLOBAL_EXTERNALS, ...DEPS_TO_IGNORE],
+      // Stub user-declared externals too, not just GLOBAL_EXTERNALS. These packages are
+      // externalized during bundling but installed at runtime, so their real modules must not
+      // be executed during validation — otherwise a dependency that throws at load time (e.g.
+      // an old CommonJS module touching an API removed in newer Node) fails the build even
+      // though the user already listed it in `bundler.externals`. See issue #18626.
+      stubbedExternals: [...GLOBAL_EXTERNALS, ...DEPS_TO_IGNORE, ...userExternals],
     });
   }
 
@@ -587,6 +594,7 @@ export async function analyzeBundle(
       projectRoot: workspaceRoot || projectRoot,
       workspaceMap,
       depsVersionInfo,
+      userExternals,
     },
     logger,
   );

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -11,7 +11,7 @@ import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
 import { validate, ValidationError } from '../validator/validate';
 import { analyzeEntry } from './analyze/analyzeEntry';
 import { bundleExternals } from './analyze/bundleExternals';
-import { DEPS_TO_IGNORE } from './analyze/constants';
+import { DEPRECATED_EXTERNALS, DEPS_TO_IGNORE, GLOBAL_EXTERNALS } from './analyze/constants';
 import { normalizeExternals } from './analyze/externals';
 import { checkConfigExport } from './babel/check-config-export';
 import { detectPinoTransports } from './babel/detect-pino-transports';
@@ -218,6 +218,84 @@ function validateError(
   }
 }
 
+/**
+ * Collects the package names a stack trace points at, closest to the throw site first.
+ *
+ * Every `node_modules` segment of a path counts, not just the last one, because a nested install
+ * layout puts a package's ancestors in its own path: a throw inside
+ * `node_modules/jsonwebtoken/node_modules/jws/node_modules/jwa/index.js` should be blamed on
+ * `jwa` first, then `jws`, then `jsonwebtoken` — the user may have externalized any of them.
+ * Handles scoped packages and skips pnpm's `.pnpm` store segment.
+ */
+function getPackageNamesFromStack(stack: string): string[] {
+  const packageNames: string[] = [];
+
+  for (const line of stack.split('\n')) {
+    const segments = [...line.matchAll(/node_modules[\\/]((?:@[^\\/]+[\\/])?[^\\/]+)/g)].map(match =>
+      match[1]!.replaceAll('\\', '/'),
+    );
+
+    // Deepest segment first: the package the file belongs to, then the packages it is nested under.
+    for (const packageName of segments.reverse()) {
+      if (packageName !== '.pnpm' && !packageNames.includes(packageName)) {
+        packageNames.push(packageName);
+      }
+    }
+  }
+
+  return packageNames;
+}
+
+/**
+ * Finds the externalized package a validation failure should be blamed on, if any.
+ *
+ * Externalized packages are installed at runtime rather than bundled, so a failure that comes
+ * from one is not evidence of a bundling problem — it is a package the validation pass should
+ * not have needed to execute at all. Two shapes are recognised:
+ *
+ * - the package could not be loaded at all (`ERR_MODULE_NOT_FOUND`), named in the message
+ * - the package threw while evaluating, in which case its files appear in the stack
+ */
+function findExternalizedPackageInError(
+  err: Error,
+  {
+    externalizablePackages,
+    externalsPreset,
+    workspaceMap,
+  }: {
+    externalizablePackages: string[];
+    externalsPreset: boolean;
+    workspaceMap: Map<string, WorkspacePackageInfo>;
+  },
+): string | undefined {
+  if (!externalsPreset && externalizablePackages.length === 0) {
+    return undefined;
+  }
+
+  const missingPackage = err.stack?.includes('[ERR_MODULE_NOT_FOUND]')
+    ? err.message.match(/Cannot find package '([^']+)'/)?.[1]
+    : undefined;
+
+  const candidates = [...(missingPackage ? [getPackageName(missingPackage) ?? missingPackage] : [])];
+  if (err.stack) {
+    candidates.push(...getPackageNamesFromStack(err.stack));
+  }
+
+  for (const packageName of candidates) {
+    // Workspace packages are always bundled, never externalized — errors in them are real.
+    if (workspaceMap.has(packageName)) {
+      continue;
+    }
+
+    // `externals: true` externalizes every non-workspace dependency.
+    if (externalsPreset || externalizablePackages.some(external => isDependencyPartOfPackage(packageName, external))) {
+      return packageName;
+    }
+  }
+
+  return undefined;
+}
+
 async function validateFile(
   root: string,
   file: OutputChunk,
@@ -227,20 +305,26 @@ async function validateFile(
     logger,
     workspaceMap,
     stubbedExternals,
+    externalizablePackages,
+    externalsPreset,
   }: {
     binaryMapData: Record<string, string[]>;
     moduleResolveMapLocation: string;
     logger: IMastraLogger;
     workspaceMap: Map<string, WorkspacePackageInfo>;
     stubbedExternals: string[];
+    externalizablePackages: string[];
+    externalsPreset: boolean;
   },
 ) {
+  let injectESMShim = false;
+
   try {
     if (!file.isDynamicEntry && file.isEntry) {
       // validate if the chunk is actually valid, a failsafe to make sure bundling didn't make any mistakes
       await validate(join(root, file.fileName), {
         moduleResolveMapLocation,
-        injectESMShim: false,
+        injectESMShim,
         stubbedExternals,
       });
     }
@@ -251,15 +335,54 @@ async function validateFile(
       err.type === 'ReferenceError' &&
       (err.message.startsWith('__dirname') || err.message.startsWith('__filename'))
     ) {
+      injectESMShim = true;
       try {
         await validate(join(root, file.fileName), {
           moduleResolveMapLocation,
-          injectESMShim: true,
+          injectESMShim,
           stubbedExternals,
         });
         errorToHandle = null;
       } catch (err) {
         errorToHandle = err;
+      }
+    }
+
+    if (errorToHandle instanceof Error) {
+      // An externalized package is installed at runtime, not bundled, so it does not have to
+      // survive being executed here. Retry with that one package stubbed out. Stubbing on demand
+      // rather than up front keeps externalized packages that bundled code legitimately uses at
+      // module-evaluation time working. See issues #18626 and #16626.
+      const externalizedPackage = findExternalizedPackageInError(errorToHandle, {
+        externalizablePackages,
+        externalsPreset,
+        workspaceMap,
+      });
+
+      if (externalizedPackage) {
+        logger.debug('Retrying validation with externalized package stubbed', {
+          fileName: file.fileName,
+          packageName: externalizedPackage,
+        });
+
+        errorToHandle = null;
+
+        try {
+          await validate(join(root, file.fileName), {
+            moduleResolveMapLocation,
+            injectESMShim,
+            stubbedExternals: [...stubbedExternals, externalizedPackage],
+          });
+        } catch {
+          // The stub is a bare `export default {}`, so it cannot stand in for every import shape
+          // — a named import of it fails to link, for instance. That tells us nothing about the
+          // bundle: this chunk can only be executed with the real package, which is precisely the
+          // package we have decided not to execute. Validation is inconclusive here rather than
+          // failed, so warn and keep going instead of ending the build.
+          logger.warn(
+            `Skipped validating "${file.fileName}": it cannot be executed without "${externalizedPackage}", which is externalized. If the built output misbehaves, check that "${externalizedPackage}" is installed where you deploy it.`,
+          );
+        }
       }
     }
 
@@ -286,6 +409,7 @@ async function validateOutput(
     reverseVirtualReferenceMap,
     usedExternals,
     mergedExternals,
+    externalsPreset,
     outputDir,
     projectRoot,
     workspaceMap,
@@ -295,6 +419,7 @@ async function validateOutput(
     reverseVirtualReferenceMap: Map<string, string>;
     usedExternals: Record<string, Record<string, string>>;
     mergedExternals: string[];
+    externalsPreset: boolean;
     outputDir: string;
     projectRoot: string;
     workspaceMap: Map<string, WorkspacePackageInfo>;
@@ -344,7 +469,11 @@ async function validateOutput(
     binaryMapData = JSON.parse(binaryMap);
   }
 
-  const stubbedExternals = [...new Set([...mergedExternals, ...DEPS_TO_IGNORE, ...result.externalDependencies.keys()])];
+  // GLOBAL_EXTERNALS, DEPRECATED_EXTERNALS and DEPS_TO_IGNORE are small, curated lists the
+  // maintainers control, so stubbing them up front is safe. Packages the *user* externalized are
+  // ordinary runtime libraries — bundled code may legitimately use them while it evaluates — so
+  // those are stubbed only in response to an actual failure, inside validateFile.
+  const stubbedExternals = [...new Set([...GLOBAL_EXTERNALS, ...DEPRECATED_EXTERNALS, ...DEPS_TO_IGNORE])];
 
   for (const file of output) {
     if (file.type === 'asset') {
@@ -363,6 +492,10 @@ async function validateOutput(
       logger,
       workspaceMap,
       stubbedExternals,
+      // Everything the build treats as external: what the config resolved to, plus what analysis
+      // discovered. Any of these can be stubbed on demand when it breaks validation.
+      externalizablePackages: [...mergedExternals, ...result.externalDependencies.keys()],
+      externalsPreset,
     });
   }
 
@@ -581,6 +714,7 @@ export async function analyzeBundle(
       reverseVirtualReferenceMap: fileNameToDependencyMap,
       usedExternals,
       mergedExternals,
+      externalsPreset,
       outputDir,
       projectRoot: workspaceRoot || projectRoot,
       workspaceMap,

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -296,6 +296,19 @@ function findExternalizedPackageInError(
   return undefined;
 }
 
+/**
+ * Whether a validation failure is the stub itself failing to link, rather than the bundle.
+ *
+ * The stub for an externalized package is a bare `export default {}`, so a chunk that imports a
+ * named binding from that package cannot link:
+ * `SyntaxError: The requested module 'pkg' does not provide an export named 'x'`.
+ */
+function isStubLinkError(err: Error, stubbedExternals: string[]): boolean {
+  const specifier = err.message.match(/^The requested module '([^']+)' does not provide an export named/)?.[1];
+
+  return specifier !== undefined && stubbedExternals.some(external => isDependencyPartOfPackage(specifier, external));
+}
+
 async function validateFile(
   root: string,
   file: OutputChunk,
@@ -353,35 +366,53 @@ async function validateFile(
       // survive being executed here. Retry with that one package stubbed out. Stubbing on demand
       // rather than up front keeps externalized packages that bundled code legitimately uses at
       // module-evaluation time working. See issues #18626 and #16626.
-      const externalizedPackage = findExternalizedPackageInError(errorToHandle, {
-        externalizablePackages,
-        externalsPreset,
-        workspaceMap,
-      });
+      //
+      // Each retry runs the chunk further than the last, so it can surface the next externalized
+      // package the chunk touches. Keep going until the chunk loads, the failure can no longer be
+      // blamed on an externalized package, or the stub itself is what fails.
+      const retryStubbedExternals = [...stubbedExternals];
 
-      if (externalizedPackage) {
+      while (errorToHandle instanceof Error) {
+        const externalizedPackage = findExternalizedPackageInError(errorToHandle, {
+          externalizablePackages,
+          externalsPreset,
+          workspaceMap,
+        });
+
+        if (!externalizedPackage || retryStubbedExternals.includes(externalizedPackage)) {
+          break;
+        }
+
+        retryStubbedExternals.push(externalizedPackage);
         logger.debug('Retrying validation with externalized package stubbed', {
           fileName: file.fileName,
           packageName: externalizedPackage,
         });
 
-        errorToHandle = null;
-
         try {
           await validate(join(root, file.fileName), {
             moduleResolveMapLocation,
             injectESMShim,
-            stubbedExternals: [...stubbedExternals, externalizedPackage],
+            stubbedExternals: retryStubbedExternals,
           });
-        } catch {
-          // The stub is a bare `export default {}`, so it cannot stand in for every import shape
-          // — a named import of it fails to link, for instance. That tells us nothing about the
-          // bundle: this chunk can only be executed with the real package, which is precisely the
-          // package we have decided not to execute. Validation is inconclusive here rather than
-          // failed, so warn and keep going instead of ending the build.
-          logger.warn(
-            `Skipped validating "${file.fileName}": it cannot be executed without "${externalizedPackage}", which is externalized. If the built output misbehaves, check that "${externalizedPackage}" is installed where you deploy it.`,
-          );
+          errorToHandle = null;
+        } catch (retryErr) {
+          if (retryErr instanceof Error && isStubLinkError(retryErr, retryStubbedExternals)) {
+            // The stub is a bare `export default {}`, so it cannot stand in for every import shape
+            // — a named import of it fails to link. That tells us nothing about the bundle: this
+            // chunk can only be executed with the real package, which is precisely the package we
+            // have decided not to execute. Validation is inconclusive here rather than failed, so
+            // warn and keep going instead of ending the build.
+            logger.warn(
+              `Skipped validating "${file.fileName}": it cannot be executed without "${externalizedPackage}", which is externalized. If the built output misbehaves, check that "${externalizedPackage}" is installed where you deploy it.`,
+            );
+            errorToHandle = null;
+          } else {
+            // Anything else is about the bundle, not the stub: either the next externalized package
+            // (the next pass stubs it) or a genuine defect, which still has to fail the build with
+            // the usual guidance.
+            errorToHandle = retryErr;
+          }
         }
       }
     }

--- a/packages/deployer/src/build/analyze.user-externals.test.ts
+++ b/packages/deployer/src/build/analyze.user-externals.test.ts
@@ -16,7 +16,7 @@ vi.mock('../validator/validate', () => ({
   },
 }));
 
-import { validate } from '../validator/validate';
+import { validate, ValidationError } from '../validator/validate';
 import { analyzeBundle } from './analyze';
 
 const tempDirs: string[] = [];
@@ -35,10 +35,10 @@ afterEach(async () => {
   vi.mocked(validate).mockClear();
 });
 
-describe('validateOutput stubbedExternals', () => {
-  it('passes normalized and user-configured externals to the validation stub list', async () => {
+describe('validateOutput stubbedExternals (issue #16626)', () => {
+  async function setupProject(prefix: string) {
     await mkdir(tempRoot, { recursive: true });
-    const tempDir = await mkdtemp(join(tempRoot, 'mastra-user-externals-'));
+    const tempDir = await mkdtemp(join(tempRoot, prefix));
     tempDirs.push(tempDir);
 
     const entryFile = join(tempDir, 'index.ts');
@@ -52,12 +52,16 @@ describe('validateOutput stubbedExternals', () => {
       `,
     );
 
-    await analyzeBundle(
+    return { entryFile, outputDir, projectRoot: tempDir };
+  }
+
+  function build({ entryFile, outputDir, projectRoot }: { entryFile: string; outputDir: string; projectRoot: string }) {
+    return analyzeBundle(
       [entryFile],
       entryFile,
       {
         outputDir,
-        projectRoot: tempDir,
+        projectRoot,
         platform: 'browser',
         bundlerOptions: {
           externals: ['drizzle-orm', 'pg'],
@@ -66,14 +70,48 @@ describe('validateOutput stubbedExternals', () => {
       },
       noopLogger,
     );
+  }
 
+  // Bundling a real @mastra/core entry through rollup is slow under parallel suite load
+  // (observed up to ~30s locally), so these give it generous headroom.
+
+  it('does not stub user-configured externals while validation is succeeding', async () => {
+    const project = await setupProject('mastra-user-externals-healthy-');
+
+    await build(project);
+
+    // Externals are ordinary runtime libraries that bundled code may use while it evaluates,
+    // so they run for real unless they actually break the validation pass.
     expect(validate).toHaveBeenCalled();
     for (const [, opts] of vi.mocked(validate).mock.calls) {
+      expect(opts.stubbedExternals).not.toContain('drizzle-orm');
+      // The curated lists stay eagerly stubbed: 'pg' is in GLOBAL_EXTERNALS and the rest are
+      // DEPRECATED_EXTERNALS, so listing 'pg' as a user external changes nothing for it.
       expect(opts.stubbedExternals).toEqual(
-        expect.arrayContaining(['drizzle-orm', 'pg', 'fastembed', 'nodemailer', 'jsdom', 'sqlite3']),
+        expect.arrayContaining(['pg', 'fastembed', 'nodemailer', 'jsdom', 'sqlite3']),
       );
     }
-    // Bundling a real @mastra/core entry through rollup is slow under parallel
-    // suite load (observed up to ~30s locally), so give it generous headroom.
+  }, 60000);
+
+  it('stubs a user-configured external that validation could not load', async () => {
+    const project = await setupProject('mastra-user-externals-missing-');
+
+    // First attempt: the chunk cannot be executed because an externalized package is not
+    // installed in the build environment. Every later attempt succeeds.
+    vi.mocked(validate).mockImplementationOnce(() => {
+      const error = new ValidationError({
+        type: 'Error',
+        message: `Cannot find package 'drizzle-orm' imported from ${project.outputDir}`,
+        stack: `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'drizzle-orm' imported from ${project.outputDir}`,
+      });
+      return Promise.reject(error);
+    });
+
+    await expect(build(project)).resolves.toBeDefined();
+
+    const retriedWithStub = vi
+      .mocked(validate)
+      .mock.calls.some(([, opts]) => opts.stubbedExternals?.includes('drizzle-orm'));
+    expect(retriedWithStub).toBe(true);
   }, 60000);
 });

--- a/packages/deployer/src/build/analyze.user-externals.test.ts
+++ b/packages/deployer/src/build/analyze.user-externals.test.ts
@@ -2,6 +2,7 @@ import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { noopLogger } from '@mastra/core/logger';
+import type { IMastraLogger } from '@mastra/core/logger';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('../validator/validate', () => ({
@@ -55,7 +56,10 @@ describe('validateOutput stubbedExternals (issue #16626)', () => {
     return { entryFile, outputDir, projectRoot: tempDir };
   }
 
-  function build({ entryFile, outputDir, projectRoot }: { entryFile: string; outputDir: string; projectRoot: string }) {
+  function build(
+    { entryFile, outputDir, projectRoot }: Awaited<ReturnType<typeof setupProject>>,
+    { externals = ['drizzle-orm', 'pg'], logger = noopLogger }: { externals?: string[]; logger?: IMastraLogger } = {},
+  ) {
     return analyzeBundle(
       [entryFile],
       entryFile,
@@ -64,12 +68,20 @@ describe('validateOutput stubbedExternals (issue #16626)', () => {
         projectRoot,
         platform: 'browser',
         bundlerOptions: {
-          externals: ['drizzle-orm', 'pg'],
+          externals,
           enableSourcemap: false,
         },
       },
-      noopLogger,
+      logger,
     );
+  }
+
+  function missingPackage(packageName: string, outputDir: string) {
+    return new ValidationError({
+      type: 'Error',
+      message: `Cannot find package '${packageName}' imported from ${outputDir}`,
+      stack: `Error [ERR_MODULE_NOT_FOUND]: Cannot find package '${packageName}' imported from ${outputDir}`,
+    });
   }
 
   // Bundling a real @mastra/core entry through rollup is slow under parallel suite load
@@ -113,5 +125,70 @@ describe('validateOutput stubbedExternals (issue #16626)', () => {
       .mocked(validate)
       .mock.calls.some(([, opts]) => opts.stubbedExternals?.includes('drizzle-orm'));
     expect(retriedWithStub).toBe(true);
+  }, 60000);
+
+  it('keeps stubbing when the retry surfaces another externalized package', async () => {
+    const project = await setupProject('mastra-user-externals-chain-');
+
+    // Stubbing the first package lets the chunk run further, where it trips over a second
+    // externalized package that is not installed either. The third attempt succeeds.
+    vi.mocked(validate)
+      .mockImplementationOnce(() => Promise.reject(missingPackage('drizzle-orm', project.outputDir)))
+      .mockImplementationOnce(() => Promise.reject(missingPackage('ioredis', project.outputDir)));
+
+    await expect(build(project, { externals: ['drizzle-orm', 'pg', 'ioredis'] })).resolves.toBeDefined();
+
+    const retriedWithBothStubs = vi
+      .mocked(validate)
+      .mock.calls.some(
+        ([, opts]) => opts.stubbedExternals?.includes('drizzle-orm') && opts.stubbedExternals?.includes('ioredis'),
+      );
+    expect(retriedWithBothStubs).toBe(true);
+  }, 60000);
+
+  it('warns instead of failing when the stub itself cannot link', async () => {
+    const project = await setupProject('mastra-user-externals-stub-link-');
+    const logger = { ...noopLogger, warn: vi.fn() } as IMastraLogger;
+
+    // The stub is a bare `export default {}`, so a chunk with a named import from the
+    // externalized package cannot link against it. That says nothing about the bundle.
+    vi.mocked(validate)
+      .mockImplementationOnce(() => Promise.reject(missingPackage('drizzle-orm', project.outputDir)))
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          new ValidationError({
+            type: 'SyntaxError',
+            message: "The requested module 'drizzle-orm' does not provide an export named 'sql'",
+            stack: `SyntaxError: The requested module 'drizzle-orm' does not provide an export named 'sql'\n    at ModuleJob._instantiate (node:internal/modules/esm/module_job:180:21)`,
+          }),
+        ),
+      );
+
+    await expect(build(project, { logger })).resolves.toBeDefined();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('"drizzle-orm"'));
+  }, 60000);
+
+  it('still fails the build when the retry surfaces a defect the stub did not cause', async () => {
+    const project = await setupProject('mastra-user-externals-retry-defect-');
+    const logger = { ...noopLogger, warn: vi.fn() } as IMastraLogger;
+
+    // With the externalized package out of the way the chunk gets further and hits a genuine
+    // bundling problem in a package that is *not* externalized. That must not be swallowed.
+    vi.mocked(validate)
+      .mockImplementationOnce(() => Promise.reject(missingPackage('drizzle-orm', project.outputDir)))
+      .mockImplementationOnce(() =>
+        Promise.reject(
+          new ValidationError({
+            type: 'TypeError',
+            message: "Cannot read properties of undefined (reading 'prototype')",
+            stack: `TypeError: Cannot read properties of undefined (reading 'prototype')\n    at Object.<anonymous> (${project.projectRoot}/node_modules/legacy-cjs-package/index.js:3:41)`,
+          }),
+        ),
+      );
+
+    await expect(build(project, { logger })).rejects.toThrow(/legacy-cjs-package/);
+    expect(logger.warn).not.toHaveBeenCalled();
   }, 60000);
 });


### PR DESCRIPTION
## Description

Build validation imports every generated chunk in a child process to sanity-check it. Packages the user externalized are installed at runtime rather than bundled, so a package that can't be loaded *during the build* shouldn't be able to end the build. Two issues come from that:

- **#18626** — an externalized package throws while loading (`jsonwebtoken` → `buffer-equal-constant-time` reads `buffer.SlowBuffer`, removed in Node 26). The error says to add it to `bundler.externals`; you already did.
- **#16626** — an externalized package isn't installed in the build environment at all, and validation fails with `ERR_MODULE_NOT_FOUND`.

This PR originally fixed the first by adding `userExternals` to the validation stub list up front. [#16639](https://github.com/mastra-ai/mastra/pull/16639) has since landed that same change on `main` for the second, and [#20719](https://github.com/mastra-ai/mastra/pull/20719) widened it to every discovered external. **Eager stubbing has a cost that is now on `main`:** a healthy externalized package that bundled code uses while it evaluates — `dotenv.config()`, `Sentry.init()`, a client constructed at module scope — receives `export default {}` and throws, failing builds that used to pass.

So this PR now stubs **reactively** instead. Each chunk is validated against the real modules first. Only if that fails, and only if the failure can be blamed on an externalized package, is that one package stubbed and the chunk retried. Healthy externals never get stubbed, because nothing ever failed.

A retry that still fails is treated as inconclusive rather than fatal: the stub is a bare `export default {}` and can't stand in for every import shape (a named import of it doesn't link), so a failure there says nothing about the bundle. It warns and moves on instead of ending the build. Worth flagging — on `main` that same `SyntaxError` is *silently* swallowed by `validateError`, which can't classify it, so today the stub path passes builds without saying anything.

`bundler: { externals: true }` is covered alongside the array form, which closes the gap noted in #18626's workarounds section.

### Verified

Five end-to-end tests in the deployer analyze suite that run the real validation subprocess (the existing `analyze.user-externals.test.ts` mocks `validate` away, so it can't observe this class of failure):

| scenario | `main` | this PR |
|---|---|---|
| throwing dep, not externalized → build fails | ✅ | ✅ |
| throwing dep in `externals` array → builds | ✅ | ✅ |
| throwing dep under `externals: true` → builds | ❌ | ✅ |
| healthy external used at module-eval time, array → builds | ❌ | ✅ |
| healthy external used at module-eval time, `externals: true` → builds | ✅ | ✅ |

Full `@mastra/deployer` suite: 649 passed, same 5 pre-existing failures as `origin/main` on this machine (unrelated `src/server` tests and a protocol-imports test). `analyze.user-externals.test.ts` is updated — it asserted the eager stub list directly, so it now asserts the reactive contract instead: externals aren't stubbed while validation succeeds, and an external that couldn't be loaded is stubbed on retry.

I used AI assistance (Claude) while working on this and have reviewed and understand the change.

## Related issue(s)

Fixes #18626

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This change lets `mastra build` handle external packages that fail during loading. It tests healthy external packages normally and uses a temporary stub only when a failure points to an external package.

## Summary

- Adds reactive validation for user-configured external packages.
- Supports `bundler.externals` arrays and `bundler.externals: true`.
- Retries validation with the detected external package stubbed.
- Preserves failures for non-externalized dependencies.
- Logs a warning when a stubbed retry remains inconclusive.
- Adds regression tests for throwing dependencies, healthy module-evaluation-time externals, transitive failures, missing packages, pnpm workspaces, and `externals: true`.
- Adds a changeset for `@mastra/deployer`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->