### PR TITLE
feat(mastracode): make memory settings easier to discover

### DIFF
--- a/.changeset/plain-dogs-hang.md
+++ b/.changeset/plain-dogs-hang.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved Observational Memory settings by adding the `/memory` command and clarifying what each token setting counts.

--- a/mastracode/tui/README.md
+++ b/mastracode/tui/README.md
@@ -88,7 +88,7 @@ Select a suggestion with arrow keys and press Tab to insert it.
 | `/custom-providers` | Manage custom OpenAI-compatible providers/models                            |
 | `/mode`             | Switch agent mode                                                           |
 | `/subagents`        | Configure subagent model defaults                                           |
-| `/om`               | Configure Observational Memory models                                       |
+| `/memory`           | Configure Observational Memory (`/om` alias)                                |
 | `/think`            | Set thinking level (Anthropic)                                              |
 | `/judge`            | Configure the default judge model and max attempts for goals                |
 | `/goal`             | Start or manage an autonomous goal                                          |

--- a/mastracode/tui/e2e/tui/om-settings.ts
+++ b/mastracode/tui/e2e/tui/om-settings.ts
@@ -8,17 +8,27 @@ export const omSettingsScenario: McE2eScenario = {
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Mastra Code|Project:/i, terminal);
 
-    terminal.submit('/om');
+    terminal.submit('/memory');
     await runtime.waitForScreenText(/Observational Memory Settings/i, terminal);
     await runtime.waitForScreenText(/Observer model/i, terminal);
     await runtime.waitForScreenText(/Reflector model/i, terminal);
-    await runtime.waitForScreenText(/Observation threshold/i, terminal);
-    await runtime.waitForScreenText(/Reflection threshold/i, terminal);
+    await runtime.waitForScreenText(/Messages before observation/i, terminal);
+    await runtime.waitForScreenText(/Observations before reflection/i, terminal);
     await runtime.waitForScreenText(/Caveman observations/i, terminal);
     await runtime.waitForScreenText(/Observe attachments/i, terminal);
-    runtime.printScreen('after /om', terminal);
+    runtime.printScreen('after /memory', terminal);
 
-    terminal.write('\x1b[B'.repeat(4));
+    terminal.write('\x1b[B'.repeat(2));
+    await runtime.waitForScreenText(
+      /Message tokens before the Observer runs\. More means a larger message window per\s+observation\./i,
+      terminal,
+    );
+    terminal.write('\x1b[B');
+    await runtime.waitForScreenText(
+      /Accumulated observation tokens before the Reflector compresses them\. More means less\s+frequent compression\./i,
+      terminal,
+    );
+    terminal.write('\x1b[B');
     terminal.write('\r');
     await runtime.waitForScreenText(/Caveman-style terse compression/i, terminal);
     await runtime.waitForScreenText(/Standard prose observations/i, terminal);
@@ -33,7 +43,9 @@ export const omSettingsScenario: McE2eScenario = {
     await runtime.waitForScreenTextAbsent(/Observational Memory Settings/i, terminal, 8_000);
     terminal.submit('/om');
     await runtime.waitForScreenText(/Observational Memory Settings/i, terminal);
+    await runtime.waitForScreenText(/Messages before observation/i, terminal);
+    await runtime.waitForScreenText(/Observations before reflection/i, terminal);
     await runtime.waitForScreenText(/Caveman observations\s+On/i, terminal);
-    runtime.printScreen('after om reopen', terminal);
+    runtime.printScreen('after /om alias reopen', terminal);
   },
 };

