### PR TITLE
fix(braintrust): show tool name instead of unknown_tool in Messages tab

### DIFF
--- a/.changeset/social-walls-worry.md
+++ b/.changeset/social-walls-worry.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+Fixed tool calls showing as `unknown_tool` in the Braintrust Messages tab. Tool spans (`TOOL_CALL` and `MCP_TOOL_CALL`) are now converted to OpenAI chat messages, so Braintrust shows the real tool name and pairs the call with its result.

--- a/observability/braintrust/src/formatter.ts
+++ b/observability/braintrust/src/formatter.ts
@@ -168,7 +168,7 @@ function convertContentPart(part: AISDKContentPart | null | undefined): string |
 /**
  * Serializes tool result data to a string for OpenAI format.
  */
-function serializeToolResult(resultData: unknown): string {
+export function serializeToolResult(resultData: unknown): string {
   if (typeof resultData === 'string') {
     return resultData;
   }

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -537,6 +537,128 @@ describe('BraintrustExporter', () => {
     });
   });
 
+  /**
+   * Tool spans must be chat-shaped so Braintrust's Messages renderer shows the
+   * real tool name. Without this the renderer finds no function.name and labels
+   * the call `unknown_tool`.
+   *
+   * @see https://github.com/mastra-ai/mastra/issues/19308
+   */
+  describe('Tool span chat shaping (unknown_tool fix)', () => {
+    it('shapes TOOL_CALL input/output as OpenAI messages with the real tool name', async () => {
+      const toolSpan = createMockSpan({
+        id: 'tool-span-1',
+        name: "tool: 'getWeather'",
+        type: SpanType.TOOL_CALL,
+        isRoot: true,
+        entityName: 'getWeather',
+        input: { city: 'Paris' },
+        output: { temperatureC: 21, conditions: 'Sunny' },
+        attributes: { toolId: 'getWeather' },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      expect(mockLogger.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            input: [
+              {
+                role: 'assistant',
+                content: '',
+                tool_calls: [
+                  {
+                    id: 'tool-span-1',
+                    type: 'function',
+                    function: { name: 'getWeather', arguments: '{"city":"Paris"}' },
+                  },
+                ],
+              },
+            ],
+            output: {
+              role: 'tool',
+              content: '{"temperatureC":21,"conditions":"Sunny"}',
+              tool_call_id: 'tool-span-1',
+            },
+          }),
+        }),
+      );
+    });
+
+    it('never emits unknown_tool: function.name is always set', async () => {
+      const toolSpan = createMockSpan({
+        id: 'tool-span-2',
+        name: "tool: 'getWeather'",
+        type: SpanType.TOOL_CALL,
+        isRoot: true,
+        entityName: 'getWeather',
+        input: { city: 'Paris' },
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      const call = mockLogger.startSpan.mock.calls.at(-1)![0];
+      const name = call.event.input[0].tool_calls[0].function.name;
+      expect(name).toBe('getWeather');
+      expect(name).not.toBe('unknown_tool');
+    });
+
+    it('falls back to the name inside the span name when entityName is missing', async () => {
+      const toolSpan = createMockSpan({
+        id: 'tool-span-3',
+        name: "tool: 'searchDocs'",
+        type: SpanType.TOOL_CALL,
+        isRoot: true,
+        input: { q: 'mastra' },
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      const call = mockLogger.startSpan.mock.calls.at(-1)![0];
+      expect(call.event.input[0].tool_calls[0].function.name).toBe('searchDocs');
+    });
+
+    it('chat-shapes MCP_TOOL_CALL spans and pairs call/result with the same id', async () => {
+      const mcpSpan = createMockSpan({
+        id: 'mcp-span-1',
+        name: "mcp_tool: 'read_file' on 'fs-server'",
+        type: SpanType.MCP_TOOL_CALL,
+        isRoot: true,
+        entityName: 'read_file',
+        input: { path: '/tmp/a.txt' },
+        output: 'file contents',
+        attributes: { mcpServer: 'fs-server' },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: mcpSpan,
+      });
+
+      const call = mockLogger.startSpan.mock.calls.at(-1)![0];
+      const callId = call.event.input[0].tool_calls[0].id;
+      expect(call.event.input[0].tool_calls[0].function.name).toBe('read_file');
+      expect(call.event.output).toEqual({
+        role: 'tool',
+        content: 'file contents',
+        tool_call_id: callId,
+      });
+      // The assistant tool_call id and the tool message id must match for pairing.
+      expect(callId).toBe('mcp-span-1');
+    });
+  });
+
   describe('LLM Generation Attributes', () => {
     it('should handle LLM generation with full attributes', async () => {
       const traceId = 'trace-id';
@@ -1429,7 +1551,9 @@ describe('BraintrustExporter', () => {
       });
 
       expect(mockSpan.log).toHaveBeenCalledWith({
-        output: { result: 42 },
+        // Tool output is chat-shaped into an OpenAI tool message so Braintrust's
+        // Messages renderer pairs it with the call instead of showing unknown_tool.
+        output: { role: 'tool', content: '{"result":42}', tool_call_id: 'tool-span' },
         metadata: {
           spanType: 'tool_call',
           toolId: 'calc',
@@ -2692,6 +2816,8 @@ function createMockSpan({
   errorInfo,
   tags,
   traceId,
+  entityName,
+  entityId,
 }: {
   id: string;
   name: string;
@@ -2704,6 +2830,8 @@ function createMockSpan({
   errorInfo?: any;
   tags?: string[];
   traceId?: string;
+  entityName?: string;
+  entityId?: string;
 }): AnyExportedSpan {
   const mockSpan = {
     id,
@@ -2715,6 +2843,8 @@ function createMockSpan({
     output,
     errorInfo,
     tags,
+    entityName,
+    entityId,
     startTime: new Date(),
     endTime: undefined,
     traceId: traceId ?? (isRoot ? id : 'parent-trace-id'),

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -13,7 +13,8 @@ import { TrackingExporter } from '@mastra/observability';
 import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import { initLogger, currentSpan } from 'braintrust';
 import type { Span, Logger } from 'braintrust';
-import { removeNullish, convertAISDKMessage } from './formatter';
+import { removeNullish, convertAISDKMessage, serializeToolResult } from './formatter';
+import type { OpenAIMessage } from './formatter';
 import { formatUsageMetrics } from './metrics';
 import { reconstructThreadOutput } from './thread-reconstruction';
 import type { ThreadData, ThreadStepData, PendingToolResult } from './thread-reconstruction';
@@ -489,15 +490,78 @@ export class BraintrustExporter extends TrackingExporter<
     return output;
   }
 
+  /**
+   * Resolve the tool name for a TOOL_CALL/MCP_TOOL_CALL span.
+   * Prefers `entityName` (set to the tool name by core), falling back to the
+   * name inside the span name (e.g. `tool: 'getWeather'`).
+   */
+  private getToolName(span: AnyExportedSpan): string {
+    if (span.entityName) {
+      return span.entityName;
+    }
+    const match = /'([^']+)'/.exec(span.name);
+    return match?.[1] ?? span.name;
+  }
+
+  /**
+   * Resolve the id used to pair the tool call with its result. Core does not
+   * currently put the `toolCallId` on the span, so fall back to the span id.
+   * Both the assistant `tool_calls[].id` and the tool message `tool_call_id`
+   * use this so Braintrust's Messages renderer can pair them.
+   */
+  private getToolCallId(span: AnyExportedSpan): string {
+    return span.id;
+  }
+
+  /**
+   * Convert a TOOL_CALL/MCP_TOOL_CALL span input (the tool arguments) into an
+   * OpenAI assistant message with a `tool_calls` entry. Without this, Braintrust's
+   * Messages renderer finds no `function.name` and labels the call `unknown_tool`.
+   */
+  private toToolCallInput(span: AnyExportedSpan): OpenAIMessage[] {
+    const args = span.input;
+    const argsString = typeof args === 'string' ? args : JSON.stringify(args ?? {});
+    return [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: this.getToolCallId(span),
+            type: 'function',
+            function: {
+              name: this.getToolName(span),
+              arguments: argsString,
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  /**
+   * Convert a TOOL_CALL/MCP_TOOL_CALL span output (the tool result) into an
+   * OpenAI tool message paired with the call via `tool_call_id`.
+   */
+  private toToolCallOutput(span: AnyExportedSpan): OpenAIMessage {
+    return {
+      role: 'tool',
+      content: serializeToolResult(span.output),
+      tool_call_id: this.getToolCallId(span),
+    };
+  }
+
   private buildSpanPayload(span: AnyExportedSpan, isCreate = true): Record<string, any> {
     const payload: Record<string, any> = {};
 
+    const isToolSpan = span.type === SpanType.TOOL_CALL || span.type === SpanType.MCP_TOOL_CALL;
+
     if (span.input !== undefined) {
-      payload.input = this.transformInput(span.input, span.type);
+      payload.input = isToolSpan ? this.toToolCallInput(span) : this.transformInput(span.input, span.type);
     }
 
     if (span.output !== undefined) {
-      payload.output = this.transformOutput(span.output, span.type);
+      payload.output = isToolSpan ? this.toToolCallOutput(span) : this.transformOutput(span.output, span.type);
     }
 
     if (isCreate && span.isRootSpan && span.tags?.length) {


### PR DESCRIPTION
## Description

Tool spans (`TOOL_CALL` and `MCP_TOOL_CALL`) were logged with raw args/result objects, so Braintrust's Messages renderer found no `function.name` and labelled every tool call `unknown_tool`. This chat-shapes tool span input/output into OpenAI messages so Braintrust shows the real tool name.

The tool name comes from the span's `entityName` (falling back to the name inside the span title, e.g. `tool: 'getWeather'`), and the call is paired with its result by the span id.

Before, the tool span input was logged as-is and the renderer couldn't read a name:

```json
{ "city": "Paris" }
```

After, it's an assistant message with a `tool_calls` entry:

```json
[
  {
    "role": "assistant",
    "content": "",
    "tool_calls": [
      {
        "id": "<span-id>",
        "type": "function",
        "function": { "name": "getWeather", "arguments": "{\"city\":\"Paris\"}" }
      }
    ]
  }
]
```

The result is shaped into a matching tool message (`{ role: "tool", content, tool_call_id }`).

This is the companion to #19311 (independent, can merge in any order). They touch different code paths and share the same reproduction.

## Related issue(s)

Fixes #19308

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
