### PR TITLE
feat(slack): SlackUserAuth + Mastra Code Slack plugin

### DIFF
--- a/.changeset/purple-planets-jump.md
+++ b/.changeset/purple-planets-jump.md
@@ -1,0 +1,15 @@
+---
+'@mastra/slack': minor
+---
+
+Added `SlackUserAuth` for connecting a Slack **user account** to a pre-existing Slack app (PKCE OAuth, no client secret). Tokens refresh automatically before expiry and rotated refresh tokens are persisted safely, so connections survive Slack's token rotation across restarts.
+
+```ts
+import { SlackUserAuth } from '@mastra/slack';
+
+const auth = new SlackUserAuth({ clientId: '1234567890.123' });
+await auth.connect({ onAuthUrl: url => console.log('Authorize:', url) }); // opens PKCE browser flow
+const token = await auth.getToken(); // transparently refreshed user token
+```
+
+Credentials are stored in `~/.mastra/slack-auth.json` by default, with a pluggable storage interface and a static `token` option for headless use.

--- a/channels/slack/src/index.ts
+++ b/channels/slack/src/index.ts
@@ -35,6 +35,28 @@ export { SlackManifestClient } from './client';
 export { verifySlackRequest, parseSlackFormBody } from './crypto';
 export { buildManifest, DEFAULT_BOT_SCOPES, DEFAULT_BOT_EVENTS } from './manifest';
 
+// User-token auth against a pre-existing Slack app (PKCE public client).
+// Used by SlackSignals; distinct from SlackProvider's bot-token credentials.
+export {
+  SlackUserAuth,
+  SlackAuthRequiredError,
+  SlackAuthReconnectRequiredError,
+  SlackRefreshTokenDeadError,
+  DEFAULT_SLACK_USER_SCOPES,
+  SLACK_CALLBACK_PORTS,
+  FileSlackCredentialStorage,
+  InMemorySlackCredentialStorage,
+  defaultSlackCredentialPath,
+  resolveSlackClientId,
+} from './user-auth';
+export type {
+  SlackUserAuthOptions,
+  SlackConnectCallbacks,
+  SlackAuthStatus,
+  SlackCredentialStorage,
+  SlackUserCredentials,
+} from './user-auth';
+
 // Re-export from @chat-adapter/slack for convenience
 export { createSlackAdapter } from '@chat-adapter/slack';
 export type { SlackAdapter } from '@chat-adapter/slack';

