### PR TITLE
fix(core): stop warning on same-stream provider-executed tool results

### DIFF
--- a/.changeset/suppress-server-tool-updatetoolinvocation-warning.md
+++ b/.changeset/suppress-server-tool-updatetoolinvocation-warning.md
@@ -1,0 +1,11 @@
+---
+'@mastra/core': patch
+---
+
+Stop logging a spurious `updateToolInvocation: no matching tool call found` warning for same-stream provider-executed tool results
+
+When a provider-executed (server-side) tool returns its result in the same stream step as its call — e.g. Anthropic native code execution — there is no preceding `state:'call'` message part yet, so the inline `updateToolInvocation` patch in the agentic loop returns `false` and logged a misleading warning on every such call. The message history was already correct (`buildMessagesFromChunks` merges the call + result), so this was log noise, not a correctness issue.
+
+`updateToolInvocation` now accepts an optional `{ warnOnMissing }` flag (default `true`); the same-stream call site passes `warnOnMissing: false`. The warning is unchanged for all other callers, where a miss is genuinely unexpected.
+
+Resolves #19182.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -1098,11 +1098,16 @@ export class MessageList {
    * If the message was already persisted (e.g. as a memory message), it is
    * moved to the response source so it will be re-saved.
    *
+   * @param options.warnOnMissing - when `false`, suppress the "no matching tool call"
+   *   warning if no part is found. Defaults to `true`. Used by callers that legitimately
+   *   expect a miss (e.g. same-stream provider-executed results, which are merged later by
+   *   buildMessagesFromChunks rather than updated here).
    * @returns true if the tool call was found and updated, false otherwise.
    */
   public updateToolInvocation(
     inputPart: Extract<MastraMessagePart, { type: 'tool-invocation' }>,
     metadata?: Record<string, unknown>,
+    options?: { warnOnMissing?: boolean },
   ): boolean {
     if (!inputPart.toolInvocation?.toolCallId) {
       return false;
@@ -1172,7 +1177,9 @@ export class MessageList {
         }
       }
     }
-    this.logger?.warn(`updateToolInvocation: no matching tool call found for toolCallId=${toolCallId}`);
+    if (options?.warnOnMissing !== false) {
+      this.logger?.warn(`updateToolInvocation: no matching tool call found for toolCallId=${toolCallId}`);
+    }
     return false;
   }
 

--- a/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
+++ b/packages/core/src/agent/message-list/tests/update-tool-invocation.test.ts
@@ -703,4 +703,46 @@ describe('MessageList.updateToolInvocation', () => {
       mastra: { modelOutput: true },
     });
   });
