### PR TITLE
feat(behaviors): add durable behavior state trees

### DIFF
--- a/.changeset/shaggy-mirrors-do.md
+++ b/.changeset/shaggy-mirrors-do.md
@@ -1,0 +1,5 @@
+---
+'@mastra/behaviors': minor
+---
+
+Added the @mastra/behaviors package for defining durable agent state trees from TypeScript or filesystem manifests. Includes transactional in-memory and LibSQL stores, guarded and judged transitions, migration safety, and state-signal projection.

--- a/docs/src/content/en/docs/long-running-agents/behaviors.mdx
+++ b/docs/src/content/en/docs/long-running-agents/behaviors.mdx
@@ -1,0 +1,126 @@
+---
+title: "Behaviors | Long-running agents"
+description: "Define durable state trees that guide a Mastra agent through explicit states and judged transitions."
+packages:
+  - "@mastra/behaviors"
+  - "@mastra/core"
+---
+
+# Behaviors
+
+Behaviors guide an agent through a durable state tree. Each state provides acting instructions and explicit transitions. A transition can require deterministic guards and a separate judge.
+
+## Install the package
+
+```bash npm2yarn
+npm install @mastra/behaviors
+```
+
+## Define a behavior in TypeScript
+
+Use `defineBehavior()` to create an immutable, validated graph.
+
+```typescript title="src/mastra/debug-behavior.ts"
+import { defineBehavior } from '@mastra/behaviors'
+
+export const debugBehavior = defineBehavior({
+  id: 'debug',
+  version: '1',
+  initialState: 'understand',
+  states: [
+    {
+      id: 'understand',
+      instructions: 'Identify and prove the root cause.',
+      judgeInstructions: 'Approve only when the evidence proves one root cause.',
+      transitions: [
+        {
+          id: 'write-test',
+          target: 'test',
+          guards: [{ id: 'cause-proven' }],
+          judge: true,
+        },
+        { id: 'exit', target: 'exit', exit: true },
+      ],
+    },
+    {
+      id: 'test',
+      instructions: 'Write a failing regression test.',
+      transitions: [{ id: 'exit', target: 'exit', exit: true }],
+    },
+  ],
+})
+```
+
+Every state requires an exit transition. Mastra rejects duplicate IDs, missing targets, unreachable states, invalid schedules, and states without an exit.
+
+## Load a behavior directory
+
+A filesystem behavior uses `behavior.yaml` as its manifest. State assets can contain acting instructions, judge-only instructions, and skills.
+
+```text
+behaviors/debug/
+├── behavior.yaml
+└── states/
+    └── understand/
+        ├── AGENTS.md
+        ├── JUDGE.md
+        └── skills/
+            └── research/
+```
+
+Reference the assets from `behavior.yaml`:
+
+```yaml title="behaviors/debug/behavior.yaml"
+id: debug
+version: '1'
+initialState: understand
+states:
+  - id: understand
+    agentsFile: states/understand/AGENTS.md
+    judgeFile: states/understand/JUDGE.md
+    skills:
+      - skills/research
+    transitions:
+      - id: exit
+        target: exit
+        exit: true
+```
+
+Load and register the behavior with an agent:
+
+```typescript title="src/mastra/index.ts"
+import { Agent } from '@mastra/core/agent'
+import {
+  BehaviorSignalProvider,
+  InMemoryBehaviorRuntimeStore,
+  loadBehaviorDirectory,
+} from '@mastra/behaviors'
+
+const definition = await loadBehaviorDirectory('./behaviors/debug')
+const behavior = new BehaviorSignalProvider({
+  definition,
+  store: new InMemoryBehaviorRuntimeStore(),
+})
+
+export const agent = new Agent({
+  id: 'debug-agent',
+  name: 'Debug agent',
+  instructions: 'Follow the active behavior state.',
+  model: 'openai/gpt-5.5',
+  signals: [behavior],
+})
+```
+
+Filesystem paths must stay inside the behavior directory. The loader rejects absolute paths, traversal, and symbolic links that escape the directory.
+
+## Persist behavior state
+
+`InMemoryBehaviorRuntimeStore` is suitable for local and single-process use. Use `LibSQLBehaviorRuntimeStore` when state must survive restarts or multiple processes need database-level transaction locking.
+
+The behavior store is authoritative. The provider can mirror committed records into Mastra thread state for interoperability, but transitions never use that mirror as their source of truth.
+
+## Judge transitions
+
+Deterministic guards run before the optional judge. A failed guard prevents the judge call. The engine commits a judged transition only when the runtime revision still matches the revision that the judge reviewed.
+
+`JUDGE.md` and `judgeInstructions` are sent only to the judge. They aren't included in the acting agent's state signal.

--- a/docs/src/content/en/docs/long-running-agents/behaviors.mdx
+++ b/docs/src/content/en/docs/long-running-agents/behaviors.mdx
@@ -106,7 +106,7 @@ export const agent = new Agent({
   id: 'debug-agent',
   name: 'Debug agent',
   instructions: 'Follow the active behavior state.',
-  model: 'openai/gpt-5.5',
+  model: '__GATEWAY_OPENAI_MODEL__',
   signals: [behavior],
 })
 ```
@@ -115,7 +115,7 @@ Filesystem paths must stay inside the behavior directory. The loader rejects abs
 
 ## Persist behavior state
 
-`InMemoryBehaviorRuntimeStore` is suitable for local and single-process use. Use `LibSQLBehaviorRuntimeStore` when state must survive restarts or multiple processes need database-level transaction locking.
+`InMemoryBehaviorRuntimeStore` is suitable for local and single-process use. Use `LibSQLBehaviorRuntimeStore` when state must survive restarts or multiple processes need revision-checked compare-and-swap updates.
 
 The behavior store is authoritative. The provider can mirror committed records into Mastra thread state for interoperability, but transitions never use that mirror as their source of truth.
 

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -530,6 +530,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'long-running-agents/behaviors',
+          label: 'Behaviors',
+          customProps: {
+            tags: ['beta'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'long-running-agents/goals',
           label: 'Goals',
           customProps: {

--- a/docs/src/content/en/reference/agents/behaviors.mdx
+++ b/docs/src/content/en/reference/agents/behaviors.mdx
@@ -58,7 +58,7 @@ await store.init()
 
 ### `LibSQLBehaviorRuntimeStore`
 
-Stores records in LibSQL write transactions. The table is created by `init()`.
+Stores records in LibSQL with revision-checked compare-and-swap updates. The table is created by `init()`.
 
 ```typescript
 import { createClient } from '@libsql/client'

--- a/docs/src/content/en/reference/agents/behaviors.mdx
+++ b/docs/src/content/en/reference/agents/behaviors.mdx
@@ -1,0 +1,130 @@
+---
+title: "Reference: Behaviors | Agents"
+description: "API reference for defining, loading, storing, and transitioning agent behaviors."
+packages:
+  - "@mastra/behaviors"
+---
+
+# Behaviors
+
+`@mastra/behaviors` provides validated behavior graphs, transactional runtime stores, a transition engine, and a signal provider.
+
+## Definition functions
+
+### `defineBehavior(input)`
+
+Validates a TypeScript definition and returns an immutable `NormalizedBehaviorDefinition`.
+
+```typescript
+import { defineBehavior } from '@mastra/behaviors'
+
+const definition = defineBehavior({
+  id: 'review',
+  version: '1',
+  initialState: 'inspect',
+  states: [
+    {
+      id: 'inspect',
+      transitions: [{ id: 'exit', target: 'exit', exit: true }],
+    },
+  ],
+})
+```
+
+### `loadBehaviorDirectory(directory)`
+
+Loads `behavior.yaml` and its referenced state assets from a directory.
+
+```typescript
+import { loadBehaviorDirectory } from '@mastra/behaviors'
+
+const definition = await loadBehaviorDirectory('./behaviors/review')
+```
+
+Returns: `Promise<NormalizedBehaviorDefinition>`
+
+## Runtime stores
+
+### `InMemoryBehaviorRuntimeStore`
+
+Stores records in memory and serializes transactions for each thread and behavior pair.
+
+```typescript
+import { InMemoryBehaviorRuntimeStore } from '@mastra/behaviors'
+
+const store = new InMemoryBehaviorRuntimeStore()
+await store.init()
+```
+
+### `LibSQLBehaviorRuntimeStore`
+
+Stores records in LibSQL write transactions. The table is created by `init()`.
+
+```typescript
+import { createClient } from '@libsql/client'
+import { LibSQLBehaviorRuntimeStore } from '@mastra/behaviors'
+
+const store = new LibSQLBehaviorRuntimeStore(createClient({ url: 'file:behaviors.db' }))
+await store.init()
+```
+
+Both stores implement `BehaviorRuntimeStore`:
+
+```typescript
+interface BehaviorRuntimeStore {
+  init(): Promise<void>
+  readThread(key: BehaviorThreadKey): Promise<BehaviorRuntimeRecord | undefined>
+  transactThread<T>(
+    key: BehaviorThreadKey,
+    operation: BehaviorTransaction<T>,
+  ): Promise<{
+    runtime: BehaviorRuntimeRecord
+    result: T
+  }>
+  listDue(before: Date, limit?: number): Promise<BehaviorDueWork[]>
+}
+```
+
+## `BehaviorTransitionEngine`
+
+Initializes records, reconciles definition versions, and commits guarded transitions.
+
+```typescript
+import { BehaviorTransitionEngine, InMemoryBehaviorRuntimeStore } from '@mastra/behaviors'
+
+const engine = new BehaviorTransitionEngine({
+  definition,
+  store: new InMemoryBehaviorRuntimeStore(),
+  guards: {
+    complete: ({ conditionState }) => conditionState.complete === true,
+  },
+  judge: async ({ judgeInstructions }) => ({
+    approved: judgeInstructions !== undefined,
+  }),
+})
+
+await engine.initialize('thread-id')
+await engine.transition({
+  threadId: 'thread-id',
+  transitionId: 'exit',
+  attemptId: crypto.randomUUID(),
+})
+```
+
+The `attemptId` makes a completed transition idempotent. A judge result can't commit after another transition changes the record revision.
+
+## `BehaviorSignalProvider`
+
+Registers `BehaviorStateProcessor` through the standard Mastra signal-provider API.
+
+```typescript
+import { BehaviorSignalProvider } from '@mastra/behaviors'
+
+const provider = new BehaviorSignalProvider({ definition, store })
+```
+
+The projected `<current-behavior>` state includes acting instructions, transition IDs, intent, and status. It excludes judge instructions.
+
+## Errors
+
+Definition failures throw `BehaviorDefinitionError` with path-specific diagnostics. Transition failures throw `BehaviorTransitionError`, including missing guards, unavailable transitions, rejected judges, and stale results.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -44,6 +44,7 @@ const sidebars = {
       collapsed: true,
       items: [
         { type: 'doc', id: 'agents/agent', label: 'Agent Class' },
+        { type: 'doc', id: 'agents/behaviors', label: 'Behaviors' },
         { type: 'doc', id: 'agents/channels', label: 'Channels' },
         { type: 'doc', id: 'agents/inngest-agent', label: 'createInngestAgent()' },
         { type: 'doc', id: 'agents/createSkill', label: 'createSkill()' },

--- a/packages/behaviors/eslint.config.js
+++ b/packages/behaviors/eslint.config.js
@@ -1,0 +1,4 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+export default [...config];

--- a/packages/behaviors/package.json
+++ b/packages/behaviors/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@mastra/behaviors",
+  "version": "0.1.0",
+  "description": "Durable behavior state trees for Mastra agents",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": ["dist", "CHANGELOG.md"],
+  "exports": {
+    ".": {
+      "import": { "types": "./dist/index.d.ts", "default": "./dist/index.js" },
+      "require": { "types": "./dist/index.d.ts", "default": "./dist/index.cjs" }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "lint": "eslint .",
+    "test": "vitest run",
+    "check": "tsc --noEmit"
+  },
+  "license": "Apache-2.0",
+  "repository": { "type": "git", "url": "git+https://github.com/mastra-ai/mastra.git", "directory": "packages/behaviors" },
+  "engines": { "node": ">=22.13.0" },
+  "peerDependencies": { "@mastra/core": ">=1.0.0-0 <2.0.0-0", "zod": ">=3.0.0 || >=4.0.0" },
+  "dependencies": { "yaml": "^2.7.1" },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/packages/behaviors/package.json
+++ b/packages/behaviors/package.json
@@ -24,7 +24,7 @@
   "repository": { "type": "git", "url": "git+https://github.com/mastra-ai/mastra.git", "directory": "packages/behaviors" },
   "engines": { "node": ">=22.13.0" },
   "peerDependencies": { "@mastra/core": ">=1.0.0-0 <2.0.0-0", "zod": ">=3.0.0 || >=4.0.0" },
-  "dependencies": { "yaml": "^2.7.1" },
+  "dependencies": { "@libsql/client": "0.17.4", "yaml": "^2.7.1" },
   "devDependencies": {
     "@internal/lint": "workspace:*",
     "@internal/types-builder": "workspace:*",

--- a/packages/behaviors/src/definition/definition.test.ts
+++ b/packages/behaviors/src/definition/definition.test.ts
@@ -1,0 +1,110 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { loadBehaviorDirectory } from './loader.js';
+import { defineBehavior } from './normalize.js';
+import { BehaviorDefinitionError, type BehaviorDefinitionInput } from './types.js';
+
+const input: BehaviorDefinitionInput = {
+  id: 'debug',
+  version: '1',
+  initialState: 'understand',
+  states: [
+    {
+      id: 'understand',
+      instructions: 'Understand the issue.',
+      judgeInstructions: 'Require a proven cause.',
+      skills: [],
+      transitions: [
+        { id: 'test', target: 'test', guards: [{ id: 'cause-proven' }], judge: true },
+        { id: 'exit', target: 'exit', exit: true },
+      ],
+    },
+    {
+      id: 'test',
+      instructions: 'Write a failing test.',
+      transitions: [{ id: 'exit', target: 'exit', exit: true }],
+      periodic: { intervalMs: 1000, transition: 'exit' },
+    },
+  ],
+  migrations: { investigate: 'understand' },
+};
+
+let tempDir: string | undefined;
+afterEach(async () => {
+  if (tempDir) await fs.rm(tempDir, { recursive: true, force: true });
+  tempDir = undefined;
+});
+
+async function writeFixture(definition = input): Promise<string> {
+  tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'behavior-definition-'));
+  await fs.mkdir(path.join(tempDir, 'states', 'understand', 'skills', 'research'), { recursive: true });
+  await fs.writeFile(path.join(tempDir, 'states', 'understand', 'AGENTS.md'), 'Understand the issue.');
+  await fs.writeFile(path.join(tempDir, 'states', 'understand', 'JUDGE.md'), 'Require a proven cause.');
+  const manifest = JSON.stringify({
+    ...definition,
+    states: definition.states.map(state =>
+      state.id === 'understand'
+        ? {
+            ...state,
+            instructions: undefined,
+            judgeInstructions: undefined,
+            agentsFile: 'states/understand/AGENTS.md',
+            judgeFile: 'states/understand/JUDGE.md',
+            skills: ['skills/research'],
+          }
+        : state,
+    ),
+  });
+  await fs.writeFile(path.join(tempDir, 'behavior.yaml'), manifest);
+  return tempDir!;
+}
+
+describe('behavior definitions', () => {
+  it('normalizes programmatic definitions into an immutable graph', () => {
+    const behavior = defineBehavior(input);
+    expect(Object.keys(behavior.states)).toEqual(['understand', 'test']);
+    expect(behavior.states.understand?.transitions[0]).toMatchObject({ id: 'test', judge: true, exit: false });
+    expect(Object.isFrozen(behavior.states.understand?.transitions)).toBe(true);
+  });
+
+  it('loads filesystem assets into the same graph semantics', async () => {
+    const root = await writeFixture();
+    const behavior = await loadBehaviorDirectory(root);
+    expect(behavior.states.understand).toMatchObject({
+      instructions: 'Understand the issue.',
+      judgeInstructions: 'Require a proven cause.',
+    });
+    expect(behavior.states.understand?.skills[0]).toBe(
+      await fs.realpath(path.join(root, 'states', 'understand', 'skills', 'research')),
+    );
+  });
+
+  it.each([
+    ['duplicate states', { ...input, states: [...input.states, input.states[0]!] }, 'duplicate state ID'],
+    ['missing target', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'bad', target: 'missing' }, { id: 'exit', target: 'exit', exit: true }] }] }, 'unknown state'],
+    ['missing exit', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'loop', target: 'understand' }] }] }, 'exit transition'],
+    ['bad schedule', { ...input, states: input.states.map(state => state.id === 'test' ? { ...state, periodic: { intervalMs: 0, transition: 'exit' } } : state) }, 'positive number'],
+  ])('rejects %s', (_name, definition, message) => {
+    expect(() => defineBehavior(definition as BehaviorDefinitionInput)).toThrow(message);
+  });
+
+  it('rejects unreachable states', () => {
+    const unreachable = { id: 'orphan', transitions: [{ id: 'exit', target: 'exit', exit: true }] };
+    expect(() => defineBehavior({ ...input, states: [...input.states, unreachable] })).toThrow('unreachable');
+  });
+
+  it('rejects traversal and symlink escape', async () => {
+    const root = await writeFixture();
+    const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'behavior-outside-'));
+    await fs.mkdir(path.join(root, 'states', 'understand', 'skills'), { recursive: true });
+    await fs.symlink(outside, path.join(root, 'states', 'understand', 'skills', 'outside'));
+    const manifest = JSON.parse(await fs.readFile(path.join(root, 'behavior.yaml'), 'utf8'));
+    manifest.states[0].skills = ['skills/outside'];
+    await fs.writeFile(path.join(root, 'behavior.yaml'), JSON.stringify(manifest));
+    await expect(loadBehaviorDirectory(root)).rejects.toBeInstanceOf(BehaviorDefinitionError);
+    await fs.rm(outside, { recursive: true, force: true });
+  });
+});

