### PR TITLE
feat(mastracode): serve plugins as MCP servers

### DIFF
--- a/.changeset/fluffy-vans-dream.md
+++ b/.changeset/fluffy-vans-dream.md
@@ -1,0 +1,12 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Added a transport-agnostic adapter that loads a local or GitHub Mastra Code plugin and exposes its tools through an MCP server.
+
+```ts
+import { createPluginMCPServer } from '@mastra/code-sdk/plugins/mcp';
+
+const { server } = await createPluginMCPServer({ specifier: '/absolute/path/to/plugin' });
+await server.startStdio();
+```

--- a/.changeset/slow-clowns-grin.md
+++ b/.changeset/slow-clowns-grin.md
@@ -1,0 +1,9 @@
+---
+'mastracode': minor
+---
+
+Added a stdio command that serves tools from a local or GitHub Mastra Code plugin to MCP clients.
+
+```bash
+mastracode plugin mcp /absolute/path/to/plugin --config region=us-west
+```

--- a/mastracode/sdk/src/plugins/__tests__/mcp.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/mcp.test.ts
@@ -1,0 +1,194 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const execaMock = vi.hoisted(() => vi.fn());
+vi.mock('execa', () => ({ execa: execaMock }));
+
+import { createPluginMCPServer, resolvePluginConfigInput } from '../mcp.js';
+import { prepareGithubPluginSource } from '../source.js';
+
+let tempDir: string | undefined;
+
+afterEach(() => {
+  vi.clearAllMocks();
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+function writePlugin(
+  dir: string,
+  options: { config?: string; name?: string; version?: string; tools?: string } = {},
+): void {
+  fs.mkdirSync(path.join(dir, 'src'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'src/index.ts'),
+    `import { createTool, defineMastraCodePlugin, z } from 'mastracode/plugin';
+export default defineMastraCodePlugin({
+  id: 'acme.mcp',
+  ${options.name ? `name: '${options.name}',` : ''}
+  ${options.version ? `version: '${options.version}',` : ''}
+  ${options.config ?? ''}
+  ${
+    options.tools === 'none'
+      ? ''
+      : `tools: context => ({ echo: { tool: createTool({ id: 'echo', description: 'echo', inputSchema: z.object({ value: z.string() }), outputSchema: z.object({ value: z.string() }), execute: async ({ value }) => ({ value: value + ':' + String(context.config.label) + ':' + String(context.config.enabled) }) }) } })`
+  }
+});`,
+  );
+}
+
+function setup(): { projectRoot: string; homeDir: string; pluginDir: string } {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-mcp-'));
+  const projectRoot = path.join(tempDir, 'project');
+  const homeDir = path.join(tempDir, 'home');
+  const pluginDir = path.join(tempDir, 'plugin');
+  fs.mkdirSync(projectRoot, { recursive: true });
+  return { projectRoot, homeDir, pluginDir };
+}
+
+describe('createPluginMCPServer', () => {
+  it('acquires a local plugin and lists and invokes its normalized tool', async () => {
+    const paths = setup();
+    writePlugin(paths.pluginDir, {
+      name: 'Acme MCP',
+      version: '1.2.3',
+      config: `config: { label: { type: 'string', default: 'default' }, enabled: { type: 'boolean', default: false } },`,
+    });
+
+    const result = await createPluginMCPServer({
+      specifier: paths.pluginDir,
+      ...paths,
+      envConfig: JSON.stringify({ label: 'environment', enabled: true }),
+      config: { label: 'explicit' },
+    });
+
+    expect(result.plugin).toEqual({ id: 'acme.mcp', name: 'Acme MCP', version: '1.2.3' });
+    expect(result.config).toEqual({ label: 'explicit', enabled: true });
+    expect(await result.server.getToolListInfo()).toMatchObject({ tools: [{ name: 'echo' }] });
+    await expect(result.server.executeTool('echo', { value: 'hello' })).resolves.toEqual({
+      value: 'hello:explicit:true',
+    });
+    await result.close();
+    await result.close();
+  });
+
+  it('uses stable identity fallbacks and supports plugins without tools', async () => {
+    const paths = setup();
+    writePlugin(paths.pluginDir, { tools: 'none' });
+    const result = await createPluginMCPServer({ specifier: paths.pluginDir, ...paths });
+    expect(result.plugin).toEqual({ id: 'acme.mcp', name: 'acme.mcp', version: '0.0.0' });
+    expect(await result.server.getToolListInfo()).toEqual({ tools: [] });
+    await result.close();
+  });
+
+  it('rejects unknown, invalid, and missing required config before returning a server', async () => {
+    const paths = setup();
+    writePlugin(paths.pluginDir, { config: `config: { label: { type: 'string' } },` });
+    await expect(createPluginMCPServer({ specifier: paths.pluginDir, ...paths })).rejects.toThrow(
+      'Missing required plugin configuration key: label',
+    );
+    await expect(
+      createPluginMCPServer({ specifier: paths.pluginDir, ...paths, config: { nope: 'x' } }),
+    ).rejects.toThrow('Unknown plugin configuration key: nope');
+    await expect(
+      createPluginMCPServer({ specifier: paths.pluginDir, ...paths, config: { label: true } }),
+    ).rejects.toThrow('Invalid value for plugin configuration key: label');
+  });
+});
+
+describe('resolvePluginConfigInput', () => {
+  it('merges explicit values over environment values', () => {
+    expect(resolvePluginConfigInput({ first: 'explicit' }, '{"first":"env","second":true}')).toEqual({
+      first: 'explicit',
+      second: true,
+    });
+    expect(resolvePluginConfigInput({ only: 'explicit' }, '{}')).toEqual({ only: 'explicit' });
+  });
+
+  it.each(['{', '[]', 'null', '"text"'])('rejects malformed or non-object environment JSON: %s', value => {
+    expect(() => resolvePluginConfigInput(undefined, value)).toThrow('MASTRACODE_PLUGIN_CONFIG must be');
+  });
+
+  it('rejects invalid environment value types without including their values', () => {
+    const secret = 'do-not-leak';
+    expect(() => resolvePluginConfigInput(undefined, JSON.stringify({ token: { secret } }))).toThrow(
+      'MASTRACODE_PLUGIN_CONFIG has an invalid value for key: token',
+    );
+    try {
+      resolvePluginConfigInput(undefined, JSON.stringify({ token: { secret } }));
+    } catch (error) {
+      expect(String(error)).not.toContain(secret);
+    }
+  });
+});
+
+describe('standalone GitHub acquisition', () => {
+  function mockCommands(pluginId = 'acme.mcp', head = ''): void {
+    execaMock.mockImplementation(async (command: string, args: string[], options?: { cwd?: string }) => {
+      if (command === 'gh' && args[0] === 'repo' && args[1] === 'clone') {
+        writePlugin(args[3], { name: pluginId, tools: 'none' });
+      }
+      if (command === 'git' && args[0] === 'rev-parse') return { stdout: head };
+      return { stdout: '', cwd: options?.cwd };
+    });
+  }
+
+  it('freshly clones mutable refs and atomically promotes the prepared checkout', async () => {
+    const paths = setup();
+    mockCommands();
+    const options = { ...paths, standalone: true, ref: 'main' };
+    const first = await prepareGithubPluginSource('https://github.com/acme/plugin', options);
+    const second = await prepareGithubPluginSource('https://github.com/acme/plugin', options);
+    expect(first.pluginRoot).toBe(second.pluginRoot);
+    expect(fs.existsSync(path.join(first.pluginRoot, 'src/index.ts'))).toBe(true);
+    expect(execaMock.mock.calls.filter(call => call[1]?.[0] === 'repo')).toHaveLength(2);
+    expect(fs.readdirSync(path.dirname(first.pluginRoot)).some(name => name.includes('.tmp-'))).toBe(false);
+  });
+
+  it('freshly clones an unpinned default source and short SHA', async () => {
+    const paths = setup();
+    mockCommands();
+    await prepareGithubPluginSource('https://github.com/acme/plugin', { ...paths, standalone: true });
+    await prepareGithubPluginSource('https://github.com/acme/plugin', { ...paths, standalone: true });
+    await prepareGithubPluginSource('https://github.com/acme/plugin', { ...paths, standalone: true, ref: 'abc1234' });
+    await prepareGithubPluginSource('https://github.com/acme/plugin', { ...paths, standalone: true, ref: 'abc1234' });
+    expect(execaMock.mock.calls.filter(call => call[1]?.[0] === 'repo')).toHaveLength(4);
+  });
+
+  it('reuses a verified full commit checkout', async () => {
+    const paths = setup();
+    const sha = 'a'.repeat(40);
+    mockCommands('acme.mcp', sha);
+    await prepareGithubPluginSource('https://github.com/acme/plugin', { ...paths, standalone: true, ref: sha });
+    await prepareGithubPluginSource('https://github.com/acme/plugin', { ...paths, standalone: true, ref: sha });
+    expect(execaMock.mock.calls.filter(call => call[1]?.[0] === 'repo')).toHaveLength(1);
+  });
+
+  it('serializes same-key preparation', async () => {
+    const paths = setup();
+    mockCommands();
+    const options = { ...paths, standalone: true, ref: 'main', lockWaitMs: 2_000 };
+    const [first, second] = await Promise.all([
+      prepareGithubPluginSource('https://github.com/acme/plugin', options),
+      prepareGithubPluginSource('https://github.com/acme/plugin', options),
+    ]);
+    expect(first.pluginRoot).toBe(second.pluginRoot);
+    expect(fs.existsSync(path.join(first.pluginRoot, 'src/index.ts'))).toBe(true);
+    expect(fs.existsSync(`${first.pluginRoot}.lock`)).toBe(false);
+  });
+
+  it('cleans stale same-key locks', async () => {
+    const paths = setup();
+    mockCommands();
+    const options = { ...paths, standalone: true, ref: 'main', lockWaitMs: 2_000, staleLockMs: 1 };
+    const first = await prepareGithubPluginSource('https://github.com/acme/plugin', options);
+    fs.mkdirSync(`${first.pluginRoot}.lock`, { recursive: true });
+    fs.utimesSync(`${first.pluginRoot}.lock`, new Date(0), new Date(0));
+    await expect(prepareGithubPluginSource('https://github.com/acme/plugin', options)).resolves.toMatchObject({
+      pluginRoot: first.pluginRoot,
+    });
+    expect(fs.existsSync(`${first.pluginRoot}.lock`)).toBe(false);
+  });
+});

--- a/mastracode/sdk/src/plugins/__tests__/package-link.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/package-link.test.ts
@@ -56,6 +56,18 @@ describe('ensureMastraCodePackageLink', () => {
     );
   });
 
+  it('replaces a dangling mastracode package link', () => {
+    const pluginRoot = makePluginRoot();
+    const linkPath = path.join(pluginRoot, 'node_modules', 'mastracode');
+    fs.writeFileSync(path.join(pluginRoot, 'package.json'), JSON.stringify({ peerDependencies: { mastracode: '*' } }));
+    fs.mkdirSync(path.dirname(linkPath), { recursive: true });
+    fs.symlinkSync(path.join(pluginRoot, 'missing-mastracode'), linkPath, 'dir');
+
+    ensureMastraCodePackageLink(pluginRoot);
+
+    expect(fs.realpathSync(linkPath)).toBe(fs.realpathSync(mastracodePackageRoot));
+  });
+
   it('does not link mastracode when the plugin declares a package dependency', () => {
     const pluginRoot = makePluginRoot();
     fs.writeFileSync(path.join(pluginRoot, 'package.json'), JSON.stringify({ dependencies: { mastracode: '^1.0.0' } }));

--- a/mastracode/sdk/src/plugins/install.ts
+++ b/mastracode/sdk/src/plugins/install.ts
@@ -1,17 +1,14 @@
 import fs from 'node:fs';
 import path from 'node:path';
 
-import { execa } from 'execa';
-
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
-import { getEntryPackageRoot, installPluginDependenciesForEntry } from './dependencies.js';
 import type { PluginInstallExecutionOptions } from './dependencies.js';
 import { loadPluginFromEntry } from './loader.js';
-import { getSingleManifestPlugin } from './manifest.js';
-import { ensureMastraCodePackageLink } from './package-link.js';
 import { getPluginRoot, getPluginScopePaths } from './paths.js';
 import type { PluginPathOptions } from './paths.js';
 import { loadPluginRegistry, removePluginRecord, savePluginRegistry, setPluginRecord } from './registry.js';
+import { detectEntry, parseGithubUrl, prepareGithubPluginSource, prepareLocalPluginSource } from './source.js';
+export { detectEntry, NON_INTERACTIVE_GIT_ENV } from './source.js';
 import type { InstalledPluginRecord, PluginScope } from './types.js';
 
 export type InstallPluginOptions = PluginPathOptions &
@@ -27,24 +24,14 @@ export type DiscoveredLocalPlugin = {
   entry: string;
 };
 
-const ENTRY_CANDIDATES = ['src/index.ts', 'index.ts'];
-
-export const NON_INTERACTIVE_GIT_ENV = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-
-const NON_INTERACTIVE_EXEC_OPTIONS = { env: NON_INTERACTIVE_GIT_ENV };
-
 export async function installLocalPlugin(
   localPath: string,
   scope: PluginScope,
   options: InstallPluginOptions,
 ): Promise<string> {
-  const sourcePath = path.resolve(options.projectRoot, localPath);
-  if (!fs.existsSync(sourcePath) || !fs.statSync(sourcePath).isDirectory()) {
-    throw new Error(`Local plugin path does not exist or is not a directory: ${localPath}`);
-  }
-
-  const entry = detectEntry(sourcePath, options.entry);
-  ensureMastraCodePackageLink(sourcePath);
+  const prepared = await prepareLocalPluginSource(localPath, { ...options, cwd: options.projectRoot });
+  const sourcePath = prepared.pluginRoot;
+  const entry = prepared.entry;
   const plugin = await loadPluginFromEntry(path.join(sourcePath, entry));
   const registryPath = getPluginScopePaths(scope, options).registryPath;
   const registry = removePluginRecord(loadPluginRegistry(registryPath), plugin.id);
@@ -69,28 +56,9 @@ export async function installGithubPlugin(
   const parsed = parseGithubUrl(url);
   const paths = getPluginScopePaths(scope, options);
   const checkoutDir = path.join(paths.sourcesPath, 'github', `${parsed.owner}-${parsed.repo}`);
-
-  const githubCli = options.githubCliPath ?? 'gh';
-  await assertGithubCliAvailable(githubCli);
-  await assertGithubCliAuthenticated(githubCli);
-
-  fs.rmSync(checkoutDir, { recursive: true, force: true });
-  fs.mkdirSync(path.dirname(checkoutDir), { recursive: true });
-  const ref = options.ref ?? parsed.ref;
-  const cloneArgs = ['repo', 'clone', parsed.repoSpec, checkoutDir, ...(ref ? [] : ['--', '--depth', '1'])];
-  await runPluginInstallCommand(githubCli, cloneArgs, { env: NON_INTERACTIVE_GIT_ENV }, options);
-  if (ref) {
-    await runPluginInstallCommand(
-      'git',
-      ['checkout', ref],
-      { cwd: checkoutDir, env: NON_INTERACTIVE_GIT_ENV },
-      options,
-    );
-  }
-
-  const entry = detectEntry(checkoutDir, options.entry);
-  await installPluginDependenciesForEntry(checkoutDir, entry, options);
-  ensureMastraCodePackageLink(getEntryPackageRoot(checkoutDir, entry));
+  const prepared = await prepareGithubPluginSource(url, { ...options, checkoutDir });
+  const ref = prepared.ref;
+  const entry = prepared.entry;
   const plugin = await loadPluginFromEntry(path.join(checkoutDir, entry));
   const registry = removePluginRecord(loadPluginRegistry(paths.registryPath), plugin.id);
   const relativePath = path.relative(getPluginRoot(scope, options), checkoutDir);
@@ -146,112 +114,4 @@ function tryDetectEntry(pluginDir: string): string | undefined {
   } catch {
     return undefined;
   }
-}
-
-export function detectEntry(pluginDir: string, explicitEntry?: string): string {
-  const root = path.resolve(pluginDir);
-  if (explicitEntry) {
-    const entryPath = path.resolve(pluginDir, explicitEntry);
-    if (!isInsideDirectory(entryPath, root)) {
-      throw new Error('Plugin entry must be inside the plugin directory');
-    }
-    if (fs.existsSync(entryPath) && fs.statSync(entryPath).isDirectory()) {
-      const nestedEntry = detectEntry(entryPath);
-      return path.relative(root, path.join(entryPath, nestedEntry));
-    }
-    if (path.extname(entryPath) !== '.ts') {
-      throw new Error('Plugin entry must be a .ts file');
-    }
-    if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
-      throw new Error(`Plugin entry file does not exist: ${explicitEntry}`);
-    }
-    return path.relative(root, entryPath);
-  }
-
-  const manifestPlugin = getSingleManifestPlugin(pluginDir);
-  if (manifestPlugin) {
-    return detectEntry(pluginDir, manifestPlugin.entry);
-  }
-
-  for (const candidate of ENTRY_CANDIDATES) {
-    const entryPath = path.join(pluginDir, candidate);
-    if (fs.existsSync(entryPath) && fs.statSync(entryPath).isFile()) {
-      return candidate;
-    }
-  }
-
-  throw new Error(`Could not find a plugin entry file. Tried: ${ENTRY_CANDIDATES.join(', ')}`);
-}
-
-function isInsideDirectory(targetPath: string, root: string): boolean {
-  return targetPath === root || targetPath.startsWith(root + path.sep);
-}
-
-async function runPluginInstallCommand(
-  command: string,
-  args: string[],
-  execaOptions: typeof NON_INTERACTIVE_EXEC_OPTIONS & { cwd?: string },
-  options: PluginInstallExecutionOptions,
-): Promise<void> {
-  const child = execa(command, args, {
-    ...execaOptions,
-    stdout: options.onOutput ? 'pipe' : 'ignore',
-    stderr: options.onOutput ? 'pipe' : 'ignore',
-    cancelSignal: options.signal,
-  });
-  if (options.onOutput) {
-    child.stdout?.on('data', options.onOutput);
-    child.stderr?.on('data', options.onOutput);
-  }
-  await child;
-}
-
-async function assertGithubCliAvailable(githubCli: string): Promise<void> {
-  try {
-    await execa(githubCli, ['--version'], NON_INTERACTIVE_EXEC_OPTIONS);
-  } catch {
-    throw new Error('GitHub CLI is required to install GitHub plugins. Install gh and run gh auth login.');
-  }
-}
-
-async function assertGithubCliAuthenticated(githubCli: string): Promise<void> {
-  try {
-    await execa(githubCli, ['auth', 'status'], NON_INTERACTIVE_EXEC_OPTIONS);
-  } catch {
-    throw new Error('GitHub CLI is not authenticated. Run gh auth login, then install the plugin again.');
-  }
-}
-
-function parseGithubUrl(specifier: string): { owner: string; repo: string; repoSpec: string; ref?: string } {
-  const [urlPart, ref] = specifier.split('#', 2);
-  if (!urlPart) {
-    throw new Error(`Invalid GitHub URL: ${specifier}`);
-  }
-  let url: URL;
-  try {
-    url = new URL(urlPart);
-  } catch {
-    throw new Error(`Invalid GitHub URL: ${specifier}`);
-  }
-
-  if (url.hostname !== 'github.com') {
-    throw new Error('Only github.com plugin URLs are supported');
-  }
-
-  const [owner, rawRepo, ...rest] = url.pathname.split('/').filter(Boolean);
-  if (!owner || !rawRepo || rest.length > 0) {
-    throw new Error('GitHub plugin URL must be in the form https://github.com/owner/repo');
-  }
-
-  const repo = rawRepo.replace(/\.git$/, '');
-  if (!/^[A-Za-z0-9_.-]+$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(repo)) {
-    throw new Error('GitHub owner and repo may only contain letters, numbers, dots, underscores, and dashes');
-  }
-
-  return {
-    owner,
-    repo,
-    repoSpec: `${owner}/${repo}`,
-    ...(ref ? { ref } : {}),
-  };
 }

--- a/mastracode/sdk/src/plugins/loader.ts
+++ b/mastracode/sdk/src/plugins/loader.ts
@@ -99,6 +99,33 @@ export async function loadPluginFromEntry(entryPath: string): Promise<MastraCode
   return validatePluginExport(await importPluginModule(entryPath));
 }
 
+export type ResolvedStandalonePlugin = {
+  plugin: MastraCodePlugin;
+  tools: MastraCodePluginTools;
+  configSchema?: MastraCodePluginConfigSchema;
+  configValues: MastraCodePluginConfigValues;
+};
+
+export async function resolveStandalonePlugin(options: {
+  entryPath: string;
+  cwd: string;
+  scope?: 'global' | 'project';
+  pluginDir: string;
+  config?: MastraCodePluginConfigValues;
+}): Promise<ResolvedStandalonePlugin> {
+  const plugin = await loadPluginFromEntry(options.entryPath);
+  const configSchema = validatePluginConfigSchema(plugin.config);
+  const configValues = resolveStandaloneConfigValues(configSchema, options.config);
+  const context: MastraCodePluginContext = {
+    cwd: options.cwd,
+    scope: options.scope ?? 'project',
+    pluginDir: options.pluginDir,
+    config: configValues,
+  };
+  const { tools } = await resolvePluginTools(plugin, context);
+  return { plugin, tools, configSchema, configValues };
+}
+
 export function resolvePluginRoot(record: ScopedInstalledPluginRecord, options: PluginPathOptions): string {
   const scopeRoot = path.resolve(getPluginRoot(record.scope, options));
   const pluginRoot = path.resolve(path.isAbsolute(record.path) ? record.path : path.join(scopeRoot, record.path));
@@ -227,6 +254,30 @@ function validatePluginConfigSchema(schema: unknown): MastraCodePluginConfigSche
     };
   }
   return Object.keys(validated).length > 0 ? validated : undefined;
+}
+
+function resolveStandaloneConfigValues(
+  schema: MastraCodePluginConfigSchema | undefined,
+  input: MastraCodePluginConfigValues | undefined,
+): MastraCodePluginConfigValues {
+  if (!schema) {
+    if (input && Object.keys(input).length > 0) throw new Error('Plugin does not define configuration options');
+    return {};
+  }
+  for (const [key, value] of Object.entries(input ?? {})) {
+    const option = schema[key];
+    if (!option) throw new Error(`Unknown plugin configuration key: ${key}`);
+    if (option.type === 'boolean' ? typeof value !== 'boolean' : typeof value !== 'string') {
+      throw new Error(`Invalid value for plugin configuration key: ${key}`);
+    }
+  }
+  const values = resolvePluginConfigValues(schema, input);
+  for (const [key, option] of Object.entries(schema)) {
+    if (values[key] === undefined && option.default === undefined) {
+      throw new Error(`Missing required plugin configuration key: ${key}`);
+    }
+  }
+  return values;
 }
 
 function resolvePluginConfigValues(

--- a/mastracode/sdk/src/plugins/mcp.ts
+++ b/mastracode/sdk/src/plugins/mcp.ts
@@ -1,0 +1,93 @@
+import path from 'node:path';
+
+import { MCPServer } from '@mastra/mcp';
+
+import type { MastraCodePluginConfigValue, MastraCodePluginConfigValues } from '../plugin.js';
+import { resolveStandalonePlugin } from './loader.js';
+import type { PluginPathOptions } from './paths.js';
+import { preparePluginSource } from './source.js';
+import type { PreparedPluginSource } from './source.js';
+
+export type CreatePluginMCPServerOptions = Partial<PluginPathOptions> & {
+  specifier: string;
+  cwd?: string;
+  ref?: string;
+  config?: Record<string, MastraCodePluginConfigValue>;
+  envConfig?: string;
+  entry?: string;
+  githubCliPath?: string;
+};
+
+export type PluginMCPServer = {
+  server: MCPServer;
+  source: PreparedPluginSource;
+  plugin: {
+    id: string;
+    name: string;
+    version: string;
+  };
+  config: MastraCodePluginConfigValues;
+  close(): Promise<void>;
+};
+
+export function resolvePluginConfigInput(
+  explicit: MastraCodePluginConfigValues | undefined,
+  environmentJson: string | undefined,
+): MastraCodePluginConfigValues {
+  let environment: MastraCodePluginConfigValues = {};
+  if (environmentJson !== undefined && environmentJson.trim() !== '') {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(environmentJson);
+    } catch {
+      throw new Error('MASTRACODE_PLUGIN_CONFIG must be valid JSON');
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new Error('MASTRACODE_PLUGIN_CONFIG must be a JSON object');
+    }
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value !== 'string' && typeof value !== 'boolean') {
+        throw new Error(`MASTRACODE_PLUGIN_CONFIG has an invalid value for key: ${key}`);
+      }
+      environment[key] = value;
+    }
+  }
+  return { ...environment, ...explicit };
+}
+
+export async function createPluginMCPServer(options: CreatePluginMCPServerOptions): Promise<PluginMCPServer> {
+  const cwd = path.resolve(options.cwd ?? options.projectRoot ?? process.cwd());
+  const projectRoot = path.resolve(options.projectRoot ?? cwd);
+  const source = await preparePluginSource(options.specifier, {
+    projectRoot,
+    cwd,
+    configDir: options.configDir,
+    homeDir: options.homeDir,
+    ref: options.ref,
+    entry: options.entry,
+    githubCliPath: options.githubCliPath,
+    standalone: true,
+  });
+  const resolved = await resolveStandalonePlugin({
+    entryPath: path.join(source.pluginRoot, source.entry),
+    cwd,
+    pluginDir: path.dirname(path.join(source.pluginRoot, source.entry)),
+    config: resolvePluginConfigInput(options.config, options.envConfig),
+  });
+  const name = resolved.plugin.name?.trim() || resolved.plugin.id;
+  const version = resolved.plugin.version?.trim() || '0.0.0';
+  const server = new MCPServer({ name, version, tools: resolved.tools });
+  let closed = false;
+
+  return {
+    server,
+    source,
+    plugin: { id: resolved.plugin.id, name, version },
+    config: resolved.configValues,
+    async close() {
+      if (closed) return;
+      closed = true;
+      await server.close();
+    },
+  };
+}

