### PR TITLE
docs(mastra-platform): document managed database vector operations

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -131,6 +131,12 @@ export const storage = new PostgresStore({ connectionString })
 export const vector = new PgVector({ connectionString })
 ```
 
+Postgres databases attached before automatic provisioning shipped may not have `pgvector` installed. Open the database in **Project Settings → Database** to see its `pgvector` status. When the extension isn't installed, select **Enable pgvector** to install it against the managed connection. The operation is idempotent and safe to run against a database that's already set up.
+
+:::note
+Enabling `pgvector` requires the **admin** role on the project.
+:::
+
 ### Wire storage and vector into Mastra
 
 Pass the `storage` and `vector` instances to your `Mastra` configuration so agents, memory, and workflows can use them:

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -88,7 +88,7 @@ npm install @mastra/libsql@latest
 
 #### Use Turso as a vector store
 
-The same Turso database also works as a vector store through [LibSQLVector](/reference/vectors/libsql). LibSQL has built-in vector search, so no extra setup is required — point `LibSQLVector` at the same environment variables and it uses the same database as your agent storage.
+The same Turso database also works as a vector store through [LibSQLVector](/reference/vectors/libsql). LibSQL has built-in vector search, so there's no extension to install or separate connection to configure — point `LibSQLVector` at the same environment variables and it uses the same database as your agent storage. Before upserting vectors, call [`createIndex`](/reference/vectors/libsql#createindex) with an `indexName` and the `dimension` of your embedding model.
 
 ```ts title="src/mastra/storage.ts" caption="Add vector search to a Turso database"
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql'
@@ -120,7 +120,7 @@ npm install @mastra/pg@latest
 
 #### Use Postgres as a vector store
 
