### PR TITLE
feat(mastracode): simplify observational memory status

### DIFF
--- a/.changeset/wide-keys-switch.md
+++ b/.changeset/wide-keys-switch.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Simplified the observational memory context indicator in the TUI footer.

--- a/mastracode/tui/e2e/tui/custom-provider-edit-share-import.ts
+++ b/mastracode/tui/e2e/tui/custom-provider-edit-share-import.ts
@@ -58,7 +58,7 @@ export const customProviderEditShareImportScenario = {
 
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
-    await runtime.waitForScreenText(/messages\s+0\/30k/i, terminal, 8_000);
+    await runtime.waitForScreenText(/━━━━━━━━━━\s+0\/70k/i, terminal, 8_000);
 
     terminal.write('/models');
     await runtime.waitForScreenText(/models\s+Switch model pack/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/custom-provider-edit-share-import.ts
+++ b/mastracode/tui/e2e/tui/custom-provider-edit-share-import.ts
@@ -58,7 +58,7 @@ export const customProviderEditShareImportScenario = {
 
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Project:\s+mastra/i, terminal);
-    await runtime.waitForScreenText(/━━━━━━━━━━\s+0\/70k/i, terminal, 8_000);
+    await runtime.waitForScreenText(/0\/70k/i, terminal, 8_000);
 
     terminal.write('/models');
     await runtime.waitForScreenText(/models\s+Switch model pack/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -67,6 +67,7 @@ import { omGlobalSettingsPersistenceScenario } from './om-global-settings-persis
 import { omModelOverrideReloadScenario } from './om-model-override-reload.js';
 import { omPackStartupRestoreScenario } from './om-pack-startup-restore.js';
 import { omSettingsScenario } from './om-settings.js';
+import { omStatusIndicatorScenario } from './om-status-indicator.js';
 import { omThresholdPersistenceScenario } from './om-threshold-persistence.js';
 import { openaiStrictSchemaScenario } from './openai-strict-schema.js';
 import { persistentGoalCommandsScenario } from './persistent-goal-commands.js';
@@ -220,6 +221,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'om-model-override-reload': omModelOverrideReloadScenario,
   'om-pack-startup-restore': omPackStartupRestoreScenario,
   'om-settings': omSettingsScenario,
+  'om-status-indicator': omStatusIndicatorScenario,
   'om-threshold-persistence': omThresholdPersistenceScenario,
   'openai-strict-schema': openaiStrictSchemaScenario,
   'persistent-goal-commands': persistentGoalCommandsScenario,

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -8,6 +8,45 @@ import type { McE2eScenario } from './types.js';
 let tuiRef: any;
 let latestStyled = '';
 
+function extractBarCellStyles(styled: string): string[] {
+  const cells: string[] = [];
+  let activeStyle = '';
+  for (const match of styled.matchAll(/\x1b\[[0-9;]*m|━/g)) {
+    const token = match[0];
+    if (token === '━') {
+      cells.push(activeStyle);
+    } else if (token === '\x1b[0m' || token === '\x1b[39m') {
+      activeStyle = '';
+    } else if (/^\x1b\[(?:3\d|9\d|38;)/.test(token)) {
+      activeStyle = token;
+    }
+  }
+  return cells.slice(0, 10);
+}
+
+function assertSegmentAnimation(
+  firstFrame: string,
+  secondFrame: string,
+  activeRange: [start: number, end: number],
+): void {
+  const first = extractBarCellStyles(firstFrame);
+  const second = extractBarCellStyles(secondFrame);
+  if (first.length !== 10 || second.length !== 10) {
+    throw new Error(`Expected 10 styled context cells, got ${first.length} and ${second.length}`);
+  }
+
+  const [start, end] = activeRange;
+  if (JSON.stringify(first.slice(start, end)) === JSON.stringify(second.slice(start, end))) {
+    throw new Error(`Expected context cells ${start}-${end - 1} to animate`);
+  }
+  if (JSON.stringify(first.slice(0, start)) !== JSON.stringify(second.slice(0, start))) {
+    throw new Error(`Expected context cells before ${start} to remain static`);
+  }
+  if (JSON.stringify(first.slice(end)) !== JSON.stringify(second.slice(end))) {
+    throw new Error(`Expected context cells after ${end - 1} to remain static`);
+  }
+}
+
 export const omStatusIndicatorScenario: McE2eScenario = {
   name: 'om-status-indicator',
   description: 'Verifies the unified opposing-fill OM context indicator in the real TUI.',
@@ -48,15 +87,17 @@ export const omStatusIndicatorScenario: McE2eScenario = {
     const proofDir = process.env.MC_OM_STATUS_PROOF_DIR;
     if (proofDir) mkdirSync(proofDir, { recursive: true });
 
-    const checkpoint = async (name: string, expected: RegExp) => {
+    const checkpoint = async (name: string, expected: RegExp): Promise<string> => {
       state.ui.requestRender?.();
       await runtime.waitForScreenText(expected, terminal, 5_000);
       await runtime.sleep(50);
       const view = terminal.serialize().view;
+      const styled = latestStyled;
       if (proofDir) {
         writeFileSync(join(proofDir, `${name}.txt`), view);
-        writeFileSync(join(proofDir, `${name}.ansi`), latestStyled);
+        writeFileSync(join(proofDir, `${name}.ansi`), styled);
       }
+      return styled;
     };
 
     const setUsage = (pendingTokens: number, observationTokens: number) => {
@@ -96,19 +137,22 @@ export const omStatusIndicatorScenario: McE2eScenario = {
       gradientAnimator.getFadeProgress = () => 0;
       displayState.bufferingMessages = true;
       updateStatusLine(state);
-      await checkpoint('message-buffer-1', /60\/120k↓/);
+      const messageFrame1 = await checkpoint('message-buffer-1', /60\/120k↓/);
       offset = 0.5;
       updateStatusLine(state);
-      await checkpoint('message-buffer-2', /60\/120k↓/);
+      const messageFrame2 = await checkpoint('message-buffer-2', /60\/120k↓/);
+      // Balanced usage renders 2 memory cells, 3 message cells, then 5 unused cells.
+      assertSegmentAnimation(messageFrame1, messageFrame2, [2, 5]);
 
       displayState.bufferingMessages = false;
       displayState.bufferingObservations = true;
       offset = 0;
       updateStatusLine(state);
-      await checkpoint('reflection-buffer-1', /60\/120k↓/);
+      const reflectionFrame1 = await checkpoint('reflection-buffer-1', /60\/120k↓/);
       offset = 0.5;
       updateStatusLine(state);
-      await checkpoint('reflection-buffer-2', /60\/120k↓/);
+      const reflectionFrame2 = await checkpoint('reflection-buffer-2', /60\/120k↓/);
+      assertSegmentAnimation(reflectionFrame1, reflectionFrame2, [0, 2]);
     } finally {
       state.statusLine.setText = setText;
       state.gradientAnimator = originalGradientAnimator;

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -41,6 +41,10 @@ export const omStatusIndicatorScenario: McE2eScenario = {
     };
     const displayState = state.session.displayState.get();
     const originalColumns = process.stdout.columns;
+    const originalGradientAnimator = state.gradientAnimator;
+    const originalOmProgress = structuredClone(displayState.omProgress);
+    const originalBufferingMessages = displayState.bufferingMessages;
+    const originalBufferingObservations = displayState.bufferingObservations;
     const proofDir = process.env.MC_OM_STATUS_PROOF_DIR;
     if (proofDir) mkdirSync(proofDir, { recursive: true });
 
@@ -71,43 +75,48 @@ export const omStatusIndicatorScenario: McE2eScenario = {
       updateStatusLine(state);
     };
 
-    process.stdout.columns = 120;
-    setUsage(30_000, 30_000);
-    await checkpoint('balanced', /60\/120k↓/);
+    try {
+      process.stdout.columns = 120;
+      setUsage(30_000, 30_000);
+      await checkpoint('balanced', /60\/120k↓/);
 
-    setUsage(45_000, 5_000);
-    await checkpoint('asymmetric', /50\/120k↓/);
+      setUsage(45_000, 5_000);
+      await checkpoint('asymmetric', /50\/120k↓/);
 
-    process.stdout.columns = 60;
-    setUsage(30_000, 30_000);
-    await checkpoint('narrow', /60\/120k↓/);
+      process.stdout.columns = 60;
+      setUsage(30_000, 30_000);
+      await checkpoint('narrow', /60\/120k↓/);
 
-    process.stdout.columns = 120;
-    let offset = 0;
-    const originalGradientAnimator = state.gradientAnimator;
-    const gradientAnimator = new GradientAnimator(() => {});
-    state.gradientAnimator = gradientAnimator;
-    gradientAnimator.isRunning = () => true;
-    gradientAnimator.getOffset = () => offset;
-    gradientAnimator.getFadeProgress = () => 0;
-    displayState.bufferingMessages = true;
-    updateStatusLine(state);
-    await checkpoint('message-buffer-1', /60\/120k↓/);
-    offset = 0.5;
-    updateStatusLine(state);
-    await checkpoint('message-buffer-2', /60\/120k↓/);
+      process.stdout.columns = 120;
+      let offset = 0;
+      const gradientAnimator = new GradientAnimator(() => {});
+      state.gradientAnimator = gradientAnimator;
+      gradientAnimator.isRunning = () => true;
+      gradientAnimator.getOffset = () => offset;
+      gradientAnimator.getFadeProgress = () => 0;
+      displayState.bufferingMessages = true;
+      updateStatusLine(state);
+      await checkpoint('message-buffer-1', /60\/120k↓/);
+      offset = 0.5;
+      updateStatusLine(state);
+      await checkpoint('message-buffer-2', /60\/120k↓/);
 
-    displayState.bufferingMessages = false;
-    displayState.bufferingObservations = true;
-    offset = 0;
-    updateStatusLine(state);
-    await checkpoint('reflection-buffer-1', /60\/120k↓/);
-    offset = 0.5;
-    updateStatusLine(state);
-    await checkpoint('reflection-buffer-2', /60\/120k↓/);
-
-    state.gradientAnimator = originalGradientAnimator;
-    process.stdout.columns = originalColumns;
-    terminal.keyCtrlC();
+      displayState.bufferingMessages = false;
+      displayState.bufferingObservations = true;
+      offset = 0;
+      updateStatusLine(state);
+      await checkpoint('reflection-buffer-1', /60\/120k↓/);
+      offset = 0.5;
+      updateStatusLine(state);
+      await checkpoint('reflection-buffer-2', /60\/120k↓/);
+    } finally {
+      state.statusLine.setText = setText;
+      state.gradientAnimator = originalGradientAnimator;
+      Object.assign(displayState.omProgress, originalOmProgress);
+      displayState.bufferingMessages = originalBufferingMessages;
+      displayState.bufferingObservations = originalBufferingObservations;
+      process.stdout.columns = originalColumns;
+      terminal.keyCtrlC();
+    }
   },
 };

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -126,8 +126,8 @@ export const omStatusIndicatorScenario: McE2eScenario = {
 
       process.stdout.columns = 60;
       setUsage(30_000, 30_000);
-      const narrow = await checkpoint('narrow', /openai\/gpt-5\.5/);
-      expect(narrow).not.toContain('60/120k');
+      const narrow = await checkpoint('narrow', /60\/120k↓/);
+      expect(narrow).not.toContain('━━━━━━━━━━');
 
       process.stdout.columns = 120;
       let offset = 0;

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -73,14 +73,14 @@ export const omStatusIndicatorScenario: McE2eScenario = {
 
     process.stdout.columns = 120;
     setUsage(30_000, 30_000);
-    await checkpoint('balanced', /60\/120k\s+↓/);
+    await checkpoint('balanced', /60\/120k↓/);
 
     setUsage(45_000, 5_000);
-    await checkpoint('asymmetric', /50\/120k\s+↓/);
+    await checkpoint('asymmetric', /50\/120k↓/);
 
     process.stdout.columns = 60;
     setUsage(30_000, 30_000);
-    await checkpoint('narrow', /60\/120k\s+↓/);
+    await checkpoint('narrow', /60\/120k↓/);
 
     process.stdout.columns = 120;
     let offset = 0;
@@ -92,19 +92,19 @@ export const omStatusIndicatorScenario: McE2eScenario = {
     gradientAnimator.getFadeProgress = () => 0;
     displayState.bufferingMessages = true;
     updateStatusLine(state);
-    await checkpoint('message-buffer-1', /60\/120k\s+↓/);
+    await checkpoint('message-buffer-1', /60\/120k↓/);
     offset = 0.5;
     updateStatusLine(state);
-    await checkpoint('message-buffer-2', /60\/120k\s+↓/);
+    await checkpoint('message-buffer-2', /60\/120k↓/);
 
     displayState.bufferingMessages = false;
     displayState.bufferingObservations = true;
     offset = 0;
     updateStatusLine(state);
-    await checkpoint('reflection-buffer-1', /60\/120k\s+↓/);
+    await checkpoint('reflection-buffer-1', /60\/120k↓/);
     offset = 0.5;
     updateStatusLine(state);
-    await checkpoint('reflection-buffer-2', /60\/120k\s+↓/);
+    await checkpoint('reflection-buffer-2', /60\/120k↓/);
 
     state.gradientAnimator = originalGradientAnimator;
     process.stdout.columns = originalColumns;

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -1,0 +1,113 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { GradientAnimator } from '../../src/tui/components/obi-loader.js';
+import { updateStatusLine } from '../../src/tui/status-line.js';
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+let tuiRef: any;
+let latestStyled = '';
+
+export const omStatusIndicatorScenario: McE2eScenario = {
+  name: 'om-status-indicator',
+  description: 'Verifies the unified opposing-fill OM context indicator in the real TUI.',
+  testName: 'renders combined OM usage responsively and confines buffering animation to each segment',
+  async inProcessApp({ startMastraCodeApp }) {
+    const app = await startMastraCodeApp({
+      onTuiCreated(tui: any) {
+        tuiRef = tui;
+      },
+    });
+    return {
+      stop() {
+        tuiRef = undefined;
+        latestStyled = '';
+        return app.stop?.();
+      },
+    };
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await (
+      expect(terminal.getByText(/Mastra Code|Build|Plan|Fast|Type|Press|>/gi, { full: true, strict: false })) as any
+    ).toBeVisible();
+
+    const state = tuiRef?.state;
+    if (!state?.statusLine) throw new Error('Expected real TUI status line state');
+    const setText = state.statusLine.setText.bind(state.statusLine);
+    state.statusLine.setText = (value: string) => {
+      latestStyled = value;
+      setText(value);
+    };
+    const displayState = state.session.displayState.get();
+    const originalColumns = process.stdout.columns;
+    const proofDir = process.env.MC_OM_STATUS_PROOF_DIR;
+    if (proofDir) mkdirSync(proofDir, { recursive: true });
+
+    const checkpoint = async (name: string, expected: RegExp) => {
+      state.ui.requestRender?.();
+      await runtime.waitForScreenText(expected, terminal, 5_000);
+      await runtime.sleep(50);
+      const view = terminal.serialize().view;
+      if (proofDir) {
+        writeFileSync(join(proofDir, `${name}.txt`), view);
+        writeFileSync(join(proofDir, `${name}.ansi`), latestStyled);
+      }
+    };
+
+    const setUsage = (pendingTokens: number, observationTokens: number) => {
+      Object.assign(displayState.omProgress, {
+        pendingTokens,
+        observationTokens,
+        threshold: 80_000,
+        reflectionThreshold: 40_000,
+        buffered: {
+          observations: { projectedMessageRemoval: 2_000 },
+          reflection: { status: 'complete', inputObservationTokens: 5_000, observationTokens: 1_000 },
+        },
+      });
+      displayState.bufferingMessages = false;
+      displayState.bufferingObservations = false;
+      updateStatusLine(state);
+    };
+
+    process.stdout.columns = 120;
+    setUsage(30_000, 30_000);
+    await checkpoint('balanced', /60\/120k\s+↓6k/);
+
+    setUsage(45_000, 5_000);
+    await checkpoint('asymmetric', /50\/120k\s+↓6k/);
+
+    process.stdout.columns = 60;
+    setUsage(30_000, 30_000);
+    await checkpoint('narrow', /60\/120k\s+↓6k/);
+
+    process.stdout.columns = 120;
+    let offset = 0;
+    const originalGradientAnimator = state.gradientAnimator;
+    const gradientAnimator = new GradientAnimator(() => {});
+    state.gradientAnimator = gradientAnimator;
+    gradientAnimator.isRunning = () => true;
+    gradientAnimator.getOffset = () => offset;
+    gradientAnimator.getFadeProgress = () => 0;
+    displayState.bufferingMessages = true;
+    updateStatusLine(state);
+    await checkpoint('message-buffer-1', /60\/120k\s+↓6k/);
+    offset = 0.5;
+    updateStatusLine(state);
+    await checkpoint('message-buffer-2', /60\/120k\s+↓6k/);
+
+    displayState.bufferingMessages = false;
+    displayState.bufferingObservations = true;
+    offset = 0;
+    updateStatusLine(state);
+    await checkpoint('reflection-buffer-1', /60\/120k\s+↓6k/);
+    offset = 0.5;
+    updateStatusLine(state);
+    await checkpoint('reflection-buffer-2', /60\/120k\s+↓6k/);
+
+    state.gradientAnimator = originalGradientAnimator;
+    process.stdout.columns = originalColumns;
+    terminal.keyCtrlC();
+  },
+};

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -126,7 +126,8 @@ export const omStatusIndicatorScenario: McE2eScenario = {
 
       process.stdout.columns = 60;
       setUsage(30_000, 30_000);
-      await checkpoint('narrow', /60\/120k↓/);
+      const narrow = await checkpoint('narrow', /openai\/gpt-5\.5/);
+      expect(narrow).not.toContain('60/120k');
 
       process.stdout.columns = 120;
       let offset = 0;

--- a/mastracode/tui/e2e/tui/om-status-indicator.ts
+++ b/mastracode/tui/e2e/tui/om-status-indicator.ts
@@ -73,14 +73,14 @@ export const omStatusIndicatorScenario: McE2eScenario = {
 
     process.stdout.columns = 120;
     setUsage(30_000, 30_000);
-    await checkpoint('balanced', /60\/120k\s+↓6k/);
+    await checkpoint('balanced', /60\/120k\s+↓/);
 
     setUsage(45_000, 5_000);
-    await checkpoint('asymmetric', /50\/120k\s+↓6k/);
+    await checkpoint('asymmetric', /50\/120k\s+↓/);
 
     process.stdout.columns = 60;
     setUsage(30_000, 30_000);
-    await checkpoint('narrow', /60\/120k\s+↓6k/);
+    await checkpoint('narrow', /60\/120k\s+↓/);
 
     process.stdout.columns = 120;
     let offset = 0;
@@ -92,19 +92,19 @@ export const omStatusIndicatorScenario: McE2eScenario = {
     gradientAnimator.getFadeProgress = () => 0;
     displayState.bufferingMessages = true;
     updateStatusLine(state);
-    await checkpoint('message-buffer-1', /60\/120k\s+↓6k/);
+    await checkpoint('message-buffer-1', /60\/120k\s+↓/);
     offset = 0.5;
     updateStatusLine(state);
-    await checkpoint('message-buffer-2', /60\/120k\s+↓6k/);
+    await checkpoint('message-buffer-2', /60\/120k\s+↓/);
 
     displayState.bufferingMessages = false;
     displayState.bufferingObservations = true;
     offset = 0;
     updateStatusLine(state);
-    await checkpoint('reflection-buffer-1', /60\/120k\s+↓6k/);
+    await checkpoint('reflection-buffer-1', /60\/120k\s+↓/);
     offset = 0.5;
     updateStatusLine(state);
-    await checkpoint('reflection-buffer-2', /60\/120k\s+↓6k/);
+    await checkpoint('reflection-buffer-2', /60\/120k\s+↓/);
 
     state.gradientAnimator = originalGradientAnimator;
     process.stdout.columns = originalColumns;

--- a/mastracode/tui/e2e/tui/persistent-goal-commands.ts
+++ b/mastracode/tui/e2e/tui/persistent-goal-commands.ts
@@ -28,7 +28,7 @@ export const persistentGoalCommandsScenario: McE2eScenario = {
 
     terminal.submit(`/goal ${OBJECTIVE}`);
     await runtime.waitForScreenText(/Persistent goal command e2e acknowledged\./i, terminal, 15_000);
-    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐[^\r\n▌]+▌[^\r\n]*\bgoal\b(?:[ \t]+<1m)?/i, terminal, 8_000);
 
     terminal.submit('/goal pause');
     await runtime.waitForScreenText(/Goal paused: "Persist the goal command e2e objective/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/persistent-goal-commands.ts
+++ b/mastracode/tui/e2e/tui/persistent-goal-commands.ts
@@ -28,7 +28,7 @@ export const persistentGoalCommandsScenario: McE2eScenario = {
 
     terminal.submit(`/goal ${OBJECTIVE}`);
     await runtime.waitForScreenText(/Persistent goal command e2e acknowledged\./i, terminal, 15_000);
-    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
 
     terminal.submit('/goal pause');
     await runtime.waitForScreenText(/Goal paused: "Persist the goal command e2e objective/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/persistent-goal-commands.ts
+++ b/mastracode/tui/e2e/tui/persistent-goal-commands.ts
@@ -28,7 +28,7 @@ export const persistentGoalCommandsScenario: McE2eScenario = {
 
     terminal.submit(`/goal ${OBJECTIVE}`);
     await runtime.waitForScreenText(/Persistent goal command e2e acknowledged\./i, terminal, 15_000);
-    await runtime.waitForScreenText(/pursuing goal/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
 
     terminal.submit('/goal pause');
     await runtime.waitForScreenText(/Goal paused: "Persist the goal command e2e objective/i, terminal, 8_000);

--- a/mastracode/tui/e2e/tui/persistent-goal-reload.ts
+++ b/mastracode/tui/e2e/tui/persistent-goal-reload.ts
@@ -52,7 +52,7 @@ values
 
     await runtime.waitForScreenText(/Switched to: E2E persisted goal fixture/i, terminal, 8_000);
     await runtime.waitForScreenText(/Seeded goal reload assistant turn/i, terminal, 8_000);
-    await runtime.waitForScreenText(/pursuing goal/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
 
     terminal.submit('/goal status');
     await runtime.waitForScreenText(

--- a/mastracode/tui/e2e/tui/persistent-goal-reload.ts
+++ b/mastracode/tui/e2e/tui/persistent-goal-reload.ts
@@ -52,7 +52,7 @@ values
 
     await runtime.waitForScreenText(/Switched to: E2E persisted goal fixture/i, terminal, 8_000);
     await runtime.waitForScreenText(/Seeded goal reload assistant turn/i, terminal, 8_000);
-    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
 
     terminal.submit('/goal status');
     await runtime.waitForScreenText(

--- a/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
+++ b/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
@@ -38,7 +38,7 @@ export const planApprovalGoalHandoffScenario: McE2eScenario = {
     await runtime.waitForScreenText(/✓\s+Set as goal/i, terminal, 10_000);
     await runtime.waitForScreenText(/Goal \(judge: openai\/gpt-5\.4-mini\)/i, terminal, 10_000);
     await runtime.waitForScreenText(/# E2E Goal Plan/i, terminal, 10_000);
-    await runtime.waitForScreenText(/pursuing goal/i, terminal, 10_000);
+    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 10_000);
     await runtime.waitForScreenText(/Plan goal handoff e2e goal run started\./i, terminal, 15_000);
 
     terminal.keyCtrlC();

--- a/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
+++ b/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
@@ -38,7 +38,7 @@ export const planApprovalGoalHandoffScenario: McE2eScenario = {
     await runtime.waitForScreenText(/✓\s+Set as goal/i, terminal, 10_000);
     await runtime.waitForScreenText(/Goal \(judge: openai\/gpt-5\.4-mini\)/i, terminal, 10_000);
     await runtime.waitForScreenText(/# E2E Goal Plan/i, terminal, 10_000);
-    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 10_000);
+    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 10_000);
     await runtime.waitForScreenText(/Plan goal handoff e2e goal run started\./i, terminal, 15_000);
 
     terminal.keyCtrlC();

--- a/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
+++ b/mastracode/tui/e2e/tui/plan-approval-goal-handoff.ts
@@ -38,7 +38,7 @@ export const planApprovalGoalHandoffScenario: McE2eScenario = {
     await runtime.waitForScreenText(/✓\s+Set as goal/i, terminal, 10_000);
     await runtime.waitForScreenText(/Goal \(judge: openai\/gpt-5\.4-mini\)/i, terminal, 10_000);
     await runtime.waitForScreenText(/# E2E Goal Plan/i, terminal, 10_000);
-    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 10_000);
+    await runtime.waitForScreenText(/▐[^\r\n▌]+▌[^\r\n]*\bgoal\b(?:[ \t]+<1m)?/i, terminal, 10_000);
     await runtime.waitForScreenText(/Plan goal handoff e2e goal run started\./i, terminal, 15_000);
 
     terminal.keyCtrlC();

--- a/mastracode/tui/e2e/tui/skills-command-activation.ts
+++ b/mastracode/tui/e2e/tui/skills-command-activation.ts
@@ -64,7 +64,7 @@ export const skillsCommandActivationScenario: McE2eScenario = {
 
     terminal.submit(`/goal/${GOAL_SKILL_NAME} ${GOAL_ARGS}`);
     await runtime.waitForScreenText(/MC goal skill e2e response/i, terminal, 15_000);
-    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐[^\r\n▌]+▌[^\r\n]*\bgoal\b(?:[ \t]+<1m)?/i, terminal, 8_000);
     runtime.printScreen('after /goal skill alias', terminal);
 
     terminal.submit('/goal status');

--- a/mastracode/tui/e2e/tui/skills-command-activation.ts
+++ b/mastracode/tui/e2e/tui/skills-command-activation.ts
@@ -64,7 +64,7 @@ export const skillsCommandActivationScenario: McE2eScenario = {
 
     terminal.submit(`/goal/${GOAL_SKILL_NAME} ${GOAL_ARGS}`);
     await runtime.waitForScreenText(/MC goal skill e2e response/i, terminal, 15_000);
-    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐[^▌]+▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
     runtime.printScreen('after /goal skill alias', terminal);
 
     terminal.submit('/goal status');

--- a/mastracode/tui/e2e/tui/skills-command-activation.ts
+++ b/mastracode/tui/e2e/tui/skills-command-activation.ts
@@ -64,7 +64,7 @@ export const skillsCommandActivationScenario: McE2eScenario = {
 
     terminal.submit(`/goal/${GOAL_SKILL_NAME} ${GOAL_ARGS}`);
     await runtime.waitForScreenText(/MC goal skill e2e response/i, terminal, 15_000);
-    await runtime.waitForScreenText(/pursuing goal/i, terminal, 8_000);
+    await runtime.waitForScreenText(/▐build▌.*\bgoal(?:\s+<1m)?/i, terminal, 8_000);
     runtime.printScreen('after /goal skill alias', terminal);
 
     terminal.submit('/goal status');

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -97,6 +97,7 @@ export type ScenarioName =
   | 'om-global-settings-persistence'
   | 'om-model-override-reload'
   | 'om-pack-startup-restore'
+  | 'om-status-indicator'
   | 'om-threshold-persistence'
   | 'quiet-settings'
   | 'quiet-tool-history-parity'

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -225,67 +225,16 @@ describe('updateStatusLine', () => {
     expect(errored.statusLine.setText.mock.calls[0]?.[0]).toContain('openai/gpt-5 1m1s ×');
   });
 
-  it('shows the active GitHub PR subscription beside the thread path', () => {
-    const state = createState();
-    state.activeGithubPrSubscriptions = [
-      {
-        owner: 'mastra-ai',
-        repo: 'mastra',
-        prNumber: 17439,
-        lastNotificationKind: 'pull-request-activity',
-        lastNotificationPriority: 'medium',
-      },
-    ];
-
-    updateStatusLine(state);
-
-    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('PR#17439');
-    expect(rendered).not.toContain('polling');
-    expect(rendered).not.toContain('updated');
-  });
-
-  it('does not animate the GitHub PR subscription during unrelated agent activity', () => {
-    const state = createState();
-    state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];
-    state.gradientAnimator = {
-      isRunning: vi.fn(() => true),
-      getOffset: vi.fn(() => 0.5),
-      getFadeProgress: vi.fn(() => 0),
-    };
-
-    updateStatusLine(state);
-
-    expect(applyGradientSweepMock).not.toHaveBeenCalledWith(
-      'PR#17439',
-      expect.anything(),
-      expect.anything(),
-      expect.anything(),
-    );
-  });
-
-  it('animates the GitHub PR subscription while GitHub polling is running', () => {
+  it('keeps the center branch-only when the thread has an active GitHub PR subscription', () => {
     const state = createState();
     state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];
     state.githubPrPollingActive = true;
-    state.githubPrGradientAnimator = {
-      isRunning: vi.fn(() => true),
-      getOffset: vi.fn(() => 0.5),
-      getFadeProgress: vi.fn(() => 0),
-    };
-
-    updateStatusLine(state);
-
-    expect(applyGradientSweepMock).toHaveBeenCalledWith('PR#17439', 0.5, '#0ea5e9', 0);
-  });
-
-  it('does not show GitHub PR status for unsubscribed threads', () => {
-    const state = createState();
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).not.toContain('PR#');
+    expect(rendered).toContain('feat/mc-queueing-ux');
+    expect(rendered).not.toContain('PR#17439');
   });
 
   it('preserves the gateway prefix when compacting gateway-backed model ids', () => {

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -268,6 +268,7 @@ describe('updateStatusLine', () => {
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(visibleWidthMock(rendered)).toBeLessThanOrEqual(70);
     expect(rendered).toContain('PR#17439');
+    expect(rendered).not.toContain('60/120k');
   });
 
   it('shows the PR label without a thread title or branch and uses orange for high priority', () => {
@@ -400,7 +401,8 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('A much longe..d app…');
+    expect(rendered).toContain('A much longe..d appear');
+    expect(rendered).not.toContain('60/120k');
     expect(rendered).not.toContain('feature/super-long-branch');
     expect(rendered).not.toContain('mastra--feat-mc-queueing-ux');
   });
@@ -567,13 +569,15 @@ describe('updateStatusLine', () => {
     expect(visibleWidthMock(withoutSavings)).toBe(visibleWidthMock(withSavings));
   });
 
-  it('keeps the unified indicator at 60 columns', () => {
+  it('drops the unified indicator before core status content at 60 columns', () => {
     const state = createState();
     process.stdout.columns = 60;
 
     updateStatusLine(state);
 
-    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('━━━━━━━━━━  60/120k↓ ');
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('feat/mc-queueing-ux');
+    expect(rendered).not.toContain('60/120k');
   });
 
   it('animates only the message segment while keeping the middle, model, badge, and text static', () => {

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -225,15 +225,17 @@ describe('updateStatusLine', () => {
     expect(errored.statusLine.setText.mock.calls[0]?.[0]).toContain('openai/gpt-5 1m1s ×');
   });
 
-  it('keeps the center branch-only when the thread has an active GitHub PR subscription', () => {
+  it('keeps the center thread-title-only when the thread has an active GitHub PR subscription', () => {
     const state = createState();
+    state.currentThreadTitle = 'Simplify the OM status indicator';
     state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];
     state.githubPrPollingActive = true;
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('feat/mc-queueing-ux');
+    expect(rendered).toContain('Simplify the OM status indicator');
+    expect(rendered).not.toContain('feat/mc-queueing-ux');
     expect(rendered).not.toContain('PR#17439');
   });
 
@@ -317,17 +319,17 @@ describe('updateStatusLine', () => {
     expect(chalkRgbMock).toHaveBeenCalledWith(53, 117, 221);
   });
 
-  it('shows only the branch in the center and abbreviates it when needed', () => {
+  it('shows the thread title in the center and abbreviates it when needed', () => {
     const state = createState();
-    state.currentThreadTitle = 'A much longer generated thread title that should never appear';
+    state.currentThreadTitle = 'A much longer generated thread title that should appear';
     state.projectInfo.gitBranch = 'feature/super-long-branch-name-for-status-footer-e2e-regression-shield-extra-long';
     process.stdout.columns = 80;
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('feature/supe..tra-l…');
-    expect(rendered).not.toContain('A much longer generated thread title');
+    expect(rendered).toContain('A much longe..d app…');
+    expect(rendered).not.toContain('feature/super-long-branch');
     expect(rendered).not.toContain('mastra--feat-mc-queueing-ux');
   });
 

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -1,3 +1,4 @@
+import type * as PiTui from '@earendil-works/pi-tui';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 const { visibleWidthMock, chalkRgbMock, applyGradientSweepMock } = vi.hoisted(() => ({
@@ -6,7 +7,8 @@ const { visibleWidthMock, chalkRgbMock, applyGradientSweepMock } = vi.hoisted(()
   applyGradientSweepMock: vi.fn((value: string) => value),
 }));
 
-vi.mock('@earendil-works/pi-tui', () => ({
+vi.mock('@earendil-works/pi-tui', async importOriginal => ({
+  ...(await importOriginal<typeof PiTui>()),
   visibleWidth: visibleWidthMock,
 }));
 
@@ -36,11 +38,6 @@ vi.mock('../components/obi-loader.js', () => ({
   applyGradientSweep: applyGradientSweepMock,
 }));
 
-vi.mock('../components/om-progress.js', () => ({
-  formatObservationStatus: vi.fn(() => ''),
-  formatReflectionStatus: vi.fn(() => ''),
-}));
-
 vi.mock('../theme.js', () => ({
   theme: {
     fg: (_tone: string, value: string) => value,
@@ -62,7 +59,6 @@ vi.mock('../theme.js', () => ({
   getTermWidth: () => process.stdout.columns || 200,
 }));
 
-import { formatObservationStatus, formatReflectionStatus } from '../components/om-progress.js';
 import { updateStatusLine } from '../status-line.js';
 
 function createState() {
@@ -72,7 +68,19 @@ function createState() {
   const session = {
     displayState: {
       get: vi.fn(() => ({
-        omProgress: { status: 'idle' },
+        omProgress: {
+          status: 'idle',
+          pendingTokens: 30_000,
+          threshold: 80_000,
+          thresholdPercent: 37.5,
+          observationTokens: 30_000,
+          reflectionThreshold: 40_000,
+          reflectionThresholdPercent: 75,
+          buffered: {
+            observations: { projectedMessageRemoval: 2_000 },
+            reflection: { status: 'complete', inputObservationTokens: 5_000, observationTokens: 3_000 },
+          },
+        },
         bufferingMessages: false,
         bufferingObservations: false,
       })),
@@ -125,9 +133,8 @@ describe('updateStatusLine', () => {
   beforeEach(() => {
     visibleWidthMock.mockClear();
     chalkRgbMock.mockClear();
-    vi.mocked(formatObservationStatus).mockReturnValue('');
-    vi.mocked(formatReflectionStatus).mockReturnValue('');
     applyGradientSweepMock.mockClear();
+    applyGradientSweepMock.mockImplementation((value: string) => value);
     process.stdout.columns = 200;
   });
 
@@ -306,7 +313,7 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('fireworks/kimi-k2.6');
+    expect(rendered).toContain('kimi-k2.6');
     expect(rendered).not.toContain('fireworks-ai/accounts/fireworks/models/');
     expect(rendered).not.toContain('kimi-k2p6');
   });
@@ -361,7 +368,7 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('feature/supe..tra-long');
+    expect(rendered).toContain('feature/supe..tr…');
     expect(rendered).not.toContain('mastra--feat-mc-queueing-ux…');
   });
 
@@ -437,8 +444,6 @@ describe('updateStatusLine', () => {
   });
 
   it('keeps judge status ahead of OM and long model details on narrow screens', () => {
-    vi.mocked(formatObservationStatus).mockReturnValue('msg 100%');
-    vi.mocked(formatReflectionStatus).mockReturnValue('mem 100%');
     const state = createState();
     state.controller.session.displayState.get.mockReturnValue({
       omProgress: { status: 'observing' },
@@ -463,8 +468,82 @@ describe('updateStatusLine', () => {
     expect(rendered).toContain('j');
     expect(rendered).toContain('gpt-5.4-mini');
     expect(rendered).not.toContain('observe');
-    expect(rendered).not.toContain('msg 100%');
-    expect(rendered).not.toContain('mem 100%');
+    expect(rendered).not.toContain('━');
     expect(rendered).not.toContain('claude-sonnet-4-20250514');
+  });
+
+  it('renders one unified context indicator with combined totals and savings', () => {
+    const state = createState();
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('[━━━─────━━] 60/120k ↓4k');
+    expect(rendered).not.toContain('messages');
+    expect(rendered).not.toContain('memory');
+  });
+
+  it('keeps the unified indicator at 60 columns', () => {
+    const state = createState();
+    process.stdout.columns = 60;
+
+    updateStatusLine(state);
+
+    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('[━━━─────━━] 60/120k ↓4k');
+  });
+
+  it('animates only the message segment while keeping the middle and text static', () => {
+    const state = createState();
+    const displayState = state.session.displayState.get();
+    state.session.displayState.get.mockReturnValue({ ...displayState, bufferingMessages: true });
+    state.gradientAnimator = {
+      isRunning: vi.fn(() => true),
+      getOffset: vi.fn(() => 0.5),
+      getFadeProgress: vi.fn(() => 0),
+    };
+    applyGradientSweepMock.mockImplementation((value: string) => `<sweep>${value}</sweep>`);
+
+    updateStatusLine(state);
+
+    expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
+    expect(applyGradientSweepMock).toHaveBeenCalledWith('━━━', 0.5, '#f97316', 0);
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('<sweep>━━━</sweep>─────━━] 60/120k ↓4k');
+  });
+
+  it('animates only the memory segment', () => {
+    const state = createState();
+    const displayState = state.session.displayState.get();
+    state.session.displayState.get.mockReturnValue({ ...displayState, bufferingObservations: true });
+    state.gradientAnimator = {
+      isRunning: vi.fn(() => true),
+      getOffset: vi.fn(() => 0.25),
+      getFadeProgress: vi.fn(() => 0.1),
+    };
+
+    updateStatusLine(state);
+
+    expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
+    expect(applyGradientSweepMock).toHaveBeenCalledWith('━━', 0.25, '#ec4899', 0.1);
+  });
+
+  it('animates both occupied segments independently when both buffers are active', () => {
+    const state = createState();
+    const displayState = state.session.displayState.get();
+    state.session.displayState.get.mockReturnValue({
+      ...displayState,
+      bufferingMessages: true,
+      bufferingObservations: true,
+    });
+    state.gradientAnimator = {
+      isRunning: vi.fn(() => true),
+      getOffset: vi.fn(() => 0.5),
+      getFadeProgress: vi.fn(() => 0),
+    };
+
+    updateStatusLine(state);
+
+    expect(applyGradientSweepMock).toHaveBeenCalledTimes(2);
+    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual(['━━━', '━━']);
   });
 });

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -268,7 +268,8 @@ describe('updateStatusLine', () => {
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(visibleWidthMock(rendered)).toBeLessThanOrEqual(70);
     expect(rendered).toContain('PR#17439');
-    expect(rendered).not.toContain('60/120k');
+    expect(rendered).toContain('60/120k');
+    expect(rendered).not.toContain('━━━━━━━━━━');
   });
 
   it('shows the PR label without a thread title or branch and uses orange for high priority', () => {
@@ -402,7 +403,8 @@ describe('updateStatusLine', () => {
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(rendered).toContain('A much longe..d appear');
-    expect(rendered).not.toContain('60/120k');
+    expect(rendered).toContain('60/120k');
+    expect(rendered).not.toContain('━━━━━━━━━━');
     expect(rendered).not.toContain('feature/super-long-branch');
     expect(rendered).not.toContain('mastra--feat-mc-queueing-ux');
   });
@@ -569,15 +571,16 @@ describe('updateStatusLine', () => {
     expect(visibleWidthMock(withoutSavings)).toBe(visibleWidthMock(withSavings));
   });
 
-  it('drops the unified indicator before core status content at 60 columns', () => {
+  it('drops only the context bar before core status content at 60 columns', () => {
     const state = createState();
     process.stdout.columns = 60;
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('feat/mc-queueing-ux');
-    expect(rendered).not.toContain('60/120k');
+    expect(rendered).toContain('feat/mc-que');
+    expect(rendered).toContain('60/120k');
+    expect(rendered).not.toContain('━━━━━━━━━━');
   });
 
   it('animates only the message segment while keeping the middle, model, badge, and text static', () => {

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -492,8 +492,12 @@ describe('updateStatusLine', () => {
     expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('[━━━─────━━] 60/120k ↓4k');
   });
 
-  it('animates only the message segment while keeping the middle and text static', () => {
+  it('animates only the message segment while keeping the middle, model, badge, and text static', () => {
     const state = createState();
+    state.controller.listModes.mockReturnValue([
+      { id: 'build', name: 'build', metadata: { color: '#00ff00' } },
+      { id: 'plan', name: 'plan', metadata: { color: '#0000ff' } },
+    ]);
     const displayState = state.session.displayState.get();
     state.session.displayState.get.mockReturnValue({ ...displayState, bufferingMessages: true });
     state.gradientAnimator = {

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -49,10 +49,18 @@ vi.mock('../theme.js', () => ({
     blue: '#3b82f6',
     specialGray: '#6b7280',
   },
+  mastraBrand: {
+    blue: '#2563eb',
+  },
   extendedColors: {
     skyBlue: '#0ea5e9',
+    lightCyan: '#22d3ee',
+    indigo: '#6366f1',
   },
-  tintHex: (_color: string, _amount: number) => '#111111',
+  tintHex: (color: string, amount: number) => {
+    const channels = [1, 3, 5].map(offset => Math.floor(parseInt(color.slice(offset, offset + 2), 16) * amount));
+    return `#${channels.map(channel => channel.toString(16).padStart(2, '0')).join('')}`;
+  },
   getThemeMode: () => 'dark',
   ensureContrast: (_color: string) => _color,
   TUI_MIN_CONTRAST: 5.5,
@@ -368,7 +376,7 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('feature/supe..tr…');
+    expect(rendered).toContain('feature/supe..tra-l…');
     expect(rendered).not.toContain('mastra--feat-mc-queueing-ux…');
   });
 
@@ -478,9 +486,30 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('[━━━─────━━] 60/120k ↓4k');
+    expect(rendered).toContain('━━━━━━━━━━  60/120k ↓');
+    expect(rendered.indexOf('feat/mc-queueing-ux')).toBeLessThan(rendered.indexOf('━━━━━━━━━━'));
+    expect(rendered).toMatch(/━━━━━━━━━━  60\/120k ↓$/);
     expect(rendered).not.toContain('messages');
     expect(rendered).not.toContain('memory');
+  });
+
+  it('keeps the indicator anchored when the savings arrow disappears', () => {
+    const state = createState();
+    updateStatusLine(state);
+    const withSavings = state.statusLine.setText.mock.calls[0]?.[0] as string;
+
+    const displayState = state.session.displayState.get();
+    displayState.omProgress.buffered.observations.projectedMessageRemoval = 0;
+    displayState.omProgress.buffered.reflection.inputObservationTokens = 3_000;
+    displayState.omProgress.buffered.reflection.observationTokens = 3_000;
+    state.session.displayState.get.mockReturnValue(displayState);
+    state.statusLine.setText.mockClear();
+    updateStatusLine(state);
+    const withoutSavings = state.statusLine.setText.mock.calls[0]?.[0] as string;
+
+    expect(withoutSavings).not.toContain('↓');
+    expect(withoutSavings.indexOf('━━━━━━━━━━')).toBe(withSavings.indexOf('━━━━━━━━━━'));
+    expect(visibleWidthMock(withoutSavings)).toBe(visibleWidthMock(withSavings));
   });
 
   it('keeps the unified indicator at 60 columns', () => {
@@ -489,7 +518,7 @@ describe('updateStatusLine', () => {
 
     updateStatusLine(state);
 
-    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('[━━━─────━━] 60/120k ↓4k');
+    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('━━━━━━━━━━  60/120k ↓');
   });
 
   it('animates only the message segment while keeping the middle, model, badge, and text static', () => {
@@ -510,9 +539,9 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
-    expect(applyGradientSweepMock).toHaveBeenCalledWith('━━━', 0.5, '#f97316', 0);
+    expect(applyGradientSweepMock).toHaveBeenCalledWith('━━━', 0.5, '#00ff00', 0);
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('<sweep>━━━</sweep>─────━━] 60/120k ↓4k');
+    expect(rendered).toContain('━━<sweep>━━━</sweep>━━━━━  60/120k ↓');
   });
 
   it('animates only the memory segment', () => {
@@ -528,7 +557,7 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
-    expect(applyGradientSweepMock).toHaveBeenCalledWith('━━', 0.25, '#ec4899', 0.1);
+    expect(applyGradientSweepMock).toHaveBeenCalledWith('━━', 0.25, '#2563eb', 0.1);
   });
 
   it('animates both occupied segments independently when both buffers are active', () => {
@@ -548,6 +577,6 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     expect(applyGradientSweepMock).toHaveBeenCalledTimes(2);
-    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual(['━━━', '━━']);
+    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual(['━━', '━━━']);
   });
 });

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -368,8 +368,9 @@ describe('updateStatusLine', () => {
     expect(chalkRgbMock).toHaveBeenCalledWith(53, 117, 221);
   });
 
-  it('uses abbreviated long branch before truncating path and dropping branch context', () => {
+  it('shows only the branch in the center and abbreviates it when needed', () => {
     const state = createState();
+    state.currentThreadTitle = 'A much longer generated thread title that should never appear';
     state.projectInfo.gitBranch = 'feature/super-long-branch-name-for-status-footer-e2e-regression-shield-extra-long';
     process.stdout.columns = 80;
 
@@ -377,7 +378,8 @@ describe('updateStatusLine', () => {
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(rendered).toContain('feature/supe..tra-l…');
-    expect(rendered).not.toContain('mastra--feat-mc-queueing-ux…');
+    expect(rendered).not.toContain('A much longer generated thread title');
+    expect(rendered).not.toContain('mastra--feat-mc-queueing-ux');
   });
 
   it('shows active goal duration instead of attempt count', () => {
@@ -399,10 +401,39 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('pursuing goal (1hr10m)');
+    expect(rendered).toContain('goal 1hr10m');
+    expect(rendered).not.toContain('· goal');
     expect(rendered).not.toContain('goal attempt');
     expect(rendered).not.toContain('1/20');
     vi.useRealTimers();
+  });
+
+  it('places goal after run duration, hides a matching goal time, and puts throughput before context', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T12:00:30.000Z'));
+    const state = createState();
+    state.agentRunStartedAt = Date.parse('2026-05-15T12:00:00.000Z');
+    state.tokensPerSec = 80;
+    state.goalManager = {
+      getGoal: vi.fn(() => ({
+        status: 'active',
+        startedAt: '2026-05-15T12:00:00.000Z',
+      })),
+    };
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0] as string;
+    expect(rendered).toContain('30s · goal');
+    expect(rendered).not.toContain('goal <1m');
+    expect(rendered).toMatch(/ 80 t\/s\s+━━━━━━━━━━/);
+    expect(rendered).not.toContain('tok/s');
+
+    state.tokensPerSec = 120;
+    updateStatusLine(state);
+    const renderedOver100 = state.statusLine.setText.mock.calls[1]?.[0] as string;
+    expect(renderedOver100).toMatch(/120 t\/s\s+━━━━━━━━━━/);
+    expect(renderedOver100.indexOf(state.projectInfo.gitBranch)).toBe(rendered.indexOf(state.projectInfo.gitBranch));
   });
 
   it('freezes active goal duration while waiting for user input', () => {
@@ -422,12 +453,12 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('pursuing goal (10m)');
+    expect(rendered).toContain('goal 10m');
     expect(rendered).not.toContain('6hr10m');
     vi.useRealTimers();
   });
 
-  it('uses a compact active goal duration label on narrow screens', () => {
+  it('keeps the concise active goal duration label on narrow screens', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-15T12:00:00.000Z'));
     const state = createState();
@@ -446,8 +477,9 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('goal (2days3hr)');
-    expect(rendered).not.toContain('pursuing goal');
+    expect(rendered).toContain('goal 2days3hr');
+    expect(rendered).not.toContain('pursuing');
+    expect(rendered).not.toContain('(');
     vi.useRealTimers();
   });
 
@@ -486,9 +518,9 @@ describe('updateStatusLine', () => {
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('━━━━━━━━━━  60/120k ↓');
+    expect(rendered).toContain('━━━━━━━━━━  60/120k↓ ');
     expect(rendered.indexOf('feat/mc-queueing-ux')).toBeLessThan(rendered.indexOf('━━━━━━━━━━'));
-    expect(rendered).toMatch(/━━━━━━━━━━  60\/120k ↓$/);
+    expect(rendered).toMatch(/━━━━━━━━━━  60\/120k↓ $/);
     expect(rendered).not.toContain('messages');
     expect(rendered).not.toContain('memory');
   });
@@ -518,7 +550,7 @@ describe('updateStatusLine', () => {
 
     updateStatusLine(state);
 
-    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('━━━━━━━━━━  60/120k ↓');
+    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('━━━━━━━━━━  60/120k↓ ');
   });
 
   it('animates only the message segment while keeping the middle, model, badge, and text static', () => {
@@ -541,7 +573,7 @@ describe('updateStatusLine', () => {
     expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
     expect(applyGradientSweepMock).toHaveBeenCalledWith('━━━', 0.5, '#00ff00', 0);
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('━━<sweep>━━━</sweep>━━━━━  60/120k ↓');
+    expect(rendered).toContain('━━<sweep>━━━</sweep>━━━━━  60/120k↓ ');
   });
 
   it('animates only the memory segment', () => {

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -257,6 +257,37 @@ describe('updateStatusLine', () => {
     expect(rendered).not.toContain('updated');
   });
 
+  it('keeps the PR label within the available width when truncating a long thread title', () => {
+    const state = createState();
+    state.currentThreadTitle = 'A very long thread title that must be truncated';
+    state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];
+    process.stdout.columns = 70;
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(visibleWidthMock(rendered)).toBeLessThanOrEqual(70);
+    expect(rendered).toContain('PR#17439');
+  });
+
+  it('shows the PR label without a thread title or branch and uses orange for high priority', () => {
+    const state = createState();
+    state.currentThreadTitle = undefined;
+    state.projectInfo.gitBranch = undefined;
+    state.activeGithubPrSubscriptions = [{ prNumber: 17439, lastNotificationPriority: 'high' }];
+    state.githubPrPollingActive = true;
+    state.githubPrGradientAnimator = {
+      isRunning: vi.fn(() => true),
+      getOffset: vi.fn(() => 0.5),
+      getFadeProgress: vi.fn(() => 0),
+    };
+
+    updateStatusLine(state);
+
+    expect(state.statusLine.setText.mock.calls[0]?.[0]).toContain('PR#17439');
+    expect(applyGradientSweepMock).toHaveBeenCalledWith('PR#17439', 0.5, '#f97316', 0);
+  });
+
   it('animates the GitHub PR subscription only while GitHub polling is running', () => {
     const state = createState();
     state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -225,18 +225,59 @@ describe('updateStatusLine', () => {
     expect(errored.statusLine.setText.mock.calls[0]?.[0]).toContain('openai/gpt-5 1m1s ×');
   });
 
-  it('keeps the center thread-title-only when the thread has an active GitHub PR subscription', () => {
+  it('shows the active GitHub PR subscription beside the thread title', () => {
     const state = createState();
     state.currentThreadTitle = 'Simplify the OM status indicator';
     state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];
-    state.githubPrPollingActive = true;
 
     updateStatusLine(state);
 
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
-    expect(rendered).toContain('Simplify the OM status indicator');
+    expect(rendered).toContain('PR#17439 Simplify the OM status indicator');
     expect(rendered).not.toContain('feat/mc-queueing-ux');
-    expect(rendered).not.toContain('PR#17439');
+  });
+
+  it('shows the active GitHub PR subscription without status noise', () => {
+    const state = createState();
+    state.activeGithubPrSubscriptions = [
+      {
+        owner: 'mastra-ai',
+        repo: 'mastra',
+        prNumber: 17439,
+        lastNotificationKind: 'pull-request-activity',
+        lastNotificationPriority: 'medium',
+      },
+    ];
+
+    updateStatusLine(state);
+
+    const rendered = state.statusLine.setText.mock.calls[0]?.[0];
+    expect(rendered).toContain('PR#17439');
+    expect(rendered).not.toContain('polling');
+    expect(rendered).not.toContain('updated');
+  });
+
+  it('animates the GitHub PR subscription only while GitHub polling is running', () => {
+    const state = createState();
+    state.activeGithubPrSubscriptions = [{ prNumber: 17439 }];
+    state.githubPrPollingActive = true;
+    state.githubPrGradientAnimator = {
+      isRunning: vi.fn(() => true),
+      getOffset: vi.fn(() => 0.5),
+      getFadeProgress: vi.fn(() => 0),
+    };
+
+    updateStatusLine(state);
+
+    expect(applyGradientSweepMock).toHaveBeenCalledWith('PR#17439', 0.5, '#0ea5e9', 0);
+  });
+
+  it('does not show GitHub PR status for unsubscribed threads', () => {
+    const state = createState();
+
+    updateStatusLine(state);
+
+    expect(state.statusLine.setText.mock.calls[0]?.[0]).not.toContain('PR#');
   });
 
   it('preserves the gateway prefix when compacting gateway-backed model ids', () => {

--- a/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
@@ -151,8 +151,8 @@ describe('formatOMContextIndicator', () => {
       createState({ messageSavings: 2_000, reflectionInput: 1_000, reflectionOutput: 5_000 }),
     );
 
-    expect(combined.plain.endsWith(' ↓')).toBe(true);
-    expect(positiveWithNegativeSource.plain.endsWith(' ↓')).toBe(true);
+    expect(combined.plain.endsWith('↓ ')).toBe(true);
+    expect(positiveWithNegativeSource.plain.endsWith('↓ ')).toBe(true);
   });
 
   it('suppresses the arrow for zero savings while preserving the indicator width', () => {

--- a/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
@@ -1,3 +1,4 @@
+import { visibleWidth } from '@earendil-works/pi-tui';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('chalk', () => {
@@ -26,60 +27,149 @@ vi.mock('../../theme.js', () => ({
   },
 }));
 
-import { formatObservationStatus, formatReflectionStatus } from '../om-progress.js';
+import { formatOMContextIndicator } from '../om-progress.js';
 
-const baseState = {
-  status: 'idle',
-  pendingTokens: 8200,
-  threshold: 30000,
-  thresholdPercent: 27,
-  observationTokens: 9100,
-  reflectionThreshold: 40000,
-  reflectionThresholdPercent: 23,
-  buffered: {
-    observations: {
-      projectedMessageRemoval: 0,
-    },
-    reflection: {
-      status: 'idle',
-      inputObservationTokens: 0,
-      observationTokens: 0,
-    },
-  },
-} as any;
-
-describe('om progress label styling', () => {
-  it('renders messages label without bold styling by default', () => {
-    const rendered = formatObservationStatus(baseState, 'full');
-
-    expect(rendered).toContain('messages ');
-  });
-
-  it('renders memory label without bold styling by default', () => {
-    const rendered = formatReflectionStatus(baseState, 'full');
-
-    expect(rendered).toContain('memory ');
-  });
-
-  it('hides reflection savings when compression saved no tokens', () => {
-    const rendered = formatReflectionStatus(
-      {
-        ...baseState,
-        observationTokens: 300,
-        buffered: {
-          ...baseState.buffered,
-          reflection: {
-            status: 'complete',
-            inputObservationTokens: 300,
-            observationTokens: 300,
-          },
-        },
+function createState(
+  values: Partial<{
+    pendingTokens: number;
+    observationTokens: number;
+    threshold: number;
+    reflectionThreshold: number;
+    messageSavings: number;
+    reflectionInput: number;
+    reflectionOutput: number;
+  }> = {},
+) {
+  return {
+    status: 'idle',
+    pendingTokens: values.pendingTokens ?? 0,
+    threshold: values.threshold ?? 80_000,
+    thresholdPercent: 0,
+    observationTokens: values.observationTokens ?? 0,
+    reflectionThreshold: values.reflectionThreshold ?? 40_000,
+    reflectionThresholdPercent: 0,
+    buffered: {
+      observations: {
+        projectedMessageRemoval: values.messageSavings ?? 0,
       },
-      'full',
+      reflection: {
+        status: 'complete',
+        inputObservationTokens: values.reflectionInput ?? 0,
+        observationTokens: values.reflectionOutput ?? 0,
+      },
+    },
+  } as any;
+}
+
+describe('formatOMContextIndicator', () => {
+  it('renders an empty track for no usage', () => {
+    const indicator = formatOMContextIndicator(createState());
+
+    expect(indicator).toMatchObject({
+      plain: '[──────────] 0/120k',
+      messageCells: 0,
+      memoryCells: 0,
+      unusedCells: 10,
+    });
+  });
+
+  it('renders an empty track when combined capacity is zero', () => {
+    const indicator = formatOMContextIndicator(createState({ threshold: 0, reflectionThreshold: 0 }));
+
+    expect(indicator.plain).toBe('[──────────] 0/0k');
+    expect(indicator.messageCells + indicator.memoryCells).toBe(0);
+  });
+
+  it('fills only the left segment for messages', () => {
+    expect(formatOMContextIndicator(createState({ pendingTokens: 60_000 })).plain).toBe('[━━━━━─────] 60/120k');
+  });
+
+  it('fills only the right segment for memory', () => {
+    expect(formatOMContextIndicator(createState({ observationTokens: 60_000 })).plain).toBe('[─────━━━━━] 60/120k');
+  });
+
+  it('splits balanced usage into three message cells and two memory cells', () => {
+    const indicator = formatOMContextIndicator(createState({ pendingTokens: 30_000, observationTokens: 30_000 }));
+
+    expect(indicator).toMatchObject({
+      plain: '[━━━─────━━] 60/120k',
+      messageCells: 3,
+      memoryCells: 2,
+      unusedCells: 5,
+    });
+  });
+
+  it('splits asymmetric usage into three message cells and one memory cell', () => {
+    const indicator = formatOMContextIndicator(createState({ pendingTokens: 45_000, observationTokens: 5_000 }));
+
+    expect(indicator).toMatchObject({
+      plain: '[━━━──────━] 50/120k',
+      messageCells: 3,
+      memoryCells: 1,
+      unusedCells: 6,
+    });
+  });
+
+  it('rounds split ties toward messages', () => {
+    const indicator = formatOMContextIndicator(
+      createState({ pendingTokens: 20_000, observationTokens: 20_000, threshold: 40_000, reflectionThreshold: 40_000 }),
     );
 
-    expect(rendered).toContain('memory 0.3/40k');
-    expect(rendered).not.toContain('↓');
-    expect(rendered).not.toContain('-0k');
+    expect(indicator).toMatchObject({ messageCells: 3, memoryCells: 2, unusedCells: 5 });
+  });
+
+  it('leaves one occupied cell for each nonzero source when possible', () => {
+    const indicator = formatOMContextIndicator(
+      createState({ pendingTokens: 23_000, observationTokens: 1_000, threshold: 80_000, reflectionThreshold: 40_000 }),
+    );
+
+    expect(indicator).toMatchObject({ messageCells: 1, memoryCells: 1, unusedCells: 8 });
+  });
+
+  it('fills the track at capacity and clamps over-capacity usage', () => {
+    expect(formatOMContextIndicator(createState({ pendingTokens: 80_000, observationTokens: 40_000 }))).toMatchObject({
+      messageCells: 7,
+      memoryCells: 3,
+      unusedCells: 0,
+    });
+    expect(formatOMContextIndicator(createState({ pendingTokens: 160_000, observationTokens: 80_000 }))).toMatchObject({
+      messageCells: 7,
+      memoryCells: 3,
+      unusedCells: 0,
+    });
+  });
+
+  it('sums each positive savings source independently', () => {
+    const indicator = formatOMContextIndicator(
+      createState({ messageSavings: 2_000, reflectionInput: 5_000, reflectionOutput: 1_000 }),
+    );
+
+    expect(indicator.plain).toContain('↓6k');
+  });
+
+  it('does not let negative savings cancel a positive source', () => {
+    const indicator = formatOMContextIndicator(
+      createState({ messageSavings: 2_000, reflectionInput: 1_000, reflectionOutput: 5_000 }),
+    );
+
+    expect(indicator.plain).toContain('↓2k');
+  });
+
+  it('suppresses zero savings and preserves visible width in styled output', () => {
+    const indicator = formatOMContextIndicator(createState({ reflectionInput: 300, reflectionOutput: 300 }));
+
+    expect(indicator.plain).not.toContain('↓');
+    expect(visibleWidth(indicator.styled)).toBe(visibleWidth(indicator.plain));
+  });
+
+  it('allows occupied segments to be styled independently', () => {
+    const indicator = formatOMContextIndicator(createState({ pendingTokens: 30_000, observationTokens: 30_000 }), {
+      messages: segment => `<orange>${segment}</orange>`,
+      memory: segment => `<pink>${segment}</pink>`,
+    });
+
+    expect(indicator.styled).toContain('<orange>━━━</orange>');
+    expect(indicator.styled).toContain('<pink>━━</pink>');
+    expect(indicator.styled).toContain('─────');
   });
 });

--- a/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
@@ -165,6 +165,16 @@ describe('formatOMContextIndicator', () => {
     expect(visibleWidth(withSavings.styled)).toBe(visibleWidth(withSavings.plain));
   });
 
+  it('preserves the numeric context measurement when the bar is hidden', () => {
+    const indicator = formatOMContextIndicator(
+      createState({ pendingTokens: 30_000, observationTokens: 30_000, messageSavings: 2_000 }),
+      { showBar: false },
+    );
+
+    expect(indicator.plain).toBe('60/120k↓ ');
+    expect(indicator.styled).toBe('60/120k↓ ');
+  });
+
   it('renders observations first, then messages, then unused capacity', () => {
     const indicator = formatOMContextIndicator(createState({ pendingTokens: 30_000, observationTokens: 30_000 }), {
       messages: segment => `<messages>${segment}</messages>`,

--- a/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
@@ -18,6 +18,10 @@ vi.mock('../../theme.js', () => ({
   theme: {
     fg: (_tone: string, value: string) => value,
   },
+  extendedColors: {
+    lightCyan: '#22d3ee',
+    indigo: '#6366f1',
+  },
   mastra: {
     red: '#ef4444',
     orange: '#f97316',
@@ -66,7 +70,7 @@ describe('formatOMContextIndicator', () => {
     const indicator = formatOMContextIndicator(createState());
 
     expect(indicator).toMatchObject({
-      plain: '[──────────] 0/120k',
+      plain: '━━━━━━━━━━  0/120k  ',
       messageCells: 0,
       memoryCells: 0,
       unusedCells: 10,
@@ -76,23 +80,23 @@ describe('formatOMContextIndicator', () => {
   it('renders an empty track when combined capacity is zero', () => {
     const indicator = formatOMContextIndicator(createState({ threshold: 0, reflectionThreshold: 0 }));
 
-    expect(indicator.plain).toBe('[──────────] 0/0k');
+    expect(indicator.plain).toBe('━━━━━━━━━━  0/0k  ');
     expect(indicator.messageCells + indicator.memoryCells).toBe(0);
   });
 
   it('fills only the left segment for messages', () => {
-    expect(formatOMContextIndicator(createState({ pendingTokens: 60_000 })).plain).toBe('[━━━━━─────] 60/120k');
+    expect(formatOMContextIndicator(createState({ pendingTokens: 60_000 })).plain).toBe('━━━━━━━━━━  60/120k  ');
   });
 
   it('fills only the right segment for memory', () => {
-    expect(formatOMContextIndicator(createState({ observationTokens: 60_000 })).plain).toBe('[─────━━━━━] 60/120k');
+    expect(formatOMContextIndicator(createState({ observationTokens: 60_000 })).plain).toBe('━━━━━━━━━━  60/120k  ');
   });
 
   it('splits balanced usage into three message cells and two memory cells', () => {
     const indicator = formatOMContextIndicator(createState({ pendingTokens: 30_000, observationTokens: 30_000 }));
 
     expect(indicator).toMatchObject({
-      plain: '[━━━─────━━] 60/120k',
+      plain: '━━━━━━━━━━  60/120k  ',
       messageCells: 3,
       memoryCells: 2,
       unusedCells: 5,
@@ -103,7 +107,7 @@ describe('formatOMContextIndicator', () => {
     const indicator = formatOMContextIndicator(createState({ pendingTokens: 45_000, observationTokens: 5_000 }));
 
     expect(indicator).toMatchObject({
-      plain: '[━━━──────━] 50/120k',
+      plain: '━━━━━━━━━━  50/120k  ',
       messageCells: 3,
       memoryCells: 1,
       unusedCells: 6,
@@ -139,37 +143,37 @@ describe('formatOMContextIndicator', () => {
     });
   });
 
-  it('sums each positive savings source independently', () => {
-    const indicator = formatOMContextIndicator(
+  it('shows one arrow when either positive savings source contributes', () => {
+    const combined = formatOMContextIndicator(
       createState({ messageSavings: 2_000, reflectionInput: 5_000, reflectionOutput: 1_000 }),
     );
-
-    expect(indicator.plain).toContain('↓6k');
-  });
-
-  it('does not let negative savings cancel a positive source', () => {
-    const indicator = formatOMContextIndicator(
+    const positiveWithNegativeSource = formatOMContextIndicator(
       createState({ messageSavings: 2_000, reflectionInput: 1_000, reflectionOutput: 5_000 }),
     );
 
-    expect(indicator.plain).toContain('↓2k');
+    expect(combined.plain.endsWith(' ↓')).toBe(true);
+    expect(positiveWithNegativeSource.plain.endsWith(' ↓')).toBe(true);
   });
 
-  it('suppresses zero savings and preserves visible width in styled output', () => {
-    const indicator = formatOMContextIndicator(createState({ reflectionInput: 300, reflectionOutput: 300 }));
+  it('suppresses the arrow for zero savings while preserving the indicator width', () => {
+    const withoutSavings = formatOMContextIndicator(createState({ reflectionInput: 300, reflectionOutput: 300 }));
+    const withSavings = formatOMContextIndicator(createState({ messageSavings: 2_000 }));
 
-    expect(indicator.plain).not.toContain('↓');
-    expect(visibleWidth(indicator.styled)).toBe(visibleWidth(indicator.plain));
+    expect(withoutSavings.plain).not.toContain('↓');
+    expect(visibleWidth(withoutSavings.plain)).toBe(visibleWidth(withSavings.plain));
+    expect(visibleWidth(withoutSavings.styled)).toBe(visibleWidth(withoutSavings.plain));
+    expect(visibleWidth(withSavings.styled)).toBe(visibleWidth(withSavings.plain));
   });
 
   it('allows occupied segments to be styled independently', () => {
     const indicator = formatOMContextIndicator(createState({ pendingTokens: 30_000, observationTokens: 30_000 }), {
       messages: segment => `<orange>${segment}</orange>`,
       memory: segment => `<pink>${segment}</pink>`,
+      unused: segment => `<gray>${segment}</gray>`,
     });
 
     expect(indicator.styled).toContain('<orange>━━━</orange>');
     expect(indicator.styled).toContain('<pink>━━</pink>');
-    expect(indicator.styled).toContain('─────');
+    expect(indicator.styled).toContain('<gray>━━━━━</gray>');
   });
 });

--- a/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/om-progress.test.ts
@@ -165,15 +165,13 @@ describe('formatOMContextIndicator', () => {
     expect(visibleWidth(withSavings.styled)).toBe(visibleWidth(withSavings.plain));
   });
 
-  it('allows occupied segments to be styled independently', () => {
+  it('renders observations first, then messages, then unused capacity', () => {
     const indicator = formatOMContextIndicator(createState({ pendingTokens: 30_000, observationTokens: 30_000 }), {
-      messages: segment => `<orange>${segment}</orange>`,
-      memory: segment => `<pink>${segment}</pink>`,
-      unused: segment => `<gray>${segment}</gray>`,
+      messages: segment => `<messages>${segment}</messages>`,
+      memory: segment => `<observations>${segment}</observations>`,
+      unused: segment => `<unused>${segment}</unused>`,
     });
 
-    expect(indicator.styled).toContain('<orange>━━━</orange>');
-    expect(indicator.styled).toContain('<pink>━━</pink>');
-    expect(indicator.styled).toContain('<gray>━━━━━</gray>');
+    expect(indicator.styled).toContain('<observations>━━</observations><messages>━━━</messages><unused>━━━━━</unused>');
   });
 });

--- a/mastracode/tui/src/tui/components/om-progress.ts
+++ b/mastracode/tui/src/tui/components/om-progress.ts
@@ -186,7 +186,7 @@ export function formatOMContextIndicator(
     state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens,
   );
   const hasSavings = messageSavings + reflectionSavings > 0;
-  const savingsSlot = hasSavings ? ' ↓' : '  ';
+  const savingsSlot = hasSavings ? '↓ ' : '  ';
 
   const plain = `${memorySegment}${messageSegment}${unusedSegment}  ${fraction}${savingsSlot}`;
   const styleMessages = stylers.messages ?? (segment => theme.fg('text', segment));
@@ -199,7 +199,7 @@ export function formatOMContextIndicator(
     '  ' +
     chalk.bold(theme.fg('text', usedText)) +
     theme.fg('thinkingText', `/${capacityText}`) +
-    (hasSavings ? ` ${theme.fg('success', '↓')}` : '  ');
+    (hasSavings ? `${theme.fg('success', '↓')} ` : '  ');
 
   return { plain, styled, messageCells, memoryCells, unusedCells };
 }

--- a/mastracode/tui/src/tui/components/om-progress.ts
+++ b/mastracode/tui/src/tui/components/om-progress.ts
@@ -145,82 +145,71 @@ function formatTokensThreshold(n: number): string {
   return (s.endsWith('.0') ? s.slice(0, -2) : s) + 'k';
 }
 
-function colorByPercent(text: string, percent: number): string {
-  if (percent >= 90) return chalk.hex(mastra.red)(text); // Mastra red
-  if (percent >= 70) return chalk.hex(mastra.orange)(text); // Mastra orange
-  return chalk.hex('#71717a')(text); // Zinc-500
-}
-/**
- * Format OM observation threshold for status bar.
- * Compact levels (most → least info):
- *   "full":        messages 12.5k/30k ↓2.1k
- *   undefined:     msg 12.5k/30k ↓2.1k
- *   "noBuffer":    msg 12.5k/30k
- *   "percentOnly": msg 42%
- *
- * @param labelStyler - Optional function to style the label text (for animation).
- *                      Receives the raw label string, returns styled string.
- */
-export function formatObservationStatus(
-  state: OMProgressState,
-  compact?: 'percentOnly' | 'noBuffer' | 'full',
-  labelStyler?: (label: string) => string,
-): string {
-  // Status is now shown in the mode badge, so just show the metrics
-  const percent = Math.round(state.thresholdPercent);
-  const pct = colorByPercent(`${percent}%`, percent);
-  const defaultStyler = (s: string) => chalk.hex(mastra.specialGray)(s);
-  const styleLabel = labelStyler ?? defaultStyler;
-  if (compact === 'percentOnly') {
-    return styleLabel('msg ') + pct;
-  }
-  const label = compact === 'full' ? 'messages' : 'msg';
-  const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`;
-  const buffered =
-    compact !== 'noBuffer' && state.buffered.observations.projectedMessageRemoval > 0
-      ? chalk.italic(
-          theme.fg('muted', ` ↓${formatTokensThreshold(state.buffered.observations.projectedMessageRemoval)}`),
-        )
-      : '';
-  return styleLabel(`${label} `) + colorByPercent(fraction, percent) + buffered;
-}
-/**
- * Format OM reflection threshold for status bar.
- * Compact levels (most → least info):
- *   "full":        memory 8.2k/40k ↓1.2k
- *   undefined:     mem 8.2k/40k ↓1.2k
- *   "noBuffer":    mem 8.2k/40k
- *   "percentOnly": mem 21%
- *
- * @param labelStyler - Optional function to style the label text (for animation).
- *                      Receives the raw label string, returns styled string.
- */
-export function formatReflectionStatus(
-  state: OMProgressState,
-  compact?: 'percentOnly' | 'noBuffer' | 'full',
-  labelStyler?: (label: string) => string,
-): string {
-  // Status is now shown in the mode badge, so just show the metrics
-  const percent = Math.round(state.reflectionThresholdPercent);
-  const pct = colorByPercent(`${percent}%`, percent);
-  const defaultStyler = (s: string) => chalk.hex(mastra.specialGray)(s);
-  const styleLabel = labelStyler ?? defaultStyler;
-  const label = styleLabel(compact === 'full' ? 'memory' : 'mem') + ' ';
-  if (compact === 'percentOnly') {
-    return label + pct;
-  }
-  const fraction = `${formatTokensValue(state.observationTokens)}/${formatTokensThreshold(state.reflectionThreshold)}`;
-  const savings = state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens;
-  const buffered =
-    compact !== 'noBuffer' && state.buffered.reflection.status === 'complete' && savings > 0
-      ? chalk.italic(theme.fg('muted', ` ↓${formatTokensThreshold(savings)}`))
-      : '';
-  return label + colorByPercent(fraction, percent) + buffered;
+interface OMContextIndicator {
+  plain: string;
+  styled: string;
+  messageCells: number;
+  memoryCells: number;
+  unusedCells: number;
 }
 
-/**
- * @deprecated Use formatObservationStatus and formatReflectionStatus instead
- */
+interface OMContextIndicatorStylers {
+  messages?: (segment: string) => string;
+  memory?: (segment: string) => string;
+}
+
+export function formatOMContextIndicator(
+  state: OMProgressState,
+  stylers: OMContextIndicatorStylers = {},
+): OMContextIndicator {
+  const used = Math.max(0, state.pendingTokens) + Math.max(0, state.observationTokens);
+  const capacity = Math.max(0, state.threshold) + Math.max(0, state.reflectionThreshold);
+  const occupiedCells = capacity === 0 ? 0 : Math.max(0, Math.min(10, Math.round((used / capacity) * 10)));
+
+  let messageCells = used === 0 ? 0 : Math.round((Math.max(0, state.pendingTokens) / used) * occupiedCells);
+  if (state.pendingTokens > 0 && state.observationTokens > 0 && occupiedCells >= 2) {
+    messageCells = Math.max(1, Math.min(occupiedCells - 1, messageCells));
+  }
+  const memoryCells = occupiedCells - messageCells;
+  const unusedCells = 10 - occupiedCells;
+
+  const messageSegment = '━'.repeat(messageCells);
+  const unusedSegment = '─'.repeat(unusedCells);
+  const memorySegment = '━'.repeat(memoryCells);
+  const fraction = `${formatTokensValue(used)}/${formatTokensThreshold(capacity)}`;
+  const messageSavings = Math.max(0, state.buffered.observations.projectedMessageRemoval);
+  const reflectionSavings = Math.max(
+    0,
+    state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens,
+  );
+  const savings = messageSavings + reflectionSavings;
+  const suffix = savings > 0 ? ` ↓${formatTokensThreshold(savings)}` : '';
+
+  const plain = `[${messageSegment}${unusedSegment}${memorySegment}] ${fraction}${suffix}`;
+  const styleMessages = stylers.messages ?? (segment => chalk.hex(mastra.orange)(segment));
+  const styleMemory = stylers.memory ?? (segment => chalk.hex(mastra.pink)(segment));
+  const styled =
+    theme.fg('muted', '[') +
+    styleMessages(messageSegment) +
+    theme.fg('muted', unusedSegment) +
+    styleMemory(memorySegment) +
+    theme.fg('muted', `] ${fraction}`) +
+    (suffix ? chalk.italic(theme.fg('muted', suffix)) : '');
+
+  return { plain, styled, messageCells, memoryCells, unusedCells };
+}
+
+/** @deprecated Retained for backward compatibility. */
 export function formatOMStatus(state: OMProgressState): string {
-  return formatObservationStatus(state);
+  const percent = Math.round(state.thresholdPercent);
+  const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`;
+  const value =
+    percent >= 90
+      ? chalk.hex(mastra.red)(fraction)
+      : percent >= 70
+        ? chalk.hex(mastra.orange)(fraction)
+        : chalk.hex('#71717a')(fraction);
+  const savings = state.buffered.observations.projectedMessageRemoval;
+  const buffered = savings > 0 ? chalk.italic(theme.fg('muted', ` ↓${formatTokensThreshold(savings)}`)) : '';
+  return chalk.hex(mastra.specialGray)('msg ') + value + buffered;
 }

--- a/mastracode/tui/src/tui/components/om-progress.ts
+++ b/mastracode/tui/src/tui/components/om-progress.ts
@@ -156,6 +156,7 @@ interface OMContextIndicator {
 interface OMContextIndicatorStylers {
   messages?: (segment: string) => string;
   memory?: (segment: string) => string;
+  unused?: (segment: string) => string;
 }
 
 export function formatOMContextIndicator(
@@ -174,27 +175,31 @@ export function formatOMContextIndicator(
   const unusedCells = 10 - occupiedCells;
 
   const messageSegment = '━'.repeat(messageCells);
-  const unusedSegment = '─'.repeat(unusedCells);
+  const unusedSegment = '━'.repeat(unusedCells);
   const memorySegment = '━'.repeat(memoryCells);
-  const fraction = `${formatTokensValue(used)}/${formatTokensThreshold(capacity)}`;
+  const usedText = formatTokensValue(used);
+  const capacityText = formatTokensThreshold(capacity);
+  const fraction = `${usedText}/${capacityText}`;
   const messageSavings = Math.max(0, state.buffered.observations.projectedMessageRemoval);
   const reflectionSavings = Math.max(
     0,
     state.buffered.reflection.inputObservationTokens - state.buffered.reflection.observationTokens,
   );
-  const savings = messageSavings + reflectionSavings;
-  const suffix = savings > 0 ? ` ↓${formatTokensThreshold(savings)}` : '';
+  const hasSavings = messageSavings + reflectionSavings > 0;
+  const savingsSlot = hasSavings ? ' ↓' : '  ';
 
-  const plain = `[${messageSegment}${unusedSegment}${memorySegment}] ${fraction}${suffix}`;
-  const styleMessages = stylers.messages ?? (segment => chalk.hex(mastra.orange)(segment));
-  const styleMemory = stylers.memory ?? (segment => chalk.hex(mastra.pink)(segment));
+  const plain = `${memorySegment}${messageSegment}${unusedSegment}  ${fraction}${savingsSlot}`;
+  const styleMessages = stylers.messages ?? (segment => theme.fg('text', segment));
+  const styleMemory = stylers.memory ?? (segment => theme.fg('dim', segment));
+  const styleUnused = stylers.unused ?? (segment => theme.fg('muted', segment));
   const styled =
-    theme.fg('muted', '[') +
-    styleMessages(messageSegment) +
-    theme.fg('muted', unusedSegment) +
     styleMemory(memorySegment) +
-    theme.fg('muted', `] ${fraction}`) +
-    (suffix ? chalk.italic(theme.fg('muted', suffix)) : '');
+    styleMessages(messageSegment) +
+    styleUnused(unusedSegment) +
+    '  ' +
+    chalk.bold(theme.fg('text', usedText)) +
+    theme.fg('thinkingText', `/${capacityText}`) +
+    (hasSavings ? ` ${theme.fg('success', '↓')}` : '  ');
 
   return { plain, styled, messageCells, memoryCells, unusedCells };
 }

--- a/mastracode/tui/src/tui/components/om-progress.ts
+++ b/mastracode/tui/src/tui/components/om-progress.ts
@@ -153,15 +153,16 @@ interface OMContextIndicator {
   unusedCells: number;
 }
 
-interface OMContextIndicatorStylers {
+interface OMContextIndicatorOptions {
   messages?: (segment: string) => string;
   memory?: (segment: string) => string;
   unused?: (segment: string) => string;
+  showBar?: boolean;
 }
 
 export function formatOMContextIndicator(
   state: OMProgressState,
-  stylers: OMContextIndicatorStylers = {},
+  options: OMContextIndicatorOptions = {},
 ): OMContextIndicator {
   const used = Math.max(0, state.pendingTokens) + Math.max(0, state.observationTokens);
   const capacity = Math.max(0, state.threshold) + Math.max(0, state.reflectionThreshold);
@@ -188,15 +189,17 @@ export function formatOMContextIndicator(
   const hasSavings = messageSavings + reflectionSavings > 0;
   const savingsSlot = hasSavings ? '↓ ' : '  ';
 
-  const plain = `${memorySegment}${messageSegment}${unusedSegment}  ${fraction}${savingsSlot}`;
-  const styleMessages = stylers.messages ?? (segment => theme.fg('text', segment));
-  const styleMemory = stylers.memory ?? (segment => theme.fg('dim', segment));
-  const styleUnused = stylers.unused ?? (segment => theme.fg('muted', segment));
+  const barPlain = options.showBar === false ? '' : `${memorySegment}${messageSegment}${unusedSegment}  `;
+  const plain = `${barPlain}${fraction}${savingsSlot}`;
+  const styleMessages = options.messages ?? (segment => theme.fg('text', segment));
+  const styleMemory = options.memory ?? (segment => theme.fg('dim', segment));
+  const styleUnused = options.unused ?? (segment => theme.fg('muted', segment));
+  const barStyled =
+    options.showBar === false
+      ? ''
+      : styleMemory(memorySegment) + styleMessages(messageSegment) + styleUnused(unusedSegment) + '  ';
   const styled =
-    styleMemory(memorySegment) +
-    styleMessages(messageSegment) +
-    styleUnused(unusedSegment) +
-    '  ' +
+    barStyled +
     chalk.bold(theme.fg('text', usedText)) +
     theme.fg('thinkingText', `/${capacityText}`) +
     (hasSavings ? `${theme.fg('success', '↓')} ` : '  ');

--- a/mastracode/tui/src/tui/components/om-progress.ts
+++ b/mastracode/tui/src/tui/components/om-progress.ts
@@ -204,7 +204,7 @@ export function formatOMContextIndicator(
   return { plain, styled, messageCells, memoryCells, unusedCells };
 }
 
-/** @deprecated Retained for backward compatibility. */
+/** @deprecated Use formatOMContextIndicator for the unified context display. */
 export function formatOMStatus(state: OMProgressState): string {
   const percent = Math.round(state.thresholdPercent);
   const fraction = `${formatTokensValue(state.pendingTokens)}/${formatTokensThreshold(state.threshold)}`;

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -8,7 +8,7 @@ import { applyGradientSweep } from './components/obi-loader.js';
 import { formatOMContextIndicator } from './components/om-progress.js';
 import type { GithubPrSubscriptionBadge, TUIState } from './state.js';
 import { formatStatusDuration } from './status-duration.js';
-import { theme, mastra, tintHex, getTermWidth, extendedColors } from './theme.js';
+import { theme, mastra, mastraBrand, tintHex, getTermWidth, extendedColors } from './theme.js';
 
 // Colors for OM modes — read from proxy at render time so they pick up contrast adaptation
 const getObserverColor = () => mastra.orange;
@@ -84,11 +84,14 @@ export function updateStatusLine(state: TUIState): void {
   let modeBadge = '';
   let modeBadgeWidth = 0;
   const modes = state.controller.listModes();
-  const currentMode = modes.length > 1 ? state.session.mode.resolve() : undefined;
+  const configuredMode = state.session.mode.resolve();
+  const currentMode = modes.length > 1 ? configuredMode : undefined;
   const judgeModeColor = mastra.blue;
   // Use judge color for goal judge activity, OM color for OM activity, otherwise mode color
   const currentModeColor = currentMode?.metadata?.color;
   const mainModeColor = typeof currentModeColor === 'string' ? currentModeColor : undefined;
+  const configuredModeColor = configuredMode?.metadata?.color;
+  const contextIndicatorColor = typeof configuredModeColor === 'string' ? configuredModeColor : mastra.green;
   const modeColor = isJudging
     ? judgeModeColor
     : showOMMode
@@ -335,33 +338,38 @@ export function updateStatusLine(state: TUIState): void {
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;
     const ds = displayState;
+    const messageColor = contextIndicatorColor;
+    const memoryColor = mastraBrand.blue;
+    const unusedColor = '#3f3f46';
     const messageSegmentStyler =
       ds.bufferingMessages && state.gradientAnimator?.isRunning()
         ? (segment: string) =>
             applyGradientSweep(
               segment,
               state.gradientAnimator!.getOffset(),
-              getObserverColor(),
+              messageColor,
               state.gradientAnimator!.getFadeProgress(),
             )
-        : undefined;
+        : (segment: string) => chalk.hex(messageColor)(segment);
     const memorySegmentStyler =
       ds.bufferingObservations && state.gradientAnimator?.isRunning()
         ? (segment: string) =>
             applyGradientSweep(
               segment,
               state.gradientAnimator!.getOffset(),
-              getReflectorColor(),
+              memoryColor,
               state.gradientAnimator!.getFadeProgress(),
             )
-        : undefined;
-    if (!isJudging && opts.showOM !== false) {
-      const indicator = formatOMContextIndicator(ds.omProgress, {
-        messages: messageSegmentStyler,
-        memory: memorySegmentStyler,
-      });
-      parts.push({ plain: indicator.plain, styled: indicator.styled });
-    }
+        : (segment: string) => chalk.hex(memoryColor)(segment);
+    const unusedSegmentStyler = (segment: string) => chalk.hex(unusedColor)(segment);
+    const indicatorPart =
+      !isJudging && opts.showOM !== false
+        ? formatOMContextIndicator(ds.omProgress, {
+            messages: messageSegmentStyler,
+            memory: memorySegmentStyler,
+            unused: unusedSegmentStyler,
+          })
+        : null;
     if (state.tokensPerSec > 0) {
       const tpsLabel = `${state.tokensPerSec} tok/s`;
       parts.push({
@@ -385,9 +393,11 @@ export function updateStatusLine(state: TUIState): void {
     // Directory / branch / thread title (lowest priority on line 1)
     let dirText = opts.dir !== undefined ? opts.dir : opts.showDir ? dirFull : null;
 
-    // Measure width of everything except dir to know how much space remains
+    // Measure width of everything except dir to know how much space remains.
+    // The context indicator is reserved at the far right even though it is appended after dir.
+    const nonDirParts = indicatorPart ? [...parts, indicatorPart] : parts;
     const nonDirWidth =
-      useBadgeWidth + parts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
+      useBadgeWidth + nonDirParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
 
     if (dirText) {
       const dirPart = formatDirPart(dirText);
@@ -410,6 +420,9 @@ export function updateStatusLine(state: TUIState): void {
     if (dirText) {
       parts.push(formatDirPart(dirText));
     }
+    if (indicatorPart) {
+      parts.push({ plain: indicatorPart.plain, styled: indicatorPart.styled });
+    }
     const totalPlain =
       useBadgeWidth + parts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
 
@@ -417,15 +430,15 @@ export function updateStatusLine(state: TUIState): void {
 
     let styledLine: string;
     const hasDir = !!dirText;
-    if (hasDir && parts.length >= 3) {
-      // Three groups: left (model), center (mem/tokens/thinking), right (dir)
-      const leftPart = parts[0]!; // model
-      const centerParts = parts.slice(1, -1); // mem, tokens, thinking
-      const dirPart = parts[parts.length - 1]!; // dir
+    if (indicatorPart && parts.length >= 2) {
+      // Three groups: left (model), center (activity + dir/thread), right (context indicator)
+      const leftPart = parts[0]!;
+      const centerParts = parts.slice(1, -1);
+      const rightPart = parts[parts.length - 1]!;
 
       const leftWidth = useBadgeWidth + visibleWidth(leftPart.plain);
       const centerWidth = centerParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
-      const rightWidth = visibleWidth(dirPart.plain);
+      const rightWidth = visibleWidth(rightPart.plain);
       const totalContent = leftWidth + centerWidth + rightWidth;
       const freeSpace = termWidth - totalContent;
       const gapLeft = Math.floor(freeSpace / 2);
@@ -437,7 +450,7 @@ export function updateStatusLine(state: TUIState): void {
         ' '.repeat(Math.max(gapLeft, 1)) +
         centerParts.map(p => p.styled).join(SEP) +
         ' '.repeat(Math.max(gapRight, 1)) +
-        dirPart.styled;
+        rightPart.styled;
     } else if (hasDir && parts.length === 2) {
       // Just model + dir, right-align dir
       const mainStr = useBadge + parts[0]!.styled;

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -6,34 +6,13 @@ import { visibleWidth } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatOMContextIndicator } from './components/om-progress.js';
-import type { GithubPrSubscriptionBadge, TUIState } from './state.js';
+import type { TUIState } from './state.js';
 import { formatStatusDuration } from './status-duration.js';
-import { theme, mastra, mastraBrand, tintHex, getTermWidth, extendedColors } from './theme.js';
+import { theme, mastra, mastraBrand, tintHex, getTermWidth } from './theme.js';
 
 // Colors for OM modes — read from proxy at render time so they pick up contrast adaptation
 const getObserverColor = () => mastra.orange;
 const getReflectorColor = () => mastra.pink;
-
-function formatGithubPrLabel(
-  state: TUIState,
-  subscription: GithubPrSubscriptionBadge,
-): { plain: string; styled: string } {
-  const plain = `PR#${subscription.prNumber}`;
-  const label = plain;
-  const color = subscription.lastNotificationPriority === 'high' ? mastra.orange : extendedColors.skyBlue;
-  if (state.githubPrPollingActive && state.githubPrGradientAnimator?.isRunning()) {
-    return {
-      plain: label,
-      styled: applyGradientSweep(
-        label,
-        state.githubPrGradientAnimator.getOffset(),
-        color,
-        state.githubPrGradientAnimator.getFadeProgress(),
-      ),
-    };
-  }
-  return { plain: label, styled: chalk.hex(color)(label) };
-}
 
 function getGoalDurationMs(
   goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number },
@@ -183,15 +162,7 @@ export function updateStatusLine(state: TUIState): void {
     state.agentRunStartedAt !== undefined &&
     Math.floor(getGoalDurationMs(goalState, now) / 60_000) === Math.floor((now - state.agentRunStartedAt) / 60_000);
   const goalLabel = goalDuration ? (goalMatchesActiveRun ? 'goal' : `goal ${goalDuration}`) : null;
-  const activeGithubPr = state.activeGithubPrSubscriptions?.[0];
-  const githubPrLabel = activeGithubPr ? formatGithubPrLabel(state, activeGithubPr) : null;
-  const formatDirPart = (value: string) => {
-    if (!githubPrLabel) return { plain: value, styled: theme.fg('thinkingText', value) };
-    return {
-      plain: `${githubPrLabel.plain} ${value}`,
-      styled: `${githubPrLabel.styled} ${theme.fg('thinkingText', value)}`,
-    };
-  };
+  const formatDirPart = (value: string) => ({ plain: value, styled: theme.fg('thinkingText', value) });
   // Build progressively shorter branch strings for layout fallback.
   const dirBranchOnly = branch || null;
   // Abbreviate long branches: keep first 12 + last 8 chars with ".." in between.
@@ -396,9 +367,7 @@ export function updateStatusLine(state: TUIState): void {
         return null;
       }
       if (dirWidth > availableForDir && availableForDir >= MIN_TRUNCATED_DIR) {
-        const reservedPrefix = githubPrLabel ? `${githubPrLabel.plain} ` : '';
-        const availableForText = availableForDir - visibleWidth(reservedPrefix);
-        dirText = availableForText > 1 ? dirText.slice(0, availableForText - 1) + '…' : null;
+        dirText = availableForDir > 1 ? dirText.slice(0, availableForDir - 1) + '…' : null;
       } else if (dirWidth > availableForDir) {
         // Not enough room even for a truncated version — drop it
         dirText = null;

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -72,7 +72,9 @@ export function updateStatusLine(state: TUIState): void {
   const SEP = '  '; // double-space separator between parts
 
   // --- Determine if we're showing observer/reflector instead of main mode ---
-  const omStatus = state.session.displayState.get().omProgress.status;
+  const displayState = state.session.displayState.get();
+  const omStatus = displayState.omProgress.status;
+  const isOMBuffering = displayState.bufferingMessages || displayState.bufferingObservations;
   const isJudging = Boolean(state.activeGoalJudge);
   const isObserving = omStatus === 'observing';
   const isReflecting = omStatus === 'reflecting';
@@ -114,7 +116,7 @@ export function updateStatusLine(state: TUIState): void {
     ];
     // Pulse the badge bg brightness opposite to the gradient sweep
     let badgeBrightness = 0.9;
-    if (state.gradientAnimator?.isRunning()) {
+    if (!isOMBuffering && state.gradientAnimator?.isRunning()) {
       const fade = state.gradientAnimator.getFadeProgress();
       const easedFade = fade * fade * (3 - 2 * fade); // smoothstep
       const offset = state.gradientAnimator.getOffset() % 1;
@@ -210,7 +212,7 @@ export function updateStatusLine(state: TUIState): void {
       return theme.fg('dim', id) + theme.fg('error', ' ✗') + theme.fg('muted', envVar ? ` (${envVar})` : ' (no key)');
     }
 
-    if (state.gradientAnimator?.isRunning() && modeColor) {
+    if (!isOMBuffering && state.gradientAnimator?.isRunning() && modeColor) {
       const fade = state.gradientAnimator.getFadeProgress();
       const easedFade = fade * fade * (3 - 2 * fade); // smoothstep
       const text = applyGradientSweep(id, state.gradientAnimator.getOffset(), modeColor, easedFade);
@@ -251,7 +253,7 @@ export function updateStatusLine(state: TUIState): void {
       parseInt(modeColor.slice(5, 7), 16),
     ];
     let sBadgeBrightness = 0.9;
-    if (state.gradientAnimator?.isRunning()) {
+    if (!isOMBuffering && state.gradientAnimator?.isRunning()) {
       const fade = state.gradientAnimator.getFadeProgress();
       if (fade < 1) {
         const offset = state.gradientAnimator.getOffset() % 1;
@@ -332,7 +334,7 @@ export function updateStatusLine(state: TUIState): void {
     });
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;
-    const ds = state.session.displayState.get();
+    const ds = displayState;
     const messageSegmentStyler =
       ds.bufferingMessages && state.gradientAnimator?.isRunning()
         ? (segment: string) =>

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -14,17 +14,6 @@ import { theme, mastra, mastraBrand, tintHex, getTermWidth, extendedColors } fro
 const getObserverColor = () => mastra.orange;
 const getReflectorColor = () => mastra.pink;
 
-/** Returns true if a thread title is generic/auto-generated and should not be displayed. */
-function isGenericTitle(title: string): boolean {
-  const lower = title.toLowerCase().trim();
-  return (
-    lower === 'new thread' ||
-    lower.startsWith('new thread') ||
-    lower.startsWith('clone of') ||
-    lower.startsWith('untitled')
-  );
-}
-
 function formatGithubPrLabel(
   state: TUIState,
   subscription: GithubPrSubscriptionBadge,
@@ -46,11 +35,18 @@ function formatGithubPrLabel(
   return { plain: label, styled: chalk.hex(color)(label) };
 }
 
-function formatGoalDuration(goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number }): string {
+function getGoalDurationMs(
+  goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number },
+  now: number,
+): number {
   const activeStartedAt = goal.activeStartedAt ?? (goal.activeDurationMs === undefined ? goal.startedAt : undefined);
   const startedMs = activeStartedAt ? Date.parse(activeStartedAt) : NaN;
-  const activeRunMs = Number.isFinite(startedMs) ? Math.max(0, Date.now() - startedMs) : 0;
-  const elapsedMinutes = Math.floor(((goal.activeDurationMs ?? 0) + activeRunMs) / 60_000);
+  const activeRunMs = Number.isFinite(startedMs) ? Math.max(0, now - startedMs) : 0;
+  return (goal.activeDurationMs ?? 0) + activeRunMs;
+}
+
+function formatGoalDuration(goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number }): string {
+  const elapsedMinutes = Math.floor(getGoalDurationMs(goal, Date.now()) / 60_000);
   if (elapsedMinutes < 1) return '<1m';
 
   const days = Math.floor(elapsedMinutes / 1_440);
@@ -175,37 +171,31 @@ export function updateStatusLine(state: TUIState): void {
     ? shortModelId
     : shortModelId.replace(/^claude-/, '').replace(/^(\w+)-(\d+)-(\d{1,2})$/, '$1 $2.$3');
 
-  const homedir = process.env.HOME || process.env.USERPROFILE || '';
-  // Use thread title if available and not generic, otherwise use project root path
-  const threadTitle =
-    state.currentThreadTitle && !isGenericTitle(state.currentThreadTitle) ? state.currentThreadTitle : null;
-  let displayPath = threadTitle || state.projectInfo.rootPath;
-  if (!threadTitle && homedir && displayPath.startsWith(homedir)) {
-    displayPath = '~' + displayPath.slice(homedir.length);
-  }
   const branch = state.projectInfo.gitBranch;
+  const now = Date.now();
   const queuedCount = state.pendingQueuedActions.length + state.session.followUps.count();
   const queuedLabel = queuedCount > 0 ? `${queuedCount} queued` : null;
   const goalState = state.goalManager?.getGoal();
   const goalDuration = !isJudging && goalState?.status === 'active' ? formatGoalDuration(goalState) : null;
-  const goalLabel = goalDuration ? `pursuing goal (${goalDuration})` : null;
-  const shortGoalLabel = goalDuration ? `goal (${goalDuration})` : null;
+  const goalMatchesActiveRun =
+    goalState?.status === 'active' &&
+    goalDuration !== null &&
+    state.agentRunStartedAt !== undefined &&
+    Math.floor(getGoalDurationMs(goalState, now) / 60_000) === Math.floor((now - state.agentRunStartedAt) / 60_000);
+  const goalLabel = goalDuration ? (goalMatchesActiveRun ? 'goal' : `goal ${goalDuration}`) : null;
   const activeGithubPr = state.activeGithubPrSubscriptions?.[0];
   const githubPrLabel = activeGithubPr ? formatGithubPrLabel(state, activeGithubPr) : null;
   const formatDirPart = (value: string) => {
-    if (!githubPrLabel) return { plain: value, styled: theme.fg('dim', value) };
+    if (!githubPrLabel) return { plain: value, styled: theme.fg('thinkingText', value) };
     return {
       plain: `${githubPrLabel.plain} ${value}`,
-      styled: `${githubPrLabel.styled} ${theme.fg('dim', value)}`,
+      styled: `${githubPrLabel.styled} ${theme.fg('thinkingText', value)}`,
     };
   };
-  // Build progressively shorter directory strings for layout fallback
-  // Only show branch when not showing thread title (thread title takes priority)
-  const dirFull = !threadTitle && branch ? `${displayPath} (${branch})` : displayPath;
-  const dirBranchOnly = !threadTitle && branch ? branch : null;
-  // Abbreviate long branches: keep first 12 + last 8 chars with ".." in between
-  const dirBranchShort =
-    !threadTitle && branch && branch.length > 24 ? branch.slice(0, 12) + '..' + branch.slice(-8) : dirBranchOnly;
+  // Build progressively shorter branch strings for layout fallback.
+  const dirBranchOnly = branch || null;
+  // Abbreviate long branches: keep first 12 + last 8 chars with ".." in between.
+  const dirBranchShort = branch && branch.length > 24 ? branch.slice(0, 12) + '..' + branch.slice(-8) : dirBranchOnly;
 
   // --- Helper to style the model ID ---
   const modelTrail = tintBg ? chalk.hex(tintBg)('▌') : '';
@@ -277,7 +267,6 @@ export function updateStatusLine(state: TUIState): void {
     shortModeBadgeWidth = shortName.length + 2;
   }
 
-  const now = Date.now();
   const activeTimingLabel =
     state.agentRunStartedAt !== undefined
       ? formatStatusDuration(now - state.agentRunStartedAt, { includeSeconds: true })
@@ -306,7 +295,6 @@ export function updateStatusLine(state: TUIState): void {
     allowDirTruncation?: boolean;
     badge?: 'full' | 'short';
     showQueue?: boolean;
-    compactGoal?: boolean;
   }): { plain: string; styled: string } | null => {
     const parts: Array<{ plain: string; styled: string }> = [];
     // Model ID (always present) — styleModelId adds padding spaces
@@ -370,11 +358,10 @@ export function updateStatusLine(state: TUIState): void {
             unused: unusedSegmentStyler,
           })
         : null;
-    if (state.tokensPerSec > 0) {
-      const tpsLabel = `${state.tokensPerSec} tok/s`;
+    if (opts.showQueue && goalLabel) {
       parts.push({
-        plain: tpsLabel,
-        styled: theme.fg('dim', tpsLabel),
+        plain: goalLabel,
+        styled: theme.fg('success', goalLabel),
       });
     }
     if (opts.showQueue && queuedLabel) {
@@ -383,19 +370,20 @@ export function updateStatusLine(state: TUIState): void {
         styled: theme.fg('warning', queuedLabel),
       });
     }
-    const renderedGoalLabel = opts.compactGoal ? shortGoalLabel : goalLabel;
-    if (opts.showQueue && renderedGoalLabel) {
-      parts.push({
-        plain: renderedGoalLabel,
-        styled: theme.fg('accent', renderedGoalLabel),
-      });
-    }
+    const tpsLabel = state.tokensPerSec > 0 ? `${String(state.tokensPerSec).padStart(3)} t/s` : null;
+    const tpsPart = tpsLabel
+      ? {
+          plain: tpsLabel,
+          styled: theme.fg('text', tpsLabel),
+        }
+      : null;
     // Directory / branch / thread title (lowest priority on line 1)
-    let dirText = opts.dir !== undefined ? opts.dir : opts.showDir ? dirFull : null;
+    let dirText = opts.dir !== undefined ? opts.dir : opts.showDir ? dirBranchOnly : null;
 
     // Measure width of everything except dir to know how much space remains.
-    // The context indicator is reserved at the far right even though it is appended after dir.
-    const nonDirParts = indicatorPart ? [...parts, indicatorPart] : parts;
+    // Throughput and the context indicator are reserved at the far right even though they are appended after dir.
+    const rightParts = indicatorPart ? [tpsPart, indicatorPart].filter(part => part !== null) : [];
+    const nonDirParts = [...parts, ...rightParts];
     const nonDirWidth =
       useBadgeWidth + nonDirParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
 
@@ -421,7 +409,9 @@ export function updateStatusLine(state: TUIState): void {
       parts.push(formatDirPart(dirText));
     }
     if (indicatorPart) {
-      parts.push({ plain: indicatorPart.plain, styled: indicatorPart.styled });
+      parts.push(...rightParts);
+    } else if (tpsPart) {
+      parts.push(tpsPart);
     }
     const totalPlain =
       useBadgeWidth + parts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
@@ -431,14 +421,18 @@ export function updateStatusLine(state: TUIState): void {
     let styledLine: string;
     const hasDir = !!dirText;
     if (indicatorPart && parts.length >= 2) {
-      // Three groups: left (model), center (activity + dir/thread), right (context indicator)
-      const leftPart = parts[0]!;
-      const centerParts = parts.slice(1, -1);
-      const rightPart = parts[parts.length - 1]!;
+      // Three groups: left (model + timing + goal), center (queue + dir/thread), right (throughput + context)
+      const leftPartCount = opts.showQueue && goalLabel ? 2 : 1;
+      const leftParts = parts.slice(0, leftPartCount);
+      const centerParts = parts.slice(leftPartCount, -rightParts.length);
+      const leftSeparatorPlain = timingLabel ? ' · ' : ' ';
+      const leftSeparatorStyled = timingLabel ? ` ${theme.fg('success', '·')} ` : ' ';
 
-      const leftWidth = useBadgeWidth + visibleWidth(leftPart.plain);
+      const leftWidth =
+        useBadgeWidth +
+        leftParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? leftSeparatorPlain.length : 0), 0);
       const centerWidth = centerParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
-      const rightWidth = visibleWidth(rightPart.plain);
+      const rightWidth = rightParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
       const totalContent = leftWidth + centerWidth + rightWidth;
       const freeSpace = termWidth - totalContent;
       const gapLeft = Math.floor(freeSpace / 2);
@@ -446,11 +440,11 @@ export function updateStatusLine(state: TUIState): void {
 
       styledLine =
         useBadge +
-        leftPart.styled +
+        leftParts.map(p => p.styled).join(leftSeparatorStyled) +
         ' '.repeat(Math.max(gapLeft, 1)) +
         centerParts.map(p => p.styled).join(SEP) +
         ' '.repeat(Math.max(gapRight, 1)) +
-        rightPart.styled;
+        rightParts.map(p => p.styled).join(SEP);
     } else if (hasDir && parts.length === 2) {
       // Just model + dir, right-align dir
       const mainStr = useBadge + parts[0]!.styled;
@@ -468,13 +462,6 @@ export function updateStatusLine(state: TUIState): void {
     buildLine({
       modelId: fullModelId,
       showDir: false,
-      dir: dirFull,
-      allowDirTruncation: false,
-      showQueue: true,
-    }) ??
-    buildLine({
-      modelId: fullModelId,
-      showDir: false,
       dir: dirBranchOnly,
       allowDirTruncation: false,
       showQueue: true,
@@ -483,16 +470,7 @@ export function updateStatusLine(state: TUIState): void {
     buildLine({ modelId: fullModelId, showDir: false, showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showDir: false, showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showDir: false, badge: 'short', showQueue: true }) ??
-    buildLine({ modelId: tinyModelId, showDir: false, badge: 'short', showQueue: true, compactGoal: true }) ??
     buildLine({ modelId: tinyModelId, showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
-    buildLine({
-      modelId: tinyModelId,
-      showOM: false,
-      showDir: false,
-      badge: 'short',
-      showQueue: true,
-      compactGoal: true,
-    }) ??
     buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showOM: false, showDir: false }) ??
     buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short' });

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -302,6 +302,7 @@ export function updateStatusLine(state: TUIState): void {
   const buildLine = (opts: {
     modelId: string;
     showOM?: boolean;
+    showOMBar?: boolean;
     showDir: boolean;
     dir?: string | null;
     allowDirTruncation?: boolean;
@@ -368,6 +369,7 @@ export function updateStatusLine(state: TUIState): void {
             messages: messageSegmentStyler,
             memory: memorySegmentStyler,
             unused: unusedSegmentStyler,
+            showBar: opts.showOMBar,
           })
         : null;
     if (opts.showQueue && goalLabel) {
@@ -480,18 +482,19 @@ export function updateStatusLine(state: TUIState): void {
     }) ??
     buildLine({
       modelId: fullModelId,
-      showOM: false,
+      showOMBar: false,
       showDir: false,
       dir: centerText,
       allowDirTruncation: false,
       showQueue: true,
     }) ??
-    buildLine({ modelId: fullModelId, showOM: false, showDir: false, dir: centerTextShort, showQueue: true }) ??
-    buildLine({ modelId: fullModelId, showOM: false, showDir: false, showQueue: true }) ??
-    buildLine({ modelId: tinyModelId, showOM: false, showDir: false, showQueue: true }) ??
+    buildLine({ modelId: fullModelId, showOMBar: false, showDir: false, dir: centerTextShort, showQueue: true }) ??
+    buildLine({ modelId: fullModelId, showOMBar: false, showDir: false, showQueue: true }) ??
+    buildLine({ modelId: tinyModelId, showOMBar: false, showDir: false, showQueue: true }) ??
+    buildLine({ modelId: tinyModelId, showOMBar: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
-    buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showOM: false, showDir: false }) ??
+    buildLine({ modelId: '', showOMBar: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short' });
 
   state.statusLine.setText(result?.styled ?? shortModeBadge + styleModelId(tinyModelId));

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -183,11 +183,11 @@ export function updateStatusLine(state: TUIState): void {
   const branch = state.projectInfo.gitBranch;
   const threadTitle =
     state.currentThreadTitle && !isGenericTitle(state.currentThreadTitle) ? state.currentThreadTitle : null;
-  const centerText = threadTitle || branch || null;
-  const centerTextShort =
-    centerText && centerText.length > 24 ? centerText.slice(0, 12) + '..' + centerText.slice(-8) : centerText;
   const activeGithubPr = state.activeGithubPrSubscriptions[0];
   const githubPrLabel = activeGithubPr ? formatGithubPrLabel(state, activeGithubPr) : null;
+  const centerText = threadTitle || branch || (githubPrLabel ? '' : null);
+  const centerTextShort =
+    centerText && centerText.length > 24 ? centerText.slice(0, 12) + '..' + centerText.slice(-8) : centerText;
   const now = Date.now();
   const queuedCount = state.pendingQueuedActions.length + state.session.followUps.count();
   const queuedLabel = queuedCount > 0 ? `${queuedCount} queued` : null;
@@ -199,12 +199,15 @@ export function updateStatusLine(state: TUIState): void {
     state.agentRunStartedAt !== undefined &&
     Math.floor(getGoalDurationMs(goalState, now) / 60_000) === Math.floor((now - state.agentRunStartedAt) / 60_000);
   const goalLabel = goalDuration ? (goalMatchesActiveRun ? 'goal' : `goal ${goalDuration}`) : null;
-  const formatDirPart = (value: string) => ({
-    plain: githubPrLabel ? `${githubPrLabel.plain} ${value}` : value,
-    styled: githubPrLabel
-      ? `${githubPrLabel.styled} ${theme.fg('thinkingText', value)}`
-      : theme.fg('thinkingText', value),
-  });
+  const formatDirPart = (value: string) => {
+    const separator = githubPrLabel && value ? ' ' : '';
+    return {
+      plain: githubPrLabel ? `${githubPrLabel.plain}${separator}${value}` : value,
+      styled: githubPrLabel
+        ? `${githubPrLabel.styled}${separator}${theme.fg('thinkingText', value)}`
+        : theme.fg('thinkingText', value),
+    };
+  };
 
   // --- Helper to style the model ID ---
   const modelTrail = tintBg ? chalk.hex(tintBg)('▌') : '';
@@ -396,23 +399,25 @@ export function updateStatusLine(state: TUIState): void {
     const nonDirWidth =
       useBadgeWidth + nonDirParts.reduce((sum, p, i) => sum + visibleWidth(p.plain) + (i > 0 ? SEP.length : 0), 0);
 
-    if (dirText) {
+    if (dirText !== null) {
       const dirPart = formatDirPart(dirText);
       const availableForDir = termWidth - nonDirWidth - SEP.length - 1; // -1 buffer for ambiguous-width chars
       const dirWidth = visibleWidth(dirPart.plain);
+      const prefixWidth = githubPrLabel ? visibleWidth(githubPrLabel.plain) + (dirText ? 1 : 0) : 0;
+      const availableForText = availableForDir - prefixWidth;
       const MIN_TRUNCATED_DIR = 10; // don't show a tiny sliver
       if (dirWidth > availableForDir && opts.allowDirTruncation === false) {
         return null;
       }
-      if (dirWidth > availableForDir && availableForDir >= MIN_TRUNCATED_DIR) {
-        dirText = availableForDir > 1 ? dirText.slice(0, availableForDir - 1) + '…' : null;
+      if (dirWidth > availableForDir && availableForText >= MIN_TRUNCATED_DIR) {
+        dirText = availableForText > 1 ? dirText.slice(0, availableForText - 1) + '…' : null;
       } else if (dirWidth > availableForDir) {
-        // Not enough room even for a truncated version — drop it
-        dirText = null;
+        // Preserve a standalone PR label when there is no room for the title.
+        dirText = githubPrLabel && visibleWidth(githubPrLabel.plain) <= availableForDir ? '' : null;
       }
     }
 
-    if (dirText) {
+    if (dirText !== null) {
       parts.push(formatDirPart(dirText));
     }
     if (indicatorPart) {
@@ -426,7 +431,7 @@ export function updateStatusLine(state: TUIState): void {
     if (totalPlain + 1 > termWidth) return null; // +1 buffer for ambiguous-width chars (▐▌)
 
     let styledLine: string;
-    const hasDir = !!dirText;
+    const hasDir = dirText !== null;
     if (indicatorPart && parts.length >= 2) {
       // Three groups: left (model + timing + goal), center (queue + dir/thread), right (throughput + context)
       const leftPartCount = opts.showQueue && goalLabel ? 2 : 1;

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -14,6 +14,16 @@ import { theme, mastra, mastraBrand, tintHex, getTermWidth } from './theme.js';
 const getObserverColor = () => mastra.orange;
 const getReflectorColor = () => mastra.pink;
 
+function isGenericTitle(title: string): boolean {
+  const lower = title.toLowerCase().trim();
+  return (
+    lower === 'new thread' ||
+    lower.startsWith('new thread') ||
+    lower.startsWith('clone of') ||
+    lower.startsWith('untitled')
+  );
+}
+
 function getGoalDurationMs(
   goal: { startedAt: string; activeStartedAt?: string; activeDurationMs?: number },
   now: number,
@@ -151,6 +161,11 @@ export function updateStatusLine(state: TUIState): void {
     : shortModelId.replace(/^claude-/, '').replace(/^(\w+)-(\d+)-(\d{1,2})$/, '$1 $2.$3');
 
   const branch = state.projectInfo.gitBranch;
+  const threadTitle =
+    state.currentThreadTitle && !isGenericTitle(state.currentThreadTitle) ? state.currentThreadTitle : null;
+  const centerText = threadTitle || branch || null;
+  const centerTextShort =
+    centerText && centerText.length > 24 ? centerText.slice(0, 12) + '..' + centerText.slice(-8) : centerText;
   const now = Date.now();
   const queuedCount = state.pendingQueuedActions.length + state.session.followUps.count();
   const queuedLabel = queuedCount > 0 ? `${queuedCount} queued` : null;
@@ -163,10 +178,6 @@ export function updateStatusLine(state: TUIState): void {
     Math.floor(getGoalDurationMs(goalState, now) / 60_000) === Math.floor((now - state.agentRunStartedAt) / 60_000);
   const goalLabel = goalDuration ? (goalMatchesActiveRun ? 'goal' : `goal ${goalDuration}`) : null;
   const formatDirPart = (value: string) => ({ plain: value, styled: theme.fg('thinkingText', value) });
-  // Build progressively shorter branch strings for layout fallback.
-  const dirBranchOnly = branch || null;
-  // Abbreviate long branches: keep first 12 + last 8 chars with ".." in between.
-  const dirBranchShort = branch && branch.length > 24 ? branch.slice(0, 12) + '..' + branch.slice(-8) : dirBranchOnly;
 
   // --- Helper to style the model ID ---
   const modelTrail = tintBg ? chalk.hex(tintBg)('▌') : '';
@@ -349,7 +360,7 @@ export function updateStatusLine(state: TUIState): void {
         }
       : null;
     // Directory / branch / thread title (lowest priority on line 1)
-    let dirText = opts.dir !== undefined ? opts.dir : opts.showDir ? dirBranchOnly : null;
+    let dirText = opts.dir !== undefined ? opts.dir : opts.showDir ? centerText : null;
 
     // Measure width of everything except dir to know how much space remains.
     // Throughput and the context indicator are reserved at the far right even though they are appended after dir.
@@ -431,11 +442,11 @@ export function updateStatusLine(state: TUIState): void {
     buildLine({
       modelId: fullModelId,
       showDir: false,
-      dir: dirBranchOnly,
+      dir: centerText,
       allowDirTruncation: false,
       showQueue: true,
     }) ??
-    buildLine({ modelId: fullModelId, showDir: false, dir: dirBranchShort, showQueue: true }) ??
+    buildLine({ modelId: fullModelId, showDir: false, dir: centerTextShort, showQueue: true }) ??
     buildLine({ modelId: fullModelId, showDir: false, showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showDir: false, showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showDir: false, badge: 'short', showQueue: true }) ??

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -5,7 +5,7 @@
 import { visibleWidth } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
-import { formatObservationStatus, formatReflectionStatus } from './components/om-progress.js';
+import { formatOMContextIndicator } from './components/om-progress.js';
 import type { GithubPrSubscriptionBadge, TUIState } from './state.js';
 import { formatStatusDuration } from './status-duration.js';
 import { theme, mastra, tintHex, getTermWidth, extendedColors } from './theme.js';
@@ -295,7 +295,7 @@ export function updateStatusLine(state: TUIState): void {
 
   const buildLine = (opts: {
     modelId: string;
-    memCompact?: 'percentOnly' | 'noBuffer' | 'full';
+    showOM?: boolean;
     showDir: boolean;
     dir?: string | null;
     allowDirTruncation?: boolean;
@@ -332,36 +332,33 @@ export function updateStatusLine(state: TUIState): void {
     });
     const useBadge = opts.badge === 'short' ? shortModeBadge : modeBadge;
     const useBadgeWidth = opts.badge === 'short' ? shortModeBadgeWidth : modeBadgeWidth;
-    // Memory info — animate label text when buffering is active
     const ds = state.session.displayState.get();
-    const msgLabelStyler =
+    const messageSegmentStyler =
       ds.bufferingMessages && state.gradientAnimator?.isRunning()
-        ? (label: string) =>
+        ? (segment: string) =>
             applyGradientSweep(
-              label,
+              segment,
               state.gradientAnimator!.getOffset(),
               getObserverColor(),
               state.gradientAnimator!.getFadeProgress(),
             )
         : undefined;
-    const obsLabelStyler =
+    const memorySegmentStyler =
       ds.bufferingObservations && state.gradientAnimator?.isRunning()
-        ? (label: string) =>
+        ? (segment: string) =>
             applyGradientSweep(
-              label,
+              segment,
               state.gradientAnimator!.getOffset(),
               getReflectorColor(),
               state.gradientAnimator!.getFadeProgress(),
             )
         : undefined;
-    const omProg = state.session.displayState.get().omProgress;
-    const obs = isJudging ? '' : formatObservationStatus(omProg, opts.memCompact, msgLabelStyler);
-    const ref = isJudging ? '' : formatReflectionStatus(omProg, opts.memCompact, obsLabelStyler);
-    if (obs) {
-      parts.push({ plain: obs, styled: obs });
-    }
-    if (ref) {
-      parts.push({ plain: ref, styled: ref });
+    if (!isJudging && opts.showOM !== false) {
+      const indicator = formatOMContextIndicator(ds.omProgress, {
+        messages: messageSegmentStyler,
+        memory: memorySegmentStyler,
+      });
+      parts.push({ plain: indicator.plain, styled: indicator.styled });
     }
     if (state.tokensPerSec > 0) {
       const tpsLabel = `${state.tokensPerSec} tok/s`;
@@ -451,99 +448,39 @@ export function updateStatusLine(state: TUIState): void {
     return { plain: '', styled: styledLine };
   };
   // Try progressively more compact layouts.
-  // Priority: token fractions + buffer > labels > provider > badge > buffer > fractions
+  // Priority: context indicator > provider > badge > queue/goal details.
   const result =
-    // 1. Full badge + full model + long labels + queue count + full dir
     buildLine({
       modelId: fullModelId,
-      memCompact: 'full',
       showDir: false,
       dir: dirFull,
       allowDirTruncation: false,
       showQueue: true,
     }) ??
-    // 2. Full badge + full model + queue count + branch only (drop path)
     buildLine({
       modelId: fullModelId,
-      memCompact: 'full',
       showDir: false,
       dir: dirBranchOnly,
       allowDirTruncation: false,
       showQueue: true,
     }) ??
-    // 3. Full badge + full model + queue count + abbreviated branch
-    buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false, dir: dirBranchShort, showQueue: true }) ??
-    // 4. Drop directory entirely
-    buildLine({ modelId: fullModelId, memCompact: 'full', showDir: false, showQueue: true }) ??
-    // 5. Drop provider + "claude-" prefix, keep full labels + queue count
-    buildLine({ modelId: tinyModelId, memCompact: 'full', showDir: false, showQueue: true }) ??
-    // 6. Short labels (msg/mem) + queue count
+    buildLine({ modelId: fullModelId, showDir: false, dir: dirBranchShort, showQueue: true }) ??
+    buildLine({ modelId: fullModelId, showDir: false, showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showDir: false, showQueue: true }) ??
-    // 7. Short badge + short labels + queue count
     buildLine({ modelId: tinyModelId, showDir: false, badge: 'short', showQueue: true }) ??
-    // 8. Short badge + short labels + compact goal label
     buildLine({ modelId: tinyModelId, showDir: false, badge: 'short', showQueue: true, compactGoal: true }) ??
-    // 9. Short badge + fractions (drop buffer indicator, keep queue count)
+    buildLine({ modelId: tinyModelId, showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({
       modelId: tinyModelId,
-      memCompact: 'noBuffer',
-      showDir: false,
-      badge: 'short',
-      showQueue: true,
-    }) ??
-    // 10. Short badge + fractions + compact goal label
-    buildLine({
-      modelId: tinyModelId,
-      memCompact: 'noBuffer',
+      showOM: false,
       showDir: false,
       badge: 'short',
       showQueue: true,
       compactGoal: true,
     }) ??
-    // 11. Full badge + percent only + queue count
-    buildLine({
-      modelId: tinyModelId,
-      memCompact: 'percentOnly',
-      showDir: false,
-      badge: 'full',
-      showQueue: true,
-    }) ??
-    // 12. Full badge + percent only + compact goal label
-    buildLine({
-      modelId: tinyModelId,
-      memCompact: 'percentOnly',
-      showDir: false,
-      badge: 'full',
-      showQueue: true,
-      compactGoal: true,
-    }) ??
-    // 13. Short badge + percent only + queue count
-    buildLine({
-      modelId: tinyModelId,
-      memCompact: 'percentOnly',
-      showDir: false,
-      badge: 'short',
-      showQueue: true,
-    }) ??
-    // 14. Short badge + percent only + compact goal label
-    buildLine({
-      modelId: tinyModelId,
-      memCompact: 'percentOnly',
-      showDir: false,
-      badge: 'short',
-      showQueue: true,
-      compactGoal: true,
-    }) ??
-    // 15. Model only + queue count
-    buildLine({ modelId: tinyModelId, showDir: false, badge: undefined, showQueue: true }) ??
-    // 16. Model only + compact goal label
-    buildLine({ modelId: tinyModelId, showDir: false, badge: undefined, showQueue: true, compactGoal: true }) ??
-    // 17. Badge only + queue count
-    buildLine({ modelId: '', showDir: false, badge: 'short', showQueue: true }) ??
-    // 13. Model only
-    buildLine({ modelId: tinyModelId, showDir: false, badge: undefined }) ??
-    // 14. Badge only
-    buildLine({ modelId: '', showDir: false, badge: 'short' });
+    buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
+    buildLine({ modelId: tinyModelId, showOM: false, showDir: false }) ??
+    buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short' });
 
   state.statusLine.setText(result?.styled ?? shortModeBadge + styleModelId(tinyModelId));
 

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -6,13 +6,33 @@ import { visibleWidth } from '@earendil-works/pi-tui';
 import chalk from 'chalk';
 import { applyGradientSweep } from './components/obi-loader.js';
 import { formatOMContextIndicator } from './components/om-progress.js';
-import type { TUIState } from './state.js';
+import type { GithubPrSubscriptionBadge, TUIState } from './state.js';
 import { formatStatusDuration } from './status-duration.js';
-import { theme, mastra, mastraBrand, tintHex, getTermWidth } from './theme.js';
+import { theme, mastra, mastraBrand, tintHex, getTermWidth, extendedColors } from './theme.js';
 
 // Colors for OM modes — read from proxy at render time so they pick up contrast adaptation
 const getObserverColor = () => mastra.orange;
 const getReflectorColor = () => mastra.pink;
+
+function formatGithubPrLabel(
+  state: TUIState,
+  subscription: GithubPrSubscriptionBadge,
+): { plain: string; styled: string } {
+  const label = `PR#${subscription.prNumber}`;
+  const color = subscription.lastNotificationPriority === 'high' ? mastra.orange : extendedColors.skyBlue;
+  if (state.githubPrPollingActive && state.githubPrGradientAnimator?.isRunning()) {
+    return {
+      plain: label,
+      styled: applyGradientSweep(
+        label,
+        state.githubPrGradientAnimator.getOffset(),
+        color,
+        state.githubPrGradientAnimator.getFadeProgress(),
+      ),
+    };
+  }
+  return { plain: label, styled: chalk.hex(color)(label) };
+}
 
 function isGenericTitle(title: string): boolean {
   const lower = title.toLowerCase().trim();
@@ -166,6 +186,8 @@ export function updateStatusLine(state: TUIState): void {
   const centerText = threadTitle || branch || null;
   const centerTextShort =
     centerText && centerText.length > 24 ? centerText.slice(0, 12) + '..' + centerText.slice(-8) : centerText;
+  const activeGithubPr = state.activeGithubPrSubscriptions[0];
+  const githubPrLabel = activeGithubPr ? formatGithubPrLabel(state, activeGithubPr) : null;
   const now = Date.now();
   const queuedCount = state.pendingQueuedActions.length + state.session.followUps.count();
   const queuedLabel = queuedCount > 0 ? `${queuedCount} queued` : null;
@@ -177,7 +199,12 @@ export function updateStatusLine(state: TUIState): void {
     state.agentRunStartedAt !== undefined &&
     Math.floor(getGoalDurationMs(goalState, now) / 60_000) === Math.floor((now - state.agentRunStartedAt) / 60_000);
   const goalLabel = goalDuration ? (goalMatchesActiveRun ? 'goal' : `goal ${goalDuration}`) : null;
-  const formatDirPart = (value: string) => ({ plain: value, styled: theme.fg('thinkingText', value) });
+  const formatDirPart = (value: string) => ({
+    plain: githubPrLabel ? `${githubPrLabel.plain} ${value}` : value,
+    styled: githubPrLabel
+      ? `${githubPrLabel.styled} ${theme.fg('thinkingText', value)}`
+      : theme.fg('thinkingText', value),
+  });
 
   // --- Helper to style the model ID ---
   const modelTrail = tintBg ? chalk.hex(tintBg)('▌') : '';

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -469,7 +469,7 @@ export function updateStatusLine(state: TUIState): void {
     return { plain: '', styled: styledLine };
   };
   // Try progressively more compact layouts.
-  // Priority: context indicator > provider > badge > queue/goal details.
+  // Preserve status content before the context indicator, which is a visual summary.
   const result =
     buildLine({
       modelId: fullModelId,
@@ -478,10 +478,17 @@ export function updateStatusLine(state: TUIState): void {
       allowDirTruncation: false,
       showQueue: true,
     }) ??
-    buildLine({ modelId: fullModelId, showDir: false, dir: centerTextShort, showQueue: true }) ??
-    buildLine({ modelId: fullModelId, showDir: false, showQueue: true }) ??
-    buildLine({ modelId: tinyModelId, showDir: false, showQueue: true }) ??
-    buildLine({ modelId: tinyModelId, showDir: false, badge: 'short', showQueue: true }) ??
+    buildLine({
+      modelId: fullModelId,
+      showOM: false,
+      showDir: false,
+      dir: centerText,
+      allowDirTruncation: false,
+      showQueue: true,
+    }) ??
+    buildLine({ modelId: fullModelId, showOM: false, showDir: false, dir: centerTextShort, showQueue: true }) ??
+    buildLine({ modelId: fullModelId, showOM: false, showDir: false, showQueue: true }) ??
+    buildLine({ modelId: tinyModelId, showOM: false, showDir: false, showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({ modelId: '', showOM: false, showDir: false, badge: 'short', showQueue: true }) ??
     buildLine({ modelId: tinyModelId, showOM: false, showDir: false }) ??


### PR DESCRIPTION
This simplifies the Mastra Code footer's observational-memory status into one compact context indicator. It combines message and observation usage into a proportional 10-cell bar, reports total active tokens against the combined threshold, and keeps buffering animation confined to the segment currently doing work.

The footer layout now keeps model and activity timing on the left, a meaningful thread title (or branch fallback) in the center, and stable-width throughput plus context usage on the right. Active GitHub PR subscriptions remain visible before the center text.

Before:
```
messages 44.9/80k ↓26.9k  memory 7.4/40k
```

After:
```
━━━━━━━━━━ 60/120k↓
```

The bar uses distinct observation, unused-capacity, and message segments while preserving a fixed width. The change includes formatter and status-line coverage, a deterministic real-TUI scenario, and a patch changeset.

<img width="1735" height="147" alt="image" src="https://github.com/user-attachments/assets/83e4e174-438f-4df1-9472-18a890fc9b49" />
<img width="427" height="116" alt="Screenshot 2026-07-09 at 8 08 51 PM" src="https://github.com/user-attachments/assets/a3386503-6eba-4731-a749-ab9cc94cfb7b" />



## Test plan

- Focused formatter and status-line tests
- Real-TUI OM status scenario
- TUI typecheck and lint
- Mastra Code build
- Broad TUI test suite
- GitHub Actions, including Mastra Code E2E


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Mastra Code’s “observational memory” footer easier to read: instead of separate message vs memory numbers, it shows one small “context bar” that summarizes how much of the combined space is used. It also improves the footer layout and keeps the buffering animation focused on what’s actually changing.

## What changed

- Simplified observational-memory status into one unified indicator
  - Added `formatOMContextIndicator` to render a proportional 10-cell segmented bar (message/observation filling vs unused), plus a combined `used/capacity` fraction.
  - Optional savings indicator (`↓`) appears only when savings are positive (arrow suppressed when savings is zero, while width stays stable).
  - Removed the old exported observation/reflection formatters, and updated `formatOMStatus` to reflect the new simplified behavior.

- Refactored the footer/status-line rendering
  - Reworked `updateStatusLine` to build a more stable left/center/right layout:
    - Left: model + activity timing
    - Center: thread title (or branch fallback) with GitHub PR subscription/label handling
    - Right: fixed-width `t/s` throughput and OM context usage when space allows
  - On narrow screens, the footer drops only the decorative context bar while preserving the essential token usage measurement.
  - Buffering/animation behavior: gradient/brightness sweeps are gated off during OM buffering, and animation is limited to the segment currently changing.

- Improved goal timing + center text details
  - Centralized goal elapsed-time logic in `getGoalDurationMs` with clearer precedence.
  - Updated goal labeling and simplified center text construction based on thread title, branch, and PR-label presence.

- Expanded and updated test coverage
  - `status-line.test.ts`: significantly updated assertions for the unified context indicator, layout ordering/truncation behavior, throughput formatting, and animation gating.
  - `om-progress.test.ts`: rewrote coverage around `formatOMContextIndicator`, including edge cases for splitting, clamping, savings-arrow rules, and styled output order.

- Added deterministic real-TUI E2E coverage for the new indicator
  - Introduced a new registered E2E scenario `om-status-indicator` that boots the real app, captures ANSI-styled output, varies terminal widths and OM buffering settings, and uses a deterministic `GradientAnimator` plus checkpoint assertions to verify which “context cells” change.
  - Updated other E2E scenarios’ synchronization/wait conditions to match more specific UI text patterns.

- Release/update
  - Added a Mastra Code patch changeset describing the observational-memory context indicator simplification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->