### PR TITLE
fix(core): carry iterationCount across evented workflow loop iterations

### DIFF
--- a/.changeset/evented-loop-iteration-count.md
+++ b/.changeset/evented-loop-iteration-count.md
@@ -1,0 +1,16 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `iterationCount` always being 1 for `dountil` and `dowhile` loops on the evented workflow engine. The count was never carried forward between iterations, so any loop whose condition depended on `iterationCount` never advanced and ran forever.
+
+**Before**
+
+```ts
+// On the evented engine this loop never terminated: iterationCount stayed 1.
+workflow.dountil(step, async ({ iterationCount }) => iterationCount >= 3);
+```
+
+**After**
+
+The condition now receives an incrementing count (1, 2, 3, ...) exactly as it does on the default engine, so the loop stops as expected. Loops whose conditions read step output (`inputData`) were unaffected.

--- a/packages/core/src/workflows/evented/workflow-event-processor/loop-iteration-count.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/loop-iteration-count.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { processWorkflowLoop } from './loop';
+
+/**
+ * Regression coverage for the evented engine's loop `iterationCount`.
+ *
+ * The default engine exposes an incrementing `iterationCount` to `dountil`/`dowhile`
+ * conditions (see handlers/control-flow.ts + handlers/step.ts). The evented engine
+ * must match that: reading `iterationCount` in a loop condition has to see 1, 2, 3...
+ * across iterations, and a condition that terminates on it has to actually terminate.
+ *
+ * The bug this guards against: `processWorkflowLoop` reads the previous count from
+ * `stepResults[bodyStepId].metadata.iterationCount`, but the loop-again event never
+ * carried that metadata forward, so every iteration re-read 0 and evaluated the
+ * condition with `iterationCount === 1` forever (an infinite loop when termination
+ * depends on the count).
+ */
+
+function makeLoopStep(loopType: 'dountil' | 'dowhile', condition: (n: number) => boolean) {
+  return {
+    type: 'loop' as const,
+    step: { id: 'body' },
+    condition,
+    loopType,
+  } as any;
+}
+
+/**
+ * Drive `processWorkflowLoop` the way the event processor does: run the body,
+ * evaluate the condition, and when it publishes a loop-again (`workflow.step.run`)
+ * event, feed that event's `stepResults` back into the next call. The body itself
+ * does not merge its result into `stepResults[bodyStepId]` on the loop-again path,
+ * so the only thing that can carry the iteration count forward is the event payload.
+ */
+async function driveLoop(loopType: 'dountil' | 'dowhile', condition: (n: number) => boolean, maxTurns = 25) {
+  const seenCounts: number[] = [];
+  const published: any[] = [];
+  const pubsub = {
+    publish: async (_topic: string, event: any) => {
+      published.push(event);
+    },
+  } as any;
+  const stepExecutor = {
+    evaluateCondition: async ({ iterationCount }: { iterationCount: number }) => {
+      seenCounts.push(iterationCount);
+      return condition(iterationCount);
+    },
+  } as any;
+
+  const step = makeLoopStep(loopType, condition);
+  const bodyResult = { status: 'success' as const, output: { n: 1 }, startedAt: 1, endedAt: 2, payload: {} };
+
+  let stepResults: Record<string, any> = {};
+  let ended = false;
+
+  for (let turn = 0; turn < maxTurns; turn++) {
+    published.length = 0;
+    await processWorkflowLoop(
+      {
+        workflowId: 'wf',
+        runId: 'run-1',
+        executionPath: [0],
+        stepResults,
+        activeStepsPath: {},
+        resumeSteps: [],
+        prevResult: bodyResult,
+        requestContext: {},
+      } as any,
+      { pubsub, stepExecutor, step, stepResult: bodyResult },
+    );
+
+    if (published.some(e => e.type === 'workflow.step.end')) {
+      ended = true;
+      break;
+    }
+
+    const runEvt = published.find(e => e.type === 'workflow.step.run');
+    // Loop-again: the body would run next, then we re-enter with the event's stepResults.
+    stepResults = runEvt.data.stepResults;
+  }
+
+  return { seenCounts, ended };
+}
+
+describe('evented loop iterationCount', () => {
+  it('dountil sees an incrementing count and terminates when the count is reached', async () => {
+    // Stop once we have run 3 iterations.
+    const { seenCounts, ended } = await driveLoop('dountil', n => n >= 3);
+
+    expect(ended).toBe(true);
+    expect(seenCounts).toEqual([1, 2, 3]);
+  });
+
+  it('dowhile sees an incrementing count and terminates when the count is reached', async () => {
+    // Keep looping while we have run fewer than 3 iterations.
+    const { seenCounts, ended } = await driveLoop('dowhile', n => n < 3);
+
+    expect(ended).toBe(true);
+    expect(seenCounts).toEqual([1, 2, 3]);
+  });
+});

