### PR TITLE
fix(core): stop workflow.fail republish loop on retry exhaustion

### DIFF
--- a/.changeset/khaki-buses-deny.md
+++ b/.changeset/khaki-buses-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an infinite retry loop in evented workflows when workflow storage is unavailable (for example when the workflows table does not exist). A failing workflow.fail event no longer republishes another workflow.fail after exhausting its retry budget, which previously flooded logs with endless "error processing event" entries.

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -2638,7 +2638,17 @@ export class WorkflowEventProcessor extends EventProcessor {
       this.#setDeliveryAttempts(eventKey, WorkflowEventProcessor.TERMINAL_SENTINEL);
       try {
         const failWorkflowData = event.data as Omit<ProcessorArgs, 'workflow'>;
-        if (failWorkflowData && failWorkflowData.workflowId && failWorkflowData.runId) {
+        // Never republish workflow.fail for an event that IS workflow.fail.
+        // Each publish gets a fresh event id (fresh retry bucket), so with a
+        // persistently-broken dependency (e.g. missing workflows table) the
+        // fail event would exhaust its own budget and publish another
+        // workflow.fail forever.
+        if (
+          event.type !== 'workflow.fail' &&
+          failWorkflowData &&
+          failWorkflowData.workflowId &&
+          failWorkflowData.runId
+        ) {
           await this.errorWorkflow(failWorkflowData, getErrorFromUnknown(err));
         }
       } catch (failErr) {

--- a/packages/core/src/workflows/evented/workflow-event-processor/retry-budget.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/retry-budget.test.ts
@@ -158,6 +158,50 @@ describe('WorkflowEventProcessor retry budget (Sig D)', () => {
     await mastra.shutdown();
   });
 
+  it('does not republish workflow.fail when a workflow.fail event itself exhausts its budget', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: { wf: makeWorkflow('wf') } as any,
+      pubsub,
+    });
+
+    const failEvents: Event[] = [];
+    await pubsub.subscribe('workflows', async event => {
+      if (event.type === 'workflow.fail') failEvents.push(event);
+    });
+
+    const processor = new AlwaysThrowsProcessor({ mastra });
+    // Simulate a workflow.fail event arriving while storage is persistently
+    // broken (e.g. workflows table missing). Exhausting its budget must NOT
+    // publish another workflow.fail — each publish gets a fresh event id, so
+    // republishing here would loop forever.
+    const failEvent: Event = {
+      id: 'fail-event-id-1',
+      type: 'workflow.fail',
+      runId: 'run-fail-loop',
+      createdAt: new Date(),
+      data: {
+        workflowId: 'wf',
+        runId: 'run-fail-loop',
+        executionPath: [],
+        stepResults: {},
+        prevResult: { status: 'failed', error: 'boom' },
+        activeStepsPath: {},
+        requestContext: {},
+      },
+    } as Event;
+
+    expect(await processor.handle(failEvent)).toEqual({ ok: false, retry: true });
+    expect(await processor.handle(failEvent)).toEqual({ ok: false, retry: true });
+    expect(await processor.handle(failEvent)).toEqual({ ok: false, retry: false });
+
+    expect(failEvents.length).toBe(0);
+
+    await mastra.shutdown();
+  });
+
   it('clears the counter on success so a later transient failure gets a fresh budget', async () => {
     const pubsub = new EventEmitterPubSub();
     const mastra = new Mastra({


### PR DESCRIPTION
When workflow storage is persistently broken (for example the workflows table doesn't exist), evented workflows would loop forever: every event throws in `#dispatch`, exhausts its 3-attempt retry budget, and publishes a `workflow.fail` event. That fail event also fails, and its own exhaustion republished another `workflow.fail` with a fresh event id — a fresh retry bucket the terminal sentinel never catches. The result is an endless fail→fail cycle flooding logs with `OrchestrationWorker: error processing event` entries.

Before, exhausting a `workflow.fail` event republished another one:

```ts
// handle() retry exhaustion
if (failWorkflowData && failWorkflowData.workflowId && failWorkflowData.runId) {
  await this.errorWorkflow(failWorkflowData, getErrorFromUnknown(err)); // publishes workflow.fail
}
```

After, a `workflow.fail` event goes terminal without republishing, mirroring the existing guard in the workflow-not-found branch of `#dispatch`:

```ts
if (event.type !== 'workflow.fail' && failWorkflowData?.workflowId && failWorkflowData?.runId) {
  await this.errorWorkflow(failWorkflowData, getErrorFromUnknown(err));
}
```

Verified with a new regression test in `retry-budget.test.ts` that fails without the guard (the exhausted fail event republishes) and passes with it. All workflow-event-processor tests and core typecheck pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change stops a “failure about a failure” loop. If workflow storage is broken and a workflow event keeps failing, the system used to keep creating new `workflow.fail` events forever; now it stops after the retry limit instead of making another failure event.

### Summary
- Prevents exhausted `workflow.fail` events from republishing another `workflow.fail`, breaking the endless fail→fail retry loop in evented workflows.
- Mirrors the existing terminal guard used when a workflow can’t be found.
- Adds a regression test to confirm an exhausted `workflow.fail` stays terminal and is not republished.
- Includes a patch Changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->