### PR TITLE
fix(rag): honor custom chunk length units

### DIFF
--- a/.changeset/slimy-moments-type.md
+++ b/.changeset/slimy-moments-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed character chunking to preserve content with custom length functions.

--- a/packages/rag/src/document/transformers/character.test.ts
+++ b/packages/rag/src/document/transformers/character.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import { CharacterTransformer } from './character';
+
+const utf8Length = (text: string) => new TextEncoder().encode(text).length;
+
+describe('CharacterTransformer', () => {
+  it('preserves character-based overlap with the default length function', () => {
+    const transformer = new CharacterTransformer({
+      maxSize: 3,
+      overlap: 1,
+      stripWhitespace: false,
+    });
+
+    expect(transformer.splitText({ text: 'abcdef' })).toEqual(['abc', 'cde', 'ef']);
+  });
+
+  it('preserves content when the length function uses non-character units', () => {
+    const transformer = new CharacterTransformer({
+      maxSize: 4,
+      overlap: 0,
+      lengthFunction: utf8Length,
+      stripWhitespace: false,
+    });
+
+    expect(transformer.splitText({ text: 'éøåß' })).toEqual(['éø', 'åß']);
+  });
+
+  it('measures overlap with the configured length function', () => {
+    const transformer = new CharacterTransformer({
+      maxSize: 4,
+      overlap: 2,
+      lengthFunction: utf8Length,
+      stripWhitespace: false,
+    });
+
+    expect(transformer.splitText({ text: 'éøåß' })).toEqual(['éø', 'øå', 'åß']);
+  });
+
+  it('preserves an oversized Unicode code point as a complete chunk', () => {
+    const transformer = new CharacterTransformer({
+      maxSize: 2,
+      overlap: 0,
+      lengthFunction: utf8Length,
+      stripWhitespace: false,
+    });
+
+    expect(transformer.splitText({ text: '😀a' })).toEqual(['😀', 'a']);
+  });
+
+  it('keeps overlap on Unicode code-point boundaries', () => {
+    const transformer = new CharacterTransformer({
+      maxSize: 4,
+      overlap: 3,
+      lengthFunction: utf8Length,
+      stripWhitespace: false,
+    });
+
+    expect(transformer.splitText({ text: '😀😀' })).toEqual(['😀', '😀']);
+  });
+});

--- a/packages/rag/src/document/transformers/character.ts
+++ b/packages/rag/src/document/transformers/character.ts
@@ -81,25 +81,57 @@ export class CharacterTransformer extends TextTransformer {
 
   private __splitChunk(text: string): string[] {
     const chunks: string[] = [];
-    let currentPosition = 0;
+    const codePointBoundaries = [0];
 
-    while (currentPosition < text.length) {
-      let chunkEnd = currentPosition;
+    // String offsets use UTF-16 code units. Record the offsets between complete
+    // Unicode code points so chunking never starts or ends inside a surrogate pair.
+    for (const codePoint of text) {
+      codePointBoundaries.push(codePointBoundaries[codePointBoundaries.length - 1]! + codePoint.length);
+    }
+
+    const finalBoundaryIndex = codePointBoundaries.length - 1;
+    let currentBoundaryIndex = 0;
+
+    while (currentBoundaryIndex < finalBoundaryIndex) {
+      let chunkEndBoundaryIndex = currentBoundaryIndex;
 
       // Build chunk up to max size
-      while (chunkEnd < text.length && this.lengthFunction(text.slice(currentPosition, chunkEnd + 1)) <= this.maxSize) {
-        chunkEnd++;
+      while (
+        chunkEndBoundaryIndex < finalBoundaryIndex &&
+        this.lengthFunction(
+          text.slice(codePointBoundaries[currentBoundaryIndex], codePointBoundaries[chunkEndBoundaryIndex + 1]),
+        ) <= this.maxSize
+      ) {
+        chunkEndBoundaryIndex++;
       }
 
-      const currentChunk = text.slice(currentPosition, chunkEnd);
-      const chunkLength = this.lengthFunction(currentChunk);
+      // Preserve a code point that is larger than maxSize as one oversized
+      // chunk instead of emitting an empty chunk and silently skipping it.
+      if (chunkEndBoundaryIndex === currentBoundaryIndex) {
+        chunkEndBoundaryIndex++;
+      }
+
+      const chunkEnd = codePointBoundaries[chunkEndBoundaryIndex]!;
+      const currentChunk = text.slice(codePointBoundaries[currentBoundaryIndex], chunkEnd);
       chunks.push(currentChunk);
 
       // If we're at the end, break to avoid tiny chunks
-      if (chunkEnd >= text.length) break;
+      if (chunkEndBoundaryIndex >= finalBoundaryIndex) break;
 
-      // Move position forward by chunk size minus overlap
-      currentPosition += Math.max(1, chunkLength - this.overlap);
+      // Find the largest complete-code-point suffix that fits the requested
+      // overlap in lengthFunction units.
+      let nextBoundaryIndex = chunkEndBoundaryIndex;
+      while (
+        this.overlap > 0 &&
+        nextBoundaryIndex > currentBoundaryIndex &&
+        this.lengthFunction(text.slice(codePointBoundaries[nextBoundaryIndex - 1], chunkEnd)) <= this.overlap
+      ) {
+        nextBoundaryIndex--;
+      }
+
+      // Always advance even if a custom length function reports zero or the
+      // requested overlap covers the entire chunk.
+      currentBoundaryIndex = Math.max(currentBoundaryIndex + 1, nextBoundaryIndex);
     }
 
     return chunks;


### PR DESCRIPTION
Fixes #19212.

`CharacterTransformer` used the configured `lengthFunction` result as a character offset when advancing to the next chunk. That only works when the function returns JavaScript string length. Byte-, token-, or word-based functions can skip source text and calculate overlap in the wrong unit.

This change keeps source positions on complete Unicode code-point boundaries and selects the retained suffix by measuring candidates with the configured length function. The loop still guarantees forward progress when the requested overlap covers a full chunk. If one code point is larger than `maxSize`, it is emitted intact as an oversized chunk instead of being silently skipped.

For a UTF-8 length function, `éøåß` with a four-byte chunk now produces `['éø', 'åß']` instead of dropping the final two characters. With a two-byte overlap it produces `['éø', 'øå', 'åß']`. Emoji regressions also verify that oversized code points are preserved and overlap never emits isolated UTF-16 surrogates.

Verified with five focused character regressions, all transformer tests (34 passed), `pnpm --filter ./packages/rag lint`, direct runtime reproductions, Prettier, and `git diff --check`. The broader `pnpm build:rag` currently stops in unchanged `@internal/llm-recorder` code because TypeScript 6 rejects its deprecated `baseUrl` option; direct package builds from a clean worktree likewise require the unbuilt internal workspace artifacts, so neither build limitation is caused by this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This fixes text splitting so no words or characters get accidentally skipped, even when measuring chunks by bytes, tokens, or words. It also keeps emoji and other Unicode characters intact.

## What changed

- Updated `CharacterTransformer` to:
  - Advance through text using Unicode code-point boundaries.
  - Calculate overlap using the configured `lengthFunction`.
  - Preserve oversized characters and guarantee forward progress.
  - Prevent skipped source text and isolated UTF-16 surrogate pairs.
- Added regression tests for UTF-8 byte lengths, emoji, overlap behavior, and oversized code points.
- Added a patch changeset for `@mastra/rag`.

## Validation

Focused transformer tests, linting, runtime checks, formatting, and diff validation passed. The broader RAG build remains blocked by unrelated TypeScript and workspace artifact issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->