--- a/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/loop.ts
@@ -69,7 +69,20 @@ export async function processWorkflowLoop(
     runId,
     executionPath,
     resumeSteps: [] as string[],
-    stepResults,
+    // Carry the iteration count forward on the loop body's stepResults entry. The
+    // loop-again path does not merge the body result back into stepResults[bodyStepId]
+    // (only prevResult carries it), and the evented step executor never writes
+    // iterationCount, so without this the next processWorkflowLoop re-reads 0 and the
+    // condition is always evaluated with iterationCount === 1 (an infinite loop when
+    // termination depends on the count). Mirrors the default engine, which stamps
+    // metadata.iterationCount onto the step result. See handlers/step.ts.
+    stepResults: {
+      ...stepResults,
+      [step.step.id]: {
+        ...stepResults[step.step.id],
+        metadata: { ...stepResults[step.step.id]?.metadata, iterationCount },
+      },
+    },
     prevResult: stepResult,
     resumeData: undefined,
     activeStepsPath,


### PR DESCRIPTION
## What

On the evented workflow engine, the `iterationCount` handed to `dountil` / `dowhile` loop conditions was permanently stuck at `1`, so any loop whose termination depended on `iterationCount` never exited and ran forever.

`processWorkflowLoop` reads the previous count from the loop body's step-result metadata:

```ts
const prevIterationCount = stepResults[step.step?.id]?.metadata?.iterationCount ?? 0;
const iterationCount = prevIterationCount + 1;
```

But on the loop-again path the body's result was forwarded only as `prevResult`; it was never merged into `stepResults[bodyStepId]`, and the evented step executor never writes `metadata.iterationCount`. So the read was always `undefined -> 0`, and `iterationCount` was always `1` on every evaluation.

The default engine does this correctly: `handlers/control-flow.ts` reads the same metadata and `handlers/step.ts` stamps `metadata: { iterationCount }` onto the step result. The evented engine had no equivalent write.

## Fix

Carry `metadata.iterationCount` forward on the loop-again event's `stepResults[bodyStepId]`, mirroring the default engine. This is the only place the count needs to travel, and it is a metadata-only merge, so it does not disturb the body's output/status/payload that the executor reads on the next run.

## Why it was not caught

Every existing loop test (in the shared workflow suite) terminates on step output (`inputData.count`), never on the `iterationCount` condition argument, so nothing exercised the broken path.

## Tests

- `loop-iteration-count.test.ts`: drives `processWorkflowLoop` the way the event processor does (run body, evaluate condition, feed the loop-again event's `stepResults` back in) and asserts the condition sees `1, 2, 3` and the loop terminates. Fails on the current code (`iterationCount` stays `1`, loop never ends) and passes with the fix, for both `dountil` and `dowhile`.
- Also verified end-to-end through the full evented engine (real `MockStore` + pubsub): a `dountil(step, ({ iterationCount }) => iterationCount >= 3)` runs the body exactly 3 times and completes. The whole evented suite stays green (300 passed).

Closes #19231


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Loops now correctly remember how many times they have run. This prevents event-driven workflows from getting stuck repeating forever when they should stop after a specific number of iterations.

## Changes

- Fixed `dountil` and `dowhile` loops to carry `iterationCount` into the next iteration.
- Added regression tests verifying counts progress as `1, 2, 3` and loops terminate correctly.
- Added coverage for both processor-level behavior and evented workflow execution.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->