### PR TITLE
feat(behaviors): enforce intent and integrate Mastra Code

### DIFF
--- a/.changeset/shy-behaviors-dream.md
+++ b/.changeset/shy-behaviors-dream.md
@@ -1,0 +1,6 @@
+---
+'@mastra/behaviors': minor
+'@mastra/code-sdk': patch
+---
+
+Add transition-stable intent enforcement, state-specific model and instruction routing, behavior control tools, and a thin Mastra Code behavior plugin adapter.

--- a/docs/src/content/en/docs/long-running-agents/behaviors.mdx
+++ b/docs/src/content/en/docs/long-running-agents/behaviors.mdx
@@ -124,3 +124,24 @@ The behavior store is authoritative. The provider can mirror committed records i
 Deterministic guards run before the optional judge. A failed guard prevents the judge call. The engine commits a judged transition only when the runtime revision still matches the revision that the judge reviewed.
 
 `JUDGE.md` and `judgeInstructions` are sent only to the judge. They aren't included in the acting agent's state signal.
+
+## Require intent for tools
+
+The provider adds an `intent` field to each governed tool once when it attaches to the agent. Tool names, schemas, and wrapper identities stay stable when the behavior changes state, preserving prompt-cache compatibility.
+
+Set `intent` to the active state ID for automatic approval. A free-form value uses `judgeIntent`. Calls without approved intent are rejected before execution and checked again against current durable state inside the wrapper.
+
+## Use behaviors in Mastra Code
+
+Create a thin local plugin with `createMastraCodeBehaviorPlugin()`. The plugin uses the same `BehaviorSignalProvider` as an ordinary agent.
+
+```typescript title=".mastracode/plugins/debug.ts"
+import { createMastraCodeBehaviorPlugin } from '@mastra/code-sdk/plugins/behavior-plugin'
+
+export default createMastraCodeBehaviorPlugin({
+  id: 'debug-behavior',
+  definition: './behaviors/debug',
+})
+```
+
+State model IDs are returned to Mastra Code's normal model resolver, so the active session's gateway and authentication configuration continue to apply.

--- a/docs/src/content/en/reference/agents/behaviors.mdx
+++ b/docs/src/content/en/reference/agents/behaviors.mdx
@@ -120,7 +120,11 @@ Registers `BehaviorStateProcessor` through the standard Mastra signal-provider A
 ```typescript
 import { BehaviorSignalProvider } from '@mastra/behaviors'
 
-const provider = new BehaviorSignalProvider({ definition, store })
+const provider = new BehaviorSignalProvider({
+  definition,
+  store,
+  resolveThreadId: requestContext => requestContext?.get('threadId'),
+})
 ```
 
 The projected `<current-behavior>` state includes acting instructions, transition IDs, intent, and status. It excludes judge instructions.

--- a/docs/src/content/en/reference/agents/behaviors.mdx
+++ b/docs/src/content/en/reference/agents/behaviors.mdx
@@ -125,6 +125,10 @@ const provider = new BehaviorSignalProvider({ definition, store })
 
 The projected `<current-behavior>` state includes acting instructions, transition IDs, intent, and status. It excludes judge instructions.
 
+The provider also exposes stable `behavior_select`, `behavior_intent`, `behavior_transition`, and `behavior_exit` tools. Configure `resolveThreadId` to read the host's thread ID from `RequestContext`. Optional `resolveModel` and `resolveSkillInstructions` callbacks route state-specific models and skill instructions without constructing provider clients.
+
+Governed host tools receive one required `intent` input. `BehaviorIntentPolicyProcessor` memoizes wrappers by original tool identity and checks authorization both before and during execution.
+
 ## Errors
 
 Definition failures throw `BehaviorDefinitionError` with path-specific diagnostics. Transition failures throw `BehaviorTransitionError`, including missing guards, unavailable transitions, rejected judges, and stale results.

--- a/mastracode/sdk/package.json
+++ b/mastracode/sdk/package.json
@@ -74,7 +74,8 @@
     "vscode-jsonrpc": "^8.2.1",
     "vscode-languageserver-protocol": "^3.17.5",
     "yaml": "^2.7.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "@mastra/behaviors": "workspace:*"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -1101,6 +1101,9 @@ export {
   renderTextResult,
   renderJsonResult,
 } from './headless/index.js';
