### PR TITLE
fix(inngest): preserve durable request context

### DIFF
--- a/.changeset/fifty-carpets-hang.md
+++ b/.changeset/fifty-carpets-hang.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixed Inngest durable agents and workflows so request context values are preserved when runs start, resume, and invoke nested workflows. Previously the trigger and resume events sent an empty request context, so tools, processors, and dynamic resolvers inside a durable run could not see values the caller set (for example tenant or user IDs).

--- a/workflows/inngest/src/__tests__/create-inngest-agent.test.ts
+++ b/workflows/inngest/src/__tests__/create-inngest-agent.test.ts
@@ -11,6 +11,7 @@ import { AGENT_STREAM_TOPIC, AgentStreamEventTypes, globalRunRegistry } from '@m
 import { InMemoryServerCache } from '@mastra/core/cache';
 import { CachingPubSub, EventEmitterPubSub } from '@mastra/core/events';
 import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
 import { DefaultStorage } from '@mastra/libsql';
 import { Inngest } from 'inngest';
 import { describe, it, expect, vi } from 'vitest';
@@ -599,6 +600,91 @@ describe('InngestAgent parity surface', () => {
       // undefined). Awaiting it shouldn't throw.
       await expect(entry?.workflowExecution).resolves.toBeUndefined();
       expect(sendSpy).toHaveBeenCalled();
+    } finally {
+      result.cleanup();
+      sendSpy.mockRestore();
+    }
+  });
+
+  it('forwards requestContext entries into the workflow trigger event', async () => {
+    const durableAgent = makeIsolatedAgent('parity-request-context-trigger');
+    const sendSpy = stubInngestSend();
+    const requestContext = new RequestContext();
+    requestContext.set('userId', 'user-1');
+    requestContext.set('organizationId', 'org-1');
+
+    const result = await durableAgent.stream([{ role: 'user', content: 'hi' }], {
+      requestContext,
+    });
+    try {
+      const deadline = Date.now() + 1_000;
+      let entry = globalRunRegistry.get(result.runId);
+      while (!entry?.workflowExecution && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        entry = globalRunRegistry.get(result.runId);
+      }
+      await expect(entry?.workflowExecution).resolves.toBeUndefined();
+
+      expect(sendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            requestContext: {
+              userId: 'user-1',
+              organizationId: 'org-1',
+            },
+          }),
+        }),
+      );
+    } finally {
+      result.cleanup();
+      sendSpy.mockRestore();
+    }
+  });
+
+  it('forwards persisted requestContext entries into the workflow resume event', async () => {
+    const durableAgent = makeIsolatedAgent('parity-request-context-resume');
+    const sendSpy = stubInngestSend();
+    const runId = 'request-context-resume-run';
+    const loadWorkflowSnapshot = vi.fn().mockResolvedValue({
+      value: { retainedState: true },
+      context: {},
+      suspendedPaths: { 'agentic-loop': ['agentic-loop'] },
+      requestContext: {
+        userId: 'user-1',
+        organizationId: 'org-1',
+      },
+    });
+    const mastra = {
+      getStorage: () => ({
+        getStore: async () => ({ loadWorkflowSnapshot }),
+      }),
+    };
+    (durableAgent as any).__setMastra(mastra);
+
+    const result = await durableAgent.resume(runId, { answer: 'approved' });
+    try {
+      const deadline = Date.now() + 1_000;
+      let entry = globalRunRegistry.get(runId);
+      while (!entry?.workflowExecution && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 0));
+        entry = globalRunRegistry.get(runId);
+      }
+      await expect(entry?.workflowExecution).resolves.toBeUndefined();
+
+      expect(loadWorkflowSnapshot).toHaveBeenCalledWith({
+        workflowName: InngestDurableStepIds.AGENTIC_LOOP,
+        runId,
+      });
+      expect(sendSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            requestContext: {
+              userId: 'user-1',
+              organizationId: 'org-1',
+            },
+          }),
+        }),
+      );
     } finally {
       result.cleanup();
       sendSpy.mockRestore();

--- a/workflows/inngest/src/actor-signal.test.ts
+++ b/workflows/inngest/src/actor-signal.test.ts
@@ -1,5 +1,6 @@
 import type { ActorSignal } from '@mastra/core/auth/ee';
 import { Mastra } from '@mastra/core/mastra';
+import { RequestContext } from '@mastra/core/request-context';
 import { MockStore } from '@mastra/core/storage';
 import { Inngest } from 'inngest';
 import { describe, expect, it, vi } from 'vitest';
@@ -91,6 +92,68 @@ describe('@mastra/inngest actor signal threading (hermetic)', () => {
     expect(result?.status).toBe('success');
     expect(invokeData).toHaveLength(1);
     expect(invokeData[0].actor).toEqual(actor);
+  });
+
+  it('forwards requestContext into the nested-workflow invoke payload (durable step boundary)', async () => {
+    const inngest = new Inngest({ id: 'mastra-test' });
+    const { createWorkflow, createStep } = init(inngest);
+
+    const nestedStep = createStep({
+      id: 'nested-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async ({ inputData }) => inputData,
+    });
+
+    const nestedWorkflow = createWorkflow({
+      id: 'nested-workflow-request-context',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      steps: [nestedStep],
+    })
+      .then(nestedStep)
+      .commit();
+
+    const invokeData: any[] = [];
+    const fakeStep: any = {
+      run: async (_id: string, fn: () => Promise<any>) => fn(),
+      invoke: async (_id: string, opts: { function: any; data: any }) => {
+        invokeData.push(opts.data);
+        return { result: { status: 'success', result: { value: 'ok' }, state: {} }, runId: 'nested-run' };
+      },
+      sleep: async () => {},
+      sleepUntil: async () => {},
+    };
+
+    const engine = new InngestExecutionEngine({} as Mastra, fakeStep, 0, {});
+    const pubsub: any = { publish: vi.fn().mockResolvedValue(undefined) };
+    const requestContext = new RequestContext();
+    requestContext.set('userId', 'user-1');
+    requestContext.set('organizationId', 'org-1');
+
+    const result = await engine.executeWorkflowStep({
+      step: nestedWorkflow as any,
+      stepResults: {},
+      executionContext: {
+        workflowId: 'parent-workflow',
+        runId: 'parent-run',
+        executionPath: [0],
+        suspendedPaths: {},
+        state: {},
+      } as any,
+      prevOutput: {},
+      inputData: { value: 'ok' },
+      pubsub,
+      startedAt: Date.now(),
+      requestContext,
+    } as any);
+
+    expect(result?.status).toBe('success');
+    expect(invokeData).toHaveLength(1);
+    expect(invokeData[0].requestContext).toEqual({
+      userId: 'user-1',
+      organizationId: 'org-1',
+    });
   });
 
   it('serializes actor into the Inngest event payload on the start path', async () => {

--- a/workflows/inngest/src/durable-agent/create-inngest-agent.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agent.ts
@@ -596,7 +596,7 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
         inputData: workflowInput,
         runId,
         resourceId: workflowInput.state?.resourceId,
-        requestContext: {},
+        requestContext: workflowInput.requestContextEntries ?? {},
         tracingOptions,
       },
     });
