### PR TITLE
fix(playground): clarify memory sidebar configuration

### DIFF
--- a/packages/playground/src/domains/agents/components/memory-sidebar/__tests__/memory-sidebar.test.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/__tests__/memory-sidebar.test.tsx
@@ -222,6 +222,7 @@ describe('MemorySidebar', () => {
     expect(card.closest('[data-testid="memory-sidebar-overlay"]')?.className).toContain('z-10');
     expect(card.closest('[data-testid="memory-sidebar-overlay"]')?.className).toContain('rounded-xl');
     expect(card.className).toContain('bg-transparent');
+    expect(screen.getByTestId('memory-config-badges')).not.toBeNull();
     expect(screen.queryByRole('tab')).toBeNull();
     expect(screen.queryByRole('heading', { name: 'Threads' })).toBeNull();
 
@@ -262,7 +263,7 @@ describe('MemorySidebar', () => {
     expect(cta.getAttribute('href')).toBe('https://mastra.ai/docs/memory/overview');
   });
 
-  it('shows the live memory content, without the static config, when the Memory card is clicked', async () => {
+  it('shows the live memory content and recent-message context when the Memory card is clicked', async () => {
     renderSidebar([thread({ id: THREAD_ID, title: 'My first chat' })]);
 
     fireEvent.click(await screen.findByTestId('memory-sidebar-card'));
@@ -274,8 +275,14 @@ describe('MemorySidebar', () => {
     expect(screen.getByTestId('memory-sidebar-card').getAttribute('aria-pressed')).toBe('true');
 
     // The static memory configuration (AgentMemoryConfig with its "General"
-    // section) moved to the agent settings view and is no longer in the panel.
+    // section) and the collapsed card's setup badges are not shown in the panel.
     expect(screen.queryByText('General')).toBeNull();
+    expect(screen.queryByTestId('memory-config-badges')).toBeNull();
+
+    // The expanded content retains the recent-message configuration that is
+    // summarized by the collapsed card's count badge.
+    expect(screen.getByRole('heading', { name: 'Recent Messages' })).not.toBeNull();
+    expect(screen.getByText('Includes the last 10 messages in context.')).not.toBeNull();
 
     // The whole Memory view scrolls on Y, and AgentMemory's root must not trap
     // scrolling with its own h-full/overflow-hidden.

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
@@ -22,6 +22,15 @@ interface AgentMemoryProps {
   memoryType?: 'local' | 'gateway';
 }
 
+function getRecentMessagesDescription(lastMessages: number | false | undefined): string {
+  if (typeof lastMessages !== 'number') {
+    return 'Recent message history is not included in context.';
+  }
+
+  const messageLabel = lastMessages === 1 ? 'message' : 'messages';
+  return `Includes the last ${lastMessages} ${messageLabel} in context.`;
+}
+
 export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps) {
   const isGatewayMemory = memoryType === 'gateway';
   const { threadInput: chatInputValue } = useThreadInput(threadId);
@@ -119,6 +128,11 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
           </div>
         </div>
       )}
+
+      <div className="p-4 border-b border-border1">
+        <h3 className="text-sm font-medium text-neutral5">Recent Messages</h3>
+        <p className="text-xs text-neutral3 mt-1">{getRecentMessagesDescription(config?.lastMessages)}</p>
+      </div>
 
       {/* Observational Memory Section - moved above Semantic Recall */}
       {isOMEnabled && (

--- a/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
@@ -36,14 +36,12 @@ const barColor = (percent: number): string => {
 
 type ConfigBadgeProps = {
   icon: LucideIcon;
-  label: string;
   tooltip: string;
   enabled: boolean;
   value?: number;
-  expanded: boolean;
 };
 
-function ConfigBadge({ icon: Icon, label, tooltip, enabled, value, expanded }: ConfigBadgeProps) {
+function ConfigBadge({ icon: Icon, tooltip, enabled, value }: ConfigBadgeProps) {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
@@ -57,11 +55,6 @@ function ConfigBadge({ icon: Icon, label, tooltip, enabled, value, expanded }: C
           {value !== undefined && (
             <Txt as="span" variant="ui-xs" className="font-medium tabular-nums leading-none">
               {value}
-            </Txt>
-          )}
-          {expanded && (
-            <Txt as="span" variant="ui-xs" className="whitespace-nowrap leading-none">
-              {label}
             </Txt>
           )}
         </span>
@@ -252,56 +245,50 @@ function MemorySidebarBody({ agentId, threadId, threads, onDelete }: MemorySideb
                 )}
               </span>
 
-              {/* Memory setup at a glance: filled badge = on, faded = off */}
-              <TooltipProvider delay={150} timeout={400}>
-                <span className="mt-1.5 flex flex-wrap items-center gap-1.5">
-                  <ConfigBadge
-                    icon={MessageSquare}
-                    label="recent messages"
-                    tooltip={
-                      lastMessages !== undefined
-                        ? `Keeps the last ${lastMessages} messages in context`
-                        : 'Recent message history is off'
-                    }
-                    enabled={lastMessages !== undefined}
-                    value={lastMessages}
-                    expanded={showMemory}
-                  />
-                  <ConfigBadge
-                    icon={Search}
-                    label="Semantic recall"
-                    tooltip={
-                      semanticRecallOn
-                        ? 'Semantic recall is on - retrieves relevant past messages'
-                        : 'Semantic recall is off'
-                    }
-                    enabled={semanticRecallOn}
-                    expanded={showMemory}
-                  />
-                  <ConfigBadge
-                    icon={NotebookPen}
-                    label="Working memory"
-                    tooltip={
-                      workingMemoryOn
-                        ? 'Working memory is on - persists notes across the conversation'
-                        : 'Working memory is off'
-                    }
-                    enabled={workingMemoryOn}
-                    expanded={showMemory}
-                  />
-                  <ConfigBadge
-                    icon={Eye}
-                    label="Observational"
-                    tooltip={
-                      observationalOn
-                        ? 'Observational memory is on - learns from the conversation'
-                        : 'Observational memory is off'
-                    }
-                    enabled={observationalOn}
-                    expanded={showMemory}
-                  />
-                </span>
-              </TooltipProvider>
+              {!showMemory ? (
+                <TooltipProvider delay={150} timeout={400}>
+                  {/* Memory setup at a glance: filled badge = on, faded = off */}
+                  <span data-testid="memory-config-badges" className="mt-1.5 flex flex-wrap items-center gap-1.5">
+                    <ConfigBadge
+                      icon={MessageSquare}
+                      tooltip={
+                        lastMessages !== undefined
+                          ? `Keeps the last ${lastMessages} messages in context`
+                          : 'Recent message history is off'
+                      }
+                      enabled={lastMessages !== undefined}
+                      value={lastMessages}
+                    />
+                    <ConfigBadge
+                      icon={Search}
+                      tooltip={
+                        semanticRecallOn
+                          ? 'Semantic recall is on - retrieves relevant past messages'
+                          : 'Semantic recall is off'
+                      }
+                      enabled={semanticRecallOn}
+                    />
+                    <ConfigBadge
+                      icon={NotebookPen}
+                      tooltip={
+                        workingMemoryOn
+                          ? 'Working memory is on - persists notes across the conversation'
+                          : 'Working memory is off'
+                      }
+                      enabled={workingMemoryOn}
+                    />
+                    <ConfigBadge
+                      icon={Eye}
+                      tooltip={
+                        observationalOn
+                          ? 'Observational memory is on - learns from the conversation'
+                          : 'Observational memory is off'
+                      }
+                      enabled={observationalOn}
+                    />
+                  </span>
+                </TooltipProvider>
+              ) : null}
 
               {observationPercent !== undefined ? (
                 <span className="mt-2 block h-1 w-full overflow-hidden rounded-full bg-surface5">


### PR DESCRIPTION
<img width="1271" height="1222" alt="CleanShot 2026-07-10 at 12 22 36" src="https://github.com/user-attachments/assets/11abf34b-0e5e-4f22-a2de-0d7d835cc348" />

Memory configuration badges were still rendered in the expanded sidebar header, which made passive status indicators look like buttons.

This keeps the compact icon summary on the collapsed Memory card only. The expanded view now shows the recent-message window as passive section content, while the existing Observational Memory, Semantic Recall, and Working Memory sections continue to communicate their own states.

Validated with the focused MemorySidebar Vitest suite, Playground typecheck, targeted ESLint, a live Studio check, and React Doctor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Memory sidebar now shows setup details only when the card is closed, keeping the expanded view easier to read. It also clearly explains how many recent messages are included and preserves the status of other memory features.

## Summary

- Show compact memory configuration badges only in the collapsed card.
- Add a “Recent Messages” section with a description based on the configured message history.
- Keep Observational Memory, Semantic Recall, and Working Memory status information visible in the expanded view.
- Update MemorySidebar tests for the revised collapsed and expanded behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->