### PR TITLE
fix(core,braintrust): show tool results in the Braintrust Thread view

### DIFF
--- a/.changeset/icy-icons-grin.md
+++ b/.changeset/icy-icons-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+Fixed tool results missing from the Braintrust Thread view. The exporter now reads the tool call ID from the span attributes to pair each tool result with its call.

--- a/.changeset/nine-heads-boil.md
+++ b/.changeset/nine-heads-boil.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added the tool call ID to tool execution spans (`TOOL_CALL` and `MCP_TOOL_CALL`) so observability exporters can correlate a tool call with its result.

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -861,6 +861,110 @@ describe('BraintrustExporter', () => {
     );
   });
 
+  /**
+   * Regression test for issue #19309: the Braintrust Thread view never showed
+   * tool results because core creates the TOOL_CALL span with input = args only
+   * (no toolCallId). The toolCallId now lives on the span attributes, and the
+   * exporter reads it from there to pair each result with its call.
+   *
+   * @see https://github.com/mastra-ai/mastra/issues/19309
+   */
+  it('attaches tool results using the toolCallId from span attributes (issue #19309)', async () => {
+    const traceId = 'tool-result-attributes-trace';
+
+    const llmSpan = createMockSpan({
+      id: 'model-gen-span',
+      traceId,
+      name: 'gpt-4-call',
+      type: SpanType.MODEL_GENERATION,
+      isRoot: true,
+      input: [{ role: 'user', content: 'What is 2+2?' }],
+      output: { text: 'The answer is 4.' },
+      attributes: { model: 'gpt-4', provider: 'openai' },
+    });
+
+    const modelStep0Span = createMockSpan({
+      id: 'model-step-0-span',
+      traceId,
+      name: 'Model Step 0',
+      type: SpanType.MODEL_STEP,
+      isRoot: false,
+      input: {},
+      output: {
+        text: '',
+        toolCalls: [{ toolCallId: 'tc-1', toolName: 'calculator', args: { a: 2, b: 2 } }],
+      },
+      attributes: { stepIndex: 0 },
+    });
+    modelStep0Span.parentSpanId = llmSpan.id;
+
+    // Realistic TOOL_CALL span: input is the validated args only (no toolCallId),
+    // and the toolCallId lives on the attributes (as core now sets it).
+    const toolCallSpan = createMockSpan({
+      id: 'tool-call-span',
+      traceId,
+      name: "tool: 'calculator'",
+      type: SpanType.TOOL_CALL,
+      isRoot: false,
+      input: { a: 2, b: 2 },
+      output: { result: 4 },
+      attributes: { toolId: 'calculator', success: true, toolCallId: 'tc-1' },
+    });
+    toolCallSpan.parentSpanId = modelStep0Span.id;
+
+    const modelStep1Span = createMockSpan({
+      id: 'model-step-1-span',
+      traceId,
+      name: 'Model Step 1',
+      type: SpanType.MODEL_STEP,
+      isRoot: false,
+      input: {},
+      output: { text: 'The answer is 4.', toolCalls: [] },
+      attributes: { stepIndex: 1 },
+    });
+    modelStep1Span.parentSpanId = llmSpan.id;
+
+    await exporter.exportTracingEvent({ type: TracingEventType.SPAN_STARTED, exportedSpan: llmSpan });
+    await exporter.exportTracingEvent({ type: TracingEventType.SPAN_STARTED, exportedSpan: modelStep0Span });
+    await exporter.exportTracingEvent({ type: TracingEventType.SPAN_STARTED, exportedSpan: toolCallSpan });
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...toolCallSpan, endTime: new Date() },
+    });
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...modelStep0Span, endTime: new Date() },
+    });
+    await exporter.exportTracingEvent({ type: TracingEventType.SPAN_STARTED, exportedSpan: modelStep1Span });
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...modelStep1Span, endTime: new Date() },
+    });
+
+    mockSpan.log.mockClear();
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_ENDED,
+      exportedSpan: { ...llmSpan, endTime: new Date() },
+    });
+
+    // The tool result (from the TOOL_CALL span) must appear as a tool message,
+    // paired with the call by tc-1.
+    expect(mockSpan.log).toHaveBeenCalledWith(
+      expect.objectContaining({
+        output: [
+          {
+            role: 'assistant',
+            content: '',
+            tool_calls: [{ id: 'tc-1', type: 'function', function: { name: 'calculator', arguments: '{"a":2,"b":2}' } }],
+          },
+          { role: 'tool', content: '{"result":4}', tool_call_id: 'tc-1' },
+          { role: 'assistant', content: 'The answer is 4.' },
+        ],
+      }),
+    );
+  });
+
   describe('AI SDK v5 Message Conversion', () => {
     it('should convert AI SDK v5 user messages to OpenAI format', async () => {
       const llmSpan = createMockSpan({

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -392,9 +392,11 @@ export class BraintrustExporter extends TrackingExporter<
       return;
     }
 
-    // Extract tool call ID from TOOL_CALL span input
+    // Extract the tool call ID. Core sets it on the span attributes; fall back to
+    // the span input for older core versions that included it there.
+    const attributes = span.attributes as { toolCallId?: string } | undefined;
     const input = span.input as { toolCallId?: string } | undefined;
-    const toolCallId = input?.toolCallId;
+    const toolCallId = attributes?.toolCallId ?? input?.toolCallId;
     if (!toolCallId) {
       return;
     }

--- a/packages/core/src/observability/types/tracing.ts
+++ b/packages/core/src/observability/types/tracing.ts
@@ -353,6 +353,8 @@ export interface ToolCallAttributes extends AIBaseAttributes {
   toolType?: string;
   toolDescription?: string;
   success?: boolean;
+  /** ID of the tool call this span belongs to, used to correlate the call with its result. */
+  toolCallId?: string;
 }
 
 /**
@@ -387,6 +389,8 @@ export interface MCPToolCallAttributes extends AIBaseAttributes {
   toolDescription?: string;
   /** Whether tool execution was successful */
   success?: boolean;
+  /** ID of the tool call this span belongs to, used to correlate the call with its result. */
+  toolCallId?: string;
 }
 
 /**

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -250,6 +250,7 @@ describe('MCP Tool Tracing', () => {
           mcpServer: 'filesystem-server',
           serverVersion: '1.2.0',
           toolDescription: 'List files in a directory',
+          toolCallId: 'test-call-id',
         },
       }),
     );
@@ -301,9 +302,50 @@ describe('MCP Tool Tracing', () => {
         attributes: {
           toolDescription: 'A regular tool',
           toolType: 'tool',
+          toolCallId: 'test-call-id',
         },
       }),
     );
+  });
+
+  it('should include the toolCallId on the tool span so exporters can correlate the result', async () => {
+    const testTool = createTool({
+      id: 'regular-tool',
+      description: 'A regular tool',
+      inputSchema: z.object({ value: z.string() }),
+      execute: async inputData => ({ result: inputData.value }),
+    });
+
+    const mockToolSpan = {
+      end: vi.fn(),
+      error: vi.fn(),
+    };
+
+    const mockAgentSpan = {
+      createChildSpan: vi.fn().mockReturnValue(mockToolSpan),
+    } as unknown as AnySpan;
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'regular-tool',
+        logger: {
+          debug: vi.fn(),
+          warn: vi.fn(),
+          error: vi.fn(),
+          trackException: vi.fn(),
+        } as any,
+        description: 'A regular tool',
+        requestContext: new RequestContext(),
+        tracingContext: { currentSpan: mockAgentSpan },
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({ value: 'test' }, { toolCallId: 'call-abc-123', messages: [] });
+
+    const spanArgs = (mockAgentSpan.createChildSpan as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(spanArgs.attributes.toolCallId).toBe('call-abc-123');
   });
 
   it('should handle mcpMetadata with missing serverVersion', async () => {
@@ -351,6 +393,7 @@ describe('MCP Tool Tracing', () => {
       mcpServer: 'my-mcp-server',
       serverVersion: undefined,
       toolDescription: 'Read a resource',
+      toolCallId: 'test-call-id',
     });
     expect(spanArgs.name).toBe("mcp_tool: 'mcp_read-resource' on 'my-mcp-server'");
   });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -753,10 +753,12 @@ export class CoreToolBuilder extends MastraBase {
               mcpServer: mcpMeta.serverName,
               serverVersion: mcpMeta.serverVersion,
               toolDescription: options.description,
+              toolCallId: execOptions?.toolCallId,
             }
           : {
               toolDescription: options.description,
               toolType: logType || 'tool',
+              toolCallId: execOptions?.toolCallId,
             },
         tracingPolicy: options.tracingPolicy,
         tracingContext: tracingContext,


### PR DESCRIPTION
## Description

The Braintrust Thread view showed each tool call but never its result. The exporter keyed pending tool results by `span.input.toolCallId`, but core creates the `TOOL_CALL` span with `input` set to the validated tool arguments only, so the id was never present and every result was dropped during thread reconstruction.

Core now sets `toolCallId` on the `TOOL_CALL` and `MCP_TOOL_CALL` span attributes (the value is already in scope as `execOptions.toolCallId`), and the exporter reads it from there, falling back to `input` for older core versions.

```ts
// core, when creating the tool span
attributes: {
  toolDescription: options.description,
  toolType: logType || 'tool',
  toolCallId: execOptions?.toolCallId, // new
}
```

```ts
// braintrust exporter, when accumulating the result
const toolCallId = span.attributes?.toolCallId ?? span.input?.toolCallId;
```

This is the companion to #19310 (independent, can merge in any order). They touch different code paths and share the same reproduction.

## Related issue(s)

Fixes #19309

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Braintrust now shows both a tool request and the tool’s answer in Thread views. The change adds a shared ID so the two can be matched, including when using older core versions.

## What changed

- Added optional `toolCallId` tracing attributes to `TOOL_CALL` and `MCP_TOOL_CALL` spans.
- Updated the Braintrust exporter to match tool results using the span attribute, with a fallback to `span.input.toolCallId`.
- Added regression and tracing tests covering regular and MCP tools.
- Added patch release changesets for `@mastra/core` and `@mastra/braintrust`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->