-Hosted Postgres databases have the [`pgvector`](https://github.com/pgvector/pgvector) extension enabled automatically when the database is provisioned. That means [PgVector](/reference/vectors/pg) works against the same `DATABASE_URL` with no extra setup.
+Hosted Postgres databases have the [`pgvector`](https://github.com/pgvector/pgvector) extension enabled automatically when the database is provisioned, so [PgVector](/reference/vectors/pg) works against the same `DATABASE_URL` without any extension setup. Before upserting vectors, call [`createIndex`](/reference/vectors/pg#createindex) with an `indexName` and the `dimension` of your embedding model.
 
 ```ts title="src/mastra/storage.ts" caption="Add vector search to a Postgres database"
 import { PostgresStore, PgVector } from '@mastra/pg'
@@ -128,7 +128,7 @@ import { PostgresStore, PgVector } from '@mastra/pg'
 const connectionString = process.env.DATABASE_URL!
 
 export const storage = new PostgresStore({ connectionString })
-export const vector = new PgVector({ connectionString })
+export const vector = new PgVector({ id: 'mastra-vector', connectionString })
 ```
 
 Postgres databases attached before automatic provisioning shipped may not have `pgvector` installed. Open the database in **Project Settings → Database** to see its `pgvector` status. When the extension isn't installed, select **Enable pgvector** to install it against the managed connection. The operation is idempotent and safe to run against a database that's already set up.

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -24,12 +24,12 @@ Hosted databases are available through three providers. Pick one when you attach
 
 You can attach one database per provider to a project. This keeps environment variable names unambiguous — for example, a project has a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
 
-For most agent-focused projects, **Turso** is the simplest starting point. It provides a lightweight, SQLite-compatible engine well suited to agent memory, conversation history, and per-tenant isolation. Choose **Postgres** when your workload needs full SQL, relational schemas, or structured application data beyond Mastra runtime state. **MongoDB** (_coming soon_) will add document storage and built-in vector search for workloads that don't map cleanly to SQL.
+For most agent-focused projects, **Turso** is the simplest starting point. It provides a lightweight, SQLite-compatible engine well suited to agent memory, conversation history, per-tenant isolation, and vector search. Choose **Postgres** when your workload needs full SQL, relational schemas, or structured application data beyond Mastra runtime state. Both providers support vector search out of the box, so you can pair a hosted database with Retrieval-Augmented Generation (RAG) or semantic recall without attaching a second store. **MongoDB** (_coming soon_) will add document storage for workloads that don't map cleanly to SQL.
 
 | Provider | Engine | Best for |
 | - | - | - |
-| **Turso** | LibSQL, SQLite-compatible | Agent memory, per-tenant isolation |
-| **PostgreSQL** | Serverless Postgres | Relational workloads, structured data |
+| **Turso** | LibSQL, SQLite-compatible | Agent memory, vector search, per-tenant isolation |
+| **PostgreSQL** | Serverless Postgres with `pgvector` | Relational workloads, vector search, structured data |
 | **MongoDB** | Document and vector search | Document storage, vector search (_coming soon_) |
 
 ## Attach a database
@@ -86,6 +86,20 @@ Install the adapter:
 npm install @mastra/libsql@latest
 ```
 
+#### Use Turso as a vector store
+
+The same Turso database also works as a vector store through [LibSQLVector](/reference/vectors/libsql). LibSQL has built-in vector search, so no extra setup is required — point `LibSQLVector` at the same environment variables and it uses the same database as your agent storage.
+
+```ts title="src/mastra/storage.ts" caption="Add vector search to a Turso database"
+import { LibSQLStore, LibSQLVector } from '@mastra/libsql'
+
+const url = process.env.TURSO_DATABASE_URL!
+const authToken = process.env.TURSO_AUTH_TOKEN!
+
+export const storage = new LibSQLStore({ url, authToken })
+export const vector = new LibSQLVector({ id: 'mastra-vector', url, authToken })
+```
+
 ### PostgreSQL
 
 PostgreSQL exposes a single `DATABASE_URL` connection string. The following example connects a [PostgresStore](/reference/storage/postgresql) using that variable.
@@ -104,16 +118,36 @@ Install the adapter:
 npm install @mastra/pg@latest
 ```
 
-Pass the `storage` instance to your `Mastra` configuration so agents, memory, and workflows can use it:
+#### Use Postgres as a vector store
+
+Hosted Postgres databases have the [`pgvector`](https://github.com/pgvector/pgvector) extension enabled automatically when the database is provisioned. That means [PgVector](/reference/vectors/pg) works against the same `DATABASE_URL` with no extra setup.
+
+```ts title="src/mastra/storage.ts" caption="Add vector search to a Postgres database"
+import { PostgresStore, PgVector } from '@mastra/pg'
+
+const connectionString = process.env.DATABASE_URL!
+
+export const storage = new PostgresStore({ connectionString })
+export const vector = new PgVector({ connectionString })
+```
+
+### Wire storage and vector into Mastra
+
+Pass the `storage` and `vector` instances to your `Mastra` configuration so agents, memory, and workflows can use them:
 
 ```ts title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core'
-import { storage } from './storage'
+import { storage, vector } from './storage'
 
 export const mastra = new Mastra({
   storage,
+  vectors: { default: vector },
 })
 ```
+
+:::note
+Visit [Memory with semantic recall](/docs/memory/semantic-recall) and [RAG overview](/docs/rag/overview) for guidance on wiring the `vector` instance into agent memory and retrieval workflows.
+:::
 
 ## Environment variables
 


### PR DESCRIPTION
## What ships

The **Hosted databases** page (`docs/mastra-platform/database`) now explains how to use managed Turso and Postgres databases as vector stores, not just as agent-storage backends — and how to enable `pgvector` on a Postgres database that was attached before automatic provisioning shipped.

## Why

Both hosted providers support vector search on the platform side:

- **Turso** — LibSQL ships `F32_BLOB` and `libsql_vector_top_k` built into the engine. Nothing to enable.
- **Postgres** — The platform's Neon provisioner runs `CREATE EXTENSION IF NOT EXISTS vector` at project creation time (see [mastra-ai/platform#1521](https://github.com/mastra-ai/platform/pull/1521)), so `pgvector` is available on every managed Postgres database going forward.

Before this PR, the docs only showed `LibSQLStore` and `PostgresStore` snippets, which nudged users toward attaching a separate vector store (Pinecone, Qdrant, etc.) even though the database they just provisioned could do the job with the same credentials.

Additionally, Postgres databases attached before automatic provisioning shipped (or brought via a user-supplied connection URI) didn't have `pgvector` installed, and the docs offered no path other than raw `CREATE EXTENSION` in `psql`. The platform now exposes an **Enable pgvector** button on the database detail view — this PR documents that path.

## What changed

- Provider comparison table now lists **vector search** under "Best for" for Turso and Postgres.
- New subsection **Use Turso as a vector store** with a `LibSQLStore + LibSQLVector` snippet against the same `TURSO_*` env vars.
- New subsection **Use Postgres as a vector store** with a `PostgresStore + PgVector` snippet against the same `DATABASE_URL`, and a note that `pgvector` is enabled automatically at provision time.
- Added guidance for enabling `pgvector` on pre-existing Postgres databases from **Project Settings → Database**, with an admin-role callout matching the platform's authorization gate.
- New subsection **Wire storage and vector into Mastra** showing `new Mastra({ storage, vectors: { default: vector } })`.
- Cross-links to [Memory with semantic recall](/docs/memory/semantic-recall) and [RAG overview](/docs/rag/overview) so users see the next step.
- Cross-links to the [LibSQLVector](/reference/vectors/libsql) and [PgVector](/reference/vectors/pg) reference pages.

## Test plan

- `pnpm run validate` — 564 files pass, sidebars linked correctly.
- `pnpm run lint:remark` — clean on the edited file.
- No sidebar or redirects changes required (existing page, no rename/delete).

## Related

- Platform PR that ships the corresponding managed-DB behavior (auto-enable at provision time + the Enable button on existing databases): [mastra-ai/platform#1521](https://github.com/mastra-ai/platform/pull/1521)

Draft until the platform PR merges.