+
+  it('warns by default when no matching tool call exists', () => {
+    const warn = vi.fn();
+    const messageList = new MessageList({ logger: { warn } as any });
+
+    const result = messageList.updateToolInvocation({
+      type: 'tool-invocation',
+      toolInvocation: {
+        state: 'result',
+        toolCallId: 'missing-1',
+        toolName: 'web_search',
+        args: {},
+        result: { ok: true },
+      },
+    });
+
+    expect(result).toBe(false);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing-1'));
+  });
+
+  it('does not warn when warnOnMissing is false (e.g. same-stream provider-executed result)', () => {
+    const warn = vi.fn();
+    const messageList = new MessageList({ logger: { warn } as any });
+
+    const result = messageList.updateToolInvocation(
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'srvtoolu_1',
+          toolName: 'code_execution',
+          args: {},
+          result: { stdout: 'ok' },
+        },
+      },
+      undefined,
+      { warnOnMissing: false },
+    );
+
+    expect(result).toBe(false);
+    expect(warn).not.toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -732,7 +732,10 @@ async function processOutputStream<OUTPUT = undefined>({
                 args: chunk.payload.args,
                 result: chunk.payload.result,
               },
-              providerMetadata: withToolPayloadTransformProviderMetadata(chunk.payload.providerMetadata, chunk.metadata),
+              providerMetadata: withToolPayloadTransformProviderMetadata(
+                chunk.payload.providerMetadata,
+                chunk.metadata,
+              ),
               providerExecuted: inferProviderExecuted(chunk.payload.providerExecuted, resultToolDef),
             },
             // A same-stream result has no preceding state:'call' part yet (see above), so a

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -722,18 +722,24 @@ async function processOutputStream<OUTPUT = undefined>({
         // so updateToolInvocation returns false — buildMessagesFromChunks handles the merge.
         if (chunk.payload.result != null) {
           const resultToolDef = resolveDirectOrProviderTool(chunk.payload.toolName);
-          messageList.updateToolInvocation({
-            type: 'tool-invocation',
-            toolInvocation: {
-              state: 'result',
-              toolCallId: chunk.payload.toolCallId,
-              toolName: chunk.payload.toolName,
-              args: chunk.payload.args,
-              result: chunk.payload.result,
+          messageList.updateToolInvocation(
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId: chunk.payload.toolCallId,
+                toolName: chunk.payload.toolName,
+                args: chunk.payload.args,
+                result: chunk.payload.result,
+              },
+              providerMetadata: withToolPayloadTransformProviderMetadata(chunk.payload.providerMetadata, chunk.metadata),
+              providerExecuted: inferProviderExecuted(chunk.payload.providerExecuted, resultToolDef),
             },
-            providerMetadata: withToolPayloadTransformProviderMetadata(chunk.payload.providerMetadata, chunk.metadata),
-            providerExecuted: inferProviderExecuted(chunk.payload.providerExecuted, resultToolDef),
-          });
+            // A same-stream result has no preceding state:'call' part yet (see above), so a
+            // miss is expected and handled by buildMessagesFromChunks — don't warn on it.
+            undefined,
+            { warnOnMissing: false },
+          );
         }
         safeEnqueue(controller, chunk);
         break;


### PR DESCRIPTION
Closes #19182.

## What

Provider-executed (server-side) tools whose result arrives in the same stream step as their call — e.g. Anthropic native code execution — logged a misleading `updateToolInvocation: no matching tool call found for toolCallId=srvtoolu_…` warning on every call. This silences that spurious warning.

## Why

The agentic loop's inline patch calls `updateToolInvocation({ state: 'result', … })` to resolve **deferred** provider results (call in step N, result in step N+1). For **same-stream** results there is no preceding `state:'call'` part yet, so it returns `false` and warned — but this is expected and already documented in the surrounding comment: `buildMessagesFromChunks` merges the call + result afterward. The message history was already correct; the warning was pure log noise, firing on every server-side code-execution / web-search call.

## How

`updateToolInvocation` gains an optional `{ warnOnMissing }` flag (default `true`, so every other caller — where a miss is genuinely unexpected — is unchanged). The same-stream call site in `llm-execution-step.ts` passes `warnOnMissing: false`.

## Testing

- Two regression tests in `update-tool-invocation.test.ts`: warns by default on a miss; silent when `warnOnMissing: false`.
- `update-tool-invocation.test.ts` (18) and `llm-execution-step.test.ts` (21) pass; `@mastra/core` builds; lint clean.
- Changeset included (patch).

## Relation to #19181

Independent of #19181 (opt-in server-tool spans) — different subsystem (message assembly vs. observability), non-overlapping edits in `llm-execution-step.ts`. Together they clean up server-tool observability: #19181 makes the call visible as a span; this removes the misleading warning about it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Sometimes a tool finishes and sends back its result immediately (in the same streaming step as the “call”). Previously, the system complained that it couldn’t find the matching tool call yet—even though it merges the call+result correctly later. This PR makes that specific, expected case quiet while keeping warnings for real mismatches.

### What changed
- `MessageList.updateToolInvocation` now accepts an optional `options` parameter: `warnOnMissing?: boolean` (defaults to `true`).
- The warning (“no matching tool call found for toolCallId=…”) still logs by default when a lookup truly fails.
- The same-stream provider-executed tool-result handling in `llm-execution-step.ts` now passes `warnOnMissing: false` to suppress the spurious warning.
- Added regression tests verifying:
  - default warning behavior when no matching `toolCallId` exists
  - no warning emitted when `warnOnMissing: false`

### Impact
- Removes noisy, misleading log spam for provider-executed/server-side tools that return results in the same stream step as the call.
- Preserves existing warning behavior for genuine missing tool-call situations.
- Keeps message assembly/merging behavior unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->