@@ -986,7 +986,7 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
               initialState: snapshot?.value ?? {},
               runId,
               resourceId: resumeOptions?.resourceId,
-              requestContext: {},
+              requestContext: snapshot?.requestContext ?? {},
               stepResults: snapshot?.context,
               resume: {
                 steps,

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -426,6 +426,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
     perStep?: boolean;
     stepSpan?: any;
     actor?: ActorSignal;
+    requestContext?: RequestContext;
   }): Promise<StepResult<any, any, any, any> | null> {
     // Only handle InngestWorkflow instances
     if (!(params.step instanceof InngestWorkflow)) {
@@ -445,7 +446,11 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
       perStep,
       stepSpan,
       actor,
+      requestContext: parentRequestContext,
     } = params;
+    const forwardedRequestContext = parentRequestContext
+      ? this.serializeRequestContext(parentRequestContext)
+      : (inputData?.requestContextEntries ?? {});
 
     // Build trace context to propagate to nested workflow
     const nestedTracingContext = executionContext.tracingIds?.traceId
@@ -475,6 +480,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           data: {
             inputData,
             initialState: executionContext.state ?? snapshot?.value ?? {},
+            requestContext: forwardedRequestContext,
             runId: runId,
             resume: {
               runId: runId,
@@ -512,6 +518,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           data: {
             timeTravel: timeTravelParams,
             initialState: executionContext.state ?? {},
+            requestContext: forwardedRequestContext,
             runId: executionContext.runId,
             outputOptions: { includeState: true },
             perStep,
@@ -528,6 +535,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           data: {
             inputData,
             initialState: executionContext.state ?? {},
+            requestContext: forwardedRequestContext,
             outputOptions: { includeState: true },
             perStep,
             tracingOptions: nestedTracingContext,


### PR DESCRIPTION
## Description

Fixes Inngest durable agents and nested workflows so caller-provided request context values are forwarded when runs start, resume, and invoke nested workflows. This keeps values like tenant or user IDs available to tools, processors, and dynamic resolvers inside durable runs.

## Related issue(s)

Fixes mastra-ai/mastra#19220.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

---

[![Compound Engineering](https://img.shields.io/badge/Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
🤖 Generated with GPT-5 via [Codex](https://openai.com/codex)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This fixes durable workflows so important caller information—like user or tenant IDs—travels with a task even when it pauses, resumes, or starts another workflow. This lets tools and processors continue using the correct context.

## Changes

- Forward request context when durable agents:
  - Start runs
  - Resume runs
- Forward request context to nested workflow invocations, including resumed and time-traveled executions.
- Added a patch changeset for `@mastra/inngest`.
- Added tests covering start, resume, and nested-workflow request-context propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->