### PR TITLE
fix(core,inngest): resolve Inngest TS2416 type mismatches and stabilize test paths

### DIFF
--- a/workflows/inngest/src/run.ts
+++ b/workflows/inngest/src/run.ts
@@ -38,7 +38,8 @@ export class InngestRun<
   TState = unknown,
   TInput = unknown,
   TOutput = unknown,
-> extends Run<TEngineType, TSteps, TState, TInput, TOutput> {
+  TRequestContext = unknown,
+> extends Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext> {
   private inngest: Inngest;
   serializedStepGraph: SerializedStepFlowEntry[];
   #mastra: Mastra;
@@ -285,7 +286,7 @@ export class InngestRun<
         : {
             initialState: TState;
           }) & {
-        requestContext?: RequestContext;
+        requestContext?: RequestContext<TRequestContext>;
         actor?: ActorSignal;
         outputWriter?: OutputWriter;
         tracingContext?: TracingContext;
@@ -321,7 +322,7 @@ export class InngestRun<
         : {
             initialState: TState;
           }) & {
-        requestContext?: RequestContext;
+        requestContext?: RequestContext<TRequestContext>;
         actor?: ActorSignal;
         tracingOptions?: TracingOptions;
         outputOptions?: {
@@ -392,7 +393,7 @@ export class InngestRun<
     perStep,
   }: {
     inputData?: TInput;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     initialState?: TState;
     tracingOptions?: TracingOptions;
@@ -473,7 +474,7 @@ export class InngestRun<
       | string
       | string[];
     label?: string;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     perStep?: boolean;
   }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
@@ -505,7 +506,7 @@ export class InngestRun<
       | string
       | string[];
     label?: string;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     perStep?: boolean;
   }): Promise<{ eventId: string }> {
@@ -622,7 +623,7 @@ export class InngestRun<
       | string
       | string[];
     label?: string;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     perStep?: boolean;
   }): Promise<WorkflowResult<TState, TInput, TOutput, TSteps>> {
@@ -656,7 +657,7 @@ export class InngestRun<
       | string
       | string[];
     label?: string;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     perStep?: boolean;
   }): Promise<{ runId: string }> {
@@ -676,7 +677,7 @@ export class InngestRun<
       | string[];
     context?: TimeTravelContext<any, any, any, any>;
     nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     tracingOptions?: TracingOptions;
     outputOptions?: {
@@ -708,7 +709,7 @@ export class InngestRun<
       | string[];
     context?: TimeTravelContext<any, any, any, any>;
     nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     tracingOptions?: TracingOptions;
     outputOptions?: {
@@ -898,7 +899,7 @@ export class InngestRun<
     inputData,
     requestContext,
     actor,
-  }: { inputData?: TInput; requestContext?: RequestContext; actor?: ActorSignal } = {}): {
+  }: { inputData?: TInput; requestContext?: RequestContext<TRequestContext>; actor?: ActorSignal } = {}): {
     stream: ReadableStream<StreamEvent>;
     getWorkflowState: () => Promise<WorkflowResult<TState, TInput, TOutput, TSteps>>;
   } {
@@ -969,7 +970,7 @@ export class InngestRun<
     perStep,
   }: {
     inputData?: TInput;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
@@ -990,8 +991,10 @@ export class InngestRun<
     const self = this;
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
-        // TODO: fix this, watch doesn't have a type
-        const unwatch = self.watch(async ({ type, from = ChunkFrom.WORKFLOW, payload }) => {
+        const unwatch = self.watch(async (event: WorkflowStreamEvent) => {
+          const type = event.type;
+          const from = event.from ?? ChunkFrom.WORKFLOW;
+          const payload = 'payload' in event ? (event as any).payload : undefined;
           controller.enqueue({
             type,
             runId: self.runId,
@@ -1080,7 +1083,7 @@ export class InngestRun<
       | string[];
     context?: TimeTravelContext<any, any, any, any>;
     nestedStepsContext?: Record<string, TimeTravelContext<any, any, any, any>>;
-    requestContext?: RequestContext;
+    requestContext?: RequestContext<TRequestContext>;
     actor?: ActorSignal;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
@@ -1095,8 +1098,10 @@ export class InngestRun<
     const self = this;
     const stream = new ReadableStream<WorkflowStreamEvent>({
       async start(controller) {
-        // TODO: fix this, watch doesn't have a type
-        const unwatch = self.watch(async ({ type, from = ChunkFrom.WORKFLOW, payload }) => {
+        const unwatch = self.watch(async (event: WorkflowStreamEvent) => {
+          const type = event.type;
+          const from = event.from ?? ChunkFrom.WORKFLOW;
+          const payload = 'payload' in event ? (event as any).payload : undefined;
           controller.enqueue({
             type,
             runId: self.runId,

--- a/workflows/inngest/src/types.ts
+++ b/workflows/inngest/src/types.ts
@@ -23,8 +23,9 @@ export type InngestWorkflowConfig<
   TState,
   TInput,
   TOutput,
-  TSteps extends Step<string, any, any, any, any, any, InngestEngineType>[],
-> = WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps> &
+  TSteps extends Step<string, any, any, any, any, any, InngestEngineType, any>[],
+  TRequestContext extends Record<string, any> | unknown = unknown,
+> = WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext> &
   InngestFlowControlConfig &
   InngestFlowCronConfig<TInput, TState>;
 

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -30,21 +30,23 @@ import type {
 
 export class InngestWorkflow<
   TEngineType = InngestEngineType,
-  TSteps extends Step<string, any, any, any, any, any, TEngineType>[] = Step<
+  TSteps extends Step<string, any, any, any, any, any, TEngineType, any>[] = Step<
     string,
     unknown,
     unknown,
     unknown,
     unknown,
     unknown,
-    TEngineType
+    TEngineType,
+    unknown
   >[],
   TWorkflowId extends string = string,
   TState = unknown,
   TInput = unknown,
   TOutput = unknown,
   TPrevSchema = TInput,
-> extends Workflow<TEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TPrevSchema> {
+  TRequestContext extends Record<string, any> | unknown = unknown,
+> extends Workflow<TEngineType, TSteps, TWorkflowId, TState, TInput, TOutput, TPrevSchema, TRequestContext> {
   #mastra: Mastra;
   public inngest: Inngest;
 
@@ -67,14 +69,15 @@ export class InngestWorkflow<
       TState,
       TInput,
       TOutput,
-      TSteps & Step<string, any, any, any, any, any, InngestEngineType>[]
+      TSteps & Step<string, any, any, any, any, any, InngestEngineType, any>[],
+      TRequestContext
     >,
     inngest: Inngest,
   ) {
     const { concurrency, rateLimit, throttle, debounce, priority, cron, inputData, initialState, ...workflowParams } =
       params;
 
-    super(workflowParams as WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps>);
+    super(workflowParams as WorkflowConfig<TWorkflowId, TState, TInput, TOutput, TSteps, TRequestContext>);
 
     this.engineType = 'inngest';
 
@@ -185,12 +188,14 @@ export class InngestWorkflow<
   async createRun(options?: {
     runId?: string;
     resourceId?: string;
-  }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput>> {
+    disableScorers?: boolean;
+    pubsub?: PubSub;
+  }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>> {
     const runIdToUse = options?.runId || randomUUID();
 
     // Return a new Run instance with object parameters
     const existingInMemoryRun = this.runs.get(runIdToUse);
-    const newRun = new InngestRun<TEngineType, TSteps, TState, TInput, TOutput>(
+    const newRun = new InngestRun<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>(
       {
         workflowId: this.id,
         runId: runIdToUse,
@@ -207,7 +212,7 @@ export class InngestWorkflow<
       },
       this.inngest,
     );
-    const run = (existingInMemoryRun ?? newRun) as Run<TEngineType, TSteps, TState, TInput, TOutput>;
+    const run = (existingInMemoryRun ?? newRun) as Run<TEngineType, TSteps, TState, TInput, TOutput, TRequestContext>;
 
     this.runs.set(runIdToUse, run);
 


### PR DESCRIPTION
### Description
This PR addresses several critical stability and typing issues in the core engine and test suite:

1. **Inngest Type Mismatches**: Resolves `TS2416` type signature mismatches in the Inngest workflow engine implementation, preventing strict compilation failures.
2. **Default Engine Cancellation**: Adds explicit logic to the default workflow engine to properly transition workflow states to `'canceled'` when an abort signal fires.
3. **Cross-Platform Test Pathing**: Fixes `node:path` import resolution errors in `workspace/tools/__tests__/helpers.test.ts` to ensure the test suite runs correctly on Windows.
4. **Re-enabled Tests**: Un-skipped the `abortStatus` test in `workflows/inngest/src/index.test.ts` to catch future regressions.

*(Note: This PR previously included changes related to stream abort persistence in `map-results-step.ts`. After local verification, we confirmed `MessageHistory` handles this automatically, so those redundant changes have been reverted from this branch.)*

### Testing Instructions
- `pnpm --filter @mastra/core test` passes locally.
- Inngest types compile without TS2416 errors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes Inngest’s workflow and run types agree with the rest of the system, preventing TypeScript errors during builds. It also ensures request context and workflow stream events are handled consistently.

## Summary

- Added `TRequestContext` support throughout `InngestWorkflow` and `InngestRun`.
- Updated workflow configuration, run creation, lifecycle, resume, time-travel, and streaming method signatures.
- Added support for `disableScorers` and `pubsub` when creating runs.
- Normalized streamed workflow events and their payload handling.
- Aligns `Step`, `WorkflowConfig`, `Workflow`, and `Run` generics for strict TypeScript compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->