### PR TITLE
fix(rag): record rerank scoring errors

### DIFF
--- a/.changeset/little-kids-bake.md
+++ b/.changeset/little-kids-bake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed RAG rerank observability spans to record scoring failures before rethrowing.

--- a/packages/rag/src/rerank/index.test.ts
+++ b/packages/rag/src/rerank/index.test.ts
@@ -2,7 +2,7 @@ import { cohere } from '@ai-sdk/cohere';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CohereRelevanceScorer } from './relevance';
 
-import { rerank } from '.';
+import { rerank, rerankWithScorer } from '.';
 
 vi.spyOn(CohereRelevanceScorer.prototype, 'getRelevanceScore').mockImplementation(async () => {
   return 1;
@@ -146,5 +146,39 @@ describe('rerank', () => {
     const { scoreSpread1, scoreSpread2 } = getScoreSpreads(results, rerankedResults);
     expect(scoreSpread1).toBe(0.20000000000000007);
     expect(scoreSpread2).toBe(0.18000000000000016);
+  });
+
+  it('should mark the rerank span as errored when scoring fails', async () => {
+    const error = new Error('scorer failed');
+    const span = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+    const currentSpan = {
+      createChildSpan: vi.fn(() => span),
+    };
+    const scorer = {
+      getRelevanceScore: vi.fn().mockRejectedValue(error),
+    };
+    const results = [{ id: '1', metadata: { text: 'Test result 1' }, score: 0.5 }];
+
+    await expect(
+      rerankWithScorer({
+        results,
+        query: 'test query',
+        scorer,
+        options: {
+          topK: 1,
+          observabilityContext: {
+            tracingContext: {
+              currentSpan,
+            },
+          } as any,
+        },
+      }),
+    ).rejects.toThrow(error);
+
+    expect(span.error).toHaveBeenCalledWith({ error, endSpan: true });
+    expect(span.end).not.toHaveBeenCalled();
   });
 });

--- a/packages/rag/src/rerank/index.ts
+++ b/packages/rag/src/rerank/index.ts
@@ -128,45 +128,51 @@ async function executeRerank({
   const queryAnalysis = queryEmbedding ? analyzeQueryEmbedding(queryEmbedding) : null;
 
   // Get scores for each result
-  const scoredResults = await Promise.all(
-    results.map(async (result, index) => {
-      // Get semantic score from chosen provider
-      let semanticScore = 0;
-      if (result?.metadata?.text) {
-        semanticScore = await scorer.getRelevanceScore(query, result?.metadata?.text);
-      }
+  let scoredResults: RerankResult[];
+  try {
+    scoredResults = await Promise.all(
+      results.map(async (result, index) => {
+        // Get semantic score from chosen provider
+        let semanticScore = 0;
+        if (result?.metadata?.text) {
+          semanticScore = await scorer.getRelevanceScore(query, result?.metadata?.text);
+        }
 
-      // Get existing vector score from result
-      const vectorScore = result.score;
+        // Get existing vector score from result
+        const vectorScore = result.score;
 
-      // Get score of vector based on position in original list
-      const positionScore = calculatePositionScore(index, resultLength);
+        // Get score of vector based on position in original list
+        const positionScore = calculatePositionScore(index, resultLength);
 
-      // Combine scores using weights for each component
-      let finalScore =
-        weights.semantic * semanticScore + weights.vector * vectorScore + weights.position * positionScore;
+        // Combine scores using weights for each component
+        let finalScore =
+          weights.semantic * semanticScore + weights.vector * vectorScore + weights.position * positionScore;
 
-      if (queryAnalysis) {
-        finalScore = adjustScores(finalScore, queryAnalysis);
-      }
+        if (queryAnalysis) {
+          finalScore = adjustScores(finalScore, queryAnalysis);
+        }
 
-      return {
-        result,
-        score: finalScore,
-        details: {
-          semantic: semanticScore,
-          vector: vectorScore,
-          position: positionScore,
-          ...(queryAnalysis && {
-            queryAnalysis: {
-              magnitude: queryAnalysis.magnitude,
-              dominantFeatures: queryAnalysis.dominantFeatures,
-            },
-          }),
-        },
-      };
-    }),
-  );
+        return {
+          result,
+          score: finalScore,
+          details: {
+            semantic: semanticScore,
+            vector: vectorScore,
+            position: positionScore,
+            ...(queryAnalysis && {
+              queryAnalysis: {
+                magnitude: queryAnalysis.magnitude,
+                dominantFeatures: queryAnalysis.dominantFeatures,
+              },
+            }),
+          },
+        };
+      }),
+    );
+  } catch (err) {
+    rerankSpan?.error({ error: err as Error, endSpan: true });
+    throw err;
+  }
 
   // Sort by score and take top K
   const final = scoredResults.sort((a, b) => b.score - a.score).slice(0, topK);


### PR DESCRIPTION
Fixes #19245

  Summary

  This PR fixes RAG rerank observability so scoring failures are recorded on the rerank RAG_ACTION span before the error is rethrown.

  Previously, executeRerank() marked the span as errored for invalid weight configuration, but failures from scorer.getRelevanceScore() were not
  recorded on the span. The caller still received the error, but traces did not show the rerank span as failed.

  Changes

  - Wrap rerank scoring in a narrow try/catch.
  - Call rerankSpan.error({ error, endSpan: true }) when scoring fails.
  - Rethrow the original error so caller behavior is unchanged.
  - Keep the existing successful rerankSpan.end(...) behavior unchanged.
  - Add regression coverage for scorer failure recording the span error.

  Validation

  pnpm --filter ./packages/rag test src/rerank/index.test.ts
  pnpm test:rag
  pnpm --filter ./packages/rag lint
  pnpm build:rag
  pnpm prettier --check packages/rag/src/rerank/index.ts packages/rag/src/rerank/index.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If reranking fails, the system now records that failure in tracing before passing the error along, making it easier to understand what went wrong without changing successful behavior.

## What changed

- Wrapped rerank scoring in a narrow `try/catch`.
- Records scoring errors on the rerank span and ends it before rethrowing.
- Preserves successful span completion and existing invalid-weight handling.
- Added regression coverage for scorer failures.
- Bumped `@mastra/rag` with a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->