### PR TITLE
feat(mcp): complete MCP notifications support

### DIFF
--- a/.changeset/shaggy-clouds-clean.md
+++ b/.changeset/shaggy-clouds-clean.md
@@ -17,7 +17,11 @@ Servers can now add and remove tools at runtime and notify clients via `notifica
 await server.toolActions.add({ myNewTool });
 await server.toolActions.remove(['myNewTool']);
 await server.toolActions.notifyListChanged();
+```
 
+When the server is registered with a Mastra instance, dynamic add/remove also keeps the Mastra instance's tool registry in sync.
+
+```typescript
 // Client: react to tool list changes
 await mcp.tools.onListChanged('myServer', async () => {
   const tools = await mcp.listTools();

--- a/.changeset/shaggy-clouds-clean.md
+++ b/.changeset/shaggy-clouds-clean.md
@@ -1,0 +1,43 @@
+---
+'@mastra/mcp': minor
+---
+
+Fixed MCP server notifications (resource updates, resource/prompt list changes) not reaching clients connected over streamable HTTP. Notifications are now broadcast to every connected session across all transports.
+
+Added support for the remaining MCP notification features:
+
+**Dynamic tools and tools/list_changed**
+
+Servers can now add and remove tools at runtime and notify clients via `notifications/tools/list_changed`:
+
+```typescript
+// Server: manage tools at runtime
+await server.toolActions.add({ myNewTool });
+await server.toolActions.remove(['myNewTool']);
+await server.toolActions.notifyListChanged();
+
+// Client: react to tool list changes
+await mcp.tools.onListChanged('myServer', async () => {
+  const tools = await mcp.listTools();
+});
+```
+
+**Server-side log messages**
+
+Servers can now emit `notifications/message` log notifications. The minimum level a client sets via `logging/setLevel` is honored per session:
+
+```typescript
+// Broadcast to all connected clients
+await server.sendLoggingMessage({ level: 'info', data: { message: 'Sync completed' } });
+
+// From inside a tool, send to the calling client
+await context.mcp.log('debug', 'Fetching weather', { location });
+```
+
+**Progress notifications from tools**
+
+Tools can now report progress to the calling client:
+
+```typescript
+await context.mcp.progress({ progress: 1, total: 3, message: 'step 1' });
+```

--- a/.changeset/shaggy-clouds-clean.md
+++ b/.changeset/shaggy-clouds-clean.md
@@ -4,6 +4,8 @@
 
 Fixed MCP server notifications (resource updates, resource/prompt list changes) not reaching clients connected over streamable HTTP. Notifications are now broadcast to every connected session across all transports.
 
+Fixed resource subscriptions being shared globally across all clients. Subscriptions are now tracked per session, so `resources.notifyUpdated()` only notifies sessions that subscribed to the resource URI, and one client unsubscribing no longer removes another client's subscription. Clients that relied on receiving `notifications/resources/updated` without subscribing must now call `resources/subscribe` first.
+
 Added support for the remaining MCP notification features:
 
 **Dynamic tools and tools/list_changed**

--- a/.changeset/tangy-dryers-nail.md
+++ b/.changeset/tangy-dryers-nail.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added optional `log` and `progress` functions to the MCP tool execution context type so tools running in an MCP server can send log and progress notifications to the calling client.

--- a/.changeset/tangy-dryers-nail.md
+++ b/.changeset/tangy-dryers-nail.md
@@ -1,7 +1,12 @@
 ---
-'@mastra/core': patch
+'@mastra/core': minor
 ---
 
 Added optional `log` and `progress` functions to the MCP tool execution context type so tools running in an MCP server can send log and progress notifications to the calling client.
 
-Added `mastra.removeTool(key)` to remove a dynamically registered tool from the Mastra instance, the counterpart to `mastra.addTool()`.
+Added `mastra.removeTool(key)` to remove a dynamically registered tool from the Mastra instance, the counterpart to `mastra.addTool()`:
+
+```typescript
+mastra.addTool(calculatorTool);
+mastra.removeTool('calculator-tool'); // returns true if a tool was removed
+```

--- a/.changeset/tangy-dryers-nail.md
+++ b/.changeset/tangy-dryers-nail.md
@@ -3,3 +3,5 @@
 ---
 
 Added optional `log` and `progress` functions to the MCP tool execution context type so tools running in an MCP server can send log and progress notifications to the calling client.
+
+Added `mastra.removeTool(key)` to remove a dynamically registered tool from the Mastra instance, the counterpart to `mastra.addTool()`.

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -705,6 +705,28 @@ mcpClient.prompts.onListChanged('myWeatherServer', () => {
 })
 ```
 
