### PR TITLE
fix(observability): retry failed storage exports

### DIFF
--- a/.changeset/funny-symbols-fry.md
+++ b/.changeset/funny-symbols-fry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed storage exporters to report persistence failures immediately and retry failed batches automatically with the configured exponential backoff.

--- a/observability/mastra/src/exporters/default.test.ts
+++ b/observability/mastra/src/exporters/default.test.ts
@@ -538,6 +538,53 @@ describe('DefaultExporter', () => {
         expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
       });
 
+      it('should report a failed flush and retry it after the configured delay without new traffic', async () => {
+        const emitDropEvent = vi.fn();
+        const exporter = new DefaultExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 3,
+          retryDelayMs: 25,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        mockObservabilityStore.batchCreateSpans
+          .mockRejectedValueOnce(new Error('Storage error'))
+          .mockRejectedValueOnce(new Error('Storage error'))
+          .mockResolvedValueOnce(undefined);
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED));
+        await exporter.flush();
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(1);
+        expect(mockLogger.warn).toHaveBeenCalledWith('Failed to persist observability events', {
+          signal: 'tracing',
+          eventCount: 1,
+          retryAttempt: 1,
+          maxRetries: 3,
+          nextRetryDelayMs: 25,
+          error: 'Storage error',
+        });
+        expect(mockLogger.debug).not.toHaveBeenCalledWith('Batch flushed', expect.anything());
+        expect(emitDropEvent).not.toHaveBeenCalled();
+        expect(timers).toHaveLength(1);
+        expect(timers[0].delay).toBe(25);
+
+        timers[0].fn();
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
+        expect(timers).toHaveLength(2);
+        expect(timers[1].delay).toBe(50);
+
+        timers[1].fn();
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(3);
+        expect(emitDropEvent).not.toHaveBeenCalled();
+      });
+
       it('should drop events after max retries exceeded', async () => {
         const exporter = new DefaultExporter({
           strategy: 'batch-with-updates',

--- a/observability/mastra/src/exporters/default.test.ts
+++ b/observability/mastra/src/exporters/default.test.ts
@@ -585,6 +585,35 @@ describe('DefaultExporter', () => {
         expect(emitDropEvent).not.toHaveBeenCalled();
       });
 
+      it('should use the scheduled retry attempt when a failed batch contains mixed retry counts', async () => {
+        const exporter = new DefaultExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 3,
+          retryDelayMs: 25,
+          maxBatchSize: 2,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra });
+
+        mockObservabilityStore.batchCreateSpans.mockRejectedValue(new Error('Storage error'));
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-1'));
+        await exporter.flush();
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-2', 'span-2'));
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
+        expect(mockLogger.warn).toHaveBeenLastCalledWith('Failed to persist observability events', {
+          signal: 'tracing',
+          eventCount: 2,
+          retryAttempt: 1,
+          maxRetries: 3,
+          nextRetryDelayMs: 25,
+          error: 'Storage error',
+        });
+        expect(timers).toHaveLength(1);
+        expect(timers[0].delay).toBe(25);
+      });
+
       it('should drop events after max retries exceeded', async () => {
         const exporter = new DefaultExporter({
           strategy: 'batch-with-updates',

--- a/observability/mastra/src/exporters/default.test.ts
+++ b/observability/mastra/src/exporters/default.test.ts
@@ -758,6 +758,7 @@ describe('DefaultExporter', () => {
           }),
         );
         expect(emitDropEvent.mock.calls[0][0]).not.toHaveProperty('error');
+        expect(mockLogger.debug).not.toHaveBeenCalledWith('Batch flushed', expect.anything());
       });
     });
 

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -510,13 +510,16 @@ export class DefaultExporter extends BaseExporter {
     flushResults.push(await this.flushSpanUpdates(updateSpanEvents, deferredUpdates, false));
     flushResults.push(await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true));
 
+    let deferredDropCount = 0;
     if (deferredUpdates.length > 0) {
       if (this.#unsupportedSignals.has('tracing')) {
-        this.emitDrop('tracing', 'unsupported-storage', deferredUpdates.length);
+        deferredDropCount = deferredUpdates.length;
+        this.emitDrop('tracing', 'unsupported-storage', deferredDropCount);
         deferredUpdates.length = 0;
       } else {
         const dropped = this.#eventBuffer.reAddUpdates(deferredUpdates);
-        this.emitDrop('tracing', 'retry-exhausted', dropped.length);
+        deferredDropCount = dropped.length;
+        this.emitDrop('tracing', 'retry-exhausted', deferredDropCount);
       }
     }
 
@@ -528,7 +531,7 @@ export class DefaultExporter extends BaseExporter {
       this.scheduleFlush(this.retryDelay(retryAttempt));
     }
 
-    if (!flushResults.some(result => result.failed)) {
+    if (!flushResults.some(result => result.failed) && deferredDropCount === 0) {
       const elapsed = Date.now() - startTime;
       this.logger.debug('Batch flushed', {
         strategy: this.#resolvedStrategy,

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -71,6 +71,13 @@ function resolveTracingStorageStrategy(
 
 type Resolve = (value: void | PromiseLike<void>) => void;
 
+type FlushResult = {
+  failed: boolean;
+  retryAttempt?: number;
+};
+
+const FLUSH_SUCCEEDED: FlushResult = { failed: false };
+
 /**
  * @deprecated Use `MastraStorageExporter` from `@mastra/observability` instead.
  * This class is preserved unchanged so existing integrations (including code
@@ -201,17 +208,46 @@ export class DefaultExporter extends BaseExporter {
   /**
    * Schedules a flush using setTimeout
    */
-  private scheduleFlush(): void {
+  private scheduleFlush(delayMs = this.#config.maxBatchWaitMs!): void {
     if (this.#flushTimer) {
       clearTimeout(this.#flushTimer);
     }
     this.#flushTimer = setTimeout(() => {
+      this.#flushTimer = undefined;
       this.flushBuffer().catch(error => {
         this.logger.error('Scheduled flush failed', {
           error: error instanceof Error ? error.message : String(error),
         });
       });
-    }, this.#config.maxBatchWaitMs);
+    }, delayMs);
+  }
+
+  private retryDelay(retryAttempt: number): number {
+    return this.#config.retryDelayMs! * 2 ** (retryAttempt - 1);
+  }
+
+  private retryAttempt(events: BufferedEvent[]): number | undefined {
+    const retryableAttempts = events
+      .filter(event => event.retryCount <= this.#config.maxRetries!)
+      .map(event => event.retryCount);
+
+    return retryableAttempts.length > 0 ? Math.min(...retryableAttempts) : undefined;
+  }
+
+  private logStorageFailure(
+    signal: ObservabilityDropSignal,
+    events: BufferedEvent[],
+    retryAttempt: number | undefined,
+    error: unknown,
+  ): void {
+    this.logger.warn('Failed to persist observability events', {
+      signal,
+      eventCount: events.length,
+      retryAttempt: Math.max(...events.map(event => event.retryCount)),
+      maxRetries: this.#config.maxRetries,
+      ...(retryAttempt === undefined ? {} : { nextRetryDelayMs: this.retryDelay(retryAttempt) }),
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   /**
@@ -274,15 +310,16 @@ export class DefaultExporter extends BaseExporter {
     signal: ObservabilityDropSignal,
     events: T[],
     storageCall: (events: T[]) => Promise<void>,
-  ): Promise<void> {
-    if (events.length === 0) return;
+  ): Promise<FlushResult> {
+    if (events.length === 0) return FLUSH_SUCCEEDED;
     if (this.#unsupportedSignals.has(signal)) {
       this.emitDrop(signal, 'unsupported-storage', events.length);
-      return;
+      return { failed: true };
     }
 
     try {
       await storageCall(events);
+      return FLUSH_SUCCEEDED;
     } catch (error) {
       if (
         error instanceof MastraError &&
@@ -292,10 +329,14 @@ export class DefaultExporter extends BaseExporter {
         this.logger.warn(error.message);
         this.#unsupportedSignals.add(signal);
         this.emitDrop(signal, 'unsupported-storage', events.length, error);
-      } else {
-        const dropped = this.#eventBuffer.reAddCreates(events);
-        this.emitDrop(signal, 'retry-exhausted', dropped.length, error);
+        return { failed: true };
       }
+
+      const dropped = this.#eventBuffer.reAddCreates(events);
+      const retryAttempt = this.retryAttempt(events);
+      this.logStorageFailure(signal, events, retryAttempt, error);
+      this.emitDrop(signal, 'retry-exhausted', dropped.length, error);
+      return { failed: true, retryAttempt };
     }
   }
 
@@ -307,12 +348,12 @@ export class DefaultExporter extends BaseExporter {
     events: (TracingEvent & RetryCount)[],
     deferredUpdates: BufferedEvent[],
     isEnd: boolean,
-  ): Promise<void> {
+  ): Promise<FlushResult> {
     const deferredCountAtEntry = deferredUpdates.length;
-    if (events.length === 0) return;
+    if (events.length === 0) return FLUSH_SUCCEEDED;
     if (this.#unsupportedSignals.has('tracing')) {
       this.emitDrop('tracing', 'unsupported-storage', events.length);
-      return;
+      return { failed: true };
     }
 
     const partials: UpdateSpanPartial[] = [];
@@ -329,13 +370,14 @@ export class DefaultExporter extends BaseExporter {
       }
     }
 
-    if (partials.length === 0) return;
+    if (partials.length === 0) return FLUSH_SUCCEEDED;
 
     try {
       await this.#observabilityStorage!.batchUpdateSpans({ records: partials });
       if (isEnd) {
         this.#eventBuffer.endFinishedSpans({ records: partials });
       }
+      return FLUSH_SUCCEEDED;
     } catch (error) {
       if (
         error instanceof MastraError &&
@@ -346,18 +388,22 @@ export class DefaultExporter extends BaseExporter {
         this.#unsupportedSignals.add('tracing');
         deferredUpdates.length = 0;
         this.emitDrop('tracing', 'unsupported-storage', events.length + deferredCountAtEntry, error);
-      } else {
-        // `events` includes both partials-bound and newly-deferred entries, so
-        // re-adding it would double-add the newly-deferred ones if they stayed
-        // in deferredUpdates. Splice off only what this call appended — entries
-        // from a prior flushSpanUpdates call must survive.
-        const newlyDeferred = deferredUpdates.length - deferredCountAtEntry;
-        if (newlyDeferred > 0) {
-          deferredUpdates.splice(deferredUpdates.length - newlyDeferred, newlyDeferred);
-        }
-        const dropped = this.#eventBuffer.reAddUpdates(events);
-        this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
+        return { failed: true };
       }
+
+      // `events` includes both partials-bound and newly-deferred entries, so
+      // re-adding it would double-add the newly-deferred ones if they stayed
+      // in deferredUpdates. Splice off only what this call appended — entries
+      // from a prior flushSpanUpdates call must survive.
+      const newlyDeferred = deferredUpdates.length - deferredCountAtEntry;
+      if (newlyDeferred > 0) {
+        deferredUpdates.splice(deferredUpdates.length - newlyDeferred, newlyDeferred);
+      }
+      const dropped = this.#eventBuffer.reAddUpdates(events);
+      const retryAttempt = this.retryAttempt(events);
+      this.logStorageFailure('tracing', events, retryAttempt, error);
+      this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
+      return { failed: true, retryAttempt };
     }
   }
 
@@ -438,7 +484,7 @@ export class DefaultExporter extends BaseExporter {
     }
 
     // Flush all creates in parallel — signals are independent
-    await Promise.all([
+    const flushResults = await Promise.all([
       this.flushCreates('feedback', createFeedbackEvents, events =>
         this.#observabilityStorage!.batchCreateFeedback({ feedbacks: events.map(f => buildFeedbackRecord(f)) }),
       ),
@@ -461,8 +507,8 @@ export class DefaultExporter extends BaseExporter {
     // Flush span updates and ends — check span existence, defer if not yet created
     const deferredUpdates: BufferedEvent[] = [];
 
-    await this.flushSpanUpdates(updateSpanEvents, deferredUpdates, false);
-    await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true);
+    flushResults.push(await this.flushSpanUpdates(updateSpanEvents, deferredUpdates, false));
+    flushResults.push(await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true));
 
     if (deferredUpdates.length > 0) {
       if (this.#unsupportedSignals.has('tracing')) {
@@ -474,14 +520,23 @@ export class DefaultExporter extends BaseExporter {
       }
     }
 
-    const elapsed = Date.now() - startTime;
-    this.logger.debug('Batch flushed', {
-      strategy: this.#resolvedStrategy,
-      batchSize,
-      durationMs: elapsed,
-      deferredUpdates: deferredUpdates.length > 0 ? deferredUpdates.length : undefined,
-    });
-    return; // Success
+    const retryAttempt = flushResults.reduce<number | undefined>((earliestAttempt, result) => {
+      if (result.retryAttempt === undefined) return earliestAttempt;
+      return earliestAttempt === undefined ? result.retryAttempt : Math.min(earliestAttempt, result.retryAttempt);
+    }, undefined);
+    if (retryAttempt !== undefined) {
+      this.scheduleFlush(this.retryDelay(retryAttempt));
+    }
+
+    if (!flushResults.some(result => result.failed)) {
+      const elapsed = Date.now() - startTime;
+      this.logger.debug('Batch flushed', {
+        strategy: this.#resolvedStrategy,
+        batchSize,
+        durationMs: elapsed,
+        deferredUpdates: deferredUpdates.length > 0 ? deferredUpdates.length : undefined,
+      });
+    }
   }
 
   async _exportTracingEvent(event: TracingEvent): Promise<void> {
@@ -574,6 +629,11 @@ export class DefaultExporter extends BaseExporter {
 
     // Flush any remaining events
     await this.flush();
+
+    if (this.#flushTimer) {
+      clearTimeout(this.#flushTimer);
+      this.#flushTimer = undefined;
+    }
 
     this.logger.info('DefaultExporter shutdown complete');
   }

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -227,11 +227,10 @@ export class DefaultExporter extends BaseExporter {
   }
 
   private retryAttempt(events: BufferedEvent[]): number | undefined {
-    const retryableAttempts = events
-      .filter(event => event.retryCount <= this.#config.maxRetries!)
-      .map(event => event.retryCount);
-
-    return retryableAttempts.length > 0 ? Math.min(...retryableAttempts) : undefined;
+    return events.reduce<number | undefined>((earliestAttempt, event) => {
+      if (event.retryCount > this.#config.maxRetries!) return earliestAttempt;
+      return earliestAttempt === undefined ? event.retryCount : Math.min(earliestAttempt, event.retryCount);
+    }, undefined);
   }
 
   private logStorageFailure(
@@ -243,7 +242,8 @@ export class DefaultExporter extends BaseExporter {
     this.logger.warn('Failed to persist observability events', {
       signal,
       eventCount: events.length,
-      retryAttempt: Math.max(...events.map(event => event.retryCount)),
+      retryAttempt:
+        retryAttempt ?? events.reduce((latestAttempt, event) => Math.max(latestAttempt, event.retryCount), 0),
       maxRetries: this.#config.maxRetries,
       ...(retryAttempt === undefined ? {} : { nextRetryDelayMs: this.retryDelay(retryAttempt) }),
       error: error instanceof Error ? error.message : String(error),

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -758,6 +758,7 @@ describe('MastraStorageExporter', () => {
           }),
         );
         expect(emitDropEvent.mock.calls[0][0]).not.toHaveProperty('error');
+        expect(mockLogger.debug).not.toHaveBeenCalledWith('Batch flushed', expect.anything());
       });
     });
 

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -538,6 +538,53 @@ describe('MastraStorageExporter', () => {
         expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
       });
 
+      it('should report a failed flush and retry it after the configured delay without new traffic', async () => {
+        const emitDropEvent = vi.fn();
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 3,
+          retryDelayMs: 25,
+          maxBatchSize: 10,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra, emitDropEvent });
+
+        mockObservabilityStore.batchCreateSpans
+          .mockRejectedValueOnce(new Error('Storage error'))
+          .mockRejectedValueOnce(new Error('Storage error'))
+          .mockResolvedValueOnce(undefined);
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED));
+        await exporter.flush();
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(1);
+        expect(mockLogger.warn).toHaveBeenCalledWith('Failed to persist observability events', {
+          signal: 'tracing',
+          eventCount: 1,
+          retryAttempt: 1,
+          maxRetries: 3,
+          nextRetryDelayMs: 25,
+          error: 'Storage error',
+        });
+        expect(mockLogger.debug).not.toHaveBeenCalledWith('Batch flushed', expect.anything());
+        expect(emitDropEvent).not.toHaveBeenCalled();
+        expect(timers).toHaveLength(1);
+        expect(timers[0].delay).toBe(25);
+
+        timers[0].fn();
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
+        expect(timers).toHaveLength(2);
+        expect(timers[1].delay).toBe(50);
+
+        timers[1].fn();
+        await new Promise(resolve => setImmediate(resolve));
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(3);
+        expect(emitDropEvent).not.toHaveBeenCalled();
+      });
+
       it('should drop events after max retries exceeded', async () => {
         const exporter = new MastraStorageExporter({
           strategy: 'batch-with-updates',

--- a/observability/mastra/src/exporters/mastra-storage.test.ts
+++ b/observability/mastra/src/exporters/mastra-storage.test.ts
@@ -585,6 +585,35 @@ describe('MastraStorageExporter', () => {
         expect(emitDropEvent).not.toHaveBeenCalled();
       });
 
+      it('should use the scheduled retry attempt when a failed batch contains mixed retry counts', async () => {
+        const exporter = new MastraStorageExporter({
+          strategy: 'batch-with-updates',
+          maxRetries: 3,
+          retryDelayMs: 25,
+          maxBatchSize: 2,
+          logger: mockLogger,
+        });
+        await exporter.init({ mastra: mockMastra });
+
+        mockObservabilityStore.batchCreateSpans.mockRejectedValue(new Error('Storage error'));
+
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-1', 'span-1'));
+        await exporter.flush();
+        await exporter.exportTracingEvent(createMockEvent(TracingEventType.SPAN_STARTED, 'trace-2', 'span-2'));
+
+        expect(mockObservabilityStore.batchCreateSpans).toHaveBeenCalledTimes(2);
+        expect(mockLogger.warn).toHaveBeenLastCalledWith('Failed to persist observability events', {
+          signal: 'tracing',
+          eventCount: 2,
+          retryAttempt: 1,
+          maxRetries: 3,
+          nextRetryDelayMs: 25,
+          error: 'Storage error',
+        });
+        expect(timers).toHaveLength(1);
+        expect(timers[0].delay).toBe(25);
+      });
+
       it('should drop events after max retries exceeded', async () => {
         const exporter = new MastraStorageExporter({
           strategy: 'batch-with-updates',

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -65,6 +65,13 @@ function resolveTracingStorageStrategy(
 
 type Resolve = (value: void | PromiseLike<void>) => void;
 
+type FlushResult = {
+  failed: boolean;
+  retryAttempt?: number;
+};
+
+const FLUSH_SUCCEEDED: FlushResult = { failed: false };
+
 /**
  * Storage-backed exporter. Buffers observability events and flushes them in
  * batches to the configured ObservabilityStorage backend with retry support.
@@ -190,17 +197,46 @@ export class MastraStorageExporter extends BaseExporter {
   /**
    * Schedules a flush using setTimeout
    */
-  private scheduleFlush(): void {
+  private scheduleFlush(delayMs = this.#config.maxBatchWaitMs!): void {
     if (this.#flushTimer) {
       clearTimeout(this.#flushTimer);
     }
     this.#flushTimer = setTimeout(() => {
+      this.#flushTimer = undefined;
       this.flushBuffer().catch(error => {
         this.logger.error('Scheduled flush failed', {
           error: error instanceof Error ? error.message : String(error),
         });
       });
-    }, this.#config.maxBatchWaitMs);
+    }, delayMs);
+  }
+
+  private retryDelay(retryAttempt: number): number {
+    return this.#config.retryDelayMs! * 2 ** (retryAttempt - 1);
+  }
+
+  private retryAttempt(events: BufferedEvent[]): number | undefined {
+    const retryableAttempts = events
+      .filter(event => event.retryCount <= this.#config.maxRetries!)
+      .map(event => event.retryCount);
+
+    return retryableAttempts.length > 0 ? Math.min(...retryableAttempts) : undefined;
+  }
+
+  private logStorageFailure(
+    signal: ObservabilityDropSignal,
+    events: BufferedEvent[],
+    retryAttempt: number | undefined,
+    error: unknown,
+  ): void {
+    this.logger.warn('Failed to persist observability events', {
+      signal,
+      eventCount: events.length,
+      retryAttempt: Math.max(...events.map(event => event.retryCount)),
+      maxRetries: this.#config.maxRetries,
+      ...(retryAttempt === undefined ? {} : { nextRetryDelayMs: this.retryDelay(retryAttempt) }),
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
 
   /**
@@ -263,15 +299,16 @@ export class MastraStorageExporter extends BaseExporter {
     signal: ObservabilityDropSignal,
     events: T[],
     storageCall: (events: T[]) => Promise<void>,
-  ): Promise<void> {
-    if (events.length === 0) return;
+  ): Promise<FlushResult> {
+    if (events.length === 0) return FLUSH_SUCCEEDED;
     if (this.#unsupportedSignals.has(signal)) {
       this.emitDrop(signal, 'unsupported-storage', events.length);
-      return;
+      return { failed: true };
     }
 
     try {
       await storageCall(events);
+      return FLUSH_SUCCEEDED;
     } catch (error) {
       if (
         error instanceof MastraError &&
@@ -281,10 +318,14 @@ export class MastraStorageExporter extends BaseExporter {
         this.logger.warn(error.message);
         this.#unsupportedSignals.add(signal);
         this.emitDrop(signal, 'unsupported-storage', events.length, error);
-      } else {
-        const dropped = this.#eventBuffer.reAddCreates(events);
-        this.emitDrop(signal, 'retry-exhausted', dropped.length, error);
+        return { failed: true };
       }
+
+      const dropped = this.#eventBuffer.reAddCreates(events);
+      const retryAttempt = this.retryAttempt(events);
+      this.logStorageFailure(signal, events, retryAttempt, error);
+      this.emitDrop(signal, 'retry-exhausted', dropped.length, error);
+      return { failed: true, retryAttempt };
     }
   }
 
@@ -296,12 +337,12 @@ export class MastraStorageExporter extends BaseExporter {
     events: (TracingEvent & RetryCount)[],
     deferredUpdates: BufferedEvent[],
     isEnd: boolean,
-  ): Promise<void> {
+  ): Promise<FlushResult> {
     const deferredCountAtEntry = deferredUpdates.length;
-    if (events.length === 0) return;
+    if (events.length === 0) return FLUSH_SUCCEEDED;
     if (this.#unsupportedSignals.has('tracing')) {
       this.emitDrop('tracing', 'unsupported-storage', events.length);
-      return;
+      return { failed: true };
     }
 
     const partials: UpdateSpanPartial[] = [];
@@ -318,13 +359,14 @@ export class MastraStorageExporter extends BaseExporter {
       }
     }
 
-    if (partials.length === 0) return;
+    if (partials.length === 0) return FLUSH_SUCCEEDED;
 
     try {
       await this.#observabilityStorage!.batchUpdateSpans({ records: partials });
       if (isEnd) {
         this.#eventBuffer.endFinishedSpans({ records: partials });
       }
+      return FLUSH_SUCCEEDED;
     } catch (error) {
       if (
         error instanceof MastraError &&
@@ -335,18 +377,22 @@ export class MastraStorageExporter extends BaseExporter {
         this.#unsupportedSignals.add('tracing');
         deferredUpdates.length = 0;
         this.emitDrop('tracing', 'unsupported-storage', events.length + deferredCountAtEntry, error);
-      } else {
-        // `events` includes both partials-bound and newly-deferred entries, so
-        // re-adding it would double-add the newly-deferred ones if they stayed
-        // in deferredUpdates. Splice off only what this call appended — entries
-        // from a prior flushSpanUpdates call must survive.
-        const newlyDeferred = deferredUpdates.length - deferredCountAtEntry;
-        if (newlyDeferred > 0) {
-          deferredUpdates.splice(deferredUpdates.length - newlyDeferred, newlyDeferred);
-        }
-        const dropped = this.#eventBuffer.reAddUpdates(events);
-        this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
+        return { failed: true };
       }
+
+      // `events` includes both partials-bound and newly-deferred entries, so
+      // re-adding it would double-add the newly-deferred ones if they stayed
+      // in deferredUpdates. Splice off only what this call appended — entries
+      // from a prior flushSpanUpdates call must survive.
+      const newlyDeferred = deferredUpdates.length - deferredCountAtEntry;
+      if (newlyDeferred > 0) {
+        deferredUpdates.splice(deferredUpdates.length - newlyDeferred, newlyDeferred);
+      }
+      const dropped = this.#eventBuffer.reAddUpdates(events);
+      const retryAttempt = this.retryAttempt(events);
+      this.logStorageFailure('tracing', events, retryAttempt, error);
+      this.emitDrop('tracing', 'retry-exhausted', dropped.length, error);
+      return { failed: true, retryAttempt };
     }
   }
 
@@ -427,7 +473,7 @@ export class MastraStorageExporter extends BaseExporter {
     }
 
     // Flush all creates in parallel — signals are independent
-    await Promise.all([
+    const flushResults = await Promise.all([
       this.flushCreates('feedback', createFeedbackEvents, events =>
         this.#observabilityStorage!.batchCreateFeedback({ feedbacks: events.map(f => buildFeedbackRecord(f)) }),
       ),
@@ -450,8 +496,8 @@ export class MastraStorageExporter extends BaseExporter {
     // Flush span updates and ends — check span existence, defer if not yet created
     const deferredUpdates: BufferedEvent[] = [];
 
-    await this.flushSpanUpdates(updateSpanEvents, deferredUpdates, false);
-    await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true);
+    flushResults.push(await this.flushSpanUpdates(updateSpanEvents, deferredUpdates, false));
+    flushResults.push(await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true));
 
     if (deferredUpdates.length > 0) {
       if (this.#unsupportedSignals.has('tracing')) {
@@ -463,14 +509,23 @@ export class MastraStorageExporter extends BaseExporter {
       }
     }
 
-    const elapsed = Date.now() - startTime;
-    this.logger.debug('Batch flushed', {
-      strategy: this.#resolvedStrategy,
-      batchSize,
-      durationMs: elapsed,
-      deferredUpdates: deferredUpdates.length > 0 ? deferredUpdates.length : undefined,
-    });
-    return; // Success
+    const retryAttempt = flushResults.reduce<number | undefined>((earliestAttempt, result) => {
+      if (result.retryAttempt === undefined) return earliestAttempt;
+      return earliestAttempt === undefined ? result.retryAttempt : Math.min(earliestAttempt, result.retryAttempt);
+    }, undefined);
+    if (retryAttempt !== undefined) {
+      this.scheduleFlush(this.retryDelay(retryAttempt));
+    }
+
+    if (!flushResults.some(result => result.failed)) {
+      const elapsed = Date.now() - startTime;
+      this.logger.debug('Batch flushed', {
+        strategy: this.#resolvedStrategy,
+        batchSize,
+        durationMs: elapsed,
+        deferredUpdates: deferredUpdates.length > 0 ? deferredUpdates.length : undefined,
+      });
+    }
   }
 
   async _exportTracingEvent(event: TracingEvent): Promise<void> {
@@ -563,6 +618,11 @@ export class MastraStorageExporter extends BaseExporter {
 
     // Flush any remaining events
     await this.flush();
+
+    if (this.#flushTimer) {
+      clearTimeout(this.#flushTimer);
+      this.#flushTimer = undefined;
+    }
 
     this.logger.info('MastraStorageExporter shutdown complete');
   }

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -216,11 +216,10 @@ export class MastraStorageExporter extends BaseExporter {
   }
 
   private retryAttempt(events: BufferedEvent[]): number | undefined {
-    const retryableAttempts = events
-      .filter(event => event.retryCount <= this.#config.maxRetries!)
-      .map(event => event.retryCount);
-
-    return retryableAttempts.length > 0 ? Math.min(...retryableAttempts) : undefined;
+    return events.reduce<number | undefined>((earliestAttempt, event) => {
+      if (event.retryCount > this.#config.maxRetries!) return earliestAttempt;
+      return earliestAttempt === undefined ? event.retryCount : Math.min(earliestAttempt, event.retryCount);
+    }, undefined);
   }
 
   private logStorageFailure(
@@ -232,7 +231,8 @@ export class MastraStorageExporter extends BaseExporter {
     this.logger.warn('Failed to persist observability events', {
       signal,
       eventCount: events.length,
-      retryAttempt: Math.max(...events.map(event => event.retryCount)),
+      retryAttempt:
+        retryAttempt ?? events.reduce((latestAttempt, event) => Math.max(latestAttempt, event.retryCount), 0),
       maxRetries: this.#config.maxRetries,
       ...(retryAttempt === undefined ? {} : { nextRetryDelayMs: this.retryDelay(retryAttempt) }),
       error: error instanceof Error ? error.message : String(error),

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -499,13 +499,16 @@ export class MastraStorageExporter extends BaseExporter {
     flushResults.push(await this.flushSpanUpdates(updateSpanEvents, deferredUpdates, false));
     flushResults.push(await this.flushSpanUpdates(endSpanEvents, deferredUpdates, true));
 
+    let deferredDropCount = 0;
     if (deferredUpdates.length > 0) {
       if (this.#unsupportedSignals.has('tracing')) {
-        this.emitDrop('tracing', 'unsupported-storage', deferredUpdates.length);
+        deferredDropCount = deferredUpdates.length;
+        this.emitDrop('tracing', 'unsupported-storage', deferredDropCount);
         deferredUpdates.length = 0;
       } else {
         const dropped = this.#eventBuffer.reAddUpdates(deferredUpdates);
-        this.emitDrop('tracing', 'retry-exhausted', dropped.length);
+        deferredDropCount = dropped.length;
+        this.emitDrop('tracing', 'retry-exhausted', deferredDropCount);
       }
     }
 
@@ -517,7 +520,7 @@ export class MastraStorageExporter extends BaseExporter {
       this.scheduleFlush(this.retryDelay(retryAttempt));
     }
 
-    if (!flushResults.some(result => result.failed)) {
+    if (!flushResults.some(result => result.failed) && deferredDropCount === 0) {
       const elapsed = Date.now() - startTime;
       this.logger.debug('Batch flushed', {
         strategy: this.#resolvedStrategy,


### PR DESCRIPTION
Storage exporter failures were re-buffered without scheduling another flush, so a failed batch could remain in memory until new trace traffic arrived. The configured `retryDelayMs` was also unused, and failed flushes could still log as successful.

Before: a temporary storage outage caused one write attempt, then no retry without new events.

Now: failed batches retry automatically with the configured exponential backoff, each failed attempt is logged immediately, and drop events remain limited to batches that exhaust all retries.

The exporter regression tests cover delayed retries, failure visibility, recovery, and exhaustion. The full observability suite passes with 939 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If saving observability data to storage fails, the exporter automatically tries again (waiting longer each time). It clearly logs the failures right away, and it only reports “dropped” data after it has tried all retries and still can’t save it.

## Summary

- Added exponential-backoff retries for failed observability storage flushes, including when there’s no new traffic.
- Standardized flush handling with a structured `FlushResult` so retries can be coordinated across create-span and tracing flush parts.
- Improved failure visibility by logging persistence errors immediately with retry metadata (e.g., `retryAttempt`, `maxRetries`, `nextRetryDelayMs`).
- Suppressed “Batch flushed” success debug logging whenever any sub-flush reports failure; conditional success logging now depends on overall batch outcome.
- Limited drop events to only the cases where retries are fully exhausted.
- Refined retry scheduling to re-arm timers using computed backoff delays and to compute the earliest retryable attempt across mixed sub-results.
- Updated shutdown behavior to safely clear any pending flush timer before flushing remaining buffered data.
- Added/expanded regression tests for delayed retries, recovery after consecutive failures, correct next-delay behavior for mixed retry counts, failure visibility, and retry exhaustion.
- Added a patch changeset for `@mastra/observability` documenting the updated retry/failure-surfacing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->