--- a/channels/slack/src/user-auth/credential-storage.ts
+++ b/channels/slack/src/user-auth/credential-storage.ts
@@ -1,0 +1,123 @@
+import { mkdir, readFile, rename, writeFile, unlink, chmod } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+/**
+ * Stored Slack user-token credentials.
+ *
+ * Slack rotates the refresh token on every refresh, so the whole record is
+ * re-persisted after each rotation — losing a rotated refresh token strands
+ * the connection (the old one is single-use).
+ */
+export interface SlackUserCredentials {
+  /** The user access token (`xoxp-…` / `xoxe.xoxp-…`). */
+  accessToken: string;
+  /** Rotated refresh token. Absent when the app has token rotation disabled. */
+  refreshToken?: string;
+  /** Epoch ms when `accessToken` expires. Absent for non-expiring tokens. */
+  expiresAt?: number;
+  /** The OAuth client_id the credentials were issued against. */
+  clientId?: string;
+  /** Slack workspace id (e.g. `T0123456`). */
+  teamId?: string;
+  /** Slack workspace name. */
+  teamName?: string;
+  /** The authed user's Slack id (e.g. `U0123456`). */
+  userId?: string;
+  /**
+   * Set when a refresh failed terminally (dead refresh token). The user must
+   * run the connect flow again; `getToken()` surfaces this as
+   * `SlackAuthReconnectRequiredError` instead of a raw `invalid_token`.
+   */
+  needsReconnect?: boolean;
+}
+
+/**
+ * Pluggable persistence for Slack user credentials.
+ *
+ * The default is {@link FileSlackCredentialStorage}. Hosts with their own
+ * secret handling (servers, mastracode) can implement this interface to back
+ * credentials with env vars, keychains, or databases.
+ */
+export interface SlackCredentialStorage {
+  load(): Promise<SlackUserCredentials | undefined>;
+  save(credentials: SlackUserCredentials): Promise<void>;
+  clear(): Promise<void>;
+}
+
+/** Default credential file location: `~/.mastra/slack-auth.json`. */
+export function defaultSlackCredentialPath(): string {
+  return join(homedir(), '.mastra', 'slack-auth.json');
+}
+
+/**
+ * File-backed credential storage. Writes are atomic (temp file + rename) and
+ * the file is chmod'd to 0600 since it contains live tokens.
+ */
+export class FileSlackCredentialStorage implements SlackCredentialStorage {
+  readonly #path: string;
+
+  constructor(path: string = defaultSlackCredentialPath()) {
+    this.#path = path;
+  }
+
+  get path(): string {
+    return this.#path;
+  }
+
+  async load(): Promise<SlackUserCredentials | undefined> {
+    let raw: string;
+    try {
+      raw = await readFile(this.#path, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+    try {
+      const parsed = JSON.parse(raw) as SlackUserCredentials;
+      if (typeof parsed?.accessToken !== 'string' || parsed.accessToken.length === 0) return undefined;
+      return parsed;
+    } catch {
+      return undefined;
+    }
+  }
+
+  async save(credentials: SlackUserCredentials): Promise<void> {
+    await mkdir(dirname(this.#path), { recursive: true });
+    const tempPath = `${this.#path}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tempPath, `${JSON.stringify(credentials, null, 2)}\n`, { mode: 0o600 });
+    await rename(tempPath, this.#path);
+    // rename preserves the temp file's mode, but be explicit in case the
+    // destination already existed with looser permissions.
+    await chmod(this.#path, 0o600).catch(() => {});
+  }
+
+  async clear(): Promise<void> {
+    try {
+      await unlink(this.#path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+  }
+}
+
+/** In-memory credential storage, mainly for tests and ephemeral processes. */
+export class InMemorySlackCredentialStorage implements SlackCredentialStorage {
+  #credentials?: SlackUserCredentials;
+
+  constructor(initial?: SlackUserCredentials) {
+    this.#credentials = initial;
+  }
+
+  async load(): Promise<SlackUserCredentials | undefined> {
+    return this.#credentials ? { ...this.#credentials } : undefined;
+  }
+
+  async save(credentials: SlackUserCredentials): Promise<void> {
+    this.#credentials = { ...credentials };
+  }
+
+  async clear(): Promise<void> {
+    this.#credentials = undefined;
+  }
+}

--- a/channels/slack/src/user-auth/index.ts
+++ b/channels/slack/src/user-auth/index.ts
@@ -1,0 +1,23 @@
+export {
+  SlackUserAuth,
+  SlackAuthRequiredError,
+  SlackAuthReconnectRequiredError,
+  DEFAULT_SLACK_USER_SCOPES,
+} from './user-auth';
+export type { SlackUserAuthOptions, SlackConnectCallbacks, SlackAuthStatus } from './user-auth';
+export {
+  FileSlackCredentialStorage,
+  InMemorySlackCredentialStorage,
+  defaultSlackCredentialPath,
+} from './credential-storage';
+export type { SlackCredentialStorage, SlackUserCredentials } from './credential-storage';
+export {
+  buildAuthorizeUrl,
+  exchangeAuthorizationCode,
+  refreshUserToken,
+  resolveSlackClientId,
+  parseAuthorizationInput,
+  SlackRefreshTokenDeadError,
+  SLACK_CALLBACK_PORTS,
+} from './oauth';
+export { generatePKCE, generateState } from './pkce';

--- a/channels/slack/src/user-auth/oauth.ts
+++ b/channels/slack/src/user-auth/oauth.ts
@@ -68,6 +68,7 @@ type SlackTokenResponse = {
   ok?: boolean;
   error?: string;
   team?: { id?: string; name?: string };
+  /** Present on the initial `authorization_code` exchange (user token nested). */
   authed_user?: {
     id?: string;
     access_token?: string;
@@ -75,6 +76,15 @@ type SlackTokenResponse = {
     expires_in?: number;
     token_type?: string;
   };
+  /**
+   * Present on `refresh_token` grants: Slack returns the rotated user token at
+   * the TOP level (`token_type: "user"`), NOT nested under `authed_user`.
+   */
+  access_token?: string;
+  refresh_token?: string;
+  expires_in?: number;
+  user_id?: string;
+  token_type?: string;
 };
 
 export function tokenResponseToCredentials(
@@ -85,19 +95,22 @@ export function tokenResponseToCredentials(
   if (!json.ok) {
     throw new Error(`Slack OAuth failed: ${json.error ?? 'unknown_error'}`);
   }
+  // Initial code exchange nests the user token under `authed_user`; refresh
+  // responses return it at the top level with `token_type: "user"`.
   const user = json.authed_user;
-  if (!user?.access_token) {
+  const accessToken = user?.access_token ?? json.access_token;
+  if (!accessToken) {
     throw new Error('Slack OAuth response missing user access token');
   }
   return {
-    accessToken: user.access_token,
+    accessToken,
     // Slack omits refresh_token when token rotation is off; keep the old one.
-    refreshToken: user.refresh_token ?? previous?.refreshToken,
-    expiresAt: Date.now() + (user.expires_in ?? DEFAULT_TOKEN_EXPIRES_IN_SECONDS) * 1000,
+    refreshToken: user?.refresh_token ?? json.refresh_token ?? previous?.refreshToken,
+    expiresAt: Date.now() + (user?.expires_in ?? json.expires_in ?? DEFAULT_TOKEN_EXPIRES_IN_SECONDS) * 1000,
     clientId,
     teamId: json.team?.id ?? previous?.teamId,
     teamName: json.team?.name ?? previous?.teamName,
-    userId: user.id ?? previous?.userId,
+    userId: user?.id ?? json.user_id ?? previous?.userId,
   };
 }
 

--- a/channels/slack/src/user-auth/oauth.ts
+++ b/channels/slack/src/user-auth/oauth.ts
@@ -1,0 +1,289 @@
+/**
+ * Slack user-token OAuth 2.0 + PKCE primitives.
+ *
+ * These functions authorize a Slack **user account** against a pre-existing
+ * Slack app (Mastra's published app by default, or a BYO client_id). The app
+ * is a PKCE public client: the token exchange sends `code` + `code_verifier`
+ * and NO client_secret, so the client_id is safe to ship.
+ *
+ * Slack rotates the refresh token on every refresh — callers MUST persist the
+ * returned credentials after each call to {@link refreshUserToken}.
+ */
+import { createServer } from 'node:http';
+
+import type { SlackUserCredentials } from './credential-storage';
+
+const AUTHORIZE_URL = 'https://slack.com/oauth/v2/authorize';
+const TOKEN_URL = 'https://slack.com/api/oauth.v2.access';
+
+/** Slack user tokens expire after 12h when token rotation is enabled. */
+const DEFAULT_TOKEN_EXPIRES_IN_SECONDS = 12 * 60 * 60;
+
+/**
+ * Loopback ports the connect flow binds for the OAuth callback. These must be
+ * listed in the Slack app's `oauth_config.redirect_urls`.
+ */
+export const SLACK_CALLBACK_PORTS: readonly number[] = [41927, 41928, 41929];
+
+/** Env var fallback for the OAuth client_id (`MASTRA_SLACK_CLIENT_ID`). */
+export function resolveSlackClientId(clientId?: string): string | undefined {
+  const explicit = clientId?.trim();
+  if (explicit) return explicit;
+  const fromEnv = typeof process !== 'undefined' ? process.env?.MASTRA_SLACK_CLIENT_ID?.trim() : undefined;
+  return fromEnv || undefined;
+}
+
+const SUCCESS_HTML = `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Slack connected</title>
+</head>
+<body>
+  <p>Slack connected. Return to your terminal to continue.</p>
+</body>
+</html>`;
+
+/** Build the Slack authorize URL for the PKCE user-token flow. */
+export function buildAuthorizeUrl(params: {
+  clientId: string;
+  redirectUri: string;
+  scopes: string[];
+  challenge: string;
+  state: string;
+}): string {
+  const url = new URL(AUTHORIZE_URL);
+  // User-token scopes go in `user_scope` (`scope` requests bot scopes).
+  url.searchParams.set('client_id', params.clientId);
+  url.searchParams.set('user_scope', params.scopes.join(','));
+  url.searchParams.set('redirect_uri', params.redirectUri);
+  url.searchParams.set('code_challenge', params.challenge);
+  url.searchParams.set('code_challenge_method', 'S256');
+  url.searchParams.set('state', params.state);
+  return url.toString();
+}
+
+type SlackTokenResponse = {
+  ok?: boolean;
+  error?: string;
+  team?: { id?: string; name?: string };
+  authed_user?: {
+    id?: string;
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    token_type?: string;
+  };
+};
+
+export function tokenResponseToCredentials(
+  json: SlackTokenResponse,
+  clientId: string,
+  previous?: Partial<SlackUserCredentials>,
+): SlackUserCredentials {
+  if (!json.ok) {
+    throw new Error(`Slack OAuth failed: ${json.error ?? 'unknown_error'}`);
+  }
+  const user = json.authed_user;
+  if (!user?.access_token) {
+    throw new Error('Slack OAuth response missing user access token');
+  }
+  return {
+    accessToken: user.access_token,
+    // Slack omits refresh_token when token rotation is off; keep the old one.
+    refreshToken: user.refresh_token ?? previous?.refreshToken,
+    expiresAt: Date.now() + (user.expires_in ?? DEFAULT_TOKEN_EXPIRES_IN_SECONDS) * 1000,
+    clientId,
+    teamId: json.team?.id ?? previous?.teamId,
+    teamName: json.team?.name ?? previous?.teamName,
+    userId: user.id ?? previous?.userId,
+  };
+}
+
+/** Exchange an authorization code for user-token credentials (no secret). */
+export async function exchangeAuthorizationCode(params: {
+  code: string;
+  verifier: string;
+  redirectUri: string;
+  clientId: string;
+}): Promise<SlackUserCredentials> {
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: params.clientId,
+      code: params.code,
+      code_verifier: params.verifier,
+      redirect_uri: params.redirectUri,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Slack token exchange HTTP ${response.status}: ${text}`);
+  }
+  return tokenResponseToCredentials((await response.json()) as SlackTokenResponse, params.clientId);
+}
+
+/** Slack error codes that mean the refresh token itself is dead. */
+const TERMINAL_REFRESH_ERRORS = new Set([
+  'invalid_refresh_token',
+  'invalid_grant_type',
+  'token_revoked',
+  'invalid_auth',
+]);
+
+/** Thrown when a refresh fails because the refresh token is no longer usable. */
+export class SlackRefreshTokenDeadError extends Error {
+  constructor(slackError: string) {
+    super(`Slack refresh token is no longer valid (${slackError}). Run the connect flow again.`);
+    this.name = 'SlackRefreshTokenDeadError';
+  }
+}
+
+/**
+ * Refresh user-token credentials. The response contains a NEW refresh token;
+ * the caller must persist the returned credentials immediately.
+ *
+ * @throws SlackRefreshTokenDeadError when the refresh token is dead and the
+ *   user needs to reconnect (vs a transient network/HTTP failure).
+ */
+export async function refreshUserToken(credentials: SlackUserCredentials): Promise<SlackUserCredentials> {
+  const clientId = resolveSlackClientId(credentials.clientId);
+  if (!clientId) {
+    throw new Error('Cannot refresh Slack token: no client_id available');
+  }
+  if (!credentials.refreshToken) {
+    throw new Error('Cannot refresh Slack token: no refresh token stored');
+  }
+  const response = await fetch(TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      refresh_token: credentials.refreshToken,
+    }),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`Slack token refresh HTTP ${response.status}: ${text}`);
+  }
+  const json = (await response.json()) as SlackTokenResponse;
+  if (!json.ok && json.error && TERMINAL_REFRESH_ERRORS.has(json.error)) {
+    throw new SlackRefreshTokenDeadError(json.error);
+  }
+  return tokenResponseToCredentials(json, clientId, credentials);
+}
+
+export type LoopbackServer = {
+  redirectUri: string;
+  close: () => void;
+  cancel: () => void;
+  waitForCode: (timeoutMs?: number) => Promise<string | null>;
+};
+
+/**
+ * Start a loopback HTTP server on one of {@link SLACK_CALLBACK_PORTS} to
+ * receive the OAuth redirect. Throws when all ports are busy.
+ */
+export async function startLoopbackServer(state: string): Promise<LoopbackServer> {
+  let lastCode: string | null = null;
+  let cancelled = false;
+
+  const server = createServer((req, res) => {
+    try {
+      const url = new URL(req.url || '', 'http://localhost');
+      if (url.pathname !== '/callback') {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+      if (url.searchParams.get('state') !== state) {
+        res.statusCode = 400;
+        res.end('State mismatch');
+        return;
+      }
+      const code = url.searchParams.get('code');
+      if (!code) {
+        res.statusCode = 400;
+        res.end('Missing authorization code');
+        return;
+      }
+      res.statusCode = 200;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.end(SUCCESS_HTML);
+      lastCode = code;
+    } catch {
+      res.statusCode = 500;
+      res.end('Internal error');
+    }
+  });
+
+  const listen = (port: number): Promise<boolean> =>
+    new Promise(resolve => {
+      const onError = () => {
+        server.off('listening', onListening);
+        resolve(false);
+      };
+      const onListening = () => {
+        server.off('error', onError);
+        resolve(true);
+      };
+      server.once('error', onError);
+      server.once('listening', onListening);
+      server.listen(port, '127.0.0.1');
+    });
+
+  let boundPort: number | null = null;
+  for (const port of SLACK_CALLBACK_PORTS) {
+    if (await listen(port)) {
+      boundPort = port;
+      break;
+    }
+  }
+
+  if (boundPort === null) {
+    throw new Error(
+      `Slack OAuth requires one of localhost ports ${SLACK_CALLBACK_PORTS.join(', ')}, but all are in use. Free one and retry.`,
+    );
+  }
+
+  return {
+    redirectUri: `http://localhost:${boundPort}/callback`,
+    close: () => server.close(),
+    cancel: () => {
+      cancelled = true;
+    },
+    waitForCode: async (timeoutMs = 180_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (lastCode) return lastCode;
+        if (cancelled) return null;
+        await new Promise(r => setTimeout(r, 100));
+      }
+      return null;
+    },
+  };
+}
+
+/** Parse a pasted redirect URL, query string, or raw authorization code. */
+export function parseAuthorizationInput(input: string): { code?: string; state?: string } {
+  const value = input.trim();
+  if (!value) return {};
+  try {
+    const url = new URL(value);
+    return {
+      code: url.searchParams.get('code') ?? undefined,
+      state: url.searchParams.get('state') ?? undefined,
+    };
+  } catch {
+    // not a URL; fall through
+  }
+  if (value.includes('code=')) {
+    const params = new URLSearchParams(value);
+    return { code: params.get('code') ?? undefined, state: params.get('state') ?? undefined };
+  }
+  return { code: value };
+}

