### PR TITLE
fix(core): omit replayed reasoning for Bedrock OpenAI models

### DIFF
--- a/.changeset/cool-moments-double.md
+++ b/.changeset/cool-moments-double.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed Amazon Bedrock OpenAI model calls failing when conversation history contains assistant reasoning parts by omitting replayed reasoning from those prompts.

--- a/packages/core/src/stream/aisdk/v5/execute.test.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.test.ts
@@ -243,4 +243,108 @@ describe('execute structured output prompt handling', () => {
     expect(promptJson).toContain('Your response will be processed by another agent to extract structured data');
     expect(promptJson).toContain('suggestions');
   });
+
+  it('removes replayed assistant reasoning for OpenAI models on Bedrock', async () => {
+    let capturedPrompt: unknown;
+    const model = new MockLanguageModelV2({
+      provider: 'amazon-bedrock',
+      modelId: 'openai.gpt-oss-20b-1:0',
+      doStream: async ({ prompt }: any) => {
+        capturedPrompt = prompt;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-bedrock-openai', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Next answer.' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: testUsage, providerMetadata: undefined },
+          ]),
+          request: { body: '' },
+          response: { headers: {} },
+          warnings: [] as any[],
+        };
+      },
+    });
+
+    const messages = [
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'First request.' }] },
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'reasoning' as const, text: 'Internal chain.' },
+          { type: 'text' as const, text: 'Visible answer.' },
+        ],
+      },
+      { role: 'assistant' as const, content: [{ type: 'reasoning' as const, text: 'Reasoning only.' }] },
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'Continue.' }] },
+    ];
+
+    const stream = execute({
+      runId: 'test-run-id-bedrock-openai-reasoning',
+      model: model as any,
+      inputMessages: messages,
+      onResult: () => {},
+      methodType: 'stream',
+    });
+
+    await readStream(stream);
+
+    expect(capturedPrompt).toEqual([
+      messages[0],
+      {
+        role: 'assistant',
+        content: [{ type: 'text', text: 'Visible answer.' }],
+      },
+      messages[3],
+    ]);
+  });
+
+  it('keeps replayed assistant reasoning for Anthropic models on Bedrock', async () => {
+    let capturedPrompt: unknown;
+    const model = new MockLanguageModelV2({
+      provider: 'amazon-bedrock',
+      modelId: 'anthropic.claude-sonnet-4-20250514-v1:0',
+      doStream: async ({ prompt }: any) => {
+        capturedPrompt = prompt;
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-bedrock-anthropic', modelId: 'mock-model-id', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'Next answer.' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: testUsage, providerMetadata: undefined },
+          ]),
+          request: { body: '' },
+          response: { headers: {} },
+          warnings: [] as any[],
+        };
+      },
+    });
+
+    const messages = [
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'First request.' }] },
+      {
+        role: 'assistant' as const,
+        content: [
+          { type: 'reasoning' as const, text: 'Internal chain.' },
+          { type: 'text' as const, text: 'Visible answer.' },
+        ],
+      },
+      { role: 'user' as const, content: [{ type: 'text' as const, text: 'Continue.' }] },
+    ];
+
+    const stream = execute({
+      runId: 'test-run-id-bedrock-anthropic-reasoning',
+      model: model as any,
+      inputMessages: messages,
+      onResult: () => {},
+      methodType: 'stream',
+    });
+
+    await readStream(stream);
+
+    expect(capturedPrompt).toEqual(messages);
+  });
 });

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -48,6 +48,38 @@ function injectJsonInstructionIntoLatestUserMessage({
   return [...prompt, { role: 'user', content: [{ type: 'text', text: instruction }] }] as LanguageModelV2Prompt;
 }
 
+function isBedrockOpenAIModel(model: MastraLanguageModel): boolean {
+  return model.provider === 'amazon-bedrock' && /(?:^|\.)openai\./.test(model.modelId);
+}
+
+function removeReasoningForBedrockOpenAIModel(
+  prompt: LanguageModelV2Prompt,
+  model: MastraLanguageModel,
+): LanguageModelV2Prompt {
+  if (!isBedrockOpenAIModel(model)) {
+    return prompt;
+  }
+
+  let changed = false;
+  const normalizedPrompt = prompt
+    .map(message => {
+      if (message.role !== 'assistant') {
+        return message;
+      }
+
+      const content = message.content.filter(part => part.type !== 'reasoning');
+      if (content.length === message.content.length) {
+        return message;
+      }
+
+      changed = true;
+      return { ...message, content };
+    })
+    .filter(message => message.role === 'system' || typeof message.content === 'string' || message.content.length > 0);
+
+  return changed ? (normalizedPrompt as LanguageModelV2Prompt) : prompt;
+}
+
 function omit<T extends object, K extends keyof T>(obj: T, keys: K[]): Omit<T, K> {
   const newObj = { ...obj };
   for (const key of keys) {
@@ -189,6 +221,8 @@ export function execute<OUTPUT = undefined>({
         },
       }
     : providerOptions;
+
+  prompt = removeReasoningForBedrockOpenAIModel(prompt, model);
 
   const stream = v5.initialize({
     runId,


### PR DESCRIPTION
Fixes #19228

  Summary

  This PR fixes Bedrock Mantle parsing failures when using OpenAI GPT-OSS models through the AI SDK Amazon Bedrock provider.

  When conversation history contains assistant reasoning parts, the Bedrock provider serializes those parts as Bedrock reasoningContent. OpenAI
  models served through Bedrock Mantle reject that content variant during request parsing, causing calls to fail with:

  Invalid 'messages': Invalid 'content': value did not match any expected variant

  Changes

  - Detects OpenAI model IDs used with the amazon-bedrock provider.
  - Removes replayed assistant reasoning parts from prompts before calling the model.
  - Drops assistant messages that become empty after removing reasoning.
  - Leaves other providers unchanged.
  - Leaves Anthropic models on Bedrock unchanged, since Bedrock Anthropic supports replayed reasoning content.
  - Adds regression coverage for:
      - OpenAI-on-Bedrock prompts stripping assistant reasoning.
      - Anthropic-on-Bedrock prompts preserving assistant reasoning.

  Validation

  pnpm --filter ./packages/core test src/stream/aisdk/v5/execute.test.ts
  pnpm --filter ./packages/core check
  pnpm build:core
  pnpm prettier --check packages/core/src/stream/aisdk/v5/execute.ts packages/core/src/stream/aisdk/v5/execute.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some Bedrock OpenAI models reject conversation history that includes hidden assistant reasoning. This change removes that hidden reasoning before sending requests, while leaving visible responses and other providers/models unchanged.

## Changes

- Detects OpenAI models hosted on Amazon Bedrock.
- Removes replayed assistant `reasoning` parts from prompts.
- Drops assistant messages that become empty after filtering.
- Preserves system messages, text content, and Bedrock Anthropic behavior.
- Adds regression tests for stripping and preserving reasoning content.
- Adds a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->