+### `tools` Property
+
+The `MCPClient` instance has a `tools` property for subscribing to tool list change notifications. To fetch tools, use `listTools()` or `listToolsets()`.
+
+#### `tools.onListChanged(serverName: string, handler: () => void)`
+
+Sets a notification handler that will be called when the list of available tools changes on a specific server (for example, when the server adds or removes tools at runtime).
+
+```typescript prettier:false
+async onListChanged(serverName: string, handler: () => void): Promise<void>
+```
+
+Example:
+
+```typescript
+await mcpClient.tools.onListChanged('myWeatherServer', async () => {
+  console.log('Tool list changed on myWeatherServer.')
+  // You should re-fetch the tools
+  // const tools = await mcpClient.listTools();
+})
+```
+
 ### `progress` Property
 
 The `MCPClient` instance has a `progress` property for subscribing to progress notifications emitted by MCP servers while tools execute.

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1116,7 +1116,7 @@ execute: async ({ items }, context) => {
 
 ## Notification delivery
 
-Notification methods (`resources.notifyUpdated()`, `resources.notifyListChanged()`, `prompts.notifyListChanged()`, `toolActions.notifyListChanged()`, and `sendLoggingMessage()`) broadcast to every connected client across all transports: the stdio/SSE connection and each streamable HTTP session. Clients using the stateless serverless mode can't receive notifications because each request uses a transient server instance.
+Notification methods (`resources.notifyListChanged()`, `prompts.notifyListChanged()`, `toolActions.notifyListChanged()`, and `sendLoggingMessage()`) broadcast to every connected client across all transports: the stdio/SSE connection and each streamable HTTP session. `resources.notifyUpdated()` is the exception: it only notifies clients that subscribed to the resource URI via `resources/subscribe`. Subscriptions are tracked per session for streamable HTTP clients; legacy SSE clients share the main server instance and therefore share one subscription set. Clients using the stateless serverless mode can't receive notifications because each request uses a transient server instance.
 
 ## Examples
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1036,6 +1036,10 @@ Sends a `notifications/tools/list_changed` message to connected clients without 
 async server.toolActions.notifyListChanged(): Promise<void>
 ```
 
+### Mastra registry synchronization
+
+When the server is registered with a Mastra instance, `toolActions.add()` and `toolActions.remove()` also update the Mastra instance's tool registry, matching the automatic tool registration that happens at startup. Added tools become available through `mastra.listTools()` (keyed by the tool's intrinsic `id` when present), and removed tools are deleted from the registry.
+
 ## Logging
 
 MCP servers can send structured log messages to clients using `notifications/message`. Clients control verbosity by sending a `logging/setLevel` request; the server drops messages below the requested minimum level (following RFC 5424 severity ordering). The level is tracked per session, so different clients can request different verbosity.

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -544,6 +544,8 @@ The serverless mode disables session management and creates fresh server instanc
 - **Resource subscriptions** - `resources/subscribe` and `resources/unsubscribe` need persistent connections to maintain subscription state
 - **Resource update notifications** - `resources.notifyUpdated()` requires active subscriptions and persistent connections to notify clients
 - **Prompt list change notifications** - `prompts.notifyListChanged()` requires persistent connections to push updates to clients
+- **Tool list change notifications** - `toolActions.notifyListChanged()` requires persistent connections to push updates to clients
+- **Server log notifications** - `sendLoggingMessage()` requires persistent connections to push log messages to clients
 
 These features work normally in long-lived server environments (Node.js servers, Docker containers, etc.).
 
@@ -981,6 +983,140 @@ await serverWithPrompts.prompts.notifyListChanged()
 - Notify clients when prompt lists change.
 - Handle errors with informative messages.
 - Document argument expectations and available versions.
+
+## Dynamic tool management
+
+Tools are usually provided when constructing the `MCPServer`, but you can also add or remove tools while the server is running. The server exposes these operations through the `toolActions` property. When the tool list changes, connected clients receive a `notifications/tools/list_changed` message prompting them to re-fetch the tool list.
+
+The property is named `toolActions` because `tools()` is the method that returns the registered tool registry.
+
+### `toolActions.add(tools)`
+
+Registers new tools on the running server and notifies connected clients. Tools are keyed by their record key, the same as tools passed to the constructor. Adding a tool under an existing key replaces it.
+
+```typescript prettier:false
+async server.toolActions.add(tools: ToolsInput): Promise<void>
+```
+
+Example:
+
+```typescript
+import { createTool } from '@mastra/core/tools'
+import { z } from 'zod'
+
+const searchTool = createTool({
+  id: 'search',
+  description: 'Searches the knowledge base.',
+  inputSchema: z.object({ query: z.string() }),
+  execute: async ({ query }) => ({ results: [] }),
+})
+
+await server.toolActions.add({ searchTool })
+```
+
+### `toolActions.remove(toolIds)`
+
+Removes tools from the running server by tool ID and notifies connected clients. Unknown tool IDs are ignored. If no tools were removed, no notification is sent.
+
+```typescript prettier:false
+async server.toolActions.remove(toolIds: string[]): Promise<void>
+```
+
+Example:
+
+```typescript
+await server.toolActions.remove(['searchTool'])
+```
+
+### `toolActions.notifyListChanged()`
+
+Sends a `notifications/tools/list_changed` message to connected clients without modifying the tool registry. Call this when tool availability changes through other means (for example, authorization changes).
+
+```typescript prettier:false
+async server.toolActions.notifyListChanged(): Promise<void>
+```
+
+## Logging
+
+MCP servers can send structured log messages to clients using `notifications/message`. Clients control verbosity by sending a `logging/setLevel` request; the server drops messages below the requested minimum level (following RFC 5424 severity ordering). The level is tracked per session, so different clients can request different verbosity.
+
+### `sendLoggingMessage()`
+
+Sends a log notification to all connected clients, honoring each client's minimum logging level.
+
+```typescript prettier:false
+async server.sendLoggingMessage(params: {
+  level: LoggingLevel;
+  data: unknown;
+  logger?: string;
+}): Promise<void>
+```
+
+Example:
+
+```typescript
+await server.sendLoggingMessage({
+  level: 'info',
+  data: { message: 'Sync completed', itemsProcessed: 42 },
+})
+```
+
+### `context.mcp.log()`
+
+Inside a tool's `execute` function, use `context.mcp.log()` to send a log message to the client that called the tool.
+
+```typescript prettier:false
+async context.mcp.log(
+  level: LoggingLevel,
+  message: string,
+  data?: Record<string, unknown>
+): Promise<void>
+```
+
+Example:
+
+```typescript
+execute: async ({ location }, context) => {
+  await context.mcp.log('debug', 'Fetching weather', { location })
+  const weather = await fetchWeather(location)
+  await context.mcp.log('info', 'Weather fetched')
+  return weather
+}
+```
+
+## Progress notifications
+
+Long-running tools can report progress to the calling client with `notifications/progress`. Progress is only sent when the caller requested progress tracking by including a `progressToken` in the request (the Mastra `MCPClient` does this when `enableProgressTracking` is set). When no token was sent, `context.mcp.progress()` is a no-op.
+
+### `context.mcp.progress()`
+
+```typescript prettier:false
+async context.mcp.progress(params: {
+  progress: number;
+  total?: number;
+  message?: string;
+}): Promise<void>
+```
+
+Example:
+
+```typescript
+execute: async ({ items }, context) => {
+  for (const [index, item] of items.entries()) {
+    await processItem(item)
+    await context.mcp.progress({
+      progress: index + 1,
+      total: items.length,
+      message: `Processed ${item.name}`,
+    })
+  }
+  return { done: true }
+}
+```
+
+## Notification delivery
+
+Notification methods (`resources.notifyUpdated()`, `resources.notifyListChanged()`, `prompts.notifyListChanged()`, `toolActions.notifyListChanged()`, and `sendLoggingMessage()`) broadcast to every connected client across all transports: the stdio/SSE connection and each streamable HTTP session. Clients using the stateless serverless mode can't receive notifications because each request uses a transient server instance.
 
 ## Examples
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -3717,6 +3717,29 @@ export class Mastra<
   }
 
   /**
+   * Removes a tool from the Mastra instance by its registration key.
+   *
+   * Also unregisters the tool's static executor from the background task
+   * manager, if one was registered.
+   *
+   * @returns `true` if a tool was removed, `false` if no tool was registered under the key
+   *
+   * @example
+   * ```typescript
+   * mastra.removeTool('calculator-tool');
+   * ```
+   */
+  public removeTool(key: string): boolean {
+    const tools = this.#tools as Record<string, ToolAction<any, any, any, any>>;
+    if (!tools[key]) {
+      return false;
+    }
+    delete tools[key];
+    this.#backgroundTaskManager?.unregisterStaticExecutor(key);
+    return true;
+  }
+
+  /**
    * Retrieves a specific processor by registration key.
    *
    * @throws {MastraError} When the specified processor is not found

--- a/packages/core/src/mastra/remove-tool.test.ts
+++ b/packages/core/src/mastra/remove-tool.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { createTool } from '../tools';
+import { Mastra } from './index';
+
+const makeTool = (id: string) =>
+  createTool({
+    id,
+    description: 'A test tool',
+    inputSchema: z.object({}),
+    execute: async () => ({ result: 'ok' }),
+  });
+
+describe('Mastra.removeTool', () => {
+  it('should remove a tool by key', () => {
+    const testTool = makeTool('test-tool-id');
+
+    const mastra = new Mastra({
+      tools: { testTool },
+    });
+
+    expect(mastra.listTools()?.testTool).toBeDefined();
+
+    const removed = mastra.removeTool('testTool');
+    expect(removed).toBe(true);
+    expect(mastra.listTools()?.testTool).toBeUndefined();
+  });
+
+  it('should return false when tool does not exist', () => {
+    const mastra = new Mastra({});
+
+    expect(mastra.removeTool('non-existent-tool')).toBe(false);
+  });
+
+  it('should allow re-adding a tool after removal', () => {
+    const testTool = makeTool('reusable-tool-id');
+
+    const mastra = new Mastra({
+      tools: { myTool: testTool },
+    });
+
+    mastra.removeTool('myTool');
+    expect(mastra.listTools()?.myTool).toBeUndefined();
+
+    mastra.addTool(makeTool('reusable-tool-id'), 'myTool');
+    expect(mastra.listTools()?.myTool).toBeDefined();
+  });
+});

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -59,8 +59,8 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
   protected readonly agents?: MCPServerConfig['agents'];
   /** Workflows to be exposed as tools. */
   protected readonly workflows?: MCPServerConfig['workflows'];
-  /** Original tools configuration for re-conversion when Mastra instance is registered. */
-  protected readonly originalTools: ToolsInput;
+  /** Original tools configuration for re-conversion when Mastra instance is registered. Mutable to support dynamic tool management. */
+  protected originalTools: ToolsInput;
 
   /**
    * Public getter for the server's unique ID.

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -242,6 +242,9 @@ export interface WorkflowToolExecutionContext<TSuspend, TResume> {
   resumeData?: TResume;
 }
 
+/** Log levels for MCP `notifications/message`, ordered per RFC 5424. */
+export type MCPLoggingLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
+
 // MCP tool execution context - properties specific when tools are executed via Model Context Protocol
 export interface MCPToolExecutionContext {
   /** MCP protocol context passed by the server */
@@ -250,6 +253,16 @@ export interface MCPToolExecutionContext {
   elicitation: {
     sendRequest: (request: ElicitRequest['params']) => Promise<ElicitResult>;
   };
+  /**
+   * Sends a `notifications/message` log notification to the calling client.
+   * Messages below the client's minimum level (set via `logging/setLevel`) are dropped.
+   */
+  log?: (level: MCPLoggingLevel, message: string, data?: Record<string, unknown>) => Promise<void>;
+  /**
+   * Sends a `notifications/progress` notification to the calling client.
+   * No-op if the caller did not request progress tracking (no progressToken in `_meta`).
+   */
+  progress?: (params: { progress: number; total?: number; message?: string }) => Promise<void>;
 }
 
 /**

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -33,6 +33,7 @@ import {
   ListPromptsResultSchema,
   GetPromptResultSchema,
   PromptListChangedNotificationSchema,
+  ToolListChangedNotificationSchema,
   ElicitRequestSchema,
   ProgressNotificationSchema,
   ListRootsRequestSchema,
@@ -752,6 +753,17 @@ export class InternalMastraMCPClient extends MastraBase {
   setPromptListChangedNotificationHandler(handler: () => void): void {
     this.log('debug', 'Setting prompt list changed notification handler');
     this.client.setNotificationHandler(PromptListChangedNotificationSchema, () => {
+      handler();
+    });
+  }
+
+  /**
+   * Register a handler to be called when the tool list changes on the server.
+   * Use this to re-fetch tools via `tools()` when notified.
+   */
+  setToolListChangedNotificationHandler(handler: () => void): void {
+    this.log('debug', 'Setting tool list changed notification handler');
+    this.client.setNotificationHandler(ToolListChangedNotificationSchema, () => {
       handler();
     });
   }

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -661,6 +661,59 @@ To fix this you have three different options:
     };
   }
 
+  /**
+   * Provides access to tool-related notification operations across all configured servers.
+   *
+   * To fetch tools, use `listTools()` or `listToolsets()`.
+   *
+   * @example
+   * ```typescript
+   * // React to tool list changes on a server
+   * await mcp.tools.onListChanged('weatherServer', async () => {
+   *   console.log('Tool list changed, re-fetching...');
+   *   const tools = await mcp.listTools();
+   * });
+   * ```
+   */
+  public get tools() {
+    this.addToInstanceCache();
+    return {
+      /**
+       * Sets a notification handler for when the tool list changes on a server.
+       *
+       * @param serverName - Name of the server to monitor
+       * @param handler - Callback function invoked when tools are added/removed/modified
+       * @returns Promise resolving when handler is registered
+       * @throws {MastraError} If setting up the handler fails
+       *
+       * @example
+       * ```typescript
+       * await mcp.tools.onListChanged('weatherServer', async () => {
+       *   const tools = await mcp.listTools();
+       * });
+       * ```
+       */
+      onListChanged: async (serverName: string, handler: () => void) => {
+        try {
+          const internalClient = await this.getConnectedClientForServer(serverName);
+          return internalClient.setToolListChangedNotificationHandler(handler);
+        } catch (error) {
+          throw new MastraError(
+            {
+              id: 'MCP_CLIENT_ON_LIST_CHANGED_TOOLS_FAILED',
+              domain: ErrorDomain.MCP,
+              category: ErrorCategory.THIRD_PARTY,
+              details: {
+                serverName,
+              },
+            },
+            error,
+          );
+        }
+      },
+    };
+  }
+
   private addToInstanceCache() {
     if (!mcpClientInstances.has(this.id)) {
       mcpClientInstances.set(this.id, this);

--- a/packages/mcp/src/server/__tests__/dynamic-tools.test.ts
+++ b/packages/mcp/src/server/__tests__/dynamic-tools.test.ts
@@ -1,5 +1,7 @@
 import http from 'node:http';
+import { Mastra } from '@mastra/core';
 import type { ToolsInput } from '@mastra/core/agent';
+import { createTool } from '@mastra/core/tools';
 import getPort from 'get-port';
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { z } from 'zod/v3';
@@ -158,6 +160,40 @@ describe('MCPServer dynamic tools + tools/list_changed', () => {
     await standaloneServer.toolActions.remove(['dynamicTool']);
     standaloneServer.__registerMastra({} as any);
     expect(Object.keys(standaloneServer.tools())).not.toContain('dynamicTool');
+
+    await standaloneServer.close();
+  });
+
+  it('keeps the Mastra tool registry in sync with dynamic add/remove', async () => {
+    // Tool with an intrinsic ID that differs from its record key, to prove the
+    // Mastra registry is keyed by tool.id (mirroring __registerMastra).
+    const syncTool = createTool({
+      id: 'sync-tool-id',
+      description: 'A tool used to verify Mastra registry sync',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'sync' }),
+    });
+
+    const standaloneServer = new MCPServer({
+      name: 'RegistrySyncTestServer',
+      version: '1.0.0',
+      tools: {},
+    });
+    const mastra = new Mastra({
+      logger: false,
+      mcpServers: { registrySyncServer: standaloneServer },
+    });
+
+    expect(mastra.listTools()?.['sync-tool-id']).toBeUndefined();
+
+    await standaloneServer.toolActions.add({ syncToolKey: syncTool });
+    expect(mastra.listTools()?.['sync-tool-id']).toBeDefined();
+
+    // MCP-side removal is by record key; Mastra registry entry (keyed by
+    // tool.id) must be removed too.
+    await standaloneServer.toolActions.remove(['syncToolKey']);
+    expect(Object.keys(standaloneServer.tools())).not.toContain('syncToolKey');
+    expect(mastra.listTools()?.['sync-tool-id']).toBeUndefined();
 
     await standaloneServer.close();
   });

--- a/packages/mcp/src/server/__tests__/dynamic-tools.test.ts
+++ b/packages/mcp/src/server/__tests__/dynamic-tools.test.ts
@@ -1,0 +1,188 @@
+import http from 'node:http';
+import type { ToolsInput } from '@mastra/core/agent';
+import getPort from 'get-port';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { z } from 'zod/v3';
+import { InternalMastraMCPClient } from '../../client/client';
+import { MCPClient } from '../../client/configuration';
+import { MCPServer } from '../server';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 });
+
+const listenOnFreePort = async (server: http.Server): Promise<number> => {
+  const port = await getPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, () => resolve());
+  });
+  return port;
+};
+
+/**
+ * Repeatedly triggers `notify` until `received` resolves, to avoid races between
+ * the client's standalone SSE stream being established and the server sending
+ * the notification.
+ */
+const notifyUntilReceived = async (notify: () => Promise<void>, received: Promise<void>): Promise<void> => {
+  let done = false;
+  void received.then(() => {
+    done = true;
+  });
+  const deadline = Date.now() + 15000;
+  while (!done && Date.now() < deadline) {
+    await notify();
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  await received;
+};
+
+const initialTools: ToolsInput = {
+  initialTool: {
+    description: 'An initial tool',
+    parameters: z.object({}),
+    execute: async () => ({ result: 'initial' }),
+  },
+};
+
+const dynamicTools: ToolsInput = {
+  dynamicTool: {
+    description: 'A dynamically added tool',
+    parameters: z.object({ input: z.string().optional() }),
+    execute: async () => ({ result: 'dynamic' }),
+  },
+};
+
+describe('MCPServer dynamic tools + tools/list_changed', () => {
+  let server: MCPServer;
+  let httpServer: http.Server;
+  let client: InternalMastraMCPClient;
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: 'DynamicToolsTestServer',
+      version: '1.0.0',
+      tools: { ...initialTools },
+    });
+
+    let port = 0;
+    httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '', `http://localhost:${port}`);
+      await server.startHTTP({
+        url,
+        httpPath: '/mcp',
+        req,
+        res,
+      });
+    });
+    port = await listenOnFreePort(httpServer);
+
+    client = new InternalMastraMCPClient({
+      name: 'dynamic-tools-test-client',
+      server: {
+        url: new URL(`http://localhost:${port}/mcp`),
+      },
+    });
+    await client.connect();
+  });
+
+  afterAll(async () => {
+    await client?.disconnect();
+    httpServer?.closeAllConnections?.();
+    if (httpServer) {
+      await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    }
+    await server?.close();
+  });
+
+  it('declares the tools listChanged capability', () => {
+    // Access the underlying SDK client to read negotiated server capabilities
+    const capabilities = (client as any)['client'].getServerCapabilities();
+    expect(capabilities?.tools?.listChanged).toBe(true);
+  });
+
+  it('adding a tool notifies the client and the new tool is listed and callable', async () => {
+    const initialToolList = await client.tools();
+    expect(Object.keys(initialToolList)).toContain('initialTool');
+    expect(Object.keys(initialToolList)).not.toContain('dynamicTool');
+
+    const notified = new Promise<void>(resolve => {
+      client.setToolListChangedNotificationHandler(() => resolve());
+    });
+
+    await server.toolActions.add(dynamicTools);
+    // add() already sent one notification; re-notify until the client's SSE stream picks it up
+    await notifyUntilReceived(() => server.toolActions.notifyListChanged(), notified);
+    await expect(notified).resolves.toBeUndefined();
+
+    const updatedToolList = await client.tools();
+    expect(Object.keys(updatedToolList)).toContain('dynamicTool');
+
+    const tool = updatedToolList['dynamicTool'];
+    const result = await (tool!.execute as any)({ input: 'hello' });
+    expect(result.content?.[0]?.text).toContain('dynamic');
+  });
+
+  it('removing a tool notifies the client and the tool is no longer listed', async () => {
+    const notified = new Promise<void>(resolve => {
+      client.setToolListChangedNotificationHandler(() => resolve());
+    });
+
+    await server.toolActions.remove(['dynamicTool']);
+    await notifyUntilReceived(() => server.toolActions.notifyListChanged(), notified);
+    await expect(notified).resolves.toBeUndefined();
+
+    const toolList = await client.tools();
+    expect(Object.keys(toolList)).not.toContain('dynamicTool');
+    expect(Object.keys(toolList)).toContain('initialTool');
+  });
+
+  it('removing an unknown tool does not throw and does not notify', async () => {
+    await expect(server.toolActions.remove(['nope'])).resolves.toBeUndefined();
+  });
+
+  it('dynamically added tools survive tool re-conversion on Mastra registration', async () => {
+    const standaloneServer = new MCPServer({
+      name: 'ReconversionTestServer',
+      version: '1.0.0',
+      tools: { ...initialTools },
+    });
+
+    await standaloneServer.toolActions.add(dynamicTools);
+    expect(Object.keys(standaloneServer.tools())).toContain('dynamicTool');
+
+    // __registerMastra re-converts tools from originalTools
+    standaloneServer.__registerMastra({} as any);
+    expect(Object.keys(standaloneServer.tools())).toContain('dynamicTool');
+    expect(Object.keys(standaloneServer.tools())).toContain('initialTool');
+
+    await standaloneServer.toolActions.remove(['dynamicTool']);
+    standaloneServer.__registerMastra({} as any);
+    expect(Object.keys(standaloneServer.tools())).not.toContain('dynamicTool');
+
+    await standaloneServer.close();
+  });
+
+  it('MCPClient.tools.onListChanged receives tool list change notifications', async () => {
+    const mcpClient = new MCPClient({
+      id: 'dynamic-tools-mcpclient-test',
+      servers: {
+        dynamicServer: {
+          url: new URL((client as any)['serverConfig'].url),
+        },
+      },
+    });
+
+    try {
+      const notified = new Promise<void>(resolve => {
+        void mcpClient.tools.onListChanged('dynamicServer', () => resolve());
+      });
+      // Ensure connection + handler registration completed before notifying
+      await mcpClient.listTools();
+
+      await notifyUntilReceived(() => server.toolActions.notifyListChanged(), notified);
+      await expect(notified).resolves.toBeUndefined();
+    } finally {
+      await mcpClient.disconnect();
+    }
+  });
+});