--- a/channels/slack/src/user-auth/pkce.ts
+++ b/channels/slack/src/user-auth/pkce.ts
@@ -1,0 +1,31 @@
+/**
+ * PKCE (RFC 7636) utilities using the Web Crypto API (global in Node.js 20+).
+ */
+
+function base64urlEncode(bytes: Uint8Array): string {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+}
+
+/** Generate a PKCE code verifier and its S256 challenge. */
+export async function generatePKCE(): Promise<{ verifier: string; challenge: string }> {
+  const verifierBytes = new Uint8Array(32);
+  crypto.getRandomValues(verifierBytes);
+  const verifier = base64urlEncode(verifierBytes);
+
+  const data = new TextEncoder().encode(verifier);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const challenge = base64urlEncode(new Uint8Array(hashBuffer));
+
+  return { verifier, challenge };
+}
+
+/** Generate a random OAuth `state` value. */
+export function generateState(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return [...bytes].map(b => b.toString(16).padStart(2, '0')).join('');
+}

--- a/channels/slack/src/user-auth/user-auth.test.ts
+++ b/channels/slack/src/user-auth/user-auth.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import type { SlackUserCredentials } from './credential-storage';
+import { InMemorySlackCredentialStorage } from './credential-storage';
+import { buildAuthorizeUrl, parseAuthorizationInput, tokenResponseToCredentials } from './oauth';
+import { SlackAuthReconnectRequiredError, SlackAuthRequiredError, SlackUserAuth } from './user-auth';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+function jsonResponse(body: Record<string, unknown>) {
+  return new Response(JSON.stringify(body), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function refreshResponse(overrides: Record<string, unknown> = {}) {
+  return jsonResponse({
+    ok: true,
+    team: { id: 'T1', name: 'Team One' },
+    authed_user: {
+      id: 'U1',
+      access_token: 'xoxe.xoxp-refreshed',
+      refresh_token: 'xoxe-1-rotated',
+      expires_in: 43200,
+      token_type: 'user',
+    },
+    ...overrides,
+  });
+}
+
+function liveCredentials(overrides: Partial<SlackUserCredentials> = {}): SlackUserCredentials {
+  return {
+    accessToken: 'xoxp-live',
+    refreshToken: 'xoxe-1-old',
+    expiresAt: Date.now() + 60 * 60 * 1000, // 1h out
+    clientId: 'client-123',
+    teamId: 'T1',
+    teamName: 'Team One',
+    userId: 'U1',
+    ...overrides,
+  };
+}
+
+function expiredCredentials(overrides: Partial<SlackUserCredentials> = {}): SlackUserCredentials {
+  return liveCredentials({ expiresAt: Date.now() - 1000, ...overrides });
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('SlackUserAuth.getToken', () => {
+  it('throws SlackAuthRequiredError when no credentials are stored', async () => {
+    const auth = new SlackUserAuth({ storage: new InMemorySlackCredentialStorage() });
+    await expect(auth.getToken()).rejects.toBeInstanceOf(SlackAuthRequiredError);
+  });
+
+  it('returns the stored token when not near expiry (no refresh)', async () => {
+    const storage = new InMemorySlackCredentialStorage(liveCredentials());
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).resolves.toBe('xoxp-live');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('refreshes proactively when within the refresh skew', async () => {
+    const storage = new InMemorySlackCredentialStorage(
+      liveCredentials({ expiresAt: Date.now() + 60 * 1000 }), // 1 min out, default skew 5 min
+    );
+    mockFetch.mockResolvedValueOnce(refreshResponse());
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).resolves.toBe('xoxe.xoxp-refreshed');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists the rotated refresh token before returning', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    mockFetch.mockResolvedValueOnce(refreshResponse());
+    const auth = new SlackUserAuth({ storage });
+
+    await auth.getToken();
+
+    const stored = await storage.load();
+    expect(stored?.accessToken).toBe('xoxe.xoxp-refreshed');
+    expect(stored?.refreshToken).toBe('xoxe-1-rotated');
+    expect(stored?.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('sends grant_type=refresh_token with the stored client_id and no secret', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    mockFetch.mockResolvedValueOnce(refreshResponse());
+    const auth = new SlackUserAuth({ storage });
+
+    await auth.getToken();
+
+    const body = mockFetch.mock.calls[0]![1]!.body as URLSearchParams;
+    expect(body.get('grant_type')).toBe('refresh_token');
+    expect(body.get('client_id')).toBe('client-123');
+    expect(body.get('refresh_token')).toBe('xoxe-1-old');
+    expect(body.get('client_secret')).toBeNull();
+  });
+
+  it('keeps the previous refresh token when the response omits one', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    mockFetch.mockResolvedValueOnce(
+      refreshResponse({
+        authed_user: { id: 'U1', access_token: 'xoxp-new', expires_in: 43200 },
+      }),
+    );
+    const auth = new SlackUserAuth({ storage });
+
+    await auth.getToken();
+
+    const stored = await storage.load();
+    expect(stored?.refreshToken).toBe('xoxe-1-old');
+  });
+
+  it('dedupes concurrent refreshes into a single rotation', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    let resolveFetch!: (r: Response) => void;
+    mockFetch.mockReturnValueOnce(new Promise<Response>(r => (resolveFetch = r)));
+    const auth = new SlackUserAuth({ storage });
+
+    const [a, b] = [auth.getToken(), auth.getToken()];
+    resolveFetch(refreshResponse());
+
+    await expect(a).resolves.toBe('xoxe.xoxp-refreshed');
+    await expect(b).resolves.toBe('xoxe.xoxp-refreshed');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-reads storage before refreshing (another process already rotated)', async () => {
+    // First load (getToken) sees expired creds; the re-read inside the
+    // refresh path sees fresh creds rotated by another process.
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    const loads = [expiredCredentials(), liveCredentials({ accessToken: 'xoxp-rotated-elsewhere' })];
+    vi.spyOn(storage, 'load').mockImplementation(async () => loads.shift());
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).resolves.toBe('xoxp-rotated-elsewhere');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('marks credentials needsReconnect and throws when the refresh token is dead', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    mockFetch.mockResolvedValueOnce(jsonResponse({ ok: false, error: 'invalid_refresh_token' }));
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).rejects.toBeInstanceOf(SlackAuthReconnectRequiredError);
+    const stored = await storage.load();
+    expect(stored?.needsReconnect).toBe(true);
+
+    // Subsequent calls fail fast without hitting Slack again.
+    mockFetch.mockClear();
+    await expect(auth.getToken()).rejects.toBeInstanceOf(SlackAuthReconnectRequiredError);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('does not flag needsReconnect on transient HTTP failures', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    mockFetch.mockResolvedValueOnce(new Response('gateway timeout', { status: 504 }));
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).rejects.toThrow('HTTP 504');
+    const stored = await storage.load();
+    expect(stored?.needsReconnect).toBeUndefined();
+  });
+
+  it('returns a non-rotating token as-is even when expiresAt has passed', async () => {
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials({ refreshToken: undefined }));
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).resolves.toBe('xoxp-live');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('SlackUserAuth static token mode', () => {
+  it('returns the static token without touching storage or network', async () => {
+    const storage = new InMemorySlackCredentialStorage();
+    const loadSpy = vi.spyOn(storage, 'load');
+    const auth = new SlackUserAuth({ token: 'xoxp-static', storage });
+
+    await expect(auth.getToken()).resolves.toBe('xoxp-static');
+    expect(loadSpy).not.toHaveBeenCalled();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('resolves userId via auth.test and caches it', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ ok: true, user_id: 'U42' }));
+    const auth = new SlackUserAuth({ token: 'xoxp-static' });
+
+    await expect(auth.getUserId()).resolves.toBe('U42');
+    await expect(auth.getUserId()).resolves.toBe('U42');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SlackUserAuth.getStatus', () => {
+  it('reports disconnected when nothing is stored', async () => {
+    const auth = new SlackUserAuth({ storage: new InMemorySlackCredentialStorage() });
+    await expect(auth.getStatus()).resolves.toEqual({ connected: false, needsReconnect: false });
+  });
+
+  it('reports needsReconnect from stored credentials', async () => {
+    const storage = new InMemorySlackCredentialStorage(liveCredentials({ needsReconnect: true }));
+    const auth = new SlackUserAuth({ storage });
+
+    const status = await auth.getStatus();
+    expect(status.connected).toBe(false);
+    expect(status.needsReconnect).toBe(true);
+    expect(status.teamName).toBe('Team One');
+  });
+
+  it('reports connected with team/user details', async () => {
+    const storage = new InMemorySlackCredentialStorage(liveCredentials());
+    const auth = new SlackUserAuth({ storage });
+
+    const status = await auth.getStatus();
+    expect(status.connected).toBe(true);
+    expect(status.userId).toBe('U1');
+  });
+});
+
+describe('oauth helpers', () => {
+  it('buildAuthorizeUrl uses user_scope and PKCE params', () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        clientId: 'cid',
+        redirectUri: 'http://localhost:41927/callback',
+        scopes: ['im:history', 'users:read'],
+        challenge: 'chal',
+        state: 'st',
+      }),
+    );
+    expect(url.origin + url.pathname).toBe('https://slack.com/oauth/v2/authorize');
+    expect(url.searchParams.get('user_scope')).toBe('im:history,users:read');
+    expect(url.searchParams.get('scope')).toBeNull();
+    expect(url.searchParams.get('code_challenge')).toBe('chal');
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+  });
+
+  it('parseAuthorizationInput handles URLs, query strings, and raw codes', () => {
+    expect(parseAuthorizationInput('http://localhost:41927/callback?code=abc&state=st')).toEqual({
+      code: 'abc',
+      state: 'st',
+    });
+    expect(parseAuthorizationInput('code=abc&state=st')).toEqual({ code: 'abc', state: 'st' });
+    expect(parseAuthorizationInput('rawcode')).toEqual({ code: 'rawcode' });
+    expect(parseAuthorizationInput('')).toEqual({});
+  });
+
+  it('tokenResponseToCredentials maps the authed_user payload', () => {
+    const credentials = tokenResponseToCredentials(
+      {
+        ok: true,
+        team: { id: 'T9', name: 'Nine' },
+        authed_user: { id: 'U9', access_token: 'xoxp-9', refresh_token: 'xoxe-9', expires_in: 100 },
+      },
+      'cid',
+    );
+    expect(credentials.accessToken).toBe('xoxp-9');
+    expect(credentials.refreshToken).toBe('xoxe-9');
+    expect(credentials.clientId).toBe('cid');
+    expect(credentials.teamId).toBe('T9');
+    expect(credentials.userId).toBe('U9');
+    expect(credentials.expiresAt).toBeGreaterThan(Date.now());
+  });
+
+  it('tokenResponseToCredentials throws on error payloads', () => {
+    expect(() => tokenResponseToCredentials({ ok: false, error: 'access_denied' }, 'cid')).toThrow(
+      'Slack OAuth failed: access_denied',
+    );
+  });
+});

