### PR TITLE
feat(mastracode): let plugins register signal providers

### DIFF
--- a/.changeset/brown-melons-slide.md
+++ b/.changeset/brown-melons-slide.md
@@ -3,4 +3,4 @@
 'mastracode': patch
 ---
 
-Added plugin signal providers so plugins can contribute processors and tools through Mastra's signal API. Providers reload without replacing active coding sessions, and can release resources with an optional dispose method.
+Added plugin signal providers so plugins can contribute processors and tools through Mastra's signal API. Providers reload without replacing active coding sessions, and can release resources with an optional dispose method. Mastra Code now also hydrates objectives created through the Agent API before rendering goal evaluations, so signal-provider goals share the existing status, pause, and judge UI.

--- a/.changeset/brown-melons-slide.md
+++ b/.changeset/brown-melons-slide.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': minor
+'mastracode': patch
+---
+
+Added plugin signal providers so plugins can contribute processors and tools through Mastra's signal API. Providers reload without replacing active coding sessions, and can release resources with an optional dispose method.

--- a/docs/src/mastra-code/index.mdx
+++ b/docs/src/mastra-code/index.mdx
@@ -17,6 +17,7 @@ Mastra Code organizes its capabilities around these areas:
 - [**Configuration**](/configuration): Project-scoped threads, MCP servers, hooks, custom commands, skills, and database settings.
 - [**Terminal notifications**](/terminal-notifications): Show clickable notifications for Mastra Code running in an inactive terminal pane.
 - [**Customization**](/customization): Extend Mastra Code programmatically with custom modes, tools, subagents, and storage.
+- [**Plugins**](/plugins): Add instructions, tools, skills, commands, and signal providers through reloadable plugins.
 - [**Headless mode**](/headless): Run Mastra Code non-interactively from your shell or from Node and CI with the `runMC` API.
 
 In this demo, you'll see Mastra Code in action:

--- a/docs/src/mastra-code/plugins.mdx
+++ b/docs/src/mastra-code/plugins.mdx
@@ -44,7 +44,7 @@ Every provider must be a `SignalProvider` instance with an ID that is unique acr
 
 Mastra Code registers a stable plugin-provider bridge when it creates the coding agent. On plugin reload, the bridge validates the complete replacement provider set and then swaps its delegates. The coding agent, controller, sessions, thread IDs, and state remain unchanged.
 
-Input and output processors are resolved from the current provider set for each request. Provider tools use stable live proxies, so a reload updates their implementations without replacing the coding agent.
+Input and output processors are resolved from the current provider set for each request. Provider tools use stable live proxies, so a reload updates their implementations without replacing the coding agent. Providers that define `pollInterval` use the standard `SignalProvider` polling lifecycle.
 
 Mastra Code calls `stop()` on every removed or replaced provider. A provider can also implement `dispose()` to release plugin-owned resources such as file watchers or schedulers:
 

--- a/docs/src/mastra-code/plugins.mdx
+++ b/docs/src/mastra-code/plugins.mdx
@@ -1,0 +1,61 @@
+---
+title: 'Plugins'
+description: 'Extend Mastra Code with instructions, tools, skills, commands, and signal providers.'
+packages:
+  - 'mastracode'
+---
+
+# Plugins
+
+Mastra Code plugins can add instructions, tools, skills, commands, and signal providers. A signal provider can contribute processors and tools through Mastra's existing `SignalProvider` API.
+
+## Add a signal provider
+
+Define `signalProviders` as a function on the plugin. Mastra Code calls the function with the resolved plugin context before it constructs the coding agent.
+
+```typescript title="src/index.ts"
+import { defineMastraCodePlugin, SignalProvider } from '@mastra/code-sdk/plugin'
+
+class PolicySignals extends SignalProvider<'policy-signals'> {
+  readonly id = 'policy-signals'
+
+  getInputProcessors() {
+    return [policyProcessor]
+  }
+}
+
+export default defineMastraCodePlugin({
+  id: 'acme.policy',
+  config: {
+    enabled: { type: 'boolean', default: true },
+  },
+  signalProviders: async context => {
+    if (!context.config.enabled) return []
+    return [new PolicySignals()]
+  },
+})
+```
+
+The factory receives the same `cwd`, `scope`, `pluginDir`, and resolved `config` values as tool and instruction factories. It can return synchronously or asynchronously.
+
+Every provider must be a `SignalProvider` instance with an ID that is unique across enabled plugins. Mastra Code marks all plugins that declare a duplicate provider ID as load failures. A rejected factory or invalid return value also fails the plugin without partially applying its providers.
+
+## Reload lifecycle
+
+Mastra Code registers a stable plugin-provider bridge when it creates the coding agent. On plugin reload, the bridge validates the complete replacement provider set and then swaps its delegates. The coding agent, controller, sessions, thread IDs, and state remain unchanged.
+
+Input and output processors are resolved from the current provider set for each request. Provider tools use stable live proxies, so a reload updates their implementations without replacing the coding agent.
+
+Mastra Code calls `stop()` on every removed or replaced provider. A provider can also implement `dispose()` to release plugin-owned resources such as file watchers or schedulers:
+
+```typescript
+class WatchedSignals extends SignalProvider<'watched-signals'> {
+  readonly id = 'watched-signals'
+
+  async dispose() {
+    await this.watcher.close()
+  }
+}
+```
+
+Cleanup runs once for each provider instance. If a replacement plugin fails to load, Mastra Code retains the previous provider snapshot and does not dispose it.

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -504,6 +504,7 @@ describe('createMastraCode', () => {
         { id: 'acme.plugin', status: 'active', toolNames: ['plugin_tool'], instructions: 'Use plugin policy.' },
       ]),
       getPluginTools: vi.fn(() => ({ plugin_tool: { id: 'plugin_tool' } })),
+      getPluginSignalProviders: vi.fn(() => []),
     };
 
     await createMastraCode({ pluginManager: pluginManager as any });
@@ -514,6 +515,23 @@ describe('createMastraCode', () => {
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'plan')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.modes?.find(mode => mode.id === 'fast')?.availableTools).toContain('plugin_tool');
     expect(agentControllerConfig?.initialState?.pluginInstructions).toEqual(['Use plugin policy.']);
