### PR TITLE
fix(core): preserve empty output processor results

### DIFF
--- a/.changeset/fancy-eels-occur.md
+++ b/.changeset/fancy-eels-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed final agent results leaking original text after an output processor clears it.

--- a/packages/core/src/agent/agent-processor.test.ts
+++ b/packages/core/src/agent/agent-processor.test.ts
@@ -24,6 +24,43 @@ const createMessage = (text: string, role: 'user' | 'assistant' = 'user'): Mastr
   createdAt: new Date(),
 });
 
+const createTextClearingProcessor = (): Processor => ({
+  id: 'text-clearing-processor',
+  name: 'Text Clearing Processor',
+  async processOutputResult({ messages }) {
+    return messages.map(message => ({
+      ...message,
+      content: {
+        ...message.content,
+        parts: message.content.parts.map(part => (part.type === 'text' ? { ...part, text: '' } : part)),
+      },
+    }));
+  },
+});
+
+const createSensitiveResponseModel = () =>
+  new MockLanguageModelV2({
+    doGenerate: async () => ({
+      content: [{ type: 'text', text: 'sensitive response' }],
+      finishReason: 'stop',
+      usage: { inputTokens: 2, outputTokens: 2, totalTokens: 4 },
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'sensitive response' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 2, outputTokens: 2, totalTokens: 4 } },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+  });
+
 describe('Input and Output Processors', () => {
   let mockModel: MockLanguageModelV2;
 
@@ -663,6 +700,22 @@ describe('Input and Output Processors', () => {
       expect((result.response.messages[0].content[0] as any).text).toBe('HELLO WORLD');
     });
 
+    it('should return empty final text when an output processor clears generated text', async () => {
+      const agent = new Agent({
+        id: 'empty-result-text-processor-test-agent',
+        name: 'Empty Result Text Processor Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: createSensitiveResponseModel(),
+        outputProcessors: [createTextClearingProcessor()],
+      });
+
+      const result = await agent.generate('Test');
+
+      expect(result.text).toBe('');
+      expect(result.steps.at(-1)?.text).toBe('');
+      expect((result.response.messages[0].content[0] as any).text).toBe('');
+    });
+
     it('should process messages through multiple output processors in sequence', async () => {
       let finalProcessedText = '';
 
@@ -866,6 +919,24 @@ describe('Input and Output Processors', () => {
   });
 
   describe('Output Processors with stream', () => {
+    it('should return empty final text when an output processor clears streamed text', async () => {
+      const agent = new Agent({
+        id: 'empty-stream-text-processor-test-agent',
+        name: 'Empty Stream Text Processor Test Agent',
+        instructions: 'You are a helpful assistant.',
+        model: createSensitiveResponseModel(),
+        outputProcessors: [createTextClearingProcessor()],
+      });
+
+      const stream = await agent.stream('Test');
+      const result = await stream.getFullOutput();
+
+      expect(await stream.text).toBe('');
+      expect(result.text).toBe('');
+      expect(result.steps.at(-1)?.text).toBe('');
+      expect((result.response.messages[0].content[0] as any).text).toBe('');
+    });
+
     it('should process text chunks through output processors in real-time', async () => {
       class TestOutputProcessor implements Processor {
         readonly id = 'test-output-processor';

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -180,6 +180,50 @@ describe('MastraModelOutput', () => {
       expect(customIndex).toBeLessThan(finishIndex);
     });
 
+    it('should keep step text when the response was already empty before output processing', async () => {
+      const processor: Processor = {
+        id: 'no-op-processor',
+        name: 'No-op Processor',
+        processOutputResult: async ({ messages }) => messages,
+      };
+      const runId = 'test-run';
+      const messageList = new MessageList({ threadId: 'test-thread' });
+
+      messageList.add(
+        {
+          id: 'msg-1',
+          role: 'assistant',
+          content: { format: 2 as const, parts: [{ type: 'text' as const, text: '' }] },
+          createdAt: new Date(),
+        },
+        'response',
+      );
+
+      const stream = createChunkStream([
+        {
+          type: 'text-delta',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: 'retry response' },
+        } as ChunkType,
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList,
+        messageId: 'msg-1',
+        options: { runId, outputProcessors: [processor] },
+      });
+
+      const result = await output.getFullOutput();
+
+      expect(await output.text).toBe('retry response');
+      expect(result.text).toBe('retry response');
+      expect(result.steps.at(-1)?.text).toBe('retry response');
+    });
+
     it('should include traceId and spanId in the final stream result when tracing context exists', async () => {
       const runId = 'test-run';
       const messageList = new MessageList({ threadId: 'test-thread' });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -900,6 +900,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   // Capture original text before processing for comparison
                   const lastStep = self.#bufferedSteps[self.#bufferedSteps.length - 1];
                   const originalText = lastStep?.text || '';
+                  const responseMessagesBeforeProcessing = self.messageList.get.response.aiV4.core();
+                  const lastResponseMessageBeforeProcessing =
+                    responseMessagesBeforeProcessing[responseMessagesBeforeProcessing.length - 1];
+                  const responseTextBeforeProcessing = lastResponseMessageBeforeProcessing
+                    ? coreContentToString(lastResponseMessageBeforeProcessing.content)
+                    : undefined;
 
                   // Create a writer from the controller so processOutputResult can emit custom chunks.
                   // Must use both #emitChunk (for fullStream/EventEmitter consumers) and
@@ -930,17 +936,26 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   // Get text from the latest response message (the last assistant message)
                   const responseMessages = self.messageList.get.response.aiV4.core();
                   const lastResponseMessage = responseMessages[responseMessages.length - 1];
-                  const outputText = lastResponseMessage ? coreContentToString(lastResponseMessage.content) : '';
+                  const processedResponseText = lastResponseMessage
+                    ? coreContentToString(lastResponseMessage.content)
+                    : undefined;
+
+                  // An empty processed message is a valid result when a processor changed the text (for example,
+                  // when a guardrail removes it). Preserve the existing step fallback when the response was already
+                  // empty before processing, as can happen after a retry, or no response message remains.
+                  const shouldUseProcessedText =
+                    processedResponseText !== undefined &&
+                    (processedResponseText !== '' || processedResponseText !== responseTextBeforeProcessing);
+                  const outputText = shouldUseProcessedText ? processedResponseText : originalText;
 
                   // Only update the last step's text if output processors actually modified it
                   // This preserves text from retry scenarios where step.text is already correct
-                  if (lastStep && outputText && outputText !== originalText) {
+                  if (lastStep && outputText !== originalText) {
                     lastStep.text = outputText;
                   }
 
-                  // Use the processed text if available, otherwise keep original
                   this.resolvePromises({
-                    text: outputText || originalText,
+                    text: outputText,
                     finishReason: self.#finishReason,
                   });
 


### PR DESCRIPTION
Fixes #19240.

When an output processor intentionally replaced the final assistant text with an empty string, the processed response message was empty but `result.text`, streamed final text, and the final step fell back to the original text. That could expose content that a redaction processor had removed.

This change treats an empty string as a real processed result when the response text changed. It preserves the existing retry fallback only when the response was already empty before processing or when there is no response message to inspect.

The regression coverage exercises both `Agent.generate()` and `Agent.stream()`, and also keeps the empty-response retry path intact. Verified with the focused output and agent-processor suites (92 tests), `pnpm --filter @mastra/core lint`, Prettier, and `git diff --check`.

`pnpm --filter @mastra/core check` is currently blocked by unchanged schema type errors in `src/llm/model/model.ts` and `src/tools/tool-builder/builder.ts`. The broader core unit suite also has existing failures in Unix-socket and evented-workflow tests; neither failure touches this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a tool intentionally removes an agent’s response, the agent now correctly returns an empty answer instead of accidentally showing the original text again. Existing retry behavior remains unchanged.

## What changed

- Updated final output handling to preserve processed empty strings.
- Ensured `generate()` and `stream()` consistently expose cleared text in:
  - Response messages
  - Result text
  - Streamed final text
  - Final step text
- Preserved fallback behavior for initially empty responses and missing response messages.
- Added regression tests for generate, stream, and retry scenarios.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->