--- a/packages/behaviors/src/definition/definition.test.ts
+++ b/packages/behaviors/src/definition/definition.test.ts
@@ -19,14 +19,14 @@ const input: BehaviorDefinitionInput = {
       skills: [],
       transitions: [
         { id: 'test', target: 'test', guards: [{ id: 'cause-proven' }], judge: true },
-        { id: 'exit', target: 'exit', exit: true },
+        { id: 'refresh', target: 'understand' },
       ],
     },
     {
       id: 'test',
       instructions: 'Write a failing test.',
-      transitions: [{ id: 'exit', target: 'exit', exit: true }],
-      periodic: { intervalMs: 1000, transition: 'exit' },
+      transitions: [{ id: 'return', target: 'understand' }],
+      periodic: { intervalMs: 1000, transition: 'return' },
     },
   ],
   migrations: { investigate: 'understand' },
@@ -66,7 +66,7 @@ describe('behavior definitions', () => {
   it('normalizes programmatic definitions into an immutable graph', () => {
     const behavior = defineBehavior(input);
     expect(Object.keys(behavior.states)).toEqual(['understand', 'test']);
-    expect(behavior.states.understand?.transitions[0]).toMatchObject({ id: 'test', judge: true, exit: false });
+    expect(behavior.states.understand?.transitions[0]).toMatchObject({ id: 'test', target: 'test', judge: true });
     expect(Object.isFrozen(behavior.states.understand?.transitions)).toBe(true);
   });
 
@@ -84,16 +84,16 @@ describe('behavior definitions', () => {
 
   it.each([
     ['duplicate states', { ...input, states: [...input.states, input.states[0]!] }, 'duplicate state ID'],
-    ['missing target', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'bad', target: 'missing' }, { id: 'exit', target: 'exit', exit: true }] }] }, 'unknown state'],
-    ['missing exit', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'loop', target: 'understand' }] }] }, 'exit transition'],
-    ['bad schedule', { ...input, states: input.states.map(state => state.id === 'test' ? { ...state, periodic: { intervalMs: 0, transition: 'exit' } } : state) }, 'positive number'],
+    ['missing target', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'bad', target: 'missing' }] }] }, 'unknown state'],
+    ['duplicate target', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'first', target: 'test' }, { id: 'second', target: 'test' }] }] }, 'duplicate target behavior'],
+    ['bad schedule', { ...input, states: input.states.map(state => state.id === 'test' ? { ...state, periodic: { intervalMs: 0, transition: 'return' } } : state) }, 'positive number'],
     ['unsafe state ID', { ...input, initialState: '../outside', states: [{ ...input.states[0]!, id: '../outside' }] }, 'may contain only'],
   ])('rejects %s', (_name, definition, message) => {
     expect(() => defineBehavior(definition as BehaviorDefinitionInput)).toThrow(message);
   });
 
   it('rejects unreachable states', () => {
-    const unreachable = { id: 'orphan', transitions: [{ id: 'exit', target: 'exit', exit: true }] };
+    const unreachable = { id: 'orphan', transitions: [{ id: 'stay', target: 'orphan' }] };
     expect(() => defineBehavior({ ...input, states: [...input.states, unreachable] })).toThrow('unreachable');
   });
 

--- a/packages/behaviors/src/definition/definition.test.ts
+++ b/packages/behaviors/src/definition/definition.test.ts
@@ -87,6 +87,7 @@ describe('behavior definitions', () => {
     ['missing target', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'bad', target: 'missing' }, { id: 'exit', target: 'exit', exit: true }] }] }, 'unknown state'],
     ['missing exit', { ...input, states: [{ ...input.states[0]!, transitions: [{ id: 'loop', target: 'understand' }] }] }, 'exit transition'],
     ['bad schedule', { ...input, states: input.states.map(state => state.id === 'test' ? { ...state, periodic: { intervalMs: 0, transition: 'exit' } } : state) }, 'positive number'],
+    ['unsafe state ID', { ...input, initialState: '../outside', states: [{ ...input.states[0]!, id: '../outside' }] }, 'may contain only'],
   ])('rejects %s', (_name, definition, message) => {
     expect(() => defineBehavior(definition as BehaviorDefinitionInput)).toThrow(message);
   });

--- a/packages/behaviors/src/definition/definition.test.ts
+++ b/packages/behaviors/src/definition/definition.test.ts
@@ -97,6 +97,16 @@ describe('behavior definitions', () => {
     expect(() => defineBehavior({ ...input, states: [...input.states, unreachable] })).toThrow('unreachable');
   });
 
+  it('rejects filesystem state ID traversal before resolving assets', async () => {
+    const root = await writeFixture();
+    const manifest = JSON.parse(await fs.readFile(path.join(root, 'behavior.yaml'), 'utf8'));
+    manifest.initialState = '../../../outside';
+    manifest.states[0].id = '../../../outside';
+    manifest.states[0].skills = ['secret'];
+    await fs.writeFile(path.join(root, 'behavior.yaml'), JSON.stringify(manifest));
+    await expect(loadBehaviorDirectory(root)).rejects.toThrow('may contain only');
+  });
+
   it('rejects traversal and symlink escape', async () => {
     const root = await writeFixture();
     const outside = await fs.mkdtemp(path.join(os.tmpdir(), 'behavior-outside-'));

--- a/packages/behaviors/src/definition/loader.ts
+++ b/packages/behaviors/src/definition/loader.ts
@@ -1,0 +1,68 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { parse } from 'yaml';
+
+import { normalizeBehavior } from './normalize.js';
+import type { BehaviorDefinitionInput, BehaviorStateInput, NormalizedBehaviorDefinition } from './types.js';
+import { BehaviorDefinitionError } from './types.js';
+
+async function resolveInside(root: string, candidate: string, field: string): Promise<string> {
+  if (path.isAbsolute(candidate)) throw new BehaviorDefinitionError([{ path: field, message: 'absolute paths are not allowed' }]);
+  const resolved = path.resolve(root, candidate);
+  const relative = path.relative(root, resolved);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    throw new BehaviorDefinitionError([{ path: field, message: 'path escapes the behavior directory' }]);
+  }
+  const real = await fs.realpath(resolved);
+  const realRelative = path.relative(root, real);
+  if (realRelative.startsWith('..') || path.isAbsolute(realRelative)) {
+    throw new BehaviorDefinitionError([{ path: field, message: 'symlink escapes the behavior directory' }]);
+  }
+  return real;
+}
+
+async function readAsset(root: string, candidate: string | undefined, field: string): Promise<string | undefined> {
+  if (!candidate) return undefined;
+  return fs.readFile(await resolveInside(root, candidate, field), 'utf8');
+}
+
+function assertDefinition(value: unknown): asserts value is BehaviorDefinitionInput {
+  if (!value || typeof value !== 'object') {
+    throw new BehaviorDefinitionError([{ path: 'behavior.yaml', message: 'must contain an object' }]);
+  }
+  const candidate = value as Partial<BehaviorDefinitionInput>;
+  if (!Array.isArray(candidate.states)) {
+    throw new BehaviorDefinitionError([{ path: 'states', message: 'must be an array' }]);
+  }
+}
+
+export async function loadBehaviorDirectory(directory: string): Promise<NormalizedBehaviorDefinition> {
+  const root = await fs.realpath(directory);
+  const manifestPath = await resolveInside(root, 'behavior.yaml', 'behavior.yaml');
+  let parsed: unknown;
+  try {
+    parsed = parse(await fs.readFile(manifestPath, 'utf8'));
+  } catch (error) {
+    throw new BehaviorDefinitionError([{ path: 'behavior.yaml', message: `could not parse manifest: ${String(error)}` }]);
+  }
+  assertDefinition(parsed);
+
+  const states: BehaviorStateInput[] = await Promise.all(
+    parsed.states.map(async (state, index) => {
+      if (!state || typeof state !== 'object') {
+        throw new BehaviorDefinitionError([{ path: `states[${index}]`, message: 'must be an object' }]);
+      }
+      const item = state as BehaviorStateInput;
+      const stateRoot = item.id ? path.join(root, 'states', item.id) : root;
+      const instructions = item.instructions ?? (await readAsset(root, item.agentsFile, `states[${index}].agentsFile`));
+      const judgeInstructions =
+        item.judgeInstructions ?? (await readAsset(root, item.judgeFile, `states[${index}].judgeFile`));
+      const skills = await Promise.all(
+        (item.skills ?? []).map(skill => resolveInside(stateRoot, skill, `states[${index}].skills`)),
+      );
+      return { ...item, instructions, judgeInstructions, skills };
+    }),
+  );
+
+  return normalizeBehavior({ ...parsed, states }, root);
+}

--- a/packages/behaviors/src/definition/loader.ts
+++ b/packages/behaviors/src/definition/loader.ts
@@ -53,7 +53,12 @@ export async function loadBehaviorDirectory(directory: string): Promise<Normaliz
         throw new BehaviorDefinitionError([{ path: `states[${index}]`, message: 'must be an object' }]);
       }
       const item = state as BehaviorStateInput;
