### PR TITLE
fix(rag): reject non-progressing token overlap

### DIFF
--- a/.changeset/full-adults-push.md
+++ b/.changeset/full-adults-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed token chunking to reject overlaps that cannot advance.

--- a/packages/rag/src/document/transformers/text.ts
+++ b/packages/rag/src/document/transformers/text.ts
@@ -20,8 +20,8 @@ export abstract class TextTransformer implements Transformer {
     addStartIndex = false,
     stripWhitespace = true,
   }: BaseChunkOptions) {
-    if (overlap > maxSize) {
-      throw new Error(`Got a larger chunk overlap (${overlap}) than chunk size ` + `(${maxSize}), should be smaller.`);
+    if (overlap >= maxSize) {
+      throw new Error(`Chunk overlap (${overlap}) must be smaller than chunk size (${maxSize}).`);
     }
     this.maxSize = maxSize;
     this.overlap = overlap;

--- a/packages/rag/src/document/transformers/token.test.ts
+++ b/packages/rag/src/document/transformers/token.test.ts
@@ -22,6 +22,15 @@ describe('TokenTransformer', () => {
   });
 
   describe('fromTikToken', () => {
+    it('rejects an overlap equal to the token chunk size', () => {
+      expect(() =>
+        TokenTransformer.fromTikToken({
+          encodingName: 'cl100k_base',
+          options: { maxSize: 100, overlap: 100 },
+        }),
+      ).toThrow(/chunk overlap \(100\) must be smaller than chunk size \(100\)/i);
+    });
+
     it('should create only one encoder when using encodingName', () => {
       TokenTransformer.fromTikToken({
         encodingName: 'cl100k_base',


### PR DESCRIPTION
Fixes #19211.

Token chunking advances by `tokensPerChunk - overlap`, but the shared chunk option guard allowed those values to be equal. For inputs longer than one chunk, that leaves the token cursor unchanged and the chunking call never completes.

This change makes the existing “overlap must be smaller than chunk size” contract enforce the equal boundary as well. A focused regression verifies that the transformer rejects the configuration before chunking begins; normal token transformer behavior remains covered by the existing tests.

The user-visible result is a clear configuration error instead of an unbounded synchronous loop.

Verified with the focused token transformer test (3 passed), all transformer tests (30 passed), `pnpm --filter ./packages/rag lint`, a public `MDocument.chunk()` reproduction, and `pnpm --filter ./packages/rag build:lib`. The broader `pnpm build:rag` currently stops in unchanged `@internal/llm-recorder` code because TypeScript 6 rejects its deprecated `baseUrl` option; that baseline failure occurs before this package is built.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Chunking text means breaking it into smaller pieces with some repeated overlap. This change rejects overlap settings that are too large to make progress, preventing the process from getting stuck forever.

## Summary

- Rejects token chunking configurations where `overlap >= maxSize`.
- Adds regression coverage for equal overlap and chunk size.
- Adds a patch changeset for `@mastra/rag`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->