### PR TITLE
docs(vercel): correct stale Vercel Sandbox limits (24h runtime, 15 ports, up to 32 vCPUs)

### DIFF
--- a/docs/src/content/en/reference/workspace/vercel-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/vercel-sandbox.mdx
@@ -187,7 +187,7 @@ Both callbacks are optional and can be used independently.
     name: 'ports',
     type: 'number[]',
     description:
-      'Ports to expose from the sandbox (up to 4). Public HTTPS domains are available via getInfo().metadata.domains.',
+      'Ports to expose from the sandbox (up to 15). Public HTTPS domains are available via getInfo().metadata.domains.',
     isOptional: true,
   },
   {
@@ -298,9 +298,9 @@ The Vercel Sandbox SDK doesn't expose a stdin channel for running commands, so `
 
 ## Limits
 
-- Up to 8 vCPUs, with 2048 MB of memory per vCPU.
-- Up to 4 exposed ports.
+- Up to 32 vCPUs, with 2048 MB of memory per vCPU.
+- Up to 15 exposed ports.
 - The filesystem is ephemeral — persisted only within the session and lost when the sandbox stops.
-- Maximum runtime is plan-dependent (45 minutes on Hobby, up to 5 hours on Pro/Enterprise), with a default of 5 minutes.
+- Maximum runtime is plan-dependent (45 minutes on Hobby, up to 24 hours on Pro and Enterprise), with a default of 5 minutes.
 
 See the [Vercel Sandbox documentation](https://vercel.com/docs/vercel-sandbox) for current limits and pricing.

--- a/workspaces/vercel/README.md
+++ b/workspaces/vercel/README.md
@@ -77,7 +77,7 @@ const info = await sandbox.getInfo();
 console.log(info.metadata.domains);
 ```
 
-Vercel supports up to 8 vCPUs and up to 4 exposed ports per sandbox. Memory is allocated at 2048 MB per vCPU.
+Vercel supports up to 32 vCPUs and up to 15 exposed ports per sandbox. Memory is allocated at 2048 MB per vCPU.
 
 ### Streaming command output
 


### PR DESCRIPTION
The `VercelSandbox` reference and package README listed a few stale limits. Corrected against the current Vercel Sandbox docs.

- Max runtime: was "up to 5 hours on Pro/Enterprise", now 24 hours (Hobby stays 45 min, default 5 min)
- Exposed ports: was "up to 4", now 15
- Max vCPUs: was "up to 8", now up to 32

Source: https://vercel.com/docs/sandbox/pricing

Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
This change updates the docs so they match Vercel’s current sandbox limits. In simple terms, it tells readers the sandbox can now run longer, use more CPU, and expose more ports than the old docs said.

## Summary
- Updated `VercelSandbox` docs in the reference content to reflect current Vercel limits:
  - Pro/Enterprise max runtime changed to 24 hours
  - Exposed ports increased to 15
  - Max vCPUs increased to 32
- Mirrored the same limit updates in `workspaces/vercel/README.md`.
- Kept the existing default runtime, Hobby runtime, and memory-per-vCPU wording unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->