-      const stateRoot = item.id ? path.join(root, 'states', item.id) : root;
+      if (!item.id || !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(item.id)) {
+        throw new BehaviorDefinitionError([
+          { path: `states[${index}].id`, message: 'may contain only letters, numbers, dots, underscores, and hyphens' },
+        ]);
+      }
+      const stateRoot = path.join(root, 'states', item.id);
       const instructions = item.instructions ?? (await readAsset(root, item.agentsFile, `states[${index}].agentsFile`));
       const judgeInstructions =
         item.judgeInstructions ?? (await readAsset(root, item.judgeFile, `states[${index}].judgeFile`));

--- a/packages/behaviors/src/definition/normalize.ts
+++ b/packages/behaviors/src/definition/normalize.ts
@@ -1,0 +1,116 @@
+import type {
+  BehaviorDefinitionInput,
+  BehaviorDiagnostic,
+  NormalizedBehaviorDefinition,
+  NormalizedBehaviorState,
+} from './types.js';
+import { BehaviorDefinitionError } from './types.js';
+
+function deepFreeze<T>(value: T): T {
+  if (value && typeof value === 'object' && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const child of Object.values(value)) deepFreeze(child);
+  }
+  return value;
+}
+
+export function defineBehavior(input: BehaviorDefinitionInput): NormalizedBehaviorDefinition {
+  return normalizeBehavior(input);
+}
+
+export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string): NormalizedBehaviorDefinition {
+  const diagnostics: BehaviorDiagnostic[] = [];
+  if (!input.id?.trim()) diagnostics.push({ path: 'id', message: 'must be a non-empty string' });
+  if (!input.version?.trim()) diagnostics.push({ path: 'version', message: 'must be a non-empty string' });
+  if (!Array.isArray(input.states) || input.states.length === 0) {
+    diagnostics.push({ path: 'states', message: 'must contain at least one state' });
+  }
+
+  const states: Record<string, NormalizedBehaviorState> = {};
+  for (const [stateIndex, state] of (input.states ?? []).entries()) {
+    const statePath = `states[${stateIndex}]`;
+    if (!state.id?.trim()) {
+      diagnostics.push({ path: `${statePath}.id`, message: 'must be a non-empty string' });
+      continue;
+    }
+    if (states[state.id]) {
+      diagnostics.push({ path: `${statePath}.id`, message: `duplicate state ID "${state.id}"` });
+      continue;
+    }
+    const transitionIds = new Set<string>();
+    for (const [transitionIndex, transition] of (state.transitions ?? []).entries()) {
+      const transitionPath = `${statePath}.transitions[${transitionIndex}]`;
+      if (!transition.id?.trim()) diagnostics.push({ path: `${transitionPath}.id`, message: 'must be non-empty' });
+      if (transitionIds.has(transition.id)) {
+        diagnostics.push({ path: `${transitionPath}.id`, message: `duplicate transition ID "${transition.id}"` });
+      }
+      transitionIds.add(transition.id);
+      if (transition.guards) {
+        const guards = new Set<string>();
+        for (const guard of transition.guards) {
+          if (guards.has(guard.id)) diagnostics.push({ path: `${transitionPath}.guards`, message: `duplicate guard ID "${guard.id}"` });
+          guards.add(guard.id);
+        }
+      }
+    }
+    states[state.id] = {
+      id: state.id,
+      description: state.description,
+      instructions: state.instructions,
+      judgeInstructions: state.judgeInstructions,
+      skills: [...(state.skills ?? [])],
+      tools: [...(state.tools ?? [])],
+      model: state.model,
+      judgeModel: state.judgeModel,
+      periodic: state.periodic ? { ...state.periodic } : undefined,
+      transitions: (state.transitions ?? []).map(transition => ({
+        ...transition,
+        guards: [...(transition.guards ?? [])],
+        judge: transition.judge ?? false,
+        exit: transition.exit ?? false,
+      })),
+    };
+  }
+
+  if (!states[input.initialState]) diagnostics.push({ path: 'initialState', message: `unknown state "${input.initialState}"` });
+  for (const state of Object.values(states)) {
+    if (!state.transitions.some(transition => transition.exit)) {
+      diagnostics.push({ path: `states.${state.id}.transitions`, message: 'must include an exit transition' });
+    }
+    if (state.periodic) {
+      if (!Number.isFinite(state.periodic.intervalMs) || state.periodic.intervalMs <= 0) {
+        diagnostics.push({ path: `states.${state.id}.periodic.intervalMs`, message: 'must be a positive number' });
+      }
+      if (!state.transitions.some(transition => transition.id === state.periodic?.transition)) {
+        diagnostics.push({ path: `states.${state.id}.periodic.transition`, message: 'must reference a transition in this state' });
+      }
+    }
+    for (const transition of state.transitions) {
+      if (!transition.exit && !states[transition.target]) {
+        diagnostics.push({ path: `states.${state.id}.transitions.${transition.id}.target`, message: `unknown state "${transition.target}"` });
+      }
+    }
+  }
+
+  if (states[input.initialState]) {
+    const reachable = new Set<string>();
+    const pending = [input.initialState];
+    while (pending.length) {
+      const id = pending.pop()!;
+      if (reachable.has(id)) continue;
+      reachable.add(id);
+      for (const transition of states[id]?.transitions ?? []) if (!transition.exit) pending.push(transition.target);
+    }
+    for (const id of Object.keys(states)) {
+      if (!reachable.has(id)) diagnostics.push({ path: `states.${id}`, message: 'state is unreachable from initialState' });
+    }
+  }
+
+  for (const [from, to] of Object.entries(input.migrations ?? {})) {
+    if (!from.trim()) diagnostics.push({ path: 'migrations', message: 'migration source must be non-empty' });
+    if (!states[to]) diagnostics.push({ path: `migrations.${from}`, message: `unknown target state "${to}"` });
+  }
+
+  if (diagnostics.length) throw new BehaviorDefinitionError(diagnostics);
+  return deepFreeze({ id: input.id, version: input.version, root, initialState: input.initialState, states, migrations: { ...(input.migrations ?? {}) } });
+}

--- a/packages/behaviors/src/definition/normalize.ts
+++ b/packages/behaviors/src/definition/normalize.ts
@@ -43,6 +43,7 @@ export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string)
       continue;
     }
     const transitionIds = new Set<string>();
+    const transitionTargets = new Set<string>();
     for (const [transitionIndex, transition] of (state.transitions ?? []).entries()) {
       const transitionPath = `${statePath}.transitions[${transitionIndex}]`;
       if (!transition.id?.trim()) diagnostics.push({ path: `${transitionPath}.id`, message: 'must be non-empty' });
@@ -50,6 +51,10 @@ export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string)
         diagnostics.push({ path: `${transitionPath}.id`, message: `duplicate transition ID "${transition.id}"` });
       }
       transitionIds.add(transition.id);
+      if (transitionTargets.has(transition.target)) {
+        diagnostics.push({ path: `${transitionPath}.target`, message: `duplicate target behavior "${transition.target}"` });
+      }
+      transitionTargets.add(transition.target);
       if (transition.guards) {
         const guards = new Set<string>();
         for (const guard of transition.guards) {
@@ -72,16 +77,12 @@ export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string)
         ...transition,
         guards: [...(transition.guards ?? [])],
         judge: transition.judge ?? false,
-        exit: transition.exit ?? false,
       })),
     };
   }
 
   if (!states[input.initialState]) diagnostics.push({ path: 'initialState', message: `unknown state "${input.initialState}"` });
   for (const state of Object.values(states)) {
-    if (!state.transitions.some(transition => transition.exit)) {
-      diagnostics.push({ path: `states.${state.id}.transitions`, message: 'must include an exit transition' });
-    }
     if (state.periodic) {
       if (!Number.isFinite(state.periodic.intervalMs) || state.periodic.intervalMs <= 0) {
         diagnostics.push({ path: `states.${state.id}.periodic.intervalMs`, message: 'must be a positive number' });
@@ -91,7 +92,7 @@ export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string)
       }
     }
     for (const transition of state.transitions) {
-      if (!transition.exit && !states[transition.target]) {
+      if (!states[transition.target]) {
         diagnostics.push({ path: `states.${state.id}.transitions.${transition.id}.target`, message: `unknown state "${transition.target}"` });
       }
     }
@@ -104,7 +105,7 @@ export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string)
       const id = pending.pop()!;
       if (reachable.has(id)) continue;
       reachable.add(id);
