### PR TITLE
feat(core): retry unknown stream errors

### DIFF
--- a/.changeset/easy-teeth-admire.md
+++ b/.changeset/easy-teeth-admire.md
@@ -2,13 +2,13 @@
 '@mastra/core': minor
 ---
 
-Added an option to retry all stream errors and enabled resilient retries for coding agents.
+Added an option to retry unknown stream errors while allowing known authorization failures to surface immediately, and enabled resilient retries for coding agents.
 
 ```typescript
 import { StreamErrorRetryProcessor } from '@mastra/core/processors';
 
 const processor = new StreamErrorRetryProcessor({
-  retryAllErrors: true,
+  retryUnknownErrors: true,
   maxRetries: 2,
   delayMs: 3000,
 });

--- a/.changeset/easy-teeth-admire.md
+++ b/.changeset/easy-teeth-admire.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': minor
+---
+
+Added an option to retry all stream errors and enabled resilient retries for coding agents.
+
+```typescript
+import { StreamErrorRetryProcessor } from '@mastra/core/processors';
+
+const processor = new StreamErrorRetryProcessor({
+  retryAllErrors: true,
+  maxRetries: 2,
+  delayMs: 3000,
+});
+```

--- a/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
+++ b/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
@@ -73,7 +73,7 @@ const agent = createCodingAgent({
     name: 'errorProcessors',
     type: 'Processor[]',
     description:
-      'Error processors for the agent. When omitted, defaults to the ECONNRESET/bad-request retry stack plus PrefillErrorHandler and ProviderHistoryCompat.',
+      'Error processors for the agent. When omitted, defaults to catch-all stream retries with specialized ECONNRESET and bad-request policies, plus PrefillErrorHandler and ProviderHistoryCompat.',
     isOptional: true,
   },
   {
@@ -106,7 +106,7 @@ The factory only fills a default when you don't provide the corresponding field.
 | - | - |
 | `workspace` | A [`Workspace`](/reference/workspace/workspace-class) backed by `LocalFilesystem` and `LocalSandbox` rooted at the base path. |
 | `signals` | A single [`TaskSignalProvider`](/reference/signals/task-signal-provider). |
-| `errorProcessors` | ECONNRESET and bad-request retry processors plus `PrefillErrorHandler` and `ProviderHistoryCompat`. |
+| `errorProcessors` | Catch-all stream retries with specialized ECONNRESET and bad-request policies, plus `PrefillErrorHandler` and `ProviderHistoryCompat`. |
 | `goal.prompt` | `DEFAULT_GOAL_JUDGE_PROMPT` (only when a `goal` is configured). |
 
 ### Workspace
@@ -137,12 +137,13 @@ const agent = createCodingAgent({
 
 ### Error processors
 
-The default error processors apply a retry policy for transient failures:
+The default [`StreamErrorRetryProcessor`](/reference/processors/stream-error-retry-processor) applies these retry policies:
 
+- Errors left unmatched by provider metadata or a specific matcher retry up to twice with a `3000ms` delay.
 - Network resets (`ECONNRESET` / `socket hang up`) retry up to twice with exponential backoff (`1000ms * 2^retryCount`, capped at `30000ms`).
 - Bad-request errors retry once after `2000ms`.
 
-`PrefillErrorHandler` and `ProviderHistoryCompat` are also included for provider compatibility.
+Specific network-reset and bad-request policies take precedence over the catch-all policy. Passing `errorProcessors` replaces the default processor stack. `PrefillErrorHandler` and `ProviderHistoryCompat` are also included for provider compatibility.
 
 ## Related
 

--- a/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
+++ b/docs/src/content/en/reference/coding-agent/create-coding-agent.mdx
@@ -73,7 +73,7 @@ const agent = createCodingAgent({
     name: 'errorProcessors',
     type: 'Processor[]',
     description:
-      'Error processors for the agent. When omitted, defaults to catch-all stream retries with specialized ECONNRESET and bad-request policies, plus PrefillErrorHandler and ProviderHistoryCompat.',
+      'Error processors for the agent. When omitted, defaults to unknown stream-error retries with specialized ECONNRESET and bad-request policies, plus PrefillErrorHandler and ProviderHistoryCompat.',
     isOptional: true,
   },
   {
@@ -106,7 +106,7 @@ The factory only fills a default when you don't provide the corresponding field.
 | - | - |
 | `workspace` | A [`Workspace`](/reference/workspace/workspace-class) backed by `LocalFilesystem` and `LocalSandbox` rooted at the base path. |
 | `signals` | A single [`TaskSignalProvider`](/reference/signals/task-signal-provider). |
-| `errorProcessors` | Catch-all stream retries with specialized ECONNRESET and bad-request policies, plus `PrefillErrorHandler` and `ProviderHistoryCompat`. |
+| `errorProcessors` | Unknown stream-error retries with specialized ECONNRESET and bad-request policies, plus `PrefillErrorHandler` and `ProviderHistoryCompat`. |
 | `goal.prompt` | `DEFAULT_GOAL_JUDGE_PROMPT` (only when a `goal` is configured). |
 
 ### Workspace
@@ -139,11 +139,11 @@ const agent = createCodingAgent({
 
 The default [`StreamErrorRetryProcessor`](/reference/processors/stream-error-retry-processor) applies these retry policies:
 
-- Errors left unmatched by provider metadata or a specific matcher retry up to twice with a `3000ms` delay.
+- Unknown errors left unmatched by provider metadata or a specific matcher retry up to twice with a `3000ms` delay. Known authorization failures surface immediately.
 - Network resets (`ECONNRESET` / `socket hang up`) retry up to twice with exponential backoff (`1000ms * 2^retryCount`, capped at `30000ms`).
 - Bad-request errors retry once after `2000ms`.
 
-Specific network-reset and bad-request policies take precedence over the catch-all policy. Passing `errorProcessors` replaces the default processor stack. `PrefillErrorHandler` and `ProviderHistoryCompat` are also included for provider compatibility.
+Specific network-reset and bad-request policies take precedence over the unknown-error policy. Passing `errorProcessors` replaces the default processor stack. `PrefillErrorHandler` and `ProviderHistoryCompat` are also included for provider compatibility.
 
 ## Related
 

--- a/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
+++ b/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
@@ -40,9 +40,9 @@ When the error is retryable, the processor returns `{ retry: true }`. It doesn't
 
 When `delayMs` is set, the processor waits before signaling a retry. This is useful for transient network errors like `ECONNRESET` where immediately retrying is likely to fail again. The delay can be a fixed number of milliseconds or a function evaluated with the error args (for example, to implement exponential backoff).
 
-## Retry unmatched errors
+## Retry unknown errors
 
-Set `retryAllErrors` to retry errors that don't match provider metadata, the built-in OpenAI matcher, or a custom matcher. Catch-all retries use the processor-level `maxRetries` and `delayMs` values:
+Set `retryUnknownErrors` to retry errors that don't match provider metadata, the built-in OpenAI matcher, or a custom matcher. Unknown-error retries use the processor-level `maxRetries` and `delayMs` values. Known authorization failures, including HTTP `401` and `403` responses, aren't retried:
 
 ```typescript title="src/mastra/agents/resilient-agent.ts"
 import { Agent } from '@mastra/core/agent'