--- a/mastracode/tui/e2e/tui/om-threshold-persistence.ts
+++ b/mastracode/tui/e2e/tui/om-threshold-persistence.ts
@@ -34,23 +34,23 @@ export const omThresholdPersistenceScenario: McE2eScenario = {
 
     terminal.submit('/om');
     await runtime.waitForScreenText(/Observational Memory Settings/i, terminal, 8_000);
-    await runtime.waitForScreenText(/Observation threshold\s+12k/i, terminal, 8_000);
-    await runtime.waitForScreenText(/Reflection threshold\s+80k/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Messages before observation\s+12k/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Observations before reflection\s+80k/i, terminal, 8_000);
 
     terminal.write('\x1b[B'.repeat(2));
     terminal.write('\r');
-    await runtime.waitForScreenText(/Observation Threshold/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Messages Before Observation/i, terminal, 8_000);
     terminal.write('15');
     terminal.write('\r');
-    await runtime.waitForScreenText(/Observation threshold\s+15k/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Messages before observation\s+15k/i, terminal, 8_000);
     await runtime.waitForScreenTextAbsent(/_k tokens/i, terminal, 8_000);
 
     terminal.write('\x1b[B');
     terminal.write('\r');
-    await runtime.waitForScreenText(/Reflection Threshold/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Observations Before Reflection/i, terminal, 8_000);
     terminal.write('60');
     terminal.write('\r');
-    await runtime.waitForScreenText(/Reflection threshold\s+60k/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Observations before reflection\s+60k/i, terminal, 8_000);
     await runtime.waitForScreenTextAbsent(/_k tokens/i, terminal, 8_000);
 
     terminal.write('\x1b');

--- a/mastracode/tui/src/tui/__tests__/command-dispatch.test.ts
+++ b/mastracode/tui/src/tui/__tests__/command-dispatch.test.ts
@@ -12,6 +12,8 @@ const mocks = vi.hoisted(() => ({
   handleGithubCommand: vi.fn().mockResolvedValue(undefined),
   handleReportIssueCommand: vi.fn().mockResolvedValue(undefined),
   handleMcpCommand: vi.fn().mockResolvedValue(undefined),
+  handleOMCommand: vi.fn().mockResolvedValue(undefined),
+  handleMemoryGatewayCommand: vi.fn().mockResolvedValue(undefined),
   handlePluginsCommand: vi.fn().mockResolvedValue(undefined),
   processSlashCommand: vi.fn().mockResolvedValue('custom output'),
   startGoalWithDefaults: vi.fn().mockResolvedValue(undefined),
@@ -42,7 +44,7 @@ vi.mock('../commands/index.js', () => ({
   handleModelsPackCommand: mocks.handleModelsPackCommand,
   handleCustomProvidersCommand: mocks.handleCustomProvidersCommand,
   handleSubagentsCommand: vi.fn(),
-  handleOMCommand: vi.fn(),
+  handleOMCommand: mocks.handleOMCommand,
   handleSettingsCommand: vi.fn(),
   handleLoginCommand: vi.fn(),
   handleReviewCommand: vi.fn(),
@@ -51,7 +53,7 @@ vi.mock('../commands/index.js', () => ({
   handleBrowserCommand: vi.fn(),
   handleThemeCommand: vi.fn(),
   handleUpdateCommand: vi.fn(),
-  handleMemoryGatewayCommand: vi.fn(),
+  handleMemoryGatewayCommand: mocks.handleMemoryGatewayCommand,
   handleApiKeysCommand: vi.fn(),
   handlePluginsCommand: mocks.handlePluginsCommand,
   handleFeedbackCommand: vi.fn(),
@@ -90,6 +92,8 @@ describe('dispatchSlashCommand models routing', () => {
     mocks.handleGithubCommand.mockClear();
     mocks.handleReportIssueCommand.mockClear();
     mocks.handleMcpCommand.mockClear();
+    mocks.handleOMCommand.mockClear();
+    mocks.handleMemoryGatewayCommand.mockClear();
     mocks.handlePluginsCommand.mockClear();
     mocks.processSlashCommand.mockClear();
     mocks.startGoalWithDefaults.mockClear();
@@ -144,6 +148,29 @@ describe('dispatchSlashCommand models routing', () => {
       resourceId: 'resource-1',
       mode: 'build',
     });
+  });
+
+  it('routes /memory and /om through the same Observational Memory handler', async () => {
+    const state = { customSlashCommands: [] } as any;
+    const ctx = {} as any;
+
+    expect(await dispatchSlashCommand('/memory', state, () => ctx)).toBe(true);
+    expect(await dispatchSlashCommand('/om', state, () => ctx)).toBe(true);
+
+    expect(mocks.handleOMCommand).toHaveBeenCalledTimes(2);
+    expect(mocks.handleOMCommand).toHaveBeenNthCalledWith(1, ctx);
+    expect(mocks.handleOMCommand).toHaveBeenNthCalledWith(2, ctx);
+    expect(mocks.handleMemoryGatewayCommand).not.toHaveBeenCalled();
+  });
+
+  it('keeps /memory-gateway routed separately from Observational Memory settings', async () => {
+    const state = { customSlashCommands: [] } as any;
+    const ctx = {} as any;
+
+    expect(await dispatchSlashCommand('/memory-gateway', state, () => ctx)).toBe(true);
+
+    expect(mocks.handleMemoryGatewayCommand).toHaveBeenCalledWith(ctx);
+    expect(mocks.handleOMCommand).not.toHaveBeenCalled();
   });
 
   it('treats /models:pack as unknown command', async () => {

--- a/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -240,6 +240,11 @@ describe('setupKeyboardShortcuts', () => {
     expect(githubCommand?.getArgumentCompletions?.('un').map(command => command.value)).toEqual(['unsubscribe']);
     expect(commandNames.indexOf('thread')).toBeLessThan(commandNames.indexOf('threads'));
     expect(commandNames).toContain('skill/');
+    expect(commandNames).toContain('memory');
+    expect(commandNames).not.toContain('om');
+    expect(autocompleteProviders[0]?.commands.find(command => command.name === 'memory')?.description).toBe(
+      'Configure Observational Memory',
+    );
     expect(commandNames).not.toContain('memory-gateway');
     expect(commandNames.indexOf('/deploy')).toBeGreaterThan(commandNames.indexOf('help'));
     expect(commandNames).toContain('skill/lint-fix');

--- a/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
+++ b/mastracode/tui/src/tui/__tests__/setup-keyboard-shortcuts.test.ts
@@ -241,9 +241,13 @@ describe('setupKeyboardShortcuts', () => {
     expect(commandNames.indexOf('thread')).toBeLessThan(commandNames.indexOf('threads'));
     expect(commandNames).toContain('skill/');
     expect(commandNames).toContain('memory');
-    expect(commandNames).not.toContain('om');
+    expect(commandNames).toContain('om');
+    expect(commandNames.indexOf('memory')).toBeLessThan(commandNames.indexOf('om'));
     expect(autocompleteProviders[0]?.commands.find(command => command.name === 'memory')?.description).toBe(
       'Configure Observational Memory',
+    );
+    expect(autocompleteProviders[0]?.commands.find(command => command.name === 'om')?.description).toBe(
+      'Alias for /memory',
     );
     expect(commandNames).not.toContain('memory-gateway');
     expect(commandNames.indexOf('/deploy')).toBeGreaterThan(commandNames.indexOf('help'));

--- a/mastracode/tui/src/tui/command-dispatch.ts
+++ b/mastracode/tui/src/tui/command-dispatch.ts
@@ -174,6 +174,7 @@ export async function dispatchSlashCommand(
     case 'subagents':
       await handleSubagentsCommand(ctx);
       return true;
+    case 'memory':
     case 'om':
       await handleOMCommand(ctx);
       return true;

--- a/mastracode/tui/src/tui/components/__tests__/help-overlay.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/help-overlay.test.ts
@@ -11,6 +11,8 @@ describe('buildHelpText', () => {
     expect(text).toContain('/settings');
     expect(text).toContain('/models');
     expect(text).toContain('/skill/<name>');
+    expect(text).toMatch(/\/memory\s+Configure Observational Memory \(\/om alias\)/);
+    expect(text).not.toMatch(/^\s*\/om\s+/m);
     expect(text).not.toContain('/models:pack');
     expect(text).not.toContain('/memory-gateway');
     expect(text).toContain('/help');

--- a/mastracode/tui/src/tui/components/help-overlay.ts
+++ b/mastracode/tui/src/tui/components/help-overlay.ts
@@ -37,7 +37,7 @@ function getCommands(modes: number): HelpEntry[] {
     { key: '/subagents', description: 'Configure subagent models' },
     { key: '/permissions', description: 'Tool approval permissions' },
     { key: '/settings', description: 'Notifications, YOLO, thinking' },
-    { key: '/om', description: 'Configure Observational Memory' },
+    { key: '/memory', description: 'Configure Observational Memory (/om alias)' },
     { key: '/review', description: 'Review a GitHub pull request' },
     { key: '/report-issue', description: 'Open or browse mastracode issues' },
     { key: '/cost', description: 'Token usage and costs' },

--- a/mastracode/tui/src/tui/components/om-settings.ts
+++ b/mastracode/tui/src/tui/components/om-settings.ts
@@ -259,14 +259,13 @@ export class OMSettingsComponent extends Box implements Focusable {
       },
       {
         id: 'obs-threshold',
-        label: 'Observation threshold',
+        label: 'Messages before observation',
         description:
-          'Token count before triggering observation. ' +
-          'Lower = more frequent, higher = more context before observing',
+          'Message tokens before the Observer runs. ' + 'More means a larger message window per observation.',
         currentValue: formatTokens(config.observationThreshold),
         submenu: (_currentValue, done) =>
           new ThresholdSubmenu(
-            'Observation Threshold',
+            'Messages Before Observation',
             config.observationThreshold,
             OBSERVATION_THRESHOLDS,
             value => {
@@ -279,14 +278,14 @@ export class OMSettingsComponent extends Box implements Focusable {
       },
       {
         id: 'ref-threshold',
-        label: 'Reflection threshold',
+        label: 'Observations before reflection',
         description:
-          'Token count of observations before triggering compression. ' +
-          'Lower = more frequent, higher = more observations before compressing',
+          'Accumulated observation tokens before the Reflector compresses them. ' +
+          'More means less frequent compression.',
         currentValue: formatTokens(config.reflectionThreshold),
         submenu: (_currentValue, done) =>
           new ThresholdSubmenu(
-            'Reflection Threshold',
+            'Observations Before Reflection',
             config.reflectionThreshold,
             REFLECTION_THRESHOLDS,
             value => {

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -326,6 +326,7 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'custom-providers', description: 'Manage custom providers and models' },
     { name: 'subagents', description: 'Configure subagent model defaults' },
     { name: 'memory', description: 'Configure Observational Memory' },
+    { name: 'om', description: 'Alias for /memory' },
     { name: 'think', description: 'Set thinking (off|low|medium|high|xhigh|status)' },
     { name: 'login', description: 'Login with OAuth provider' },
     { name: 'skills', description: 'List available skills' },

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -325,7 +325,7 @@ export function setupAutocomplete(state: TUIState): void {
     { name: 'models', description: 'Switch model pack' },
     { name: 'custom-providers', description: 'Manage custom providers and models' },
     { name: 'subagents', description: 'Configure subagent model defaults' },
-    { name: 'om', description: 'Configure Observational Memory models' },
+    { name: 'memory', description: 'Configure Observational Memory' },
     { name: 'think', description: 'Set thinking (off|low|medium|high|xhigh|status)' },
     { name: 'login', description: 'Login with OAuth provider' },
     { name: 'skills', description: 'List available skills' },

--- a/mastracode/web/src/web/ui/domains/settings/components/OMSection.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/OMSection.tsx
@@ -163,8 +163,8 @@ export function OMSection({ resourceId, models }: { resourceId?: string; models:
   return (
     <div className="flex flex-col gap-4">
       <Txt as="p" variant="ui-sm" className="text-icon3">
-        Observer and reflector models, their token thresholds, and attachment observation. Mirrors the TUI{' '}
-        <code>/om</code> command.
+        Observer and reflector models, their token settings, and attachment observation. Mirrors the TUI{' '}
+        <code>/memory</code> command.
       </Txt>
       {error && (
         <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
@@ -180,7 +180,10 @@ export function OMSection({ resourceId, models }: { resourceId?: string; models:
         {modelSelect(config?.reflectorModelId ?? '', v => switchModel('reflector', v))}
       </Field>
 
-      <Field label="Observation threshold" hint="Tokens in the message window before an observation fires">
+      <Field
+        label="Messages before observation"
+        hint="Message tokens before the Observer runs. More means a larger message window per observation."
+      >
         <Input
           size="sm"
           type="number"
@@ -193,7 +196,10 @@ export function OMSection({ resourceId, models }: { resourceId?: string; models:
         />
       </Field>
 
-      <Field label="Reflection threshold" hint="Accumulated observation tokens before a reflection fires">
+      <Field
+        label="Observations before reflection"
+        hint="Accumulated observation tokens before the Reflector compresses them. More means less frequent compression."
+      >
         <Input
           size="sm"
           type="number"

--- a/mastracode/web/src/web/ui/domains/settings/components/__tests__/OMSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/__tests__/OMSection.msw.test.tsx
@@ -71,6 +71,18 @@ describe('OMSection', () => {
       const obs = (await screen.findByDisplayValue('1000')) as HTMLInputElement;
       expect(obs).toBeInTheDocument();
       expect(screen.getByDisplayValue('2000')).toBeInTheDocument();
+      expect(screen.getByText('Messages before observation')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Message tokens before the Observer runs. More means a larger message window per observation.',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Observations before reflection')).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          'Accumulated observation tokens before the Reflector compresses them. More means less frequent compression.',
+        ),
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
Mastra Code's Observational Memory settings were difficult to discover and the threshold labels did not explain what they counted.

This adds `/memory` as the canonical command while keeping `/om` visible and supported as an alias. The TUI and web settings now explain that observation is triggered by message tokens and reflection/compression by accumulated observation tokens. Existing defaults, persistence fields, and runtime behavior are unchanged.

Before:

```text
/om
Observation threshold
Reflection threshold
```

After:

```text
/memory — Configure Observational Memory
/om — Alias for /memory
Messages before observation
Observations before reflection
```

Tested with focused TUI unit tests, both Observational Memory TUI E2E scenarios, TUI typecheck/lint, the web MSW component suite, web typecheck, and built TUI red/green proof.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This makes Observational Memory settings easier to find and understand. Users can use `/memory`, while `/om` still works as an alias, and the settings now clearly explain what each token limit controls.

## Summary

- Added `/memory` as the canonical TUI command for Observational Memory.
- Preserved `/om` as a discoverable alias across autocomplete, help, documentation, and command dispatch.
- Renamed TUI and web settings to clarify:
  - Messages before observation
  - Observations before reflection
- Kept existing values, persistence, and runtime behavior unchanged.
- Added focused unit, E2E, and web component test coverage.
- Added a patch changeset and retained typecheck, lint, and build validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->