### PR TITLE
Fix MCP elicitation capability advertisement

### DIFF
--- a/.changeset/dry-worlds-jam.md
+++ b/.changeset/dry-worlds-jam.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP clients advertising elicitation support before a handler is registered.

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1111,6 +1111,34 @@ describe('MastraMCPClient - Elicitation Tests', () => {
         };
       },
     );
+
+    testServer.mcpServer.tool(
+      'workflowNeedingOptionalInput',
+      'Only elicits when the client advertised elicitation support',
+      {},
+      async (): Promise<CallToolResult> => {
+        if (!testServer.mcpServer.server.getClientCapabilities()?.elicitation) {
+          return {
+            content: [{ type: 'text', text: 'NEEDS_INPUT: please confirm' }],
+          };
+        }
+
+        const result = await testServer.mcpServer.server.elicitInput({
+          message: 'Please confirm',
+          requestedSchema: {
+            type: 'object',
+            properties: {
+              confirm: { type: 'boolean', title: 'Confirm' },
+            },
+            required: ['confirm'],
+          },
+        });
+
+        return {
+          content: [{ type: 'text', text: JSON.stringify(result) }],
+        };
+      },
+    );
   });
 
   afterEach(async () => {
@@ -1265,6 +1293,24 @@ describe('MastraMCPClient - Elicitation Tests', () => {
 
     // Call the tool which will trigger elicitation; the in-band error is surfaced by throwing.
     await expect(collectUserInfoTool?.execute?.({ message: 'This should fail gracefully' }, {})).rejects.toThrow();
+  });
+
+  it('should not advertise elicitation without a handler', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'no-elicitation-advertisement-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+    await client.connect();
+
+    const tools = await client.tools();
+    const workflowTool = tools['workflowNeedingOptionalInput'];
+    expect(workflowTool).toBeDefined();
+
+    const result = await workflowTool?.execute?.({}, {});
+
+    expect(result.content).toEqual([{ type: 'text', text: 'NEEDS_INPUT: please confirm' }]);
   });
 
   it('should validate elicitation request schema structure', async () => {
@@ -1996,12 +2042,46 @@ describe('MastraMCPClient - Roots Capability (Issue #8660)', () => {
     });
 
     const internalClient = (client as any).client;
-    const capabilities = internalClient._options?.capabilities;
+    const capabilities = internalClient._capabilities;
 
     expect(capabilities).toMatchObject({
       roots: { listChanged: true },
-      elicitation: {},
     });
+    expect(capabilities.elicitation).toBeUndefined();
+
+    await client.disconnect().catch(() => {});
+  });
+
+  it('should not advertise elicitation by default', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'default-capability-test-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+
+    const internalClient = (client as any).client;
+    const capabilities = internalClient._capabilities;
+
+    expect(capabilities.elicitation).toBeUndefined();
+
+    await client.disconnect().catch(() => {});
+  });
+
+  it('should advertise form elicitation when a handler is registered before connecting', async () => {
+    const client = new InternalMastraMCPClient({
+      name: 'registered-elicitation-capability-test-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+
+    client.elicitation.onRequest(async () => ({ action: 'decline' }));
+
+    const internalClient = (client as any).client;
+    const capabilities = internalClient._capabilities;
+
+    expect(capabilities.elicitation).toMatchObject({ form: {} });
 
     await client.disconnect().catch(() => {});
   });
@@ -2022,7 +2102,7 @@ describe('MastraMCPClient - Roots Capability (Issue #8660)', () => {
     });
 
     const internalClient = (client as any).client;
-    const capabilities = internalClient._options?.capabilities;
+    const capabilities = internalClient._capabilities;
 
     expect(capabilities).toMatchObject({
       elicitation: customElicitationCapabilities,
@@ -2048,7 +2128,7 @@ describe('MastraMCPClient - Roots Capability (Issue #8660)', () => {
     });
 
     const internalClient = (client as any).client;
-    const capabilities = internalClient._options?.capabilities;
+    const capabilities = internalClient._capabilities;
 
     expect(capabilities).toMatchObject({
       roots: { listChanged: true },

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1313,6 +1313,20 @@ describe('MastraMCPClient - Elicitation Tests', () => {
     expect(result.content).toEqual([{ type: 'text', text: 'NEEDS_INPUT: please confirm' }]);
   });
 
+  it('should throw when registering an elicitation handler after connecting without capability', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'late-elicitation-handler-client',
+      server: {
+        url: testServer.baseUrl,
+      },
+    });
+    await client.connect();
+
+    expect(() => client.elicitation.onRequest(async () => ({ action: 'decline' }))).toThrow(
+      'Cannot register an elicitation handler after connecting',
+    );
+  });
+
   it('should validate elicitation request schema structure', async () => {
     const mockHandler = vi.fn(async request => {
       // Verify the request has the expected structure

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -22,6 +22,7 @@ import type {
   ListResourceTemplatesResult,
   LoggingLevel,
   ReadResourceResult,
+  ClientCapabilities,
 } from '@modelcontextprotocol/sdk/types.js';
 import {
   CallToolResultSchema,
@@ -221,6 +222,7 @@ export class InternalMastraMCPClient extends MastraBase {
   private sigHupHandler?: () => void;
   private serverInstructions?: string;
   private _roots: Root[];
+  private hasElicitationCapability: boolean;
   private readonly requireToolApproval: RequireToolApproval | undefined;
   private readonly onToolError: 'throw' | 'return';
 
@@ -255,15 +257,15 @@ export class InternalMastraMCPClient extends MastraBase {
 
     // Initialize roots from server config
     this._roots = server.roots ?? [];
+    this.hasElicitationCapability = capabilities.elicitation !== undefined;
 
     // Build client capabilities, automatically enabling roots if configured
     const hasRoots = this._roots.length > 0 || !!capabilities.roots;
-    const clientCapabilities = {
+    const clientCapabilities: ClientCapabilities = {
       ...capabilities,
-      // Merge elicitation capabilities instead of overwriting
-      elicitation: {
-        ...(capabilities.elicitation ?? {}),
-      },
+      // Only advertise elicitation when explicitly configured or when a handler
+      // registers it before connect(). `elicitation: {}` is legacy form support.
+      ...(capabilities.elicitation !== undefined ? { elicitation: { ...capabilities.elicitation } } : {}),
       // Auto-enable roots capability if roots are provided
       ...(hasRoots ? { roots: { listChanged: true, ...(capabilities.roots ?? {}) } } : {}),
       // Advertise MCP Apps extension support so servers know we can render UI resources
@@ -772,6 +774,17 @@ export class InternalMastraMCPClient extends MastraBase {
 
   setElicitationRequestHandler(handler: ElicitationHandler): void {
     this.log('debug', 'Setting elicitation request handler');
+    if (!this.hasElicitationCapability) {
+      try {
+        this.client.registerCapabilities({ elicitation: { form: {} } });
+        this.hasElicitationCapability = true;
+      } catch (error) {
+        this.log('debug', 'Unable to register elicitation capability after connect', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+
     this.client.setRequestHandler(ElicitRequestSchema, async request => {
       this.log('debug', `Received elicitation request: ${request.params.message}`);
       return handler(request.params);

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -779,9 +779,10 @@ export class InternalMastraMCPClient extends MastraBase {
         this.client.registerCapabilities({ elicitation: { form: {} } });
         this.hasElicitationCapability = true;
       } catch (error) {
-        this.log('debug', 'Unable to register elicitation capability after connect', {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        throw new Error(
+          'Cannot register an elicitation handler after connecting unless elicitation capability was configured before initialization.',
+          { cause: error },
+        );
       }
     }
 

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -227,10 +227,33 @@ describe('MCPClient tool discovery retries', () => {
     clients.push(client);
 
     const internalClient = await (client as any).getConnectedClientForServer('weather');
-    const capabilities = (internalClient as any).client._options?.capabilities;
+    const capabilities = (internalClient as any).client._capabilities;
 
     expect(connectSpy).toHaveBeenCalledTimes(1);
     expect(capabilities).toMatchObject(customCapabilities);
+  });
+
+  it('registers elicitation handlers before connecting the server', async () => {
+    const connectSpy = vi.spyOn(InternalMastraMCPClient.prototype, 'connect').mockResolvedValue(true);
+
+    const client = new MCPClient({
+      id: `configuration-test-${++clientId}`,
+      servers: {
+        weather: {
+          url: new URL('http://localhost:1234/sse'),
+        },
+      },
+    });
+
+    clients.push(client);
+
+    await client.elicitation.onRequest('weather', async () => ({ action: 'decline' }));
+
+    const internalClient = (client as any).mcpClientsById.get('weather');
+    const capabilities = internalClient.client._capabilities;
+
+    expect(connectSpy).not.toHaveBeenCalled();
+    expect(capabilities.elicitation).toMatchObject({ form: {} });
   });
 
   it('returns cached server instructions for configured servers', async () => {

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -981,7 +981,15 @@ To fix this you have three different options:
     return client.stderr;
   }
 
-  private async getConnectedClient(name: string, config: MastraMCPServerDefinition): Promise<InternalMastraMCPClient> {
+  private getServerConfig(serverName: string): MastraMCPServerDefinition {
+    const serverConfig = this.serverConfigs[serverName];
+    if (!serverConfig) {
+      throw new Error(`Server configuration not found for name: ${serverName}`);
+    }
+    return serverConfig;
+  }
+
+  private async getOrCreateClient(name: string, config: MastraMCPServerDefinition): Promise<InternalMastraMCPClient> {
     if (this.disconnectPromise) {
       await this.disconnectPromise;
     }
@@ -997,17 +1005,9 @@ To fix this you have three different options:
       if (!existingClient) {
         throw new Error(`Client ${name} exists but is undefined`);
       }
-      try {
-        await existingClient.connect();
-      } catch (e) {
-        throw this.handleConnectError(name, e);
-      }
       return existingClient;
     }
 
-    this.logger.debug('Connecting to MCP server', { name });
-
-    // Create client with server configuration including log handler
     const mcpClient = new InternalMastraMCPClient({
       name,
       server: config,
@@ -1018,6 +1018,14 @@ To fix this you have three different options:
     mcpClient.__setLogger(this.logger);
 
     this.mcpClientsById.set(name, mcpClient);
+
+    return mcpClient;
+  }
+
+  private async getConnectedClient(name: string, config: MastraMCPServerDefinition): Promise<InternalMastraMCPClient> {
+    this.logger.debug('Connecting to MCP server', { name });
+
+    const mcpClient = await this.getOrCreateClient(name, config);
 
     try {
       await mcpClient.connect();
@@ -1050,38 +1058,11 @@ To fix this you have three different options:
   }
 
   private async getConnectedClientForServer(serverName: string): Promise<InternalMastraMCPClient> {
-    const serverConfig = this.serverConfigs[serverName];
-    if (!serverConfig) {
-      throw new Error(`Server configuration not found for name: ${serverName}`);
-    }
-    return this.getConnectedClient(serverName, serverConfig);
+    return this.getConnectedClient(serverName, this.getServerConfig(serverName));
   }
 
   private async getClientForServer(serverName: string): Promise<InternalMastraMCPClient> {
-    if (this.disconnectPromise) {
-      await this.disconnectPromise;
-    }
-
-    const serverConfig = this.serverConfigs[serverName];
-    if (!serverConfig) {
-      throw new Error(`Server configuration not found for name: ${serverName}`);
-    }
-
-    const existingClient = this.mcpClientsById.get(serverName);
-    if (existingClient) {
-      return existingClient;
-    }
-
-    const mcpClient = new InternalMastraMCPClient({
-      name: serverName,
-      server: serverConfig,
-      timeout: serverConfig.timeout ?? this.defaultTimeout,
-      capabilities: serverConfig.capabilities,
-    });
-
-    mcpClient.__setLogger(this.logger);
-    this.mcpClientsById.set(serverName, mcpClient);
-    return mcpClient;
+    return this.getOrCreateClient(serverName, this.getServerConfig(serverName));
   }
 
   private async getToolsForServer(serverName: string): Promise<Record<string, Tool<any, any, any, any>>> {

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -233,7 +233,7 @@ To fix this you have three different options:
        */
       onRequest: async (serverName: string, handler: (request: ElicitRequest['params']) => Promise<ElicitResult>) => {
         try {
-          const internalClient = await this.getConnectedClientForServer(serverName);
+          const internalClient = await this.getClientForServer(serverName);
           return internalClient.elicitation.onRequest(handler);
         } catch (err) {
           throw new MastraError(
@@ -997,7 +997,11 @@ To fix this you have three different options:
       if (!existingClient) {
         throw new Error(`Client ${name} exists but is undefined`);
       }
-      await existingClient.connect();
+      try {
+        await existingClient.connect();
+      } catch (e) {
+        throw this.handleConnectError(name, e);
+      }
       return existingClient;
     }
 
@@ -1018,25 +1022,31 @@ To fix this you have three different options:
     try {
       await mcpClient.connect();
     } catch (e) {
-      const mastraError = new MastraError(
-        {
-          id: 'MCP_CLIENT_CONNECT_FAILED',
-          domain: ErrorDomain.MCP,
-          category: ErrorCategory.THIRD_PARTY,
-          text: `Failed to connect to MCP server ${name}: ${e instanceof Error ? e.stack || e.message : String(e)}`,
-          details: {
-            name,
-          },
-        },
-        e,
-      );
-      this.logger.trackException(mastraError);
-      this.logger.error('MCPClient errored connecting to MCP server:', { error: mastraError.toString() });
-      this.mcpClientsById.delete(name);
-      throw mastraError;
+      throw this.handleConnectError(name, e);
     }
     this.logger.debug('Connected to MCP server', { name });
     return mcpClient;
+  }
+
+  private handleConnectError(name: string, error: unknown): MastraError {
+    const mastraError = new MastraError(
+      {
+        id: 'MCP_CLIENT_CONNECT_FAILED',
+        domain: ErrorDomain.MCP,
+        category: ErrorCategory.THIRD_PARTY,
+        text: `Failed to connect to MCP server ${name}: ${
+          error instanceof Error ? error.stack || error.message : String(error)
+        }`,
+        details: {
+          name,
+        },
+      },
+      error,
+    );
+    this.logger.trackException(mastraError);
+    this.logger.error('MCPClient errored connecting to MCP server:', { error: mastraError.toString() });
+    this.mcpClientsById.delete(name);
+    return mastraError;
   }
 
   private async getConnectedClientForServer(serverName: string): Promise<InternalMastraMCPClient> {
@@ -1045,6 +1055,33 @@ To fix this you have three different options:
       throw new Error(`Server configuration not found for name: ${serverName}`);
     }
     return this.getConnectedClient(serverName, serverConfig);
+  }
+
+  private async getClientForServer(serverName: string): Promise<InternalMastraMCPClient> {
+    if (this.disconnectPromise) {
+      await this.disconnectPromise;
+    }
+
+    const serverConfig = this.serverConfigs[serverName];
+    if (!serverConfig) {
+      throw new Error(`Server configuration not found for name: ${serverName}`);
+    }
+
+    const existingClient = this.mcpClientsById.get(serverName);
+    if (existingClient) {
+      return existingClient;
+    }
+
+    const mcpClient = new InternalMastraMCPClient({
+      name: serverName,
+      server: serverConfig,
+      timeout: serverConfig.timeout ?? this.defaultTimeout,
+      capabilities: serverConfig.capabilities,
+    });
+
+    mcpClient.__setLogger(this.logger);
+    this.mcpClientsById.set(serverName, mcpClient);
+    return mcpClient;
   }
 
   private async getToolsForServer(serverName: string): Promise<Record<string, Tool<any, any, any, any>>> {


### PR DESCRIPTION
## Issue

  Fixes #19189

  ## Summary

  Fixes `MCPClient` advertising elicitation support when no elicitation handler is registered.

  Previously, `InternalMastraMCPClient` always sent `elicitation: {}` during MCP initialization. In the MCP SDK, that means legacy form
  elicitation support. Servers that check `getClientCapabilities()?.elicitation` could then send `elicitation/create`, but Mastra had no request
  handler registered unless the app had called `mcp.elicitation.onRequest(...)`. The SDK responded with `-32601 Method not found`, causing tool
  calls to fail.

  ## Changes

  - Stop advertising `elicitation` by default.
  - Preserve explicitly configured `capabilities.elicitation`.
  - Register form elicitation capability when `client.elicitation.onRequest(...)` is installed before connect.
  - Update public `MCPClient.elicitation.onRequest(serverName, handler)` so it installs the handler before connecting the server.
  - Keep normal connection error wrapping and cache cleanup for clients created before connection.
  - Add regression coverage for:
    - default clients not advertising elicitation
    - roots capability no longer implying elicitation
    - handler registration enabling form elicitation before connect
    - spec-style server fallback when elicitation is not advertised
    - public `MCPClient` registering elicitation handlers before server connection

  ## Behavior

  Default clients now behave like the raw MCP SDK client: if no elicitation handler is registered, they do not advertise elicitation support, so
  compliant servers can degrade gracefully.

  Clients that register an elicitation handler before connection still advertise support and handle `elicitation/create` requests normally.

  ## Validation

  Ran:

  ```bash
  pnpm --filter ./packages/mcp test:client
  pnpm --filter ./packages/mcp build:lib
  pnpm --filter ./packages/mcp lint
  git diff --check

  All passed.

  ## Changeset

  Added a patch changeset for @mastra/mcp.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Your MCP client used to “claim” it could handle elicitation questions even when it had no handler ready. Now it only advertises that ability when a handler is actually installed, so servers won’t ask for something the client can’t answer.

## Summary
- Stop MCP clients from advertising `elicitation` by default in `@mastra/mcp`
- Preserve `elicitation` capabilities when they’re explicitly configured
- Only register `elicitation.form` support when `client.elicitation.onRequest(serverName, handler)` is installed **before** the server connection is made
- Update the public `MCPClient.elicitation.onRequest(...)` flow to install the handler without forcing an immediate connection
- Refactor internal client creation/connection so connection errors are consistently wrapped and failed clients are cleaned up from cache
- Add regression coverage for:
  - default non-advertising behavior
  - roots capability handling
  - handler registration before connect
  - server fallback when elicitation isn’t advertised
  - public client handler registration behavior (including the “cannot register after connecting” constraint)
- Include an `@mastra/mcp` patch changeset documenting the fix
<!-- end of auto-generated comment: release notes by coderabbit.ai -->