@@ -55,7 +55,7 @@ export const agent = new Agent({
   model: '__GATEWAY_OPENAI_MODEL_BASE__',
   errorProcessors: [
     new StreamErrorRetryProcessor({
-      retryAllErrors: true,
+      retryUnknownErrors: true,
       maxRetries: 2,
       delayMs: 3000,
     }),
@@ -63,7 +63,7 @@ export const agent = new Agent({
 })
 ```
 
-Specific matcher policies still take precedence over the catch-all values. The option defaults to `false`, so unmatched errors aren't retried unless you enable it.
+Specific matcher policies still take precedence over the unknown-error values. The option defaults to `false`, so unknown errors aren't retried unless you enable it.
 
 ## Delaying retries
 
@@ -127,10 +127,10 @@ export const agent = new Agent({
         defaultValue: '[]',
       },
       {
-        name: 'retryAllErrors',
+        name: 'retryUnknownErrors',
         type: 'boolean',
         description:
-          'Whether to retry errors left unmatched by provider metadata, built-in matchers, and custom matchers. Catch-all retries use the processor-level maxRetries and delayMs values.',
+          'Whether to retry unknown errors left unmatched by provider metadata, built-in matchers, and custom matchers. Known authorization failures are excluded. Uses the processor-level maxRetries and delayMs values.',
         isOptional: true,
         defaultValue: 'false',
       },

--- a/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
+++ b/docs/src/content/en/reference/processors/stream-error-retry-processor.mdx
@@ -40,6 +40,31 @@ When the error is retryable, the processor returns `{ retry: true }`. It doesn't
 
 When `delayMs` is set, the processor waits before signaling a retry. This is useful for transient network errors like `ECONNRESET` where immediately retrying is likely to fail again. The delay can be a fixed number of milliseconds or a function evaluated with the error args (for example, to implement exponential backoff).
 
+## Retry unmatched errors
+
+Set `retryAllErrors` to retry errors that don't match provider metadata, the built-in OpenAI matcher, or a custom matcher. Catch-all retries use the processor-level `maxRetries` and `delayMs` values:
+
+```typescript title="src/mastra/agents/resilient-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { StreamErrorRetryProcessor } from '@mastra/core/processors'
+
+export const agent = new Agent({
+  id: 'resilient-agent',
+  name: 'Resilient agent',
+  instructions: 'You are a helpful assistant.',
+  model: '__GATEWAY_OPENAI_MODEL_BASE__',
+  errorProcessors: [
+    new StreamErrorRetryProcessor({
+      retryAllErrors: true,
+      maxRetries: 2,
+      delayMs: 3000,
+    }),
+  ],
+})
+```
+
+Specific matcher policies still take precedence over the catch-all values. The option defaults to `false`, so unmatched errors aren't retried unless you enable it.
+
 ## Delaying retries
 
 Use `delayMs` with a custom matcher to retry transient network resets with a wait:
@@ -100,6 +125,14 @@ export const agent = new Agent({
         description: 'Additional functions that identify provider-specific retryable stream errors.',
         isOptional: true,
         defaultValue: '[]',
+      },
+      {
+        name: 'retryAllErrors',
+        type: 'boolean',
+        description:
+          'Whether to retry errors left unmatched by provider metadata, built-in matchers, and custom matchers. Catch-all retries use the processor-level maxRetries and delayMs values.',
+        isOptional: true,
+        defaultValue: 'false',
       },
       {
         name: 'delayMs',

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -44,12 +44,16 @@ function isECONNRESETError(error: unknown): boolean {
 }
 
 /**
- * Builds the portable default error processors: an ECONNRESET + bad-request
- * retry policy, prefill-error recovery, and provider-history compatibility.
+ * Builds the portable default error processors: catch-all stream retries with
+ * specialized ECONNRESET and bad-request policies, prefill-error recovery, and
+ * provider-history compatibility.
  */
 function defaultErrorProcessors(): NonNullable<AgentConfig['errorProcessors']> {
   return [
     new StreamErrorRetryProcessor({
+      retryAllErrors: true,
+      maxRetries: 2,
+      delayMs: 3000,
       matchers: [
         { match: isBadRequestError, maxRetries: 1, delayMs: 2000 },
         {
@@ -82,7 +86,7 @@ function defaultWorkspace(basePath: string): Workspace {
  *
  * Most fields are passed straight through to the underlying `Agent`. The
  * factory fills portable defaults for the pieces a coding agent always needs —
- * a local workspace, the task-list signal provider, network-retry error
+ * a local workspace, the task-list signal provider, stream-retry error
  * processors, and the goal judge prompt — so a caller can get a working coding
  * agent by supplying only `model`, `instructions`, and `tools`.
  */
@@ -96,7 +100,7 @@ export interface CreateCodingAgentConfig extends AgentConfig {
 
 /**
  * Creates a coding agent as a Mastra {@link Agent}, applying portable defaults
- * for the workspace, task-list signal, network-retry error processors, and goal
+ * for the workspace, task-list signal, stream-retry error processors, and goal
  * judge prompt.
  *
  * Caller-provided values always win:
@@ -109,8 +113,8 @@ export interface CreateCodingAgentConfig extends AgentConfig {
  *   {@link TaskSignalProvider} — which requires a memory-backed thread — into
  *   agents that have no memory.
  * - `errorProcessors` is used verbatim when provided; otherwise it defaults to
- *   the ECONNRESET/bad-request retry stack plus prefill + provider-history
- *   compatibility processors.
+ *   catch-all stream retries with specialized ECONNRESET/bad-request policies,
+ *   plus prefill + provider-history compatibility processors.
  * - `goal.prompt` defaults to {@link DEFAULT_GOAL_JUDGE_PROMPT} when a goal is
  *   configured without one.
  *

--- a/packages/core/src/coding-agent/index.ts
+++ b/packages/core/src/coding-agent/index.ts
@@ -51,7 +51,7 @@ function isECONNRESETError(error: unknown): boolean {
 function defaultErrorProcessors(): NonNullable<AgentConfig['errorProcessors']> {
   return [
     new StreamErrorRetryProcessor({
-      retryAllErrors: true,
+      retryUnknownErrors: true,
       maxRetries: 2,
       delayMs: 3000,
       matchers: [

--- a/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
@@ -1,0 +1,72 @@
+import { createOpenAI } from '@ai-sdk/openai-v5';
+import { LLMock } from '@copilotkit/aimock';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+import { createCodingAgent } from '../../../../coding-agent';
+
+const UNMATCHED_ERROR = {
+  error: {
+    message: 'AIMOCK_UNMATCHED_STREAM_ERROR',
+    type: 'unknown_stream_failure',
+    code: 'unknown_stream_failure',
+  },
+  status: 422,
+} as const;
+
+describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
+  let llm: LLMock;
+
+  beforeAll(async () => {
+    llm = new LLMock({ port: 0 });
+    await llm.start();
+  });
+
+  afterEach(() => {
+    llm.clearFixtures();
+    llm.clearRequests();
+    llm.resetMatchCounts();
+  });
+
+  afterAll(async () => {
+    await llm.stop();
+  });
+
+  function createAgent(errorProcessors?: []) {
+    const openai = createOpenAI({
+      apiKey: 'aimock-test-key',
+      baseURL: `${llm.url.replace(/\/+$/, '')}/v1`,
+    });
+
+    return createCodingAgent({
+      id: `retry-all-errors-${errorProcessors ? 'control' : 'default'}`,
+      name: 'Retry all stream errors test agent',
+      instructions: 'Return the scripted AIMock response.',
+      model: openai('gpt-4o-mini'),
+      tools: {},
+      workspace: undefined,
+      ...(errorProcessors ? { errorProcessors } : {}),
+    });
+  }
+
+  it('retries two unmatched failures and succeeds on the third request', async () => {
+    let attempt = 0;
+    llm.onMessage(/.*/, () => {
+      attempt += 1;
+      return attempt <= 2 ? UNMATCHED_ERROR : { content: 'recovered after unmatched stream errors' };
+    });
+
+    const output = await createAgent().stream('Recover from the scripted failures.');
+
+    await expect(output.text).resolves.toBe('recovered after unmatched stream errors');
+    expect(llm.getRequests()).toHaveLength(3);
+  }, 15_000);
+
+  it('does not apply factory retries when caller supplies errorProcessors', async () => {
+    llm.onMessage(/.*/, UNMATCHED_ERROR);
+
+    const output = await createAgent([]).stream('Surface the scripted failure.');
+
+    await expect(output.finishReason).rejects.toThrow('AIMOCK_UNMATCHED_STREAM_ERROR');
+    expect(llm.getRequests()).toHaveLength(1);
+  });
+});

--- a/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
@@ -14,6 +14,15 @@ const UNMATCHED_ERROR = {
   status: 422,
 } as const;
 
+const AUTHORIZATION_ERROR = {
+  error: {
+    message: 'AIMOCK_PERMISSION_DENIED',
+    type: 'permission_denied',
+    code: 'permission_denied',
+  },
+  status: 403,
+} as const;
+
 describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
   let llm: LLMock;
 
@@ -61,6 +70,15 @@ describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
     await expect(output.text).resolves.toBe('recovered after unmatched stream errors');
     expect(llm.getRequests()).toHaveLength(3);
   }, 15_000);
+
+  it('does not retry known authorization failures', async () => {
+    llm.onMessage(/.*/, AUTHORIZATION_ERROR);
+
+    const output = await createAgent().stream('Surface the scripted authorization failure.');
+
+    await expect(output.finishReason).rejects.toThrow('AIMOCK_PERMISSION_DENIED');
+    expect(llm.getRequests()).toHaveLength(1);
+  });
 
   it('delivers the non-retryable provider error to caller processors without provider-level retries', async () => {
     llm.onMessage(/.*/, UNMATCHED_ERROR);

--- a/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
@@ -23,7 +23,7 @@ const AUTHORIZATION_ERROR = {
   status: 403,
 } as const;
 
-describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
+describe('AIMock coding-agent scenario: retry unknown stream errors', () => {
   let llm: LLMock;
 
   beforeAll(async () => {
@@ -48,8 +48,8 @@ describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
     });
 
     return createCodingAgent({
-      id: `retry-all-errors-${errorProcessors ? 'control' : 'default'}`,
-      name: 'Retry all stream errors test agent',
+      id: `retry-unknown-errors-${errorProcessors ? 'control' : 'default'}`,
+      name: 'Retry unknown stream errors test agent',
       instructions: 'Return the scripted AIMock response.',
       model: openai('gpt-4o-mini'),
       tools: {},

--- a/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts
@@ -3,6 +3,7 @@ import { LLMock } from '@copilotkit/aimock';
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 import { createCodingAgent } from '../../../../coding-agent';
+import type { ErrorProcessor } from '../../../../processors';
 
 const UNMATCHED_ERROR = {
   error: {
@@ -31,7 +32,7 @@ describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
     await llm.stop();
   });
 
-  function createAgent(errorProcessors?: []) {
+  function createAgent(errorProcessors?: ErrorProcessor[]) {
     const openai = createOpenAI({
       apiKey: 'aimock-test-key',
       baseURL: `${llm.url.replace(/\/+$/, '')}/v1`,
@@ -61,12 +62,24 @@ describe('AIMock coding-agent scenario: retry unmatched stream errors', () => {
     expect(llm.getRequests()).toHaveLength(3);
   }, 15_000);
 
-  it('does not apply factory retries when caller supplies errorProcessors', async () => {
+  it('delivers the non-retryable provider error to caller processors without provider-level retries', async () => {
     llm.onMessage(/.*/, UNMATCHED_ERROR);
+    let processedError: unknown;
+    const observer: ErrorProcessor = {
+      id: 'observe-unmatched-error',
+      processAPIError: async ({ error }) => {
+        processedError = error;
+      },
+    };
 
-    const output = await createAgent([]).stream('Surface the scripted failure.');
+    const output = await createAgent([observer]).stream('Surface the scripted failure.');
 
     await expect(output.finishReason).rejects.toThrow('AIMOCK_UNMATCHED_STREAM_ERROR');
+    expect(processedError).toMatchObject({
+      message: 'AIMOCK_UNMATCHED_STREAM_ERROR',
+      statusCode: 422,
+      isRetryable: false,
+    });
     expect(llm.getRequests()).toHaveLength(1);
   });
 });

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -229,7 +229,7 @@ describe('StreamErrorRetryProcessor', () => {
     await expect(processor.processAPIError(makeArgs({ error, retryCount: 1 }))).resolves.toBeUndefined();
   });
 
-  describe('retryAllErrors', () => {
+  describe('retryUnknownErrors', () => {
     afterEach(() => {
       vi.useRealTimers();
     });
@@ -239,12 +239,12 @@ describe('StreamErrorRetryProcessor', () => {
 
       await expect(new StreamErrorRetryProcessor().processAPIError(makeArgs({ error }))).resolves.toBeUndefined();
       await expect(
-        new StreamErrorRetryProcessor({ retryAllErrors: false }).processAPIError(makeArgs({ error })),
+        new StreamErrorRetryProcessor({ retryUnknownErrors: false }).processAPIError(makeArgs({ error })),
       ).resolves.toBeUndefined();
     });
 
     it('retries unmatched errors up to the processor maxRetries', async () => {
-      const processor = new StreamErrorRetryProcessor({ retryAllErrors: true, maxRetries: 2 });
+      const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true, maxRetries: 2 });
       const error = new Error('unmatched stream error');
 
       await expect(processor.processAPIError(makeArgs({ error, retryCount: 0 }))).resolves.toEqual({ retry: true });
@@ -252,9 +252,27 @@ describe('StreamErrorRetryProcessor', () => {
       await expect(processor.processAPIError(makeArgs({ error, retryCount: 2 }))).resolves.toBeUndefined();
     });
 
+    it.each([401, 403])('does not retry terminal HTTP %s authorization errors', async statusCode => {
+      const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true });
+
+      await expect(processor.processAPIError(makeArgs({ error: { statusCode } }))).resolves.toBeUndefined();
+      await expect(
+        processor.processAPIError(makeArgs({ error: new Error('wrapped', { cause: { status: statusCode } }) })),
+      ).resolves.toBeUndefined();
+    });
+
+    it.each(['access_denied', 'authentication_error', 'forbidden', 'invalid_api_key', 'permission_denied'])(
+      'does not retry terminal authorization code %s',
+      async code => {
+        const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true });
+
+        await expect(processor.processAPIError(makeArgs({ error: { error: { code } } }))).resolves.toBeUndefined();
+      },
+    );
+
     it('uses the processor delayMs for unmatched errors', async () => {
       vi.useFakeTimers();
-      const processor = new StreamErrorRetryProcessor({ retryAllErrors: true, delayMs: 1000 });
+      const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true, delayMs: 1000 });
       const promise = processor.processAPIError(makeArgs({ error: new Error('unmatched stream error') }));
 
       let resolved = false;
@@ -269,7 +287,7 @@ describe('StreamErrorRetryProcessor', () => {
 
     it('preserves specific matcher policies before the catch-all fallback', async () => {
       const processor = new StreamErrorRetryProcessor({
-        retryAllErrors: true,
+        retryUnknownErrors: true,
         maxRetries: 3,
         matchers: [{ match: isBadRequestError, maxRetries: 1 }],
       });
@@ -284,7 +302,7 @@ describe('StreamErrorRetryProcessor', () => {
 
     it('resolves a specific policy in the cause chain before falling back', async () => {
       const processor = new StreamErrorRetryProcessor({
-        retryAllErrors: true,
+        retryUnknownErrors: true,
         maxRetries: 3,
         matchers: [{ match: isBadRequestError, maxRetries: 1 }],
       });
@@ -297,7 +315,7 @@ describe('StreamErrorRetryProcessor', () => {
       vi.useFakeTimers();
       const controller = new AbortController();
       const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
-      const processor = new StreamErrorRetryProcessor({ retryAllErrors: true, delayMs: 60_000 });
+      const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true, delayMs: 60_000 });
       const promise = processor.processAPIError(
         makeArgs({ error: new Error('unmatched stream error'), abortSignal: controller.signal }),
       );

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -270,6 +270,34 @@ describe('StreamErrorRetryProcessor', () => {
       },
     );
 
+    it('detects terminal authorization codes in API call response bodies', async () => {
+      const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true });
+      const error = new APICallError({
+        message: 'invalid credentials',
+        url: 'https://api.example.com/v1/messages',
+        requestBodyValues: {},
+        statusCode: 400,
+        responseBody: JSON.stringify({ error: { type: 'authentication_error' } }),
+        isRetryable: false,
+      });
+
+      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toBeUndefined();
+    });
+
+    it('does not treat isRetryable false alone as a terminal error', async () => {
+      const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true });
+      const error = new APICallError({
+        message: 'unknown provider failure',
+        url: 'https://api.example.com/v1/messages',
+        requestBodyValues: {},
+        statusCode: 422,
+        responseBody: JSON.stringify({ error: { type: 'unknown_stream_failure' } }),
+        isRetryable: false,
+      });
+
+      await expect(processor.processAPIError(makeArgs({ error }))).resolves.toEqual({ retry: true });
+    });
+
     it('uses the processor delayMs for unmatched errors', async () => {
       vi.useFakeTimers();
       const processor = new StreamErrorRetryProcessor({ retryUnknownErrors: true, delayMs: 1000 });

--- a/packages/core/src/processors/stream-error-retry-processor.test.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.test.ts
@@ -229,6 +229,85 @@ describe('StreamErrorRetryProcessor', () => {
     await expect(processor.processAPIError(makeArgs({ error, retryCount: 1 }))).resolves.toBeUndefined();
   });
 
+  describe('retryAllErrors', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('does not retry unmatched errors when omitted or false', async () => {
+      const error = new Error('unmatched stream error');
+
+      await expect(new StreamErrorRetryProcessor().processAPIError(makeArgs({ error }))).resolves.toBeUndefined();
+      await expect(
+        new StreamErrorRetryProcessor({ retryAllErrors: false }).processAPIError(makeArgs({ error })),
+      ).resolves.toBeUndefined();
+    });
+
+    it('retries unmatched errors up to the processor maxRetries', async () => {
+      const processor = new StreamErrorRetryProcessor({ retryAllErrors: true, maxRetries: 2 });
+      const error = new Error('unmatched stream error');
+
+      await expect(processor.processAPIError(makeArgs({ error, retryCount: 0 }))).resolves.toEqual({ retry: true });
+      await expect(processor.processAPIError(makeArgs({ error, retryCount: 1 }))).resolves.toEqual({ retry: true });
+      await expect(processor.processAPIError(makeArgs({ error, retryCount: 2 }))).resolves.toBeUndefined();
+    });
+
+    it('uses the processor delayMs for unmatched errors', async () => {
+      vi.useFakeTimers();
+      const processor = new StreamErrorRetryProcessor({ retryAllErrors: true, delayMs: 1000 });
+      const promise = processor.processAPIError(makeArgs({ error: new Error('unmatched stream error') }));
+
+      let resolved = false;
+      void promise.then(() => {
+        resolved = true;
+      });
+      await vi.advanceTimersByTimeAsync(999);
+      expect(resolved).toBe(false);
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(promise).resolves.toEqual({ retry: true });
+    });
+
+    it('preserves specific matcher policies before the catch-all fallback', async () => {
+      const processor = new StreamErrorRetryProcessor({
+        retryAllErrors: true,
+        maxRetries: 3,
+        matchers: [{ match: isBadRequestError, maxRetries: 1 }],
+      });
+
+      await expect(
+        processor.processAPIError(makeArgs({ error: { statusCode: 400 }, retryCount: 1 })),
+      ).resolves.toBeUndefined();
+      await expect(
+        processor.processAPIError(makeArgs({ error: new Error('unmatched stream error'), retryCount: 1 })),
+      ).resolves.toEqual({ retry: true });
+    });
+
+    it('resolves a specific policy in the cause chain before falling back', async () => {
+      const processor = new StreamErrorRetryProcessor({
+        retryAllErrors: true,
+        maxRetries: 3,
+        matchers: [{ match: isBadRequestError, maxRetries: 1 }],
+      });
+      const error = new Error('wrapped', { cause: { statusCode: 400 } });
+
+      await expect(processor.processAPIError(makeArgs({ error, retryCount: 1 }))).resolves.toBeUndefined();
+    });
+
+    it('uses the abort-aware delay path and removes its listener for catch-all retries', async () => {
+      vi.useFakeTimers();
+      const controller = new AbortController();
+      const removeSpy = vi.spyOn(controller.signal, 'removeEventListener');
+      const processor = new StreamErrorRetryProcessor({ retryAllErrors: true, delayMs: 60_000 });
+      const promise = processor.processAPIError(
+        makeArgs({ error: new Error('unmatched stream error'), abortSignal: controller.signal }),
+      );
+
+      controller.abort();
+      await expect(promise).resolves.toEqual({ retry: true });
+      expect(removeSpy).toHaveBeenCalledWith('abort', expect.any(Function));
+    });
+  });
+
   describe('per-matcher policy', () => {
     it('uses per-matcher maxRetries instead of processor-level default', async () => {
       const processor = new StreamErrorRetryProcessor({

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -24,6 +24,12 @@ export type StreamErrorRetryProcessorOptions = {
   maxRetries?: number;
   matchers?: StreamErrorRetryMatcherEntry[];
   /**
+   * Retry errors that are not matched by provider metadata, built-in matchers,
+   * or custom matchers. Uses the processor-level `maxRetries` and `delayMs`.
+   * Defaults to false.
+   */
+  retryAllErrors?: boolean;
+  /**
    * Optional delay (ms) to wait before signaling a retry. Accepts a number or an
    * async function evaluated with the current error args. Negative/non-finite
    * values are clamped to 0. Defaults to 0 (retry immediately), preserving the
@@ -174,19 +180,21 @@ export class StreamErrorRetryProcessor implements Processor<'stream-error-retry-
 
   readonly #maxRetries: number;
   readonly #entries: StreamErrorRetryMatcherConfig[];
+  readonly #retryAllErrors: boolean;
   readonly #delayMs: StreamErrorRetryDelayMs | undefined;
 
   constructor(options: StreamErrorRetryProcessorOptions = {}) {
     this.#maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
     const defaultEntries: StreamErrorRetryMatcherConfig[] = DEFAULT_MATCHERS.map(m => ({ match: m }));
     this.#entries = [...defaultEntries, ...(options.matchers ?? []).map(normalizeEntry)];
+    this.#retryAllErrors = options.retryAllErrors ?? false;
     this.#delayMs = options.delayMs;
   }
 
   async processAPIError(args: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
     const { error, retryCount, abortSignal } = args;
 
-    const policy = findMatchingPolicy(error, this.#entries);
+    const policy = findMatchingPolicy(error, this.#entries) ?? (this.#retryAllErrors ? {} : undefined);
     if (!policy) return;
 
     const effectiveMaxRetries = policy.maxRetries ?? this.#maxRetries;

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -155,9 +155,19 @@ function isKnownTerminalAuthorizationError(error: unknown): boolean {
     if (statusCode === 401 || statusCode === 403) return true;
 
     const code = getStringProperty(candidate, 'code') ?? getStringProperty(candidate, 'type');
-    if (code && TERMINAL_AUTHORIZATION_ERROR_CODES.has(code.toLowerCase())) return true;
+    if (code && TERMINAL_AUTHORIZATION_ERROR_CODES.has(code.trim().toLowerCase())) return true;
 
-    return visit(candidate.error) || visit(candidate.cause);
+    const responseBody = getStringProperty(candidate, 'responseBody');
+    let parsedResponseBody: unknown;
+    if (responseBody) {
+      try {
+        parsedResponseBody = JSON.parse(responseBody);
+      } catch {
+        // Ignore non-JSON provider response bodies.
+      }
+    }
+
+    return visit(candidate.error) || visit(candidate.data) || visit(parsedResponseBody) || visit(candidate.cause);
   }
 
   return visit(error);

--- a/packages/core/src/processors/stream-error-retry-processor.ts
+++ b/packages/core/src/processors/stream-error-retry-processor.ts
@@ -24,11 +24,11 @@ export type StreamErrorRetryProcessorOptions = {
   maxRetries?: number;
   matchers?: StreamErrorRetryMatcherEntry[];
   /**
-   * Retry errors that are not matched by provider metadata, built-in matchers,
-   * or custom matchers. Uses the processor-level `maxRetries` and `delayMs`.
-   * Defaults to false.
+   * Retry unknown errors that are not matched by provider metadata, built-in
+   * matchers, or custom matchers. Known authorization failures are excluded.
+   * Uses the processor-level `maxRetries` and `delayMs`. Defaults to false.
    */
-  retryAllErrors?: boolean;
+  retryUnknownErrors?: boolean;
   /**
    * Optional delay (ms) to wait before signaling a retry. Accepts a number or an
    * async function evaluated with the current error args. Negative/non-finite
@@ -49,6 +49,13 @@ const RETRYABLE_OPENAI_ERROR_CODES = [
   'overloaded',
 ];
 const OPENAI_RETRY_MESSAGE_PATTERN = /you can retry your request/i;
+const TERMINAL_AUTHORIZATION_ERROR_CODES = new Set([
+  'access_denied',
+  'authentication_error',
+  'forbidden',
+  'invalid_api_key',
+  'permission_denied',
+]);
 const DEFAULT_MATCHERS = [isRetryableOpenAIResponsesStreamError];
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -136,6 +143,26 @@ function isRetryableProviderMetadata(error: unknown): boolean {
   return retryable === true;
 }
 
+function isKnownTerminalAuthorizationError(error: unknown): boolean {
+  const visited = new WeakSet<object>();
+
+  function visit(candidate: unknown): boolean {
+    if (!isRecord(candidate)) return false;
+    if (visited.has(candidate)) return false;
+    visited.add(candidate);
+
+    const statusCode = candidate.statusCode ?? candidate.status;
+    if (statusCode === 401 || statusCode === 403) return true;
+
+    const code = getStringProperty(candidate, 'code') ?? getStringProperty(candidate, 'type');
+    if (code && TERMINAL_AUTHORIZATION_ERROR_CODES.has(code.toLowerCase())) return true;
+
+    return visit(candidate.error) || visit(candidate.cause);
+  }
+
+  return visit(error);
+}
+
 type MatchedPolicy = { maxRetries?: number; delayMs?: StreamErrorRetryDelayMs };
 
 function normalizeEntry(entry: StreamErrorRetryMatcherEntry): StreamErrorRetryMatcherConfig {
@@ -180,21 +207,23 @@ export class StreamErrorRetryProcessor implements Processor<'stream-error-retry-
 
   readonly #maxRetries: number;
   readonly #entries: StreamErrorRetryMatcherConfig[];
-  readonly #retryAllErrors: boolean;
+  readonly #retryUnknownErrors: boolean;
   readonly #delayMs: StreamErrorRetryDelayMs | undefined;
 
   constructor(options: StreamErrorRetryProcessorOptions = {}) {
     this.#maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
     const defaultEntries: StreamErrorRetryMatcherConfig[] = DEFAULT_MATCHERS.map(m => ({ match: m }));
     this.#entries = [...defaultEntries, ...(options.matchers ?? []).map(normalizeEntry)];
-    this.#retryAllErrors = options.retryAllErrors ?? false;
+    this.#retryUnknownErrors = options.retryUnknownErrors ?? false;
     this.#delayMs = options.delayMs;
   }
 
   async processAPIError(args: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | void> {
     const { error, retryCount, abortSignal } = args;
 
-    const policy = findMatchingPolicy(error, this.#entries) ?? (this.#retryAllErrors ? {} : undefined);
+    const matchedPolicy = findMatchingPolicy(error, this.#entries);
+    const policy =
+      matchedPolicy ?? (this.#retryUnknownErrors && !isKnownTerminalAuthorizationError(error) ? {} : undefined);
     if (!policy) return;
 
     const effectiveMaxRetries = policy.maxRetries ?? this.#maxRetries;


### PR DESCRIPTION
## Summary

- Add opt-in `retryUnknownErrors` support to `StreamErrorRetryProcessor`.
- Retry unmatched stream errors only after provider metadata and configured matchers fail, preserving first-match policy precedence.
- Exclude known terminal authorization failures: HTTP `401`/`403` and provider codes such as `authentication_error`, `permission_denied`, `access_denied`, `forbidden`, and `invalid_api_key`, including codes found in nested response bodies.
- Enable unknown-error retries in `createCodingAgent` by default with 2 retries and a 3-second delay, while retaining the existing HTTP 400 and `ECONNRESET` policies.
- Document the new option and add a minor `@mastra/core` changeset.

```ts
new StreamErrorRetryProcessor({
  retryUnknownErrors: true,
  maxRetries: 2,
  delayMs: 3000,
});
```

## Behavior

Specific provider metadata and matcher policies continue to take precedence. The unknown-error fallback applies only when no existing policy matches. An explicit `isRetryable: false` value alone does not classify an otherwise unknown stream error as terminal; known authorization status codes and provider error codes do.

Callers that provide their own `errorProcessors` to `createCodingAgent` still replace the default processor stack.

## Test plan

- `pnpm build:core`
- `pnpm test:unit src/processors/stream-error-retry-processor.test.ts --bail 1 --reporter=dot`
- `pnpm test:unit src/loop/test-utils/aimock/scenarios/stream-error-retry.scenario.test.ts --bail 1 --reporter=dot`
- `pnpm typecheck`
- AIMock proof through the real OpenAI provider path:
  - branch: two unmatched stream failures are retried and the third request succeeds
  - base: the first unmatched stream failure surfaces without retry
  - known authorization failures surface after one request