+export { createMastraCodeBehaviorPlugin } from './plugins/behavior-plugin.js';
+export type { MastraCodeBehaviorPluginOptions } from './plugins/behavior-plugin.js';
+
 export type {
   RunMCOptions,
   RunMCResult,

--- a/mastracode/sdk/src/plugins/__tests__/behavior-plugin.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/behavior-plugin.test.ts
@@ -1,0 +1,36 @@
+import { defineBehavior, InMemoryBehaviorRuntimeStore } from '@mastra/behaviors';
+import { describe, expect, it } from 'vitest';
+
+import { createMastraCodeBehaviorPlugin } from '../behavior-plugin.js';
+
+const definition = defineBehavior({
+  id: 'coding',
+  version: '1',
+  initialState: 'work',
+  states: [{ id: 'work', transitions: [{ id: 'exit', target: 'exit', exit: true }] }],
+});
+
+describe('createMastraCodeBehaviorPlugin', () => {
+  it('returns the shared behavior provider through the plugin signal contract', async () => {
+    const plugin = createMastraCodeBehaviorPlugin({
+      id: 'coding-behavior',
+      definition,
+      store: new InMemoryBehaviorRuntimeStore(),
+    });
+    expect(typeof plugin.signalProviders).toBe('function');
+    const providers = await plugin.signalProviders!({
+      cwd: '/tmp/project',
+      scope: 'project',
+      pluginDir: '/tmp/project/.mastracode/plugins/coding-behavior',
+      config: {},
+    });
+    expect(providers).toHaveLength(1);
+    expect(providers[0]?.id).toBe('behavior-coding');
+    expect(Object.keys(providers[0]?.getTools?.() ?? {})).toEqual([
+      'behavior_select',
+      'behavior_intent',
+      'behavior_transition',
+      'behavior_exit',
+    ]);
+  });
+});

--- a/mastracode/sdk/src/plugins/__tests__/behavior-plugin.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/behavior-plugin.test.ts
@@ -1,29 +1,30 @@
-import { defineBehavior, InMemoryBehaviorRuntimeStore } from '@mastra/behaviors';
-import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
 
 import { createMastraCodeBehaviorPlugin } from '../behavior-plugin.js';
 
-const definition = defineBehavior({
-  id: 'coding',
-  version: '1',
-  initialState: 'work',
-  states: [{ id: 'work', transitions: [{ id: 'exit', target: 'exit', exit: true }] }],
+let tempDir: string | undefined;
+afterEach(() => {
+  if (tempDir) fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
 describe('createMastraCodeBehaviorPlugin', () => {
-  it('returns the shared behavior provider through the plugin signal contract', async () => {
-    const plugin = createMastraCodeBehaviorPlugin({
-      id: 'coding-behavior',
-      definition,
-      store: new InMemoryBehaviorRuntimeStore(),
-    });
-    expect(typeof plugin.signalProviders).toBe('function');
-    const providers = await plugin.signalProviders!({
-      cwd: '/tmp/project',
-      scope: 'project',
-      pluginDir: '/tmp/project/.mastracode/plugins/coding-behavior',
-      config: {},
-    });
+  it('loads a filesystem definition and returns the shared provider', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mastracode-behavior-'));
+    fs.writeFileSync(
+      path.join(tempDir, 'behavior.yaml'),
+      JSON.stringify({
+        id: 'coding',
+        version: '1',
+        initialState: 'work',
+        states: [{ id: 'work', transitions: [{ id: 'leave', target: 'exit', exit: true }] }],
+      }),
+    );
+    const plugin = createMastraCodeBehaviorPlugin({ id: 'coding-plugin', definition: tempDir });
+    const providers = await plugin.signalProviders!({ cwd: tempDir } as never);
+
     expect(providers).toHaveLength(1);
     expect(providers[0]?.id).toBe('behavior-coding');
     expect(Object.keys(providers[0]?.getTools?.() ?? {})).toEqual([

--- a/mastracode/sdk/src/plugins/__tests__/behavior-plugin.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/behavior-plugin.test.ts
@@ -19,7 +19,7 @@ describe('createMastraCodeBehaviorPlugin', () => {
         id: 'coding',
         version: '1',
         initialState: 'work',
-        states: [{ id: 'work', transitions: [{ id: 'leave', target: 'exit', exit: true }] }],
+        states: [{ id: 'work', transitions: [{ id: 'continue', target: 'work' }] }],
       }),
     );
     const plugin = createMastraCodeBehaviorPlugin({ id: 'coding-plugin', definition: tempDir });
@@ -27,11 +27,6 @@ describe('createMastraCodeBehaviorPlugin', () => {
 
     expect(providers).toHaveLength(1);
     expect(providers[0]?.id).toBe('behavior-coding');
-    expect(Object.keys(providers[0]?.getTools?.() ?? {})).toEqual([
-      'behavior_select',
-      'behavior_intent',
-      'behavior_transition',
-      'behavior_exit',
-    ]);
+    expect(Object.keys(providers[0]?.getTools?.() ?? {})).toEqual(['behavior', 'behavior_intent']);
   });
 });

--- a/mastracode/sdk/src/plugins/behavior-plugin.ts
+++ b/mastracode/sdk/src/plugins/behavior-plugin.ts
@@ -1,3 +1,5 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { BehaviorSignalProvider, InMemoryBehaviorRuntimeStore, loadBehaviorDirectory } from '@mastra/behaviors';
 import type { BehaviorRuntimeStore, NormalizedBehaviorDefinition } from '@mastra/behaviors';
 
@@ -35,6 +37,16 @@ export function createMastraCodeBehaviorPlugin(options: MastraCodeBehaviorPlugin
             return controller?.threadId ?? requestContext?.get('threadId');
           },
           resolveModel: (model, { requestContext }) => resolveModel(model, { requestContext }),
+          resolveSkillInstructions: async skills =>
+            Promise.all(
+              skills.map(async skill => {
+                try {
+                  return await readFile(join(skill, 'SKILL.md'), 'utf8');
+                } catch {
+                  return await readFile(skill, 'utf8');
+                }
+              }),
+            ),
           unavailableModel: 'error',
         }),
       ];

--- a/mastracode/sdk/src/plugins/behavior-plugin.ts
+++ b/mastracode/sdk/src/plugins/behavior-plugin.ts
@@ -1,0 +1,43 @@
+import { BehaviorSignalProvider, InMemoryBehaviorRuntimeStore, loadBehaviorDirectory } from '@mastra/behaviors';
+import type { BehaviorRuntimeStore, NormalizedBehaviorDefinition } from '@mastra/behaviors';
+
+import { resolveModel } from '../agents/model.js';
+import type { MastraCodePlugin } from '../plugin.js';
+
+export type MastraCodeBehaviorPluginOptions = {
+  id: string;
+  name?: string;
+  version?: string;
+  definition: NormalizedBehaviorDefinition | string;
+  store?: BehaviorRuntimeStore;
+};
+
+/** Creates a thin Mastra Code plugin backed by the shared behavior signal provider. */
+export function createMastraCodeBehaviorPlugin(options: MastraCodeBehaviorPluginOptions): MastraCodePlugin {
+  return {
+    id: options.id,
+    name: options.name ?? options.id,
+    version: options.version ?? '1.0.0',
+    description: 'Govern the Mastra Code agent with a durable behavior tree',
+    signalProviders: async context => {
+      const definition =
+        typeof options.definition === 'string'
+          ? await loadBehaviorDirectory(
+              options.definition.startsWith('/') ? options.definition : `${context.cwd}/${options.definition}`,
+            )
+          : options.definition;
+      return [
+        new BehaviorSignalProvider({
+          definition,
+          store: options.store ?? new InMemoryBehaviorRuntimeStore(),
+          resolveThreadId: requestContext => {
+            const controller = requestContext?.get('controller') as { threadId?: string } | undefined;
+            return controller?.threadId ?? requestContext?.get('threadId');
+          },
+          resolveModel: (model, { requestContext }) => resolveModel(model, { requestContext }),
+          unavailableModel: 'fallback',
+        }),
+      ];
+    },
+  };
+}

--- a/mastracode/sdk/src/plugins/behavior-plugin.ts
+++ b/mastracode/sdk/src/plugins/behavior-plugin.ts
@@ -35,7 +35,7 @@ export function createMastraCodeBehaviorPlugin(options: MastraCodeBehaviorPlugin
             return controller?.threadId ?? requestContext?.get('threadId');
           },
           resolveModel: (model, { requestContext }) => resolveModel(model, { requestContext }),
-          unavailableModel: 'fallback',
+          unavailableModel: 'error',
         }),
       ];
     },

--- a/mastracode/tui/e2e/fixtures/behaviors.json
+++ b/mastracode/tui/e2e/fixtures/behaviors.json
@@ -19,7 +19,6 @@
     {
       "match": {
         "endpoint": "chat",
-        "toolCallId": "call_behavior_select",
         "hasToolResult": true
       },
       "response": {

--- a/mastracode/tui/e2e/fixtures/behaviors.json
+++ b/mastracode/tui/e2e/fixtures/behaviors.json
@@ -3,15 +3,17 @@
     {
       "match": {
         "endpoint": "chat",
-        "userMessage": "Activate the coding behavior.",
+        "userMessage": "Move to the implementation behavior.",
         "hasToolResult": false
       },
       "response": {
         "toolCalls": [
           {
-            "id": "call_behavior_select",
-            "name": "behavior_select",
-            "arguments": {}
+            "id": "call_behavior",
+            "name": "behavior",
+            "arguments": {
+              "name": "implement"
+            }
           }
         ]
       }

--- a/mastracode/tui/e2e/fixtures/behaviors.json
+++ b/mastracode/tui/e2e/fixtures/behaviors.json
@@ -3,7 +3,6 @@
     {
       "match": {
         "endpoint": "chat",
-        "userMessage": "Move to the implementation behavior.",
         "hasToolResult": false
       },
       "response": {

--- a/mastracode/tui/e2e/fixtures/behaviors.json
+++ b/mastracode/tui/e2e/fixtures/behaviors.json
@@ -1,0 +1,30 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "endpoint": "chat",
+        "userMessage": "Activate the coding behavior.",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_behavior_select",
+            "name": "behavior_select",
+            "arguments": {}
+          }
+        ]
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "toolCallId": "call_behavior_select",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Behavior provider active."
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -76,6 +76,7 @@ import { planApprovalGoalHandoffScenario } from './plan-approval-goal-handoff.js
 import { planApprovalHandoffScenario } from './plan-approval-handoff.js';
 import { planApprovalRequestChangesScenario } from './plan-approval-request-changes.js';
 import {
+  behaviorsScenario,
   pluginsAssetsLoadingScenario,
   pluginsBlockedConfigScenario,
   pluginsCommandUiScenario,
@@ -228,6 +229,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'plan-approval-goal-handoff': planApprovalGoalHandoffScenario,
   'plan-approval-handoff': planApprovalHandoffScenario,
   'plan-approval-request-changes': planApprovalRequestChangesScenario,
+  behaviors: behaviorsScenario,
   'plugins-local-tool': pluginsLocalToolScenario,
   'plugins-local-hot-reload': pluginsLocalHotReloadScenario,
   'plugins-github-install-gh-cli': pluginsGithubInstallGhCliScenario,

--- a/mastracode/tui/e2e/tui/plugins.ts
+++ b/mastracode/tui/e2e/tui/plugins.ts
@@ -66,6 +66,34 @@ export default defineMastraCodePlugin({
   return pluginDir;
 }
 
+function writeBehaviorPlugin({ projectDir }: Pick<McE2ePrepareContext, 'projectDir'>): string {
+  const pluginDir = join(projectDir, 'fixtures', 'plugins', 'behavior-plugin');
+  const pluginSrcDir = join(pluginDir, 'src');
+  mkdirSync(pluginSrcDir, { recursive: true });
+  writePluginPackageLink(pluginDir);
+  writeFileSync(
+    join(pluginSrcDir, 'index.ts'),
+    `import { createMastraCodeBehaviorPlugin } from 'mastracode';
+
+export default createMastraCodeBehaviorPlugin({
+  id: '${PLUGIN_ID}',
+  definition: {
+    id: 'coding',
+    version: '1',
+    initialState: 'understand',
+    states: [{
+      id: 'understand',
+      instructions: 'Understand before editing.',
+      tools: ['view'],
+      transitions: [{ id: 'exit', target: 'exit', exit: true }],
+    }],
+  },
+});
+`,
+  );
+  return pluginDir;
+}
+
 function writeAssetPlugin({ projectDir }: Pick<McE2ePrepareContext, 'projectDir'>): string {
   const pluginDir = join(projectDir, 'fixtures', 'plugins', 'asset-plugin');
   const pluginSrcDir = join(pluginDir, 'src');
@@ -457,6 +485,37 @@ export const pluginsLocalToolScenario: McE2eScenario = {
     const names = getToolNames(requests);
     if (!names.includes(TOOL_NAME)) {
       throw new Error(`Expected provider request to expose plugin tool ${TOOL_NAME}. Names: ${names.join(', ')}`);
+    }
+  },
+};
+
+export const behaviorsScenario: McE2eScenario = {
+  name: 'behaviors',
+  description: 'Loads a behavior plugin into the real coding agent and exposes its stable control tools.',
+  testName: 'governs the coding agent with a behavior signal provider',
+  useOpenAIModel: true,
+  aimockFixture: 'behaviors.json',
+  prepare({ projectDir }) {
+    resetPluginScenarioState();
+    writePluginRegistry(projectDir, writeBehaviorPlugin({ projectDir }));
+  },
+  async inProcessApp({ homeDir, projectDir, startMastraCodeApp }) {
+    const { PluginManager } = await import('@mastra/code-sdk/plugins/manager');
+    return startMastraCodeApp({
+      config: { pluginManager: new PluginManager({ projectRoot: projectDir, configDir: '.mastracode', homeDir }) },
+    });
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Resource ID:/i, terminal);
+    terminal.submit('Activate the coding behavior.');
+    await runtime.waitForScreenText(/Behavior provider active/i, terminal);
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    const names = getToolNames(requests);
+    for (const name of ['behavior_select', 'behavior_intent', 'behavior_transition', 'behavior_exit']) {
+      if (!names.includes(name)) throw new Error(`Expected behavior tool ${name}. Names: ${names.join(', ')}`);
     }
   },
 };

--- a/mastracode/tui/e2e/tui/plugins.ts
+++ b/mastracode/tui/e2e/tui/plugins.ts
@@ -72,23 +72,53 @@ function writeBehaviorPlugin({ projectDir }: Pick<McE2ePrepareContext, 'projectD
   mkdirSync(pluginSrcDir, { recursive: true });
   writePluginPackageLink(pluginDir);
   writeFileSync(
+    join(pluginDir, 'behavior.yaml'),
+    JSON.stringify({
+      id: 'coding',
+      version: '1',
+      initialState: 'understand',
+      states: [
+        {
+          id: 'understand',
+          instructions: 'Understand before editing.',
+          tools: ['e2e_governed_probe'],
+          transitions: [
+            { id: 'implement', target: 'implement' },
+            { id: 'exit', target: 'exit', exit: true },
+          ],
+        },
+        {
+          id: 'implement',
+          instructions: 'Implementation state.',
+          tools: ['e2e_governed_probe'],
+          transitions: [{ id: 'exit', target: 'exit', exit: true }],
+        },
+      ],
+    }),
+  );
+  writeFileSync(
     join(pluginSrcDir, 'index.ts'),
     `import { createMastraCodeBehaviorPlugin } from 'mastracode';
+import { createTool, z } from 'mastracode/plugin';
 
-export default createMastraCodeBehaviorPlugin({
+const behavior = createMastraCodeBehaviorPlugin({
   id: '${PLUGIN_ID}',
-  definition: {
-    id: 'coding',
-    version: '1',
-    initialState: 'understand',
-    states: [{
-      id: 'understand',
-      instructions: 'Understand before editing.',
-      tools: ['view'],
-      transitions: [{ id: 'exit', target: 'exit', exit: true }],
-    }],
-  },
+  definition: ${JSON.stringify(pluginDir)},
 });
+
+export default {
+  ...behavior,
+  tools: {
+    e2e_governed_probe: {
+      tool: createTool({
+        id: 'e2e_governed_probe',
+        description: 'Return behavior enforcement proof.',
+        inputSchema: z.object({ value: z.string() }),
+        execute: async input => ({ value: input.value, governed: true }),
+      }),
+    },
+  },
+};
 `,
   );
   return pluginDir;
@@ -517,6 +547,16 @@ export const behaviorsScenario: McE2eScenario = {
     for (const name of ['behavior_select', 'behavior_intent', 'behavior_transition', 'behavior_exit']) {
       if (!names.includes(name)) throw new Error(`Expected behavior tool ${name}. Names: ${names.join(', ')}`);
     }
+    const schemas = (
+      requests as Array<{ body?: { tools?: Array<{ function?: { name?: string; parameters?: unknown } }> } }>
+    )
+      .flatMap(request => request.body?.tools ?? [])
+      .filter(tool => tool.function?.name === 'e2e_governed_probe')
+      .map(tool => JSON.stringify(tool.function?.parameters));
+    if (!schemas.length || !schemas.every(schema => schema.includes('intent'))) {
+      throw new Error(`Expected governed probe schema to require intent. Schemas: ${schemas.join(', ')}`);
+    }
+    if (new Set(schemas).size !== 1) throw new Error('Expected governed probe schema to remain stable across requests');
   },
 };
 

--- a/mastracode/tui/e2e/tui/plugins.ts
+++ b/mastracode/tui/e2e/tui/plugins.ts
@@ -82,16 +82,13 @@ function writeBehaviorPlugin({ projectDir }: Pick<McE2ePrepareContext, 'projectD
           id: 'understand',
           instructions: 'Understand before editing.',
           tools: ['e2e_governed_probe'],
-          transitions: [
-            { id: 'implement', target: 'implement' },
-            { id: 'exit', target: 'exit', exit: true },
-          ],
+          transitions: [{ id: 'implement', target: 'implement' }],
         },
         {
           id: 'implement',
           instructions: 'Implementation state.',
           tools: ['e2e_governed_probe'],
-          transitions: [{ id: 'exit', target: 'exit', exit: true }],
+          transitions: [{ id: 'return', target: 'understand' }],
         },
       ],
     }),
@@ -538,13 +535,13 @@ export const behaviorsScenario: McE2eScenario = {
   async run({ terminal, runtime }) {
     runtime.startLiveOutput(terminal);
     await runtime.waitForScreenText(/Resource ID:/i, terminal);
-    terminal.submit('Activate the coding behavior.');
+    terminal.submit('Move to the implementation behavior.');
     await runtime.waitForScreenText(/Behavior provider active/i, terminal);
     terminal.keyCtrlC();
   },
   verifyAimockRequests(requests) {
     const names = getToolNames(requests);
-    for (const name of ['behavior_select', 'behavior_intent', 'behavior_transition', 'behavior_exit']) {
+    for (const name of ['behavior', 'behavior_intent']) {
       if (!names.includes(name)) throw new Error(`Expected behavior tool ${name}. Names: ${names.join(', ')}`);
     }
     const schemas = (

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -15,6 +15,7 @@ export type ScenarioName =
   | 'api-key-reopen-stored'
   | 'ask-user-advanced-prompts'
   | 'automated-chat'
+  | 'behaviors'
   | 'browser-active-pending-status'
   | 'browser-profile-provider-mismatch'
   | 'browser-settings-persistence'

--- a/packages/behaviors/src/enforcement/intent-policy.test.ts
+++ b/packages/behaviors/src/enforcement/intent-policy.test.ts
@@ -14,18 +14,12 @@ const definition = normalizeBehavior({
     {
       id: 'understand',
       tools: ['read'],
-      transitions: [
-        { id: 'implement', target: 'implement' },
-        { id: 'exit', target: 'exit', exit: true },
-      ],
+      transitions: [{ id: 'implement', target: 'implement' }],
     },
     {
       id: 'implement',
       tools: ['write'],
-      transitions: [
-        { id: 'back', target: 'understand' },
-        { id: 'exit', target: 'exit', exit: true },
-      ],
+      transitions: [{ id: 'back', target: 'understand' }],
     },
   ],
 });
@@ -52,7 +46,7 @@ describe('BehaviorIntentPolicyProcessor', () => {
     const second = await processor.processInputStep({ tools: { read: tool } } as never);
     expect(second.tools!.read).toBe(wrapped);
     const schemaBefore = JSON.stringify((wrapped.inputSchema as z.ZodType).toJSONSchema());
-    await engine.transition({ threadId: 'thread', transitionId: 'implement', attemptId: 'move' });
+    await engine.transition({ threadId: 'thread', name: 'implement', idempotencyKey: 'move' });
     const third = await processor.processInputStep({ tools: { read: tool } } as never);
     expect(third.tools!.read).toBe(wrapped);
     expect(JSON.stringify((wrapped.inputSchema as z.ZodType).toJSONSchema())).toBe(schemaBefore);
@@ -70,7 +64,7 @@ describe('BehaviorIntentPolicyProcessor', () => {
     const { wrapped, engine, judgeIntent } = await setup();
     await expect(wrapped.execute({ path: 'x', intent: 'inspect code' }, { threadId: 'thread' })).resolves.toEqual({ path: 'x' });
     expect(judgeIntent).toHaveBeenCalledOnce();
-    await engine.transition({ threadId: 'thread', transitionId: 'implement', attemptId: 'move' });
+    await engine.transition({ threadId: 'thread', name: 'implement', idempotencyKey: 'move' });
     await expect(wrapped.execute({ path: 'x', intent: 'understand' }, { threadId: 'thread' })).rejects.toThrow('not allowed');
   });
 

--- a/packages/behaviors/src/enforcement/intent-policy.test.ts
+++ b/packages/behaviors/src/enforcement/intent-policy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { normalizeBehavior } from '../definition/normalize.js';
+import { InMemoryBehaviorRuntimeStore } from '../runtime/in-memory-store.js';
+import { BehaviorTransitionEngine } from '../runtime/transition-engine.js';
+import { BehaviorIntentPolicyProcessor } from './intent-policy.js';
+
+const definition = normalizeBehavior({
+  id: 'coding',
+  version: '1',
+  initialState: 'understand',
+  states: [
+    {
+      id: 'understand',
+      tools: ['read'],
+      transitions: [
+        { id: 'implement', target: 'implement' },
+        { id: 'exit', target: 'exit', exit: true },
+      ],
+    },
+    {
+      id: 'implement',
+      tools: ['write'],
+      transitions: [
+        { id: 'back', target: 'understand' },
+        { id: 'exit', target: 'exit', exit: true },
+      ],
+    },
+  ],
+});
+
+const setup = async () => {
+  const store = new InMemoryBehaviorRuntimeStore();
+  await store.init();
+  const engine = new BehaviorTransitionEngine({ definition, store });
+  await engine.initialize('thread');
+  const judgeIntent = vi.fn(async ({ intent }: { intent: string }) => ({ approved: intent === 'inspect code' }));
+  const processor = new BehaviorIntentPolicyProcessor({ definition, store, judgeIntent });
+  const execute = vi.fn(async (input: unknown) => input);
+  const tool = { inputSchema: z.object({ path: z.string() }), execute };
+  const result = await processor.processInputStep({ tools: { read: tool } } as never);
+  const wrapped = result.tools!.read as typeof tool & {
+    execute(input: Record<string, unknown>, context?: unknown): Promise<unknown>;
+  };
+  return { store, engine, processor, judgeIntent, execute, tool, wrapped };
+};
+
+describe('BehaviorIntentPolicyProcessor', () => {
+  it('memoizes wrappers and keeps their schema stable across transitions', async () => {
+    const { processor, engine, tool, wrapped } = await setup();
+    const second = await processor.processInputStep({ tools: { read: tool } } as never);
+    expect(second.tools!.read).toBe(wrapped);
+    const schemaBefore = JSON.stringify((wrapped.inputSchema as z.ZodType).toJSONSchema());
+    await engine.transition({ threadId: 'thread', transitionId: 'implement', attemptId: 'move' });
+    const third = await processor.processInputStep({ tools: { read: tool } } as never);
+    expect(third.tools!.read).toBe(wrapped);
+    expect(JSON.stringify((wrapped.inputSchema as z.ZodType).toJSONSchema())).toBe(schemaBefore);
+  });
+
+  it('requires matching state intent and strips intent before execution', async () => {
+    const { wrapped, execute } = await setup();
+    await expect(wrapped.execute({ path: 'x' }, { threadId: 'thread' })).rejects.toThrow('requires an intent');
+    await expect(wrapped.execute({ path: 'x', intent: 'wrong' }, { threadId: 'thread' })).rejects.toThrow('rejected');
+    await expect(wrapped.execute({ path: 'x', intent: 'understand' }, { threadId: 'thread' })).resolves.toEqual({ path: 'x' });
+    expect(execute).toHaveBeenCalledWith({ path: 'x' }, { threadId: 'thread' });
+  });
+
+  it('supports judged freeform intent and rejects stale intent after a transition', async () => {
+    const { wrapped, engine, judgeIntent } = await setup();
+    await expect(wrapped.execute({ path: 'x', intent: 'inspect code' }, { threadId: 'thread' })).resolves.toEqual({ path: 'x' });
+    expect(judgeIntent).toHaveBeenCalledOnce();
+    await engine.transition({ threadId: 'thread', transitionId: 'implement', attemptId: 'move' });
+    await expect(wrapped.execute({ path: 'x', intent: 'understand' }, { threadId: 'thread' })).rejects.toThrow('not allowed');
+  });
+
+  it('aborts missing output intent before execution', async () => {
+    const { processor } = await setup();
+    const abort = vi.fn(() => {
+      throw new Error('retry');
+    });
+    await expect(
+      processor.processOutputStep({ toolCalls: [{ toolName: 'read', toolCallId: '1', args: {} }], abort } as never),
+    ).rejects.toThrow('retry');
+    expect(abort).toHaveBeenCalledWith('Tool "read" requires an intent', { retry: true });
+  });
+});

--- a/packages/behaviors/src/enforcement/intent-policy.ts
+++ b/packages/behaviors/src/enforcement/intent-policy.ts
@@ -5,6 +5,8 @@ import type {
 } from '@mastra/core/processors';
 import { z } from 'zod';
 
+import type { RequestContext } from '@mastra/core/request-context';
+
 import type { NormalizedBehaviorDefinition } from '../definition/types.js';
 import type { BehaviorRuntimeRecord, BehaviorRuntimeStore } from '../runtime/types.js';
 
@@ -21,6 +23,7 @@ export type BehaviorIntentPolicyOptions = {
   definition: NormalizedBehaviorDefinition;
   store: BehaviorRuntimeStore;
   judgeIntent?: BehaviorIntentJudge;
+  resolveThreadId?: (requestContext?: RequestContext) => string | undefined;
 };
 
 type ToolLike = {
@@ -55,10 +58,32 @@ export class BehaviorIntentPolicyProcessor {
 
   async processOutputStep(args: ProcessOutputStepArgs) {
     for (const call of args.toolCalls ?? []) {
+      if (call.toolName.startsWith('behavior_')) continue;
       const intent = this.readIntent(call.args);
       if (!intent) args.abort(`Tool "${call.toolName}" requires an intent`, { retry: true });
+      const threadId = this.options.resolveThreadId?.(args.requestContext);
+      if (!threadId) args.abort(`Tool "${call.toolName}" requires behavior thread context`, { retry: true });
+      try {
+        await this.authorize(threadId, call.toolName, intent);
+      } catch (error) {
+        args.abort(error instanceof Error ? error.message : String(error), { retry: true });
+      }
     }
     return args.messages;
+  }
+
+  async setIntent(threadId: string, intent: string): Promise<BehaviorRuntimeRecord> {
+    const current = await this.options.store.readThread({ threadId, behaviorId: this.options.definition.id });
+    if (!current || current.status !== 'active') throw new Error('Behavior is not active');
+    await this.authorize(threadId, 'behavior_intent', intent);
+    const committed = await this.options.store.transactThread(
+      { threadId, behaviorId: this.options.definition.id },
+      latest => {
+        if (!latest || latest.revision !== current.revision) throw new Error('Behavior state changed while intent was approved');
+        return { next: { ...latest, intent, revision: latest.revision + 1 }, result: undefined };
+      },
+    );
+    return committed.runtime;
   }
 
   private wrapTool(name: string, tool: ToolLike): ToolLike {
@@ -71,7 +96,10 @@ export class BehaviorIntentPolicyProcessor {
       ...tool,
       inputSchema,
       execute: async (input, context) => {
-        const threadId = getThreadId(context);
+        const requestContext = context && typeof context === 'object'
+          ? (context as { requestContext?: RequestContext }).requestContext
+          : undefined;
+        const threadId = this.options.resolveThreadId?.(requestContext) ?? getThreadId(context);
         if (!threadId) throw new Error(`Tool "${name}" requires behavior thread context`);
         await this.authorize(threadId, name, this.readIntent(input));
         const { intent: _intent, ...originalInput } = input;
@@ -100,7 +128,9 @@ export class BehaviorIntentPolicyProcessor {
     if (!record || record.status !== 'active') throw new Error('Behavior is not active');
     const state = this.options.definition.states[record.activeState];
     if (!state) throw new Error(`Behavior state "${record.activeState}" is unavailable`);
-    if (state.tools.length && !state.tools.includes(toolName)) throw new Error(`Tool "${toolName}" is not allowed in state "${state.id}"`);
+    if (!toolName.startsWith('behavior_') && state.tools.length && !state.tools.includes(toolName)) {
+      throw new Error(`Tool "${toolName}" is not allowed in state "${state.id}"`);
+    }
     if (intent === state.id) return;
     if (!this.options.judgeIntent) throw new Error(`Intent must equal active state "${state.id}"`);
     const result = await this.options.judgeIntent({ intent, toolName, record, allowedTools: state.tools });

--- a/packages/behaviors/src/enforcement/intent-policy.ts
+++ b/packages/behaviors/src/enforcement/intent-policy.ts
@@ -1,0 +1,109 @@
+import type {
+  ProcessInputStepArgs,
+  ProcessInputStepResult,
+  ProcessOutputStepArgs,
+} from '@mastra/core/processors';
+import { z } from 'zod';
+
+import type { NormalizedBehaviorDefinition } from '../definition/types.js';
+import type { BehaviorRuntimeRecord, BehaviorRuntimeStore } from '../runtime/types.js';
+
+export const behaviorIntentField = 'intent';
+
+export type BehaviorIntentJudge = (input: {
+  intent: string;
+  toolName: string;
+  record: BehaviorRuntimeRecord;
+  allowedTools: readonly string[];
+}) => Promise<{ approved: boolean; feedback?: string }>;
+
+export type BehaviorIntentPolicyOptions = {
+  definition: NormalizedBehaviorDefinition;
+  store: BehaviorRuntimeStore;
+  judgeIntent?: BehaviorIntentJudge;
+};
+
+type ToolLike = {
+  inputSchema?: unknown;
+  execute?: (input: Record<string, unknown>, context?: unknown) => unknown;
+  [key: string]: unknown;
+};
+
+const getThreadId = (value: unknown): string | undefined => {
+  if (!value || typeof value !== 'object') return undefined;
+  const record = value as Record<string, unknown>;
+  if (typeof record.threadId === 'string') return record.threadId;
+  return getThreadId(record.context) ?? getThreadId(record.requestContext);
+};
+
+export class BehaviorIntentPolicyProcessor {
+  readonly id: string;
+  readonly name = 'Behavior intent policy';
+  private readonly wrappers = new WeakMap<object, ToolLike>();
+
+  constructor(private readonly options: BehaviorIntentPolicyOptions) {
+    this.id = `behavior-intent-${options.definition.id}`;
+  }
+
+  async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
+    if (!args.tools) return {};
+    const tools = Object.fromEntries(
+      Object.entries(args.tools).map(([name, tool]) => [name, this.wrapTool(name, tool as ToolLike)]),
+    );
+    return { tools };
+  }
+
+  async processOutputStep(args: ProcessOutputStepArgs) {
+    for (const call of args.toolCalls ?? []) {
+      const intent = this.readIntent(call.args);
+      if (!intent) args.abort(`Tool "${call.toolName}" requires an intent`, { retry: true });
+    }
+    return args.messages;
+  }
+
+  private wrapTool(name: string, tool: ToolLike): ToolLike {
+    if (!tool || typeof tool !== 'object' || typeof tool.execute !== 'function' || name.startsWith('behavior_')) return tool;
+    const cached = this.wrappers.get(tool);
+    if (cached) return cached;
+    const originalExecute = tool.execute.bind(tool);
+    const inputSchema = this.extendSchema(tool.inputSchema);
+    const wrapped: ToolLike = {
+      ...tool,
+      inputSchema,
+      execute: async (input, context) => {
+        const threadId = getThreadId(context);
+        if (!threadId) throw new Error(`Tool "${name}" requires behavior thread context`);
+        await this.authorize(threadId, name, this.readIntent(input));
+        const { intent: _intent, ...originalInput } = input;
+        return originalExecute(originalInput, context);
+      },
+    };
+    this.wrappers.set(tool, wrapped);
+    return wrapped;
+  }
+
+  private extendSchema(schema: unknown): unknown {
+    const intent = z.string().min(1).describe('Current behavior state name or a judged explanation of intent');
+    if (schema instanceof z.ZodObject) return schema.extend({ intent });
+    return z.object({ intent }).passthrough();
+  }
+
+  private readIntent(input: unknown): string | undefined {
+    if (!input || typeof input !== 'object') return undefined;
+    const value = (input as Record<string, unknown>)[behaviorIntentField];
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+  }
+
+  private async authorize(threadId: string, toolName: string, intent?: string): Promise<void> {
+    if (!intent) throw new Error(`Tool "${toolName}" requires an intent`);
+    const record = await this.options.store.readThread({ threadId, behaviorId: this.options.definition.id });
+    if (!record || record.status !== 'active') throw new Error('Behavior is not active');
+    const state = this.options.definition.states[record.activeState];
+    if (!state) throw new Error(`Behavior state "${record.activeState}" is unavailable`);
+    if (state.tools.length && !state.tools.includes(toolName)) throw new Error(`Tool "${toolName}" is not allowed in state "${state.id}"`);
+    if (intent === state.id) return;
+    if (!this.options.judgeIntent) throw new Error(`Intent must equal active state "${state.id}"`);
+    const result = await this.options.judgeIntent({ intent, toolName, record, allowedTools: state.tools });
+    if (!result.approved) throw new Error(result.feedback ?? `Intent was rejected for tool "${toolName}"`);
+  }
+}

--- a/packages/behaviors/src/enforcement/intent-policy.ts
+++ b/packages/behaviors/src/enforcement/intent-policy.ts
@@ -12,6 +12,8 @@ import type { BehaviorRuntimeRecord, BehaviorRuntimeStore } from '../runtime/typ
 
 export const behaviorIntentField = 'intent';
 
+const isBehaviorControlTool = (name: string) => name === 'behavior' || name === 'behavior_intent';
+
 export type BehaviorIntentJudge = (input: {
   intent: string;
   toolName: string;
@@ -58,7 +60,7 @@ export class BehaviorIntentPolicyProcessor {
 
   async processOutputStep(args: ProcessOutputStepArgs) {
     for (const call of args.toolCalls ?? []) {
-      if (call.toolName.startsWith('behavior_')) continue;
+      if (isBehaviorControlTool(call.toolName)) continue;
       const intent = this.readIntent(call.args);
       if (!intent) args.abort(`Tool "${call.toolName}" requires an intent`, { retry: true });
       const threadId = this.options.resolveThreadId?.(args.requestContext);
@@ -87,7 +89,7 @@ export class BehaviorIntentPolicyProcessor {
   }
 
   private wrapTool(name: string, tool: ToolLike): ToolLike {
-    if (!tool || typeof tool !== 'object' || typeof tool.execute !== 'function' || name.startsWith('behavior_')) return tool;
+    if (!tool || typeof tool !== 'object' || typeof tool.execute !== 'function' || isBehaviorControlTool(name)) return tool;
     const cached = this.wrappers.get(tool);
     if (cached) return cached;
     const originalExecute = tool.execute.bind(tool);
@@ -128,7 +130,7 @@ export class BehaviorIntentPolicyProcessor {
     if (!record || record.status !== 'active') throw new Error('Behavior is not active');
     const state = this.options.definition.states[record.activeState];
     if (!state) throw new Error(`Behavior state "${record.activeState}" is unavailable`);
-    if (!toolName.startsWith('behavior_') && state.tools.length && !state.tools.includes(toolName)) {
+    if (!isBehaviorControlTool(toolName) && state.tools.length && !state.tools.includes(toolName)) {
       throw new Error(`Tool "${toolName}" is not allowed in state "${state.id}"`);
     }
     if (intent === state.id) return;

--- a/packages/behaviors/src/index.ts
+++ b/packages/behaviors/src/index.ts
@@ -11,6 +11,8 @@ export type {
   NormalizedBehaviorState,
   NormalizedBehaviorTransition,
 } from './definition/types.js';
+export { BehaviorIntentPolicyProcessor, behaviorIntentField } from './enforcement/intent-policy.js';
+export type { BehaviorIntentJudge, BehaviorIntentPolicyOptions } from './enforcement/intent-policy.js';
 export { InMemoryBehaviorRuntimeStore } from './runtime/in-memory-store.js';
 export { LibSQLBehaviorRuntimeStore } from './runtime/libsql-store.js';
 export { BehaviorSignalProvider } from './runtime/provider.js';

--- a/packages/behaviors/src/integration/provider.test.ts
+++ b/packages/behaviors/src/integration/provider.test.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, expect, it, vi } from 'vitest';
 
 import { normalizeBehavior } from '../definition/normalize.js';
@@ -65,6 +66,24 @@ describe('BehaviorSignalProvider integration', () => {
     const { provider } = await makeProvider({ resolveModel: () => undefined, unavailableModel: 'error' });
     const routing = provider.getInputProcessors()[1] as { processInputStep(args: never): Promise<unknown> };
     await expect(routing.processInputStep(inputArgs())).rejects.toThrow('is unavailable');
+  });
+
+  it('uses state-signal thread context for tools in ordinary memory-backed agents', async () => {
+    const { provider, store } = await makeProvider({ resolveThreadId: () => undefined });
+    const requestContext = new RequestContext();
+    const stateProcessor = provider.getInputProcessors()[2] as {
+      computeStateSignal(args: never): Promise<unknown>;
+    };
+    await stateProcessor.computeStateSignal({
+      threadId: 'studio-thread',
+      requestContext,
+      contextWindow: { hasSnapshot: false },
+      activeStateSignals: [],
+      deltasSinceSnapshot: [],
+    } as never);
+    const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
+    await tools.behavior_select!.execute({}, { requestContext });
+    expect((await store.readThread({ threadId: 'studio-thread', behaviorId: 'coding' }))?.activeState).toBe('understand');
   });
 
   it('exposes stable selection, intent, transition, and exit tools', async () => {

--- a/packages/behaviors/src/integration/provider.test.ts
+++ b/packages/behaviors/src/integration/provider.test.ts
@@ -15,7 +15,11 @@ const definition = normalizeBehavior({
       instructions: 'Understand before editing.',
       skills: ['debugging'],
       model: 'small',
-      transitions: [{ id: 'exit', target: 'exit', exit: true }],
+      transitions: [{ id: 'implement', target: 'implement' }],
+    },
+    {
+      id: 'implement',
+      transitions: [{ id: 'return', target: 'understand' }],
     },
   ],
 });
@@ -29,7 +33,6 @@ const makeProvider = async (overrides = {}) => {
     ...overrides,
   });
   await provider.start();
-  await provider.engine.initialize('thread');
   return { provider, store };
 };
 
@@ -81,9 +84,10 @@ describe('BehaviorSignalProvider integration', () => {
       activeStateSignals: [],
       deltasSinceSnapshot: [],
     } as never);
-    const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
-    await tools.behavior_select!.execute({}, { requestContext });
     expect((await store.readThread({ threadId: 'studio-thread', behaviorId: 'coding' }))?.activeState).toBe('understand');
+    const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
+    await tools.behavior!.execute({ name: 'implement' }, { requestContext, agent: { toolCallId: 'move-1' } });
+    expect((await store.readThread({ threadId: 'studio-thread', behaviorId: 'coding' }))?.activeState).toBe('implement');
     const signal = await stateProcessor.computeStateSignal({
       threadId: 'studio-thread',
       requestContext,
@@ -93,19 +97,30 @@ describe('BehaviorSignalProvider integration', () => {
     } as never) as { tagName?: string; contents?: string; attributes?: Record<string, string> };
     expect(signal).toMatchObject({
       tagName: 'current-behavior',
-      attributes: { id: 'coding', state: 'understand', status: 'active' },
+      attributes: { id: 'coding', state: 'implement', status: 'active' },
     });
-    expect(signal.contents).toContain('State: understand');
+    expect(signal.contents).toContain('State: implement');
   });
 
-  it('exposes stable selection, intent, transition, and exit tools', async () => {
+  it('exposes one stable behavior transition tool with runtime-owned idempotency', async () => {
     const { provider, store } = await makeProvider();
-    const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
-    expect(Object.keys(tools)).toEqual(['behavior_select', 'behavior_intent', 'behavior_transition', 'behavior_exit']);
-    const context = { requestContext: { get: (key: string) => (key === 'threadId' ? 'thread' : undefined) } };
-    await tools.behavior_intent!.execute({ intent: 'understand' }, context);
-    expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.intent).toBe('understand');
-    await tools.behavior_exit!.execute({ attemptId: 'exit-1' }, context);
-    expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.status).toBe('exited');
+    const tools = provider.getTools() as Record<string, { inputSchema: { toJSONSchema(): unknown }; execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
+    expect(Object.keys(tools)).toEqual(['behavior', 'behavior_intent']);
+    expect(tools.behavior!.inputSchema.toJSONSchema()).toMatchObject({
+      required: ['name'],
+      properties: { name: expect.any(Object) },
+    });
+    expect(JSON.stringify(tools.behavior!.inputSchema.toJSONSchema())).not.toContain('attemptId');
+    const context = {
+      requestContext: { get: (key: string) => (key === 'threadId' ? 'thread' : undefined) },
+      agent: { toolCallId: 'move-1' },
+    };
+    await tools.behavior!.execute({ name: 'implement' }, context);
+    expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.activeState).toBe('implement');
+    await tools.behavior!.execute({ name: 'implement' }, context);
+    expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.revision).toBe(2);
+    await expect(tools.behavior!.execute({ name: 'missing' }, { ...context, agent: { toolCallId: 'move-2' } })).rejects.toThrow(
+      'is not available',
+    );
   });
 });

--- a/packages/behaviors/src/integration/provider.test.ts
+++ b/packages/behaviors/src/integration/provider.test.ts
@@ -21,7 +21,12 @@ const definition = normalizeBehavior({
 
 const makeProvider = async (overrides = {}) => {
   const store = new InMemoryBehaviorRuntimeStore();
-  const provider = new BehaviorSignalProvider({ definition, store, ...overrides });
+  const provider = new BehaviorSignalProvider({
+    definition,
+    store,
+    resolveThreadId: requestContext => requestContext?.get('threadId'),
+    ...overrides,
+  });
   await provider.start();
   await provider.engine.initialize('thread');
   return { provider, store };
@@ -42,8 +47,14 @@ describe('BehaviorSignalProvider integration', () => {
       processInputStep(args: never): Promise<{ systemMessages?: unknown[] }>;
     };
     const result = await routing.processInputStep(inputArgs());
-    expect(resolveModel).toHaveBeenCalledWith('small', { threadId: 'thread', stateId: 'understand' });
-    expect(resolveSkillInstructions).toHaveBeenCalledWith(['debugging'], { threadId: 'thread', stateId: 'understand' });
+    expect(resolveModel).toHaveBeenCalledWith(
+      'small',
+      expect.objectContaining({ threadId: 'thread', stateId: 'understand' }),
+    );
+    expect(resolveSkillInstructions).toHaveBeenCalledWith(
+      ['debugging'],
+      expect.objectContaining({ threadId: 'thread', stateId: 'understand' }),
+    );
     expect(result.systemMessages).toEqual([
       { role: 'system', content: 'Understand before editing.\n\nDebug systematically.' },
     ]);
@@ -60,9 +71,10 @@ describe('BehaviorSignalProvider integration', () => {
     const { provider, store } = await makeProvider();
     const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
     expect(Object.keys(tools)).toEqual(['behavior_select', 'behavior_intent', 'behavior_transition', 'behavior_exit']);
-    await tools.behavior_intent!.execute({ intent: 'understand' }, { threadId: 'thread' });
+    const context = { requestContext: { get: (key: string) => (key === 'threadId' ? 'thread' : undefined) } };
+    await tools.behavior_intent!.execute({ intent: 'understand' }, context);
     expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.intent).toBe('understand');
-    await tools.behavior_exit!.execute({ attemptId: 'exit-1' }, { threadId: 'thread' });
+    await tools.behavior_exit!.execute({ attemptId: 'exit-1' }, context);
     expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.status).toBe('exited');
   });
 });

--- a/packages/behaviors/src/integration/provider.test.ts
+++ b/packages/behaviors/src/integration/provider.test.ts
@@ -84,6 +84,18 @@ describe('BehaviorSignalProvider integration', () => {
     const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
     await tools.behavior_select!.execute({}, { requestContext });
     expect((await store.readThread({ threadId: 'studio-thread', behaviorId: 'coding' }))?.activeState).toBe('understand');
+    const signal = await stateProcessor.computeStateSignal({
+      threadId: 'studio-thread',
+      requestContext,
+      contextWindow: { hasSnapshot: false },
+      activeStateSignals: [],
+      deltasSinceSnapshot: [],
+    } as never) as { tagName?: string; contents?: string; attributes?: Record<string, string> };
+    expect(signal).toMatchObject({
+      tagName: 'current-behavior',
+      attributes: { id: 'coding', state: 'understand', status: 'active' },
+    });
+    expect(signal.contents).toContain('State: understand');
   });
 
   it('exposes stable selection, intent, transition, and exit tools', async () => {

--- a/packages/behaviors/src/integration/provider.test.ts
+++ b/packages/behaviors/src/integration/provider.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { normalizeBehavior } from '../definition/normalize.js';
+import { InMemoryBehaviorRuntimeStore } from '../runtime/in-memory-store.js';
+import { BehaviorSignalProvider } from '../runtime/provider.js';
+
+const definition = normalizeBehavior({
+  id: 'coding',
+  version: '1',
+  initialState: 'understand',
+  states: [
+    {
+      id: 'understand',
+      instructions: 'Understand before editing.',
+      skills: ['debugging'],
+      model: 'small',
+      transitions: [{ id: 'exit', target: 'exit', exit: true }],
+    },
+  ],
+});
+
+const makeProvider = async (overrides = {}) => {
+  const store = new InMemoryBehaviorRuntimeStore();
+  const provider = new BehaviorSignalProvider({ definition, store, ...overrides });
+  await provider.start();
+  await provider.engine.initialize('thread');
+  return { provider, store };
+};
+
+const inputArgs = () =>
+  ({
+    requestContext: { get: (key: string) => (key === 'threadId' ? 'thread' : undefined) },
+    systemMessages: [],
+  }) as never;
+
+describe('BehaviorSignalProvider integration', () => {
+  it('routes acting models and injects only active-state instructions and skills', async () => {
+    const resolveModel = vi.fn(() => ({ specificationVersion: 'v2' }));
+    const resolveSkillInstructions = vi.fn(() => ['Debug systematically.']);
+    const { provider } = await makeProvider({ resolveModel, resolveSkillInstructions, unavailableModel: 'error' });
+    const routing = provider.getInputProcessors()[1] as {
+      processInputStep(args: never): Promise<{ systemMessages?: unknown[] }>;
+    };
+    const result = await routing.processInputStep(inputArgs());
+    expect(resolveModel).toHaveBeenCalledWith('small', { threadId: 'thread', stateId: 'understand' });
+    expect(resolveSkillInstructions).toHaveBeenCalledWith(['debugging'], { threadId: 'thread', stateId: 'understand' });
+    expect(result.systemMessages).toEqual([
+      { role: 'system', content: 'Understand before editing.\n\nDebug systematically.' },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('judgeInstructions');
+  });
+
+  it('fails closed when a configured model is unavailable', async () => {
+    const { provider } = await makeProvider({ resolveModel: () => undefined, unavailableModel: 'error' });
+    const routing = provider.getInputProcessors()[1] as { processInputStep(args: never): Promise<unknown> };
+    await expect(routing.processInputStep(inputArgs())).rejects.toThrow('is unavailable');
+  });
+
+  it('exposes stable selection, intent, transition, and exit tools', async () => {
+    const { provider, store } = await makeProvider();
+    const tools = provider.getTools() as Record<string, { execute(input: Record<string, unknown>, context: unknown): Promise<unknown> }>;
+    expect(Object.keys(tools)).toEqual(['behavior_select', 'behavior_intent', 'behavior_transition', 'behavior_exit']);
+    await tools.behavior_intent!.execute({ intent: 'understand' }, { threadId: 'thread' });
+    expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.intent).toBe('understand');
+    await tools.behavior_exit!.execute({ attemptId: 'exit-1' }, { threadId: 'thread' });
+    expect((await store.readThread({ threadId: 'thread', behaviorId: 'coding' }))?.status).toBe('exited');
+  });
+});

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -130,7 +130,10 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
       behavior_transition: createBehaviorTool({
         id: 'behavior_transition',
         description: 'Move through an available behavior transition',
-        inputSchema: z.object({ transition: z.string().min(1), attemptId: z.string().min(1) }),
+        inputSchema: z.object({
+          transition: z.string().min(1),
+          attemptId: z.string().min(1).describe('Unique idempotency key; use a new value for every transition attempt'),
+        }),
         execute: async (input, context) =>
           this.engine.transition({
             threadId: threadId(context),
@@ -142,7 +145,9 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
       behavior_exit: createBehaviorTool({
         id: 'behavior_exit',
         description: 'Exit the active behavior through the current state exit transition',
-        inputSchema: z.object({ attemptId: z.string().min(1) }),
+        inputSchema: z.object({
+          attemptId: z.string().min(1).describe('Unique idempotency key; use a new value for this exit attempt'),
+        }),
         execute: async (input, context) => {
           const id = threadId(context);
           const record = await this.options.store.readThread({ threadId: id, behaviorId: this.options.definition.id });

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -1,6 +1,7 @@
 import { SignalProvider } from '@mastra/core/signals';
 
 import type { NormalizedBehaviorDefinition } from '../definition/types.js';
+import { BehaviorIntentPolicyProcessor, type BehaviorIntentJudge } from '../enforcement/intent-policy.js';
 import { BehaviorStateProcessor } from './state-processor.js';
 import { BehaviorTransitionEngine, type BehaviorTransitionEngineOptions } from './transition-engine.js';
 import type { BehaviorRuntimeStore } from './types.js';
@@ -8,18 +9,21 @@ import type { BehaviorRuntimeStore } from './types.js';
 export type BehaviorSignalProviderOptions = Omit<BehaviorTransitionEngineOptions, 'definition' | 'store'> & {
   definition: NormalizedBehaviorDefinition;
   store: BehaviorRuntimeStore;
+  judgeIntent?: BehaviorIntentJudge;
 };
 
 export class BehaviorSignalProvider extends SignalProvider<string> {
   readonly id: string;
   readonly engine: BehaviorTransitionEngine;
   private readonly stateProcessor: BehaviorStateProcessor;
+  private readonly intentProcessor: BehaviorIntentPolicyProcessor;
 
   constructor(readonly options: BehaviorSignalProviderOptions) {
     super();
     this.id = `behavior-${options.definition.id}`;
     this.engine = new BehaviorTransitionEngine(options);
     this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store);
+    this.intentProcessor = new BehaviorIntentPolicyProcessor(options);
   }
 
   async start(): Promise<void> {
@@ -27,6 +31,10 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
   }
 
   getInputProcessors() {
-    return [this.stateProcessor];
+    return [this.intentProcessor, this.stateProcessor];
+  }
+
+  getOutputProcessors() {
+    return [this.intentProcessor];
   }
 }

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -26,7 +26,11 @@ export type BehaviorSignalProviderOptions = Omit<BehaviorTransitionEngineOptions
   unavailableModel?: 'fallback' | 'error';
 };
 
-type BehaviorToolContext = { requestContext?: RequestContext; abortSignal?: AbortSignal };
+type BehaviorToolContext = {
+  requestContext?: RequestContext;
+  abortSignal?: AbortSignal;
+  agent?: { toolCallId?: string };
+};
 type BehaviorToolFactory = (definition: {
   id: string;
   description: string;
@@ -39,15 +43,20 @@ class BehaviorRoutingProcessor {
   readonly id: string;
   readonly name = 'Behavior state routing';
 
-  constructor(private readonly options: BehaviorSignalProviderOptions) {
+  constructor(
+    private readonly options: BehaviorSignalProviderOptions,
+    private readonly engine: BehaviorTransitionEngine,
+  ) {
     this.id = `behavior-routing-${options.definition.id}`;
   }
 
   async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
     const threadId = this.options.resolveThreadId(args.requestContext);
     if (!threadId) return {};
-    const record = await this.options.store.readThread({ threadId, behaviorId: this.options.definition.id });
-    if (!record || record.status !== 'active') return {};
+    const record =
+      (await this.options.store.readThread({ threadId, behaviorId: this.options.definition.id })) ??
+      (await this.engine.initialize(threadId));
+    if (record.status !== 'active') return {};
     const state = this.options.definition.states[record.activeState];
     if (!state) return {};
     const resolverInput = { threadId, stateId: state.id, requestContext: args.requestContext };
@@ -84,11 +93,16 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
       options.resolveThreadId(requestContext) ?? (requestContext ? this.threadIds.get(requestContext) : undefined);
     const runtimeOptions = { ...options, resolveThreadId: this.resolveThreadId };
     this.engine = new BehaviorTransitionEngine(options);
-    this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store, (requestContext, threadId) => {
-      if (requestContext) this.threadIds.set(requestContext, threadId);
-    });
+    this.stateProcessor = new BehaviorStateProcessor(
+      options.definition,
+      options.store,
+      (requestContext, threadId) => {
+        if (requestContext) this.threadIds.set(requestContext, threadId);
+      },
+      threadId => this.engine.initialize(threadId),
+    );
     this.intentProcessor = new BehaviorIntentPolicyProcessor(runtimeOptions);
-    this.routingProcessor = new BehaviorRoutingProcessor(runtimeOptions);
+    this.routingProcessor = new BehaviorRoutingProcessor(runtimeOptions, this.engine);
     this.tools = this.createTools();
   }
 
@@ -115,46 +129,25 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
       return id;
     };
     return {
-      behavior_select: createBehaviorTool({
-        id: 'behavior_select',
-        description: 'Start or resume this behavior for the current thread',
-        inputSchema: z.object({}),
-        execute: async (_input, context) => this.engine.initialize(threadId(context)),
+      behavior: createBehaviorTool({
+        id: 'behavior',
+        description: 'Move to an available behavior connected to the current behavior',
+        inputSchema: z.object({
+          name: z.string().min(1).describe('Name of the destination behavior'),
+        }),
+        execute: async (input, context) =>
+          this.engine.transition({
+            threadId: threadId(context),
+            name: input.name,
+            idempotencyKey: context.agent?.toolCallId,
+            signal: context.abortSignal,
+          }),
       }),
       behavior_intent: createBehaviorTool({
         id: 'behavior_intent',
         description: 'Set an approved intent for the active behavior state',
         inputSchema: z.object({ intent: z.string().min(1) }),
         execute: async (input, context) => this.intentProcessor.setIntent(threadId(context), input.intent),
-      }),
-      behavior_transition: createBehaviorTool({
-        id: 'behavior_transition',
-        description: 'Move through an available behavior transition',
-        inputSchema: z.object({
-          transition: z.string().min(1),
-          attemptId: z.string().min(1).describe('Unique idempotency key; use a new value for every transition attempt'),
-        }),
-        execute: async (input, context) =>
-          this.engine.transition({
-            threadId: threadId(context),
-            transitionId: input.transition,
-            attemptId: input.attemptId,
-            signal: context.abortSignal,
-          }),
-      }),
-      behavior_exit: createBehaviorTool({
-        id: 'behavior_exit',
-        description: 'Exit the active behavior through the current state exit transition',
-        inputSchema: z.object({
-          attemptId: z.string().min(1).describe('Unique idempotency key; use a new value for this exit attempt'),
-        }),
-        execute: async (input, context) => {
-          const id = threadId(context);
-          const record = await this.options.store.readThread({ threadId: id, behaviorId: this.options.definition.id });
-          const exit = record ? this.options.definition.states[record.activeState]?.transitions.find(item => item.exit) : undefined;
-          if (!exit) throw new Error('Active behavior state has no exit transition');
-          return this.engine.transition({ threadId: id, transitionId: exit.id, attemptId: input.attemptId, signal: context.abortSignal });
-        },
       }),
     };
   }

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -1,4 +1,7 @@
+import type { ProcessInputStepArgs, ProcessInputStepResult } from '@mastra/core/processors';
 import { SignalProvider } from '@mastra/core/signals';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
 
 import type { NormalizedBehaviorDefinition } from '../definition/types.js';
 import { BehaviorIntentPolicyProcessor, type BehaviorIntentJudge } from '../enforcement/intent-policy.js';
@@ -10,13 +13,57 @@ export type BehaviorSignalProviderOptions = Omit<BehaviorTransitionEngineOptions
   definition: NormalizedBehaviorDefinition;
   store: BehaviorRuntimeStore;
   judgeIntent?: BehaviorIntentJudge;
+  resolveModel?: (model: string, input: { threadId: string; stateId: string }) => Promise<unknown> | unknown;
+  resolveSkillInstructions?: (skills: readonly string[], input: { threadId: string; stateId: string }) => Promise<string[]> | string[];
+  unavailableModel?: 'fallback' | 'error';
 };
+
+type BehaviorToolContext = { threadId?: string; context?: { threadId?: string } };
+type BehaviorToolFactory = (definition: {
+  id: string;
+  description: string;
+  inputSchema: z.ZodTypeAny;
+  execute: (input: Record<string, unknown>, context?: BehaviorToolContext) => Promise<unknown>;
+}) => unknown;
+const createBehaviorTool = createTool as unknown as BehaviorToolFactory;
+
+class BehaviorRoutingProcessor {
+  readonly id: string;
+  readonly name = 'Behavior state routing';
+
+  constructor(private readonly options: BehaviorSignalProviderOptions) {
+    this.id = `behavior-routing-${options.definition.id}`;
+  }
+
+  async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
+    const threadId = args.requestContext?.get('threadId');
+    if (typeof threadId !== 'string') return {};
+    const record = await this.options.store.readThread({ threadId, behaviorId: this.options.definition.id });
+    if (!record || record.status !== 'active') return {};
+    const state = this.options.definition.states[record.activeState];
+    if (!state) return {};
+    const skillInstructions = this.options.resolveSkillInstructions
+      ? await this.options.resolveSkillInstructions(state.skills, { threadId, stateId: state.id })
+      : [];
+    const instruction = [state.instructions, ...skillInstructions].filter(Boolean).join('\n\n');
+    let model: unknown;
+    if (state.model && this.options.resolveModel) {
+      model = await this.options.resolveModel(state.model, { threadId, stateId: state.id });
+      if (!model && this.options.unavailableModel === 'error') throw new Error(`Behavior model "${state.model}" is unavailable`);
+    }
+    return {
+      ...(model ? { model: model as ProcessInputStepResult['model'] } : {}),
+      ...(instruction ? { systemMessages: [...args.systemMessages, { role: 'system', content: instruction }] } : {}),
+    };
+  }
+}
 
 export class BehaviorSignalProvider extends SignalProvider<string> {
   readonly id: string;
   readonly engine: BehaviorTransitionEngine;
   private readonly stateProcessor: BehaviorStateProcessor;
   private readonly intentProcessor: BehaviorIntentPolicyProcessor;
+  private readonly routingProcessor: BehaviorRoutingProcessor;
 
   constructor(readonly options: BehaviorSignalProviderOptions) {
     super();
@@ -24,6 +71,7 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
     this.engine = new BehaviorTransitionEngine(options);
     this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store);
     this.intentProcessor = new BehaviorIntentPolicyProcessor(options);
+    this.routingProcessor = new BehaviorRoutingProcessor(options);
   }
 
   async start(): Promise<void> {
@@ -31,7 +79,58 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
   }
 
   getInputProcessors() {
-    return [this.intentProcessor, this.stateProcessor];
+    return [this.intentProcessor, this.routingProcessor, this.stateProcessor];
+  }
+
+  getTools() {
+    const threadId = (context?: BehaviorToolContext) => context?.threadId ?? context?.context?.threadId;
+    return {
+      behavior_select: createBehaviorTool({
+        id: 'behavior_select',
+        description: 'Start or resume this behavior for the current thread',
+        inputSchema: z.object({}),
+        execute: async (_input, context) => {
+          const id = threadId(context);
+          if (!id) throw new Error('behavior_select requires thread context');
+          return this.engine.initialize(id);
+        },
+      }),
+      behavior_intent: createBehaviorTool({
+        id: 'behavior_intent',
+        description: 'Set the intent for the active behavior state',
+        inputSchema: z.object({ intent: z.string().min(1) }),
+        execute: async (input, context) => {
+          const id = threadId(context);
+          if (!id) throw new Error('behavior_intent requires thread context');
+          const key = { threadId: id, behaviorId: this.options.definition.id };
+          const committed = await this.options.store.transactThread(key, current => {
+            if (!current || current.status !== 'active') throw new Error('Behavior is not active');
+            return { next: { ...current, revision: current.revision + 1, intent: String(input.intent) }, result: undefined };
+          });
+          return committed.runtime;
+        },
+      }),
+      behavior_transition: createBehaviorTool({
+        id: 'behavior_transition',
+        description: 'Move through an available behavior transition',
+        inputSchema: z.object({ transition: z.string().min(1), attemptId: z.string().min(1) }),
+        execute: async (input, context) => {
+          const id = threadId(context);
+          if (!id) throw new Error('behavior_transition requires thread context');
+          return this.engine.transition({ threadId: id, transitionId: String(input.transition), attemptId: String(input.attemptId) });
+        },
+      }),
+      behavior_exit: createBehaviorTool({
+        id: 'behavior_exit',
+        description: 'Exit the active behavior through its reserved exit transition',
+        inputSchema: z.object({ attemptId: z.string().min(1) }),
+        execute: async (input, context) => {
+          const id = threadId(context);
+          if (!id) throw new Error('behavior_exit requires thread context');
+          return this.engine.transition({ threadId: id, transitionId: 'exit', attemptId: String(input.attemptId) });
+        },
+      }),
+    };
   }
 
   getOutputProcessors() {

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -74,14 +74,21 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
   private readonly intentProcessor: BehaviorIntentPolicyProcessor;
   private readonly routingProcessor: BehaviorRoutingProcessor;
   private readonly tools: Record<string, unknown>;
+  private readonly threadIds = new WeakMap<RequestContext, string>();
+  private readonly resolveThreadId: (requestContext?: RequestContext) => string | undefined;
 
   constructor(readonly options: BehaviorSignalProviderOptions) {
     super();
     this.id = `behavior-${options.definition.id}`;
+    this.resolveThreadId = requestContext =>
+      options.resolveThreadId(requestContext) ?? (requestContext ? this.threadIds.get(requestContext) : undefined);
+    const runtimeOptions = { ...options, resolveThreadId: this.resolveThreadId };
     this.engine = new BehaviorTransitionEngine(options);
-    this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store);
-    this.intentProcessor = new BehaviorIntentPolicyProcessor(options);
-    this.routingProcessor = new BehaviorRoutingProcessor(options);
+    this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store, (requestContext, threadId) => {
+      if (requestContext) this.threadIds.set(requestContext, threadId);
+    });
+    this.intentProcessor = new BehaviorIntentPolicyProcessor(runtimeOptions);
+    this.routingProcessor = new BehaviorRoutingProcessor(runtimeOptions);
     this.tools = this.createTools();
   }
 
@@ -103,7 +110,7 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
 
   private createTools(): Record<string, unknown> {
     const threadId = (context: BehaviorToolContext) => {
-      const id = this.options.resolveThreadId(context.requestContext);
+      const id = this.resolveThreadId(context.requestContext);
       if (!id) throw new Error('Behavior tool requires thread context');
       return id;
     };

--- a/packages/behaviors/src/runtime/provider.ts
+++ b/packages/behaviors/src/runtime/provider.ts
@@ -1,4 +1,5 @@
 import type { ProcessInputStepArgs, ProcessInputStepResult } from '@mastra/core/processors';
+import type { RequestContext } from '@mastra/core/request-context';
 import { SignalProvider } from '@mastra/core/signals';
 import { createTool } from '@mastra/core/tools';
 import { z } from 'zod';
@@ -12,18 +13,25 @@ import type { BehaviorRuntimeStore } from './types.js';
 export type BehaviorSignalProviderOptions = Omit<BehaviorTransitionEngineOptions, 'definition' | 'store'> & {
   definition: NormalizedBehaviorDefinition;
   store: BehaviorRuntimeStore;
+  resolveThreadId: (requestContext?: RequestContext) => string | undefined;
   judgeIntent?: BehaviorIntentJudge;
-  resolveModel?: (model: string, input: { threadId: string; stateId: string }) => Promise<unknown> | unknown;
-  resolveSkillInstructions?: (skills: readonly string[], input: { threadId: string; stateId: string }) => Promise<string[]> | string[];
+  resolveModel?: (
+    model: string,
+    input: { threadId: string; stateId: string; requestContext?: RequestContext },
+  ) => Promise<unknown> | unknown;
+  resolveSkillInstructions?: (
+    skills: readonly string[],
+    input: { threadId: string; stateId: string; requestContext?: RequestContext },
+  ) => Promise<string[]> | string[];
   unavailableModel?: 'fallback' | 'error';
 };
 
-type BehaviorToolContext = { threadId?: string; context?: { threadId?: string } };
+type BehaviorToolContext = { requestContext?: RequestContext; abortSignal?: AbortSignal };
 type BehaviorToolFactory = (definition: {
   id: string;
   description: string;
   inputSchema: z.ZodTypeAny;
-  execute: (input: Record<string, unknown>, context?: BehaviorToolContext) => Promise<unknown>;
+  execute: (input: any, context: BehaviorToolContext) => Promise<unknown>;
 }) => unknown;
 const createBehaviorTool = createTool as unknown as BehaviorToolFactory;
 
@@ -36,19 +44,20 @@ class BehaviorRoutingProcessor {
   }
 
   async processInputStep(args: ProcessInputStepArgs): Promise<ProcessInputStepResult> {
-    const threadId = args.requestContext?.get('threadId');
-    if (typeof threadId !== 'string') return {};
+    const threadId = this.options.resolveThreadId(args.requestContext);
+    if (!threadId) return {};
     const record = await this.options.store.readThread({ threadId, behaviorId: this.options.definition.id });
     if (!record || record.status !== 'active') return {};
     const state = this.options.definition.states[record.activeState];
     if (!state) return {};
+    const resolverInput = { threadId, stateId: state.id, requestContext: args.requestContext };
     const skillInstructions = this.options.resolveSkillInstructions
-      ? await this.options.resolveSkillInstructions(state.skills, { threadId, stateId: state.id })
+      ? await this.options.resolveSkillInstructions(state.skills, resolverInput)
       : [];
     const instruction = [state.instructions, ...skillInstructions].filter(Boolean).join('\n\n');
     let model: unknown;
     if (state.model && this.options.resolveModel) {
-      model = await this.options.resolveModel(state.model, { threadId, stateId: state.id });
+      model = await this.options.resolveModel(state.model, resolverInput);
       if (!model && this.options.unavailableModel === 'error') throw new Error(`Behavior model "${state.model}" is unavailable`);
     }
     return {
@@ -64,6 +73,7 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
   private readonly stateProcessor: BehaviorStateProcessor;
   private readonly intentProcessor: BehaviorIntentPolicyProcessor;
   private readonly routingProcessor: BehaviorRoutingProcessor;
+  private readonly tools: Record<string, unknown>;
 
   constructor(readonly options: BehaviorSignalProviderOptions) {
     super();
@@ -72,6 +82,7 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
     this.stateProcessor = new BehaviorStateProcessor(options.definition, options.store);
     this.intentProcessor = new BehaviorIntentPolicyProcessor(options);
     this.routingProcessor = new BehaviorRoutingProcessor(options);
+    this.tools = this.createTools();
   }
 
   async start(): Promise<void> {
@@ -83,57 +94,56 @@ export class BehaviorSignalProvider extends SignalProvider<string> {
   }
 
   getTools() {
-    const threadId = (context?: BehaviorToolContext) => context?.threadId ?? context?.context?.threadId;
+    return this.tools;
+  }
+
+  getOutputProcessors() {
+    return [this.intentProcessor];
+  }
+
+  private createTools(): Record<string, unknown> {
+    const threadId = (context: BehaviorToolContext) => {
+      const id = this.options.resolveThreadId(context.requestContext);
+      if (!id) throw new Error('Behavior tool requires thread context');
+      return id;
+    };
     return {
       behavior_select: createBehaviorTool({
         id: 'behavior_select',
         description: 'Start or resume this behavior for the current thread',
         inputSchema: z.object({}),
-        execute: async (_input, context) => {
-          const id = threadId(context);
-          if (!id) throw new Error('behavior_select requires thread context');
-          return this.engine.initialize(id);
-        },
+        execute: async (_input, context) => this.engine.initialize(threadId(context)),
       }),
       behavior_intent: createBehaviorTool({
         id: 'behavior_intent',
-        description: 'Set the intent for the active behavior state',
+        description: 'Set an approved intent for the active behavior state',
         inputSchema: z.object({ intent: z.string().min(1) }),
-        execute: async (input, context) => {
-          const id = threadId(context);
-          if (!id) throw new Error('behavior_intent requires thread context');
-          const key = { threadId: id, behaviorId: this.options.definition.id };
-          const committed = await this.options.store.transactThread(key, current => {
-            if (!current || current.status !== 'active') throw new Error('Behavior is not active');
-            return { next: { ...current, revision: current.revision + 1, intent: String(input.intent) }, result: undefined };
-          });
-          return committed.runtime;
-        },
+        execute: async (input, context) => this.intentProcessor.setIntent(threadId(context), input.intent),
       }),
       behavior_transition: createBehaviorTool({
         id: 'behavior_transition',
         description: 'Move through an available behavior transition',
         inputSchema: z.object({ transition: z.string().min(1), attemptId: z.string().min(1) }),
-        execute: async (input, context) => {
-          const id = threadId(context);
-          if (!id) throw new Error('behavior_transition requires thread context');
-          return this.engine.transition({ threadId: id, transitionId: String(input.transition), attemptId: String(input.attemptId) });
-        },
+        execute: async (input, context) =>
+          this.engine.transition({
+            threadId: threadId(context),
+            transitionId: input.transition,
+            attemptId: input.attemptId,
+            signal: context.abortSignal,
+          }),
       }),
       behavior_exit: createBehaviorTool({
         id: 'behavior_exit',
-        description: 'Exit the active behavior through its reserved exit transition',
+        description: 'Exit the active behavior through the current state exit transition',
         inputSchema: z.object({ attemptId: z.string().min(1) }),
         execute: async (input, context) => {
           const id = threadId(context);
-          if (!id) throw new Error('behavior_exit requires thread context');
-          return this.engine.transition({ threadId: id, transitionId: 'exit', attemptId: String(input.attemptId) });
+          const record = await this.options.store.readThread({ threadId: id, behaviorId: this.options.definition.id });
+          const exit = record ? this.options.definition.states[record.activeState]?.transitions.find(item => item.exit) : undefined;
+          if (!exit) throw new Error('Active behavior state has no exit transition');
+          return this.engine.transition({ threadId: id, transitionId: exit.id, attemptId: input.attemptId, signal: context.abortSignal });
         },
       }),
     };
-  }
-
-  getOutputProcessors() {
-    return [this.intentProcessor];
   }
 }

--- a/packages/behaviors/src/runtime/state-processor.ts
+++ b/packages/behaviors/src/runtime/state-processor.ts
@@ -14,12 +14,14 @@ export class BehaviorStateProcessor {
   constructor(
     private readonly definition: NormalizedBehaviorDefinition,
     private readonly store: BehaviorRuntimeStore,
+    private readonly rememberThreadId?: (requestContext: ComputeStateSignalArgs['requestContext'], threadId: string) => void,
   ) {
     this.id = `behavior-state-${definition.id}`;
     this.stateId = `behavior:${definition.id}`;
   }
 
   async computeStateSignal(args: ComputeStateSignalArgs): Promise<ComputeStateSignalResult> {
+    this.rememberThreadId?.(args.requestContext, args.threadId);
     const record = await this.store.readThread({ threadId: args.threadId, behaviorId: this.definition.id });
     const prior = args.lastSnapshot?.metadata?.record as { revision?: number; status?: string } | undefined;
     const hasBase = Boolean(args.lastSnapshot) && args.contextWindow.hasSnapshot;

--- a/packages/behaviors/src/runtime/state-processor.ts
+++ b/packages/behaviors/src/runtime/state-processor.ts
@@ -15,6 +15,7 @@ export class BehaviorStateProcessor {
     private readonly definition: NormalizedBehaviorDefinition,
     private readonly store: BehaviorRuntimeStore,
     private readonly rememberThreadId?: (requestContext: ComputeStateSignalArgs['requestContext'], threadId: string) => void,
+    private readonly initialize?: (threadId: string) => Promise<unknown>,
   ) {
     this.id = `behavior-state-${definition.id}`;
     this.stateId = `behavior:${definition.id}`;
@@ -22,7 +23,11 @@ export class BehaviorStateProcessor {
 
   async computeStateSignal(args: ComputeStateSignalArgs): Promise<ComputeStateSignalResult> {
     this.rememberThreadId?.(args.requestContext, args.threadId);
-    const record = await this.store.readThread({ threadId: args.threadId, behaviorId: this.definition.id });
+    let record = await this.store.readThread({ threadId: args.threadId, behaviorId: this.definition.id });
+    if (!record && this.initialize) {
+      await this.initialize(args.threadId);
+      record = await this.store.readThread({ threadId: args.threadId, behaviorId: this.definition.id });
+    }
     const prior = args.lastSnapshot?.metadata?.record as { revision?: number; status?: string } | undefined;
     const hasBase = Boolean(args.lastSnapshot) && args.contextWindow.hasSnapshot;
     if (!record || record.status !== 'active') {
@@ -40,14 +45,14 @@ export class BehaviorStateProcessor {
     }
     const state = this.definition.states[record.activeState];
     if (!state) return;
-    const transitions = state.transitions.map(item => item.id).join(', ');
+    const behaviors = state.transitions.map(item => item.target).join(', ');
     const cacheKey = `${this.stateId}:${lp(record.definitionVersion)}${lp(record.activeState)}${lp(record.intent ?? '')}`;
     if (hasBase && args.lastSnapshot?.metadata?.state?.cacheKey === cacheKey) return;
     const contents = [
       `Behavior: ${this.definition.id}`,
       `State: ${record.activeState}`,
       state.instructions ? `Instructions:\n${state.instructions}` : undefined,
-      `Available transitions: ${transitions}`,
+      `Available behaviors: ${behaviors}`,
       record.intent ? `Current intent: ${record.intent}` : 'Current intent: not set',
     ]
       .filter(Boolean)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,7 +594,7 @@ importers:
     dependencies:
       firebase-admin:
         specifier: ^13.7.0
-        version: 13.9.0
+        version: 13.9.0(encoding@0.1.13)
     devDependencies:
       '@internal/auth':
         specifier: workspace:*
@@ -1656,7 +1656,7 @@ importers:
         version: 3.10.1
       '@docusaurus/types':
         specifier: ^3.10.1
-        version: 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.60.0
@@ -2157,6 +2157,9 @@ importers:
       '@mastra/agent-browser':
         specifier: workspace:*
         version: link:../../browser/agent-browser
+      '@mastra/behaviors':
+        specifier: workspace:*
+        version: link:../../packages/behaviors
       '@mastra/core':
         specifier: workspace:*
         version: link:../../packages/core
@@ -23964,10 +23967,6 @@ packages:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
-  iconv-lite@0.7.0:
-    resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -27496,10 +27495,6 @@ packages:
     resolution: {integrity: sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==}
     engines: {node: '>= 0.8'}
 
-  raw-body@3.0.1:
-    resolution: {integrity: sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA==}
-    engines: {node: '>= 0.10'}
-
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
@@ -29387,10 +29382,6 @@ packages:
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
-    engines: {node: '>= 0.6'}
-
-  type-is@2.0.1:
-    resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
   type-is@2.1.0:
@@ -34055,7 +34046,7 @@ snapshots:
     dependencies:
       '@codemirror/state': 6.7.1
       '@codemirror/view': 6.43.6
-      crelt: 1.0.6
+      crelt: 1.0.7
 
   '@codemirror/state@6.7.1':
     dependencies:
@@ -34781,6 +34772,40 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@docusaurus/babel@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/core': 7.29.6
+      '@babel/generator': 7.29.7
+      '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.29.6)
+      '@babel/plugin-transform-runtime': 7.29.0(@babel/core@7.29.6)
+      '@babel/preset-env': 7.28.5(@babel/core@7.29.6)
+      '@babel/preset-react': 7.28.5(@babel/core@7.29.6)
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.6)
+      '@babel/runtime': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@docusaurus/logger': 3.10.1
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      babel-plugin-dynamic-import-node: 2.3.3
+      fs-extra: 11.3.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - react
+      - react-dom
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
   '@docusaurus/bundler@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@babel/core': 7.29.6
@@ -34828,12 +34853,12 @@ snapshots:
 
   '@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
-      '@docusaurus/babel': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/babel': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/bundler': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
       boxen: 6.2.1
@@ -34869,7 +34894,7 @@ snapshots:
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
       webpack-bundle-analyzer: 4.10.2(bufferutil@4.1.0)
       webpack-dev-server: 5.2.5(bufferutil@4.1.0)(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       webpack-merge: 6.0.1
@@ -34906,7 +34931,7 @@ snapshots:
 
   '@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       '@swc/html': 1.15.11
@@ -34915,7 +34940,7 @@ snapshots:
       semver: 7.8.4
       swc-loader: 0.2.7(@swc/core@1.15.7(@swc/helpers@0.5.17))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/css'
@@ -34937,7 +34962,7 @@ snapshots:
   '@docusaurus/mdx-loader@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
@@ -34961,7 +34986,7 @@ snapshots:
       unist-util-visit: 5.1.0
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       vfile: 6.0.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -34980,7 +35005,7 @@ snapshots:
 
   '@docusaurus/module-type-aliases@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -35012,9 +35037,9 @@ snapshots:
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
@@ -35028,7 +35053,7 @@ snapshots:
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35060,9 +35085,9 @@ snapshots:
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
@@ -35074,7 +35099,7 @@ snapshots:
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35103,14 +35128,14 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35138,8 +35163,8 @@ snapshots:
   '@docusaurus/plugin-css-cascade-layers@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -35171,8 +35196,8 @@ snapshots:
   '@docusaurus/plugin-debug@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -35205,7 +35230,7 @@ snapshots:
   '@docusaurus/plugin-google-analytics@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -35237,7 +35262,7 @@ snapshots:
   '@docusaurus/plugin-google-gtag@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/gtag.js': 0.0.20
       react: 19.2.7
@@ -35270,7 +35295,7 @@ snapshots:
   '@docusaurus/plugin-google-tag-manager@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -35303,9 +35328,9 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       react: 19.2.7
@@ -35339,15 +35364,15 @@ snapshots:
   '@docusaurus/plugin-svgr@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@svgr/core': 8.1.0(typescript@6.0.3)
       '@svgr/webpack': 8.1.0(typescript@6.0.3)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@docusaurus/faster'
       - '@mdx-js/react'
@@ -35376,8 +35401,8 @@ snapshots:
     dependencies:
       '@docusaurus/core': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@vercel/analytics': 1.6.1(react@19.2.7)
       react: 19.2.7
@@ -35429,7 +35454,7 @@ snapshots:
       '@docusaurus/theme-classic': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(@types/react@19.2.14)(bufferutil@4.1.0)(lightningcss@1.32.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-search-algolia': 3.10.1(@algolia/client-search@5.55.2)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(@types/react@19.2.14)(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@6.0.3)
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     transitivePeerDependencies:
@@ -35485,9 +35510,9 @@ snapshots:
       '@docusaurus/plugin-content-pages': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.7)
       clsx: 2.1.1
@@ -35532,8 +35557,8 @@ snapshots:
       '@docusaurus/mdx-loader': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/module-type-aliases': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/history': 4.7.11
       '@types/react': 19.2.14
       '@types/react-router-config': 5.0.11
@@ -35569,7 +35594,7 @@ snapshots:
       '@docusaurus/plugin-content-docs': 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
       '@docusaurus/theme-common': 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@swc/helpers@0.5.17)(postcss@8.5.15))(@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.7))(@rspack/core@1.7.12(@swc/helpers@0.5.17))(@swc/core@1.15.7(@swc/helpers@0.5.17))(bufferutil@4.1.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/theme-translations': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@docusaurus/utils-validation': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       algoliasearch: 5.55.2
       algoliasearch-helper: 3.27.0(algoliasearch@5.55.2)
@@ -35645,6 +35670,36 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@mdx-js/mdx': 3.1.1
+      '@types/history': 4.7.11
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.14
+      commander: 5.1.0
+      joi: 17.13.4
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-helmet-async: '@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)'
+      utility-types: 3.11.0
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack-merge: 5.10.0
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
   '@docusaurus/utils-common@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -35667,11 +35722,33 @@ snapshots:
       - uglify-js
       - webpack-cli
 
+  '@docusaurus/utils-common@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - react
+      - react-dom
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
   '@docusaurus/utils-validation@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@docusaurus/logger': 3.10.1
-      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       fs-extra: 11.3.5
       joi: 17.13.4
       js-yaml: 3.15.0
@@ -35718,6 +35795,47 @@ snapshots:
       url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       utility-types: 3.11.0
       webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - react
+      - react-dom
+      - supports-color
+      - uglify-js
+      - webpack-cli
+
+  '@docusaurus/utils@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@docusaurus/logger': 3.10.1
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/utils-common': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      escape-string-regexp: 4.0.0
+      execa: 5.1.1
+      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
+      fs-extra: 11.3.5
+      github-slugger: 1.5.0
+      globby: 11.1.0
+      gray-matter: 4.0.3
+      jiti: 1.21.7
+      js-yaml: 3.15.0
+      lodash: 4.18.1
+      micromatch: 4.0.8
+      p-queue: 6.6.2
+      prompts: 2.4.2
+      resolve-pathname: 3.0.0
+      tslib: 2.8.1
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
+      utility-types: 3.11.0
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'
@@ -36582,7 +36700,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@google-cloud/firestore@7.11.6':
+  '@google-cloud/firestore@7.11.6(encoding@0.1.13)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       fast-deep-equal: 3.1.3
@@ -37779,7 +37897,7 @@ snapshots:
 
   '@mastra/docusaurus-plugin-algolia@1.1.2(@docusaurus/types@3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(clsx@2.1.1)(lucide-react@1.23.0(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@docusaurus/types': 3.10.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-dialog': 1.1.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@tanstack/react-virtual': 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       algoliasearch: 5.55.2
@@ -37961,7 +38079,7 @@ snapshots:
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
-      raw-body: 3.0.1
+      raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     optionalDependencies:
@@ -37985,7 +38103,7 @@ snapshots:
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.0
-      raw-body: 3.0.1
+      raw-body: 3.0.2
       zod: 4.4.3
       zod-to-json-schema: 3.25.1(zod@4.4.3)
     optionalDependencies:
@@ -43976,7 +44094,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.2.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/eslint-plugin@1.6.19(@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9)':
     dependencies:
@@ -44105,7 +44223,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.5(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -44922,7 +45040,7 @@ snapshots:
       '@babel/core': 7.29.6
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
@@ -46024,7 +46142,7 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   core-js-compat@3.49.0:
     dependencies:
@@ -46151,7 +46269,7 @@ snapshots:
       semver: 7.8.4
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(lightningcss@1.32.0)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)):
     dependencies:
@@ -46161,7 +46279,7 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       clean-css: 5.3.3
       lightningcss: 1.32.0
@@ -47677,7 +47795,7 @@ snapshots:
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.1.0
-      semver: 7.8.4
+      semver: 7.8.5
       toad-cache: 3.7.0
 
   fastq@1.20.1:
@@ -47750,7 +47868,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   file-type@21.3.4:
     dependencies:
@@ -47883,7 +48001,7 @@ snapshots:
       pkg-types: 1.3.1
       yaml: 2.9.0
 
-  firebase-admin@13.9.0:
+  firebase-admin@13.9.0(encoding@0.1.13):
     dependencies:
       '@fastify/busboy': 3.2.0
       '@firebase/database-compat': 2.1.0
@@ -47896,7 +48014,7 @@ snapshots:
       node-forge: 1.4.0
       uuid: 11.1.1
     optionalDependencies:
-      '@google-cloud/firestore': 7.11.6
+      '@google-cloud/firestore': 7.11.6(encoding@0.1.13)
       '@google-cloud/storage': 7.19.0(encoding@0.1.13)
     transitivePeerDependencies:
       - encoding
@@ -48724,7 +48842,7 @@ snapshots:
       tapable: 2.3.3
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   htmlfy@0.8.1: {}
 
@@ -48876,10 +48994,6 @@ snapshots:
       safer-buffer: '@socketregistry/safer-buffer@1.0.10'
 
   iconv-lite@0.6.3:
-    dependencies:
-      safer-buffer: '@socketregistry/safer-buffer@1.0.10'
-
-  iconv-lite@0.7.0:
     dependencies:
       safer-buffer: '@socketregistry/safer-buffer@1.0.10'
 
@@ -49582,11 +49696,11 @@ snapshots:
       http-assert: 1.5.0
       http-errors: 2.0.1
       koa-compose: 4.1.0
-      mime-types: 3.0.1
+      mime-types: 3.0.2
       on-finished: 2.4.1
       parseurl: 1.3.3
       statuses: 2.0.2
-      type-is: 2.0.1
+      type-is: 2.1.0
       vary: 1.1.2
 
   kolorist@1.8.0: {}
@@ -49656,7 +49770,7 @@ snapshots:
 
   light-my-request@6.6.0:
     dependencies:
-      cookie: 1.1.1
+      cookie: 2.0.1
       process-warning: 4.0.1
       set-cookie-parser: 2.7.2
 
@@ -50930,7 +51044,7 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   miniflare@4.20260701.0(bufferutil@4.1.0):
     dependencies:
@@ -50982,12 +51096,24 @@ snapshots:
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.44.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.5.15)
       html-minifier-terser: 7.2.0
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15)):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.44.1
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
+    optionalDependencies:
+      '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       lightningcss: 1.32.0
       postcss: 8.5.15
 
@@ -51495,7 +51621,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   nunjucks@3.2.4(chokidar@3.6.0):
     dependencies:
@@ -52446,7 +52572,7 @@ snapshots:
       jiti: 1.21.7
       postcss: 8.5.15
       semver: 7.8.4
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -53096,13 +53222,6 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  raw-body@3.0.1:
-    dependencies:
-      bytes: 3.1.2
-      http-errors: 2.0.0
-      iconv-lite: 0.7.0
-      unpipe: 1.0.0
-
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
@@ -53195,7 +53314,7 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.29.7
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@19.2.7)'
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   react-markdown@8.0.7(@types/react@19.2.14)(react@19.2.7):
     dependencies:
@@ -55106,7 +55225,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
       '@swc/counter': 0.1.3
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   swc-loader@0.2.7(@swc/core@1.15.7(@swc/helpers@0.5.17))(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.16)):
     dependencies:
@@ -55294,7 +55413,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.5
       terser: 5.44.1
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       '@swc/core': 1.15.7(@swc/helpers@0.5.17)
 
@@ -55646,12 +55765,6 @@ snapshots:
     dependencies:
       media-typer: 0.3.0
       mime-types: 2.1.35
-
-  type-is@2.0.1:
-    dependencies:
-      content-type: 1.0.5
-      media-typer: 1.1.0
-      mime-types: 3.0.1
 
   type-is@2.1.0:
     dependencies:
@@ -56021,7 +56134,7 @@ snapshots:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
 
@@ -56724,7 +56837,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - tslib
 
@@ -56759,7 +56872,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       ws: 8.21.0(bufferutil@4.1.0)
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -56802,6 +56915,44 @@ snapshots:
       loader-runner: 4.3.2
       mime-db: 1.54.0
       minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.3
+      watchpack: 2.5.2
+      webpack-sources: 3.5.1
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15):
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.17.0
+      acorn-import-phases: 1.0.4(acorn@8.17.0)
+      browserslist: 4.28.5
+      chrome-trace-event: 1.0.4
+      enhanced-resolve: 5.24.2
+      es-module-lexer: 2.3.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      graceful-fs: 4.2.11
+      loader-runner: 4.3.2
+      mime-db: 1.54.0
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(@swc/html@1.15.11)(lightningcss@1.32.0)(postcss@8.5.15))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -56906,7 +57057,7 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       '@rspack/core': 1.7.12(@swc/helpers@0.5.17)
-      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.15))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.15)
+      webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(lightningcss@1.32.0)(postcss@8.5.15)
 
   webrtc-adapter@9.0.5:
     dependencies:


### PR DESCRIPTION
## Summary\n\n- enforce behavior intent before and during governed tool execution while preserving tool names, schemas, and wrapper identity across transitions\n- route state-specific models, acting instructions, and skills through host resolvers without exposing judge instructions\n- add stable behavior control tools and a thin Mastra Code plugin adapter backed by the shared provider\n- cover ordinary-provider behavior, plugin loading, and the real Mastra Code TUI path\n\n## Test plan\n\n- pnpm --filter @mastra/behaviors exec vitest run --reporter=dot --bail 1\n- pnpm --filter @mastra/behaviors check\n- pnpm build:mastracode\n- pnpm --filter ./mastracode/sdk exec vitest run src/plugins --reporter=dot --bail 1\n- MC_E2E_VITEST_SCENARIOS=behaviors pnpm --filter ./mastracode/tui exec vitest run --config e2e/vitest.config.ts --reporter=dot --bail 1\n- pnpm validate (from docs/)\n- live proof transcript ends with PROOF: GREEN\n