### PR TITLE
fix(mastracode): reflow terminal content on resize

### DIFF
--- a/.changeset/polite-falcons-post.md
+++ b/.changeset/polite-falcons-post.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed terminal output reflow and slash command input alignment when resizing.

--- a/mastracode/AGENTS.md
+++ b/mastracode/AGENTS.md
@@ -1,17 +1,16 @@
-Mastra Code is split into `mastracode/sdk` (`@mastra/code-sdk`), `mastracode/tui` (`mastracode`), and the standalone `mastracode/web` project. Scope package commands to the package being changed.
+Packages: `mastracode/sdk` (`@mastra/code-sdk`), `mastracode/tui` (`mastracode`), and standalone `mastracode/web`. Scope commands to the changed package.
 
-Build the TUI and its dependency graph from root: pnpm build:mastracode
-Test SDK and TUI from root: pnpm test:mastracode
-Typecheck TUI from root: pnpm --filter ./mastracode/tui check
-Lint TUI from root: pnpm --filter ./mastracode/tui lint
+Build TUI dependencies from root: pnpm build:mastracode
+Test SDK and TUI: pnpm test:mastracode
+Typecheck TUI: pnpm --filter ./mastracode/tui check
+Lint TUI: pnpm --filter ./mastracode/tui lint
 
-Run pnpm build:mastracode before broad Mastra Code test audits so workspace dependency dist artifacts are available.
-For focused TUI tests, prefer pnpm --filter ./mastracode/tui exec vitest run <test-file> --reporter=dot --bail 1 before the full package suite.
+Run pnpm build:mastracode before broad tests so workspace dist artifacts exist.
+Focused TUI test: pnpm --filter ./mastracode/tui exec vitest run <test-file> --reporter=dot --bail 1
 
-Most unit tests live under `mastracode/sdk/src` or `mastracode/tui/src` and are colocated with the code they cover.
-Run focused agent, model, headless, TUI, command, MCP, plugin, or processor tests in the owning package before broader validation when those areas change.
+Unit tests are colocated under `mastracode/sdk/src` or `mastracode/tui/src`. Test the owning package first.
 
-Mastra Code TUI/e2e scenarios live under mastracode/tui/e2e/tui/ with fixtures in mastracode/tui/e2e/fixtures/.
+TUI/e2e scenarios are in mastracode/tui/e2e/tui/; fixtures are in mastracode/tui/e2e/fixtures/.
 List scenarios with pnpm --filter ./mastracode/tui run e2e:list.
 Run smoke scenarios with pnpm --filter ./mastracode/tui run e2e:smoke.
 For focused scenario development, use MC_E2E_VITEST_SCENARIOS=<scenario> pnpm --filter ./mastracode/tui exec vitest run --config e2e/vitest.config.ts --reporter=dot.

--- a/mastracode/AGENTS.md
+++ b/mastracode/AGENTS.md
@@ -1,21 +1,23 @@
-Build from root: pnpm build:mastracode
-Test from root: pnpm test:mastracode
-Typecheck from root: pnpm --filter ./mastracode check
-Lint from root: pnpm --filter ./mastracode lint
+Mastra Code is split into `mastracode/sdk` (`@mastra/code-sdk`), `mastracode/tui` (`mastracode`), and the standalone `mastracode/web` project. Scope package commands to the package being changed.
+
+Build the TUI and its dependency graph from root: pnpm build:mastracode
+Test SDK and TUI from root: pnpm test:mastracode
+Typecheck TUI from root: pnpm --filter ./mastracode/tui check
+Lint TUI from root: pnpm --filter ./mastracode/tui lint
 
 Run pnpm build:mastracode before broad Mastra Code test audits so workspace dependency dist artifacts are available.
-For focused tests, prefer pnpm --filter ./mastracode exec vitest run <test-file> --reporter=dot --bail 1 before the full package suite.
+For focused TUI tests, prefer pnpm --filter ./mastracode/tui exec vitest run <test-file> --reporter=dot --bail 1 before the full package suite.
 
-Most unit tests live under mastracode/src/ and are colocated with the code they cover.
-Run focused agent, model, headless, TUI, command, MCP, plugin, or processor tests before broader validation when those areas change.
+Most unit tests live under `mastracode/sdk/src` or `mastracode/tui/src` and are colocated with the code they cover.
+Run focused agent, model, headless, TUI, command, MCP, plugin, or processor tests in the owning package before broader validation when those areas change.
 
-Mastra Code TUI/e2e scenarios live under mastracode/e2e/tui/ with fixtures in mastracode/e2e/fixtures/.
-List scenarios with pnpm --filter ./mastracode run e2e:list.
-Run smoke scenarios with pnpm --filter ./mastracode run e2e:smoke.
-For focused scenario development, use MC_E2E_VITEST_SCENARIOS=<scenario> pnpm --filter ./mastracode exec vitest run --config e2e/vitest.config.ts --reporter=dot.
-Run pnpm --filter ./mastracode run e2e:test -- --reporter=dot before shipping runner changes.
+Mastra Code TUI/e2e scenarios live under mastracode/tui/e2e/tui/ with fixtures in mastracode/tui/e2e/fixtures/.
+List scenarios with pnpm --filter ./mastracode/tui run e2e:list.
+Run smoke scenarios with pnpm --filter ./mastracode/tui run e2e:smoke.
+For focused scenario development, use MC_E2E_VITEST_SCENARIOS=<scenario> pnpm --filter ./mastracode/tui exec vitest run --config e2e/vitest.config.ts --reporter=dot.
+Run pnpm --filter ./mastracode/tui run e2e:test -- --reporter=dot before shipping runner changes.
 
-For Mastra Code TUI work, use the testing-mastracode-tui skill for interactive/manual testing guidance, but prefer mastracode/e2e/README.md as the source of truth for runner commands.
+For Mastra Code TUI work, use the testing-mastracode-tui skill for interactive/manual testing guidance, but prefer mastracode/tui/e2e/README.md as the source of truth for runner commands.
 
 TUI-visible or TUI-triggered behavior should have checked-in TUI e2e coverage; lower-level tests are supporting shields, not substitutes.
 If realistic long conversation or OM fixture data is needed, read the local Mastra Code Application Support database only via read-only operations, sanitize it, and transform it into deterministic AIMock-compatible fixtures.

--- a/mastracode/tui/e2e/README.md
+++ b/mastracode/tui/e2e/README.md
@@ -1,23 +1,23 @@
 # Mastra Code TUI e2e runner
 
-Mastra Code scenarios live in `e2e/scenarios/` and run through the zero-subprocess Vitest runner.
+Mastra Code scenarios live in `e2e/tui/` and run through the zero-subprocess Vitest runner.
 
 ## Run all scenarios
 
 ```bash
-pnpm --filter ./mastracode run e2e:test -- --reporter=dot
+pnpm --filter ./mastracode/tui run e2e:test -- --reporter=dot
 ```
 
 The runner constructs Mastra Code in-process, injects a `pi-tui` terminal backed by `@xterm/headless`, and runs four static Vitest shard files in one CI job. It does not launch the `mastracode` CLI, `tsx` scenario entrypoints, worker threads, or Mastra Code subprocesses.
 
-Failed runs keep their per-scenario temp directories under `mastracode/.tmp-mc-e2e-vitest/` until cleanup runs; inspect that directory when debugging a failed scenario.
+Failed runs keep their per-scenario temp directories under `mastracode/tui/.tmp-mc-e2e-vitest/` until cleanup runs; inspect that directory when debugging a failed scenario.
 
 ## Smoke test
 
 Run the default smoke scenarios (`startup`, `automated-chat`, and `modal-and-shell`):
 
 ```bash
-pnpm --filter ./mastracode run e2e:smoke
+pnpm --filter ./mastracode/tui run e2e:smoke
 ```
 
 ## Focused scenario runs
