### PR TITLE
chore(docs): Remove unnecessary admonitions

### DIFF
--- a/docs/src/content/en/docs/agent-builder/skill-registries.mdx
+++ b/docs/src/content/en/docs/agent-builder/skill-registries.mdx
@@ -31,13 +31,7 @@ new MastraEditor({
 })
 ```
 
-The Builder library tab now exposes a **Browse** view backed by skills.sh. End users can preview a skill, then install it into an agent.
-
-:::note
-
-See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) for the full `registries` schema.
-
-:::
+The Builder library tab now exposes a **Browse** view backed by skills.sh. End users can preview a skill, then install it into an agent. See the [AgentBuilderOptions reference](/reference/editor/agent-builder/agent-builder-options) for the full `registries` schema.
 
 ## Related
 

--- a/docs/src/content/en/docs/agent-controller/overview.mdx
+++ b/docs/src/content/en/docs/agent-controller/overview.mdx
@@ -97,11 +97,7 @@ await agentController.selectOrCreateThread()
 await agentController.sendMessage({ content: 'Hello!' })
 ```
 
-:::note
-
 Visit the [AgentController reference](/reference/agent-controller/agent-controller-class) for the full constructor parameters and method signatures.
-
-:::
 
 ## Architecture
 

--- a/docs/src/content/en/docs/agent-controller/session.mdx
+++ b/docs/src/content/en/docs/agent-controller/session.mdx
@@ -138,13 +138,7 @@ agentController.subscribe(event => {
 })
 ```
 
-This is the recommended pattern for most UIs. Subscribe to individual typed events only when you need to react to a specific transition rather than re-render the whole view.
-
-:::note
-
-Visit the [Session reference](/reference/agent-controller/session) for the full list of sub-objects and method signatures.
-
-:::
+This is the recommended pattern for most UIs. Subscribe to individual typed events only when you need to react to a specific transition rather than re-render the whole view. Visit the [Session reference](/reference/agent-controller/session) for the full list of sub-objects and method signatures.
 
 ## Related
 

--- a/docs/src/content/en/docs/agents/code-mode.mdx
+++ b/docs/src/content/en/docs/agents/code-mode.mdx
@@ -103,11 +103,7 @@ For `createCodeMode()` to work well, keep these tips in mind:
 - Keep tools focused, so each does one thing well and the model composes them in code.
 - Code mode helps most when calls can be parallelized with `Promise.all`.
 
-:::note
-
 Visit the [`createCodeMode()` reference](/reference/tools/create-code-mode) for configuration options, return values, result shape, and instructions inspection.
-
-:::
 
 ## Scoping tools across multiple code tools
 

--- a/docs/src/content/en/docs/agents/guardrails.mdx
+++ b/docs/src/content/en/docs/agents/guardrails.mdx
@@ -34,11 +34,7 @@ export const normalizedAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`UnicodeNormalizer()`](/reference/processors/unicode-normalizer) reference for a full list of configuration options.
-
-:::
 
 ### Prevent prompt injection
 
@@ -61,11 +57,7 @@ export const secureAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`PromptInjectionDetector()`](/reference/processors/prompt-injection-detector) reference for a full list of configuration options.
-
-:::
 
 ### Detect and translate language
 
@@ -88,11 +80,7 @@ export const multilingualAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`LanguageDetector()`](/reference/processors/language-detector) reference for a full list of configuration options.
-
-:::
 
 ## Output processors
 
@@ -118,11 +106,7 @@ export const batchedAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`BatchPartsProcessor()`](/reference/processors/batch-parts-processor) reference for a full list of configuration options.
-
-:::
 
 ### Scrub system prompts
 
@@ -149,11 +133,7 @@ const scrubbedAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`SystemPromptScrubber()`](/reference/processors/system-prompt-scrubber) reference for a full list of configuration options.
-
-:::
 
 :::note
 When streaming responses over HTTP, Mastra redacts sensitive request data (system prompts, tool definitions, API keys) from stream chunks at the server level by default. See [Stream data redaction](/docs/server/mastra-server#stream-data-redaction) for details.
@@ -185,11 +165,7 @@ export const moderatedAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`ModerationProcessor()`](/reference/processors/moderation-processor) reference for a full list of configuration options.
-
-:::
 
 ### Detect and redact PII
 
@@ -215,11 +191,7 @@ export const privateAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`PIIDetector()`](/reference/processors/pii-detector) reference for a full list of configuration options.
-
-:::
 
 ### Enforce cost limits
 
@@ -241,11 +213,7 @@ export const budgetedAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [`CostGuardProcessor()`](/reference/processors/cost-guard-processor) reference for scoping modes, time windows, metric persistence delays, and the `onViolation` callback. Requires observability storage with `getMetricAggregate` support.
-
-:::
 
 ## Processor strategies
 

--- a/docs/src/content/en/docs/agents/overview.mdx
+++ b/docs/src/content/en/docs/agents/overview.mdx
@@ -57,15 +57,11 @@ export const mastra = new Mastra({
 
 Once registered, it can be called from workflows, tools, or other agents, and has access to shared resources such as memory, logging, and observability features.
 
+Visit the [agent reference](/reference/agents/agent) for more information on available properties and configurations.
+
 :::tip
 
 Use [Studio](/docs/studio/overview) to test your agent with different messages, inspect tool calls and responses, and debug agent behavior.
-
-:::
-
-:::note
-
-Visit the [agent reference](/reference/agents/agent) for more information on available properties and configurations.
 
 :::
 

--- a/docs/src/content/en/docs/agents/skills.mdx
+++ b/docs/src/content/en/docs/agents/skills.mdx
@@ -75,11 +75,7 @@ export const releaseChecklist = createSkill({
 })
 ```
 
-The `references` field bundles supporting documents that the agent can read with the `skill_read` tool, like `references/` files in a filesystem skill.
-
-:::note
-Visit [`createSkill()` reference](/reference/agents/createSkill) for the full API.
-:::
+The `references` field bundles supporting documents that the agent can read with the `skill_read` tool, like `references/` files in a filesystem skill. Visit [`createSkill()` reference](/reference/agents/createSkill) for the full API.
 
 ## Filesystem path skills
 
@@ -189,9 +185,7 @@ for (const meta of allSkills) {
 }
 ```
 
-:::note
 Visit [`.getSkill()` reference](/reference/agents/getSkill) and [`.listSkills()` reference](/reference/agents/listSkills) for the full API.
-:::
 
 ## Related
 

--- a/docs/src/content/en/docs/agents/structured-output.mdx
+++ b/docs/src/content/en/docs/agents/structured-output.mdx
@@ -113,11 +113,7 @@ Agents can return structured data by defining the expected output with either [S
   </TabItem>
 </Tabs>
 
-:::note
-
 Visit [`.generate()`](/reference/agents/generate) for a full list of configuration options.
-
-:::
 
 **Example output:** The `response.object` will contain the structured data as defined by the schema.
 

--- a/docs/src/content/en/docs/agents/supervisor-agents.mdx
+++ b/docs/src/content/en/docs/agents/supervisor-agents.mdx
@@ -240,13 +240,7 @@ How it works:
 1. **Scoped memory saves**: Only the delegation prompt and the subagent's response are saved to the subagent's memory
 1. **Fresh thread per invocation**: Each delegation uses a unique thread ID, ensuring clean separation
 
-This ensures subagents have the context they need without cluttering their memory with the entire supervisor conversation.
-
-:::note
-
-Visit [memory in multi-agent systems](/docs/memory/overview#memory-in-multi-agent-systems) for more details.
-
-:::
+This ensures subagents have the context they need without cluttering their memory with the entire supervisor conversation. Visit [memory in multi-agent systems](/docs/memory/overview#memory-in-multi-agent-systems) for more details.
 
 ## Tool approval propagation
 

--- a/docs/src/content/en/docs/agents/using-tools.mdx
+++ b/docs/src/content/en/docs/agents/using-tools.mdx
@@ -46,13 +46,7 @@ export const weatherTool = createTool({
 })
 ```
 
