### PR TITLE
fix(code-sdk): securely discover symlinked commands and skills

### DIFF
--- a/.changeset/fruity-nails-spend.md
+++ b/.changeset/fruity-nails-spend.md
@@ -2,4 +2,4 @@
 '@mastra/code-sdk': patch
 ---
 
-Fixed discovery of individually symlinked custom commands.
+Fixed secure discovery of symlinked custom commands and skills.

--- a/.changeset/fruity-nails-spend.md
+++ b/.changeset/fruity-nails-spend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed discovery of individually symlinked custom commands.

--- a/mastracode/sdk/src/agents/__tests__/build-skill-paths.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/build-skill-paths.test.ts
@@ -217,6 +217,31 @@ describe('buildSkillPaths', () => {
       expect(result).not.toContain('/outside/skills');
     });
 
+    it('rejects skill symlinks whose resolved parent escapes the project root', () => {
+      const skillsDir = path.join(projectPath, '.mastracode', 'skills');
+      const symlinkEntry = {
+        name: 'project-root',
+        isSymbolicLink: () => true,
+        isDirectory: () => false,
+        isFile: () => false,
+      } as fs.Dirent;
+
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p) === skillsDir);
+      mockedFs.readdirSync.mockImplementation((p: fs.PathLike, _opts?: any) => {
+        if (String(p) === skillsDir) return [symlinkEntry] as any;
+        return [] as any;
+      });
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        if (String(p) === path.join(skillsDir, 'project-root')) return projectPath;
+        return String(p);
+      });
+      mockedFs.statSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
+
+      expect(result).not.toContain(path.dirname(projectPath));
+    });
+
     it('rejects plugin skill symlinks that escape the plugin skill root', () => {
       const pluginSkillsDir = '/plugins/example/skills';
       const symlinkEntry = {

--- a/mastracode/sdk/src/agents/__tests__/build-skill-paths.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/build-skill-paths.test.ts
@@ -116,7 +116,7 @@ describe('buildSkillPaths', () => {
         return [] as any;
       });
 
-      const realPath = '/real/location/my-skill';
+      const realPath = path.join(projectPath, 'shared-skills', 'my-skill');
       mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
         if (String(p) === path.join(skillsDir, 'my-skill')) return realPath;
         return String(p);
@@ -131,8 +131,8 @@ describe('buildSkillPaths', () => {
 
       const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
 
-      // Should include the parent of the real path
-      expect(result).toContain('/real/location');
+      // Should include symlink targets that remain inside the project boundary
+      expect(result).toContain(path.join(projectPath, 'shared-skills'));
     });
 
     it('does not add duplicate resolved parents', () => {
@@ -164,8 +164,8 @@ describe('buildSkillPaths', () => {
       // Both symlinks resolve to the same parent directory
       mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
         const s = String(p);
-        if (s === path.join(skillsDir, 'skill-a')) return '/shared/skills-repo/skill-a';
-        if (s === path.join(skillsDir, 'skill-b')) return '/shared/skills-repo/skill-b';
+        if (s === path.join(skillsDir, 'skill-a')) return path.join(projectPath, 'shared-skills', 'skill-a');
+        if (s === path.join(skillsDir, 'skill-b')) return path.join(projectPath, 'shared-skills', 'skill-b');
         return s;
       });
 
@@ -173,8 +173,97 @@ describe('buildSkillPaths', () => {
 
       const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
 
-      const occurrences = result.filter(p => p === '/shared/skills-repo');
+      const occurrences = result.filter(p => p === path.join(projectPath, 'shared-skills'));
       expect(occurrences).toHaveLength(1);
+    });
+
+    it('rejects project skill directories symlinked outside the project root', () => {
+      const skillsDir = path.join(projectPath, '.claude', 'skills');
+
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p) === skillsDir);
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        if (String(p) === skillsDir) return '/outside/skills';
+        return String(p);
+      });
+
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
+
+      expect(result).not.toContain(skillsDir);
+    });
+
+    it('rejects project skill symlinks that escape the project root', () => {
+      const skillsDir = path.join(projectPath, '.mastracode', 'skills');
+      const symlinkEntry = {
+        name: 'escaped-skill',
+        isSymbolicLink: () => true,
+        isDirectory: () => false,
+        isFile: () => false,
+      } as fs.Dirent;
+
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p) === skillsDir);
+      mockedFs.readdirSync.mockImplementation((p: fs.PathLike, _opts?: any) => {
+        if (String(p) === skillsDir) return [symlinkEntry] as any;
+        return [] as any;
+      });
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        if (String(p) === path.join(skillsDir, 'escaped-skill')) return '/outside/skills/escaped-skill';
+        return String(p);
+      });
+      mockedFs.statSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
+
+      expect(result).not.toContain('/outside/skills');
+    });
+
+    it('rejects plugin skill symlinks that escape the plugin skill root', () => {
+      const pluginSkillsDir = '/plugins/example/skills';
+      const symlinkEntry = {
+        name: 'escaped-skill',
+        isSymbolicLink: () => true,
+        isDirectory: () => false,
+        isFile: () => false,
+      } as fs.Dirent;
+
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p) === pluginSkillsDir);
+      mockedFs.readdirSync.mockImplementation((p: fs.PathLike, _opts?: any) => {
+        if (String(p) === pluginSkillsDir) return [symlinkEntry] as any;
+        return [] as any;
+      });
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        if (String(p) === path.join(pluginSkillsDir, 'escaped-skill')) return '/outside/skills/escaped-skill';
+        return String(p);
+      });
+      mockedFs.statSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR, home, [pluginSkillsDir]);
+
+      expect(result).not.toContain('/outside/skills');
+    });
+
+    it('allows global skill symlinks to external user-managed locations', () => {
+      const globalSkillsDir = path.join(home, '.mastracode', 'skills');
+      const symlinkEntry = {
+        name: 'global-skill',
+        isSymbolicLink: () => true,
+        isDirectory: () => false,
+        isFile: () => false,
+      } as fs.Dirent;
+
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p) === globalSkillsDir);
+      mockedFs.readdirSync.mockImplementation((p: fs.PathLike, _opts?: any) => {
+        if (String(p) === globalSkillsDir) return [symlinkEntry] as any;
+        return [] as any;
+      });
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        if (String(p) === path.join(globalSkillsDir, 'global-skill')) return '/external/skills/global-skill';
+        return String(p);
+      });
+      mockedFs.statSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
+
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
+
+      expect(result).toContain('/external/skills');
     });
 
     it('ignores symlinks that resolve to files, not directories', () => {

--- a/mastracode/sdk/src/agents/__tests__/build-skill-paths.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/build-skill-paths.test.ts
@@ -34,6 +34,7 @@ describe('buildSkillPaths', () => {
     // Default: no directories exist
     mockedFs.existsSync.mockReturnValue(false);
     mockedFs.readdirSync.mockReturnValue([]);
+    mockedFs.realpathSync.mockImplementation(p => String(p));
   });
 
   afterEach(() => {
@@ -299,41 +300,47 @@ describe('buildSkillPaths', () => {
       expect(result).not.toContain('/some');
     });
 
-    it('silently handles errors during symlink resolution', () => {
+    it('continues resolving skills after a broken symlink', () => {
       const skillsDir = path.join(projectPath, '.mastracode', 'skills');
+      const entries = ['broken-link', 'valid-skill'].map(
+        name =>
+          ({
+            name,
+            isSymbolicLink: () => true,
+            isDirectory: () => false,
+            isFile: () => false,
+          }) as fs.Dirent,
+      );
 
-      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => {
-        return String(p) === skillsDir;
-      });
-
-      const symlinkEntry = {
-        name: 'broken-link',
-        isSymbolicLink: () => true,
-        isDirectory: () => false,
-        isFile: () => false,
-        isBlockDevice: () => false,
-        isCharacterDevice: () => false,
-        isFIFO: () => false,
-        isSocket: () => false,
-        path: skillsDir,
-        parentPath: skillsDir,
-      } as fs.Dirent;
-
+      mockedFs.existsSync.mockImplementation((p: fs.PathLike) => String(p) === skillsDir);
       mockedFs.readdirSync.mockImplementation((p: fs.PathLike, _opts?: any) => {
-        if (String(p) === skillsDir) return [symlinkEntry] as any;
+        if (String(p) === skillsDir) return entries as any;
         return [] as any;
       });
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        const value = String(p);
+        if (value.endsWith('broken-link')) throw new Error('ENOENT: broken symlink');
+        if (value.endsWith('valid-skill')) return path.join(skillsDir, 'sources', 'valid-skill');
+        return value;
+      });
+      mockedFs.statSync.mockReturnValue({ isDirectory: () => true } as fs.Stats);
 
-      mockedFs.realpathSync.mockImplementation(() => {
-        throw new Error('ENOENT: broken symlink');
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
+
+      expect(result).toContain(path.join(skillsDir, 'sources'));
+    });
+
+    it('returns no project skill paths when the project root cannot be canonicalized', () => {
+      mockedFs.realpathSync.mockImplementation((p: fs.PathLike) => {
+        if (String(p) === projectPath) throw new Error('EACCES');
+        return String(p);
       });
 
-      // Should not throw — errors are silently caught
-      expect(() => buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR)).not.toThrow();
+      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR, home);
 
-      // Base paths should still be returned
-      const result = buildSkillPaths(projectPath, DEFAULT_CONFIG_DIR);
-      expect(result.length).toBeGreaterThanOrEqual(6);
+      expect(result).not.toContain(path.join(projectPath, '.mastracode', 'skills'));
+      expect(result).not.toContain(path.join(projectPath, '.claude', 'skills'));
+      expect(result).not.toContain(path.join(projectPath, '.agents', 'skills'));
     });
   });
 });