-      for (const transition of states[id]?.transitions ?? []) if (!transition.exit) pending.push(transition.target);
+      for (const transition of states[id]?.transitions ?? []) pending.push(transition.target);
     }
     for (const id of Object.keys(states)) {
       if (!reachable.has(id)) diagnostics.push({ path: `states.${id}`, message: 'state is unreachable from initialState' });

--- a/packages/behaviors/src/definition/normalize.ts
+++ b/packages/behaviors/src/definition/normalize.ts
@@ -21,6 +21,7 @@ export function defineBehavior(input: BehaviorDefinitionInput): NormalizedBehavi
 export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string): NormalizedBehaviorDefinition {
   const diagnostics: BehaviorDiagnostic[] = [];
   if (!input.id?.trim()) diagnostics.push({ path: 'id', message: 'must be a non-empty string' });
+  else if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(input.id)) diagnostics.push({ path: 'id', message: 'may contain only letters, numbers, dots, underscores, and hyphens' });
   if (!input.version?.trim()) diagnostics.push({ path: 'version', message: 'must be a non-empty string' });
   if (!Array.isArray(input.states) || input.states.length === 0) {
     diagnostics.push({ path: 'states', message: 'must contain at least one state' });
@@ -31,6 +32,10 @@ export function normalizeBehavior(input: BehaviorDefinitionInput, root?: string)
     const statePath = `states[${stateIndex}]`;
     if (!state.id?.trim()) {
       diagnostics.push({ path: `${statePath}.id`, message: 'must be a non-empty string' });
+      continue;
+    }
+    if (!/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(state.id)) {
+      diagnostics.push({ path: `${statePath}.id`, message: 'may contain only letters, numbers, dots, underscores, and hyphens' });
       continue;
     }
     if (states[state.id]) {

--- a/packages/behaviors/src/definition/types.ts
+++ b/packages/behaviors/src/definition/types.ts
@@ -1,0 +1,73 @@
+export type BehaviorGuard = { id: string; description?: string };
+
+export type BehaviorTransitionInput = {
+  id: string;
+  target: string;
+  description?: string;
+  guards?: BehaviorGuard[];
+  judge?: boolean;
+  exit?: boolean;
+};
+
+export type BehaviorStateInput = {
+  id: string;
+  description?: string;
+  instructions?: string;
+  judgeInstructions?: string;
+  agentsFile?: string;
+  judgeFile?: string;
+  skills?: string[];
+  tools?: string[];
+  model?: string;
+  judgeModel?: string;
+  transitions: BehaviorTransitionInput[];
+  periodic?: { intervalMs: number; transition: string };
+};
+
+export type BehaviorDefinitionInput = {
+  id: string;
+  version: string;
+  initialState: string;
+  states: BehaviorStateInput[];
+  migrations?: Record<string, string>;
+};
+
+export type NormalizedBehaviorTransition = Readonly<{
+  id: string;
+  target: string;
+  description?: string;
+  guards: readonly Readonly<BehaviorGuard>[];
+  judge: boolean;
+  exit: boolean;
+}>;
+
+export type NormalizedBehaviorState = Readonly<{
+  id: string;
+  description?: string;
+  instructions?: string;
+  judgeInstructions?: string;
+  skills: readonly string[];
+  tools: readonly string[];
+  model?: string;
+  judgeModel?: string;
+  transitions: readonly NormalizedBehaviorTransition[];
+  periodic?: Readonly<{ intervalMs: number; transition: string }>;
+}>;
+
+export type NormalizedBehaviorDefinition = Readonly<{
+  id: string;
+  version: string;
+  root?: string;
+  initialState: string;
+  states: Readonly<Record<string, NormalizedBehaviorState>>;
+  migrations: Readonly<Record<string, string>>;
+}>;
+
+export type BehaviorDiagnostic = { path: string; message: string };
+
+export class BehaviorDefinitionError extends Error {
+  constructor(readonly diagnostics: BehaviorDiagnostic[]) {
+    super(diagnostics.map(item => `${item.path}: ${item.message}`).join('\n'));
+    this.name = 'BehaviorDefinitionError';
+  }
+}

--- a/packages/behaviors/src/definition/types.ts
+++ b/packages/behaviors/src/definition/types.ts
@@ -6,7 +6,6 @@ export type BehaviorTransitionInput = {
   description?: string;
   guards?: BehaviorGuard[];
   judge?: boolean;
-  exit?: boolean;
 };
 
 export type BehaviorStateInput = {
@@ -38,7 +37,6 @@ export type NormalizedBehaviorTransition = Readonly<{
   description?: string;
   guards: readonly Readonly<BehaviorGuard>[];
   judge: boolean;
-  exit: boolean;
 }>;
 
 export type NormalizedBehaviorState = Readonly<{

--- a/packages/behaviors/src/index.ts
+++ b/packages/behaviors/src/index.ts
@@ -1,0 +1,13 @@
+export { defineBehavior, normalizeBehavior } from './definition/normalize.js';
+export { loadBehaviorDirectory } from './definition/loader.js';
+export { BehaviorDefinitionError } from './definition/types.js';
+export type {
+  BehaviorDefinitionInput,
+  BehaviorDiagnostic,
+  BehaviorGuard,
+  BehaviorStateInput,
+  BehaviorTransitionInput,
+  NormalizedBehaviorDefinition,
+  NormalizedBehaviorState,
+  NormalizedBehaviorTransition,
+} from './definition/types.js';

--- a/packages/behaviors/src/index.ts
+++ b/packages/behaviors/src/index.ts
@@ -11,3 +11,26 @@ export type {
   NormalizedBehaviorState,
   NormalizedBehaviorTransition,
 } from './definition/types.js';
+export { InMemoryBehaviorRuntimeStore } from './runtime/in-memory-store.js';
+export { LibSQLBehaviorRuntimeStore } from './runtime/libsql-store.js';
+export { BehaviorSignalProvider } from './runtime/provider.js';
+export type { BehaviorSignalProviderOptions } from './runtime/provider.js';
+export { BehaviorStateProcessor } from './runtime/state-processor.js';
+export {
+  behaviorThreadStateType,
+  BehaviorTransitionEngine,
+  BehaviorTransitionError,
+} from './runtime/transition-engine.js';
+export type { BehaviorTransitionEngineOptions } from './runtime/transition-engine.js';
+export type {
+  BehaviorDueWork,
+  BehaviorGuardEvaluator,
+  BehaviorRuntimeRecord,
+  BehaviorRuntimeStore,
+  BehaviorStatus,
+  BehaviorThreadKey,
+  BehaviorThreadStateMirror,
+  BehaviorTransactionResult,
+  BehaviorTransitionJudge,
+  BehaviorTransitionRecord,
+} from './runtime/types.js';

--- a/packages/behaviors/src/runtime/in-memory-store.ts
+++ b/packages/behaviors/src/runtime/in-memory-store.ts
@@ -1,0 +1,52 @@
+import type {
+  BehaviorDueWork,
+  BehaviorRuntimeRecord,
+  BehaviorRuntimeStore,
+  BehaviorThreadKey,
+  BehaviorTransactionResult,
+} from './types.js';
+
+const clone = <T>(value: T): T => structuredClone(value);
+const keyOf = ({ threadId, behaviorId }: BehaviorThreadKey) => `${threadId}\0${behaviorId}`;
+
+export class InMemoryBehaviorRuntimeStore implements BehaviorRuntimeStore {
+  private readonly records = new Map<string, BehaviorRuntimeRecord>();
+  private readonly tails = new Map<string, Promise<void>>();
+
+  async init(): Promise<void> {}
+
+  async readThread(key: BehaviorThreadKey): Promise<BehaviorRuntimeRecord | undefined> {
+    const value = this.records.get(keyOf(key));
+    return value ? clone(value) : undefined;
+  }
+
+  async transactThread<T>(
+    key: BehaviorThreadKey,
+    operation: (current: BehaviorRuntimeRecord | undefined) => Promise<BehaviorTransactionResult<T>> | BehaviorTransactionResult<T>,
+  ): Promise<{ runtime: BehaviorRuntimeRecord; result: T }> {
+    const storageKey = keyOf(key);
+    const prior = this.tails.get(storageKey) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const queued = prior.then(() => gate);
+    this.tails.set(storageKey, queued);
+    await prior;
+    try {
+      const current = this.records.get(storageKey);
+      const { next, result } = await operation(current ? clone(current) : undefined);
+      this.records.set(storageKey, clone(next));
+      return { runtime: clone(next), result };
+    } finally {
+      release();
+      if (this.tails.get(storageKey) === queued) this.tails.delete(storageKey);
+    }
+  }
+
+  async listDue(before: Date, limit = 100): Promise<BehaviorDueWork[]> {
+    return [...this.records.values()]
+      .filter(record => record.status === 'active' && record.nextCheckAt && record.nextCheckAt <= before.toISOString())
+      .sort((a, b) => a.nextCheckAt!.localeCompare(b.nextCheckAt!))
+      .slice(0, limit)
+      .map(record => ({ threadId: record.threadId, behaviorId: record.behaviorId, dueAt: record.nextCheckAt! }));
+  }
+}

--- a/packages/behaviors/src/runtime/libsql-store.ts
+++ b/packages/behaviors/src/runtime/libsql-store.ts
@@ -59,28 +59,35 @@ export class LibSQLBehaviorRuntimeStore implements BehaviorRuntimeStore {
     key: BehaviorThreadKey,
     operation: (current: BehaviorRuntimeRecord | undefined) => Promise<BehaviorTransactionResult<T>> | BehaviorTransactionResult<T>,
   ): Promise<{ runtime: BehaviorRuntimeRecord; result: T }> {
-    const tx = await this.client.transaction('write');
-    try {
-      const selected = await tx.execute({
-        sql: `SELECT value FROM ${TABLE} WHERE thread_id = ? AND behavior_id = ?`,
+    for (let attempt = 0; attempt < 50; attempt++) {
+      const selected = await this.client.execute({
+        sql: `SELECT revision, value FROM ${TABLE} WHERE thread_id = ? AND behavior_id = ?`,
         args: [key.threadId, key.behaviorId],
       });
-      const value = selected.rows[0]?.value;
-      const current = typeof value === 'string' ? (JSON.parse(value) as BehaviorRuntimeRecord) : undefined;
+      const row = selected.rows[0];
+      const current = typeof row?.value === 'string' ? (JSON.parse(row.value) as BehaviorRuntimeRecord) : undefined;
       const { next, result } = await operation(current);
-      await tx.execute({
-        sql: `INSERT INTO ${TABLE} (thread_id, behavior_id, revision, next_check_at, value)
-          VALUES (?, ?, ?, ?, ?)
-          ON CONFLICT(thread_id, behavior_id) DO UPDATE SET
-            revision = excluded.revision, next_check_at = excluded.next_check_at, value = excluded.value`,
-        args: [key.threadId, key.behaviorId, next.revision, next.nextCheckAt ?? null, JSON.stringify(next)],
-      });
-      await tx.commit();
-      return { runtime: structuredClone(next), result };
-    } catch (error) {
-      if (!tx.closed) await tx.rollback();
-      throw error;
+      const write = current
+        ? await this.client.execute({
+            sql: `UPDATE ${TABLE} SET revision = ?, next_check_at = ?, value = ?
+              WHERE thread_id = ? AND behavior_id = ? AND revision = ?`,
+            args: [
+              next.revision,
+              next.nextCheckAt ?? null,
+              JSON.stringify(next),
+              key.threadId,
+              key.behaviorId,
+              current.revision,
+            ],
+          })
+        : await this.client.execute({
+            sql: `INSERT OR IGNORE INTO ${TABLE} (thread_id, behavior_id, revision, next_check_at, value)
+              VALUES (?, ?, ?, ?, ?)`,
+            args: [key.threadId, key.behaviorId, next.revision, next.nextCheckAt ?? null, JSON.stringify(next)],
+          });
+      if ((write.rowsAffected ?? 0) > 0) return { runtime: structuredClone(next), result };
     }
+    throw new Error(`Behavior transaction contention exceeded for ${key.behaviorId}/${key.threadId}`);
   }
 
   async listDue(before: Date, limit = 100): Promise<BehaviorDueWork[]> {

--- a/packages/behaviors/src/runtime/libsql-store.ts
+++ b/packages/behaviors/src/runtime/libsql-store.ts
@@ -1,0 +1,98 @@
+import type { Client } from '@libsql/client';
+
+import type {
+  BehaviorDueWork,
+  BehaviorRuntimeRecord,
+  BehaviorRuntimeStore,
+  BehaviorThreadKey,
+  BehaviorTransactionResult,
+} from './types.js';
+
+const TABLE = 'mastra_behavior_runtime';
+
+export class LibSQLBehaviorRuntimeStore implements BehaviorRuntimeStore {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  constructor(private readonly client: Client) {}
+
+  async init(): Promise<void> {
+    await this.client.execute(`CREATE TABLE IF NOT EXISTS ${TABLE} (
+      thread_id TEXT NOT NULL,
+      behavior_id TEXT NOT NULL,
+      revision INTEGER NOT NULL,
+      next_check_at TEXT,
+      value TEXT NOT NULL,
+      PRIMARY KEY (thread_id, behavior_id)
+    )`);
+    await this.client.execute(`CREATE INDEX IF NOT EXISTS idx_${TABLE}_due ON ${TABLE} (next_check_at)`);
+  }
+
+  async readThread(key: BehaviorThreadKey): Promise<BehaviorRuntimeRecord | undefined> {
+    const result = await this.client.execute({
+      sql: `SELECT value FROM ${TABLE} WHERE thread_id = ? AND behavior_id = ?`,
+      args: [key.threadId, key.behaviorId],
+    });
+    const value = result.rows[0]?.value;
+    return typeof value === 'string' ? (JSON.parse(value) as BehaviorRuntimeRecord) : undefined;
+  }
+
+  async transactThread<T>(
+    key: BehaviorThreadKey,
+    operation: (current: BehaviorRuntimeRecord | undefined) => Promise<BehaviorTransactionResult<T>> | BehaviorTransactionResult<T>,
+  ): Promise<{ runtime: BehaviorRuntimeRecord; result: T }> {
+    const storageKey = `${key.threadId}\0${key.behaviorId}`;
+    const prior = this.tails.get(storageKey) ?? Promise.resolve();
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const queued = prior.then(() => gate);
+    this.tails.set(storageKey, queued);
+    await prior;
+    try {
+      return await this.transactUnlocked(key, operation);
+    } finally {
+      release();
+      if (this.tails.get(storageKey) === queued) this.tails.delete(storageKey);
+    }
+  }
+
+  private async transactUnlocked<T>(
+    key: BehaviorThreadKey,
+    operation: (current: BehaviorRuntimeRecord | undefined) => Promise<BehaviorTransactionResult<T>> | BehaviorTransactionResult<T>,
+  ): Promise<{ runtime: BehaviorRuntimeRecord; result: T }> {
+    const tx = await this.client.transaction('write');
+    try {
+      const selected = await tx.execute({
+        sql: `SELECT value FROM ${TABLE} WHERE thread_id = ? AND behavior_id = ?`,
+        args: [key.threadId, key.behaviorId],
+      });
+      const value = selected.rows[0]?.value;
+      const current = typeof value === 'string' ? (JSON.parse(value) as BehaviorRuntimeRecord) : undefined;
+      const { next, result } = await operation(current);
+      await tx.execute({
+        sql: `INSERT INTO ${TABLE} (thread_id, behavior_id, revision, next_check_at, value)
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(thread_id, behavior_id) DO UPDATE SET
+            revision = excluded.revision, next_check_at = excluded.next_check_at, value = excluded.value`,
+        args: [key.threadId, key.behaviorId, next.revision, next.nextCheckAt ?? null, JSON.stringify(next)],
+      });
+      await tx.commit();
+      return { runtime: structuredClone(next), result };
+    } catch (error) {
+      if (!tx.closed) await tx.rollback();
+      throw error;
+    }
+  }
+
+  async listDue(before: Date, limit = 100): Promise<BehaviorDueWork[]> {
+    const result = await this.client.execute({
+      sql: `SELECT thread_id, behavior_id, next_check_at FROM ${TABLE}
+        WHERE next_check_at IS NOT NULL AND next_check_at <= ? ORDER BY next_check_at LIMIT ?`,
+      args: [before.toISOString(), limit],
+    });
+    return result.rows.map(row => ({
+      threadId: String(row.thread_id),
+      behaviorId: String(row.behavior_id),
+      dueAt: String(row.next_check_at),
+    }));
+  }
+}

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -1,0 +1,32 @@
+import { SignalProvider } from '@mastra/core/signals';
+
+import type { NormalizedBehaviorDefinition } from '../definition/types.js';
+import { BehaviorStateProcessor } from './state-processor.js';
+import { BehaviorTransitionEngine, type BehaviorTransitionEngineOptions } from './transition-engine.js';
+import type { BehaviorRuntimeStore } from './types.js';
+
+export type BehaviorSignalProviderOptions = Omit<BehaviorTransitionEngineOptions, 'definition' | 'store'> & {
+  definition: NormalizedBehaviorDefinition;
+  store: BehaviorRuntimeStore;
+};
+
+export class BehaviorSignalProvider extends SignalProvider<string> {
+  readonly id: string;
+  readonly engine: BehaviorTransitionEngine;
+  private readonly stateProcessor: BehaviorStateProcessor;
+
+  constructor(readonly options: BehaviorSignalProviderOptions) {
+    super();
+    this.id = `behavior-${options.definition.id}`;
+    this.engine = new BehaviorTransitionEngine(options);
+    this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store);
+  }
+
+  async start(): Promise<void> {
+    await this.options.store.init();
+  }
+
+  getInputProcessors() {
+    return [this.stateProcessor];
+  }
+}

--- a/packages/behaviors/src/runtime/runtime.test.ts
+++ b/packages/behaviors/src/runtime/runtime.test.ts
@@ -20,10 +20,10 @@ const definition = defineBehavior({
       judgeInstructions: 'Secret judge instructions',
       transitions: [
         { id: 'test', target: 'test', guards: [{ id: 'ready' }], judge: true },
-        { id: 'exit', target: 'exit', exit: true },
+        { id: 'refresh', target: 'understand' },
       ],
     },
-    { id: 'test', transitions: [{ id: 'exit', target: 'exit', exit: true }] },
+    { id: 'test', transitions: [{ id: 'return', target: 'understand' }] },
   ],
   migrations: { investigate: 'understand' },
 });
@@ -88,8 +88,7 @@ describe('BehaviorTransitionEngine', () => {
       guards: { ready: () => { order.push('guard'); return true; } },
       judge: async input => { order.push('judge'); expect(input.judgeInstructions).toBe('Secret judge instructions'); return { approved: true }; },
     });
-    await engine.initialize('thread');
-    const result = await engine.transition({ threadId: 'thread', transitionId: 'test', attemptId: 'attempt' });
+    const result = await engine.transition({ threadId: 'thread', name: 'test', idempotencyKey: 'attempt' });
     expect(order).toEqual(['guard', 'judge']);
     expect(result).toMatchObject({ activeState: 'test', revision: 2 });
     expect(mirror.setState).toHaveBeenLastCalledWith(expect.objectContaining({ type: '@mastra/behaviors:debug' }));
@@ -106,9 +105,9 @@ describe('BehaviorTransitionEngine', () => {
       judge: async () => { await pending; return { approved: true }; },
     });
     await engine.initialize('thread');
-    const judged = engine.transition({ threadId: 'thread', transitionId: 'test', attemptId: 'judged' });
+    const judged = engine.transition({ threadId: 'thread', name: 'test', idempotencyKey: 'judged' });
     await Promise.resolve();
-    await engine.transition({ threadId: 'thread', transitionId: 'exit', attemptId: 'exit' });
+    await engine.transition({ threadId: 'thread', name: 'understand', idempotencyKey: 'refresh' });
     release();
     await expect(judged).rejects.toThrow('Stale transition result');
   });
@@ -116,8 +115,7 @@ describe('BehaviorTransitionEngine', () => {
   it('fails closed before judging when a guard rejects', async () => {
     const judge = vi.fn();
     const engine = new BehaviorTransitionEngine({ definition, store: new InMemoryBehaviorRuntimeStore(), guards: { ready: () => false }, judge });
-    await engine.initialize('thread');
-    await expect(engine.transition({ threadId: 'thread', transitionId: 'test', attemptId: 'bad' })).rejects.toThrow('Guard');
+    await expect(engine.transition({ threadId: 'thread', name: 'test' })).rejects.toThrow('Guard');
     expect(judge).not.toHaveBeenCalled();
   });
 

--- a/packages/behaviors/src/runtime/runtime.test.ts
+++ b/packages/behaviors/src/runtime/runtime.test.ts
@@ -143,6 +143,17 @@ describe('BehaviorStateProcessor', () => {
     const signal = await processor.computeStateSignal(args);
     expect(signal?.contents).toContain('Actor instructions');
     expect(signal?.contents).not.toContain('Secret judge instructions');
-    expect(await processor.computeStateSignal({ ...args, contextWindow: { hasSnapshot: true }, lastSnapshot: { metadata: { state: { cacheKey: signal?.cacheKey }, record: { revision: 1, status: 'active' } } } } as any)).toBeUndefined();
+    const activeWindow = {
+      ...args,
+      contextWindow: { hasSnapshot: true },
+      lastSnapshot: { metadata: { state: { cacheKey: signal?.cacheKey }, record: { revision: 1, status: 'active' } } },
+    } as any;
+    expect(await processor.computeStateSignal(activeWindow)).toBeUndefined();
+
+    await store.transactThread({ threadId: 'thread', behaviorId: definition.id }, current => ({
+      next: { ...current!, revision: current!.revision + 1 },
+      result: undefined,
+    }));
+    expect(await processor.computeStateSignal(activeWindow)).toBeUndefined();
   });
 });

--- a/packages/behaviors/src/runtime/runtime.test.ts
+++ b/packages/behaviors/src/runtime/runtime.test.ts
@@ -51,6 +51,31 @@ describe.each([
   });
 });
 
+it('serializes LibSQL transactions across store instances', async () => {
+  const url = `file:${path.join(os.tmpdir(), `behavior-shared-${crypto.randomUUID()}.db`)}`;
+  const firstClient = createClient({ url });
+  const secondClient = createClient({ url });
+  const first = new LibSQLBehaviorRuntimeStore(firstClient);
+  const second = new LibSQLBehaviorRuntimeStore(secondClient);
+  await first.init();
+  const key = { threadId: 'thread', behaviorId: 'shared' };
+  const initial = {
+    threadId: 'thread', behaviorId: 'shared', definitionVersion: '1', revision: 0, status: 'active' as const,
+    activeState: 'state', enteredAt: '', transitionHistory: [], conditionState: {}, checkpoints: {}, judgeResults: {}, audit: {},
+  };
+  await first.transactThread(key, () => ({ next: initial, result: undefined }));
+  await Promise.all([
+    first.transactThread(key, async current => {
+      await new Promise(resolve => setTimeout(resolve, 20));
+      return { next: { ...current!, revision: current!.revision + 1 }, result: undefined };
+    }),
+    second.transactThread(key, current => ({ next: { ...current!, revision: current!.revision + 1 }, result: undefined })),
+  ]);
+  expect((await first.readThread(key))?.revision).toBe(2);
+  firstClient.close();
+  secondClient.close();
+});
+
 describe('BehaviorTransitionEngine', () => {
   it('runs guards before judges, commits atomically, and mirrors committed state', async () => {
     const order: string[] = [];

--- a/packages/behaviors/src/runtime/runtime.test.ts
+++ b/packages/behaviors/src/runtime/runtime.test.ts
@@ -1,0 +1,123 @@
+import os from 'node:os';
+import path from 'node:path';
+import { createClient } from '@libsql/client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { defineBehavior } from '../definition/normalize.js';
+import { InMemoryBehaviorRuntimeStore } from './in-memory-store.js';
+import { LibSQLBehaviorRuntimeStore } from './libsql-store.js';
+import { BehaviorStateProcessor } from './state-processor.js';
+import { BehaviorTransitionEngine } from './transition-engine.js';
+
+const definition = defineBehavior({
+  id: 'debug',
+  version: '2',
+  initialState: 'understand',
+  states: [
+    {
+      id: 'understand',
+      instructions: 'Actor instructions',
+      judgeInstructions: 'Secret judge instructions',
+      transitions: [
+        { id: 'test', target: 'test', guards: [{ id: 'ready' }], judge: true },
+        { id: 'exit', target: 'exit', exit: true },
+      ],
+    },
+    { id: 'test', transitions: [{ id: 'exit', target: 'exit', exit: true }] },
+  ],
+  migrations: { investigate: 'understand' },
+});
+
+describe.each([
+  ['memory', () => new InMemoryBehaviorRuntimeStore()],
+  ['libsql', () => new LibSQLBehaviorRuntimeStore(createClient({ url: `file:${path.join(os.tmpdir(), `behavior-${crypto.randomUUID()}.db`)}` }))],
+])('%s behavior runtime store', (_name, createStore) => {
+  it('serializes concurrent transactions and enumerates due work', async () => {
+    const store = createStore();
+    await store.init();
+    const key = { threadId: 'thread', behaviorId: 'debug' };
+    const base = {
+      threadId: 'thread', behaviorId: 'debug', definitionVersion: '1', revision: 0, status: 'active' as const,
+      activeState: 'understand', enteredAt: '2026-01-01T00:00:00.000Z', transitionHistory: [], conditionState: {},
+      checkpoints: {}, judgeResults: {}, audit: {}, nextCheckAt: '2026-01-02T00:00:00.000Z',
+    };
+    await store.transactThread(key, () => ({ next: base, result: undefined }));
+    await Promise.all([
+      store.transactThread(key, current => ({ next: { ...current!, revision: current!.revision + 1 }, result: undefined })),
+      store.transactThread(key, current => ({ next: { ...current!, revision: current!.revision + 1 }, result: undefined })),
+    ]);
+    expect((await store.readThread(key))?.revision).toBe(2);
+    expect(await store.listDue(new Date('2026-01-03T00:00:00.000Z'))).toHaveLength(1);
+  });
+});
+
+describe('BehaviorTransitionEngine', () => {
+  it('runs guards before judges, commits atomically, and mirrors committed state', async () => {
+    const order: string[] = [];
+    const mirror = { setState: vi.fn() };
+    const store = new InMemoryBehaviorRuntimeStore();
+    const engine = new BehaviorTransitionEngine({
+      definition,
+      store,
+      mirror,
+      guards: { ready: () => { order.push('guard'); return true; } },
+      judge: async input => { order.push('judge'); expect(input.judgeInstructions).toBe('Secret judge instructions'); return { approved: true }; },
+    });
+    await engine.initialize('thread');
+    const result = await engine.transition({ threadId: 'thread', transitionId: 'test', attemptId: 'attempt' });
+    expect(order).toEqual(['guard', 'judge']);
+    expect(result).toMatchObject({ activeState: 'test', revision: 2 });
+    expect(mirror.setState).toHaveBeenLastCalledWith(expect.objectContaining({ type: '@mastra/behaviors:debug' }));
+  });
+
+  it('rejects stale judge results after a concurrent transition', async () => {
+    const store = new InMemoryBehaviorRuntimeStore();
+    let release!: () => void;
+    const pending = new Promise<void>(resolve => (release = resolve));
+    const engine = new BehaviorTransitionEngine({
+      definition,
+      store,
+      guards: { ready: () => true },
+      judge: async () => { await pending; return { approved: true }; },
+    });
+    await engine.initialize('thread');
+    const judged = engine.transition({ threadId: 'thread', transitionId: 'test', attemptId: 'judged' });
+    await Promise.resolve();
+    await engine.transition({ threadId: 'thread', transitionId: 'exit', attemptId: 'exit' });
+    release();
+    await expect(judged).rejects.toThrow('Stale transition result');
+  });
+
+  it('fails closed before judging when a guard rejects', async () => {
+    const judge = vi.fn();
+    const engine = new BehaviorTransitionEngine({ definition, store: new InMemoryBehaviorRuntimeStore(), guards: { ready: () => false }, judge });
+    await engine.initialize('thread');
+    await expect(engine.transition({ threadId: 'thread', transitionId: 'test', attemptId: 'bad' })).rejects.toThrow('Guard');
+    expect(judge).not.toHaveBeenCalled();
+  });
+
+  it('migrates mapped states and pauses removed states', async () => {
+    const store = new InMemoryBehaviorRuntimeStore();
+    const old = { threadId: 'thread', behaviorId: 'debug', definitionVersion: '1', revision: 1, status: 'active' as const, activeState: 'investigate', enteredAt: '', transitionHistory: [], conditionState: {}, checkpoints: {}, judgeResults: {}, audit: {} };
+    await store.transactThread({ threadId: 'thread', behaviorId: 'debug' }, () => ({ next: old, result: undefined }));
+    const engine = new BehaviorTransitionEngine({ definition, store });
+    expect((await engine.initialize('thread')).activeState).toBe('understand');
+
+    await store.transactThread({ threadId: 'other', behaviorId: 'debug' }, () => ({ next: { ...old, threadId: 'other', activeState: 'removed' }, result: undefined }));
+    expect(await engine.initialize('other')).toMatchObject({ status: 'paused', pausedReason: expect.stringContaining('removed') });
+  });
+});
+
+describe('BehaviorStateProcessor', () => {
+  it('re-snapshots after compaction and never projects judge instructions', async () => {
+    const store = new InMemoryBehaviorRuntimeStore();
+    const engine = new BehaviorTransitionEngine({ definition, store });
+    await engine.initialize('thread');
+    const processor = new BehaviorStateProcessor(definition, store);
+    const args = { threadId: 'thread', contextWindow: { hasSnapshot: false }, lastSnapshot: undefined } as any;
+    const signal = await processor.computeStateSignal(args);
+    expect(signal?.contents).toContain('Actor instructions');
+    expect(signal?.contents).not.toContain('Secret judge instructions');
+    expect(await processor.computeStateSignal({ ...args, contextWindow: { hasSnapshot: true }, lastSnapshot: { metadata: { state: { cacheKey: signal?.cacheKey }, record: { revision: 1, status: 'active' } } } } as any)).toBeUndefined();
+  });
+});

--- a/packages/behaviors/src/runtime/state-processor.ts
+++ b/packages/behaviors/src/runtime/state-processor.ts
@@ -50,15 +50,23 @@ export class BehaviorStateProcessor {
     ]
       .filter(Boolean)
       .join('\n');
+    const projected = {
+      id: this.definition.id,
+      version: record.definitionVersion,
+      revision: record.revision,
+      state: record.activeState,
+      status: record.status,
+      intent: record.intent,
+    };
     return {
       id: this.stateId,
       cacheKey,
       mode: 'snapshot',
       tagName: 'current-behavior',
       contents: `\n${contents}\n`,
-      value: { behavior: record },
+      value: { behavior: projected },
       attributes: { id: this.definition.id, state: record.activeState, status: record.status },
-      metadata: { record },
+      metadata: { record: { revision: record.revision, status: record.status } },
     };
   }
 }

--- a/packages/behaviors/src/runtime/state-processor.ts
+++ b/packages/behaviors/src/runtime/state-processor.ts
@@ -1,0 +1,64 @@
+import type { ComputeStateSignalArgs, ComputeStateSignalResult } from '@mastra/core/processors';
+
+import type { NormalizedBehaviorDefinition } from '../definition/types.js';
+import type { BehaviorRuntimeStore } from './types.js';
+
+function lp(value: string): string {
+  return `${value.length}:${value}`;
+}
+
+export class BehaviorStateProcessor {
+  readonly id: string;
+  readonly stateId: string;
+
+  constructor(
+    private readonly definition: NormalizedBehaviorDefinition,
+    private readonly store: BehaviorRuntimeStore,
+  ) {
+    this.id = `behavior-state-${definition.id}`;
+    this.stateId = `behavior:${definition.id}`;
+  }
+
+  async computeStateSignal(args: ComputeStateSignalArgs): Promise<ComputeStateSignalResult> {
+    const record = await this.store.readThread({ threadId: args.threadId, behaviorId: this.definition.id });
+    const prior = args.lastSnapshot?.metadata?.record as { revision?: number; status?: string } | undefined;
+    const hasBase = Boolean(args.lastSnapshot) && args.contextWindow.hasSnapshot;
+    if (!record || record.status !== 'active') {
+      if (!hasBase || !prior || prior.status !== 'active') return;
+      return {
+        id: this.stateId,
+        cacheKey: `${this.stateId}:none`,
+        mode: 'snapshot',
+        tagName: 'current-behavior',
+        contents: '\n',
+        value: { behavior: undefined },
+        attributes: { status: 'none' },
+        metadata: { record: record ?? { status: 'none' } },
+      };
+    }
+    const state = this.definition.states[record.activeState];
+    if (!state) return;
+    const transitions = state.transitions.map(item => item.id).join(', ');
+    const cacheKey = `${this.stateId}:${lp(String(record.revision))}${lp(record.activeState)}${lp(record.intent ?? '')}`;
+    if (hasBase && args.lastSnapshot?.metadata?.state?.cacheKey === cacheKey) return;
+    const contents = [
+      `Behavior: ${this.definition.id}`,
+      `State: ${record.activeState}`,
+      state.instructions ? `Instructions:\n${state.instructions}` : undefined,
+      `Available transitions: ${transitions}`,
+      record.intent ? `Current intent: ${record.intent}` : 'Current intent: not set',
+    ]
+      .filter(Boolean)
+      .join('\n');
+    return {
+      id: this.stateId,
+      cacheKey,
+      mode: 'snapshot',
+      tagName: 'current-behavior',
+      contents: `\n${contents}\n`,
+      value: { behavior: record },
+      attributes: { id: this.definition.id, state: record.activeState, status: record.status },
+      metadata: { record },
+    };
+  }
+}

--- a/packages/behaviors/src/runtime/state-processor.ts
+++ b/packages/behaviors/src/runtime/state-processor.ts
@@ -39,7 +39,7 @@ export class BehaviorStateProcessor {
     const state = this.definition.states[record.activeState];
     if (!state) return;
     const transitions = state.transitions.map(item => item.id).join(', ');
-    const cacheKey = `${this.stateId}:${lp(String(record.revision))}${lp(record.activeState)}${lp(record.intent ?? '')}`;
+    const cacheKey = `${this.stateId}:${lp(record.definitionVersion)}${lp(record.activeState)}${lp(record.intent ?? '')}`;
     if (hasBase && args.lastSnapshot?.metadata?.state?.cacheKey === cacheKey) return;
     const contents = [
       `Behavior: ${this.definition.id}`,

--- a/packages/behaviors/src/runtime/transition-engine.ts
+++ b/packages/behaviors/src/runtime/transition-engine.ts
@@ -116,11 +116,23 @@ export class BehaviorTransitionEngine {
   private reconcile(record: BehaviorRuntimeRecord): BehaviorRuntimeRecord {
     if (record.definitionVersion === this.options.definition.version) return record;
     if (this.options.definition.states[record.activeState]) {
-      return { ...record, definitionVersion: this.options.definition.version, revision: record.revision + 1 };
+      return {
+        ...record,
+        definitionVersion: this.options.definition.version,
+        revision: record.revision + 1,
+        nextCheckAt: this.nextCheckAt(record.activeState),
+      };
     }
     const mapped = this.options.definition.migrations[record.activeState];
     if (mapped) {
-      return { ...record, activeState: mapped, definitionVersion: this.options.definition.version, revision: record.revision + 1, enteredAt: this.now().toISOString() };
+      return {
+        ...record,
+        activeState: mapped,
+        definitionVersion: this.options.definition.version,
+        revision: record.revision + 1,
+        enteredAt: this.now().toISOString(),
+        nextCheckAt: this.nextCheckAt(mapped),
+      };
     }
     return {
       ...record,
@@ -129,6 +141,11 @@ export class BehaviorTransitionEngine {
       definitionVersion: this.options.definition.version,
       revision: record.revision + 1,
     };
+  }
+
+  private nextCheckAt(stateId: string): string | undefined {
+    const periodic = this.options.definition.states[stateId]?.periodic;
+    return periodic ? new Date(this.now().getTime() + periodic.intervalMs).toISOString() : undefined;
   }
 
   private async evaluateGuards(record: BehaviorRuntimeRecord, transition: NormalizedBehaviorTransition): Promise<void> {

--- a/packages/behaviors/src/runtime/transition-engine.ts
+++ b/packages/behaviors/src/runtime/transition-engine.ts
@@ -58,22 +58,24 @@ export class BehaviorTransitionEngine {
 
   async transition(input: {
     threadId: string;
-    transitionId: string;
-    attemptId: string;
+    name: string;
+    idempotencyKey?: string;
     signal?: AbortSignal;
   }): Promise<BehaviorRuntimeRecord> {
     const key = { threadId: input.threadId, behaviorId: this.options.definition.id };
-    const current = await this.options.store.readThread(key);
-    if (!current) throw new BehaviorTransitionError('Behavior has not been initialized');
+    const current = (await this.options.store.readThread(key)) ?? (await this.initialize(input.threadId));
     if (current.status !== 'active') throw new BehaviorTransitionError(`Behavior is ${current.status}`);
     if (current.definitionVersion !== this.options.definition.version) {
       throw new BehaviorTransitionError('Behavior definition changed; initialize to reconcile state first');
     }
-    if (current.transitionHistory.some(item => item.id === input.attemptId)) return current;
+    const idempotencyKey = input.idempotencyKey ?? crypto.randomUUID();
+    if (current.transitionHistory.some(item => item.id === idempotencyKey)) return current;
 
     const state = this.options.definition.states[current.activeState];
-    const transition = state?.transitions.find(item => item.id === input.transitionId);
-    if (!state || !transition) throw new BehaviorTransitionError(`Transition "${input.transitionId}" is not available`);
+    const transition = state?.transitions.find(item => item.target === input.name);
+    if (!state || !transition) {
+      throw new BehaviorTransitionError(`Behavior "${input.name}" is not available from "${current.activeState}"`);
+    }
     await this.evaluateGuards(current, transition);
     const judgeResult = transition.judge ? await this.evaluateJudge(current, transition, input.signal) : undefined;
 
@@ -83,24 +85,25 @@ export class BehaviorTransitionEngine {
       }
       if (judgeResult && !judgeResult.approved) throw new BehaviorTransitionError(judgeResult.reason ?? 'Transition rejected by judge');
       const now = this.now().toISOString();
-      const target = transition.exit ? undefined : this.options.definition.states[transition.target];
+      const target = this.options.definition.states[transition.target]!;
       const next: BehaviorRuntimeRecord = {
         ...latest,
         revision: latest.revision + 1,
-        status: transition.exit ? 'exited' : 'active',
-        activeState: target?.id ?? latest.activeState,
+        status: 'active',
+        activeState: target.id,
+        intent: undefined,
         enteredAt: now,
-        nextCheckAt: target?.periodic
+        nextCheckAt: target.periodic
           ? new Date(this.now().getTime() + target.periodic.intervalMs).toISOString()
           : undefined,
-        judgeResults: judgeResult ? { ...latest.judgeResults, [input.attemptId]: judgeResult } : latest.judgeResults,
+        judgeResults: judgeResult ? { ...latest.judgeResults, [idempotencyKey]: judgeResult } : latest.judgeResults,
         transitionHistory: [
           ...latest.transitionHistory,
           {
-            id: input.attemptId,
+            id: idempotencyKey,
             transitionId: transition.id,
             from: latest.activeState,
-            to: target?.id,
+            to: target.id,
             at: now,
             revision: latest.revision + 1,
             reason: judgeResult?.reason,

--- a/packages/behaviors/src/runtime/transition-engine.ts
+++ b/packages/behaviors/src/runtime/transition-engine.ts
@@ -1,0 +1,172 @@
+import type { NormalizedBehaviorDefinition, NormalizedBehaviorTransition } from '../definition/types.js';
+import type {
+  BehaviorGuardEvaluator,
+  BehaviorRuntimeRecord,
+  BehaviorRuntimeStore,
+  BehaviorThreadStateMirror,
+  BehaviorTransitionJudge,
+} from './types.js';
+
+export const behaviorThreadStateType = (behaviorId: string) => `@mastra/behaviors:${behaviorId}`;
+
+export class BehaviorTransitionError extends Error {}
+
+export type BehaviorTransitionEngineOptions = {
+  definition: NormalizedBehaviorDefinition;
+  store: BehaviorRuntimeStore;
+  guards?: Record<string, BehaviorGuardEvaluator>;
+  judge?: BehaviorTransitionJudge;
+  judgeTimeoutMs?: number;
+  mirror?: BehaviorThreadStateMirror;
+  now?: () => Date;
+};
+
+export class BehaviorTransitionEngine {
+  private readonly now: () => Date;
+  constructor(private readonly options: BehaviorTransitionEngineOptions) {
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async initialize(threadId: string): Promise<BehaviorRuntimeRecord> {
+    const key = { threadId, behaviorId: this.options.definition.id };
+    const committed = await this.options.store.transactThread(key, current => {
+      if (current) return { next: this.reconcile(current), result: undefined };
+      const enteredAt = this.now().toISOString();
+      const initial = this.options.definition.states[this.options.definition.initialState]!;
+      return {
+        next: {
+          threadId,
+          behaviorId: this.options.definition.id,
+          definitionVersion: this.options.definition.version,
+          revision: 1,
+          status: 'active' as const,
+          activeState: initial.id,
+          enteredAt,
+          transitionHistory: [],
+          conditionState: {},
+          checkpoints: {},
+          judgeResults: {},
+          nextCheckAt: initial.periodic ? new Date(this.now().getTime() + initial.periodic.intervalMs).toISOString() : undefined,
+          audit: {},
+        },
+        result: undefined,
+      };
+    });
+    await this.mirror(committed.runtime);
+    return committed.runtime;
+  }
+
+  async transition(input: {
+    threadId: string;
+    transitionId: string;
+    attemptId: string;
+    signal?: AbortSignal;
+  }): Promise<BehaviorRuntimeRecord> {
+    const key = { threadId: input.threadId, behaviorId: this.options.definition.id };
+    const current = await this.options.store.readThread(key);
+    if (!current) throw new BehaviorTransitionError('Behavior has not been initialized');
+    if (current.status !== 'active') throw new BehaviorTransitionError(`Behavior is ${current.status}`);
+    if (current.definitionVersion !== this.options.definition.version) {
+      throw new BehaviorTransitionError('Behavior definition changed; initialize to reconcile state first');
+    }
+    if (current.transitionHistory.some(item => item.id === input.attemptId)) return current;
+
+    const state = this.options.definition.states[current.activeState];
+    const transition = state?.transitions.find(item => item.id === input.transitionId);
+    if (!state || !transition) throw new BehaviorTransitionError(`Transition "${input.transitionId}" is not available`);
+    await this.evaluateGuards(current, transition);
+    const judgeResult = transition.judge ? await this.evaluateJudge(current, transition, input.signal) : undefined;
+
+    const committed = await this.options.store.transactThread(key, latest => {
+      if (!latest || latest.revision !== current.revision || latest.definitionVersion !== current.definitionVersion) {
+        throw new BehaviorTransitionError('Stale transition result');
+      }
+      if (judgeResult && !judgeResult.approved) throw new BehaviorTransitionError(judgeResult.reason ?? 'Transition rejected by judge');
+      const now = this.now().toISOString();
+      const target = transition.exit ? undefined : this.options.definition.states[transition.target];
+      const next: BehaviorRuntimeRecord = {
+        ...latest,
+        revision: latest.revision + 1,
+        status: transition.exit ? 'exited' : 'active',
+        activeState: target?.id ?? latest.activeState,
+        enteredAt: now,
+        nextCheckAt: target?.periodic
+          ? new Date(this.now().getTime() + target.periodic.intervalMs).toISOString()
+          : undefined,
+        judgeResults: judgeResult ? { ...latest.judgeResults, [input.attemptId]: judgeResult } : latest.judgeResults,
+        transitionHistory: [
+          ...latest.transitionHistory,
+          {
+            id: input.attemptId,
+            transitionId: transition.id,
+            from: latest.activeState,
+            to: target?.id,
+            at: now,
+            revision: latest.revision + 1,
+            reason: judgeResult?.reason,
+          },
+        ],
+      };
+      return { next, result: undefined };
+    });
+    await this.mirror(committed.runtime);
+    return committed.runtime;
+  }
+
+  private reconcile(record: BehaviorRuntimeRecord): BehaviorRuntimeRecord {
+    if (record.definitionVersion === this.options.definition.version) return record;
+    if (this.options.definition.states[record.activeState]) {
+      return { ...record, definitionVersion: this.options.definition.version, revision: record.revision + 1 };
+    }
+    const mapped = this.options.definition.migrations[record.activeState];
+    if (mapped) {
+      return { ...record, activeState: mapped, definitionVersion: this.options.definition.version, revision: record.revision + 1, enteredAt: this.now().toISOString() };
+    }
+    return {
+      ...record,
+      status: 'paused',
+      pausedReason: `State "${record.activeState}" was removed without a migration`,
+      definitionVersion: this.options.definition.version,
+      revision: record.revision + 1,
+    };
+  }
+
+  private async evaluateGuards(record: BehaviorRuntimeRecord, transition: NormalizedBehaviorTransition): Promise<void> {
+    for (const guard of transition.guards) {
+      const evaluate = this.options.guards?.[guard.id];
+      if (!evaluate) throw new BehaviorTransitionError(`Guard "${guard.id}" has no evaluator`);
+      if (!(await evaluate({ record, transition, conditionState: record.conditionState }))) {
+        throw new BehaviorTransitionError(`Guard "${guard.id}" rejected the transition`);
+      }
+    }
+  }
+
+  private async evaluateJudge(
+    record: BehaviorRuntimeRecord,
+    transition: NormalizedBehaviorTransition,
+    signal?: AbortSignal,
+  ): Promise<{ approved: boolean; reason?: string; metadata?: unknown }> {
+    if (!this.options.judge) throw new BehaviorTransitionError('Transition requires a judge');
+    const timeout = AbortSignal.timeout(this.options.judgeTimeoutMs ?? 30_000);
+    const combined = signal ? AbortSignal.any([signal, timeout]) : timeout;
+    try {
+      return await this.options.judge({
+        definition: this.options.definition,
+        record,
+        transition,
+        judgeInstructions: this.options.definition.states[record.activeState]?.judgeInstructions,
+        signal: combined,
+      });
+    } catch (error) {
+      throw new BehaviorTransitionError(`Judge failed closed: ${String(error)}`);
+    }
+  }
+
+  private async mirror(record: BehaviorRuntimeRecord): Promise<void> {
+    await this.options.mirror?.setState({
+      threadId: record.threadId,
+      type: behaviorThreadStateType(record.behaviorId),
+      value: record,
+    });
+  }
+}

--- a/packages/behaviors/src/runtime/types.ts
+++ b/packages/behaviors/src/runtime/types.ts
@@ -1,6 +1,6 @@
 import type { NormalizedBehaviorDefinition, NormalizedBehaviorTransition } from '../definition/types.js';
 
-export type BehaviorStatus = 'active' | 'exited' | 'paused' | 'error';
+export type BehaviorStatus = 'active' | 'paused' | 'error';
 
 export type BehaviorTransitionRecord = {
   id: string;

--- a/packages/behaviors/src/runtime/types.ts
+++ b/packages/behaviors/src/runtime/types.ts
@@ -1,0 +1,65 @@
+import type { NormalizedBehaviorDefinition, NormalizedBehaviorTransition } from '../definition/types.js';
+
+export type BehaviorStatus = 'active' | 'exited' | 'paused' | 'error';
+
+export type BehaviorTransitionRecord = {
+  id: string;
+  transitionId: string;
+  from: string;
+  to?: string;
+  at: string;
+  revision: number;
+  reason?: string;
+};
+
+export type BehaviorRuntimeRecord = {
+  threadId: string;
+  behaviorId: string;
+  definitionVersion: string;
+  revision: number;
+  status: BehaviorStatus;
+  activeState: string;
+  enteredAt: string;
+  intent?: string;
+  transitionHistory: BehaviorTransitionRecord[];
+  conditionState: Record<string, unknown>;
+  checkpoints: Record<string, string>;
+  judgeResults: Record<string, unknown>;
+  nextCheckAt?: string;
+  pausedReason?: string;
+  error?: string;
+  audit: Record<string, unknown>;
+};
+
+export type BehaviorThreadKey = { threadId: string; behaviorId: string };
+export type BehaviorDueWork = BehaviorThreadKey & { dueAt: string };
+
+export type BehaviorTransactionResult<T> = { next: BehaviorRuntimeRecord; result: T };
+
+export interface BehaviorRuntimeStore {
+  init(): Promise<void>;
+  readThread(key: BehaviorThreadKey): Promise<BehaviorRuntimeRecord | undefined>;
+  transactThread<T>(
+    key: BehaviorThreadKey,
+    operation: (current: BehaviorRuntimeRecord | undefined) => Promise<BehaviorTransactionResult<T>> | BehaviorTransactionResult<T>,
+  ): Promise<{ runtime: BehaviorRuntimeRecord; result: T }>;
+  listDue(before: Date, limit?: number): Promise<BehaviorDueWork[]>;
+}
+
+export type BehaviorGuardEvaluator = (input: {
+  record: BehaviorRuntimeRecord;
+  transition: NormalizedBehaviorTransition;
+  conditionState: Readonly<Record<string, unknown>>;
+}) => boolean | Promise<boolean>;
+
+export type BehaviorTransitionJudge = (input: {
+  definition: NormalizedBehaviorDefinition;
+  record: BehaviorRuntimeRecord;
+  transition: NormalizedBehaviorTransition;
+  judgeInstructions?: string;
+  signal?: AbortSignal;
+}) => Promise<{ approved: boolean; reason?: string; metadata?: unknown }>;
+
+export type BehaviorThreadStateMirror = {
+  setState<T>(args: { threadId: string; type: string; value: T }): Promise<void>;
+};

--- a/packages/behaviors/tsconfig.build.json
+++ b/packages/behaviors/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": { "outDir": "./dist", "rootDir": "./src" },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/behaviors/tsconfig.json
+++ b/packages/behaviors/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/packages/behaviors/tsup.config.ts
+++ b/packages/behaviors/tsup.config.ts
@@ -1,0 +1,13 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: { preset: 'smallest' },
+  sourcemap: true,
+  onSuccess: async () => generateTypes(process.cwd()),
+});

--- a/packages/behaviors/vitest.config.ts
+++ b/packages/behaviors/vitest.config.ts
@@ -1,0 +1,3 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({ test: { name: 'unit:behaviors', environment: 'node', include: ['src/**/*.test.ts'] } });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.7.0
-        version: 13.9.0(encoding@0.1.13)
+        version: 13.9.0
     devDependencies:
       '@internal/auth':
         specifier: workspace:*
@@ -1656,7 +1656,7 @@ importers:
         version: 3.10.1
       '@docusaurus/types':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.60.0
@@ -3821,6 +3821,9 @@ importers:
 
   packages/behaviors:
     dependencies:
+      '@libsql/client':
+        specifier: 0.17.4
+        version: 0.17.4(bufferutil@4.1.0)
       yaml:
         specifier: ^2.7.1
         version: 2.9.0
@@ -34778,40 +34781,6 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/babel@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@babel/core': 7.29.6
-      '@babel/generator': 7.29.7
-      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.6)
-      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.6)
-      '@babel/preset-env': 7.28.5(@babel/core@7.29.6)
-      '@babel/preset-react': 7.28.5(@babel/core@7.29.6)
-      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.6)
-      '@babel/runtime': 7.29.7
-      '@babel/traverse': 7.29.7
-      '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      babel-plugin-dynamic-import-node: 2.3.3
-      fs-extra: 11.3.5
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
   '@docusaurus/bundler@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.6
@@ -34859,12 +34828,12 @@ snapshots:
 
   '@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/babel': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/bundler': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
       boxen: 6.2.1
@@ -34900,7 +34869,7 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
       webpack-bundle-analyzer: 4.10.2(bufferutil@4.1.0)
       webpack-dev-server: 5.2.5(bufferutil@4.1.0)(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       webpack-merge: 6.0.1
@@ -34937,7 +34906,7 @@ snapshots:
 
   '@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       '@swc/html': 1.15.11
@@ -34946,7 +34915,7 @@ snapshots:
       semver: 7.8.4
       swc-loader: 0.2.7(@swc/core@1.15.7(@swc/helpers@0.5.17))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -34968,7 +34937,7 @@ snapshots:
   '@docusaurus/mdx-loader@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
@@ -34992,7 +34961,7 @@ snapshots:
       unist-util-visit: 5.1.0
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       vfile: 6.0.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -35011,7 +34980,7 @@ snapshots:
 
   '@docusaurus/module-type-aliases@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -35043,9 +35012,9 @@ snapshots:
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
@@ -35059,7 +35028,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35091,9 +35060,9 @@ snapshots:
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
@@ -35105,7 +35074,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35134,14 +35103,14 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35169,8 +35138,8 @@ snapshots:
   '@docusaurus/plugin-css-cascade-layers@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -35202,8 +35171,8 @@ snapshots:
   '@docusaurus/plugin-debug@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -35236,7 +35205,7 @@ snapshots:
   '@docusaurus/plugin-google-analytics@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -35268,7 +35237,7 @@ snapshots:
   '@docusaurus/plugin-google-gtag@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/gtag.js': 0.0.20
       react: 19.2.7
@@ -35301,7 +35270,7 @@ snapshots:
   '@docusaurus/plugin-google-tag-manager@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -35334,9 +35303,9 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       react: 19.2.7
@@ -35370,15 +35339,15 @@ snapshots:
   '@docusaurus/plugin-svgr@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35407,8 +35376,8 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vercel/analytics': 1.6.1(react@19.2.7)
       react: 19.2.7
@@ -35460,7 +35429,7 @@ snapshots:
       '@docusaurus/theme-classic': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(@types/react@19.2.14)(bufferutil@4.1.0)(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.55.2)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(@types/react@19.2.14)(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -35516,9 +35485,9 @@ snapshots:
       '@docusaurus/plugin-content-pages': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
       clsx: 2.1.1
@@ -35563,8 +35532,8 @@ snapshots:
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -35600,7 +35569,7 @@ snapshots:
       '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       algoliasearch: 5.55.2
       algoliasearch-helper: 3.27.0(algoliasearch@5.55.2)
@@ -35676,36 +35645,6 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@mdx-js/mdx': 3.1.1
-      '@types/history': 4.7.11
-      '@types/mdast': 4.0.4
-      '@types/react': 19.2.14
-      commander: 5.1.0
-      joi: 17.13.4
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)'
-      utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
-      webpack-merge: 5.10.0
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
   '@docusaurus/utils-common@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -35728,33 +35667,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
   '@docusaurus/utils-validation@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       joi: 17.13.4
       js-yaml: 3.15.0
@@ -35801,47 +35718,6 @@ snapshots:
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  '@docusaurus/utils@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
-    dependencies:
-      '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      escape-string-regexp: 4.0.0
-      execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
-      fs-extra: 11.3.5
-      github-slugger: 1.5.0
-      globby: 11.1.0
-      gray-matter: 4.0.3
-      jiti: 1.21.7
-      js-yaml: 3.15.0
-      lodash: 4.18.1
-      micromatch: 4.0.8
-      p-queue: 6.6.2
-      prompts: 2.4.2
-      resolve-pathname: 3.0.0
-      tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
-      utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -36706,7 +36582,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
+  '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.1
       fast-deep-equal: 3.1.3
@@ -37903,7 +37779,7 @@ snapshots:
 
   '@mastra/docusaurus-plugin-algolia@1.1.2(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(clsx@2.1.1)(lucide-react@1.23.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual': 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       algoliasearch: 5.55.2
@@ -45046,7 +44922,7 @@ snapshots:
       '@babel/core': 7.29.6
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -46148,7 +46024,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -46275,7 +46151,7 @@ snapshots:
       semver: 7.8.4
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(lightningcss@1.32.0)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -46285,7 +46161,7 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       clean-css: 5.3.3
       lightningcss: 1.32.0
@@ -47874,7 +47750,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   file-type@21.3.4:
     dependencies:
@@ -48007,7 +47883,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.9.0
 
-  firebase-admin@13.9.0(encoding@0.1.13):
+  firebase-admin@13.9.0:
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -48020,7 +47896,7 @@ snapshots:
       node-forge: 1.4.0
       uuid: 11.1.1
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
+      '@google-cloud/firestore': 7.11.6
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -48848,7 +48724,7 @@ snapshots:
       tapable: 2.3.3
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   htmlfy@0.8.1: {}
 
@@ -51054,7 +50930,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   miniflare@4.20260701.0(bufferutil@4.1.0):
     dependencies:
@@ -51106,24 +50982,12 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.15)
       html-minifier-terser: 7.2.0
-      lightningcss: 1.32.0
-      postcss: 8.5.15
-
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.44.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
-    optionalDependencies:
-      '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       lightningcss: 1.32.0
       postcss: 8.5.15
 
@@ -51631,7 +51495,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
@@ -52582,7 +52446,7 @@ snapshots:
       jiti: 1.21.7
       postcss: 8.5.15
       semver: 7.8.4
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -53331,7 +53195,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.7)'
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   react-markdown@8.0.7(@types/react@19.2.14)(react@19.2.7):
     dependencies:
@@ -55242,7 +55106,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       '@swc/counter': 0.1.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   swc-loader@0.2.7(@swc/core@1.15.7(@swc/helpers@0.5.17))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.16)):
     dependencies:
@@ -55430,7 +55294,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       terser: 5.44.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
 
@@ -56157,7 +56021,7 @@ snapshots:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
 
@@ -56860,7 +56724,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - tslib
 
@@ -56895,7 +56759,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       ws: 8.21.0(bufferutil@4.1.0)
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -56938,44 +56802,6 @@ snapshots:
       loader-runner: 4.3.2
       mime-db: 1.54.0
       minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15):
-    dependencies:
-      '@types/estree': 1.0.9
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.5
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.2
-      es-module-lexer: 2.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -57080,7 +56906,7 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
 
   webrtc-adapter@9.0.5:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3819,6 +3819,34 @@ importers:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
+  packages/behaviors:
+    dependencies:
+      yaml:
+        specifier: ^2.7.1
+        version: 2.9.0
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../core
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.9(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   packages/cli:
     dependencies:
       '@babel/parser':
@@ -6976,7 +7004,7 @@ importers:
         version: 5.2.0(encoding@0.1.13)
       mongodb:
         specifier: ^7.2.0
-        version: 7.2.0(@aws-sdk/credential-providers@3.1006.0)(@mongodb-js/zstd@7.0.0)(socks@2.8.7)
+        version: 7.2.0(@aws-sdk/credential-providers@3.1006.0)(@mongodb-js/zstd@7.0.0)(socks@2.8.9)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -8756,7 +8784,7 @@ importers:
     dependencies:
       '@blaxel/core':
         specifier: ^0.2.87
-        version: 0.2.87(@cfworker/json-schema@4.1.1)(@hey-api/openapi-ts@0.97.3(magicast@0.5.2)(typescript@6.0.3))(bufferutil@4.1.0)
+        version: 0.2.87(@cfworker/json-schema@4.1.1)(@hey-api/openapi-ts@0.97.3(magicast@0.5.3)(typescript@6.0.3))(bufferutil@4.1.0)
     devDependencies:
       '@internal/lint':
         specifier: workspace:*
@@ -25044,9 +25072,6 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
-  magicast@0.5.2:
-    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
-
   magicast@0.5.3:
     resolution: {integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==}
 
@@ -26079,9 +26104,6 @@ packages:
 
   obuf@1.1.2:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
-
-  obug@2.1.1:
-    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   obug@2.1.3:
     resolution: {integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==}
@@ -28484,10 +28506,6 @@ packages:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
 
-  socks@2.8.7:
-    resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   socks@2.8.9:
     resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
@@ -28649,9 +28667,6 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
-
-  std-env@4.1.0:
-    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
@@ -33575,9 +33590,9 @@ snapshots:
 
   '@better-fetch/fetch@1.1.21': {}
 
-  '@blaxel/core@0.2.87(@cfworker/json-schema@4.1.1)(@hey-api/openapi-ts@0.97.3(magicast@0.5.2)(typescript@6.0.3))(bufferutil@4.1.0)':
+  '@blaxel/core@0.2.87(@cfworker/json-schema@4.1.1)(@hey-api/openapi-ts@0.97.3(magicast@0.5.3)(typescript@6.0.3))(bufferutil@4.1.0)':
     dependencies:
-      '@hey-api/client-fetch': 0.10.2(@hey-api/openapi-ts@0.97.3(magicast@0.5.2)(typescript@6.0.3))
+      '@hey-api/client-fetch': 0.10.2(@hey-api/openapi-ts@0.97.3(magicast@0.5.3)(typescript@6.0.3))
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       archiver: 7.0.1
       axios: 1.16.0
@@ -36924,15 +36939,15 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
 
-  '@hey-api/client-fetch@0.10.2(@hey-api/openapi-ts@0.97.3(magicast@0.5.2)(typescript@6.0.3))':
+  '@hey-api/client-fetch@0.10.2(@hey-api/openapi-ts@0.97.3(magicast@0.5.3)(typescript@6.0.3))':
     dependencies:
-      '@hey-api/openapi-ts': 0.97.3(magicast@0.5.2)(typescript@6.0.3)
+      '@hey-api/openapi-ts': 0.97.3(magicast@0.5.3)(typescript@6.0.3)
 
-  '@hey-api/codegen-core@0.8.2(magicast@0.5.2)':
+  '@hey-api/codegen-core@0.8.2(magicast@0.5.3)':
     dependencies:
       '@hey-api/types': 0.1.4
       ansi-colors: 4.1.3
-      c12: 3.3.4(magicast@0.5.2)
+      c12: 3.3.4(magicast@0.5.3)
       color-support: 1.1.3
     transitivePeerDependencies:
       - magicast
@@ -36943,11 +36958,11 @@ snapshots:
       '@types/json-schema': 7.0.15
       js-yaml: 3.15.0
 
-  '@hey-api/openapi-ts@0.97.3(magicast@0.5.2)(typescript@6.0.3)':
+  '@hey-api/openapi-ts@0.97.3(magicast@0.5.3)(typescript@6.0.3)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.2(magicast@0.5.2)
+      '@hey-api/codegen-core': 0.8.2(magicast@0.5.3)
       '@hey-api/json-schema-ref-parser': 1.4.2
-      '@hey-api/shared': 0.4.5(magicast@0.5.2)
+      '@hey-api/shared': 0.4.5(magicast@0.5.3)
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
       '@lukeed/ms': 2.0.2
@@ -36959,9 +36974,9 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@hey-api/shared@0.4.5(magicast@0.5.2)':
+  '@hey-api/shared@0.4.5(magicast@0.5.3)':
     dependencies:
-      '@hey-api/codegen-core': 0.8.2(magicast@0.5.2)
+      '@hey-api/codegen-core': 0.8.2(magicast@0.5.3)
       '@hey-api/json-schema-ref-parser': 1.4.2
       '@hey-api/spec-types': 0.2.0
       '@hey-api/types': 0.1.4
@@ -38016,7 +38031,7 @@ snapshots:
       '@rushstack/rig-package': 0.7.3
       '@rushstack/terminal': 0.24.0(@types/node@22.19.15)
       '@rushstack/ts-command-line': 5.3.10(@types/node@22.19.15)
-      diff: 8.0.3
+      diff: 8.0.4
       minimatch: 10.2.3
       resolve: 1.22.12
       semver: 7.7.4
@@ -38631,7 +38646,7 @@ snapshots:
 
   '@openrouter/sdk@0.1.27':
     dependencies:
-      zod: 4.4.3
+      zod: 3.25.76
 
   '@opensearch-project/opensearch@3.6.0':
     dependencies:
@@ -39954,7 +39969,7 @@ snapshots:
       detect-libc: 2.1.2
       is-glob: 4.0.3
       node-addon-api: 7.1.1
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.5.6
       '@parcel/watcher-darwin-arm64': 2.5.6
@@ -41275,7 +41290,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
-      picomatch: 4.0.4
+      picomatch: 4.0.5
     optionalDependencies:
       rollup: 4.62.0
 
@@ -43411,7 +43426,7 @@ snapshots:
   '@types/react-router@5.1.20':
     dependencies:
       '@types/history': 4.7.11
-      '@types/react': 19.2.14
+      '@types/react': 19.2.17
 
   '@types/react-syntax-highlighter@15.5.13':
     dependencies:
@@ -44085,7 +44100,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
@@ -44214,7 +44229,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@26.1.0(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -45467,7 +45482,7 @@ snapshots:
 
   bytestreamjs@2.0.1: {}
 
-  c12@3.3.4(magicast@0.5.2):
+  c12@3.3.4(magicast@0.5.3):
     dependencies:
       chokidar: 5.0.0
       confbox: 0.2.4
@@ -45482,7 +45497,7 @@ snapshots:
       pkg-types: 2.3.1
       rc9: 3.0.1
     optionalDependencies:
-      magicast: 0.5.2
+      magicast: 0.5.3
 
   cac@6.7.14: {}
 
@@ -48024,7 +48039,7 @@ snapshots:
     dependencies:
       magic-string: 0.30.21
       mlly: 1.8.0
-      rollup: 4.62.0
+      rollup: 4.62.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -50082,13 +50097,6 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  magicast@0.5.2:
-    dependencies:
-      '@babel/parser': 7.29.7
-      '@babel/types': 7.29.7
-      source-map-js: 1.2.1
-    optional: true
-
   magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
@@ -51238,16 +51246,6 @@ snapshots:
       '@types/whatwg-url': 13.0.0
       whatwg-url: 14.2.0
 
-  mongodb@7.2.0(@aws-sdk/credential-providers@3.1006.0)(@mongodb-js/zstd@7.0.0)(socks@2.8.7):
-    dependencies:
-      '@mongodb-js/saslprep': 1.4.12
-      bson: 7.3.1
-      mongodb-connection-string-url: 7.0.1
-    optionalDependencies:
-      '@aws-sdk/credential-providers': 3.1006.0
-      '@mongodb-js/zstd': 7.0.0
-      socks: 2.8.7
-
   mongodb@7.2.0(@aws-sdk/credential-providers@3.1006.0)(@mongodb-js/zstd@7.0.0)(socks@2.8.9):
     dependencies:
       '@mongodb-js/saslprep': 1.4.12
@@ -51257,7 +51255,6 @@ snapshots:
       '@aws-sdk/credential-providers': 3.1006.0
       '@mongodb-js/zstd': 7.0.0
       socks: 2.8.9
-    optional: true
 
   mri@1.2.0: {}
 
@@ -51651,8 +51648,6 @@ snapshots:
   obliterator@1.6.1: {}
 
   obuf@1.1.2: {}
-
-  obug@2.1.1: {}
 
   obug@2.1.3: {}
 
@@ -52569,6 +52564,15 @@ snapshots:
     optionalDependencies:
       jiti: 2.7.0
       postcss: 8.5.15
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.7.0
+      postcss: 8.5.16
       tsx: 4.22.4
       yaml: 2.9.0
 
@@ -54760,12 +54764,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  socks@2.8.7:
-    dependencies:
-      ip-address: 10.2.0
-      smart-buffer: 4.2.0
-    optional: true
-
   socks@2.8.9:
     dependencies:
       ip-address: 10.2.0
@@ -54941,8 +54939,6 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
-
-  std-env@4.1.0: {}
 
   std-env@4.2.0: {}
 
@@ -55672,7 +55668,7 @@ snapshots:
       picocolors: 1.1.1
       postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
       resolve-from: 5.0.0
-      rollup: 4.62.0
+      rollup: 4.62.2
       source-map: 0.7.6
       sucrase: 3.35.0
       tinyexec: 0.3.2
@@ -55682,6 +55678,36 @@ snapshots:
       '@microsoft/api-extractor': 7.58.9(@types/node@22.19.15)
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       postcss: 8.5.15
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
+
+  tsup@8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.9(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.7)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.7
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.4)(yaml@2.9.0)
+      resolve-from: 5.0.0
+      rollup: 4.62.2
+      source-map: 0.7.6
+      sucrase: 3.35.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tree-kill: 1.2.2
+    optionalDependencies:
+      '@microsoft/api-extractor': 7.58.9(@types/node@22.19.15)
+      '@swc/core': 1.15.7(@swc/helpers@0.5.17)
+      postcss: 8.5.16
       typescript: 6.0.3
     transitivePeerDependencies:
       - jiti
@@ -56038,7 +56064,7 @@ snapshots:
   unplugin-utils@0.2.5:
     dependencies:
       pathe: 2.0.3
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   unplugin@1.16.1:
     dependencies:
@@ -56049,7 +56075,7 @@ snapshots:
     dependencies:
       '@jridgewell/remapping': 2.3.5
       acorn: 8.16.0
-      picomatch: 4.0.4
+      picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
   unrs-resolver@1.11.1:
@@ -56441,10 +56467,10 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -56472,10 +56498,10 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -56503,10 +56529,10 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -56534,10 +56560,10 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -56565,10 +56591,10 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -56596,10 +56622,10 @@ snapshots:
       es-module-lexer: 2.3.0
       expect-type: 1.3.0
       magic-string: 0.30.21
-      obug: 2.1.1
+      obug: 2.1.3
       pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
+      picomatch: 4.0.5
+      std-env: 4.2.0
       tinybench: 2.9.0
       tinyexec: 1.2.4
       tinyglobby: 0.2.17


### PR DESCRIPTION
## Summary

- add the reusable `@mastra/behaviors` package
- normalize TypeScript and filesystem behavior definitions into one validated immutable graph
- provide authoritative in-memory and LibSQL runtime stores with atomic per-thread updates
- add guarded and judged transitions, stale-result protection, migrations, state projection, and thread-state mirroring
- document behavior authoring and public runtime APIs

## Test plan

- `pnpm --filter @mastra/behaviors exec vitest run --reporter=dot --bail 1` — 18 passed
- `pnpm --filter @mastra/behaviors check`
- `pnpm --filter @mastra/behaviors build:lib`
- `pnpm validate` from `docs/` — 566 files passed
- scoped Remark and Vale checks for both behavior docs
- `git diff --check feat/behavgoal-plugin-signals...HEAD`

## Scope

This stacked PR contains the reusable runtime only. Intent/tool enforcement and the Mastra Code adapter follow in the next PR. No `packages/core` files changed.