-When creating tools, keep descriptions concise and focused on what the tool does, emphasizing its primary use case. Descriptive schema names can also help guide the agent on how to use the tool.
-
-:::note
-
-Visit the [`createTool`](/reference/tools/create-tool) reference for more information on available properties, configurations, and examples.
-
-:::
+When creating tools, keep descriptions concise and focused on what the tool does, emphasizing its primary use case. Descriptive schema names can also help guide the agent on how to use the tool. Visit the [`createTool`](/reference/tools/create-tool) reference for more information on available properties, configurations, and examples.
 
 To make a tool available to an agent, add it to the `tools` property on the `Agent` class. Mentioning available tools and their general purpose in the agent's system prompt helps the agent decide when to call a tool and when not to.
 
@@ -377,11 +371,7 @@ await agent.generate('Check the forecast', {
 })
 ```
 
-:::note
-
 See the [`Agent.generate()` reference](/reference/agents/generate) for all runtime options including `toolsets`, `clientTools`, and `prepareStep`.
-
-:::
 
 ## Control `toolName` in stream responses
 

--- a/docs/src/content/en/docs/browser/agent-browser.mdx
+++ b/docs/src/content/en/docs/browser/agent-browser.mdx
@@ -88,13 +88,7 @@ const browser = new AgentBrowser({
 })
 ```
 
-This adds `browser_record` and `browser_record_caption` to the agent's toolset. See [Browser recording (alpha)](/docs/browser/recording) for details.
-
-:::note
-
-See [AgentBrowser reference](/reference/browser/agent-browser) for all configuration options and tool details.
-
-:::
+This adds `browser_record` and `browser_record_caption` to the agent's toolset. See [Browser recording (alpha)](/docs/browser/recording) for details. See [AgentBrowser reference](/reference/browser/agent-browser) for all configuration options and tool details.
 
 ## Related
 

--- a/docs/src/content/en/docs/browser/browser-viewer.mdx
+++ b/docs/src/content/en/docs/browser/browser-viewer.mdx
@@ -125,13 +125,7 @@ npm install -g browse
 browse skills install
 ```
 
-CDP flag: `--ws`
-
-:::note
-
-See [BrowserViewer reference](/reference/browser/browser-viewer) for all configuration options, advanced connection modes, and method details.
-
-:::
+CDP flag: `--ws` See [BrowserViewer reference](/reference/browser/browser-viewer) for all configuration options, advanced connection modes, and method details.
 
 ## Related
 

--- a/docs/src/content/en/docs/browser/stagehand.mdx
+++ b/docs/src/content/en/docs/browser/stagehand.mdx
@@ -131,11 +131,7 @@ const browser = new StagehandBrowser({
 })
 ```
 
-:::note
-
 See [StagehandBrowser reference](/reference/browser/stagehand-browser) for all configuration options.
-
-:::
 
 ## Recording
 

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -187,13 +187,7 @@ With this configuration:
 - A user pastes a YouTube link and the agent watches and discusses the video.
 - A user pastes an imgur link and the agent sees the image directly.
 