--- a/packages/mcp/src/server/__tests__/logging-progress-emission.test.ts
+++ b/packages/mcp/src/server/__tests__/logging-progress-emission.test.ts
@@ -1,0 +1,198 @@
+import http from 'node:http';
+import type { ToolsInput } from '@mastra/core/agent';
+import getPort from 'get-port';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { z } from 'zod/v3';
+import type { LogMessage } from '../../client/client';
+import { InternalMastraMCPClient } from '../../client/client';
+import { MCPServer } from '../server';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 });
+
+const listenOnFreePort = async (server: http.Server): Promise<number> => {
+  const port = await getPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, () => resolve());
+  });
+  return port;
+};
+
+const waitFor = async (predicate: () => boolean, timeoutMs = 10000): Promise<void> => {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate() && Date.now() < deadline) {
+    await new Promise(resolve => setTimeout(resolve, 50));
+  }
+  expect(predicate()).toBe(true);
+};
+
+describe('MCPServer logging and progress emission', () => {
+  let server: MCPServer;
+  let httpServer: http.Server;
+
+  const tools: ToolsInput = {
+    loggingTool: {
+      description: 'A tool that emits log messages at multiple levels',
+      parameters: z.object({}),
+      execute: async (_args: any, options: any) => {
+        await options.mcp.log('debug', 'debug message');
+        await options.mcp.log('info', 'info message');
+        await options.mcp.log('error', 'error message', { code: 42 });
+        return { result: 'logged' };
+      },
+    },
+    progressTool: {
+      description: 'A tool that emits progress notifications',
+      parameters: z.object({}),
+      execute: async (_args: any, options: any) => {
+        await options.mcp.progress({ progress: 1, total: 3, message: 'step 1' });
+        await options.mcp.progress({ progress: 2, total: 3, message: 'step 2' });
+        await options.mcp.progress({ progress: 3, total: 3, message: 'done' });
+        return { result: 'progressed' };
+      },
+    },
+  };
+
+  const createClient = async (options?: { enableProgressTracking?: boolean; onLog?: (log: LogMessage) => void }) => {
+    const address = httpServer.address();
+    const port = typeof address === 'object' && address ? address.port : 0;
+    const client = new InternalMastraMCPClient({
+      name: 'logging-progress-test-client',
+      server: {
+        url: new URL(`http://localhost:${port}/mcp`),
+        enableServerLogs: true,
+        enableProgressTracking: options?.enableProgressTracking ?? false,
+        logger: options?.onLog ?? (() => {}),
+      },
+    });
+    await client.connect();
+    return client;
+  };
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: 'LoggingProgressTestServer',
+      version: '1.0.0',
+      tools,
+    });
+
+    let port = 0;
+    httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '', `http://localhost:${port}`);
+      await server.startHTTP({
+        url,
+        httpPath: '/mcp',
+        req,
+        res,
+      });
+    });
+    port = await listenOnFreePort(httpServer);
+  });
+
+  afterAll(async () => {
+    httpServer?.closeAllConnections?.();
+    if (httpServer) {
+      await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    }
+    await server?.close();
+  });
+
+  describe('tool-emitted logs (mcp.log)', () => {
+    it('are delivered to the calling client log handler', async () => {
+      const logs: LogMessage[] = [];
+      const client = await createClient({ onLog: log => logs.push(log) });
+
+      try {
+        const clientTools = await client.tools();
+        await (clientTools['loggingTool']!.execute as any)({});
+
+        await waitFor(() => logs.some(l => l.details?.data?.message === 'error message'));
+        const serverLogs = logs.filter(l => l.details?.data?.message !== undefined);
+        expect(serverLogs.map(l => l.level)).toEqual(['debug', 'info', 'error']);
+        expect(serverLogs[2]!.details?.data?.code).toBe(42);
+        expect(serverLogs[2]!.details?.logger).toBe('LoggingProgressTestServer');
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    it('honors the minimum level set via logging/setLevel', async () => {
+      const logs: LogMessage[] = [];
+      const client = await createClient({ onLog: log => logs.push(log) });
+
+      try {
+        // Set minimum level to 'error': debug and info must be dropped
+        await (client as any)['client'].setLoggingLevel('error');
+
+        const clientTools = await client.tools();
+        await (clientTools['loggingTool']!.execute as any)({});
+
+        await waitFor(() => logs.some(l => l.details?.data?.message === 'error message'));
+        const serverLogs = logs.filter(l => l.details?.data?.message !== undefined);
+        expect(serverLogs.map(l => l.level)).toEqual(['error']);
+      } finally {
+        await client.disconnect();
+      }
+    });
+  });
+
+  describe('server-level logs (server.sendLoggingMessage)', () => {
+    it('broadcasts to connected clients honoring their minimum level', async () => {
+      const logs: LogMessage[] = [];
+      const client = await createClient({ onLog: log => logs.push(log) });
+
+      try {
+        await (client as any)['client'].setLoggingLevel('warning');
+
+        // Below minimum level: skipped entirely (no eligible clients)
+        await server.sendLoggingMessage({ level: 'info', data: { message: 'not delivered' } });
+        // At/above minimum level: delivered
+        await server.sendLoggingMessage({ level: 'error', data: { message: 'delivered' } });
+
+        await waitFor(() => logs.some(l => l.details?.data?.message === 'delivered'));
+        expect(logs.some(l => l.details?.data?.message === 'not delivered')).toBe(false);
+      } finally {
+        await client.disconnect();
+      }
+    });
+  });
+
+  describe('tool-emitted progress (mcp.progress)', () => {
+    it('is delivered to the calling client with its progress token', async () => {
+      const client = await createClient({ enableProgressTracking: true });
+      const received: any[] = [];
+      client.setProgressNotificationHandler(params => received.push(params));
+
+      try {
+        const clientTools = await client.tools();
+        await (clientTools['progressTool']!.execute as any)({});
+
+        await waitFor(() => received.length >= 3);
+        expect(received.map(p => p.progress)).toEqual([1, 2, 3]);
+        expect(received[0].total).toBe(3);
+        expect(received[0].message).toBe('step 1');
+        expect(received[0].progressToken).toBeDefined();
+      } finally {
+        await client.disconnect();
+      }
+    });
+
+    it('is a no-op when the caller sent no progress token', async () => {
+      const client = await createClient({ enableProgressTracking: false });
+      const received: any[] = [];
+      client.setProgressNotificationHandler(params => received.push(params));
+
+      try {
+        const clientTools = await client.tools();
+        const result = await (clientTools['progressTool']!.execute as any)({});
+        expect(result.isError).toBeFalsy();
+
+        // Give any stray notifications a moment to arrive
+        await new Promise(resolve => setTimeout(resolve, 300));
+        expect(received).toHaveLength(0);
+      } finally {
+        await client.disconnect();
+      }
+    });
+  });
+});

--- a/packages/mcp/src/server/__tests__/notification-broadcast.test.ts
+++ b/packages/mcp/src/server/__tests__/notification-broadcast.test.ts
@@ -127,3 +127,93 @@ describe('Notification broadcast to streamable HTTP sessions', () => {
     await client.unsubscribeResource(uri);
   });
 });
