### PR TITLE
fix(core): retry plain OpenAI retryable errors

### DIFF
--- a/.changeset/clear-parrots-make.md
+++ b/.changeset/clear-parrots-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed retries for plain OpenAI retryable errors.

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -117,6 +117,16 @@ describe('StreamErrorRetryProcessor', () => {
     await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
   });
 
+  it('retries plain OpenAI retry guidance errors by default', async () => {
+    const processor = new StreamErrorRetryProcessor();
+    const error = new Error(
+      'An error occurred while processing your request. You can retry your request, or contact us through our help center at help.openai.com if the error persists. Please include the request ID f8c5b61a-372c-4fcd-98d1-45a2744470cc in your message.',
+    );
+
+    expect(isRetryableOpenAIResponsesStreamError(error)).toBe(true);
+    await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
+  });
+
   it('retries stream errors through additional matchers', async () => {
     const processor = new StreamErrorRetryProcessor({
       matchers: [error => error instanceof Error && error.message === 'custom retryable stream error'],

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -98,13 +98,26 @@ function hasExplicitRetryMessage(payload: Record<string, unknown>): boolean {
   return message !== undefined && OPENAI_RETRY_MESSAGE_PATTERN.test(message);
 }
 
-export function isRetryableOpenAIResponsesStreamError(error: unknown): boolean {
-  const payload = getOpenAIErrorPayload(error);
-  if (!payload) {
-    return false;
+function getErrorMessage(error: unknown): string | undefined {
+  if (error instanceof Error) {
+    return error.message;
   }
 
-  return hasRetryableOpenAIErrorCode(payload) || hasExplicitRetryMessage(payload);
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return getStringProperty(error, 'message');
+}
+
+export function isRetryableOpenAIResponsesStreamError(error: unknown): boolean {
+  const payload = getOpenAIErrorPayload(error);
+  if (payload) {
+    return hasRetryableOpenAIErrorCode(payload) || hasExplicitRetryMessage(payload);
+  }
+
+  const message = getErrorMessage(error);
+  return message !== undefined && OPENAI_RETRY_MESSAGE_PATTERN.test(message);
 }
 
 /**


### PR DESCRIPTION
## Summary
- retry plain OpenAI retry-guidance errors in StreamErrorRetryProcessor
- preserve existing structured OpenAI Responses envelope matching
- add coverage for the plain request-ID error shape observed in MastraCode

## Test plan
- pnpm --filter ./packages/core exec vitest run src/processors/stream-error-retry-processor.test.ts --reporter=dot --bail 1
- pnpm --filter ./packages/core check

## Notes
This does not prove every live MastraCode request-ID error is fixed; it ensures the plain Error shape now flows through the existing retry policy when it reaches StreamErrorRetryProcessor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change teaches the retry logic to notice another kind of OpenAI error message that can show up as a plain `Error`, not just in a structured response. That means some failures that should be tried again will now be retried correctly instead of being missed.

## Summary
- Expanded `StreamErrorRetryProcessor` to detect retry-guidance text from top-level `Error.message` values when no OpenAI payload is present.
- Kept the existing structured OpenAI Responses envelope handling unchanged.
- Added a test covering the plain `Error` retry case.
- Added a changeset for the `@mastra/core` patch release noting the retry fix for plain OpenAI retryable errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->