### PR TITLE
feat(cli): manage platform databases, environments, and deploys from the CLI

### DIFF
--- a/.changeset/good-sites-try.md
+++ b/.changeset/good-sites-try.md
@@ -1,0 +1,32 @@
+---
+'mastra': minor
+---
+
+Added CLI commands to manage platform databases, environments, and deploys without leaving the terminal.
+
+The project is resolved automatically from `MASTRA_PROJECT_ID`, the `--project <name|slug|id>` flag, or the `.mastra-project.json` written by `mastra deploy` — run the commands from your project directory and you never need to name the project.
+
+**Databases**
+
+```bash
+mastra env db list                     # kind, status, scope, injected env var names
+mastra env db list staging             # only databases feeding one environment
+mastra env db create --kind turso      # shared by all environments, polls until ready
+mastra env db create staging --kind turso   # scoped to one environment
+mastra env db show <database>          # detail + connection env vars (secrets masked)
+mastra env db detach <database>        # confirm prompt, admin only
+```
+
+`env db list` shows the attachment mapping: shared (project-scoped) databases feed all environments, environment-scoped databases feed only their environment. Provisioning failures are surfaced with the provider error instead of being swallowed.
+
+**Environments and deploys**
+
+```bash
+mastra env list             # now shows latest deploy status + managed env var names
+mastra env create staging   # explicit environment creation
+mastra env restart <env>    # push saved env vars and restart the running service
+mastra env deploys          # all deploys across environments, active marker
+mastra env deploys staging  # only one environment's deploys
+```
+
+Breaking change to the existing `mastra env` commands: the `<project>` positional argument is replaced by the resolution above (`mastra env list <project>` → `mastra env list --project <project>`), and `mastra env create <project> -n <name>` is now `mastra env create <name>`.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -292,31 +292,29 @@ mastra deploy --env staging --yes
 
 ## `mastra env`
 