+
+describe('Per-session resource subscriptions', () => {
+  let server: MCPServer;
+  let httpServer: http.Server;
+  let clientA: InternalMastraMCPClient;
+  let clientB: InternalMastraMCPClient;
+
+  const uri = 'test://resource/1';
+  const resources: MCPServerResources = {
+    listResources: async () => [{ uri, name: 'Resource One', mimeType: 'text/plain' }],
+    getResourceContent: async () => ({ text: 'hello' }),
+  };
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: 'SubscriptionIsolationTestServer',
+      version: '1.0.0',
+      tools: {},
+      resources,
+    });
+
+    let port = 0;
+    httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '', `http://localhost:${port}`);
+      await server.startHTTP({ url, httpPath: '/mcp', req, res });
+    });
+    port = await listenOnFreePort(httpServer);
+
+    const makeClient = (name: string) =>
+      new InternalMastraMCPClient({ name, server: { url: new URL(`http://localhost:${port}/mcp`) } });
+    clientA = makeClient('subscriber-client');
+    clientB = makeClient('non-subscriber-client');
+    await clientA.connect();
+    await clientB.connect();
+    expect(clientA.sessionId).toBeDefined();
+    expect(clientB.sessionId).toBeDefined();
+    expect(clientA.sessionId).not.toBe(clientB.sessionId);
+  });
+
+  afterAll(async () => {
+    await clientA?.disconnect();
+    await clientB?.disconnect();
+    httpServer?.closeAllConnections?.();
+    if (httpServer) {
+      await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    }
+    await server?.close();
+  });
+
+  it('only delivers resources/updated to the session that subscribed', async () => {
+    let bNotified = 0;
+    clientB.setResourceUpdatedNotificationHandler(() => {
+      bNotified++;
+    });
+    const aReceived = new Promise<void>(resolve => {
+      clientA.setResourceUpdatedNotificationHandler((params: { uri: string }) => {
+        if (params.uri === uri) resolve();
+      });
+    });
+
+    await clientA.subscribeResource(uri);
+
+    await notifyUntilReceived(() => server.resources.notifyUpdated({ uri }), aReceived);
+    await expect(aReceived).resolves.toBeUndefined();
+
+    // Give any in-flight notification to B time to arrive before asserting it never did.
+    await new Promise(resolve => setTimeout(resolve, 500));
+    expect(bNotified).toBe(0);
+
+    await clientA.unsubscribeResource(uri);
+  });
+
+  it('one session unsubscribing does not remove another session subscription', async () => {
+    const aReceived = new Promise<void>(resolve => {
+      clientA.setResourceUpdatedNotificationHandler((params: { uri: string }) => {
+        if (params.uri === uri) resolve();
+      });
+    });
+
+    await clientA.subscribeResource(uri);
+    await clientB.subscribeResource(uri);
+    // Previously subscriptions were global, so B unsubscribing clobbered A's subscription.
+    await clientB.unsubscribeResource(uri);
+
+    await notifyUntilReceived(() => server.resources.notifyUpdated({ uri }), aReceived);
+    await expect(aReceived).resolves.toBeUndefined();
+
+    await clientA.unsubscribeResource(uri);
+  });
+});

