### PR TITLE
fix(core): prevent fatal crash when LSP server dies mid-write

### DIFF
--- a/.changeset/lsp-write-epipe-crash.md
+++ b/.changeset/lsp-write-epipe-crash.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a fatal crash (write EPIPE) when a language server process exits or stops reading while a request is being sent to it. LSP requests now fail with a clean timeout error instead of crashing the host process.

--- a/.changeset/lsp-write-epipe-crash.md
+++ b/.changeset/lsp-write-epipe-crash.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed a fatal crash (write EPIPE) when a language server process exits or stops reading while a request is being sent to it. LSP requests now fail with a clean timeout error instead of crashing the host process.
+Fixed a crash that could happen when a language server process exited or stopped responding while a request was being sent to it. The request now fails with a clean timeout error instead of crashing the host process.

--- a/packages/core/src/workspace/lsp/client.test.ts
+++ b/packages/core/src/workspace/lsp/client.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'vitest';
-import { diagnosticsKey } from './client';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { LocalSandbox } from '../sandbox/local-sandbox';
+import { LSPClient, diagnosticsKey } from './client';
+import type { LSPServerDef } from './types';
 
 describe('diagnosticsKey', () => {
   it('returns the same key for Windows file URIs that differ in drive-letter case and colon encoding', () => {
@@ -23,4 +31,121 @@ describe('diagnosticsKey', () => {
   it('passes through non-file-URI strings unchanged', () => {
     expect(diagnosticsKey('/already/a/path.ts')).toBe('/already/a/path.ts');
   });
+});
+
+/**
+ * A minimal fake LSP server: answers the `initialize` request correctly, then
+ * closes its stdin while staying alive. From the client's point of view the
+ * connection still looks healthy (stdout is open, the process is running), so
+ * the next request goes through the full stream write path and fails with
+ * EPIPE — the same failure mode as a language server that hangs or dies while
+ * a request is being written to it.
+ */
+const FAKE_SERVER_SCRIPT = `
+const fs = require('node:fs');
+const markerPath = process.argv[2];
+let buf = Buffer.alloc(0);
+process.stdin.on('data', (chunk) => {
+  buf = Buffer.concat([buf, chunk]);
+  for (;;) {
+    const headerEnd = buf.indexOf('\\r\\n\\r\\n');
+    if (headerEnd === -1) return;
+    const header = buf.subarray(0, headerEnd).toString('utf8');
+    const match = header.match(/Content-Length: (\\d+)/);
+    if (!match) return;
+    const bodyStart = headerEnd + 4;
+    const length = parseInt(match[1], 10);
+    if (buf.length < bodyStart + length) return;
+    let msg;
+    try {
+      msg = JSON.parse(buf.subarray(bodyStart, bodyStart + length).toString('utf8'));
+    } catch {
+      return;
+    }
+    buf = buf.subarray(bodyStart + length);
+    if (msg.method === 'initialize') {
+      const response = JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: { capabilities: {} } });
+      process.stdout.write('Content-Length: ' + Buffer.byteLength(response) + '\\r\\n\\r\\n' + response, () => {
+        // Close the read end of the stdin pipe while staying alive, so the
+        // client's next write hits EPIPE instead of a closed connection.
+        process.stdin.pause();
+        fs.closeSync(0);
+        setImmediate(() => fs.writeFileSync(markerPath, 'closed'));
+      });
+    }
+  }
+});
+// Stay alive so the connection does not observe the server going away.
+const keepalive = setInterval(() => {}, 1000);
+// Safety net: never outlive the test run.
+setTimeout(() => { clearInterval(keepalive); process.exit(0); }, 15000).unref();
+`;
+
+describe('LSPClient — server write failures', () => {
+  let dir: string;
+  let sandbox: LocalSandbox;
+  let client: LSPClient;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'lsp-client-test-'));
+    sandbox = new LocalSandbox({ workingDirectory: dir });
+    await sandbox.start();
+  });
+
+  afterEach(async () => {
+    await client?.shutdown().catch(() => {});
+    await sandbox.stop().catch(() => {});
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  // EPIPE pipe semantics are POSIX-specific; the crash this guards against is
+  // platform-independent (it lives in vscode-jsonrpc), so one platform suffices.
+  it.skipIf(process.platform === 'win32')(
+    'does not leak an unhandled rejection when a request write fails (EPIPE)',
+    async () => {
+      const scriptPath = path.join(dir, 'fake-lsp-server.cjs');
+      const markerPath = path.join(dir, 'stdin-closed.marker');
+      await writeFile(scriptPath, FAKE_SERVER_SCRIPT, 'utf8');
+
+      const serverDef: LSPServerDef = {
+        id: 'fake',
+        name: 'Fake LSP',
+        languageIds: ['plaintext'],
+        markers: [],
+        // `exec` so node replaces the intermediate shell — otherwise the shell
+        // keeps the stdin pipe's read end open and the write never hits EPIPE.
+        command: () => `exec node "${scriptPath}" "${markerPath}"`,
+      };
+
+      client = new LSPClient(serverDef, dir, sandbox.processes);
+      await client.initialize(5000);
+
+      // Wait until the fake server has closed its stdin.
+      await vi.waitFor(() => expect(existsSync(markerPath)).toBe(true), { timeout: 5000 });
+
+      // Track unhandled rejections. Without the writer-rejection guard in
+      // LSPClient.initialize, vscode-jsonrpc re-throws the stream write error
+      // inside an async promise executor nothing awaits, which surfaces as an
+      // unhandled rejection and crashes the host process.
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => {
+        unhandled.push(reason);
+      };
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        // The request must fail cleanly (timeout or write error) — not crash.
+        await expect(
+          client.queryHover(`file://${dir}/some-file.txt`, { line: 0, character: 0 }, 1000),
+        ).rejects.toThrow();
+
+        // Give any stray rejection a macrotask to surface.
+        await new Promise(resolve => setTimeout(resolve, 250));
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    },
+    20000,
+  );
 });

--- a/packages/core/src/workspace/lsp/client.ts
+++ b/packages/core/src/workspace/lsp/client.ts
@@ -193,6 +193,16 @@ export class LSPClient {
 
     const reader = new StreamMessageReader(this.handle.reader);
     const writer = new StreamMessageWriter(this.handle.writer);
+    // vscode-jsonrpc's Connection.sendRequest re-throws stream write errors inside
+    // an `async` promise executor. That throw rejects the executor's own implicit
+    // promise (which nothing awaits) instead of the request promise, so when the
+    // server process dies mid-write (e.g. EPIPE), it surfaces as an unhandled
+    // rejection and crashes the host process. Swallow write rejections here: the
+    // error still reaches the connection's error handler via the writer's
+    // handleError, and every request we send is wrapped in a timeout, so callers
+    // get a clean timeout error instead of a fatal crash.
+    const originalWrite = writer.write.bind(writer);
+    writer.write = (msg: unknown) => originalWrite(msg).catch(() => {});
     this.connection = createMessageConnection(reader, writer);
 
     // Silently ignore stream destroyed errors during shutdown


### PR DESCRIPTION
When an LSP server process dies (or stops reading its stdin) while a request is being written to it, the whole host process crashes with a fatal `write EPIPE`. We hit this repeatedly in Mastra Code — any language server crashing mid-session takes the entire CLI down with it.

The root cause is in how vscode-jsonrpc's `Connection.sendRequest` handles write failures: it re-throws the stream write error inside an `async` promise executor that nothing awaits, so the failure surfaces as an unhandled rejection instead of rejecting the request promise.

This guards the message writer in `LSPClient.initialize` so write rejections are swallowed — the error still reaches the connection's error handler, and every request is already wrapped in a timeout, so callers now get a clean timeout error instead of a crash.

```ts
// before: server dies mid-write → unhandled rejection → fatal "write EPIPE"
// after:  queryHover(...) rejects with "LSP request timed out" and the process survives
```

Includes a regression test with a fake LSP server that completes the initialize handshake and then closes its stdin while staying alive, reproducing the exact EPIPE write path (fails without the fix, passes with it).



Fixes #19323


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sometimes an app sends a message to a language server, but the server dies or stops accepting input mid-message. This PR makes the app handle that safely, so it doesn’t crash—instead the request fails cleanly (via the existing timeout).

## Summary

- Updated `LSPClient.initialize` to swallow failed JSON-RPC stream writes (preventing host-crashing unhandled write rejections) while still routing errors through the connection’s existing error handling.
- Kept the existing per-request timeout behavior so affected requests resolve as a clean timeout error rather than crashing the host.
- Added a regression test with a fake LSP server that completes `initialize`, then closes stdin while staying alive; asserts hover requests reject without emitting `unhandledRejection` events.
- Added a patch changeset for `@mastra/core` describing the user-visible “crash to timeout error” outcome.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->