-By default, only images are sent inline (`inlineMedia: ['image/*']`). Unsupported types are described as text summaries so the agent knows about the file without failing on models that reject them.
-
-:::note
-
-See [Channels reference](/reference/agents/channels#inline-media) for all `inlineMedia` patterns and [inlineLinks reference](/reference/agents/channels#inline-links) for domain matching, HEAD detection, and forced MIME types.
-
-:::
+By default, only images are sent inline (`inlineMedia: ['image/*']`). Unsupported types are described as text summaries so the agent knows about the file without failing on models that reject them. See [Channels reference](/reference/agents/channels#inline-media) for all `inlineMedia` patterns and [inlineLinks reference](/reference/agents/channels#inline-links) for domain matching, HEAD detection, and forced MIME types.
 
 ## Serverless deployment
 

--- a/docs/src/content/en/docs/deployment/mastra-server.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-server.mdx
@@ -23,13 +23,7 @@ Run the build command from your project root:
 mastra build
 ```
 
-This creates a `.mastra` directory containing your production-ready server.
-
-:::info
-
-Read the [`mastra build`](/reference/cli/mastra#mastra-build) reference for all available flags.
-
-:::
+This creates a `.mastra` directory containing your production-ready server. Read the [`mastra build`](/reference/cli/mastra#mastra-build) reference for all available flags.
 
 ## Build output
 
@@ -72,11 +66,7 @@ The `mastra start` command provides additional features:
 - Provides helpful error messages for missing modules
 - Handles process signals for graceful shutdown
 
-:::info
-
 Read the [`mastra start`](/reference/cli/mastra#mastra-start) reference for all available flags.
-
-:::
 
 ## Build configuration
 

--- a/docs/src/content/en/docs/editor/overview.mdx
+++ b/docs/src/content/en/docs/editor/overview.mdx
@@ -51,13 +51,7 @@ export const mastra = new Mastra({
 })
 ```
 
-Once registered, you can manage agents through [Studio](/docs/studio/overview) or programmatically through the server API and Client SDK.
-
-:::note
-
-See the [MastraEditor reference](/reference/editor/mastra-editor) for all configuration options.
-
-:::
+Once registered, you can manage agents through [Studio](/docs/studio/overview) or programmatically through the server API and Client SDK. See the [MastraEditor reference](/reference/editor/mastra-editor) for all configuration options.
 
 ## Code and database sources
 
@@ -164,13 +158,7 @@ Because stored agents are data, you can build automation loops that tune agents 
 - Re-run the experiment against the draft and compare scores to the baseline.
 - Promote the draft to the published version when the scores improve.
 
-This turns agent tuning into a closed feedback loop. One agent owns the production configuration, another agent iterates on it, and every change is versioned so you can roll back if a round of automated edits makes things worse. Combine this with [version targeting](#version-targeting-and-experimentation) to keep production traffic on the published version while the draft is being tested.
-
-:::note
-
-See the [MastraEditor reference](/reference/editor/mastra-editor) for the full namespace API.
-
-:::
+This turns agent tuning into a closed feedback loop. One agent owns the production configuration, another agent iterates on it, and every change is versioned so you can roll back if a round of automated edits makes things worse. Combine this with [version targeting](#version-targeting-and-experimentation) to keep production traffic on the published version while the draft is being tested. See the [MastraEditor reference](/reference/editor/mastra-editor) for the full namespace API.
 
 ## What can be overridden
 

--- a/docs/src/content/en/docs/editor/prompts.mdx
+++ b/docs/src/content/en/docs/editor/prompts.mdx
@@ -128,11 +128,7 @@ await editor.agent.update({
 })
 ```
 
-:::note
-
 See the [MastraEditor reference](/reference/editor/mastra-editor#namespaces) for the full `editor.prompt` API.
-
-:::
 
 ## Versioning
 

--- a/docs/src/content/en/docs/editor/tools.mdx
+++ b/docs/src/content/en/docs/editor/tools.mdx
@@ -148,13 +148,7 @@ When an agent runs, tools from all sources are merged in this order:
 1. Integration tools
 1. MCP tools
 
-If a tool ID exists in multiple sources, later sources take precedence. Description overrides set at the agent level always take priority over the original tool description.
-
-:::note
-
-See the [ToolProvider reference](/reference/editor/tool-provider) for the full provider API.
-
-:::
+If a tool ID exists in multiple sources, later sources take precedence. Description overrides set at the agent level always take priority over the original tool description. See the [ToolProvider reference](/reference/editor/tool-provider) for the full provider API.
 
 ## Related
 

--- a/docs/src/content/en/docs/evals/custom-scorers.mdx
+++ b/docs/src/content/en/docs/evals/custom-scorers.mdx
@@ -349,13 +349,7 @@ A custom scorer in Mastra uses `createScorer` with four core components:
 1. [**Score Generation**](#score-generation)
 1. [**Reason Generation**](#reason-generation)
 
-Together, these components allow you to define custom evaluation logic using LLMs as judges.
-
-:::info
-
-Visit [createScorer](/reference/evals/create-scorer) for the full API and configuration options.
-
-:::
+Together, these components allow you to define custom evaluation logic using LLMs as judges. Visit [createScorer](/reference/evals/create-scorer) for the full API and configuration options.
 
 ```typescript title="src/mastra/scorers/gluten-checker.ts"
 import { createScorer } from '@mastra/core/evals'

--- a/docs/src/content/en/docs/evals/datasets/overview.mdx
+++ b/docs/src/content/en/docs/evals/datasets/overview.mdx
@@ -49,11 +49,7 @@ const existing = await datasets.get({ id: 'dataset-id' })
 const { datasets: all } = await datasets.list()
 ```
 
-:::info
-
 Visit the [`DatasetsManager` reference](/reference/datasets/datasets-manager) for the full list of methods.
-
-:::
 
 ## Studio
 
@@ -208,13 +204,7 @@ Fetch the exact items that existed at a past version:
 const items = await dataset.listItems({ version: 2 })
 ```
 
-You can also pin experiments to a version, see [running experiments](/docs/evals/datasets/running-experiments).
-
-:::info
-
-Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list of methods and parameters.
-
-:::
+You can also pin experiments to a version, see [running experiments](/docs/evals/datasets/running-experiments). Visit the [`Dataset` reference](/reference/datasets/dataset) for the full list of methods and parameters.
 
 ## Related
 

--- a/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
+++ b/docs/src/content/en/docs/evals/datasets/running-experiments.mdx
@@ -137,11 +137,7 @@ for (const item of summary.results) {
 }
 ```
 
-:::info
-
 Visit the [Scorers overview](/docs/evals/overview) for details on available and custom scorers.
-
-:::
 
 ## Tool mocks
 
@@ -362,11 +358,7 @@ for (const result of results) {
 - `completedWithErrors` is `true` when the experiment finished but some items failed.
 - Items cancelled via `signal` appear in `skippedCount`.
 
-:::info
-
 Visit the [`startExperiment` reference](/reference/datasets/startExperiment) for the full parameter and return type documentation.
-
-:::
 
 ## Related
 

--- a/docs/src/content/en/docs/evals/evals-with-memory.mdx
+++ b/docs/src/content/en/docs/evals/evals-with-memory.mdx
@@ -144,11 +144,7 @@ const summary = await dataset.startExperiment({
 })
 ```
 
-The inline `task` receives the item's `metadata`, so each row can drive its own thread without changing the agent or any scorer.
-
-:::note
-Visit [runEvals reference](/reference/evals/run-evals) and [Dataset reference](/reference/datasets/dataset) for full configuration.
-:::
+The inline `task` receives the item's `metadata`, so each row can drive its own thread without changing the agent or any scorer. Visit [runEvals reference](/reference/evals/run-evals) and [Dataset reference](/reference/datasets/dataset) for full configuration.
 
 ## Related
 

--- a/docs/src/content/en/docs/evals/gates-and-verdicts.mdx
+++ b/docs/src/content/en/docs/evals/gates-and-verdicts.mdx
@@ -69,11 +69,7 @@ const result = await runEvals({
 // result.gateResults: [{ id: 'check-called-tool', passed: true, score: 1 }]
 ```
 
-Any scorer works as a gate. Quick Checks are a natural fit because they return binary 1/0 scores.
-
-:::note
-Visit [runEvals() reference](/reference/evals/run-evals) for the full parameter and return type documentation.
-:::
+Any scorer works as a gate. Quick Checks are a natural fit because they return binary 1/0 scores. Visit [runEvals() reference](/reference/evals/run-evals) for the full parameter and return type documentation.
 
 ## Thresholds
 

--- a/docs/src/content/en/docs/evals/quick-checks.mdx
+++ b/docs/src/content/en/docs/evals/quick-checks.mdx
@@ -132,11 +132,7 @@ Each check is a standard `createScorer()` instance with a `preprocess` step and 
 1. **preprocess**: Extracts and normalizes relevant data from the agent run (text content, tool calls)
 1. **generateScore**: Converts the preprocessed result into a score (typically binary 1 or 0)
 
-Because checks skip the `analyze` and `generateReason` steps and make no LLM calls, they run in microseconds.
-
-:::note
-Visit the [Quick Checks reference](/reference/evals/checks) for the full API, including all parameters and options for each check.
-:::
+Because checks skip the `analyze` and `generateReason` steps and make no LLM calls, they run in microseconds. Visit the [Quick Checks reference](/reference/evals/checks) for the full API, including all parameters and options for each check.
 
 ## Related
 

--- a/docs/src/content/en/docs/long-running-agents/background-tasks.mdx
+++ b/docs/src/content/en/docs/long-running-agents/background-tasks.mdx
@@ -182,11 +182,7 @@ const stream = await agent.stream('Research solana for me', {
 })
 ```
 
-:::note
-
 Visit [`Agent.stream()`](/reference/streaming/agents/stream) for the full API.
-
-:::
 
 ### Aggregate properties
 

--- a/docs/src/content/en/docs/long-running-agents/durable-agents.mdx
+++ b/docs/src/content/en/docs/long-running-agents/durable-agents.mdx
@@ -70,13 +70,7 @@ for await (const chunk of output.fullStream) {
 cleanup()
 ```
 
-The returned `runId` identifies the execution. Pass it to `observe()` to reconnect from a different client.
-
-:::note
-
-Visit the [DurableAgent reference](/reference/agents/durable-agent) for the full configuration and method API.
-
-:::
+The returned `runId` identifies the execution. Pass it to `observe()` to reconnect from a different client. Visit the [DurableAgent reference](/reference/agents/durable-agent) for the full configuration and method API.
 
 ## How it works
 
@@ -154,11 +148,7 @@ const agent = new Agent({
 export const inngestAnalyst = createInngestAgent({ agent, inngest })
 ```
 
-:::note
-
 Visit the [`createInngestAgent()` reference](/reference/agents/inngest-agent) for the full API, including Inngest-specific options like PubSub and cache configuration.
-
-:::
 
 ## Resumable streams
 
@@ -217,11 +207,7 @@ await durableAgent.stream('Research topic', {
 })
 ```
 
-:::note
-
 Visit [Background tasks](/docs/long-running-agents/background-tasks) for the full background task guide, including configuration, subagents, and suspend/resume.
-
-:::
 
 ## Cleanup
 

--- a/docs/src/content/en/docs/long-running-agents/goals.mdx
+++ b/docs/src/content/en/docs/long-running-agents/goals.mdx
@@ -113,13 +113,7 @@ await worker.updateObjectiveOptions({ threadId, maxRuns: 100 })
 await worker.clearObjective({ threadId })
 ```
 
-Per-objective values written by `setObjective` / `updateObjectiveOptions` take precedence over the agent's `goal` config, and that precedence is remembered in thread state.
-
-:::note
-
-See the [`GoalEvaluationPayload` in the ChunkType reference](/reference/streaming/ChunkType) for the full goal chunk shape.
-
-:::
+Per-objective values written by `setObjective` / `updateObjectiveOptions` take precedence over the agent's `goal` config, and that precedence is remembered in thread state. See the [`GoalEvaluationPayload` in the ChunkType reference](/reference/streaming/ChunkType) for the full goal chunk shape.
 
 ## Related
 

--- a/docs/src/content/en/docs/long-running-agents/signal-providers.mdx
+++ b/docs/src/content/en/docs/long-running-agents/signal-providers.mdx
@@ -170,11 +170,7 @@ export class CiSignals extends SignalProvider<'ci-signals'> {
 }
 ```
 
-`handleWebhook()` is a provider method, not an auto-mounted HTTP route. Invoke it from your own endpoint, passing the request body, headers, and any route params.
-
-:::note
-Visit [`SignalProvider` reference](/reference/signals/signal-provider) for subscription, polling, lifecycle, and `notify()` details. For the complete notification payload shape, including deduplication and coalescing fields, visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options).
-:::
+`handleWebhook()` is a provider method, not an auto-mounted HTTP route. Invoke it from your own endpoint, passing the request body, headers, and any route params. Visit [`SignalProvider` reference](/reference/signals/signal-provider) for subscription, polling, lifecycle, and `notify()` details. For the complete notification payload shape, including deduplication and coalescing fields, visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options).
 
 ## Built-in webhook provider
 

--- a/docs/src/content/en/docs/long-running-agents/signals.mdx
+++ b/docs/src/content/en/docs/long-running-agents/signals.mdx
@@ -126,11 +126,7 @@ const result = agent.sendSignal(
 await result.persisted
 ```
 
-Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context.
-
-:::note
-Visit [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for `ifActive`, `ifIdle`, branch attributes, and `streamOptions`.
-:::
+Pass `ifIdle.streamOptions` when the idle wake-up stream needs options such as model settings, tools, or runtime context. Visit [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for `ifActive`, `ifIdle`, branch attributes, and `streamOptions`.
 
 ### Send notification context
 
@@ -215,11 +211,7 @@ Awaiting `sendSignal()` preserves stream echo ordering when a subscribed thread 
 
 ### Conditional attributes
 
-Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that depends on whether the agent is active or idle at delivery time. Top-level `attributes` always apply, and Mastra merges the selected branch's `attributes` into them when the input is accepted.
-
-:::note
-Visit [`Agent.sendMessage()` reference](/reference/agents/agent#sendmessagemessage-options) and [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for branch-specific attributes.
-:::
+Use `ifActive.attributes` and `ifIdle.attributes` to tag input with context that depends on whether the agent is active or idle at delivery time. Top-level `attributes` always apply, and Mastra merges the selected branch's `attributes` into them when the input is accepted. Visit [`Agent.sendMessage()` reference](/reference/agents/agent#sendmessagemessage-options) and [`Agent.sendSignal()` reference](/reference/agents/agent#sendsignalsignal-options) for branch-specific attributes.
 
 ## State and notification signals
 
@@ -294,11 +286,7 @@ Notification signals represent external events such as GitHub activity, email, S
 
 Notification delivery has two phases. During ingress, `agent.sendNotificationSignal()` stores a notification record and resolves the agent's delivery policy. During dispatch, Mastra consumes due records and emits full notification or summary signals.
 
-The default delivery policy is priority-aware. Urgent notifications deliver immediately, while lower-priority notifications may be batched into summaries or wait until the thread is idle.
-
-:::note
-Visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options) for notification fields, [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` configuration, and [`createNotificationInboxTool()` reference](/reference/signals/create-notification-inbox-tool) for inbox tool actions.
-:::
+The default delivery policy is priority-aware. Urgent notifications deliver immediately, while lower-priority notifications may be batched into summaries or wait until the thread is idle. Visit [`Agent.sendNotificationSignal()` reference](/reference/agents/agent#sendnotificationsignalnotification-options) for notification fields, [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` configuration, and [`createNotificationInboxTool()` reference](/reference/signals/create-notification-inbox-tool) for inbox tool actions.
 
 ```typescript title="src/mastra/notifications.ts"
 await agent.sendNotificationSignal(
@@ -334,19 +322,11 @@ Notification summaries tell the model that inbox records are waiting:
 
 When Mastra emits a summary, it clears `summaryAt` and sets `summarySignalId` on each summarized record. The records stay pending and readable. When Mastra emits a full notification, it sets `deliveredSignalId` and marks the record `delivered`. If the inbox tool reads a notification first, it can inject the full notification signal and mark the record `seen`, which prevents duplicate full delivery.
 
-Configure a delivery policy on the agent when some notifications should wait for a different dispatch window or summary rollup. Enable scheduled dispatch at the Mastra level when deferred notifications and summary rollups should be delivered automatically.
-
-:::note
-Visit [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` and [`Mastra` class reference](/reference/core/mastra-class#constructor-parameters) for runtime notification dispatch configuration.
-:::
+Configure a delivery policy on the agent when some notifications should wait for a different dispatch window or summary rollup. Enable scheduled dispatch at the Mastra level when deferred notifications and summary rollups should be delivered automatically. Visit [`Agent` constructor reference](/reference/agents/agent#constructor-parameters) for `notifications.deliveryPolicy` and [`Mastra` class reference](/reference/core/mastra-class#constructor-parameters) for runtime notification dispatch configuration.
 
 #### Notification inbox tool
 
-Use `createNotificationInboxTool()` to give agents one tool for inbox actions instead of many CRUD tools. Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The notification contents are delivered as signals, not as normal tool output.
-
-:::note
-Visit [`createNotificationInboxTool()` reference](/reference/signals/create-notification-inbox-tool) for the setup example, input schema, and action behavior.
-:::
+Use `createNotificationInboxTool()` to give agents one tool for inbox actions instead of many CRUD tools. Use `read` after a `<notification-summary>` signal when the agent needs the full records behind the summary. The notification contents are delivered as signals, not as normal tool output. Visit [`createNotificationInboxTool()` reference](/reference/signals/create-notification-inbox-tool) for the setup example, input schema, and action behavior.
 
 `sendNotificationSignal()` requires a storage domain with `notifications` support. Use `sendSignal({ type: 'notification' })` only for lower-level notification-shaped context that should bypass inbox storage.
 
@@ -382,19 +362,11 @@ Mastra still accepts legacy signal payloads such as `type: 'user-message'` and `
 - `type: 'user-message'`: Normalizes to `type: 'user'` and `tagName: 'user'`
 - `type: 'system-reminder'`: Normalizes to `type: 'reactive'` and `tagName: 'system-reminder'`
 
-Existing stored signal rows and older clients continue to load through the compatibility layer. New clients call the message routes when the server supports them; React's thread signal path falls back to the legacy `/signals` route when it detects an older server.
-
-:::note
-Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the full message, signal, and subscription types.
-:::
+Existing stored signal rows and older clients continue to load through the compatibility layer. New clients call the message routes when the server supports them; React's thread signal path falls back to the legacy `/signals` route when it detects an older server. Visit [Agent signals reference](/reference/agents/agent#thread-signals) for the full message, signal, and subscription types.
 
 ### Approve tool calls
 
-When a subscribed run pauses for tool approval, approve or decline the tool call with the subscription-native methods. The resumed chunks arrive through the existing thread subscription.
-
-:::note
-Visit [`client.getAgent().sendToolApproval()` reference](/reference/client-js/agents#sendtoolapproval) and [server agent routes](/reference/server/routes#subscription-tool-approval-routes) for request and response shapes.
-:::
+When a subscribed run pauses for tool approval, approve or decline the tool call with the subscription-native methods. The resumed chunks arrive through the existing thread subscription. Visit [`client.getAgent().sendToolApproval()` reference](/reference/client-js/agents#sendtoolapproval) and [server agent routes](/reference/server/routes#subscription-tool-approval-routes) for request and response shapes.
 
 ### Use HTTP routes
 

--- a/docs/src/content/en/docs/mcp/mcp-apps.mdx
+++ b/docs/src/content/en/docs/mcp/mcp-apps.mdx
@@ -86,11 +86,7 @@ calculatorTool._meta = {
 }
 ```
 
-:::note
-
 Visit [MCPServer reference](/reference/tools/mcp-server#mcp-apps-appresources) for the full `appResources` configuration.
-
-:::
 
 ## Connecting MCP Apps to agents
 
@@ -262,11 +258,7 @@ Establishes the connection to the host. Call this after registering all event ha
 await app.connect()
 ```
 
-:::note
-
 See the [`App` class API reference](https://apps.extensions.modelcontextprotocol.io/api/classes/app.App.html) for the full list of methods, callbacks, and lifecycle hooks.
-
-:::
 
 ## Using external MCP servers with apps
 
@@ -301,11 +293,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::note
-
 Visit [MCPClient reference](/reference/tools/mcp-client#tomcpserverproxies) for more details on proxying external servers.
-
-:::
 
 ## Sandbox security
 

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -50,11 +50,7 @@ export const testMcpClient = new MCPClient({
 })
 ```
 
-:::info
-
 Visit [MCPClient](/reference/tools/mcp-client) for a full list of configuration options.
-
-:::
 
 :::tip Authentication
 
@@ -85,11 +81,7 @@ export const testAgent = new Agent({
 })
 ```
 
-:::info
-
 Visit [Agent Class](/reference/agents/agent) for a full list of configuration options.
-
-:::
 
 ## Tool approval
 
@@ -129,11 +121,7 @@ export const testMcpServer = new MCPServer({
 })
 ```
 
-:::info
-
 Visit [MCPServer](/reference/tools/mcp-server) for a full list of configuration options.
-
-:::
 
 :::tip Authentication
 
@@ -168,13 +156,7 @@ export const mastra = new Mastra({
 
 ### Static tools
 
-Use the `.listTools()` method to fetch tools from all configured MCP servers. This is suitable when configuration (such as API keys) is static and consistent across users or requests. Call it once and pass the result to the `tools` property when defining your agent.
-
-:::info
-
-Visit [listTools()](/reference/tools/mcp-client#listtools) for more information.
-
-:::
+Use the `.listTools()` method to fetch tools from all configured MCP servers. This is suitable when configuration (such as API keys) is static and consistent across users or requests. Call it once and pass the result to the `tools` property when defining your agent. Visit [listTools()](/reference/tools/mcp-client#listtools) for more information.
 
 ```typescript {6} title="src/mastra/agents/test-agent.ts"
 import { Agent } from '@mastra/core/agent'
@@ -223,11 +205,7 @@ async function handleRequest(userPrompt: string, userApiKey: string) {
 }
 ```
 
-:::info
-
 Visit [listToolsets()](/reference/tools/mcp-client#listtoolsets) for more information.
-
-:::
 
 ## Connecting to an MCP registry
 
@@ -430,13 +408,7 @@ MCP servers can be discovered through registries. Here's how to connect to some 
 
 ## MCP Apps
 
-MCP servers can serve interactive HTML UIs via the MCP Apps extension. Tools with associated `ui://` resources render sandboxed iframes in Studio — both on tool detail pages and inline in agent chat. The app iframe can call server tools and inject messages into the conversation.
-
-:::note
-
-Visit [MCP Apps](/docs/mcp/mcp-apps) for setup instructions and the app bridge API.
-
-:::
+MCP servers can serve interactive HTML UIs via the MCP Apps extension. Tools with associated `ui://` resources render sandboxed iframes in Studio — both on tool detail pages and inline in agent chat. The app iframe can call server tools and inject messages into the conversation. Visit [MCP Apps](/docs/mcp/mcp-apps) for setup instructions and the app bridge API.
 
 ## Related
 

--- a/docs/src/content/en/docs/memory/overview.mdx
+++ b/docs/src/content/en/docs/memory/overview.mdx
@@ -55,11 +55,7 @@ Use memory when your agent needs to maintain multi-turn conversations that refer
     npm install @mastra/libsql@latest
     ```
 
-    :::note
-
     For more details on available providers and how storage works in Mastra, visit the [storage](/docs/storage/overview) documentation.
-
-    :::
   </StepItem>
 
   <StepItem>
@@ -96,11 +92,7 @@ Use memory when your agent needs to maintain multi-turn conversations that refer
     })
     ```
 
-    :::note
-
     Visit [Memory Class](/reference/memory/memory-class) for a full list of configuration options.
-
-    :::
   </StepItem>
 
   <StepItem>
@@ -165,11 +157,7 @@ export const memoryAgent = new Agent({
 })
 ```
 
-:::note
-
 See [Observational Memory](../memory/observational-memory) for details on how observations and reflections work, and [the reference](/reference/memory/observational-memory) for all configuration options.
-
-:::
 
 ## Memory in multi-agent systems
 
@@ -249,11 +237,7 @@ export const memoryAgent = new Agent({
 })
 ```
 
-:::note
-
 Visit [Request Context](/docs/server/request-context) for more information.
-
-:::
 
 ## Related
 

--- a/docs/src/content/en/docs/observability/integrations/exporters/mastra-platform.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/mastra-platform.mdx
@@ -139,13 +139,7 @@ If you prefer, rely entirely on environment variables:
 new MastraPlatformExporter()
 ```
 
-With `MASTRA_PLATFORM_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` set, `MastraPlatformExporter` sends data to the Mastra platform project you configured. If you also set `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT`, it sends data to that collector instead.
-
-:::note
-
-Visit [MastraPlatformExporter reference](/reference/observability/tracing/exporters/mastra-platform-exporter) for the full list of configuration options.
-
-:::
+With `MASTRA_PLATFORM_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` set, `MastraPlatformExporter` sends data to the Mastra platform project you configured. If you also set `MASTRA_PLATFORM_OBSERVABILITY_ENDPOINT`, it sends data to that collector instead. Visit [MastraPlatformExporter reference](/reference/observability/tracing/exporters/mastra-platform-exporter) for the full list of configuration options.
 
 ## Recommended configuration
 

--- a/docs/src/content/en/docs/observability/logging.mdx
+++ b/docs/src/content/en/docs/observability/logging.mdx
@@ -28,11 +28,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::info
-
 Visit [PinoLogger](/reference/logging/pino-logger) for all available configuration options.
-
-:::
 
 ## Logging to observability storage
 

--- a/docs/src/content/en/docs/observability/tracing/overview.mdx
+++ b/docs/src/content/en/docs/observability/tracing/overview.mdx
@@ -327,11 +327,7 @@ const result = await agent.generate([{ role: 'user', content: 'Sensitive operati
 })
 ```
 
-:::tip
-
 For more granular control over sensitive data, consider using the [Sensitive Data Filter](/docs/observability/integrations/processors/sensitive-data-filter) processor, which can redact specific fields (like passwords, tokens, and keys) while preserving the rest of the input/output.
-
-:::
 
 #### Child spans and metadata extraction
 

--- a/docs/src/content/en/docs/server/auth/auth0.mdx
+++ b/docs/src/content/en/docs/server/auth/auth0.mdx
@@ -99,11 +99,7 @@ const auth0Provider = new MastraAuthAuth0({
 })
 ```
 
-:::info
-
 Visit [MastraAuthAuth0](/reference/auth/auth0) for all available configuration options.
-
-:::
 
 ## Client-side setup
 

--- a/docs/src/content/en/docs/server/auth/better-auth.mdx
+++ b/docs/src/content/en/docs/server/auth/better-auth.mdx
@@ -79,11 +79,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::info
-
 Visit [MastraAuthBetterAuth](/reference/auth/better-auth) for all available configuration options.
-
-:::
 
 ## Custom authorization
 
@@ -176,11 +172,7 @@ export const mastraClient = new MastraClient({
 })
 ```
 
-:::info
-
 Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration options.
-
-:::
 
 ### Making authenticated requests
 

--- a/docs/src/content/en/docs/server/auth/clerk.mdx
+++ b/docs/src/content/en/docs/server/auth/clerk.mdx
@@ -86,11 +86,7 @@ export const useClerkAuth = () => {
 }
 ```
 
-:::info
-
 Refer to the [Clerk documentation](https://clerk.com/docs) for more information.
-
-:::
 
 ## Configuring `MastraClient`
 

--- a/docs/src/content/en/docs/server/auth/firebase.mdx
+++ b/docs/src/content/en/docs/server/auth/firebase.mdx
@@ -116,11 +116,7 @@ const firebaseAuth = new MastraAuthFirebase({
 })
 ```
 
-:::info
-
 Visit [MastraAuthFirebase](/reference/auth/firebase) for all available configuration options.
-
-:::
 
 ## Client-side setup
 

--- a/docs/src/content/en/docs/server/auth/google.mdx
+++ b/docs/src/content/en/docs/server/auth/google.mdx
@@ -164,11 +164,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::info
-
 Visit [MastraAuthGoogle](/reference/auth/google) for all available configuration options.
-
-:::
 
 ## Role mapping
 
@@ -242,11 +238,7 @@ export const createMastraClient = (idToken: string) => {
 }
 ```
 
-:::info
-
 Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration options.
-
-:::
 
 ### Making authenticated requests
 

--- a/docs/src/content/en/docs/server/auth/jwt.mdx
+++ b/docs/src/content/en/docs/server/auth/jwt.mdx
@@ -51,11 +51,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::info
-
 Visit [MastraJwtAuth](/reference/auth/jwt) for all available configuration options.
-
-:::
 
 Inside [Studio](/docs/studio/overview), go to **Settings** and under **Headers** select the **"Add Header"** button. Enter `Authorization` as the header name and `Bearer <your-jwt>` as the value.
 
@@ -74,11 +70,7 @@ export const mastraClient = new MastraClient({
 })
 ```
 
-:::info
-
 Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration options.
-
-:::
 
 ### Making authenticated requests
 

--- a/docs/src/content/en/docs/server/auth/okta.mdx
+++ b/docs/src/content/en/docs/server/auth/okta.mdx
@@ -116,11 +116,7 @@ To link users between providers, store the Okta user ID in the other provider's 
 
 :::
 
-:::info
-
 Visit [MastraAuthOkta](/reference/auth/okta) for all available configuration options.
-
-:::
 
 ## Role mapping
 
@@ -194,11 +190,7 @@ export const createMastraClient = (accessToken: string) => {
 }
 ```
 
-:::info
-
 Visit [Mastra Client SDK](/docs/server/mastra-client) for more configuration options.
-
-:::
 
 ### Making authenticated requests
 

--- a/docs/src/content/en/docs/server/auth/workos.mdx
+++ b/docs/src/content/en/docs/server/auth/workos.mdx
@@ -143,11 +143,7 @@ const workosAuth = new AdminOnlyWorkosAuth({
 })
 ```
 
-:::info
-
 Visit [MastraAuthWorkos](/reference/auth/workos) for all available configuration options.
-
-:::
 
 ## Client-side setup
 

--- a/docs/src/content/en/docs/server/mastra-client.mdx
+++ b/docs/src/content/en/docs/server/mastra-client.mdx
@@ -133,11 +133,7 @@ export const mastraClient = new MastraClient({
 })
 ```
 
-:::info
-
 Visit [MastraClient](/reference/client-js/mastra-client) for more configuration options.
-
-:::
 
 ## Credentials and session cookies
 

--- a/docs/src/content/en/docs/server/mastra-server.mdx
+++ b/docs/src/content/en/docs/server/mastra-server.mdx
@@ -41,11 +41,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::info
-
 Visit the [configuration reference](/reference/configuration#server-options) for a full list of available server options.
-
-:::
 
 ## Deploy your server
 

--- a/docs/src/content/en/docs/server/pubsub.mdx
+++ b/docs/src/content/en/docs/server/pubsub.mdx
@@ -123,11 +123,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::note
-
 Visit the [PubSub reference](/reference/pubsub/base) for the full delivery contract and the configuration options for each backend.
-
-:::
 
 ## Related
 

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -91,11 +91,7 @@ export const mastra = new Mastra({
 })
 ```
 
-:::info
-
 Visit [Middleware](/docs/server/middleware) for how to use server middleware.
-
-:::
 
 ## Studio
 
@@ -201,11 +197,7 @@ export const registryAgent = new Agent({
 })
 ```
 
-:::info
-
 Visit [Agent](/reference/agents/agent) for a full list of configuration options.
-
-:::
 
 ## Accessing values from workflow steps
 
@@ -227,11 +219,7 @@ const stepOne = createStep({
 })
 ```
 
-:::info
-
 Visit [createStep()](/reference/workflows/step) for a full list of configuration options.
-
-:::
 
 ## Accessing values with tools
 
@@ -253,11 +241,7 @@ export const weatherTool = createTool({
 })
 ```
 
-:::info
-
 Visit [createTool()](/reference/tools/create-tool) for a full list of configuration options.
-
-:::
 
 ## Reserved keys
 

--- a/docs/src/content/en/docs/server/server-adapters.mdx
+++ b/docs/src/content/en/docs/server/server-adapters.mdx
@@ -99,11 +99,7 @@ Initialize your app as usual, then create a `MastraServer` by passing in the `ap
     })
     ```
 
-    :::info
-
     See the [Express Adapter](/reference/server/express-adapter) documentation for full configuration options.
-
-    :::
   </TabItem>
 
   <TabItem value="hono" label="Hono">
@@ -124,11 +120,7 @@ Initialize your app as usual, then create a `MastraServer` by passing in the `ap
     })
     ```
 
-    :::info
-
     See the [Hono Adapter](/reference/server/hono-adapter) documentation for full configuration options.
-
-    :::
   </TabItem>
 
   <TabItem value="fastify" label="Fastify">
@@ -156,11 +148,7 @@ Initialize your app as usual, then create a `MastraServer` by passing in the `ap
     })
     ```
 
-    :::info
-
     See the [Fastify Adapter](/reference/server/fastify-adapter) documentation for full configuration options.
-
-    :::
   </TabItem>
 
   <TabItem value="koa" label="Koa">
@@ -195,11 +183,7 @@ Initialize your app as usual, then create a `MastraServer` by passing in the `ap
     })
     ```
 
-    :::info
-
     See the [Koa Adapter](/reference/server/koa-adapter) documentation for full configuration options.
-
-    :::
   </TabItem>
 
   <TabItem value="nestjs" label="NestJS">
@@ -230,11 +214,7 @@ Initialize your app as usual, then create a `MastraServer` by passing in the `ap
     bootstrap()
     ```
 
-    :::info
-
     See the [NestJS Adapter](/reference/server/nestjs-adapter) documentation for full configuration options.
-
-    :::
   </TabItem>
 </Tabs>
 
@@ -282,11 +262,7 @@ You can add your own routes to the app alongside Mastra's routes.
 - When you want Mastra-managed auth and route metadata such as `requiresAuth`, prefer `registerApiRoute()`.
 - When you mount routes directly on the framework app, use the adapter's exported `createAuthMiddleware()` helper if those routes need Mastra auth.
 
-:::info
-
 Visit "Adding custom routes" for [Express](/reference/server/express-adapter#adding-custom-routes) and [Hono](/reference/server/hono-adapter#adding-custom-routes) for more information.
-
-:::
 
 ## Route prefixes
 
@@ -339,11 +315,7 @@ const server = new MastraServer({
 })
 ```
 
-:::info
-
 See [MastraServer](/reference/server/mastra-server) for full configuration options.
-
-:::
 
 ## Per-route auth overrides
 
@@ -370,11 +342,7 @@ const server = new MastraServer({
 })
 ```
 
-:::info
-
 See [MastraServer](/reference/server/mastra-server) for full configuration options.
-
-:::
 
 ## Accessing the app
 

--- a/docs/src/content/en/docs/studio/auth.mdx
+++ b/docs/src/content/en/docs/studio/auth.mdx
@@ -40,13 +40,7 @@ export const mastra = new Mastra({
 })
 ```
 
-Once configured, Studio shows a login screen and requires authentication for all API requests.
-
-:::note
-
-Visit the [Auth docs](/docs/server/auth) for a full list of supported providers.
-
-:::
+Once configured, Studio shows a login screen and requires authentication for all API requests. Visit the [Auth docs](/docs/server/auth) for a full list of supported providers.
 
 ## How it works
 

--- a/docs/src/content/en/docs/workflows/agents-and-tools.mdx
+++ b/docs/src/content/en/docs/workflows/agents-and-tools.mdx
@@ -62,11 +62,7 @@ export const testWorkflow = createWorkflow({})
   .commit()
 ```
 
-:::info
-
 Visit [Input Data Mapping](/docs/workflows/control-flow#input-data-mapping) for more information.
-
-:::
 
 When no `structuredOutput` option is provided, Mastra agents use a default schema that expects a `prompt` string as input and returns a `text` string as output:
 
@@ -115,13 +111,7 @@ export const testWorkflow = createWorkflow({})
   .commit()
 ```
 
-The `structuredOutput.schema` option accepts any Standard JSON Schema. The agent will generate output conforming to this schema, and the step's `outputSchema` will be automatically set to match.
-
-:::info
-
-Visit [Structured Output](/docs/agents/structured-output) for more options like error handling strategies and streaming with structured output.
-
-:::
+The `structuredOutput.schema` option accepts any Standard JSON Schema. The agent will generate output conforming to this schema, and the step's `outputSchema` will be automatically set to match. Visit [Structured Output](/docs/agents/structured-output) for more options like error handling strategies and streaming with structured output.
 
 ## Using tools in workflows
 
@@ -170,11 +160,7 @@ export const testWorkflow = createWorkflow({})
   .commit()
 ```
 
-:::info
-
 Visit [Input Data Mapping](/docs/workflows/control-flow#input-data-mapping) for more information.
-
-:::
 
 ## Related
 

--- a/docs/src/content/en/docs/workflows/control-flow.mdx
+++ b/docs/src/content/en/docs/workflows/control-flow.mdx
@@ -213,11 +213,7 @@ const writerStep = createStep({
 })
 ```
 
-:::info
-
 Visit [Choosing the right pattern](#choosing-the-right-pattern) to understand when to use `.parallel()` vs `.foreach()`.
-
-:::
 
 ## Conditional logic with `.branch()`
 

--- a/docs/src/content/en/docs/workflows/overview.mdx
+++ b/docs/src/content/en/docs/workflows/overview.mdx
@@ -111,11 +111,7 @@ The `execute` function defines what the step does. Use it to call functions in y
   </TabItem>
 </Tabs>
 
-:::info
-
 Visit [`Step`](/reference/workflows/step) for a full list of configuration options.
-
-:::
 
 ### Using agents and tools
 
@@ -191,11 +187,7 @@ Create a workflow using `createWorkflow()` with `inputSchema` and `outputSchema`
   </TabItem>
 </Tabs>
 
-:::info
-
 Visit [Workflow Class](/reference/workflows/workflow) for a full list of configuration options.
-
-:::
 
 ### Understanding control flow
 
@@ -232,11 +224,7 @@ const step1 = createStep({
 })
 ```
 
-:::info
-
 Visit [Workflow State](/docs/workflows/workflow-state) for complete documentation on state schemas, initial state, persistence across suspend/resume, and nested workflows.
-
-:::
 
 ## Workflows as steps
 
@@ -565,11 +553,7 @@ const step1 = createStep({
 })
 ```
 
-:::info
-
 Visit [Request Context](/docs/server/request-context) for more information.
-
-:::
 
 :::tip
 

--- a/docs/src/content/en/guides/build-your-ui/assistant-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/assistant-ui.mdx
@@ -16,11 +16,7 @@ For a full-stack integration approach where Mastra runs directly in your Next.js
 
 :::
 
-:::tip
-
 Visit Mastra's [**"UI Dojo"**](https://ui-dojo.mastra.ai/) to see real-world examples of Assistant UI integrated with Mastra.
-
-:::
 
 ## Integration guide
 

--- a/docs/src/content/en/guides/build-your-ui/copilotkit/overview.mdx
+++ b/docs/src/content/en/guides/build-your-ui/copilotkit/overview.mdx
@@ -20,11 +20,7 @@ For a full-stack integration approach where Mastra runs directly in your Next.js
 
 :::
 
-:::tip
-
 Visit Mastra's ["UI Dojo"](https://ui-dojo.mastra.ai/) to see real-world examples of CopilotKit integrated with Mastra.
-
-:::
 
 ## Integration guide
 

--- a/docs/src/content/en/guides/concepts/streaming.mdx
+++ b/docs/src/content/en/guides/concepts/streaming.mdx
@@ -35,11 +35,7 @@ for await (const chunk of stream.textStream) {
 }
 ```
 
-:::info
-
 Visit [Agent.stream()](/reference/streaming/agents/stream) for more information.
-
-:::
 
 :::tip
 
@@ -115,11 +111,7 @@ for await (const chunk of stream) {
 }
 ```
 
-:::info
-
 Visit [Run.stream()](/reference/streaming/workflows/stream) for more information.
-
-:::
 
 ### Output from `Run.stream()`
 
@@ -179,11 +171,7 @@ for await (const chunk of stream) {
 }
 ```
 
-:::info
-
 Visit [Agent.stream()](/reference/streaming/agents/stream) for more information.
-
-:::
 
 ### Example agent output
 

--- a/docs/src/content/en/reference/server/express-adapter.mdx
+++ b/docs/src/content/en/reference/server/express-adapter.mdx
@@ -11,13 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # Express adapter
 
-The `@mastra/express` package provides a server adapter for running Mastra with [Express](https://expressjs.com).
-
-:::info
-
-For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
-
-:::
+The `@mastra/express` package provides a server adapter for running Mastra with [Express](https://expressjs.com). For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
 
 ## Installation
 

--- a/docs/src/content/en/reference/server/fastify-adapter.mdx
+++ b/docs/src/content/en/reference/server/fastify-adapter.mdx
@@ -11,13 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # Fastify adapter
 
-The `@mastra/fastify` package provides a server adapter for running Mastra with [Fastify](https://fastify.dev).
-
-:::info
-
-For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
-
-:::
+The `@mastra/fastify` package provides a server adapter for running Mastra with [Fastify](https://fastify.dev). For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
 
 ## Installation
 

--- a/docs/src/content/en/reference/server/hono-adapter.mdx
+++ b/docs/src/content/en/reference/server/hono-adapter.mdx
@@ -11,13 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # Hono adapter
 
-The `@mastra/hono` package provides a server adapter for running Mastra with [Hono](https://hono.dev).
-
-:::info
-
-For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
-
-:::
+The `@mastra/hono` package provides a server adapter for running Mastra with [Hono](https://hono.dev). For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
 
 ## Installation
 

--- a/docs/src/content/en/reference/server/koa-adapter.mdx
+++ b/docs/src/content/en/reference/server/koa-adapter.mdx
@@ -11,13 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 # Koa adapter
 
-The `@mastra/koa` package provides a server adapter for running Mastra with [Koa](https://koajs.com).
-
-:::info
-
-For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
-
-:::
+The `@mastra/koa` package provides a server adapter for running Mastra with [Koa](https://koajs.com). For general adapter concepts (constructor options, initialization flow, etc.), see [Server Adapters](/docs/server/server-adapters).
 
 ## Installation
 

--- a/docs/src/content/en/reference/server/nestjs-adapter.mdx
+++ b/docs/src/content/en/reference/server/nestjs-adapter.mdx
@@ -11,13 +11,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 The `@mastra/nestjs` package provides a NestJS module for running Mastra with the Express-based NestJS platform.
 
-It's intentionally Express-only for v1. If Nest is bootstrapped with a different HTTP adapter, `MastraModule` throws during startup instead of attempting a partial integration.
-
-:::info
-
-For general adapter concepts, see [Server Adapters](/docs/server/server-adapters).
-
-:::
+It's intentionally Express-only for v1. If Nest is bootstrapped with a different HTTP adapter, `MastraModule` throws during startup instead of attempting a partial integration. For general adapter concepts, see [Server Adapters](/docs/server/server-adapters).
 
 ## Installation
 

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1835,13 +1835,7 @@ const server = new MCPServer({
 })
 ```
 
-Link a tool to its app resource by setting `_meta.ui.resourceUri` on the tool to the matching `ui://` URI. The server auto-normalizes this metadata when registering tools.
-
-:::note
-
-Visit [MCP Apps](/docs/mcp/mcp-apps) for the full app bridge API and usage patterns.
-
-:::
+Link a tool to its app resource by setting `_meta.ui.resourceUri` on the tool to the matching `ui://` URI. The server auto-normalizes this metadata when registering tools. Visit [MCP Apps](/docs/mcp/mcp-apps) for the full app bridge API and usage patterns.
 
 ## Related information
 

--- a/docs/src/content/en/reference/workspace/agentcore-runtime-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/agentcore-runtime-sandbox.mdx
@@ -9,13 +9,7 @@ packages:
 
 Executes shell commands in an [AWS Bedrock AgentCore Runtime](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/runtime-execute-command.html) session by using `InvokeAgentRuntimeCommand`.
 
-Use `AgentCoreRuntimeSandbox` when your agent already runs in AgentCore Runtime and you want Mastra workspace command execution to use the same runtime session.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Use `AgentCoreRuntimeSandbox` when your agent already runs in AgentCore Runtime and you want Mastra workspace command execution to use the same runtime session. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 :::warning
 

--- a/docs/src/content/en/reference/workspace/agentfs-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/agentfs-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # AgentFSFilesystem
 
-Stores files in a Turso/SQLite database via the [AgentFS](https://github.com/nichochar/agentfs) SDK. Files are persisted across sessions in a local SQLite database, giving agents durable storage without external cloud services.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in a Turso/SQLite database via the [AgentFS](https://github.com/nichochar/agentfs) SDK. Files are persisted across sessions in a local SQLite database, giving agents durable storage without external cloud services. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/apple-container-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/apple-container-sandbox.mdx
@@ -7,13 +7,7 @@ packages:
 
 # AppleContainerSandbox
 
-Executes commands inside local OCI Linux containers through Apple's [`container`](https://github.com/apple/container) CLI. The provider starts a long-lived container and uses `container exec` for workspace commands.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands inside local OCI Linux containers through Apple's [`container`](https://github.com/apple/container) CLI. The provider starts a long-lived container and uses `container exec` for workspace commands. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/archil-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/archil-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # ArchilFilesystem
 
-Stores files on [Archil](https://docs.archil.com) elastic, serverless disks. Combines an S3-compatible object API for fast reads/writes with `exec()` for POSIX shell operations and `grep()` for parallel server-side search.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files on [Archil](https://docs.archil.com) elastic, serverless disks. Combines an S3-compatible object API for fast reads/writes with `exec()` for POSIX shell operations and `grep()` for parallel server-side search. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/azure-blob-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/azure-blob-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # AzureBlobFilesystem
 
-Stores files in Azure Blob Storage containers.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in Azure Blob Storage containers. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/blaxel-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/blaxel-sandbox.mdx
@@ -10,13 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # BlaxelSandbox
 
-Executes commands in isolated [Blaxel](https://blaxel.ai/) cloud sandboxes. Provides secure, isolated code execution environments with support for mounting cloud storage (S3, GCS) via FUSE.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands in isolated [Blaxel](https://blaxel.ai/) cloud sandboxes. Provides secure, isolated code execution environments with support for mounting cloud storage (S3, GCS) via FUSE. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/daytona-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/daytona-sandbox.mdx
@@ -10,13 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # DaytonaSandbox
 
-Executes commands in isolated [Daytona](https://www.daytona.io) cloud sandboxes. Supports multiple runtimes, resource configuration, volumes, snapshots, streaming output, sandbox reconnection, filesystem mounting (S3, GCS), and network isolation.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands in isolated [Daytona](https://www.daytona.io) cloud sandboxes. Supports multiple runtimes, resource configuration, volumes, snapshots, streaming output, sandbox reconnection, filesystem mounting (S3, GCS), and network isolation. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/docker-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/docker-sandbox.mdx
@@ -7,13 +7,7 @@ packages:
 
 # DockerSandbox
 
-Executes commands inside Docker containers on the local machine. Uses long-lived containers with `docker exec` for command execution. Targets local development, CI/CD, air-gapped deployments, and cost-sensitive scenarios where cloud sandboxes are unnecessary.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands inside Docker containers on the local machine. Uses long-lived containers with `docker exec` for command execution. Targets local development, CI/CD, air-gapped deployments, and cost-sensitive scenarios where cloud sandboxes are unnecessary. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/e2b-sandbox.mdx
@@ -7,13 +7,7 @@ packages:
 
 # E2BSandbox
 
-Executes commands in isolated [E2B](https://e2b.dev) cloud sandboxes. Provides secure, ephemeral environments with support for mounting cloud storage.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands in isolated [E2B](https://e2b.dev) cloud sandboxes. Provides secure, ephemeral environments with support for mounting cloud storage. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/files-sdk-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # FilesSDKFilesystem
 
-Stores files in any storage backend supported by [FilesSDK](https://files-sdk.dev) — a unified abstraction over S3, Cloudflare R2, Google Cloud Storage, Azure Blob, Vercel Blob, MinIO, the local filesystem, and more.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in any storage backend supported by [FilesSDK](https://files-sdk.dev) — a unified abstraction over S3, Cloudflare R2, Google Cloud Storage, Azure Blob, Vercel Blob, MinIO, the local filesystem, and more. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 Use `FilesSDKFilesystem` when you want a single adapter that can target multiple storage backends with the same code. Swap the underlying driver without changing the workspace setup. If you only target one backend and want first-class options for that backend, prefer the dedicated provider (for example [`S3Filesystem`](/reference/workspace/s3-filesystem) or [`GCSFilesystem`](/reference/workspace/gcs-filesystem)).
 

--- a/docs/src/content/en/reference/workspace/gcs-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/gcs-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # GCSFilesystem
 
-Stores files in Google Cloud Storage.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in Google Cloud Storage. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/google-drive-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/google-drive-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # GoogleDriveFilesystem
 
-Stores files in a single Google Drive folder. Each directory maps to a Drive folder under the configured root, and paths use POSIX semantics (for example `/notes/todo.txt`).
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in a single Google Drive folder. Each directory maps to a Drive folder under the configured root, and paths use POSIX semantics (for example `/notes/todo.txt`). For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/local-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/local-filesystem.mdx
@@ -9,13 +9,7 @@ packages:
 
 **Added in:** `@mastra/core@1.1.0`
 
-Stores files in a directory on the local filesystem.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in a directory on the local filesystem. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Usage
 

--- a/docs/src/content/en/reference/workspace/local-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/local-sandbox.mdx
@@ -9,13 +9,7 @@ packages:
 
 **Added in:** `@mastra/core@1.1.0`
 
-Executes commands on the local system.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands on the local system. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Usage
 

--- a/docs/src/content/en/reference/workspace/modal-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/modal-sandbox.mdx
@@ -7,13 +7,7 @@ packages:
 
 # ModalSandbox
 
-Executes commands in isolated [Modal](https://modal.com) cloud sandboxes. Provides secure, ephemeral environments backed by Modal's infrastructure.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands in isolated [Modal](https://modal.com) cloud sandboxes. Provides secure, ephemeral environments backed by Modal's infrastructure. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/railway-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/railway-sandbox.mdx
@@ -10,13 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # RailwaySandbox
 
-Executes commands in ephemeral, isolated [Railway](https://docs.railway.com/sandboxes) sandboxes. Each sandbox is an isolated Debian Linux VM provisioned on demand through the Railway TypeScript SDK. Supports command execution with streaming output, command timeouts, configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base images via the Railway template builder, forking a running sandbox, and reattaching to an existing sandbox by ID.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands in ephemeral, isolated [Railway](https://docs.railway.com/sandboxes) sandboxes. Each sandbox is an isolated Debian Linux VM provisioned on demand through the Railway TypeScript SDK. Supports command execution with streaming output, command timeouts, configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base images via the Railway template builder, forking a running sandbox, and reattaching to an existing sandbox by ID. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/s3-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/s3-filesystem.mdx
@@ -7,13 +7,7 @@ packages:
 
 # S3Filesystem
 
-Stores files in Amazon S3 or S3-compatible storage services like Cloudflare R2, MinIO, DigitalOcean Spaces, and Tigris.
-
-:::info
-
-For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
-
-:::
+Stores files in Amazon S3 or S3-compatible storage services like Cloudflare R2, MinIO, DigitalOcean Spaces, and Tigris. For interface details, see [WorkspaceFilesystem Interface](/reference/workspace/filesystem).
 
 ## Installation
 

--- a/docs/src/content/en/reference/workspace/vercel-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/vercel-sandbox.mdx
@@ -10,13 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # VercelSandbox
 
-Executes commands inside [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) which is an ephemeral [Firecracker](https://firecracker-microvm.github.io/) MicroVM running Amazon Linux 2023. Provides a persistent in-session filesystem, `sudo` access, exposed ports, and background processes.
-
-:::info
-
-For interface details, see the [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands inside [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) which is an ephemeral [Firecracker](https://firecracker-microvm.github.io/) MicroVM running Amazon Linux 2023. Provides a persistent in-session filesystem, `sudo` access, exposed ports, and background processes. For interface details, see the [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 :::note
 

--- a/docs/src/content/en/reference/workspace/vercel-serverless.mdx
+++ b/docs/src/content/en/reference/workspace/vercel-serverless.mdx
@@ -7,13 +7,7 @@ packages:
 
 # VercelServerlessSandbox
 
-Executes commands as [Vercel](https://vercel.com) serverless functions. Provides globally distributed, zero-infrastructure execution with automatic scaling.
-
-:::info
-
-For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
-
-:::
+Executes commands as [Vercel](https://vercel.com) serverless functions. Provides globally distributed, zero-infrastructure execution with automatic scaling. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 :::warning
 


### PR DESCRIPTION
## Description

Remove admonitions that can just be a normal paragraph. Makes the docs easier to read and less cluttered.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR removes extra boxed notes from the documentation and turns them into regular paragraphs. The information and links stay the same, making the pages cleaner and easier to read.

## Summary

- Replaced unnecessary `:::note`, `:::info`, and `:::tip` admonitions with normal text across documentation pages.
- Preserved and clarified reference links, configuration guidance, and inline explanations.
- Updated documentation across agents, browsers, evaluations, servers, workflows, authentication, workspaces, and other areas.
- Documentation-only change; no public APIs or code behavior were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->