### PR TITLE
fix(core): type registerApiRoute createHandler arg as { mastra }

### DIFF
--- a/.changeset/fix-createhandler-arg-type.md
+++ b/.changeset/fix-createhandler-arg-type.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix the `createHandler` option type on `registerApiRoute`. It's called with `{ mastra }` at runtime but was typed as `(c: Context)`; it's now `(opts: { mastra: Mastra }) => Promise<ApiRouteHandler>`, matching the runtime and the internal `ApiRoute` type.

--- a/docs/src/content/en/reference/server/register-api-route.mdx
+++ b/docs/src/content/en/reference/server/register-api-route.mdx
@@ -47,8 +47,9 @@ registerApiRoute("/items/:itemId", { ... })
   },
   {
     name: 'createHandler',
-    type: '(c: Context) => Promise<Handler>',
-    description: 'Async factory function to create the handler. Use either `handler` or `createHandler`, not both.',
+    type: '({ mastra }: { mastra: Mastra }) => Promise<ApiRouteHandler>',
+    description:
+      'Async factory that receives the Mastra instance and returns the route handler. Runs once at server startup, so it can perform one-time setup. Use either `handler` or `createHandler`, not both.',
     isOptional: true,
   },
   {
@@ -303,12 +304,13 @@ For routes that need async initialization:
 ```typescript
 registerApiRoute('/dynamic', {
   method: 'GET',
-  createHandler: async c => {
-    // Perform async setup
+  createHandler: async ({ mastra }) => {
+    // Perform one-time async setup
     const config = await loadConfig()
+    const agent = mastra.getAgent('weatherAgent')
 
     return async c => {
-      return c.json({ config })
+      return c.json({ config, agent: agent.name })
     }
   },
 })

--- a/packages/core/src/server/index.ts
+++ b/packages/core/src/server/index.ts
@@ -1,4 +1,4 @@
-import type { Context, Handler, MiddlewareHandler } from 'hono';
+import type { Handler, MiddlewareHandler } from 'hono';
 import type { DescribeRouteOptions } from 'hono-openapi';
 import { MastraError, ErrorDomain, ErrorCategory } from '../error';
 import type { Mastra } from '../mastra';
@@ -53,7 +53,7 @@ type RegisterApiRouteOptions<P extends string> = {
     P,
     ParamsFromPath<P>
   >;
-  createHandler?: (c: Context) => Promise<ApiRouteHandler>;
+  createHandler?: (opts: { mastra: Mastra }) => Promise<ApiRouteHandler>;
   middleware?: MiddlewareHandler | MiddlewareHandler[];
   /**
    * Route-specific CORS configuration.

--- a/packages/core/src/server/server.test-d.ts
+++ b/packages/core/src/server/server.test-d.ts
@@ -64,6 +64,19 @@ describe('registerApiRoute Type Tests', () => {
         },
       });
     });
+
+    it('types the createHandler factory arg as { mastra }, not a Hono Context', () => {
+      registerApiRoute('/factory', {
+        method: 'GET',
+        createHandler: async ({ mastra }) => {
+          // adapter calls this as route.createHandler({ mastra }), so mastra
+          // should be the Mastra instance, not a Hono Context
+          expectTypeOf(mastra).toEqualTypeOf<Mastra>();
+
+          return async c => c.json({ ok: true });
+        },
+      });
+    });
   });
 });
 


### PR DESCRIPTION
## Description

`registerApiRoute`'s `createHandler` is typed `(c: Context)`, but at runtime it's called with `{ mastra }` ([server-adapter/index.ts:904](https://github.com/mastra-ai/mastra/blob/cf7831a9271df60609073c84f527668eeadd0406/packages/server/src/server/server-adapter/index.ts#L904)), which is also what the `ApiRoute` type says ([types.ts:36](https://github.com/mastra-ai/mastra/blob/cf7831a9271df60609073c84f527668eeadd0406/packages/core/src/server/types.ts#L36)). So the correct-at-runtime `({ mastra }) => ...` doesn't typecheck and you have to cast.

Types the arg as `{ mastra: Mastra }`. `Context` was only used there, so it's dropped from the import. The returned handler's `(c: any)` is intentional and left as is.

No docs change needed: the createHandler reference example never reads the arg, so it still compiles under the new type.

## Related issue(s)

Fixes #19319

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The route setup function now receives the Mastra instance it actually uses, instead of being told to expect the wrong kind of object. This prevents TypeScript errors and updates the documentation and type tests to match.

## Changes

- Fixed `registerApiRoute`’s `createHandler` argument type to `{ mastra: Mastra }`.
- Added a type test verifying the corrected callback argument.
- Updated the reference documentation and example to use `{ mastra }`.
- Added changeset metadata for the bug fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->