-Manages environments on Mastra platform. Environments are named deploy targets (for example `production`, `staging`, `preview-42`) that belong to a project. Every subcommand takes a `<project>` argument (name, slug, or ID) and resolves the current organization from stored credentials.
+Manages environments on Mastra platform. Environments are named deploy targets (for example `production`, `staging`, `preview-42`) that belong to a project. The current organization is resolved from stored credentials.
+
+Every subcommand resolves its project from, in order: the `MASTRA_PROJECT_ID` environment variable, the `--project <name|slug|id>` flag, or the `.mastra-project.json` file written by [`mastra deploy`](#mastra-deploy) in the current directory. Run from your project directory and you never need to name the project.
 
 ### `mastra env list`
 
-Lists environments for a project.
+Lists environments for a project. Each environment shows its latest deploy (with an `(active)` marker when it's serving traffic) and the env var names injected by managed resources such as attached databases.
 
 ```bash
-mastra env list <project>
+mastra env list
 ```
 
 #### `--json`
 
-Emit machine-readable JSON. Only non-sensitive metadata (id, name, slug, type, region, branch, and URLs) is included so the output is safe to log in CI.
+Emit machine-readable JSON. Only non-sensitive metadata (id, name, slug, type, region, branch, URLs, managed env var names, and latest deploy status) is included so the output is safe to log in CI.
 
 ### `mastra env create`
 
 Creates a new environment for a project.
 
 ```bash
-mastra env create <project> --name staging --type staging --region eu
+mastra env create staging --type staging --region eu
 ```
-
-#### `-n, --name`
-
-Environment name (required).
 
 #### `-t, --type`
 
@@ -335,7 +333,7 @@ Emit machine-readable JSON. Sensitive fields are omitted, as with [`mastra env l
 Deletes an environment.
 
 ```bash
-mastra env delete <project> <env>
+mastra env delete <env>
 ```
 
 `<env>` can be an environment name, slug, or ID. The CLI prompts for confirmation unless `--yes` is passed.
@@ -343,6 +341,112 @@ mastra env delete <project> <env>
 #### `-y, --yes`
 
 Skip the confirmation prompt.
+
+### `mastra env restart`
+
+Restarts an environment's running service so saved env vars (including managed vars from attached databases) take effect immediately, without a new deploy.
+
+```bash
+mastra env restart <env>
+```
+
+`<env>` can be an environment name, slug, or ID. Fails with a conflict error if the environment has never been deployed.
+
+### `mastra env db`
+
+Manages databases attached to a project on Mastra platform. Databases are provisioned from a managed provider (for example Turso or Neon) and inject their connection env vars into deploys automatically.
+
+A database is either **environment-scoped** (its env vars only go to one environment) or **shared** (project-scoped: its env vars go to all environments). Pass the environment argument to work with environment-scoped databases; omit it for shared databases.
+
+Creating and detaching databases requires the `admin` role in the organization.
+
+### `mastra env db list`
+
+Lists databases attached to a project, including provider, provisioning status, scope (which environment each database feeds), and the env var names each database injects. Pass an environment to only show databases feeding that environment (environment-scoped plus shared).
+
+```bash
+mastra env db list
+mastra env db list <env>
+```
+
+#### `--json`
+
+Emit machine-readable JSON.
+
+### `mastra env db create`
+
+Provisions a managed database, attaches it, and polls until it's ready. Provisioning errors are printed with the provider's error detail.
+
+With an environment argument, the database is scoped to that environment: only it receives the database's connection env vars, and the provider region is derived from the environment's region. Without one, the database is shared by all environments.
+
+```bash
+mastra env db create <env> --kind turso
+mastra env db create --kind neon --name my-app-db --region aws-us-east-1
+```
+
+#### `--kind`
+
+Database provider (required). One of `turso` or `neon`.
+
+#### `--name`
+
+Database name. Defaults to a name derived from the project slug (for example `my-app-db`).
+
+#### `--region`
+
+Provider region ID for shared databases. Ignored for environment-scoped databases.
+
+#### `--no-wait`
+
+Return immediately after the attach is queued instead of polling until the database is ready. Check progress later with `mastra env db show`.
+
+#### `--json`
+
+Emit machine-readable JSON.
+
+### `mastra env db show`
+
+Shows database details and, once the database is ready, its connection env vars. Secret values are masked by default.
+
+```bash
+mastra env db show <database>
+```
+
+`<database>` can be a database ID or name.
+
+#### `--show-secrets`
+
+Print secret connection values instead of masking them.
+
+#### `--json`
+
+Emit machine-readable JSON. Secret values are masked unless `--show-secrets` is passed.
+
+### `mastra env db detach`
+
+Detaches a database from the project. The CLI prompts for confirmation unless `--yes` is passed. After detaching, deploys no longer receive the database's env vars.
+
+```bash
+mastra env db detach <database>
+```
+
+#### `-y, --yes`
+
+Skip the confirmation prompt.
+
+### `mastra env deploys`
+
+Lists deploys for a project, newest first. Deploys that are serving traffic are marked `(active)`.
+
+```bash
+mastra env deploys [environment]
+```
+
+Omit `[environment]` to show deploys across all environments; pass an environment name, slug, or ID to filter to one.
+
+#### `--json`
+
+Emit machine-readable JSON.
 
 ## `mastra studio deploy`
 

--- a/packages/cli/src/commands/db/db.test.ts
+++ b/packages/cli/src/commands/db/db.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import type { Environment } from '../env/platform-api.js';
+import { defaultDatabaseName, formatScope } from './db.js';
+
+const environment = {
+  id: 'env-1',
+  projectId: 'proj-1',
+  name: 'Staging',
+  slug: 'my-app-staging',
+  type: 'staging',
+  region: 'eu',
+  branch: null,
+  instanceUrl: null,
+  customServerUrl: null,
+  observabilityProjectId: null,
+  envVars: null,
+  createdAt: '2026-07-09T00:00:00.000Z',
+  updatedAt: '2026-07-09T00:00:00.000Z',
+} as Environment;
+
+describe('formatScope', () => {
+  it('labels project-scoped databases as shared by all environments', () => {
+    expect(formatScope({ environmentId: null }, [environment])).toBe('project (all environments)');
+  });
+
+  it('resolves env-scoped databases to the environment slug', () => {
+    expect(formatScope({ environmentId: 'env-1' }, [environment])).toBe('environment: my-app-staging');
+  });
+
+  it('falls back to the raw environment id when the environment is gone', () => {
+    expect(formatScope({ environmentId: 'env-gone' }, [environment])).toBe('environment: env-gone');
+  });
+});
+
+describe('defaultDatabaseName', () => {
+  it('derives a name from the project slug', () => {
+    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' })).toBe('my-app-db');
+  });
+
+  it('falls back to the project name and sanitizes it for DNS-safe providers', () => {
+    expect(defaultDatabaseName({ name: 'My_Fancy App!', slug: null })).toBe('my-fancy-app-db');
+  });
+
+  it('never returns leading/trailing hyphens or an empty base', () => {
+    expect(defaultDatabaseName({ name: '---', slug: null })).toBe('mastra-db');
+  });
+});

--- a/packages/cli/src/commands/db/db.ts
+++ b/packages/cli/src/commands/db/db.ts
@@ -1,0 +1,369 @@
+import * as p from '@clack/prompts';
+import type { Command } from 'commander';
+import { getToken } from '../auth/credentials.js';
+import { resolveCurrentOrg } from '../auth/orgs.js';
+import type { Environment, Project } from '../env/platform-api.js';
+import { fetchEnvironments } from '../env/platform-api.js';
+import { resolveProject } from '../env/resolve-project.js';
+import { wrapAction } from '../utils.js';
+import type { DatabaseKind, ProjectDatabase } from './platform-api.js';
+import {
+  attachDatabase,
+  DB_ENV_VAR_NAMES,
+  detachDatabase,
+  fetchDatabase,
+  fetchDatabaseConnection,
+  fetchDatabases,
+  pollDatabaseUntilReady,
+} from './platform-api.js';
+
+const PROJECT_OPTION = ['--project <project>', 'Project name, slug, or ID (default: linked project)'] as const;
+
+export function registerEnvDbCommands(envCommand: Command) {
+  const db = envCommand.command('db').description('Manage databases attached to a project and its environments');
+
+  db.command('list')
+    .description('List databases and which environment each one feeds (filtered when an environment is given)')
+    .argument('[environment]', 'Environment name, slug, or ID (default: all databases)')
+    .option(...PROJECT_OPTION)
+    .option('--json', 'Output as JSON')
+    .action(wrapAction(listDatabasesAction));
+
+  db.command('create')
+    .description('Provision a database, attach it, and wait until it is ready')
+    .argument('[environment]', 'Environment name, slug, or ID (default: shared by all environments)')
+    .requiredOption('--kind <kind>', 'Database provider (turso, neon)')
+    .option(...PROJECT_OPTION)
+    .option('--name <name>', 'Database name (default: derived from the project slug)')
+    .option('--region <region>', 'Provider region ID (shared databases only; environment region wins otherwise)')
+    .option('--no-wait', 'Return immediately instead of polling until the database is ready')
+    .option('--json', 'Output as JSON')
+    .action(wrapAction(createDatabaseAction));
+
+  db.command('show')
+    .description('Show database details and connection instructions')
+    .argument('<database>', 'Database ID or name')
+    .option(...PROJECT_OPTION)
+    .option('--show-secrets', 'Print secret connection values instead of masking them')
+    .option('--json', 'Output as JSON')
+    .action(wrapAction(showDatabaseAction));
+
+  db.command('detach')
+    .description('Detach a database from the project (soft-delete; admin only)')
+    .argument('<database>', 'Database ID or name')
+    .option(...PROJECT_OPTION)
+    .option('-y, --yes', 'Skip confirmation')
+    .action(wrapAction(detachDatabaseAction));
+}
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+/**
+ * Human-readable attachment scope: which environment(s) receive this
+ * database's env vars.
+ */
+export function formatScope(db: Pick<ProjectDatabase, 'environmentId'>, environments: Environment[]): string {
+  if (!db.environmentId) {
+    return 'project (all environments)';
+  }
+  const env = environments.find(e => e.id === db.environmentId);
+  return env ? `environment: ${env.slug}` : `environment: ${db.environmentId}`;
+}
+
+/**
+ * Derive a provider-safe default database name from the project slug/name.
+ * Turso names become DNS labels, so: lowercase letters, digits, hyphens,
+ * no leading/trailing hyphen, max 64 chars.
+ */
+export function defaultDatabaseName(project: Pick<Project, 'name' | 'slug'>): string {
+  const base = (project.slug || project.name)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+  return `${base || 'mastra'}-db`.slice(0, 64).replace(/-+$/g, '');
+}
+
+function envVarNamesFor(kind: DatabaseKind): string {
+  const names = DB_ENV_VAR_NAMES[kind] ?? [];
+  return names.length > 0 ? names.join(', ') : '—';
+}
+
+function withScope(db: ProjectDatabase, environments: Environment[]) {
+  return {
+    ...db,
+    scope: formatScope(db, environments),
+    envVarNames: DB_ENV_VAR_NAMES[db.kind] ?? [],
+  };
+}
+
+async function findDatabase(token: string, orgId: string, project: Project, dbArg: string): Promise<ProjectDatabase> {
+  const databases = await fetchDatabases(token, orgId, project.id);
+  const db = databases.find(d => d.id === dbArg || d.name === dbArg);
+  if (!db) {
+    throw new Error(`Database not found: ${dbArg}. List databases with: mastra env db list`);
+  }
+  return db;
+}
+
+/* ------------------------------------------------------------------ */
+/*  mastra env db list                                                 */
+/* ------------------------------------------------------------------ */
+
+async function findEnvironment(token: string, orgId: string, project: Project, envArg: string): Promise<Environment> {
+  const environments = await fetchEnvironments(token, orgId, project.id);
+  const env = environments.find(e => e.id === envArg || e.name === envArg || e.slug === envArg);
+  if (!env) {
+    throw new Error(`Environment not found: ${envArg}. List environments with: mastra env list`);
+  }
+  return env;
+}
+
+async function listDatabasesAction(envArg: string | undefined, options: { project?: string; json?: boolean }) {
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+  const project = await resolveProject(token, orgId, options.project);
+
+  const [databases, environments] = await Promise.all([
+    fetchDatabases(token, orgId, project.id),
+    fetchEnvironments(token, orgId, project.id),
+  ]);
+
+  const env = envArg
+    ? (environments.find(e => e.id === envArg || e.name === envArg || e.slug === envArg) ??
+      (() => {
+        throw new Error(`Environment not found: ${envArg}. List environments with: mastra env list`);
+      })())
+    : undefined;
+
+  // When filtering by environment, a database "feeds" it if it's scoped to
+  // that environment or shared (project-scoped).
+  const visible = env ? databases.filter(db => db.environmentId === env.id || !db.environmentId) : databases;
+
+  if (options.json) {
+    process.stdout.write(
+      `${JSON.stringify(
+        {
+          ...(env ? { environment: env.slug } : {}),
+          databases: visible.map(db => withScope(db, environments)),
+        },
+        null,
+        2,
+      )}\n`,
+    );
+    return;
+  }
+
+  console.info(env ? `\nDatabases feeding ${env.slug}:\n` : `\nDatabases for ${project.name}:\n`);
+
+  if (visible.length === 0) {
+    console.info(
+      `  No databases attached. Create one with: mastra env db create${env ? ` ${env.slug}` : ''} --kind turso\n`,
+    );
+    return;
+  }
+
+  for (const db of visible) {
+    console.info(`  ${db.name} (${db.kind}) — ${db.status}`);
+    console.info(`    ID: ${db.id}`);
+    console.info(`    Scope: ${formatScope(db, environments)}`);
+    if (db.region) {
+      console.info(`    Region: ${db.region}`);
+    }
+    console.info(`    Env vars: ${envVarNamesFor(db.kind)}`);
+    if (db.error) {
+      console.info(`    Error: ${db.error}`);
+    }
+  }
+  console.info('');
+}
+
+/* ------------------------------------------------------------------ */
+/*  mastra env db create                                               */
+/* ------------------------------------------------------------------ */
+
+function parseKind(kind: string): DatabaseKind {
+  if (kind !== 'turso' && kind !== 'neon') {
+    throw new Error(`Unsupported database kind: ${kind}. Supported kinds: turso, neon`);
+  }
+  return kind;
+}
+
+async function createDatabaseAction(
+  envArg: string | undefined,
+  options: { project?: string; kind: string; name?: string; region?: string; wait: boolean; json?: boolean },
+) {
+  const kind = parseKind(options.kind);
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+  const project = await resolveProject(token, orgId, options.project);
+  const environment = envArg ? await findEnvironment(token, orgId, project, envArg) : undefined;
+
+  if (environment && options.region && !options.json) {
+    console.info(`Note: --region is ignored for environment-scoped databases; the environment's region is used.`);
+  }
+
+  await createDatabase({
+    token,
+    orgId,
+    project,
+    environment,
+    kind,
+    name: options.name,
+    regionId: options.region,
+    wait: options.wait,
+    json: options.json,
+  });
+}
+
+async function createDatabase(opts: {
+  token: string;
+  orgId: string;
+  project: Project;
+  environment?: Environment;
+  kind: DatabaseKind;
+  name?: string;
+  regionId?: string;
+  wait: boolean;
+  json?: boolean;
+}) {
+  const { token, orgId, project, environment, kind } = opts;
+  const name = opts.name ?? defaultDatabaseName(project);
+
+  const created = await attachDatabase(token, orgId, project.id, {
+    kind,
+    name,
+    ...(environment ? { environmentId: environment.id } : {}),
+    ...(opts.regionId && !environment ? { regionId: opts.regionId } : {}),
+  });
+
+  const scopeLabel = environment ? `environment: ${environment.slug}` : 'project (shared by all environments)';
+
+  if (!opts.wait) {
+    if (opts.json) {
+      process.stdout.write(`${JSON.stringify({ database: created, scope: scopeLabel }, null, 2)}\n`);
+    } else {
+      console.info(`\nDatabase ${created.name} (${created.kind}) is provisioning.`);
+      console.info(`  ID: ${created.id}`);
+      console.info(`  Scope: ${scopeLabel}`);
+      console.info(`  Check progress with: mastra env db show ${created.id}\n`);
+    }
+    return;
+  }
+
+  let ready: ProjectDatabase;
+  if (opts.json) {
+    ready = await pollDatabaseUntilReady(token, orgId, project.id, created.id);
+    process.stdout.write(`${JSON.stringify({ database: ready, scope: scopeLabel }, null, 2)}\n`);
+    return;
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Provisioning ${created.kind} database "${created.name}"...`);
+  try {
+    ready = await pollDatabaseUntilReady(token, orgId, project.id, created.id, {
+      onStatus: status => spinner.message(`Provisioning ${created.kind} database "${created.name}" — ${status}`),
+    });
+  } catch (error) {
+    spinner.stop('Provisioning failed.');
+    throw error;
+  }
+  spinner.stop(`Database "${ready.name}" is ready.`);
+
+  console.info(`\n  ID: ${ready.id}`);
+  console.info(`  Kind: ${ready.kind}`);
+  console.info(`  Scope: ${scopeLabel}`);
+  if (ready.region) {
+    console.info(`  Region: ${ready.region}`);
+  }
+  console.info(`  Env vars injected at deploy time: ${envVarNamesFor(ready.kind)}`);
+  console.info(`\n  Connection details: mastra env db show ${ready.id}\n`);
+}
+
+/* ------------------------------------------------------------------ */
+/*  mastra env db show                                                 */
+/* ------------------------------------------------------------------ */
+
+async function showDatabaseAction(dbArg: string, options: { project?: string; showSecrets?: boolean; json?: boolean }) {
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+  const project = await resolveProject(token, orgId, options.project);
+
+  const found = await findDatabase(token, orgId, project, dbArg);
+  const [db, environments] = await Promise.all([
+    fetchDatabase(token, orgId, project.id, found.id),
+    fetchEnvironments(token, orgId, project.id),
+  ]);
+
+  const connection = db.status === 'ready' ? await fetchDatabaseConnection(token, orgId, project.id, db.id) : null;
+
+  if (options.json) {
+    const jsonConnection = connection
+      ? {
+          ...connection,
+          envVars: connection.envVars.map(v => ({
+            ...v,
+            value: v.secret && !options.showSecrets ? '********' : v.value,
+          })),
+        }
+      : null;
+    process.stdout.write(
+      `${JSON.stringify({ database: withScope(db, environments), connection: jsonConnection }, null, 2)}\n`,
+    );
+    return;
+  }
+
+  console.info(`\n${db.name} (${db.kind})`);
+  console.info(`  ID: ${db.id}`);
+  console.info(`  Status: ${db.status}`);
+  console.info(`  Scope: ${formatScope(db, environments)}`);
+  if (db.region) {
+    console.info(`  Region: ${db.region}`);
+  }
+  console.info(`  Created: ${db.createdAt}`);
+  if (db.error) {
+    console.info(`  Error: ${db.error}`);
+  }
+
+  if (connection) {
+    console.info('\n  Connection env vars (injected automatically at deploy time):');
+    for (const envVar of connection.envVars) {
+      const value = envVar.secret && !options.showSecrets ? '******** (use --show-secrets to reveal)' : envVar.value;
+      console.info(`    ${envVar.name}=${value}`);
+    }
+    if (connection.docsUrl) {
+      console.info(`\n  Docs: ${connection.docsUrl}`);
+    }
+  } else if (db.status === 'provisioning') {
+    console.info('\n  Connection instructions become available once the database is ready.');
+  }
+  console.info('');
+}
+
+/* ------------------------------------------------------------------ */
+/*  mastra env db detach                                               */
+/* ------------------------------------------------------------------ */
+
+async function detachDatabaseAction(dbArg: string, options: { project?: string; yes?: boolean }) {
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+  const project = await resolveProject(token, orgId, options.project);
+
+  const db = await findDatabase(token, orgId, project, dbArg);
+
+  if (!options.yes) {
+    const confirm = await p.confirm({
+      message: `Detach database "${db.name}" (${db.kind}) from ${project.name}? Deploys will no longer receive its env vars.`,
+    });
+
+    if (p.isCancel(confirm) || !confirm) {
+      p.cancel('Cancelled.');
+      process.exit(0);
+    }
+  }
+
+  await detachDatabase(token, orgId, project.id, db.id);
+  console.info(`Database "${db.name}" detached.`);
+}

--- a/packages/cli/src/commands/db/index.ts
+++ b/packages/cli/src/commands/db/index.ts
@@ -1,0 +1,1 @@
+export { registerEnvDbCommands } from './db.js';

--- a/packages/cli/src/commands/db/platform-api.test.ts
+++ b/packages/cli/src/commands/db/platform-api.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPlatformFetch = vi.fn();
+
+vi.mock('../auth/client.js', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    platformFetch: mockPlatformFetch,
+  };
+});
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const dbRow = {
+  id: 'db-1',
+  platformProjectId: 'proj-1',
+  organizationId: 'org-1',
+  environmentId: null,
+  kind: 'turso' as const,
+  name: 'my-app-db',
+  status: 'provisioning' as const,
+  region: 'iad',
+  providerResourceId: null,
+  error: null,
+  createdAt: '2026-07-09T00:00:00.000Z',
+  updatedAt: '2026-07-09T00:00:00.000Z',
+  deletedAt: null,
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  process.env.MASTRA_PLATFORM_API_URL = 'http://localhost:9999';
+});
+
+afterEach(() => {
+  delete process.env.MASTRA_PLATFORM_API_URL;
+});
+
+describe('fetchDatabases', () => {
+  it('returns databases on success', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(200, { databases: [dbRow] }));
+
+    const { fetchDatabases } = await import('./platform-api.js');
+    await expect(fetchDatabases('tok', 'org-1', 'proj-1')).resolves.toEqual([dbRow]);
+    expect(mockPlatformFetch).toHaveBeenCalledWith(
+      'http://localhost:9999/v1/server/projects/proj-1/databases',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer tok', 'x-organization-id': 'org-1' }),
+      }),
+    );
+  });
+
+  it('throws session expired on 401', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(401, {}));
+
+    const { fetchDatabases } = await import('./platform-api.js');
+    await expect(fetchDatabases('tok', 'org-1', 'proj-1')).rejects.toThrow('Session expired. Run: mastra auth login');
+  });
+});
+
+describe('attachDatabase', () => {
+  it('posts the attach input and returns the database', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(201, { database: dbRow }));
+
+    const { attachDatabase } = await import('./platform-api.js');
+    await expect(
+      attachDatabase('tok', 'org-1', 'proj-1', { kind: 'turso', name: 'my-app-db', environmentId: 'env-1' }),
+    ).resolves.toEqual(dbRow);
+
+    const [url, init] = mockPlatformFetch.mock.calls[0]!;
+    expect(url).toBe('http://localhost:9999/v1/server/projects/proj-1/databases');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ kind: 'turso', name: 'my-app-db', environmentId: 'env-1' });
+  });
+
+  it('throws a clear admin-role message on 403', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(403, { detail: 'Forbidden' }));
+
+    const { attachDatabase } = await import('./platform-api.js');
+    await expect(attachDatabase('tok', 'org-1', 'proj-1', { kind: 'turso', name: 'db' })).rejects.toThrow(
+      'You need the admin role in this organization to manage databases.',
+    );
+  });
+
+  it('surfaces the server detail on 409 env var collision', async () => {
+    mockPlatformFetch.mockResolvedValue(
+      jsonResponse(409, { detail: 'TURSO_DATABASE_URL is already set on this project' }),
+    );
+
+    const { attachDatabase } = await import('./platform-api.js');
+    await expect(attachDatabase('tok', 'org-1', 'proj-1', { kind: 'turso', name: 'db' })).rejects.toThrow(
+      'TURSO_DATABASE_URL is already set on this project',
+    );
+  });
+});
+
+describe('detachDatabase', () => {
+  it('resolves on 204', async () => {
+    mockPlatformFetch.mockResolvedValue({ ok: true, status: 204 } as unknown as Response);
+
+    const { detachDatabase } = await import('./platform-api.js');
+    await expect(detachDatabase('tok', 'org-1', 'proj-1', 'db-1')).resolves.toBeUndefined();
+
+    const [url, init] = mockPlatformFetch.mock.calls[0]!;
+    expect(url).toBe('http://localhost:9999/v1/server/projects/proj-1/databases/db-1');
+    expect(init.method).toBe('DELETE');
+  });
+
+  it('throws a clear admin-role message on 403', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(403, { detail: 'Forbidden' }));
+
+    const { detachDatabase } = await import('./platform-api.js');
+    await expect(detachDatabase('tok', 'org-1', 'proj-1', 'db-1')).rejects.toThrow(
+      'You need the admin role in this organization to manage databases.',
+    );
+  });
+});
+
+describe('fetchDatabaseConnection', () => {
+  it('returns connection instructions', async () => {
+    const connection = {
+      envVars: [{ name: 'TURSO_DATABASE_URL', value: 'libsql://x', secret: false }],
+      snippets: [],
+      docsUrl: 'https://mastra.ai/docs',
+    };
+    mockPlatformFetch.mockResolvedValue(jsonResponse(200, connection));
+
+    const { fetchDatabaseConnection } = await import('./platform-api.js');
+    await expect(fetchDatabaseConnection('tok', 'org-1', 'proj-1', 'db-1')).resolves.toEqual(connection);
+  });
+
+  it('surfaces not-ready detail on 400', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(400, { detail: 'Database is not ready (status=provisioning)' }));
+
+    const { fetchDatabaseConnection } = await import('./platform-api.js');
+    await expect(fetchDatabaseConnection('tok', 'org-1', 'proj-1', 'db-1')).rejects.toThrow(
+      'Database is not ready (status=provisioning)',
+    );
+  });
+});
+
+describe('pollDatabaseUntilReady', () => {
+  it('resolves once the database becomes ready and reports status changes', async () => {
+    mockPlatformFetch
+      .mockResolvedValueOnce(jsonResponse(200, { database: dbRow }))
+      .mockResolvedValueOnce(jsonResponse(200, { database: { ...dbRow, status: 'ready' } }));
+
+    const onStatus = vi.fn();
+    const { pollDatabaseUntilReady } = await import('./platform-api.js');
+    const result = await pollDatabaseUntilReady('tok', 'org-1', 'proj-1', 'db-1', { intervalMs: 0, onStatus });
+
+    expect(result.status).toBe('ready');
+    expect(onStatus).toHaveBeenCalledWith('provisioning');
+    expect(onStatus).toHaveBeenCalledWith('ready');
+  });
+
+  it('throws the provider error when provisioning fails', async () => {
+    mockPlatformFetch.mockResolvedValue(
+      jsonResponse(200, { database: { ...dbRow, status: 'failed', error: 'quota exceeded' } }),
+    );
+
+    const { pollDatabaseUntilReady } = await import('./platform-api.js');
+    await expect(pollDatabaseUntilReady('tok', 'org-1', 'proj-1', 'db-1', { intervalMs: 0 })).rejects.toThrow(
+      'Database provisioning failed: quota exceeded',
+    );
+  });
+
+  it('throws a generic message when the failed row has no error detail', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(200, { database: { ...dbRow, status: 'failed' } }));
+
+    const { pollDatabaseUntilReady } = await import('./platform-api.js');
+    await expect(pollDatabaseUntilReady('tok', 'org-1', 'proj-1', 'db-1', { intervalMs: 0 })).rejects.toThrow(
+      'Database provisioning failed (no error detail from provider)',
+    );
+  });
+
+  it('times out with a pointer to mastra env db show', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(200, { database: dbRow }));
+
+    const { pollDatabaseUntilReady } = await import('./platform-api.js');
+    await expect(
+      pollDatabaseUntilReady('tok', 'org-1', 'proj-1', 'db-1', { intervalMs: 0, maxWaitMs: 0 }),
+    ).rejects.toThrow(
+      'Timed out waiting for database to become ready (last status: provisioning). Check again with: mastra env db show db-1',
+    );
+  });
+
+  it('does not swallow polling request errors', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(500, { detail: 'internal error' }));
+
+    const { pollDatabaseUntilReady } = await import('./platform-api.js');
+    await expect(pollDatabaseUntilReady('tok', 'org-1', 'proj-1', 'db-1', { intervalMs: 0 })).rejects.toThrow(
+      'internal error',
+    );
+  });
+});

--- a/packages/cli/src/commands/db/platform-api.ts
+++ b/packages/cli/src/commands/db/platform-api.ts
@@ -1,0 +1,199 @@
+import { withPollingRetries } from '../../utils/polling.js';
+import { authHeaders, platformFetch, throwApiError } from '../auth/client.js';
+
+export type DatabaseKind = 'turso' | 'neon' | 'mongodb';
+export type DatabaseStatus = 'provisioning' | 'ready' | 'failed' | 'deleting' | 'deleted';
+
+export interface ProjectDatabase {
+  id: string;
+  platformProjectId: string;
+  organizationId: string;
+  /** Null = project-scoped (shared by all environments). */
+  environmentId: string | null;
+  kind: DatabaseKind;
+  name: string;
+  status: DatabaseStatus;
+  region: string | null;
+  providerResourceId: string | null;
+  error: string | null;
+  createdAt: string;
+  updatedAt: string;
+  deletedAt: string | null;
+}
+
+export interface DatabaseConnectionEnvVar {
+  name: string;
+  value: string;
+  secret: boolean;
+}
+
+export interface DatabaseConnection {
+  envVars: DatabaseConnectionEnvVar[];
+  snippets: { language: string; title: string; code: string }[];
+  docsUrl: string;
+}
+
+/**
+ * Env var names each provider injects at deploy time (names only — values are
+ * managed by the platform). Mirrors `deriveEnvVars` in the platform's
+ * project-databases service.
+ */
+export const DB_ENV_VAR_NAMES: Record<DatabaseKind, string[]> = {
+  turso: ['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'],
+  neon: ['DATABASE_URL'],
+  mongodb: [],
+};
+
+const ADMIN_REQUIRED_MESSAGE = 'You need the admin role in this organization to manage databases.';
+
+function getApiUrl(): string {
+  return process.env.MASTRA_PLATFORM_API_URL || 'https://platform.mastra.ai';
+}
+
+async function readErrorDetail(resp: Response): Promise<string | undefined> {
+  try {
+    const err = (await resp.json()) as { detail?: string; error?: string };
+    return err.detail ?? err.error;
+  } catch {
+    return undefined;
+  }
+}
+
+async function handleFailure(resp: Response, message: string): Promise<never> {
+  if (resp.status === 403) {
+    throw new Error(ADMIN_REQUIRED_MESSAGE);
+  }
+  throwApiError(message, resp.status, await readErrorDetail(resp));
+}
+
+export async function fetchDatabases(token: string, orgId: string, projectId: string): Promise<ProjectDatabase[]> {
+  const resp = await platformFetch(`${getApiUrl()}/v1/server/projects/${projectId}/databases`, {
+    headers: authHeaders(token, orgId),
+  });
+
+  if (!resp.ok) {
+    await handleFailure(resp, 'Failed to fetch databases');
+  }
+
+  const data = (await resp.json()) as { databases: ProjectDatabase[] };
+  return data.databases;
+}
+
+export async function attachDatabase(
+  token: string,
+  orgId: string,
+  projectId: string,
+  input: { kind: DatabaseKind; name: string; regionId?: string; environmentId?: string },
+): Promise<ProjectDatabase> {
+  const resp = await platformFetch(`${getApiUrl()}/v1/server/projects/${projectId}/databases`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...authHeaders(token, orgId) },
+    body: JSON.stringify(input),
+  });
+
+  if (!resp.ok) {
+    await handleFailure(resp, 'Failed to create database');
+  }
+
+  const data = (await resp.json()) as { database: ProjectDatabase };
+  return data.database;
+}
+
+export async function fetchDatabase(
+  token: string,
+  orgId: string,
+  projectId: string,
+  dbId: string,
+): Promise<ProjectDatabase> {
+  const resp = await platformFetch(`${getApiUrl()}/v1/server/projects/${projectId}/databases/${dbId}`, {
+    headers: authHeaders(token, orgId),
+  });
+
+  if (!resp.ok) {
+    await handleFailure(resp, 'Failed to fetch database');
+  }
+
+  const data = (await resp.json()) as { database: ProjectDatabase };
+  return data.database;
+}
+
+export async function detachDatabase(token: string, orgId: string, projectId: string, dbId: string): Promise<void> {
+  const resp = await platformFetch(`${getApiUrl()}/v1/server/projects/${projectId}/databases/${dbId}`, {
+    method: 'DELETE',
+    headers: authHeaders(token, orgId),
+  });
+
+  if (!resp.ok) {
+    await handleFailure(resp, 'Failed to detach database');
+  }
+}
+
+export async function fetchDatabaseConnection(
+  token: string,
+  orgId: string,
+  projectId: string,
+  dbId: string,
+): Promise<DatabaseConnection> {
+  const resp = await platformFetch(`${getApiUrl()}/v1/server/projects/${projectId}/databases/${dbId}/connection`, {
+    headers: authHeaders(token, orgId),
+  });
+
+  if (!resp.ok) {
+    await handleFailure(resp, 'Failed to fetch connection instructions');
+  }
+
+  return (await resp.json()) as DatabaseConnection;
+}
+
+/**
+ * Poll a database row until it leaves `provisioning`.
+ *
+ * - Resolves with the row once `status === 'ready'`.
+ * - Throws when provisioning fails (`status === 'failed'`), surfacing the
+ *   provider error — never swallowed.
+ * - Throws on timeout with a pointer to `mastra env db show` for later inspection.
+ */
+export async function pollDatabaseUntilReady(
+  token: string,
+  orgId: string,
+  projectId: string,
+  dbId: string,
+  opts?: { maxWaitMs?: number; intervalMs?: number; onStatus?: (status: DatabaseStatus) => void },
+): Promise<ProjectDatabase> {
+  const maxWaitMs = opts?.maxWaitMs ?? 5 * 60 * 1000;
+  const intervalMs = opts?.intervalMs ?? 3000;
+  const start = Date.now();
+  let lastStatus: DatabaseStatus | '' = '';
+
+  while (true) {
+    const db = await withPollingRetries(() => fetchDatabase(token, orgId, projectId, dbId));
+
+    if (db.status !== lastStatus) {
+      lastStatus = db.status;
+      opts?.onStatus?.(db.status);
+    }
+
+    if (db.status === 'ready') {
+      return db;
+    }
+
+    if (db.status === 'failed') {
+      throw new Error(`Database provisioning failed${db.error ? `: ${db.error}` : ' (no error detail from provider)'}`);
+    }
+
+    if (db.status === 'deleting' || db.status === 'deleted') {
+      throw new Error(
+        `Database was ${db.status === 'deleted' ? 'deleted' : 'scheduled for deletion'} while provisioning`,
+      );
+    }
+
+    if (Date.now() - start >= maxWaitMs) {
+      throw new Error(
+        `Timed out waiting for database to become ready (last status: ${db.status}). ` +
+          `Check again with: mastra env db show ${dbId}`,
+      );
+    }
+
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+}

--- a/packages/cli/src/commands/env/env.test.ts
+++ b/packages/cli/src/commands/env/env.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { isActiveDeployStatus, latestDeployByEnvironment } from './env.js';
+import type { EnvironmentDeploy } from './platform-api.js';
+import { restartEnvironment } from './platform-api.js';
+
+function deploy(overrides: Partial<EnvironmentDeploy>): EnvironmentDeploy {
+  return {
+    id: 'd-1',
+    projectId: 'proj-1',
+    organizationId: 'org-1',
+    environmentId: 'env-1',
+    projectName: 'My App',
+    environmentName: 'Production',
+    environmentSlug: 'my-app',
+    region: null,
+    status: 'running',
+    instanceUrl: null,
+    error: null,
+    errorCode: null,
+    createdAt: '2026-07-09T00:00:00.000Z',
+    githubBranch: null,
+    githubCommitSha: null,
+    ...overrides,
+  };
+}
+
+describe('latestDeployByEnvironment', () => {
+  it('keeps the newest deploy per environment', () => {
+    const deploys = [
+      deploy({ id: 'old', environmentId: 'env-1', createdAt: '2026-07-01T00:00:00.000Z', status: 'failed' }),
+      deploy({ id: 'new', environmentId: 'env-1', createdAt: '2026-07-08T00:00:00.000Z', status: 'running' }),
+      deploy({ id: 'other-env', environmentId: 'env-2', createdAt: '2026-07-05T00:00:00.000Z', status: 'stopped' }),
+    ];
+
+    const latest = latestDeployByEnvironment(deploys);
+    expect(latest.get('env-1')?.id).toBe('new');
+    expect(latest.get('env-2')?.id).toBe('other-env');
+  });
+
+  it('handles null createdAt without dropping deploys', () => {
+    const deploys = [deploy({ id: 'no-date', createdAt: null })];
+    expect(latestDeployByEnvironment(deploys).get('env-1')?.id).toBe('no-date');
+  });
+});
+
+describe('isActiveDeployStatus', () => {
+  it('treats running and sleeping deploys as active', () => {
+    expect(isActiveDeployStatus('running')).toBe(true);
+    expect(isActiveDeployStatus('sleeping')).toBe(true);
+  });
+
+  it('treats terminal and in-flight statuses as inactive', () => {
+    expect(isActiveDeployStatus('failed')).toBe(false);
+    expect(isActiveDeployStatus('building')).toBe(false);
+    expect(isActiveDeployStatus('stopped')).toBe(false);
+  });
+});
+
+describe('restartEnvironment', () => {
+  const mockFetch = vi.fn();
+
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    vi.stubEnv('MASTRA_PLATFORM_API_URL', 'http://localhost:9999');
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('posts to the restart endpoint', async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200, json: async () => ({ status: 'ok' }) });
+
+    await expect(restartEnvironment('tok', 'org-1', 'proj-1', 'env-1')).resolves.toBeUndefined();
+
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe('http://localhost:9999/v1/projects/proj-1/environments/env-1/restart');
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({ Authorization: 'Bearer tok', 'x-organization-id': 'org-1' });
+  });
+
+  it('surfaces the 409 never-deployed detail', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 409,
+      json: async () => ({ detail: 'Environment has no active deployment to restart' }),
+    });
+
+    await expect(restartEnvironment('tok', 'org-1', 'proj-1', 'env-1')).rejects.toThrow(
+      'Environment has no active deployment to restart',
+    );
+  });
+
+  it('surfaces the 402 billing detail', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 402,
+      json: async () => ({ detail: 'Billing grace period has elapsed. Add credits or upgrade your plan.' }),
+    });
+
+    await expect(restartEnvironment('tok', 'org-1', 'proj-1', 'env-1')).rejects.toThrow(
+      'Billing grace period has elapsed',
+    );
+  });
+
+  it('throws session expired on 401', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401, json: async () => ({}) });
+
+    await expect(restartEnvironment('tok', 'org-1', 'proj-1', 'env-1')).rejects.toThrow(
+      'Session expired. Run: mastra auth login',
+    );
+  });
+});

--- a/packages/cli/src/commands/env/env.ts
+++ b/packages/cli/src/commands/env/env.ts
@@ -2,8 +2,16 @@ import * as p from '@clack/prompts';
 import type { Command } from 'commander';
 import { getToken } from '../auth/credentials.js';
 import { resolveCurrentOrg } from '../auth/orgs.js';
-import type { Environment } from './platform-api.js';
-import { fetchProjects, fetchEnvironments, createEnvironment, deleteEnvironment } from './platform-api.js';
+import { wrapAction } from '../utils.js';
+import type { Environment, EnvironmentDeploy } from './platform-api.js';
+import {
+  fetchEnvironments,
+  fetchEnvironmentDeploys,
+  createEnvironment,
+  deleteEnvironment,
+  restartEnvironment,
+} from './platform-api.js';
+import { resolveProject } from './resolve-project.js';
 
 /**
  * Shape returned by `mastra env list --json` and `mastra env create --json`.
@@ -24,6 +32,7 @@ type PublicEnvironment = Pick<
   | 'branch'
   | 'instanceUrl'
   | 'customServerUrl'
+  | 'managedEnvVarNames'
   | 'createdAt'
   | 'updatedAt'
 >;
@@ -39,70 +48,106 @@ function toPublicEnvironment(env: Environment): PublicEnvironment {
     branch: env.branch,
     instanceUrl: env.instanceUrl,
     customServerUrl: env.customServerUrl,
+    // Names only — never values. Safe for CI logs.
+    managedEnvVarNames: env.managedEnvVarNames ?? [],
     createdAt: env.createdAt,
     updatedAt: env.updatedAt,
   };
 }
 
-export function registerEnvCommands(program: Command) {
+/**
+ * Pick the deploy that best represents "what is live" for an environment:
+ * the newest deploy, preferring one that is actually serving traffic.
+ */
+export function latestDeployByEnvironment(deploys: EnvironmentDeploy[]): Map<string, EnvironmentDeploy> {
+  const byCreatedAtDesc = [...deploys].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+  const latest = new Map<string, EnvironmentDeploy>();
+  for (const deploy of byCreatedAtDesc) {
+    if (!latest.has(deploy.environmentId)) {
+      latest.set(deploy.environmentId, deploy);
+    }
+  }
+  return latest;
+}
+
+export function isActiveDeployStatus(status: EnvironmentDeploy['status']): boolean {
+  return status === 'running' || status === 'sleeping';
+}
+
+const PROJECT_OPTION = ['--project <project>', 'Project name, slug, or ID (default: linked project)'] as const;
+
+export function registerEnvCommands(program: Command): Command {
   const env = program.command('env').description('Manage environments');
 
   env
     .command('list')
-    .description('List environments for a project')
-    .argument('<project>', 'Project name, slug, or ID')
+    .description("List the project's environments")
+    .option(...PROJECT_OPTION)
     .option('--json', 'Output as JSON')
-    .action(listEnvironmentsAction);
+    .action(wrapAction(listEnvironmentsAction));
 
   env
     .command('create')
     .description('Create a new environment')
-    .argument('<project>', 'Project name, slug, or ID')
-    .requiredOption('-n, --name <name>', 'Environment name (e.g., staging, preview)')
+    .argument('<name>', 'Environment name (e.g., staging, preview)')
+    .option(...PROJECT_OPTION)
     .option('-t, --type <type>', 'Environment type (production, staging, preview)', 'staging')
     .option('-r, --region <region>', 'Region for the environment (e.g., us, eu)')
     .option('--json', 'Output as JSON')
-    .action(createEnvironmentAction);
+    .action(wrapAction(createEnvironmentAction));
 
   env
     .command('delete')
     .description('Delete an environment')
-    .argument('<project>', 'Project name, slug, or ID')
     .argument('<environment>', 'Environment name, slug, or ID')
+    .option(...PROJECT_OPTION)
     .option('-y, --yes', 'Skip confirmation')
-    .action(deleteEnvironmentAction);
+    .action(wrapAction(deleteEnvironmentAction));
+
+  env
+    .command('restart')
+    .description("Restart an environment's running service so saved env vars take effect immediately")
+    .argument('<environment>', 'Environment name, slug, or ID')
+    .option(...PROJECT_OPTION)
+    .action(wrapAction(restartEnvironmentAction));
+
+  env
+    .command('deploys')
+    .description('List deploys across environments (filtered when an environment is given)')
+    .argument('[environment]', 'Environment name, slug, or ID (omit to show all environments)')
+    .option(...PROJECT_OPTION)
+    .option('--json', 'Output as JSON')
+    .action(wrapAction(listDeploysAction));
+
+  return env;
 }
 
-async function findProject(token: string, orgId: string, projectArg: string) {
-  const projects = await fetchProjects(token, orgId);
-
-  if (projects.length === 0) {
-    console.error('error: no projects found. Create one with: mastra studio projects create');
-    process.exit(1);
-  }
-
-  const project = projects.find(
-    (proj: { id: string; name: string; slug: string | null }) =>
-      proj.id === projectArg || proj.name === projectArg || proj.slug === projectArg,
-  );
-
-  if (!project) {
-    console.error(`error: project not found: ${projectArg}`);
-    process.exit(1);
-  }
-
-  return project;
-}
-
-async function listEnvironmentsAction(projectArg: string, options?: { json?: boolean }) {
+async function listEnvironmentsAction(options?: { project?: string; json?: boolean }) {
   const token = await getToken();
   const { orgId } = await resolveCurrentOrg(token);
 
-  const project = await findProject(token, orgId, projectArg);
-  const environments = await fetchEnvironments(token, orgId, project.id);
+  const project = await resolveProject(token, orgId, options?.project);
+  const [environments, deploys] = await Promise.all([
+    fetchEnvironments(token, orgId, project.id),
+    fetchEnvironmentDeploys(token, orgId, project.id),
+  ]);
+  const latestDeploys = latestDeployByEnvironment(deploys);
 
   if (options?.json) {
-    const safeEnvironments = environments.map(toPublicEnvironment);
+    const safeEnvironments = environments.map(env => {
+      const deploy = latestDeploys.get(env.id);
+      return {
+        ...toPublicEnvironment(env),
+        activeDeploy: deploy
+          ? {
+              id: deploy.id,
+              status: deploy.status,
+              active: isActiveDeployStatus(deploy.status),
+              createdAt: deploy.createdAt,
+            }
+          : null,
+      };
+    });
     process.stdout.write(`${JSON.stringify({ environments: safeEnvironments }, null, 2)}\n`);
     return;
   }
@@ -110,7 +155,7 @@ async function listEnvironmentsAction(projectArg: string, options?: { json?: boo
   console.info(`\nEnvironments for ${project.name}:\n`);
 
   if (environments.length === 0) {
-    console.info('  No environments yet. Create one with: mastra env create <project> -n <name>\n');
+    console.info('  No environments yet. Create one with: mastra env create <name>\n');
     return;
   }
 
@@ -125,22 +170,93 @@ async function listEnvironmentsAction(projectArg: string, options?: { json?: boo
     if (env.customServerUrl) {
       console.info(`    Custom Server: ${env.customServerUrl}`);
     }
+    const deploy = latestDeploys.get(env.id);
+    if (deploy) {
+      const marker = isActiveDeployStatus(deploy.status) ? ' (active)' : '';
+      console.info(`    Deploy: ${deploy.id} — ${deploy.status}${marker}`);
+    } else {
+      console.info(`    Deploy: none`);
+    }
+    if (env.managedEnvVarNames && env.managedEnvVarNames.length > 0) {
+      console.info(`    Managed env vars: ${env.managedEnvVarNames.join(', ')}`);
+    }
+  }
+  console.info('');
+}
+
+async function listDeploysAction(envArg: string | undefined, options?: { project?: string; json?: boolean }) {
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+
+  const project = await resolveProject(token, orgId, options?.project);
+  let deploys = await fetchEnvironmentDeploys(token, orgId, project.id);
+
+  if (envArg) {
+    const environments = await fetchEnvironments(token, orgId, project.id);
+    const env = environments.find(e => e.id === envArg || e.name === envArg || e.slug === envArg);
+    if (!env) {
+      console.error(`error: environment not found: ${envArg}`);
+      process.exit(1);
+    }
+    deploys = deploys.filter(d => d.environmentId === env.id);
+  }
+
+  const sorted = [...deploys].sort((a, b) => (b.createdAt ?? '').localeCompare(a.createdAt ?? ''));
+
+  if (options?.json) {
+    const safeDeploys = sorted.map(d => ({
+      id: d.id,
+      environmentId: d.environmentId,
+      environmentName: d.environmentName,
+      environmentSlug: d.environmentSlug,
+      status: d.status,
+      active: isActiveDeployStatus(d.status),
+      instanceUrl: d.instanceUrl,
+      error: d.error,
+      createdAt: d.createdAt,
+      githubBranch: d.githubBranch,
+      githubCommitSha: d.githubCommitSha,
+    }));
+    process.stdout.write(`${JSON.stringify({ deploys: safeDeploys }, null, 2)}\n`);
+    return;
+  }
+
+  console.info(`\nDeploys for ${project.name}:\n`);
+
+  if (sorted.length === 0) {
+    console.info('  No deploys yet. Deploy with: mastra deploy\n');
+    return;
+  }
+
+  for (const deploy of sorted) {
+    const marker = isActiveDeployStatus(deploy.status) ? ' (active)' : '';
+    console.info(`  ${deploy.id} — ${deploy.status}${marker}`);
+    console.info(`    Environment: ${deploy.environmentSlug} (${deploy.environmentName})`);
+    if (deploy.createdAt) {
+      console.info(`    Created: ${deploy.createdAt}`);
+    }
+    if (deploy.instanceUrl) {
+      console.info(`    URL: ${deploy.instanceUrl}`);
+    }
+    if (deploy.error) {
+      console.info(`    Error: ${deploy.error}`);
+    }
   }
   console.info('');
 }
 
 async function createEnvironmentAction(
-  projectArg: string,
-  options: { name: string; type?: string; region?: string; json?: boolean },
+  name: string,
+  options: { project?: string; type?: string; region?: string; json?: boolean },
 ) {
   const token = await getToken();
   const { orgId } = await resolveCurrentOrg(token);
 
-  const project = await findProject(token, orgId, projectArg);
+  const project = await resolveProject(token, orgId, options.project);
   const type = (options.type || 'staging') as 'production' | 'staging' | 'preview';
 
   const environment = await createEnvironment(token, orgId, project.id, {
-    name: options.name,
+    name,
     type,
     ...(options.region ? { region: options.region } : {}),
   });
@@ -157,11 +273,35 @@ async function createEnvironmentAction(
   console.info(`  Type: ${environment.type}\n`);
 }
 
-async function deleteEnvironmentAction(projectArg: string, envArg: string, options?: { yes?: boolean }) {
+async function restartEnvironmentAction(envArg: string, options?: { project?: string }) {
   const token = await getToken();
   const { orgId } = await resolveCurrentOrg(token);
 
-  const project = await findProject(token, orgId, projectArg);
+  const project = await resolveProject(token, orgId, options?.project);
+  const environments = await fetchEnvironments(token, orgId, project.id);
+  const env = environments.find(e => e.id === envArg || e.name === envArg || e.slug === envArg);
+
+  if (!env) {
+    console.error(`error: environment not found: ${envArg}`);
+    process.exit(1);
+  }
+
+  const spinner = p.spinner();
+  spinner.start(`Restarting ${env.slug}...`);
+  try {
+    await restartEnvironment(token, orgId, project.id, env.id);
+  } catch (err) {
+    spinner.stop('Restart failed.');
+    throw err;
+  }
+  spinner.stop(`Restarted ${env.slug}. Saved env vars are now live.`);
+}
+
+async function deleteEnvironmentAction(envArg: string, options?: { project?: string; yes?: boolean }) {
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+
+  const project = await resolveProject(token, orgId, options?.project);
   const environments = await fetchEnvironments(token, orgId, project.id);
 
   if (environments.length === 0) {

--- a/packages/cli/src/commands/env/platform-api.ts
+++ b/packages/cli/src/commands/env/platform-api.ts
@@ -29,6 +29,38 @@ export interface Environment {
   updatedAt: string;
 }
 
+export type EnvironmentDeployStatus =
+  | 'queued'
+  | 'uploading'
+  | 'starting'
+  | 'building'
+  | 'deploying'
+  | 'running'
+  | 'sleeping'
+  | 'stopped'
+  | 'failed'
+  | 'crashed'
+  | 'cancelled'
+  | 'unknown';
+
+export interface EnvironmentDeploy {
+  id: string;
+  projectId: string;
+  organizationId: string;
+  environmentId: string;
+  projectName: string;
+  environmentName: string;
+  environmentSlug: string;
+  region: string | null;
+  status: EnvironmentDeployStatus;
+  instanceUrl: string | null;
+  error: string | null;
+  errorCode: string | null;
+  createdAt: string | null;
+  githubBranch: string | null;
+  githubCommitSha: string | null;
+}
+
 export async function fetchProjects(token: string, orgId: string): Promise<Project[]> {
   const resp = await fetch(`${getApiUrl()}/v1/projects`, {
     headers: {
@@ -63,6 +95,27 @@ export async function fetchEnvironments(token: string, orgId: string, projectId:
   return data.environments;
 }
 
+export async function fetchEnvironmentDeploys(
+  token: string,
+  orgId: string,
+  projectId: string,
+): Promise<EnvironmentDeploy[]> {
+  const resp = await fetch(`${getApiUrl()}/v1/projects/${projectId}/environment-deploys`, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'x-organization-id': orgId,
+    },
+  });
+
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throwApiError('Failed to fetch deploys', resp.status, (err as { detail?: string }).detail);
+  }
+
+  const data = (await resp.json()) as { deploys: EnvironmentDeploy[] };
+  return data.deploys;
+}
+
 export async function createEnvironment(
   token: string,
   orgId: string,
@@ -86,6 +139,30 @@ export async function createEnvironment(
 
   const data = (await resp.json()) as { environment: Environment };
   return data.environment;
+}
+
+/**
+ * Restart an environment's running service so saved env vars take effect
+ * immediately. 409 means the environment has never been deployed.
+ */
+export async function restartEnvironment(
+  token: string,
+  orgId: string,
+  projectId: string,
+  envId: string,
+): Promise<void> {
+  const resp = await fetch(`${getApiUrl()}/v1/projects/${projectId}/environments/${envId}/restart`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'x-organization-id': orgId,
+    },
+  });
+
+  if (!resp.ok) {
+    const err = await resp.json().catch(() => ({}));
+    throwApiError('Failed to restart environment', resp.status, (err as { detail?: string }).detail);
+  }
 }
 
 export async function deleteEnvironment(token: string, orgId: string, projectId: string, envId: string): Promise<void> {

--- a/packages/cli/src/commands/env/resolve-project.test.ts
+++ b/packages/cli/src/commands/env/resolve-project.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveProject } from './resolve-project.js';
+
+vi.mock('./platform-api.js', () => ({
+  fetchProjects: vi.fn(),
+}));
+
+vi.mock('../studio/project-config.js', () => ({
+  loadProjectConfig: vi.fn(),
+}));
+
+const { fetchProjects } = await import('./platform-api.js');
+const { loadProjectConfig } = await import('../studio/project-config.js');
+
+const projects = [
+  { id: 'proj-1', name: 'My App', slug: 'my-app' },
+  { id: 'proj-2', name: 'Other', slug: 'other' },
+];
+
+describe('resolveProject', () => {
+  beforeEach(() => {
+    vi.mocked(fetchProjects).mockResolvedValue(projects as never);
+    vi.mocked(loadProjectConfig).mockResolvedValue(null as never);
+    delete process.env.MASTRA_PROJECT_ID;
+  });
+
+  afterEach(() => {
+    delete process.env.MASTRA_PROJECT_ID;
+    vi.clearAllMocks();
+  });
+
+  it('resolves from the --project flag by id, name, or slug', async () => {
+    expect((await resolveProject('t', 'org', 'proj-2')).id).toBe('proj-2');
+    expect((await resolveProject('t', 'org', 'My App')).id).toBe('proj-1');
+    expect((await resolveProject('t', 'org', 'my-app')).id).toBe('proj-1');
+  });
+
+  it('prefers MASTRA_PROJECT_ID over the flag', async () => {
+    process.env.MASTRA_PROJECT_ID = 'proj-2';
+    expect((await resolveProject('t', 'org', 'my-app')).id).toBe('proj-2');
+  });
+
+  it('falls back to the linked .mastra-project.json', async () => {
+    vi.mocked(loadProjectConfig).mockResolvedValue({ projectId: 'proj-1' } as never);
+    expect((await resolveProject('t', 'org')).id).toBe('proj-1');
+  });
+
+  it('throws a clear error when the flagged project does not exist', async () => {
+    await expect(resolveProject('t', 'org', 'missing')).rejects.toThrow('Project not found: missing');
+  });
+
+  it('throws a guidance error when nothing resolves the project', async () => {
+    await expect(resolveProject('t', 'org')).rejects.toThrow(
+      'Pass --project <name|slug|id>, set MASTRA_PROJECT_ID, or run from a directory with a linked .mastra-project.json.',
+    );
+  });
+});

--- a/packages/cli/src/commands/env/resolve-project.ts
+++ b/packages/cli/src/commands/env/resolve-project.ts
@@ -1,0 +1,32 @@
+import { loadProjectConfig } from '../studio/project-config.js';
+import type { Project } from './platform-api.js';
+import { fetchProjects } from './platform-api.js';
+
+/**
+ * Resolve the target project for env-group commands without requiring a
+ * positional argument. Resolution order: `MASTRA_PROJECT_ID` env var,
+ * `--project` flag, then the `.mastra-project.json` written by
+ * `mastra deploy` in the current directory.
+ */
+export async function resolveProject(token: string, orgId: string, projectArg?: string): Promise<Project> {
+  const projects = await fetchProjects(token, orgId);
+
+  const wanted = process.env.MASTRA_PROJECT_ID ?? projectArg;
+  if (wanted) {
+    const project = projects.find(proj => proj.id === wanted || proj.name === wanted || proj.slug === wanted);
+    if (!project) {
+      throw new Error(`Project not found: ${wanted}`);
+    }
+    return project;
+  }
+
+  const config = await loadProjectConfig(process.cwd());
+  if (config?.projectId) {
+    const project = projects.find(proj => proj.id === config.projectId);
+    if (project) return project;
+  }
+
+  throw new Error(
+    'No project specified. Pass --project <name|slug|id>, set MASTRA_PROJECT_ID, or run from a directory with a linked .mastra-project.json.',
+  );
+}

--- a/packages/cli/src/commands/utils.ts
+++ b/packages/cli/src/commands/utils.ts
@@ -41,6 +41,19 @@ export function getPackageManager(): PackageManager {
   return 'npm'; // Default fallback
 }
 
+/**
+ * Wrap an async commander action so failures print a clean error message
+ * (never a stack trace) and exit non-zero.
+ */
+export function wrapAction(fn: (...args: any[]) => Promise<void>): (...args: any[]) => void {
+  return (...args: any[]) => {
+    fn(...args).catch((err: Error) => {
+      console.error(`Error: ${err.message}`);
+      process.exit(1);
+    });
+  };
+}
+
 export function parseMcp(value: string) {
   if (!isValidEditor(value)) {
     throw new InvalidArgumentError(`Choose a valid value: ${EDITOR.join(', ')}`);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -22,6 +22,7 @@ import { loginAction, logoutAction } from './commands/auth/login';
 import { listOrgsAction, switchOrgAction } from './commands/auth/orgs';
 import { createTokenAction, listTokensAction, revokeTokenAction } from './commands/auth/tokens';
 import { whoamiAction } from './commands/auth/whoami';
+import { registerEnvDbCommands } from './commands/db/index.js';
 import { unifiedDeployAction } from './commands/deploy/index.js';
 import { registerEnvCommands } from './commands/env/index.js';
 import { COMPONENTS, LLMProvider } from './commands/init/utils';
@@ -35,19 +36,10 @@ import { logsAction } from './commands/studio/deploy-logs';
 import { statusAction } from './commands/studio/deploy-status';
 import { suggestionsAction } from './commands/studio/deploy-suggestions';
 import { listProjectsAction, createProjectAction } from './commands/studio/projects';
-import { parseComponents, parseLlmProvider, parseMcp, parseSkills } from './commands/utils';
+import { parseComponents, parseLlmProvider, parseMcp, parseSkills, wrapAction } from './commands/utils';
 import { buildWorker } from './commands/worker/build';
 import { devWorker } from './commands/worker/dev';
 import { startWorker } from './commands/worker/start';
-
-function wrapAction(fn: (...args: any[]) => Promise<void>): (...args: any[]) => void {
-  return (...args: any[]) => {
-    fn(...args).catch((err: Error) => {
-      console.error(`Error: ${err.message}`);
-      process.exit(1);
-    });
-  };
-}
 
 const mastraPkg = pkgJson as PackageJson;
 export const version = mastraPkg.version;
@@ -366,7 +358,10 @@ authTokens.command('revoke <token-id>').description('Revoke an API token').actio
 
 // ---- Environment commands ----
 
-registerEnvCommands(program);
+const envCommand = registerEnvCommands(program);
+
+// Databases: mastra env db ...
+registerEnvDbCommands(envCommand);
 
 // ---- Server commands ----
 


### PR DESCRIPTION
## Summary

The CLI can deploy a project but is blind to everything that happens after: attaching a database, seeing which environments exist, or checking deploy history all require the UI. This PR gives the CLI full read/write visibility into platform databases, environments, and deploys.

### Databases — `mastra env db`

```bash
mastra env db list                        # kind, status, scope, injected env var names
mastra env db list staging                # only databases feeding one environment
mastra env db create --kind turso         # project-scoped (shared by all envs), polls to ready
mastra env db create staging --kind turso # environment-scoped (isolated data)
mastra env db show <database>             # detail + connection env vars (secrets masked, --show-secrets to reveal)
mastra env db detach <database>           # confirm prompt, admin only
```

- `list` shows the attachment mapping: which database feeds which environment (project-scoped = all environments)
- Environment-scoped creates enable per-environment data isolation (staging data separate from production)
- Provisioning is polled until ready/failed; provider errors are surfaced, never swallowed
- Secrets are masked in human and `--json` output — safe to paste into CI logs

### Environments & deploys — `mastra env`

```bash
mastra env list             # now includes latest deploy status + managed env var names
mastra env create staging   # explicit environment creation
mastra env restart <env>    # push saved env vars + restart without a redeploy
mastra env deploys [env]    # deploy history with active marker
```

### Project resolution

All commands resolve the project from context — `MASTRA_PROJECT_ID` → `--project <name|slug|id>` → the `.mastra-project.json` written by `mastra deploy` — so they run bare from a project directory. **Breaking:** the previous `mastra env list <project>` positional becomes `--project`; `mastra env create <project> -n <name>` becomes `mastra env create <name>`.

All commands support `--json` for CI/machine consumption. Permission errors map to clear messages (e.g. non-admin on create/detach) instead of stack traces.

## Test plan

- [x] 614 unit tests pass (`pnpm test:cli`), including attach/detach, 403/409 mapping, polling ready/failed/timeout, scope formatting, project resolution precedence
- [x] Typecheck, lint, build clean
- [x] Verified end-to-end against the live platform on a real project: turso + neon provisioning (~6s to ready), deploy preflight passes with managed vars, thread data confirmed in Turso and survives container replacement, staging/production data isolation holds with env-scoped databases, detach immediately clears managed var names and re-exposes preflight errors, all failure modes (bad kind, unknown env, unknown db, `--no-wait`) return exact messages with exit 1
- [x] Docs updated (`docs/src/content/en/reference/cli/mastra.mdx`), changeset included (minor)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds new terminal commands for managing databases and environments without needing to use the platform website. You can create, monitor, inspect, restart, and detach resources while seeing clear status updates and errors.

## Summary

- Added `mastra env db` commands to list, create, show, and detach databases.
- Added database provisioning polling, provider error reporting, masked connection secrets, and JSON output.
- Added `mastra env restart` and `mastra env deploys`.
- Enhanced `mastra env list` with latest deploy status and managed environment variable names.
- Added project resolution through `MASTRA_PROJECT_ID`, `--project`, or `.mastra-project.json`.
- Replaced positional project arguments with `--project`.
- Improved CLI error handling and added extensive unit tests, documentation, validation, and a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->