### PR TITLE
fix(ai-sdk): approving a tool call could resume the wrong one

### DIFF
--- a/.changeset/lovely-trams-hammer.md
+++ b/.changeset/lovely-trams-hammer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed AI SDK v6 native tool approvals resuming the wrong tool call. When multiple tool calls were awaiting approval, approving one could execute a different one. The approval response now carries the answered tool call's ID through to the resume, so the approved tool call is the one that runs.

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -165,7 +165,11 @@ describe('extractV6NativeApproval', () => {
 
     const result = extractV6NativeApproval(messages as any);
 
-    expect(result).toEqual({ resumeData: { approved: true }, runId: 'run-123' });
+    expect(result).toEqual({
+      resumeData: { approved: true },
+      runId: 'run-123',
+      toolCallId: 'tooluse_abc123',
+    });
   });
 
   it('includes reason when the user denied with a reason', () => {
@@ -188,7 +192,11 @@ describe('extractV6NativeApproval', () => {
 
     const result = extractV6NativeApproval(messages as any);
 
-    expect(result).toEqual({ resumeData: { approved: false, reason: 'Not safe' }, runId: 'run-456' });
+    expect(result).toEqual({
+      resumeData: { approved: false, reason: 'Not safe' },
+      runId: 'run-456',
+      toolCallId: 'tooluse_xyz',
+    });
   });
 
   it('omits reason when not provided', () => {
@@ -395,7 +403,7 @@ describe('handleChatStream v6 native approve() resume flow', () => {
     expect(mockAgent.resumeStream).toHaveBeenCalledTimes(1);
     expect(mockAgent.resumeStream).toHaveBeenCalledWith(
       { approved: true },
-      expect.objectContaining({ runId: 'run-123' }),
+      expect.objectContaining({ runId: 'run-123', toolCallId: 'tooluse_abc123' }),
     );
     expect(mockAgent.stream).not.toHaveBeenCalled();
   });

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -26,8 +26,8 @@ import type {
 /**
  * Scans a v6 UIMessage array for the most recent 'approval-responded' tool
  * part in the last trailing assistant message only. When found, splits the
- * composite approvalId ("${runId}::${toolCallId}") to recover the runId
- * needed for resumeStream.
+ * composite approvalId ("${runId}::${toolCallId}") to recover the runId and
+ * toolCallId needed for a targeted resumeStream.
  *
  * Only the last trailing assistant message is inspected so that approval
  * responses from earlier turns are never re-processed. Within that message,
@@ -39,7 +39,7 @@ import type {
  */
 export function extractV6NativeApproval(
   messages: V6UIMessage[],
-): { resumeData: Record<string, unknown>; runId: string } | null {
+): { resumeData: Record<string, unknown>; runId: string; toolCallId: string } | null {
   // Only inspect the actual trailing message. If a user has already sent a
   // follow-up turn after an approval response, we must treat that as a normal
   // chat submission rather than replaying the stale approval response.
@@ -54,7 +54,8 @@ export function extractV6NativeApproval(
     const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);
     if (lastSep === -1) continue;
     const runId = part.approval.id.slice(0, lastSep);
-    if (!runId) continue;
+    const toolCallId = part.approval.id.slice(lastSep + APPROVAL_ID_SEPARATOR.length);
+    if (!runId || !toolCallId) continue;
 
     return {
       resumeData: {
@@ -62,6 +63,7 @@ export function extractV6NativeApproval(
         ...(part.approval.reason != null ? { reason: part.approval.reason } : {}),
       },
       runId,
+      toolCallId,
     };
   }
 
@@ -234,6 +236,7 @@ export async function handleChatStream<OUTPUT = undefined>({
     ...defaultOptionsRest,
     ...restOptions,
     ...(effectiveRunId && { runId: effectiveRunId }),
+    ...(nativeApproval?.toolCallId && { toolCallId: nativeApproval.toolCallId }),
     requestContext: requestContext || defaultOptions?.requestContext,
     ...(Object.keys(mergedProviderOptions).length > 0 && { providerOptions: mergedProviderOptions }),
   };


### PR DESCRIPTION
When multiple tool calls are awaiting approval in AI SDK v6, approving one could execute a different one. The native approval flow encodes `${runId}::${toolCallId}` in the approval ID, but `extractV6NativeApproval` only recovered the `runId`, so `handleChatStream` resumed untargeted and the engine picked whichever tool call happened to be suspended.

This keeps the `toolCallId` from the approval ID and passes it to `resumeStream`, so the resume goes to the tool call the user actually answered.

Before:
```ts
// approval id "run-123::tooluse_b" -> untargeted resume, may execute tooluse_a
agent.resumeStream({ approved: true }, { runId: 'run-123' });
```

After:
```ts
agent.resumeStream({ approved: true }, { runId: 'run-123', toolCallId: 'tooluse_b' });
```

Test plan: updated `tool-call-approval.test.ts` to assert the extracted `toolCallId` and the targeted `resumeStream` call (19/19 passing), plus tsc, eslint, and package build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When several tools are waiting for approval, approving one could accidentally run another. This fix keeps the specific tool’s ID and resumes only the tool call that was approved.

## Changes

- Preserve both `runId` and `toolCallId` from AI SDK v6 approval IDs.
- Pass `toolCallId` through `resumeStream` for targeted resumption.
- Add tests covering approval extraction and targeted resume behavior.
- Add a patch changeset for `@mastra/ai-sdk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->