@@ -25,13 +25,13 @@ pnpm --filter ./mastracode run e2e:smoke
 Run one or more scenarios through the single-wrapper Vitest config:
 
 ```bash
-MC_E2E_VITEST_SCENARIOS=startup,automated-chat pnpm --filter ./mastracode exec vitest run --config e2e/vitest.config.ts --reporter=dot
+MC_E2E_VITEST_SCENARIOS=startup,automated-chat pnpm --filter ./mastracode/tui exec vitest run --config e2e/vitest.config.ts --reporter=dot
 ```
 
 List available scenarios:
 
 ```bash
-pnpm --filter ./mastracode run e2e:list
+pnpm --filter ./mastracode/tui run e2e:list
 ```
 
 Use focused runs for scenario development, then run `e2e:test` before shipping runner changes.

--- a/mastracode/tui/e2e/fixtures/terminal-resize-reflow.json
+++ b/mastracode/tui/e2e/fixtures/terminal-resize-reflow.json
@@ -1,0 +1,44 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Terminal resize fixture complete."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Create the terminal resize regression task.",
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_terminal_resize_task_write",
+            "name": "task_write",
+            "arguments": {
+              "tasks": [
+                {
+                  "id": "terminal-resize-task",
+                  "content": "Terminal resize historical content alpha beta gamma delta epsilon unique-restored-tail",
+                  "status": "in_progress",
+                  "activeForm": "Rendering terminal resize historical content alpha beta gamma delta epsilon unique-restored-tail"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "streamingProfile": {
+        "ttft": 50,
+        "tps": 100
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -47,8 +47,8 @@ class EmulatedTerminal implements Terminal {
   private outputQueue = Promise.resolve();
   private resizeHandler?: () => void;
   private stdinBuffer?: StdinBuffer;
-  private readonly terminalColumns: number;
-  private readonly terminalRows: number;
+  private terminalColumns: number;
+  private terminalRows: number;
 
   constructor(terminalColumns: number, terminalRows: number) {
     this.terminalColumns = terminalColumns;
@@ -154,6 +154,8 @@ class EmulatedTerminal implements Terminal {
   }
 
   resize(columns: number, rows: number): void {
+    this.terminalColumns = columns;
+    this.terminalRows = rows;
     this.xterm.resize(columns, rows);
     this.resizeHandler?.();
   }
@@ -213,6 +215,9 @@ function createScenarioTerminal(terminal: EmulatedTerminal): McE2eTerminal {
     },
     keyCtrlC() {
       terminal.sendInput('\x03');
+    },
+    resize(columns: number, rows: number) {
+      terminal.resize(columns, rows);
     },
     serialize() {
       return terminal.serialize();

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -127,6 +127,7 @@ import { taskInlineTransitionsScenario } from './task-inline-transitions.js';
 import { taskPatchToolsScenario } from './task-patch-tools.js';
 import { taskProgressEventsScenario } from './task-progress-events.js';
 import { taskPromptContextNextTurnScenario } from './task-prompt-context-next-turn.js';
+import { terminalResizeReflowScenario } from './terminal-resize-reflow.js';
 import { threadHistoryScenario } from './thread-history.js';
 import { toolHistoryReloadScenario } from './tool-history-reload.js';
 import { toolSchemaCompatScenario } from './tool-schema-compat.js';
@@ -273,6 +274,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'task-patch-tools': taskPatchToolsScenario,
   'task-progress-events': taskProgressEventsScenario,
   'task-prompt-context-next-turn': taskPromptContextNextTurnScenario,
+  'terminal-resize-reflow': terminalResizeReflowScenario,
   'thread-history': threadHistoryScenario,
   'tool-history-reload': toolHistoryReloadScenario,
   'tool-schema-compat': toolSchemaCompatScenario,

--- a/mastracode/tui/e2e/tui/terminal-resize-reflow.ts
+++ b/mastracode/tui/e2e/tui/terminal-resize-reflow.ts
@@ -1,0 +1,75 @@
+import { expect } from './expect.js';
+import type { McE2eScenario, McE2eTerminal } from './types.js';
+
+const WIDE_COLUMNS = 120;
+const NARROW_COLUMNS = 52;
+const ROWS = 36;
+const TASK_PREFIX = 'Rendering terminal resize historical content';
+const TASK_TAIL = 'unique-restored-tail';
+const EDITOR_TEXT = '/resize-editor-boundary-' + 'x'.repeat(90);
+
+function linesContaining(view: string, text: string): string[] {
+  return view.split('\n').filter(line => line.includes(text));
+}
+
+function expectEditorBordersAligned(terminal: McE2eTerminal, columns: number): void {
+  const lines = terminal.serialize().view.split('\n');
+  const topBorder = lines.findLastIndex(line => /^╭─+╮$/.test(line));
+  const bottomBorder = lines.findIndex((line, index) => index > topBorder && /^╰─+╯$/.test(line));
+  const editorRows = lines.slice(topBorder + 1, bottomBorder);
+  expect(editorRows.length).toBeGreaterThan(0);
+  expect(editorRows.join('\n')).toContain('resize-editor-boundary-');
+  for (const line of editorRows) {
+    if (line.length !== columns || !line.endsWith('│')) {
+      throw new Error(`Expected ${columns}-column editor row with aligned right border, got ${JSON.stringify(line)}`);
+    }
+  }
+}
+
+export const terminalResizeReflowScenario: McE2eScenario = {
+  name: 'terminal-resize-reflow',
+  description:
+    'Resize the real xterm-backed TUI and verify historical custom content and active editor alignment reflow.',
+  testName: 'reflows historical custom content and the active slash editor across terminal resizes',
+  useOpenAIModel: true,
+  aimockFixture: 'terminal-resize-reflow.json',
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    terminal.resize(WIDE_COLUMNS, ROWS);
+
+    await (expect(terminal.getByText(/Project:|Resource ID:|>/gi, { full: true, strict: false })) as any).toBeVisible();
+    terminal.submit('Create the terminal resize regression task.');
+    await runtime.waitForScreenText(/Terminal resize fixture complete\./i, terminal, 8_000);
+    await runtime.waitForScreenText(/unique-restored-tail/i, terminal, 8_000);
+
+    terminal.write(EDITOR_TEXT);
+    await terminal.flushInput?.();
+
+    const wide = terminal.serialize().view;
+    expect(linesContaining(wide, TASK_PREFIX).join('\n')).toContain(TASK_TAIL);
+    expectEditorBordersAligned(terminal, WIDE_COLUMNS);
+    runtime.printScreen('wide terminal', terminal);
+
+    terminal.resize(NARROW_COLUMNS, ROWS);
+    await runtime.sleep(100);
+    await terminal.flushInput?.();
+
+    const narrow = terminal.serialize().view;
+    expect(narrow).toContain(TASK_PREFIX);
+    expect(narrow).toContain(TASK_TAIL);
+    expect(linesContaining(narrow, TASK_PREFIX).join('\n')).not.toContain(TASK_TAIL);
+    expectEditorBordersAligned(terminal, NARROW_COLUMNS);
+    runtime.printScreen('narrow terminal', terminal);
+
+    terminal.resize(WIDE_COLUMNS, ROWS);
+    await runtime.sleep(100);
+    await terminal.flushInput?.();
+
+    const restored = terminal.serialize().view;
+    expect(linesContaining(restored, TASK_PREFIX).join('\n')).toContain(TASK_TAIL);
+    expectEditorBordersAligned(terminal, WIDE_COLUMNS);
+    runtime.printScreen('restored wide terminal', terminal);
+
+    terminal.keyCtrlC();
+  },
+};

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -128,6 +128,7 @@ export type ScenarioName =
   | 'task-inline-transitions'
   | 'task-patch-tools'
   | 'task-progress-events'
+  | 'terminal-resize-reflow'
   | 'task-prompt-context-next-turn'
   | 'thread-history'
   | 'tool-history-reload'
@@ -151,6 +152,7 @@ export type McE2eTerminal = {
   getByText: (text: string | RegExp, options?: { full?: boolean; strict?: boolean }) => any;
   flushInput?: () => Promise<void>;
   keyCtrlC: () => void;
+  resize: (columns: number, rows: number) => void;
   serialize: () => { view: string };
   submit: (text: string) => void;
   write: (text: string) => void;

--- a/mastracode/tui/src/tui/components/__tests__/custom-editor.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/custom-editor.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   superHandleInput: vi.fn(),
   superRender: vi.fn((_width?: number, _text?: string, _cursorCol?: number) => ['────', 'hello', '────']),
+  superRenderCursorLine: vi.fn(),
   editorSetText: vi.fn(),
   getClipboardImage: vi.fn(),
   getClipboardText: vi.fn(),
@@ -33,6 +34,7 @@ vi.mock('@earendil-works/pi-tui', () => {
     }
 
     render(width: number): string[] {
+      mocks.superRenderCursorLine(this.state.cursorLine);
       return mocks.superRender(width, this.state.lines.join('\n'), this.state.cursorCol);
     }
 
@@ -244,7 +246,10 @@ describe('CustomEditor image paste handling', () => {
       const contentRows = output.slice(1, -1).map(line => stripAnsi(line));
 
       expect(mocks.superRender).toHaveBeenCalledWith(8, '1234567\n7654321', 0);
+      expect(mocks.superRenderCursorLine).toHaveBeenCalledWith(-1);
+      expect(output[1]).toContain(`\x1b[7m${marker}\x1b[0m`);
       expect(editor.getText()).toBe(`${marker}1234567\n7654321`);
+      expect(state).toMatchObject({ cursorLine: 0, cursorCol: 0 });
       expect(contentRows).toHaveLength(2);
       expect(contentRows.every(line => line.length === 14 && line.endsWith('│'))).toBe(true);
     });

--- a/mastracode/tui/src/tui/components/__tests__/custom-editor.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/custom-editor.test.ts
@@ -1,8 +1,9 @@
+import stripAnsi from 'strip-ansi';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
   superHandleInput: vi.fn(),
-  superRender: vi.fn(() => ['────', 'hello', '────']),
+  superRender: vi.fn((_width?: number, _text?: string, _cursorCol?: number) => ['────', 'hello', '────']),
   editorSetText: vi.fn(),
   getClipboardImage: vi.fn(),
   getClipboardText: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock('node:fs', () => ({
 vi.mock('@earendil-works/pi-tui', () => {
   class MockEditor {
     protected tui: unknown;
+    private state = { lines: [''], cursorLine: 0, cursorCol: 0 };
     constructor(_tui: unknown, _theme: unknown) {
       this.tui = _tui;
     }
@@ -30,15 +32,18 @@ vi.mock('@earendil-works/pi-tui', () => {
       mocks.superHandleInput(data);
     }
 
-    render(_width: number): string[] {
-      return mocks.superRender();
+    render(width: number): string[] {
+      return mocks.superRender(width, this.state.lines.join('\n'), this.state.cursorCol);
     }
 
     getText(): string {
-      return '';
+      return this.state.lines.join('\n');
     }
 
     setText(text: string): void {
+      this.state.lines = text.split('\n');
+      this.state.cursorLine = this.state.lines.length - 1;
+      this.state.cursorCol = this.state.lines.at(-1)?.length ?? 0;
       mocks.editorSetText(text);
     }
 
@@ -193,6 +198,82 @@ describe('CustomEditor image paste handling', () => {
 
     expect(undo).toHaveBeenCalledTimes(1);
     expect(mocks.superHandleInput).not.toHaveBeenCalled();
+  });
+
+  describe('decorative prompt width accounting', () => {
+    const renderWrappedEditor = (receivedWidth?: number, text = '', _cursorCol = 0): string[] => {
+      const width = receivedWidth ?? 1;
+      const layoutWidth = Math.max(1, width - 1);
+      const lines = text
+        .split('\n')
+        .flatMap(sourceLine => sourceLine.match(new RegExp(`.{1,${layoutWidth}}`, 'g')) ?? ['']);
+      return ['─'.repeat(width), ...lines.map(line => line.padEnd(width)), '─'.repeat(width)];
+    };
+
+    beforeEach(() => {
+      mocks.chalkBoldRgb.mockImplementation((_r: number, _g: number, _b: number) => (value: string) => value);
+      mocks.superRender.mockImplementation(renderWrappedEditor);
+    });
+
+    it.each([
+      { marker: '/', text: '/1234567890123' },
+      { marker: '@', text: '@1234567890123' },
+    ])('removes $marker before wrapping and restores editor state', ({ marker, text }) => {
+      const editor = new CustomEditor({ terminal: { rows: 24 } } as any, {} as any);
+      editor.getModeColor = vi.fn(() => '#16c858');
+      editor.setText(text);
+
+      const output = editor.render(20);
+
+      expect(mocks.superRender).toHaveBeenCalledWith(14, text.slice(1), text.length - 1);
+      expect(editor.getText()).toBe(text);
+      expect(output).toHaveLength(3);
+      expect(stripAnsi(output[1]!)).toHaveLength(20);
+      expect(stripAnsi(output[1]!)).toBe(`│ ${marker} 1234567890123  │`);
+    });
+
+    it.each(['/', '@'])('accounts for a cursor-highlighted %s across explicit multiline input', marker => {
+      const editor = new CustomEditor({ terminal: { rows: 24 } } as any, {} as any);
+      editor.getModeColor = vi.fn(() => '#16c858');
+      editor.setText(`${marker}1234567\n7654321`);
+      const state = (editor as any).state as { cursorLine: number; cursorCol: number };
+      state.cursorLine = 0;
+      state.cursorCol = 0;
+
+      const output = editor.render(14);
+      const contentRows = output.slice(1, -1).map(line => stripAnsi(line));
+
+      expect(mocks.superRender).toHaveBeenCalledWith(8, '1234567\n7654321', 0);
+      expect(editor.getText()).toBe(`${marker}1234567\n7654321`);
+      expect(contentRows).toHaveLength(2);
+      expect(contentRows.every(line => line.length === 14 && line.endsWith('│'))).toBe(true);
+    });
+
+    it('does not remove a content column from the ordinary prompt', () => {
+      const editor = new CustomEditor({ terminal: { rows: 24 } } as any, {} as any);
+      editor.getModeColor = vi.fn(() => '#16c858');
+      editor.setText('1234567890123');
+
+      const output = editor.render(20);
+
+      expect(mocks.superRender).toHaveBeenCalledWith(14, '1234567890123', 13);
+      expect(stripAnsi(output[1]!)).toBe('│ › 1234567890123  │');
+      expect(stripAnsi(output[1]!)).toHaveLength(20);
+    });
+
+    it.each(['/', '@'])('keeps multiline narrow rows and right borders aligned for %s', marker => {
+      const editor = new CustomEditor({ terminal: { rows: 24 } } as any, {} as any);
+      editor.getModeColor = vi.fn(() => '#16c858');
+      editor.setText(`${marker}12345678901234567890`);
+
+      const output = editor.render(14);
+      const contentRows = output.slice(1, -1);
+
+      expect(mocks.superRender).toHaveBeenCalledWith(8, '12345678901234567890', 20);
+      expect(contentRows).toHaveLength(3);
+      expect(contentRows.every(line => stripAnsi(line).length === 14 && stripAnsi(line).endsWith('│'))).toBe(true);
+      expect(stripAnsi(contentRows[0]!)).toBe(`│ ${marker} 1234567  │`);
+    });
   });
 
   it('renders a chevron prompt when no animator is active', () => {

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -823,8 +823,8 @@ Test plan:
     const boxLines = rendered.filter(line => /^[╭│╰]/.test(stripAnsi(line)));
 
     const visible = stripAnsi(rendered.join('\n'));
-    expect(visible).toContain('This');
-    expect(visible).toContain('follows up on the quiet-mode terminal rendering work.');
+    expect(visible).toContain('This follows up on the');
+    expect(visible).toContain('quiet-mode terminal rendering work.');
     expect(visible).not.toContain('…');
     expect(boxLines.length).toBeGreaterThan(3);
     expect(boxLines.every(line => visibleWidth(line) === topWidth)).toBe(true);
@@ -910,7 +910,8 @@ Test plan:
       .split('\n')
       .filter(line => line.startsWith('│') && line.trim() !== '│');
     expect(footerLines.length).toBeGreaterThan(1);
-    expect(stripAnsi(output)).toContain('then fi"');
+    expect(stripAnsi(output)).toContain('then');
+    expect(stripAnsi(output)).toContain('fi"');
     expect(output).not.toContain(chalk.blue('then'));
   });
 

--- a/mastracode/tui/src/tui/components/__tests__/width-aware-rendering.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/width-aware-rendering.test.ts
@@ -1,0 +1,133 @@
+import { Text, visibleWidth } from '@earendil-works/pi-tui';
+import { describe, expect, it } from 'vitest';
+
+import { JudgeDisplayComponent } from '../judge-display.js';
+import { NotificationComponent } from '../notification.js';
+import { OMOutputComponent } from '../om-output.js';
+import { ShellStreamComponent } from '../shell-output.js';
+import { SlashCommandComponent } from '../slash-command.js';
+import { SubagentExecutionComponent } from '../subagent-execution.js';
+import { SystemReminderComponent } from '../system-reminder.js';
+import { TaskProgressComponent } from '../task-progress.js';
+import { ToolExecutionComponentEnhanced } from '../tool-execution-enhanced.js';
+import { WidthAwareContainer } from '../width-aware-container.js';
+
+const ui = { requestRender() {} } as any;
+const source =
+  'alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu nu xi omicron pi rho sigma tau unique-restored-tail';
+
+function expectReflow(component: { render(width: number): string[] }, wide = 140, narrow = 42): void {
+  const firstWide = component.render(wide);
+  const narrowLines = component.render(narrow);
+  const restoredWide = component.render(wide);
+
+  expect(narrowLines.every(line => visibleWidth(line) <= narrow)).toBe(true);
+  expect(firstWide.every(line => visibleWidth(line) <= wide)).toBe(true);
+  expect(restoredWide).toEqual(firstWide);
+  expect(narrowLines).not.toEqual(firstWide);
+}
+
+describe('width-aware custom component rendering', () => {
+  it('rebuilds only when the received width changes', () => {
+    class CountingComponent extends WidthAwareContainer {
+      builds = 0;
+
+      protected rebuildForWidth(width: number): void {
+        this.builds += 1;
+        this.clear();
+        this.addChild(new Text(String(width), 0, 0));
+      }
+    }
+
+    const component = new CountingComponent();
+    component.render(80);
+    component.render(80);
+    component.render(40);
+    component.render(40);
+    component.render(80);
+
+    expect(component.builds).toBe(3);
+  });
+
+  it('reflows judge output without changing its result', () => {
+    const component = new JudgeDisplayComponent({ decision: 'continue', reason: source }, 2, 10);
+    expectReflow(component);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows notifications while retaining metadata and source content', () => {
+    const component = new NotificationComponent({
+      message: source,
+      source: 'goal-judge',
+      priority: 'high',
+      kind: 'status',
+    });
+    expectReflow(component);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows expanded observational-memory output without collapsing it', () => {
+    const component = new OMOutputComponent({ type: 'observation', observations: source });
+    component.setExpanded(true);
+    expectReflow(component);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows streaming shell output without changing expansion or its buffer', () => {
+    const component = new ShellStreamComponent('printf output');
+    component.setExpanded(true);
+    component.appendOutput(source);
+    expectReflow(component);
+    expect(component.isExpanded()).toBe(true);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows expanded slash-command output without collapsing it', () => {
+    const component = new SlashCommandComponent('review', source);
+    component.setExpanded(true);
+    expectReflow(component);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows subagent activity without changing completion or expansion state', () => {
+    const component = new SubagentExecutionComponent('explore', source, ui);
+    component.setExpanded(true);
+    component.addText(source);
+    component.finish(false, 25, source);
+    expectReflow(component);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows expanded system reminders without collapsing them', () => {
+    const component = new SystemReminderComponent({ message: source, reminderType: 'goal-judge' });
+    component.setExpanded(true);
+    expectReflow(component);
+    expect(component.isExpanded()).toBe(true);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('reflows quiet task progress without changing task status', () => {
+    const component = new TaskProgressComponent();
+    component.updateTasks([
+      { id: 'active', content: source, activeForm: source, status: 'in_progress' },
+      { id: 'pending', content: source, activeForm: source, status: 'pending' },
+    ]);
+    component.setQuietMode(true);
+    expectReflow(component);
+    expect(component.getTasks().map(task => task.status)).toEqual(['in_progress', 'pending']);
+  });
+
+  it('reflows enhanced tool output without changing quiet, streaming, or partial state', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command: source },
+      { quietDisplayMode: 'quiet', collapsedByDefault: false },
+      ui,
+    );
+    component.appendStreamingOutput(source);
+    expectReflow(component);
+    expect(component.getChatSpacingKind()).toBe('quiet-shell-tool');
+    expect(component.isComplete()).toBe(false);
+    expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+});

--- a/mastracode/tui/src/tui/components/__tests__/width-aware-rendering.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/width-aware-rendering.test.ts
@@ -89,6 +89,11 @@ describe('width-aware custom component rendering', () => {
     expect(component.render(140).join('\n')).toContain('unique-restored-tail');
   });
 
+  it('renders slash-command output at widths narrower than its fixed chrome', () => {
+    const component = new SlashCommandComponent('review', source);
+    expect(component.render(8).length).toBeGreaterThan(0);
+  });
+
   it('reflows subagent activity without changing completion or expansion state', () => {
     const component = new SubagentExecutionComponent('explore', source, ui);
     component.setExpanded(true);
@@ -96,6 +101,11 @@ describe('width-aware custom component rendering', () => {
     component.finish(false, 25, source);
     expectReflow(component);
     expect(component.render(140).join('\n')).toContain('unique-restored-tail');
+  });
+
+  it('renders subagent tasks at widths narrower than their fixed chrome', () => {
+    const component = new SubagentExecutionComponent('explore', source, ui);
+    expect(component.render(8).length).toBeGreaterThan(0);
   });
 
   it('reflows expanded system reminders without collapsing them', () => {

--- a/mastracode/tui/src/tui/components/custom-editor.ts
+++ b/mastracode/tui/src/tui/components/custom-editor.ts
@@ -72,10 +72,8 @@ export type AppAction =
   | 'cycleMode'
   | 'toggleYolo';
 
-// Pre-compiled constants (avoid re-creation per render)
+// Pre-compiled constant (avoid re-creation per render)
 const ANSI_STRIP_RE = /\x1b\[[0-9;]*m/g;
-const SLASH_CURSOR_RE = /\x1b\[7m\/\x1b\[0m/;
-const AT_CURSOR_RE = /\x1b\[7m@\x1b\[0m/;
 function parseHex(hex: string): [number, number, number] {
   const h = hex.replace('#', '');
   return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
@@ -307,8 +305,34 @@ export class CustomEditor extends Editor {
     // Left: "│ > " (4) or "│   " (4), Right: " │" (2) = 6 chars total
     const promptWidth = 4; // "│ > " or "│   "
     const contentWidth = width - 6;
-    // Editor renders at content width (prompt char space is separate)
-    const editorLines = super.render(contentWidth);
+    // Slash and mention markers are rendered in the prompt chrome, so remove them
+    // from the editor's layout state before wrapping and restore the state after.
+    const editorState = (
+      this as unknown as {
+        state: { lines: string[]; cursorLine: number; cursorCol: number };
+      }
+    ).state;
+    const decorativePrompt = isSlash ? '/' : isAt ? '@' : undefined;
+    const firstLine = editorState.lines[0];
+    const markerIndex = firstLine?.search(/\S/) ?? -1;
+    const shouldHideDecorativePrompt =
+      decorativePrompt !== undefined && firstLine !== undefined && firstLine[markerIndex] === decorativePrompt;
+    const cursorCol = editorState.cursorCol;
+    let editorLines: string[];
+    if (shouldHideDecorativePrompt) {
+      editorState.lines[0] = firstLine.slice(0, markerIndex) + firstLine.slice(markerIndex + 1);
+      if (editorState.cursorLine === 0 && cursorCol > markerIndex) {
+        editorState.cursorCol = cursorCol - 1;
+      }
+      try {
+        editorLines = super.render(contentWidth);
+      } finally {
+        editorState.lines[0] = firstLine;
+        editorState.cursorCol = cursorCol;
+      }
+    } else {
+      editorLines = super.render(contentWidth);
+    }
 
     // Extract content lines (skip editor's invisible borders)
     const contentLines: string[] = [];
@@ -328,20 +352,6 @@ export class CustomEditor extends Editor {
         continue;
       }
       contentLines.push(line);
-    }
-
-    // Strip leading "/" or "@" from first content line when shown in prompt
-    if ((isSlash || isAt) && contentLines.length > 0) {
-      let l = contentLines[0]!;
-      const char = isSlash ? '/' : '@';
-      // Handle cursor-highlighted char (reverse video)
-      l = l.replace(isSlash ? SLASH_CURSOR_RE : AT_CURSOR_RE, '');
-      // Remove the first plain occurrence
-      const idx = l.indexOf(char);
-      if (idx !== -1) {
-        l = l.slice(0, idx) + l.slice(idx + 1);
-      }
-      contentLines[0] = l;
     }
 
     // Build rounded box

--- a/mastracode/tui/src/tui/components/custom-editor.ts
+++ b/mastracode/tui/src/tui/components/custom-editor.ts
@@ -317,17 +317,25 @@ export class CustomEditor extends Editor {
     const markerIndex = firstLine?.search(/\S/) ?? -1;
     const shouldHideDecorativePrompt =
       decorativePrompt !== undefined && firstLine !== undefined && firstLine[markerIndex] === decorativePrompt;
+    const cursorLine = editorState.cursorLine;
     const cursorCol = editorState.cursorCol;
+    const cursorOnDecorativePrompt = shouldHideDecorativePrompt && cursorLine === 0 && cursorCol === markerIndex;
+    if (cursorOnDecorativePrompt && !this.voiceListening) {
+      prompt = `\x1b[7m${prompt}\x1b[0m`;
+    }
     let editorLines: string[];
     if (shouldHideDecorativePrompt) {
       editorState.lines[0] = firstLine.slice(0, markerIndex) + firstLine.slice(markerIndex + 1);
-      if (editorState.cursorLine === 0 && cursorCol > markerIndex) {
+      if (cursorOnDecorativePrompt) {
+        editorState.cursorLine = -1;
+      } else if (editorState.cursorLine === 0 && cursorCol > markerIndex) {
         editorState.cursorCol = cursorCol - 1;
       }
       try {
         editorLines = super.render(contentWidth);
       } finally {
         editorState.lines[0] = firstLine;
+        editorState.cursorLine = cursorLine;
         editorState.cursorCol = cursorCol;
       }
     } else {

--- a/mastracode/tui/src/tui/components/judge-display.ts
+++ b/mastracode/tui/src/tui/components/judge-display.ts
@@ -2,13 +2,14 @@
  * JudgeDisplayComponent — renders the goal judge's decision inline in the chat.
  */
 
-import { Container, Text } from '@earendil-works/pi-tui';
+import { Text } from '@earendil-works/pi-tui';
 import type { GoalEvaluationPayload } from '@mastra/core/stream';
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
 
-import { BOX_INDENT, getTermWidth, mastraBrand, theme } from '../theme.js';
+import { BOX_INDENT, mastraBrand, theme } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 /** Display-only decision derived from a goal evaluation. */
 export interface GoalJudgeResult {
@@ -33,7 +34,7 @@ const MUTED_COLOR = '#8a8a8a';
 const PAUSED_COLOR = '#f5a524';
 const WAITING_COLOR = '#8a8a8a';
 
-export class JudgeDisplayComponent extends Container {
+export class JudgeDisplayComponent extends WidthAwareContainer {
   private result: GoalJudgeResult | null;
   private turnsUsed: number;
   private maxTurns: number;
@@ -45,7 +46,7 @@ export class JudgeDisplayComponent extends Container {
     this.result = result;
     this.turnsUsed = turnsUsed;
     this.maxTurns = maxTurns;
-    this.renderContent();
+    this.rebuild();
   }
 
   addActivity(line: string): void {
@@ -55,12 +56,12 @@ export class JudgeDisplayComponent extends Container {
     if (this.activity.length > 6) {
       this.activity = this.activity.slice(-6);
     }
-    this.renderContent();
+    this.rebuild();
   }
 
   setStreamingReason(reason: string): void {
     this.streamingReason = reason;
-    this.renderContent();
+    this.rebuild();
   }
 
   setResult(result: GoalJudgeResult, turnsUsed: number, maxTurns: number): void {
@@ -68,7 +69,7 @@ export class JudgeDisplayComponent extends Container {
     this.streamingReason = '';
     this.turnsUsed = turnsUsed;
     this.maxTurns = maxTurns;
-    this.renderContent();
+    this.rebuild();
   }
 
   /** Render the result of an in-loop goal evaluation chunk. */
@@ -80,12 +81,11 @@ export class JudgeDisplayComponent extends Container {
     this.setResult({ decision: 'paused', reason: 'Judge evaluation was interrupted.' }, this.turnsUsed, this.maxTurns);
   }
 
-  private renderContent(): void {
+  protected rebuildForWidth(termWidth: number): void {
     this.clear();
 
     const border = (char: string) => chalk.hex(JUDGE_COLOR)(char);
     const title = chalk.hex(JUDGE_COLOR).bold('Goal');
-    const termWidth = getTermWidth();
     const innerWidth = Math.max(20, termWidth - BOX_INDENT * 2 - 4);
     const horizontal = '─'.repeat(innerWidth + 1);
 

--- a/mastracode/tui/src/tui/components/notification.ts
+++ b/mastracode/tui/src/tui/components/notification.ts
@@ -1,7 +1,8 @@
-import { Container, Text, visibleWidth } from '@earendil-works/pi-tui';
+import { Text, visibleWidth } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
-import { BOX_INDENT, getTermWidth, mastra, theme } from '../theme.js';
+import { BOX_INDENT, mastra, theme } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 export interface NotificationOptions {
   message: string;
@@ -71,16 +72,24 @@ function wrapText(value: string, maxWidth: number): string[] {
   return lines;
 }
 
-export class NotificationComponent extends Container {
+export class NotificationComponent extends WidthAwareContainer {
+  private readonly options: NotificationOptions;
+
   constructor(options: NotificationOptions) {
     super();
+    this.options = options;
+  }
 
+  protected rebuildForWidth(width: number): void {
+    this.clear();
+
+    const options = this.options;
     const titleText = options.source ? `notification from ${options.source}` : 'notification';
     const details = [options.priority, options.kind, options.status].filter(Boolean).join(' · ');
     const message = options.message.trim();
     const maxContentWidth = Math.max(
       MIN_NOTIFICATION_CONTENT_WIDTH,
-      Math.min(MAX_NOTIFICATION_CONTENT_WIDTH, getTermWidth() - BOX_INDENT - 4),
+      Math.min(MAX_NOTIFICATION_CONTENT_WIDTH, width - BOX_INDENT - 4),
     );
     const titleLines = wrapText(titleText, maxContentWidth);
     const detailLines = details ? wrapText(details, maxContentWidth) : [];

--- a/mastracode/tui/src/tui/components/om-output.ts
+++ b/mastracode/tui/src/tui/components/om-output.ts
@@ -5,10 +5,11 @@
  * Includes marker info (emoji, compression stats) in the footer.
  */
 
-import { Container, Text } from '@earendil-works/pi-tui';
+import { Text } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
-import { BOX_INDENT, getTermWidth, mastra } from '../theme.js';
+import { BOX_INDENT, mastra } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 // Read from proxy at render time so they pick up contrast adaptation
 const getObserverColor = () => mastra.orange;
@@ -102,7 +103,7 @@ export interface OMOutputData {
   compressedTokens?: number;
 }
 
-export class OMOutputComponent extends Container {
+export class OMOutputComponent extends WidthAwareContainer {
   private data: OMOutputData;
   private expanded: boolean = false;
 
@@ -120,14 +121,13 @@ export class OMOutputComponent extends Container {
   toggleExpanded(): void {
     this.setExpanded(!this.expanded);
   }
-  private rebuild(): void {
+  protected rebuildForWidth(termWidth: number): void {
     this.clear();
 
     const isReflection = this.data.type === 'reflection';
     const color = isReflection ? getReflectorColor() : getObserverColor();
     const border = (char: string) => chalk.bold.hex(color)(char);
 
-    const termWidth = getTermWidth();
     const maxLineWidth = termWidth - 6 - BOX_INDENT * 2; // "│ " prefix + buffer + indent
     // Soft-wrap all original lines to terminal width
     const originalLines = this.data.observations.split('\n');

--- a/mastracode/tui/src/tui/components/shell-output.ts
+++ b/mastracode/tui/src/tui/components/shell-output.ts
@@ -3,10 +3,11 @@
  * Shows a bordered box with live stdout/stderr and a status footer.
  */
 
-import { Container, Text } from '@earendil-works/pi-tui';
-import { getTermWidth, theme } from '../theme.js';
+import { Text } from '@earendil-works/pi-tui';
+import { theme } from '../theme.js';
 import { truncateAnsi } from './ansi.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 const MAX_LINES = 200;
 const COLLAPSED_LINES = 20;
@@ -17,7 +18,7 @@ function formatDuration(ms: number): string {
   return seconds < 60 ? `${seconds.toFixed(1)}s` : `${Math.floor(seconds / 60)}m${Math.floor(seconds % 60)}s`;
 }
 
-export class ShellStreamComponent extends Container {
+export class ShellStreamComponent extends WidthAwareContainer {
   private command: string;
   private lines: string[] = [];
   private trailingPartial = '';
@@ -65,11 +66,10 @@ export class ShellStreamComponent extends Container {
     this.rebuild();
   }
 
-  private rebuild(): void {
+  protected rebuildForWidth(termWidth: number): void {
     this.clear();
 
     const border = (char: string) => theme.bold(theme.fg('accent', char));
-    const termWidth = getTermWidth();
     const maxLineWidth = termWidth - 6;
 
     const done = this.exitCode !== undefined;

--- a/mastracode/tui/src/tui/components/slash-command.ts
+++ b/mastracode/tui/src/tui/components/slash-command.ts
@@ -46,7 +46,7 @@ export class SlashCommandComponent extends WidthAwareContainer {
     this.clear();
 
     const border = (char: string) => chalk.bold.hex(getBorderColor())(char);
-    const maxLineWidth = termWidth - 6 - BOX_INDENT * 2;
+    const maxLineWidth = Math.max(1, termWidth - 6 - BOX_INDENT * 2);
 
     const heading = chalk.hex(mastra.specialGray)(`/${this.commandName}`);
 

--- a/mastracode/tui/src/tui/components/slash-command.ts
+++ b/mastracode/tui/src/tui/components/slash-command.ts
@@ -4,15 +4,16 @@
  * expanded with ctrl+e. The full content is still sent to the assistant.
  */
 
-import { Container, Text } from '@earendil-works/pi-tui';
+import { Text } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
-import { BOX_INDENT, getTermWidth, mastra } from '../theme.js';
+import { BOX_INDENT, mastra } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 const MAX_COLLAPSED_LINES = 3;
 const getBorderColor = () => mastra.green;
 
-export class SlashCommandComponent extends Container {
+export class SlashCommandComponent extends WidthAwareContainer {
   private commandName: string;
   private contentLines: string[];
   private expanded = false;
@@ -41,11 +42,10 @@ export class SlashCommandComponent extends Container {
     this.rebuild();
   }
 
-  private rebuild(): void {
+  protected rebuildForWidth(termWidth: number): void {
     this.clear();
 
     const border = (char: string) => chalk.bold.hex(getBorderColor())(char);
-    const termWidth = getTermWidth();
     const maxLineWidth = termWidth - 6 - BOX_INDENT * 2;
 
     const heading = chalk.hex(mastra.specialGray)(`/${this.commandName}`);

--- a/mastracode/tui/src/tui/components/subagent-execution.ts
+++ b/mastracode/tui/src/tui/components/subagent-execution.ts
@@ -205,7 +205,7 @@ export class SubagentExecutionComponent extends WidthAwareContainer implements I
 
     const border = (char: string) =>
       theme.bold(colorText(this.colors.border, char, (text: string) => theme.fg('accent', text)));
-    const maxLineWidth = termWidth - 6 - BOX_INDENT * 2;
+    const maxLineWidth = Math.max(1, termWidth - 6 - BOX_INDENT * 2);
 
     // ── Bottom border with info (always rendered) ──
     const typeLabelText = this.forked ? 'fork' : this.agentType;

--- a/mastracode/tui/src/tui/components/subagent-execution.ts
+++ b/mastracode/tui/src/tui/components/subagent-execution.ts
@@ -8,13 +8,14 @@
  *  - Bottom border with agent type, model, status, duration
  */
 
-import { Container, Text } from '@earendil-works/pi-tui';
+import { Text } from '@earendil-works/pi-tui';
 import type { TUI } from '@earendil-works/pi-tui';
 import { safeStringify } from '@mastra/core/utils';
 import chalk from 'chalk';
-import { BOX_INDENT, getTermWidth, theme } from '../theme.js';
+import { BOX_INDENT, theme } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
 import type { IToolExecutionComponent } from './tool-execution-interface.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Types
@@ -69,7 +70,7 @@ export interface SubagentExecutionOptions {
   };
 }
 
-export class SubagentExecutionComponent extends Container implements IToolExecutionComponent {
+export class SubagentExecutionComponent extends WidthAwareContainer implements IToolExecutionComponent {
   private ui: TUI;
 
   // State
@@ -199,12 +200,11 @@ export class SubagentExecutionComponent extends Container implements IToolExecut
 
   // ── Rendering ──────────────────────────────────────────────────────────
 
-  private rebuild(): void {
+  protected rebuildForWidth(termWidth: number): void {
     this.clear();
 
     const border = (char: string) =>
       theme.bold(colorText(this.colors.border, char, (text: string) => theme.fg('accent', text)));
-    const termWidth = getTermWidth();
     const maxLineWidth = termWidth - 6 - BOX_INDENT * 2;
 
     // ── Bottom border with info (always rendered) ──

--- a/mastracode/tui/src/tui/components/system-reminder.ts
+++ b/mastracode/tui/src/tui/components/system-reminder.ts
@@ -4,11 +4,12 @@
  */
 
 import process from 'node:process';
-import { Container, Text } from '@earendil-works/pi-tui';
+import { Text } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 import stripAnsi from 'strip-ansi';
-import { BOX_INDENT, getTermWidth, mastraBrand, theme } from '../theme.js';
+import { BOX_INDENT, mastraBrand, theme } from '../theme.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 const MAX_COLLAPSED_LINES = 10;
 const LOADED_INSTRUCTION_INDENT = BOX_INDENT + 2;
@@ -21,7 +22,7 @@ export interface SystemReminderOptions {
   judgeModelId?: string;
 }
 
-export class SystemReminderComponent extends Container {
+export class SystemReminderComponent extends WidthAwareContainer {
   private messageLines: string[];
   private readonly reminderType?: string;
   private readonly path?: string;
@@ -62,7 +63,7 @@ export class SystemReminderComponent extends Container {
     return 'system';
   }
 
-  private rebuild(): void {
+  protected rebuildForWidth(termWidth: number): void {
     this.clear();
 
     if (isLoadedInstructionPathReminder(this.reminderType, this.path)) {
@@ -81,7 +82,6 @@ export class SystemReminderComponent extends Container {
     const metadataColor = (text: string) => theme.fg('dim', text);
     const bodyColor = (text: string) => theme.fg('text', text);
     const hintColor = (text: string) => theme.fg('dim', text);
-    const termWidth = getTermWidth();
     const innerWidth = Math.max(20, termWidth - BOX_INDENT * 2 - 4);
     const horizontal = '─'.repeat(innerWidth + 1);
 

--- a/mastracode/tui/src/tui/components/task-progress.ts
+++ b/mastracode/tui/src/tui/components/task-progress.ts
@@ -4,11 +4,12 @@
  * Hidden when no tasks exist OR when all tasks are completed.
  * Renders between status and editor.
  */
-import { Container, Text, Spacer, visibleWidth } from '@earendil-works/pi-tui';
+import { Text, Spacer, visibleWidth } from '@earendil-works/pi-tui';
 import type { TaskItemInput } from '@mastra/core/signals';
 import chalk from 'chalk';
-import { getTermWidth, theme } from '../theme.js';
+import { theme } from '../theme.js';
 import { truncateAnsi } from './ansi.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 export function formatTaskProgressLine(task: TaskItemInput, indent = '    '): string {
   switch (task.status) {
@@ -30,13 +31,13 @@ export function formatTaskProgressLine(task: TaskItemInput, indent = '    '): st
   }
 }
 
-export class TaskProgressComponent extends Container {
+export class TaskProgressComponent extends WidthAwareContainer {
   private tasks: TaskItemInput[] = [];
   private quietMode = false;
 
   constructor() {
     super();
-    this.rebuildDisplay();
+    this.rebuild();
   }
 
   /**
@@ -44,12 +45,12 @@ export class TaskProgressComponent extends Container {
    */
   updateTasks(tasks: TaskItemInput[]): void {
     this.tasks = tasks;
-    this.rebuildDisplay();
+    this.rebuild();
   }
 
   setQuietMode(enabled: boolean): void {
     this.quietMode = enabled;
-    this.rebuildDisplay();
+    this.rebuild();
   }
 
   /**
@@ -59,7 +60,7 @@ export class TaskProgressComponent extends Container {
     return [...this.tasks];
   }
 
-  private rebuildDisplay(): void {
+  protected rebuildForWidth(width: number): void {
     this.clear();
 
     const completed = this.tasks.filter(t => t.status === 'completed').length;
@@ -74,7 +75,7 @@ export class TaskProgressComponent extends Container {
     this.addChild(new Spacer(1));
 
     if (this.quietMode) {
-      for (const line of this.formatQuietTaskLines(completed, total)) {
+      for (const line of this.formatQuietTaskLines(completed, total, width)) {
         this.addChild(new Text(line, 0, 0));
       }
       return;
@@ -92,11 +93,11 @@ export class TaskProgressComponent extends Container {
     }
   }
 
-  private formatQuietTaskLines(completed: number, total: number): string[] {
+  private formatQuietTaskLines(completed: number, total: number, width: number): string[] {
     const prefix = '  ' + theme.fg('muted', `${completed}/${total}`);
     const prefixWidth = visibleWidth(prefix);
     const continuationPrefix = ' '.repeat(prefixWidth);
-    const maxWidth = Math.max(20, getTermWidth());
+    const maxWidth = Math.max(20, width);
     const itemSeparator = '  ';
     const separatorWidth = itemSeparator.length;
     const lines: string[] = [prefix];

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -4,7 +4,7 @@
  */
 
 import * as os from 'node:os';
-import { Box, Container, Spacer, Text, visibleWidth } from '@earendil-works/pi-tui';
+import { Box, Spacer, Text, visibleWidth } from '@earendil-works/pi-tui';
 import type { TUI } from '@earendil-works/pi-tui';
 import { MC_TOOLS } from '@mastra/code-sdk/tool-names';
 import type { TaskItemInput } from '@mastra/core/signals';
@@ -12,7 +12,7 @@ import chalk from 'chalk';
 import { highlight } from 'cli-highlight';
 import type { Theme as HighlightTheme } from 'cli-highlight';
 import { sanitizeAnsiForRendering } from '../sanitize-ansi.js';
-import { BOX_INDENT, getTermWidth, theme, mastra, tintHex, ensureTerminalGlyphContrast } from '../theme.js';
+import { BOX_INDENT, theme, mastra, tintHex, ensureTerminalGlyphContrast } from '../theme.js';
 import { truncateAnsi } from './ansi.js';
 import type { ChatSpacingKind } from './chat-spacing.js';
 import { ErrorDisplayComponent } from './error-display.js';
@@ -23,6 +23,7 @@ import type {
   ToolResult,
 } from './tool-execution-interface.js';
 import { ToolValidationErrorComponent, parseValidationErrors } from './tool-validation-error.js';
+import { WidthAwareContainer } from './width-aware-container.js';
 
 export type { ToolResult };
 
@@ -189,7 +190,7 @@ function extractContent(text: string): { content: string; isError: boolean } {
 /**
  * Enhanced tool execution component with collapsible sections
  */
-export class ToolExecutionComponentEnhanced extends Container implements IToolExecutionComponent {
+export class ToolExecutionComponentEnhanced extends WidthAwareContainer implements IToolExecutionComponent {
   private contentBox: Box;
   private toolName: string;
   private args: unknown;
@@ -379,7 +380,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
    * - expand/collapse on a tool with no collapsible child
    * - initial construction
    */
-  private rebuild(): void {
+  protected rebuildForWidth(_width: number): void {
     this.updateBgColor();
     this.contentBox.clear();
 
@@ -424,7 +425,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   }
 
   private renderCompactTool(): void {
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const maxLineWidth = termWidth - BOX_INDENT * 2 - 2;
     const lines = this.getCompactToolSummaryLines();
 
@@ -629,7 +630,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const toolLabel = this.getCompactToolLabel();
     const toolLabelColor = this.getCompactToolLabelColor();
     const summary = this.compactToolContinuation ? this.getCompactContinuationSummary() : this.getCompactToolSummary();
-    const detailLines = this.getQuietPreviewLines(getTermWidth() - BOX_INDENT * 2 - 2);
+    const detailLines = this.getQuietPreviewLines(this.renderWidth - BOX_INDENT * 2 - 2);
     const firstLine = this.compactToolContinuation
       ? summary
         ? `${this.getCompactContinuationIndent()}${this.formatCompactContinuationLine(summary)}${status}`
@@ -1317,7 +1318,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const status = this.getStatusIndicator();
 
     // Calculate available width for path and truncate from beginning if needed
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const fixedParts = '╰── view  ' + (rangeDisplay ? `:XXX,XXX` : '') + ' ✓'; // approximate fixed width
     const availableForPath = termWidth - fixedParts.length - 6 - BOX_INDENT * 2; // buffer
     let path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
@@ -1339,7 +1340,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     // Syntax-highlighted content with left border, truncated to prevent soft wrap
     const output = this.getFormattedOutput();
     if (output) {
-      const termWidth = getTermWidth();
+      const termWidth = this.renderWidth;
       const maxLineWidth = termWidth - 4 - BOX_INDENT * 2; // Account for border "│ " (2) + buffer (2)
       const highlighted = highlightCode(output, fullPath, startLine);
       let lines = highlighted.split('\n');
@@ -1398,7 +1399,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const border = (char: string) => this.formatToolBorder(char);
       const footerPrompt = `${theme.bold(theme.fg('toolTitle', '$'))} `;
       const footerSuffix = `${cwdSuffix}${timeSuffix}${status}`;
-      const termWidth = getTermWidth();
+      const termWidth = this.renderWidth;
       const contentWidth = Math.max(20, termWidth - BOX_INDENT * 2 - 4); // Account for "│ " + " │"
       const horizontal = '─'.repeat(contentWidth + 2);
       const renderLine = (line: string, color: (value: string) => string = value => theme.fg('toolOutput', value)) => {
@@ -1522,7 +1523,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
       this.contentBox.addChild(new Text(border('╭──'), 0, 0));
 
-      const termWidth = getTermWidth();
+      const termWidth = this.renderWidth;
       const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
       const borderedLines = outputLines.map(line => {
         const truncated = truncateAnsi(line, maxLineWidth);
@@ -1578,7 +1579,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       const newStr = argsObj?.new_str ?? argsObj?.new_string;
       if (oldStr != null && newStr != null) {
         const border = (char: string) => this.formatToolBorder(char);
-        const termWidth = getTermWidth();
+        const termWidth = this.renderWidth;
         const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
         const footerText = `${theme.bold(theme.fg('toolTitle', 'edit'))} ${pathDisplay}${theme.fg('muted', startLine)}${status}`;
 
@@ -1626,7 +1627,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const status = this.getStatusIndicator();
 
     // Calculate available width for path and truncate from beginning if needed
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const fixedParts = '╰── edit  ' + startLine + ' ✓'; // approximate fixed width
     const availableForPath = termWidth - fixedParts.length - 6 - BOX_INDENT * 2; // buffer
     let path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
@@ -1841,7 +1842,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
       // Content is streaming in — show bordered box with syntax-highlighted preview
       const border = (char: string) => this.formatToolBorder(char);
       const status = this.getStatusIndicator();
-      const termWidth = getTermWidth();
+      const termWidth = this.renderWidth;
       const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
 
       let path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
@@ -1887,7 +1888,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     // Complete — show final bordered result
     const border = (char: string) => this.formatToolBorder(char);
     const status = this.getStatusIndicator();
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
 
     let path = argsObj?.path ? shortenPath(String(argsObj.path)) : '...';
@@ -1947,7 +1948,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const patternDisplay = pattern ? ' ' + theme.fg('muted', pattern) : '';
     const border = (char: string) => this.formatToolBorder(char);
     const status = this.getStatusIndicator();
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
 
     if (!this.result || this.isPartial) {
@@ -2003,7 +2004,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
   private renderLspInspectEnhanced(): void {
     const border = (char: string) => this.formatToolBorder(char);
     const status = this.getStatusIndicator();
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
     const argsObj = this.args as { path?: string; line?: number; match?: string } | undefined;
     const path_ = argsObj?.path;
@@ -2279,7 +2280,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     // Parse search results and format as a clean list of titles + URLs
     const output = this.formatWebSearchResults();
     if (output) {
-      const termWidth = getTermWidth();
+      const termWidth = this.renderWidth;
       const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
 
       // Empty line padding above
@@ -2414,7 +2415,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
 
     const output = this.getFormattedOutput();
     if (output) {
-      const termWidth = getTermWidth();
+      const termWidth = this.renderWidth;
       const maxLineWidth = termWidth - 4 - BOX_INDENT * 2;
 
       // Empty line padding above
@@ -2464,7 +2465,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const keys = Object.keys(argsObj);
     if (keys.length === 0) return [];
 
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     const maxLineWidth = termWidth - 4 - BOX_INDENT * 2 - 2; // -2 for "│ " border prefix
     const lines: string[] = [];
 
@@ -2515,7 +2516,7 @@ export class ToolExecutionComponentEnhanced extends Container implements IToolEx
     const entries = Object.entries(argsObj).filter(([, v]) => v !== undefined);
     if (entries.length === 0) return '';
 
-    const termWidth = getTermWidth();
+    const termWidth = this.renderWidth;
     // Leave room for tool name, status indicator, borders
     const maxLen = Math.max(20, termWidth - this.toolName.length - 15 - BOX_INDENT * 2);
     const parts: string[] = [];

--- a/mastracode/tui/src/tui/components/width-aware-container.ts
+++ b/mastracode/tui/src/tui/components/width-aware-container.ts
@@ -1,0 +1,26 @@
+import { Container } from '@earendil-works/pi-tui';
+
+/** Rebuilds width-derived children only when state or the received render width changes. */
+export abstract class WidthAwareContainer extends Container {
+  private builtWidth: number | undefined;
+
+  protected get renderWidth(): number {
+    return this.builtWidth!;
+  }
+
+  protected rebuild(): void {
+    if (this.builtWidth !== undefined) {
+      this.rebuildForWidth(this.builtWidth);
+    }
+  }
+
+  protected abstract rebuildForWidth(width: number): void;
+
+  override render(width: number): string[] {
+    if (this.builtWidth !== width) {
+      this.builtWidth = width;
+      this.rebuildForWidth(width);
+    }
+    return super.render(width);
+  }
+}


### PR DESCRIPTION
Mastra Code’s custom-rendered chat components cached wrapping and truncation using the terminal width that existed when their child trees were built. Resizing the terminal rerendered those stale trees, so wide → narrow → wide transitions could leave content incorrectly wrapped or permanently clipped.

This makes the nine affected components rebuild their width-derived children only when the width passed to `render(width)` changes, while preserving expansion, streaming, task, notification, and quiet-mode state.

It also treats `/` and `@` as editor prompt chrome before wrapping content. This keeps the right border aligned at exact wrap boundaries and preserves cursor placement when the cursor is on the decorative prompt.

Before:
```
wide render → resize → stale pre-wrapped content
/editor input → slash consumes a hidden content column
```

After:
```
wide render → narrow reflow → wide content restoration
/editor input → slash is decorative and borders stay aligned
```

Focused unit coverage exercises all nine components, editor boundary cases, and state preservation. A deterministic xterm scenario drives the real TUI resize path across wide → narrow → wide and verifies historical output reflow plus active editor alignment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When you resize the terminal, Mastra Code’s chat UI now “reshuffles” itself to fit the new width without breaking formatting or forgetting what was expanded/streaming. It also keeps the special `/` and `@` prompt markers lined up so borders and the cursor stay in the right place.

## Summary
- Added a `WidthAwareContainer` base class so nine width-dependent TUI components only rebuild when `render(width)` actually changes, preserving streaming, expansion, task/notification progress, and quiet-mode state.
- Updated the custom editor prompt rendering so `/` and `@` are treated as decorative chrome before wrapping—keeping borders aligned and cursor placement correct.
- Refactored these nine components to be width-aware: judge display, notifications, observational memory output, shell stream output, slash command, subagent execution, system reminders, task progress, and enhanced tool execution.
- Clamped slash-command and subagent wrapping widths so resizing below fixed decorative chrome won’t trigger non-converging wrapping behavior.
- Added focused unit tests for reflow behavior, editor prompt width accounting, and state preservation, plus boundary tests at very narrow widths.
- Added a deterministic xterm end-to-end scenario (`terminal-resize-reflow`) that resizes wide → narrow → wide and verifies historical output reflow and active editor border/cursor alignment.
- Updated TUI e2e/testing docs and agent workflow scoping, and included a patch changeset for the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->