### PR TITLE
fix(background-tasks): distinguish `cancelled` tasks from `completed` tasks in continuation prompt

### DIFF
--- a/.changeset/brave-clocks-fly.md
+++ b/.changeset/brave-clocks-fly.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed background-task cancellation so terminal workflow events always carry a valid `prevResult`, and split the continuation prompt so completed, failed, cancelled, and suspended background tasks each get clearer LLM instructions.

--- a/.changeset/brave-clocks-fly.md
+++ b/.changeset/brave-clocks-fly.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed background-task cancellation so terminal workflow events always carry a valid `prevResult`, and split the continuation prompt so completed, failed, cancelled, and suspended background tasks each get clearer LLM instructions.
+Fixed background-task cancellation so cancelled tasks no longer look completed to the agent, terminal workflow events still surface a valid result when cancellation happens before one is produced, and completed, failed, cancelled, and suspended background tasks each get clearer continuation instructions.

--- a/packages/core/src/loop/shared/stream-until-idle-helpers.ts
+++ b/packages/core/src/loop/shared/stream-until-idle-helpers.ts
@@ -76,7 +76,7 @@ export async function resolveScope(
 
 /**
  * Build the ephemeral user-prompt text that tells the LLM which tool-call
- * IDs just completed. The directive stops the LLM from (a) re-processing
+ * IDs just completed / failed / canceled. The directive stops the LLM from (a) re-processing
  * results already handled on a prior continuation and (b) mimicking the
  * prior assistant ack text ("I'm running it in the background") and
  * re-dispatching the same tool.
@@ -86,6 +86,7 @@ export function buildContinuationDirective(batch: Array<Record<string, unknown>>
     .map(chunk => {
       const payload = (chunk as { payload?: Record<string, unknown> }).payload ?? {};
       return {
+        type: (chunk as { type?: string }).type,
         toolCallId: payload.toolCallId as string | undefined,
         toolName: payload.toolName as string | undefined,
         isSuspended: !!payload.suspendedAt,
@@ -93,25 +94,53 @@ export function buildContinuationDirective(batch: Array<Record<string, unknown>>
     })
     .filter(e => !!e.toolCallId);
 
-  const idList = entries
-    .filter(e => !e.isSuspended)
-    .map(e => (e.toolName ? `${e.toolCallId} (${e.toolName})` : e.toolCallId))
-    .join(', ');
-
   // Suspend payloads are tool-controlled and may carry secrets, PII, or
   // large opaque blobs — never serialize them into the continuation
   // prompt. Just name the suspended tool-call IDs.
-  const suspendedIdList = entries
-    .filter(e => e.isSuspended)
-    .map(e => `${e.toolCallId} (${e.toolName})`)
+  const formatEntry = (e: (typeof entries)[number]) => (e.toolName ? `${e.toolCallId} (${e.toolName})` : e.toolCallId!);
+
+  const completedIdList = entries
+    .filter(e => e.type === 'background-task-completed' && !e.isSuspended)
+    .map(formatEntry)
     .join(', ');
 
-  let directive =
-    `Background task(s) you previously dispatched have completed. ` +
-    `Process ONLY these tool-call IDs (their results are now in the conversation): ${idList}. ` +
-    `IMPORTANT: Do NOT process any tool-call IDs that were not in the list, ` +
-    `and do NOT call the same tool again — the result is already available. ` +
-    `Use these result(s) to answer the user's original question.`;
+  const failedIdList = entries
+    .filter(e => e.type === 'background-task-failed' && !e.isSuspended)
+    .map(formatEntry)
+    .join(', ');
+
+  const cancelledIdList = entries
+    .filter(e => e.type === 'background-task-cancelled' && !e.isSuspended)
+    .map(formatEntry)
+    .join(', ');
+
+  const suspendedIdList = entries
+    .filter(e => e.isSuspended)
+    .map(formatEntry)
+    .join(', ');
+
+  let directive = '';
+
+  if (completedIdList) {
+    directive +=
+      ` IMPORTANT: The following tool-call IDs completed successfully: ${completedIdList}. ` +
+      `Their results are now in the conversation. ` +
+      `Do not call the same tool again — the result is already available. `;
+  }
+
+  if (failedIdList) {
+    directive +=
+      ` IMPORTANT: The following tool-call IDs failed: ${failedIdList}. ` +
+      `Their failure information is now in the conversation. ` +
+      `Do not retry these tools unless the user explicitly requests it. `;
+  }
+
+  if (cancelledIdList) {
+    directive +=
+      ` IMPORTANT: The following tool-call IDs were cancelled by the user before completion: ${cancelledIdList}. ` +
+      `These tasks do not have results. ` +
+      `Do not treat them as completed and do not call the same tool again unless the user explicitly requests it. `;
+  }
 
   if (suspendedIdList) {
     directive +=
@@ -119,7 +148,7 @@ export function buildContinuationDirective(batch: Array<Record<string, unknown>>
       `Do not attempt to resume them; let the user know they are waiting for explicit resume input.`;
   }
 
-  return directive;
+  return directive.trim();
 }
 
 /**

--- a/packages/core/src/workflows/evented/workflow-event-processor/end-workflow.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/end-workflow.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import type { Event } from '../../../events/types';
+import { Mastra } from '../../../mastra';
+import { MockStore } from '../../../storage/mock';
+import { WorkflowEventProcessor } from './index';
+
+class TestWorkflowEventProcessor extends WorkflowEventProcessor {
+  callEndWorkflow(args: any, status?: 'success' | 'failed' | 'canceled' | 'paused') {
+    return this.endWorkflow(args, status);
+  }
+}
+
+describe('WorkflowEventProcessor #endWorkflow', () => {
+  it('normalizes a missing prevResult for canceled terminal events', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const mastra = new Mastra({
+      logger: false,
+      storage: new MockStore(),
+      workflows: {} as any,
+      pubsub,
+    });
+    const processor = new TestWorkflowEventProcessor({ mastra });
+    const workflowEndEvents: Event[] = [];
+
+    await pubsub.subscribe('workflows', async event => {
+      if (event.type === 'workflow.end') {
+        workflowEndEvents.push(event);
+      }
+    });
+
+    await processor.callEndWorkflow(
+      {
+        workflowId: 'wf',
+        runId: 'run-1',
+        executionPath: [],
+        resumeSteps: [],
+        stepResults: {},
+        activeStepsPath: {},
+        requestContext: {},
+        prevResult: undefined,
+      },
+      'canceled',
+    );
+
+    expect(workflowEndEvents).toHaveLength(1);
+    expect(workflowEndEvents[0]?.data.prevResult).toMatchObject({
+      status: 'canceled',
+    });
+
+    await mastra.shutdown();
+  });
+});

--- a/packages/core/src/workflows/evented/workflow-event-processor/end-workflow.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/end-workflow.test.ts
@@ -13,15 +13,35 @@ class TestWorkflowEventProcessor extends WorkflowEventProcessor {
 
 describe('WorkflowEventProcessor #endWorkflow', () => {
   it('normalizes a missing prevResult for canceled terminal events', async () => {
+    const storage = new MockStore();
+    const workflows = (await storage.getStore('workflows'))!;
     const pubsub = new EventEmitterPubSub();
     const mastra = new Mastra({
       logger: false,
-      storage: new MockStore(),
+      storage,
       workflows: {} as any,
       pubsub,
     });
     const processor = new TestWorkflowEventProcessor({ mastra });
     const workflowEndEvents: Event[] = [];
+
+    await workflows.persistWorkflowSnapshot({
+      workflowName: 'wf',
+      runId: 'run-1',
+      snapshot: {
+        runId: 'run-1',
+        status: 'running',
+        value: {},
+        context: {},
+        activePaths: [],
+        activeStepsPath: {},
+        suspendedPaths: {},
+        resumeLabels: {},
+        serializedStepGraph: [],
+        waitingPaths: {},
+        timestamp: Date.now(),
+      } as any,
+    });
 
     await pubsub.subscribe('workflows', async event => {
       if (event.type === 'workflow.end') {
@@ -43,8 +63,13 @@ describe('WorkflowEventProcessor #endWorkflow', () => {
       'canceled',
     );
 
+    const run = await workflows.getWorkflowRunById({ runId: 'run-1', workflowName: 'wf' });
     expect(workflowEndEvents).toHaveLength(1);
     expect(workflowEndEvents[0]?.data.prevResult).toMatchObject({
+      status: 'canceled',
+    });
+    expect(run).not.toBeNull();
+    expect((run?.snapshot as any).result).toMatchObject({
       status: 'canceled',
     });
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -448,6 +448,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       parentWorkflow,
     } = args;
     const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
+    const normalizedPrevResult = prevResult ?? ({ status } as StepResult<any, any, any, any>);
 
     // Check shouldPersistSnapshot option - default to true if not specified
     const finalStatus = perStep && status === 'success' ? 'paused' : status;
@@ -463,7 +464,7 @@ export class WorkflowEventProcessor extends EventProcessor {
         runId,
         opts: {
           status: finalStatus,
-          result: prevResult,
+          result: normalizedPrevResult,
           activePaths: executionPath,
           activeStepsPath: activeStepsPath,
         },
@@ -508,7 +509,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     await this.mastra.pubsub.publish('workflows', {
       type: 'workflow.end',
       runId,
-      data: { ...args, workflow: undefined },
+      data: { ...args, prevResult: normalizedPrevResult, workflow: undefined },
     });
   }
 


### PR DESCRIPTION
fixes https://github.com/mastra-ai/mastra/issues/19190

## Description

You can use the setup here to reproduce the same https://github.com/JayaKrishnaNamburu/split-background-statuses/blob/main/src/mastra/index.ts. 

By registering a cancel route and triggering to cancel it.
https://github.com/JayaKrishnaNamburu/split-background-statuses/blob/d58cfafaaa90a937735df7a13ed367444f96d0b2/src/mastra/index.ts#L49-L69

When passing status of the background tasks to the LLM, all the tasks are sent under one list. So, according to LLM anything other than `suspended` considered as completed.
https://github.com/mastra-ai/mastra/blob/1b2f2cca30f04f2cb8e20df661733a1367d779a0/packages/core/src/loop/shared/stream-until-idle-helpers.ts#L96-L122

A fix is to separate  the `taskId`'s w.r.t to the statuses. 
https://github.com/JayaKrishnaNamburu/mastra/blob/d4b95b2ae5dc9fc2a5b4267e8ac80cdb60c2d46f/packages/core/src/loop/shared/stream-until-idle-helpers.ts#L124-L149

While checking this, i noticed that when a `prevResult` is not preset for the execution engine is seems to throw an error as the engine is trying to read status on top of it. Normalised that too.
Here is the stack-trace

```
background-task workflow start failed for 6b268dcd-dcd8-4c9f-9a23-3ef2e095a478: TypeError: Cannot read properties of undefined (reading 'status')
    at EventedExecutionEngine.execute (file:///Users/jk/Documents/personal/test/zod-repro/node_modules/.pnpm/@mastra+core@1.50.1_express@5.2.1_zod@4.4.3/node_modules/@mastra/core/dist/chunk-OE4IEL7C.js:19024:31)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```

## Current Behaviour
<img width="960" height="605" alt="Screen Recording 2026-07-11 at 4 04 36 PM" src="https://github.com/user-attachments/assets/08254787-9833-4698-83db-c510653868bf" />


## Behaviour after the fix
<img width="960" height="605" alt="Screen Recording 2026-07-11 at 3 57 21 PM" src="https://github.com/user-attachments/assets/07d91f6d-c0de-4b9e-b32d-4bcedc2b99da" />


## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The system was telling the AI that “cancelled” background work had actually “finished,” which could lead to wrong next steps. This PR keeps cancelled vs completed outcomes separate, and also makes sure terminal workflow events always include the right status even when there’s no previous result.

## Changes
- Updated the continuation prompt to build separate tool-call ID groups (and instructions) for **completed**, **failed**, **cancelled**, and **suspended** tasks, so cancelled tasks aren’t treated as completed.
- Normalized workflow terminal handling when `prevResult` is missing:
  - In `WorkflowEventProcessor.endWorkflow`, it now creates a non-undefined `normalizedPrevResult`.
  - Persists and publishes the normalized result so `status` is correctly set (e.g., `'canceled'`).
- Added/updated a test to verify `endWorkflow('canceled', undefined)` emits exactly one `workflow.end` event and that both the published payload and persisted snapshot contain `prevResult.status: 'canceled'`.
- Added a `@mastra/core` patch changeset documenting the fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->