### PR TITLE
fix(studio): prevent copy icon from getting cut off

### DIFF
--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -258,7 +258,7 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
           <MessageFactory message={dbMessage} {...assistantRenderers} status={messageStatusRenderers} />
         </div>
         {showActionBar && (
-          <div className="h-6 pt-4 flex gap-2 items-center">
+          <div className="h-8 pt-2 flex gap-2 items-center">
             <AssistantActionBar
               text={getTextFromParts(message)}
               modelMetadata={modelMetadata}


### PR DESCRIPTION
## Description

Fixes a layout issue in the studio where the action icons (like the copy button) at the bottom of the response blocks are vertically cut off. Adjusting the container from `h-6 pt-4` to `h-8 pt-2` increases the total height and reduces the top padding, giving the icons enough vertical clearance to render fully.

## Related issue(s)

None. Fixes a self-contained visual layout bug in the studio UI.

### Visuals

| Before | After |
| :--- | :--- |
| <img width="634" alt="Before - Cut off icon" src="https://github.com/user-attachments/assets/0145d6b6-3736-41db-84e8-5a84312db535" /> | <img width="730" alt="After - Fixed icon" src="https://github.com/user-attachments/assets/43d8b7a3-9c22-4f2e-ab75-dc3fe02b4269" /> |

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The buttons under assistant messages were getting cut off. This change gives them a little more room so icons like Copy display properly.

## Changes

- Increased the action bar height from `h-6` to `h-8`.
- Reduced top padding from `pt-4` to `pt-2`.
- No message rendering logic or public APIs changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->