--- a/packages/mcp/src/server/__tests__/notification-broadcast.test.ts
+++ b/packages/mcp/src/server/__tests__/notification-broadcast.test.ts
@@ -1,0 +1,129 @@
+import http from 'node:http';
+import type { Prompt } from '@modelcontextprotocol/sdk/types.js';
+import getPort from 'get-port';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import { InternalMastraMCPClient } from '../../client/client';
+import { MCPServer } from '../server';
+import type { MCPServerResources } from '../types';
+
+vi.setConfig({ testTimeout: 20000, hookTimeout: 20000 });
+
+const listenOnFreePort = async (server: http.Server): Promise<number> => {
+  const port = await getPort();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, () => resolve());
+  });
+  return port;
+};
+
+/**
+ * Repeatedly triggers `notify` until `received` resolves, to avoid races between
+ * the client's standalone SSE stream being established and the server sending
+ * the notification.
+ */
+const notifyUntilReceived = async (notify: () => Promise<void>, received: Promise<void>): Promise<void> => {
+  let done = false;
+  void received.then(() => {
+    done = true;
+  });
+  const deadline = Date.now() + 15000;
+  while (!done && Date.now() < deadline) {
+    await notify();
+    await new Promise(resolve => setTimeout(resolve, 200));
+  }
+  await received;
+};
+
+describe('Notification broadcast to streamable HTTP sessions', () => {
+  let server: MCPServer;
+  let httpServer: http.Server;
+  let client: InternalMastraMCPClient;
+
+  const resources: MCPServerResources = {
+    listResources: async () => [{ uri: 'test://resource/1', name: 'Resource One', mimeType: 'text/plain' }],
+    getResourceContent: async () => ({ text: 'hello' }),
+  };
+
+  const prompts: Prompt[] = [{ name: 'test-prompt', description: 'A test prompt' }];
+
+  beforeAll(async () => {
+    server = new MCPServer({
+      name: 'BroadcastTestServer',
+      version: '1.0.0',
+      tools: {},
+      resources,
+      prompts: {
+        listPrompts: async () => prompts,
+        getPromptMessages: async () => [{ role: 'user', content: { type: 'text', text: 'hi' } }],
+      },
+    });
+
+    let port = 0;
+    httpServer = http.createServer(async (req, res) => {
+      const url = new URL(req.url || '', `http://localhost:${port}`);
+      // Stateful streamable HTTP: each session gets its own server instance
+      await server.startHTTP({
+        url,
+        httpPath: '/mcp',
+        req,
+        res,
+      });
+    });
+    port = await listenOnFreePort(httpServer);
+
+    client = new InternalMastraMCPClient({
+      name: 'broadcast-test-client',
+      server: {
+        url: new URL(`http://localhost:${port}/mcp`),
+      },
+    });
+    await client.connect();
+    // Sanity: the client must be connected via a streamable HTTP session,
+    // which means notifications go through an httpServerInstances entry.
+    expect(client.sessionId).toBeDefined();
+  });
+
+  afterAll(async () => {
+    await client?.disconnect();
+    httpServer?.closeAllConnections?.();
+    if (httpServer) {
+      await new Promise<void>(resolve => httpServer.close(() => resolve()));
+    }
+    await server?.close();
+  });
+
+  it('delivers resources/list_changed to a streamable HTTP client', async () => {
+    const received = new Promise<void>(resolve => {
+      client.setResourceListChangedNotificationHandler(() => resolve());
+    });
+
+    await notifyUntilReceived(() => server.resources.notifyListChanged(), received);
+    await expect(received).resolves.toBeUndefined();
+  });
+
+  it('delivers prompts/list_changed to a streamable HTTP client', async () => {
+    const received = new Promise<void>(resolve => {
+      client.setPromptListChangedNotificationHandler(() => resolve());
+    });
+
+    await notifyUntilReceived(() => server.prompts.notifyListChanged(), received);
+    await expect(received).resolves.toBeUndefined();
+  });
+
+  it('delivers resources/updated to a subscribed streamable HTTP client', async () => {
+    const uri = 'test://resource/1';
+    const received = new Promise<void>(resolve => {
+      client.setResourceUpdatedNotificationHandler((params: { uri: string }) => {
+        if (params.uri === uri) resolve();
+      });
+    });
+
+    await client.subscribeResource(uri);
+
+    await notifyUntilReceived(() => server.resources.notifyUpdated({ uri }), received);
+    await expect(received).resolves.toBeUndefined();
+
+    await client.unsubscribeResource(uri);
+  });
+});

