### PR TITLE
fix(rag): handle Cohere scorer env key and zero scores

### DIFF
--- a/.changeset/strict-pots-sit.md
+++ b/.changeset/strict-pots-sit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed Cohere relevance scoring to use COHERE_API_KEY by default and accept zero relevance scores.

--- a/packages/rag/src/rerank/relevance/cohere/index.test.ts
+++ b/packages/rag/src/rerank/relevance/cohere/index.test.ts
@@ -11,6 +11,7 @@ describe('CohereRelevanceScorer', () => {
   let scorer: RelevanceScoreProvider;
   let lastRequest: { body: any; headers: any; url: string } | null = null;
   let originalFetch: typeof fetch;
+  let originalCohereApiKey: string | undefined;
 
   const invalidResponseCases = [
     {
@@ -25,6 +26,8 @@ describe('CohereRelevanceScorer', () => {
 
   beforeEach(() => {
     lastRequest = null;
+    originalCohereApiKey = process.env.COHERE_API_KEY;
+    delete process.env.COHERE_API_KEY;
     scorer = new CohereRelevanceScorer(TEST_MODEL, TEST_API_KEY);
 
     originalFetch = global.fetch;
@@ -47,6 +50,11 @@ describe('CohereRelevanceScorer', () => {
     vi.restoreAllMocks();
     if (originalFetch) {
       global.fetch = originalFetch;
+    }
+    if (originalCohereApiKey === undefined) {
+      delete process.env.COHERE_API_KEY;
+    } else {
+      process.env.COHERE_API_KEY = originalCohereApiKey;
     }
   });
 
@@ -76,6 +84,39 @@ describe('CohereRelevanceScorer', () => {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${TEST_API_KEY}`,
     });
+  });
+
+  it('should use COHERE_API_KEY when no API key is passed to the constructor', async () => {
+    process.env.COHERE_API_KEY = 'env-api-key';
+    const scorer = new CohereRelevanceScorer(TEST_MODEL);
+
+    await scorer.getRelevanceScore(TEST_QUERY, TEST_TEXT);
+
+    expect(lastRequest?.headers).toMatchObject({
+      Authorization: 'Bearer env-api-key',
+    });
+  });
+
+  it('should prefer the constructor API key over COHERE_API_KEY', async () => {
+    process.env.COHERE_API_KEY = 'env-api-key';
+    const scorer = new CohereRelevanceScorer(TEST_MODEL, TEST_API_KEY);
+
+    await scorer.getRelevanceScore(TEST_QUERY, TEST_TEXT);
+
+    expect(lastRequest?.headers).toMatchObject({
+      Authorization: `Bearer ${TEST_API_KEY}`,
+    });
+  });
+
+  it('should throw before calling Cohere when no API key is available', async () => {
+    const mockFetch = vi.fn();
+    vi.stubGlobal('fetch', mockFetch);
+    const scorer = new CohereRelevanceScorer(TEST_MODEL);
+
+    await expect(scorer.getRelevanceScore(TEST_QUERY, TEST_TEXT)).rejects.toThrow(
+      'Cohere API key is required. Pass an apiKey or set COHERE_API_KEY.',
+    );
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('should return the relevance score from a successful API response', async () => {
@@ -114,6 +155,26 @@ describe('CohereRelevanceScorer', () => {
         top_n: 1,
       }),
     });
+  });
+
+  it('should return zero when Cohere returns a zero relevance score', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        results: [
+          {
+            relevance_score: 0,
+          },
+        ],
+      }),
+      text: vi.fn().mockResolvedValue(''),
+    };
+
+    const mockFetch = vi.fn().mockResolvedValue(mockResponse);
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(scorer.getRelevanceScore(TEST_QUERY, TEST_TEXT)).resolves.toBe(0);
   });
 
   it('should throw an error when the API returns a non-ok response', async () => {

--- a/packages/rag/src/rerank/relevance/cohere/index.ts
+++ b/packages/rag/src/rerank/relevance/cohere/index.ts
@@ -21,11 +21,15 @@ export class CohereRelevanceScorer implements RelevanceScoreProvider {
   private model: string;
   private apiKey?: string;
   constructor(model: string, apiKey?: string) {
-    this.apiKey = apiKey;
+    this.apiKey = apiKey ?? process.env.COHERE_API_KEY;
     this.model = model;
   }
 
   async getRelevanceScore(query: string, text: string): Promise<number> {
+    if (!this.apiKey) {
+      throw new Error('Cohere API key is required. Pass an apiKey or set COHERE_API_KEY.');
+    }
+
     const response = await fetch(`https://api.cohere.com/v2/rerank`, {
       method: 'POST',
       headers: {
@@ -47,7 +51,7 @@ export class CohereRelevanceScorer implements RelevanceScoreProvider {
     const data = (await response.json()) as CohereRerankingResponse;
     const relevanceScore = data.results[0]?.relevance_score;
 
-    if (!relevanceScore) {
+    if (typeof relevanceScore !== 'number' || !Number.isFinite(relevanceScore)) {
       throw new Error('No relevance score found on Cohere response');
     }
 


### PR DESCRIPTION
Fixes #19237

  Summary

  This PR fixes two edge cases in CohereRelevanceScorer:

  - new CohereRelevanceScorer('rerank-v3.5') now uses COHERE_API_KEY when an API key is not passed directly.
  - Valid Cohere responses with relevance_score: 0 are now returned as 0 instead of throwing No relevance score found on Cohere response.

  Changes

  - Default the Cohere API key to process.env.COHERE_API_KEY.
  - Throw a clear error before making a network request when no Cohere API key is available.
  - Replace truthy score validation with finite-number validation.
  - Add regression tests for:
      - COHERE_API_KEY fallback
      - constructor API key precedence
      - missing API key no-fetch behavior
      - zero relevance scores

  Validation

  pnpm --filter ./packages/rag test src/rerank/relevance/cohere/index.test.ts
  pnpm test:rag
  pnpm build:rag
  pnpm --filter ./packages/rag lint
  pnpm prettier --check packages/rag/src/rerank/relevance/cohere/index.ts packages/rag/src/rerank/relevance/cohere/index.test.ts