### PR TITLE
feat(observability): opt-in spans for provider-executed (server-side) tools

### DIFF
--- a/.changeset/trace-server-tool-spans.md
+++ b/.changeset/trace-server-tool-spans.md
@@ -14,7 +14,21 @@ Enable the new `traceServerTools` observability config option (off by default) t
 reconstruct a `TOOL_CALL` span from the stream — input = tool args from the `tool-call`
 chunk, output = result from the paired `tool-result` chunk. The span is anchored on the
 agent-run span (as client-tool spans are) so it is durable regardless of
-`includeInternalSpans`. Can also be enabled with the `MASTRA_TRACE_SERVER_TOOLS=true`
+`includeInternalSpans`. It can also be enabled with the `MASTRA_TRACE_SERVER_TOOLS=true`
 environment variable.
+
+```ts
+import { Observability, MastraStorageExporter } from '@mastra/observability';
+
+new Observability({
+  configs: {
+    default: {
+      serviceName: 'my-service',
+      traceServerTools: true, // record provider-executed (server-side) tool calls
+      exporters: [new MastraStorageExporter()],
+    },
+  },
+});
+```
 
 Resolves #19180.

--- a/.changeset/trace-server-tool-spans.md
+++ b/.changeset/trace-server-tool-spans.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': minor
+'@mastra/observability': minor
+---
+
+Add opt-in observability spans for provider-executed (server-side) tools
+
+Provider-executed tools — e.g. Anthropic native code execution or server-side web search —
+run on the model provider, so the agent loop never enters Mastra's tool-execution path and
+no span is created; the tool's input and output are otherwise invisible in traces (unlike
+client-executed tools, which get a `CLIENT_TOOL_CALL` span).
+
+Enable the new `traceServerTools` observability config option (off by default) to
+reconstruct a `TOOL_CALL` span from the stream — input = tool args from the `tool-call`
+chunk, output = result from the paired `tool-result` chunk. The span is anchored on the
+agent-run span (as client-tool spans are) so it is durable regardless of
+`includeInternalSpans`. Can also be enabled with the `MASTRA_TRACE_SERVER_TOOLS=true`
+environment variable.
+
+Resolves #19180.