--- a/packages/mcp/src/server/notificationBroadcast.ts
+++ b/packages/mcp/src/server/notificationBroadcast.ts
@@ -1,0 +1,64 @@
+import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
+import type { IMastraLogger } from '@mastra/core/logger';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+/**
+ * Sends a notification to every active server instance (the main stdio/SSE
+ * instance plus each streamable HTTP session instance).
+ *
+ * Failures are aggregated: if only some instances fail, the failure is logged
+ * and the broadcast is considered best-effort. A `MastraError` is thrown only
+ * when every send fails.
+ *
+ * Note: clients connected in stateless/serverless mode cannot receive
+ * notifications because each request uses a transient server instance.
+ *
+ * @internal
+ */
+export async function broadcastNotification({
+  servers,
+  send,
+  logger,
+  errorId,
+  errorText,
+  errorDetails,
+}: {
+  servers: Server[];
+  send: (server: Server) => Promise<void>;
+  logger: IMastraLogger;
+  errorId: Uppercase<string>;
+  errorText: string;
+  errorDetails?: Record<string, string | number>;
+}): Promise<void> {
+  const errors: unknown[] = [];
+  for (const server of servers) {
+    try {
+      await send(server);
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+
+  if (errors.length === 0) return;
+
+  const mastraError = new MastraError(
+    {
+      id: errorId,
+      domain: ErrorDomain.MCP,
+      category: ErrorCategory.THIRD_PARTY,
+      text: errorText,
+      details: {
+        ...errorDetails,
+        failedInstances: errors.length,
+        totalInstances: servers.length,
+      },
+    },
+    errors[0],
+  );
+  logger.error(`${errorText}:`, { error: mastraError.toString() });
+
+  if (errors.length === servers.length) {
+    logger.trackException(mastraError);
+    throw mastraError;
+  }
+}

--- a/packages/mcp/src/server/promptActions.ts
+++ b/packages/mcp/src/server/promptActions.ts
@@ -1,10 +1,10 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { IMastraLogger } from '@mastra/core/logger';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { broadcastNotification } from './notificationBroadcast';
 
 interface ServerPromptActionsDependencies {
   getLogger: () => IMastraLogger;
-  getSdkServer: () => Server;
+  getSdkServers: () => Server[];
   clearDefinedPrompts: () => void;
 }
 
@@ -13,10 +13,15 @@ interface ServerPromptActionsDependencies {
  *
  * This class provides methods for MCP servers to notify connected clients when
  * the list of available prompts changes.
+ *
+ * Notifications are broadcast to every active server instance (the main
+ * stdio/SSE instance plus each streamable HTTP session). Clients connected in
+ * stateless/serverless mode cannot receive notifications because each request
+ * uses a transient server instance.
  */
 export class ServerPromptActions {
   private readonly getLogger: () => IMastraLogger;
-  private readonly getSdkServer: () => Server;
+  private readonly getSdkServers: () => Server[];
   private readonly clearDefinedPrompts: () => void;
 
   /**
@@ -24,7 +29,7 @@ export class ServerPromptActions {
    */
   constructor(dependencies: ServerPromptActionsDependencies) {
     this.getLogger = dependencies.getLogger;
-    this.getSdkServer = dependencies.getSdkServer;
+    this.getSdkServers = dependencies.getSdkServers;
     this.clearDefinedPrompts = dependencies.clearDefinedPrompts;
   }
 
@@ -34,7 +39,7 @@ export class ServerPromptActions {
    * This clears the internal prompt cache and sends a `notifications/prompts/list_changed`
    * message to all clients, prompting them to re-fetch the prompt list.
    *
-   * @throws {MastraError} If sending the notification fails
+   * @throws {MastraError} If sending the notification fails on all server instances
    *
    * @example
    * ```typescript
@@ -45,23 +50,12 @@ export class ServerPromptActions {
   public async notifyListChanged(): Promise<void> {
     this.getLogger().info('Prompt list change externally notified. Clearing definedPrompts and sending notification.');
     this.clearDefinedPrompts();
-    try {
-      await this.getSdkServer().sendPromptListChanged();
-    } catch (error) {
-      const mastraError = new MastraError(
-        {
-          id: 'MCP_SERVER_PROMPT_LIST_CHANGED_NOTIFICATION_FAILED',
-          domain: ErrorDomain.MCP,
-          category: ErrorCategory.THIRD_PARTY,
-          text: 'Failed to send prompt list changed notification',
-        },
-        error,
-      );
-      this.getLogger().error('Failed to send prompt list changed notification:', {
-        error: mastraError.toString(),
-      });
-      this.getLogger().trackException(mastraError);
-      throw mastraError;
-    }
+    await broadcastNotification({
+      servers: this.getSdkServers(),
+      send: server => server.sendPromptListChanged(),
+      logger: this.getLogger(),
+      errorId: 'MCP_SERVER_PROMPT_LIST_CHANGED_NOTIFICATION_FAILED',
+      errorText: 'Failed to send prompt list changed notification',
+    });
   }
 }

--- a/packages/mcp/src/server/resourceActions.ts
+++ b/packages/mcp/src/server/resourceActions.ts
@@ -1,11 +1,11 @@
-import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { IMastraLogger } from '@mastra/core/logger';
 import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { broadcastNotification } from './notificationBroadcast';
 
 interface ServerResourceActionsDependencies {
   getSubscriptions: () => Set<string>;
   getLogger: () => IMastraLogger;
-  getSdkServer: () => Server;
+  getSdkServers: () => Server[];
 }
 
 /**
@@ -13,11 +13,16 @@ interface ServerResourceActionsDependencies {
  *
  * This class provides methods for MCP servers to notify connected clients when
  * resources are updated or when the resource list changes.
+ *
+ * Notifications are broadcast to every active server instance (the main
+ * stdio/SSE instance plus each streamable HTTP session). Clients connected in
+ * stateless/serverless mode cannot receive notifications because each request
+ * uses a transient server instance.
  */
 export class ServerResourceActions {
   private readonly getSubscriptions: () => Set<string>;
   private readonly getLogger: () => IMastraLogger;
-  private readonly getSdkServer: () => Server;
+  private readonly getSdkServers: () => Server[];
 
   /**
    * @internal
@@ -25,7 +30,7 @@ export class ServerResourceActions {
   constructor(dependencies: ServerResourceActionsDependencies) {
     this.getSubscriptions = dependencies.getSubscriptions;
     this.getLogger = dependencies.getLogger;
-    this.getSdkServer = dependencies.getSdkServer;
+    this.getSdkServers = dependencies.getSdkServers;
   }
 
   /**
@@ -36,7 +41,7 @@ export class ServerResourceActions {
    *
    * @param params - Notification parameters
    * @param params.uri - URI of the resource that was updated
-   * @throws {MastraError} If sending the notification fails
+   * @throws {MastraError} If sending the notification fails on all server instances
    *
    * @example
    * ```typescript
@@ -47,27 +52,14 @@ export class ServerResourceActions {
   public async notifyUpdated({ uri }: { uri: string }): Promise<void> {
     if (this.getSubscriptions().has(uri)) {
       this.getLogger().info(`Sending notifications/resources/updated for externally notified resource: ${uri}`);
-      try {
-        await this.getSdkServer().sendResourceUpdated({ uri });
-      } catch (error) {
-        const mastraError = new MastraError(
-          {
-            id: 'MCP_SERVER_RESOURCE_UPDATED_NOTIFICATION_FAILED',
-            domain: ErrorDomain.MCP,
-            category: ErrorCategory.THIRD_PARTY,
-            text: 'Failed to send resource updated notification',
-            details: {
-              uri,
-            },
-          },
-          error,
-        );
-        this.getLogger().trackException(mastraError);
-        this.getLogger().error('Failed to send resource updated notification:', {
-          error: mastraError.toString(),
-        });
-        throw mastraError;
-      }
+      await broadcastNotification({
+        servers: this.getSdkServers(),
+        send: server => server.sendResourceUpdated({ uri }),
+        logger: this.getLogger(),
+        errorId: 'MCP_SERVER_RESOURCE_UPDATED_NOTIFICATION_FAILED',
+        errorText: 'Failed to send resource updated notification',
+        errorDetails: { uri },
+      });
     } else {
       this.getLogger().debug(`Resource ${uri} was updated, but no active subscriptions for it.`);
     }
@@ -80,7 +72,7 @@ export class ServerResourceActions {
    * them to re-fetch the resource list. Resource lists and templates are always evaluated
    * per request, so there is no server-side cache to clear.
    *
-   * @throws {MastraError} If sending the notification fails
+   * @throws {MastraError} If sending the notification fails on all server instances
    *
    * @example
    * ```typescript
@@ -90,23 +82,12 @@ export class ServerResourceActions {
    */
   public async notifyListChanged(): Promise<void> {
     this.getLogger().info('Resource list change externally notified. Sending notification.');
-    try {
-      await this.getSdkServer().sendResourceListChanged();
-    } catch (error) {
-      const mastraError = new MastraError(
-        {
-          id: 'MCP_SERVER_RESOURCE_LIST_CHANGED_NOTIFICATION_FAILED',
-          domain: ErrorDomain.MCP,
-          category: ErrorCategory.THIRD_PARTY,
-          text: 'Failed to send resource list changed notification',
-        },
-        error,
-      );
-      this.getLogger().trackException(mastraError);
-      this.getLogger().error('Failed to send resource list changed notification:', {
-        error: mastraError.toString(),
-      });
-      throw mastraError;
-    }
+    await broadcastNotification({
+      servers: this.getSdkServers(),
+      send: server => server.sendResourceListChanged(),
+      logger: this.getLogger(),
+      errorId: 'MCP_SERVER_RESOURCE_LIST_CHANGED_NOTIFICATION_FAILED',
+      errorText: 'Failed to send resource list changed notification',
+    });
   }
 }

--- a/packages/mcp/src/server/resourceActions.ts
+++ b/packages/mcp/src/server/resourceActions.ts
@@ -3,7 +3,7 @@ import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { broadcastNotification } from './notificationBroadcast';
 
 interface ServerResourceActionsDependencies {
-  getSubscriptions: () => Set<string>;
+  getSubscribedServers: (uri: string) => Server[];
   getLogger: () => IMastraLogger;
   getSdkServers: () => Server[];
 }
@@ -20,7 +20,7 @@ interface ServerResourceActionsDependencies {
  * uses a transient server instance.
  */
 export class ServerResourceActions {
-  private readonly getSubscriptions: () => Set<string>;
+  private readonly getSubscribedServers: (uri: string) => Server[];
   private readonly getLogger: () => IMastraLogger;
   private readonly getSdkServers: () => Server[];
 
@@ -28,7 +28,7 @@ export class ServerResourceActions {
    * @internal
    */
   constructor(dependencies: ServerResourceActionsDependencies) {
-    this.getSubscriptions = dependencies.getSubscriptions;
+    this.getSubscribedServers = dependencies.getSubscribedServers;
     this.getLogger = dependencies.getLogger;
     this.getSdkServers = dependencies.getSdkServers;
   }
@@ -36,12 +36,13 @@ export class ServerResourceActions {
   /**
    * Notifies subscribed clients that a specific resource has been updated.
    *
-   * If clients are subscribed to the resource URI, they will receive a
-   * `notifications/resources/updated` message to re-fetch the resource content.
+   * Only clients that subscribed to the resource URI (via `resources/subscribe`)
+   * receive a `notifications/resources/updated` message prompting them to
+   * re-fetch the resource content.
    *
    * @param params - Notification parameters
    * @param params.uri - URI of the resource that was updated
-   * @throws {MastraError} If sending the notification fails on all server instances
+   * @throws {MastraError} If sending the notification fails on all subscribed server instances
    *
    * @example
    * ```typescript
@@ -50,19 +51,20 @@ export class ServerResourceActions {
    * ```
    */
   public async notifyUpdated({ uri }: { uri: string }): Promise<void> {
-    if (this.getSubscriptions().has(uri)) {
-      this.getLogger().info(`Sending notifications/resources/updated for externally notified resource: ${uri}`);
-      await broadcastNotification({
-        servers: this.getSdkServers(),
-        send: server => server.sendResourceUpdated({ uri }),
-        logger: this.getLogger(),
-        errorId: 'MCP_SERVER_RESOURCE_UPDATED_NOTIFICATION_FAILED',
-        errorText: 'Failed to send resource updated notification',
-        errorDetails: { uri },
-      });
-    } else {
+    const subscribedServers = this.getSubscribedServers(uri);
+    if (subscribedServers.length === 0) {
       this.getLogger().debug(`Resource ${uri} was updated, but no active subscriptions for it.`);
+      return;
     }
+    this.getLogger().info(`Sending notifications/resources/updated for externally notified resource: ${uri}`);
+    await broadcastNotification({
+      servers: subscribedServers,
+      send: server => server.sendResourceUpdated({ uri }),
+      logger: this.getLogger(),
+      errorId: 'MCP_SERVER_RESOURCE_UPDATED_NOTIFICATION_FAILED',
+      errorText: 'Failed to send resource updated notification',
+      errorDetails: { uri },
+    });
   }
 
   /**

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -58,9 +58,25 @@ import { streamSSE } from 'hono/streaming';
 import { SSETransport } from 'hono-mcp-server-sse-transport';
 
 import { withMastraToolStrictMeta } from '../shared/mastra-tool-meta';
+import { broadcastNotification } from './notificationBroadcast';
 import { ServerPromptActions } from './promptActions';
 import { ServerResourceActions } from './resourceActions';
+import { ServerToolActions } from './toolActions';
 import type { MCPServerPrompts, MCPServerResources, ElicitationActions, MastraPrompt, AppResources } from './types';
+
+// RFC 5424 syslog severity ordering used by the MCP logging utility.
+// Higher numbers are more severe; messages below a client's minimum level are dropped.
+const LOG_LEVEL_SEVERITY: Record<LoggingLevel, number> = {
+  debug: 0,
+  info: 1,
+  notice: 2,
+  warning: 3,
+  error: 4,
+  critical: 5,
+  alert: 6,
+  emergency: 7,
+};
+
 /**
  * MCPServer exposes Mastra tools, agents, and workflows as a Model Context Protocol (MCP) server.
  *
@@ -109,7 +125,8 @@ export class MCPServer extends MCPServerBase {
   private mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
   private fga?: MCPServerFGAConfig;
   private subscriptions: Set<string> = new Set();
-  private currentLoggingLevel: LoggingLevel | undefined;
+  // Minimum logging level per server instance (main + per HTTP session), set via logging/setLevel
+  private loggingLevels: WeakMap<Server, LoggingLevel> = new WeakMap();
 
   /**
    * Provides methods to notify clients about resource changes.
@@ -135,6 +152,25 @@ export class MCPServer extends MCPServerBase {
    * ```
    */
   public readonly prompts: ServerPromptActions;
+
+  /**
+   * Provides methods to dynamically manage tools and notify clients about
+   * tool list changes. Named `toolActions` because `tools()` is the tool
+   * registry getter inherited from `MCPServerBase`.
+   *
+   * @example
+   * ```typescript
+   * // Register a new tool at runtime and notify clients
+   * await server.toolActions.add({ myNewTool });
+   *
+   * // Remove a tool and notify clients
+   * await server.toolActions.remove(['myNewTool']);
+   *
+   * // Notify that the tool list changed (e.g. authorization changes)
+   * await server.toolActions.notifyListChanged();
+   * ```
+   */
+  public readonly toolActions: ServerToolActions;
 
   /**
    * Provides methods for interactive user input collection during tool execution.
@@ -319,7 +355,7 @@ export class MCPServer extends MCPServerBase {
     this.fga = opts.fga;
 
     const capabilities: ServerCapabilities = {
-      tools: {},
+      tools: { listChanged: true },
       logging: { enabled: true },
     };
 
@@ -370,15 +406,22 @@ export class MCPServer extends MCPServerBase {
     this.resources = new ServerResourceActions({
       getSubscriptions: () => this.subscriptions,
       getLogger: () => this.logger,
-      getSdkServer: () => this.server,
+      getSdkServers: () => this.getAllSdkServers(),
     });
 
     this.prompts = new ServerPromptActions({
       getLogger: () => this.logger,
-      getSdkServer: () => this.server,
+      getSdkServers: () => this.getAllSdkServers(),
       clearDefinedPrompts: () => {
         this.definedPrompts = undefined;
       },
+    });
+
+    this.toolActions = new ServerToolActions({
+      getLogger: () => this.logger,
+      getSdkServers: () => this.getAllSdkServers(),
+      addTools: tools => this.addTools(tools),
+      removeTools: toolIds => this.removeTools(toolIds),
     });
 
     this.elicitation = {
@@ -386,6 +429,107 @@ export class MCPServer extends MCPServerBase {
         return this.handleElicitationRequest(request, undefined, options);
       },
     };
+  }
+
+  /**
+   * Returns every connected SDK server instance: the main instance (stdio/SSE
+   * transports) plus one instance per streamable HTTP session. Used to
+   * broadcast notifications to all connected clients. Instances without a
+   * connected transport are skipped.
+   *
+   * Note: stateless/serverless requests use transient server instances and
+   * cannot receive notifications.
+   */
+  private getAllSdkServers(): Server[] {
+    return [this.server, ...this.httpServerInstances.values()].filter(server => server.transport !== undefined);
+  }
+
+  /**
+   * Determines whether a log message at the given level should be sent to the
+   * client connected to the given server instance, honoring the minimum level
+   * the client set via `logging/setLevel` (RFC 5424 severity ordering).
+   * When the client never set a level, all messages are sent.
+   */
+  private shouldSendLog(serverInstance: Server, level: LoggingLevel): boolean {
+    const minimumLevel = this.loggingLevels.get(serverInstance);
+    if (minimumLevel === undefined) return true;
+    return LOG_LEVEL_SEVERITY[level] >= LOG_LEVEL_SEVERITY[minimumLevel];
+  }
+
+  /**
+   * Sends a `notifications/message` log notification to connected clients.
+   *
+   * The notification is broadcast to every active server instance, honoring
+   * the minimum logging level each client set via `logging/setLevel`.
+   *
+   * @param params - Log message parameters
+   * @param params.level - Log severity level
+   * @param params.data - Arbitrary JSON-serializable data to log
+   * @param params.logger - Optional logger name
+   * @throws {MastraError} If sending the notification fails on all eligible server instances
+   *
+   * @example
+   * ```typescript
+   * await server.sendLoggingMessage({
+   *   level: 'info',
+   *   data: { message: 'Sync completed', itemsProcessed: 42 },
+   * });
+   * ```
+   */
+  public async sendLoggingMessage(params: { level: LoggingLevel; data: unknown; logger?: string }): Promise<void> {
+    const eligibleServers = this.getAllSdkServers().filter(server => this.shouldSendLog(server, params.level));
+    if (eligibleServers.length === 0) {
+      this.logger.debug('No eligible clients for log message; skipping.', { level: params.level });
+      return;
+    }
+    await broadcastNotification({
+      servers: eligibleServers,
+      send: server => server.sendLoggingMessage(params),
+      logger: this.logger,
+      errorId: 'MCP_SERVER_LOGGING_MESSAGE_NOTIFICATION_FAILED',
+      errorText: 'Failed to send logging message notification',
+      errorDetails: { level: params.level },
+    });
+  }
+
+  /**
+   * Registers new tools on the running server. Tools are merged into both the
+   * converted tool registry (used by list/call handlers) and the original
+   * tools config so they survive tool re-conversion when the server is
+   * registered with a Mastra instance.
+   */
+  private addTools(tools: ToolsInput): void {
+    const converted = this.convertTools(tools);
+    for (const key of Object.keys(converted)) {
+      if (this.convertedTools[key]) {
+        this.logger.warn(`Tool '${key}' already exists and will be replaced.`);
+      }
+    }
+    this.convertedTools = { ...this.convertedTools, ...converted };
+    this.originalTools = { ...this.originalTools, ...tools };
+  }
+
+  /**
+   * Removes tools from the running server by tool ID.
+   *
+   * @returns The IDs of the tools that were actually removed
+   */
+  private removeTools(toolIds: string[]): string[] {
+    const removed: string[] = [];
+    const convertedTools = { ...this.convertedTools };
+    const originalTools = { ...this.originalTools };
+    for (const toolId of toolIds) {
+      if (convertedTools[toolId]) {
+        delete convertedTools[toolId];
+        delete originalTools[toolId];
+        removed.push(toolId);
+      } else {
+        this.logger.warn(`Cannot remove tool '${toolId}': tool not found.`);
+      }
+    }
+    this.convertedTools = convertedTools;
+    this.originalTools = originalTools;
+    return removed;
   }
 
   /**
@@ -556,7 +700,7 @@ export class MCPServer extends MCPServerBase {
    */
   private createServerInstance(): Server {
     const capabilities: ServerCapabilities = {
-      tools: {},
+      tools: { listChanged: true },
       logging: { enabled: true },
     };
 
@@ -696,6 +840,47 @@ export class MCPServer extends MCPServerBase {
 
         const proxiedContext = await this.createProxiedRequestContext(extra);
 
+        // Session-aware log emission: sends notifications/message to the calling
+        // client, honoring the minimum level it set via logging/setLevel.
+        const sessionLog = async (
+          level: LoggingLevel,
+          message: string,
+          data?: Record<string, unknown>,
+        ): Promise<void> => {
+          if (!this.shouldSendLog(serverInstance, level)) return;
+          await extra.sendNotification({
+            method: 'notifications/message',
+            params: {
+              level,
+              logger: this.name,
+              data: { message, ...data },
+            },
+          });
+        };
+
+        // Session-aware progress emission: sends notifications/progress with the
+        // progressToken the caller provided. No-op when no token was sent, per spec.
+        const progressToken = extra._meta?.progressToken;
+        const sessionProgress = async (params: {
+          progress: number;
+          total?: number;
+          message?: string;
+        }): Promise<void> => {
+          if (progressToken === undefined) {
+            this.logger.debug('Tool attempted to send progress but the caller sent no progressToken; skipping.', {
+              tool: request.params.name,
+            });
+            return;
+          }
+          await extra.sendNotification({
+            method: 'notifications/progress',
+            params: {
+              progressToken,
+              ...params,
+            },
+          });
+        };
+
         const mcpOptions: MastraToolInvocationOptions = {
           messages: [],
           toolCallId: '',
@@ -704,6 +889,8 @@ export class MCPServer extends MCPServerBase {
           mcp: {
             elicitation: sessionElicitation,
             extra,
+            log: sessionLog,
+            progress: sessionProgress,
           },
           // @ts-expect-error this is to let people know that the elicitation and extra keys are now nested under mcp.elicitation and mcp.extra in tool arguments
           get elicitation() {
@@ -806,9 +993,10 @@ export class MCPServer extends MCPServerBase {
       }
     });
 
-    // Set logging level handler
+    // Set logging level handler. The level is tracked per server instance so
+    // each HTTP session (which gets its own instance) can set its own level.
     serverInstance.setRequestHandler(SetLevelRequestSchema, async request => {
-      this.currentLoggingLevel = request.params.level;
+      this.loggingLevels.set(serverInstance, request.params.level);
       this.logger.debug('Logging level set', { level: request.params.level });
       return {};
     });
@@ -1632,12 +1820,20 @@ export class MCPServer extends MCPServerBase {
           if (isInitializeRequest(body)) {
             this.logger.debug('Received initialize request, creating new transport');
 
-            // Create a new transport for the new session
+            // Create a new server instance for this HTTP session
+            const sessionServerInstance = this.createServerInstance();
+
+            // Create a new transport for the new session.
+            // The session ID is only assigned while the transport handles the
+            // initialize request, so the transport and server instance must be
+            // registered in the onsessioninitialized callback.
             transport = new StreamableHTTPServerTransport({
               ...mergedOptions,
               sessionIdGenerator: mergedOptions.sessionIdGenerator,
               onsessioninitialized: id => {
                 this.streamableHTTPTransports.set(id, transport!);
+                this.httpServerInstances.set(id, sessionServerInstance);
+                this.logger.debug('Session initialized and stored', { sessionId: id });
               },
             });
 
@@ -1655,22 +1851,12 @@ export class MCPServer extends MCPServerBase {
               }
             };
 
-            // Create a new server instance for this HTTP session
-            const sessionServerInstance = this.createServerInstance();
-
             // Connect the new server instance to the new transport
             await sessionServerInstance.connect(transport);
 
-            // Store both the transport and server instance when the session is initialized
-            if (transport.sessionId) {
-              this.streamableHTTPTransports.set(transport.sessionId, transport);
-              this.httpServerInstances.set(transport.sessionId, sessionServerInstance);
-              this.logger.debug('Session initialized and stored', { sessionId: transport.sessionId });
-            } else {
-              this.logger.warn('Transport initialized without a session ID');
-            }
-
-            // Handle the initialize request
+            // Handle the initialize request. This assigns the session ID and
+            // triggers onsessioninitialized, which stores the transport and
+            // server instance for the session.
             return await transport.handleRequest(req, res, body);
           } else {
             // POST request but not initialize, and no session ID

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -511,6 +511,15 @@ export class MCPServer extends MCPServerBase {
     }
     this.convertedTools = { ...this.convertedTools, ...converted };
     this.originalTools = { ...this.originalTools, ...tools };
+    // Keep the Mastra instance's tool registry in sync, mirroring the
+    // auto-registration done in __registerMastra.
+    if (this.mastra) {
+      for (const [key, tool] of Object.entries(tools)) {
+        if (tool && typeof tool === 'object' && 'id' in tool) {
+          this.mastra.addTool(tool as any, this.mastraToolKey(key, tool));
+        }
+      }
+    }
   }
 
   /**
@@ -524,9 +533,14 @@ export class MCPServer extends MCPServerBase {
     const originalTools = { ...this.originalTools };
     for (const toolId of toolIds) {
       if (convertedTools[toolId]) {
+        const originalTool = originalTools[toolId];
         delete convertedTools[toolId];
         delete originalTools[toolId];
         removed.push(toolId);
+        // Keep the Mastra instance's tool registry in sync.
+        if (this.mastra && originalTool && typeof originalTool === 'object' && 'id' in originalTool) {
+          this.mastra.removeTool(this.mastraToolKey(toolId, originalTool));
+        }
       } else {
         this.logger.warn(`Cannot remove tool '${toolId}': tool not found.`);
       }
@@ -534,6 +548,15 @@ export class MCPServer extends MCPServerBase {
     this.convertedTools = convertedTools;
     this.originalTools = originalTools;
     return removed;
+  }
+
+  /**
+   * The key a tool is registered under in the Mastra instance's tool
+   * registry: the tool's intrinsic ID when present (avoids collisions across
+   * MCP servers), falling back to its record key. Mirrors __registerMastra.
+   */
+  private mastraToolKey(key: string, tool: NonNullable<ToolsInput[string]>): string {
+    return 'id' in tool && typeof (tool as any).id === 'string' ? (tool as any).id : key;
   }
 
   /**

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -124,7 +124,10 @@ export class MCPServer extends MCPServerBase {
   private jsonSchemaValidator?: jsonSchemaValidator;
   private mapAuthInfoToUser?: MCPAuthInfoToUserMapper;
   private fga?: MCPServerFGAConfig;
-  private subscriptions: Set<string> = new Set();
+  // Resource subscriptions per server instance (main + per HTTP session), set via
+  // resources/subscribe. Note: legacy SSE sessions share the main instance, so they
+  // share one subscription set; streamable HTTP sessions are isolated per session.
+  private subscriptionsByInstance: WeakMap<Server, Set<string>> = new WeakMap();
   // Minimum logging level per server instance (main + per HTTP session), set via logging/setLevel
   private loggingLevels: WeakMap<Server, LoggingLevel> = new WeakMap();
 
@@ -404,7 +407,8 @@ export class MCPServer extends MCPServerBase {
     this.registerHandlersOnServer(this.server);
 
     this.resources = new ServerResourceActions({
-      getSubscriptions: () => this.subscriptions,
+      getSubscribedServers: (uri: string) =>
+        this.getAllSdkServers().filter(server => this.subscriptionsByInstance.get(server)?.has(uri)),
       getLogger: () => this.logger,
       getSdkServers: () => this.getAllSdkServers(),
     });
@@ -1115,14 +1119,19 @@ export class MCPServer extends MCPServerBase {
     serverInstance.setRequestHandler(SubscribeRequestSchema, async (request: { params: { uri: string } }) => {
       const uri = request.params.uri;
       this.logger.info('Received resources/subscribe request', { uri });
-      this.subscriptions.add(uri);
+      let subscriptions = this.subscriptionsByInstance.get(serverInstance);
+      if (!subscriptions) {
+        subscriptions = new Set();
+        this.subscriptionsByInstance.set(serverInstance, subscriptions);
+      }
+      subscriptions.add(uri);
       return {};
     });
 
     serverInstance.setRequestHandler(UnsubscribeRequestSchema, async (request: { params: { uri: string } }) => {
       const uri = request.params.uri;
       this.logger.info('Received resources/unsubscribe request', { uri });
-      this.subscriptions.delete(uri);
+      this.subscriptionsByInstance.get(serverInstance)?.delete(uri);
       return {};
     });
   }

--- a/packages/mcp/src/server/toolActions.ts
+++ b/packages/mcp/src/server/toolActions.ts
@@ -1,0 +1,106 @@
+import type { ToolsInput } from '@mastra/core/agent';
+import type { IMastraLogger } from '@mastra/core/logger';
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { broadcastNotification } from './notificationBroadcast';
+
+interface ServerToolActionsDependencies {
+  getLogger: () => IMastraLogger;
+  getSdkServers: () => Server[];
+  addTools: (tools: ToolsInput) => void;
+  removeTools: (toolIds: string[]) => string[];
+}
+
+/**
+ * Server-side tool actions for dynamic tool management and notifying clients
+ * about tool list changes.
+ *
+ * Notifications are broadcast to every active server instance (the main
+ * stdio/SSE instance plus each streamable HTTP session). Clients connected in
+ * stateless/serverless mode cannot receive notifications because each request
+ * uses a transient server instance.
+ */
+export class ServerToolActions {
+  private readonly getLogger: () => IMastraLogger;
+  private readonly getSdkServers: () => Server[];
+  private readonly addTools: (tools: ToolsInput) => void;
+  private readonly removeTools: (toolIds: string[]) => string[];
+
+  /**
+   * @internal
+   */
+  constructor(dependencies: ServerToolActionsDependencies) {
+    this.getLogger = dependencies.getLogger;
+    this.getSdkServers = dependencies.getSdkServers;
+    this.addTools = dependencies.addTools;
+    this.removeTools = dependencies.removeTools;
+  }
+
+  /**
+   * Registers new tools on the running server and notifies connected clients
+   * that the tool list has changed.
+   *
+   * Tools are keyed by their record key, the same as tools passed to the
+   * `MCPServer` constructor. Adding a tool under an existing key replaces it.
+   *
+   * @param tools - Tools to register
+   * @throws {MastraError} If sending the notification fails on all server instances
+   *
+   * @example
+   * ```typescript
+   * await server.toolActions.add({ myNewTool });
+   * ```
+   */
+  public async add(tools: ToolsInput): Promise<void> {
+    this.addTools(tools);
+    await this.notifyListChanged();
+  }
+
+  /**
+   * Removes tools from the running server and notifies connected clients that
+   * the tool list has changed.
+   *
+   * Unknown tool IDs are ignored (logged as a warning). If no tools were
+   * actually removed, no notification is sent.
+   *
+   * @param toolIds - IDs of the tools to remove
+   * @throws {MastraError} If sending the notification fails on all server instances
+   *
+   * @example
+   * ```typescript
+   * await server.toolActions.remove(['myNewTool']);
+   * ```
+   */
+  public async remove(toolIds: string[]): Promise<void> {
+    const removed = this.removeTools(toolIds);
+    if (removed.length === 0) {
+      this.getLogger().debug('No tools were removed; skipping tool list changed notification.');
+      return;
+    }
+    await this.notifyListChanged();
+  }
+
+  /**
+   * Notifies clients that the overall list of available tools has changed.
+   *
+   * This sends a `notifications/tools/list_changed` message to all clients,
+   * prompting them to re-fetch the tool list.
+   *
+   * @throws {MastraError} If sending the notification fails on all server instances
+   *
+   * @example
+   * ```typescript
+   * // After changing which tools are available
+   * await server.toolActions.notifyListChanged();
+   * ```
+   */
+  public async notifyListChanged(): Promise<void> {
+    this.getLogger().info('Tool list changed. Sending notification.');
+    await broadcastNotification({
+      servers: this.getSdkServers(),
+      send: server => server.sendToolListChanged(),
+      logger: this.getLogger(),
+      errorId: 'MCP_SERVER_TOOL_LIST_CHANGED_NOTIFICATION_FAILED',
+      errorText: 'Failed to send tool list changed notification',
+    });
+  }
+}


### PR DESCRIPTION
Mastra's MCP package had partial notification coverage: clients could receive most notifications, but servers had no way to emit several of them, and a session registration bug meant existing notifications never reached streamable HTTP clients at all. This PR closes those gaps so `@mastra/mcp` covers the full MCP notification spec.

Notifications now reach streamable HTTP clients. `httpServerInstances` was never populated (sessions were registered before the session ID existed), so `resources.notifyUpdated()`, `resources.notifyListChanged()`, and `prompts.notifyListChanged()` silently went nowhere for HTTP sessions. Sessions are now registered on `onsessioninitialized` and notifications broadcast to every connected instance.

Resource subscriptions are now tracked per session instead of one global set, so `notifications/resources/updated` only goes to clients that subscribed, and one client unsubscribing no longer clears everyone else's subscription.

Servers can add and remove tools at runtime, with clients notified via `notifications/tools/list_changed`:

```typescript
await server.toolActions.add({ myNewTool });
await server.toolActions.remove(['myNewTool']);

// client side
await mcp.tools.onListChanged('myServer', async () => {
  const tools = await mcp.listTools();
});
```

Dynamic add/remove also keeps a registered Mastra instance's tool registry in sync, via a new `mastra.removeTool(key)` API in core.

Servers can emit log and progress notifications, honoring each client's `logging/setLevel` per session:

```typescript
await server.sendLoggingMessage({ level: 'info', data: { message: 'Sync completed' } });

// from inside a tool, sent to the calling client
await context.mcp.log('debug', 'Fetching weather', { location });
await context.mcp.progress({ progress: 1, total: 3, message: 'step 1' });
```

Tested with 20 new tests across broadcast delivery, subscription isolation, dynamic tools, registry sync, and logging/progress emission. Docs and changesets included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This PR makes MCP servers much better at keeping clients in sync. Now when things change—like tools, resources, prompts, logs, or progress updates—connected clients are told correctly, even if there are many sessions at once.

## Summary
- Fixed MCP notification delivery over streamable HTTP sessions.
- Broadcasted resource, prompt, and tool list-change notifications to the right connected sessions.
- Switched resource subscriptions to be tracked per session so one client unsubscribing does not affect others.
- Added dynamic tool add/remove support, plus client-side handling for tool list changes.
- Added server-side logging and progress notifications for tools.
- Added `mastra.removeTool(key)` and kept the Mastra tool registry in sync with MCP tool changes.
- Updated docs, changesets, and tests to cover the new behavior.

## Testing
- Added integration coverage for notification broadcasting
- Added tests for per-session subscription isolation
- Added tests for dynamic tool add/remove and registry sync
- Added tests for logging and progress emission
- Added unit coverage for `Mastra.removeTool`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->