--- a/mastracode/sdk/src/plugins/package-link.ts
+++ b/mastracode/sdk/src/plugins/package-link.ts
@@ -74,6 +74,7 @@ export function ensureMastraCodePackageLink(pluginDir: string): void {
     fs.rmSync(linkPath, { recursive: true, force: true });
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    fs.rmSync(linkPath, { recursive: true, force: true });
   }
 
   fs.mkdirSync(nodeModulesDir, { recursive: true });

--- a/mastracode/sdk/src/plugins/source.ts
+++ b/mastracode/sdk/src/plugins/source.ts
@@ -10,10 +10,10 @@ import { getEntryPackageRoot, installPluginDependenciesForEntry } from './depend
 import type { PluginInstallExecutionOptions } from './dependencies.js';
 import { getSingleManifestPlugin } from './manifest.js';
 import { ensureMastraCodePackageLink } from './package-link.js';
+import type { PluginPathOptions } from './paths.js';
 
 const ENTRY_CANDIDATES = ['src/index.ts', 'index.ts'];
 export const NON_INTERACTIVE_GIT_ENV = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
-import type { PluginPathOptions } from './paths.js';
 
 export type PreparedPluginSource = {
   source: 'local' | 'github';

--- a/mastracode/sdk/src/plugins/source.ts
+++ b/mastracode/sdk/src/plugins/source.ts
@@ -1,0 +1,286 @@
+import { createHash, randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { execa } from 'execa';
+
+import { DEFAULT_CONFIG_DIR } from '../constants.js';
+import { getEntryPackageRoot, installPluginDependenciesForEntry } from './dependencies.js';
+import type { PluginInstallExecutionOptions } from './dependencies.js';
+import { getSingleManifestPlugin } from './manifest.js';
+import { ensureMastraCodePackageLink } from './package-link.js';
+
+const ENTRY_CANDIDATES = ['src/index.ts', 'index.ts'];
+export const NON_INTERACTIVE_GIT_ENV = { ...process.env, GIT_TERMINAL_PROMPT: '0' };
+import type { PluginPathOptions } from './paths.js';
+
+export type PreparedPluginSource = {
+  source: 'local' | 'github';
+  pluginRoot: string;
+  entry: string;
+  ref?: string;
+};
+
+export type PreparePluginSourceOptions = PluginPathOptions &
+  PluginInstallExecutionOptions & {
+    cwd?: string;
+    entry?: string;
+    ref?: string;
+    githubCliPath?: string;
+    standalone?: boolean;
+    checkoutDir?: string;
+    lockWaitMs?: number;
+    staleLockMs?: number;
+  };
+
+export type ParsedGithubUrl = { owner: string; repo: string; repoSpec: string; ref?: string };
+
+const FULL_COMMIT_SHA = /^[a-fA-F0-9]{40}$/;
+const DEFAULT_LOCK_WAIT_MS = 30_000;
+const DEFAULT_STALE_LOCK_MS = 120_000;
+
+export async function preparePluginSource(
+  specifier: string,
+  options: PreparePluginSourceOptions,
+): Promise<PreparedPluginSource> {
+  if (/^https?:\/\//i.test(specifier)) return prepareGithubPluginSource(specifier, options);
+  return prepareLocalPluginSource(specifier, options);
+}
+
+export async function prepareLocalPluginSource(
+  specifier: string,
+  options: PreparePluginSourceOptions,
+): Promise<PreparedPluginSource> {
+  const pluginRoot = path.resolve(options.cwd ?? options.projectRoot, specifier);
+  if (!fs.existsSync(pluginRoot) || !fs.statSync(pluginRoot).isDirectory()) {
+    throw new Error(`Local plugin path does not exist or is not a directory: ${specifier}`);
+  }
+  const entry = detectEntry(pluginRoot, options.entry);
+  ensureMastraCodePackageLink(getEntryPackageRoot(pluginRoot, entry));
+  return { source: 'local', pluginRoot, entry };
+}
+
+export async function prepareGithubPluginSource(
+  specifier: string,
+  options: PreparePluginSourceOptions,
+): Promise<PreparedPluginSource> {
+  const parsed = parseGithubUrl(specifier);
+  const ref = options.ref ?? parsed.ref;
+  if (ref?.startsWith('-')) throw new Error('GitHub plugin ref must not start with a dash');
+  const checkoutDir = options.checkoutDir ?? getStandaloneCheckoutDir(parsed, ref, options);
+  const githubCli = options.githubCliPath ?? 'gh';
+
+  if (!options.standalone) {
+    await assertGithubCliAvailable(githubCli);
+    await assertGithubCliAuthenticated(githubCli);
+    await cloneAndPrepare(parsed, ref, checkoutDir, githubCli, options);
+    return {
+      source: 'github',
+      pluginRoot: checkoutDir,
+      entry: detectEntry(checkoutDir, options.entry),
+      ...(ref ? { ref } : {}),
+    };
+  }
+
+  return withCheckoutLock(checkoutDir, options, async () => {
+    if (ref && FULL_COMMIT_SHA.test(ref) && (await checkoutMatchesCommit(checkoutDir, ref))) {
+      return {
+        source: 'github' as const,
+        pluginRoot: checkoutDir,
+        entry: detectEntry(checkoutDir, options.entry),
+        ref,
+      };
+    }
+
+    await assertGithubCliAvailable(githubCli);
+    await assertGithubCliAuthenticated(githubCli);
+    const temporaryDir = `${checkoutDir}.tmp-${process.pid}-${randomUUID()}`;
+    fs.rmSync(temporaryDir, { recursive: true, force: true });
+    try {
+      await cloneAndPrepare(parsed, ref, temporaryDir, githubCli, options);
+      fs.rmSync(checkoutDir, { recursive: true, force: true });
+      fs.mkdirSync(path.dirname(checkoutDir), { recursive: true });
+      fs.renameSync(temporaryDir, checkoutDir);
+    } catch (error) {
+      fs.rmSync(temporaryDir, { recursive: true, force: true });
+      throw error;
+    }
+
+    return {
+      source: 'github' as const,
+      pluginRoot: checkoutDir,
+      entry: detectEntry(checkoutDir, options.entry),
+      ...(ref ? { ref } : {}),
+    };
+  });
+}
+
+async function cloneAndPrepare(
+  parsed: ParsedGithubUrl,
+  ref: string | undefined,
+  checkoutDir: string,
+  githubCli: string,
+  options: PreparePluginSourceOptions,
+): Promise<void> {
+  fs.rmSync(checkoutDir, { recursive: true, force: true });
+  fs.mkdirSync(path.dirname(checkoutDir), { recursive: true });
+  await runCommand(
+    githubCli,
+    ['repo', 'clone', parsed.repoSpec, checkoutDir, ...(ref ? [] : ['--', '--depth', '1'])],
+    undefined,
+    options,
+  );
+  if (ref) await runCommand('git', ['checkout', ref], checkoutDir, options);
+  const entry = detectEntry(checkoutDir, options.entry);
+  await installPluginDependenciesForEntry(checkoutDir, entry, options);
+  ensureMastraCodePackageLink(getEntryPackageRoot(checkoutDir, entry));
+}
+
+async function checkoutMatchesCommit(checkoutDir: string, ref: string): Promise<boolean> {
+  if (!fs.existsSync(checkoutDir)) return false;
+  try {
+    const result = await execa('git', ['rev-parse', 'HEAD'], {
+      cwd: checkoutDir,
+      env: NON_INTERACTIVE_GIT_ENV,
+      stdout: 'pipe',
+      stderr: 'ignore',
+    });
+    return result.stdout.trim().toLowerCase() === ref.toLowerCase();
+  } catch {
+    return false;
+  }
+}
+
+async function withCheckoutLock<T>(
+  checkoutDir: string,
+  options: PreparePluginSourceOptions,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const lockDir = `${checkoutDir}.lock`;
+  const waitMs = options.lockWaitMs ?? DEFAULT_LOCK_WAIT_MS;
+  const staleMs = options.staleLockMs ?? DEFAULT_STALE_LOCK_MS;
+  const deadline = Date.now() + waitMs;
+  fs.mkdirSync(path.dirname(lockDir), { recursive: true });
+
+  while (true) {
+    try {
+      fs.mkdirSync(lockDir);
+      break;
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST') throw error;
+      const stat = fs.statSync(lockDir);
+      if (Date.now() - stat.mtimeMs > staleMs) {
+        fs.rmSync(lockDir, { recursive: true, force: true });
+        continue;
+      }
+      if (Date.now() >= deadline) throw new Error('Timed out waiting to prepare GitHub plugin source');
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+  }
+
+  try {
+    return await operation();
+  } finally {
+    fs.rmSync(lockDir, { recursive: true, force: true });
+  }
+}
+
+function getStandaloneCheckoutDir(
+  parsed: ParsedGithubUrl,
+  ref: string | undefined,
+  options: PluginPathOptions,
+): string {
+  const baseDir = options.homeDir ?? os.homedir();
+  const configDir = options.configDir ?? DEFAULT_CONFIG_DIR;
+  const refKey = ref && FULL_COMMIT_SHA.test(ref) ? ref.toLowerCase() : hashRef(ref ?? 'default');
+  return path.join(baseDir, configDir, 'plugins', 'standalone', 'github', `${parsed.owner}-${parsed.repo}`, refKey);
+}
+
+function hashRef(ref: string): string {
+  return createHash('sha256').update(ref).digest('hex').slice(0, 16);
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  cwd: string | undefined,
+  options: PluginInstallExecutionOptions,
+): Promise<void> {
+  const child = execa(command, args, {
+    ...(cwd ? { cwd } : {}),
+    env: NON_INTERACTIVE_GIT_ENV,
+    stdout: options.onOutput ? 'pipe' : 'ignore',
+    stderr: options.onOutput ? 'pipe' : 'ignore',
+    cancelSignal: options.signal,
+  });
+  if (options.onOutput) {
+    child.stdout?.on('data', options.onOutput);
+    child.stderr?.on('data', options.onOutput);
+  }
+  await child;
+}
+
+async function assertGithubCliAvailable(githubCli: string): Promise<void> {
+  try {
+    await execa(githubCli, ['--version'], { env: NON_INTERACTIVE_GIT_ENV });
+  } catch {
+    throw new Error('GitHub CLI is required to install GitHub plugins. Install gh and run gh auth login.');
+  }
+}
+
+async function assertGithubCliAuthenticated(githubCli: string): Promise<void> {
+  try {
+    await execa(githubCli, ['auth', 'status'], { env: NON_INTERACTIVE_GIT_ENV });
+  } catch {
+    throw new Error('GitHub CLI is not authenticated. Run gh auth login, then install the plugin again.');
+  }
+}
+
+export function detectEntry(pluginDir: string, explicitEntry?: string): string {
+  const root = path.resolve(pluginDir);
+  if (explicitEntry) {
+    const entryPath = path.resolve(pluginDir, explicitEntry);
+    if (entryPath !== root && !entryPath.startsWith(root + path.sep)) {
+      throw new Error('Plugin entry must be inside the plugin directory');
+    }
+    if (fs.existsSync(entryPath) && fs.statSync(entryPath).isDirectory()) {
+      return path.relative(root, path.join(entryPath, detectEntry(entryPath)));
+    }
+    if (path.extname(entryPath) !== '.ts') throw new Error('Plugin entry must be a .ts file');
+    if (!fs.existsSync(entryPath) || !fs.statSync(entryPath).isFile()) {
+      throw new Error(`Plugin entry file does not exist: ${explicitEntry}`);
+    }
+    return path.relative(root, entryPath);
+  }
+  const manifestPlugin = getSingleManifestPlugin(pluginDir);
+  if (manifestPlugin) return detectEntry(pluginDir, manifestPlugin.entry);
+  for (const candidate of ENTRY_CANDIDATES) {
+    const entryPath = path.join(pluginDir, candidate);
+    if (fs.existsSync(entryPath) && fs.statSync(entryPath).isFile()) return candidate;
+  }
+  throw new Error(`Could not find a plugin entry file. Tried: ${ENTRY_CANDIDATES.join(', ')}`);
+}
+
+export function parseGithubUrl(specifier: string): ParsedGithubUrl {
+  const [urlPart, ref] = specifier.split('#', 2);
+  if (!urlPart) throw new Error(`Invalid GitHub URL: ${specifier}`);
+  let url: URL;
+  try {
+    url = new URL(urlPart);
+  } catch {
+    throw new Error(`Invalid GitHub URL: ${specifier}`);
+  }
+  if (url.protocol !== 'https:' || url.hostname !== 'github.com') {
+    throw new Error('Only https://github.com plugin URLs are supported');
+  }
+  const [owner, rawRepo, ...rest] = url.pathname.split('/').filter(Boolean);
+  if (!owner || !rawRepo || rest.length > 0) {
+    throw new Error('GitHub plugin URL must be in the form https://github.com/owner/repo');
+  }
+  const repo = rawRepo.replace(/\.git$/, '');
+  if (!/^[A-Za-z0-9_.-]+$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(repo)) {
+    throw new Error('GitHub owner and repo may only contain letters, numbers, dots, underscores, and dashes');
+  }
+  return { owner, repo, repoSpec: `${owner}/${repo}`, ...(ref ? { ref } : {}) };
+}

--- a/mastracode/tui/README.md
+++ b/mastracode/tui/README.md
@@ -131,7 +131,7 @@ The source can be a local plugin directory or an `https://github.com/...` URL. A
 Repeat `--config key=value` for non-secret string settings. Values remain strings, including `true` and `false`. Put booleans, other typed values, and secrets in the `MASTRACODE_PLUGIN_CONFIG` environment variable as a JSON object instead of command-line arguments:
 
 ```bash
-MASTRACODE_PLUGIN_CONFIG='{"apiKey":"...","region":"us-east"}' \
+MASTRACODE_PLUGIN_CONFIG='{"apiKey":"...","region":"us-east","enabled":true}' \
   mastracode plugin mcp /absolute/path/to/plugin --config region=us-west
 ```
 

--- a/mastracode/tui/README.md
+++ b/mastracode/tui/README.md
@@ -128,7 +128,7 @@ mastracode plugin mcp <local-directory-or-github-url> \
 
 The source can be a local plugin directory or an `https://github.com/...` URL. A GitHub source requires the GitHub CLI (`gh`) and an authenticated session. Use `--ref` to select a Git branch, tag, or commit. Pin a commit or tag when you need reproducible behavior.
 
-Repeat `--config key=value` for non-secret plugin settings. Put secrets in the `MASTRACODE_PLUGIN_CONFIG` environment variable as a JSON object instead of command-line arguments:
+Repeat `--config key=value` for non-secret string settings. Values remain strings, including `true` and `false`. Put booleans, other typed values, and secrets in the `MASTRACODE_PLUGIN_CONFIG` environment variable as a JSON object instead of command-line arguments:
 
 ```bash
 MASTRACODE_PLUGIN_CONFIG='{"apiKey":"...","region":"us-east"}' \

--- a/mastracode/tui/README.md
+++ b/mastracode/tui/README.md
@@ -116,6 +116,88 @@ Select a suggestion with arrow keys and press Tab to insert it.
 
 Use `/plugins` to install and manage trusted local or GitHub plugins. Plugins can add tools, commands, skills, and system instructions. Because plugins execute code inside Mastra Code and their instructions are appended to the agent prompt, only install plugins from sources you trust.
 
+#### Serve a plugin as an MCP server
+
+Run a plugin's tools as a Model Context Protocol (MCP) server for an external client:
+
+```bash
+mastracode plugin mcp <local-directory-or-github-url> \
+  [--ref <git-ref>] \
+  [--config key=value ...]
+```
+
+The source can be a local plugin directory or an `https://github.com/...` URL. A GitHub source requires the GitHub CLI (`gh`) and an authenticated session. Use `--ref` to select a Git branch, tag, or commit. Pin a commit or tag when you need reproducible behavior.
+
+Repeat `--config key=value` for non-secret plugin settings. Put secrets in the `MASTRACODE_PLUGIN_CONFIG` environment variable as a JSON object instead of command-line arguments:
+
+```bash
+MASTRACODE_PLUGIN_CONFIG='{"apiKey":"...","region":"us-east"}' \
+  mastracode plugin mcp /absolute/path/to/plugin --config region=us-west
+```
+
+Explicit `--config` values take precedence over `MASTRACODE_PLUGIN_CONFIG`, which takes precedence over defaults declared by the plugin. Mastra Code validates unknown, missing, and invalid settings before starting MCP.
+
+The command serves MCP over standard input/output (stdio) only. It acquires the supplied source directly and doesn't add it to the installed-plugin registry. Plugin code runs on your computer, and plugin dependencies may be installed locally. Review and trust the source before running it, and pin GitHub refs when possible.
+
+##### Configure Claude Desktop on macOS
+
+Claude Desktop launches this command as a child process. Add it to Claude Desktop's configuration file; don't type the command into Claude chat.
+
+1. Run `command -v mastracode` in a terminal and copy the absolute path. A graphical app might not inherit your shell `PATH`.
+2. In Claude Desktop, open **Claude > Settings > Developer > Edit Config**. The configuration file is `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS.
+3. Add an entry under the top-level `mcpServers` object.
+
+The following example serves a GitHub plugin at a pinned commit:
+
+```json
+{
+  "mcpServers": {
+    "mastracode-github-plugin": {
+      "command": "/absolute/path/from-command-v/mastracode",
+      "args": [
+        "plugin",
+        "mcp",
+        "https://github.com/OWNER/REPOSITORY",
+        "--ref",
+        "0123456789abcdef0123456789abcdef01234567",
+        "--config",
+        "region=us-west"
+      ],
+      "env": {
+        "MASTRACODE_PLUGIN_CONFIG": "{\"apiKey\":\"YOUR_SECRET\"}"
+      }
+    }
+  }
+}
+```
+
+The following example serves a local plugin directory:
+
+```json
+{
+  "mcpServers": {
+    "mastracode-local-plugin": {
+      "command": "/absolute/path/from-command-v/mastracode",
+      "args": ["plugin", "mcp", "/Users/your-name/code/my-plugin"]
+    }
+  }
+}
+```
+
+4. Save the file, completely quit Claude Desktop, and restart it.
+5. Open the MCP server indicator near the conversation input, or open **Connectors**, and confirm the server and its tools are listed.
+6. Ask Claude to use a specific plugin tool. For a plugin with a `greet` tool, ask: `Use the greet tool to greet Mastra.`
+
+If the server doesn't connect:
+
+- Open **Settings > Developer** to inspect the connection status and server logs.
+- On macOS, inspect `~/Library/Logs/Claude/mcp.log` for connection failures and `~/Library/Logs/Claude/mcp-server-mastracode-local-plugin.log` (or the matching server name) for stderr from this command.
+- Confirm that `command` is the absolute result from `command -v mastracode` and that local plugin paths are absolute.
+- Run the same command in a terminal to see startup diagnostics on stderr. For GitHub sources, also run `gh auth status`.
+- Correct malformed JSON or missing/invalid plugin configuration, then completely restart Claude Desktop.
+
+The Claude Desktop paths, `mcpServers` format, restart requirement, tool verification, and log locations follow the [official MCP guide for connecting local servers](https://modelcontextprotocol.io/docs/develop/connect-local-servers). Claude's [local MCP server guide](https://support.claude.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop) also describes checking connected tools and logs from Claude Desktop.
+
 ### Goals
 
 Use `/goal <objective>` to have Mastra Code keep working toward an objective across turns. Goals use a judge model to decide whether the goal is complete, should continue, or should wait for an explicit user checkpoint. Configure defaults with `/judge`.

--- a/mastracode/tui/src/__tests__/plugin-mcp.test.ts
+++ b/mastracode/tui/src/__tests__/plugin-mcp.test.ts
@@ -7,10 +7,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { parsePluginMCPArgs, startPluginMCPCommand } from '../plugin-mcp.js';
 
 describe('parsePluginMCPArgs', () => {
-  it('parses local and GitHub sources, refs, booleans, empty values, and values containing equals', () => {
+  it('parses local and GitHub sources, refs, literal strings, empty values, and values containing equals', () => {
     expect(parsePluginMCPArgs(['/tmp/plugin', '--config', 'label=a=b', '--config', 'enabled=false'])).toEqual({
       specifier: '/tmp/plugin',
-      config: { label: 'a=b', enabled: false },
+      config: { label: 'a=b', enabled: 'false' },
     });
     expect(parsePluginMCPArgs(['https://github.com/acme/plugin', '--ref', 'main', '--config', 'empty='])).toEqual({
       specifier: 'https://github.com/acme/plugin',

--- a/mastracode/tui/src/__tests__/plugin-mcp.test.ts
+++ b/mastracode/tui/src/__tests__/plugin-mcp.test.ts
@@ -1,0 +1,114 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { execa } from 'execa';
+import { describe, expect, it, vi } from 'vitest';
+
+import { parsePluginMCPArgs, startPluginMCPCommand } from '../plugin-mcp.js';
+
+describe('parsePluginMCPArgs', () => {
+  it('parses local and GitHub sources, refs, booleans, empty values, and values containing equals', () => {
+    expect(parsePluginMCPArgs(['/tmp/plugin', '--config', 'label=a=b', '--config', 'enabled=false'])).toEqual({
+      specifier: '/tmp/plugin',
+      config: { label: 'a=b', enabled: false },
+    });
+    expect(parsePluginMCPArgs(['https://github.com/acme/plugin', '--ref', 'main', '--config', 'empty='])).toEqual({
+      specifier: 'https://github.com/acme/plugin',
+      ref: 'main',
+      config: { empty: '' },
+    });
+  });
+
+  it.each([
+    [[], 'Missing plugin specifier'],
+    [['--ref', 'main'], 'Missing plugin specifier'],
+    [['plugin', '--ref'], 'Missing value for --ref'],
+    [['plugin', '--ref', 'main', '--ref', 'next'], 'Duplicate --ref flag'],
+    [['plugin', '--config'], 'Missing value for --config'],
+    [['plugin', '--config', '=value'], '--config must use key=value'],
+    [['plugin', '--config', 'key=one', '--config', 'key=two'], 'Duplicate --config key: key'],
+    [['plugin', '--wat'], 'Unknown argument: --wat'],
+  ])('rejects malformed arguments', (args, message) => {
+    expect(() => parsePluginMCPArgs(args)).toThrow(message);
+  });
+});
+
+describe('startPluginMCPCommand', () => {
+  it('passes CLI and environment options and starts stdio after resolution', async () => {
+    const events: string[] = [];
+    const listeners = new Map<string, () => void>();
+    const runtime = {
+      cwd: () => '/project',
+      env: { MASTRACODE_PLUGIN_CONFIG: '{"label":"environment"}' },
+      on: vi.fn((event: string, listener: () => void) => listeners.set(event, listener)),
+      exit: vi.fn() as never,
+    };
+    const lifecycle = {
+      server: { startStdio: vi.fn(async () => events.push('stdio')) },
+      close: vi.fn(async () => events.push('close')),
+    };
+    const createServer = vi.fn(async () => {
+      events.push('resolved');
+      return lifecycle;
+    });
+
+    await startPluginMCPCommand(
+      ['https://github.com/acme/plugin', '--ref', 'main', '--config', 'label=explicit'],
+      runtime,
+      createServer as never,
+    );
+
+    expect(createServer).toHaveBeenCalledWith({
+      specifier: 'https://github.com/acme/plugin',
+      cwd: '/project',
+      ref: 'main',
+      config: { label: 'explicit' },
+      envConfig: '{"label":"environment"}',
+    });
+    expect(events).toEqual(['resolved', 'stdio']);
+    expect(lifecycle.server.startStdio).toHaveBeenCalledOnce();
+    expect(listeners.has('SIGINT')).toBe(true);
+    expect(listeners.has('SIGTERM')).toBe(true);
+  });
+
+  it('does not start stdio when resolution fails', async () => {
+    const runtime = { cwd: () => '/project', env: {}, on: vi.fn(), exit: vi.fn() as never };
+    const createServer = vi.fn(async () => {
+      throw new Error('startup failed');
+    });
+    await expect(startPluginMCPCommand(['plugin'], runtime, createServer as never)).rejects.toThrow('startup failed');
+  });
+
+  it('closes exactly once when multiple termination signals arrive', async () => {
+    const listeners = new Map<string, () => void>();
+    const runtime = {
+      cwd: () => '/project',
+      env: {},
+      on: vi.fn((event: string, listener: () => void) => listeners.set(event, listener)),
+      exit: vi.fn() as never,
+    };
+    const lifecycle = { server: { startStdio: vi.fn() }, close: vi.fn(async () => {}) };
+    await startPluginMCPCommand(['plugin'], runtime, vi.fn(async () => lifecycle) as never);
+    listeners.get('SIGINT')?.();
+    listeners.get('SIGTERM')?.();
+    await vi.waitFor(() => expect(lifecycle.close).toHaveBeenCalledOnce());
+  });
+});
+
+describe('plugin MCP process boundary', () => {
+  it('writes startup failures only to stderr without terminal reset bytes or config values', async () => {
+    const testDir = path.dirname(fileURLToPath(import.meta.url));
+    const mainPath = path.resolve(testDir, '../main.ts');
+    const tsxCli = fileURLToPath(import.meta.resolve('tsx/cli'));
+    const secret = 'must-not-leak';
+    const result = await execa(process.execPath, [tsxCli, mainPath, 'plugin', 'mcp'], {
+      reject: false,
+      env: { ...process.env, MASTRACODE_PLUGIN_CONFIG: JSON.stringify({ token: secret }) },
+    });
+    expect(result.exitCode).toBe(1);
+    expect(result.stdout).toBe('');
+    expect(result.stdout).not.toContain('\x1b');
+    expect(result.stderr).toContain('Missing plugin specifier');
+    expect(result.stderr).not.toContain(secret);
+  });
+});

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -14,6 +14,7 @@ import { setupDebugLogging } from '@mastra/code-sdk/utils/debug-log';
 import { drainPipedStdin, reopenStdinFromTTY } from '@mastra/code-sdk/utils/stdin-pipe';
 import { releaseAllThreadLocks } from '@mastra/code-sdk/utils/thread-lock';
 import { getCurrentVersion } from '@mastra/code-sdk/utils/update-check';
+import { PLUGIN_MCP_USAGE, startPluginMCPCommand } from './plugin-mcp.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
@@ -38,17 +39,21 @@ function resolveInitialStateFromEnv() {
   return Object.keys(initialState).length > 0 ? initialState : undefined;
 }
 
+const isPluginMCPCommand = process.argv[2] === 'plugin' && process.argv[3] === 'mcp';
+
 // Global safety nets — catch any uncaught errors from storage init, etc.
-process.on('uncaughtException', error => {
-  // ERR_STREAM_DESTROYED is non-fatal — happens routinely when streams close
-  // during shutdown, cancelled LLM requests, or LSP/subprocess exits (#13548, #13549)
-  if (isStreamDestroyedError(error)) return;
-  handleFatalError(error);
-});
-process.on('unhandledRejection', reason => {
-  if (isStreamDestroyedError(reason)) return;
-  handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
-});
+if (!isPluginMCPCommand) {
+  process.on('uncaughtException', error => {
+    // ERR_STREAM_DESTROYED is non-fatal — happens routinely when streams close
+    // during shutdown, cancelled LLM requests, or LSP/subprocess exits (#13548, #13549)
+    if (isStreamDestroyedError(error)) return;
+    handleFatalError(error);
+  });
+  process.on('unhandledRejection', reason => {
+    if (isStreamDestroyedError(reason)) return;
+    handleFatalError(reason instanceof Error ? reason : new Error(String(reason)));
+  });
+}
 
 async function tuiMain(pipedInput?: string | null) {
   const settings = loadSettings();
@@ -160,57 +165,59 @@ const asyncCleanup = async () => {
   ]);
 };
 
-process.on('beforeExit', () => {
-  void asyncCleanup();
-});
-process.on('exit', () => {
-  // Ensure terminal protocols (kitty keyboard, modifyOtherKeys, bracketed paste,
-  // raw mode) are disabled on ANY exit path. Without this, killing the process
-  // via SIGINT/SIGTERM leaves the terminal in a corrupted state where keypresses
-  // produce escape sequences like "5;99~" instead of normal characters.
-  try {
-    tui?.stop();
-  } catch {
-    // Failsafe: even if MastraTUI.stop() throws, write raw terminal reset
-    // sequences to disable Kitty keyboard protocol, bracketed paste, and
-    // modifyOtherKeys. These are the exact sequences pi-tui's terminal.stop()
-    // would write.
-  }
-  // Belt-and-suspenders: always write terminal reset sequences directly,
-  // regardless of whether tui.stop() succeeded. Writing them twice is harmless
-  // but missing them leaves the terminal in a corrupted state.
-  try {
-    process.stdout.write(
-      '\x1b[?2004l' + // disable bracketed paste
-        '\x1b[<u' + // pop kitty keyboard protocol
-        '\x1b[>4;0m' + // disable modifyOtherKeys
-        '\x1b[?25h', // show cursor
-    );
-    if (process.stdin.setRawMode) {
-      process.stdin.setRawMode(false);
+if (!isPluginMCPCommand) {
+  process.on('beforeExit', () => {
+    void asyncCleanup();
+  });
+  process.on('exit', () => {
+    // Ensure terminal protocols (kitty keyboard, modifyOtherKeys, bracketed paste,
+    // raw mode) are disabled on ANY exit path. Without this, killing the process
+    // via SIGINT/SIGTERM leaves the terminal in a corrupted state where keypresses
+    // produce escape sequences like "5;99~" instead of normal characters.
+    try {
+      tui?.stop();
+    } catch {
+      // Failsafe: even if MastraTUI.stop() throws, write raw terminal reset
+      // sequences to disable Kitty keyboard protocol, bracketed paste, and
+      // modifyOtherKeys. These are the exact sequences pi-tui's terminal.stop()
+      // would write.
     }
-  } catch {
-    // stdout may already be closed during exit
-  }
-  restoreTerminalForeground();
-  releaseAllThreadLocks();
-});
+    // Belt-and-suspenders: always write terminal reset sequences directly,
+    // regardless of whether tui.stop() succeeded. Writing them twice is harmless
+    // but missing them leaves the terminal in a corrupted state.
+    try {
+      process.stdout.write(
+        '\x1b[?2004l' + // disable bracketed paste
+          '\x1b[<u' + // pop kitty keyboard protocol
+          '\x1b[>4;0m' + // disable modifyOtherKeys
+          '\x1b[?25h', // show cursor
+      );
+      if (process.stdin.setRawMode) {
+        process.stdin.setRawMode(false);
+      }
+    } catch {
+      // stdout may already be closed during exit
+    }
+    restoreTerminalForeground();
+    releaseAllThreadLocks();
+  });
 
-// For all termination signals: stop the TUI FIRST (synchronous, disables keyboard
-// protocol immediately) before doing any async cleanup. This ensures the terminal
-// escape sequences are written even if asyncCleanup hangs or the process is killed
-// during cleanup.
-const handleTermSignal = () => {
-  try {
-    tui?.stop();
-  } catch {
-    // ignored — exit handler has failsafe reset
-  }
-  void asyncCleanup().finally(() => process.exit(0));
-};
-process.on('SIGINT', handleTermSignal);
-process.on('SIGTERM', handleTermSignal);
-process.on('SIGHUP', handleTermSignal);
+  // For all termination signals: stop the TUI FIRST (synchronous, disables keyboard
+  // protocol immediately) before doing any async cleanup. This ensures the terminal
+  // escape sequences are written even if asyncCleanup hangs or the process is killed
+  // during cleanup.
+  const handleTermSignal = () => {
+    try {
+      tui?.stop();
+    } catch {
+      // ignored — exit handler has failsafe reset
+    }
+    void asyncCleanup().finally(() => process.exit(0));
+  };
+  process.on('SIGINT', handleTermSignal);
+  process.on('SIGTERM', handleTermSignal);
+  process.on('SIGHUP', handleTermSignal);
+}
 
 function hasEconnrefused(err: unknown, depth = 0): boolean {
   if (!err || depth > 5) return false;
@@ -222,7 +229,18 @@ function hasEconnrefused(err: unknown, depth = 0): boolean {
   return false;
 }
 
-function pluginMain(args: string[]): void {
+async function pluginMain(args: string[]): Promise<void> {
+  if (args[0] === 'mcp') {
+    try {
+      await startPluginMCPCommand(args.slice(1));
+    } catch (error) {
+      process.stderr.write(
+        `Plugin MCP error: ${error instanceof Error ? error.message : String(error)}\n${PLUGIN_MCP_USAGE}\n`,
+      );
+      process.exitCode = 1;
+    }
+    return;
+  }
   if (args[0] !== 'scaffold') {
     process.stderr.write('Usage: mastracode plugin scaffold <dir> [--id acme.foo] [--name "Foo Tools"]\n');
     process.exit(1);

--- a/mastracode/tui/src/plugin-mcp.ts
+++ b/mastracode/tui/src/plugin-mcp.ts
@@ -41,7 +41,7 @@ export function parsePluginMCPArgs(args: string[]): PluginMCPCommandOptions {
       const key = pair.slice(0, separator);
       if (key in config) throw new Error(`Duplicate --config key: ${key}`);
       const value = pair.slice(separator + 1);
-      config[key] = value === 'true' ? true : value === 'false' ? false : value;
+      config[key] = value;
       continue;
     }
     throw new Error(`Unknown argument: ${flag}`);

--- a/mastracode/tui/src/plugin-mcp.ts
+++ b/mastracode/tui/src/plugin-mcp.ts
@@ -1,0 +1,74 @@
+import type { MastraCodePluginConfigValues } from '@mastra/code-sdk/plugin';
+import { createPluginMCPServer } from '@mastra/code-sdk/plugins/mcp';
+
+export const PLUGIN_MCP_USAGE = 'Usage: mastracode plugin mcp <specifier> [--ref <git-ref>] [--config key=value ...]';
+
+export type PluginMCPCommandOptions = {
+  specifier: string;
+  ref?: string;
+  config: MastraCodePluginConfigValues;
+};
+
+type PluginMCPLifecycle = Awaited<ReturnType<typeof createPluginMCPServer>>;
+
+type PluginMCPRuntime = {
+  cwd(): string;
+  env: NodeJS.ProcessEnv;
+  on(event: 'SIGINT' | 'SIGTERM', listener: () => void): unknown;
+  exit(code: number): never;
+};
+
+export function parsePluginMCPArgs(args: string[]): PluginMCPCommandOptions {
+  const specifier = args[0];
+  if (!specifier || specifier.startsWith('--')) throw new Error('Missing plugin specifier');
+
+  const config: MastraCodePluginConfigValues = {};
+  let ref: string | undefined;
+  for (let index = 1; index < args.length; index++) {
+    const flag = args[index];
+    if (flag === '--ref') {
+      if (ref !== undefined) throw new Error('Duplicate --ref flag');
+      const value = args[++index];
+      if (!value || value.startsWith('--')) throw new Error('Missing value for --ref');
+      ref = value;
+      continue;
+    }
+    if (flag === '--config') {
+      const pair = args[++index];
+      if (!pair || pair.startsWith('--')) throw new Error('Missing value for --config');
+      const separator = pair.indexOf('=');
+      if (separator <= 0) throw new Error('--config must use key=value');
+      const key = pair.slice(0, separator);
+      if (key in config) throw new Error(`Duplicate --config key: ${key}`);
+      const value = pair.slice(separator + 1);
+      config[key] = value === 'true' ? true : value === 'false' ? false : value;
+      continue;
+    }
+    throw new Error(`Unknown argument: ${flag}`);
+  }
+
+  return { specifier, config, ...(ref ? { ref } : {}) };
+}
+
+export async function startPluginMCPCommand(
+  args: string[],
+  runtime: PluginMCPRuntime = process,
+  createServer: typeof createPluginMCPServer = createPluginMCPServer,
+): Promise<PluginMCPLifecycle> {
+  const parsed = parsePluginMCPArgs(args);
+  const lifecycle = await createServer({
+    specifier: parsed.specifier,
+    cwd: runtime.cwd(),
+    config: parsed.config,
+    envConfig: runtime.env.MASTRACODE_PLUGIN_CONFIG,
+    ...(parsed.ref ? { ref: parsed.ref } : {}),
+  });
+  let closing: Promise<void> | undefined;
+  const shutdown = () => {
+    closing ??= lifecycle.close().finally(() => runtime.exit(0));
+  };
+  runtime.on('SIGINT', shutdown);
+  runtime.on('SIGTERM', shutdown);
+  await lifecycle.server.startStdio();
+  return lifecycle;
+}


### PR DESCRIPTION
Mastra Code plugins can now run as standalone MCP servers for clients such as Claude Desktop and Claude Code, without first adding them to Mastra Code's installed-plugin registry.

The SDK exposes a transport-agnostic adapter that acquires a plugin from a local directory or GitHub URL, resolves its tools and typed configuration, and returns an `MCPServer`. The CLI adds a stdio entry point:

```bash
mastracode plugin mcp https://github.com/owner/plugin \
  --ref <commit-or-tag> \
  --config key=value
```

Configuration resolves explicit `--config` values before `MASTRACODE_PLUGIN_CONFIG`, then plugin defaults. GitHub acquisition remains non-interactive and supports pinned refs, while MCP stdout stays protocol-only.

The change includes focused SDK and CLI coverage, package changesets, setup and troubleshooting documentation, and a packed-package proof using a real MCP stdio client.

Test plan:
- `pnpm build:mastracode`
- focused SDK plugin tests
- focused TUI plugin MCP tests
- MCP dynamic-tools tests
- SDK/TUI typecheck and lint
- packed `mastracode` + `@mastra/code-sdk` MCP client proof
- manual Claude Code verification with a private GitHub plugin


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now run a Mastra Code plugin directly as an MCP server for tools like Claude Desktop and Claude Code, without installing it into Mastra Code first. Plugins can come from a local folder or GitHub, with simple configuration options and safer, non-interactive startup.

## What changed

- Added SDK support for:
  - Preparing local and GitHub plugin sources.
  - Resolving standalone plugin tools and typed configuration.
  - Creating and managing MCP servers over stdio.
  - Reusing pinned GitHub checkouts safely during concurrent launches.
- Added the `mastracode plugin mcp <source>` CLI command with:
  - `--ref` support for GitHub commits or tags.
  - Repeated `--config key=value` options.
  - Configuration precedence of CLI values, environment JSON, then plugin defaults.
  - Protocol-only stdout and error reporting via stderr.
- Fixed replacement of dangling `mastracode` package links.
- Added SDK and CLI tests, changesets, setup documentation, troubleshooting guidance, packed-package verification, and Claude Code verification instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->