### PR TITLE
fix(playground): wrap editor test-chat in ThreadInputProvider so the …

### DIFF
--- a/.changeset/fix-editor-composer-input-19175.md
+++ b/.changeset/fix-editor-composer-input-19175.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed the agent editor's test-chat composer rejecting all typed input. Typing in the editor's chat box now updates the input as expected, matching the regular chat page.

--- a/packages/playground/src/domains/agents/components/__tests__/agent-playground-test-chat.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-playground-test-chat.test.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -81,6 +81,34 @@ describe('AgentPlaygroundTestChat', () => {
 
     await waitFor(() => {
       expect(onBrowserProbe).toHaveBeenCalled();
+    });
+  });
+
+  // Regression test for #19175: the editor test-chat tree was never wrapped in
+  // ThreadInputProvider, so Composer's useThreadInput resolved the default no-op
+  // context and every keystroke reverted the controlled textarea to empty.
+  it('accepts typed input in the composer', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/agents/${AGENT_ID}`, () => HttpResponse.json({ ...v2Agent, modelList: [] })),
+      http.get(`${BASE_URL}/api/memory/config`, () => HttpResponse.json({ config: {} })),
+      http.get(`${BASE_URL}/api/memory/status`, () => HttpResponse.json(memoryDisabled)),
+      http.get(`${BASE_URL}/api/agents/${AGENT_ID}/voice/speakers`, () => HttpResponse.json([])),
+      http.post(`${BASE_URL}/api/agents/${AGENT_ID}/threads/subscribe`, () => HttpResponse.json({ ok: true })),
+      http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json({ enabled: false, login: null })),
+      http.get(`${BASE_URL}/api/agents/providers`, () => HttpResponse.json({ providers: [] })),
+      http.get(`${BASE_URL}/api/editor/builder/settings`, () => HttpResponse.json({ enabled: false })),
+      http.get(`${BASE_URL}/api/editor/builder/models/available`, () => HttpResponse.json({ providers: [] })),
+    );
+
+    renderEditorTestChat();
+
+    const composer = (await screen.findByPlaceholderText('Enter your message...')) as HTMLTextAreaElement;
+    expect(composer.value).toBe('');
+
+    fireEvent.change(composer, { target: { value: 'hello there' } });
+
+    await waitFor(() => {
+      expect(composer.value).toBe('hello there');
     });
   });
 });

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
@@ -15,6 +15,7 @@ import { buildAgentDefaultSettings } from '../../utils/agent-default-settings';
 import { AgentChat } from '../agent-chat';
 import { BrowserViewPanel } from '../browser-view/browser-view-panel';
 import { ComposerRunOptions } from '../composer-run-options';
+import { ThreadInputProvider } from '@/domains/conversation/context/ThreadInputContext';
 import { useMergedRequestContext } from '@/domains/request-context/context/schema-request-context';
 import { DatasetSaveProvider } from '@/lib/ai-ui/context/dataset-save-context';
 
@@ -91,24 +92,26 @@ export function AgentPlaygroundTestChat({
               agentId={agentId}
               requestContext={hasRequestContext ? mergedRequestContext : undefined}
             >
-              <div className="flex flex-col h-full">
-                {editFormCtx && <UnsavedChangesBanner ctx={editFormCtx} />}
-                <div className="flex-1 min-h-0">
-                  <AgentChat
-                    key={testThreadId}
-                    agentId={agentId}
-                    agentName={agentName}
-                    modelVersion={modelVersion}
-                    agentVersionId={agentVersionId}
-                    supportsMemory={agent?.supportsMemory}
-                    threadId={testThreadId}
-                    memory={hasMemory}
-                    modelList={agent?.modelList}
-                    isNewThread
-                    runOptionsSlot={<ComposerRunOptions requestContextSchema={agent?.requestContextSchema} />}
-                  />
+              <ThreadInputProvider>
+                <div className="flex flex-col h-full">
+                  {editFormCtx && <UnsavedChangesBanner ctx={editFormCtx} />}
+                  <div className="flex-1 min-h-0">
+                    <AgentChat
+                      key={testThreadId}
+                      agentId={agentId}
+                      agentName={agentName}
+                      modelVersion={modelVersion}
+                      agentVersionId={agentVersionId}
+                      supportsMemory={agent?.supportsMemory}
+                      threadId={testThreadId}
+                      memory={hasMemory}
+                      modelList={agent?.modelList}
+                      isNewThread
+                      runOptionsSlot={<ComposerRunOptions requestContextSchema={agent?.requestContextSchema} />}
+                    />
+                  </div>
                 </div>
-              </div>
+              </ThreadInputProvider>
             </DatasetSaveProvider>
           </ActivatedSkillsProvider>
           <BrowserViewPanel />


### PR DESCRIPTION
## What

The agent **editor** page's test-chat composer rejected all typed input - characters reverted to empty on every keystroke, while the regular chat page worked fine. `Closes #19175`.

## Why

The editor tree was never wrapped in `ThreadInputProvider` #18227 ("Preserve unsent composer drafts per thread") moved the composer's input to a shared `ThreadInputContext`. The regular chat page wraps its tree in the provider:

- `packages/playground/src/pages/agents/agent/index.tsx:130`
- `packages/playground/src/pages/agents/agent/session.tsx:81`

But the editor's test chat (`agent-playground-test-chat.tsx`) was never wrapped. So `Thread`'s `Composer` (`packages/playground/src/lib/ai-ui/thread.tsx:191`) resolves the **default** context in `thread-input-context.ts:13-16`, where `setThreadInputForThread` is a no-op:

```ts
export const ThreadInputContext = createContext<ThreadInputContextValue>({
  getThreadInput: () => '',
  setThreadInputForThread: () => {},
});
```

The controlled <textarea value={text}> therefore reverts every keystroke to empty. That's why the chat page worked but the editor page didn't - an incomplete refactor from #18227.

## How

Wrap the editor's AgentChat subtree in <ThreadInputProvider> in agent-playground-test-chat.tsx, mirroring the chat page. One-line provider addition (+ re-indent).

## Testing

Added a labeled regression test to the existing MSW suite that types into the composer and asserts the value updates. Fails on main (the no-op default context leaves the value empty and waitFor times out), passes with this change.

```
pnpm --filter ./packages/playground exec vitest run src/domains/agents/components/__tests__/agent-playground-test-chat.test.tsx
```

Expected: 2 passed (the existing provider-parity test + the new accepts typed input in the composer).

## Impact / regression risk
Minimal, additive. ThreadInputProvider is a self-contained state provider added to one isolated page; no interface or behavior change for any other consumer. The regular chat page is untouched. Worst case would be an extra provider in the editor tree — which is exactly the parity the chat page already has.