--- a/observability/mastra/src/config.ts
+++ b/observability/mastra/src/config.ts
@@ -79,6 +79,13 @@ export interface ObservabilityInstanceConfig {
   /** Set to `true` if you want to see spans internal to the operation of mastra */
   includeInternalSpans?: boolean;
   /**
+   * Set to `true` to emit tool-call spans for provider-executed (server-side) tools —
+   * e.g. Anthropic native code execution or server-side web search. These tools run on the
+   * model provider, so Mastra never enters its own tool-execution path and emits no span by
+   * default; their input/output are otherwise invisible in traces. Off by default.
+   */
+  traceServerTools?: boolean;
+  /**
    * Span types to exclude from export. Spans of these types are silently dropped
    * before reaching exporters. This is useful for reducing noise and costs in
    * observability platforms that charge per-span (e.g., Langfuse).
@@ -235,6 +242,7 @@ const observabilityInstanceConfigFields = {
   bridge: z.any().optional(),
   spanOutputProcessors: z.array(z.any()).optional(),
   includeInternalSpans: z.boolean().optional(),
+  traceServerTools: z.boolean().optional(),
   excludeSpanTypes: z.array(z.nativeEnum(SpanType)).optional(),
   spanFilter: spanFilterSchema,
   requestContextKeys: z.array(z.string()).optional(),

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -88,6 +88,7 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
       spanOutputProcessors: config.spanOutputProcessors ?? [],
       bridge: config.bridge ?? undefined,
       includeInternalSpans: config.includeInternalSpans ?? false,
+      traceServerTools: config.traceServerTools ?? false,
       excludeSpanTypes: config.excludeSpanTypes,
       spanFilter: config.spanFilter,
       requestContextKeys: config.requestContextKeys ?? [],

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -678,6 +678,125 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
+  const createServerToolExecutionStep = (currentSpan: unknown) => {
+    const tools = {
+      perplexitySearch: {
+        type: 'provider' as const,
+        id: 'gateway.perplexity_search',
+        args: {},
+      },
+    };
+    const step = createLLMExecutionStep({
+      agentId: 'test-agent',
+      messageId: 'msg-0',
+      runId: 'test-run',
+      startTimestamp: Date.now(),
+      methodType: 'stream',
+      controller,
+      outputWriter: vi.fn(),
+      messageList,
+      models: [
+        {
+          id: 'test-model',
+          maxRetries: 0,
+          model: {
+            specificationVersion: 'v2' as const,
+            provider: 'mock-provider',
+            modelId: 'mock-model-id',
+            supportedUrls: {},
+            doGenerate: vi.fn(),
+            doStream: vi.fn(async () => ({
+              stream: convertArrayToReadableStream([
+                {
+                  type: 'tool-call',
+                  toolCallId: 'call-1',
+                  toolName: 'perplexity_search',
+                  input: '{"query":"latest AI agent news"}',
+                  providerExecuted: true,
+                },
+                {
+                  type: 'tool-result',
+                  toolCallId: 'call-1',
+                  toolName: 'perplexity_search',
+                  result: { answer: 'fresh gateway result' },
+                  providerExecuted: true,
+                },
+                {
+                  type: 'finish',
+                  finishReason: 'tool-calls',
+                  usage: testUsage,
+                },
+              ]),
+              request: {},
+              response: { headers: undefined },
+              warnings: [],
+            })),
+          } as any,
+        },
+      ],
+      tools,
+      streamState: { serialize: vi.fn(), deserialize: vi.fn() },
+      _internal: { generateId: () => 'generated-id' },
+      logger: { error: vi.fn(), warn: vi.fn(), debug: vi.fn() } as any,
+    } as unknown as OuterLLMRun<typeof tools>);
+    const executeParams = createExecuteParams(createIterationInput());
+    executeParams.tracingContext = { currentSpan } as any;
+    return { step, executeParams };
+  };
+
+  it('creates a server-tool span for provider-executed tools when traceServerTools is enabled', async () => {
+    const serverToolSpan = {
+      id: 'server-tool-span',
+      traceId: '1234567890abcdef1234567890abcdef',
+      type: SpanType.TOOL_CALL,
+      end: vi.fn(),
+    };
+    const agentRunSpan = {
+      id: 'agent-span',
+      traceId: '1234567890abcdef1234567890abcdef',
+      type: SpanType.AGENT_RUN,
+      createChildSpan: vi.fn(() => serverToolSpan),
+      findParent: vi.fn(),
+      observabilityInstance: { getConfig: () => ({ traceServerTools: true }) },
+    };
+
+    const { step, executeParams } = createServerToolExecutionStep(agentRunSpan);
+    await step.execute(executeParams);
+
+    expect(agentRunSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.TOOL_CALL,
+        name: 'perplexity_search',
+        entityType: 'tool',
+        entityId: 'perplexity_search',
+        entityName: 'perplexity_search',
+        attributes: expect.objectContaining({ toolType: 'server-tool' }),
+        input: { query: 'latest AI agent news' },
+      }),
+    );
+    expect(serverToolSpan.end).toHaveBeenCalledWith({ output: { answer: 'fresh gateway result' } });
+  });
+
+  it('does not create a server-tool span when traceServerTools is disabled (opt-in)', async () => {
+    const agentRunSpan = {
+      id: 'agent-span',
+      traceId: '1234567890abcdef1234567890abcdef',
+      type: SpanType.AGENT_RUN,
+      createChildSpan: vi.fn(),
+      findParent: vi.fn(),
+      observabilityInstance: { getConfig: () => ({ traceServerTools: false }) },
+    };
+
+    const { step, executeParams } = createServerToolExecutionStep(agentRunSpan);
+    await step.execute(executeParams);
+
+    expect(agentRunSpan.createChildSpan).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        attributes: expect.objectContaining({ toolType: 'server-tool' }),
+      }),
+    );
+  });
+
   it('resolves streamed tool payload transforms without rescanning tools per delta', async () => {
     const onInputDelta = vi.fn();
     const rawTools = {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.test.ts
@@ -678,7 +678,10 @@ describe('createLLMExecutionStep gateway provider tools', () => {
     });
   });
 
-  const createServerToolExecutionStep = (currentSpan: unknown) => {
+  const createServerToolExecutionStep = (
+    currentSpan: unknown,
+    { withProviderExecutedFlag = true }: { withProviderExecutedFlag?: boolean } = {},
+  ) => {
     const tools = {
       perplexitySearch: {
         type: 'provider' as const,
@@ -712,14 +715,14 @@ describe('createLLMExecutionStep gateway provider tools', () => {
                   toolCallId: 'call-1',
                   toolName: 'perplexity_search',
                   input: '{"query":"latest AI agent news"}',
-                  providerExecuted: true,
+                  ...(withProviderExecutedFlag ? { providerExecuted: true } : {}),
                 },
                 {
                   type: 'tool-result',
                   toolCallId: 'call-1',
                   toolName: 'perplexity_search',
                   result: { answer: 'fresh gateway result' },
-                  providerExecuted: true,
+                  ...(withProviderExecutedFlag ? { providerExecuted: true } : {}),
                 },
                 {
                   type: 'finish',
@@ -795,6 +798,39 @@ describe('createLLMExecutionStep gateway provider tools', () => {
         attributes: expect.objectContaining({ toolType: 'server-tool' }),
       }),
     );
+  });
+
+  it('creates a server-tool span for provider tools whose providerExecuted is inferred (not on the chunk)', async () => {
+    const serverToolSpan = {
+      id: 'server-tool-span',
+      traceId: '1234567890abcdef1234567890abcdef',
+      type: SpanType.TOOL_CALL,
+      end: vi.fn(),
+    };
+    const agentRunSpan = {
+      id: 'agent-span',
+      traceId: '1234567890abcdef1234567890abcdef',
+      type: SpanType.AGENT_RUN,
+      createChildSpan: vi.fn(() => serverToolSpan),
+      findParent: vi.fn(),
+      observabilityInstance: { getConfig: () => ({ traceServerTools: true }) },
+    };
+
+    // The `type: 'provider'` tool infers providerExecuted from its definition even though the
+    // raw stream chunks don't carry the flag — the span should still be created and closed.
+    const { step, executeParams } = createServerToolExecutionStep(agentRunSpan, {
+      withProviderExecutedFlag: false,
+    });
+    await step.execute(executeParams);
+
+    expect(agentRunSpan.createChildSpan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: SpanType.TOOL_CALL,
+        attributes: expect.objectContaining({ toolType: 'server-tool' }),
+        input: { query: 'latest AI agent news' },
+      }),
+    );
+    expect(serverToolSpan.end).toHaveBeenCalledWith({ output: { answer: 'fresh gateway result' } });
   });
 
   it('resolves streamed tool payload transforms without rescanning tools per delta', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -458,6 +458,13 @@ async function processOutputStream<OUTPUT = undefined>({
   // chunk (input = args) and close it on the paired tool-result chunk (output = result).
   // Anchored on the agent-run span, as client-tool spans are, so it survives
   // `includeInternalSpans: false`.
+  //
+  // Scope: this handles same-stream results (call + result in one step), which covers native
+  // code execution. A provider result DEFERRED to a later step (e.g. a server-side search
+  // called alongside a client tool) is closed without output at end of stream, since this
+  // map is per-step; full deferred support is left as a follow-up.
+  const resolveAgentRunSpan = (span: AnySpan): AnySpan =>
+    span.type === SpanType.AGENT_RUN ? span : (span.findParent(SpanType.AGENT_RUN) ?? span);
   const serverToolSpanByToolCallId = new Map<string, AnySpan>();
   const openServerToolSpan = (toolCallId: string, toolName: string, args: unknown): void => {
     const enabled =
@@ -467,11 +474,7 @@ async function processOutputStream<OUTPUT = undefined>({
       return;
     }
     try {
-      const parentSpan =
-        tracingContext.currentSpan.type === SpanType.AGENT_RUN
-          ? tracingContext.currentSpan
-          : (tracingContext.currentSpan.findParent(SpanType.AGENT_RUN) ?? tracingContext.currentSpan);
-      const span = parentSpan.createChildSpan({
+      const span = resolveAgentRunSpan(tracingContext.currentSpan).createChildSpan({
         type: SpanType.TOOL_CALL,
         name: toolName,
         entityType: EntityType.TOOL,
@@ -563,11 +566,7 @@ async function processOutputStream<OUTPUT = undefined>({
     }
 
     try {
-      const parentSpan =
-        tracingContext.currentSpan.type === SpanType.AGENT_RUN
-          ? tracingContext.currentSpan
-          : (tracingContext.currentSpan.findParent(SpanType.AGENT_RUN) ?? tracingContext.currentSpan);
-      const clientToolSpan = parentSpan.createChildSpan({
+      const clientToolSpan = resolveAgentRunSpan(tracingContext.currentSpan).createChildSpan({
         type: SpanType.CLIENT_TOOL_CALL,
         name: `client_tool: '${toolName}'`,
         entityType: EntityType.TOOL,
@@ -651,17 +650,22 @@ async function processOutputStream<OUTPUT = undefined>({
         endClientToolObservabilitySpan(chunk.payload.toolCallId, parsedArgs);
       }
     } else if (chunk.type === 'tool-call') {
-      injectClientToolObservability({
+      const { inferredProviderExecuted } = injectClientToolObservability({
         toolCallId: chunk.payload.toolCallId,
         toolName: chunk.payload.toolName,
         args: chunk.payload.args,
         providerExecuted: chunk.payload.providerExecuted,
         payload: chunk.payload as unknown as Record<string, unknown> & { observability?: unknown },
       });
-      if (chunk.payload.providerExecuted) {
+      // Use the normalized value: gateway/`type:'provider'` tools infer providerExecuted
+      // from the tool definition rather than carrying it on the chunk.
+      if (inferredProviderExecuted) {
         openServerToolSpan(chunk.payload.toolCallId, chunk.payload.toolName, chunk.payload.args);
       }
-    } else if (chunk.type === 'tool-result' && chunk.payload.providerExecuted) {
+    } else if (
+      chunk.type === 'tool-result' &&
+      inferProviderExecuted(chunk.payload.providerExecuted, resolveDirectOrProviderTool(chunk.payload.toolName))
+    ) {
       closeServerToolSpan(chunk.payload.toolCallId, chunk.payload.result);
     }
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -450,6 +450,53 @@ async function processOutputStream<OUTPUT = undefined>({
     }
   >();
 
+  // Provider-executed (server-side) tools — e.g. Anthropic native code execution or
+  // server-side web search — run on the model provider, so this loop never enters Mastra's
+  // tool-execution path and no span is created; the tool's input/output are otherwise
+  // invisible in traces. When enabled via the `traceServerTools` observability option (off
+  // by default), reconstruct a TOOL_CALL span from the stream: open it on the tool-call
+  // chunk (input = args) and close it on the paired tool-result chunk (output = result).
+  // Anchored on the agent-run span, as client-tool spans are, so it survives
+  // `includeInternalSpans: false`.
+  const serverToolSpanByToolCallId = new Map<string, AnySpan>();
+  const openServerToolSpan = (toolCallId: string, toolName: string, args: unknown): void => {
+    const enabled =
+      tracingContext?.currentSpan?.observabilityInstance?.getConfig?.().traceServerTools === true ||
+      process.env.MASTRA_TRACE_SERVER_TOOLS === 'true';
+    if (!enabled || !tracingContext?.currentSpan || serverToolSpanByToolCallId.has(toolCallId)) {
+      return;
+    }
+    try {
+      const parentSpan =
+        tracingContext.currentSpan.type === SpanType.AGENT_RUN
+          ? tracingContext.currentSpan
+          : (tracingContext.currentSpan.findParent(SpanType.AGENT_RUN) ?? tracingContext.currentSpan);
+      const span = parentSpan.createChildSpan({
+        type: SpanType.TOOL_CALL,
+        name: toolName,
+        entityType: EntityType.TOOL,
+        entityId: toolName,
+        entityName: toolName,
+        attributes: { toolType: 'server-tool' },
+        ...(args !== undefined ? { input: args } : {}),
+      });
+      if (span) {
+        serverToolSpanByToolCallId.set(toolCallId, span);
+      }
+    } catch (err) {
+      logger?.warn?.('failed to create server-tool span', {
+        error: err instanceof Error ? err.message : String(err),
+        toolName,
+      });
+    }
+  };
+  const closeServerToolSpan = (toolCallId: string, result: unknown): void => {
+    const span = serverToolSpanByToolCallId.get(toolCallId);
+    if (!span) return;
+    span.end(result !== undefined ? { output: result } : undefined);
+    serverToolSpanByToolCallId.delete(toolCallId);
+  };
+
   const endClientToolObservabilitySpan = (toolCallId: string, args?: unknown): void => {
     const entry = clientToolObservabilityByToolCallId.get(toolCallId);
     if (!entry || entry.ended) {
@@ -611,6 +658,11 @@ async function processOutputStream<OUTPUT = undefined>({
         providerExecuted: chunk.payload.providerExecuted,
         payload: chunk.payload as unknown as Record<string, unknown> & { observability?: unknown },
       });
+      if (chunk.payload.providerExecuted) {
+        openServerToolSpan(chunk.payload.toolCallId, chunk.payload.toolName, chunk.payload.args);
+      }
+    } else if (chunk.type === 'tool-result' && chunk.payload.providerExecuted) {
+      closeServerToolSpan(chunk.payload.toolCallId, chunk.payload.result);
     }
 
     // Collect every chunk for post-stream message building
@@ -779,6 +831,12 @@ async function processOutputStream<OUTPUT = undefined>({
     }
   }
   clientToolArgsTextByToolCallId.clear();
+
+  // Close any server-tool spans whose tool-result chunk never arrived (e.g. an aborted run).
+  for (const [, span] of serverToolSpanByToolCallId.entries()) {
+    span.end();
+  }
+  serverToolSpanByToolCallId.clear();
 
   return { collectedChunks };
 }

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -465,6 +465,13 @@ export interface ObservabilityInstanceConfig {
   /** Set to `true` if you want to see spans internal to the operation of mastra */
   includeInternalSpans?: boolean;
   /**
+   * Set to `true` to emit tool-call spans for provider-executed (server-side) tools —
+   * e.g. Anthropic native code execution or server-side web search — whose input/output are
+   * otherwise invisible in traces because they run on the model provider, not in Mastra's
+   * tool-execution path. Off by default.
+   */
+  traceServerTools?: boolean;
+  /**
    * Span types to exclude from export. Spans of these types are silently dropped
    * before reaching exporters. This is useful for reducing noise and costs in
    * observability platforms that charge per-span (e.g., Langfuse).


### PR DESCRIPTION
Closes #19180.

## What

Adds an opt-in `traceServerTools` Observability config option (off by default; the `MASTRA_TRACE_SERVER_TOOLS=true` env var is also honored) that records provider-executed (server-side) tools as spans.

## Why

Client-executed tools get a `CLIENT_TOOL_CALL` span, but provider-executed tools — Anthropic native code execution, server-side web search, etc. (`providerExecuted: true`) — get none, because they run on the model provider and the agentic loop never enters Mastra's tool-execution path. Their input/output are invisible in traces; for code execution, the authored code and its stdout never appear anywhere.

## How

When `traceServerTools` is enabled, the agentic loop opens a `TOOL_CALL` span on a provider-executed `tool-call` chunk (input = args) and closes it on the paired `tool-result` chunk (output = result), anchored on the agent-run span via `findParent(AGENT_RUN)` — the same anchor client-tool spans use — so it survives `includeInternalSpans: false`. A span whose result chunk never arrives (e.g. an aborted run) is closed at end of stream.

## Notes / scope

- Reuses the generic `TOOL_CALL` span type rather than introducing a `SERVER_TOOL_CALL` type; happy to switch to a dedicated type for parity with `CLIENT_TOOL_CALL` if you'd prefer.
- Scoped to the non-durable agentic loop (`loop/workflows/agentic-execution/llm-execution-step.ts`). The durable agent path (`agent/durable/workflows/steps/llm-execution.ts`) has the same gap and can get the parallel treatment — here or in a follow-up.

## Testing

- Two regression tests: enabled → a `TOOL_CALL` span is created with `input`/`output` and `attributes.toolType: 'server-tool'`; disabled → no server-tool span (opt-in default).
- Full `llm-execution-step.test.ts` suite: 23/23 passing.
- Changeset included (minor bump, `@mastra/core` + `@mastra/observability`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Normally, when the AI provider runs tools itself (like server-side code execution or web search), Mastra can’t show those steps in your trace. With this opt-in setting, Mastra reconstructs those tool steps so you can see what was asked and what came back.

## Summary
- Added an opt-in `traceServerTools` observability setting (default off) and config toggle via `MASTRA_TRACE_SERVER_TOOLS=true`.
- When enabled, reconstructs spans for provider-executed server-side tools from streamed `tool-call` / `tool-result` chunks in the non-durable agentic loop.
- Opens a server-tool `TOOL_CALL` span on the `tool-call` chunk (capturing tool input/args when available) and closes it on the matching `tool-result` chunk with the tool output.
- Anchors server-tool spans to the `AGENT_RUN` span so they remain visible even when `includeInternalSpans: false`.
- If the run ends before a `tool-result` arrives, closes any still-open server-tool spans at end of stream.
- Supports inferred `providerExecuted` behavior for tools where the flag may be omitted in chunks (via `inferProviderExecuted` / resolve logic).
- Updated shared span-parent resolution via a `resolveAgentRunSpan` helper for consistent anchoring.
- Added regression tests covering enabled/disabled behavior and inferred `providerExecuted`, plus a changeset for `@mastra/core` and `@mastra/observability`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->