+  });
+
+  it('registers plugin signal providers before constructing the code agent', async () => {
+    const { createMastraCode } = await import('../index.js');
+    const provider = { id: 'plugin-signals' };
+    const pluginManager = {
+      reload: vi.fn(async () => []),
+      getPluginTools: vi.fn(() => ({})),
+      getPluginSignalProviders: vi.fn(() => [provider]),
+    };
+
+    await createMastraCode({ pluginManager: pluginManager as any });
+
+    const codeAgentConfig = agentConstructorMock.mock.calls
+      .map(call => call?.[0] as { id?: string; signals?: unknown[] } | undefined)
+      .find(config => config?.id === 'code-agent');
+    expect(codeAgentConfig?.signals).toContain(provider);
   });
 
   it('registers the TaskSignalProvider on the code agent so task tools persist via state signals', async () => {

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -520,10 +520,13 @@ describe('createMastraCode', () => {
   it('registers plugin signal providers before constructing the code agent', async () => {
     const { createMastraCode } = await import('../index.js');
     const provider = { id: 'plugin-signals' };
+    const pluginProcessor = { id: 'plugin-processor' };
     const pluginManager = {
       reload: vi.fn(async () => []),
       getPluginTools: vi.fn(() => ({})),
       getPluginSignalProviders: vi.fn(() => [provider]),
+      getPluginInputProcessors: vi.fn(() => [pluginProcessor]),
+      getPluginOutputProcessors: vi.fn(() => []),
     };
 
     await createMastraCode({ pluginManager: pluginManager as any });
@@ -532,6 +535,8 @@ describe('createMastraCode', () => {
       .map(call => call?.[0] as { id?: string; signals?: unknown[] } | undefined)
       .find(config => config?.id === 'code-agent');
     expect(codeAgentConfig?.signals).toContain(provider);
+    const inputProcessors = await (codeAgentConfig as { inputProcessors: () => Promise<unknown[]> }).inputProcessors();
+    expect(inputProcessors).toContain(pluginProcessor);
   });
 
   it('registers the TaskSignalProvider on the code agent so task tools persist via state signals', async () => {
@@ -810,9 +815,16 @@ describe('createMastraCode', () => {
 
     expect(agentConstructorMock).toHaveBeenCalled();
     const agentConfig = agentConstructorMock.mock.calls[0]?.[0] as
-      | { inputProcessors?: Array<{ id?: string }>; errorProcessors?: Array<{ id?: string }> }
+      | {
+          inputProcessors?: Array<{ id?: string }> | (() => Promise<Array<{ id?: string }>>);
+          errorProcessors?: Array<{ id?: string }>;
+        }
       | undefined;
-    expect(agentConfig?.inputProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
+    const inputProcessors =
+      typeof agentConfig?.inputProcessors === 'function'
+        ? await agentConfig.inputProcessors()
+        : agentConfig?.inputProcessors;
+    expect(inputProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
     expect(agentConfig?.errorProcessors?.map(processor => processor.id)).toContain('provider-history-compat');
   });
 

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -498,6 +498,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     : (config?.pluginManager ?? new PluginManager({ projectRoot: project.rootPath, configDir, homeDir }));
   const loadedPlugins = pluginManager ? await pluginManager.reload() : [];
   const pluginTools = pluginManager?.getPluginTools() ?? {};
+  const pluginSignalProviders = pluginManager?.getPluginSignalProviders() ?? [];
 
   // Scorers (live evaluation with sampling)
   const outcomeScorer = createOutcomeScorer();
@@ -588,7 +589,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
     // TaskSignalProvider bundles the task tools + TaskStateProcessor: it merges
     // the tools into the toolset and registers the task state-signal processor,
     // so the task list persists across turns and survives OM truncation.
-    signals: [new TaskSignalProvider(), ...(githubSignals ? [githubSignals] : [])],
+    signals: [new TaskSignalProvider(), ...(githubSignals ? [githubSignals] : []), ...pluginSignalProviders],
     // Native goal mechanism: the in-loop goal step judges the thread's active
     // objective each qualifying iteration. The judge model is required for any
     // gating to occur; when unset the goal step is a complete no-op. A6 auto-wires

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -613,7 +613,8 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       // per-request from the active workspace (mirrors `judge`).
       tools: getGoalJudgeTools,
     },
-    inputProcessors: [
+    inputProcessors: async () => [
+      ...(pluginManager?.getPluginInputProcessors() ?? []),
       new PlanRejectionAbortProcessor(),
       new AgentsMDInjector({
         getIgnoredInstructionPaths: ({ requestContext }) => {
@@ -626,6 +627,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
       }),
       new ProviderHistoryCompat(),
     ],
+    outputProcessors: async () => pluginManager?.getPluginOutputProcessors() ?? [],
     errorProcessors: [
       new StreamErrorRetryProcessor({
         matchers: [

--- a/mastracode/sdk/src/plugin.ts
+++ b/mastracode/sdk/src/plugin.ts
@@ -1,6 +1,7 @@
 import type { SignalProvider } from '@mastra/core/signals';
 import type { Tool, ToolAction, ToolExecutionContext } from '@mastra/core/tools';
 
+export { SignalProvider } from '@mastra/core/signals';
 export { createTool } from '@mastra/core/tools';
 export type { Tool, ToolAction, ToolExecutionContext } from '@mastra/core/tools';
 export { z } from 'zod';
@@ -106,7 +107,9 @@ export type MastraCodePluginToolEntry = {
 export type MastraCodePluginTools = Record<string, MastraCodePluginTool>;
 export type MastraCodePluginToolEntries = Record<string, MastraCodePluginToolEntry>;
 export type MastraCodePluginInstructions = string | ((context: MastraCodePluginContext) => string | Promise<string>);
-export type MastraCodePluginSignalProvider = SignalProvider<string>;
+export type MastraCodePluginSignalProvider = SignalProvider<string> & {
+  dispose?: () => void | Promise<void>;
+};
 export type MastraCodePluginSignalProviders = (
   context: MastraCodePluginContext,
 ) => MastraCodePluginSignalProvider[] | Promise<MastraCodePluginSignalProvider[]>;

--- a/mastracode/sdk/src/plugin.ts
+++ b/mastracode/sdk/src/plugin.ts
@@ -1,3 +1,4 @@
+import type { SignalProvider } from '@mastra/core/signals';
 import type { Tool, ToolAction, ToolExecutionContext } from '@mastra/core/tools';
 
 export { createTool } from '@mastra/core/tools';
@@ -105,6 +106,10 @@ export type MastraCodePluginToolEntry = {
 export type MastraCodePluginTools = Record<string, MastraCodePluginTool>;
 export type MastraCodePluginToolEntries = Record<string, MastraCodePluginToolEntry>;
 export type MastraCodePluginInstructions = string | ((context: MastraCodePluginContext) => string | Promise<string>);
+export type MastraCodePluginSignalProvider = SignalProvider<string>;
+export type MastraCodePluginSignalProviders = (
+  context: MastraCodePluginContext,
+) => MastraCodePluginSignalProvider[] | Promise<MastraCodePluginSignalProvider[]>;
 
 export type MastraCodePlugin = {
   id: string;
@@ -113,6 +118,7 @@ export type MastraCodePlugin = {
   description?: string;
   config?: MastraCodePluginConfigSchema;
   instructions?: MastraCodePluginInstructions;
+  signalProviders?: MastraCodePluginSignalProviders;
   tools?:
     | MastraCodePluginToolEntries
     | ((context: MastraCodePluginContext) => MastraCodePluginToolEntries | Promise<MastraCodePluginToolEntries>);

--- a/mastracode/sdk/src/plugins/__tests__/loader.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/loader.test.ts
@@ -82,6 +82,118 @@ describe('plugin loader', () => {
     expect(loaded.find(plugin => plugin.id === 'acme.enabled')?.toolNames).toEqual(['enabled_tool']);
   });
 
+  it('resolves async signal provider factories with plugin context', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-loader-'));
+    const projectRoot = path.join(tempDir, 'project');
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.symlinkSync(path.resolve('node_modules'), path.join(projectRoot, 'node_modules'), 'dir');
+    const pluginDir = path.join(projectRoot, '.mastracode', 'plugins', 'signals');
+    writePlugin(
+      path.join(pluginDir, 'src/index.ts'),
+      `import { SignalProvider } from '@mastra/core/signals';
+       class PluginSignals extends SignalProvider {
+         constructor(id) { super(); this.id = id; }
+       }
+       export default {
+         id: 'acme.signals',
+         config: { providerId: { type: 'string', default: 'default-signals' } },
+         signalProviders: async context => [new PluginSignals(context.config.providerId)]
+       };`,
+    );
+
+    const loaded = await loadPlugins({
+      projectRoot,
+      homeDir: path.join(tempDir, 'home'),
+      projectRegistry: {
+        plugins: {
+          'acme.signals': {
+            enabled: true,
+            source: 'local',
+            specifier: '../signals',
+            path: pluginDir,
+            entry: 'src/index.ts',
+            config: { providerId: 'configured-signals' },
+          },
+        },
+      },
+      globalRegistry: { plugins: {} },
+    });
+
+    expect(loaded[0]?.error).toBeUndefined();
+    expect(loaded[0]).toMatchObject({ id: 'acme.signals', status: 'active' });
+    expect(loaded[0]?.signalProviders?.map(provider => provider.id)).toEqual(['configured-signals']);
+  });
+
+  it('fails closed for invalid signal provider factory results', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-loader-'));
+    const projectRoot = path.join(tempDir, 'project');
+    const pluginDir = path.join(projectRoot, '.mastracode', 'plugins', 'invalid-signals');
+    writePlugin(
+      path.join(pluginDir, 'src/index.ts'),
+      `export default { id: 'acme.invalid-signals', signalProviders: async () => [{}] };`,
+    );
+
+    const loaded = await loadPlugins({
+      projectRoot,
+      homeDir: path.join(tempDir, 'home'),
+      projectRegistry: {
+        plugins: {
+          'acme.invalid-signals': {
+            enabled: true,
+            source: 'local',
+            specifier: '../invalid-signals',
+            path: pluginDir,
+            entry: 'src/index.ts',
+          },
+        },
+      },
+      globalRegistry: { plugins: {} },
+    });
+
+    expect(loaded[0]).toMatchObject({
+      id: 'acme.invalid-signals',
+      status: 'load failed',
+      error: 'Plugin signalProviders function must return an array of SignalProvider instances',
+    });
+  });
+
+  it('fails every plugin that declares a duplicate signal provider id', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-loader-'));
+    const projectRoot = path.join(tempDir, 'project');
+    fs.mkdirSync(projectRoot, { recursive: true });
+    fs.symlinkSync(path.resolve('node_modules'), path.join(projectRoot, 'node_modules'), 'dir');
+    const pluginsRoot = path.join(projectRoot, '.mastracode', 'plugins');
+    for (const id of ['acme.first', 'acme.second']) {
+      writePlugin(
+        path.join(pluginsRoot, id, 'index.ts'),
+        `import { SignalProvider } from '@mastra/core/signals';
+         class PluginSignals extends SignalProvider { id = 'shared-signals'; }
+         export default { id: '${id}', signalProviders: () => [new PluginSignals()] };`,
+      );
+    }
+    const registry: PluginRegistry = {
+      plugins: Object.fromEntries(
+        ['acme.first', 'acme.second'].map(id => [
+          id,
+          { enabled: true, source: 'local', specifier: id, path: path.join(pluginsRoot, id), entry: 'index.ts' },
+        ]),
+      ),
+    };
+
+    const loaded = await loadPlugins({
+      projectRoot,
+      homeDir: path.join(tempDir, 'home'),
+      projectRegistry: registry,
+      globalRegistry: { plugins: {} },
+    });
+
+    expect(loaded.map(plugin => plugin.status)).toEqual(['load failed', 'load failed']);
+    expect(loaded.map(plugin => plugin.error)).toEqual([
+      'Duplicate signal provider id: shared-signals',
+      'Duplicate signal provider id: shared-signals',
+    ]);
+  });
+
   it('passes configured plugin option values into tools functions', async () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-loader-'));
     const projectRoot = path.join(tempDir, 'project');

--- a/mastracode/sdk/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/manager.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import type { Agent } from '@mastra/core/agent';
 import { SignalProvider } from '@mastra/core/signals';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -73,6 +74,27 @@ describe('PluginSignalProviderBridge', () => {
     await bridge.replace([]);
     await bridge.replace([]);
     expect(second.dispose).toHaveBeenCalledOnce();
+  });
+
+  it('retains the previous providers when a replacement fails to start', async () => {
+    const bridge = new PluginSignalProviderBridge();
+    bridge.connect({} as Agent<any, any, any, any>);
+    const previous = new (class extends SignalProvider {
+      readonly id = 'previous-provider';
+    })();
+    const failing = new (class extends SignalProvider {
+      readonly id = 'failing-provider';
+      readonly dispose = vi.fn();
+      start() {
+        throw new Error('start failed');
+      }
+    })();
+
+    await bridge.replace([previous]);
+    await expect(bridge.replace([failing])).rejects.toThrow('start failed');
+
+    expect(bridge.currentProviders).toEqual([previous]);
+    expect(failing.dispose).toHaveBeenCalledOnce();
   });
 });
 

--- a/mastracode/sdk/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/manager.test.ts
@@ -96,6 +96,29 @@ describe('PluginSignalProviderBridge', () => {
     expect(bridge.currentProviders).toEqual([previous]);
     expect(failing.dispose).toHaveBeenCalledOnce();
   });
+
+  it('starts polling and removes initial providers that fail to start', async () => {
+    const bridge = new PluginSignalProviderBridge();
+    const polling = new (class extends SignalProvider {
+      readonly id = 'polling-provider';
+    })();
+    const failing = new (class extends SignalProvider {
+      readonly id = 'initial-failing-provider';
+      readonly dispose = vi.fn();
+      start() {
+        throw new Error('initial start failed');
+      }
+    })();
+    const startPolling = vi.spyOn(polling, 'startPolling');
+
+    await bridge.replace([polling, failing]);
+    bridge.connect({} as Agent<any, any, any, any>);
+    await bridge.start();
+
+    expect(bridge.currentProviders).toEqual([polling]);
+    expect(startPolling).toHaveBeenCalledOnce();
+    expect(failing.dispose).toHaveBeenCalledOnce();
+  });
 });
 
 describe('PluginManager', () => {

--- a/mastracode/sdk/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/manager.test.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { SignalProvider } from '@mastra/core/signals';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const execaMock = vi.hoisted(() => vi.fn());
@@ -11,6 +12,7 @@ vi.mock('execa', () => ({ execa: execaMock }));
 import { PluginManager } from '../manager.js';
 import { findMastraCodePackageRoot } from '../package-link.js';
 import { loadPluginRegistry } from '../registry.js';
+import { PluginSignalProviderBridge } from '../signal-provider-bridge.js';
 
 const mastracodePackageRoot = findMastraCodePackageRoot(path.dirname(fileURLToPath(import.meta.url)));
 
@@ -40,6 +42,39 @@ async function waitUntil(assertion: () => boolean, timeoutMs = 3000): Promise<vo
   }
   expect(assertion()).toBe(true);
 }
+
+describe('PluginSignalProviderBridge', () => {
+  it('atomically replaces processor delegates and disposes removed providers once', async () => {
+    const bridge = new PluginSignalProviderBridge();
+    const firstProcessor = { id: 'first', processInputStep: vi.fn() };
+    const secondProcessor = { id: 'second', processInputStep: vi.fn() };
+    const first = new (class extends SignalProvider {
+      readonly id = 'first-provider';
+      readonly dispose = vi.fn();
+      getInputProcessors() {
+        return [firstProcessor];
+      }
+    })();
+    const second = new (class extends SignalProvider {
+      readonly id = 'second-provider';
+      readonly dispose = vi.fn();
+      getInputProcessors() {
+        return [secondProcessor];
+      }
+    })();
+
+    await bridge.replace([first]);
+    expect(bridge.getCurrentInputProcessors()).toEqual([firstProcessor]);
+
+    await bridge.replace([second]);
+    expect(bridge.getCurrentInputProcessors()).toEqual([secondProcessor]);
+    expect(first.dispose).toHaveBeenCalledOnce();
+
+    await bridge.replace([]);
+    await bridge.replace([]);
+    expect(second.dispose).toHaveBeenCalledOnce();
+  });
+});
 
 describe('PluginManager', () => {
   it('installs, lists, disables, enables, and uninstalls local plugins', async () => {

--- a/mastracode/sdk/src/plugins/loader.ts
+++ b/mastracode/sdk/src/plugins/loader.ts
@@ -2,11 +2,14 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 
+import { SignalProvider } from '@mastra/core/signals';
+
 import type {
   MastraCodePlugin,
   MastraCodePluginConfigSchema,
   MastraCodePluginConfigValues,
   MastraCodePluginContext,
+  MastraCodePluginSignalProvider,
   MastraCodePluginToolEntries,
   MastraCodePluginTools,
   MastraCodeToolRenderConfig,
@@ -42,7 +45,7 @@ export async function loadPlugins(options: LoadPluginsOptions): Promise<LoadedPl
     loaded.push(await loadPluginRecord(record, options));
   }
 
-  return markToolConflicts(loaded);
+  return markSignalProviderConflicts(markToolConflicts(loaded));
 }
 
 export async function loadPluginRecord(
@@ -68,6 +71,7 @@ export async function loadPluginRecord(
     };
     const { tools, renderConfigs } = await resolvePluginTools(plugin, context);
     const instructions = await resolvePluginInstructions(plugin, context);
+    const signalProviders = await resolvePluginSignalProviders(plugin, context);
 
     return {
       ...record,
@@ -75,6 +79,7 @@ export async function loadPluginRecord(
       version: plugin.version ?? record.version,
       description: plugin.description,
       instructions,
+      signalProviders,
       status: 'active',
       tools,
       renderConfigs,
@@ -160,6 +165,9 @@ function validatePluginExport(value: unknown): MastraCodePlugin {
   if (plugin.tools !== undefined && typeof plugin.tools !== 'object' && typeof plugin.tools !== 'function') {
     throw new Error('Plugin tools must be an object or function');
   }
+  if (plugin.signalProviders !== undefined && typeof plugin.signalProviders !== 'function') {
+    throw new Error('Plugin signalProviders must be a function');
+  }
 
   return plugin;
 }
@@ -174,6 +182,18 @@ async function resolvePluginTools(
     throw new Error('Plugin tools function must return an object');
   }
   return normalizePluginToolEntries(entries);
+}
+
+async function resolvePluginSignalProviders(
+  plugin: MastraCodePlugin,
+  context: MastraCodePluginContext,
+): Promise<MastraCodePluginSignalProvider[]> {
+  if (!plugin.signalProviders) return [];
+  const providers = await plugin.signalProviders(context);
+  if (!Array.isArray(providers) || providers.some(provider => !(provider instanceof SignalProvider))) {
+    throw new Error('Plugin signalProviders function must return an array of SignalProvider instances');
+  }
+  return providers;
 }
 
 async function resolvePluginInstructions(
@@ -257,6 +277,30 @@ export function collectActivePluginTools(plugins: LoadedPlugin[]): MastraCodePlu
     }
   }
   return tools;
+}
+
+function markSignalProviderConflicts(plugins: LoadedPlugin[]): LoadedPlugin[] {
+  const owners = new Map<string, string[]>();
+  for (const plugin of plugins) {
+    if (plugin.status !== 'active') continue;
+    for (const provider of plugin.signalProviders ?? []) {
+      const providerOwners = owners.get(provider.id) ?? [];
+      providerOwners.push(plugin.id);
+      owners.set(provider.id, providerOwners);
+    }
+  }
+  return plugins.map(plugin => {
+    if (plugin.status !== 'active') return plugin;
+    const duplicateIds = (plugin.signalProviders ?? [])
+      .map(provider => provider.id)
+      .filter(id => (owners.get(id)?.length ?? 0) > 1);
+    if (duplicateIds.length === 0) return plugin;
+    return {
+      ...plugin,
+      status: 'load failed',
+      error: `Duplicate signal provider id${duplicateIds.length === 1 ? '' : 's'}: ${duplicateIds.join(', ')}`,
+    };
+  });
 }
 
 function markToolConflicts(plugins: LoadedPlugin[]): LoadedPlugin[] {

--- a/mastracode/sdk/src/plugins/manager.ts
+++ b/mastracode/sdk/src/plugins/manager.ts
@@ -81,6 +81,10 @@ export class PluginManager {
     return this.pluginTools;
   }
 
+  getPluginSignalProviders() {
+    return this.loadedPlugins.flatMap(plugin => (plugin.status === 'active' ? (plugin.signalProviders ?? []) : []));
+  }
+
   getToolRenderConfig(toolName: string) {
     return this.toolRenderConfigs.get(toolName);
   }

--- a/mastracode/sdk/src/plugins/manager.ts
+++ b/mastracode/sdk/src/plugins/manager.ts
@@ -12,6 +12,7 @@ import { ensureMastraCodePackageLink } from './package-link.js';
 import { getPluginScopePaths } from './paths.js';
 import type { PluginPathOptions } from './paths.js';
 import { loadPluginRegistry, removePluginRecord, savePluginRegistry, setPluginRecord } from './registry.js';
+import { PluginSignalProviderBridge } from './signal-provider-bridge.js';
 import type { LoadedPlugin, PluginScope } from './types.js';
 
 const GITHUB_PLUGIN_POLL_INTERVAL_MS = 60_000;
@@ -33,6 +34,8 @@ export class PluginManager {
   private loadedPlugins: LoadedPlugin[] = [];
   private readonly pluginTools: ReturnType<typeof collectActivePluginTools> = {};
   private readonly rawPluginTools: ReturnType<typeof collectActivePluginTools> = {};
+  private readonly signalProviderBridge = new PluginSignalProviderBridge();
+  private hasLoadedSignalProviders = false;
   private readonly toolRenderConfigs = new Map<string, NonNullable<LoadedPlugin['renderConfigs']>[string]>();
   private readonly watchedLocalEntries = new Set<string>();
   private readonly localEntryVersions = new Map<string, string>();
@@ -52,11 +55,24 @@ export class PluginManager {
     if (this.reloadInFlight) return this.reloadInFlight;
 
     this.reloadInFlight = (async () => {
-      this.loadedPlugins = await loadPlugins(this.options);
+      const nextPlugins = await loadPlugins(this.options);
+      const providerReloadFailed =
+        nextPlugins.some(plugin => plugin.status === 'load failed') && this.hasLoadedSignalProviders;
+      if (!providerReloadFailed) {
+        const nextProviders = nextPlugins.flatMap(plugin =>
+          plugin.status === 'active' ? (plugin.signalProviders ?? []) : [],
+        );
+        await this.signalProviderBridge.replace(nextProviders);
+        this.hasLoadedSignalProviders = true;
+      }
+      this.loadedPlugins = providerReloadFailed ? this.loadedPlugins : nextPlugins;
       this.updateLocalEntryWatchers(this.loadedPlugins);
       this.updateGithubPoller(this.loadedPlugins);
       this.updatePluginRenderConfigs(this.loadedPlugins);
-      this.updatePluginTools(collectActivePluginTools(this.loadedPlugins));
+      this.updatePluginTools({
+        ...collectActivePluginTools(this.loadedPlugins),
+        ...this.collectSignalProviderTools(),
+      });
       await this.notifyReloadListeners(this.loadedPlugins);
       return this.loadedPlugins;
     })().finally(() => {
@@ -82,7 +98,15 @@ export class PluginManager {
   }
 
   getPluginSignalProviders() {
-    return this.loadedPlugins.flatMap(plugin => (plugin.status === 'active' ? (plugin.signalProviders ?? []) : []));
+    return [this.signalProviderBridge];
+  }
+
+  getPluginInputProcessors() {
+    return this.signalProviderBridge.getCurrentInputProcessors();
+  }
+
+  getPluginOutputProcessors() {
+    return this.signalProviderBridge.getCurrentOutputProcessors();
   }
 
   getToolRenderConfig(toolName: string) {
@@ -101,6 +125,14 @@ export class PluginManager {
     return this.loadedPlugins.flatMap(plugin =>
       plugin.status === 'active' && plugin.instructions ? [plugin.instructions] : [],
     );
+  }
+
+  private collectSignalProviderTools(): ReturnType<typeof collectActivePluginTools> {
+    const tools: ReturnType<typeof collectActivePluginTools> = {};
+    for (const provider of this.signalProviderBridge.currentProviders) {
+      Object.assign(tools, provider.getTools?.() ?? {});
+    }
+    return tools;
   }
 
   private async notifyReloadListeners(plugins: LoadedPlugin[]): Promise<void> {
@@ -377,6 +409,16 @@ export class PluginManager {
   private async readGitHead(cwd: string): Promise<string> {
     const { stdout } = await execa('git', ['rev-parse', 'HEAD'], gitExecOptions(cwd));
     return stdout.trim();
+  }
+
+  async dispose(): Promise<void> {
+    for (const entryPath of this.watchedLocalEntries) fs.unwatchFile(entryPath);
+    this.watchedLocalEntries.clear();
+    this.localEntryVersions.clear();
+    if (this.githubPollTimer) clearInterval(this.githubPollTimer);
+    this.githubPollTimer = undefined;
+    this.reloadListeners.clear();
+    await this.signalProviderBridge.replace([]);
   }
 
   discoverLocal(searchRoot = '.'): ReturnType<typeof discoverLocalPlugins> {

--- a/mastracode/sdk/src/plugins/signal-provider-bridge.ts
+++ b/mastracode/sdk/src/plugins/signal-provider-bridge.ts
@@ -38,6 +38,10 @@ export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugi
     for (const provider of this.providers) this.connectProvider(provider);
   }
 
+  async start(): Promise<void> {
+    await Promise.all(this.providers.map(provider => provider.start?.()));
+  }
+
   __registerMastra(...args: Parameters<SignalProvider['__registerMastra']>): void {
     super.__registerMastra(...args);
     for (const provider of this.providers) provider.__registerMastra(...args);
@@ -45,13 +49,23 @@ export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugi
 
   async replace(nextProviders: DisposableMastraCodePluginSignalProvider[]): Promise<void> {
     const previousProviders = this.providers;
-    this.providers = nextProviders;
 
-    for (const provider of nextProviders) {
-      if (this.mastra) provider.__registerMastra(this.mastra);
-      if (this.connectedAgent) this.connectProvider(provider);
+    try {
+      for (const provider of nextProviders) {
+        if (this.mastra) provider.__registerMastra(this.mastra);
+        if (this.connectedAgent) {
+          this.connectProvider(provider);
+          await provider.start?.();
+        }
+      }
+    } catch (error) {
+      await Promise.all(
+        nextProviders.filter(provider => !previousProviders.includes(provider)).map(provider => this.dispose(provider)),
+      );
+      throw error;
     }
 
+    this.providers = nextProviders;
     await Promise.all(
       previousProviders.filter(provider => !nextProviders.includes(provider)).map(provider => this.dispose(provider)),
     );
@@ -66,7 +80,6 @@ export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugi
   private connectProvider(provider: DisposableMastraCodePluginSignalProvider): void {
     if (!this.connectedAgent || provider.isConnected) return;
     provider.connect(this.connectedAgent);
-    void provider.start?.();
   }
 
   private async dispose(provider: DisposableMastraCodePluginSignalProvider): Promise<void> {

--- a/mastracode/sdk/src/plugins/signal-provider-bridge.ts
+++ b/mastracode/sdk/src/plugins/signal-provider-bridge.ts
@@ -1,0 +1,78 @@
+import type { Agent } from '@mastra/core/agent';
+import type { InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '@mastra/core/processors';
+import { SignalProvider } from '@mastra/core/signals';
+
+import type { MastraCodePluginSignalProvider } from '../plugin.js';
+
+export type DisposableMastraCodePluginSignalProvider = MastraCodePluginSignalProvider;
+
+export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugin-signals'> {
+  readonly id = 'mastracode-plugin-signals' as const;
+  private providers: DisposableMastraCodePluginSignalProvider[] = [];
+  private connectedAgent?: Agent<any, any, any, any>;
+  private readonly disposed = new WeakSet<DisposableMastraCodePluginSignalProvider>();
+
+  get currentProviders(): readonly DisposableMastraCodePluginSignalProvider[] {
+    return this.providers;
+  }
+
+  getInputProcessors(): InputProcessorOrWorkflow[] {
+    return [];
+  }
+
+  getOutputProcessors(): OutputProcessorOrWorkflow[] {
+    return [];
+  }
+
+  getCurrentInputProcessors(): InputProcessorOrWorkflow[] {
+    return this.providers.flatMap(provider => provider.getInputProcessors?.() ?? []);
+  }
+
+  getCurrentOutputProcessors(): OutputProcessorOrWorkflow[] {
+    return this.providers.flatMap(provider => provider.getOutputProcessors?.() ?? []);
+  }
+
+  connect(agent: Agent<any, any, any, any>): void {
+    super.connect(agent);
+    this.connectedAgent = agent;
+    for (const provider of this.providers) this.connectProvider(provider);
+  }
+
+  __registerMastra(...args: Parameters<SignalProvider['__registerMastra']>): void {
+    super.__registerMastra(...args);
+    for (const provider of this.providers) provider.__registerMastra(...args);
+  }
+
+  async replace(nextProviders: DisposableMastraCodePluginSignalProvider[]): Promise<void> {
+    const previousProviders = this.providers;
+    this.providers = nextProviders;
+
+    for (const provider of nextProviders) {
+      if (this.mastra) provider.__registerMastra(this.mastra);
+      if (this.connectedAgent) this.connectProvider(provider);
+    }
+
+    await Promise.all(
+      previousProviders.filter(provider => !nextProviders.includes(provider)).map(provider => this.dispose(provider)),
+    );
+  }
+
+  stop(): void {
+    super.stop();
+    for (const provider of this.providers) void this.dispose(provider);
+    this.providers = [];
+  }
+
+  private connectProvider(provider: DisposableMastraCodePluginSignalProvider): void {
+    if (!this.connectedAgent || provider.isConnected) return;
+    provider.connect(this.connectedAgent);
+    void provider.start?.();
+  }
+
+  private async dispose(provider: DisposableMastraCodePluginSignalProvider): Promise<void> {
+    if (this.disposed.has(provider)) return;
+    this.disposed.add(provider);
+    provider.stop();
+    await provider.dispose?.();
+  }
+}

--- a/mastracode/sdk/src/plugins/signal-provider-bridge.ts
+++ b/mastracode/sdk/src/plugins/signal-provider-bridge.ts
@@ -39,7 +39,13 @@ export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugi
   }
 
   async start(): Promise<void> {
-    await Promise.all(this.providers.map(provider => provider.start?.()));
+    const providers = this.providers;
+    const results = await Promise.allSettled(providers.map(provider => this.startProvider(provider)));
+    const failedProviders = providers.filter((_, index) => results[index]?.status === 'rejected');
+    if (failedProviders.length === 0) return;
+
+    this.providers = providers.filter(provider => !failedProviders.includes(provider));
+    await Promise.all(failedProviders.map(provider => this.dispose(provider)));
   }
 
   __registerMastra(...args: Parameters<SignalProvider['__registerMastra']>): void {
@@ -53,9 +59,9 @@ export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugi
     try {
       for (const provider of nextProviders) {
         if (this.mastra) provider.__registerMastra(this.mastra);
-        if (this.connectedAgent) {
+        if (this.connectedAgent && !previousProviders.includes(provider)) {
           this.connectProvider(provider);
-          await provider.start?.();
+          await this.startProvider(provider);
         }
       }
     } catch (error) {
@@ -80,6 +86,11 @@ export class PluginSignalProviderBridge extends SignalProvider<'mastracode-plugi
   private connectProvider(provider: DisposableMastraCodePluginSignalProvider): void {
     if (!this.connectedAgent || provider.isConnected) return;
     provider.connect(this.connectedAgent);
+  }
+
+  private async startProvider(provider: DisposableMastraCodePluginSignalProvider): Promise<void> {
+    await provider.start?.();
+    provider.startPolling();
   }
 
   private async dispose(provider: DisposableMastraCodePluginSignalProvider): Promise<void> {

--- a/mastracode/sdk/src/plugins/types.ts
+++ b/mastracode/sdk/src/plugins/types.ts
@@ -1,6 +1,7 @@
 import type {
   MastraCodePluginConfigSchema,
   MastraCodePluginConfigValue,
+  MastraCodePluginSignalProvider,
   MastraCodePluginTools,
   MastraCodeToolRenderConfig,
 } from '../plugin.js';
@@ -38,6 +39,7 @@ export type LoadedPlugin = ScopedInstalledPluginRecord & {
   status: PluginStatus;
   error?: string;
   tools: MastraCodePluginTools;
+  signalProviders?: MastraCodePluginSignalProvider[];
   renderConfigs?: Record<string, MastraCodeToolRenderConfig>;
   toolNames: string[];
   skillPaths?: string[];

--- a/mastracode/tui/src/tui/__tests__/goal-manager.test.ts
+++ b/mastracode/tui/src/tui/__tests__/goal-manager.test.ts
@@ -146,6 +146,112 @@ describe('GoalManager adapter', () => {
     expect(manager.isActive()).toBe(false);
   });
 
+  it('syncs the first objective created through the Agent API', async () => {
+    const agent = createAgent();
+    agent.getObjective.mockResolvedValue(makeRecord({ id: 'external-1', objective: 'external goal', runsUsed: 2 }));
+    const manager = new GoalManager();
+
+    const result = await manager.syncFromThread(createState(agent));
+
+    expect(result).toMatchObject({ status: 'synced', replaced: true });
+    expect(manager.getGoal()).toMatchObject({ id: 'external-1', objective: 'external goal', turnsUsed: 2 });
+  });
+
+  it('merges the same durable objective without resetting timers or persistence flags', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T10:00:00.000Z'));
+    const agent = createAgent();
+    agent.getObjective.mockResolvedValue(makeRecord({ id: 'external-1', objective: 'external goal' }));
+    const manager = new GoalManager();
+    await manager.syncFromThread(createState(agent));
+    const startedAt = manager.getGoal()?.activeStartedAt;
+    manager.persistOnNextThreadCreate();
+
+    vi.setSystemTime(new Date('2026-05-15T10:05:00.000Z'));
+    agent.getObjective.mockResolvedValue(
+      makeRecord({ id: 'external-1', objective: 'external goal', runsUsed: 3, maxRuns: 25 }),
+    );
+    const result = await manager.syncFromThread(createState(agent));
+
+    expect(result).toMatchObject({ status: 'synced', replaced: false });
+    expect(manager.getGoal()).toMatchObject({ turnsUsed: 3, maxTurns: 25, activeStartedAt: startedAt });
+    expect(manager.consumePersistOnNextThreadCreate()).toBe(true);
+    vi.useRealTimers();
+  });
+
+  it('treats a different durable ID with the same objective as a replacement exactly once', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T10:00:00.000Z'));
+    const agent = createAgent();
+    const manager = new GoalManager();
+    agent.getObjective.mockResolvedValue(makeRecord({ id: 'external-1', objective: 'same text' }));
+    await manager.syncFromThread(createState(agent));
+
+    vi.setSystemTime(new Date('2026-05-15T10:05:00.000Z'));
+    agent.getObjective.mockResolvedValue(makeRecord({ id: 'external-2', objective: 'same text' }));
+    const replaced = await manager.syncFromThread(createState(agent));
+    const replacedStartedAt = manager.getGoal()?.activeStartedAt;
+
+    vi.setSystemTime(new Date('2026-05-15T10:10:00.000Z'));
+    const repeated = await manager.syncFromThread(createState(agent));
+
+    expect(replaced).toMatchObject({ status: 'synced', replaced: true });
+    expect(repeated).toMatchObject({ status: 'synced', replaced: false });
+    expect(manager.getGoal()).toMatchObject({
+      id: 'external-2',
+      objective: 'same text',
+      activeStartedAt: replacedStartedAt,
+    });
+    expect(replacedStartedAt).toBe('2026-05-15T10:05:00.000Z');
+    vi.useRealTimers();
+  });
+
+  it('replaces the mirror when the durable objective text changes', async () => {
+    const agent = createAgent();
+    const manager = new GoalManager();
+    agent.getObjective.mockResolvedValue(makeRecord({ id: 'external-1', objective: 'first goal' }));
+    await manager.syncFromThread(createState(agent));
+    agent.getObjective.mockResolvedValue(makeRecord({ id: 'external-2', objective: 'second goal', status: 'paused' }));
+
+    const result = await manager.syncFromThread(createState(agent));
+
+    expect(result).toMatchObject({ status: 'synced', replaced: true });
+    expect(manager.getGoal()).toMatchObject({ id: 'external-2', objective: 'second goal', status: 'paused' });
+    expect(manager.getGoal()?.activeStartedAt).toBeUndefined();
+  });
+
+  it('leaves the current mirror untouched when no durable objective exists', async () => {
+    const agent = createAgent();
+    const manager = new GoalManager();
+    await manager.setGoal(createState(agent), 'rendering goal', '__GATEWAY_OPENAI_MODEL__');
+    const before = manager.getGoal();
+    agent.getObjective.mockResolvedValue(undefined);
+
+    const result = await manager.syncFromThread(createState(agent));
+
+    expect(result).toEqual({ status: 'no-record' });
+    expect(manager.getGoal()).toEqual(before);
+  });
+
+  it('returns a typed read error without changing the mirror or timers', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-15T10:00:00.000Z'));
+    const agent = createAgent();
+    const manager = new GoalManager();
+    await manager.setGoal(createState(agent), 'rendering goal', '__GATEWAY_OPENAI_MODEL__');
+    manager.persistOnNextThreadCreate();
+    const before = manager.getGoal();
+    const failure = new Error('storage unavailable');
+    agent.getObjective.mockRejectedValue(failure);
+
+    const result = await manager.syncFromThread(createState(agent));
+
+    expect(result).toEqual({ status: 'read-error', error: failure });
+    expect(manager.getGoal()).toEqual(before);
+    expect(manager.consumePersistOnNextThreadCreate()).toBe(true);
+    vi.useRealTimers();
+  });
+
   it('loads an objective from ThreadState via the agent', async () => {
     const agent = createAgent();
     agent.getObjective.mockResolvedValue(makeRecord({ objective: 'persisted goal', runsUsed: 4, status: 'paused' }));

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -23,6 +23,7 @@ vi.mock('../display.js', () => ({
   notify: vi.fn(),
 }));
 
+import { dispatchEvent } from '../event-dispatch.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
 import { handleAgentAborted, handleAgentEnd, handleGoalEvaluation } from '../handlers/agent-lifecycle.js';
 import type { EventHandlerContext } from '../handlers/types.js';
@@ -571,6 +572,153 @@ describe('MastraTUI queueing', () => {
     expect(state.pendingFollowUpMessages).toEqual([]);
     expect(state.pendingSlashCommands).toEqual([]);
     expect(ctx.updateStatusLine).toHaveBeenCalledTimes(6);
+  });
+
+  it('awaits external objective hydration before rendering each goal chunk', async () => {
+    const order: string[] = [];
+    let releaseSync!: () => void;
+    const syncGate = new Promise<void>(resolve => {
+      releaseSync = resolve;
+    });
+    const state = createQueueState({
+      goalManager: {
+        syncFromThread: vi.fn(async () => {
+          order.push('sync-start');
+          await syncGate;
+          order.push('sync-end');
+          return { status: 'synced', replaced: true };
+        }),
+        applyEvaluation: vi.fn(() => order.push('apply')),
+        getGoal: vi.fn(() => ({
+          id: 'external-goal',
+          status: 'active',
+          judgeModelId: '__GATEWAY_OPENAI_MODEL__',
+          turnsUsed: 1,
+          maxTurns: 20,
+        })),
+      } as any,
+    });
+    const ctx = createQueueContext(state);
+
+    const dispatched = dispatchEvent(
+      { type: 'goal_evaluation', payload: createGoalPayload({ status: 'active' }) } as any,
+      ctx,
+      state,
+    );
+    await Promise.resolve();
+    expect(order).toEqual(['sync-start']);
+
+    releaseSync();
+    await dispatched;
+
+    expect(order).toEqual(['sync-start', 'sync-end', 'apply']);
+  });
+
+  it('hydrates pending, activity, and completed chunks before applying external goal status', async () => {
+    const applyEvaluation = vi.fn();
+    const syncFromThread = vi.fn().mockResolvedValue({ status: 'synced', replaced: false });
+    const state = createQueueState({
+      goalManager: {
+        syncFromThread,
+        applyEvaluation,
+        getGoal: vi.fn(() => ({
+          id: 'external-goal',
+          status: 'active',
+          judgeModelId: '__GATEWAY_OPENAI_MODEL__',
+          turnsUsed: 1,
+          maxTurns: 20,
+        })),
+      } as any,
+    });
+    const ctx = createQueueContext(state);
+
+    await dispatchEvent({ type: 'goal_evaluation', payload: createGoalPayload({ pending: true }) } as any, ctx, state);
+    await dispatchEvent(
+      {
+        type: 'goal_evaluation',
+        payload: createGoalPayload({
+          pending: true,
+          activity: [{ type: 'tool-call', name: 'read', message: 'read' }],
+        } as any),
+      } as any,
+      ctx,
+      state,
+    );
+    await dispatchEvent(
+      { type: 'goal_evaluation', payload: createGoalPayload({ iteration: 2, status: 'active' }) } as any,
+      ctx,
+      state,
+    );
+    await dispatchEvent(
+      { type: 'goal_evaluation', payload: createGoalPayload({ iteration: 3, status: 'done', passed: true }) } as any,
+      ctx,
+      state,
+    );
+
+    expect(syncFromThread).toHaveBeenCalledTimes(4);
+    expect(applyEvaluation).toHaveBeenNthCalledWith(1, { runsUsed: 2, status: 'active' });
+    expect(applyEvaluation).toHaveBeenNthCalledWith(2, { runsUsed: 3, status: 'done' });
+  });
+
+  it('does not correlate a same-text external replacement with a plan-started goal', async () => {
+    const switchMode = vi.fn().mockResolvedValue({ accepted: true });
+    let currentGoalId = 'plan-goal-original';
+    const state = createQueueState({
+      planStartedGoalId: 'plan-goal-original',
+      session: { mode: { switch: switchMode } } as any,
+      goalManager: {
+        syncFromThread: vi.fn(async () => {
+          currentGoalId = 'external-replacement';
+          return { status: 'synced', replaced: true };
+        }),
+        applyEvaluation: vi.fn(),
+        getGoal: vi.fn(() => ({
+          id: currentGoalId,
+          objective: 'same objective text',
+          status: 'done',
+          judgeModelId: '__GATEWAY_OPENAI_MODEL__',
+          turnsUsed: 2,
+          maxTurns: 20,
+        })),
+      } as any,
+    });
+    const ctx = createQueueContext(state);
+
+    await dispatchEvent(
+      { type: 'goal_evaluation', payload: createGoalPayload({ iteration: 2, status: 'done', passed: true }) } as any,
+      ctx,
+      state,
+    );
+
+    expect(switchMode).not.toHaveBeenCalled();
+    expect(state.planStartedGoalId).toBe('plan-goal-original');
+  });
+
+  it('reports objective read errors without skipping evaluation rendering', async () => {
+    const applyEvaluation = vi.fn();
+    const state = createQueueState({
+      goalManager: {
+        syncFromThread: vi.fn().mockResolvedValue({ status: 'read-error', error: new Error('storage unavailable') }),
+        applyEvaluation,
+        getGoal: vi.fn(() => ({
+          id: 'rendering-goal',
+          status: 'active',
+          judgeModelId: '__GATEWAY_OPENAI_MODEL__',
+          turnsUsed: 1,
+          maxTurns: 20,
+        })),
+      } as any,
+    });
+    const ctx = createQueueContext(state);
+
+    await dispatchEvent(
+      { type: 'goal_evaluation', payload: createGoalPayload({ iteration: 2, status: 'active' }) } as any,
+      ctx,
+      state,
+    );
+
+    expect(ctx.showError).toHaveBeenCalledWith('Failed to synchronize objective state: storage unavailable');
+    expect(applyEvaluation).toHaveBeenCalledWith({ runsUsed: 2, status: 'active' });
   });
 
   it('adds goal activity to the active judge display while pending', () => {

--- a/mastracode/tui/src/tui/event-dispatch.ts
+++ b/mastracode/tui/src/tui/event-dispatch.ts
@@ -444,6 +444,10 @@ export async function dispatchEvent(
     }
 
     case 'goal_evaluation': {
+      const sync = await state.goalManager.syncFromThread(state);
+      if (sync.status === 'read-error') {
+        ectx.showError(`Failed to synchronize objective state: ${sync.error.message}`);
+      }
       handleGoalEvaluation(ectx, event.payload);
       break;
     }

--- a/mastracode/tui/src/tui/goal-manager.ts
+++ b/mastracode/tui/src/tui/goal-manager.ts
@@ -41,6 +41,11 @@ export interface GoalState {
   activeDurationMs?: number;
 }
 
+export type GoalSyncResult =
+  | { status: 'synced'; goal: GoalState; replaced: boolean }
+  | { status: 'no-record' }
+  | { status: 'read-error'; error: Error };
+
 // =============================================================================
 // Constants
 // =============================================================================
@@ -209,6 +214,37 @@ export class GoalManager {
     this.activeStartedAt = null;
     this.activeDurationMs = 0;
     this.persistGoalOnNextThreadCreate = false;
+  }
+
+  /**
+   * Hydrate objectives created through the Agent API before rendering an
+   * evaluation chunk. Unlike thread-switch loading, this preserves display
+   * timers and pending thread-create state when the objective is unchanged.
+   */
+  async syncFromThread(state: TUIState): Promise<GoalSyncResult> {
+    const threadId = state.session.thread.getId();
+    const agent = this.getAgent(state);
+    if (!agent || !threadId) return { status: 'no-record' };
+
+    let durable: GoalObjectiveRecord | undefined;
+    try {
+      durable = await agent.getObjective({ threadId });
+    } catch (error) {
+      return { status: 'read-error', error: error instanceof Error ? error : new Error(String(error)) };
+    }
+    if (!durable) return { status: 'no-record' };
+
+    const durableId = durable.id ?? `external:${durable.startedAt}:${durable.objective}`;
+    const current = this.record;
+    if (current && current.id === durableId && current.objective === durable.objective) {
+      this.record = { ...durable, id: durableId };
+      return { status: 'synced', goal: this.getGoal()!, replaced: false };
+    }
+
+    this.record = { ...durable, id: durableId };
+    this.activeStartedAt = durable.status === 'active' ? new Date().toISOString() : null;
+    this.activeDurationMs = 0;
+    return { status: 'synced', goal: this.getGoal()!, replaced: true };
   }
 
   /**

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -556,6 +556,7 @@ export class MastraTUI {
       this.cleanupPluginReloadListener();
       this.cleanupPluginReloadListener = undefined;
     }
+    void this.state.pluginManager?.dispose();
 
     if (this.state.unsubscribe) {
       this.state.unsubscribe();


### PR DESCRIPTION
## Summary

- add an async plugin contract for registering Mastra signal providers
- preserve active coding sessions through a stable provider bridge during plugin reloads
- validate provider identity, roll back failed startup, and clean up replaced provider resources
- document the public plugin lifecycle and add release changesets

## Test plan

- `pnpm --filter ./mastracode/sdk exec vitest run src/plugins --reporter=dot --bail 1`
- isolated-HOME SDK suite: 839 tests passed
- `pnpm --filter ./mastracode/sdk check`
- `pnpm --filter ./mastracode/tui check`
- `pnpm --dir docs validate`
- scoped Vale check for `docs/src/mastra-code/plugins.mdx`

## Notes

The full TUI suite reaches a pre-existing deterministic failure in `shell-output.test.ts`; the Segment 1 TUI change only disposes the plugin manager during shutdown.