--- a/channels/slack/src/user-auth/user-auth.test.ts
+++ b/channels/slack/src/user-auth/user-auth.test.ts
@@ -14,17 +14,20 @@ function jsonResponse(body: Record<string, unknown>) {
   });
 }
 
+/**
+ * Real `refresh_token` grant response shape (verified against the live API):
+ * the rotated user token comes back at the TOP level with `token_type: "user"`
+ * — there is no `authed_user` nesting like the initial code exchange.
+ */
 function refreshResponse(overrides: Record<string, unknown> = {}) {
   return jsonResponse({
     ok: true,
+    access_token: 'xoxe.xoxp-refreshed',
+    refresh_token: 'xoxe-1-rotated',
+    expires_in: 43200,
+    token_type: 'user',
+    user_id: 'U1',
     team: { id: 'T1', name: 'Team One' },
-    authed_user: {
-      id: 'U1',
-      access_token: 'xoxe.xoxp-refreshed',
-      refresh_token: 'xoxe-1-rotated',
-      expires_in: 43200,
-      token_type: 'user',
-    },
     ...overrides,
   });
 }
@@ -109,8 +112,12 @@ describe('SlackUserAuth.getToken', () => {
   it('keeps the previous refresh token when the response omits one', async () => {
     const storage = new InMemorySlackCredentialStorage(expiredCredentials());
     mockFetch.mockResolvedValueOnce(
-      refreshResponse({
-        authed_user: { id: 'U1', access_token: 'xoxp-new', expires_in: 43200 },
+      jsonResponse({
+        ok: true,
+        access_token: 'xoxp-new',
+        expires_in: 43200,
+        token_type: 'user',
+        user_id: 'U1',
       }),
     );
     const auth = new SlackUserAuth({ storage });
@@ -119,6 +126,29 @@ describe('SlackUserAuth.getToken', () => {
 
     const stored = await storage.load();
     expect(stored?.refreshToken).toBe('xoxe-1-old');
+  });
+
+  it('also accepts a refresh response nested under authed_user (code-exchange shape)', async () => {
+    // Defensive: the initial code exchange nests the user token; tolerate both.
+    const storage = new InMemorySlackCredentialStorage(expiredCredentials());
+    mockFetch.mockResolvedValueOnce(
+      jsonResponse({
+        ok: true,
+        team: { id: 'T1', name: 'Team One' },
+        authed_user: {
+          id: 'U1',
+          access_token: 'xoxe.xoxp-nested',
+          refresh_token: 'xoxe-1-nested-rotated',
+          expires_in: 43200,
+          token_type: 'user',
+        },
+      }),
+    );
+    const auth = new SlackUserAuth({ storage });
+
+    await expect(auth.getToken()).resolves.toBe('xoxe.xoxp-nested');
+    const stored = await storage.load();
+    expect(stored?.refreshToken).toBe('xoxe-1-nested-rotated');
   });
 
   it('dedupes concurrent refreshes into a single rotation', async () => {

--- a/channels/slack/src/user-auth/user-auth.ts
+++ b/channels/slack/src/user-auth/user-auth.ts
@@ -1,0 +1,270 @@
+import type { SlackCredentialStorage, SlackUserCredentials } from './credential-storage';
+import { FileSlackCredentialStorage } from './credential-storage';
+import {
+  buildAuthorizeUrl,
+  exchangeAuthorizationCode,
+  parseAuthorizationInput,
+  refreshUserToken,
+  resolveSlackClientId,
+  SlackRefreshTokenDeadError,
+  startLoopbackServer,
+} from './oauth';
+import { generatePKCE, generateState } from './pkce';
+
+/**
+ * Default user-token scopes requested during connect. Enough for SlackSignals
+ * to read subscribed conversations and resolve authors.
+ */
+export const DEFAULT_SLACK_USER_SCOPES: readonly string[] = [
+  'channels:history',
+  'groups:history',
+  'im:history',
+  'mpim:history',
+  'users:read',
+];
+
+/** Refresh the access token this many ms before it expires. */
+const DEFAULT_REFRESH_SKEW_MS = 5 * 60 * 1000;
+
+/** Thrown when no credentials exist yet — the user must run `connect()`. */
+export class SlackAuthRequiredError extends Error {
+  constructor() {
+    super('Not connected to Slack. Run the connect flow (SlackUserAuth.connect) or supply a static token.');
+    this.name = 'SlackAuthRequiredError';
+  }
+}
+
+/**
+ * Thrown when stored credentials can no longer be refreshed (dead refresh
+ * token). The user must run `connect()` again.
+ */
+export class SlackAuthReconnectRequiredError extends Error {
+  constructor(cause?: string) {
+    super(`Slack connection expired and could not be refreshed${cause ? ` (${cause})` : ''}. Reconnect required.`);
+    this.name = 'SlackAuthReconnectRequiredError';
+  }
+}
+
+export interface SlackUserAuthOptions {
+  /**
+   * Static user token (`xoxp-…`). Bypasses OAuth, storage, and refresh
+   * entirely — for headless/CI environments that manage tokens themselves.
+   */
+  token?: string;
+  /**
+   * OAuth client_id of a pre-existing Slack app configured as a PKCE public
+   * client. Falls back to the `MASTRA_SLACK_CLIENT_ID` env var.
+   */
+  clientId?: string;
+  /** User-token scopes to request during connect. */
+  scopes?: string[];
+  /** Credential persistence. Defaults to `~/.mastra/slack-auth.json` (0600). */
+  storage?: SlackCredentialStorage;
+  /** Refresh this many ms before `expiresAt`. Default 5 minutes. */
+  refreshSkewMs?: number;
+}
+
+export interface SlackConnectCallbacks {
+  /** Called with the authorize URL — open it in a browser or display it. */
+  onAuthUrl: (url: string) => void | Promise<void>;
+  /**
+   * Fallback when the loopback callback never arrives (e.g. remote shell):
+   * prompt the user to paste the redirect URL or code.
+   */
+  onManualCodeInput?: () => Promise<string>;
+}
+
+export interface SlackAuthStatus {
+  connected: boolean;
+  needsReconnect: boolean;
+  teamId?: string;
+  teamName?: string;
+  userId?: string;
+  expiresAt?: number;
+}
+
+/**
+ * Manages a Slack **user-token** connection against a pre-existing Slack app.
+ *
+ * - `connect()` runs the PKCE loopback OAuth flow and persists credentials.
+ * - `getToken()` returns a live access token, transparently refreshing it
+ *   before expiry. Slack rotates the refresh token on every refresh, so each
+ *   rotation is persisted atomically before the new token is handed out.
+ * - When the refresh token dies, the stored credentials are flagged
+ *   `needsReconnect` and `getToken()` throws {@link SlackAuthReconnectRequiredError}
+ *   instead of surfacing raw `invalid_token` API errors.
+ *
+ * Distinct from `SlackProvider` (channels), which owns **bot-token**
+ * credentials for apps it creates. This class authorizes a user account so
+ * the caller can act as that user (read anything the user can see).
+ */
+export class SlackUserAuth {
+  readonly #staticToken?: string;
+  readonly #clientId?: string;
+  readonly #scopes: string[];
+  readonly #storage: SlackCredentialStorage;
+  readonly #refreshSkewMs: number;
+
+  /** In-flight refresh, shared so concurrent callers don't double-rotate. */
+  #refreshPromise: Promise<SlackUserCredentials> | null = null;
+  /** Cached userId for static-token mode (resolved via `auth.test`). */
+  #staticTokenUserId?: string;
+
+  constructor(options: SlackUserAuthOptions = {}) {
+    this.#staticToken = options.token?.trim() || undefined;
+    this.#clientId = options.clientId;
+    this.#scopes = options.scopes ? [...options.scopes] : [...DEFAULT_SLACK_USER_SCOPES];
+    this.#storage = options.storage ?? new FileSlackCredentialStorage();
+    this.#refreshSkewMs = options.refreshSkewMs ?? DEFAULT_REFRESH_SKEW_MS;
+  }
+
+  /**
+   * Run the PKCE loopback connect flow: build the authorize URL, wait for the
+   * redirect (or manual paste), exchange the code, persist credentials.
+   */
+  async connect(callbacks: SlackConnectCallbacks): Promise<SlackUserCredentials> {
+    const clientId = resolveSlackClientId(this.#clientId);
+    if (!clientId) {
+      throw new Error(
+        'No Slack client_id available. Pass `clientId` (or set MASTRA_SLACK_CLIENT_ID) for a Slack app configured as a PKCE public client.',
+      );
+    }
+
+    const state = generateState();
+    const { verifier, challenge } = await generatePKCE();
+    const server = await startLoopbackServer(state);
+
+    const url = buildAuthorizeUrl({
+      clientId,
+      redirectUri: server.redirectUri,
+      scopes: this.#scopes,
+      challenge,
+      state,
+    });
+
+    try {
+      await callbacks.onAuthUrl(url);
+
+      let code = await server.waitForCode();
+      if (!code && callbacks.onManualCodeInput) {
+        const parsed = parseAuthorizationInput(await callbacks.onManualCodeInput());
+        if (parsed.state && parsed.state !== state) {
+          throw new Error('State mismatch');
+        }
+        code = parsed.code ?? null;
+      }
+      if (!code) {
+        throw new Error('Slack authorization did not complete (no authorization code received)');
+      }
+
+      const credentials = await exchangeAuthorizationCode({
+        code,
+        verifier,
+        redirectUri: server.redirectUri,
+        clientId,
+      });
+      await this.#storage.save(credentials);
+      return credentials;
+    } finally {
+      server.close();
+    }
+  }
+
+  /**
+   * Get a live access token, refreshing (and persisting the rotation) when
+   * the stored token is expired or within the refresh skew.
+   */
+  async getToken(): Promise<string> {
+    if (this.#staticToken) return this.#staticToken;
+
+    const credentials = await this.#storage.load();
+    if (!credentials) throw new SlackAuthRequiredError();
+    if (credentials.needsReconnect) throw new SlackAuthReconnectRequiredError();
+
+    if (!this.#isExpiring(credentials)) return credentials.accessToken;
+
+    // Token can't be refreshed (no rotation) — hand it out and let the API
+    // call fail loudly if it's actually dead.
+    if (!credentials.refreshToken) return credentials.accessToken;
+
+    const refreshed = await this.#refreshAndPersist(credentials);
+    return refreshed.accessToken;
+  }
+
+  /** The authed user's Slack id — used to skip the user's own messages. */
+  async getUserId(): Promise<string | undefined> {
+    if (this.#staticToken) {
+      if (!this.#staticTokenUserId) {
+        try {
+          const response = await fetch('https://slack.com/api/auth.test', {
+            method: 'POST',
+            headers: { Authorization: `Bearer ${this.#staticToken}` },
+          });
+          const json = (await response.json()) as { ok?: boolean; user_id?: string };
+          if (json.ok && json.user_id) this.#staticTokenUserId = json.user_id;
+        } catch {
+          // best-effort; self-skip degrades gracefully without it
+        }
+      }
+      return this.#staticTokenUserId;
+    }
+    const credentials = await this.#storage.load();
+    return credentials?.userId;
+  }
+
+  /** Connection status for UIs/status commands. */
+  async getStatus(): Promise<SlackAuthStatus> {
+    if (this.#staticToken) {
+      return { connected: true, needsReconnect: false };
+    }
+    const credentials = await this.#storage.load();
+    if (!credentials) return { connected: false, needsReconnect: false };
+    return {
+      connected: !credentials.needsReconnect,
+      needsReconnect: credentials.needsReconnect === true,
+      teamId: credentials.teamId,
+      teamName: credentials.teamName,
+      userId: credentials.userId,
+      expiresAt: credentials.expiresAt,
+    };
+  }
+
+  /** Remove stored credentials. */
+  async disconnect(): Promise<void> {
+    await this.#storage.clear();
+  }
+
+  #isExpiring(credentials: SlackUserCredentials): boolean {
+    if (!credentials.expiresAt) return false;
+    return Date.now() >= credentials.expiresAt - this.#refreshSkewMs;
+  }
+
+  async #refreshAndPersist(credentials: SlackUserCredentials): Promise<SlackUserCredentials> {
+    if (this.#refreshPromise) return this.#refreshPromise;
+
+    this.#refreshPromise = (async () => {
+      // Re-read storage first: another process sharing the credential file
+      // may have already rotated (our refresh token would now be dead).
+      const latest = (await this.#storage.load()) ?? credentials;
+      if (latest.needsReconnect) throw new SlackAuthReconnectRequiredError();
+      if (!this.#isExpiring(latest)) return latest;
+
+      try {
+        const refreshed = await refreshUserToken(latest);
+        // Persist BEFORE returning — the old refresh token is single-use.
+        await this.#storage.save(refreshed);
+        return refreshed;
+      } catch (error) {
+        if (error instanceof SlackRefreshTokenDeadError) {
+          await this.#storage.save({ ...latest, needsReconnect: true });
+          throw new SlackAuthReconnectRequiredError(error.message);
+        }
+        throw error;
+      }
+    })().finally(() => {
+      this.#refreshPromise = null;
+    });
+
+    return this.#refreshPromise;
+  }
+}


### PR DESCRIPTION
## Summary

Connect your **own Slack user account** to Mastra agents — no bot install, no webhooks, no infra.

Two pieces:

### `SlackUserAuth` (`@mastra/slack`)
A shared auth helper that authorizes a Slack user account against a pre-existing Slack app via PKCE OAuth (public client, no client secret — Mastra app `client_id` by default or BYO):

- PKCE loopback connect flow (local redirect server, browser authorize)
- **Rotation-safe refresh**: Slack rotates the refresh token on every refresh; each rotation is persisted atomically *before* the new token is used. Fixes the `invalid_token`-after-a-day failure mode seen with token rotation.
- Handles both Slack OAuth response shapes (`oauth.v2.access` nests the user token under `authed_user`; the `refresh_token` grant returns it at the top level)
- Clear `needsReconnect` state when the refresh token dies, instead of silent `invalid_token`
- Pluggable credential storage (file-based default at `~/.mastra/slack-auth.json`, 0600, atomic writes) + static `token` escape hatch for headless/CI

### Mastra Code Slack plugin (`mastracode/plugins/slack`)
An MC plugin that consumes `SlackUserAuth` and exposes Slack tools acting as the connected user:

- `slack_connect` / `slack_status` / `slack_disconnect`
- Read tools: `slack_search` (Slack search syntax), channel/thread/message fetch, user lookup — built on chat-sdk's Slack adapter + `chat/ai` tools, with the user token supplied through the adapter's per-call `botToken` function seam
- Write tools (`slack_post_message`, `slack_send_direct_message`, `slack_add_reaction`, …) gated behind a `readWrite` config option that also widens the requested OAuth scopes

## Relationship to other Slack pieces
- `SlackProvider` (channels): bot identity, webhook-driven, needs a public endpoint. This PR: user identity, outbound-only, zero infra.
- `SlackSignals` (#19079): polling signal provider that wakes agents on subscribed threads — will be restacked onto this branch and reduced to just the provider.
- #19017 (MCP/PKCE `/slack` command) stays open as reference; its PKCE flow is now a shared package helper instead of MC-owned code.

## Test plan
- [x] 21 `SlackUserAuth` unit tests (PKCE, credential storage, OAuth exchange, rotation persistence, refresh-failure handling); 89 package tests green
- [x] Plugin typecheck (`tsc --noEmit`) clean
- [x] Live smoke test with a real user token: plugin loads, tools build, `slack_status` / `slack_fetch_channel_messages` / `slack_get_user` return live data; write tools only appear with `readWrite: true`; scope-gated tools fail cleanly with a legacy-scoped token
- [ ] Fresh end-to-end `slack_connect` browser flow (needs re-consent with the updated scope set)

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>