### PR TITLE
Surface agent session run errors in server logs and on the wire

### DIFF
--- a/.agents/skills/testing-core-processors/SKILL.md
+++ b/.agents/skills/testing-core-processors/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: testing-core-processors
+description: How to write integration tests for error processors in packages/core/src/processors/. Use when testing retry behavior, error handling, or processor pipelines with MockLanguageModelV2 from @internal/ai-sdk-v5/test.
+---
+
 # Testing Core Error Processors
 
 How to write integration tests for error processors in `packages/core/src/processors/`.

--- a/.changeset/twenty-hounds-dig.md
+++ b/.changeset/twenty-hounds-dig.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed agent session run failures surfacing as "Run failed with an unknown error" in clients. Error events now flatten Error-like payloads so the real failure message reaches the client, and run errors are logged on the server so the logs contain the failure details.

--- a/.claude/skills/testing-core-processors/SKILL.md
+++ b/.claude/skills/testing-core-processors/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: testing-core-processors
+description: How to write integration tests for error processors in packages/core/src/processors/. Use when testing retry behavior, error handling, or processor pipelines with MockLanguageModelV2 from @internal/ai-sdk-v5/test.
+---
+
 # Testing Core Error Processors
 
 How to write integration tests for error processors in `packages/core/src/processors/`.

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -286,6 +286,41 @@ describe('agent-controller routes', () => {
       expect(JSON.parse(JSON.stringify(received)).error.message).toBe('model quota exhausted');
       expect(received.errorType).toBe('provider');
     });
+
+    it('flattens Error-like objects on error events (e.g. cross-realm Errors)', async () => {
+      const stream = (await STREAM_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-err-like',
+        abortSignal: new AbortController().signal,
+      } as any)) as ReadableStream<unknown>;
+
+      const reader = stream.getReader();
+
+      const controller = mastra.getAgentController('code')!;
+      await controller.init();
+      const session = await controller.createSession({
+        resourceId: 'user-err-like',
+        id: 'user-err-like',
+        ownerId: 'code',
+      });
+      // Error-like object whose message is non-enumerable, mimicking an Error
+      // from another realm (fails `instanceof Error`) that would otherwise
+      // serialize to `{}` on the wire.
+      const errorLike = Object.defineProperty({}, 'message', { value: 'sandbox provider unavailable' });
+      session.emit({ type: 'error', error: errorLike } as any);
+
+      let received: any;
+      for (let i = 0; i < 10 && received === undefined; i++) {
+        const { value } = await reader.read();
+        if (value && typeof value === 'object' && (value as any).type === 'error') received = value;
+      }
+      await reader.cancel();
+
+      expect(received).toBeDefined();
+      expect(received.error).toEqual({ name: 'Error', message: 'sandbox provider unavailable' });
+      expect(JSON.parse(JSON.stringify(received)).error.message).toBe('sandbox provider unavailable');
+    });
   });
 
   describe('LIST_AGENT_CONTROLLER_MODES_ROUTE', () => {

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -318,15 +318,24 @@ export const CREATE_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
  * Error into a plain object so the actual failure reaches the client.
  */
 function toWireEvent(event: unknown): unknown {
-  if (
-    typeof event === 'object' &&
-    event !== null &&
-    (event as { type?: unknown }).type === 'error' &&
-    (event as { error?: unknown }).error instanceof Error
-  ) {
-    const error = (event as { error: Error }).error;
+  if (typeof event !== 'object' || event === null || (event as { type?: unknown }).type !== 'error') {
+    return event;
+  }
+  const error = (event as { error?: unknown }).error;
+  if (error instanceof Error) {
     return { ...event, error: { name: error.name, message: error.message } };
   }
+  // Non-Error payloads (cross-realm Errors, thrown objects) can still carry a
+  // useful message on non-enumerable properties; flatten them the same way so
+  // the client never renders a bare `{}`.
+  if (typeof error === 'object' && error !== null) {
+    const { name, message } = error as { name?: unknown; message?: unknown };
+    if (typeof message === 'string' && message) {
+      return { ...event, error: { name: typeof name === 'string' && name ? name : 'Error', message } };
+    }
+  }
+  // Strings pass through as-is; nullish payloads stay untouched so the client
+  // can fall back to `errorType`.
   return event;
 }
 
@@ -346,6 +355,7 @@ export const STREAM_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId);
+      const logger = mastra.getLogger();
 
       let cleanedUp = false;
       let heartbeat: ReturnType<typeof setTimeout> | undefined;
@@ -391,6 +401,16 @@ export const STREAM_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
 
           unsubscribe = session.subscribe(event => {
             if (cleanedUp) return;
+            // Session error events are otherwise invisible server-side; log
+            // them so "check the server logs" in the client is actionable.
+            if (typeof event === 'object' && event !== null && (event as { type?: unknown }).type === 'error') {
+              const err = (event as { error?: unknown }).error;
+              logger?.error?.(
+                `[AgentController] session run error (controller=${controllerId} resource=${resourceId}): ${
+                  err instanceof Error ? (err.stack ?? err.message) : JSON.stringify(toWireEvent(event))
+                }`,
+              );
+            }
             try {
               // Enqueue the raw event object. The server adapter is responsible
               // for SSE framing (`data: <json>\n\n`); enqueuing a pre-framed


### PR DESCRIPTION
## Summary

When an agent session run fails, the web/TUI client shows **"Run failed with an unknown error. Check the server logs for details."** — but the server logs contained nothing about the failure, making it undebuggable.

Two gaps fixed in the agent-controller SSE route (`@mastra/server`):

- **Server-side logging**: session `error` events are now logged (with stack trace when available) before being forwarded to the client, so "check the server logs" is actionable.
- **Wire serialization**: `toWireEvent` only flattened `error instanceof Error`. Error-like payloads (cross-realm Errors, thrown objects with non-enumerable `message`) serialized to `{}`, which is exactly what produces the generic "unknown error" notice. These are now flattened to `{ name, message }` too.

Also adds the missing YAML frontmatter (`name`/`description`) to the `testing-core-processors` skill, which was failing workspace skill validation on every checkout:

```
[WorkspaceSkills] Failed to load skill from .../.claude/skills: Invalid skill metadata ...
name: Expected string, received undefined
```

## Test plan

- New test: Error-like object with non-enumerable `message` survives JSON serialization on the wire
- `packages/server` handler tests: 25/25 passing
- `pnpm build:server` clean
- Changeset added (patch `@mastra/server`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an agent run fails, the server now records the real problem and sends a useful error message to the client instead of hiding it behind a generic failure.

## Changes

- Log session error events with stack traces or messages when available.
- Serialize regular, cross-realm, and non-enumerable-message errors as `{ name, message }` for SSE clients.
- Add coverage for Error-like payload serialization.
- Add required YAML frontmatter to testing skill files.
- Add a patch changeset for `@mastra/server`.

## Validation

- 25/25 server handler tests passing.
- Server build completed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->