--- a/mastracode/sdk/src/agents/workspace.ts
+++ b/mastracode/sdk/src/agents/workspace.ts
@@ -93,6 +93,7 @@ function collectSkillPaths(skillsDirs: string[], allowedRoot?: string): string[]
             const stat = fs.statSync(realPath);
             if (stat.isDirectory()) {
               const realParent = path.dirname(realPath);
+              if (realAllowedRoot && !isPathWithinRoot(realParent, realAllowedRoot)) continue;
               if (!seen.has(realParent)) {
                 seen.add(realParent);
                 paths.push(realParent);

--- a/mastracode/sdk/src/agents/workspace.ts
+++ b/mastracode/sdk/src/agents/workspace.ts
@@ -59,7 +59,7 @@ function collectSkillPaths(skillsDirs: string[], allowedRoot?: string): string[]
     try {
       realAllowedRoot = fs.realpathSync(allowedRoot);
     } catch {
-      return skillsDirs;
+      return [];
     }
   }
 
@@ -86,16 +86,20 @@ function collectSkillPaths(skillsDirs: string[], allowedRoot?: string): string[]
       const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
       for (const entry of entries) {
         if (entry.isSymbolicLink()) {
-          const linkPath = path.join(skillsDir, entry.name);
-          const realPath = fs.realpathSync(linkPath);
-          if (realAllowedRoot && !isPathWithinRoot(realPath, realAllowedRoot)) continue;
-          const stat = fs.statSync(realPath);
-          if (stat.isDirectory()) {
-            const realParent = path.dirname(realPath);
-            if (!seen.has(realParent)) {
-              seen.add(realParent);
-              paths.push(realParent);
+          try {
+            const linkPath = path.join(skillsDir, entry.name);
+            const realPath = fs.realpathSync(linkPath);
+            if (realAllowedRoot && !isPathWithinRoot(realPath, realAllowedRoot)) continue;
+            const stat = fs.statSync(realPath);
+            if (stat.isDirectory()) {
+              const realParent = path.dirname(realPath);
+              if (!seen.has(realParent)) {
+                seen.add(realParent);
+                paths.push(realParent);
+              }
             }
+          } catch {
+            continue;
           }
         }
       }
@@ -127,9 +131,17 @@ export function buildSkillPaths(
     ...pluginSkillPaths.flatMap(pluginSkillPath => collectSkillPaths([pluginSkillPath], pluginSkillPath)),
   ];
 
-  return paths.filter((skillPath, index) => {
-    const resolved = path.resolve(skillPath);
-    return paths.findIndex(candidate => path.resolve(candidate) === resolved) === index;
+  const seenPaths = new Set<string>();
+  return paths.filter(skillPath => {
+    let resolved: string;
+    try {
+      resolved = fs.realpathSync(skillPath);
+    } catch {
+      resolved = path.resolve(skillPath);
+    }
+    if (seenPaths.has(resolved)) return false;
+    seenPaths.add(resolved);
+    return true;
   });
 }
 

--- a/mastracode/sdk/src/agents/workspace.ts
+++ b/mastracode/sdk/src/agents/workspace.ts
@@ -11,6 +11,7 @@ import type { LSPConfig } from '@mastra/core/workspace';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
 import { loadSettings } from '../onboarding/settings.js';
 import type { MastraCodeState } from '../schema.js';
+import { isPathWithinRoot } from '../utils/path-security.js';
 import { getPlansDir } from '../utils/plans.js';
 import { SandboxFilesystem } from './sandbox-filesystem.js';
 import { reattachProjectSandbox } from './sandbox-reattach.js';
@@ -49,18 +50,37 @@ function buildSandboxEnv(): NodeJS.ProcessEnv {
 // returns false for symlinks. Tools like `npx skills add` install skills as
 // symlinks, so we need to resolve them. For each symlinked skill directory,
 // we add the real (resolved) parent path as an additional skill scan path.
-function collectSkillPaths(skillsDirs: string[]): string[] {
+function collectSkillPaths(skillsDirs: string[], allowedRoot?: string): string[] {
   const paths: string[] = [];
   const seen = new Set<string>();
+  let realAllowedRoot: string | undefined;
+
+  if (allowedRoot) {
+    try {
+      realAllowedRoot = fs.realpathSync(allowedRoot);
+    } catch {
+      return skillsDirs;
+    }
+  }
 
   for (const skillsDir of skillsDirs) {
+    const skillsDirExists = fs.existsSync(skillsDir);
+    if (skillsDirExists && realAllowedRoot) {
+      try {
+        const realSkillsDir = fs.realpathSync(skillsDir);
+        if (!isPathWithinRoot(realSkillsDir, realAllowedRoot)) continue;
+      } catch {
+        continue;
+      }
+    }
+
     const resolved = path.resolve(skillsDir);
     if (!seen.has(resolved)) {
       seen.add(resolved);
       paths.push(skillsDir);
     }
 
-    if (!fs.existsSync(skillsDir)) continue;
+    if (!skillsDirExists) continue;
 
     try {
       const entries = fs.readdirSync(skillsDir, { withFileTypes: true });
@@ -68,6 +88,7 @@ function collectSkillPaths(skillsDirs: string[]): string[] {
         if (entry.isSymbolicLink()) {
           const linkPath = path.join(skillsDir, entry.name);
           const realPath = fs.realpathSync(linkPath);
+          if (realAllowedRoot && !isPathWithinRoot(realPath, realAllowedRoot)) continue;
           const stat = fs.statSync(realPath);
           if (stat.isDirectory()) {
             const realParent = path.dirname(realPath);
@@ -100,15 +121,16 @@ export function buildSkillPaths(
   const claudeGlobalSkillsPath = path.join(homeDir, '.claude', 'skills');
   const agentSkillsGlobalPath = path.join(homeDir, '.agents', 'skills');
 
-  return collectSkillPaths([
-    mastraCodeLocalSkillsPath,
-    claudeLocalSkillsPath,
-    agentSkillsLocalPath,
-    mastraCodeGlobalSkillsPath,
-    claudeGlobalSkillsPath,
-    agentSkillsGlobalPath,
-    ...pluginSkillPaths,
-  ]);
+  const paths = [
+    ...collectSkillPaths([mastraCodeLocalSkillsPath, claudeLocalSkillsPath, agentSkillsLocalPath], projectPath),
+    ...collectSkillPaths([mastraCodeGlobalSkillsPath, claudeGlobalSkillsPath, agentSkillsGlobalPath]),
+    ...pluginSkillPaths.flatMap(pluginSkillPath => collectSkillPaths([pluginSkillPath], pluginSkillPath)),
+  ];
+
+  return paths.filter((skillPath, index) => {
+    const resolved = path.resolve(skillPath);
+    return paths.findIndex(candidate => path.resolve(candidate) === resolved) === index;
+  });
 }
 
 /**

--- a/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -30,6 +30,26 @@ describe('slash command loader', () => {
 
     expect(commands).toHaveLength(1);
     expect(commands[0]).toMatchObject({ name: 'review', goal: true });
+  });
+
+  it('loads individually symlinked command files', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastracode-commands-'));
+    const sourceDir = await mkdtemp(join(tmpdir(), 'mastracode-command-source-'));
+    const sourceFile = join(sourceDir, 'review.md');
+    await writeFile(sourceFile, 'Review the code\n');
+    await symlink(sourceFile, join(dir, 'review.md'));
+
+    const commands = await scanCommandDirectory(dir);
+
+    expect(commands).toHaveLength(1);
+    expect(commands[0]).toMatchObject({ name: 'review', sourcePath: join(dir, 'review.md') });
+  });
+
+  it('ignores broken command symlinks', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastracode-commands-'));
+    await symlink(join(dir, 'missing.md'), join(dir, 'broken.md'));
+
+    await expect(scanCommandDirectory(dir)).resolves.toEqual([]);
   });
 
   it('loads plugin command directories after built-in custom command locations', async () => {

--- a/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
@@ -2,11 +2,19 @@ import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadCustomCommands, parseCommandFile, scanCommandDirectory } from '../slash-command-loader.js';
 
 describe('slash command loader', () => {
+  beforeEach(async () => {
+    vi.stubEnv('HOME', await mkdtemp(join(tmpdir(), 'mastracode-home-')));
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('parses goal metadata from frontmatter', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'mastracode-command-'));
     const file = join(dir, 'ship.md');

--- a/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/slash-command-loader.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, symlink, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -43,6 +43,60 @@ describe('slash command loader', () => {
 
     expect(commands).toHaveLength(1);
     expect(commands[0]).toMatchObject({ name: 'review', sourcePath: join(dir, 'review.md') });
+  });
+
+  it('loads project command symlinks that stay within the project root', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'mastracode-project-'));
+    const commandsDir = join(projectDir, '.mastracode', 'commands');
+    const sourcesDir = join(projectDir, '.mastracode', 'command-sources');
+    await mkdir(commandsDir, { recursive: true });
+    await mkdir(sourcesDir, { recursive: true });
+    await writeFile(join(sourcesDir, 'review.md'), 'Review the code\n');
+    await symlink(join(sourcesDir, 'review.md'), join(commandsDir, 'review.md'));
+
+    const commands = await loadCustomCommands(projectDir);
+
+    expect(commands.find(command => command.name === 'review')).toMatchObject({
+      sourcePath: join(commandsDir, 'review.md'),
+    });
+  });
+
+  it('rejects project command symlinks that escape the project root', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'mastracode-project-'));
+    const commandsDir = join(projectDir, '.mastracode', 'commands');
+    const externalDir = await mkdtemp(join(tmpdir(), 'mastracode-command-secret-'));
+    await mkdir(commandsDir, { recursive: true });
+    await writeFile(join(externalDir, '.env'), 'SECRET=value\n');
+    await symlink(join(externalDir, '.env'), join(commandsDir, 'leaked.md'));
+
+    const commands = await loadCustomCommands(projectDir);
+
+    expect(commands.find(command => command.name === 'leaked')).toBeUndefined();
+  });
+
+  it('rejects project command directories symlinked outside the project root', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'mastracode-project-'));
+    const claudeDir = join(projectDir, '.claude');
+    const externalCommandsDir = await mkdtemp(join(tmpdir(), 'mastracode-external-commands-'));
+    await mkdir(claudeDir, { recursive: true });
+    await writeFile(join(externalCommandsDir, 'leaked.md'), 'External command\n');
+    await symlink(externalCommandsDir, join(claudeDir, 'commands'));
+
+    const commands = await loadCustomCommands(projectDir);
+
+    expect(commands.find(command => command.name === 'leaked')).toBeUndefined();
+  });
+
+  it('rejects plugin command symlinks that escape the plugin command root', async () => {
+    const projectDir = await mkdtemp(join(tmpdir(), 'mastracode-project-'));
+    const pluginCommandsDir = await mkdtemp(join(tmpdir(), 'mastracode-plugin-commands-'));
+    const externalDir = await mkdtemp(join(tmpdir(), 'mastracode-command-secret-'));
+    await writeFile(join(externalDir, 'secret.txt'), 'plugin secret\n');
+    await symlink(join(externalDir, 'secret.txt'), join(pluginCommandsDir, 'leaked.md'));
+
+    const commands = await loadCustomCommands(projectDir, '.mastracode', [pluginCommandsDir]);
+
+    expect(commands.find(command => command.name === 'leaked')).toBeUndefined();
   });
 
   it('ignores broken command symlinks', async () => {

--- a/mastracode/sdk/src/utils/path-security.ts
+++ b/mastracode/sdk/src/utils/path-security.ts
@@ -1,0 +1,9 @@
+import path from 'node:path';
+
+export function isPathWithinRoot(candidatePath: string, rootPath: string): boolean {
+  const relativePath = path.relative(rootPath, candidatePath);
+  return (
+    relativePath === '' ||
+    (!relativePath.startsWith(`..${path.sep}`) && relativePath !== '..' && !path.isAbsolute(relativePath))
+  );
+}

--- a/mastracode/sdk/src/utils/slash-command-loader.ts
+++ b/mastracode/sdk/src/utils/slash-command-loader.ts
@@ -118,7 +118,11 @@ export async function scanCommandDirectory(dirPath: string, rootDir?: string): P
         // Recursively scan subdirectories, preserving the root directory for namespace derivation
         const subCommands = await scanCommandDirectory(fullPath, baseDir);
         commands.push(...subCommands);
-      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      } else if (entry.name.endsWith('.md')) {
+        const symlinkTarget = entry.isSymbolicLink() ? await fs.stat(fullPath).catch(() => null) : null;
+        const isCommandFile = entry.isFile() || symlinkTarget?.isFile();
+        if (!isCommandFile) continue;
+
         // Parse markdown command files, passing the root commands dir as baseDir for name derivation
         const command = await parseCommandFile(fullPath, baseDir);
         if (command) {

--- a/mastracode/sdk/src/utils/slash-command-loader.ts
+++ b/mastracode/sdk/src/utils/slash-command-loader.ts
@@ -2,6 +2,7 @@ import { promises as fs } from 'node:fs';
 import * as path from 'node:path';
 import { parse as parseYaml } from 'yaml';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
+import { isPathWithinRoot } from './path-security.js';
 
 /**
  * Metadata for a slash command
@@ -104,24 +105,46 @@ export function extractCommandName(filePath: string, baseDir: string): string {
  * @param rootDir - Original root commands directory (used for namespace derivation).
  *                  When omitted the first call sets it to dirPath.
  */
-export async function scanCommandDirectory(dirPath: string, rootDir?: string): Promise<SlashCommandMetadata[]> {
+export interface ScanCommandDirectoryOptions {
+  allowedRoot?: string;
+  visitedDirectories?: Set<string>;
+}
+
+export async function scanCommandDirectory(
+  dirPath: string,
+  rootDir?: string,
+  options: ScanCommandDirectoryOptions = {},
+): Promise<SlashCommandMetadata[]> {
   const baseDir = rootDir ?? dirPath;
   const commands: SlashCommandMetadata[] = [];
+  const visitedDirectories = options.visitedDirectories ?? new Set<string>();
 
   try {
+    const realDirectory = await fs.realpath(dirPath);
+    const realAllowedRoot = options.allowedRoot ? await fs.realpath(options.allowedRoot) : undefined;
+    if (realAllowedRoot && !isPathWithinRoot(realDirectory, realAllowedRoot)) return commands;
+    if (visitedDirectories.has(realDirectory)) return commands;
+    visitedDirectories.add(realDirectory);
+
     const entries = await fs.readdir(dirPath, { withFileTypes: true });
 
     for (const entry of entries) {
       const fullPath = path.join(dirPath, entry.name);
+      const stats = entry.isSymbolicLink() ? await fs.stat(fullPath).catch(() => null) : entry;
+      if (!stats) continue;
 
-      if (entry.isDirectory()) {
+      if (stats.isDirectory()) {
         // Recursively scan subdirectories, preserving the root directory for namespace derivation
-        const subCommands = await scanCommandDirectory(fullPath, baseDir);
+        const subCommands = await scanCommandDirectory(fullPath, baseDir, {
+          ...options,
+          visitedDirectories,
+        });
         commands.push(...subCommands);
-      } else if (entry.name.endsWith('.md')) {
-        const symlinkTarget = entry.isSymbolicLink() ? await fs.stat(fullPath).catch(() => null) : null;
-        const isCommandFile = entry.isFile() || symlinkTarget?.isFile();
-        if (!isCommandFile) continue;
+      } else if (entry.name.endsWith('.md') && stats.isFile()) {
+        if (realAllowedRoot) {
+          const realFile = await fs.realpath(fullPath).catch(() => null);
+          if (!realFile || !isPathWithinRoot(realFile, realAllowedRoot)) continue;
+        }
 
         // Parse markdown command files, passing the root commands dir as baseDir for name derivation
         const command = await parseCommandFile(fullPath, baseDir);
@@ -180,27 +203,33 @@ export async function loadCustomCommands(
   // 4. Load from opencode project directory .opencode/command
   if (projectDir) {
     const opencodeProjectDir = path.join(projectDir, '.opencode', 'command');
-    const opencodeProjectCommands = await scanCommandDirectory(opencodeProjectDir);
+    const opencodeProjectCommands = await scanCommandDirectory(opencodeProjectDir, undefined, {
+      allowedRoot: projectDir,
+    });
     addCommands(opencodeProjectCommands);
   }
 
   // 5. Load from claude project directory .claude/commands (Claude Code compat)
   if (projectDir) {
     const claudeProjectDir = path.join(projectDir, '.claude', 'commands');
-    const claudeProjectCommands = await scanCommandDirectory(claudeProjectDir);
+    const claudeProjectCommands = await scanCommandDirectory(claudeProjectDir, undefined, {
+      allowedRoot: projectDir,
+    });
     addCommands(claudeProjectCommands);
   }
 
   // 6. Load from mastra project directory <configDirName>/commands
   if (projectDir) {
     const mastraProjectDir = path.join(projectDir, configDirName, 'commands');
-    const mastraProjectCommands = await scanCommandDirectory(mastraProjectDir);
+    const mastraProjectCommands = await scanCommandDirectory(mastraProjectDir, undefined, {
+      allowedRoot: projectDir,
+    });
     addCommands(mastraProjectCommands);
   }
 
   // 7. Load from active plugin command directories (highest priority)
   for (const commandsDir of extraCommandDirs) {
-    addCommands(await scanCommandDirectory(commandsDir));
+    addCommands(await scanCommandDirectory(commandsDir, undefined, { allowedRoot: commandsDir }));
   }
 
   return Array.from(commandMap.values());

--- a/mastracode/tui/e2e/tui/custom-slash-command.ts
+++ b/mastracode/tui/e2e/tui/custom-slash-command.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, symlinkSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { expect } from './expect.js';
 import type { McE2eScenario } from './types.js';
@@ -17,11 +17,14 @@ export const customSlashCommandScenario: McE2eScenario = {
   aimockFixture: 'custom-slash-command.json',
   prepare({ projectDir }) {
     const commandsDir = join(projectDir, '.mastracode', 'commands');
+    const commandSourcesDir = join(projectDir, '.mastracode', 'command-sources');
     mkdirSync(commandsDir, { recursive: true });
+    mkdirSync(commandSourcesDir, { recursive: true });
     writeFileSync(
-      join(commandsDir, 'deploy.md'),
+      join(commandSourcesDir, 'deploy.md'),
       `---\ndescription: Deploy checklist\n---\nDeploy using the standard checklist.\n`,
     );
+    symlinkSync(join(commandSourcesDir, 'deploy.md'), join(commandsDir, 'deploy.md'));
     writeFileSync(join(commandsDir, 'review.md'), `---\ndescription: Review changed files\n---\nReview $1+\n`);
   },
   async run({ terminal, runtime }) {


### PR DESCRIPTION
Custom commands and skills can be installed as symlinks, but their trust boundary depends on where they were configured. Project-controlled assets should not be able to read files outside the project, while user-global links need to keep supporting shared command and skill repositories.\n\nThis adds source-aware containment: project commands and skills must resolve within the project root, plugin assets must remain within their plugin asset root, and user-global assets may still resolve externally. It also handles symlinked command directories, broken links, and directory cycles while preserving individually symlinked command files.\n\nFor example, a project link like `.mastracode/commands/review.md -> ~/.env` is ignored, while a user-global link like `~/.claude/commands/review.md -> /path/to/repo/.mastracode/commands/review.md` continues to work.\n\nTest plan:\n- SDK slash command loader tests\n- SDK skill path tests\n- SDK typecheck\n- TUI lint and typecheck\n- `pnpm build:mastracode`\n- focused `custom-slash-command` TUI E2E scenario

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes Mastra ignore “symlink tricks” that could make custom commands and skills appear to live in the wrong folder. It still lets user-global symlinks point anywhere, but it blocks project/plugin symlinks that resolve outside the trusted roots.

## Summary
- Updated slash-command discovery to be symlink- and realpath-aware:
  - Added `ScanCommandDirectoryOptions` (`allowedRoot`, `visitedDirectories`) so scanning is restricted to a trusted root and won’t loop.
  - `scanCommandDirectory` now resolves real paths, processes only valid `.md` entries, skips anything that resolves outside `allowedRoot`, avoids re-scanning via `visitedDirectories`, and treats broken symlinks safely.
  - `loadCustomCommands` applies `allowedRoot` for project command sources and plugin “extra command dirs”.
  - Introduced/used `isPathWithinRoot` for containment checks.
- Updated skill path collection to prevent symlink escapes:
  - Added `allowedRoot` support to `collectSkillPaths` with realpath-based filtering of symlink targets and containment via `isPathWithinRoot`.
  - `buildSkillPaths` now constrains project/local and plugin sources with appropriate `allowedRoot` rules, keeps global symlinks unrestricted, and deduplicates based on resolved paths.
- Test + E2E coverage:
  - Expanded slash-command loader tests for individually symlinked command files, acceptance/rejection of project/plugin escape attempts, and correct behavior with broken symlinks (with isolated per-test `HOME`).
  - Expanded skill-path tests for project/plugin containment, file-vs-directory symlinks, broken-link continuation, and behavior when canonicalization fails.
  - Updated the TUI custom slash command E2E scenario to write a command source under `.mastracode/command-sources` and symlink it into `.mastracode/commands`, verifying behavior through the symlink.
- Added a `@mastra/code-sdk` changeset documenting the security fix for secure discovery of individually symlinked custom commands and skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->