### PR TITLE
fix(rag): validate agent relevance score output

### DIFF
--- a/.changeset/puny-bananas-join.md
+++ b/.changeset/puny-bananas-join.md
@@ -1,0 +1,5 @@
+---
+'@mastra/rag': patch
+---
+
+Fixed Mastra agent relevance scoring to reject invalid model score output.

--- a/packages/rag/src/rerank/relevance/mastra-agent/index.test.ts
+++ b/packages/rag/src/rerank/relevance/mastra-agent/index.test.ts
@@ -1,0 +1,67 @@
+import type { MastraLanguageModel } from '@mastra/core/agent';
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { MastraAgentRelevanceScorer } from './';
+
+const TEST_MODEL = {} as MastraLanguageModel;
+
+const agentMock = vi.hoisted(() => ({
+  responseText: '0.5',
+  supportedLanguageModel: true,
+  generate: vi.fn(),
+  generateLegacy: vi.fn(),
+  getModel: vi.fn(),
+}));
+
+vi.mock('@mastra/core/agent', () => ({
+  Agent: class {
+    getModel = agentMock.getModel;
+    generate = agentMock.generate;
+    generateLegacy = agentMock.generateLegacy;
+  },
+  isSupportedLanguageModel: () => agentMock.supportedLanguageModel,
+}));
+
+describe('MastraAgentRelevanceScorer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    agentMock.responseText = '0.5';
+    agentMock.supportedLanguageModel = true;
+    agentMock.getModel.mockResolvedValue({});
+    agentMock.generate.mockImplementation(async () => ({ text: agentMock.responseText }));
+    agentMock.generateLegacy.mockImplementation(async () => ({ text: agentMock.responseText }));
+  });
+
+  it('returns a numeric relevance score from model output', async () => {
+    agentMock.responseText = ' 0.75 ';
+    const scorer = new MastraAgentRelevanceScorer('test', TEST_MODEL);
+
+    await expect(scorer.getRelevanceScore('query', 'text')).resolves.toBe(0.75);
+  });
+
+  it('uses legacy generation for legacy models', async () => {
+    agentMock.supportedLanguageModel = false;
+    agentMock.responseText = '0.25';
+    const scorer = new MastraAgentRelevanceScorer('test', TEST_MODEL);
+
+    await expect(scorer.getRelevanceScore('query', 'text')).resolves.toBe(0.25);
+    expect(agentMock.generateLegacy).toHaveBeenCalled();
+    expect(agentMock.generate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['non-numeric text', 'not a number'],
+    ['partial numeric text', '0.4 relevant'],
+    ['empty text', ''],
+    ['NaN', 'NaN'],
+    ['Infinity', 'Infinity'],
+    ['negative score', '-0.1'],
+    ['score above one', '1.1'],
+  ])('rejects %s model output', async (_name, responseText) => {
+    agentMock.responseText = responseText;
+    const scorer = new MastraAgentRelevanceScorer('test', TEST_MODEL);
+
+    await expect(scorer.getRelevanceScore('query', 'text')).rejects.toThrow(
+      'Invalid relevance score returned by model',
+    );
+  });
+});

--- a/packages/rag/src/rerank/relevance/mastra-agent/index.ts
+++ b/packages/rag/src/rerank/relevance/mastra-agent/index.ts
@@ -3,6 +3,17 @@ import type { MastraLanguageModel, MastraLegacyLanguageModel } from '@mastra/cor
 import { createSimilarityPrompt } from '@mastra/core/relevance';
 import type { RelevanceScoreProvider } from '@mastra/core/relevance';
 
+function parseRelevanceScore(responseText: string): number {
+  const trimmed = responseText.trim();
+  const score = Number(trimmed);
+
+  if (!trimmed || !Number.isFinite(score) || score < 0 || score > 1) {
+    throw new Error(`Invalid relevance score returned by model: ${responseText}`);
+  }
+
+  return score;
+}
+
 // Mastra Agent implementation
 export class MastraAgentRelevanceScorer implements RelevanceScoreProvider {
   private agent: Agent;
@@ -37,6 +48,6 @@ Always return just the number, no explanation.`,
       response = await this.agent.generateLegacy(prompt);
     }
 
-    return parseFloat(response.text);
+    return parseRelevanceScore(response.text);
   }
 }


### PR DESCRIPTION
Fixes #19248

  What changed

  This PR updates MastraAgentRelevanceScorer to validate the model response before returning a relevance score.

  Previously, the scorer used parseFloat(response.text), which could silently return bad values:

  - non-numeric output returned NaN
  - partial numeric output like "0.4 relevant" was accepted as 0.4
  - out-of-range values like -0.1 or 1.1 were not rejected

  The scorer now only accepts finite numeric values between 0 and 1, matching the prompt contract for relevance scores.

  Tests

  Added regression coverage for:

  - valid numeric score output
  - whitespace around numeric score output
  - legacy model generation path
  - non-numeric output
  - partial numeric output
  - empty output
  - NaN
  - Infinity
  - scores below 0
  - scores above 1

  Validation

  Ran:

  pnpm --filter ./packages/rag test src/rerank/relevance/mastra-agent/index.test.ts
  pnpm test:rag
  pnpm --filter ./packages/rag lint
  pnpm build:rag
  pnpm prettier --check packages/rag/src/rerank/relevance/mastra-agent/index.ts packages/rag/src/rerank/relevance/mastra-agent/
  index.test.ts .changeset/puny-bananas-join.md
  git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The scorer now checks that the model gives a real score between 0 and 1 before using it. This prevents bad responses from breaking reranking or producing unreliable results.

## Changes

- Added strict relevance-score validation:
  - Accepts finite numeric values from `0` to `1`.
  - Trims surrounding whitespace.
  - Rejects non-numeric, partial, empty, `NaN`, infinite, and out-of-range values.
- Preserved legacy model-generation behavior.
- Added regression tests covering valid, legacy, and invalid responses.
- Added a patch changeset for `@mastra/rag`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->