### PR TITLE
fix(playground): improve clone thread icon

### DIFF
--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { ExternalLink, Copy } from 'lucide-react';
+import { ExternalLink, GitFork } from 'lucide-react';
 import { useCallback } from 'react';
 import { AgentObservationalMemory } from './agent-observational-memory';
 import { AgentWorkingMemory } from './agent-working-memory';
@@ -113,7 +113,7 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
               <p className="text-xs text-neutral3 mt-1">Create a copy of this conversation</p>
             </div>
             <Button onClick={handleCloneThread} disabled={isCloning}>
-              <Copy className="w-4 h-4 mr-2" />
+              <GitFork className="w-4 h-4 mr-2" />
               {isCloning ? 'Cloning...' : 'Clone'}
             </Button>
           </div>


### PR DESCRIPTION
This replaces the generic Copy icon in the agent memory sidebar’s Clone Thread action with Lucide’s GitFork icon.

The action creates a new thread derived from the current conversation, so the fork metaphor better matches the behavior than a clipboard-style copy icon. Behavior and layout are unchanged.

Validated with focused ESLint, the Playground dependency-graph build and typecheck, and git diff checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Clone Thread button now uses a fork-shaped icon to better show that it creates a new thread from the current one. Everything else works and looks the same.

## Changes

- Replaced Lucide’s `Copy` icon with `GitFork` in the agent memory sidebar.
- Updated the corresponding `lucide-react` import.
- No behavior, layout, or public API changes.
- Validation included focused ESLint, dependency-graph build, typecheck, and git diff checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->