### PR TITLE
chore(playground): add Tailwind CSS linting

### DIFF
--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -1,5 +1,6 @@
 import { createConfig } from '@internal/lint/eslint';
 import reactRefresh from 'eslint-plugin-react-refresh';
+import tailwindcss from 'eslint-plugin-tailwindcss';
 
 const reactHooks = (await import('eslint-plugin-react-hooks')).default;
 
@@ -203,6 +204,20 @@ export default [
     ],
   },
   ...config,
+  {
+    ...tailwindcss.configs.recommended,
+    rules: {
+      ...tailwindcss.configs.recommended.rules,
+      // The rule currently flags valid v4 infinite-spacing utilities, imported
+      // theme tokens, and intentional CSS hooks as custom class names.
+      'tailwindcss/no-custom-classname': 'off',
+    },
+    settings: {
+      tailwindcss: {
+        cssConfigPath: './src/index.css',
+      },
+    },
+  },
   {
     plugins: {
       'react-hooks': reactHooks,

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -110,6 +110,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-tailwindcss": "^4.1.0",
     "jsdom": "^27",
     "react-grab": "^0.1.37",
     "tailwindcss": "4.2.2",

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -36,7 +36,7 @@ function MobileNavbar() {
   };
 
   return (
-    <header className="lg:hidden sticky top-0 z-20 flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border1 bg-surface1 px-3">
+    <header className="sticky top-0 z-20 flex h-12 shrink-0 items-center justify-between gap-3 border-b border-border1 bg-surface1 px-3 lg:hidden">
       <div className="flex min-w-0 items-center gap-3">
         <MainSidebar.MobileTrigger />
         <span className="flex min-w-0 items-center gap-2">
@@ -74,7 +74,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
       <NavigationCommand />
       <div className={cn('h-full', shouldShowSidebar && 'lg:grid lg:grid-cols-[auto_1fr] lg:grid-rows-[1fr]')}>
         {shouldShowSidebar && <AppSidebar />}
-        <div className="flex flex-col h-full min-h-0">
+        <div className="flex h-full min-h-0 flex-col">
           {shouldShowSidebar && <MobileNavbar />}
           {shouldShowSidebar && (
             <div className="mx-1.5 mt-1 shrink-0 lg:mx-2 lg:mt-1.5">
@@ -84,8 +84,8 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
           <PageHeadingContext.Provider value={pageHeading}>
             <div
               className={cn(
-                'ml-0 mx-1.5 mb-1.5 flex-1 min-h-0 overflow-y-auto [--studio-frame-radius:1.5rem] [--studio-frame-inset:0.5rem] rounded-studio-frame border border-border1 bg-surface2 shadow-main-frame lg:mx-2 lg:mb-2 lg:ml-0',
-                shouldShowSidebar ? 'mt-0' : 'mt-1.5 lg:mt-2 h-[calc(100%-1.5rem)]',
+                'mx-1.5 mb-1.5 ml-0 min-h-0 flex-1 overflow-y-auto rounded-studio-frame border border-border1 bg-surface2 shadow-main-frame [--studio-frame-inset:0.5rem] [--studio-frame-radius:1.5rem] lg:mx-2 lg:mb-2 lg:ml-0',
+                shouldShowSidebar ? 'mt-0' : 'mt-1.5 h-[calc(100%-1.5rem)] lg:mt-2',
               )}
             >
               <AuthRequired>
@@ -103,7 +103,7 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
   const { experimentalUIEnabled } = useExperimentalUIEnabled();
 
   return (
-    <div className="bg-surface1 font-sans h-screen">
+    <div className="h-screen bg-surface1 font-sans">
       <Toaster position="bottom-right" />
       <ThemeProvider defaultTheme="dark">
         <TooltipProvider delayDuration={0}>

--- a/packages/playground/src/components/minimal-layout.tsx
+++ b/packages/playground/src/components/minimal-layout.tsx
@@ -5,7 +5,7 @@ import { AuthRequired } from '@/domains/auth/components/auth-required';
 
 export const MinimalLayout = ({ children }: { children: React.ReactNode }) => {
   return (
-    <div className="bg-surface1 font-sans h-screen">
+    <div className="h-screen bg-surface1 font-sans">
       <Toaster position="bottom-right" />
       <ThemeProvider defaultTheme="dark">
         <TooltipProvider delayDuration={0}>

--- a/packages/playground/src/components/session-header.tsx
+++ b/packages/playground/src/components/session-header.tsx
@@ -51,7 +51,7 @@ export const SessionHeader = () => {
       {presets && Object.keys(presets).length > 0 && (
         <HeaderAction>
           <Select value={selectedPreset} onValueChange={handlePresetChange}>
-            <SelectTrigger size="sm" className="w-[200px]">
+            <SelectTrigger size="sm" className="w-50">
               <SelectValue placeholder="Select a preset..." />
             </SelectTrigger>
             <SelectContent>

--- a/packages/playground/src/components/ui/app-sidebar.tsx
+++ b/packages/playground/src/components/ui/app-sidebar.tsx
@@ -90,13 +90,13 @@ export function AppSidebar() {
 
   return (
     <MainSidebar>
-      <div className="pt-2 mb-2">
+      <div className="mb-2 pt-2">
         {state === 'collapsed' ? (
-          <div className="flex flex-col gap-2 items-center">
-            <div className="relative grid place-items-center size-9">
+          <div className="flex flex-col items-center gap-2">
+            <div className="relative grid size-9 place-items-center">
               <LogoWithoutText
                 className={cn(
-                  'h-[1.5rem] w-[1.5rem] shrink-0 transition-opacity duration-150',
+                  'size-[1.5rem] shrink-0 transition-opacity duration-150',
                   !isMobile && 'group-hover/sidebar:opacity-0',
                 )}
               />
@@ -109,10 +109,10 @@ export function AppSidebar() {
             {isUserAuthenticated && <AuthStatus />}
           </div>
         ) : isUserAuthenticated ? (
-          <span className="flex items-center justify-between pl-3 pr-2">
-            <span className="flex items-center gap-2 flex-1 min-w-0">
-              <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
-              <span className="font-display text-sm font-semibold tracking-tight whitespace-nowrap truncate">
+          <span className="flex items-center justify-between pr-2 pl-3">
+            <span className="flex min-w-0 flex-1 items-center gap-2">
+              <LogoWithoutText className="size-[1.5rem] shrink-0" />
+              <span className="truncate font-display text-sm font-semibold tracking-tight whitespace-nowrap">
                 Mastra Studio
               </span>
               {!isMobile && <MainSidebar.Trigger />}
@@ -120,9 +120,9 @@ export function AppSidebar() {
             <AuthStatus />
           </span>
         ) : (
-          <span className="flex items-center gap-2 pl-3 pr-2">
-            <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
-            <span className="font-display text-sm font-semibold tracking-tight whitespace-nowrap truncate">
+          <span className="flex items-center gap-2 pr-2 pl-3">
+            <LogoWithoutText className="size-[1.5rem] shrink-0" />
+            <span className="truncate font-display text-sm font-semibold tracking-tight whitespace-nowrap">
               Mastra Studio
             </span>
             {!isMobile && <MainSidebar.Trigger />}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-builder-title.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-builder-title.tsx
@@ -15,8 +15,8 @@ export const AgentBuilderTitle = ({ className, isLoading = false }: AgentBuilder
 
   return (
     <div className={className} data-testid="agent-builder-title">
-      <div className="flex items-center gap-2 min-w-0">
-        <span className="block text-ui-md leading-ui-md text-white truncate" data-testid="agent-builder-title-name">
+      <div className="flex min-w-0 items-center gap-2">
+        <span className="block truncate text-ui-md leading-ui-md text-white" data-testid="agent-builder-title-name">
           {isLoading ? (
             <Skeleton className="inline-block h-4 w-24 align-middle" data-testid="agent-builder-title-skeleton" />
           ) : (

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-chat-panel.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-chat-panel.tsx
@@ -157,7 +157,7 @@ const AgentChatMessageList = ({ onStarterPromptSelect }: AgentChatMessageListPro
               <Avatar name={agentName ?? 'Agent'} src={agentAvatarUrl} size="lg" />
             </div>
             <div className="starter-chip" style={{ animationDelay: '150ms' }}>
-              <Txt variant="ui-lg" className="text-neutral6 font-semibold" style={{ viewTransitionName: 'agent-name' }}>
+              <Txt variant="ui-lg" className="font-semibold text-neutral6" style={{ viewTransitionName: 'agent-name' }}>
                 {agentName ?? 'your agent'}
               </Txt>
             </div>
@@ -165,7 +165,7 @@ const AgentChatMessageList = ({ onStarterPromptSelect }: AgentChatMessageListPro
               <div className="starter-chip" style={{ animationDelay: '220ms' }}>
                 <Txt
                   variant="ui-sm"
-                  className="text-neutral4 max-w-[40ch]"
+                  className="max-w-[40ch] text-neutral4"
                   style={{ viewTransitionName: 'agent-description' }}
                 >
                   {agentDescription}
@@ -182,7 +182,7 @@ const AgentChatMessageList = ({ onStarterPromptSelect }: AgentChatMessageListPro
                 onClick={() => onStarterPromptSelect(starterPrompt.prompt)}
                 data-testid={`agent-builder-agent-chat-starter-${starterPrompt.title.toLowerCase().replace(/\s+/g, '-')}`}
                 style={{ animationDelay: `${280 + index * 40}ms` }}
-                className="starter-chip group flex gap-3 rounded-3xl border border-border1 bg-surface2 p-4 text-left transition-colors duration-normal ease-out-custom hover:border-border2 hover:bg-surface3 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent1"
+                className="starter-chip group duration-normal flex gap-3 rounded-3xl border border-border1 bg-surface2 p-4 text-left transition-colors ease-out-custom hover:border-border2 hover:bg-surface3 focus-visible:ring-2 focus-visible:ring-accent1 focus-visible:outline-none"
               >
                 <span className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-md bg-surface3 text-neutral4 transition-colors group-hover:text-neutral6">
                   <starterPrompt.Icon className="size-4" aria-hidden="true" />
@@ -190,7 +190,7 @@ const AgentChatMessageList = ({ onStarterPromptSelect }: AgentChatMessageListPro
                 <span className="min-w-0">
                   <Txt
                     variant="ui-sm"
-                    className="text-neutral6 font-medium transition-colors group-hover:text-neutral6"
+                    className="font-medium text-neutral6 transition-colors group-hover:text-neutral6"
                   >
                     {starterPrompt.title}
                   </Txt>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-impact-warnings.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-impact-warnings.tsx
@@ -60,7 +60,7 @@ export const AgentImpactWarnings = ({ agentId, variant, enabled = true }: AgentI
             ))}
           </ul>
           {overflow > 0 && (
-            <p data-testid="agent-impact-dependents-more" className="mt-1 text-icon-3">
+            <p data-testid="agent-impact-dependents-more" className="text-icon-3 mt-1">
               and {overflow} more
             </p>
           )}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/agent-profile-model-step.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/agent-profile-model-step.test.tsx
@@ -81,7 +81,6 @@ describe('AgentProfileModelStep', () => {
     expect(screen.getByTestId('agent-step-content').className).toContain('overflow-hidden');
     expect(screen.getByTestId('models-provider-filter').className).toContain('h-full');
     expect(screen.getByTestId('agent-step-footer').className).toContain('border-t');
-    expect(screen.getByTestId('agent-step-footer').className).toContain('pt-6');
   });
 
   it('makes the model picker read-only while the builder stream runs (parity with the Tools step)', async () => {

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/agent-profile-tools-step.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/agent-profile-tools-step.test.tsx
@@ -65,7 +65,7 @@ describe('AgentProfileToolsStep', () => {
     expect(count.parentElement?.className).toContain('rounded-full');
   });
 
-  it('renders the navigation footer with a top border and pt-6 spacing', () => {
+  it('renders the navigation footer with a top border', () => {
     render(
       <Harness>
         <AgentProfileToolsStep />
@@ -74,6 +74,5 @@ describe('AgentProfileToolsStep', () => {
 
     const footer = screen.getByTestId('agent-step-footer');
     expect(footer.className).toContain('border-t');
-    expect(footer.className).toContain('pt-6');
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools-loading.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools-loading.test.tsx
@@ -43,7 +43,7 @@ describe('Tools loading state', () => {
     cleanup();
   });
 
-  it('shows a skeleton (never the empty state) while provider tools load, then the padded empty state', async () => {
+  it('shows a skeleton while provider tools load, then the empty state', async () => {
     const gate = (() => {
       let resolve: () => void = () => {};
       const promise = new Promise<void>(r => {
@@ -74,13 +74,9 @@ describe('Tools loading state', () => {
 
     gate.resolve();
 
-    // Once resolved-empty, the empty state appears with the pane padding the
-    // two-column layouts use, so it is not flush under the `!py-0` tab shell.
     await waitFor(() => {
       expect(screen.queryByTestId('tools-card-picker-loading')).toBeNull();
     });
     expect(screen.getByText('No tools available in this project')).toBeTruthy();
-    expect(screen.getByTestId('tools-empty-state').className).toContain('px-6');
-    expect(screen.getByTestId('tools-empty-state').className).toContain('py-6');
   });
 });

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools.test.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/__tests__/tools.test.tsx
@@ -187,19 +187,6 @@ describe('Tools', () => {
     await findByText('No selected tools match unchecked');
   });
 
-  it('uses the small-size classes matching the provider-filter checkbox in models.tsx', () => {
-    const { getByTestId } = render(
-      <FormHarness>
-        <Tools availableAgentTools={availableTools} />
-      </FormHarness>,
-    );
-
-    const checkbox = getByTestId('tools-only-selected-filter-checkbox');
-    expect(checkbox.className).toContain('h-3');
-    expect(checkbox.className).toContain('w-3');
-    expect(checkbox.className).toContain('[&_svg]:h-2.5');
-  });
-
   it('paints the filter checkbox with the agent color only when the filter is checked', () => {
     const { getByTestId } = render(
       <FormHarness>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-avatar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-avatar.tsx
@@ -38,14 +38,14 @@ export const AgentProfileAvatar = ({ disabled = false }: AgentProfileAvatarProps
   };
 
   return (
-    <div className="rounded-full bg-surface3 p-1 scale-[1.65]" style={{ viewTransitionName: 'agent-avatar' }}>
+    <div className="scale-1.65 rounded-full bg-surface3 p-1" style={{ viewTransitionName: 'agent-avatar' }}>
       {interactive ? (
         <>
           <button
             type="button"
             onClick={() => fileInputRef.current?.click()}
             disabled={disabled}
-            className="relative rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-neutral3 disabled:cursor-not-allowed disabled:opacity-60"
+            className="relative rounded-full focus-visible:ring-2 focus-visible:ring-neutral3 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
             aria-label="Upload avatar"
             data-testid="agent-configure-avatar-trigger"
           >
@@ -58,7 +58,7 @@ export const AgentProfileAvatar = ({ disabled = false }: AgentProfileAvatarProps
               textColor={avatarTextColor}
             />
             <span className="absolute inset-0 flex items-center justify-center rounded-full bg-surface4 opacity-0 transition-opacity">
-              <Plus className="h-5 w-5 text-neutral5" />
+              <Plus className="size-5 text-neutral5" />
             </span>
           </button>
           <input

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-details.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-details.tsx
@@ -30,7 +30,7 @@ export const AgentProfileDetails = ({ disabled = false, className, mode = 'defau
   return (
     <div
       className={cn(
-        'flex w-full flex-col items-start gap-0.5 max-w-[44ch]',
+        'flex w-full max-w-[44ch] flex-col items-start gap-0.5',
         isHighlighted && HIGHLIGHTED_CLASSNAME,
         className,
       )}
@@ -54,7 +54,7 @@ export const AgentProfileDetails = ({ disabled = false, className, mode = 'defau
         disabled={disabled}
         data-testid="agent-configure-description"
         rows={2}
-        className="w-full resize-none field-sizing-content rounded-lg px-3 py-2 text-ui-md text-neutral6 placeholder:text-neutral2 hover:bg-surface4 focus:bg-surface4 focus:outline-none disabled:cursor-not-allowed"
+        className="field-sizing-content w-full resize-none rounded-lg px-3 py-2 text-ui-md text-neutral6 placeholder:text-neutral2 hover:bg-surface4 focus:bg-surface4 focus:outline-none disabled:cursor-not-allowed"
         style={{ viewTransitionName: 'agent-description' }}
       />
     </div>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-identity-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-identity-step.tsx
@@ -33,7 +33,7 @@ export const AgentProfileIdentityStep = ({ avatar, details }: AgentProfileIdenti
         </Button>
       }
     >
-      <div className="relative w-full h-full flex flex-col items-center justify-center gap-4 py-6 px-6 text-center">
+      <div className="relative flex size-full flex-col items-center justify-center gap-4 p-6 text-center">
         {avatar}
         {details}
       </div>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-library-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-library-step.tsx
@@ -41,7 +41,7 @@ export const AgentProfileLibraryStep = ({ agentId }: AgentProfileLibraryStepProp
       }
     >
       <div
-        className="relative w-full h-full flex flex-col items-center justify-center gap-4 py-6 px-6 text-center"
+        className="relative flex size-full flex-col items-center justify-center gap-4 p-6 text-center"
         data-testid="agent-builder-library-step"
       >
         <Icon size="lg" className="text-neutral4">
@@ -64,7 +64,7 @@ export const AgentProfileLibraryStep = ({ agentId }: AgentProfileLibraryStepProp
             Add to library
           </Button>
         )}
-        <p className="text-neutral3 max-w-md">
+        <p className="max-w-md text-neutral3">
           You can change this at any time from the agent&apos;s visibility settings — adding to the library now is
           optional.
         </p>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-ready-step.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-ready-step.tsx
@@ -45,7 +45,7 @@ export const AgentProfileReadyStep = () => {
       panelClassName="ready-stage"
       panelOverlay={<span ref={sweepRef} className="ready-stage-sweep" aria-hidden="true" />}
       cta={
-        <div className="relative z-[2] flex items-center justify-center gap-3">
+        <div className="relative z-2 flex items-center justify-center gap-3">
           <Button variant="outline" onClick={handleReview} data-testid="agent-builder-ready-review">
             Review my agent
           </Button>
@@ -55,12 +55,12 @@ export const AgentProfileReadyStep = () => {
         </div>
       }
     >
-      <div className="w-full h-full flex flex-col items-center justify-center py-6 px-6 text-center">
+      <div className="flex size-full flex-col items-center justify-center p-6 text-center">
         <div className="ready-stage-content flex flex-col items-center gap-4">
           <h2 className="text-4xl font-semibold text-neutral6" data-testid="agent-builder-ready-heading">
             Your agent is ready
           </h2>
-          <p className="text-neutral3 text-lg max-w-md">
+          <p className="max-w-md text-lg text-neutral3">
             You can review and fine-tune everything, or jump straight in and try it out.
           </p>
         </div>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-tabs.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile-tabs.tsx
@@ -72,7 +72,7 @@ export const AgentProfileTabs = ({
           {integrationsTabEnabled && <Tab value="integrations">Integrations</Tab>}
         </TabList>
 
-        <div className="min-h-0 overflow-y-auto h-full">
+        <div className="h-full min-h-0 overflow-y-auto">
           {modelTabEnabled && (
             <TabContent value="model" className={twoPaneTabContentClassName}>
               <Models editable={isEditable} />

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-profile.tsx
@@ -7,7 +7,7 @@ export interface AgentProfileProps {
 export const AgentProfile = ({ children }: AgentProfileProps) => {
   return (
     <div
-      className="grid grid-rows-[auto_1fr] border border-border1 bg-surface3 rounded-3xl h-full min-h-0 overflow-hidden"
+      className="grid h-full min-h-0 grid-rows-[auto_1fr] overflow-hidden rounded-3xl border border-border1 bg-surface3"
       data-testid="agent-profile"
     >
       {children}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/agent-step-container.tsx
@@ -66,7 +66,7 @@ export const AgentStepContainer = ({
   ) : null;
 
   return (
-    <div className="relative w-full h-full min-h-0 border border-border1 rounded-3xl overflow-hidden p-4">
+    <div className="relative size-full min-h-0 overflow-hidden rounded-3xl border border-border1 p-4">
       <div
         aria-hidden
         className={cn('agent-step-banner pointer-events-none', isStreaming && 'agent-step-banner-rotating')}
@@ -74,7 +74,7 @@ export const AgentStepContainer = ({
       />
       <div
         className={cn(
-          'relative h-full overflow-hidden bg-surface3 rounded-2xl grid min-h-0',
+          'relative grid h-full min-h-0 overflow-hidden rounded-2xl bg-surface3',
           title ? 'grid-rows-[auto_minmax(0,1fr)_auto]' : 'grid-rows-[minmax(0,1fr)_auto]',
           panelClassName,
         )}
@@ -82,7 +82,7 @@ export const AgentStepContainer = ({
         {panelOverlay}
         {title && (
           <div className="border-b border-border1 px-6 pt-6 pb-4" data-testid="agent-step-title-section">
-            <h2 className="text-3xl font-semibold text-neutral6 pb-1">{title}</h2>
+            <h2 className="pb-1 text-3xl font-semibold text-neutral6">{title}</h2>
             {description && <div className="w-1/2 text-neutral3">{description}</div>}
           </div>
         )}
@@ -91,7 +91,7 @@ export const AgentStepContainer = ({
         </div>
         {showLastStepCtas ? (
           <div
-            className="flex justify-center items-center gap-2 shrink-0 border-t border-border1 pt-6 pb-6"
+            className="flex shrink-0 items-center justify-center gap-2 border-t border-border1 py-6"
             data-testid="agent-step-footer"
           >
             {backButton}
@@ -108,7 +108,7 @@ export const AgentStepContainer = ({
           </div>
         ) : (
           <div
-            className="flex justify-center items-center gap-2 shrink-0 border-t border-border1 pt-6 pb-6"
+            className="flex shrink-0 items-center justify-center gap-2 border-t border-border1 py-6"
             data-testid="agent-step-footer"
           >
             {backButton}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/browser.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/browser.tsx
@@ -29,9 +29,9 @@ export const Browser = ({ editable = true }: BrowserProps) => {
 
   return (
     <div className="flex h-full min-h-0 items-center justify-center px-6 py-8" data-testid="browser-detail-picker">
-      <div className="flex w-full max-w-[28rem] flex-col items-center gap-5 text-center">
+      <div className="flex w-full max-w-md flex-col items-center gap-5 text-center">
         <div className="grid size-14 place-items-center rounded-full" style={iconStyle}>
-          <GlobeIcon className="h-7 w-7" />
+          <GlobeIcon className="size-7" />
         </div>
 
         <div className="flex flex-col gap-2">

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/filterable-list.tsx
@@ -52,7 +52,7 @@ export const FilterableList = ({
 
   return (
     <div
-      className="flex h-full min-h-0 flex-col gap-3 border-r border-border1 py-6 px-6"
+      className="flex h-full min-h-0 flex-col gap-3 border-r border-border1 p-6"
       data-testid={`${testIdPrefix}-filter`}
     >
       <div className="shrink-0 rounded-full bg-surface3" data-testid={`${testIdPrefix}-filter-search`}>
@@ -116,7 +116,7 @@ export const FilterableList = ({
                     data-testid={`${testIdPrefix}-filter-item-${item.id}`}
                     data-checked={checked ? 'true' : 'false'}
                     className={cn(
-                      'flex cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-ui-sm text-neutral6 transition-colors hover:bg-surface4',
+                      'flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-ui-sm text-neutral6 transition-colors select-none hover:bg-surface4',
                       disabled && 'cursor-not-allowed opacity-60',
                     )}
                   >
@@ -126,7 +126,7 @@ export const FilterableList = ({
                       onCheckedChange={() => onToggle(item.id)}
                       style={checkboxStyle}
                       data-testid={`${testIdPrefix}-filter-checkbox-${item.id}`}
-                      className="h-3.5 w-3.5 shrink-0 shadow-none [&_svg]:h-2.5 [&_svg]:w-2.5 data-[state=checked]:shadow-none"
+                      className="size-3.5 shrink-0 shadow-none data-[state=checked]:shadow-none [&_svg]:size-2.5"
                     />
                     {item.icon && <span className="flex shrink-0 items-center">{item.icon}</span>}
                     <span className="truncate">{item.label}</span>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/instructions.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/instructions.tsx
@@ -27,7 +27,7 @@ export const Instructions = ({ editable = true, fallbackPrompt }: InstructionsPr
         editable={editable}
         placeholder="You are a helpful assistant that…"
         showCopyButton={false}
-        className="min-h-0 w-full border-0 bg-transparent p-0 rounded-none [&_.cm-editor]:h-full [&_.cm-scroller]:overflow-y-auto [&_.cm-scroller]:!font-sans [&_.cm-line]:leading-relaxed"
+        className="min-h-0 w-full rounded-none border-0 bg-transparent p-0 [&_.cm-editor]:h-full [&_.cm-line]:leading-relaxed [&_.cm-scroller]:overflow-y-auto [&_.cm-scroller]:!font-sans"
       />
     </div>
   );

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/integrations.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/integrations.tsx
@@ -24,7 +24,7 @@ export const Integrations = ({ agentId, editable = true }: IntegrationsProps) =>
   if (isLoading) {
     return (
       <div className="flex justify-center px-6 py-8" data-testid="integrations-detail-picker-loading">
-        <div className="flex w-full max-w-[48rem] flex-col items-center gap-6 text-center">
+        <div className="flex w-full max-w-3xl flex-col items-center gap-6 text-center">
           <div className="flex flex-col items-center gap-2">
             <Skeleton className="h-6 w-48" />
             <Skeleton className="h-4 w-80" />
@@ -65,7 +65,7 @@ export const Integrations = ({ agentId, editable = true }: IntegrationsProps) =>
 
   return (
     <div className="flex justify-center px-6 py-8" data-testid="integrations-detail-picker">
-      <div className="flex w-full max-w-[48rem] flex-col items-center gap-6 text-center">
+      <div className="flex w-full max-w-3xl flex-col items-center gap-6 text-center">
         <div className="flex flex-col gap-2">
           <Txt variant="header-sm" className="font-semibold text-neutral6">
             Channel integrations
@@ -121,10 +121,10 @@ const IntegrationCard = ({ platform, agentId, disabled, requiresLibrary, onSelec
       onClick={() => onSelect(installation)}
       disabled={disabled}
       data-testid={`integration-card-${platform.id}`}
-      className="flex w-48 flex-col items-center gap-3 rounded-xl border border-border1 bg-surface3 px-4 py-6 text-center transition-colors hover:bg-surface4 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent1 disabled:cursor-not-allowed disabled:opacity-60"
+      className="flex w-48 flex-col items-center gap-3 rounded-xl border border-border1 bg-surface3 px-4 py-6 text-center transition-colors hover:bg-surface4 focus-visible:ring-2 focus-visible:ring-accent1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
     >
       <div className="grid size-14 place-items-center rounded-xl bg-surface4">
-        <PlatformIcon platform={platform.id} className="h-7 w-7" />
+        <PlatformIcon platform={platform.id} className="size-7" />
       </div>
 
       <div className="flex flex-col items-center gap-1">

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/models.tsx
@@ -25,7 +25,7 @@ export const Models = ({ editable = true }: Modelprops) => {
     const policyModelId = policy.default?.modelId;
 
     return (
-      <div className="px-6 py-6">
+      <div className="p-6">
         <LockedModelChip provider={policyProvider} modelId={policyModelId} />
       </div>
     );
@@ -135,8 +135,8 @@ const ModelPicker = ({ disabled = false }: ModelPickerProps) => {
           />
         )}
 
-        <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 px-6 py-6">
-          <div data-testid="model-card-picker-search" className="shrink-0 max-w-[30ch] rounded-full bg-surface3">
+        <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 p-6">
+          <div data-testid="model-card-picker-search" className="max-w-[30ch] shrink-0 rounded-full bg-surface3">
             <InputGroup variant="outline" size="lg">
               <InputGroupAddon align="inline-start">
                 <SearchIcon />
@@ -203,12 +203,12 @@ const ModelGroups = ({ groups, selectedProvider, selectedModel, disabled, onChan
           <Txt
             variant="ui-sm"
             as="h3"
-            className="text-neutral3 uppercase tracking-wide"
+            className="tracking-wide text-neutral3 uppercase"
             data-testid={`model-provider-section-title-${group.providerId}`}
           >
             {group.providerName}
           </Txt>
-          <div className="grid grid-cols-1 content-start gap-2 lg:gap-6 sm:grid-cols-2 2xl:grid-cols-3">
+          <div className="grid grid-cols-1 content-start gap-2 2xl:grid-cols-3 sm:grid-cols-2 lg:gap-6">
             {group.models.map(entry => {
               const cleanedProvider = cleanProviderId(entry.provider);
               const isSelected = cleanedProvider === selectedProvider && entry.model === selectedModel;
@@ -246,7 +246,7 @@ const StaleWarning = ({ provider, modelId }: StaleWarningProps) => {
       data-testid="model-detail-stale-warning"
       role="alert"
     >
-      <TriangleAlertIcon className="h-4 w-4 shrink-0 mt-0.5" />
+      <TriangleAlertIcon className="mt-0.5 size-4 shrink-0" />
       <Txt variant="ui-xs">
         <span className="font-medium">
           {provider}/{modelId}
@@ -267,8 +267,8 @@ const LockedModelChip = ({ provider, modelId }: LockedModelChipProps) => (
     className="flex items-center gap-2 rounded-md border border-border1 bg-surface3 px-3 py-2"
     data-testid="model-detail-locked-chip"
   >
-    <LockIcon className="h-4 w-4 shrink-0 text-neutral3" />
-    <Txt variant="ui-sm" className="font-medium text-neutral6 truncate">
+    <LockIcon className="size-4 shrink-0 text-neutral3" />
+    <Txt variant="ui-sm" className="truncate font-medium text-neutral6">
       {provider && modelId ? `${provider}/${modelId}` : 'Locked by admin'}
     </Txt>
     <Txt variant="ui-xs" className="ml-auto shrink-0 text-neutral3">

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tool-grid.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tool-grid.tsx
@@ -41,7 +41,7 @@ export const ToolGrid = ({
     : undefined;
 
   return (
-    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 px-6 py-6">
+    <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 p-6">
       <div className="flex shrink-0 items-center justify-between gap-4">
         <div data-testid="tools-card-picker-search" className="max-w-[30ch] flex-1 rounded-full bg-surface3">
           <InputGroup variant="outline" size="lg">
@@ -60,7 +60,7 @@ export const ToolGrid = ({
         <label
           data-testid="tools-only-selected-filter"
           className={cn(
-            'inline-flex items-center gap-2 text-ui-xs text-neutral3 select-none cursor-pointer',
+            'inline-flex cursor-pointer items-center gap-2 text-ui-xs text-neutral3 select-none',
             !editable && 'cursor-not-allowed opacity-60',
           )}
         >
@@ -70,7 +70,7 @@ export const ToolGrid = ({
             disabled={!editable}
             data-testid="tools-only-selected-filter-checkbox"
             style={filterCheckboxStyle}
-            className="h-3 w-3 shadow-none [&_svg]:h-2.5 [&_svg]:w-2.5 data-[state=checked]:shadow-none"
+            className="size-3 shadow-none data-[state=checked]:shadow-none [&_svg]:size-2.5"
           />
           <span>Show only selected</span>
         </label>
@@ -79,7 +79,7 @@ export const ToolGrid = ({
       {tools.length === 0 ? (
         <ToolListEmptyState details={emptyStateDetails} />
       ) : (
-        <div className="grid min-h-0 grid-cols-1 content-start gap-2 lg:gap-6 overflow-y-auto sm:grid-cols-2 2xl:grid-cols-3">
+        <div className="grid min-h-0 grid-cols-1 content-start gap-2 overflow-y-auto 2xl:grid-cols-3 sm:grid-cols-2 lg:gap-6">
           {tools.map(item => (
             <ToolCard key={`${item.type}__${item.id}`} item={item} editable={editable} onToggle={onToggle} />
           ))}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/toolkit-filter-pane.tsx
@@ -47,7 +47,7 @@ const ToolkitFilterRow = memo(
           data-testid={`${TEST_ID_PREFIX}-filter-item-${item.id}`}
           data-checked={checked ? 'true' : 'false'}
           className={cn(
-            'flex min-w-0 flex-1 cursor-pointer select-none items-center gap-2 rounded-md px-2 py-1.5 text-ui-sm text-neutral6 transition-colors hover:bg-surface4',
+            'flex min-w-0 flex-1 cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-ui-sm text-neutral6 transition-colors select-none hover:bg-surface4',
             disabled && 'cursor-not-allowed opacity-60',
           )}
         >
@@ -57,7 +57,7 @@ const ToolkitFilterRow = memo(
             onCheckedChange={() => onToggle(item.id)}
             style={checkboxStyle}
             data-testid={`${TEST_ID_PREFIX}-filter-checkbox-${item.id}`}
-            className="h-3.5 w-3.5 shrink-0 shadow-none [&_svg]:h-2.5 [&_svg]:w-2.5 data-[state=checked]:shadow-none"
+            className="size-3.5 shrink-0 shadow-none data-[state=checked]:shadow-none [&_svg]:size-2.5"
           />
           {item.icon && (
             <img
@@ -65,7 +65,7 @@ const ToolkitFilterRow = memo(
               alt=""
               aria-hidden
               data-testid={`${TEST_ID_PREFIX}-filter-icon-${item.id}`}
-              className="h-4 w-4 shrink-0 rounded object-contain"
+              className="size-4 shrink-0 rounded object-contain"
             />
           )}
           <span className="truncate">{item.label}</span>
@@ -146,7 +146,7 @@ const ProviderToolkitSection = ({
       <Txt
         variant="ui-xs"
         data-testid={`tools-provider-section-${provider.providerId}`}
-        className="px-2 pt-1 text-neutral3 uppercase tracking-wide"
+        className="px-2 pt-1 tracking-wide text-neutral3 uppercase"
       >
         {provider.providerName}
       </Txt>
@@ -209,7 +209,7 @@ export const ToolkitFilterPane = ({
 
   return (
     <div
-      className="flex h-full min-h-0 flex-col gap-3 border-r border-border1 py-6 px-6"
+      className="flex h-full min-h-0 flex-col gap-3 border-r border-border1 p-6"
       data-testid={`${TEST_ID_PREFIX}-filter`}
     >
       <div className="shrink-0 rounded-full bg-surface3" data-testid={`${TEST_ID_PREFIX}-filter-search`}>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tools.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/tools.tsx
@@ -47,7 +47,7 @@ export const Tools = ({ editable = true, availableAgentTools = [] }: ToolsProps)
       return <TwoPanePickerSkeleton testId="tools-card-picker-loading" />;
     }
     return (
-      <div className="px-6 py-6" data-testid="tools-empty-state">
+      <div className="p-6" data-testid="tools-empty-state">
         <ToolListEmptyState details={'No tools available in this project'} />
       </div>
     );

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/two-pane-picker-skeleton.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-profile/two-pane-picker-skeleton.tsx
@@ -7,7 +7,7 @@ interface TwoPanePickerSkeletonProps {
 export const TwoPanePickerSkeleton = ({ testId }: TwoPanePickerSkeletonProps) => (
   <div className="h-full min-h-0 overflow-hidden">
     <div className="grid h-full min-h-0 grid-cols-[280px_minmax(0,1fr)] overflow-hidden" data-testid={testId}>
-      <div className="flex h-full min-h-0 flex-col gap-3 border-r border-border1 py-6 px-6">
+      <div className="flex h-full min-h-0 flex-col gap-3 border-r border-border1 p-6">
         <Skeleton className="h-10 w-full rounded-md" />
         <Skeleton className="h-4 w-28" />
         <Skeleton className="h-7 w-full rounded-md" />
@@ -16,15 +16,15 @@ export const TwoPanePickerSkeleton = ({ testId }: TwoPanePickerSkeletonProps) =>
         <Skeleton className="h-7 w-full rounded-md" />
       </div>
 
-      <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 px-6 py-6">
-        <div className="shrink-0 max-w-[30ch]">
+      <div className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-6 p-6">
+        <div className="max-w-[30ch] shrink-0">
           <Skeleton className="h-10 w-full rounded-md" />
         </div>
 
         <div className="flex min-h-0 flex-col gap-6 overflow-y-auto">
           <div className="flex flex-col gap-3">
             <Skeleton className="h-4 w-24" />
-            <div className="grid grid-cols-1 content-start gap-2 lg:gap-6 sm:grid-cols-2 2xl:grid-cols-3">
+            <div className="grid grid-cols-1 content-start gap-2 2xl:grid-cols-3 sm:grid-cols-2 lg:gap-6">
               <Skeleton className="h-20 rounded-lg" />
               <Skeleton className="h-20 rounded-lg" />
               <Skeleton className="h-20 rounded-lg" />

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/agent-selectable-card.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/agent-selectable-card.tsx
@@ -56,7 +56,7 @@ export const AgentSelectableCard = ({
       style={containerStyle}
       className={cn(
         'flex w-full flex-col gap-2 rounded-lg border bg-surface3 p-4 transition-colors',
-        'focus-visible:!border-[var(--agent-color-bg)] focus-within:!border-[var(--agent-color-bg)]',
+        'focus-within:!border-[var(--agent-color-bg)] focus-visible:!border-[var(--agent-color-bg)]',
         isSelected ? 'bg-surface4' : 'border-border1',
         disabled && 'opacity-60',
       )}
@@ -89,11 +89,11 @@ export const AgentSelectableCard = ({
           data-testid={checkTestId}
           style={checkStyle}
           className={cn(
-            'flex h-4 w-4 shrink-0 items-center justify-center rounded border transition-colors',
+            'flex size-4 shrink-0 items-center justify-center rounded border transition-colors',
             !isSelected && 'border-border1 bg-transparent',
           )}
         >
-          {isSelected && <Check className="h-3 w-3" />}
+          {isSelected && <Check className="size-3" />}
         </span>
       </button>
       {footer}

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/autosave-indicator.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/autosave-indicator.tsx
@@ -21,7 +21,7 @@ export const AutosaveIndicator = ({ status, lastError, onRetry }: AutosaveIndica
   if (status === 'saved') {
     return (
       <span className="flex items-center gap-1.5 text-ui-sm text-neutral3" data-testid="agent-builder-autosave-saved">
-        <CheckIcon className="h-3.5 w-3.5" />
+        <CheckIcon className="size-3.5" />
         Saved
       </span>
     );

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/connect-channel-message.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/connect-channel-message.tsx
@@ -34,10 +34,10 @@ export function ConnectChannelMessage({ platformId, agentId }: ConnectChannelMes
   return (
     <>
       <div
-        className="border border-1 p-3 rounded-xl flex items-center gap-3"
+        className="flex items-center gap-3 rounded-xl border p-3"
         data-testid={`agent-builder-chat-connect-channel-${platformId}`}
       >
-        <PlatformIcon platform={platform.id} className="h-5 w-5 shrink-0" />
+        <PlatformIcon platform={platform.id} className="size-5 shrink-0" />
         <Txt variant="ui-md" className="flex-1 text-neutral4" as="div">
           {platform.name}
         </Txt>

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/edit-top-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/edit-top-bar.tsx
@@ -45,9 +45,9 @@ export const EditTopBar = ({
           <AgentBuilderTitle isLoading={isLoading} />
         </Crumb>
       </Breadcrumb>
-      <div className="justify-self-end flex items-center gap-2 shrink-0">
-        {rightAside && <div className="shrink-0 mr-1">{rightAside}</div>}
-        {primaryAction && <div className="shrink-0 flex">{primaryAction}</div>}
+      <div className="flex shrink-0 items-center gap-2 justify-self-end">
+        {rightAside && <div className="mr-1 shrink-0">{rightAside}</div>}
+        {primaryAction && <div className="flex shrink-0">{primaryAction}</div>}
         {mobileExtra && <div className="shrink-0 lg:hidden">{mobileExtra}</div>}
         {mode && onModeToggle && (
           <Button
@@ -55,7 +55,7 @@ export const EditTopBar = ({
             size="sm"
             onClick={onModeToggle}
             disabled={modeToggleDisabled}
-            className="hidden lg:inline-flex shrink-0"
+            className="hidden shrink-0 lg:inline-flex"
             data-testid="agent-builder-mode-toggle"
             aria-label={toggleLabel}
           >

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/publish-channel-dialogs/publish-channel-content.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/publish-channel-dialogs/publish-channel-content.tsx
@@ -69,7 +69,7 @@ export function PublishChannelContent({
     <>
       <DialogHeader>
         <div className="flex items-center gap-2">
-          <PlatformIcon platform={platform.id} className="h-8 w-8 shrink-0" />
+          <PlatformIcon platform={platform.id} className="size-8 shrink-0" />
           <DialogTitle>{platform.name} integration</DialogTitle>
         </div>
 

--- a/packages/playground/src/domains/agent-builder/components/agent-edit/visibility-select.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-edit/visibility-select.tsx
@@ -26,7 +26,7 @@ export function VisibilitySelect({ agentId }: VisibilitySelectProps) {
           onClick={() => requestChange('public')}
           data-testid="agent-builder-visibility-add"
         >
-          <Globe className="h-3.5 w-3.5" />
+          <Globe className="size-3.5" />
           Add to library
         </Button>
       ) : (
@@ -36,7 +36,7 @@ export function VisibilitySelect({ agentId }: VisibilitySelectProps) {
           onClick={() => requestChange('private')}
           data-testid="agent-builder-visibility-remove"
         >
-          <LockIcon className="h-3.5 w-3.5" />
+          <LockIcon className="size-3.5" />
           Remove from library
         </Button>
       )}

--- a/packages/playground/src/domains/agent-builder/components/agent-list/agent-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-list/agent-builder-list.tsx
@@ -45,9 +45,9 @@ function AuthorBadge({ agent, className }: { agent: StoredAgentResponse; classNa
   const avatarUrl = agent.author?.avatarUrl;
 
   return (
-    <div className={cn('flex items-center gap-1.5 min-w-0', className)} data-testid="agent-builder-row-author">
+    <div className={cn('flex min-w-0 items-center gap-1.5', className)} data-testid="agent-builder-row-author">
       <Avatar name={label} src={avatarUrl} size="sm" />
-      <span className="text-ui-xs text-neutral3 truncate">{label}</span>
+      <span className="truncate text-ui-xs text-neutral3">{label}</span>
     </div>
   );
 }
@@ -57,7 +57,7 @@ function PrivateVisibilityIcon() {
     <Tooltip>
       <TooltipTrigger asChild>
         <span
-          className="text-neutral3 shrink-0"
+          className="shrink-0 text-neutral3"
           aria-label="Private agent"
           data-testid="agent-builder-private-visibility-icon"
         >
@@ -89,7 +89,7 @@ export function AgentBuilderList({ agents, search, rowTestId, showFavorites = tr
     return (
       <div className="flex items-center justify-center pt-10">
         <EmptyState
-          iconSlot={<SearchIcon className="h-8 w-8 text-neutral3" />}
+          iconSlot={<SearchIcon className="size-8 text-neutral3" />}
           titleSlot="No agents match your search"
           descriptionSlot="Try a different name or description."
         />
@@ -98,7 +98,7 @@ export function AgentBuilderList({ agents, search, rowTestId, showFavorites = tr
   }
 
   return (
-    <div className="bg-surface2 border h-full border-border1 rounded-xl divide-y divide-border1 overflow-y-auto content-start">
+    <div className="h-full content-start divide-y divide-border1 overflow-y-auto rounded-xl border border-border1 bg-surface2">
       {filtered.map(agent => {
         const avatar = getAvatarUrl(agent);
 
@@ -106,18 +106,18 @@ export function AgentBuilderList({ agents, search, rowTestId, showFavorites = tr
           <Link
             key={agent.id}
             href={`/agent-builder/agents/${agent.id}/view`}
-            className="px-6 py-5 flex items-start gap-4 hover:bg-surface3 transition-colors md:items-center"
+            className="flex items-start gap-4 px-6 py-5 transition-colors hover:bg-surface3 md:items-center"
             data-testid={rowTestId}
           >
             <Avatar name={agent.name ?? ''} src={avatar} size="lg" />
 
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 min-w-0">
-                <div className="text-ui-md text-neutral6 truncate">{agent.name}</div>
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="truncate text-ui-md text-neutral6">{agent.name}</div>
                 {agent.visibility === 'private' && <PrivateVisibilityIcon />}
               </div>
-              <div className="flex items-center gap-2 mt-0.5">
-                <span className="text-ui-sm text-neutral3 line-clamp-1">{agent.description || 'No description'}</span>
+              <div className="mt-0.5 flex items-center gap-2">
+                <span className="line-clamp-1 text-ui-sm text-neutral3">{agent.description || 'No description'}</span>
               </div>
               <AuthorBadge agent={agent} className="mt-2 md:hidden" />
               {showFavorites && (
@@ -131,14 +131,14 @@ export function AgentBuilderList({ agents, search, rowTestId, showFavorites = tr
                 </div>
               )}
             </div>
-            <AuthorBadge agent={agent} className="shrink-0 hidden md:flex max-w-[12rem]" />
+            <AuthorBadge agent={agent} className="hidden max-w-48 shrink-0 md:flex" />
             {showFavorites && (
               <FavoriteButton
                 agentId={agent.id}
                 isFavorited={agent.isFavorited}
                 favoriteCount={agent.favoriteCount}
                 size="sm"
-                className="shrink-0 hidden md:inline-flex"
+                className="hidden shrink-0 md:inline-flex"
               />
             )}
           </Link>
@@ -150,12 +150,12 @@ export function AgentBuilderList({ agents, search, rowTestId, showFavorites = tr
 
 export function AgentBuilderListSkeleton({ rows = 4, rowTestId }: AgentBuilderListSkeletonProps) {
   return (
-    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+    <div className="divide-y divide-border1 overflow-hidden rounded-xl border border-border1 bg-surface2">
       {Array.from({ length: rows }).map((_, i) => (
-        <div key={i} className="px-6 py-5 flex items-center gap-4" data-testid={rowTestId}>
-          <div className="flex-1 min-w-0 space-y-2">
-            <div className="h-3.5 w-48 bg-surface3 rounded animate-pulse" />
-            <div className="h-3 w-72 max-w-full bg-surface3 rounded animate-pulse" />
+        <div key={i} className="flex items-center gap-4 px-6 py-5" data-testid={rowTestId}>
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="h-3.5 w-48 animate-pulse rounded bg-surface3" />
+            <div className="h-3 w-72 max-w-full animate-pulse rounded bg-surface3" />
           </div>
         </div>
       ))}

--- a/packages/playground/src/domains/agent-builder/components/agent-starter/agent-builder-starter.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-starter/agent-builder-starter.tsx
@@ -89,7 +89,7 @@ export const AgentBuilderStarter = () => {
 
         <form
           onSubmit={handleSubmit}
-          className="starter-prompt rounded-2xl border border-border1 bg-surface2 transition-colors duration-normal ease-out-custom focus-within:border-neutral3"
+          className="starter-prompt duration-normal rounded-2xl border border-border1 bg-surface2 transition-colors ease-out-custom focus-within:border-neutral3"
           style={{ viewTransitionName: 'chat-composer' }}
         >
           <Textarea
@@ -102,7 +102,7 @@ export const AgentBuilderStarter = () => {
             onChange={e => setMessage(e.target.value)}
             onKeyDown={handleKeyDown}
             disabled={isCreating}
-            className="min-h-[112px] resize-none px-5 py-4 text-ui-md outline-none placeholder:text-neutral3 focus:outline-none focus-visible:outline-none"
+            className="min-h-28 resize-none px-5 py-4 text-ui-md outline-none placeholder:text-neutral3 focus:outline-none focus-visible:outline-none"
             rows={3}
           />
 

--- a/packages/playground/src/domains/agent-builder/components/agent-starter/example-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-starter/example-list.tsx
@@ -16,9 +16,9 @@ export const ExampleList = ({ onExampleClick }: ExampleListProps) => {
             onClick={() => onExampleClick(example.prompt)}
             data-testid={`agent-builder-starter-example-${example.title.toLowerCase().replace(/\s+/g, '-')}`}
             style={{ animationDelay: `${280 + i * 40}ms` }}
-            className="starter-chip group inline-flex items-center gap-2 rounded-full border border-border1 bg-transparent px-4 py-2 text-ui-sm text-neutral4 transition-colors duration-normal ease-out-custom hover:border-border2 hover:bg-surface2 hover:text-neutral6"
+            className="starter-chip group duration-normal inline-flex items-center gap-2 rounded-full border border-border1 bg-transparent px-4 py-2 text-ui-sm text-neutral4 transition-colors ease-out-custom hover:border-border2 hover:bg-surface2 hover:text-neutral6"
           >
-            <Icon className="h-3.5 w-3.5 text-neutral3 transition-colors group-hover:text-neutral5" />
+            <Icon className="size-3.5 text-neutral3 transition-colors group-hover:text-neutral5" />
             {example.title}
           </button>
         );

--- a/packages/playground/src/domains/agent-builder/components/agent-view/view-top-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/components/agent-view/view-top-bar.tsx
@@ -44,8 +44,8 @@ export const ViewTopBar = ({
           <AgentBuilderTitle isLoading={false} />
         </Crumb>
       </Breadcrumb>
-      <div className="justify-self-end flex items-center gap-2 shrink-0">
-        {ownerActions && <div className="shrink-0 hidden lg:flex items-center gap-2">{ownerActions}</div>}
+      <div className="flex shrink-0 items-center gap-2 justify-self-end">
+        {ownerActions && <div className="hidden shrink-0 items-center gap-2 lg:flex">{ownerActions}</div>}
         {mobileMenu && <div className="shrink-0 lg:hidden">{mobileMenu}</div>}
         {mode && onModeToggle && (
           <Button
@@ -53,7 +53,7 @@ export const ViewTopBar = ({
             size="sm"
             onClick={onModeToggle}
             disabled={modeToggleDisabled}
-            className="hidden lg:inline-flex shrink-0"
+            className="hidden shrink-0 lg:inline-flex"
             data-testid="agent-builder-mode-toggle"
             aria-label={toggleLabel}
           >

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/chat-textarea.tsx
@@ -13,7 +13,7 @@ export const ChatTextarea = forwardRef<HTMLTextAreaElement, ChatTextareaProps>((
       variant="unstyled"
       rows={1}
       className={cn(
-        'min-h-[44px] resize-none text-ui-md bg-transparent text-neutral6 placeholder:text-neutral3',
+        'min-h-11 resize-none bg-transparent text-ui-md text-neutral6 placeholder:text-neutral3',
         'outline-none focus:outline-none focus-visible:outline-none',
         'disabled:cursor-not-allowed disabled:opacity-50',
         className,

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/message-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/message-list.tsx
@@ -81,7 +81,7 @@ export const MessageList = ({
   return (
     <div
       ref={scrollRef}
-      className="flex-1 min-h-0 overflow-y-auto py-6 px-6"
+      className="min-h-0 flex-1 overflow-y-auto p-6"
       style={{ viewTransitionName: 'agent-builder-messages' }}
     >
       {showSkeleton ? (

--- a/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
+++ b/packages/playground/src/domains/agent-builder/components/chat-primitives/messages.tsx
@@ -82,11 +82,11 @@ const ToolApprovalPrompt = ({ toolCallId, toolName }: { toolCallId: string; tool
   };
 
   return (
-    <ToolCard testId="agent-builder-chat-tool-approval" className="bg-surface4 border-transparent">
-      <Txt variant="ui-sm" className="text-neutral5 pb-2" as="div">
+    <ToolCard testId="agent-builder-chat-tool-approval" className="border-transparent bg-surface4">
+      <Txt variant="ui-sm" className="pb-2 text-neutral5" as="div">
         Approval required for <span className="font-mono text-neutral6">{toolName}</span>
       </Txt>
-      <div className="flex gap-2 items-center">
+      <div className="flex items-center gap-2">
         <Button
           variant="default"
           onClick={handleApprove}
@@ -268,7 +268,7 @@ export const Txtmessage = ({
       <div className="flex justify-end">
         <Txt
           variant="ui-md"
-          className="bg-white text-black rounded-2xl px-4 py-2.5 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
+          className="max-w-[80%] rounded-2xl bg-white px-4 py-2.5 text-black [&_li]:!my-0 [&_li]:!leading-normal [&_ol]:!space-y-1 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_ul]:!space-y-1"
           as="div"
         >
           <MarkdownRenderer>{txt}</MarkdownRenderer>
@@ -281,7 +281,7 @@ export const Txtmessage = ({
     return (
       <Txt
         variant="ui-md"
-        className="text-neutral4 max-w-[80%] [&_ul]:!space-y-1 [&_ol]:!space-y-1 [&_li]:!my-0 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_li]:!leading-normal"
+        className="max-w-[80%] text-neutral4 [&_li]:!my-0 [&_li]:!leading-normal [&_ol]:!space-y-1 [&_p]:!leading-normal [&_p]:!whitespace-normal [&_ul]:!space-y-1"
         as="div"
       >
         <MessageText text={txt} metadata={metadata} />
@@ -295,19 +295,19 @@ export const Txtmessage = ({
 export const ErrorMessage = ({ error, onRetry }: { error: ParsedStreamError; onRetry: (() => void) | null }) => {
   return (
     <Card
-      className="border-accent6/40 bg-accent6/5 max-w-[80%] p-4 flex flex-col gap-3"
+      className="flex max-w-[80%] flex-col gap-3 border-accent6/40 bg-accent6/5 p-4"
       role="alert"
       data-testid="agent-builder-chat-error"
     >
       <div className="flex items-start gap-2.5">
-        <AlertTriangle className="size-4 mt-0.5 shrink-0 text-accent6" aria-hidden />
-        <div className="flex flex-col gap-1 min-w-0">
+        <AlertTriangle className="mt-0.5 size-4 shrink-0 text-accent6" aria-hidden />
+        <div className="flex min-w-0 flex-col gap-1">
           <Txt variant="ui-md" className="text-icon6 font-medium" as="div">
             Something went wrong while building the agent.
           </Txt>
           <Txt
             variant="ui-sm"
-            className="text-neutral4 break-words"
+            className="break-words text-neutral4"
             as="div"
             data-testid="agent-builder-chat-error-summary"
           >
@@ -331,7 +331,7 @@ export const ErrorMessage = ({ error, onRetry }: { error: ParsedStreamError; onR
               </Button>
             )}
             <CollapsibleTrigger
-              className="text-neutral4 hover:text-neutral6 text-sm underline-offset-2 hover:underline"
+              className="text-sm text-neutral4 underline-offset-2 hover:text-neutral6 hover:underline"
               data-testid="agent-builder-chat-error-details-trigger"
             >
               Details
@@ -339,7 +339,7 @@ export const ErrorMessage = ({ error, onRetry }: { error: ParsedStreamError; onR
           </div>
           <CollapsibleContent>
             <pre
-              className="text-xs text-neutral4 whitespace-pre-wrap break-all bg-surface1 rounded-md p-2 max-h-48 overflow-auto"
+              className="max-h-48 overflow-auto rounded-md bg-surface1 p-2 text-xs break-all whitespace-pre-wrap text-neutral4"
               data-testid="agent-builder-chat-error-details"
             >
               {error.details}
@@ -399,7 +399,7 @@ const GenericTool = ({ toolName, input, output }: { toolName: string; input?: un
     <ToolCard testId="agent-builder-chat-generic-tool">
       <Collapsible>
         <CollapsibleTrigger
-          className="flex w-full items-center gap-2 text-left group"
+          className="group flex w-full items-center gap-2 text-left"
           data-testid="agent-builder-chat-generic-tool-trigger"
         >
           <span className="inline-flex items-center gap-1.5 rounded-md border border-border1/60 bg-surface1 px-2 py-0.5">
@@ -415,24 +415,24 @@ const GenericTool = ({ toolName, input, output }: { toolName: string; input?: un
         </CollapsibleTrigger>
         <CollapsibleContent>
           <div className="mt-3 flex flex-col gap-2" data-testid="agent-builder-chat-generic-tool-content">
-            <div className="rounded-md border border-border1/60 bg-surface1 overflow-hidden">
-              <div className="px-2 py-1 border-b border-border1/60">
+            <div className="overflow-hidden rounded-md border border-border1/60 bg-surface1">
+              <div className="border-b border-border1/60 px-2 py-1">
                 <Txt variant="ui-sm" className="text-neutral3" as="div">
                   Input
                 </Txt>
               </div>
-              <pre className="m-0 max-h-[320px] overflow-auto p-3 text-xs leading-relaxed text-neutral5 whitespace-pre-wrap break-words">
+              <pre className="m-0 max-h-80 overflow-auto p-3 text-xs leading-relaxed break-words whitespace-pre-wrap text-neutral5">
                 {inputJson || '{}'}
               </pre>
             </div>
             {hasOutput ? (
-              <div className="rounded-md border border-border1/60 bg-surface1 overflow-hidden">
-                <div className="px-2 py-1 border-b border-border1/60">
+              <div className="overflow-hidden rounded-md border border-border1/60 bg-surface1">
+                <div className="border-b border-border1/60 px-2 py-1">
                   <Txt variant="ui-sm" className="text-neutral3" as="div">
                     Output
                   </Txt>
                 </div>
-                <pre className="m-0 max-h-[320px] overflow-auto p-3 text-xs leading-relaxed text-neutral5 whitespace-pre-wrap break-words">
+                <pre className="m-0 max-h-80 overflow-auto p-3 text-xs leading-relaxed break-words whitespace-pre-wrap text-neutral5">
                   {outputJson}
                 </pre>
               </div>
@@ -456,7 +456,7 @@ export const ToolCard = ({
   <Card
     data-testid={testId}
     className={cn(
-      'max-w-[80%] p-3 bg-surface2/60 border-border1/60 animate-in fade-in slide-in-from-left-2 duration-300',
+      'max-w-[80%] animate-in border-border1/60 bg-surface2/60 p-3 duration-300 fade-in slide-in-from-left-2',
       className,
     )}
   >
@@ -465,11 +465,11 @@ export const ToolCard = ({
 );
 
 const SkillToolLine = ({ icon, label, value }: { icon: ReactNode; label: string; value: ReactNode }) => (
-  <div className="flex items-start gap-2 min-w-0 max-w-full animate-in fade-in slide-in-from-right-4 duration-500 ease-out">
+  <div className="flex max-w-full min-w-0 animate-in items-start gap-2 duration-500 ease-out fade-in slide-in-from-right-4">
     <div className="pt-0.5">
       <Icon>{icon}</Icon>
     </div>
-    <Txt variant="ui-md" className="text-neutral3 min-w-0 flex-1 truncate" as="div">
+    <Txt variant="ui-md" className="min-w-0 flex-1 truncate text-neutral3" as="div">
       {label} <strong className="font-semibold text-neutral6">{value}</strong>
     </Txt>
   </div>

--- a/packages/playground/src/domains/agent-builder/components/skill-edit/visibility-select.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-edit/visibility-select.tsx
@@ -25,7 +25,7 @@ export function VisibilitySelect({ skillId }: VisibilitySelectProps) {
           onClick={() => requestChange('public')}
           data-testid="skill-builder-visibility-add"
         >
-          <Globe className="h-3.5 w-3.5" />
+          <Globe className="size-3.5" />
           Add to library
         </Button>
       ) : (
@@ -35,7 +35,7 @@ export function VisibilitySelect({ skillId }: VisibilitySelectProps) {
           onClick={() => requestChange('private')}
           data-testid="skill-builder-visibility-remove"
         >
-          <LockIcon className="h-3.5 w-3.5" />
+          <LockIcon className="size-3.5" />
           Remove from library
         </Button>
       )}

--- a/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/builder-add-skill-dialog.tsx
@@ -175,7 +175,7 @@ export function BuilderAddSkillDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
+      <DialogContent className="flex h-[80vh] max-w-4xl flex-col">
         <DialogHeader>
           <DialogTitle>Browse {registryLabel}</DialogTitle>
           <DialogDescription>
@@ -183,9 +183,9 @@ export function BuilderAddSkillDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="flex-1 flex flex-col gap-4 overflow-hidden max-h-none">
+        <DialogBody className="flex max-h-none flex-1 flex-col gap-4 overflow-hidden">
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral3" />
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-neutral3" />
             <Input
               placeholder={`Search ${registryLabel}...`}
               value={searchQuery}
@@ -195,24 +195,24 @@ export function BuilderAddSkillDialog({
             />
           </div>
 
-          <div className="flex flex-1 gap-4 min-h-0">
+          <div className="flex min-h-0 flex-1 gap-4">
             {/* Skills list */}
-            <div className="w-1/2 flex flex-col min-h-0">
-              <div className="text-xs font-medium text-neutral4 uppercase tracking-wide mb-2">
+            <div className="flex min-h-0 w-1/2 flex-col">
+              <div className="mb-2 text-xs font-medium tracking-wide text-neutral4 uppercase">
                 {hasSearchResults ? 'Search results' : 'Popular skills'}
               </div>
-              <ScrollArea className="flex-1 border border-border1 rounded-lg">
+              <ScrollArea className="flex-1 rounded-lg border border-border1">
                 {isLoadingPopular || isSearching ? (
                   <div className="flex items-center justify-center py-8">
-                    <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                    <Loader2 className="size-6 animate-spin text-neutral3" />
                   </div>
                 ) : displaySkills.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-8 text-neutral4">
-                    <Package className="h-8 w-8 mb-2" />
+                    <Package className="mb-2 size-8" />
                     <p className="text-sm">{hasSearchResults ? 'No skills found' : 'No skills available'}</p>
                   </div>
                 ) : (
-                  <div className="p-2 space-y-1">
+                  <div className="space-y-1 p-2">
                     {displaySkills.map(skill => {
                       const skillUniqueId = getSkillUniqueId(skill);
                       const isInstalled = installedSkillIds.includes(skill.name);
@@ -222,26 +222,26 @@ export function BuilderAddSkillDialog({
                           key={skillUniqueId}
                           onClick={() => setSelectedSkill(skill)}
                           className={cn(
-                            'w-full text-left px-3 py-2 rounded-md transition-colors',
+                            'w-full rounded-md px-3 py-2 text-left transition-colors',
                             'hover:bg-surface4',
-                            selectedUniqueId === skillUniqueId && 'bg-surface5 border border-accent1',
+                            selectedUniqueId === skillUniqueId && 'border border-accent1 bg-surface5',
                           )}
                         >
                           <div className="flex items-start justify-between gap-2">
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">
-                                <span className="font-medium text-sm text-neutral6 truncate">{skill.name}</span>
+                                <span className="truncate text-sm font-medium text-neutral6">{skill.name}</span>
                                 {isInstalled && (
-                                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent1/20 text-accent1">
-                                    <Check className="h-2.5 w-2.5" />
+                                  <span className="inline-flex items-center gap-1 rounded bg-accent1/20 px-1.5 py-0.5 text-[10px] font-medium text-accent1">
+                                    <Check className="size-2.5" />
                                     Installed
                                   </span>
                                 )}
                               </div>
-                              <div className="text-xs text-neutral4 truncate">{skill.topSource}</div>
+                              <div className="truncate text-xs text-neutral4">{skill.topSource}</div>
                             </div>
-                            <div className="flex items-center gap-1 text-xs text-neutral3 shrink-0">
-                              <Download className="h-3 w-3" />
+                            <div className="flex shrink-0 items-center gap-1 text-xs text-neutral3">
+                              <Download className="size-3" />
                               <span>{skill.installs.toLocaleString()}</span>
                             </div>
                           </div>
@@ -254,28 +254,28 @@ export function BuilderAddSkillDialog({
             </div>
 
             {/* Preview pane */}
-            <div className="w-1/2 flex flex-col min-h-0 border border-border1 rounded-lg overflow-hidden">
+            <div className="flex min-h-0 w-1/2 flex-col overflow-hidden rounded-lg border border-border1">
               {!selectedSkill ? (
-                <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
-                  <Package className="h-8 w-8 mb-2" />
+                <div className="flex flex-1 flex-col items-center justify-center text-neutral4">
+                  <Package className="mb-2 size-8" />
                   <p className="text-sm">Select a skill to preview</p>
                 </div>
               ) : (
                 <>
-                  <div className="p-4 border-b border-border1 bg-surface3">
+                  <div className="border-b border-border1 bg-surface3 p-4">
                     <div className="flex items-start gap-3">
-                      <div className="p-2 rounded-lg bg-surface5">
-                        <SkillIcon className="h-5 w-5 text-neutral4" />
+                      <div className="rounded-lg bg-surface5 p-2">
+                        <SkillIcon className="size-5 text-neutral4" />
                       </div>
-                      <div className="flex-1 min-w-0">
-                        <h3 className="font-semibold text-neutral6 truncate">{selectedSkill.name}</h3>
-                        <div className="flex items-center gap-3 mt-1 text-xs text-neutral4">
+                      <div className="min-w-0 flex-1">
+                        <h3 className="truncate font-semibold text-neutral6">{selectedSkill.name}</h3>
+                        <div className="mt-1 flex items-center gap-3 text-xs text-neutral4">
                           <span className="flex items-center gap-1">
-                            <Github className="h-3 w-3" />
+                            <Github className="size-3" />
                             {selectedSkill.topSource}
                           </span>
                           <span className="flex items-center gap-1">
-                            <Download className="h-3 w-3" />
+                            <Download className="size-3" />
                             {selectedSkill.installs.toLocaleString()} installs
                           </span>
                         </div>
@@ -285,18 +285,18 @@ export function BuilderAddSkillDialog({
                           href={githubUrl}
                           target="_blank"
                           rel="noopener noreferrer"
-                          className="text-neutral4 hover:text-neutral5 transition-colors"
+                          className="text-neutral4 transition-colors hover:text-neutral5"
                           title="View on GitHub"
                         >
-                          <ExternalLink className="h-4 w-4" />
+                          <ExternalLink className="size-4" />
                         </a>
                       )}
                     </div>
                   </div>
 
                   {isLoadingPreview ? (
-                    <div className="flex-1 flex items-center justify-center">
-                      <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                    <div className="flex flex-1 items-center justify-center">
+                      <Loader2 className="size-6 animate-spin text-neutral3" />
                     </div>
                   ) : previewContent ? (
                     <ScrollArea className="flex-1">
@@ -305,8 +305,8 @@ export function BuilderAddSkillDialog({
                       </div>
                     </ScrollArea>
                   ) : (
-                    <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
-                      <Package className="h-8 w-8 mb-2" />
+                    <div className="flex flex-1 flex-col items-center justify-center text-neutral4">
+                      <Package className="mb-2 size-8" />
                       <p className="text-sm">Preview unavailable</p>
                     </div>
                   )}
@@ -316,9 +316,9 @@ export function BuilderAddSkillDialog({
           </div>
 
           {selectedSkill && (
-            <div className="flex flex-col gap-3 pt-4 border-t border-border1">
+            <div className="flex flex-col gap-3 border-t border-border1 pt-4">
               {installError && (
-                <div className="text-sm text-red-400 px-3 py-2 rounded-md bg-red-500/10 border border-red-500/20">
+                <div className="rounded-md border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-400">
                   {installError}
                 </div>
               )}
@@ -334,17 +334,17 @@ export function BuilderAddSkillDialog({
                 >
                   {installMutation.isPending ? (
                     <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      <Loader2 className="mr-2 size-4 animate-spin" />
                       Installing...
                     </>
                   ) : isSelectedInstalled ? (
                     <>
-                      <Check className="h-4 w-4 mr-2" />
+                      <Check className="mr-2 size-4" />
                       Already installed
                     </>
                   ) : (
                     <>
-                      <Download className="h-4 w-4 mr-2" />
+                      <Download className="mr-2 size-4" />
                       Install
                     </>
                   )}

--- a/packages/playground/src/domains/agent-builder/components/skill-list/copy-skill-dialog.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/copy-skill-dialog.tsx
@@ -54,7 +54,7 @@ export function CopySkillDialog({
           </AlertDialog.Description>
         </AlertDialog.Header>
         <div className="px-6 py-2">
-          <label className="block text-ui-sm text-neutral4 mb-1.5" htmlFor="copy-skill-name">
+          <label className="mb-1.5 block text-ui-sm text-neutral4" htmlFor="copy-skill-name">
             New skill name
           </label>
           <Input

--- a/packages/playground/src/domains/agent-builder/components/skill-list/skill-builder-list.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-list/skill-builder-list.tsx
@@ -29,7 +29,7 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
     return (
       <div className="flex items-center justify-center pt-10">
         <EmptyState
-          iconSlot={<SearchIcon className="h-8 w-8 text-neutral3" />}
+          iconSlot={<SearchIcon className="size-8 text-neutral3" />}
           titleSlot="No skills match your search"
           descriptionSlot="Try a different name or description."
         />
@@ -38,18 +38,18 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
   }
 
   return (
-    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+    <div className="divide-y divide-border1 overflow-hidden rounded-xl border border-border1 bg-surface2">
       {filtered.map(skill => {
         const row = (
           <>
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center gap-2 min-w-0">
-                <div className="text-ui-md text-neutral6 truncate">{skill.name}</div>
+            <div className="min-w-0 flex-1">
+              <div className="flex min-w-0 items-center gap-2">
+                <div className="truncate text-ui-md text-neutral6">{skill.name}</div>
                 {skill.visibility === 'private' && (
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span
-                        className="text-neutral3 shrink-0"
+                        className="shrink-0 text-neutral3"
                         aria-label="Private skill"
                         data-testid="skill-builder-private-visibility-icon"
                       >
@@ -69,11 +69,11 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <span
-                          className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-surface5 text-neutral4 shrink-0"
+                          className="inline-flex shrink-0 items-center gap-1 rounded bg-surface5 px-1.5 py-0.5 text-[10px] font-medium text-neutral4"
                           aria-label={isCopy ? 'Copied skill' : 'Imported skill'}
                           data-testid="skill-builder-origin-badge"
                         >
-                          {isCopy ? <CopyIcon className="h-2.5 w-2.5" /> : <DownloadIcon className="h-2.5 w-2.5" />}
+                          {isCopy ? <CopyIcon className="size-2.5" /> : <DownloadIcon className="size-2.5" />}
                           {origin.type === 'skills-sh' ? 'skills.sh' : isCopy ? 'copied' : 'imported'}
                         </span>
                       </TooltipTrigger>
@@ -88,8 +88,8 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
                   );
                 })()}
               </div>
-              <div className="flex items-center gap-2 mt-0.5">
-                <span className="text-ui-sm text-neutral3 line-clamp-1">{skill.description || 'No description'}</span>
+              <div className="mt-0.5 flex items-center gap-2">
+                <span className="line-clamp-1 text-ui-sm text-neutral3">{skill.description || 'No description'}</span>
               </div>
               {showFavorites && (
                 <div className="mt-2 md:hidden">
@@ -108,7 +108,7 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
                 isFavorited={skill.isFavorited}
                 favoriteCount={skill.favoriteCount}
                 size="sm"
-                className="shrink-0 hidden md:inline-flex"
+                className="hidden shrink-0 md:inline-flex"
               />
             )}
           </>
@@ -117,13 +117,13 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
         return onSkillClick ? (
           <button
             key={skill.id}
-            className="px-6 py-5 flex items-start gap-4 w-full text-left hover:bg-surface3/50 transition-colors md:items-center"
+            className="flex w-full items-start gap-4 px-6 py-5 text-left transition-colors hover:bg-surface3/50 md:items-center"
             onClick={() => onSkillClick(skill)}
           >
             {row}
           </button>
         ) : (
-          <div key={skill.id} className="px-6 py-5 flex items-start gap-4 md:items-center">
+          <div key={skill.id} className="flex items-start gap-4 px-6 py-5 md:items-center">
             {row}
           </div>
         );
@@ -134,14 +134,14 @@ export function SkillBuilderList({ skills, search, onSkillClick, showFavorites =
 
 export function SkillBuilderListSkeleton({ rows = 4 }: { rows?: number }) {
   return (
-    <div className="bg-surface2 border border-border1 rounded-xl divide-y divide-border1 overflow-hidden">
+    <div className="divide-y divide-border1 overflow-hidden rounded-xl border border-border1 bg-surface2">
       {Array.from({ length: rows }).map((_, i) => (
-        <div key={i} className="px-6 py-5 flex items-center gap-4">
-          <div className="flex-1 min-w-0 space-y-2">
-            <div className="h-3.5 w-48 bg-surface3 rounded animate-pulse" />
-            <div className="h-3 w-72 max-w-full bg-surface3 rounded animate-pulse" />
+        <div key={i} className="flex items-center gap-4 px-6 py-5">
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="h-3.5 w-48 animate-pulse rounded bg-surface3" />
+            <div className="h-3 w-72 max-w-full animate-pulse rounded bg-surface3" />
           </div>
-          <div className="h-3 w-16 bg-surface3 rounded animate-pulse" />
+          <div className="h-3 w-16 animate-pulse rounded bg-surface3" />
         </div>
       ))}
     </div>

--- a/packages/playground/src/domains/agent-builder/components/skill-starter/skill-builder-starter.tsx
+++ b/packages/playground/src/domains/agent-builder/components/skill-starter/skill-builder-starter.tsx
@@ -119,7 +119,7 @@ export const SkillBuilderStarter = () => {
 
         <form onSubmit={handleSubmit}>
           <div
-            className="starter-prompt rounded-2xl border border-border1 bg-surface2 transition-colors duration-normal ease-out-custom focus-within:border-neutral3"
+            className="starter-prompt duration-normal rounded-2xl border border-border1 bg-surface2 transition-colors ease-out-custom focus-within:border-neutral3"
             style={{ viewTransitionName: 'skill-chat-composer' }}
           >
             <Textarea
@@ -132,7 +132,7 @@ export const SkillBuilderStarter = () => {
               onChange={e => setMessage(e.target.value)}
               onKeyDown={handleKeyDown}
               disabled={isCreating}
-              className="min-h-[112px] resize-none px-5 py-4 text-ui-md outline-none placeholder:text-neutral3 focus:outline-none focus-visible:outline-none"
+              className="min-h-28 resize-none px-5 py-4 text-ui-md outline-none placeholder:text-neutral3 focus:outline-none focus-visible:outline-none"
               rows={3}
             />
             <div className="flex items-center justify-end px-3 pb-2.5">
@@ -167,9 +167,9 @@ export const SkillBuilderStarter = () => {
                 onClick={() => handleExampleClick(example.prompt)}
                 data-testid={`skill-builder-starter-example-${example.title.toLowerCase().replace(/\s+/g, '-')}`}
                 style={{ animationDelay: `${280 + i * 40}ms` }}
-                className="starter-chip group inline-flex items-center gap-2 rounded-full border border-border1 bg-transparent px-4 py-2 text-ui-sm text-neutral4 transition-colors duration-normal ease-out-custom hover:border-border2 hover:bg-surface2 hover:text-neutral6"
+                className="starter-chip group duration-normal inline-flex items-center gap-2 rounded-full border border-border1 bg-transparent px-4 py-2 text-ui-sm text-neutral4 transition-colors ease-out-custom hover:border-border2 hover:bg-surface2 hover:text-neutral6"
               >
-                <Icon className="h-3.5 w-3.5 text-neutral3 transition-colors group-hover:text-neutral5" />
+                <Icon className="size-3.5 text-neutral3 transition-colors group-hover:text-neutral5" />
                 {example.title}
               </button>
             );

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-edit-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-edit-layout.tsx
@@ -39,25 +39,25 @@ export const AgentBuilderEditLayout = ({
   const applyMobileChatHide = hideMobileChat && !isCentered;
 
   return (
-    <div className="h-full grid grid-rows-[auto_1fr]">
+    <div className="grid h-full grid-rows-[auto_1fr]">
       {topBar}
       <div
         className={cn(
-          'flex flex-1 min-h-0 min-w-0 flex-col pt-4 pb-4 md:pb-10',
-          !isCentered && 'lg:grid lg:grid-rows-1 lg:grid-cols-[1fr_2fr]',
+          'flex min-h-0 min-w-0 flex-1 flex-col py-4 md:pb-10',
+          !isCentered && 'lg:grid lg:grid-cols-[1fr_2fr] lg:grid-rows-1',
         )}
       >
         <div
           className={cn(
-            'h-full w-full min-w-0 overflow-hidden px-4 md:px-10',
+            'size-full min-w-0 overflow-hidden px-4 md:px-10',
             isCentered && 'lg:mx-auto lg:max-w-[80ch]',
             applyMobileChatHide && 'hidden lg:block',
           )}
           data-testid="agent-builder-panel-chat"
           style={{ viewTransitionName: 'agent-builder-chat-panel' }}
         >
-          <div className="min-h-0 min-w-0 h-full overflow-hidden md:max-w-[80ch] md:mx-auto w-full grid grid-rows-[1fr_auto]">
-            <div className="min-h-0 min-w-0 h-full overflow-hidden">{chat}</div>
+          <div className="grid size-full min-h-0 min-w-0 grid-rows-[1fr_auto] overflow-hidden md:mx-auto md:max-w-[80ch]">
+            <div className="h-full min-h-0 min-w-0 overflow-hidden">{chat}</div>
             {chatFooter ? (
               <div data-testid="agent-builder-chat-footer" className="w-full pt-3 lg:hidden">
                 {chatFooter}
@@ -71,12 +71,12 @@ export const AgentBuilderEditLayout = ({
             className={cn(
               'min-w-0 overflow-hidden',
               'flex-1 px-4 md:px-10',
-              'lg:flex-none lg:h-full lg:min-h-0 lg:pl-0 lg:pr-10',
+              'lg:h-full lg:min-h-0 lg:flex-none lg:pr-10 lg:pl-0',
             )}
             data-testid="agent-builder-panel-profile"
             style={{ viewTransitionName: 'agent-builder-profile-panel' }}
           >
-            <div className="h-full min-h-0 w-full min-w-0 overflow-hidden">{profile}</div>
+            <div className="size-full min-h-0 min-w-0 overflow-hidden">{profile}</div>
           </div>
         )}
       </div>

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-layout.tsx
@@ -5,14 +5,14 @@ import { AgentBuilderSidebar } from './agent-builder-sidebar';
 
 export const AgentBuilderLayout = () => {
   return (
-    <div className="bg-surface1 font-sans h-screen">
+    <div className="h-screen bg-surface1 font-sans">
       <MainSidebarProvider>
         <div className="grid h-full grid-rows-1 md:grid-cols-[auto_1fr] md:divide-x md:divide-border1">
           <div className="hidden md:block">
             <AgentBuilderSidebar />
           </div>
-          <div className="flex flex-col h-full min-h-0">
-            <div className="flex-1 min-h-0 bg-transparent overflow-y-auto pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-0">
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="min-h-0 flex-1 overflow-y-auto bg-transparent pb-[calc(3.5rem+env(safe-area-inset-bottom))] md:pb-0">
               <Outlet />
             </div>
           </div>
@@ -25,7 +25,7 @@ export const AgentBuilderLayout = () => {
 
 export const AgentBuilderEditionLayout = () => {
   return (
-    <div className="bg-surface1 font-sans h-screen grid grid-rows-1 grid-cols-[minmax(0,1fr)]">
+    <div className="grid h-screen grid-cols-[minmax(0,1fr)] grid-rows-1 bg-surface1 font-sans">
       <Outlet />
     </div>
   );

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-mobile-bottom-bar.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-mobile-bottom-bar.tsx
@@ -61,7 +61,7 @@ export function AgentBuilderMobileBottomBar() {
   return (
     <nav
       aria-label="Primary"
-      className="md:hidden fixed inset-x-0 bottom-0 z-40 border-t border-border1 bg-surface1/95 backdrop-blur-sm pb-[env(safe-area-inset-bottom)]"
+      className="fixed inset-x-0 bottom-0 z-40 border-t border-border1 bg-surface1/95 pb-[env(safe-area-inset-bottom)] backdrop-blur-sm md:hidden"
     >
       <ul className="grid" style={{ gridTemplateColumns: `repeat(${links.length}, minmax(0, 1fr))` }}>
         {links.map(link => {
@@ -71,7 +71,7 @@ export function AgentBuilderMobileBottomBar() {
               <Link
                 href={link.url}
                 aria-current={isActive ? 'page' : undefined}
-                className={`relative flex flex-col items-center justify-center gap-1 py-2 text-[11px] transition-colors duration-normal ease-out-custom ${
+                className={`duration-normal relative flex flex-col items-center justify-center gap-1 py-2 text-[11px] transition-colors ease-out-custom ${
                   isActive
                     ? 'text-icon6 before:absolute before:inset-x-0 before:-top-px before:h-0.5 before:bg-current'
                     : 'text-icon3 hover:text-icon6'

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
@@ -23,7 +23,7 @@ export const AgentBuilderRootLayout = ({ paths }: AgentBuilderRootLayoutProps) =
 
   if (isLoading) {
     return (
-      <div className="h-screen w-full flex items-center justify-center">
+      <div className="flex h-screen w-full items-center justify-center">
         <Spinner />
       </div>
     );
@@ -44,7 +44,7 @@ const AgentBuilderPermissionsGuard = ({ paths }: AgentBuilderRootLayoutProps) =>
 
   if (isLoading) {
     return (
-      <div className="h-screen w-full flex items-center justify-center">
+      <div className="flex h-screen w-full items-center justify-center">
         <Spinner />
       </div>
     );
@@ -114,12 +114,12 @@ function AccessDeniedScreen() {
         />
         <div className="flex items-center gap-2">
           <Button as="a" href="/agents" variant="outline" size="sm">
-            <ArrowLeft className="h-3.5 w-3.5" />
+            <ArrowLeft className="size-3.5" />
             Back to Studio
           </Button>
           {isImpersonating && (
             <Button variant="default" size="sm" onClick={stopImpersonation}>
-              <Eye className="h-3.5 w-3.5" />
+              <Eye className="size-3.5" />
               Exit {impersonatedRole?.name} preview
             </Button>
           )}

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-sidebar.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-sidebar.tsx
@@ -36,13 +36,13 @@ const libraryLink: NavLink = {
 const skillsLink: NavLink = {
   name: 'Skills',
   url: '/agent-builder/skills',
-  icon: <Blocks className="h-4 w-4" />,
+  icon: <Blocks className="size-4" />,
 };
 
 const infrastructureLink: NavLink = {
   name: 'Infrastructure',
   url: '/agent-builder/infrastructure',
-  icon: <ServerCogIcon className="h-4 w-4" />,
+  icon: <ServerCogIcon className="size-4" />,
 };
 
 type AgentBuilderSidebarProps = {
@@ -76,16 +76,16 @@ export function AgentBuilderSidebar({ forceExpanded = false }: AgentBuilderSideb
   return (
     <MainSidebar className="h-full">
       {!forceExpanded && (
-        <div className="pt-3 mb-4">
+        <div className="mb-4 pt-3">
           {state === 'collapsed' ? (
-            <div className="flex flex-col gap-3 items-center">
-              <div className="relative grid place-items-center size-9">
+            <div className="flex flex-col items-center gap-3">
+              <div className="relative grid size-9 place-items-center">
                 <Link
                   href="/agents"
                   aria-label="Back to Mastra Studio"
                   className={cn('transition-opacity duration-150', !isMobile && 'group-hover/sidebar:opacity-0')}
                 >
-                  <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
+                  <LogoWithoutText className="size-[1.5rem] shrink-0" />
                 </Link>
                 {!isMobile && (
                   <div className="absolute inset-0 opacity-0 transition-opacity duration-150 group-hover/sidebar:opacity-100">
@@ -96,29 +96,29 @@ export function AgentBuilderSidebar({ forceExpanded = false }: AgentBuilderSideb
               {isUserAuthenticated && <AuthStatus />}
             </div>
           ) : isUserAuthenticated ? (
-            <span className="flex items-center justify-between pl-3 pr-2">
-              <span className="flex items-center gap-2 flex-1 min-w-0">
+            <span className="flex items-center justify-between pr-2 pl-3">
+              <span className="flex min-w-0 flex-1 items-center gap-2">
                 <Link
                   href="/agents"
                   aria-label="Back to Mastra Studio"
-                  className="flex items-center gap-2 rounded-sm hover:opacity-80 min-w-0"
+                  className="flex min-w-0 items-center gap-2 rounded-sm hover:opacity-80"
                 >
-                  <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
-                  <span className="font-display text-sm whitespace-nowrap truncate">Mastra Studio</span>
+                  <LogoWithoutText className="size-[1.5rem] shrink-0" />
+                  <span className="truncate font-display text-sm whitespace-nowrap">Mastra Studio</span>
                 </Link>
                 {!isMobile && <MainSidebar.Trigger />}
               </span>
               <AuthStatus />
             </span>
           ) : (
-            <span className="flex items-center gap-2 pl-3 pr-2">
+            <span className="flex items-center gap-2 pr-2 pl-3">
               <Link
                 href="/agents"
                 aria-label="Back to Mastra Studio"
-                className="flex items-center gap-2 rounded-sm hover:opacity-80 min-w-0"
+                className="flex min-w-0 items-center gap-2 rounded-sm hover:opacity-80"
               >
-                <LogoWithoutText className="h-[1.5rem] w-[1.5rem] shrink-0" />
-                <span className="font-display text-sm whitespace-nowrap truncate">Mastra Studio</span>
+                <LogoWithoutText className="size-[1.5rem] shrink-0" />
+                <span className="truncate font-display text-sm whitespace-nowrap">Mastra Studio</span>
               </Link>
               {!isMobile && <MainSidebar.Trigger />}
             </span>

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-view-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-view-layout.tsx
@@ -9,11 +9,11 @@ export interface AgentBuilderViewLayoutProps {
 
 export const AgentBuilderViewLayout = ({ topBar, chat, browserOverlay }: AgentBuilderViewLayoutProps) => {
   return (
-    <div className="flex flex-1 min-w-0 flex-col h-full min-h-0">
+    <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col">
       {topBar}
 
       <div
-        className="flex-1 min-h-0 w-full min-w-0 overflow-hidden px-4 md:px-10 md:max-w-[80ch] md:mx-auto pt-10 md:pt-4 pb-4 md:pb-10"
+        className="min-h-0 w-full min-w-0 flex-1 overflow-hidden px-4 pt-10 pb-4 md:mx-auto md:max-w-[80ch] md:px-10 md:pt-4 md:pb-10"
         data-testid="agent-builder-panel-chat"
       >
         {chat}

--- a/packages/playground/src/domains/agent-builder/layouts/skill-workspace-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/skill-workspace-layout.tsx
@@ -62,7 +62,7 @@ export const SkillWorkspaceLayout = ({
       {/* Mobile tabs — only when there's a configure side to switch to.
        *  Mirrors the agent-builder pill-style segmented switch for visual parity. */}
       {showForm && (
-        <div className="md:hidden px-4 pt-4 pb-2">
+        <div className="px-4 pt-4 pb-2 md:hidden">
           <div
             role="tablist"
             aria-label="Workspace view"
@@ -120,20 +120,20 @@ export const SkillWorkspaceLayout = ({
       >
         <div
           className={cn(
-            'min-w-0 min-h-0 overflow-hidden bg-surface1',
+            'min-h-0 min-w-0 overflow-hidden bg-surface1',
             showForm && activeTab !== 'chat' ? 'hidden' : 'block',
             'md:block',
             'md:transition-[grid-column] md:duration-300 md:ease-out',
           )}
         >
           <div className="flex h-full min-h-0 flex-col px-4 pt-4 pb-6 md:px-10">
-            <div className="flex min-h-0 flex-1 flex-col md:max-w-[80ch] md:mx-auto w-full">{chat}</div>
+            <div className="flex min-h-0 w-full flex-1 flex-col md:mx-auto md:max-w-[80ch]">{chat}</div>
           </div>
         </div>
         {showForm && (
           <div
             className={cn(
-              'min-w-0 min-h-0 overflow-hidden bg-surface1',
+              'min-h-0 min-w-0 overflow-hidden bg-surface1',
               activeTab === 'configure' ? 'block' : 'hidden',
               'md:block',
               // Mobile uses the same page-layout padding as the rest of the
@@ -142,7 +142,7 @@ export const SkillWorkspaceLayout = ({
               // slides in from the right. The slide is driven by a CSS
               // keyframe animation triggered the first time this element
               // mounts (which matches the moment showForm flips to true).
-              'px-4 pb-6 md:p-4 md:bg-transparent',
+              'px-4 pb-6 md:bg-transparent md:p-4',
             )}
             data-testid="skill-edit-configure-panel"
           >
@@ -154,7 +154,7 @@ export const SkillWorkspaceLayout = ({
             >
               <div className="min-h-0 flex-1 overflow-hidden">{form}</div>
               {deleteAction && (
-                <div className="border-t border-border1 px-4 pb-4 pt-4 md:px-6" data-testid="skill-edit-delete-action">
+                <div className="border-t border-border1 p-4 md:px-6" data-testid="skill-edit-delete-action">
                   {deleteAction}
                 </div>
               )}

--- a/packages/playground/src/domains/agents/components/AgentToolPanel.tsx
+++ b/packages/playground/src/domains/agents/components/AgentToolPanel.tsx
@@ -61,7 +61,7 @@ export const AgentToolPanel = ({ toolId, agentId }: AgentToolPanelProps) => {
 
   if (!tool)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="header-md" className="text-neutral3">
           Tool not found
         </Txt>
@@ -70,7 +70,7 @@ export const AgentToolPanel = ({ toolId, agentId }: AgentToolPanelProps) => {
 
   if (!canExecuteTool)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="ui-sm" className="text-neutral3">
           You don't have permission to execute tools.
         </Txt>

--- a/packages/playground/src/domains/agents/components/__tests__/resizable-layouts.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/resizable-layouts.test.tsx
@@ -95,9 +95,7 @@ function expectPanelGroupsShrinkable() {
   expect(panelGroups.length).toBeGreaterThan(0);
 
   for (const panelGroup of panelGroups) {
-    expect(panelGroup.className).toContain('h-full');
     expect(panelGroup.className).toContain('min-h-0');
-    expect(panelGroup.className).toContain('w-full');
     expect(panelGroup.className).toContain('min-w-0');
     expect(panelGroup.className).not.toContain('min-w-min');
   }

--- a/packages/playground/src/domains/agents/components/agent-advanced-settings.tsx
+++ b/packages/playground/src/domains/agents/components/agent-advanced-settings.tsx
@@ -234,7 +234,7 @@ export const AgentAdvancedSettingsBody = ({ canEdit = true }: AgentAdvancedSetti
         </div>
 
         <div className="space-y-1">
-          <div className="flex justify-between items-center">
+          <div className="flex items-center justify-between">
             <Txt as="label" className="text-neutral3" variant="ui-sm" htmlFor="provider-options">
               Provider Options
             </Txt>
@@ -290,7 +290,7 @@ export const AgentAdvancedSettingsBody = ({ canEdit = true }: AgentAdvancedSetti
             theme={theme}
             extensions={[jsonLanguage]}
             readOnly={!canEdit}
-            className="h-dropdown-max-height overflow-scroll rounded-lg border bg-transparent shadow-sm transition-colors p-2"
+            className="h-dropdown-max-height overflow-scroll rounded-lg border bg-transparent p-2 shadow-sm transition-colors"
           />
           {error && (
             <Txt variant="ui-md" className="text-accent2">

--- a/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
+++ b/packages/playground/src/domains/agents/components/agent-channels/agent-channels.tsx
@@ -109,12 +109,12 @@ function ChannelRow({ platform, agentId }: ChannelRowProps) {
   return (
     <DataList.RowStatic>
       <DataList.Cell className="text-left text-neutral4">
-        <span className="flex items-center gap-3 min-w-0">
-          <PlatformIcon platform={platform.id} className="h-5 w-5 shrink-0" />
-          <span className="flex flex-col min-w-0">
+        <span className="flex min-w-0 items-center gap-3">
+          <PlatformIcon platform={platform.id} className="size-5 shrink-0" />
+          <span className="flex min-w-0 flex-col">
             <span className="truncate">{platform.name}</span>
             {activeInstallation ? (
-              <Txt variant="ui-xs" className="text-neutral5 truncate">
+              <Txt variant="ui-xs" className="truncate text-neutral5">
                 {activeInstallation.displayName || 'Workspace'}
               </Txt>
             ) : null}
@@ -140,7 +140,7 @@ function ChannelRow({ platform, agentId }: ChannelRowProps) {
             type="button"
             onClick={handleDisconnect}
             disabled={isDisconnecting}
-            className="shrink-0 text-[11px] text-neutral5 hover:text-accent2 transition-colors disabled:opacity-50"
+            className="shrink-0 text-[11px] text-neutral5 transition-colors hover:text-accent2 disabled:opacity-50"
           >
             {isDisconnecting ? 'Removing...' : 'Remove'}
           </button>

--- a/packages/playground/src/domains/agents/components/agent-chat-shell.tsx
+++ b/packages/playground/src/domains/agents/components/agent-chat-shell.tsx
@@ -26,7 +26,7 @@ export function AgentChatShell({
       leftSlot={leftSlot}
       browserOverlay={browserOverlay}
     >
-      <div className="grid grid-rows-[auto_1fr] h-full min-h-0">
+      <div className="grid h-full min-h-0 grid-rows-[auto_1fr]">
         <AgentViewHeader agentId={agentId} view={view} />
         {children}
       </div>

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -196,14 +196,14 @@ const InlineBlockContent = ({
     <>
       <div
         className={cn(
-          'relative group rounded-md transition-colors duration-150 hover:bg-surface2/50',
+          'group relative rounded-md transition-colors duration-150 hover:bg-surface2/50',
           !readOnly && 'pr-20',
         )}
       >
         {/* Left gutter — drag handle (visible on hover/focus-within) */}
         {!readOnly && (
-          <div className="absolute -left-8 top-1 flex flex-col items-center transition-opacity duration-150 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
-            <div {...dragHandleProps} className="text-neutral3 hover:text-neutral6 cursor-grab active:cursor-grabbing">
+          <div className="absolute top-1 -left-8 flex flex-col items-center opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+            <div {...dragHandleProps} className="cursor-grab text-neutral3 hover:text-neutral6 active:cursor-grabbing">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Icon>
@@ -218,7 +218,7 @@ const InlineBlockContent = ({
 
         {/* Right toolbar — conditions + save as ref + delete (visible on hover/focus-within) */}
         {!readOnly && (
-          <div className="absolute right-0 top-1 z-10 flex items-center gap-0.5 transition-opacity duration-150 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
+          <div className="absolute top-1 right-0 z-10 flex items-center gap-0.5 opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
             <DisplayConditionsDialog
               entityName={`Block ${index + 1}`}
               schema={schema}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.stories.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.stories.tsx
@@ -69,14 +69,14 @@ const InteractiveExample = () => {
   ]);
 
   return (
-    <div className="w-[800px]">
+    <div className="w-200">
       <TooltipProvider>
         <AgentCMSBlocks items={items} onChange={setItems} placeholder="Enter content..." schema={complexSchema} />
       </TooltipProvider>
 
-      <div className="mt-4 p-3 bg-surface2 rounded-lg">
-        <p className="text-xs text-neutral3 mb-2">Current state:</p>
-        <pre className="text-xs text-neutral6 whitespace-pre-wrap">{JSON.stringify(items, null, 2)}</pre>
+      <div className="mt-4 rounded-lg bg-surface2 p-3">
+        <p className="mb-2 text-xs text-neutral3">Current state:</p>
+        <pre className="text-xs whitespace-pre-wrap text-neutral6">{JSON.stringify(items, null, 2)}</pre>
       </div>
     </div>
   );
@@ -90,7 +90,7 @@ const EmptyExample = () => {
   const [items, setItems] = useState<Array<InstructionBlock>>([]);
 
   return (
-    <div className="w-[500px]">
+    <div className="w-125">
       <TooltipProvider>
         <AgentCMSBlocks
           items={items}
@@ -113,7 +113,7 @@ const SingleBlockExample = () => {
   ]);
 
   return (
-    <div className="w-[500px]">
+    <div className="w-125">
       <TooltipProvider>
         <AgentCMSBlocks items={items} onChange={setItems} placeholder="Enter content..." schema={complexSchema} />
       </TooltipProvider>

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-blocks.tsx
@@ -28,19 +28,19 @@ interface AddBlockButtonProps {
 const AddBlockButton = ({ onAddInline, onPickRef, className }: AddBlockButtonProps) => {
   return (
     <div className={cn('group/add flex items-center gap-2 py-0.5', className)}>
-      <div className="flex-1 h-px bg-border1 opacity-0 group-hover/add:opacity-100 transition-opacity duration-150" />
+      <div className="h-px flex-1 bg-border1 opacity-0 transition-opacity duration-150 group-hover/add:opacity-100" />
       <DropdownMenu>
         <DropdownMenu.Trigger asChild>
           <button
             type="button"
-            className="flex items-center justify-center h-6 w-6 rounded-full text-neutral3 hover:text-neutral6 hover:bg-surface4 opacity-0 group-hover/add:opacity-100 transition-all duration-150 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1"
+            className="flex size-6 items-center justify-center rounded-full text-neutral3 opacity-0 transition-all duration-150 group-hover/add:opacity-100 hover:bg-surface4 hover:text-neutral6 focus-visible:opacity-100 focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden"
           >
             <Icon>
               <PlusIcon />
             </Icon>
           </button>
         </DropdownMenu.Trigger>
-        <DropdownMenu.Content align="start" className="w-[240px]">
+        <DropdownMenu.Content align="start" className="w-60">
           <DropdownMenu.Item onSelect={onAddInline}>
             <Icon>
               <PenLine />
@@ -55,7 +55,7 @@ const AddBlockButton = ({ onAddInline, onPickRef, className }: AddBlockButtonPro
           </DropdownMenu.Item>
         </DropdownMenu.Content>
       </DropdownMenu>
-      <div className="flex-1 h-px bg-border1 opacity-0 group-hover/add:opacity-100 transition-opacity duration-150" />
+      <div className="h-px flex-1 bg-border1 opacity-0 transition-opacity duration-150 group-hover/add:opacity-100" />
     </div>
   );
 };
@@ -117,10 +117,10 @@ export const AgentCMSBlocks = ({
   };
 
   return (
-    <div className={cn('flex flex-col w-full h-full overflow-y-auto', className)}>
+    <div className={cn('flex size-full flex-col overflow-y-auto', className)}>
       {items.length > 0 && (
-        <div className="overflow-y-auto h-full pl-10 pr-2">
-          <ContentBlocks items={items} onChange={onChange} className="flex flex-col w-full">
+        <div className="h-full overflow-y-auto pr-2 pl-10">
+          <ContentBlocks items={items} onChange={onChange} className="flex w-full flex-col">
             {items.map((block, index) => (
               <div key={block.id}>
                 {/* Add-block handle between blocks */}
@@ -148,7 +148,7 @@ export const AgentCMSBlocks = ({
       )}
 
       {!readOnly && (
-        <div className="pl-10 pr-2">
+        <div className="pr-2 pl-10">
           <AddBlockButton
             onAddInline={() => handleAddInlineAt(items.length)}
             onPickRef={() => handlePickRefAt(items.length)}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-ref-block.tsx
@@ -95,11 +95,11 @@ const RefBlockContent = ({
   }, [storedAgentsData?.agents, block.promptBlockId]);
 
   return (
-    <div className="relative group rounded-md transition-colors duration-150 hover:bg-surface2/50">
+    <div className="group relative rounded-md transition-colors duration-150 hover:bg-surface2/50">
       {/* Left gutter — drag handle (visible on hover/focus-within) */}
       {!readOnly && (
-        <div className="absolute -left-8 top-1 flex flex-col items-center transition-opacity duration-150 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
-          <div {...dragHandleProps} className="text-neutral3 hover:text-neutral6 cursor-grab active:cursor-grabbing">
+        <div className="absolute top-1 -left-8 flex flex-col items-center opacity-0 transition-opacity duration-150 group-focus-within:opacity-100 group-hover:opacity-100">
+          <div {...dragHandleProps} className="cursor-grab text-neutral3 hover:text-neutral6 active:cursor-grabbing">
             <Tooltip>
               <TooltipTrigger asChild>
                 <Icon>
@@ -115,15 +115,15 @@ const RefBlockContent = ({
       {/* Content area with left accent border */}
       <div className="border-l-2 border-accent3/30 pl-3">
         {isLoading ? (
-          <div className="flex items-center gap-2 text-neutral3 py-3">
-            <Spinner className="h-4 w-4" />
+          <div className="flex items-center gap-2 py-3 text-neutral3">
+            <Spinner className="size-4" />
             <Txt variant="ui-sm">Loading prompt block...</Txt>
           </div>
         ) : promptBlock ? (
           <>
             {/* Sync-block header — always visible, with Popover on caret */}
-            <div className="flex items-center gap-1.5 py-1 px-1 -ml-1">
-              <Txt variant="ui-xs" className="text-neutral3 truncate">
+            <div className="-ml-1 flex items-center gap-1.5 p-1">
+              <Txt variant="ui-xs" className="truncate text-neutral3">
                 {promptBlock.name}
               </Txt>
               {!readOnly && (
@@ -132,20 +132,20 @@ const RefBlockContent = ({
                     <button
                       type="button"
                       aria-label={`Open actions for ${promptBlock.name}`}
-                      className="ml-auto rounded p-0.5 hover:bg-surface4/50 transition-colors duration-150 text-neutral3 hover:text-neutral5"
+                      className="ml-auto rounded p-0.5 text-neutral3 transition-colors duration-150 hover:bg-surface4/50 hover:text-neutral5"
                     >
-                      <Icon className="h-3! w-3!">
+                      <Icon className="size-3">
                         <ChevronDown />
                       </Icon>
                     </button>
                   </PopoverTrigger>
-                  <PopoverContent align="end" className="w-[280px] p-0">
-                    <div className="p-3 border-b border-border1">
+                  <PopoverContent align="end" className="w-70 p-0">
+                    <div className="border-b border-border1 p-3">
                       <Txt variant="ui-sm" className="font-medium text-neutral6">
                         {promptBlock.name}
                       </Txt>
                       {promptBlock.description && (
-                        <Txt variant="ui-xs" className="text-neutral3 mt-0.5 line-clamp-2">
+                        <Txt variant="ui-xs" className="mt-0.5 line-clamp-2 text-neutral3">
                           {promptBlock.description}
                         </Txt>
                       )}
@@ -153,10 +153,10 @@ const RefBlockContent = ({
                     <div className="p-1">
                       <button
                         type="button"
-                        className="flex items-center gap-2 w-full px-2 py-1.5 text-left rounded hover:bg-surface4/50 transition-colors text-neutral5 text-ui-xs"
+                        className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-ui-xs text-neutral5 transition-colors hover:bg-surface4/50"
                         onClick={() => navigate(paths.cmsPromptBlockEditLink(block.promptBlockId))}
                       >
-                        <Icon className="h-3.5! w-3.5! text-neutral3">
+                        <Icon className="size-3.5 text-neutral3">
                           <ExternalLink />
                         </Icon>
                         Open original
@@ -164,13 +164,13 @@ const RefBlockContent = ({
                       {onDereference && (
                         <button
                           type="button"
-                          className="flex items-center gap-2 w-full px-2 py-1.5 text-left rounded hover:bg-surface4/50 transition-colors text-neutral5 text-ui-xs"
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-ui-xs text-neutral5 transition-colors hover:bg-surface4/50"
                           onClick={() => {
                             debouncedSave.flush();
                             onDereference(localContent);
                           }}
                         >
-                          <Icon className="h-3.5! w-3.5! text-neutral3">
+                          <Icon className="size-3.5 text-neutral3">
                             <X />
                           </Icon>
                           De-reference block
@@ -179,10 +179,10 @@ const RefBlockContent = ({
                       {onDelete && (
                         <button
                           type="button"
-                          className="flex items-center gap-2 w-full px-2 py-1.5 text-left rounded hover:bg-surface4/50 transition-colors text-error text-ui-xs"
+                          className="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-ui-xs text-error transition-colors hover:bg-surface4/50"
                           onClick={onDelete}
                         >
-                          <Icon className="h-3.5! w-3.5!">
+                          <Icon className="size-3.5">
                             <X />
                           </Icon>
                           Remove block
@@ -191,12 +191,12 @@ const RefBlockContent = ({
                     </div>
                     {usedByAgents.length > 0 && (
                       <div className="border-t border-border1 p-3">
-                        <Txt variant="ui-xs" className="text-neutral3 mb-1.5">
+                        <Txt variant="ui-xs" className="mb-1.5 text-neutral3">
                           Used by {usedByAgents.length} agent{usedByAgents.length !== 1 ? 's' : ''}
                         </Txt>
                         <div className="flex flex-col gap-1">
                           {usedByAgents.map(agent => (
-                            <Txt key={agent.id} variant="ui-xs" className="text-neutral5 truncate">
+                            <Txt key={agent.id} variant="ui-xs" className="truncate text-neutral5">
                               {agent.name}
                             </Txt>
                           ))}
@@ -224,7 +224,7 @@ const RefBlockContent = ({
             />
           </>
         ) : (
-          <div className="flex items-center gap-2 text-warning py-3">
+          <div className="text-warning flex items-center gap-2 py-3">
             <Txt variant="ui-sm">Prompt block not found (ID: {block.promptBlockId})</Txt>
           </div>
         )}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/prompt-block-picker-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/prompt-block-picker-dialog.tsx
@@ -56,28 +56,28 @@ export function PromptBlockPickerDialog({ open, onOpenChange, onSelect }: Prompt
         <DialogBody>
           <div className="flex flex-col gap-3">
             <div className="flex items-center gap-2 rounded-md border border-border1 bg-surface2 px-3 py-2">
-              <Search className="h-4 w-4 text-neutral3" />
+              <Search className="size-4 text-neutral3" />
               <input
                 type="text"
                 value={search}
                 onChange={e => setSearch(e.target.value)}
                 placeholder="Search prompt blocks..."
-                className="flex-1 bg-transparent text-ui-sm text-neutral6 placeholder:text-neutral3 outline-hidden"
+                className="flex-1 bg-transparent text-ui-sm text-neutral6 outline-hidden placeholder:text-neutral3"
               />
             </div>
 
             {isLoading ? (
               <div className="flex flex-col items-center justify-center gap-2 py-8 text-neutral3">
-                <Spinner className="h-6 w-6" />
+                <Spinner className="size-6" />
                 <Txt variant="ui-sm">Loading prompt blocks...</Txt>
               </div>
             ) : filtered.length === 0 ? (
               <div className="flex flex-col items-center justify-center gap-2 py-8 text-neutral3">
-                <FileText className="h-8 w-8" />
+                <FileText className="size-8" />
                 <Txt variant="ui-sm">{search ? 'No matching prompt blocks' : 'No prompt blocks available'}</Txt>
               </div>
             ) : (
-              <div className="flex flex-col gap-1 max-h-dropdown-max-height overflow-y-auto">
+              <div className="flex max-h-dropdown-max-height flex-col gap-1 overflow-y-auto">
                 {filtered.map(block => (
                   <button
                     key={block.id}
@@ -85,14 +85,14 @@ export function PromptBlockPickerDialog({ open, onOpenChange, onSelect }: Prompt
                     onClick={() => handleSelect(block.id)}
                     className={cn(
                       'flex flex-col gap-0.5 rounded-md px-3 py-2 text-left',
-                      'hover:bg-surface4 active:bg-surface5 transition-colors',
+                      'transition-colors hover:bg-surface4 active:bg-surface5',
                     )}
                   >
-                    <Txt variant="ui-sm" className="text-neutral6 font-medium">
+                    <Txt variant="ui-sm" className="font-medium text-neutral6">
                       {block.name}
                     </Txt>
                     {block.description && (
-                      <Txt variant="ui-xs" className="text-neutral3 line-clamp-1">
+                      <Txt variant="ui-xs" className="line-clamp-1 text-neutral3">
                         {block.description}
                       </Txt>
                     )}

--- a/packages/playground/src/domains/agents/components/agent-cms-layout/agent-cms-layout.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-layout/agent-cms-layout.tsx
@@ -14,18 +14,18 @@ export function AgentsCmsLayout({ children, currentPath, basePath, versionId, ri
   return (
     <div
       className={cn(
-        'grid overflow-y-auto h-full',
+        'grid h-full overflow-y-auto',
         rightPanel ? 'grid-cols-[240px_1fr_240px]' : 'grid-cols-[240px_1fr]',
       )}
     >
-      <div className="overflow-y-auto h-full border-r border-border1">
+      <div className="h-full overflow-y-auto border-r border-border1">
         <AgentCmsSidebar basePath={basePath} currentPath={currentPath} versionId={versionId} />
       </div>
-      <div className="flex flex-col h-full overflow-hidden">
-        <div className="overflow-y-auto flex-1 p-8 max-w-5xl w-full">{children}</div>
+      <div className="flex h-full flex-col overflow-hidden">
+        <div className="w-full max-w-5xl flex-1 overflow-y-auto p-8">{children}</div>
         <AgentCmsBottomBar basePath={basePath} currentPath={currentPath} />
       </div>
-      {rightPanel && <div className="overflow-y-auto h-full border-l border-border1">{rightPanel}</div>}
+      {rightPanel && <div className="h-full overflow-y-auto border-l border-border1">{rightPanel}</div>}
     </div>
   );
 }

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/agents-page.tsx
@@ -136,8 +136,8 @@ export function AgentsPage() {
                           type="text"
                           disabled={isDisabled}
                           className={cn(
-                            'border border-transparent appearance-none block w-full text-neutral3 bg-transparent',
-                            !isDisabled && 'border-border1 border-dashed ',
+                            'block w-full appearance-none border border-transparent bg-transparent text-neutral3',
+                            !isDisabled && 'border-dashed border-border1 ',
                           )}
                           value={
                             isSelected

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/instruction-blocks-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/instruction-blocks-page.tsx
@@ -11,7 +11,7 @@ export function InstructionBlocksPage() {
 
   return (
     <ScrollArea className="h-full">
-      <div className="py-6 px-2">
+      <div className="px-2 py-6">
         <Controller
           name="instructionBlocks"
           control={form.control}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/memory-page.tsx
@@ -80,8 +80,8 @@ function LastMessagesEntity() {
   const lastMessagesEnabled = lastMessages !== false;
 
   return (
-    <Entity className="flex-col gap-0 p-0 overflow-hidden">
-      <div className="flex gap-3 py-3 px-4">
+    <Entity className="flex-col gap-0 overflow-hidden p-0">
+      <div className="flex gap-3 px-4 py-3">
         <EntityContent>
           <EntityName>Message History</EntityName>
           <EntityDescription>Number of recent messages to include in context</EntityDescription>
@@ -107,7 +107,7 @@ function LastMessagesEntity() {
       </div>
 
       {lastMessagesEnabled && (
-        <div className="bg-surface2 border-t border-border1 p-4">
+        <div className="border-t border-border1 bg-surface2 p-4">
           <Controller
             name="memory.lastMessages"
             control={control}
@@ -145,8 +145,8 @@ function SemanticRecallEntity() {
   const embedders = embeddersData?.embedders ?? [];
 
   return (
-    <Entity className="flex-col gap-0 p-0 overflow-hidden">
-      <div className="flex gap-3 py-3 px-4">
+    <Entity className="flex-col gap-0 overflow-hidden p-0">
+      <div className="flex gap-3 px-4 py-3">
         <EntityContent>
           <EntityName>Semantic Recall</EntityName>
           <EntityDescription>Enable semantic search in memory</EntityDescription>
@@ -162,7 +162,7 @@ function SemanticRecallEntity() {
       </div>
 
       {semanticRecallEnabled && (
-        <div className="bg-surface2 border-t border-border1 p-4 grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-2 gap-4 border-t border-border1 bg-surface2 p-4">
           <Controller
             name="memory.vector"
             control={control}
@@ -246,8 +246,8 @@ function ObservationalMemoryEntity() {
   const observationalMemoryEnabled = useWatch({ control, name: 'memory.observationalMemory.enabled' }) ?? false;
 
   return (
-    <Entity className="flex-col gap-0 p-0 overflow-hidden">
-      <div className="flex gap-3 py-3 px-4">
+    <Entity className="flex-col gap-0 overflow-hidden p-0">
+      <div className="flex gap-3 px-4 py-3">
         <EntityContent>
           <EntityName>Observational Memory</EntityName>
           <EntityDescription>
@@ -275,7 +275,7 @@ function ObservationalMemoryEntity() {
       </div>
 
       {observationalMemoryEnabled && (
-        <div className="bg-surface2 border-t border-border1 p-4">
+        <div className="border-t border-border1 bg-surface2 p-4">
           <ObservationalMemoryFields />
         </div>
       )}
@@ -371,10 +371,10 @@ function ObservationalMemoryFields() {
         />
       </div>
 
-      <div className="border-t border-border1 pt-4 mt-2">
+      <div className="mt-2 border-t border-border1 pt-4">
         <ObserverFields observerProvider={observerProvider} />
       </div>
-      <div className="border-t border-border1 pt-4 mt-2">
+      <div className="mt-2 border-t border-border1 pt-4">
         <ReflectorFields reflectorProvider={reflectorProvider} />
       </div>
     </div>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/scorers-page.tsx
@@ -142,8 +142,8 @@ export function ScorersPage() {
                             type="text"
                             disabled={isDisabled}
                             className={cn(
-                              'border border-transparent appearance-none block w-full text-neutral3 bg-transparent',
-                              !isDisabled && 'border-border1 border-dashed ',
+                              'block w-full appearance-none border border-transparent bg-transparent text-neutral3',
+                              !isDisabled && 'border-dashed border-border1 ',
                             )}
                             value={
                               isSelected
@@ -229,20 +229,20 @@ function ScorerConfigPanel({ scorerId, samplingConfig, onSamplingChange, readOnl
         >
           <div className="flex items-center gap-2">
             <RadioGroupItem value="none" id={`${scorerId}-none`} disabled={readOnly} />
-            <Label htmlFor={`${scorerId}-none`} className="text-ui-xs text-neutral5 cursor-pointer">
+            <Label htmlFor={`${scorerId}-none`} className="cursor-pointer text-ui-xs text-neutral5">
               None (evaluate all)
             </Label>
           </div>
           <div className="flex items-center gap-2">
             <RadioGroupItem value="ratio" id={`${scorerId}-ratio`} disabled={readOnly} />
-            <Label htmlFor={`${scorerId}-ratio`} className="text-ui-xs text-neutral5 cursor-pointer">
+            <Label htmlFor={`${scorerId}-ratio`} className="cursor-pointer text-ui-xs text-neutral5">
               Ratio (percentage)
             </Label>
           </div>
         </RadioGroup>
 
         {samplingType === 'ratio' && (
-          <div className="flex flex-col gap-1.5 mt-2">
+          <div className="mt-2 flex flex-col gap-1.5">
             <Label htmlFor={`rate-${scorerId}`} className="text-xs text-neutral4">
               Sample Rate (0-1)
             </Label>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-chat-composer.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-chat-composer.tsx
@@ -131,12 +131,12 @@ export function SkillChatComposer({
   }, [initialUserMessage, sendMessage, threadId, clientTools]);
 
   const emptyState = (
-    <div className="flex h-full flex-col items-center justify-center gap-3 text-center px-6 py-8">
+    <div className="flex h-full flex-col items-center justify-center gap-3 px-6 py-8 text-center">
       <div className="rounded-full bg-accent5/10 p-3">
-        <Sparkles className="h-6 w-6 text-accent5" />
+        <Sparkles className="size-6 text-accent5" />
       </div>
       <div className="flex flex-col gap-1">
-        <Txt variant="ui-md" className="text-neutral5 font-medium" as="p">
+        <Txt variant="ui-md" className="font-medium text-neutral5" as="p">
           {hasFields ? 'Refine your skill' : 'Describe your skill'}
         </Txt>
         <Txt variant="ui-sm" className="text-neutral3" as="p">

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-edit-dialog.tsx
@@ -254,12 +254,12 @@ export function SkillEditDialog({
       className="h-full"
     >
       <SideDialog.Top>
-        <span className="flex-1 flex items-center gap-2">
+        <span className="flex flex-1 items-center gap-2">
           {dialogTitle}
           {isViewMode && skill?.visibility === 'private' && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="text-neutral3 shrink-0" aria-label="Private skill">
+                <span className="shrink-0 text-neutral3" aria-label="Private skill">
                   <Icon size="sm">
                     <LockIcon />
                   </Icon>
@@ -269,17 +269,17 @@ export function SkillEditDialog({
             </Tooltip>
           )}
         </span>
-        <div className="flex items-center gap-2 mr-6">
+        <div className="mr-6 flex items-center gap-2">
           {isViewMode && isOwner && (
             <Button variant="outline" size="sm" onClick={() => setIsEditing(true)}>
-              <Pencil className="h-3.5 w-3.5" /> Edit
+              <Pencil className="size-3.5" /> Edit
             </Button>
           )}
           {isViewMode && !isOwner && onCopy && skill && (
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="outline" size="sm" onClick={() => onCopy(skill)}>
-                  <CopyIcon className="h-3.5 w-3.5" /> Copy
+                  <CopyIcon className="size-3.5" /> Copy
                 </Button>
               </TooltipTrigger>
               <TooltipContent>Make your own private copy you can edit</TooltipContent>
@@ -295,13 +295,13 @@ export function SkillEditDialog({
                   <SelectContent>
                     <SelectItem value="private">
                       <span className="flex items-center gap-2">
-                        <LockIcon className="h-3.5 w-3.5" />
+                        <LockIcon className="size-3.5" />
                         Private
                       </span>
                     </SelectItem>
                     <SelectItem value="public">
                       <span className="flex items-center gap-2">
-                        <Globe className="h-3.5 w-3.5" />
+                        <Globe className="size-3.5" />
                         Public
                       </span>
                     </SelectItem>
@@ -349,15 +349,15 @@ export function SkillEditDialog({
               <div className="border-t border-border1 pt-4">
                 <button
                   onClick={() => setShowForm(false)}
-                  className="flex items-center gap-1.5 text-xs text-neutral3 hover:text-neutral5 transition-colors mb-3"
+                  className="mb-3 flex items-center gap-1.5 text-xs text-neutral3 transition-colors hover:text-neutral5"
                 >
-                  <ChevronDown className="h-3 w-3" />
+                  <ChevronDown className="size-3" />
                   Hide skill details
                 </button>
 
                 {isAdmin && (!hasFilesystem || !workspaceId) && (
                   <div className="mb-4 flex items-start gap-2 rounded-lg bg-yellow-500/10 p-3 text-xs text-yellow-600">
-                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                    <AlertTriangle className="mt-0.5 size-4 shrink-0" />
                     <span>
                       {!workspaceId
                         ? 'No workspace available. The skill will be saved to the database only.'
@@ -393,11 +393,11 @@ export function SkillEditDialog({
                           }
                           setMode('advanced');
                         }}
-                        className="mt-3 flex items-center gap-1.5 text-xs text-neutral3 hover:text-neutral5 transition-colors"
+                        className="mt-3 flex items-center gap-1.5 text-xs text-neutral3 transition-colors hover:text-neutral5"
                       >
-                        <Settings2 className="h-3.5 w-3.5" />
+                        <Settings2 className="size-3.5" />
                         Advanced mode
-                        <ChevronRight className="h-3 w-3" />
+                        <ChevronRight className="size-3" />
                       </button>
                     )}
                   </>
@@ -413,11 +413,11 @@ export function SkillEditDialog({
                           }
                           setMode('simple');
                         }}
-                        className="mb-3 flex items-center gap-1.5 text-xs text-neutral3 hover:text-neutral5 transition-colors"
+                        className="mb-3 flex items-center gap-1.5 text-xs text-neutral3 transition-colors hover:text-neutral5"
                       >
-                        <Pencil className="h-3.5 w-3.5" />
+                        <Pencil className="size-3.5" />
                         Simple mode
-                        <ChevronRight className="h-3 w-3" />
+                        <ChevronRight className="size-3" />
                       </button>
                     )}
                     <SkillFolder
@@ -435,9 +435,9 @@ export function SkillEditDialog({
               <div className="border-t border-border1 pt-3">
                 <button
                   onClick={() => setShowForm(true)}
-                  className="flex items-center gap-1.5 text-xs text-neutral3 hover:text-neutral5 transition-colors"
+                  className="flex items-center gap-1.5 text-xs text-neutral3 transition-colors hover:text-neutral5"
                 >
-                  <ChevronRight className="h-3 w-3" />
+                  <ChevronRight className="size-3" />
                   {hasFields ? 'Show skill details' : 'or fill in manually'}
                 </button>
               </div>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-folder.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-folder.tsx
@@ -77,8 +77,8 @@ export function SkillFolder({
   const isImage = isImageContent(selectedFileContent);
 
   return (
-    <div className="grid grid-cols-[300px_1fr] h-full">
-      <div className="overflow-y-auto h-full border-r border-border1 p-4">
+    <div className="grid h-full grid-cols-[300px_1fr]">
+      <div className="h-full overflow-y-auto border-r border-border1 p-4">
         {workspaceOptions.length > 0 && (
           <div className="flex flex-col gap-1.5 pb-4">
             <Txt as="label" variant="ui-sm" className="text-neutral3">
@@ -107,11 +107,11 @@ export function SkillFolder({
         {isFileSelected ? (
           <>
             {isImage ? (
-              <div className="flex items-center justify-center flex-1 p-4 bg-surface2">
+              <div className="flex flex-1 items-center justify-center bg-surface2 p-4">
                 <img
                   src={selectedFileContent}
                   alt={selectedFileName}
-                  className="max-w-full max-h-dropdown-max-height rounded-md object-contain"
+                  className="max-h-dropdown-max-height max-w-full rounded-md object-contain"
                 />
               </div>
             ) : (
@@ -127,7 +127,7 @@ export function SkillFolder({
             )}
           </>
         ) : (
-          <div className="flex items-center justify-center h-full text-xs text-neutral3">
+          <div className="flex h-full items-center justify-center text-xs text-neutral3">
             Select a file to edit its content
           </div>
         )}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/skill-simple-form.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/skill-simple-form.tsx
@@ -23,7 +23,7 @@ export function SkillSimpleForm({
   readOnly,
 }: SkillSimpleFormProps) {
   return (
-    <div className="flex flex-col gap-4 h-full">
+    <div className="flex h-full flex-col gap-4">
       <div className="flex flex-col gap-1.5">
         <Txt as="label" variant="ui-sm" className="text-neutral3">
           Name
@@ -43,13 +43,13 @@ export function SkillSimpleForm({
         />
       </div>
 
-      <div className="flex flex-col gap-1.5 flex-1 min-h-0">
+      <div className="flex min-h-0 flex-1 flex-col gap-1.5">
         <Txt as="label" variant="ui-sm" className="text-neutral3">
           Instructions
         </Txt>
 
         {readOnly ? (
-          <div className="flex-1 min-h-0 overflow-y-auto rounded-lg border border-border1 bg-surface2 p-4">
+          <div className="min-h-0 flex-1 overflow-y-auto rounded-lg border border-border1 bg-surface2 p-4">
             {instructions ? (
               <MarkdownRenderer>{instructions}</MarkdownRenderer>
             ) : (
@@ -59,7 +59,7 @@ export function SkillSimpleForm({
             )}
           </div>
         ) : (
-          <div className="flex-1 min-h-0 flex flex-col">
+          <div className="flex min-h-0 flex-1 flex-col">
             <CodeEditor
               data-testid="skill-instructions-input"
               value={instructions}
@@ -68,7 +68,7 @@ export function SkillSimpleForm({
               editable
               placeholder="You are a helpful assistant that…"
               showCopyButton={false}
-              className="h-full w-full"
+              className="size-full"
             />
           </div>
         )}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/tools-page.tsx
@@ -155,7 +155,7 @@ export function ToolsPage() {
               aria-label={`Description for ${tool.label}`}
               disabled={!canEditToolDescriptions}
               className={cn(
-                'border border-transparent appearance-none block w-full text-neutral3 bg-transparent rounded px-1 -mx-1 transition-colors focus:outline-solid focus:outline-1 focus:outline-white focus-visible:outline-solid focus-visible:outline-1 focus-visible:outline-white',
+                '-mx-1 block w-full appearance-none rounded border border-transparent bg-transparent px-1 text-neutral3 transition-colors focus:outline-1 focus:outline-white focus:outline-solid focus-visible:outline-1 focus-visible:outline-white focus-visible:outline-solid',
                 canEditToolDescriptions && 'hover:bg-surface4 focus:bg-surface4',
               )}
               value={selectedTools?.[tool.value]?.description ?? tool.description}
@@ -177,7 +177,7 @@ export function ToolsPage() {
           <button
             type="button"
             onClick={() => handleValueChange(tool.value)}
-            className="text-neutral3 hover:text-neutral5 transition-colors rounded-sm focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-white/30"
+            className="rounded-sm text-neutral3 transition-colors hover:text-neutral5 focus-visible:ring-1 focus-visible:ring-white/30 focus-visible:outline-hidden"
             aria-label={`Remove ${tool.label}`}
           >
             <Icon size="sm">
@@ -222,13 +222,13 @@ export function ToolsPage() {
                     Add Tools
                   </Button>
                 </PopoverTrigger>
-                <PopoverContent align="end" className="w-80 p-0 pt-4 max-h-72 overflow-y-auto">
+                <PopoverContent align="end" className="max-h-72 w-80 overflow-y-auto p-0 pt-4">
                   {unselectedOptions.map(tool => (
                     <button
                       key={tool.value}
                       type="button"
                       onClick={() => handleAddTool(tool.value)}
-                      className="flex flex-col gap-0.5 w-full text-left px-3 py-2.5 hover:bg-white/10 focus:bg-white/10 transition-colors focus-visible:outline-hidden focus-visible:ring-0"
+                      className="flex w-full flex-col gap-0.5 px-3 py-2.5 text-left transition-colors hover:bg-white/10 focus:bg-white/10 focus-visible:ring-0 focus-visible:outline-hidden"
                     >
                       <span className="text-ui-md font-normal text-neutral5">{tool.label}</span>
                       {tool.description && <span className="text-ui-xs text-neutral3">{tool.description}</span>}

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/variables-page.tsx
@@ -21,7 +21,7 @@ function RecursiveFieldRenderer({
     <div className="py-2 ">
       <JSONSchemaForm.Field key={field.id} field={field} parentPath={parentPath} depth={depth}>
         <div className="space-y-2 px-2">
-          <div className="flex flex-row gap-4 items-center">
+          <div className="flex flex-row items-center gap-4">
             <JSONSchemaForm.FieldName placeholder="Variable name" className="w-64" />
             <JSONSchemaForm.FieldType placeholder="Type" />
             <JSONSchemaForm.FieldOptional />
@@ -42,7 +42,7 @@ function RecursiveFieldRenderer({
             )}
           </JSONSchemaForm.FieldList>
           <JSONSchemaForm.AddField variant="ghost" size="sm" className="mt-2">
-            <PlusIcon className="w-3 h-3 mr-1" />
+            <PlusIcon className="mr-1 size-3" />
             Add nested variable
           </JSONSchemaForm.AddField>
         </JSONSchemaForm.NestedFields>

--- a/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/workflows-page.tsx
@@ -125,8 +125,8 @@ export function WorkflowsPage() {
                           type="text"
                           disabled={isDisabled}
                           className={cn(
-                            'border border-transparent appearance-none block w-full text-neutral3 bg-transparent',
-                            !isDisabled && 'border-border1 border-dashed ',
+                            'block w-full appearance-none border border-transparent bg-transparent text-neutral3',
+                            !isDisabled && 'border-dashed border-border1 ',
                           )}
                           value={
                             isSelected

--- a/packages/playground/src/domains/agents/components/agent-cms-sidebar/agent-cms-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-sidebar/agent-cms-sidebar.tsx
@@ -43,8 +43,8 @@ export function AgentCmsSidebar({ basePath, currentPath, versionId }: AgentCmsSi
   }, [isCodeAgentOverride, editorConfig, features]);
 
   return (
-    <div className="h-full flex flex-col">
-      <ScrollArea className="flex-1 min-h-0">
+    <div className="flex h-full flex-col">
+      <ScrollArea className="min-h-0 flex-1">
         <nav className="py-4">
           <ul className="flex flex-col gap-0">
             {sections.map((section, index) => (
@@ -99,17 +99,17 @@ const SidebarLink = ({
       <Link
         href={href}
         className={cn(
-          'flex items-center gap-2.5 px-3 py-2 text-sm transition-colors border-r-2 border-transparent',
-          active ? 'bg-surface2 text-neutral5 border-accent1' : 'text-neutral3 hover:bg-surface3 hover:text-neutral5',
+          'flex items-center gap-2.5 border-r-2 border-transparent px-3 py-2 text-sm transition-colors',
+          active ? 'border-accent1 bg-surface2 text-neutral5' : 'text-neutral3 hover:bg-surface3 hover:text-neutral5',
         )}
       >
         {done ? (
-          <div className="size-6 rounded-full bg-accent1 flex items-center justify-center shrink-0">
+          <div className="flex size-6 shrink-0 items-center justify-center rounded-full bg-accent1">
             <Check className="size-3.5 text-white" />
           </div>
         ) : (
           <Txt
-            className="size-6 rounded-full border border-neutral2 flex items-center justify-center text-neutral2 font-mono shrink-0"
+            className="flex size-6 shrink-0 items-center justify-center rounded-full border border-neutral2 font-mono text-neutral2"
             variant="ui-sm"
           >
             {index + 1}
@@ -127,7 +127,7 @@ const SidebarLink = ({
         </div>
       </Link>
 
-      {!isLast && <div className="bg-surface3 w-0.5 h-2 inline-block ml-6" />}
+      {!isLast && <div className="ml-6 inline-block h-2 w-0.5 bg-surface3" />}
     </li>
   );
 };

--- a/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-layout.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-layout.tsx
@@ -5,9 +5,9 @@ export interface AgentEditLayoutProps {
 
 export const AgentEditLayout = ({ children, leftSlot }: AgentEditLayoutProps) => {
   return (
-    <div className="grid overflow-y-auto h-full grid-cols-[auto_1fr]">
-      <div className="overflow-y-auto h-full border-r border-border1 bg-surface3">{leftSlot}</div>
-      <div className="overflow-y-auto h-full py-4">{children}</div>
+    <div className="grid h-full grid-cols-[auto_1fr] overflow-y-auto">
+      <div className="h-full overflow-y-auto border-r border-border1 bg-surface3">{leftSlot}</div>
+      <div className="h-full overflow-y-auto py-4">{children}</div>
     </div>
   );
 };

--- a/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-main-blocks.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-main-blocks.tsx
@@ -15,7 +15,7 @@ export function AgentEditMainContentBlocks({ form, readOnly: _readOnly = false }
   const schema = form.watch('variables');
 
   return (
-    <div className="grid grid-rows-[auto_1fr] gap-6 h-full px-4 pb-4">
+    <div className="grid h-full grid-rows-[auto_1fr] gap-6 px-4 pb-4">
       <SectionHeader title="Instruction blocks" subtitle="Add instruction blocks to your agent." icon={<Blocks />} />
 
       <div className="h-full overflow-y-auto">

--- a/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/agent-edit-sidebar.tsx
@@ -33,22 +33,22 @@ function RecursiveFieldRenderer({
   depth: number;
 }) {
   return (
-    <div className="py-2 border-border1 border-l-4 border-b">
+    <div className="border-b border-l-4 border-border1 py-2">
       <JSONSchemaForm.Field key={field.id} field={field} parentPath={parentPath} depth={depth}>
         <div className="space-y-2 px-2">
-          <div className="flex flex-row gap-2 items-center">
+          <div className="flex flex-row items-center gap-2">
             <JSONSchemaForm.FieldName
               labelIsHidden
               placeholder="Variable name"
               size="md"
-              className="[&_input]:bg-surface3 w-full"
+              className="w-full [&_input]:bg-surface3"
             />
 
-            <JSONSchemaForm.FieldType placeholder="Type" size="md" className="[&_button]:bg-surface3 w-full" />
+            <JSONSchemaForm.FieldType placeholder="Type" size="md" className="w-full [&_button]:bg-surface3" />
             <JSONSchemaForm.FieldRemove variant="default" className="shrink-0" />
           </div>
 
-          <div className="flex flex-row gap-2 items-center">
+          <div className="flex flex-row items-center gap-2">
             <JSONSchemaForm.FieldOptional />
             <JSONSchemaForm.FieldNullable />
           </div>
@@ -66,7 +66,7 @@ function RecursiveFieldRenderer({
             )}
           </JSONSchemaForm.FieldList>
           <JSONSchemaForm.AddField variant="ghost" size="sm" className="mt-2">
-            <PlusIcon className="w-3 h-3 mr-1" />
+            <PlusIcon className="mr-1 size-3" />
             Add nested variable
           </JSONSchemaForm.AddField>
         </JSONSchemaForm.NestedFields>
@@ -112,8 +112,8 @@ export function AgentEditSidebar({
   const initialFields = useMemo(() => jsonSchemaToFields(watchedVariables), [watchedVariables]);
 
   return (
-    <div className="h-full flex flex-col">
-      <Tabs defaultTab="identity" className="flex-1 min-h-0 flex flex-col">
+    <div className="flex h-full flex-col">
+      <Tabs defaultTab="identity" className="flex min-h-0 flex-1 flex-col">
         <TabList className="shrink-0">
           <Tab value="identity">
             <Icon size="sm">
@@ -136,14 +136,14 @@ export function AgentEditSidebar({
           </Tab>
         </TabList>
 
-        <TabContent value="identity" className="flex-1 min-h-0 py-0 pb-3">
+        <TabContent value="identity" className="min-h-0 flex-1 py-0 pb-3">
           <ScrollArea className="h-full">
             <div className="flex flex-col gap-6 p-4">
               <SectionHeader title="Identity" subtitle="Define your agent's name, description, and model." />
 
               {/* Agent Name */}
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="agent-name" className="text-xs text-icon5">
+                <Label htmlFor="agent-name" className="text-icon5 text-xs">
                   Name <span className="text-accent2">*</span>
                 </Label>
                 <Input
@@ -159,7 +159,7 @@ export function AgentEditSidebar({
 
               {/* Description */}
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="agent-description" className="text-xs text-icon5">
+                <Label htmlFor="agent-description" className="text-icon5 text-xs">
                   Description
                 </Label>
                 <Textarea
@@ -175,7 +175,7 @@ export function AgentEditSidebar({
 
               {/* Provider */}
               <div className="flex flex-col gap-1.5">
-                <Label className="text-xs text-icon5">
+                <Label className="text-icon5 text-xs">
                   Provider <span className="text-accent2">*</span>
                 </Label>
                 <Controller
@@ -194,7 +194,7 @@ export function AgentEditSidebar({
 
               {/* Model */}
               <div className="flex flex-col gap-1.5">
-                <Label className="text-xs text-icon5">
+                <Label className="text-icon5 text-xs">
                   Model <span className="text-accent2">*</span>
                 </Label>
                 <Controller
@@ -217,7 +217,7 @@ export function AgentEditSidebar({
           </ScrollArea>
         </TabContent>
 
-        <TabContent value="capabilities" className="flex-1 min-h-0 py-0 pb-3">
+        <TabContent value="capabilities" className="min-h-0 flex-1 py-0 pb-3">
           <ScrollArea className="h-full">
             <div className="flex flex-col gap-6 p-4">
               <SectionHeader
@@ -239,16 +239,16 @@ export function AgentEditSidebar({
           </ScrollArea>
         </TabContent>
 
-        <TabContent value="variables" className="flex-1 min-h-0 py-0 pb-3">
+        <TabContent value="variables" className="min-h-0 flex-1 py-0 pb-3">
           <ScrollArea className="h-full">
-            <div className="flex flex-col gap-6 p-4 border-b border-border1">
+            <div className="flex flex-col gap-6 border-b border-border1 p-4">
               <SectionHeader
                 title="Variables"
                 subtitle={
                   <>
                     Variables are dynamic values that change based on the context of each request. Use them in your
                     agent's instructions with the{' '}
-                    <code className="text-[#F59E0B] font-medium">{'{{variableName}}'}</code> syntax.
+                    <code className="font-medium text-[#F59E0B]">{'{{variableName}}'}</code> syntax.
                   </>
                 }
               />
@@ -264,7 +264,7 @@ export function AgentEditSidebar({
 
                 <div className="p-2">
                   <JSONSchemaForm.AddField variant="outline" size="sm">
-                    <PlusIcon className="w-4 h-4 mr-2" />
+                    <PlusIcon className="mr-2 size-4" />
                     Add variable
                   </JSONSchemaForm.AddField>
                 </div>
@@ -280,7 +280,7 @@ export function AgentEditSidebar({
           <Button variant="primary" onClick={onPublish} disabled={isSubmitting} className="w-full">
             {isSubmitting ? (
               <>
-                <Spinner className="h-4 w-4" />
+                <Spinner className="size-4" />
                 {mode === 'edit' ? 'Updating...' : 'Creating...'}
               </>
             ) : (

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/agents-section.tsx
@@ -83,17 +83,17 @@ export function AgentsSection({ control, error, currentAgentId, readOnly = false
           return (
             <>
               <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-                <div className="flex items-center justify-between p-3 bg-surface3">
-                  <CollapsibleTrigger className="flex items-center gap-1 w-full">
-                    <ChevronRight className="h-4 w-4 text-neutral3" />
+                <div className="flex items-center justify-between bg-surface3 p-3">
+                  <CollapsibleTrigger className="flex w-full items-center gap-1">
+                    <ChevronRight className="size-4 text-neutral3" />
                     <SectionTitle icon={<AgentIcon className="text-accent1" />}>
-                      Sub-Agents{count > 0 && <span className="text-neutral3 font-normal">({count})</span>}
+                      Sub-Agents{count > 0 && <span className="font-normal text-neutral3">({count})</span>}
                     </SectionTitle>
                   </CollapsibleTrigger>
                 </div>
 
                 <CollapsibleContent>
-                  <div className="p-3 border-t border-border1">
+                  <div className="border-t border-border1 p-3">
                     <div className="flex flex-col gap-2">
                       <Combobox
                         multiple
@@ -107,7 +107,7 @@ export function AgentsSection({ control, error, currentAgentId, readOnly = false
                         error={error}
                       />
                       {selectedOptions.length > 0 && (
-                        <div className="flex flex-col gap-3 mt-2">
+                        <div className="mt-2 flex flex-col gap-3">
                           {selectedOptions.map(agent => (
                             <EntityAccordionItem
                               key={agent.value}

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/memory-section.tsx
@@ -41,14 +41,14 @@ export function MemorySection({ control, setValue, readOnly = false }: MemorySec
   return (
     <div className="rounded-md border border-border1 bg-surface2">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger className="flex items-center gap-1 w-full p-3 bg-surface3">
-          <ChevronRight className="h-4 w-4 text-neutral3" />
+        <CollapsibleTrigger className="flex w-full items-center gap-1 bg-surface3 p-3">
+          <ChevronRight className="size-4 text-neutral3" />
           <SectionTitle icon={<MemoryIcon className="text-neutral3" />}>
-            Memory{isEnabled && <span className="text-accent1 font-normal">(enabled)</span>}
+            Memory{isEnabled && <span className="font-normal text-accent1">(enabled)</span>}
           </SectionTitle>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="p-3 border-t border-border1 flex flex-col gap-4">
+          <div className="flex flex-col gap-4 border-t border-border1 p-3">
             <Controller
               name="memory.enabled"
               control={control}
@@ -219,7 +219,7 @@ export function MemorySection({ control, setValue, readOnly = false }: MemorySec
                 />
 
                 {observationalMemoryEnabled && (
-                  <div className="ml-2 pl-3 border-l-2 border-border1 flex flex-col gap-4">
+                  <div className="ml-2 flex flex-col gap-4 border-l-2 border-border1 pl-3">
                     <div className="flex flex-col gap-1.5">
                       <Label className="text-xs text-neutral4">Provider</Label>
                       <span className="text-xs text-neutral3">Provider for the observer and reflector agents</span>
@@ -303,14 +303,14 @@ export function MemorySection({ control, setValue, readOnly = false }: MemorySec
 
                     {/* Observer Configuration */}
                     <Collapsible open={isObserverOpen} onOpenChange={setIsObserverOpen}>
-                      <CollapsibleTrigger className="flex items-center gap-1 w-full">
+                      <CollapsibleTrigger className="flex w-full items-center gap-1">
                         <ChevronRight
-                          className={`h-3 w-3 text-neutral3 transition-transform ${isObserverOpen ? 'rotate-90' : ''}`}
+                          className={`size-3 text-neutral3 transition-transform ${isObserverOpen ? 'rotate-90' : ''}`}
                         />
-                        <Label className="text-sm text-neutral5 cursor-pointer">Observer</Label>
+                        <Label className="cursor-pointer text-sm text-neutral5">Observer</Label>
                       </CollapsibleTrigger>
                       <CollapsibleContent>
-                        <div className="ml-2 pl-3 border-l-2 border-border1 mt-2 flex flex-col gap-4">
+                        <div className="mt-2 ml-2 flex flex-col gap-4 border-l-2 border-border1 pl-3">
                           <div className="flex flex-col gap-1.5">
                             <Label className="text-xs text-neutral4">Provider Override</Label>
                             <span className="text-xs text-neutral3">
@@ -508,14 +508,14 @@ export function MemorySection({ control, setValue, readOnly = false }: MemorySec
 
                     {/* Reflector Configuration */}
                     <Collapsible open={isReflectorOpen} onOpenChange={setIsReflectorOpen}>
-                      <CollapsibleTrigger className="flex items-center gap-1 w-full">
+                      <CollapsibleTrigger className="flex w-full items-center gap-1">
                         <ChevronRight
-                          className={`h-3 w-3 text-neutral3 transition-transform ${isReflectorOpen ? 'rotate-90' : ''}`}
+                          className={`size-3 text-neutral3 transition-transform ${isReflectorOpen ? 'rotate-90' : ''}`}
                         />
-                        <Label className="text-sm text-neutral5 cursor-pointer">Reflector</Label>
+                        <Label className="cursor-pointer text-sm text-neutral5">Reflector</Label>
                       </CollapsibleTrigger>
                       <CollapsibleContent>
-                        <div className="ml-2 pl-3 border-l-2 border-border1 mt-2 flex flex-col gap-4">
+                        <div className="mt-2 ml-2 flex flex-col gap-4 border-l-2 border-border1 pl-3">
                           <div className="flex flex-col gap-1.5">
                             <Label className="text-xs text-neutral4">Provider Override</Label>
                             <span className="text-xs text-neutral3">

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/scorers-section.tsx
@@ -85,17 +85,17 @@ export function ScorersSection({ control, error, readOnly = false }: ScorersSect
           return (
             <>
               <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-                <div className="flex items-center justify-between p-3 bg-surface3">
-                  <CollapsibleTrigger className="flex items-center gap-1 w-full">
-                    <ChevronRight className="h-4 w-4 text-neutral3" />
+                <div className="flex items-center justify-between bg-surface3 p-3">
+                  <CollapsibleTrigger className="flex w-full items-center gap-1">
+                    <ChevronRight className="size-4 text-neutral3" />
                     <SectionTitle icon={<JudgeIcon className="text-neutral3" />}>
-                      Scorers{count > 0 && <span className="text-neutral3 font-normal">({count})</span>}
+                      Scorers{count > 0 && <span className="font-normal text-neutral3">({count})</span>}
                     </SectionTitle>
                   </CollapsibleTrigger>
                 </div>
 
                 <CollapsibleContent>
-                  <div className="p-3 border-t border-border1">
+                  <div className="border-t border-border1 p-3">
                     <div className="flex flex-col gap-2">
                       <Combobox
                         multiple
@@ -110,7 +110,7 @@ export function ScorersSection({ control, error, readOnly = false }: ScorersSect
                       />
 
                       {selectedOptions.length > 0 && (
-                        <div className="flex flex-col gap-3 mt-2">
+                        <div className="mt-2 flex flex-col gap-3">
                           {selectedOptions.map(scorer => (
                             <ScorerConfigPanel
                               key={scorer.value}
@@ -196,7 +196,7 @@ function ScorerConfigPanel({
         value={description}
         onChange={e => onDescriptionChange(e.target.value)}
         placeholder="Custom description for this scorer..."
-        className="min-h-[40px] text-xs bg-surface3 border-dashed px-2 py-1"
+        className="min-h-table-row-small border-dashed bg-surface3 px-2 py-1 text-xs"
         size="sm"
         disabled={readOnly}
       />
@@ -214,20 +214,20 @@ function ScorerConfigPanel({
         >
           <div className="flex items-center gap-2">
             <RadioGroupItem value="none" id={`${scorerId}-none`} disabled={readOnly} />
-            <Label htmlFor={`${scorerId}-none`} className="text-sm text-neutral5 cursor-pointer">
+            <Label htmlFor={`${scorerId}-none`} className="cursor-pointer text-sm text-neutral5">
               None (evaluate all)
             </Label>
           </div>
           <div className="flex items-center gap-2">
             <RadioGroupItem value="ratio" id={`${scorerId}-ratio`} disabled={readOnly} />
-            <Label htmlFor={`${scorerId}-ratio`} className="text-sm text-neutral5 cursor-pointer">
+            <Label htmlFor={`${scorerId}-ratio`} className="cursor-pointer text-sm text-neutral5">
               Ratio (percentage)
             </Label>
           </div>
         </RadioGroup>
 
         {samplingType === 'ratio' && (
-          <div className="flex flex-col gap-1.5 mt-1">
+          <div className="mt-1 flex flex-col gap-1.5">
             <Label htmlFor={`rate-${scorerId}`} className="text-xs text-neutral4">
               Sample Rate (0-1)
             </Label>

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/tools-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/tools-section.tsx
@@ -40,14 +40,14 @@ export function ToolsSection({ control, error, readOnly = false }: ToolsSectionP
   return (
     <div className="rounded-md border border-border1 bg-surface2">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger className="flex items-center gap-1 w-full p-3 bg-surface3">
-          <ChevronRight className="h-4 w-4 text-neutral3" />
+        <CollapsibleTrigger className="flex w-full items-center gap-1 bg-surface3 p-3">
+          <ChevronRight className="size-4 text-neutral3" />
           <SectionTitle icon={<ToolsIcon className="text-accent6" />}>
-            Tools{count > 0 && <span className="text-neutral3 font-normal">({count})</span>}
+            Tools{count > 0 && <span className="font-normal text-neutral3">({count})</span>}
           </SectionTitle>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="p-3 border-t border-border1">
+          <div className="border-t border-border1 p-3">
             <Controller
               name="tools"
               control={control}
@@ -95,7 +95,7 @@ export function ToolsSection({ control, error, readOnly = false }: ToolsSectionP
                       error={error}
                     />
                     {selectedOptions.length > 0 && (
-                      <div className="flex flex-col gap-3 mt-2">
+                      <div className="mt-2 flex flex-col gap-3">
                         {selectedOptions.map(tool => (
                           <EntityAccordionItem
                             key={tool.value}

--- a/packages/playground/src/domains/agents/components/agent-edit-page/sections/workflows-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-edit-page/sections/workflows-section.tsx
@@ -40,14 +40,14 @@ export function WorkflowsSection({ control, error, readOnly = false }: Workflows
   return (
     <div className="rounded-md border border-border1 bg-surface2">
       <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-        <CollapsibleTrigger className="flex items-center gap-1 w-full p-3 bg-surface3">
-          <ChevronRight className="h-4 w-4 text-neutral3" />
+        <CollapsibleTrigger className="flex w-full items-center gap-1 bg-surface3 p-3">
+          <ChevronRight className="size-4 text-neutral3" />
           <SectionTitle icon={<WorkflowIcon className="text-accent3" />}>
-            Workflows{count > 0 && <span className="text-neutral3 font-normal">({count})</span>}
+            Workflows{count > 0 && <span className="font-normal text-neutral3">({count})</span>}
           </SectionTitle>
         </CollapsibleTrigger>
         <CollapsibleContent>
-          <div className="p-3 border-t border-border1">
+          <div className="border-t border-border1 p-3">
             <Controller
               name="workflows"
               control={control}
@@ -92,7 +92,7 @@ export function WorkflowsSection({ control, error, readOnly = false }: Workflows
                       error={error}
                     />
                     {selectedOptions.length > 0 && (
-                      <div className="flex flex-col gap-3 mt-2">
+                      <div className="mt-2 flex flex-col gap-3">
                         {selectedOptions.map(workflow => (
                           <EntityAccordionItem
                             key={workflow.value}

--- a/packages/playground/src/domains/agents/components/agent-entity-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-entity-header.tsx
@@ -18,14 +18,14 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
 
   return (
     <TooltipProvider>
-      <div className="p-3 min-w-0 overflow-x-hidden">
+      <div className="min-w-0 overflow-x-hidden p-3">
         <Tooltip>
           <TooltipTrigger asChild>
             <button
               type="button"
               onClick={handleCopy}
               aria-label="Copy Agent ID for use in code"
-              className="group/agent-title text-neutral6 flex min-w-0 max-w-full cursor-pointer items-center gap-2"
+              className="group/agent-title flex max-w-full min-w-0 cursor-pointer items-center gap-2 text-neutral6"
               data-testid="agent-entity-header-copy-id"
             >
               <span className="flex size-7 shrink-0 items-center justify-center">
@@ -41,9 +41,9 @@ export const AgentEntityHeader = ({ agentId }: AgentEntityHeaderProps) => {
                 </Txt>
               )}
               {isCopied ? (
-                <Check className="h-4 w-4 shrink-0 text-neutral3" />
+                <Check className="size-4 shrink-0 text-neutral3" />
               ) : (
-                <CopyIcon className="h-4 w-4 shrink-0 text-neutral3 opacity-0 transition-opacity group-hover/agent-title:opacity-100 group-focus-visible/agent-title:opacity-100" />
+                <CopyIcon className="size-4 shrink-0 text-neutral3 opacity-0 transition-opacity group-hover/agent-title:opacity-100 group-focus-visible/agent-title:opacity-100" />
               )}
             </button>
           </TooltipTrigger>

--- a/packages/playground/src/domains/agents/components/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/components/agent-layout.tsx
@@ -63,8 +63,8 @@ export const AgentLayout = ({
   // side slots move into edge drawers and the main content takes the full width.
   if (isMobile) {
     return (
-      <div className="relative h-full w-full overflow-hidden">
-        <div className="h-full w-full min-w-0">{children}</div>
+      <div className="relative size-full overflow-hidden">
+        <div className="size-full min-w-0">{children}</div>
         {leftSlot && (
           <PanelDrawer direction="left" label={leftDrawerLabel}>
             {leftSlot}
@@ -81,8 +81,8 @@ export const AgentLayout = ({
   }
 
   return (
-    <div className="relative h-full w-full overflow-hidden">
-      <Group className="h-full min-h-0 w-full min-w-0" defaultLayout={defaultLayout} onLayoutChange={onLayoutChange}>
+    <div className="relative size-full overflow-hidden">
+      <Group className="size-full min-h-0 min-w-0" defaultLayout={defaultLayout} onLayoutChange={onLayoutChange}>
         {leftSlot && (
           <Panel
             id="left-slot"
@@ -97,7 +97,7 @@ export const AgentLayout = ({
         )}
 
         {leftSlot && <PanelSeparator />}
-        <Panel id="main-slot" className="grid min-w-0 overflow-y-auto relative">
+        <Panel id="main-slot" className="relative grid min-w-0 overflow-y-auto">
           {children}
         </Panel>
         {rightSlot && (

--- a/packages/playground/src/domains/agents/components/agent-loading-skeletons.tsx
+++ b/packages/playground/src/domains/agents/components/agent-loading-skeletons.tsx
@@ -6,7 +6,7 @@ import { SidebarPanel } from './sidebar-panel';
 export function AgentViewLoadingSkeleton({ agentId, view }: { agentId: string; view: 'chat' | 'settings' }) {
   return (
     <AgentLayout agentId={agentId} leftDrawerLabel="Open threads and memory" leftSlot={<AgentSidebarLoadingSkeleton />}>
-      <div className="grid grid-rows-[auto_1fr] h-full min-h-0" data-testid="agent-route-skeleton" aria-busy="true">
+      <div className="grid h-full min-h-0 grid-rows-[auto_1fr]" data-testid="agent-route-skeleton" aria-busy="true">
         <AgentViewHeaderLoadingSkeleton />
         <div className="min-h-0 overflow-hidden">
           {view === 'settings' ? <AgentSettingsLoadingSkeleton /> : <AgentChatLoadingSkeleton />}
@@ -19,14 +19,14 @@ export function AgentViewLoadingSkeleton({ agentId, view }: { agentId: string; v
 function AgentViewHeaderLoadingSkeleton() {
   return (
     <div className="flex items-center justify-between gap-2 pr-3 max-lg:py-2">
-      <div className="flex-1 min-w-0 max-lg:hidden">
+      <div className="min-w-0 flex-1 max-lg:hidden">
         <div className="flex min-w-0 items-center gap-2 p-3">
           <Skeleton className="size-7 shrink-0 rounded-full" />
           <Skeleton className="h-4 w-36" />
         </div>
       </div>
       <div className="ml-auto flex shrink-0 items-center gap-2">
-        <Skeleton className="h-9 w-9 rounded-lg" />
+        <Skeleton className="size-9 rounded-lg" />
         <Skeleton className="h-9 w-24 rounded-lg" />
       </div>
     </div>
@@ -37,9 +37,9 @@ export function AgentSidebarLoadingSkeleton() {
   return (
     <SidebarPanel>
       <div className="min-h-0 flex-1 p-1" data-testid="agent-route-sidebar-skeleton">
-        <div className="flex h-full w-full flex-col">
+        <div className="flex size-full flex-col">
           <SidebarLoadingRow>
-            <Skeleton className="h-4 w-4 shrink-0 rounded" />
+            <Skeleton className="size-4 shrink-0 rounded" />
             <Skeleton className="h-3 w-16" />
           </SidebarLoadingRow>
           <hr aria-hidden="true" className="-mx-1 my-1 h-px border-0 bg-border1/40" />
@@ -63,10 +63,10 @@ export function AgentSidebarLoadingSkeleton() {
       <div className="m-2 rounded-studio-panel border border-border1/40 bg-surface4 px-3 py-2.5">
         <div className="flex items-center justify-between gap-2">
           <div className="flex min-w-0 items-center gap-1.5">
-            <Skeleton className="h-4 w-4 shrink-0 rounded" />
+            <Skeleton className="size-4 shrink-0 rounded" />
             <Skeleton className="h-4 w-20" />
           </div>
-          <Skeleton className="h-4 w-4 shrink-0 rounded" />
+          <Skeleton className="size-4 shrink-0 rounded" />
         </div>
         <div className="mt-2 flex flex-wrap items-center gap-2">
           <Skeleton className="h-3 w-20 rounded-full" />
@@ -83,8 +83,8 @@ function SidebarLoadingRow({ children }: { children: ReactNode }) {
 
 export function AgentChatLoadingSkeleton() {
   return (
-    <div className="grid h-full min-h-0 w-full overflow-hidden px-4 py-6 md:px-10">
-      <div className="mx-auto grid h-full min-h-0 w-full max-w-[80ch] grid-rows-[1fr_auto]">
+    <div className="grid size-full min-h-0 overflow-hidden px-4 py-6 md:px-10">
+      <div className="mx-auto grid size-full min-h-0 max-w-[80ch] grid-rows-[1fr_auto]">
         <div className="min-h-0 space-y-4 overflow-hidden pt-6">
           <div className="flex justify-start">
             <Skeleton className="h-10 w-2/3 rounded-2xl" />
@@ -105,7 +105,7 @@ export function AgentChatLoadingSkeleton() {
           <Skeleton className="h-5 w-1/2 rounded-full" />
           <div className="mt-4 flex items-center justify-between">
             <Skeleton className="h-8 w-24 rounded-full" />
-            <Skeleton className="h-8 w-8 rounded-full" />
+            <Skeleton className="size-8 rounded-full" />
           </div>
         </div>
       </div>
@@ -115,7 +115,7 @@ export function AgentChatLoadingSkeleton() {
 
 function AgentSettingsLoadingSkeleton() {
   return (
-    <div className="h-full w-full min-w-0" data-testid="agent-settings-skeleton" aria-busy="true">
+    <div className="size-full min-w-0" data-testid="agent-settings-skeleton" aria-busy="true">
       <div className="sticky top-0 z-10 px-3 py-1.5">
         <div className="flex items-center gap-1">
           <Skeleton className="h-9 w-24 rounded-full" />

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-list.tsx
@@ -15,7 +15,7 @@ export interface AgentMetadataListItemProps {
 }
 
 export const AgentMetadataListItem = ({ children, className }: AgentMetadataListItemProps) => {
-  return <li className={cn('shrink-0 font-medium flex', className)}>{children}</li>;
+  return <li className={cn('flex shrink-0 font-medium', className)}>{children}</li>;
 };
 
 export interface AgentMetadataListEmptyProps {

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-list.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-list.tsx
@@ -104,16 +104,16 @@ const AgentMetadataModelListItem = ({
   const [enabled, setEnabled] = useState(() => modelConfig.enabled);
 
   return (
-    <div className="rounded-lg bg-surface1 hover:bg-surface4/50 transition-colors">
+    <div className="rounded-lg bg-surface1 transition-colors hover:bg-surface4/50">
       <div className="flex items-center gap-2 p-2">
         {showDragHandle && (
-          <div {...dragHandleProps} className="text-neutral3 cursor-grab active:cursor-grabbing shrink-0">
+          <div {...dragHandleProps} className="shrink-0 cursor-grab text-neutral3 active:cursor-grabbing">
             <Icon>
               <GripVertical />
             </Icon>
           </div>
         )}
-        <div className="flex-1 min-w-0">
+        <div className="min-w-0 flex-1">
           <AgentMetadataModelSwitcher
             defaultProvider={modelConfig.model.provider}
             defaultModel={modelConfig.model.modelId}

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-model-switcher.tsx
@@ -180,7 +180,7 @@ export const AgentMetadataModelSwitcher = ({
         className="flex items-center gap-2 rounded-md border border-border1 bg-surface3 px-3 py-2"
         data-testid="agent-metadata-model-locked"
       >
-        <Lock className="h-4 w-4 shrink-0 text-neutral3" />
+        <Lock className="size-4 shrink-0 text-neutral3" />
         <span className="truncate text-ui-sm text-neutral6">{lockedLabel}</span>
         <span className="ml-auto shrink-0 text-ui-xs text-neutral3">Set by admin</span>
       </div>
@@ -195,7 +195,7 @@ export const AgentMetadataModelSwitcher = ({
 
   return (
     <div className="@container">
-      <div className="flex flex-col @xs:flex-row items-stretch @xs:items-center gap-2 w-full">
+      <div className="flex w-full flex-col items-stretch gap-2 @xs:flex-row @xs:items-center">
         <div className="w-full @xs:w-2/5">
           <LLMProviders
             value={currentModelProvider}
@@ -220,18 +220,18 @@ export const AgentMetadataModelSwitcher = ({
           size="md"
           onClick={handleReset}
           disabled={loading}
-          className="flex items-center gap-1.5 text-xs whitespace-nowrap border-0!"
+          className="flex items-center gap-1.5 border-0! text-xs whitespace-nowrap"
           title="Reset to original model"
         >
-          <RotateCcw className="w-3.5 h-3.5" />
+          <RotateCcw className="size-3.5" />
         </Button>
       </div>
 
       {stale && (
-        <div className="pt-2 p-2" data-testid="agent-metadata-model-stale-warning">
+        <div className="p-2 pt-2" data-testid="agent-metadata-model-stale-warning">
           <Notice variant="warning" title="Model not allowed">
             <Notice.Message>
-              <code className="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900/50 rounded">
+              <code className="rounded bg-yellow-100 px-1 py-0.5 dark:bg-yellow-900/50">
                 {selectedProvider}/{selectedModel}
               </code>{' '}
               is no longer allowed by the admin policy. Pick a different model to save changes.
@@ -242,11 +242,11 @@ export const AgentMetadataModelSwitcher = ({
 
       {/* Show warning if selected provider is not connected */}
       {currentProvider && !currentProvider.connected && (
-        <div className="pt-2 p-2">
+        <div className="p-2 pt-2">
           <Notice variant="warning" title="Provider not connected">
             <Notice.Message>
               Set the{' '}
-              <code className="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900/50 rounded">
+              <code className="rounded bg-yellow-100 px-1 py-0.5 dark:bg-yellow-900/50">
                 {Array.isArray(currentProvider.envVar) ? currentProvider.envVar.join(', ') : currentProvider.envVar}
               </code>{' '}
               environment{' '}

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-section.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-section.tsx
@@ -18,7 +18,7 @@ export const AgentMetadataSection = ({ title, children, hint }: AgentMetadataSec
   const { Link } = useLinkComponent();
   return (
     <section className="space-y-2 pb-7 last:pb-0">
-      <Txt as="h3" variant="ui-md" className="text-neutral3 flex items-center gap-1">
+      <Txt as="h3" variant="ui-md" className="flex items-center gap-1 text-neutral3">
         {title}
         {hint && (
           <TooltipProvider>

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-wrapper.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata-wrapper.tsx
@@ -3,5 +3,5 @@ export interface AgentMetadataWrapperProps {
 }
 
 export const AgentMetadataWrapper = ({ children }: AgentMetadataWrapperProps) => {
-  return <div className="py-2 overflow-y-auto h-full px-5">{children}</div>;
+  return <div className="h-full overflow-y-auto px-5 py-2">{children}</div>;
 };

--- a/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/agent-metadata.tsx
@@ -187,7 +187,7 @@ export const AgentMetadata = ({ agentId }: AgentMetadataProps) => {
       </AgentMetadataSection>
       <AgentMetadataSection title="System Prompt">
         <CodeMirror
-          className="border border-border1 rounded-md"
+          className="rounded-md border border-border1"
           value={extractPrompt(agent.instructions)}
           editable={false}
           extensions={[markdown({ base: markdownLanguage, codeLanguages }), EditorView.lineWrapping]}
@@ -330,7 +330,7 @@ export const AgentMetadataSkillList = ({ skills, agentId, workspaceId }: AgentMe
         const isActivated = isSkillActivated(skill.name);
         const badge = (
           <Badge
-            icon={<SkillIcon className={`h-3 w-3 ${isActivated ? 'text-green-400' : 'text-accent2'}`} />}
+            icon={<SkillIcon className={`size-3 ${isActivated ? 'text-green-400' : 'text-accent2'}`} />}
             variant={isActivated ? 'success' : 'default'}
           >
             {skill.name}
@@ -351,7 +351,7 @@ export const AgentMetadataSkillList = ({ skills, agentId, workspaceId }: AgentMe
                       {badge}
                     </Link>
                   </TooltipTrigger>
-                  <TooltipContent className="bg-surface3 text-neutral6 border border-border1">Active</TooltipContent>
+                  <TooltipContent className="border border-border1 bg-surface3 text-neutral6">Active</TooltipContent>
                 </Tooltip>
               </TooltipProvider>
             ) : (
@@ -391,7 +391,7 @@ export const AgentMetadataWorkspaceToolsList = ({ tools }: AgentMetadataWorkspac
     <AgentMetadataList>
       {tools.map(tool => (
         <AgentMetadataListItem key={tool}>
-          <Badge icon={<Folder className="h-3 w-3 text-accent1" />}>{formatWorkspaceToolName(tool)}</Badge>
+          <Badge icon={<Folder className="size-3 text-accent1" />}>{formatWorkspaceToolName(tool)}</Badge>
         </AgentMetadataListItem>
       ))}
     </AgentMetadataList>
@@ -411,7 +411,7 @@ export const AgentMetadataBrowserToolsList = ({ tools }: AgentMetadataBrowserToo
     <AgentMetadataList>
       {tools.map(tool => (
         <AgentMetadataListItem key={tool}>
-          <Badge icon={<Globe className="h-3 w-3 text-cyan-500" />}>{tool}</Badge>
+          <Badge icon={<Globe className="size-3 text-cyan-500" />}>{tool}</Badge>
         </AgentMetadataListItem>
       ))}
     </AgentMetadataList>

--- a/packages/playground/src/domains/agents/components/agent-metadata/provider-logo.tsx
+++ b/packages/playground/src/domains/agents/components/agent-metadata/provider-logo.tsx
@@ -50,7 +50,7 @@ export const ProviderLogo = ({ providerId, className = '', size = 20 }: Provider
     if (providerMapToIcon[fallbackIcon as keyof typeof providerMapToIcon]) {
       return <Icon>{providerMapToIcon[fallbackIcon as keyof typeof providerMapToIcon]}</Icon>;
     }
-    return <div className={`bg-surface4 rounded ${className}`} style={{ width: size, height: size }} />;
+    return <div className={`rounded bg-surface4 ${className}`} style={{ width: size, height: size }} />;
   }
 
   return (

--- a/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
+++ b/packages/playground/src/domains/agents/components/agent-page-tabs.tsx
@@ -25,7 +25,7 @@ function DocsLink({ href, children }: { href: string; children: React.ReactNode 
       href={href}
       target="_blank"
       rel="noopener noreferrer"
-      className="inline-flex items-center gap-1 underline text-inherit hover:text-white"
+      className="inline-flex items-center gap-1 text-inherit underline hover:text-white"
     >
       {children}
       <ExternalLink className="size-3" />
@@ -55,7 +55,7 @@ function AgentTab({
         {label}
       </Txt>
       {badge !== undefined && badge > 0 && (
-        <span className="ml-1 bg-accent1 text-white text-xs font-medium rounded-full px-1.5 py-0 min-w-[18px] text-center leading-[18px]">
+        <span className="ml-1 min-w-[18px] rounded-full bg-accent1 px-1.5 py-0 text-center text-xs leading-[18px] font-medium text-white">
           {badge}
         </span>
       )}
@@ -128,7 +128,7 @@ export function AgentPageTabs({
         value={activeTab}
         defaultTab={activeTab}
         onValueChange={handleTabChange}
-        className="flex-1 min-w-0 max-lg:flex-auto"
+        className="min-w-0 flex-1 max-lg:flex-auto"
       >
         <TabList variant="pill-ghost">
           <AgentTab value="chat" icon={<MessageSquare />} label="Chat" />

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -46,10 +46,10 @@ function VariableProperty({ name, prop, depth }: { name: string; prop: JsonSchem
       <div className="flex items-center gap-2 py-1">
         <code className="text-xs text-accent1">{name}</code>
         <span className="text-[11px] text-neutral3">{typeLabel}</span>
-        {prop.description && <span className="text-[11px] text-neutral3 italic truncate">— {prop.description}</span>}
+        {prop.description && <span className="truncate text-[11px] text-neutral3 italic">— {prop.description}</span>}
       </div>
       {hasChildren && (
-        <div className="border-l border-border1 ml-1">
+        <div className="ml-1 border-l border-border1">
           {Object.entries(prop.properties!).map(([childName, childProp]) => (
             <VariableProperty key={childName} name={childName} prop={childProp} depth={depth + 1} />
           ))}
@@ -161,7 +161,7 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
               <BlockCopyButton block={block} />
             </div>
           )}
-          <Txt variant="ui-sm" className="text-neutral4 whitespace-pre-wrap font-mono">
+          <Txt variant="ui-sm" className="font-mono whitespace-pre-wrap text-neutral4">
             {oldStr || '(empty)'}
           </Txt>
         </div>
@@ -170,7 +170,7 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
 
     const diffLines = computeLineDiff(oldStr, newStr);
     return (
-      <div className="relative rounded-md border border-border1 overflow-hidden font-mono text-sm">
+      <div className="relative overflow-hidden rounded-md border border-border1 font-mono text-sm">
         {block && (
           <div className="absolute top-2 right-2 z-10">
             <BlockCopyButton block={block} />
@@ -180,13 +180,13 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
           <div
             key={idx}
             className={cn(
-              'px-3 py-0.5 whitespace-pre-wrap wrap-break-word',
+              'px-3 py-0.5 wrap-break-word whitespace-pre-wrap',
               line.type === 'removed' && 'bg-red-950/20 text-red-300',
               line.type === 'added' && 'bg-green-950/20 text-green-300',
               line.type === 'equal' && 'text-neutral4',
             )}
           >
-            <span className="inline-block w-4 shrink-0 text-neutral3/50 select-none mr-2">
+            <span className="mr-2 inline-block w-4 shrink-0 text-neutral3/50 select-none">
               {line.type === 'removed' ? '−' : line.type === 'added' ? '+' : ' '}
             </span>
             {line.text || '\u00A0'}
@@ -209,10 +209,10 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
         if (!prevBlock && currBlock) {
           return (
             <div key={idx} className="rounded-md border border-green-900/30 bg-green-950/10 p-3 font-mono text-sm">
-              <Txt variant="ui-xs" className="text-green-400 mb-1">
+              <Txt variant="ui-xs" className="mb-1 text-green-400">
                 + Added block
               </Txt>
-              <Txt variant="ui-sm" className="text-green-300 whitespace-pre-wrap">
+              <Txt variant="ui-sm" className="whitespace-pre-wrap text-green-300">
                 {newStr}
               </Txt>
             </div>
@@ -225,10 +225,10 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
               <div className="absolute top-2 right-2">
                 <BlockCopyButton block={prevBlock} />
               </div>
-              <Txt variant="ui-xs" className="text-red-400 mb-1">
+              <Txt variant="ui-xs" className="mb-1 text-red-400">
                 − Removed in latest
               </Txt>
-              <Txt variant="ui-sm" className="text-red-300 whitespace-pre-wrap">
+              <Txt variant="ui-sm" className="whitespace-pre-wrap text-red-300">
                 {oldStr}
               </Txt>
             </div>
@@ -243,7 +243,7 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
                   <BlockCopyButton block={prevBlock} />
                 </div>
               )}
-              <Txt variant="ui-sm" className="text-neutral4 whitespace-pre-wrap font-mono">
+              <Txt variant="ui-sm" className="font-mono whitespace-pre-wrap text-neutral4">
                 {oldStr || '(empty)'}
               </Txt>
             </div>
@@ -252,7 +252,7 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
 
         const diffLines = computeLineDiff(oldStr, newStr);
         return (
-          <div key={idx} className="relative rounded-md border border-border1 overflow-hidden font-mono text-sm">
+          <div key={idx} className="relative overflow-hidden rounded-md border border-border1 font-mono text-sm">
             {prevBlock && (
               <div className="absolute top-2 right-2 z-10">
                 <BlockCopyButton block={prevBlock} />
@@ -262,13 +262,13 @@ function InstructionsDiffView({ previousBlocks, currentBlocks }: { previousBlock
               <div
                 key={lidx}
                 className={cn(
-                  'px-3 py-0.5 whitespace-pre-wrap wrap-break-word',
+                  'px-3 py-0.5 wrap-break-word whitespace-pre-wrap',
                   line.type === 'removed' && 'bg-red-950/20 text-red-300',
                   line.type === 'added' && 'bg-green-950/20 text-green-300',
                   line.type === 'equal' && 'text-neutral4',
                 )}
               >
-                <span className="inline-block w-4 shrink-0 text-neutral3/50 select-none mr-2">
+                <span className="mr-2 inline-block w-4 shrink-0 text-neutral3/50 select-none">
                   {line.type === 'removed' ? '−' : line.type === 'added' ? '+' : ' '}
                 </span>
                 {line.text || '\u00A0'}
@@ -287,7 +287,7 @@ function RefBlockPreview({ promptBlockId }: { promptBlockId: string }) {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-4">
-        <Spinner className="h-4 w-4" />
+        <Spinner className="size-4" />
       </div>
     );
   }
@@ -301,11 +301,11 @@ function RefBlockPreview({ promptBlockId }: { promptBlockId: string }) {
         </div>
       )}
       {promptBlock?.name && (
-        <Txt variant="ui-xs" className="text-neutral3 mb-1 font-medium">
+        <Txt variant="ui-xs" className="mb-1 font-medium text-neutral3">
           {promptBlock.name}
         </Txt>
       )}
-      <Txt variant="ui-sm" className="text-neutral4 whitespace-pre-wrap font-mono">
+      <Txt variant="ui-sm" className="font-mono whitespace-pre-wrap text-neutral4">
         {content || '(empty)'}
       </Txt>
     </div>
@@ -317,7 +317,7 @@ function ReadOnlyInstructions({ blocks }: { blocks: unknown }) {
 
   if (blocksArr.length === 0) {
     return (
-      <Txt variant="ui-sm" className="text-neutral3 py-2">
+      <Txt variant="ui-sm" className="py-2 text-neutral3">
         No instruction blocks configured
       </Txt>
     );
@@ -339,7 +339,7 @@ function ReadOnlyInstructions({ blocks }: { blocks: unknown }) {
                 <CopyButton content={content} tooltip="Copy prompt text" size="sm" />
               </div>
             )}
-            <Txt variant="ui-sm" className="text-neutral4 whitespace-pre-wrap font-mono">
+            <Txt variant="ui-sm" className="font-mono whitespace-pre-wrap text-neutral4">
               {content || '(empty)'}
             </Txt>
           </div>
@@ -415,7 +415,7 @@ function ReadOnlyTools({ tools }: { tools: Record<string, unknown> | undefined }
 
   if (entries.length === 0) {
     return (
-      <Txt variant="ui-sm" className="text-neutral3 py-2">
+      <Txt variant="ui-sm" className="py-2 text-neutral3">
         No tools configured
       </Txt>
     );
@@ -425,11 +425,11 @@ function ReadOnlyTools({ tools }: { tools: Record<string, unknown> | undefined }
     <div className="flex flex-col gap-1.5">
       {entries.map(([id, config]) => (
         <div key={id} className="rounded-md border border-border1 bg-surface2 px-3 py-1.5">
-          <Txt variant="ui-sm" className="text-neutral5 font-mono">
+          <Txt variant="ui-sm" className="font-mono text-neutral5">
             {id}
           </Txt>
           {(config as Record<string, unknown>)?.description ? (
-            <Txt variant="ui-xs" className="text-neutral3 mt-0.5">
+            <Txt variant="ui-xs" className="mt-0.5 text-neutral3">
               {String((config as Record<string, unknown>).description)}
             </Txt>
           ) : null}
@@ -455,7 +455,7 @@ function VariablesDiffView({
 
   if (allKeys.length === 0) {
     return (
-      <Txt variant="ui-sm" className="text-neutral3 py-2">
+      <Txt variant="ui-sm" className="py-2 text-neutral3">
         No variables configured
       </Txt>
     );
@@ -516,7 +516,7 @@ function ReadOnlyVariables({ variables }: { variables: Record<string, unknown> |
 
   if (entries.length === 0) {
     return (
-      <Txt variant="ui-sm" className="text-neutral3 py-2">
+      <Txt variant="ui-sm" className="py-2 text-neutral3">
         No variables configured
       </Txt>
     );
@@ -526,7 +526,7 @@ function ReadOnlyVariables({ variables }: { variables: Record<string, unknown> |
     <div className="flex flex-col gap-1.5">
       {entries.map(([name, schema]) => (
         <div key={name} className="flex items-center gap-2 rounded-md border border-border1 bg-surface2 px-3 py-1.5">
-          <Txt variant="ui-sm" className="text-neutral5 font-mono">
+          <Txt variant="ui-sm" className="font-mono text-neutral5">
             {`{{${name}}}`}
           </Txt>
           {(schema as Record<string, unknown>)?.type ? (
@@ -598,7 +598,7 @@ function ReadOnlyConfigWithDiff({
   if (isLoadingCompare) {
     return (
       <div className="flex items-center justify-center py-8">
-        <Spinner className="h-5 w-5" />
+        <Spinner className="size-5" />
       </div>
     );
   }
@@ -617,7 +617,7 @@ function ReadOnlyConfigWithDiff({
         </Tab>
       </TabList>
 
-      <TabContent value="variables" className="px-4 py-4">
+      <TabContent value="variables" className="p-4">
         {variablesDiff ? (
           <VariablesDiffView
             previousVars={variablesDiff.previousValue as Record<string, unknown> | undefined}
@@ -628,7 +628,7 @@ function ReadOnlyConfigWithDiff({
         )}
       </TabContent>
 
-      <TabContent value="instructions" className="px-4 py-4">
+      <TabContent value="instructions" className="p-4">
         {instructionsDiff ? (
           <InstructionsDiffView
             previousBlocks={instructionsDiff.previousValue}
@@ -639,7 +639,7 @@ function ReadOnlyConfigWithDiff({
         )}
       </TabContent>
 
-      <TabContent value="tools" className="px-4 py-4">
+      <TabContent value="tools" className="p-4">
         {toolsDiff ? (
           <ToolsDiffView
             previousTools={toolsDiff.previousValue as Record<string, unknown> | undefined}
@@ -675,10 +675,10 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
   const showDiff = readOnly && !!selectedVersionId && !!latestVersionId && selectedVersionId !== latestVersionId;
 
   return (
-    <div className={cn('flex flex-col h-full')}>
-      <div className="px-4 py-3 border-b border-border1" />
+    <div className={cn('flex h-full flex-col')}>
+      <div className="border-b border-border1 px-4 py-3" />
 
-      <ScrollArea className="flex-1 min-h-0">
+      <ScrollArea className="min-h-0 flex-1">
         {showDiff ? (
           <ReadOnlyConfigWithDiff
             agentId={agentId}
@@ -704,7 +704,7 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
             </TabList>
 
             <TabContent value="variables" className="py-0">
-              <div className="flex flex-col gap-1 px-4 py-4">
+              <div className="flex flex-col gap-1 p-4">
                 {variableEntries.length > 0 ? (
                   <div className="flex flex-col">
                     {variableEntries.map(([name, prop]) => (
@@ -712,7 +712,7 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
                     ))}
                   </div>
                 ) : null}
-                <Txt variant="ui-xs" className="text-neutral3 mt-1">
+                <Txt variant="ui-xs" className="mt-1 text-neutral3">
                   {variableEntries.length > 0
                     ? 'Defined via requestContextSchema in code.'
                     : 'No variables defined. Add a requestContextSchema to your agent to define variables.'}
@@ -728,7 +728,7 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
                     <PopoverTrigger asChild>
                       <button
                         type="button"
-                        className="text-neutral3 underline decoration-dotted hover:text-neutral5 cursor-pointer inline"
+                        className="inline cursor-pointer text-neutral3 underline decoration-dotted hover:text-neutral5"
                       >
                         use variables
                       </button>
@@ -736,7 +736,7 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
                     as part of your instruction blocks.
                     <PopoverContent side="bottom" align="start">
                       <p className="text-ui-sm text-neutral5">
-                        Use <code className="text-accent1 font-medium">{'{{variableName}}'}</code> syntax to insert
+                        Use <code className="font-medium text-accent1">{'{{variableName}}'}</code> syntax to insert
                         dynamic values into your instruction blocks.
                       </p>
                     </PopoverContent>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-datasets.tsx
@@ -36,33 +36,33 @@ export function AgentPlaygroundDatasets({ agentId }: AgentPlaygroundDatasetsProp
   }, [experiments]);
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="px-4 py-3 border-b border-border1 flex items-center justify-between">
+    <div className="flex h-full flex-col">
+      <div className="flex items-center justify-between border-b border-border1 px-4 py-3">
         <Txt variant="ui-sm" className="text-neutral3">
           Manage test datasets for this agent. Create datasets, generate seed data, and run experiments.
         </Txt>
         <Button variant="primary" size="sm" onClick={() => setShowCreateDialog(true)}>
-          <Plus className="h-3.5 w-3.5 mr-1" />
+          <Plus className="mr-1 size-3.5" />
           Create
         </Button>
       </div>
 
       <ScrollArea className="flex-1">
-        <div className="p-4 space-y-2">
+        <div className="space-y-2 p-4">
           {isDatasetsLoading ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-5 w-5 animate-spin text-neutral3" />
+              <Loader2 className="size-5 animate-spin text-neutral3" />
             </div>
           ) : datasets.length === 0 ? (
-            <div className="text-center py-12 space-y-3">
-              <Icon size="lg" className="text-neutral3 mx-auto">
+            <div className="space-y-3 py-12 text-center">
+              <Icon size="lg" className="mx-auto text-neutral3">
                 <Database />
               </Icon>
               <div>
                 <Txt variant="ui-sm" className="text-neutral3">
                   No datasets yet
                 </Txt>
-                <Txt variant="ui-xs" className="text-neutral3 mt-1">
+                <Txt variant="ui-xs" className="mt-1 text-neutral3">
                   Create a dataset to start testing your agent with structured test cases.
                 </Txt>
               </div>
@@ -119,11 +119,11 @@ function DatasetCard({
     : null;
 
   return (
-    <div className="border border-border1 rounded-lg p-3 hover:bg-surface2 transition-colors">
+    <div className="rounded-lg border border-border1 p-3 transition-colors hover:bg-surface2">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <Txt variant="ui-sm" className="text-neutral5 font-medium truncate">
+            <Txt variant="ui-sm" className="truncate font-medium text-neutral5">
               {name}
             </Txt>
             <Txt variant="ui-xs" className="text-neutral3">
@@ -131,16 +131,16 @@ function DatasetCard({
             </Txt>
           </div>
           {description && (
-            <Txt variant="ui-xs" className="text-neutral3 mt-0.5 line-clamp-1">
+            <Txt variant="ui-xs" className="mt-0.5 line-clamp-1 text-neutral3">
               {description}
             </Txt>
           )}
         </div>
 
-        <div className="flex items-center gap-1.5 shrink-0">
+        <div className="flex shrink-0 items-center gap-1.5">
           {latestExperiment && <ExperimentBadge status={latestExperiment.status} passRate={passRate} />}
           <Button variant="ghost" size="sm" onClick={onGenerate} title="Generate test data with AI">
-            <Sparkles className="h-3.5 w-3.5" />
+            <Sparkles className="size-3.5" />
           </Button>
         </div>
       </div>
@@ -152,7 +152,7 @@ function ExperimentBadge({ status, passRate }: { status: string; passRate: numbe
   if (status === 'running' || status === 'pending') {
     return (
       <div className="flex items-center gap-1 text-blue-400">
-        <Loader2 className="h-3 w-3 animate-spin" />
+        <Loader2 className="size-3 animate-spin" />
         <Txt variant="ui-xs" className="text-blue-400">
           Running
         </Txt>
@@ -163,7 +163,7 @@ function ExperimentBadge({ status, passRate }: { status: string; passRate: numbe
   if (status === 'failed') {
     return (
       <div className="flex items-center gap-1 text-red-400">
-        <XCircle className="h-3 w-3" />
+        <XCircle className="size-3" />
         <Txt variant="ui-xs" className="text-red-400">
           Failed
         </Txt>
@@ -178,7 +178,7 @@ function ExperimentBadge({ status, passRate }: { status: string; passRate: numbe
 
   return (
     <div className={`flex items-center gap-1 ${color}`}>
-      <StatusIcon className="h-3 w-3" />
+      <StatusIcon className="size-3" />
       <Txt variant="ui-xs" className={color}>
         {passRate}%
       </Txt>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-eval.tsx
@@ -45,28 +45,28 @@ function ExperimentStatusBadge({ status }: { status: string }) {
     case 'completed':
       return (
         <Badge variant="success" className="gap-1">
-          <CheckCircle className="h-3 w-3" />
+          <CheckCircle className="size-3" />
           completed
         </Badge>
       );
     case 'failed':
       return (
         <Badge variant="error" className="gap-1">
-          <XCircle className="h-3 w-3" />
+          <XCircle className="size-3" />
           failed
         </Badge>
       );
     case 'running':
       return (
         <Badge variant="info" className="gap-1">
-          <Loader2 className="h-3 w-3 animate-spin" />
+          <Loader2 className="size-3 animate-spin" />
           running
         </Badge>
       );
     case 'pending':
       return (
         <Badge variant="default" className="gap-1">
-          <Clock className="h-3 w-3" />
+          <Clock className="size-3" />
           pending
         </Badge>
       );
@@ -134,43 +134,43 @@ function TrajectoryStepsSection({ traceId }: { traceId: string }) {
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-purple-400 font-medium hover:text-purple-300">
-        <ChevronRight className="h-3 w-3 shrink-0" />
+      <CollapsibleTrigger className="flex items-center gap-1.5 text-xs font-medium text-purple-400 hover:text-purple-300">
+        <ChevronRight className="size-3 shrink-0" />
         Trajectory Steps
       </CollapsibleTrigger>
       <CollapsibleContent>
         {isLoading ? (
-          <div className="flex items-center gap-2 mt-1 px-3 py-2">
-            <Spinner className="h-3 w-3" />
+          <div className="mt-1 flex items-center gap-2 px-3 py-2">
+            <Spinner className="size-3" />
             <Txt variant="ui-xs" className="text-neutral3">
               Loading trajectory...
             </Txt>
           </div>
         ) : isError ? (
-          <Txt variant="ui-xs" className="text-red-400 mt-1 px-3 py-2">
+          <Txt variant="ui-xs" className="mt-1 px-3 py-2 text-red-400">
             Failed to load trajectory steps
           </Txt>
         ) : trajectory?.steps && trajectory.steps.length > 0 ? (
           <div className="mt-1 space-y-1">
             {trajectory.steps.map((step: Record<string, unknown>, i: number) => (
-              <div key={i} className="flex items-center gap-2 px-3 py-1.5 bg-surface1 rounded text-xs">
+              <div key={i} className="flex items-center gap-2 rounded bg-surface1 px-3 py-1.5 text-xs">
                 <Chip size="small" color="purple">
                   {String(step.stepType || 'step')}
                 </Chip>
-                <span className="text-neutral5 font-mono font-medium">{String(step.name || `Step ${i + 1}`)}</span>
+                <span className="font-mono font-medium text-neutral5">{String(step.name || `Step ${i + 1}`)}</span>
                 {typeof step.durationMs === 'number' && (
-                  <span className="text-neutral2 ml-auto">{step.durationMs}ms</span>
+                  <span className="ml-auto text-neutral2">{step.durationMs}ms</span>
                 )}
               </div>
             ))}
             {typeof trajectory.totalDurationMs === 'number' && (
-              <Txt variant="ui-xs" className="text-neutral3 px-3 py-1">
+              <Txt variant="ui-xs" className="px-3 py-1 text-neutral3">
                 Total: {trajectory.totalDurationMs}ms
               </Txt>
             )}
           </div>
         ) : (
-          <Txt variant="ui-xs" className="text-neutral2 mt-1 px-3 py-2">
+          <Txt variant="ui-xs" className="mt-1 px-3 py-2 text-neutral2">
             No trajectory steps found
           </Txt>
         )}
@@ -196,10 +196,10 @@ function ResultOutputSection({
       {/* Response text */}
       {parsed.text ? (
         <div className="space-y-1">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Response
           </Txt>
-          <div className="text-sm text-neutral5 bg-surface1 rounded px-3 py-2 whitespace-pre-wrap wrap-break-word max-h-48 overflow-y-auto">
+          <div className="max-h-48 overflow-y-auto rounded bg-surface1 px-3 py-2 text-sm wrap-break-word whitespace-pre-wrap text-neutral5">
             {parsed.text}
           </div>
         </div>
@@ -208,10 +208,10 @@ function ResultOutputSection({
       {/* Object output (for structured generation) */}
       {parsed.object && (
         <div className="space-y-1">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Structured Output
           </Txt>
-          <pre className="text-xs text-neutral4 bg-surface1 rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-48 overflow-y-auto">
+          <pre className="max-h-48 overflow-auto rounded bg-surface1 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-neutral4">
             {JSON.stringify(parsed.object, null, 2)}
           </pre>
         </div>
@@ -220,18 +220,18 @@ function ResultOutputSection({
       {/* Tool Calls */}
       {parsed.toolCalls.length > 0 && (
         <div className="space-y-1">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Tool Calls ({parsed.toolCalls.length})
           </Txt>
           <div className="space-y-1">
             {parsed.toolCalls.map((call, i) => (
               <Collapsible key={i}>
-                <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-neutral4 hover:text-neutral5 w-full text-left px-2 py-1 rounded bg-surface1">
-                  <ChevronRight className="h-3 w-3 shrink-0" />
+                <CollapsibleTrigger className="flex w-full items-center gap-1.5 rounded bg-surface1 px-2 py-1 text-left text-xs text-neutral4 hover:text-neutral5">
+                  <ChevronRight className="size-3 shrink-0" />
                   <span className="font-mono font-medium">{call.toolName}</span>
                 </CollapsibleTrigger>
                 <CollapsibleContent>
-                  <pre className="text-xs text-neutral4 bg-surface2 rounded px-3 py-2 ml-4 mt-1 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-32 overflow-y-auto">
+                  <pre className="mt-1 ml-4 max-h-32 overflow-auto rounded bg-surface2 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-neutral4">
                     {JSON.stringify(call.args, null, 2)}
                   </pre>
                 </CollapsibleContent>
@@ -244,18 +244,18 @@ function ResultOutputSection({
       {/* Tool Results */}
       {parsed.toolResults.length > 0 && (
         <div className="space-y-1">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Tool Results ({parsed.toolResults.length})
           </Txt>
           <div className="space-y-1">
             {parsed.toolResults.map((result, i) => (
               <Collapsible key={i}>
-                <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-neutral4 hover:text-neutral5 w-full text-left px-2 py-1 rounded bg-surface1">
-                  <ChevronRight className="h-3 w-3 shrink-0" />
+                <CollapsibleTrigger className="flex w-full items-center gap-1.5 rounded bg-surface1 px-2 py-1 text-left text-xs text-neutral4 hover:text-neutral5">
+                  <ChevronRight className="size-3 shrink-0" />
                   <span className="font-mono">Result {i + 1}</span>
                 </CollapsibleTrigger>
                 <CollapsibleContent>
-                  <pre className="text-xs text-neutral4 bg-surface2 rounded px-3 py-2 ml-4 mt-1 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-32 overflow-y-auto">
+                  <pre className="mt-1 ml-4 max-h-32 overflow-auto rounded bg-surface2 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-neutral4">
                     {JSON.stringify(result, null, 2)}
                   </pre>
                 </CollapsibleContent>
@@ -268,10 +268,10 @@ function ResultOutputSection({
       {/* Usage stats */}
       {parsed.usage && (
         <div className="flex items-center gap-3">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Usage
           </Txt>
-          <Txt variant="ui-xs" className="text-neutral2 font-mono">
+          <Txt variant="ui-xs" className="font-mono text-neutral2">
             {parsed.usage.promptTokens} prompt · {parsed.usage.completionTokens} completion · {parsed.usage.totalTokens}{' '}
             total
           </Txt>
@@ -281,10 +281,10 @@ function ResultOutputSection({
       {/* Trace ID + View Trace button */}
       {effectiveTraceId && (
         <div className="flex items-center gap-2">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Trace
           </Txt>
-          <Txt variant="ui-xs" className="text-neutral2 font-mono truncate">
+          <Txt variant="ui-xs" className="truncate font-mono text-neutral2">
             {effectiveTraceId}
           </Txt>
           <CopyButton content={effectiveTraceId} tooltip="Copy trace ID" size="sm" />
@@ -292,9 +292,9 @@ function ResultOutputSection({
             <button
               type="button"
               onClick={() => onViewTrace(effectiveTraceId)}
-              className="flex items-center gap-1 text-xs text-accent1 hover:text-accent2 transition-colors cursor-pointer"
+              className="flex cursor-pointer items-center gap-1 text-xs text-accent1 transition-colors hover:text-accent2"
             >
-              <ExternalLink className="h-3 w-3" />
+              <ExternalLink className="size-3" />
               View Trace
             </button>
           )}
@@ -304,10 +304,10 @@ function ResultOutputSection({
       {/* Fallback if no structured content */}
       {!parsed.text && !parsed.object && parsed.toolCalls.length === 0 && (
         <div className="space-y-1">
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Output
           </Txt>
-          <pre className="text-xs text-neutral4 bg-surface1 rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-48 overflow-y-auto">
+          <pre className="max-h-48 overflow-auto rounded bg-surface1 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-neutral4">
             {formatResultValue(output)}
           </pre>
         </div>
@@ -382,13 +382,13 @@ export function ExperimentResultsPanel({
   const selectedResults = results?.filter(r => selectedIds.has(r.id)) || [];
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex h-full flex-col">
       {/* Header */}
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-border1">
+      <div className="flex items-center gap-2 border-b border-border1 px-4 py-3">
         <button
           type="button"
           onClick={onBack}
-          className="flex items-center gap-1 text-neutral3 hover:text-neutral5 transition-colors cursor-pointer"
+          className="flex cursor-pointer items-center gap-1 text-neutral3 transition-colors hover:text-neutral5"
         >
           <Icon size="sm">
             <ArrowLeft />
@@ -409,7 +409,7 @@ export function ExperimentResultsPanel({
                   {' · '}
                   <button
                     type="button"
-                    className="underline hover:text-neutral5 transition-colors cursor-pointer"
+                    className="cursor-pointer underline transition-colors hover:text-neutral5"
                     onClick={() =>
                       navigate(`/agents/${agentId}/editor?version=${encodeURIComponent(experiment.agentVersion!)}`)
                     }
@@ -426,8 +426,8 @@ export function ExperimentResultsPanel({
 
       {/* Selection action bar */}
       {selectedIds.size > 0 && (
-        <div className="flex items-center gap-2 px-4 py-2 bg-surface3 border-b border-border1">
-          <Txt variant="ui-xs" className="text-neutral5 font-medium">
+        <div className="flex items-center gap-2 border-b border-border1 bg-surface3 px-4 py-2">
+          <Txt variant="ui-xs" className="font-medium text-neutral5">
             {selectedIds.size} selected
           </Txt>
           <div className="flex-1" />
@@ -495,7 +495,7 @@ export function ExperimentResultsPanel({
 
       {/* Quick filter bar */}
       {results && results.length > 0 && selectedIds.size === 0 && (
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-border1">
+        <div className="flex items-center gap-2 border-b border-border1 px-4 py-2">
           <Button variant="ghost" size="sm" onClick={selectAllFailed}>
             Select all failures
           </Button>
@@ -503,10 +503,10 @@ export function ExperimentResultsPanel({
       )}
 
       {/* Results */}
-      <ScrollArea className="flex-1 min-h-0">
+      <ScrollArea className="min-h-0 flex-1">
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
-            <Spinner className="h-5 w-5" />
+            <Spinner className="size-5" />
           </div>
         ) : !results || results.length === 0 ? (
           <div className="px-4 py-8 text-center">
@@ -524,16 +524,16 @@ export function ExperimentResultsPanel({
               return (
                 <div
                   key={result.id}
-                  className={cn('border-b border-border1 px-4 py-3 space-y-2', isChecked && 'bg-surface3/50')}
+                  className={cn('space-y-2 border-b border-border1 px-4 py-3', isChecked && 'bg-surface3/50')}
                 >
                   <div className="flex items-center gap-2">
                     <Checkbox checked={isChecked} onCheckedChange={() => toggleItem(result.id)} />
                     <Badge variant={hasError ? 'error' : 'success'}>{hasError ? 'Error' : 'Success'}</Badge>
-                    <Txt variant="ui-xs" className="text-neutral2 font-mono">
+                    <Txt variant="ui-xs" className="font-mono text-neutral2">
                       {result.itemId.slice(0, 8)}
                     </Txt>
                     {itemScores.length > 0 && (
-                      <div className="flex items-center gap-2 ml-auto flex-wrap">
+                      <div className="ml-auto flex flex-wrap items-center gap-2">
                         {itemScores
                           .filter(s => s.entityType !== 'TRAJECTORY')
                           .map(s => (
@@ -555,8 +555,8 @@ export function ExperimentResultsPanel({
                   {/* Trajectory Score Details */}
                   {itemScores.some(s => s.entityType === 'TRAJECTORY') && (
                     <Collapsible>
-                      <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-purple-400 font-medium hover:text-purple-300">
-                        <ChevronRight className="h-3 w-3 shrink-0" />
+                      <CollapsibleTrigger className="flex items-center gap-1.5 text-xs font-medium text-purple-400 hover:text-purple-300">
+                        <ChevronRight className="size-3 shrink-0" />
                         Trajectory Score Details
                       </CollapsibleTrigger>
                       <CollapsibleContent>
@@ -564,13 +564,13 @@ export function ExperimentResultsPanel({
                           {itemScores
                             .filter(s => s.entityType === 'TRAJECTORY')
                             .map(s => (
-                              <div key={s.scorerId} className="bg-surface1 rounded px-3 py-2 space-y-1">
-                                <Txt variant="ui-xs" className="text-purple-400 font-medium">
+                              <div key={s.scorerId} className="space-y-1 rounded bg-surface1 px-3 py-2">
+                                <Txt variant="ui-xs" className="font-medium text-purple-400">
                                   {s.scorerId}
                                 </Txt>
                                 {s.reason && <p className="text-xs text-neutral4">{s.reason}</p>}
                                 {s.preprocessStepResult && (
-                                  <pre className="text-xs text-neutral3 overflow-x-auto whitespace-pre-wrap break-words max-h-48 overflow-y-auto">
+                                  <pre className="max-h-48 overflow-auto text-xs break-words whitespace-pre-wrap text-neutral3">
                                     {JSON.stringify(s.preprocessStepResult, null, 2)}
                                   </pre>
                                 )}
@@ -588,12 +588,12 @@ export function ExperimentResultsPanel({
 
                   {/* Input */}
                   <Collapsible>
-                    <CollapsibleTrigger className="flex items-center gap-1.5 text-xs text-neutral3 font-medium hover:text-neutral5">
-                      <ChevronRight className="h-3 w-3 shrink-0" />
+                    <CollapsibleTrigger className="flex items-center gap-1.5 text-xs font-medium text-neutral3 hover:text-neutral5">
+                      <ChevronRight className="size-3 shrink-0" />
                       Input
                     </CollapsibleTrigger>
                     <CollapsibleContent>
-                      <pre className="text-xs text-neutral4 bg-surface1 rounded px-3 py-2 mt-1 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-32 overflow-y-auto">
+                      <pre className="mt-1 max-h-32 overflow-auto rounded bg-surface1 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-neutral4">
                         {formatResultValue(result.input)}
                       </pre>
                     </CollapsibleContent>
@@ -603,28 +603,28 @@ export function ExperimentResultsPanel({
                   {hasError ? (
                     <div className="space-y-2">
                       <div className="space-y-1">
-                        <Txt variant="ui-xs" className="text-red-400 font-medium">
+                        <Txt variant="ui-xs" className="font-medium text-red-400">
                           Error
                         </Txt>
-                        <pre className="text-xs text-red-300 bg-surface1 rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-32 overflow-y-auto">
+                        <pre className="max-h-32 overflow-auto rounded bg-surface1 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-red-300">
                           {formatResultValue(result.error)}
                         </pre>
                       </div>
                       {result.traceId && (
                         <div className="flex items-center gap-2">
-                          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+                          <Txt variant="ui-xs" className="font-medium text-neutral3">
                             Trace
                           </Txt>
-                          <Txt variant="ui-xs" className="text-neutral2 font-mono truncate">
+                          <Txt variant="ui-xs" className="truncate font-mono text-neutral2">
                             {result.traceId}
                           </Txt>
                           <CopyButton content={result.traceId} tooltip="Copy trace ID" size="sm" />
                           <button
                             type="button"
                             onClick={() => navigate(`/traces/${result.traceId}`)}
-                            className="flex items-center gap-1 text-xs text-accent1 hover:text-accent2 transition-colors cursor-pointer"
+                            className="flex cursor-pointer items-center gap-1 text-xs text-accent1 transition-colors hover:text-accent2"
                           >
-                            <ExternalLink className="h-3 w-3" />
+                            <ExternalLink className="size-3" />
                             View Trace
                           </button>
                         </div>
@@ -644,11 +644,11 @@ export function ExperimentResultsPanel({
             <div ref={setEndOfListElement} className="h-1">
               {isFetchingNextPage && (
                 <div className="flex items-center justify-center py-4">
-                  <Spinner className="h-4 w-4" />
+                  <Spinner className="size-4" />
                 </div>
               )}
               {!hasNextPage && results.length > 0 && (
-                <div className="text-center py-2">
+                <div className="py-2 text-center">
                   <Txt variant="ui-xs" className="text-neutral2">
                     All results loaded
                   </Txt>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-evaluate.tsx
@@ -352,7 +352,7 @@ export function AgentPlaygroundEvaluate({
     if (!detailView) return null;
 
     const backButton = (label: string, onClick: () => void) => (
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-border1">
+      <div className="flex items-center gap-2 border-b border-border1 px-4 py-2">
         <Button variant="ghost" size="sm" onClick={onClick}>
           <ChevronLeft className="size-4" />
           {label}
@@ -683,7 +683,7 @@ export function AgentPlaygroundEvaluate({
                 <Badge variant={source === 'code' ? 'default' : 'success'}>{source}</Badge>
               </DataList.Cell>
               <DataList.Cell height="compact" className="min-w-0">
-                <span className="block truncate max-w-[200px]">
+                <span className="max-w-50 block truncate">
                   {description || <span className="text-neutral2">—</span>}
                 </span>
               </DataList.Cell>
@@ -753,7 +753,7 @@ export function AgentPlaygroundEvaluate({
                   <button
                     key={ds.id}
                     type="button"
-                    className="w-full text-left px-3 py-2 hover:bg-surface3 rounded-md transition-colors flex items-center justify-between"
+                    className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left transition-colors hover:bg-surface3"
                     onClick={async () => {
                       try {
                         await updateDataset.mutateAsync({
@@ -774,7 +774,7 @@ export function AgentPlaygroundEvaluate({
                         {ds.name}
                       </Txt>
                       {ds.description && (
-                        <Txt variant="ui-xs" className="text-neutral3 block">
+                        <Txt variant="ui-xs" className="block text-neutral3">
                           {ds.description}
                         </Txt>
                       )}
@@ -784,7 +784,7 @@ export function AgentPlaygroundEvaluate({
               {unattachedDatasets.filter(
                 ds => !attachDatasetSearch || ds.name.toLowerCase().includes(attachDatasetSearch.toLowerCase()),
               ).length === 0 && (
-                <Txt variant="ui-sm" className="text-neutral3 text-center py-4 block">
+                <Txt variant="ui-sm" className="block py-4 text-center text-neutral3">
                   No datasets available to attach
                 </Txt>
               )}
@@ -820,7 +820,7 @@ export function AgentPlaygroundEvaluate({
                   <button
                     key={id}
                     type="button"
-                    className="w-full text-left px-3 py-2 hover:bg-surface3 rounded-md transition-colors flex items-center justify-between"
+                    className="flex w-full items-center justify-between rounded-md px-3 py-2 text-left transition-colors hover:bg-surface3"
                     onClick={async () => {
                       try {
                         await attachScorer(id, scorer);
@@ -836,7 +836,7 @@ export function AgentPlaygroundEvaluate({
                         {scorer.scorer?.name || id}
                       </Txt>
                       {scorer.scorer?.description && (
-                        <Txt variant="ui-xs" className="text-neutral3 block">
+                        <Txt variant="ui-xs" className="block text-neutral3">
                           {scorer.scorer.description}
                         </Txt>
                       )}
@@ -848,7 +848,7 @@ export function AgentPlaygroundEvaluate({
                 const name = scorer.scorer?.name || id;
                 return name.toLowerCase().includes(attachScorerSearch.toLowerCase());
               }).length === 0 && (
-                <Txt variant="ui-sm" className="text-neutral3 text-center py-4 block">
+                <Txt variant="ui-sm" className="block py-4 text-center text-neutral3">
                   No scorers available to attach
                 </Txt>
               )}
@@ -867,7 +867,7 @@ export function AgentPlaygroundEvaluate({
         defaultTab="experiments"
         value={activeTab}
         onValueChange={handleTabChange}
-        className="flex flex-col h-full overflow-hidden"
+        className="flex h-full flex-col overflow-hidden"
       >
         <div className="flex items-center justify-between border-b border-border1">
           <TabList className="border-b-0">
@@ -882,12 +882,12 @@ export function AgentPlaygroundEvaluate({
               <>
                 {unattachedDatasets.length > 0 && (
                   <Button variant="ghost" size="sm" onClick={() => setShowAttachDialog(true)}>
-                    <Paperclip className="size-3.5 mr-1" />
+                    <Paperclip className="mr-1 size-3.5" />
                     Attach
                   </Button>
                 )}
                 <Button variant="ghost" size="sm" onClick={() => setShowCreateDialog(true)}>
-                  <Plus className="size-3.5 mr-1" />
+                  <Plus className="mr-1 size-3.5" />
                   Create
                 </Button>
               </>
@@ -896,12 +896,12 @@ export function AgentPlaygroundEvaluate({
               <>
                 {unattachedScorers.length > 0 && (
                   <Button variant="ghost" size="sm" onClick={() => setShowAttachScorerDialog(true)}>
-                    <Paperclip className="size-3.5 mr-1" />
+                    <Paperclip className="mr-1 size-3.5" />
                     Attach
                   </Button>
                 )}
                 <Button variant="ghost" size="sm" onClick={() => setDetailView({ type: 'new-scorer' })}>
-                  <Plus className="size-3.5 mr-1" />
+                  <Plus className="mr-1 size-3.5" />
                   New
                 </Button>
               </>
@@ -910,7 +910,7 @@ export function AgentPlaygroundEvaluate({
         </div>
 
         {/* Search bar below tabs */}
-        <div className="py-2 border-b border-border1">
+        <div className="border-b border-border1 py-2">
           {activeTab === 'experiments' && (
             <InputGroup variant="outline">
               <InputGroupAddon align="inline-start">

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-review.tsx
@@ -362,7 +362,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
               <div className="space-y-1">
                 <Label>Model</Label>
                 <div className="flex items-center gap-1.5">
-                  <div className="w-[160px]">
+                  <div className="w-40">
                     <LLMProviders
                       value={analyzeProvider}
                       onValueChange={value => {
@@ -438,12 +438,12 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
           <DialogHeader>
             <DialogTitle>Proposed Tag Assignments</DialogTitle>
             {analysisModelId && (
-              <Txt variant="ui-xs" className="text-neutral3 mt-1">
+              <Txt variant="ui-xs" className="mt-1 text-neutral3">
                 Analyzed by <span className="font-medium text-neutral4">{analysisModelId}</span>
               </Txt>
             )}
           </DialogHeader>
-          <DialogBody className="max-h-[400px] overflow-y-auto space-y-2">
+          <DialogBody className="max-h-100 space-y-2 overflow-y-auto">
             {proposedAssignments.map((proposal, idx) => {
               const item = items.find(i => i.id === proposal.itemId);
               const inputStr =
@@ -452,7 +452,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                 <div
                   key={proposal.itemId}
                   className={cn(
-                    'flex items-start gap-2 p-2 rounded-md border border-border1',
+                    'flex items-start gap-2 rounded-md border border-border1 p-2',
                     proposal.accepted ? 'bg-surface1' : 'bg-surface1 opacity-50',
                   )}
                 >
@@ -465,11 +465,11 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     }}
                     className="mt-1"
                   />
-                  <div className="flex-1 min-w-0">
-                    <Txt variant="ui-xs" className="text-neutral4 truncate block">
+                  <div className="min-w-0 flex-1">
+                    <Txt variant="ui-xs" className="block truncate text-neutral4">
                       {inputStr || `Item ${proposal.itemId.slice(0, 8)}`}
                     </Txt>
-                    <div className="flex flex-wrap gap-1 mt-1">
+                    <div className="mt-1 flex flex-wrap gap-1">
                       {proposal.tags.map((tag, tagIdx) => (
                         <ProposalTag
                           key={`${tag}-${tagIdx}`}
@@ -492,7 +492,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                       ))}
                     </div>
                     {proposal.reason && (
-                      <Txt variant="ui-xs" className="text-neutral3 mt-1 italic">
+                      <Txt variant="ui-xs" className="mt-1 text-neutral3 italic">
                         {proposal.reason}
                       </Txt>
                     )}
@@ -530,7 +530,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     {activeFilterCount > 0 && (
                       <span
                         className={cn(
-                          'ml-0.5 inline-flex items-center justify-center rounded-full bg-accent1/50 text-neutral5 text-ui-sm w-5 h-5',
+                          'ml-0.5 inline-flex size-5 items-center justify-center rounded-full bg-accent1/50 text-ui-sm text-neutral5',
                         )}
                       >
                         {activeFilterCount}
@@ -657,7 +657,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     <DropdownMenu.Trigger asChild>
                       <Button disabled={isAnalyzing}>
                         {isAnalyzing ? (
-                          <Spinner className="w-4 h-4" />
+                          <Spinner className="size-4" />
                         ) : (
                           <Icon size="sm">
                             <ChevronDown />
@@ -723,16 +723,16 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
           </Column.Toolbar>
 
           {isLoadingDisplay ? (
-            <div className="flex-1 flex items-center justify-center">
-              <Spinner className="h-4 w-4" />
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner className="size-4" />
             </div>
           ) : displayItems.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center">
-              <div className="text-center px-8">
-                <Txt variant="ui-sm" className="text-neutral3 block">
+            <div className="flex flex-1 items-center justify-center">
+              <div className="px-8 text-center">
+                <Txt variant="ui-sm" className="block text-neutral3">
                   {showCompleted ? 'No completed reviews yet' : 'No items to review'}
                 </Txt>
-                <Txt variant="ui-xs" className="text-neutral3 mt-2 block">
+                <Txt variant="ui-xs" className="mt-2 block text-neutral3">
                   {showCompleted
                     ? 'Items marked as complete will appear here for auditing.'
                     : 'When you identify failures in experiment results, send them here to annotate, cluster, and create scorers from failure patterns.'}
@@ -774,7 +774,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     {/* Comment preview */}
                     <DataList.Cell height="compact" className="min-w-0">
                       {item.comment ? (
-                        <Txt variant="ui-xs" className="text-neutral3 truncate">
+                        <Txt variant="ui-xs" className="truncate text-neutral3">
                           {item.comment}
                         </Txt>
                       ) : (
@@ -787,7 +787,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                     {/* Tags */}
                     <DataList.Cell height="compact" className="min-w-0">
                       {item.tags.length > 0 ? (
-                        <Txt variant="ui-xs" className="text-neutral4 truncate">
+                        <Txt variant="ui-xs" className="truncate text-neutral4">
                           {item.tags.join(', ')}
                         </Txt>
                       ) : (
@@ -823,7 +823,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                           <Icon size="sm" className="text-neutral3">
                             <GaugeIcon />
                           </Icon>
-                          <Txt variant="ui-xs" className="text-neutral4 font-mono">
+                          <Txt variant="ui-xs" className="font-mono text-neutral4">
                             {scoreEntries[0][1].toFixed(2)}
                           </Txt>
                           {scoreEntries.length > 1 && <Badge variant="default">+{scoreEntries.length - 1}</Badge>}
@@ -851,7 +851,7 @@ export function AgentPlaygroundReview({ agentId, onCreateScorer }: AgentPlaygrou
                           role="img"
                           aria-label={item.error ? 'Error' : 'Success'}
                           title={item.error ? 'Error' : 'Success'}
-                          className={cn('w-2 h-2 rounded-full', item.error ? 'bg-red-700' : 'bg-green-600')}
+                          className={cn('size-2 rounded-full', item.error ? 'bg-red-700' : 'bg-green-600')}
                         />
                       </DataList.Cell>
                     )}

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-scorers.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-scorers.tsx
@@ -61,8 +61,8 @@ export function AgentPlaygroundScorers(_props: AgentPlaygroundScorersProps) {
   };
 
   return (
-    <div className="flex flex-col h-full">
-      <div className="px-4 py-3 border-b border-border1 space-y-2">
+    <div className="flex h-full flex-col">
+      <div className="space-y-2 border-b border-border1 px-4 py-3">
         <div className="flex items-center justify-between">
           <Txt variant="ui-sm" className="text-neutral3">
             Toggle scorers to evaluate agent responses during experiments.
@@ -85,21 +85,21 @@ export function AgentPlaygroundScorers(_props: AgentPlaygroundScorersProps) {
       </div>
 
       <ScrollArea className="flex-1">
-        <div className="p-4 space-y-2">
+        <div className="space-y-2 p-4">
           {isLoading ? (
             <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-5 w-5 animate-spin text-neutral3" />
+              <Loader2 className="size-5 animate-spin text-neutral3" />
             </div>
           ) : filteredScorers.length === 0 ? (
-            <div className="text-center py-12 space-y-3">
-              <Icon size="lg" className="text-neutral3 mx-auto">
+            <div className="space-y-3 py-12 text-center">
+              <Icon size="lg" className="mx-auto text-neutral3">
                 <Calculator />
               </Icon>
               <div>
                 <Txt variant="ui-sm" className="text-neutral3">
                   {search ? 'No scorers match your search' : 'No scorers available'}
                 </Txt>
-                <Txt variant="ui-xs" className="text-neutral3 mt-1">
+                <Txt variant="ui-xs" className="mt-1 text-neutral3">
                   {search
                     ? 'Try a different search term.'
                     : 'Create scorers in your Mastra config or through the Scorers page.'}
@@ -112,28 +112,28 @@ export function AgentPlaygroundScorers(_props: AgentPlaygroundScorersProps) {
               return (
                 <div
                   key={scorer.id}
-                  className="border border-border1 rounded-lg p-3 hover:bg-surface2 transition-colors"
+                  className="rounded-lg border border-border1 p-3 transition-colors hover:bg-surface2"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
-                        <Txt variant="ui-sm" className="text-neutral5 font-medium truncate">
+                        <Txt variant="ui-sm" className="truncate font-medium text-neutral5">
                           {scorer.name}
                         </Txt>
                         {scorer.isRegistered && (
                           <Badge variant="default">
-                            <CheckCircle2 className="h-3 w-3 mr-1" />
+                            <CheckCircle2 className="mr-1 size-3" />
                             Registered
                           </Badge>
                         )}
                       </div>
                       {scorer.description && (
-                        <Txt variant="ui-xs" className="text-neutral3 mt-0.5 line-clamp-2">
+                        <Txt variant="ui-xs" className="mt-0.5 line-clamp-2 text-neutral3">
                           {scorer.description}
                         </Txt>
                       )}
                     </div>
-                    <div className="flex items-center gap-2 shrink-0 pt-0.5">
+                    <div className="flex shrink-0 items-center gap-2 pt-0.5">
                       <Label htmlFor={`scorer-${scorer.id}`} className="sr-only">
                         Toggle {scorer.name}
                       </Label>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-test-chat.tsx
@@ -47,7 +47,7 @@ function UnsavedChangesBanner({ ctx }: { ctx: NonNullable<ReturnType<typeof useO
       action={
         handleSaveDraft && (
           <Button type="button" variant="default" size="sm" onClick={() => handleSaveDraft()} disabled={isSavingDraft}>
-            <Save className="h-3.5 w-3.5" />
+            <Save className="size-3.5" />
             {isSavingDraft ? 'Saving...' : saveLabel}
           </Button>
         )
@@ -91,9 +91,9 @@ export function AgentPlaygroundTestChat({
               agentId={agentId}
               requestContext={hasRequestContext ? mergedRequestContext : undefined}
             >
-              <div className="flex flex-col h-full">
+              <div className="flex h-full flex-col">
                 {editFormCtx && <UnsavedChangesBanner ctx={editFormCtx} />}
-                <div className="flex-1 min-h-0">
+                <div className="min-h-0 flex-1">
                   <AgentChat
                     key={testThreadId}
                     agentId={agentId}

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-version-bar.tsx
@@ -130,7 +130,7 @@ export function AgentPlaygroundVersionBar({
 
   return {
     versionSelector: (
-      <div className="flex items-center gap-2 px-4 py-3 border-b border-border1 bg-surface3">
+      <div className="flex items-center gap-2 border-b border-border1 bg-surface3 px-4 py-3">
         {versions.length > 0 ? (
           <Combobox
             options={versionOptions}
@@ -153,7 +153,7 @@ export function AgentPlaygroundVersionBar({
             <button
               type="button"
               aria-label="Version information"
-              className="text-neutral3 hover:text-neutral5 transition-colors shrink-0 rounded-sm focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-white/30"
+              className="shrink-0 rounded-sm text-neutral3 transition-colors hover:text-neutral5 focus-visible:ring-1 focus-visible:ring-white/30 focus-visible:outline-hidden"
             >
               <Icon size="sm">
                 <Info />
@@ -167,14 +167,14 @@ export function AgentPlaygroundVersionBar({
           </PopoverContent>
         </HoverPopover>
 
-        <div className="flex items-center gap-2 ml-auto shrink-0">
+        <div className="ml-auto flex shrink-0 items-center gap-2">
           {readOnly && <Badge variant="warning">Read-only</Badge>}
           {!readOnly && hasDraft && !isCodeSourceAgent && <Badge variant="info">Unpublished</Badge>}
         </div>
       </div>
     ),
     actionBar: (
-      <div className="flex items-center justify-end px-3 py-2 border-t border-border1 bg-surface3">
+      <div className="flex items-center justify-end border-t border-border1 bg-surface3 px-3 py-2">
         {showCodeModeActions ? (
           <ButtonsGroup className="flex-wrap justify-end">
             <Button variant="default" size="md" onClick={() => void onDownloadJson?.()}>

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-view.tsx
@@ -104,7 +104,7 @@ function LeftPanel({
         </Txt>
       </div>
 
-      <div className="flex-1 min-h-0">
+      <div className="min-h-0 flex-1">
         <AgentPlaygroundConfig
           agentId={agentId}
           selectedVersionId={selectedVersionId}

--- a/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/dataset-detail-view.tsx
@@ -215,21 +215,21 @@ export function DatasetDetailView({
   ]);
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
-      <div className="p-4 border-b border-border1 space-y-3">
+      <div className="space-y-3 border-b border-border1 p-4">
         <div className="flex items-center justify-between">
           <div className="min-w-0">
-            <Txt variant="ui-sm" className="text-neutral5 font-medium block truncate">
+            <Txt variant="ui-sm" className="block truncate font-medium text-neutral5">
               {datasetName}
             </Txt>
             {datasetDescription && (
-              <Txt variant="ui-xs" className="text-neutral3 block mt-0.5 truncate">
+              <Txt variant="ui-xs" className="mt-0.5 block truncate text-neutral3">
                 {datasetDescription}
               </Txt>
             )}
             {datasetTags.length > 0 && (
-              <div className="flex flex-wrap gap-1 mt-1.5">
+              <div className="mt-1.5 flex flex-wrap gap-1">
                 {datasetTags.map(tag => (
                   <Chip key={tag} color={getTagColor(tag)} size="small">
                     {tag}
@@ -238,7 +238,7 @@ export function DatasetDetailView({
               </div>
             )}
           </div>
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex shrink-0 items-center gap-2">
             <Button variant="ghost" size="sm" onClick={onGenerate}>
               <Icon size="sm">
                 <Sparkles />
@@ -253,7 +253,7 @@ export function DatasetDetailView({
             >
               {isRunning ? (
                 <>
-                  <Spinner className="h-3 w-3" /> Running...
+                  <Spinner className="size-3" /> Running...
                 </>
               ) : (
                 <>
@@ -268,8 +268,8 @@ export function DatasetDetailView({
         </div>
         {/* Version selectors */}
         <div className="flex items-center gap-3">
-          <div className="flex-1 min-w-0">
-            <Txt variant="ui-xs" className="text-neutral3 mb-1 block">
+          <div className="min-w-0 flex-1">
+            <Txt variant="ui-xs" className="mb-1 block text-neutral3">
               Dataset version
             </Txt>
             <Combobox
@@ -288,8 +288,8 @@ export function DatasetDetailView({
             />
           </div>
           {isAgentTarget && (
-            <div className="flex-1 min-w-0">
-              <Txt variant="ui-xs" className="text-neutral3 mb-1 block">
+            <div className="min-w-0 flex-1">
+              <Txt variant="ui-xs" className="mb-1 block text-neutral3">
                 Agent version
               </Txt>
               <div className="flex items-center gap-1">
@@ -321,20 +321,20 @@ export function DatasetDetailView({
       </div>
 
       {/* Scorers + Items + Past runs */}
-      <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
-        <ScrollArea className="flex-1 min-h-0">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <ScrollArea className="min-h-0 flex-1">
           {/* Scorers section (collapsible) */}
           <div className="border-b border-border1">
             <div className="flex items-center justify-between">
               <button
                 type="button"
                 onClick={() => setScorersCollapsed(prev => !prev)}
-                className="flex-1 px-4 py-2 flex items-center gap-1 hover:bg-surface3 transition-colors"
+                className="flex flex-1 items-center gap-1 px-4 py-2 transition-colors hover:bg-surface3"
               >
                 <Icon size="sm" className="text-neutral3">
                   {scorersCollapsed ? <ChevronRight /> : <ChevronDown />}
                 </Icon>
-                <Txt variant="ui-xs" className="text-neutral3 font-semibold uppercase tracking-wider">
+                <Txt variant="ui-xs" className="font-semibold tracking-wider text-neutral3 uppercase">
                   Scorers ({attachedScorerEntries.length})
                 </Txt>
               </button>
@@ -348,7 +348,7 @@ export function DatasetDetailView({
             </div>
             {!scorersCollapsed &&
               (attachedScorerEntries.length === 0 ? (
-                <div className="px-4 py-4 text-center">
+                <div className="p-4 text-center">
                   <Txt variant="ui-xs" className="text-neutral3">
                     No scorers attached to this dataset.
                   </Txt>
@@ -367,16 +367,16 @@ export function DatasetDetailView({
                     return (
                       <div
                         key={id}
-                        className="flex items-center justify-between px-4 py-1.5 hover:bg-surface3 transition-colors group"
+                        className="group flex items-center justify-between px-4 py-1.5 transition-colors hover:bg-surface3"
                       >
-                        <Txt variant="ui-xs" className="text-neutral5 truncate">
+                        <Txt variant="ui-xs" className="truncate text-neutral5">
                           {name}
                         </Txt>
                         <button
                           type="button"
                           onClick={() => handleDetachScorer(id)}
                           aria-label={`Detach "${name}" from this dataset`}
-                          className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 transition-opacity text-neutral3 hover:text-red-500 p-0.5"
+                          className="p-0.5 text-neutral3 opacity-0 transition-opacity group-hover:opacity-100 hover:text-red-500 focus-visible:opacity-100"
                           title="Detach scorer"
                         >
                           <Icon size="sm">
@@ -395,12 +395,12 @@ export function DatasetDetailView({
             <button
               type="button"
               onClick={() => setItemsCollapsed(prev => !prev)}
-              className="w-full px-4 py-2 flex items-center gap-1 hover:bg-surface3 transition-colors"
+              className="flex w-full items-center gap-1 px-4 py-2 transition-colors hover:bg-surface3"
             >
               <Icon size="sm" className="text-neutral3">
                 {itemsCollapsed ? <ChevronRight /> : <ChevronDown />}
               </Icon>
-              <Txt variant="ui-xs" className="text-neutral3 font-semibold uppercase tracking-wider">
+              <Txt variant="ui-xs" className="font-semibold tracking-wider text-neutral3 uppercase">
                 Items ({items.length})
               </Txt>
             </button>
@@ -420,13 +420,13 @@ export function DatasetDetailView({
                         <button
                           type="button"
                           onClick={() => setExpandedItemId(isExpanded ? null : item.id)}
-                          className="w-full text-left px-4 py-2 hover:bg-surface3 transition-colors flex items-start gap-2"
+                          className="flex w-full items-start gap-2 px-4 py-2 text-left transition-colors hover:bg-surface3"
                         >
-                          <Icon size="sm" className="text-neutral3 mt-0.5 shrink-0">
+                          <Icon size="sm" className="mt-0.5 shrink-0 text-neutral3">
                             {isExpanded ? <ChevronDown /> : <ChevronRight />}
                           </Icon>
-                          <div className="flex-1 min-w-0 flex items-center gap-2">
-                            <Txt variant="ui-xs" className="text-neutral5 block truncate flex-1">
+                          <div className="flex min-w-0 flex-1 items-center gap-2">
+                            <Txt variant="ui-xs" className="block flex-1 truncate text-neutral5">
                               {truncateValue(item.input)}
                             </Txt>
                             {item.expectedTrajectory != null && (
@@ -443,7 +443,7 @@ export function DatasetDetailView({
                   <div ref={setEndOfListElement} />
                   {isFetchingNextPage && (
                     <div className="flex items-center justify-center py-2">
-                      <Spinner className="h-3 w-3" />
+                      <Spinner className="size-3" />
                     </div>
                   )}
                 </div>
@@ -455,7 +455,7 @@ export function DatasetDetailView({
             <button
               type="button"
               onClick={() => setRunsCollapsed(prev => !prev)}
-              className="w-full px-4 py-2 flex items-center gap-1 hover:bg-surface3 transition-colors"
+              className="flex w-full items-center gap-1 px-4 py-2 transition-colors hover:bg-surface3"
             >
               <Icon size="sm" className="text-neutral3">
                 {runsCollapsed ? <ChevronRight /> : <ChevronDown />}
@@ -463,13 +463,13 @@ export function DatasetDetailView({
               <Icon size="sm" className="text-neutral3">
                 <Clock />
               </Icon>
-              <Txt variant="ui-xs" className="text-neutral3 font-semibold uppercase tracking-wider">
+              <Txt variant="ui-xs" className="font-semibold tracking-wider text-neutral3 uppercase">
                 Past Runs ({datasetExperiments.length})
               </Txt>
             </button>
             {!runsCollapsed &&
               (datasetExperiments.length === 0 ? (
-                <div className="px-4 py-4 text-center">
+                <div className="p-4 text-center">
                   <Txt variant="ui-xs" className="text-neutral3">
                     No experiment runs yet
                   </Txt>
@@ -481,11 +481,11 @@ export function DatasetDetailView({
                       key={exp.id}
                       type="button"
                       onClick={() => onViewExperiment(exp.id)}
-                      className="w-full text-left px-4 py-2 hover:bg-surface3 transition-colors flex items-center gap-2"
+                      className="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-surface3"
                     >
                       <ExperimentStatusDot status={exp.status} />
-                      <div className="flex-1 min-w-0">
-                        <Txt variant="ui-xs" className="text-neutral5 block">
+                      <div className="min-w-0 flex-1">
+                        <Txt variant="ui-xs" className="block text-neutral5">
                           {exp.startedAt ? formatTimestamp(exp.startedAt) : 'Unknown'}
                         </Txt>
                         <Txt variant="ui-xs" className="text-neutral3">
@@ -523,7 +523,7 @@ export function DatasetDetailView({
           </DialogHeader>
           <DialogBody className="max-h-[50vh] overflow-y-auto">
             {unattachedScorerEntries.length === 0 ? (
-              <Txt variant="ui-sm" className="text-neutral3 py-4 text-center">
+              <Txt variant="ui-sm" className="py-4 text-center text-neutral3">
                 No scorers available to attach.
               </Txt>
             ) : (
@@ -533,7 +533,7 @@ export function DatasetDetailView({
                   placeholder="Search scorers..."
                   value={attachScorerSearch}
                   onChange={e => setAttachScorerSearch(e.target.value)}
-                  className="w-full px-3 py-1.5 text-sm rounded border border-border1 bg-surface2 text-text1 placeholder:text-neutral3 focus:outline-none focus:ring-1 focus:ring-accent1"
+                  className="w-full rounded border border-border1 bg-surface2 px-3 py-1.5 text-sm text-text1 placeholder:text-neutral3 focus:ring-1 focus:ring-accent1 focus:outline-none"
                 />
                 {unattachedScorerEntries
                   .filter(([id, scorer]) => {
@@ -547,7 +547,7 @@ export function DatasetDetailView({
                       <button
                         key={id}
                         type="button"
-                        className="w-full text-left px-3 py-2 rounded hover:bg-surface4 transition-colors"
+                        className="w-full rounded px-3 py-2 text-left transition-colors hover:bg-surface4"
                         onClick={async () => {
                           try {
                             await handleAttachScorer(id);
@@ -656,9 +656,9 @@ function ExpandedItemEditor({
 
   if (isEditing) {
     return (
-      <div className="px-4 pb-3 pl-10 space-y-2">
+      <div className="space-y-2 px-4 pb-3 pl-10">
         <div>
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Input
           </Txt>
           <Textarea
@@ -669,7 +669,7 @@ function ExpandedItemEditor({
           />
         </div>
         <div>
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Ground Truth
           </Txt>
           <Textarea
@@ -681,7 +681,7 @@ function ExpandedItemEditor({
           />
         </div>
         <div>
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Expected Trajectory (JSON)
           </Txt>
           <Textarea
@@ -695,7 +695,7 @@ function ExpandedItemEditor({
         <div className="flex items-center gap-2 pt-1">
           <Button variant="primary" size="sm" onClick={handleSave} disabled={updateItem.isPending}>
             {updateItem.isPending ? (
-              <Spinner className="h-3 w-3" />
+              <Spinner className="size-3" />
             ) : (
               <Icon size="sm">
                 <Save />
@@ -715,31 +715,31 @@ function ExpandedItemEditor({
   }
 
   return (
-    <div className="px-4 pb-3 pl-10 space-y-2">
+    <div className="space-y-2 px-4 pb-3 pl-10">
       <div>
-        <Txt variant="ui-xs" className="text-neutral3 font-medium">
+        <Txt variant="ui-xs" className="font-medium text-neutral3">
           Input
         </Txt>
-        <pre className="text-xs text-neutral5 bg-surface1 rounded px-2 py-1.5 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-48 overflow-y-auto mt-1">
+        <pre className="mt-1 max-h-48 overflow-auto rounded bg-surface1 px-2 py-1.5 text-xs wrap-break-word whitespace-pre-wrap text-neutral5">
           {formatValue(item.input)}
         </pre>
       </div>
       {item.groundTruth !== undefined && item.groundTruth !== null && (
         <div>
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Ground Truth
           </Txt>
-          <pre className="text-xs text-neutral5 bg-surface1 rounded px-2 py-1.5 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-48 overflow-y-auto mt-1">
+          <pre className="mt-1 max-h-48 overflow-auto rounded bg-surface1 px-2 py-1.5 text-xs wrap-break-word whitespace-pre-wrap text-neutral5">
             {formatValue(item.groundTruth)}
           </pre>
         </div>
       )}
       {item.expectedTrajectory != null && (
         <div>
-          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+          <Txt variant="ui-xs" className="font-medium text-neutral3">
             Expected Trajectory
           </Txt>
-          <pre className="text-xs text-neutral5 bg-surface1 rounded px-2 py-1.5 overflow-x-auto whitespace-pre-wrap break-words max-h-48 overflow-y-auto mt-1">
+          <pre className="mt-1 max-h-48 overflow-auto rounded bg-surface1 px-2 py-1.5 text-xs break-words whitespace-pre-wrap text-neutral5">
             {formatValue(item.expectedTrajectory)}
           </pre>
         </div>
@@ -753,7 +753,7 @@ function ExpandedItemEditor({
         </Button>
         {isConfirmingDelete ? (
           <>
-            <Txt variant="ui-xs" className="text-negative1 font-medium">
+            <Txt variant="ui-xs" className="font-medium text-negative1">
               Delete this item?
             </Txt>
             <Button
@@ -763,7 +763,7 @@ function ExpandedItemEditor({
               disabled={deleteItem.isPending}
               className="text-negative1 hover:text-negative1"
             >
-              {deleteItem.isPending ? <Spinner className="h-3 w-3" /> : 'Yes'}
+              {deleteItem.isPending ? <Spinner className="size-3" /> : 'Yes'}
             </Button>
             <Button variant="ghost" size="sm" onClick={() => setIsConfirmingDelete(false)}>
               No
@@ -804,5 +804,5 @@ function ExperimentStatusDot({ status }: { status: string }) {
         : status === 'failed'
           ? 'bg-negative1'
           : 'bg-neutral3';
-  return <div className={cn('w-2 h-2 rounded-full shrink-0', color)} />;
+  return <div className={cn('size-2 shrink-0 rounded-full', color)} />;
 }

--- a/packages/playground/src/domains/agents/components/agent-playground/scorer-detail-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/scorer-detail-view.tsx
@@ -33,7 +33,7 @@ export function ScorerDetailView({
 }: ScorerDetailViewProps) {
   if (!scorerData) {
     return (
-      <div className="flex items-center justify-center h-full">
+      <div className="flex h-full items-center justify-center">
         <Txt variant="ui-sm" className="text-neutral3">
           Scorer not found
         </Txt>
@@ -47,13 +47,13 @@ export function ScorerDetailView({
   const isTrajectory = scorerData.scorer?.config?.type === 'trajectory';
 
   return (
-    <div className="flex flex-col h-full overflow-hidden">
+    <div className="flex h-full flex-col overflow-hidden">
       {/* Header */}
-      <div className="p-4 border-b border-border1 space-y-3">
+      <div className="space-y-3 border-b border-border1 p-4">
         <div className="flex items-center justify-between">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <Txt variant="ui-sm" className="text-neutral5 font-medium truncate">
+              <Txt variant="ui-sm" className="truncate font-medium text-neutral5">
                 {name}
               </Txt>
               {isTrajectory && (
@@ -68,12 +68,12 @@ export function ScorerDetailView({
               )}
             </div>
             {description && (
-              <Txt variant="ui-xs" className="text-neutral3 block mt-1">
+              <Txt variant="ui-xs" className="mt-1 block text-neutral3">
                 {description}
               </Txt>
             )}
           </div>
-          <div className="flex items-center gap-3 shrink-0">
+          <div className="flex shrink-0 items-center gap-3">
             {!isCode && (
               <Button variant="ghost" size="sm" onClick={onEdit}>
                 <Icon size="sm">
@@ -86,12 +86,12 @@ export function ScorerDetailView({
         </div>
 
         {/* Attach toggle */}
-        <div className="flex items-center justify-between py-2 px-3 bg-surface3 rounded-md">
+        <div className="flex items-center justify-between rounded-md bg-surface3 px-3 py-2">
           <div>
-            <Txt variant="ui-xs" className="text-neutral5 block">
+            <Txt variant="ui-xs" className="block text-neutral5">
               Run in experiments
             </Txt>
-            <Txt variant="ui-xs" className="text-neutral3 block mt-0.5">
+            <Txt variant="ui-xs" className="mt-0.5 block text-neutral3">
               When enabled, this scorer grades results for this agent
             </Txt>
           </div>
@@ -100,9 +100,9 @@ export function ScorerDetailView({
       </div>
 
       {/* Details */}
-      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+      <div className="flex-1 space-y-4 overflow-y-auto p-4">
         <div>
-          <Txt variant="ui-xs" className="text-neutral3 font-medium uppercase tracking-wider block mb-2">
+          <Txt variant="ui-xs" className="mb-2 block font-medium tracking-wider text-neutral3 uppercase">
             Details
           </Txt>
           <div className="space-y-2">
@@ -120,7 +120,7 @@ export function ScorerDetailView({
 
         {linkedDatasets && linkedDatasets.length > 0 && (
           <div>
-            <Txt variant="ui-xs" className="text-neutral3 font-medium uppercase tracking-wider block mb-2">
+            <Txt variant="ui-xs" className="mb-2 block font-medium tracking-wider text-neutral3 uppercase">
               Datasets
             </Txt>
             <div className="space-y-1">
@@ -129,14 +129,14 @@ export function ScorerDetailView({
                   <button
                     key={ds.id}
                     onClick={() => onViewDataset(ds.id)}
-                    className="w-full text-left px-3 py-2 rounded-md bg-surface3 hover:bg-surface4 transition-colors cursor-pointer"
+                    className="w-full cursor-pointer rounded-md bg-surface3 px-3 py-2 text-left transition-colors hover:bg-surface4"
                   >
                     <Txt variant="ui-xs" className="text-neutral5">
                       {ds.name}
                     </Txt>
                   </button>
                 ) : (
-                  <div key={ds.id} className="px-3 py-2 rounded-md bg-surface3">
+                  <div key={ds.id} className="rounded-md bg-surface3 px-3 py-2">
                     <Txt variant="ui-xs" className="text-neutral5">
                       {ds.name}
                     </Txt>
@@ -148,7 +148,7 @@ export function ScorerDetailView({
         )}
 
         {isCode && (
-          <div className="p-3 bg-surface3 rounded-md">
+          <div className="rounded-md bg-surface3 p-3">
             <Txt variant="ui-xs" className="text-neutral3">
               This scorer is defined in code and cannot be edited in the UI. You can toggle whether it runs in
               experiments for this agent.
@@ -163,10 +163,10 @@ export function ScorerDetailView({
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex items-start gap-2">
-      <Txt variant="ui-xs" className="text-neutral3 w-24 shrink-0">
+      <Txt variant="ui-xs" className="w-24 shrink-0 text-neutral3">
         {label}
       </Txt>
-      <Txt variant="ui-xs" className="text-neutral5 break-all">
+      <Txt variant="ui-xs" className="break-all text-neutral5">
         {value}
       </Txt>
     </div>

--- a/packages/playground/src/domains/agents/components/agent-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/agent-run-options.tsx
@@ -14,7 +14,7 @@ const RUN_OPTIONS_EDITOR_HEIGHT = 'h-[260px] md:h-[360px]';
 export function AgentRunOptionsContent({ requestContextSchema }: AgentRunOptionsContentProps) {
   return (
     <ScrollArea className="w-full" maxHeight="min(600px, calc(100dvh - 8rem))">
-      <div className="p-4 space-y-4">
+      <div className="space-y-4 p-4">
         <Txt as="h3" variant="ui-md" className="text-neutral3">
           Run options
         </Txt>
@@ -29,12 +29,7 @@ export function AgentRunOptionsContent({ requestContextSchema }: AgentRunOptions
           </section>
 
           <section className="min-w-0">
-            <TracingRunOptions
-              className="px-0 py-0"
-              editorClassName={RUN_OPTIONS_EDITOR_HEIGHT}
-              hideTitle
-              showEditorHeader
-            />
+            <TracingRunOptions className="p-0" editorClassName={RUN_OPTIONS_EDITOR_HEIGHT} hideTitle showEditorHeader />
           </section>
         </div>
       </div>

--- a/packages/playground/src/domains/agents/components/agent-settings/agent-memory-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-settings/agent-memory-config.tsx
@@ -61,12 +61,12 @@ function MemoryConfigValue({ value, badge }: { value: MemoryConfigItemValue; bad
     return (
       <span
         className={cn(
-          'text-xs font-medium px-2 py-0.5 rounded',
+          'rounded px-2 py-0.5 text-xs font-medium',
           value
             ? badge === 'info'
-              ? 'dark:bg-blue-500/20 dark:text-blue-400 bg-blue-500/10 text-blue-600'
-              : 'dark:bg-green-500/20 dark:text-green-400 bg-green-500/10 text-green-600'
-            : 'dark:bg-red-500/20 dark:text-red-400 bg-red-500/10 text-red-600',
+              ? 'bg-blue-500/10 text-blue-600 dark:bg-blue-500/20 dark:text-blue-400'
+              : 'bg-green-500/10 text-green-600 dark:bg-green-500/20 dark:text-green-400'
+            : 'bg-red-500/10 text-red-600 dark:bg-red-500/20 dark:text-red-400',
         )}
       >
         {value ? 'Yes' : 'No'}
@@ -75,7 +75,7 @@ function MemoryConfigValue({ value, badge }: { value: MemoryConfigItemValue; bad
   }
 
   if (badge) {
-    return <span className={cn('text-xs font-medium px-2 py-0.5 rounded', badgeColors[badge])}>{value}</span>;
+    return <span className={cn('rounded px-2 py-0.5 text-xs font-medium', badgeColors[badge])}>{value}</span>;
   }
 
   return <span className="text-xs text-neutral3">{value}</span>;
@@ -191,7 +191,7 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
   if (!config || configSections.length === 0) {
     return (
       <div className="p-4">
-        <h3 className="text-sm font-medium text-neutral5 mb-3">Memory Configuration</h3>
+        <h3 className="mb-3 text-sm font-medium text-neutral5">Memory Configuration</h3>
         <p className="text-xs text-neutral3">No memory configuration available</p>
       </div>
     );
@@ -199,24 +199,24 @@ export const AgentMemoryConfig = ({ agentId }: AgentMemoryConfigProps) => {
 
   return (
     <div className="p-4">
-      <h3 className="text-sm font-medium text-neutral5 mb-3">Memory Configuration</h3>
+      <h3 className="mb-3 text-sm font-medium text-neutral5">Memory Configuration</h3>
       <div className="space-y-2">
         {configSections.map(section => (
-          <div key={section.title} className="border border-border1 rounded-lg bg-surface3">
+          <div key={section.title} className="rounded-lg border border-border1 bg-surface3">
             <button
               type="button"
               onClick={() => toggleSection(section.title)}
-              className="w-full px-3 py-2 flex items-center justify-between hover:bg-surface4 transition-colors rounded-t-lg"
+              className="flex w-full items-center justify-between rounded-t-lg px-3 py-2 transition-colors hover:bg-surface4"
             >
               <span className="text-xs font-medium text-neutral5">{section.title}</span>
               {expandedSections.has(section.title) ? (
-                <ChevronDown className="w-3 h-3 text-neutral3" />
+                <ChevronDown className="size-3 text-neutral3" />
               ) : (
-                <ChevronRight className="w-3 h-3 text-neutral3" />
+                <ChevronRight className="size-3 text-neutral3" />
               )}
             </button>
             {expandedSections.has(section.title) && (
-              <div className="px-3 pb-2 space-y-1">
+              <div className="space-y-1 px-3 pb-2">
                 {section.items.map(item => (
                   <div key={`${section.title}-${item.label}`} className="flex items-center justify-between py-1">
                     <span className="text-xs text-neutral3">{item.label}</span>

--- a/packages/playground/src/domains/agents/components/agent-settings/agent-settings-view.tsx
+++ b/packages/playground/src/domains/agents/components/agent-settings/agent-settings-view.tsx
@@ -33,11 +33,11 @@ export function AgentSettingsView({ agentId }: AgentSettingsViewProps) {
 
   return (
     <div
-      className="h-full w-full min-w-0"
+      className="size-full min-w-0"
       data-testid="agent-settings-view"
       style={{ viewTransitionName: 'agent-settings-view' }}
     >
-      <ScrollArea className="h-full w-full" viewPortClassName="h-full" mask={{ top: false }}>
+      <ScrollArea className="size-full" viewPortClassName="h-full" mask={{ top: false }}>
         <Tabs value={selectedTab} defaultTab="overview" onValueChange={handleTabChange}>
           <div className="sticky top-0 z-10 px-3 py-1.5">
             <TabList variant="pill-ghost">

--- a/packages/playground/src/domains/agents/components/agent-version-panel.tsx
+++ b/packages/playground/src/domains/agents/components/agent-version-panel.tsx
@@ -39,14 +39,14 @@ export function AgentVersionPanel({
   const activeVersionNumber = activeVersion?.versionNumber;
 
   return (
-    <div className="h-full flex flex-col">
-      <div className="px-3 py-3 border-b border-border1">
+    <div className="flex h-full flex-col">
+      <div className="border-b border-border1 p-3">
         <Txt variant="ui-sm" className="font-medium text-neutral5">
           Version history
         </Txt>
       </div>
 
-      <ScrollArea className="flex-1 min-h-0">
+      <ScrollArea className="min-h-0 flex-1">
         {isLoading ? (
           <div className="px-3 py-4">
             <Txt variant="ui-xs" className="text-neutral2">
@@ -67,9 +67,9 @@ export function AgentVersionPanel({
                     type="button"
                     onClick={() => onVersionSelect(version.id)}
                     className={cn(
-                      'w-full text-left px-3 py-2.5 text-sm transition-colors border-l-2',
+                      'w-full border-l-2 px-3 py-2.5 text-left text-sm transition-colors',
                       isSelected
-                        ? 'bg-surface2 text-neutral5 border-accent1'
+                        ? 'border-accent1 bg-surface2 text-neutral5'
                         : 'border-transparent text-neutral3 hover:bg-surface3 hover:text-neutral5',
                     )}
                   >
@@ -80,7 +80,7 @@ export function AgentVersionPanel({
                       {isPublished && <Badge variant="success">Published</Badge>}
                       {isDraft && <Badge variant="info">Draft</Badge>}
                     </div>
-                    <Txt variant="ui-xs" className="text-neutral2 mt-0.5">
+                    <Txt variant="ui-xs" className="mt-0.5 text-neutral2">
                       {formatTimestamp(version.createdAt)}
                     </Txt>
                   </button>

--- a/packages/playground/src/domains/agents/components/agent-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-view-header.tsx
@@ -52,7 +52,7 @@ export function AgentViewHeader({ agentId, view }: AgentViewHeaderProps) {
         className="flex items-center justify-between gap-2 pr-3 max-lg:py-2"
         style={{ viewTransitionName: 'agent-view-header' }}
       >
-        <div className="flex-1 min-w-0 max-lg:hidden">
+        <div className="min-w-0 flex-1 max-lg:hidden">
           <AgentEntityHeader agentId={agentId} />
         </div>
         <div className="ml-auto flex shrink-0 items-center gap-2">
@@ -72,19 +72,19 @@ export function AgentViewHeader({ agentId, view }: AgentViewHeaderProps) {
             data-testid="agent-entity-header-share"
           >
             {isShareCopied ? (
-              <Check className="h-4 w-4 text-neutral3" />
+              <Check className="size-4 text-neutral3" />
             ) : (
-              <LinkIcon className="h-4 w-4 text-neutral3 hover:text-neutral6" />
+              <LinkIcon className="size-4 text-neutral3 hover:text-neutral6" />
             )}
           </Button>
           <Button variant="default" type="button" onClick={handleToggle} data-testid="agent-view-header-toggle">
             {view === 'chat' ? (
               <>
-                <SlidersHorizontal className="h-4 w-4 text-neutral3" /> Settings
+                <SlidersHorizontal className="size-4 text-neutral3" /> Settings
               </>
             ) : (
               <>
-                <X className="h-4 w-4 text-neutral3" /> Close
+                <X className="size-4 text-neutral3" /> Close
               </>
             )}
           </Button>

--- a/packages/playground/src/domains/agents/components/browser-view/agent-busy-overlay.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/agent-busy-overlay.tsx
@@ -37,9 +37,9 @@ export function AgentBusyOverlay({ toolName }: AgentBusyOverlayProps) {
     : 'Working';
 
   return (
-    <div className="absolute inset-0 bg-surface1/40 flex items-center justify-center z-10 cursor-not-allowed">
-      <div className="flex items-center gap-2 bg-surface2 px-3 py-1.5 rounded-md border border-border1 shadow-sm">
-        <Loader2 className="h-3.5 w-3.5 text-accent1 animate-spin" />
+    <div className="absolute inset-0 z-10 flex cursor-not-allowed items-center justify-center bg-surface1/40">
+      <div className="flex items-center gap-2 rounded-md border border-border1 bg-surface2 px-3 py-1.5 shadow-sm">
+        <Loader2 className="size-3.5 animate-spin text-accent1" />
         <span className="text-xs font-medium text-neutral4">Agent: {displayName}</span>
       </div>
     </div>

--- a/packages/playground/src/domains/agents/components/browser-view/browser-thumbnail.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-thumbnail.tsx
@@ -90,7 +90,7 @@ export function BrowserThumbnail({ agentName = 'Agent' }: BrowserThumbnailProps)
   return (
     <div
       className={cn(
-        'bg-surface2 border border-border1 rounded-3xl overflow-hidden transition-all duration-200',
+        'overflow-hidden rounded-3xl border border-border1 bg-surface2 transition-all duration-200',
         'hover:border-border2',
       )}
     >
@@ -99,38 +99,38 @@ export function BrowserThumbnail({ agentName = 'Agent' }: BrowserThumbnailProps)
         type="button"
         onClick={handleToggleExpand}
         className={cn(
-          'group flex items-center gap-3 w-full px-4 py-3',
-          'hover:bg-surface3 transition-colors',
-          'focus:outline-none focus:ring-2 focus:ring-accent1 focus:ring-inset',
+          'group flex w-full items-center gap-3 px-4 py-3',
+          'transition-colors hover:bg-surface3',
+          'focus:ring-2 focus:ring-accent1 focus:outline-none focus:ring-inset',
         )}
       >
         {/* Thumbnail preview */}
-        <div className="relative shrink-0 w-24 h-14 bg-surface3 rounded-md overflow-hidden border border-border1">
+        <div className="relative h-14 w-24 shrink-0 overflow-hidden rounded-md border border-border1 bg-surface3">
           {hasFrame ? (
-            <img ref={imgRef} alt="Browser preview" className="w-full h-full object-cover" />
+            <img ref={imgRef} alt="Browser preview" className="size-full object-cover" />
           ) : (
-            <div className="flex items-center justify-center w-full h-full">
-              <Monitor className="h-5 w-5 text-neutral3" />
+            <div className="flex size-full items-center justify-center">
+              <Monitor className="size-5 text-neutral3" />
             </div>
           )}
           {/* Live indicator dot */}
-          {isLive && <div className="absolute top-1 right-1 w-2 h-2 bg-success rounded-full animate-pulse" />}
+          {isLive && <div className="bg-success absolute top-1 right-1 size-2 animate-pulse rounded-full" />}
         </div>
 
         {/* Info section */}
-        <div className="flex-1 min-w-0 text-left">
+        <div className="min-w-0 flex-1 text-left">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-medium text-neutral6 truncate">{agentName}&apos;s browser</span>
+            <span className="truncate text-sm font-medium text-neutral6">{agentName}&apos;s browser</span>
             <StatusBadge variant={isLive ? 'success' : 'neutral'} size="sm" withDot pulse={isLive}>
               {isLive ? 'Live' : 'Idle'}
             </StatusBadge>
           </div>
-          <p className="text-xs text-neutral4 truncate mt-0.5">{displayUrl}</p>
+          <p className="mt-0.5 truncate text-xs text-neutral4">{displayUrl}</p>
         </div>
 
         {/* Expand/collapse indicator */}
-        <div className="shrink-0 text-neutral4 group-hover:text-neutral5 transition-colors">
-          {isExpanded ? <ChevronDown className="h-5 w-5" /> : <ChevronUp className="h-5 w-5" />}
+        <div className="shrink-0 text-neutral4 transition-colors group-hover:text-neutral5">
+          {isExpanded ? <ChevronDown className="size-5" /> : <ChevronUp className="size-5" />}
         </div>
       </button>
 
@@ -150,7 +150,7 @@ export function BrowserThumbnail({ agentName = 'Agent' }: BrowserThumbnailProps)
                   onClick={handleOpenModal}
                   className="bg-surface1/80 backdrop-blur-sm"
                 >
-                  <Maximize2 className="h-3.5 w-3.5" />
+                  <Maximize2 className="size-3.5" />
                 </Button>
                 <Button
                   variant="default"
@@ -159,7 +159,7 @@ export function BrowserThumbnail({ agentName = 'Agent' }: BrowserThumbnailProps)
                   onClick={handleClose}
                   className="bg-surface1/80 backdrop-blur-sm"
                 >
-                  <X className="h-3.5 w-3.5" />
+                  <X className="size-3.5" />
                 </Button>
               </div>
             </div>
@@ -167,9 +167,9 @@ export function BrowserThumbnail({ agentName = 'Agent' }: BrowserThumbnailProps)
 
           {/* Browser actions (scrollable, max height) */}
           {toolCalls.length > 0 && (
-            <div ref={actionsRef} className="border-t border-border1 max-h-40 overflow-y-auto">
+            <div ref={actionsRef} className="max-h-40 overflow-y-auto border-t border-border1">
               <div className="px-3 py-2">
-                <h4 className="text-xs font-medium text-neutral4 mb-2">Browser Actions</h4>
+                <h4 className="mb-2 text-xs font-medium text-neutral4">Browser Actions</h4>
                 <div className="space-y-1">
                   {toolCalls.slice(-5).map(entry => (
                     <BrowserToolCallItem key={entry.toolCallId} entry={entry} />

--- a/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-history.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-history.tsx
@@ -32,9 +32,9 @@ export function BrowserToolCallHistory({ className }: BrowserToolCallHistoryProp
         type="button"
         onClick={() => setIsExpanded(prev => !prev)}
         aria-expanded={isExpanded}
-        className="flex items-center gap-2 w-full px-3 py-1 text-left hover:bg-surface3 transition-colors shrink-0"
+        className="flex w-full shrink-0 items-center gap-2 px-3 py-1 text-left transition-colors hover:bg-surface3"
       >
-        <ChevronDown className={cn('h-3.5 w-3.5 text-neutral3 transition-transform', isExpanded ? 'rotate-180' : '')} />
+        <ChevronDown className={cn('size-3.5 text-neutral3 transition-transform', isExpanded ? 'rotate-180' : '')} />
         <span className="text-xs font-medium text-neutral4">Browser Actions ({toolCalls.length})</span>
       </button>
 

--- a/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-item.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-tool-call-item.tsx
@@ -90,31 +90,29 @@ export function BrowserToolCallItem({ entry }: BrowserToolCallItemProps) {
         type="button"
         onClick={() => setIsExpanded(prev => !prev)}
         aria-expanded={isExpanded}
-        className="flex items-center gap-2 w-full px-3 py-0.5 text-left hover:bg-surface3 transition-colors"
+        className="flex w-full items-center gap-2 px-3 py-0.5 text-left transition-colors hover:bg-surface3"
       >
-        <ChevronRight
-          className={cn('h-3 w-3 text-neutral3 transition-transform shrink-0', isExpanded && 'rotate-90')}
-        />
+        <ChevronRight className={cn('size-3 shrink-0 text-neutral3 transition-transform', isExpanded && 'rotate-90')} />
 
         <StatusDot status={entry.status} />
 
-        <span className="text-xs font-medium text-neutral6 shrink-0">{displayName}</span>
+        <span className="shrink-0 text-xs font-medium text-neutral6">{displayName}</span>
 
-        {keyArg && <span className="text-xs text-neutral3 truncate">{keyArg}</span>}
+        {keyArg && <span className="truncate text-xs text-neutral3">{keyArg}</span>}
       </button>
 
       {isExpanded && (
-        <div className="px-3 pb-2 space-y-2">
+        <div className="space-y-2 px-3 pb-2">
           <div>
-            <p className="text-xs font-medium text-neutral4 pb-1">Arguments</p>
+            <p className="pb-1 text-xs font-medium text-neutral4">Arguments</p>
             <CodeEditor data={displayArgs} data-testid="browser-tool-args" />
           </div>
 
           {entry.result !== undefined && entry.result !== null && (
             <div>
-              <p className="text-xs font-medium text-neutral4 pb-1">Result</p>
+              <p className="pb-1 text-xs font-medium text-neutral4">Result</p>
               {typeof entry.result === 'string' ? (
-                <pre className="whitespace-pre text-xs bg-surface4 p-2 rounded-md overflow-x-auto max-h-40 overflow-y-auto">
+                <pre className="max-h-40 overflow-auto rounded-md bg-surface4 p-2 text-xs whitespace-pre">
                   {entry.result}
                 </pre>
               ) : (
@@ -134,10 +132,10 @@ export function BrowserToolCallItem({ entry }: BrowserToolCallItemProps) {
 function StatusDot({ status }: { status: BrowserToolCallEntry['status'] }) {
   switch (status) {
     case 'pending':
-      return <Loader2 className="h-3 w-3 text-neutral4 animate-spin shrink-0" />;
+      return <Loader2 className="size-3 shrink-0 animate-spin text-neutral4" />;
     case 'complete':
-      return <Check className="h-3 w-3 text-green-500 shrink-0" />;
+      return <Check className="size-3 shrink-0 text-green-500" />;
     case 'error':
-      return <X className="h-3 w-3 text-red-500 shrink-0" />;
+      return <X className="size-3 shrink-0 text-red-500" />;
   }
 }

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-frame.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-frame.tsx
@@ -130,7 +130,7 @@ export function BrowserViewFrame({ className, onStatusChange, onUrlChange, onFir
     <div
       ref={containerRef}
       className={cn(
-        'relative w-full aspect-video bg-surface2 rounded-md overflow-hidden',
+        'relative aspect-video w-full overflow-hidden rounded-md bg-surface2',
         isInteractive && !isAgentBusy && 'ring-2 ring-accent1',
         isInteractive && isAgentBusy && 'ring-2 ring-amber-400',
         className,
@@ -150,7 +150,7 @@ export function BrowserViewFrame({ className, onStatusChange, onUrlChange, onFir
         tabIndex={status === 'streaming' ? 0 : -1}
         role="button"
         className={cn(
-          'absolute inset-0 w-full h-full object-contain',
+          'absolute inset-0 size-full object-contain',
           hasFrame ? 'opacity-100' : 'opacity-0',
           status === 'streaming' && (isInteractive ? 'cursor-text' : 'cursor-pointer'),
         )}
@@ -167,9 +167,9 @@ export function BrowserViewFrame({ className, onStatusChange, onUrlChange, onFir
 
       {/* Reconnecting overlay - shown over last frame */}
       {isReconnecting && (
-        <div className="absolute inset-0 bg-surface1/80 flex items-center justify-center">
+        <div className="absolute inset-0 flex items-center justify-center bg-surface1/80">
           <div className="flex flex-col items-center gap-2">
-            <div className="w-4 h-4 border-2 border-neutral4 border-t-transparent rounded-full animate-spin" />
+            <div className="size-4 animate-spin rounded-full border-2 border-neutral4 border-t-transparent" />
             <span className="text-sm text-neutral4">Reconnecting...</span>
           </div>
         </div>
@@ -177,11 +177,11 @@ export function BrowserViewFrame({ className, onStatusChange, onUrlChange, onFir
 
       {/* Error overlay */}
       {hasError && (
-        <div className="absolute inset-0 z-50 bg-black/70 backdrop-blur-sm flex items-center justify-center">
+        <div className="absolute inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
           <div className="flex flex-col items-center gap-3 px-6 py-4 text-center">
-            <div className="w-14 h-14 rounded-full bg-red-500/20 flex items-center justify-center">
+            <div className="flex size-14 items-center justify-center rounded-full bg-red-500/20">
               <svg
-                className="w-7 h-7 text-red-400"
+                className="size-7 text-red-400"
                 fill="none"
                 viewBox="0 0 24 24"
                 stroke="currentColor"

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-header.tsx
@@ -60,14 +60,14 @@ export function BrowserViewHeader({
   return (
     <div
       className={cn(
-        'flex items-center justify-between px-3 py-2 border-b border-border1 bg-surface1',
+        'flex items-center justify-between border-b border-border1 bg-surface1 px-3 py-2',
         isCollapsed ? 'rounded-md' : 'rounded-t-md',
         className,
       )}
     >
       {/* URL display */}
-      <div className="flex-1 min-w-0 mr-3">
-        <span className={cn('text-sm text-neutral4 truncate block', !url && 'text-neutral3 italic')}>
+      <div className="mr-3 min-w-0 flex-1">
+        <span className={cn('block truncate text-sm text-neutral4', !url && 'text-neutral3 italic')}>
           {url || 'No URL'}
         </span>
       </div>
@@ -82,10 +82,10 @@ export function BrowserViewHeader({
         {onTuck && (
           <button
             onClick={onTuck}
-            className="p-1 rounded hover:bg-surface3 text-neutral3 hover:text-neutral6 transition-colors"
+            className="rounded p-1 text-neutral3 transition-colors hover:bg-surface3 hover:text-neutral6"
             title="Minimize to pill"
           >
-            <Minus className="h-4 w-4" />
+            <Minus className="size-4" />
           </button>
         )}
 
@@ -93,10 +93,10 @@ export function BrowserViewHeader({
         {onToggleCollapse && (
           <button
             onClick={onToggleCollapse}
-            className="p-1 rounded hover:bg-surface3 text-neutral3 hover:text-neutral6 transition-colors"
+            className="rounded p-1 text-neutral3 transition-colors hover:bg-surface3 hover:text-neutral6"
             title={isCollapsed ? 'Expand browser view' : 'Minimize browser view'}
           >
-            {isCollapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+            {isCollapsed ? <ChevronDown className="size-4" /> : <ChevronUp className="size-4" />}
           </button>
         )}
 
@@ -104,10 +104,10 @@ export function BrowserViewHeader({
         {onClose && (
           <button
             onClick={onClose}
-            className="p-1 rounded hover:bg-surface3 text-neutral3 hover:text-neutral6 transition-colors"
+            className="rounded p-1 text-neutral3 transition-colors hover:bg-surface3 hover:text-neutral6"
             title="Close browser session"
           >
-            <X className="h-4 w-4" />
+            <X className="size-4" />
           </button>
         )}
       </div>

--- a/packages/playground/src/domains/agents/components/browser-view/browser-view-panel.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/browser-view-panel.tsx
@@ -99,7 +99,7 @@ export function BrowserViewPanel() {
       className={cn(
         'fixed inset-0 z-50 flex items-center justify-center p-8',
         'bg-black/60 backdrop-blur-sm transition-opacity duration-200',
-        isModal ? 'opacity-100' : 'opacity-0 pointer-events-none',
+        isModal ? 'opacity-100' : 'pointer-events-none opacity-0',
       )}
       onClick={handleBackdropClick}
       aria-hidden={!isModal}
@@ -111,35 +111,35 @@ export function BrowserViewPanel() {
         aria-label="Browser view"
         tabIndex={-1}
         className={cn(
-          'flex flex-col w-full max-w-5xl max-h-full',
-          'bg-surface2 rounded-xl border border-border1 shadow-2xl overflow-hidden',
+          'flex max-h-full w-full max-w-5xl flex-col',
+          'overflow-hidden rounded-xl border border-border1 bg-surface2 shadow-2xl',
           'transition-transform duration-200 outline-none',
           isModal ? 'scale-100' : 'scale-95',
         )}
         onClick={e => e.stopPropagation()}
       >
         {/* Header with URL bar and controls */}
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-border1 shrink-0">
-          <Globe className="h-4 w-4 text-neutral4 shrink-0" />
-          <div className="flex-1 min-w-0 px-3 py-1.5 bg-surface3 rounded-md border border-border1">
-            <span className={cn('text-sm truncate block', currentUrl ? 'text-neutral5' : 'text-neutral3 italic')}>
+        <div className="flex shrink-0 items-center gap-3 border-b border-border1 px-4 py-3">
+          <Globe className="size-4 shrink-0 text-neutral4" />
+          <div className="min-w-0 flex-1 rounded-md border border-border1 bg-surface3 px-3 py-1.5">
+            <span className={cn('block truncate text-sm', currentUrl ? 'text-neutral5' : 'text-neutral3 italic')}>
               {currentUrl || 'No URL'}
             </span>
           </div>
           <StatusBadge variant={statusConfig.variant} size="sm" withDot pulse={statusConfig.pulse}>
             {statusConfig.label}
           </StatusBadge>
-          <div className="flex items-center gap-1 ml-2">
+          <div className="ml-2 flex items-center gap-1">
             <Button variant="ghost" size="icon-sm" tooltip="Minimize to chat" onClick={hide}>
-              <Minimize2 className="h-4 w-4" />
+              <Minimize2 className="size-4" />
             </Button>
             {currentUrl && (
               <Button variant="ghost" size="icon-sm" tooltip="Open in new tab" onClick={handleOpenExternal}>
-                <ExternalLink className="h-4 w-4" />
+                <ExternalLink className="size-4" />
               </Button>
             )}
             <Button variant="ghost" size="icon-sm" tooltip="Close browser" onClick={closeBrowser}>
-              <X className="h-4 w-4" />
+              <X className="size-4" />
             </Button>
           </div>
         </div>
@@ -148,7 +148,7 @@ export function BrowserViewPanel() {
         <div className="flex-1 overflow-y-auto">
           {/* Screencast */}
           <div className="p-4">
-            <BrowserViewFrame className="w-full max-h-[60vh]" />
+            <BrowserViewFrame className="max-h-[60vh] w-full" />
           </div>
 
           {/* Browser actions history */}

--- a/packages/playground/src/domains/agents/components/browser-view/click-ripple-overlay.tsx
+++ b/packages/playground/src/domains/agents/components/browser-view/click-ripple-overlay.tsx
@@ -27,7 +27,7 @@ export function ClickRippleOverlay({ ripples, onAnimationEnd }: ClickRippleOverl
       {ripples.map(ripple => (
         <span
           key={ripple.id}
-          className="absolute rounded-full pointer-events-none animate-click-ripple bg-accent1/40"
+          className="animate-click-ripple pointer-events-none absolute rounded-full bg-accent1/40"
           style={{
             left: ripple.x - RIPPLE_RADIUS,
             top: ripple.y - RIPPLE_RADIUS,

--- a/packages/playground/src/domains/agents/components/composer-model-settings.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-settings.tsx
@@ -38,7 +38,7 @@ const NetworkRadio = ({ hasMemory, hasSubAgents, disabled }: NetworkRadioProps) 
     <div className="flex items-center gap-2">
       <RadioGroupItem value="network" id="network" className="text-neutral6" disabled={itemDisabled} />
       <Label
-        className={cn('text-neutral6 text-ui-md', !isNetworkAvailable && 'text-neutral3! cursor-not-allowed')}
+        className={cn('text-ui-md text-neutral6', !isNetworkAvailable && 'cursor-not-allowed text-neutral3!')}
         htmlFor="network"
       >
         Network
@@ -85,7 +85,7 @@ const StreamSubscriptionRadio = ({ supported, disabled }: StreamSubscriptionRadi
         disabled={itemDisabled}
       />
       <Label
-        className={cn('text-neutral6 text-ui-md', !supported && 'text-neutral3! cursor-not-allowed')}
+        className={cn('text-ui-md text-neutral6', !supported && 'cursor-not-allowed text-neutral3!')}
         htmlFor="streamSubscription"
       >
         Stream subscription (default)
@@ -180,14 +180,14 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
             tooltip="Model settings"
             data-testid="composer-model-settings-trigger"
           >
-            <Sliders className="h-5 w-5 text-neutral3 hover:text-neutral6" />
+            <Sliders className="size-5 text-neutral3 hover:text-neutral6" />
           </Button>
         </PopoverTrigger>
         <PopoverContent align="start" className="w-80 p-4">
           {isLoading || isMemoryLoading ? (
             <Skeleton className="h-40 w-full" data-testid="composer-model-settings-skeleton" />
           ) : (
-            <section className="space-y-5 @container">
+            <section className="@container space-y-5">
               <Entry label="Chat Method">
                 <RadioGroup
                   value={radioValue}
@@ -215,7 +215,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                         className="text-neutral6"
                         disabled={!canEditSettings}
                       />
-                      <Label className="text-neutral6 text-ui-md" htmlFor="generateLegacy">
+                      <Label className="text-ui-md text-neutral6" htmlFor="generateLegacy">
                         Generate (Legacy)
                       </Label>
                     </div>
@@ -228,7 +228,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                         className="text-neutral6"
                         disabled={!canEditSettings}
                       />
-                      <Label className="text-neutral6 text-ui-md" htmlFor="generate">
+                      <Label className="text-ui-md text-neutral6" htmlFor="generate">
                         Generate
                       </Label>
                     </div>
@@ -241,7 +241,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                         className="text-neutral6"
                         disabled={!canEditSettings}
                       />
-                      <Label className="text-neutral6 text-ui-md" htmlFor="streamLegacy">
+                      <Label className="text-ui-md text-neutral6" htmlFor="streamLegacy">
                         Stream (Legacy)
                       </Label>
                     </div>
@@ -257,7 +257,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
                         className="text-neutral6"
                         disabled={!canEditSettings}
                       />
-                      <Label className="text-neutral6 text-ui-md" htmlFor="stream">
+                      <Label className="text-ui-md text-neutral6" htmlFor="stream">
                         Stream
                       </Label>
                     </div>
@@ -284,10 +284,10 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
 
               {showSamplingBanner && (
                 <div
-                  className="flex items-center gap-2 text-xs text-neutral3 bg-surface3 rounded px-3 py-2"
+                  className="flex items-center gap-2 rounded bg-surface3 px-3 py-2 text-xs text-neutral3"
                   data-testid="sampling-restriction-banner"
                 >
-                  <Info className="w-3.5 h-3.5 shrink-0" />
+                  <Info className="size-3.5 shrink-0" />
                   <span>
                     {settings?.modelSettings?.temperature !== undefined
                       ? 'Claude 4.5+ models only accept Temperature OR Top P. Clear Temperature to use Top P.'
@@ -297,7 +297,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
               )}
 
               <Entry label="Temperature">
-                <div className="flex flex-row justify-between items-center gap-2">
+                <div className="flex flex-row items-center justify-between gap-2">
                   <Slider
                     value={[settings?.modelSettings?.temperature ?? -0.1]}
                     max={1}
@@ -322,7 +322,7 @@ export const ComposerModelSettings = ({ agentId }: ComposerModelSettingsProps) =
               </Entry>
 
               <Entry label="Top P">
-                <div className="flex flex-row justify-between items-center gap-2">
+                <div className="flex flex-row items-center justify-between gap-2">
                   <Slider
                     disabled={!canEditSettings}
                     onValueChange={value =>

--- a/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
@@ -93,14 +93,14 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
         className="flex items-center gap-1.5 rounded-md border border-border1 bg-surface3 px-2 py-1 text-ui-xs text-neutral6"
         data-testid="composer-model-locked"
       >
-        <Lock className="h-3.5 w-3.5 shrink-0 text-neutral3" />
+        <Lock className="size-3.5 shrink-0 text-neutral3" />
         <span className="truncate">{lockedLabel}</span>
       </div>
     );
   }
 
   return (
-    <div className="inline-flex items-stretch max-w-full">
+    <div className="inline-flex max-w-full items-stretch">
       <LLMProviders
         value={currentModelProvider}
         onValueChange={handleProviderSelect}
@@ -108,7 +108,7 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
         className={cn(
           COMPOSER_TRIGGER_CLASS,
           'shrink-0',
-          'rounded-none! rounded-tl-full! rounded-bl-full!',
+          'rounded-none! rounded-l-full',
           // Collapse provider to icon-only in narrow containers.
           '@max-md:px-2 @max-md:[&>span>span]:hidden @max-md:[&>svg]:hidden',
         )}
@@ -121,7 +121,7 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
         open={modelOpen}
         onOpenChange={setModelOpen}
         size="md"
-        className={cn(COMPOSER_TRIGGER_CLASS, 'rounded-none! rounded-tr-full! rounded-br-full!', 'max-w-[10rem]')}
+        className={cn(COMPOSER_TRIGGER_CLASS, 'rounded-none! rounded-r-full', 'max-w-40')}
       />
     </div>
   );
@@ -159,13 +159,13 @@ export const ComposerModelWarning = ({ agentId }: ComposerModelSwitcherProps) =>
     <div className="flex flex-col gap-1 px-3 pb-1.5">
       {stale && (
         <div
-          className="flex items-start gap-1 text-accent6 text-xs min-w-0 max-w-full"
+          className="flex max-w-full min-w-0 items-start gap-1 text-xs text-accent6"
           data-testid="composer-model-stale-warning"
           role="alert"
         >
-          <TriangleAlert className="w-3 h-3 shrink-0 mt-0.5" />
+          <TriangleAlert className="mt-0.5 size-3 shrink-0" />
           <span className="min-w-0 break-words">
-            <code className="px-1 py-0.5 bg-accent6Dark rounded text-accent6 break-all">
+            <code className="rounded bg-accent6Dark px-1 py-0.5 break-all text-accent6">
               {agent.provider}/{selectedModel}
             </code>{' '}
             is no longer allowed by admin policy. Pick a different model.
@@ -173,10 +173,10 @@ export const ComposerModelWarning = ({ agentId }: ComposerModelSwitcherProps) =>
         </div>
       )}
       {showProviderWarning && (
-        <div className="flex items-start gap-1 text-accent6 text-xs min-w-0 max-w-full">
-          <TriangleAlert className="w-3 h-3 shrink-0 mt-0.5" />
+        <div className="flex max-w-full min-w-0 items-start gap-1 text-xs text-accent6">
+          <TriangleAlert className="mt-0.5 size-3 shrink-0" />
           <span className="min-w-0 break-words">
-            Set <code className="px-1 py-0.5 bg-accent6Dark rounded text-accent6 break-all">{envVar}</code> to use this
+            Set <code className="rounded bg-accent6Dark px-1 py-0.5 break-all text-accent6">{envVar}</code> to use this
             provider
           </span>
         </div>

--- a/packages/playground/src/domains/agents/components/composer-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/composer-run-options.tsx
@@ -30,7 +30,7 @@ export function ComposerRunOptions({ requestContextSchema }: ComposerRunOptionsP
           tooltip="Run options"
           data-testid="composer-run-options-trigger"
         >
-          <Settings2 className="h-5 w-5 text-neutral3 hover:text-neutral6" />
+          <Settings2 className="size-5 text-neutral3 hover:text-neutral6" />
         </Button>
       </PopoverTrigger>
       <PopoverContent

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-capabilities-footer.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-capabilities-footer.tsx
@@ -99,13 +99,13 @@ function CapabilityItem({ view, label, status, description, docsHref, enabled, t
       target="_blank"
       rel="noopener noreferrer"
       className={cn(
-        'group/capability-row flex min-w-0 items-start gap-2 rounded-md px-2 py-1.5 text-ui-xs text-neutral4 transition-colors duration-normal',
-        'hover:bg-surface4/60 hover:text-neutral6 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-border2',
+        'group/capability-row duration-normal flex min-w-0 items-start gap-2 rounded-md px-2 py-1.5 text-ui-xs text-neutral4 transition-colors',
+        'hover:bg-surface4/60 hover:text-neutral6 focus-visible:ring-1 focus-visible:ring-border2 focus-visible:outline-none',
       )}
     >
       <span
         className={cn(
-          'mt-0.5 size-3.5 shrink-0 text-neutral3 transition-colors duration-normal [&>svg]:size-3.5',
+          'duration-normal mt-0.5 size-3.5 shrink-0 text-neutral3 transition-colors [&>svg]:size-3.5',
           enabled ? toneIcon : 'group-hover/capability-row:text-neutral5',
         )}
       >
@@ -114,13 +114,13 @@ function CapabilityItem({ view, label, status, description, docsHref, enabled, t
       <span className="min-w-0 flex-1">
         <span className="flex min-w-0 items-center gap-2">
           <span className="min-w-0 truncate font-medium text-neutral5">{label}</span>
-          <span className="shrink-0 tabular-nums text-neutral3">{status}</span>
+          <span className="shrink-0 text-neutral3 tabular-nums">{status}</span>
         </span>
-        <span className="mt-0.5 block text-neutral3 transition-colors duration-normal group-hover/capability-row:text-neutral4">
+        <span className="duration-normal mt-0.5 block text-neutral3 transition-colors group-hover/capability-row:text-neutral4">
           {description}
         </span>
       </span>
-      <ExternalLink className="mt-0.5 size-3 shrink-0 text-neutral3 transition-colors duration-normal group-hover/capability-row:text-neutral5" />
+      <ExternalLink className="duration-normal mt-0.5 size-3 shrink-0 text-neutral3 transition-colors group-hover/capability-row:text-neutral5" />
     </a>
   );
 }
@@ -302,7 +302,7 @@ export function AgentCapabilitiesFooter({ agentId }: { agentId: string }) {
           <button
             type="button"
             data-testid="agent-capabilities-footer"
-            className="flex w-full cursor-pointer items-center gap-1.5 px-2 py-2 text-left text-neutral4 transition-colors duration-normal hover:!text-neutral4 hover:bg-surface4 focus-visible:!text-neutral4 focus-visible:bg-surface4 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-border2 active:bg-surface5/80 aria-expanded:bg-surface4/70 data-[panel-open]:bg-surface4/70"
+            className="duration-normal flex w-full cursor-pointer items-center gap-1.5 p-2 text-left text-neutral4 transition-colors hover:bg-surface4 hover:!text-neutral4 focus-visible:bg-surface4 focus-visible:!text-neutral4 focus-visible:ring-1 focus-visible:ring-border2 focus-visible:outline-none focus-visible:ring-inset active:bg-surface5/80 aria-expanded:bg-surface4/70 data-[panel-open]:bg-surface4/70"
           >
             <div className="flex min-w-0 flex-1 items-center gap-1.5 overflow-hidden">
               <MemoryCapability agentId={agentId} view="chip" />
@@ -315,7 +315,7 @@ export function AgentCapabilitiesFooter({ agentId }: { agentId: string }) {
             <CapabilitiesSummary agentId={agentId} />
             <ChevronRight
               className={cn(
-                'size-3.5 shrink-0 text-neutral3 transition-transform duration-normal ease-out-custom',
+                'duration-normal size-3.5 shrink-0 text-neutral3 transition-transform ease-out-custom',
                 isExpanded ? 'rotate-90' : undefined,
               )}
             />

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-memory.tsx
@@ -103,7 +103,7 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
 
   if (isConfigLoading) {
     return (
-      <div className="flex flex-col h-full p-4 gap-4">
+      <div className="flex h-full flex-col gap-4 p-4">
         <Skeleton className="h-12 w-full" />
         <Skeleton className="h-32 w-full" />
         <Skeleton className="h-48 w-full" />
@@ -112,45 +112,45 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
   }
 
   return (
-    <div className="flex flex-col min-w-0">
+    <div className="flex min-w-0 flex-col">
       {/* Clone Thread Section */}
       {threadId && (
-        <div className="p-4 border-b border-border1">
+        <div className="border-b border-border1 p-4">
           <div className="flex items-center justify-between">
             <div>
               <h3 className="text-sm font-medium text-neutral5">Clone Thread</h3>
-              <p className="text-xs text-neutral3 mt-1">Create a copy of this conversation</p>
+              <p className="mt-1 text-xs text-neutral3">Create a copy of this conversation</p>
             </div>
             <Button onClick={handleCloneThread} disabled={isCloning}>
-              <GitFork className="w-4 h-4 mr-2" />
+              <GitFork className="mr-2 size-4" />
               {isCloning ? 'Cloning...' : 'Clone'}
             </Button>
           </div>
         </div>
       )}
 
-      <div className="p-4 border-b border-border1">
+      <div className="border-b border-border1 p-4">
         <h3 className="text-sm font-medium text-neutral5">Recent Messages</h3>
-        <p className="text-xs text-neutral3 mt-1">{getRecentMessagesDescription(config?.lastMessages)}</p>
+        <p className="mt-1 text-xs text-neutral3">{getRecentMessagesDescription(config?.lastMessages)}</p>
       </div>
 
       {/* Observational Memory Section - moved above Semantic Recall */}
       {isOMEnabled && (
-        <div className="border-b border-border1 min-w-0 overflow-hidden">
+        <div className="min-w-0 overflow-hidden border-b border-border1">
           <AgentObservationalMemory agentId={agentId} resourceId={effectiveResourceId} threadId={threadId} />
         </div>
       )}
 
       {/* Memory Search Section - hidden for gateway memory */}
       {!isGatewayMemory && (
-        <div className="p-4 border-b border-border1">
+        <div className="border-b border-border1 p-4">
           <div className="mb-2">
-            <div className="flex items-center gap-2 mb-2">
+            <div className="mb-2 flex items-center gap-2">
               <h3 className="text-sm font-medium text-neutral5">Semantic Recall</h3>
               {searchMemoryData?.searchScope && (
                 <span
                   className={cn(
-                    'text-xs font-medium px-2 py-0.5 rounded',
+                    'rounded px-2 py-0.5 text-xs font-medium',
                     searchScope === 'resource' ? 'bg-purple-500/20 text-purple-400' : 'bg-blue-500/20 text-blue-400',
                   )}
                   title={
@@ -171,18 +171,18 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
               chatInputValue={chatInputValue}
             />
           ) : (
-            <div className="bg-surface3 border border-border1 rounded-lg p-4">
-              <p className="text-sm text-neutral3 mb-3">
+            <div className="rounded-lg border border-border1 bg-surface3 p-4">
+              <p className="mb-3 text-sm text-neutral3">
                 Semantic recall is not enabled for this agent. Enable it to search through conversation history.
               </p>
               <a
                 href="https://mastra.ai/en/docs/memory/semantic-recall"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="inline-flex items-center gap-2 text-sm text-blue-400 hover:text-blue-300 transition-colors"
+                className="inline-flex items-center gap-2 text-sm text-blue-400 transition-colors hover:text-blue-300"
               >
                 Learn about semantic recall
-                <ExternalLink className="w-3 h-3" />
+                <ExternalLink className="size-3" />
               </a>
             </div>
           )}
@@ -198,10 +198,10 @@ export function AgentMemory({ agentId, threadId, memoryType }: AgentMemoryProps)
 
       {/* Gateway Memory indicator */}
       {isGatewayMemory && (
-        <div className="p-4 border-b border-border1">
-          <div className="bg-surface3 border border-border1 rounded-lg p-4">
-            <div className="flex items-center gap-2 mb-1">
-              <span className="text-xs font-medium px-2 py-0.5 rounded bg-green-500/20 text-green-400">Gateway</span>
+        <div className="border-b border-border1 p-4">
+          <div className="rounded-lg border border-border1 bg-surface3 p-4">
+            <div className="mb-1 flex items-center gap-2">
+              <span className="rounded bg-green-500/20 px-2 py-0.5 text-xs font-medium text-green-400">Gateway</span>
               <h3 className="text-sm font-medium text-neutral5">Memory Gateway</h3>
             </div>
             <p className="text-xs text-neutral3">

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-observational-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-observational-memory.tsx
@@ -109,18 +109,18 @@ const ProgressBar = ({
   const tokenTextColor = isProcessing ? 'text-blue-600' : 'text-neutral3';
 
   return (
-    <div className="flex-1 min-w-0">
+    <div className="min-w-0 flex-1">
       {/* Label above bar - fixed height to prevent layout shift */}
-      <div className="flex items-center gap-1 mb-1 h-4">
-        <span className="text-[9px] text-neutral4 uppercase tracking-wider font-normal">{label}</span>
+      <div className="mb-1 flex h-4 items-center gap-1">
+        <span className="text-[9px] font-normal tracking-wider text-neutral4 uppercase">{label}</span>
         <Tooltip>
           <TooltipTrigger asChild>
             <button type="button" className="inline-flex items-center justify-center">
-              <Info className="w-2.5 h-2.5 text-neutral4 hover:text-neutral3 cursor-help" />
+              <Info className="size-2.5 cursor-help text-neutral4 hover:text-neutral3" />
             </button>
           </TooltipTrigger>
-          <TooltipContent side="top" className="max-w-xs bg-surface3 border border-border1 text-foreground">
-            <div className="text-xs space-y-1.5">
+          <TooltipContent side="top" className="text-foreground max-w-xs border border-border1 bg-surface3">
+            <div className="space-y-1.5 text-xs">
               <div className="font-medium text-neutral5">
                 {label === 'Messages' ? 'Observer' : 'Reflector'} Settings
               </div>
@@ -132,7 +132,7 @@ const ProgressBar = ({
                 {modelRouting?.length ? (
                   <div>
                     <span className="text-neutral4">Routing:</span>
-                    <div className="mt-0.5 pl-2 space-y-0.5">
+                    <div className="mt-0.5 space-y-0.5 pl-2">
                       {modelRouting.map(route => (
                         <div key={`${route.upTo}-${route.model}`} className="text-neutral5">
                           ≤{formatTokens(route.upTo)} → {route.model}
@@ -160,7 +160,7 @@ const ProgressBar = ({
 
       <div className="flex items-stretch">
         {/* Progress bar with percentage inside */}
-        <div className={`relative flex-1 h-5 ${containerBg} rounded-l overflow-hidden`}>
+        <div className={`relative h-5 flex-1 ${containerBg} overflow-hidden rounded-l`}>
           <div className={`h-full ${fillColor} transition-all`} style={{ width: `${percentage}%` }} />
           <span
             className={`absolute inset-0 flex items-center ${isProcessing ? 'justify-start pl-2' : 'justify-center'} text-[10px] font-medium ${textColor} pointer-events-none`}
@@ -185,16 +185,16 @@ const ProgressBar = ({
 
         {/* Token count connected to bar */}
         <span
-          className={`text-[10px] ${tokenTextColor} tabular-nums whitespace-nowrap font-mono ${tokenBg} px-1.5 flex items-center gap-1 rounded-r -ml-px`}
+          className={`text-[10px] ${tokenTextColor} font-mono whitespace-nowrap tabular-nums ${tokenBg} -ml-px flex items-center gap-1 rounded-r px-1.5`}
         >
           {formatTokens(value)}
           <span className={isProcessing ? 'text-blue-500' : 'text-neutral4'}>/{formatTokens(max)}</span>
           {isAdaptive && totalBudget && (
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="text-amber-400 cursor-help">({formatTokens(baseThreshold)})</span>
+                <span className="cursor-help text-amber-400">({formatTokens(baseThreshold)})</span>
               </TooltipTrigger>
-              <TooltipContent side="top" className="max-w-xs bg-surface3 border border-border1 text-foreground">
+              <TooltipContent side="top" className="text-foreground max-w-xs border border-border1 bg-surface3">
                 <div className="text-xs">
                   <span className="text-amber-400">{formatTokens(baseThreshold)}</span>
                   <span className="text-neutral4"> is the configured threshold. </span>
@@ -212,20 +212,20 @@ const ProgressBar = ({
 };
 
 const ObservationalMemoryHeader = () => (
-  <div className="flex items-center gap-2 mb-3">
-    <Brain className="w-4 h-4 text-purple-400" />
+  <div className="mb-3 flex items-center gap-2">
+    <Brain className="size-4 text-purple-400" />
     <h3 className="text-sm font-medium text-neutral5">Observational Memory</h3>
   </div>
 );
 
 const ObservationalMemoryDisabled = () => (
   <div className="p-4">
-    <div className="flex items-center gap-2 mb-3">
-      <Brain className="w-4 h-4 text-neutral3" />
+    <div className="mb-3 flex items-center gap-2">
+      <Brain className="size-4 text-neutral3" />
       <h3 className="text-sm font-medium text-neutral5">Observational Memory</h3>
     </div>
-    <div className="bg-surface3 border border-border1 rounded-lg p-4">
-      <p className="text-sm text-neutral3 mb-3">
+    <div className="rounded-lg border border-border1 bg-surface3 p-4">
+      <p className="mb-3 text-sm text-neutral3">
         Observational Memory is not enabled for this agent. Enable it to automatically extract and maintain observations
         from conversations.
       </p>
@@ -233,10 +233,10 @@ const ObservationalMemoryDisabled = () => (
         href="https://mastra.ai/en/docs/memory/observational-memory"
         target="_blank"
         rel="noopener noreferrer"
-        className="inline-flex items-center gap-2 text-sm text-blue-400 hover:text-blue-300 transition-colors"
+        className="inline-flex items-center gap-2 text-sm text-blue-400 transition-colors hover:text-blue-300"
       >
         Learn about Observational Memory
-        <ExternalLink className="w-3 h-3" />
+        <ExternalLink className="size-3" />
       </a>
     </div>
   </div>
@@ -273,7 +273,7 @@ function ObservationalMemoryProgressBars({
 }) {
   return (
     <TooltipProvider delayDuration={0}>
-      <div className="flex gap-3 mb-3">
+      <div className="mb-3 flex gap-3">
         <ProgressBar
           value={pendingMessageTokens}
           max={messageTokensThreshold}
@@ -471,7 +471,7 @@ export const AgentObservationalMemory = ({ agentId, resourceId, threadId }: Agen
   }
 
   return (
-    <div className="p-4 overflow-hidden min-w-0 w-full">
+    <div className="w-full min-w-0 overflow-hidden p-4">
       <ObservationalMemoryHeader />
       <ObservationalMemoryProgressBars
         pendingMessageTokens={pendingMessageTokens}
@@ -493,7 +493,7 @@ export const AgentObservationalMemory = ({ agentId, resourceId, threadId }: Agen
         className="w-full justify-center gap-2"
         onClick={() => (isDetailViewOpen ? closeDetailView() : openDetailView())}
       >
-        <Brain className="h-3.5 w-3.5" />
+        <Brain className="size-3.5" />
         Analyze Observations
       </Button>
     </div>

--- a/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/agent-working-memory.tsx
@@ -50,12 +50,12 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
   return (
     <div className="flex flex-col gap-4 p-4">
       <div>
-        <div className="flex items-center gap-2 mb-2">
+        <div className="mb-2 flex items-center gap-2">
           <h3 className="text-sm font-medium text-neutral5">Working Memory</h3>
           {isWorkingMemoryEnabled && workingMemorySource && (
             <span
               className={cn(
-                'text-xs font-medium px-2 py-0.5 rounded',
+                'rounded px-2 py-0.5 text-xs font-medium',
                 workingMemorySource === 'resource'
                   ? 'bg-purple-500/20 text-purple-400'
                   : 'bg-blue-500/20 text-blue-400',
@@ -86,28 +86,28 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                       content={workingMemoryData || ''}
                       isCopied={isCopied}
                       onCopy={handleCopy}
-                      className="bg-surface3 text-sm font-mono min-h-[150px] border border-border1 rounded-lg"
+                      className="min-h-[150px] rounded-lg border border-border1 bg-surface3 font-mono text-sm"
                     />
                   ) : (
                     <>
-                      <div className="bg-surface3 border border-border1 rounded-lg" style={{ height: '300px' }}>
+                      <div className="rounded-lg border border-border1 bg-surface3" style={{ height: '300px' }}>
                         <ScrollArea className="h-full">
-                          <div className="p-3 cursor-pointer hover:bg-surface4/20 transition-colors relative group text-ui-xs">
+                          <div className="group relative cursor-pointer p-3 text-ui-xs transition-colors hover:bg-surface4/20">
                             <button
                               type="button"
                               onClick={handleCopy}
                               aria-label="Copy working memory"
-                              className="absolute inset-0 z-10 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent1"
+                              className="absolute inset-0 z-10 rounded-lg focus-visible:ring-2 focus-visible:ring-accent1 focus-visible:outline-hidden"
                             />
                             <div className="pointer-events-none">
                               <MarkdownRenderer>{workingMemoryData}</MarkdownRenderer>
                             </div>
                             {isCopied && (
-                              <span className="absolute top-2 right-2 z-20 text-ui-xs px-1.5 py-0.5 rounded-full bg-green-500/20 text-green-500 pointer-events-none">
+                              <span className="pointer-events-none absolute top-2 right-2 z-20 rounded-full bg-green-500/20 px-1.5 py-0.5 text-ui-xs text-green-500">
                                 Copied!
                               </span>
                             )}
-                            <span className="absolute top-2 right-2 z-20 text-ui-xs px-1.5 py-0.5 rounded-full bg-surface3 text-neutral4 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                            <span className="pointer-events-none absolute top-2 right-2 z-20 rounded-full bg-surface3 px-1.5 py-0.5 text-ui-xs text-neutral4 opacity-0 transition-opacity group-hover:opacity-100">
                               Click to copy
                             </span>
                           </div>
@@ -117,14 +117,14 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                   )}
                 </>
               ) : (
-                <div className="text-sm text-neutral3 font-mono">
+                <div className="font-mono text-sm text-neutral3">
                   No working memory content yet. Click "Edit Working Memory" to add content.
                 </div>
               )}
             </>
           ) : (
             <textarea
-              className="w-full min-h-[150px] p-3 border border-border1 rounded-lg bg-surface3 font-mono text-sm text-neutral5 resize-none"
+              className="min-h-[150px] w-full resize-none rounded-lg border border-border1 bg-surface3 p-3 font-mono text-sm text-neutral5"
               value={editState.value}
               onChange={e => setEditState(state => ({ ...state, value: e.target.value }))}
               disabled={isUpdating}
@@ -142,7 +142,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                         type="button"
                         aria-disabled="true"
                         onClick={event => event.preventDefault()}
-                        className="text-xs cursor-not-allowed opacity-50"
+                        className="cursor-not-allowed text-xs opacity-50"
                       >
                         Edit Working Memory
                       </Button>
@@ -172,7 +172,7 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
                   disabled={isUpdating}
                   className="text-xs"
                 >
-                  {isUpdating ? <RefreshCcwIcon className="w-3 h-3 animate-spin" /> : 'Save Changes'}
+                  {isUpdating ? <RefreshCcwIcon className="size-3 animate-spin" /> : 'Save Changes'}
                 </Button>
                 <Button
                   onClick={() => {
@@ -189,18 +189,18 @@ export const AgentWorkingMemory = ({ agentId }: AgentWorkingMemoryProps) => {
           </div>
         </>
       ) : (
-        <div className="bg-surface3 border border-border1 rounded-lg p-4">
-          <p className="text-sm text-neutral3 mb-3">
+        <div className="rounded-lg border border-border1 bg-surface3 p-4">
+          <p className="mb-3 text-sm text-neutral3">
             Working memory is not enabled for this agent. Enable it to maintain context across conversations.
           </p>
           <a
             href="https://mastra.ai/en/docs/memory/working-memory"
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 text-sm text-blue-400 hover:text-blue-300 transition-colors"
+            className="inline-flex items-center gap-2 text-sm text-blue-400 transition-colors hover:text-blue-300"
           >
             Learn about working memory
-            <ExternalLink className="w-3 h-3" />
+            <ExternalLink className="size-3" />
           </a>
         </div>
       )}

--- a/packages/playground/src/domains/agents/components/memory-sidebar/code-display.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/code-display.tsx
@@ -20,30 +20,30 @@ export function CodeDisplay({
   return (
     <div className={`rounded-md border ${className}`} style={{ height }}>
       <ScrollArea className="h-full">
-        <div className={`p-2 transition-colors group relative ${onCopy ? 'cursor-pointer hover:bg-surface4/50' : ''}`}>
+        <div className={`group relative p-2 transition-colors ${onCopy ? 'cursor-pointer hover:bg-surface4/50' : ''}`}>
           {onCopy && (
             <button
               type="button"
               onClick={onCopy}
               aria-label="Copy code"
-              className="absolute inset-0 z-10 rounded-md focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent1"
+              className="absolute inset-0 z-10 rounded-md focus-visible:ring-2 focus-visible:ring-accent1 focus-visible:outline-hidden"
             />
           )}
-          <pre className="text-ui-xs whitespace-pre-wrap font-mono pointer-events-none">{content}</pre>
+          <pre className="pointer-events-none font-mono text-ui-xs whitespace-pre-wrap">{content}</pre>
           {isDraft && (
             <div className="mt-1.5">
-              <span className="text-ui-xs px-1.5 py-0.5 rounded-full bg-yellow-500/20 text-yellow-500">
+              <span className="rounded-full bg-yellow-500/20 px-1.5 py-0.5 text-ui-xs text-yellow-500">
                 Draft - Save changes to apply
               </span>
             </div>
           )}
           {isCopied && (
-            <span className="absolute top-2 right-2 z-20 text-ui-xs px-1.5 py-0.5 rounded-full bg-green-500/20 text-green-500 pointer-events-none">
+            <span className="pointer-events-none absolute top-2 right-2 z-20 rounded-full bg-green-500/20 px-1.5 py-0.5 text-ui-xs text-green-500">
               Copied!
             </span>
           )}
           {onCopy && (
-            <span className="absolute top-2 right-2 z-20 text-ui-xs px-1.5 py-0.5 rounded-full bg-surface4 text-neutral4 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+            <span className="pointer-events-none absolute top-2 right-2 z-20 rounded-full bg-surface4 px-1.5 py-0.5 text-ui-xs text-neutral4 opacity-0 transition-opacity group-hover:opacity-100">
               Click to copy
             </span>
           )}

--- a/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
+++ b/packages/playground/src/domains/agents/components/memory-sidebar/memory-sidebar.tsx
@@ -47,13 +47,13 @@ function ConfigBadge({ icon: Icon, tooltip, enabled, value }: ConfigBadgeProps) 
       <TooltipTrigger asChild>
         <span
           className={cn(
-            'inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 transition-colors duration-normal',
+            'duration-normal inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 transition-colors',
             enabled ? 'border-border1 bg-surface4 text-neutral6' : 'border-border1/40 text-neutral3/50',
           )}
         >
-          <Icon className="h-3 w-3 shrink-0" />
+          <Icon className="size-3 shrink-0" />
           {value !== undefined && (
-            <Txt as="span" variant="ui-xs" className="font-medium tabular-nums leading-none">
+            <Txt as="span" variant="ui-xs" className="leading-none font-medium tabular-nums">
               {value}
             </Txt>
           )}
@@ -66,7 +66,7 @@ function ConfigBadge({ icon: Icon, tooltip, enabled, value }: ConfigBadgeProps) 
 
 function MemorySidebarSkeleton() {
   return (
-    <div data-testid="memory-sidebar-skeleton" className="flex h-full min-h-0 w-full flex-col gap-2.5 p-3">
+    <div data-testid="memory-sidebar-skeleton" className="flex size-full min-h-0 flex-col gap-2.5 p-3">
       <Skeleton className="h-3 w-28" />
       <Skeleton className="h-3 w-20" />
       <Skeleton className="h-3 w-24" />
@@ -166,7 +166,7 @@ function MemorySidebarBody({ agentId, threadId, threads, onDelete }: MemorySideb
   }
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
+    <div className="flex size-full min-h-0 flex-col overflow-hidden">
       <div className="relative min-h-0 flex-1 overflow-hidden">
         <div
           aria-hidden={showMemory && hasMemory}
@@ -233,15 +233,15 @@ function MemorySidebarBody({ agentId, threadId, threads, onDelete }: MemorySideb
             >
               <span className="flex items-center justify-between gap-2">
                 <span className="flex min-w-0 items-center gap-1.5 text-neutral6">
-                  <MemoryIcon className="h-4 w-4 shrink-0" />
+                  <MemoryIcon className="size-4 shrink-0" />
                   <Txt as="span" variant="ui-sm" className="font-medium">
                     Memory
                   </Txt>
                 </span>
                 {showMemory ? (
-                  <ChevronDown className="h-4 w-4 shrink-0 text-neutral3" />
+                  <ChevronDown className="size-4 shrink-0 text-neutral3" />
                 ) : (
-                  <ChevronUp className="h-4 w-4 shrink-0 text-neutral3" />
+                  <ChevronUp className="size-4 shrink-0 text-neutral3" />
                 )}
               </span>
 
@@ -294,7 +294,7 @@ function MemorySidebarBody({ agentId, threadId, threads, onDelete }: MemorySideb
                 <span className="mt-2 block h-1 w-full overflow-hidden rounded-full bg-surface5">
                   <span
                     className={cn(
-                      'block h-full rounded-full transition-all duration-normal',
+                      'duration-normal block h-full rounded-full transition-all',
                       barColor(observationPercent),
                     )}
                     style={{ width: `${observationPercent}%` }}

--- a/packages/playground/src/domains/agents/components/model-picker/provider-not-connected-alert.tsx
+++ b/packages/playground/src/domains/agents/components/model-picker/provider-not-connected-alert.tsx
@@ -11,11 +11,11 @@ export const ProviderNotConnectedAlert = ({ provider }: ProviderNotConnectedAler
   }
 
   return (
-    <div className="pt-2 p-2">
+    <div className="p-2 pt-2">
       <Notice variant="warning" title="Provider not connected">
         <Notice.Message>
           Set the{' '}
-          <code className="px-1 py-0.5 bg-yellow-100 dark:bg-yellow-900/50 rounded">
+          <code className="rounded bg-yellow-100 px-1 py-0.5 dark:bg-yellow-900/50">
             {Array.isArray(provider.envVar) ? provider.envVar.join(', ') : provider.envVar}
           </code>{' '}
           environment {Array.isArray(provider.envVar) && provider.envVar.length > 1 ? 'variables' : 'variable'} to use

--- a/packages/playground/src/domains/agents/components/request-context-run-options.tsx
+++ b/packages/playground/src/domains/agents/components/request-context-run-options.tsx
@@ -88,7 +88,7 @@ function ModeSwitcher({ mode, onModeChange }: { mode: InputMode; onModeChange: (
         aria-pressed={mode === 'form'}
         onClick={() => onModeChange('form')}
         className={cn(
-          'flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors',
+          'flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors',
           mode === 'form' ? 'bg-surface3 text-neutral5' : 'text-neutral3 hover:text-neutral5',
         )}
       >
@@ -102,7 +102,7 @@ function ModeSwitcher({ mode, onModeChange }: { mode: InputMode; onModeChange: (
         aria-pressed={mode === 'json'}
         onClick={() => onModeChange('json')}
         className={cn(
-          'flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors',
+          'flex items-center gap-1.5 rounded px-2 py-1 text-xs transition-colors',
           mode === 'json' ? 'bg-surface3 text-neutral5' : 'text-neutral3 hover:text-neutral5',
         )}
       >
@@ -157,7 +157,7 @@ export function AgentRequestContextRunOptionsBody({
 
 export function AgentRequestContextRunOptions({ requestContextSchema }: AgentRequestContextRunOptionsProps) {
   return (
-    <ScrollArea className="max-h-[500px]">
+    <ScrollArea className="max-h-125">
       <div className="p-4">
         <AgentRequestContextRunOptionsBody requestContextSchema={requestContextSchema} />
       </div>

--- a/packages/playground/src/domains/agents/components/request-context.tsx
+++ b/packages/playground/src/domains/agents/components/request-context.tsx
@@ -189,7 +189,7 @@ export const RequestContext = ({ editorClassName = 'h-[400px]', labelTooltip }: 
           extensions={[jsonLanguage]}
           className={cn(
             editorClassName,
-            'overflow-y-scroll rounded-lg border border-border1 bg-surface2 overflow-hidden p-3',
+            'overflow-hidden overflow-y-scroll rounded-lg border border-border1 bg-surface2 p-3',
             '[&_.cm-editor]:!bg-surface2 [&_.cm-gutters]:!bg-surface2',
           )}
         />

--- a/packages/playground/src/domains/agents/components/sidebar-panel.tsx
+++ b/packages/playground/src/domains/agents/components/sidebar-panel.tsx
@@ -5,7 +5,7 @@ export function SidebarPanel({ children, className }: { children: ReactNode; cla
   return (
     <div
       className={cn(
-        'bg-surface3 rounded-tr-studio-panel border-t border-r border-border1/50 flex h-full w-full min-h-0 min-w-0 flex-col overflow-hidden',
+        'flex size-full min-h-0 min-w-0 flex-col overflow-hidden rounded-tr-studio-panel border-t border-r border-border1/50 bg-surface3',
         className,
       )}
     >

--- a/packages/playground/src/domains/auth/components/auth-required.tsx
+++ b/packages/playground/src/domains/auth/components/auth-required.tsx
@@ -55,9 +55,9 @@ export function AuthRequired({ children, loginUrl = '/login', signupUrl = '/sign
   // No login capability available - show auth required message without login option
   if (!capabilities.login) {
     return (
-      <div className="flex h-full w-full items-center justify-center">
+      <div className="flex size-full items-center justify-center">
         <div className="flex flex-col items-center space-y-6 text-center">
-          <LogoWithoutText className="h-16 w-16 opacity-50" />
+          <LogoWithoutText className="size-16 opacity-50" />
           <div className="space-y-2">
             <h2 className="text-xl font-semibold text-neutral6">Authentication Required</h2>
             <p className="max-w-sm text-neutral3">
@@ -79,16 +79,16 @@ export function AuthRequired({ children, loginUrl = '/login', signupUrl = '/sign
   };
 
   return (
-    <div className="flex h-full w-full items-center justify-center">
+    <div className="flex size-full items-center justify-center">
       <div className="flex flex-col items-center space-y-6 text-center">
-        <LogoWithoutText className="h-16 w-16 opacity-50" />
+        <LogoWithoutText className="size-16 opacity-50" />
         <div className="space-y-2">
           <h2 className="text-xl font-semibold text-neutral6">Sign in to continue</h2>
           <p className="max-w-sm text-neutral3">You need to sign in to access this page.</p>
         </div>
         {capabilities.login.description && (
           <div className="flex items-start gap-2.5 rounded-md border border-border1 bg-surface2 p-3 text-left">
-            <Lock className="mt-0.5 h-4 w-4 shrink-0 text-neutral4" />
+            <Lock className="mt-0.5 size-4 shrink-0 text-neutral4" />
             <p className="max-w-sm text-sm text-neutral3">{capabilities.login.description}</p>
           </div>
         )}

--- a/packages/playground/src/domains/auth/components/impersonation-banner.tsx
+++ b/packages/playground/src/domains/auth/components/impersonation-banner.tsx
@@ -13,18 +13,18 @@ export function ImpersonationBanner() {
   if (!isImpersonating || !impersonatedRole) return null;
 
   return (
-    <div className="flex items-center gap-2 bg-info1/10 border border-info1/20 rounded-md mx-3 mb-2 px-3 py-1.5">
-      <Eye className="h-3.5 w-3.5 text-info1 shrink-0" />
+    <div className="bg-info1/10 border-info1/20 mx-3 mb-2 flex items-center gap-2 rounded-md border px-3 py-1.5">
+      <Eye className="text-info1 size-3.5 shrink-0" />
       <Txt variant="ui-xs" className="text-info1 truncate">
         Previewing <span className="font-medium capitalize">{impersonatedRole.name}</span> experience
       </Txt>
       <button
         type="button"
         onClick={stopImpersonation}
-        className="ml-auto shrink-0 rounded p-0.5 text-info1 hover:bg-info1/20 transition-colors"
+        className="text-info1 hover:bg-info1/20 ml-auto shrink-0 rounded p-0.5 transition-colors"
         title="Exit role preview"
       >
-        <X className="h-3 w-3" />
+        <X className="size-3" />
       </button>
     </div>
   );

--- a/packages/playground/src/domains/auth/components/login-layout.tsx
+++ b/packages/playground/src/domains/auth/components/login-layout.tsx
@@ -20,7 +20,7 @@ export function LoginLayout({ title, description, errorBanner, children }: Login
     <div data-testid="login-page" className="flex min-h-screen items-center justify-center bg-surface1">
       <div className="w-full max-w-sm space-y-6">
         <div className="flex flex-col items-center space-y-2">
-          <LogoWithoutText className="h-10 w-10" />
+          <LogoWithoutText className="size-10" />
           <h1 className="text-xl font-semibold text-neutral6">{title}</h1>
         </div>
 

--- a/packages/playground/src/domains/auth/components/login-page.tsx
+++ b/packages/playground/src/domains/auth/components/login-page.tsx
@@ -116,7 +116,7 @@ export function LoginPage({ redirectUri, onSuccess, initialMode = 'signin', erro
 
   const description = login.description ? (
     <div className="flex items-start gap-2.5 rounded-md border border-border1 bg-surface1 p-3">
-      <Lock className="mt-0.5 h-4 w-4 shrink-0 text-neutral4" />
+      <Lock className="mt-0.5 size-4 shrink-0 text-neutral4" />
       <p className="text-sm text-neutral3">{login.description}</p>
     </div>
   ) : null;

--- a/packages/playground/src/domains/auth/components/route-permission-guard.tsx
+++ b/packages/playground/src/domains/auth/components/route-permission-guard.tsx
@@ -22,7 +22,7 @@ export function RoutePermissionGuard({ children }: { children: React.ReactNode }
   // already loaded and validated by RoutePermissionsGate higher in the tree.
   if (isLoading) {
     return (
-      <div className="flex h-full w-full items-center justify-center">
+      <div className="flex size-full items-center justify-center">
         <Spinner />
       </div>
     );

--- a/packages/playground/src/domains/auth/components/user-menu.tsx
+++ b/packages/playground/src/domains/auth/components/user-menu.tsx
@@ -49,7 +49,7 @@ export function UserMenu({ user }: UserMenuProps) {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button type="button" className="flex items-center gap-2 rounded-md p-1 hover:bg-surface2 transition-colors">
+        <button type="button" className="flex items-center gap-2 rounded-md p-1 transition-colors hover:bg-surface2">
           <UserAvatar user={user} size="sm" />
         </button>
       </PopoverTrigger>
@@ -73,7 +73,7 @@ export function UserMenu({ user }: UserMenuProps) {
         {/* Preview as role section — only for admins with available roles */}
         {availableRoles && availableRoles.length > 0 && (
           <div className="border-b border-border1 p-2">
-            <Txt variant="ui-xs" className="px-2 py-1 text-neutral3 uppercase tracking-wider">
+            <Txt variant="ui-xs" className="px-2 py-1 tracking-wider text-neutral3 uppercase">
               Preview as role
             </Txt>
             {availableRoles.map(role => {
@@ -91,20 +91,20 @@ export function UserMenu({ user }: UserMenuProps) {
                     }
                     setOpen(false);
                   }}
-                  className={`w-full flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
+                  className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors ${
                     isActive ? 'bg-surface2' : 'hover:bg-surface2'
-                  } ${isSwitching ? 'opacity-50 cursor-not-allowed' : ''}`}
+                  } ${isSwitching ? 'cursor-not-allowed opacity-50' : ''}`}
                 >
-                  {isSwitching && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                  {isSwitching && <Loader2 className="size-3.5 animate-spin" />}
                   <span className="flex-1 capitalize">{role.name}</span>
-                  {isActive && <X className="h-3.5 w-3.5 text-neutral3 hover:text-neutral1" />}
+                  {isActive && <X className="size-3.5 text-neutral3 hover:text-neutral1" />}
                 </button>
               );
             })}
           </div>
         )}
 
-        <div className="p-2 flex flex-col gap-1">
+        <div className="flex flex-col gap-1 p-2">
           <Button
             as={Link}
             to="/settings"
@@ -112,7 +112,7 @@ export function UserMenu({ user }: UserMenuProps) {
             className="w-full justify-start"
             onClick={() => setOpen(false)}
           >
-            <Settings className="h-4 w-4" />
+            <Settings className="size-4" />
             Settings
           </Button>
           <Button variant="ghost" onClick={handleLogout} disabled={isPending} className="w-full justify-start">

--- a/packages/playground/src/domains/cms/components/display-conditions/display-conditions-dialog.tsx
+++ b/packages/playground/src/domains/cms/components/display-conditions/display-conditions-dialog.tsx
@@ -43,7 +43,7 @@ export function DisplayConditionsDialog({ entityName, schema, rules, onRulesChan
           {ruleCount > 0 && <span className="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-accent1" />}
         </Button>
       </DialogTrigger>
-      <DialogContent className="max-w-5xl w-full">
+      <DialogContent className="w-full max-w-5xl">
         <DialogHeader>
           <DialogTitle>Display Conditions for {entityName}</DialogTitle>
           <DialogDescription>

--- a/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
+++ b/packages/playground/src/domains/cms/components/entity-accordion-item/entity-accordion-item.tsx
@@ -41,8 +41,8 @@ export function EntityAccordionItem({
   const [isRulesOpen, setIsRulesOpen] = useState(ruleCount > 0);
 
   return (
-    <div className="rounded-md border border-border1 overflow-hidden">
-      <div className="bg-surface2 p-3 flex flex-col gap-2">
+    <div className="overflow-hidden rounded-md border border-border1">
+      <div className="flex flex-col gap-2 bg-surface2 p-3">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Icon size="sm">{icon}</Icon>
@@ -60,7 +60,7 @@ export function EntityAccordionItem({
           value={description}
           onChange={onDescriptionChange ? e => onDescriptionChange(e.target.value) : undefined}
           placeholder="Custom description for this entity..."
-          className="min-h-[40px] text-xs bg-surface3 border-dashed px-2 py-1"
+          className="min-h-table-row-small border-dashed bg-surface3 px-2 py-1 text-xs"
           size="sm"
           disabled={isReadOnly}
         />
@@ -68,7 +68,7 @@ export function EntityAccordionItem({
 
       {showRulesSection && (
         <Collapsible open={isRulesOpen} onOpenChange={setIsRulesOpen} className="border-t border-border1 bg-surface2">
-          <CollapsibleTrigger className="flex items-center gap-2 w-full px-3 py-2">
+          <CollapsibleTrigger className="flex w-full items-center gap-2 px-3 py-2">
             <Icon>
               <ChevronRight
                 className={cn('text-neutral3 transition-transform', {
@@ -79,9 +79,9 @@ export function EntityAccordionItem({
             <Icon>
               <Ruler className="text-accent6" />
             </Icon>
-            <span className="text-neutral5 text-ui-sm">Display Conditions</span>
+            <span className="text-ui-sm text-neutral5">Display Conditions</span>
             {ruleCount > 0 && (
-              <span className="text-neutral3 text-ui-sm">
+              <span className="text-ui-sm text-neutral3">
                 ({ruleCount} {ruleCount === 1 ? 'rule' : 'rules'})
               </span>
             )}

--- a/packages/playground/src/domains/cms/components/section/section-header.tsx
+++ b/packages/playground/src/domains/cms/components/section/section-header.tsx
@@ -11,7 +11,7 @@ export type SectionHeaderProps = {
 
 export function SectionHeader({ title, subtitle, icon, className }: SectionHeaderProps) {
   return (
-    <header className={cn('flex flex-col w-fit', className)}>
+    <header className={cn('flex w-fit flex-col', className)}>
       <Txt as="h2" variant="header-md" className="flex items-center gap-2">
         {icon && (
           <Icon size="lg" className="text-accent1">
@@ -20,7 +20,7 @@ export function SectionHeader({ title, subtitle, icon, className }: SectionHeade
         )}
         {title}
       </Txt>
-      {subtitle && <Txt className="text-ui-md text-neutral3 !font-light">{subtitle}</Txt>}
+      {subtitle && <Txt className="text-ui-md !font-light text-neutral3">{subtitle}</Txt>}
     </header>
   );
 }

--- a/packages/playground/src/domains/cms/components/section/section-title.tsx
+++ b/packages/playground/src/domains/cms/components/section/section-title.tsx
@@ -9,11 +9,7 @@ export type SectionTitleProps = {
 export function SectionTitle({ icon, children, className }: SectionTitleProps) {
   return (
     <h3
-      className={cn(
-        'flex items-center gap-2 text-ui-sm font-medium text-neutral4',
-        '[&>svg]:w-[1.2em] [&>svg]:h-[1.2em]',
-        className,
-      )}
+      className={cn('flex items-center gap-2 text-ui-sm font-medium text-neutral4', '[&>svg]:size-[1.2em]', className)}
     >
       {icon}
       {children}

--- a/packages/playground/src/domains/configuration/components/header-list-form.tsx
+++ b/packages/playground/src/domains/configuration/components/header-list-form.tsx
@@ -33,7 +33,7 @@ export const HeaderListForm = ({ headers, onAddHeader, onRemoveHeader }: HeaderL
           </ul>
         )}
 
-        <div className="flex items-center gap-2 justify-between">
+        <div className="flex items-center justify-between gap-2">
           {headers.length === 0 && <Txt className="text-neutral3">No header yet</Txt>}
           <Button
             type="button"
@@ -61,7 +61,7 @@ const HeaderListFormItem = ({ index, header, onRemove }: HeaderListFormItemProps
   const valueId = useId();
 
   return (
-    <div className="grid grid-cols-[1fr_1fr_auto] gap-4 items-end">
+    <div className="grid grid-cols-[1fr_1fr_auto] items-end gap-4">
       <TextFieldBlock
         id={nameId}
         name={`headers.${index}.name`}

--- a/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
+++ b/packages/playground/src/domains/configuration/components/mastra-version-footer.tsx
@@ -64,8 +64,8 @@ export const MastraVersionFooter = ({ collapsed }: MastraVersionFooterProps) => 
 
   if (isLoadingPackages) {
     return (
-      <div className="flex items-center justify-end gap-2 px-3 h-9">
-        <div className="animate-pulse h-[1.125rem] w-20 bg-surface4 rounded-full" />
+      <div className="flex h-9 items-center justify-end gap-2 px-3">
+        <div className="h-[1.125rem] w-20 animate-pulse rounded-full bg-surface4" />
       </div>
     );
   }
@@ -86,11 +86,11 @@ export const MastraVersionFooter = ({ collapsed }: MastraVersionFooterProps) => 
         <DialogTrigger asChild>
           <button
             type="button"
-            className="flex rounded-lg p-1 hover:bg-sidebar-nav-hover transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:shadow-focus-ring"
+            className="flex rounded-lg p-1 transition-colors hover:bg-sidebar-nav-hover focus-visible:shadow-focus-ring focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden"
           >
             <span className="relative inline-flex">
               {(isLoadingUpdates || outdatedCount > 0 || deprecatedCount > 0) && (
-                <span className="absolute -right-1.5 -top-1.5 flex items-center gap-1">
+                <span className="absolute -top-1.5 -right-1.5 flex items-center gap-1">
                   {isLoadingUpdates && <Spinner className="size-3 text-neutral3" />}
                   {outdatedCount > 0 && <CountBadge count={outdatedCount} variant="warning" />}
                   {deprecatedCount > 0 && <CountBadge count={deprecatedCount} variant="error" />}
@@ -129,7 +129,7 @@ function CountBadge({ count, variant }: { count: number; variant: 'warning' | 'e
   return (
     <span
       className={cn(
-        'inline-flex items-center justify-center min-w-[1.125rem] h-[1.125rem] px-1 rounded-full text-ui-xs font-bold text-black',
+        'inline-flex h-[1.125rem] min-w-[1.125rem] items-center justify-center rounded-full px-1 text-ui-xs font-bold text-black',
         variant === 'error' ? 'bg-red-700' : 'bg-yellow-700',
       )}
     >
@@ -142,7 +142,7 @@ function StatusBadge({ value, variant }: { value: string | number; variant: 'war
   return (
     <span
       className={cn(
-        'inline-flex font-bold rounded-md px-1.5 py-0.5 items-center justify-center text-black text-xs min-w-5',
+        'inline-flex min-w-5 items-center justify-center rounded-md px-1.5 py-0.5 text-xs font-bold text-black',
         variant === 'error' ? 'bg-red-700' : 'bg-yellow-700',
       )}
     >
@@ -183,7 +183,7 @@ const PackagesModalContent = ({
 
       <DialogBody>
         {/* Status summary */}
-        <div className="flex items-center justify-between gap-3 text-sm text-neutral3 py-2">
+        <div className="flex items-center justify-between gap-3 py-2 text-sm text-neutral3">
           {isLoadingUpdates ? (
             <span className="text-neutral3">Checking for updates...</span>
           ) : !hasUpdates ? (
@@ -213,22 +213,22 @@ const PackagesModalContent = ({
         </div>
 
         {/* Package list */}
-        <div className="max-h-64 overflow-y-auto border border-border1 rounded-md">
+        <div className="max-h-64 overflow-y-auto rounded-md border border-border1">
           <div className="grid grid-cols-[1fr_auto_auto] text-sm">
             {packages.map((pkg, index) => (
               <div key={pkg.name} className={cn('contents', index > 0 && '[&>div]:border-t [&>div]:border-border1')}>
-                <div className="py-2 px-3 font-mono text-text1 truncate min-w-0">
+                <div className="min-w-0 truncate px-3 py-2 font-mono text-text1">
                   <a
                     href={`https://www.npmjs.com/package/${pkg.name}`}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="hover:text-accent1 hover:underline inline-flex items-center gap-1 group"
+                    className="group inline-flex items-center gap-1 hover:text-accent1 hover:underline"
                   >
                     {pkg.name}
-                    <ExternalLink className="w-3 h-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                    <ExternalLink className="size-3 opacity-0 transition-opacity group-hover:opacity-100" />
                   </a>
                 </div>
-                <div className="py-2 px-3 font-mono text-neutral3 flex items-center gap-1.5">
+                <div className="flex items-center gap-1.5 px-3 py-2 font-mono text-neutral3">
                   {pkg.isOutdated || pkg.isDeprecated ? (
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -251,10 +251,10 @@ const PackagesModalContent = ({
                     <span>{pkg.version}</span>
                   )}
                 </div>
-                <div className="py-2 px-3 font-mono text-neutral3 flex items-center">
+                <div className="flex items-center px-3 py-2 font-mono text-neutral3">
                   {(pkg.isOutdated || pkg.isDeprecated) && pkg.latestVersion && (
                     <>
-                      <MoveRight className="w-4 h-4 mx-2 text-neutral3" />
+                      <MoveRight className="mx-2 size-4 text-neutral3" />
                       <span className="text-accent1">{pkg.latestVersion}</span>
                     </>
                   )}
@@ -266,9 +266,9 @@ const PackagesModalContent = ({
 
         {/* Update command section */}
         {hasUpdates && updateCommand && (
-          <div className="space-y-2 pt-2 border-t border-border1">
+          <div className="space-y-2 border-t border-border1 pt-2">
             <div className="flex items-center gap-2 pt-3">
-              <Info className="w-4 h-4 text-neutral3" />
+              <Info className="size-4 text-neutral3" />
               <Txt as="span" variant="ui-sm" className="text-neutral3">
                 Use the command below to update your packages
               </Txt>

--- a/packages/playground/src/domains/configuration/components/playground-config-guard.tsx
+++ b/packages/playground/src/domains/configuration/components/playground-config-guard.tsx
@@ -3,8 +3,8 @@ import { StudioConfigForm } from './studio-config-form';
 
 export const PlaygroundConfigGuard = () => {
   return (
-    <div className="flex flex-col h-screen w-full items-center justify-center bg-surface1">
-      <div className="max-w-md w-full mx-auto px-4 pt-4">
+    <div className="flex h-screen w-full flex-col items-center justify-center bg-surface1">
+      <div className="mx-auto w-full max-w-md px-4 pt-4">
         <div className="flex items-center justify-center pb-4">
           <LogoWithoutText className="size-32" />
         </div>

--- a/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
@@ -41,8 +41,8 @@ function ValidationErrors({ field, errors }: { field: string; errors: Array<{ pa
   return (
     <div className="mt-2 space-y-1">
       {errors.map((err, idx) => (
-        <p key={idx} className="text-xs text-destructive">
-          <code className="bg-destructive/10 px-1 rounded">
+        <p key={idx} className="text-destructive text-xs">
+          <code className="bg-destructive/10 rounded px-1">
             {field}
             {err.path !== '/' ? err.path : ''}
           </code>
@@ -206,7 +206,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="item-input">Input (JSON) *</Label>
-              <CodeEditor value={input} onChange={handleInputChange} showCopyButton={false} className="min-h-[120px]" />
+              <CodeEditor value={input} onChange={handleInputChange} showCopyButton={false} className="min-h-30" />
               {validationErrors?.field === 'input' && (
                 <ValidationErrors field="input" errors={validationErrors.errors} />
               )}
@@ -218,7 +218,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
                 value={groundTruth}
                 onChange={handleGroundTruthChange}
                 showCopyButton={false}
-                className="min-h-[80px]"
+                className="min-h-20"
               />
               {validationErrors?.field === 'groundTruth' && (
                 <ValidationErrors field="groundTruth" errors={validationErrors.errors} />
@@ -231,7 +231,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
                 value={expectedTrajectory}
                 onChange={setExpectedTrajectory}
                 showCopyButton={false}
-                className="min-h-[80px]"
+                className="min-h-20"
               />
             </div>
 
@@ -241,7 +241,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
                 value={toolMocks}
                 onChange={handleToolMocksChange}
                 showCopyButton={false}
-                className="min-h-[80px]"
+                className="min-h-20"
               />
               {validationErrors?.field === 'toolMocks' && (
                 <ValidationErrors field="toolMocks" errors={validationErrors.errors} />
@@ -254,7 +254,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
                 value={requestContext}
                 onChange={setRequestContext}
                 showCopyButton={false}
-                className="min-h-[80px]"
+                className="min-h-20"
               />
             </div>
 

--- a/packages/playground/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-items-to-dataset-dialog.tsx
@@ -107,7 +107,7 @@ export function AddItemsToDatasetDialog({
                 </SelectTrigger>
                 <SelectContent>
                   {availableDatasets.length === 0 ? (
-                    <div className="px-2 py-4 text-sm text-neutral4 text-center">No other datasets available</div>
+                    <div className="px-2 py-4 text-center text-sm text-neutral4">No other datasets available</div>
                   ) : (
                     availableDatasets.map(dataset => (
                       <SelectItem key={dataset.id} value={dataset.id}>
@@ -119,19 +119,19 @@ export function AddItemsToDatasetDialog({
               </Select>
             </div>
 
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               {items.length} item{items.length !== 1 ? 's' : ''} will be copied to the selected dataset
             </p>
 
             {isAdding && (
               <div className="space-y-2">
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
                   <div
-                    className="h-full bg-primary transition-all duration-200"
+                    className="bg-primary h-full transition-all duration-200"
                     style={{ width: `${progressPercent}%` }}
                   />
                 </div>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Adding items: {progress} / {items.length}
                 </p>
               </div>

--- a/packages/playground/src/domains/datasets/components/bulk-trace-review-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/bulk-trace-review-dialog.tsx
@@ -133,7 +133,7 @@ export function BulkTraceReviewDialog({
       </SideDialog.Top>
 
       <SideDialog.Content>
-        <div className="flex items-center justify-between mb-4">
+        <div className="mb-4 flex items-center justify-between">
           <div className="flex items-center gap-2">
             <Button
               tooltip="Previous item"
@@ -170,7 +170,7 @@ export function BulkTraceReviewDialog({
               value={currentItem.input}
               onChange={(v: string | undefined) => updateCurrentItem('input', v ?? '')}
               showCopyButton={false}
-              className="min-h-[120px]"
+              className="min-h-30"
             />
           </div>
 
@@ -180,7 +180,7 @@ export function BulkTraceReviewDialog({
               value={currentItem.groundTruth}
               onChange={(v: string | undefined) => updateCurrentItem('groundTruth', v ?? '')}
               showCopyButton={false}
-              className="min-h-[80px]"
+              className="min-h-20"
             />
           </div>
 
@@ -190,7 +190,7 @@ export function BulkTraceReviewDialog({
               value={currentItem.expectedTrajectory}
               onChange={(v: string | undefined) => updateCurrentItem('expectedTrajectory', v ?? '')}
               showCopyButton={false}
-              className="min-h-[80px]"
+              className="min-h-20"
             />
           </div>
 

--- a/packages/playground/src/domains/datasets/components/create-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-dialog.tsx
@@ -146,7 +146,7 @@ export function CreateDatasetDialog({
             {targetType && !showCustomSchema ? (
               <button
                 type="button"
-                className="text-xs text-neutral3 hover:text-accent1 transition-colors"
+                className="text-xs text-neutral3 transition-colors hover:text-accent1"
                 onClick={() => setShowCustomSchema(true)}
               >
                 + Custom schema

--- a/packages/playground/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/create-dataset-from-items-dialog.tsx
@@ -119,19 +119,19 @@ export function CreateDatasetFromItemsDialog({
               />
             </div>
 
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               {items.length} item{items.length !== 1 ? 's' : ''} will be copied to the new dataset
             </p>
 
             {isCreating && (
               <div className="space-y-2">
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
                   <div
-                    className="h-full bg-primary transition-all duration-200"
+                    className="bg-primary h-full transition-all duration-200"
                     style={{ width: `${progressPercent}%` }}
                   />
                 </div>
-                <p className="text-sm text-muted-foreground">
+                <p className="text-muted-foreground text-sm">
                   Copying items: {progress} / {items.length}
                 </p>
               </div>

--- a/packages/playground/src/domains/datasets/components/csv-import/column-mapping-step.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/column-mapping-step.tsx
@@ -69,8 +69,8 @@ export function ColumnMappingStep({ headers, mapping, onMappingChange }: ColumnM
                     ref={provided.innerRef}
                     {...provided.droppableProps}
                     className={`
-                      min-h-header-default rounded-lg border-2 border-dashed p-2
-                      flex flex-wrap gap-2 items-center
+                      flex min-h-header-default flex-wrap items-center gap-2
+                      rounded-lg border-2 border-dashed p-2
                       transition-colors
                       ${snapshot.isDraggingOver ? 'border-accent1/50 bg-accent1/5' : 'border-surface4'}
                       ${needsAttention ? 'border-warning bg-warning/5' : ''}
@@ -91,19 +91,19 @@ export function ColumnMappingStep({ headers, mapping, onMappingChange }: ColumnM
                               {...provided.draggableProps}
                               style={provided.draggableProps.style}
                               className={`
-                                inline-flex items-center gap-1.5 px-2.5 py-1.5
-                                rounded-md text-sm font-medium
-                                bg-surface2 text-neutral1
+                                inline-flex items-center gap-1.5 rounded-md bg-surface2
+                                px-2.5 py-1.5 text-sm
+                                font-medium text-neutral1
                                 transition-all
                                 ${snapshot.isDragging ? 'shadow-lg ring-2 ring-accent1/30' : 'hover:bg-surface3'}
                               `}
                             >
                               <span
                                 {...provided.dragHandleProps}
-                                className="text-neutral4 cursor-grab active:cursor-grabbing"
+                                className="cursor-grab text-neutral4 active:cursor-grabbing"
                               >
                                 <Icon>
-                                  <GripVertical className="h-3.5 w-3.5" />
+                                  <GripVertical className="size-3.5" />
                                 </Icon>
                               </span>
                               <span>{column}</span>
@@ -130,7 +130,7 @@ export function ColumnMappingStep({ headers, mapping, onMappingChange }: ColumnM
         })}
 
         {/* Validation message */}
-        {!inputHasColumns && <div className="text-sm text-warning">At least one column must be mapped to Input</div>}
+        {!inputHasColumns && <div className="text-warning text-sm">At least one column must be mapped to Input</div>}
       </div>
     </DragDropContext>
   );

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-import-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-import-dialog.tsx
@@ -353,7 +353,7 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
 
             {/* Compact preview */}
             <div className="border-t border-border1 pt-4">
-              <div className="text-xs text-neutral4 mb-2">Data Preview</div>
+              <div className="mb-2 text-xs text-neutral4">Data Preview</div>
               <CSVPreviewTable headers={parsedCSV.headers} data={parsedCSV.data} maxRows={3} />
             </div>
           </div>
@@ -370,18 +370,18 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
 
             {/* Prominent validation summary banner */}
             {schemaValidation.invalidCount > 0 ? (
-              <div className="p-3 bg-warning/10 border border-warning/30 rounded-md">
-                <div className="flex items-center gap-2 text-warning font-medium">
+              <div className="bg-warning/10 border-warning/30 rounded-md border p-3">
+                <div className="text-warning flex items-center gap-2 font-medium">
                   <span className="text-lg">⚠</span>
                   {schemaValidation.invalidCount} row{schemaValidation.invalidCount !== 1 ? 's' : ''} will be skipped
                 </div>
-                <p className="text-sm text-muted-foreground mt-1">
+                <p className="text-muted-foreground mt-1 text-sm">
                   {schemaValidation.validCount} of {schemaValidation.totalRows} rows will be imported
                 </p>
               </div>
             ) : (
-              <div className="p-3 bg-success/10 border border-success/30 rounded-md">
-                <div className="flex items-center gap-2 text-success font-medium">
+              <div className="bg-success/10 border-success/30 rounded-md border p-3">
+                <div className="text-success flex items-center gap-2 font-medium">
                   <span className="text-lg">✓</span>
                   All {schemaValidation.totalRows} row{schemaValidation.totalRows !== 1 ? 's are' : ' is'} valid
                 </div>
@@ -390,7 +390,7 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
 
             {/* No valid rows warning */}
             {schemaValidation.validCount === 0 && (
-              <p className="text-sm text-destructive">
+              <p className="text-destructive text-sm">
                 No valid rows to import. Please fix the data or adjust the schema.
               </p>
             )}
@@ -406,7 +406,7 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
             <Spinner />
             <div className="text-center">
               <div className="text-lg font-medium text-neutral1">Importing items...</div>
-              <div className="text-sm text-neutral4 mt-1">
+              <div className="mt-1 text-sm text-neutral4">
                 {importProgress.current} of {importProgress.total}
               </div>
             </div>
@@ -419,7 +419,7 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
             <div className="text-4xl">{importResult && importResult.errors === 0 ? '✓' : '⚠'}</div>
             <div className="text-center">
               <div className="text-lg font-medium text-neutral1">Import Complete</div>
-              <div className="text-sm text-neutral4 mt-1">
+              <div className="mt-1 text-sm text-neutral4">
                 {importResult?.success ?? 0} item{importResult?.success !== 1 ? 's' : ''} imported
                 {importResult && importResult.errors > 0 && (
                   <span className="text-accent2">
@@ -500,15 +500,15 @@ export function CSVImportDialog({ datasetId, open, onOpenChange, onSuccess }: CS
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh]">
+      <DialogContent className="max-h-[90vh] max-w-2xl">
         <DialogHeader>
           <DialogTitle>{stepTitles[step]}</DialogTitle>
           <DialogDescription>Import dataset items from a CSV file.</DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="min-h-[200px] max-h-[50vh] overflow-y-auto">{renderStepContent()}</DialogBody>
+        <DialogBody className="min-h-50 max-h-[50vh] overflow-y-auto">{renderStepContent()}</DialogBody>
 
-        <DialogFooter className="px-6 pt-4 flex justify-end gap-2">{renderFooter()}</DialogFooter>
+        <DialogFooter className="flex justify-end gap-2 px-6 pt-4">{renderFooter()}</DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-preview-table.tsx
@@ -54,7 +54,7 @@ export function CSVPreviewTable({ headers, data, maxRows = 5 }: CSVPreviewTableP
                       <DataList.RowHeaderCell
                         key={`${index}-${header}`}
                         height="compact"
-                        className="max-w-[14rem] text-ui-sm"
+                        className="max-w-56 text-ui-sm"
                       >
                         {value}
                       </DataList.RowHeaderCell>
@@ -62,7 +62,7 @@ export function CSVPreviewTable({ headers, data, maxRows = 5 }: CSVPreviewTableP
                   }
 
                   return (
-                    <DataList.Cell key={`${index}-${header}`} height="compact" className="max-w-[12rem] text-ui-sm">
+                    <DataList.Cell key={`${index}-${header}`} height="compact" className="max-w-48 text-ui-sm">
                       <span className="block truncate">{value}</span>
                     </DataList.Cell>
                   );

--- a/packages/playground/src/domains/datasets/components/csv-import/csv-upload-step.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/csv-upload-step.tsx
@@ -91,7 +91,7 @@ export function CSVUploadStep({ onFileSelect, isParsing, error }: CSVUploadStepP
         onDrop={handleDrop}
         className={cn(
           'flex flex-col items-center justify-center gap-3',
-          'min-h-[160px] rounded-lg border-2 border-dashed p-6',
+          'min-h-40 rounded-lg border-2 border-dashed p-6',
           'cursor-pointer transition-colors',
           // Default state
           'border-surface4 bg-surface2',
@@ -111,7 +111,7 @@ export function CSVUploadStep({ onFileSelect, isParsing, error }: CSVUploadStepP
         ) : (
           <>
             <Icon className="text-neutral4">
-              <Upload className="h-8 w-8" />
+              <Upload className="size-8" />
             </Icon>
             <div className="flex flex-col items-center gap-1">
               <span className="text-sm font-medium text-neutral1">Click to upload or drag and drop</span>

--- a/packages/playground/src/domains/datasets/components/csv-import/validation-report.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/validation-report.tsx
@@ -19,8 +19,8 @@ export function ValidationReport({ result, className }: ValidationReportProps) {
   // All rows valid
   if (invalidCount === 0) {
     return (
-      <div className={cn('flex items-center gap-2 text-sm text-success', className)}>
-        <CheckCircleIcon className="w-4 h-4" />
+      <div className={cn('text-success flex items-center gap-2 text-sm', className)}>
+        <CheckCircleIcon className="size-4" />
         All {totalRows} row{totalRows !== 1 ? 's' : ''} valid
       </div>
     );
@@ -29,15 +29,15 @@ export function ValidationReport({ result, className }: ValidationReportProps) {
   return (
     <div className={cn('space-y-3', className)}>
       {/* Summary warning */}
-      <div className="flex items-center gap-2 text-sm text-warning">
-        <AlertTriangleIcon className="w-4 h-4" />
+      <div className="text-warning flex items-center gap-2 text-sm">
+        <AlertTriangleIcon className="size-4" />
         {invalidCount} of {totalRows} rows will be skipped (validation failed)
       </div>
 
-      {validCount > 0 && <div className="text-sm text-muted-foreground">{validCount} rows will be imported</div>}
+      {validCount > 0 && <div className="text-muted-foreground text-sm">{validCount} rows will be imported</div>}
 
       {/* Failing rows table */}
-      <div className="max-h-48 overflow-y-auto border rounded-md">
+      <div className="max-h-48 overflow-y-auto rounded-md border">
         <table className="w-full text-xs">
           <thead className="bg-muted sticky top-0">
             <tr>
@@ -52,7 +52,7 @@ export function ValidationReport({ result, className }: ValidationReportProps) {
             ))}
             {invalidCount > invalidRows.length && (
               <tr>
-                <td colSpan={3} className="px-2 py-1 text-muted-foreground italic">
+                <td colSpan={3} className="text-muted-foreground px-2 py-1 italic">
                   ... and {invalidCount - invalidRows.length} more
                 </td>
               </tr>
@@ -73,14 +73,14 @@ function ValidationRow({ row }: { row: RowValidationResult }) {
 
   return (
     <tr className="border-t">
-      <td className="px-2 py-1 text-muted-foreground">{row.rowNumber}</td>
+      <td className="text-muted-foreground px-2 py-1">{row.rowNumber}</td>
       <td className="px-2 py-1">
-        <code className="text-xs bg-muted px-1 rounded">
+        <code className="bg-muted rounded px-1 text-xs">
           {row.field}
           {errorPath !== '/' ? errorPath : ''}
         </code>
       </td>
-      <td className="px-2 py-1 text-destructive">{errorMessage}</td>
+      <td className="text-destructive px-2 py-1">{errorMessage}</td>
     </tr>
   );
 }

--- a/packages/playground/src/domains/datasets/components/csv-import/validation-summary.tsx
+++ b/packages/playground/src/domains/datasets/components/csv-import/validation-summary.tsx
@@ -22,7 +22,7 @@ export function ValidationSummary({ errors }: ValidationSummaryProps) {
 
   return (
     <Notice variant="destructive" title={`${errors.length} validation error${errors.length !== 1 ? 's' : ''} found`}>
-      <div className="max-h-[120px] overflow-y-auto space-y-1 text-sm">
+      <div className="max-h-30 space-y-1 overflow-y-auto text-sm">
         {errors.map((error: ValidationError, index: number) => (
           <div key={index}>
             Row {error.row}: <span className="font-medium">[{error.column}]</span> - {error.message}

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
@@ -18,8 +18,8 @@ function ValidationErrors({ field, errors }: { field: string; errors: Array<{ pa
   return (
     <div className="mt-2 space-y-1">
       {errors.map((err, idx) => (
-        <p key={idx} className="text-xs text-destructive">
-          <code className="bg-destructive/10 px-1 rounded">
+        <p key={idx} className="text-destructive text-xs">
+          <code className="bg-destructive/10 rounded px-1">
             {field}
             {err.path !== '/' ? err.path : ''}
           </code>
@@ -73,15 +73,15 @@ export function EditModeContent({
   return (
     <>
       <div className="mb-4">
-        <h3 className="text-lg font-medium flex items-center gap-2">
-          <Pencil className="w-5 h-5" /> Edit Item
+        <h3 className="flex items-center gap-2 text-lg font-medium">
+          <Pencil className="size-5" /> Edit Item
         </h3>
       </div>
 
       <div className="space-y-6">
         <div className="space-y-2">
           <Label>Input (JSON) *</Label>
-          <CodeEditor value={inputValue} onChange={setInputValue} showCopyButton={false} className="min-h-[120px]" />
+          <CodeEditor value={inputValue} onChange={setInputValue} showCopyButton={false} className="min-h-30" />
           {validationErrors?.field === 'input' && <ValidationErrors field="input" errors={validationErrors.errors} />}
         </div>
 
@@ -91,7 +91,7 @@ export function EditModeContent({
             value={groundTruthValue}
             onChange={setGroundTruthValue}
             showCopyButton={false}
-            className="min-h-[100px]"
+            className="min-h-25"
           />
           {validationErrors?.field === 'groundTruth' && (
             <ValidationErrors field="groundTruth" errors={validationErrors.errors} />
@@ -104,23 +104,18 @@ export function EditModeContent({
             value={trajectoryValue}
             onChange={setTrajectoryValue}
             showCopyButton={false}
-            className="min-h-[80px]"
+            className="min-h-20"
           />
         </div>
 
         <div className="space-y-2">
           <Label>Tool Mocks (JSON array, optional)</Label>
-          <p className="text-xs text-muted-foreground">
+          <p className="text-muted-foreground text-xs">
             Ordered static mocks served in place of executing the tool. Each entry is{' '}
             <code>{`{ "toolName", "args", "output" }`}</code>. Calling a mocked tool with non-matching args fails the
             item; unmocked tools run live.
           </p>
-          <CodeEditor
-            value={toolMocksValue}
-            onChange={setToolMocksValue}
-            showCopyButton={false}
-            className="min-h-[100px]"
-          />
+          <CodeEditor value={toolMocksValue} onChange={setToolMocksValue} showCopyButton={false} className="min-h-25" />
           {validationErrors?.field === 'toolMocks' && (
             <ValidationErrors field="toolMocks" errors={validationErrors.errors} />
           )}
@@ -132,18 +127,13 @@ export function EditModeContent({
             value={requestContextValue}
             onChange={setRequestContextValue}
             showCopyButton={false}
-            className="min-h-[80px]"
+            className="min-h-20"
           />
         </div>
 
         <div className="space-y-2">
           <Label>Metadata (JSON, optional)</Label>
-          <CodeEditor
-            value={metadataValue}
-            onChange={setMetadataValue}
-            showCopyButton={false}
-            className="min-h-[80px]"
-          />
+          <CodeEditor value={metadataValue} onChange={setMetadataValue} showCopyButton={false} className="min-h-20" />
         </div>
 
         <div className="flex gap-2 pt-4">

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-page-tabs.tsx
@@ -163,7 +163,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
         defaultTab="items"
         value={activeTab}
         onValueChange={handleTabChange}
-        className="grid grid-rows-[auto_1fr] h-full"
+        className="grid h-full grid-rows-[auto_1fr]"
       >
         <TabList>
           <Tab value="items">
@@ -179,7 +179,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
           </Tab>
         </TabList>
 
-        <TabContent value="items" className="grid overflow-auto mt-5 pb-0">
+        <TabContent value="items" className="mt-5 grid overflow-auto pb-0">
           <DatasetItems
             datasetId={datasetId}
             items={items}
@@ -207,7 +207,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
           />
         </TabContent>
 
-        <TabContent value="experiments" className="grid overflow-auto mt-5 pb-0">
+        <TabContent value="experiments" className="mt-5 grid overflow-auto pb-0">
           <DatasetExperiments
             experiments={experiments}
             allExperiments={allExperiments}
@@ -218,7 +218,7 @@ export function DatasetPageTabs({ datasetId, onAddItemClick, onNavigateToDataset
           />
         </TabContent>
 
-        <TabContent value="review" className="overflow-auto mt-2 pb-0">
+        <TabContent value="review" className="mt-2 overflow-auto pb-0">
           <DatasetReview datasetId={datasetId} />
         </TabContent>
       </Tabs>

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-detail-dialog.tsx
@@ -369,7 +369,7 @@ function EditModeContent({
       <div className="space-y-6">
         <div className="space-y-2">
           <Label>Input (JSON) *</Label>
-          <CodeEditor value={inputValue} onChange={setInputValue} showCopyButton={false} className="min-h-[120px]" />
+          <CodeEditor value={inputValue} onChange={setInputValue} showCopyButton={false} className="min-h-30" />
         </div>
 
         <div className="space-y-2">
@@ -378,7 +378,7 @@ function EditModeContent({
             value={groundTruthValue}
             onChange={setGroundTruthValue}
             showCopyButton={false}
-            className="min-h-[100px]"
+            className="min-h-25"
           />
         </div>
 
@@ -388,7 +388,7 @@ function EditModeContent({
             value={trajectoryValue}
             onChange={setTrajectoryValue}
             showCopyButton={false}
-            className="min-h-[80px]"
+            className="min-h-20"
           />
         </div>
 
@@ -398,18 +398,13 @@ function EditModeContent({
             value={requestContextValue}
             onChange={setRequestContextValue}
             showCopyButton={false}
-            className="min-h-[80px]"
+            className="min-h-20"
           />
         </div>
 
         <div className="space-y-2">
           <Label>Metadata (JSON, optional)</Label>
-          <CodeEditor
-            value={metadataValue}
-            onChange={setMetadataValue}
-            showCopyButton={false}
-            className="min-h-[80px]"
-          />
+          <CodeEditor value={metadataValue} onChange={setMetadataValue} showCopyButton={false} className="min-h-20" />
         </div>
 
         <div className="flex justify-end gap-2 pt-4">

--- a/packages/playground/src/domains/datasets/components/dataset-detail/item-page-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/item-page-toolbar.tsx
@@ -39,7 +39,7 @@ export function ItemPageToolbar({ onBack, onEdit, onDelete, isEditing = false }:
                 </Button>
               </PopoverTrigger>
 
-              <PopoverContent align="end" className="w-48 p-1 bg-surface4 ">
+              <PopoverContent align="end" className="w-48 bg-surface4 p-1 ">
                 <div className="flex flex-col gap-2">
                   <Button
                     variant="ghost"

--- a/packages/playground/src/domains/datasets/components/dataset-detail/items-list-actions.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/items-list-actions.tsx
@@ -35,7 +35,7 @@ export function ActionsMenu({
       <PopoverTrigger asChild>
         <Button variant="ghost" size="sm" disabled={disabled} aria-label="Actions menu">
           <Icon>
-            <MoreVertical className="w-4 h-4" />
+            <MoreVertical className="size-4" />
           </Icon>
         </Button>
       </PopoverTrigger>
@@ -48,7 +48,7 @@ export function ActionsMenu({
             onClick={() => handleAction(onExportClick)}
           >
             <Icon>
-              <Download className="w-4 h-4" />
+              <Download className="size-4" />
             </Icon>
             Export
           </Button>
@@ -59,7 +59,7 @@ export function ActionsMenu({
             onClick={() => handleAction(onCreateDatasetClick)}
           >
             <Icon>
-              <FolderPlus className="w-4 h-4" />
+              <FolderPlus className="size-4" />
             </Icon>
             Create Dataset
           </Button>
@@ -70,7 +70,7 @@ export function ActionsMenu({
             onClick={() => handleAction(onDeleteClick)}
           >
             <Icon>
-              <Trash2 className="w-4 h-4" />
+              <Trash2 className="size-4" />
             </Icon>
             Delete
           </Button>

--- a/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-list/datasets-list.tsx
@@ -158,7 +158,7 @@ export function DatasetsList({
                 )}
               </EntityList.Cell>
               <EntityList.TextCell>v{ds.version ?? 1}</EntityList.TextCell>
-              <EntityList.Cell className="text-neutral4 text-ui-smd">
+              <EntityList.Cell className="text-ui-smd text-neutral4">
                 {ds.targetTypes.length > 0 ? (
                   <span className="flex min-w-0 items-center gap-2 overflow-hidden">
                     {ds.targetTypes.map(type => (
@@ -183,7 +183,7 @@ export function DatasetsList({
                 to={`${paths.datasetLink(ds.id)}?tab=experiments`}
                 variant="ghost"
                 size="sm"
-                className="w-full  rounded-lg h-full p-0!"
+                className="size-full  rounded-lg p-0!"
               >
                 <Chip color={experimentsChipColor}>
                   {ds.experimentCount} ({ds.successPct ?? 0}%)
@@ -197,7 +197,7 @@ export function DatasetsList({
                 to={`${paths.datasetLink(ds.id)}?tab=review`}
                 variant="ghost"
                 size="sm"
-                className="w-full  rounded-lg h-full p-0!"
+                className="size-full  rounded-lg p-0!"
               >
                 {review.needsReview > 0 ? (
                   <Chip color="yellow">{review.needsReview} pending</Chip>

--- a/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/datasets-toolbar.tsx
@@ -43,7 +43,7 @@ export function DatasetsToolbar({
 }: DatasetsToolbarProps) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <div className="min-w-64 max-w-120 flex-1">
+      <div className="max-w-120 min-w-64 flex-1">
         <ListSearch
           label="Search datasets"
           placeholder="Filter by dataset name"

--- a/packages/playground/src/domains/datasets/components/duplicate-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/duplicate-dataset-dialog.tsx
@@ -179,19 +179,19 @@ export function DuplicateDatasetDialog({
               />
             </div>
 
-            <p className="text-sm text-muted-foreground">
+            <p className="text-muted-foreground text-sm">
               All items from &quot;{sourceDatasetName}&quot; will be copied to the new dataset
             </p>
 
             {isDuplicating && (
               <div className="space-y-2">
-                <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+                <div className="bg-muted h-2 w-full overflow-hidden rounded-full">
                   <div
-                    className="h-full bg-primary transition-all duration-200"
+                    className="bg-primary h-full transition-all duration-200"
                     style={{ width: `${progressPercent}%` }}
                   />
                 </div>
-                <p className="text-sm text-muted-foreground">{getProgressText()}</p>
+                <p className="text-muted-foreground text-sm">{getProgressText()}</p>
               </div>
             )}
 

--- a/packages/playground/src/domains/datasets/components/edit-dataset-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/edit-dataset-dialog.tsx
@@ -205,7 +205,7 @@ function EditDatasetDialogForm({ onOpenChange, dataset, onSuccess }: EditDataset
           />
 
           {formState.validationError && (
-            <div className="p-3 bg-red-950/20 border border-red-900/50 rounded-md">
+            <div className="rounded-md border border-red-900/50 bg-red-950/20 p-3">
               <p className="text-sm text-red-200">{formState.validationError}</p>
             </div>
           )}

--- a/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
+++ b/packages/playground/src/domains/datasets/components/empty-datasets-table.tsx
@@ -15,7 +15,7 @@ export function EmptyDatasetsTable({ onCreateClick }: EmptyDatasetsTableProps) {
         titleSlot="No Datasets Yet"
         descriptionSlot="Create your first dataset to start evaluating your agents and workflows."
         actionSlot={
-          <div className="flex flex-col sm:flex-row gap-2">
+          <div className="flex flex-col gap-2 sm:flex-row">
             {onCreateClick && (
               <Button size="lg" variant="default" onClick={onCreateClick}>
                 <Icon>

--- a/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/experiment-trigger/experiment-trigger-dialog.tsx
@@ -52,7 +52,7 @@ function RequestContextForm({
   }, [requestContextSchema]);
 
   if (!zodSchema) {
-    return <p className="text-sm text-destructive">Failed to parse request context schema</p>;
+    return <p className="text-destructive text-sm">Failed to parse request context schema</p>;
   }
 
   return (
@@ -193,7 +193,7 @@ export function ExperimentTriggerDialog({
                 value={requestContextRaw}
                 onChange={setRequestContextRaw}
                 showCopyButton={false}
-                className="min-h-[80px]"
+                className="min-h-20"
               />
             </div>
           )}
@@ -206,7 +206,7 @@ export function ExperimentTriggerDialog({
           <Button variant="primary" onClick={handleRun} disabled={!canRun || isRunning}>
             {isRunning ? (
               <>
-                <Spinner className="w-4 h-4" />
+                <Spinner className="size-4" />
                 Running...
               </>
             ) : (

--- a/packages/playground/src/domains/datasets/components/experiments/comparison-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/comparison-item-panel.tsx
@@ -107,9 +107,9 @@ export function ComparisonItemPanel({
                       return (
                         <div
                           key={scorerId}
-                          className="flex items-center justify-between gap-4 px-3 py-2 rounded-lg bg-surface2"
+                          className="flex items-center justify-between gap-4 rounded-lg bg-surface2 px-3 py-2"
                         >
-                          <span className="text-sm text-neutral5 font-medium">{scorerId}</span>
+                          <span className="text-sm font-medium text-neutral5">{scorerId}</span>
                           <div className="flex items-center gap-4">
                             <span className="text-sm text-neutral3">
                               {baselineScore != null ? baselineScore.toFixed(3) : '-'} →{' '}

--- a/packages/playground/src/domains/datasets/components/experiments/comparison-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/comparison-items-list.tsx
@@ -63,10 +63,10 @@ export function ComparisonItemsList({
                             baselineScore != null && contenderScore != null ? contenderScore - baselineScore : null;
 
                           return (
-                            <ItemList.Cell key={scorerId} className="flex items-center gap-5 justify-center font-mono">
+                            <ItemList.Cell key={scorerId} className="flex items-center justify-center gap-5 font-mono">
                               {delta != null ? (
                                 <>
-                                  <span className="flex items-center text-neutral2 min-w-24">
+                                  <span className="flex min-w-24 items-center text-neutral2">
                                     {baselineScore?.toFixed(2)} → {contenderScore?.toFixed(2)}
                                   </span>
                                   <ScoreDelta delta={delta} />

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-comparison.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-comparison.tsx
@@ -135,7 +135,7 @@ export function DatasetExperimentsComparison({
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center h-64">
+      <div className="flex h-64 items-center justify-center">
         <Spinner />
       </div>
     );
@@ -150,7 +150,7 @@ export function DatasetExperimentsComparison({
   }
 
   if (!comparison || comparison.items.length === 0) {
-    return <div className="text-neutral4 text-sm text-center py-8">No comparison data</div>;
+    return <div className="py-8 text-center text-sm text-neutral4">No comparison data</div>;
   }
 
   const baselineId = comparison.baselineId;
@@ -160,11 +160,11 @@ export function DatasetExperimentsComparison({
     <div className="grid gap-10">
       {/* Experiment infos */}
       {expA && expB && (
-        <div className={cn('relative grid xl:grid-cols-[1fr_auto_1fr] gap-4 xl:gap-0')}>
+        <div className={cn('relative grid gap-4 xl:grid-cols-[1fr_auto_1fr] xl:gap-0')}>
           <ExperimentInComparisonInfo datasetId={datasetId} experiment={expA} type="baseline" />
 
-          <div className="relative flex items-center justify-center px-[2vw] before:absolute before:inset-y-0 before:left-1/2 before:-translate-x-1/2 before:w-[2px] before:bg-border1">
-            <div className="relative z-1 bg-surface2 rounded-lg p-2">
+          <div className="relative flex items-center justify-center px-[2vw] before:absolute before:inset-y-0 before:left-1/2 before:w-[2px] before:-translate-x-1/2 before:bg-border1">
+            <div className="relative z-1 rounded-lg bg-surface2 p-2">
               <Tooltip>
                 <TooltipTrigger asChild>
                   <Button onClick={onSwap}>VS</Button>

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-list.tsx
@@ -76,9 +76,9 @@ export function DatasetExperimentsList({
               {experiment.status && (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <div className="flex items-center justify-center w-10 relative bg-transparent h-full">
+                    <div className="relative flex h-full w-10 items-center justify-center bg-transparent">
                       <div
-                        className={cn('w-2 h-2 rounded-full', {
+                        className={cn('size-2 rounded-full', {
                           'bg-green-600': ['success', 'completed'].includes(experiment.status),
                           'bg-red-700': ['error', 'failed'].includes(experiment.status),
                           'bg-yellow-500': ['pending', 'running'].includes(experiment.status),
@@ -110,7 +110,7 @@ export function DatasetExperimentsList({
               </Tooltip>
             </DataList.Cell>
             <DataList.Cell height="compact" className="min-w-0">
-              <span className="block text-ui-smd text-neutral2 truncate">{formatDate(createdAtDate)}</span>
+              <span className="block truncate text-ui-smd text-neutral2">{formatDate(createdAtDate)}</span>
             </DataList.Cell>
           </>
         );
@@ -146,7 +146,7 @@ function EmptyDatasetExperimentsList() {
   return (
     <div className="flex h-full items-center justify-center py-12">
       <EmptyState
-        iconSlot={<Play className="w-8 h-8 text-neutral3" />}
+        iconSlot={<Play className="size-8 text-neutral3" />}
         titleSlot="No experiments yet"
         descriptionSlot="Trigger an experiment to evaluate your dataset against an agent, workflow, or scorer."
       />

--- a/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/dataset-experiments-toolbar.tsx
@@ -50,9 +50,9 @@ export function DatasetExperimentsToolbar({
 
   if (isSelectionActive) {
     return (
-      <div className="flex items-center justify-end gap-4 w-full">
+      <div className="flex w-full items-center justify-end gap-4">
         <div className="flex gap-5">
-          <div className="text-sm text-neutral3 flex items-center gap-2 pl-6">
+          <div className="flex items-center gap-2 pl-6 text-sm text-neutral3">
             <Chip size="large" color={selectedCount < 2 ? 'red' : 'green'}>
               {selectedCount}
             </Chip>
@@ -61,7 +61,7 @@ export function DatasetExperimentsToolbar({
           </div>
           <ButtonsGroup>
             <Button variant="primary" disabled={selectedCount !== 2} onClick={onExecuteCompare}>
-              <GitCompare className="w-4 h-4" />
+              <GitCompare className="size-4" />
               Compare Experiments
             </Button>
             <Button onClick={onCancelSelection}>Cancel</Button>
@@ -72,7 +72,7 @@ export function DatasetExperimentsToolbar({
   }
 
   return (
-    <div className="flex items-center justify-between gap-4 w-full">
+    <div className="flex w-full items-center justify-between gap-4">
       <ButtonsGroup>
         <SelectFieldBlock
           label="Status"

--- a/packages/playground/src/domains/datasets/components/experiments/experiment-in-comparison-info.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/experiment-in-comparison-info.tsx
@@ -40,8 +40,8 @@ export function ExperimentInComparisonInfo({ datasetId, experiment, type }: Expe
   const createdAt = experiment.createdAt ? new Date(experiment.createdAt) : null;
 
   return (
-    <div className={`grid border-2 border-border1 rounded-lg p-5 gap-3 ${customStyle}`}>
-      <div className="flex items-center gap-3 w-full overflow-clip">
+    <div className={`grid gap-3 rounded-lg border-2 border-border1 p-5 ${customStyle}`}>
+      <div className="flex w-full items-center gap-3 overflow-clip">
         {type === 'contender' && (
           <Chip size="small" color={color}>
             {label}
@@ -50,7 +50,7 @@ export function ExperimentInComparisonInfo({ datasetId, experiment, type }: Expe
         )}
 
         <Button as={Link} href={`/datasets/${datasetId}/experiments/${experiment.id}`}>
-          <span className="truncate min-w-0">{experiment.id}</span>
+          <span className="min-w-0 truncate">{experiment.id}</span>
         </Button>
 
         {type === 'baseline' && (

--- a/packages/playground/src/domains/datasets/components/experiments/score-delta.tsx
+++ b/packages/playground/src/domains/datasets/components/experiments/score-delta.tsx
@@ -24,8 +24,8 @@ export function ScoreDelta({ delta }: ScoreDeltaProps) {
     ) : null;
 
   return (
-    <span className={cn('font-mono text-sm text-neutral4 min-w-20')}>
-      <span className="w-3 inline-block">{delta > 0 ? '+ ' : delta < 0 ? '- ' : ''}</span>
+    <span className={cn('min-w-20 font-mono text-sm text-neutral4')}>
+      <span className="inline-block w-3">{delta > 0 ? '+ ' : delta < 0 ? '- ' : ''}</span>
       {Math.abs(delta).toFixed(2)}&nbsp;{arrow}
     </span>
   );

--- a/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/generate-items-dialog.tsx
@@ -116,7 +116,7 @@ export function GenerateConfigDialog({ datasetId, agentContext, onDismiss }: Gen
             <div className="space-y-1">
               <Label>Model</Label>
               <div className="flex items-center gap-1.5">
-                <div className="w-[160px]">
+                <div className="w-40">
                   <LLMProviders
                     value={localProvider}
                     onValueChange={value => {
@@ -290,8 +290,8 @@ export function GenerateReviewDialog({
         <DialogHeader>
           <DialogTitle>Review Generated Items</DialogTitle>
         </DialogHeader>
-        <DialogBody className="max-h-[70vh] flex flex-col">
-          <div className="flex flex-col flex-1 min-h-0 gap-4">
+        <DialogBody className="flex max-h-[70vh] flex-col">
+          <div className="flex min-h-0 flex-1 flex-col gap-4">
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-2">
                 <Checkbox checked={selectedIndices.size === generatedItems.length} onCheckedChange={toggleAll} />
@@ -306,14 +306,14 @@ export function GenerateReviewDialog({
               )}
             </div>
 
-            <ScrollArea className="flex-1 min-h-0">
+            <ScrollArea className="min-h-0 flex-1">
               <div className="space-y-2">
                 {generatedItems.map((item, index) => (
-                  <div key={index} className="border border-border1 rounded-lg">
+                  <div key={index} className="rounded-lg border border-border1">
                     <div className="flex items-center gap-2 px-3 py-2">
                       <Checkbox checked={selectedIndices.has(index)} onCheckedChange={() => toggleIndex(index)} />
                       <button type="button" className="flex-1 text-left" onClick={() => toggleExpanded(index)}>
-                        <Txt variant="ui-sm" className="text-neutral5 truncate">
+                        <Txt variant="ui-sm" className="truncate text-neutral5">
                           Item {index + 1}: {formatItemPreview(item.input)}
                         </Txt>
                       </button>
@@ -325,21 +325,21 @@ export function GenerateReviewDialog({
                     </div>
 
                     {expandedIndices.has(index) && (
-                      <div className="border-t border-border1 px-3 py-2 space-y-2">
+                      <div className="space-y-2 border-t border-border1 px-3 py-2">
                         <div>
-                          <Txt variant="ui-xs" className="text-neutral3 font-medium">
+                          <Txt variant="ui-xs" className="font-medium text-neutral3">
                             Input
                           </Txt>
-                          <pre className="text-xs text-neutral5 bg-surface1 rounded px-2 py-1.5 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-32 overflow-y-auto mt-1">
+                          <pre className="mt-1 max-h-32 overflow-auto rounded bg-surface1 px-2 py-1.5 text-xs wrap-break-word whitespace-pre-wrap text-neutral5">
                             {JSON.stringify(item.input, null, 2)}
                           </pre>
                         </div>
                         {item.groundTruth !== undefined && (
                           <div>
-                            <Txt variant="ui-xs" className="text-neutral3 font-medium">
+                            <Txt variant="ui-xs" className="font-medium text-neutral3">
                               Ground Truth
                             </Txt>
-                            <pre className="text-xs text-neutral5 bg-surface1 rounded px-2 py-1.5 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-32 overflow-y-auto mt-1">
+                            <pre className="mt-1 max-h-32 overflow-auto rounded bg-surface1 px-2 py-1.5 text-xs wrap-break-word whitespace-pre-wrap text-neutral5">
                               {JSON.stringify(item.groundTruth, null, 2)}
                             </pre>
                           </div>
@@ -362,7 +362,7 @@ export function GenerateReviewDialog({
             >
               {batchInsertItems.isPending ? (
                 <>
-                  <Spinner className="h-4 w-4" />
+                  <Spinner className="size-4" />
                   Adding...
                 </>
               ) : (

--- a/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
@@ -340,7 +340,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
                 )}
               </DataKeysAndValues>
 
-              <div className="grid gap-3 mt-3">
+              <div className="mt-3 grid gap-3">
                 <DataPanel.CodeSection
                   title="Input"
                   icon={<FileInputIcon />}

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-layout.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-layout.tsx
@@ -22,12 +22,12 @@ export function DatasetItemsLayout({ listSlot, detailPanelSlot, versionsPanelSlo
 
   return (
     <div
-      className={cn('grid max-h-full min-h-0 gap-4 items-start', {
+      className={cn('grid max-h-full min-h-0 items-start gap-4', {
         'grid-cols-[1fr_1fr]': showDetail,
         'grid-cols-[1fr_auto]': showVersions,
       })}
     >
-      <div className="grid gap-8 content-start max-w-full overflow-y-auto">{listSlot}</div>
+      <div className="grid max-w-full content-start gap-8 overflow-y-auto">{listSlot}</div>
       {showDetail && detailPanelSlot}
       {showVersions && versionsPanelSlot}
     </div>

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-list.tsx
@@ -152,7 +152,7 @@ export function DatasetItemsList({
                   )}
                 </DataList.Cell>
                 <DataList.Cell height="compact" className="min-w-0">
-                  <span className="block text-ui-smd text-neutral2 truncate">{formatDate(createdAtDate)}</span>
+                  <span className="block truncate text-ui-smd text-neutral2">{formatDate(createdAtDate)}</span>
                 </DataList.Cell>
               </>
             );
@@ -199,7 +199,7 @@ function EmptyDatasetItemList({ onAddClick, onImportClick, onImportJsonClick }: 
   return (
     <div className="flex h-full items-center justify-center py-12">
       <EmptyState
-        iconSlot={<Plus className="w-8 h-8 text-neutral3" />}
+        iconSlot={<Plus className="size-8 text-neutral3" />}
         titleSlot="No items yet"
         descriptionSlot="Add items to this dataset to use them in experiment runs."
         actionSlot={

--- a/packages/playground/src/domains/datasets/components/items/dataset-items-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items-toolbar.tsx
@@ -149,7 +149,7 @@ export function DatasetItemsToolbar({
         <div className="flex gap-5">
           <Tooltip>
             <TooltipTrigger asChild>
-              <div className="text-sm text-neutral3 flex items-center gap-2">
+              <div className="flex items-center gap-2 text-sm text-neutral3">
                 <Chip
                   size="large"
                   color={
@@ -195,7 +195,7 @@ export function DatasetItemsToolbar({
   }
 
   return (
-    <div className="flex items-center justify-between gap-4 w-full">
+    <div className="flex w-full items-center justify-between gap-4">
       <SearchFieldBlock
         name="search-items"
         label="Search"
@@ -244,7 +244,7 @@ export function DatasetItemsToolbar({
 
         {!isItemPanelOpen && !isVersionsPanelOpen && (
           <Button onClick={onVersionsClick} aria-label="View versions">
-            <History className="w-4 h-4" />
+            <History className="size-4" />
             Versions
           </Button>
         )}

--- a/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-versions-panel.tsx
@@ -77,7 +77,7 @@ export function DatasetVersionsPanel({
   return (
     <Column withLeftSeparator={true} className="w-56">
       {isSelectionActive ? (
-        <Column.Toolbar className="grid justify-stretch gap-3 w-full">
+        <Column.Toolbar className="grid w-full justify-stretch gap-3">
           <ButtonsGroup>
             <Button onClick={handleCancelSelection}>Cancel</Button>
             <Button
@@ -153,7 +153,7 @@ export function DatasetVersionsPanel({
                 })}
               </ItemList.Items>
               {hasNextPage && (
-                <Button size="md" onClick={() => fetchNextPage()} disabled={isFetchingNextPage} className="w-full mt-2">
+                <Button size="md" onClick={() => fetchNextPage()} disabled={isFetchingNextPage} className="mt-2 w-full">
                   {isFetchingNextPage ? 'Loading...' : 'Load More'}
                 </Button>
               )}

--- a/packages/playground/src/domains/datasets/components/json-import/json-import-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-import-dialog.tsx
@@ -164,7 +164,7 @@ export function JSONImportDialog({ datasetId, open, onOpenChange, onSuccess }: J
             <Spinner />
             <div className="text-center">
               <div className="text-lg font-medium text-neutral1">Importing items...</div>
-              <div className="text-sm text-neutral4 mt-1">
+              <div className="mt-1 text-sm text-neutral4">
                 {importProgress.current} of {importProgress.total}
               </div>
             </div>
@@ -177,7 +177,7 @@ export function JSONImportDialog({ datasetId, open, onOpenChange, onSuccess }: J
             <div className="text-4xl">{importResult && importResult.errors === 0 ? '✓' : '⚠'}</div>
             <div className="text-center">
               <div className="text-lg font-medium text-neutral1">Import Complete</div>
-              <div className="text-sm text-neutral4 mt-1">
+              <div className="mt-1 text-sm text-neutral4">
                 {importResult?.success ?? 0} item{importResult?.success !== 1 ? 's' : ''} imported
                 {importResult && importResult.errors > 0 && (
                   <span className="text-accent2">
@@ -230,15 +230,15 @@ export function JSONImportDialog({ datasetId, open, onOpenChange, onSuccess }: J
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="max-w-2xl max-h-[90vh]">
+      <DialogContent className="max-h-[90vh] max-w-2xl">
         <DialogHeader>
           <DialogTitle>{stepTitles[step]}</DialogTitle>
           <DialogDescription>Import dataset items from a JSON file.</DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="min-h-[200px] max-h-[50vh] overflow-y-auto">{renderStepContent()}</DialogBody>
+        <DialogBody className="min-h-50 max-h-[50vh] overflow-y-auto">{renderStepContent()}</DialogBody>
 
-        <DialogFooter className="px-6 pt-4 flex justify-end gap-2">{renderFooter()}</DialogFooter>
+        <DialogFooter className="flex justify-end gap-2 px-6 pt-4">{renderFooter()}</DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/packages/playground/src/domains/datasets/components/json-import/json-preview-table.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-preview-table.tsx
@@ -25,23 +25,23 @@ export function JSONPreviewTable({ items, maxRows = 5 }: JSONPreviewTableProps) 
   const hiddenCount = items.length - maxRows;
 
   return (
-    <div className="border border-border1 rounded-md overflow-hidden">
+    <div className="overflow-hidden rounded-md border border-border1">
       <table className="w-full text-sm">
         <thead>
-          <tr className="bg-surface2 border-b border-border1">
-            <th className="px-3 py-2 text-left font-medium text-neutral3 w-8">#</th>
+          <tr className="border-b border-border1 bg-surface2">
+            <th className="w-8 px-3 py-2 text-left font-medium text-neutral3">#</th>
             <th className="px-3 py-2 text-left font-medium text-neutral3">Input</th>
             <th className="px-3 py-2 text-left font-medium text-neutral3">Ground Truth</th>
-            <th className="px-3 py-2 text-left font-medium text-neutral3 w-24">Metadata</th>
+            <th className="w-24 px-3 py-2 text-left font-medium text-neutral3">Metadata</th>
           </tr>
         </thead>
         <tbody>
           {displayItems.map((item: ImportableItem, index: number) => (
             <tr key={index} className="border-b border-border1 last:border-b-0">
               <td className="px-3 py-2 text-neutral4">{index + 1}</td>
-              <td className="px-3 py-2 text-neutral1 font-mono text-xs">{truncateValue(item.input)}</td>
-              <td className="px-3 py-2 text-neutral2 font-mono text-xs">{truncateValue(item.groundTruth)}</td>
-              <td className="px-3 py-2 text-neutral3 text-xs">
+              <td className="px-3 py-2 font-mono text-xs text-neutral1">{truncateValue(item.input)}</td>
+              <td className="px-3 py-2 font-mono text-xs text-neutral2">{truncateValue(item.groundTruth)}</td>
+              <td className="px-3 py-2 text-xs text-neutral3">
                 {item.metadata ? `${Object.keys(item.metadata).length} keys` : '-'}
               </td>
             </tr>
@@ -50,7 +50,7 @@ export function JSONPreviewTable({ items, maxRows = 5 }: JSONPreviewTableProps) 
       </table>
 
       {hiddenCount > 0 && (
-        <div className="bg-surface2 px-3 py-2 text-xs text-neutral4 text-center border-t border-border1">
+        <div className="border-t border-border1 bg-surface2 px-3 py-2 text-center text-xs text-neutral4">
           +{hiddenCount} more item{hiddenCount !== 1 ? 's' : ''}
         </div>
       )}

--- a/packages/playground/src/domains/datasets/components/json-import/json-upload-step.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-upload-step.tsx
@@ -91,7 +91,7 @@ export function JSONUploadStep({ onFileSelect, isParsing, error }: JSONUploadSte
         onDrop={handleDrop}
         className={cn(
           'flex flex-col items-center justify-center gap-3',
-          'min-h-[160px] rounded-lg border-2 border-dashed p-6',
+          'min-h-40 rounded-lg border-2 border-dashed p-6',
           'cursor-pointer transition-colors',
           // Default state
           'border-surface4 bg-surface2',
@@ -111,7 +111,7 @@ export function JSONUploadStep({ onFileSelect, isParsing, error }: JSONUploadSte
         ) : (
           <>
             <Icon className="text-neutral4">
-              <FileJson className="h-8 w-8" />
+              <FileJson className="size-8" />
             </Icon>
             <div className="flex flex-col items-center gap-1">
               <span className="text-sm font-medium text-neutral1">Click to upload or drag and drop</span>
@@ -125,9 +125,9 @@ export function JSONUploadStep({ onFileSelect, isParsing, error }: JSONUploadSte
       {error && <div className="text-sm text-accent2">{error}</div>}
 
       {/* Format hint */}
-      <div className="text-xs text-neutral4 bg-surface2 p-3 rounded-md">
-        <p className="font-medium mb-1">Expected format:</p>
-        <pre className="text-[10px] overflow-x-auto">
+      <div className="rounded-md bg-surface2 p-3 text-xs text-neutral4">
+        <p className="mb-1 font-medium">Expected format:</p>
+        <pre className="overflow-x-auto text-[10px]">
           {`[
   {
     "input": "Your input data",

--- a/packages/playground/src/domains/datasets/components/json-import/json-validation-summary.tsx
+++ b/packages/playground/src/domains/datasets/components/json-import/json-validation-summary.tsx
@@ -19,17 +19,17 @@ export function JSONValidationSummary({ errors, maxErrors = 5 }: JSONValidationS
   const hiddenCount = errors.length - maxErrors;
 
   return (
-    <div className="bg-accent2/10 border border-accent2/30 rounded-md p-3">
-      <div className="flex items-center gap-2 text-accent2 mb-2">
+    <div className="rounded-md border border-accent2/30 bg-accent2/10 p-3">
+      <div className="mb-2 flex items-center gap-2 text-accent2">
         <Icon>
-          <AlertTriangle className="w-4 h-4" />
+          <AlertTriangle className="size-4" />
         </Icon>
-        <span className="font-medium text-sm">
+        <span className="text-sm font-medium">
           {errors.length} validation error{errors.length !== 1 ? 's' : ''}
         </span>
       </div>
 
-      <ul className="text-sm text-accent2/80 space-y-1">
+      <ul className="space-y-1 text-sm text-accent2/80">
         {displayErrors.map((error: JSONValidationError, index: number) => (
           <li key={index} className="flex gap-2">
             <span className="shrink-0">•</span>
@@ -39,7 +39,7 @@ export function JSONValidationSummary({ errors, maxErrors = 5 }: JSONValidationS
       </ul>
 
       {hiddenCount > 0 && (
-        <div className="text-xs text-accent2/60 mt-2">
+        <div className="mt-2 text-xs text-accent2/60">
           +{hiddenCount} more error{hiddenCount !== 1 ? 's' : ''}
         </div>
       )}

--- a/packages/playground/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/save-as-dataset-item-dialog.tsx
@@ -239,7 +239,7 @@ export function SaveAsDatasetItemDialog({
               </SelectTrigger>
               <SelectContent>
                 {datasets.length === 0 ? (
-                  <div className="px-2 py-4 text-sm text-neutral4 text-center">No datasets available</div>
+                  <div className="px-2 py-4 text-center text-sm text-neutral4">No datasets available</div>
                 ) : (
                   datasets.map(dataset => (
                     <SelectItem key={dataset.id} value={dataset.id}>
@@ -253,7 +253,7 @@ export function SaveAsDatasetItemDialog({
 
           <div className="grid gap-2">
             <Label htmlFor="item-input">Input (JSON) *</Label>
-            <CodeEditor value={input} onChange={handleInputChange} showCopyButton={false} className="min-h-[120px]" />
+            <CodeEditor value={input} onChange={handleInputChange} showCopyButton={false} className="min-h-30" />
           </div>
 
           <div className="grid gap-2">
@@ -262,7 +262,7 @@ export function SaveAsDatasetItemDialog({
               value={groundTruth}
               onChange={handleGroundTruthChange}
               showCopyButton={false}
-              className="min-h-[80px]"
+              className="min-h-20"
             />
           </div>
 
@@ -272,7 +272,7 @@ export function SaveAsDatasetItemDialog({
               value={expectedTrajectory}
               onChange={handleExpectedTrajectoryChange}
               showCopyButton={false}
-              className="min-h-[80px]"
+              className="min-h-20"
             />
           </div>
 
@@ -282,7 +282,7 @@ export function SaveAsDatasetItemDialog({
               value={toolMocks}
               onChange={handleToolMocksChange}
               showCopyButton={false}
-              className="min-h-[80px]"
+              className="min-h-20"
             />
           </div>
 

--- a/packages/playground/src/domains/datasets/components/schema-config-section.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-config-section.tsx
@@ -171,12 +171,12 @@ export function SchemaConfigSection({
 
   return (
     <Collapsible open={isOpen} onOpenChange={setIsOpen}>
-      <CollapsibleTrigger className="flex items-center gap-2 text-sm font-medium text-neutral4 hover:text-neutral5 w-full py-2">
-        <ChevronRight className="w-4 h-4" />
+      <CollapsibleTrigger className="flex w-full items-center gap-2 py-2 text-sm font-medium text-neutral4 hover:text-neutral5">
+        <ChevronRight className="size-4" />
         Schema Configuration (Optional)
       </CollapsibleTrigger>
 
-      <CollapsibleContent className="pt-4 space-y-4">
+      <CollapsibleContent className="space-y-4 pt-4">
         {/* JSON Schema info notification */}
         <Notice variant="info" title="JSON Schema Format">
           <Notice.Message>
@@ -185,7 +185,7 @@ export function SchemaConfigSection({
               href="https://json-schema.org/"
               target="_blank"
               rel="noopener noreferrer"
-              className="underline hover:text-accent5Lighter"
+              className="hover:text-accent5Lighter underline"
             >
               JSON Schema
             </a>{' '}

--- a/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-settings/schema-field.tsx
@@ -105,10 +105,10 @@ export function SchemaField({
             value={jsonText}
             onChange={handleJsonChange}
             showCopyButton={false}
-            className={cn('h-48 border rounded-md', (parseError || error) && 'border-destructive')}
+            className={cn('h-48 rounded-md border', (parseError || error) && 'border-destructive')}
           />
-          {parseError && <p className="text-xs text-destructive">{parseError}</p>}
-          {error && !parseError && <p className="text-xs text-destructive">{error}</p>}
+          {parseError && <p className="text-destructive text-xs">{parseError}</p>}
+          {error && !parseError && <p className="text-destructive text-xs">{error}</p>}
         </div>
       )}
     </div>

--- a/packages/playground/src/domains/datasets/components/schema-settings/schema-import.tsx
+++ b/packages/playground/src/domains/datasets/components/schema-settings/schema-import.tsx
@@ -158,7 +158,7 @@ export function SchemaImport({ schemaType, onImport }: SchemaImportProps) {
       )}
 
       <Button size="sm" variant="outline" onClick={handleImport} disabled={!canImport()}>
-        <Download className="w-4 h-4" />
+        <Download className="size-4" />
         Import
       </Button>
 

--- a/packages/playground/src/domains/datasets/components/versions/dataset-compare-version-toolbar.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-compare-version-toolbar.tsx
@@ -32,7 +32,7 @@ export function DatasetCompareVersionToolbar({
   }));
 
   return (
-    <Column.Toolbar className="grid grid-cols-[1fr_1fr_1fr_10rem] gap-4 w-full">
+    <Column.Toolbar className="grid w-full grid-cols-[1fr_1fr_1fr_10rem] gap-4">
       <div />
       <SelectFieldBlock
         label="Version A"

--- a/packages/playground/src/domains/datasets/components/versions/dataset-compare-versions-list.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-compare-versions-list.tsx
@@ -49,7 +49,7 @@ function EmptyCell({ red = false, tooltip }: { red?: boolean; tooltip?: React.Re
     <Tooltip>
       <TooltipTrigger asChild>
         <BanIcon
-          className={cn('text-neutral3/40 w-5 h-5 ', {
+          className={cn('size-5 text-neutral3/40 ', {
             'text-red-900': red,
           })}
         />
@@ -69,7 +69,7 @@ function VersionInfo({ variant, version }: { variant?: keyof typeof versionInfoC
       <TooltipTrigger asChild>
         <div className="grid grid-cols-[1fr_auto]">
           {version !== undefined && (
-            <span className="pr-3 text-ui-md text-neutral4 min-w-16 flex justify-end">v. {version}</span>
+            <span className="flex min-w-16 justify-end pr-3 text-ui-md text-neutral4">v. {version}</span>
           )}
           <Chip color={color} size="small">
             {icon}
@@ -127,7 +127,7 @@ export function DatasetCompareVersionsList({
                         )}
                       </ItemList.LinkCell>
                     ) : (
-                      <ItemList.Cell className={'justify-center flex  items-center'}>
+                      <ItemList.Cell className={'flex items-center  justify-center'}>
                         <EmptyCell
                           red={isANewer}
                           tooltip={isANewer ? 'Deleted in this version' : 'Not present in this version'}
@@ -149,7 +149,7 @@ export function DatasetCompareVersionsList({
                         )}
                       </ItemList.LinkCell>
                     ) : (
-                      <ItemList.Cell className={'justify-center flex items-center'}>
+                      <ItemList.Cell className={'flex items-center justify-center'}>
                         <EmptyCell
                           red={!isANewer}
                           tooltip={!isANewer ? 'Deleted in this version' : 'Not present in this version'}

--- a/packages/playground/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/versions/dataset-item-versions-panel.tsx
@@ -77,7 +77,7 @@ export function DatasetItemVersionsPanel({
   return (
     <Column className="min-w-56">
       {isSelectionActive ? (
-        <Column.Toolbar className="grid justify-stretch gap-3 w-full">
+        <Column.Toolbar className="grid w-full justify-stretch gap-3">
           <ButtonsGroup>
             <Button onClick={handleCancelSelection}>Cancel</Button>
             <Button

--- a/packages/playground/src/domains/datasets/pages/datasets/item/index.tsx
+++ b/packages/playground/src/domains/datasets/pages/datasets/item/index.tsx
@@ -34,11 +34,11 @@ function DatasetItemContent({ item }: { item: DatasetItem }) {
   return (
     <>
       <div className="mb-4">
-        <h3 className="text-lg font-medium flex items-center gap-2">
-          <FileInputIcon className="w-5 h-5" /> Dataset Item
+        <h3 className="flex items-center gap-2 text-lg font-medium">
+          <FileInputIcon className="size-5" /> Dataset Item
         </h3>
         <TextAndIcon>
-          <HashIcon className="w-4 h-4" /> {item.id}
+          <HashIcon className="size-4" /> {item.id}
         </TextAndIcon>
       </div>
 

--- a/packages/playground/src/domains/experimental-ui/experimental-ui-manager.tsx
+++ b/packages/playground/src/domains/experimental-ui/experimental-ui-manager.tsx
@@ -35,7 +35,7 @@ export function ExperimentalUIManager({ pathname }: { pathname?: string }) {
                 className="mt-2"
               >
                 {experiment.variants.map(option => (
-                  <label key={option.value} className="flex items-center gap-3 text-ui-md text-neutral3 cursor-pointer">
+                  <label key={option.value} className="flex cursor-pointer items-center gap-3 text-ui-md text-neutral3">
                     <RadioGroupItem value={option.value} />
                     {option.label}
                   </label>

--- a/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-page-tabs.tsx
@@ -260,7 +260,7 @@ export function ExperimentPageTabs({
       defaultTab="summary"
       value={activeTab}
       onValueChange={handleTabChange}
-      className="grid grid-rows-[auto_1fr] h-full overflow-hidden"
+      className="grid h-full grid-rows-[auto_1fr] overflow-hidden"
     >
       <TabList>
         <Tab value="summary">Summary</Tab>
@@ -271,19 +271,19 @@ export function ExperimentPageTabs({
         </Tab>
       </TabList>
 
-      <TabContent value="summary" className="overflow-y-auto mt-5">
+      <TabContent value="summary" className="mt-5 overflow-y-auto">
         <ExperimentScorerSummary scoresByItemId={scoresByExperimentId} experimentStatus={experimentStatus} />
       </TabContent>
 
-      <TabContent value="reviews" className="overflow-auto mt-2 pb-0">
+      <TabContent value="reviews" className="mt-2 overflow-auto pb-0">
         <DatasetReview datasetId={datasetId} experimentId={experimentId} featuredItemId={reviewFeaturedItemId} />
       </TabContent>
 
-      <TabContent value="results" className="grid grid-rows-[auto_1fr] overflow-hidden mt-2">
+      <TabContent value="results" className="mt-2 grid grid-rows-[auto_1fr] overflow-hidden">
         <div className="mb-4">
           {selectedIds.size > 0 && (
-            <div className="flex items-center gap-2 px-4 py-2 bg-surface3">
-              <Txt variant="ui-xs" className="text-neutral5 font-medium">
+            <div className="flex items-center gap-2 bg-surface3 px-4 py-2">
+              <Txt variant="ui-xs" className="font-medium text-neutral5">
                 {selectedIds.size} selected
               </Txt>
               <div className="flex-1" />
@@ -307,14 +307,11 @@ export function ExperimentPageTabs({
           )}
         </div>
         <div
-          className={cn(
-            'grid w-full h-full grid-cols-1 gap-4 overflow-y-auto',
-            featuredResult && 'grid-cols-[1fr_1fr]',
-          )}
+          className={cn('grid size-full grid-cols-1 gap-4 overflow-y-auto', featuredResult && 'grid-cols-[1fr_1fr]')}
         >
           {/* List column - always visible */}
-          <div className="flex overflow-y-auto w-full">
-            <div className="grid gap-8 content-start w-full overflow-y-auto">
+          <div className="flex w-full overflow-y-auto">
+            <div className="grid w-full content-start gap-8 overflow-y-auto">
               <ExperimentResultsList
                 results={results}
                 isLoading={isLoading}
@@ -334,7 +331,7 @@ export function ExperimentPageTabs({
 
           {featuredResult && (
             <div
-              className="grid gap-4 max-h-full min-h-0 overflow-auto content-start"
+              className="grid max-h-full min-h-0 content-start gap-4 overflow-auto"
               style={{ gridTemplateRows: rightColumnGridRows }}
             >
               <ExperimentResultPanel

--- a/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-result-panel.tsx
@@ -97,7 +97,7 @@ export function ExperimentResultPanel({
 
       {!collapsed && (
         <DataPanel.Content>
-          <div className="grid gap-4 mb-6">
+          <div className="mb-6 grid gap-4">
             <DataKeysAndValues>
               <DataKeysAndValues.Key>Item Id</DataKeysAndValues.Key>
               <DataKeysAndValues.ValueWithCopyBtn copyTooltip="Copy Item Id to clipboard" copyValue={result.itemId}>
@@ -148,10 +148,10 @@ export function ExperimentResultPanel({
                   Review
                 </DataPanel.SectionHeading>
                 {(result.status || tags.length > 0) && (
-                  <div className="flex flex-wrap gap-2 items-center">
+                  <div className="flex flex-wrap items-center gap-2">
                     {result.status && (
                       <span
-                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
                           result.status === 'needs-review'
                             ? 'bg-orange-500/10 text-orange-400'
                             : result.status === 'complete'
@@ -163,7 +163,7 @@ export function ExperimentResultPanel({
                       </span>
                     )}
                     {tags.map(tag => (
-                      <span key={tag} className="text-xs px-2 py-0.5 rounded bg-surface4 text-neutral4">
+                      <span key={tag} className="rounded bg-surface4 px-2 py-0.5 text-xs text-neutral4">
                         {tag}
                       </span>
                     ))}

--- a/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-results-list.tsx
@@ -72,11 +72,11 @@ export function ExperimentResultsList({
                 <DataList.Cell height="compact">
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <div className="flex items-center justify-center w-10 relative bg-transparent h-full">
+                      <div className="relative flex h-full w-10 items-center justify-center bg-transparent">
                         <div
                           role="img"
                           aria-label={hasError ? 'Error' : 'Success'}
-                          className={cn('w-2 h-2 rounded-full', hasError ? 'bg-red-700' : 'bg-green-600')}
+                          className={cn('size-2 rounded-full', hasError ? 'bg-red-700' : 'bg-green-600')}
                         />
                       </div>
                     </TooltipTrigger>
@@ -90,7 +90,7 @@ export function ExperimentResultsList({
                   const scores = scoresByItemId?.[result.itemId];
                   const score = scores?.find(s => s.scorerId === scorerId);
                   return (
-                    <DataList.Cell key={scorerId} height="compact" className="font-mono text-neutral3 text-ui-smd">
+                    <DataList.Cell key={scorerId} height="compact" className="font-mono text-ui-smd text-neutral3">
                       {score != null ? score.score.toFixed(3) : '-'}
                     </DataList.Cell>
                   );

--- a/packages/playground/src/domains/experiments/components/experiment-scorer-summary.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-scorer-summary.tsx
@@ -62,7 +62,7 @@ export function ExperimentScorerSummary({ scoresByItemId, experimentStatus }: Ex
     return (
       <div className="flex h-full items-center justify-center py-12">
         <EmptyState
-          iconSlot={<GaugeIcon className="w-8 h-8 text-neutral3" />}
+          iconSlot={<GaugeIcon className="size-8 text-neutral3" />}
           titleSlot={title}
           descriptionSlot={description}
         />

--- a/packages/playground/src/domains/experiments/components/experiment-stats.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-stats.tsx
@@ -22,9 +22,9 @@ export function ExperimentStats({ experiment, className }: ExperimentStatsProps)
 
   return (
     <div className={cn('grid justify-items-end gap-3', className)}>
-      <div className="flex p-1 px-3 text-ui-lg capitalize text-neutral4 gap-2 items-center bg-surface5 rounded-lg ">
+      <div className="flex items-center gap-2 rounded-lg bg-surface5 p-1 px-3 text-ui-lg text-neutral4 capitalize ">
         <span
-          className={cn('w-5 h-5 flex items-center justify-center rounded-full text-black', '[&>svg]:w-4 [&>svg]:h-4', {
+          className={cn('flex size-5 items-center justify-center rounded-full text-black', '[&>svg]:size-4', {
             'bg-green-700': status === 'completed',
             'bg-red-700': status === 'failed',
             'bg-cyan-600': status === 'running',
@@ -37,9 +37,9 @@ export function ExperimentStats({ experiment, className }: ExperimentStatsProps)
       </div>
       <div
         className={cn(
-          'flex items-center gap-3 text-neutral3 text-ui-md ',
-          '[&>span]:flex [&>span]:gap-1 [&>span]:items-center ',
-          '[&_b]:text-neutral4 [&_b]:font-semibold',
+          'flex items-center gap-3 text-ui-md text-neutral3 ',
+          '[&>span]:flex [&>span]:items-center [&>span]:gap-1 ',
+          '[&_b]:font-semibold [&_b]:text-neutral4',
         )}
       >
         <span>

--- a/packages/playground/src/domains/experiments/components/experiment-trace-span-type-icon.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-span-type-icon.tsx
@@ -9,8 +9,8 @@ export function ExperimentTraceSpanTypeIcon({ icon, color }: ExperimentTraceSpan
   return (
     <span
       className={cn(
-        'flex w-[1.1rem] h-[1.1rem] shrink-0 rounded-md items-center justify-center',
-        '[&>svg]:w-[.9rem] [&>svg]:h-[.9rem] [&>svg]:text-surface2',
+        'flex size-[1.1rem] shrink-0 items-center justify-center rounded-md',
+        '[&>svg]:size-[.9rem] [&>svg]:text-surface2',
       )}
       style={{ backgroundColor: color }}
     >

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-expand-col.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-expand-col.tsx
@@ -24,7 +24,7 @@ export function ExperimentTraceTimelineExpandCol({
 }: ExperimentTraceTimelineExpandColProps) {
   return (
     <div
-      className={cn('flex items-center justify-end h-full px-3', {
+      className={cn('flex h-full items-center justify-end px-3', {
         'opacity-30 [&:hover]:opacity-60': isFaded,
         'bg-surface4': isSelected,
       })}
@@ -58,9 +58,9 @@ function ExpandButton({ onClick, children, className }: ExpandButtonProps) {
     <button onClick={onClick} className={cn('h-full', className)}>
       <div
         className={cn(
-          'flex items-center gap-[0.1rem] text-ui-sm text-neutral5 border border-border1 pl-2 pr-1 rounded-lg transition-all',
+          'flex items-center gap-[0.1rem] rounded-lg border border-border1 pr-1 pl-2 text-ui-sm text-neutral5 transition-all',
           'hover:text-yellow-500',
-          '[&>svg]:shrink-0 [&>svg]:opacity-80 [&>svg]:w-4 [&>svg]:h-4 [&>svg]:transition-all',
+          '[&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:opacity-80 [&>svg]:transition-all',
         )}
       >
         {children}

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-structure-sign.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-structure-sign.tsx
@@ -15,11 +15,11 @@ export function ExperimentTraceTimelineStructureSign({
   return (
     <div
       className={cn(
-        'w-12 h-[2.8rem] relative opacity-100',
-        'after:content-[""] after:absolute after:left-[-1px] after:top-0 after:bottom-0 after:w-0 after:border-l after:border-neutral3 after:border-dashed ',
-        'before:content-[""] before:absolute before:left-0 before:top-[50%] before:w-full before:h-0 before:border-b before:border-neutral3 before:border-dashed',
+        'relative h-[2.8rem] w-12 opacity-100',
+        'after:absolute after:inset-y-0 after:-left-px after:w-0 after:border-l after:border-dashed after:border-neutral3 after:content-[""] ',
+        'before:absolute before:top-[50%] before:left-0 before:h-0 before:w-full before:border-b before:border-dashed before:border-neutral3 before:content-[""]',
         '[&_svg]:transition-all',
-        '[&:hover_svg]:text-yellow-500 [&:hover_svg]:scale-[1.3] [&:hover_svg]:opacity-100',
+        '[&:hover_svg]:scale-1.3 [&:hover_svg]:text-yellow-500 [&:hover_svg]:opacity-100',
         {
           'after:bottom-[50%]': isLastChild,
         },
@@ -28,8 +28,8 @@ export function ExperimentTraceTimelineStructureSign({
       {hasChildren && (
         <span
           className={cn(
-            'flex absolute left-[50%] top-[50%] translate-y-[-50%] translate-x-[-50%] items-center justify-center bg-surface2 p-1',
-            '[&>svg]:shrink-0 [&>svg]:opacity-60 [&>svg]:w-[0.8rem] [&>svg]:h-[0.8rem]',
+            'absolute top-[50%] left-[50%] flex translate-[-50%] items-center justify-center bg-surface2 p-1',
+            '[&>svg]:size-[0.8rem] [&>svg]:shrink-0 [&>svg]:opacity-60',
           )}
         >
           {expanded ? <CircleChevronUpIcon /> : <CircleChevronDownIcon />}

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-timing-col.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-timing-col.tsx
@@ -35,7 +35,7 @@ export function ExperimentTraceTimelineTimingCol({
     <HoverCard.Root openDelay={250}>
       <HoverCard.Trigger
         className={cn(
-          'h-12 p-2 grid grid-cols-[1fr_auto] gap-4 items-center cursor-help pr-3 rounded-r-lg col-span-2 xl:col-span-1 ',
+          'col-span-2 grid h-12 cursor-help grid-cols-[1fr_auto] items-center gap-4 rounded-r-lg p-2 pr-3 xl:col-span-1 ',
           '[&:hover>div]:bg-surface5',
           {
             'opacity-30 [&:hover]:opacity-60': isFaded,
@@ -44,10 +44,10 @@ export function ExperimentTraceTimelineTimingCol({
         )}
         style={{ border: '2px dashed blue' }}
       >
-        <div className={cn('w-full p-2.5 rounded-lg bg-surface4 transition-colors duration-1000 min-w-40')}>
-          <div className="relative w-full h-1.5 rounded-sm">
+        <div className={cn('w-full min-w-40 rounded-lg bg-surface4 p-2.5 transition-colors duration-1000')}>
+          <div className="relative h-1.5 w-full rounded-sm">
             <div
-              className={cn('bg-neutral1 absolute rounded-sm h-1.5 top-0')}
+              className={cn('absolute top-0 h-1.5 rounded-sm bg-neutral1')}
               style={{
                 width: percentageSpanLatency ? `${percentageSpanLatency}%` : '2px',
                 left: `${percentageSpanStartTime || 0}%`,
@@ -57,24 +57,24 @@ export function ExperimentTraceTimelineTimingCol({
           </div>
         </div>
 
-        <div className={cn('flex justify-end text-neutral3 text-ui-sm')}>{(span.latency / 1000).toFixed(3)}&nbsp;s</div>
+        <div className={cn('flex justify-end text-ui-sm text-neutral3')}>{(span.latency / 1000).toFixed(3)}&nbsp;s</div>
       </HoverCard.Trigger>
       <HoverCard.Portal>
         <HoverCard.Content
-          className="z-50 w-auto max-w-[25rem] rounded-md bg-surface4 p-2 px-4 pr-6 text-ui-sm text-neutral5 text-center border border-border1"
+          className="max-w-100 z-50 w-auto rounded-md border border-border1 bg-surface4 p-2 px-4 pr-6 text-center text-ui-sm text-neutral5"
           sideOffset={5}
           side="top"
         >
           <div
             className={cn(
-              'text-ui-md flex items-center gap-2 mb-4',
-              '[&>svg]:w-[1.25em] [&>svg]:h-[1.25em] [&>svg]:shrink-0 [&>svg]:opacity-50',
+              'mb-4 flex items-center gap-2 text-ui-md',
+              '[&>svg]:size-[1.25em] [&>svg]:shrink-0 [&>svg]:opacity-50',
             )}
           >
             <TimerIcon /> Span Timing
           </div>
           <KeyValueList
-            className="[&>dd]:text-ui-md [&>dt]:text-ui-md [&>dt]:min-h-0 [&>dd]:min-h-0"
+            className="[&>dd]:min-h-0 [&>dd]:text-ui-md [&>dt]:min-h-0 [&>dt]:text-ui-md"
             data={[
               {
                 key: 'Latency',

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline-tools.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline-tools.tsx
@@ -55,7 +55,7 @@ export function ExperimentTraceTimelineTools({
   }, 1000);
 
   return (
-    <div className="flex gap-3 items-center justify-between">
+    <div className="flex items-center justify-between gap-3">
       <div className="flex">
         <SearchFieldBlock
           name="search-spans"

--- a/packages/playground/src/domains/experiments/components/experiment-trace-timeline.tsx
+++ b/packages/playground/src/domains/experiments/components/experiment-trace-timeline.tsx
@@ -33,8 +33,8 @@ export function ExperimentTraceTimeline({
       {isLoading ? (
         <div
           className={cn(
-            'flex items-center text-ui-md gap-4 bg-surface3/50 rounded-md p-6 justify-center text-neutral3',
-            '[&_svg]:w-[1.25em] [&_svg]:h-[1.25em] [&_svg]:opacity-50',
+            'flex items-center justify-center gap-4 rounded-md bg-surface3/50 p-6 text-ui-md text-neutral3',
+            '[&_svg]:size-[1.25em] [&_svg]:opacity-50',
           )}
         >
           <Spinner /> Loading Trace Timeline ...

--- a/packages/playground/src/domains/experiments/components/tool-mock-report-section.tsx
+++ b/packages/playground/src/domains/experiments/components/tool-mock-report-section.tsx
@@ -57,7 +57,7 @@ export function ToolMockReportSection({ report }: ToolMockReportSectionProps) {
         </Notice>
       )}
 
-      <div className="rounded border border-border1 divide-y divide-border1 text-sm">
+      <div className="divide-y divide-border1 rounded border border-border1 text-sm">
         {rows.map((row, i) => (
           <div
             key={`${row.outcome}-${row.toolName}-${i}`}
@@ -67,7 +67,7 @@ export function ToolMockReportSection({ report }: ToolMockReportSectionProps) {
               <span className="font-mono text-neutral4">{row.toolName}</span>
               <span className="ml-2 font-mono text-xs text-neutral3">{formatArgs(row.args)}</span>
             </span>
-            <span className={`shrink-0 text-xs px-2 py-0.5 rounded ${outcomeClass(row.outcome)}`}>{row.outcome}</span>
+            <span className={`shrink-0 rounded px-2 py-0.5 text-xs ${outcomeClass(row.outcome)}`}>{row.outcome}</span>
           </div>
         ))}
       </div>

--- a/packages/playground/src/domains/llm/components/llm-models.tsx
+++ b/packages/playground/src/domains/llm/components/llm-models.tsx
@@ -51,7 +51,7 @@ export const LLMModels = ({
   }, [filteredModels]);
 
   if (providersLoading) {
-    return <Skeleton className="w-full h-8" />;
+    return <Skeleton className="h-8 w-full" />;
   }
 
   return (

--- a/packages/playground/src/domains/llm/components/llm-providers.tsx
+++ b/packages/playground/src/domains/llm/components/llm-providers.tsx
@@ -52,7 +52,7 @@ export const LLMProviders = ({
         <div className="relative shrink-0">
           <ProviderLogo providerId={provider.id} size={16} />
           <div
-            className={`absolute -top-0.5 -right-0.5 w-1.5 h-1.5 rounded-full ${
+            className={`absolute -top-0.5 -right-0.5 size-1.5 rounded-full ${
               provider.connected ? 'bg-accent1' : 'bg-accent2'
             }`}
             title={provider.connected ? 'Connected' : 'Not connected'}
@@ -62,7 +62,7 @@ export const LLMProviders = ({
       end: provider.docUrl ? (
         <Info
           className={cn(
-            'size-3.5 text-neutral2 opacity-0 transition-opacity duration-100 cursor-pointer',
+            'size-3.5 cursor-pointer text-neutral2 opacity-0 transition-opacity duration-100',
             'hover:text-neutral4 hover:opacity-100',
             'group-data-[highlighted]/item:opacity-100',
           )}
@@ -81,7 +81,7 @@ export const LLMProviders = ({
   };
 
   if (providersLoading) {
-    return <Skeleton className="w-full h-8" />;
+    return <Skeleton className="h-8 w-full" />;
   }
 
   // Find the matching provider, handling gateway prefix fallback

--- a/packages/playground/src/domains/llm/components/provider-logo.tsx
+++ b/packages/playground/src/domains/llm/components/provider-logo.tsx
@@ -55,7 +55,7 @@ export const ProviderLogo = ({ providerId, className = '', size = 20, style }: P
     }
     return (
       <div
-        className={cn('bg-surface4 rounded shrink-0', className)}
+        className={cn('shrink-0 rounded bg-surface4', className)}
         style={{ width: size, height: size, minWidth: size, minHeight: size, ...style }}
       />
     );

--- a/packages/playground/src/domains/mcps/components/MCPDetail.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPDetail.tsx
@@ -60,7 +60,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
   if (!server)
     return (
       <MainContentContent>
-        <Txt as="h1" variant="header-md" className="text-neutral3 font-medium py-20 text-center">
+        <Txt as="h1" variant="header-md" className="py-20 text-center font-medium text-neutral3">
           Server not found
         </Txt>
       </MainContentContent>
@@ -70,8 +70,8 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
 
   return (
     <MainContentContent isDivided={true}>
-      <div className="px-8 py-12 mx-auto max-w-2xl w-full">
-        <Txt as="h1" variant="header-md" className="text-neutral6 font-medium pb-4">
+      <div className="mx-auto w-full max-w-2xl px-8 py-12">
+        <Txt as="h1" variant="header-md" className="pb-4 font-medium text-neutral6">
           {server.name}
         </Txt>
 
@@ -82,7 +82,7 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
           <Badge className="rounded-l-sm text-neutral4!">{server.version_detail.version}</Badge>
         </div>
 
-        <Txt className="text-neutral3 pb-4">
+        <Txt className="pb-4 text-neutral3">
           This MCP server can be accessed through multiple transport methods. Choose the one that best fits your use
           case.
         </Txt>
@@ -90,14 +90,14 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
         <div className="flex flex-col gap-4">
           {/* HTTP Stream */}
           <div className="rounded-lg border border-border1 bg-surface3 p-4">
-            <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">HTTP</span>}>
+            <Badge icon={<span className="mr-1 w-6 font-mono font-medium text-accent1">HTTP</span>}>
               Regular HTTP Endpoint
             </Badge>
 
-            <Txt className="text-neutral3 pt-1 pb-2">Use for stateless HTTP transport with streamable responses.</Txt>
+            <Txt className="pt-1 pb-2 text-neutral3">Use for stateless HTTP transport with streamable responses.</Txt>
 
             <div className="flex items-start gap-2">
-              <Txt className="px-2 py-1 bg-surface4 rounded-lg">{httpStreamUrl}</Txt>
+              <Txt className="rounded-lg bg-surface4 px-2 py-1">{httpStreamUrl}</Txt>
               <div className="pt-1">
                 <CopyButton tooltip="Copy HTTP Stream URL" content={httpStreamUrl} />
               </div>
@@ -106,14 +106,14 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
 
           {/* SSE */}
           <div className="rounded-lg border border-border1 bg-surface3 p-4">
-            <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">SSE</span>}>
+            <Badge icon={<span className="mr-1 w-6 font-mono font-medium text-accent1">SSE</span>}>
               Server-Sent Events
             </Badge>
 
-            <Txt className="text-neutral3 pt-1 pb-2">Use for real-time communication via SSE.</Txt>
+            <Txt className="pt-1 pb-2 text-neutral3">Use for real-time communication via SSE.</Txt>
 
             <div className="flex items-start gap-2">
-              <Txt className="px-2 py-1 bg-surface4 rounded-lg">{sseUrl}</Txt>
+              <Txt className="rounded-lg bg-surface4 px-2 py-1">{sseUrl}</Txt>
               <div className="pt-1">
                 <CopyButton tooltip="Copy SSE URL" content={sseUrl} />
               </div>
@@ -122,12 +122,12 @@ export const MCPDetail = ({ isLoading, server }: MCPDetailProps) => {
 
           {/* Command Line */}
           <div className="rounded-lg border border-border1 bg-surface3 p-4">
-            <Badge icon={<span className="font-mono w-6 text-accent1 font-medium mr-1">CLI</span>}>Command Line</Badge>
+            <Badge icon={<span className="mr-1 w-6 font-mono font-medium text-accent1">CLI</span>}>Command Line</Badge>
 
-            <Txt className="text-neutral3 pt-1 pb-2">Use for local command-line access via npx and mcp-remote.</Txt>
+            <Txt className="pt-1 pb-2 text-neutral3">Use for local command-line access via npx and mcp-remote.</Txt>
 
             <div className="flex items-start gap-2">
-              <Txt className="px-2 py-1 bg-surface4 rounded-lg">{commandLineConfig}</Txt>
+              <Txt className="rounded-lg bg-surface4 px-2 py-1">{commandLineConfig}</Txt>
               <div className="pt-1">
                 <CopyButton tooltip="Copy Command Line Config" content={commandLineConfig} />
               </div>
@@ -151,9 +151,9 @@ const McpToolList = ({ server }: { server: ServerInfo }) => {
   const toolsKeyArray = Object.keys(tools);
 
   return (
-    <div className="p-5 overflow-y-scroll">
-      <div className="text-neutral6 flex gap-2 items-center">
-        <Icon size="lg" className="bg-surface4 rounded-md p-1">
+    <div className="overflow-y-scroll p-5">
+      <div className="flex items-center gap-2 text-neutral6">
+        <Icon size="lg" className="rounded-md bg-surface4 p-1">
           <McpServerIcon />
         </Icon>
 
@@ -201,7 +201,7 @@ const ToolEntry = ({ tool, serverId }: { tool: McpToolInfo; serverId: string }) 
             <Link ref={linkRef} href={paths.mcpServerToolLink(serverId, tool.id)}>
               {tool.id}
             </Link>
-            {isAppTool && <Badge className="text-[10px] py-0">App</Badge>}
+            {isAppTool && <Badge className="py-0 text-[10px]">App</Badge>}
           </span>
         </EntityName>
         <EntityDescription>{tool.description}</EntityDescription>

--- a/packages/playground/src/domains/mcps/components/MCPToolPanel.tsx
+++ b/packages/playground/src/domains/mcps/components/MCPToolPanel.tsx
@@ -75,7 +75,7 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
   if (isLoading) {
     return (
       <div className="p-6">
-        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="mb-4 h-8 w-48" />
         <Skeleton className="h-32 w-full" />
       </div>
     );
@@ -85,7 +85,7 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
 
   if (!tool)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="header-md" className="text-neutral3">
           Tool not found
         </Txt>
@@ -94,7 +94,7 @@ export const MCPToolPanel = ({ toolId, serverId }: MCPToolPanelProps) => {
 
   if (!canExecuteTool)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="ui-sm" className="text-neutral3">
           You don't have permission to execute tools.
         </Txt>

--- a/packages/playground/src/domains/mcps/components/mcp-app-tool-result.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-app-tool-result.tsx
@@ -43,7 +43,7 @@ export function McpAppToolResult({ appInfo, toolArgs, toolResult, onSendMessage 
 
   if (isLoading || !html) {
     return (
-      <div className="rounded-md border border-border1 bg-surface2 p-4 text-text2 text-sm">Loading MCP App UI…</div>
+      <div className="text-text2 rounded-md border border-border1 bg-surface2 p-4 text-sm">Loading MCP App UI…</div>
     );
   }
 

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-edit-layout.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-edit-layout.tsx
@@ -5,9 +5,9 @@ export interface MCPClientEditLayoutProps {
 
 export const MCPClientEditLayout = ({ children, leftSlot }: MCPClientEditLayoutProps) => {
   return (
-    <div className="grid overflow-hidden h-full bg-surface1 grid-cols-[1fr_2fr]">
-      <div className="overflow-hidden h-full border-r border-border1 bg-surface2">{leftSlot}</div>
-      <div className="overflow-y-auto h-full py-4">{children}</div>
+    <div className="grid h-full grid-cols-[1fr_2fr] overflow-hidden bg-surface1">
+      <div className="h-full overflow-hidden border-r border-border1 bg-surface2">{leftSlot}</div>
+      <div className="h-full overflow-y-auto py-4">{children}</div>
     </div>
   );
 };

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-form-sidebar.tsx
@@ -70,8 +70,8 @@ export function MCPClientFormSidebar({
   };
 
   return (
-    <div className="h-full flex flex-col">
-      <ScrollArea className="flex-1 min-h-0">
+    <div className="flex h-full flex-col">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-6 p-4">
           <SectionHeader title="Identity" subtitle="Define the MCP client name and description." />
 
@@ -225,7 +225,7 @@ export function MCPClientFormSidebar({
                 <Label className="text-xs text-neutral5">Environment Variables</Label>
                 <div className="flex flex-col gap-2">
                   {env.map((_, index) => (
-                    <div key={index} className="flex gap-2 items-center">
+                    <div key={index} className="flex items-center gap-2">
                       <Input
                         placeholder="KEY"
                         className={`${SOLID_FIELD} flex-1`}
@@ -240,14 +240,14 @@ export function MCPClientFormSidebar({
                       />
                       {!readOnly && (
                         <Button variant="ghost" size="sm" onClick={() => removeEnvVar(index)}>
-                          <XIcon className="h-3 w-3" />
+                          <XIcon className="size-3" />
                         </Button>
                       )}
                     </div>
                   ))}
                   {!readOnly && (
                     <Button variant="outline" size="sm" onClick={addEnvVar} className="w-fit">
-                      <PlusIcon className="h-3 w-3 mr-1" />
+                      <PlusIcon className="mr-1 size-3" />
                       Add variable
                     </Button>
                   )}
@@ -259,7 +259,7 @@ export function MCPClientFormSidebar({
       </ScrollArea>
 
       {(showSubmit ?? !readOnly) && (
-        <div className="shrink-0 p-4 flex flex-col gap-2">
+        <div className="flex shrink-0 flex-col gap-2 p-4">
           {!readOnly &&
             (() => {
               const isDisabled = serverType !== 'http' || !url.trim() || isTryingConnect;
@@ -280,7 +280,7 @@ export function MCPClientFormSidebar({
                 >
                   {isTryingConnect ? (
                     <>
-                      <Spinner className="h-4 w-4" />
+                      <Spinner className="size-4" />
                       Connecting...
                     </>
                   ) : (
@@ -291,7 +291,7 @@ export function MCPClientFormSidebar({
                 <Button variant="outline" onClick={onTryConnect} disabled={isDisabled} className="w-full">
                   {isTryingConnect ? (
                     <>
-                      <Spinner className="h-4 w-4" />
+                      <Spinner className="size-4" />
                       Connecting...
                     </>
                   ) : (
@@ -303,7 +303,7 @@ export function MCPClientFormSidebar({
           <Button variant="primary" onClick={onPublish} disabled={isSubmitting} className="w-full">
             {isSubmitting ? (
               <>
-                <Spinner className="h-4 w-4" />
+                <Spinner className="size-4" />
                 Creating...
               </>
             ) : (

--- a/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-create/mcp-client-tool-preview.tsx
@@ -63,7 +63,7 @@ export function MCPClientToolPreview({
     <div className="p-5">
       {tryConnect.isPending && (
         <div className="flex items-center gap-2">
-          <Spinner className="h-3 w-3" />
+          <Spinner className="size-3" />
           <Txt className="text-neutral3">Connecting...</Txt>
         </div>
       )}
@@ -91,7 +91,7 @@ export function MCPClientToolPreview({
 }
 
 function EmptyState({ children }: { children: React.ReactNode }) {
-  return <div className="flex items-center justify-center h-full p-8 text-center">{children}</div>;
+  return <div className="flex h-full items-center justify-center p-8 text-center">{children}</div>;
 }
 
 function ToolList({
@@ -108,9 +108,9 @@ function ToolList({
   const selectedCount = Object.keys(selectedTools).length;
 
   return (
-    <div className="p-5 overflow-y-auto">
-      <div className="text-neutral6 flex gap-2 items-center">
-        <Icon size="lg" className="bg-surface4 rounded-md p-1">
+    <div className="overflow-y-auto p-5">
+      <div className="flex items-center gap-2 text-neutral6">
+        <Icon size="lg" className="rounded-md bg-surface4 p-1">
           <McpServerIcon />
         </Icon>
         <Txt variant="header-md" as="h2" className="font-medium">
@@ -135,8 +135,8 @@ function ToolList({
                     type="text"
                     disabled={isDisabled}
                     className={cn(
-                      'border border-transparent appearance-none block w-full text-neutral3 bg-transparent',
-                      !isDisabled && 'border-border1 border-dashed',
+                      'block w-full appearance-none border border-transparent bg-transparent text-neutral3',
+                      !isDisabled && 'border-dashed border-border1',
                     )}
                     value={
                       isSelected

--- a/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
+++ b/packages/playground/src/domains/mcps/components/mcp-client-list/mcp-client-list.tsx
@@ -145,11 +145,11 @@ export function MCPClientList() {
         </Section.Header>
 
         {mcpClients.length === 0 && (
-          <div className="rounded-xl border border-border2 border-dashed py-8 text-center">
+          <div className="rounded-xl border border-dashed border-border2 py-8 text-center">
             <EmptyState
               className="py-4!"
               iconSlot={
-                <div className="size-6 text-neutral3 rounded-full bg-surface3 p-2 flex items-center justify-center">
+                <div className="flex size-6 items-center justify-center rounded-full bg-surface3 p-2 text-neutral3">
                   <LaptopMinimal className="size-6" />
                 </div>
               }
@@ -181,7 +181,7 @@ export function MCPClientList() {
                   onClick={() => setViewIndex(index)}
                 >
                   <div
-                    className="size-11 rounded-lg flex items-center justify-center uppercase shrink-0"
+                    className="flex size-11 shrink-0 items-center justify-center rounded-lg uppercase"
                     style={{ backgroundColor: bg, color: text }}
                   >
                     <Icon>

--- a/packages/playground/src/domains/metrics/components/chart-card.tsx
+++ b/packages/playground/src/domains/metrics/components/chart-card.tsx
@@ -17,19 +17,19 @@ export function ChartCard({
 }) {
   return (
     <div className={`flex flex-col rounded-lg border border-border1 bg-surface2 ${className}`}>
-      <div className="flex items-start justify-between px-4 py-3 shrink-0">
+      <div className="flex shrink-0 items-start justify-between px-4 py-3">
         <div>
-          <h3 className="text-base font-semibold text-icon6">{title}</h3>
-          {description && <p className="text-xs text-icon2 mt-0.5">{description}</p>}
+          <h3 className="text-icon6 text-base font-semibold">{title}</h3>
+          {description && <p className="text-icon2 mt-0.5 text-xs">{description}</p>}
         </div>
         {summary && (
           <div className="text-right">
-            <span className="text-base font-semibold font-mono text-icon6">{summary}</span>
-            {summaryLabel && <p className="text-xs text-icon2">{summaryLabel}</p>}
+            <span className="text-icon6 font-mono text-base font-semibold">{summary}</span>
+            {summaryLabel && <p className="text-icon2 text-xs">{summaryLabel}</p>}
           </div>
         )}
       </div>
-      <div className="flex-1 flex flex-col px-4 pt-3 pb-4">{children}</div>
+      <div className="flex flex-1 flex-col px-4 pt-3 pb-4">{children}</div>
     </div>
   );
 }
@@ -48,7 +48,7 @@ export function CustomTooltip({
   if (!active || !payload?.length) return null;
   return (
     <div className="rounded-md border border-border1 bg-surface2 px-3 py-2 text-xs shadow-lg">
-      <p className="mb-1 font-medium text-icon6">{label}</p>
+      <p className="text-icon6 mb-1 font-medium">{label}</p>
       {payload.map(entry => (
         <p key={entry.name} className="text-icon2">
           <span className="mr-2 inline-block size-2 rounded-full" style={{ backgroundColor: entry.color }} />

--- a/packages/playground/src/domains/metrics/components/dashboard-line-chart.tsx
+++ b/packages/playground/src/domains/metrics/components/dashboard-line-chart.tsx
@@ -22,7 +22,7 @@ export function DashboardLineChart({
 }) {
   return (
     <div>
-      <div className="flex flex-wrap items-end gap-4 mb-4">
+      <div className="mb-4 flex flex-wrap items-end gap-4">
         {series.map(s => {
           const aggregated = s.aggregate?.(data);
           return (
@@ -32,7 +32,7 @@ export function DashboardLineChart({
                 <span className="text-ui-xs text-neutral3 uppercase">{s.label}</span>
               </div>
               {aggregated && (
-                <p className="text-ui-md text-neutral4 pl-5">
+                <p className="pl-5 text-ui-md text-neutral4">
                   {aggregated.value}
                   {aggregated.suffix && <span className="text-ui-sm text-neutral2"> {aggregated.suffix}</span>}
                 </p>

--- a/packages/playground/src/domains/metrics/components/metrics-toolbar.tsx
+++ b/packages/playground/src/domains/metrics/components/metrics-toolbar.tsx
@@ -33,7 +33,7 @@ export function MetricsToolbar({
   const hasNonDefaultFilter = filterTokens.some(token => isNonDefaultFilter(token, filterFields));
 
   return (
-    <div className={cn('grid grid-cols-[1fr_auto] gap-3 items-start')}>
+    <div className={cn('grid grid-cols-[1fr_auto] items-start gap-3')}>
       <PropertyFilterApplied
         fields={filterFields}
         tokens={filterTokens}

--- a/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
@@ -178,7 +178,7 @@ function AddTraceMocksForm({ initialMocksJson, onClose }: AddTraceMocksFormProps
           </SelectTrigger>
           <SelectContent>
             {datasets.length === 0 ? (
-              <div className="px-2 py-4 text-sm text-neutral4 text-center">No datasets available</div>
+              <div className="px-2 py-4 text-center text-sm text-neutral4">No datasets available</div>
             ) : (
               datasets.map(dataset => (
                 <SelectItem key={dataset.id} value={dataset.id}>
@@ -206,7 +206,7 @@ function AddTraceMocksForm({ initialMocksJson, onClose }: AddTraceMocksFormProps
           </SelectTrigger>
           <SelectContent>
             {items.length === 0 ? (
-              <div className="px-2 py-4 text-sm text-neutral4 text-center">No items available</div>
+              <div className="px-2 py-4 text-center text-sm text-neutral4">No items available</div>
             ) : (
               items.map(item => (
                 <SelectItem key={item.id} value={item.id}>
@@ -220,7 +220,7 @@ function AddTraceMocksForm({ initialMocksJson, onClose }: AddTraceMocksFormProps
 
       <div className="grid gap-2">
         <Label htmlFor="derived-mocks">Tool Mocks (JSON)</Label>
-        <CodeEditor value={mocksJson} onChange={setMocksJson} showCopyButton={false} className="min-h-[160px]" />
+        <CodeEditor value={mocksJson} onChange={setMocksJson} showCopyButton={false} className="min-h-40" />
         <p className="text-xs text-neutral4">
           Seeded from the trace&apos;s tool calls. Edit or remove entries before appending.
         </p>

--- a/packages/playground/src/domains/observability/components/tracing-run-options.tsx
+++ b/packages/playground/src/domains/observability/components/tracing-run-options.tsx
@@ -68,7 +68,7 @@ export const TracingRunOptions = ({
         extensions={[jsonLanguage]}
         className={cn(
           editorClassName,
-          'overflow-y-scroll rounded-lg border border-border1 bg-surface2 overflow-hidden p-3',
+          'overflow-hidden overflow-y-scroll rounded-lg border border-border1 bg-surface2 p-3',
           '[&_.cm-editor]:!bg-surface2 [&_.cm-gutters]:!bg-surface2',
         )}
       />

--- a/packages/playground/src/domains/processors/components/processor-panel.tsx
+++ b/packages/playground/src/domains/processors/components/processor-panel.tsx
@@ -47,7 +47,7 @@ export function ProcessorPanel({ processorId }: ProcessorPanelProps) {
   if (isLoading) {
     return (
       <div className="p-6">
-        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="mb-4 h-8 w-48" />
         <Skeleton className="h-32 w-full" />
       </div>
     );
@@ -57,7 +57,7 @@ export function ProcessorPanel({ processorId }: ProcessorPanelProps) {
 
   if (!processor)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="header-md" className="text-neutral3">
           Processor not found
         </Txt>
@@ -121,10 +121,10 @@ function ProcessorDetailPanel({ processor }: ProcessorDetailPanelProps) {
 
   return (
     <MainContentContent hasLeftServiceColumn={true} className="relative">
-      <div className="bg-surface2 border-r border-border1 w-[22rem] overflow-y-auto">
+      <div className="w-88 overflow-y-auto border-r border-border1 bg-surface2">
         <ProcessorInformation processor={processor} />
 
-        <div className="p-5 space-y-5">
+        <div className="space-y-5 p-5">
           <div className="space-y-2">
             <Txt as="label" variant="ui-sm" className="text-neutral3">
               Phase
@@ -176,7 +176,7 @@ function ProcessorDetailPanel({ processor }: ProcessorDetailPanelProps) {
               onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => setTestMessage(e.target.value)}
               placeholder="Enter a test message..."
               rows={4}
-              className="w-full bg-transparent border border-border1 rounded-md p-3 text-ui-sm text-neutral6 placeholder:text-neutral3 focus:outline-hidden focus:ring-2 focus:ring-accent1"
+              className="w-full rounded-md border border-border1 bg-transparent p-3 text-ui-sm text-neutral6 placeholder:text-neutral3 focus:ring-2 focus:ring-accent1 focus:outline-hidden"
             />
           </div>
 
@@ -195,7 +195,7 @@ function ProcessorDetailPanel({ processor }: ProcessorDetailPanelProps) {
           )}
 
           {result && (
-            <div className="space-y-2 pt-4 border-t border-border1">
+            <div className="space-y-2 border-t border-border1 pt-4">
               <Txt variant="ui-sm" className="text-neutral3">
                 Status
               </Txt>
@@ -204,11 +204,11 @@ function ProcessorDetailPanel({ processor }: ProcessorDetailPanelProps) {
                 {result.tripwire?.triggered && <Badge variant="info">Tripwire Triggered</Badge>}
               </div>
               {result.tripwire?.triggered && result.tripwire.reason && (
-                <div className="mt-2 p-3 bg-accent6Dark rounded-md border border-accent6/20">
-                  <Txt variant="ui-sm" className="text-accent6 font-medium">
+                <div className="mt-2 rounded-md border border-accent6/20 bg-accent6Dark p-3">
+                  <Txt variant="ui-sm" className="font-medium text-accent6">
                     Tripwire Reason
                   </Txt>
-                  <Txt variant="ui-sm" className="text-neutral3 mt-1">
+                  <Txt variant="ui-sm" className="mt-1 text-neutral3">
                     {result.tripwire.reason}
                   </Txt>
                 </div>
@@ -222,7 +222,7 @@ function ProcessorDetailPanel({ processor }: ProcessorDetailPanelProps) {
         <CopyButton content={resultCode} tooltip="Copy JSON result to clipboard" />
       </div>
 
-      <div className="p-5 h-full relative overflow-x-auto overflow-y-auto">
+      <div className="relative h-full overflow-auto p-5">
         <CodeMirror value={errorString || resultCode} editable={true} theme={theme} extensions={[jsonLanguage]} />
       </div>
     </MainContentContent>
@@ -235,16 +235,16 @@ interface ProcessorInformationProps {
 
 function ProcessorInformation({ processor }: ProcessorInformationProps) {
   return (
-    <div className="px-5 pt-5 pb-4 border-b border-border1">
-      <Txt variant="header-md" className="text-neutral1 mb-2">
+    <div className="border-b border-border1 px-5 pt-5 pb-4">
+      <Txt variant="header-md" className="mb-2 text-neutral1">
         {processor.name || processor.id}
       </Txt>
       {processor.name && processor.name !== processor.id && (
-        <Txt variant="ui-sm" className="text-neutral4 mb-3">
+        <Txt variant="ui-sm" className="mb-3 text-neutral4">
           {processor.id}
         </Txt>
       )}
-      <div className="flex flex-wrap gap-1 mt-3">
+      <div className="mt-3 flex flex-wrap gap-1">
         {processor.phases.map(phase => (
           <Badge key={phase} variant="default">
             {phase}

--- a/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
+++ b/packages/playground/src/domains/processors/components/processors-list/processors-list.tsx
@@ -100,7 +100,7 @@ export function ProcessorsList({ processors, isLoading, search = '' }: Processor
             <EntityList.DescriptionCell>{description}</EntityList.DescriptionCell>
             {phaseKeys.map(key => (
               <EntityList.TextCell key={key} className="text-center">
-                {phaseSet.has(key) && <CheckIcon className="size-4 mx-auto" />}
+                {phaseSet.has(key) && <CheckIcon className="mx-auto size-4" />}
               </EntityList.TextCell>
             ))}
             <EntityList.TextCell className="text-center">{agentsCount || ''}</EntityList.TextCell>

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-main.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-main.tsx
@@ -24,7 +24,7 @@ export function PromptBlockEditMain({ form, formResetKey = 0 }: PromptBlockEditM
   };
 
   return (
-    <div className="flex flex-col gap-3 h-full px-4">
+    <div className="flex h-full flex-col gap-3 px-4">
       <div className="flex items-center justify-between">
         <SectionHeader
           title="Content"
@@ -41,7 +41,7 @@ export function PromptBlockEditMain({ form, formResetKey = 0 }: PromptBlockEditM
         name="content"
         control={control}
         render={({ field }) => (
-          <div className="flex-1 flex flex-col">
+          <div className="flex flex-1 flex-col">
             <CodeEditor
               key={formResetKey}
               value={field.value ?? ''}
@@ -51,7 +51,7 @@ export function PromptBlockEditMain({ form, formResetKey = 0 }: PromptBlockEditM
               placeholder="Enter prompt block content..."
               highlightVariables
               schema={schema}
-              className="flex-1 min-h-[200px]"
+              className="min-h-50 flex-1"
             />
           </div>
         )}

--- a/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompt-block-edit-page/prompt-block-edit-sidebar.tsx
@@ -31,12 +31,12 @@ function RecursiveFieldRenderer({
     <div className={'py-2'} style={{ paddingLeft: depth * 8 }}>
       <JSONSchemaForm.Field key={field.id} field={field} parentPath={parentPath} depth={depth}>
         <div className="space-y-2 px-2">
-          <div className="flex flex-row gap-4 items-center">
+          <div className="flex flex-row items-center gap-4">
             <JSONSchemaForm.FieldName
               labelIsHidden
               placeholder="Variable name"
               size="md"
-              className="[&_input]:bg-surface3 w-full"
+              className="w-full [&_input]:bg-surface3"
             />
 
             <JSONSchemaForm.FieldType placeholder="Type" />
@@ -123,8 +123,8 @@ export function PromptBlockEditSidebar({
   }, [blockId, storedAgentsData]);
 
   return (
-    <div className="h-full flex flex-col">
-      <ScrollArea className="flex-1 min-h-0">
+    <div className="flex h-full flex-col">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-6 p-4">
           <SectionHeader title="Configuration" subtitle="Define your prompt block's name and description." />
 
@@ -160,13 +160,13 @@ export function PromptBlockEditSidebar({
         </div>
 
         {/* Variables */}
-        <div className="flex flex-col gap-4 p-4 border-t border-border1">
+        <div className="flex flex-col gap-4 border-t border-border1 p-4">
           <SectionHeader
             title="Variables"
             subtitle={
               <>
                 Define variables for this prompt block. Use{' '}
-                <code className="text-accent1 font-medium">{'{{variableName}}'}</code> syntax in your content.
+                <code className="font-medium text-accent1">{'{{variableName}}'}</code> syntax in your content.
               </>
             }
           />
@@ -194,7 +194,7 @@ export function PromptBlockEditSidebar({
 
         {/* Used by */}
         {mode === 'edit' && blockId && (
-          <div className="flex flex-col gap-3 p-4 border-t border-border1">
+          <div className="flex flex-col gap-3 border-t border-border1 p-4">
             <SectionHeader title="Used by" subtitle="Agents that reference this prompt block." />
             {usedByAgents.length > 0 ? (
               <div className="flex flex-col gap-1.5">
@@ -203,9 +203,9 @@ export function PromptBlockEditSidebar({
                     key={agent.id}
                     type="button"
                     onClick={() => navigate(paths.agentLink(agent.id))}
-                    className="flex items-center gap-2 px-2 py-1.5 rounded-md text-left hover:bg-surface3 transition-colors"
+                    className="flex items-center gap-2 rounded-md px-2 py-1.5 text-left transition-colors hover:bg-surface3"
                   >
-                    <Txt variant="ui-sm" className="text-neutral5 truncate">
+                    <Txt variant="ui-sm" className="truncate text-neutral5">
                       {agent.name || agent.id}
                     </Txt>
                   </button>
@@ -227,7 +227,7 @@ export function PromptBlockEditSidebar({
             <Button onClick={onSaveDraft} disabled={!isDirty || isSavingDraft || isSubmitting} className="flex-1">
               {isSavingDraft ? (
                 <>
-                  <Spinner className="h-4 w-4" />
+                  <Spinner className="size-4" />
                   Saving...
                 </>
               ) : (
@@ -245,7 +245,7 @@ export function PromptBlockEditSidebar({
             >
               {isSubmitting ? (
                 <>
-                  <Spinner className="h-4 w-4" />
+                  <Spinner className="size-4" />
                   Publishing...
                 </>
               ) : (
@@ -260,7 +260,7 @@ export function PromptBlockEditSidebar({
           <Button variant="primary" onClick={onPublish} disabled={isSubmitting} className="w-full">
             {isSubmitting ? (
               <>
-                <Spinner className="h-4 w-4" />
+                <Spinner className="size-4" />
                 Creating...
               </>
             ) : (

--- a/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
+++ b/packages/playground/src/domains/prompt-blocks/components/prompts-list/prompts-list.tsx
@@ -48,10 +48,10 @@ export function PromptsList({ promptBlocks, isLoading, search = '' }: PromptsLis
             <EntityList.NameCell>{name}</EntityList.NameCell>
             <EntityList.DescriptionCell>{description}</EntityList.DescriptionCell>
             <EntityList.TextCell className="text-center">
-              {(block.hasDraft || !block.activeVersionId) && <CheckIcon className="size-4 mx-auto" />}
+              {(block.hasDraft || !block.activeVersionId) && <CheckIcon className="mx-auto size-4" />}
             </EntityList.TextCell>
             <EntityList.TextCell className="text-center">
-              {block.activeVersionId && <CheckIcon className="size-4 mx-auto" />}
+              {block.activeVersionId && <CheckIcon className="mx-auto size-4" />}
             </EntityList.TextCell>
           </EntityList.RowLink>
         );

--- a/packages/playground/src/domains/request-context/components/request-context-label.tsx
+++ b/packages/playground/src/domains/request-context/components/request-context-label.tsx
@@ -27,14 +27,14 @@ export function RequestContextLabel({ as = 'span', children, tooltip }: RequestC
               <button
                 type="button"
                 aria-label={ariaLabel}
-                className="rounded-sm text-neutral3 transition-colors hover:text-neutral6 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border2"
+                className="rounded-sm text-neutral3 transition-colors hover:text-neutral6 focus-visible:ring-2 focus-visible:ring-border2 focus-visible:outline-none"
               >
                 <Icon size="sm">
                   <Info />
                 </Icon>
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-[240px]">
+            <TooltipContent side="top" className="max-w-60">
               {tooltip}
             </TooltipContent>
           </Tooltip>

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -435,14 +435,14 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
 
   if (isLoadingReview) {
     return (
-      <div className="flex-1 flex items-center justify-center">
-        <Spinner className="w-6 h-6" />
+      <div className="flex flex-1 items-center justify-center">
+        <Spinner className="size-6" />
       </div>
     );
   }
 
   return (
-    <div className="flex flex-1 min-h-0 overflow-hidden">
+    <div className="flex min-h-0 flex-1 overflow-hidden">
       {/* Analyze config dialog */}
       <Dialog open={showAnalyzeDialog} onOpenChange={setShowAnalyzeDialog}>
         <DialogContent>
@@ -453,11 +453,11 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
           <div className="space-y-4 py-2">
             <div className="grid grid-cols-2 gap-2">
               <div>
-                <Label className="text-xs mb-1 block">Provider</Label>
+                <Label className="mb-1 block text-xs">Provider</Label>
                 <LLMProviders value={analyzeProvider} onValueChange={setAnalyzeProvider} />
               </div>
               <div>
-                <Label className="text-xs mb-1 block">Model</Label>
+                <Label className="mb-1 block text-xs">Model</Label>
                 <LLMModels llmId={analyzeProvider} value={analyzeModel} onValueChange={setAnalyzeModel} />
               </div>
             </div>
@@ -471,7 +471,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                 onChange={e => setAnalyzePrompt(e.target.value)}
                 placeholder="E.g., Focus on safety issues and factual errors..."
                 rows={3}
-                className="text-xs mt-1"
+                className="mt-1 text-xs"
               />
             </div>
           </div>
@@ -480,7 +480,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
               Cancel
             </Button>
             <Button onClick={handleAnalyze} disabled={!analyzeProvider || !analyzeModel || isAnalyzing}>
-              {isAnalyzing ? <Spinner className="w-4 h-4 mr-1" /> : null}
+              {isAnalyzing ? <Spinner className="mr-1 size-4" /> : null}
               Analyze
             </Button>
           </DialogFooter>
@@ -489,7 +489,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
 
       {/* Proposal confirmation dialog */}
       <Dialog open={showProposalDialog} onOpenChange={setShowProposalDialog}>
-        <DialogContent className="max-w-2xl max-h-[80vh] overflow-y-auto">
+        <DialogContent className="max-h-[80vh] max-w-2xl overflow-y-auto">
           <DialogHeader>
             <DialogTitle>Review Proposed Tags</DialogTitle>
             <DialogDescription>
@@ -500,7 +500,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
             {proposedAssignments.map((proposal, idx) => {
               const item = items.find(i => i.id === proposal.itemId);
               return (
-                <div key={proposal.itemId} className={cn('p-3 border rounded-lg', !proposal.accepted && 'opacity-50')}>
+                <div key={proposal.itemId} className={cn('rounded-lg border p-3', !proposal.accepted && 'opacity-50')}>
                   <div className="flex items-start gap-2">
                     <Checkbox
                       checked={proposal.accepted}
@@ -510,15 +510,15 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                         )
                       }
                     />
-                    <div className="flex-1 min-w-0">
-                      <Txt variant="ui-xs" className="text-neutral4 truncate block">
+                    <div className="min-w-0 flex-1">
+                      <Txt variant="ui-xs" className="block truncate text-neutral4">
                         {item
                           ? typeof item.input === 'string'
                             ? item.input.slice(0, 100)
                             : JSON.stringify(item.input).slice(0, 100)
                           : proposal.itemId}
                       </Txt>
-                      <div className="flex gap-1 flex-wrap mt-1.5">
+                      <div className="mt-1.5 flex flex-wrap gap-1">
                         {proposal.tags.map((tag, ti) => (
                           <ProposalTag
                             key={`${tag}-${ti}`}
@@ -539,7 +539,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                         ))}
                       </div>
                       {proposal.reason && (
-                        <Txt variant="ui-xs" className="text-neutral3 mt-1 block italic">
+                        <Txt variant="ui-xs" className="mt-1 block text-neutral3 italic">
                           {proposal.reason}
                         </Txt>
                       )}
@@ -561,11 +561,9 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
       </Dialog>
 
       {/* Main layout: toolbar + List + Detail Panel */}
-      <div
-        className={cn('grid w-full h-full grid-cols-1 gap-4 overflow-y-auto', featuredItem && 'grid-cols-[1fr_1fr]')}
-      >
-        <div className="grid gap-8 content-start w-full overflow-y-auto">
-          <div className="flex items-center justify-between w-full flex-wrap gap-4 gap-x-6">
+      <div className={cn('grid size-full grid-cols-1 gap-4 overflow-y-auto', featuredItem && 'grid-cols-[1fr_1fr]')}>
+        <div className="grid w-full content-start gap-8 overflow-y-auto">
+          <div className="flex w-full flex-wrap items-center justify-between gap-4 gap-x-6">
             {/* Filters (left) */}
             <div className="flex items-center gap-3">
               <DropdownMenu>
@@ -576,7 +574,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                     {activeFilterCount > 0 && (
                       <span
                         className={cn(
-                          'ml-0.5 inline-flex items-center justify-center rounded-full bg-accent1/50 text-neutral5 text-ui-sm w-5 h-5',
+                          'ml-0.5 inline-flex size-5 items-center justify-center rounded-full bg-accent1/50 text-ui-sm text-neutral5',
                         )}
                       >
                         {activeFilterCount}
@@ -704,7 +702,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                   <DropdownMenu.Trigger asChild>
                     <Button disabled={isAnalyzing}>
                       {isAnalyzing ? (
-                        <Spinner className="w-4 h-4" />
+                        <Spinner className="size-4" />
                       ) : (
                         <Icon size="sm">
                           <ChevronDown />
@@ -740,16 +738,16 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
           </div>
 
           {isLoadingDisplay ? (
-            <div className="flex-1 flex items-center justify-center">
-              <Spinner className="w-6 h-6" />
+            <div className="flex flex-1 items-center justify-center">
+              <Spinner className="size-6" />
             </div>
           ) : displayItems.length === 0 ? (
-            <div className="flex-1 flex items-center justify-center">
-              <div className="text-center px-8">
-                <Txt variant="ui-sm" className="text-neutral3 block">
+            <div className="flex flex-1 items-center justify-center">
+              <div className="px-8 text-center">
+                <Txt variant="ui-sm" className="block text-neutral3">
                   {showCompleted ? 'No completed reviews yet' : 'No items to review'}
                 </Txt>
-                <Txt variant="ui-xs" className="text-neutral3 mt-2 block">
+                <Txt variant="ui-xs" className="mt-2 block text-neutral3">
                   {showCompleted
                     ? 'Items marked as complete will appear here for auditing.'
                     : 'When experiment results are flagged for review, they will appear here.'}
@@ -791,7 +789,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                     {/* Comment preview */}
                     <DataList.Cell height="compact" className="min-w-0">
                       {item.comment ? (
-                        <Txt variant="ui-xs" className="text-neutral3 truncate">
+                        <Txt variant="ui-xs" className="truncate text-neutral3">
                           {item.comment}
                         </Txt>
                       ) : (
@@ -804,7 +802,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                     {/* Tags */}
                     <DataList.Cell height="compact" className="min-w-0">
                       {item.tags.length > 0 ? (
-                        <Txt variant="ui-xs" className="text-neutral4 truncate">
+                        <Txt variant="ui-xs" className="truncate text-neutral4">
                           {item.tags.join(', ')}
                         </Txt>
                       ) : (
@@ -840,7 +838,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                           <Icon size="sm" className="text-neutral3">
                             <GaugeIcon />
                           </Icon>
-                          <Txt variant="ui-xs" className="text-neutral4 font-mono">
+                          <Txt variant="ui-xs" className="font-mono text-neutral4">
                             {scoreEntries[0][1].toFixed(2)}
                           </Txt>
                           {scoreEntries.length > 1 && <Badge variant="default">+{scoreEntries.length - 1}</Badge>}
@@ -868,7 +866,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
                           role="img"
                           aria-label={item.error ? 'Error' : 'Success'}
                           title={item.error ? 'Error' : 'Success'}
-                          className={cn('w-2 h-2 rounded-full', item.error ? 'bg-red-700' : 'bg-green-600')}
+                          className={cn('size-2 rounded-full', item.error ? 'bg-red-700' : 'bg-green-600')}
                         />
                       </DataList.Cell>
                     )}

--- a/packages/playground/src/domains/review/components/proposal-tag.tsx
+++ b/packages/playground/src/domains/review/components/proposal-tag.tsx
@@ -31,7 +31,7 @@ export function ProposalTag({
 
   if (isEditing) {
     return (
-      <span className="inline-flex items-center gap-0.5 bg-surface3 border border-border1 rounded-md px-1">
+      <span className="inline-flex items-center gap-0.5 rounded-md border border-border1 bg-surface3 px-1">
         <input
           ref={inputRef}
           value={editValue}
@@ -47,7 +47,7 @@ export function ProposalTag({
             }
           }}
           onBlur={handleConfirm}
-          className="bg-transparent text-xs text-neutral4 outline-hidden w-20 py-0.5"
+          className="w-20 bg-transparent py-0.5 text-xs text-neutral4 outline-hidden"
         />
         <button
           type="button"
@@ -55,16 +55,16 @@ export function ProposalTag({
             e.preventDefault();
             handleConfirm();
           }}
-          className="text-positive1 hover:text-positive2 p-0.5"
+          className="hover:text-positive2 p-0.5 text-positive1"
         >
-          <Check className="w-3 h-3" />
+          <Check className="size-3" />
         </button>
       </span>
     );
   }
 
   return (
-    <span className="inline-flex items-center gap-0.5 bg-surface3 border border-border1 rounded-md px-1.5 py-0.5 text-xs text-neutral4 group">
+    <span className="group inline-flex items-center gap-0.5 rounded-md border border-border1 bg-surface3 px-1.5 py-0.5 text-xs text-neutral4">
       {tag}
       <button
         type="button"
@@ -72,18 +72,18 @@ export function ProposalTag({
           setEditValue(tag);
           setIsEditing(true);
         }}
-        className="text-neutral2 hover:text-neutral4 p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+        className="p-0.5 text-neutral2 opacity-0 transition-opacity group-hover:opacity-100 hover:text-neutral4"
         title="Edit tag"
       >
-        <Pencil className="w-3 h-3" />
+        <Pencil className="size-3" />
       </button>
       <button
         type="button"
         onClick={onRemove}
-        className="text-neutral2 hover:text-negative1 p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+        className="p-0.5 text-neutral2 opacity-0 transition-opacity group-hover:opacity-100 hover:text-negative1"
         title="Remove tag"
       >
-        <X className="w-3 h-3" />
+        <X className="size-3" />
       </button>
     </span>
   );

--- a/packages/playground/src/domains/review/components/review-item-card.tsx
+++ b/packages/playground/src/domains/review/components/review-item-card.tsx
@@ -76,7 +76,7 @@ export function ReviewItemCard({
   return (
     <div
       className={cn(
-        'border border-border1 rounded-lg p-3 transition-colors',
+        'rounded-lg border border-border1 p-3 transition-colors',
         isSelected && 'ring-1 ring-accent1',
         item.tags.length > 0 && 'border-l-2 border-l-accent1',
       )}
@@ -84,7 +84,7 @@ export function ReviewItemCard({
       {/* Header row */}
       <div className="flex items-center gap-2">
         {isCompleted ? (
-          <Icon size="sm" className="text-positive1 shrink-0">
+          <Icon size="sm" className="shrink-0 text-positive1">
             <CheckCircle />
           </Icon>
         ) : (
@@ -92,11 +92,11 @@ export function ReviewItemCard({
             type="checkbox"
             checked={isSelected}
             onChange={onToggleSelect}
-            className="w-3.5 h-3.5 rounded border-border1 accent-accent1"
+            className="size-3.5 rounded border-border1 accent-accent1"
           />
         )}
-        <button type="button" onClick={onToggleExpand} className="flex-1 text-left min-w-0">
-          <Txt variant="ui-xs" className="text-neutral4 truncate block">
+        <button type="button" onClick={onToggleExpand} className="min-w-0 flex-1 text-left">
+          <Txt variant="ui-xs" className="block truncate text-neutral4">
             {inputPreview}
           </Txt>
         </button>
@@ -104,16 +104,16 @@ export function ReviewItemCard({
 
       {/* Error indicator */}
       {Boolean(item.error) && (
-        <Txt variant="ui-xs" className="text-negative1 mt-1 block truncate">
+        <Txt variant="ui-xs" className="mt-1 block truncate text-negative1">
           Error: {typeof item.error === 'string' ? item.error : String(item.error)}
         </Txt>
       )}
 
       {/* Rating + Tags + Remove row */}
       <TooltipProvider delayDuration={200}>
-        <div className="flex items-center gap-2 mt-2">
+        <div className="mt-2 flex items-center gap-2">
           {/* Rating: thumbs up / down */}
-          <div className="flex items-center gap-0.5 mr-1">
+          <div className="mr-1 flex items-center gap-0.5">
             <Button
               tooltip="Good — this result is acceptable"
               variant={item.rating === 'positive' ? 'default' : 'ghost'}
@@ -140,9 +140,9 @@ export function ReviewItemCard({
           </div>
 
           {/* Tags */}
-          <div className="flex-1 min-w-0">
+          <div className="min-w-0 flex-1">
             {isCompleted ? (
-              <div className="flex gap-1 flex-wrap">
+              <div className="flex flex-wrap gap-1">
                 {item.tags.map(tag => (
                   <Badge key={tag} variant="default">
                     {tag}
@@ -156,7 +156,7 @@ export function ReviewItemCard({
 
           {/* Scores */}
           {item.scores && Object.keys(item.scores).length > 0 && (
-            <div className="flex items-center gap-1 mr-1">
+            <div className="mr-1 flex items-center gap-1">
               <Icon size="sm" className="text-neutral3">
                 <GaugeIcon />
               </Icon>
@@ -203,35 +203,35 @@ export function ReviewItemCard({
               <Txt variant="ui-xs" className="text-neutral3">
                 Experiment:
               </Txt>
-              <code className="text-[10px] font-mono text-neutral4 bg-surface2 px-1.5 py-0.5 rounded">
+              <code className="rounded bg-surface2 px-1.5 py-0.5 font-mono text-[10px] text-neutral4">
                 {item.experimentId.slice(0, 8)}
               </code>
             </div>
           )}
           <div>
-            <Txt variant="ui-xs" className="text-neutral3 block font-semibold mb-1">
+            <Txt variant="ui-xs" className="mb-1 block font-semibold text-neutral3">
               Input
             </Txt>
-            <pre className="text-xs text-neutral5 whitespace-pre-wrap bg-surface2 rounded p-2 overflow-auto max-h-40">
+            <pre className="max-h-40 overflow-auto rounded bg-surface2 p-2 text-xs whitespace-pre-wrap text-neutral5">
               {formatUnknown(item.input)}
             </pre>
           </div>
           {item.output !== undefined && item.output !== null && (
             <div>
-              <Txt variant="ui-xs" className="text-neutral3 block font-semibold mb-1">
+              <Txt variant="ui-xs" className="mb-1 block font-semibold text-neutral3">
                 Output
               </Txt>
-              <pre className="text-xs text-neutral5 whitespace-pre-wrap bg-surface2 rounded p-2 overflow-auto max-h-40">
+              <pre className="max-h-40 overflow-auto rounded bg-surface2 p-2 text-xs whitespace-pre-wrap text-neutral5">
                 {formatUnknown(item.output)}
               </pre>
             </div>
           )}
           {Boolean(item.error) && (
             <div>
-              <Txt variant="ui-xs" className="text-neutral3 block font-semibold mb-1">
+              <Txt variant="ui-xs" className="mb-1 block font-semibold text-neutral3">
                 Error
               </Txt>
-              <pre className="text-xs text-negative1 whitespace-pre-wrap bg-surface2 rounded p-2 overflow-auto max-h-20">
+              <pre className="max-h-20 overflow-auto rounded bg-surface2 p-2 text-xs whitespace-pre-wrap text-negative1">
                 {formatUnknown(item.error)}
               </pre>
             </div>
@@ -239,7 +239,7 @@ export function ReviewItemCard({
           {/* Comment */}
           {!isCompleted && (
             <div>
-              <Txt variant="ui-xs" className="text-neutral3 block font-semibold mb-1">
+              <Txt variant="ui-xs" className="mb-1 block font-semibold text-neutral3">
                 Comment
               </Txt>
               <Textarea
@@ -260,7 +260,7 @@ export function ReviewItemCard({
                 className="text-xs"
               />
               {commentSaved && (
-                <Txt variant="ui-xs" className="text-positive1 mt-0.5">
+                <Txt variant="ui-xs" className="mt-0.5 text-positive1">
                   Saved
                 </Txt>
               )}
@@ -268,10 +268,10 @@ export function ReviewItemCard({
           )}
           {isCompleted && item.comment && (
             <div>
-              <Txt variant="ui-xs" className="text-neutral3 block font-semibold mb-1">
+              <Txt variant="ui-xs" className="mb-1 block font-semibold text-neutral3">
                 Comment
               </Txt>
-              <Txt variant="ui-xs" className="text-neutral4 block">
+              <Txt variant="ui-xs" className="block text-neutral4">
                 {item.comment}
               </Txt>
             </div>

--- a/packages/playground/src/domains/review/components/review-item-panel.tsx
+++ b/packages/playground/src/domains/review/components/review-item-panel.tsx
@@ -95,7 +95,7 @@ export function ReviewItemPanel({
         </DataPanel.Header>
 
         <DataPanel.Content>
-          <div className="grid gap-4 mb-6">
+          <div className="mb-6 grid gap-4">
             {/* Rating */}
             {!isCompleted && (
               <div className="flex items-center gap-2">
@@ -143,11 +143,11 @@ export function ReviewItemPanel({
 
             {/* Tags */}
             <div className="flex flex-wrap gap-2">
-              <Txt variant="ui-sm" className="text-neutral3 block mt-0">
+              <Txt variant="ui-sm" className="mt-0 block text-neutral3">
                 Tags
               </Txt>
               {isCompleted ? (
-                <div className="flex gap-1 flex-wrap">
+                <div className="flex flex-wrap gap-1">
                   {item.tags.length > 0 ? (
                     item.tags.map(tag => (
                       <Badge key={tag} variant="default">
@@ -168,7 +168,7 @@ export function ReviewItemPanel({
             {/* Scores */}
             {item.scores && Object.keys(item.scores).length > 0 && (
               <div>
-                <Txt variant="ui-xs" className="text-neutral3 block mb-2">
+                <Txt variant="ui-xs" className="mb-2 block text-neutral3">
                   Scores
                 </Txt>
                 <div className="flex flex-wrap gap-2">
@@ -212,10 +212,10 @@ export function ReviewItemPanel({
           {/* Error */}
           {item.error != null && (
             <div>
-              <Txt variant="ui-xs" className="text-neutral3 block mb-1">
+              <Txt variant="ui-xs" className="mb-1 block text-neutral3">
                 Error
               </Txt>
-              <pre className="text-ui-xs text-negative1 whitespace-pre-wrap wrap-break-word bg-surface2 rounded-md p-3 max-h-48 overflow-auto">
+              <pre className="max-h-48 overflow-auto rounded-md bg-surface2 p-3 text-ui-xs wrap-break-word whitespace-pre-wrap text-negative1">
                 {formatUnknown(item.error)}
               </pre>
             </div>
@@ -223,8 +223,8 @@ export function ReviewItemPanel({
 
           {/* Comment */}
           <div className="mt-4">
-            <div className="flex items-center gap-2 mb-2">
-              <Txt variant="ui-sm" className="uppercase tracking-widest text-neutral2">
+            <div className="mb-2 flex items-center gap-2">
+              <Txt variant="ui-sm" className="tracking-widest text-neutral2 uppercase">
                 Comment
               </Txt>
               {commentSaved && (
@@ -234,7 +234,7 @@ export function ReviewItemPanel({
               )}
             </div>
             {isCompleted ? (
-              <Txt variant="ui-xs" className="text-neutral4 block">
+              <Txt variant="ui-xs" className="block text-neutral4">
                 {item.comment || 'No comment'}
               </Txt>
             ) : (
@@ -251,7 +251,7 @@ export function ReviewItemPanel({
 
           {/* Actions */}
           {!isCompleted && (
-            <div className="flex items-center gap-2 mt-4 pt-4 border-t border-border1">
+            <div className="mt-4 flex items-center gap-2 border-t border-border1 pt-4">
               {onComplete && (
                 <Button size="md" onClick={onComplete}>
                   <CheckCircle />

--- a/packages/playground/src/domains/review/components/tag-picker.tsx
+++ b/packages/playground/src/domains/review/components/tag-picker.tsx
@@ -38,15 +38,15 @@ export function TagPicker({
   };
 
   return (
-    <div className="flex items-center gap-1 flex-wrap">
+    <div className="flex flex-wrap items-center gap-1">
       {tags.map(tag => (
         <span
           key={tag}
-          className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-accent1/10 text-accent1 text-[10px] font-medium"
+          className="inline-flex items-center gap-0.5 rounded-md bg-accent1/10 px-1.5 py-0.5 text-[10px] font-medium text-accent1"
         >
           {tag}
           <button type="button" onClick={() => removeTag(tag)} className="hover:text-accent1/70">
-            <X className="w-2.5 h-2.5" />
+            <X className="size-2.5" />
           </button>
         </span>
       ))}
@@ -54,9 +54,9 @@ export function TagPicker({
         <PopoverTrigger asChild>
           <button
             type="button"
-            className="inline-flex items-center gap-0.5 px-1 py-0.5 rounded text-[10px] text-neutral3 hover:text-neutral5 hover:bg-surface3 transition-colors"
+            className="inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] text-neutral3 transition-colors hover:bg-surface3 hover:text-neutral5"
           >
-            <Plus className="w-3 h-3" />
+            <Plus className="size-3" />
             tag
           </button>
         </PopoverTrigger>
@@ -67,16 +67,16 @@ export function TagPicker({
             onChange={e => setSearch(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Search or create tag..."
-            className="h-7 text-xs mb-1"
+            className="mb-1 h-7 text-xs"
             autoFocus
           />
-          <div className="max-h-32 overflow-y-auto space-y-0.5">
+          <div className="max-h-32 space-y-0.5 overflow-y-auto">
             {filtered.map(tag => (
               <button
                 key={tag}
                 type="button"
                 onClick={() => addTag(tag)}
-                className="w-full text-left px-2 py-1 text-xs rounded hover:bg-surface3 text-neutral4"
+                className="w-full rounded px-2 py-1 text-left text-xs text-neutral4 hover:bg-surface3"
               >
                 {tag}
               </button>
@@ -85,13 +85,13 @@ export function TagPicker({
               <button
                 type="button"
                 onClick={() => addTag(search.trim())}
-                className="w-full text-left px-2 py-1 text-xs rounded hover:bg-surface3 text-accent1"
+                className="w-full rounded px-2 py-1 text-left text-xs text-accent1 hover:bg-surface3"
               >
                 Create &quot;{search.trim()}&quot;
               </button>
             )}
             {filtered.length === 0 && !canCreate && (
-              <Txt variant="ui-xs" className="text-neutral3 px-2 py-1 block">
+              <Txt variant="ui-xs" className="block px-2 py-1 text-neutral3">
                 No tags available
               </Txt>
             )}

--- a/packages/playground/src/domains/schedules/components/schedule-status-badge.tsx
+++ b/packages/playground/src/domains/schedules/components/schedule-status-badge.tsx
@@ -16,7 +16,7 @@ const STATUS_TEXT_COLOR: Record<ScheduleStatus, string> = {
 export const ScheduleStatusText = ({ status }: { status: ScheduleStatus }) => {
   return (
     <span className="inline-flex items-center gap-2 whitespace-nowrap">
-      <span className={`h-1.5 w-1.5 rounded-full ${STATUS_DOT_COLOR[status]}`} aria-hidden />
+      <span className={`size-1.5 rounded-full ${STATUS_DOT_COLOR[status]}`} aria-hidden />
       <span className={`text-ui-sm ${STATUS_TEXT_COLOR[status]}`}>{status}</span>
     </span>
   );

--- a/packages/playground/src/domains/schedules/components/schedule-triggers-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedule-triggers-list.tsx
@@ -57,7 +57,7 @@ export function ScheduleTriggersList({
 
   if (triggers.length === 0) {
     return (
-      <Txt variant="ui-md" className="text-neutral4 p-4">
+      <Txt variant="ui-md" className="p-4 text-neutral4">
         No trigger history yet.
       </Txt>
     );
@@ -88,8 +88,8 @@ export function ScheduleTriggersList({
           <span
             className={
               isLinked
-                ? 'text-accent1 font-mono text-ui-sm whitespace-nowrap'
-                : 'text-neutral3 font-mono text-ui-sm whitespace-nowrap'
+                ? 'font-mono text-ui-sm whitespace-nowrap text-accent1'
+                : 'font-mono text-ui-sm whitespace-nowrap text-neutral3'
             }
           >
             {t.runId}
@@ -103,21 +103,21 @@ export function ScheduleTriggersList({
             <DataList.Cell height="compact">
               <span className="inline-flex items-center gap-2">
                 {isPublishFailure ? (
-                  <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-ui-sm text-accent2">
+                  <span className="inline-flex items-center gap-1.5 text-ui-sm whitespace-nowrap text-accent2">
                     <AlertTriangleIcon size={14} />
                     publish failed
                   </span>
                 ) : t.run ? (
                   <WorkflowRunStatusInline status={t.run.status} />
                 ) : (
-                  <span className="inline-flex items-center gap-1.5 whitespace-nowrap text-ui-sm text-neutral3">
+                  <span className="inline-flex items-center gap-1.5 text-ui-sm whitespace-nowrap text-neutral3">
                     pending
                   </span>
                 )}
                 {errorMessage ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="text-accent2 inline-flex">
+                      <span className="inline-flex text-accent2">
                         <AlertTriangleIcon size={14} />
                       </span>
                     </TooltipTrigger>
@@ -133,7 +133,7 @@ export function ScheduleTriggersList({
                 {showDriftWarning ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="text-accent3 inline-flex">
+                      <span className="inline-flex text-accent3">
                         <AlertTriangleIcon size={14} />
                       </span>
                     </TooltipTrigger>

--- a/packages/playground/src/domains/schedules/components/schedules-list.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-list.tsx
@@ -54,7 +54,7 @@ export function SchedulesList({ schedules, isLoading, search = '' }: SchedulesLi
           <DataList.Cell height="compact">
             <span className="inline-flex items-center gap-2 whitespace-nowrap">
               <code className="font-mono text-ui-sm">{s.cron}</code>
-              {s.timezone ? <span className="text-neutral4 text-ui-xs">{s.timezone}</span> : null}
+              {s.timezone ? <span className="text-ui-xs text-neutral4">{s.timezone}</span> : null}
             </span>
           </DataList.Cell>
           <DataList.Cell height="compact">
@@ -69,7 +69,7 @@ export function SchedulesList({ schedules, isLoading, search = '' }: SchedulesLi
             {s.lastRun ? (
               <span className="inline-flex items-center gap-2 whitespace-nowrap">
                 <WorkflowRunStatusInline status={s.lastRun.status} />
-                <span className="text-neutral4 text-ui-sm" title={formatScheduleTimestamp(s.lastFireAt)}>
+                <span className="text-ui-sm text-neutral4" title={formatScheduleTimestamp(s.lastFireAt)}>
                   {s.lastFireAt ? formatRelativeTime(s.lastFireAt) : ''}
                 </span>
               </span>

--- a/packages/playground/src/domains/schedules/components/schedules-page.tsx
+++ b/packages/playground/src/domains/schedules/components/schedules-page.tsx
@@ -13,7 +13,7 @@ export function SchedulesPage({ workflowId }: { workflowId?: string } = {}) {
   }
 
   return (
-    <div className="grid grid-rows-[auto_1fr] gap-4 h-full overflow-hidden">
+    <div className="grid h-full grid-rows-[auto_1fr] gap-4 overflow-hidden">
       <div className="max-w-120">
         <ListSearch onSearch={setSearch} label="Filter schedules" placeholder="Filter by id or workflow" />
       </div>

--- a/packages/playground/src/domains/schedules/components/workflow-run-status-inline.tsx
+++ b/packages/playground/src/domains/schedules/components/workflow-run-status-inline.tsx
@@ -14,7 +14,7 @@ export interface WorkflowRunStatusInlineProps {
 export function WorkflowRunStatusInline({ status }: WorkflowRunStatusInlineProps) {
   const { icon, color } = getStatusVisual(status);
   return (
-    <span className={`inline-flex items-center gap-1.5 whitespace-nowrap text-ui-sm ${color}`}>
+    <span className={`inline-flex items-center gap-1.5 text-ui-sm whitespace-nowrap ${color}`}>
       <span className="inline-flex shrink-0 items-center" aria-hidden>
         {icon}
       </span>

--- a/packages/playground/src/domains/scores/components/score-dialog.tsx
+++ b/packages/playground/src/domains/scores/components/score-dialog.tsx
@@ -101,7 +101,7 @@ export function ScoreDialog({
           </TextAndIcon>
           |
           <SideDialog.Nav onNext={onNext} onPrevious={onPrevious} />
-          <Button size="lg" className="ml-auto mr-8" disabled={!score} onClick={() => setDatasetDialogOpen(true)}>
+          <Button size="lg" className="mr-8 ml-auto" disabled={!score} onClick={() => setDatasetDialogOpen(true)}>
             <Icon>
               <SaveIcon />
             </Icon>

--- a/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-main.tsx
+++ b/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-main.tsx
@@ -13,20 +13,20 @@ export function ScorerEditMain({ form }: ScorerEditMainProps) {
   const { control } = form;
 
   return (
-    <div className="flex flex-col gap-3 h-full px-4">
+    <div className="flex h-full flex-col gap-3 px-4">
       <SectionHeader title="Instructions" subtitle="Write your scorer's system prompt." />
       <Controller
         name="instructions"
         control={control}
         render={({ field }) => (
-          <div className="flex-1 flex flex-col">
+          <div className="flex flex-1 flex-col">
             <CodeEditor
               value={field.value ?? ''}
               onChange={field.onChange}
               language="markdown"
               showCopyButton={false}
               placeholder="Enter scorer instructions..."
-              className="flex-1 min-h-[200px]"
+              className="min-h-50 flex-1"
             />
           </div>
         )}

--- a/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-sidebar.tsx
+++ b/packages/playground/src/domains/scores/components/scorer-edit-page/scorer-edit-sidebar.tsx
@@ -44,8 +44,8 @@ export function ScorerEditSidebar({
   const watchedProvider = useWatch({ control, name: 'model.provider' });
 
   return (
-    <div className="h-full flex flex-col">
-      <ScrollArea className="flex-1 min-h-0">
+    <div className="flex h-full flex-col">
+      <ScrollArea className="min-h-0 flex-1">
         <div className="flex flex-col gap-6 p-4">
           <SectionHeader title="Configuration" subtitle="Define your scorer's name, type, and settings." />
 
@@ -117,7 +117,7 @@ export function ScorerEditSidebar({
           {/* Score Range */}
           <div className="flex flex-col gap-1.5">
             <Label className="text-xs text-neutral5">Score Range</Label>
-            <div className="flex gap-2 items-center">
+            <div className="flex items-center gap-2">
               <Controller
                 name="scoreRange.min"
                 control={control}
@@ -200,7 +200,7 @@ export function ScorerEditSidebar({
             <Button variant="outline" onClick={onSaveDraft} disabled={isSavingDraft || isSubmitting} className="flex-1">
               {isSavingDraft ? (
                 <>
-                  <Spinner className="h-4 w-4" />
+                  <Spinner className="size-4" />
                   Saving...
                 </>
               ) : (
@@ -215,7 +215,7 @@ export function ScorerEditSidebar({
             <Button variant="primary" onClick={onPublish} disabled={isSubmitting || isSavingDraft} className="flex-1">
               {isSubmitting ? (
                 <>
-                  <Spinner className="h-4 w-4" />
+                  <Spinner className="size-4" />
                   Publishing...
                 </>
               ) : (
@@ -232,7 +232,7 @@ export function ScorerEditSidebar({
           <Button variant="primary" onClick={onPublish} disabled={isSubmitting} className="w-full">
             {isSubmitting ? (
               <>
-                <Spinner className="h-4 w-4" />
+                <Spinner className="size-4" />
                 Creating...
               </>
             ) : (

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-list.tsx
@@ -76,7 +76,7 @@ export function ScorersList({ scorers, isLoading, search = '', sourceFilter = 'a
         return (
           <EntityList.RowLink key={scorer.id} to={paths.scorerLink(scorer.id)} LinkComponent={Link}>
             <EntityList.NameCell>
-              <span className="flex min-w-0 max-w-full items-center gap-1.5">
+              <span className="flex max-w-full min-w-0 items-center gap-1.5">
                 <span className="min-w-0 truncate">{name}</span>
                 {isTrajectory && (
                   <Chip size="small" color="purple" className="shrink-0">

--- a/packages/playground/src/domains/scores/components/scorers-list/scorers-toolbar.tsx
+++ b/packages/playground/src/domains/scores/components/scorers-list/scorers-toolbar.tsx
@@ -82,10 +82,10 @@ export function ScorersToolbar({
   }, [onReset, debouncedSearch]);
 
   return (
-    <div className="flex items-center gap-2 w-full max-w-[40rem]">
+    <div className="max-w-160 flex w-full items-center gap-2">
       {/* Search + source filter fused into one pill (ButtonsGroup spacing="close").
           `size="default"` to match the other list searches (e.g. /agents). */}
-      <ButtonsGroup spacing="close" className="flex-1 min-w-0">
+      <ButtonsGroup spacing="close" className="min-w-0 flex-1">
         <InputGroup variant="outline" size="default">
           <InputGroupAddon align="inline-start">
             <SearchIcon />

--- a/packages/playground/src/domains/scores/components/scores-list.tsx
+++ b/packages/playground/src/domains/scores/components/scores-list.tsx
@@ -151,10 +151,10 @@ export function ScoresList({
 
   return (
     <div
-      className={cn('grid h-full min-h-0 gap-4 items-start', hasSidePanel ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]')}
+      className={cn('grid h-full min-h-0 items-start gap-4', hasSidePanel ? 'grid-cols-[1fr_1fr]' : 'grid-cols-[1fr]')}
     >
-      <div className="flex flex-col h-full min-h-0 gap-0">
-        <div className="flex items-center justify-end pb-2 shrink-0">
+      <div className="flex h-full min-h-0 flex-col gap-0">
+        <div className="flex shrink-0 items-center justify-end pb-2">
           <DropdownMenu>
             <DropdownMenu.Trigger asChild>
               <Button variant="outline" size="sm">
@@ -177,7 +177,7 @@ export function ScoresList({
           </DropdownMenu>
         </div>
 
-        <ScoresDataList columns={columns} className="flex-1 min-h-0">
+        <ScoresDataList columns={columns} className="min-h-0 flex-1">
           {header}
 
           {scores.map(score => (

--- a/packages/playground/src/domains/shared/components/bulk-tag-picker.tsx
+++ b/packages/playground/src/domains/shared/components/bulk-tag-picker.tsx
@@ -50,21 +50,21 @@ export function BulkTagPicker({
             }
           }}
           placeholder="Search or create tag..."
-          className="h-7 text-xs mb-1"
+          className="mb-1 h-7 text-xs"
           autoFocus
         />
-        <div className="max-h-40 overflow-y-auto space-y-0.5">
+        <div className="max-h-40 space-y-0.5 overflow-y-auto">
           {filtered.map(tag => (
-            <div key={tag} className="flex items-center justify-between px-2 py-1 text-xs rounded hover:bg-surface3">
-              <button type="button" onClick={() => onApplyTag(tag)} className="text-left flex-1 text-neutral4">
+            <div key={tag} className="flex items-center justify-between rounded px-2 py-1 text-xs hover:bg-surface3">
+              <button type="button" onClick={() => onApplyTag(tag)} className="flex-1 text-left text-neutral4">
                 {tag}
               </button>
               <button
                 type="button"
                 onClick={() => onRemoveTag(tag)}
-                className="text-neutral2 hover:text-negative1 ml-2"
+                className="ml-2 text-neutral2 hover:text-negative1"
               >
-                <X className="w-3 h-3" />
+                <X className="size-3" />
               </button>
             </div>
           ))}
@@ -75,7 +75,7 @@ export function BulkTagPicker({
                 onNewTag(search.trim());
                 setSearch('');
               }}
-              className="w-full text-left px-2 py-1 text-xs rounded hover:bg-surface3 text-accent1"
+              className="w-full rounded px-2 py-1 text-left text-xs text-accent1 hover:bg-surface3"
             >
               Create &amp; apply &quot;{search.trim()}&quot;
             </button>

--- a/packages/playground/src/domains/shared/components/proposal-tag.tsx
+++ b/packages/playground/src/domains/shared/components/proposal-tag.tsx
@@ -31,7 +31,7 @@ export function ProposalTag({
 
   if (isEditing) {
     return (
-      <span className="inline-flex items-center gap-0.5 bg-surface3 border border-border1 rounded-md px-1">
+      <span className="inline-flex items-center gap-0.5 rounded-md border border-border1 bg-surface3 px-1">
         <input
           ref={inputRef}
           value={editValue}
@@ -47,7 +47,7 @@ export function ProposalTag({
             }
           }}
           onBlur={handleConfirm}
-          className="bg-transparent text-xs text-neutral4 outline-hidden w-20 py-0.5"
+          className="w-20 bg-transparent py-0.5 text-xs text-neutral4 outline-hidden"
         />
         <button
           type="button"
@@ -55,16 +55,16 @@ export function ProposalTag({
             e.preventDefault();
             handleConfirm();
           }}
-          className="text-positive1 hover:text-positive2 p-0.5"
+          className="hover:text-positive2 p-0.5 text-positive1"
         >
-          <Check className="w-3 h-3" />
+          <Check className="size-3" />
         </button>
       </span>
     );
   }
 
   return (
-    <span className="inline-flex items-center gap-0.5 bg-surface3 border border-border1 rounded-md px-1.5 py-0.5 text-xs text-neutral4 group">
+    <span className="group inline-flex items-center gap-0.5 rounded-md border border-border1 bg-surface3 px-1.5 py-0.5 text-xs text-neutral4">
       {tag}
       <button
         type="button"
@@ -72,18 +72,18 @@ export function ProposalTag({
           setEditValue(tag);
           setIsEditing(true);
         }}
-        className="text-neutral2 hover:text-neutral4 p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+        className="p-0.5 text-neutral2 opacity-0 transition-opacity group-hover:opacity-100 hover:text-neutral4"
         title="Edit tag"
       >
-        <Pencil className="w-3 h-3" />
+        <Pencil className="size-3" />
       </button>
       <button
         type="button"
         onClick={onRemove}
-        className="text-neutral2 hover:text-negative1 p-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
+        className="p-0.5 text-neutral2 opacity-0 transition-opacity group-hover:opacity-100 hover:text-negative1"
         title="Remove tag"
       >
-        <X className="w-3 h-3" />
+        <X className="size-3" />
       </button>
     </span>
   );

--- a/packages/playground/src/domains/shared/components/review-item-card.tsx
+++ b/packages/playground/src/domains/shared/components/review-item-card.tsx
@@ -68,7 +68,7 @@ export function ReviewItemCard({
   return (
     <div
       className={cn(
-        'border border-border1 rounded-lg p-3 transition-colors',
+        'rounded-lg border border-border1 p-3 transition-colors',
         isSelected && 'ring-1 ring-accent1',
         item.tags.length > 0 && 'border-l-2 border-l-accent1',
       )}
@@ -76,7 +76,7 @@ export function ReviewItemCard({
       {/* Header row */}
       <div className="flex items-center gap-2">
         {isCompleted ? (
-          <Icon size="sm" className="text-positive1 shrink-0">
+          <Icon size="sm" className="shrink-0 text-positive1">
             <CheckCircle />
           </Icon>
         ) : (
@@ -84,11 +84,11 @@ export function ReviewItemCard({
             type="checkbox"
             checked={isSelected}
             onChange={onToggleSelect}
-            className="w-3.5 h-3.5 rounded border-border1 accent-accent1"
+            className="size-3.5 rounded border-border1 accent-accent1"
           />
         )}
-        <button type="button" onClick={onToggleExpand} className="flex-1 text-left min-w-0">
-          <Txt variant="ui-xs" className="text-neutral4 truncate block">
+        <button type="button" onClick={onToggleExpand} className="min-w-0 flex-1 text-left">
+          <Txt variant="ui-xs" className="block truncate text-neutral4">
             {inputPreview}
           </Txt>
         </button>
@@ -97,16 +97,16 @@ export function ReviewItemCard({
 
       {/* Error indicator */}
       {Boolean(item.error) && (
-        <Txt variant="ui-xs" className="text-negative1 mt-1 block truncate">
+        <Txt variant="ui-xs" className="mt-1 block truncate text-negative1">
           Error: {typeof item.error === 'string' ? item.error : 'Failed'}
         </Txt>
       )}
 
       {/* Rating + Tags + Remove row */}
       <TooltipProvider delayDuration={200}>
-        <div className="flex items-center gap-2 mt-2">
+        <div className="mt-2 flex items-center gap-2">
           {/* Rating: thumbs up / down */}
-          <div className="flex items-center gap-0.5 mr-1">
+          <div className="mr-1 flex items-center gap-0.5">
             <Button
               tooltip="Good — this result is acceptable"
               variant={item.rating === 'positive' ? 'default' : 'ghost'}
@@ -132,10 +132,10 @@ export function ReviewItemCard({
           </div>
 
           {/* Tags */}
-          <div className="flex-1 min-w-0">
+          <div className="min-w-0 flex-1">
             {isCompleted ? (
               item.tags.length > 0 ? (
-                <div className="flex items-center gap-1 flex-wrap">
+                <div className="flex flex-wrap items-center gap-1">
                   {item.tags.map(t => (
                     <Badge key={t} variant="default">
                       {t}
@@ -176,10 +176,10 @@ export function ReviewItemCard({
 
       {/* Expanded content */}
       {isExpanded && (
-        <div className="mt-3 pt-2 border-t border-border1 space-y-2">
+        <div className="mt-3 space-y-2 border-t border-border1 pt-2">
           {/* Scores */}
           {scoresEntries.length > 0 && (
-            <div className="flex items-center gap-2 flex-wrap">
+            <div className="flex flex-wrap items-center gap-2">
               {scoresEntries.map(([scorerId, score]) => (
                 <Badge key={scorerId} variant={score >= 0.5 ? 'success' : 'error'}>
                   {scorerId.slice(0, 12)}: {score.toFixed(3)}
@@ -190,23 +190,23 @@ export function ReviewItemCard({
 
           {/* Input */}
           <div>
-            <Txt variant="ui-xs" className="text-neutral3 font-medium block mb-1">
+            <Txt variant="ui-xs" className="mb-1 block font-medium text-neutral3">
               Input
             </Txt>
-            <pre className="text-xs text-neutral4 bg-surface3 rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-24 overflow-y-auto">
+            <pre className="max-h-24 overflow-auto rounded bg-surface3 px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap text-neutral4">
               {formatUnknown(item.input)}
             </pre>
           </div>
 
           {/* Output / Error */}
           <div>
-            <Txt variant="ui-xs" className="text-neutral3 font-medium block mb-1">
+            <Txt variant="ui-xs" className="mb-1 block font-medium text-neutral3">
               {item.error ? 'Error' : 'Output'}
             </Txt>
             <pre
               className={cn(
-                'text-xs rounded px-3 py-2 overflow-x-auto whitespace-pre-wrap wrap-break-word max-h-24 overflow-y-auto',
-                item.error ? 'text-negative1 bg-negative1/10' : 'text-neutral4 bg-surface3',
+                'max-h-24 overflow-auto rounded px-3 py-2 text-xs wrap-break-word whitespace-pre-wrap',
+                item.error ? 'bg-negative1/10 text-negative1' : 'bg-surface3 text-neutral4',
               )}
             >
               {formatUnknown(item.error || item.output)}
@@ -215,8 +215,8 @@ export function ReviewItemCard({
 
           {/* Comment */}
           <div>
-            <div className="flex items-center justify-between mb-1">
-              <Txt variant="ui-xs" className="text-neutral3 font-medium">
+            <div className="mb-1 flex items-center justify-between">
+              <Txt variant="ui-xs" className="font-medium text-neutral3">
                 Comment
               </Txt>
               {commentSaved && (

--- a/packages/playground/src/domains/shared/components/tag-picker.tsx
+++ b/packages/playground/src/domains/shared/components/tag-picker.tsx
@@ -37,15 +37,15 @@ export function TagPicker({
   };
 
   return (
-    <div className="flex items-center gap-1 flex-wrap">
+    <div className="flex flex-wrap items-center gap-1">
       {tags.map(tag => (
         <span
           key={tag}
-          className="inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded-md bg-accent1/10 text-accent1 text-[10px] font-medium"
+          className="inline-flex items-center gap-0.5 rounded-md bg-accent1/10 px-1.5 py-0.5 text-[10px] font-medium text-accent1"
         >
           {tag}
           <button type="button" onClick={() => removeTag(tag)} className="hover:text-accent1/70">
-            <X className="w-2.5 h-2.5" />
+            <X className="size-2.5" />
           </button>
         </span>
       ))}
@@ -53,9 +53,9 @@ export function TagPicker({
         <PopoverTrigger asChild>
           <button
             type="button"
-            className="inline-flex items-center gap-0.5 px-1 py-0.5 rounded text-[10px] text-neutral3 hover:text-neutral5 hover:bg-surface3 transition-colors"
+            className="inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[10px] text-neutral3 transition-colors hover:bg-surface3 hover:text-neutral5"
           >
-            <Plus className="w-3 h-3" />
+            <Plus className="size-3" />
             tag
           </button>
         </PopoverTrigger>
@@ -66,16 +66,16 @@ export function TagPicker({
             onChange={e => setSearch(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Search or create tag..."
-            className="h-7 text-xs mb-1"
+            className="mb-1 h-7 text-xs"
             autoFocus
           />
-          <div className="max-h-32 overflow-y-auto space-y-0.5">
+          <div className="max-h-32 space-y-0.5 overflow-y-auto">
             {filtered.map(tag => (
               <button
                 key={tag}
                 type="button"
                 onClick={() => addTag(tag)}
-                className="w-full text-left px-2 py-1 text-xs rounded hover:bg-surface3 text-neutral4"
+                className="w-full rounded px-2 py-1 text-left text-xs text-neutral4 hover:bg-surface3"
               >
                 {tag}
               </button>
@@ -84,13 +84,13 @@ export function TagPicker({
               <button
                 type="button"
                 onClick={() => addTag(search.trim())}
-                className="w-full text-left px-2 py-1 text-xs rounded hover:bg-surface3 text-accent1"
+                className="w-full rounded px-2 py-1 text-left text-xs text-accent1 hover:bg-surface3"
               >
                 Create &quot;{search.trim()}&quot;
               </button>
             )}
             {filtered.length === 0 && !canCreate && (
-              <Txt variant="ui-xs" className="text-neutral2 px-2 py-1">
+              <Txt variant="ui-xs" className="px-2 py-1 text-neutral2">
                 {vocabulary.length === 0 ? 'Type to create a tag' : 'No matching tags'}
               </Txt>
             )}

--- a/packages/playground/src/domains/templates/template-failure.tsx
+++ b/packages/playground/src/domains/templates/template-failure.tsx
@@ -39,11 +39,11 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
   const { icon, title } = getIconAndTitle();
 
   return (
-    <Container className="space-y-4 text-neutral3 mb-8 content-center">
+    <Container className="mb-8 content-center space-y-4 text-neutral3">
       {/* Main Error Display */}
-      <div className={cn('grid items-center justify-items-center gap-4 content-center', '[&>svg]:w-8 [&>svg]:h-8')}>
+      <div className={cn('grid content-center items-center justify-items-center gap-4', '[&>svg]:size-8')}>
         {icon}
-        <div className="text-center space-y-2">
+        <div className="space-y-2 text-center">
           <p className="text-ui-md font-medium text-neutral5">{title}</p>
           <p className="text-ui-md text-neutral3">{getUserFriendlyMessage()}</p>
         </div>
@@ -52,16 +52,16 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
       {/* Validation Errors */}
       {validationErrors && validationErrors.length > 0 && (
         <details className="text-xs">
-          <summary className="cursor-pointer text-neutral3 hover:text-neutral4 select-none text-center">
+          <summary className="cursor-pointer text-center text-neutral3 select-none hover:text-neutral4">
             Show Validation Issues ({validationErrors.length})
           </summary>
-          <div className="mt-4 p-3 bg-gray-100 dark:bg-gray-800 rounded text-xs overflow-auto max-h-60 text-left space-y-2">
+          <div className="mt-4 max-h-60 space-y-2 overflow-auto rounded bg-gray-100 p-3 text-left text-xs dark:bg-gray-800">
             {validationErrors.map((error, index) => (
               <div key={index} className="border-l-2 border-red-400 pl-2">
                 <div className="font-medium text-red-600 dark:text-red-400">
                   {error.type === 'typescript' ? '🔴 TypeScript Error' : '⚠️ Lint Error'}
                 </div>
-                <div className="text-xs font-mono text-gray-700 dark:text-gray-300 mt-1 whitespace-pre-wrap wrap-break-word">
+                <div className="mt-1 font-mono text-xs wrap-break-word whitespace-pre-wrap text-gray-700 dark:text-gray-300">
                   {error.message}
                 </div>
               </div>
@@ -73,11 +73,11 @@ export function TemplateFailure({ errorMsg, validationErrors }: TemplateFailureP
       {/* General Error Details */}
       {errorString && !isValidationError && (
         <details className="text-xs">
-          <summary className="cursor-pointer text-neutral3 hover:text-neutral4 select-none text-center">
+          <summary className="cursor-pointer text-center text-neutral3 select-none hover:text-neutral4">
             Show Details
           </summary>
-          <div className="mt-4 p-3 bg-gray-100 dark:bg-gray-800 rounded text-xs font-mono overflow-auto max-h-60 text-left">
-            <div className="whitespace-pre-wrap wrap-break-word">{errorString}</div>
+          <div className="mt-4 max-h-60 overflow-auto rounded bg-gray-100 p-3 text-left font-mono text-xs dark:bg-gray-800">
+            <div className="wrap-break-word whitespace-pre-wrap">{errorString}</div>
           </div>
         </details>
       )}

--- a/packages/playground/src/domains/templates/template-form.tsx
+++ b/packages/playground/src/domains/templates/template-form.tsx
@@ -40,11 +40,11 @@ export function TemplateForm({
 }: TemplateFormProps) {
   return (
     <Container>
-      <div className="max-w-[40rem] my-4 p-4 lg:p-8 mx-auto gap-8 grid">
+      <div className="max-w-160 mx-auto my-4 grid gap-8 p-4 lg:p-8">
         <h2
           className={cn(
-            'text-neutral4 text-header-sm font-semibold flex items-center gap-2',
-            '[&>svg]:w-[1.2em] [&_svg]:h-[1.2em] [&_svg]:opacity-70',
+            'flex items-center gap-2 text-header-sm font-semibold text-neutral4',
+            '[&_svg]:h-[1.2em] [&_svg]:opacity-70 [&>svg]:w-[1.2em]',
           )}
         >
           Install Template <PackageOpenIcon />
@@ -61,14 +61,14 @@ export function TemplateForm({
 
         {selectedProvider && Object.entries(variables || {}).length > 0 && (
           <>
-            <h3 className="text-neutral3 text-ui-md">Set required Environmental Variables</h3>
-            <div className="grid grid-cols-[1fr_1fr] gap-4 items-start">
+            <h3 className="text-ui-md text-neutral3">Set required Environmental Variables</h3>
+            <div className="grid grid-cols-[1fr_1fr] items-start gap-4">
               {isLoadingEnvVars ? (
                 <div
                   className={cn(
-                    'flex items-center justify-center col-span-2 text-neutral3 text-ui-sm gap-4',
-                    '[&_svg]:opacity-50 [&_svg]:w-[1.1em] [&_svg]:h-[1.1em]',
-                    'animate-in fade-in duration-300',
+                    'col-span-2 flex items-center justify-center gap-4 text-ui-sm text-neutral3',
+                    '[&_svg]:size-[1.1em] [&_svg]:opacity-50',
+                    'animate-in duration-300 fade-in',
                   )}
                 >
                   <Spinner /> Loading variables...
@@ -98,13 +98,13 @@ export function TemplateForm({
                 ))
               )}
             </div>
-            <div className="border-t border-border1 pt-12 mt-3.5 relative">
-              <div className="absolute w-8 h-8 rounded-full bg-surface2 top-0 left-1/2 -translate-x-1/2 -translate-y-4 text-ui-sm text-neutral3 flex items-center justify-center">
+            <div className="relative mt-3.5 border-t border-border1 pt-12">
+              <div className="absolute top-0 left-1/2 flex size-8 -translate-x-1/2 -translate-y-4 items-center justify-center rounded-full bg-surface2 text-ui-sm text-neutral3">
                 And
               </div>
 
-              <h3 className="text-neutral4 text-ui-lg">Set AI Model for Template Installation</h3>
-              <p className="text-neutral3 text-ui-md mt-2 mb-8">
+              <h3 className="text-ui-lg text-neutral4">Set AI Model for Template Installation</h3>
+              <p className="mt-2 mb-8 text-ui-md text-neutral3">
                 This model will be used by the workflow to process and install the template
               </p>
 
@@ -123,8 +123,8 @@ export function TemplateForm({
         {selectedProvider && !isLoadingEnvVars && (
           <Button
             className={cn(
-              'flex items-center gap-2 mt-4 justify-center text-ui-md w-full bg-surface5 min-h-10 rounded-lg text-neutral5 hover:bg-surface6 transition-colors',
-              '[&>svg]:w-[1.1em] [&_svg]:h-[1.1em] [&_svg]:text-neutral5',
+              'mt-4 flex min-h-10 w-full items-center justify-center gap-2 rounded-lg bg-surface5 text-ui-md text-neutral5 transition-colors hover:bg-surface6',
+              '[&_svg]:h-[1.1em] [&_svg]:text-neutral5 [&>svg]:w-[1.1em]',
             )}
             onClick={handleInstallTemplate}
             disabled={
@@ -133,7 +133,7 @@ export function TemplateForm({
           >
             {isInstalling ? (
               <>
-                <Spinner className="w-4 h-4" /> Installing...
+                <Spinner className="size-4" /> Installing...
               </>
             ) : (
               <>

--- a/packages/playground/src/domains/templates/template-info.tsx
+++ b/packages/playground/src/domains/templates/template-info.tsx
@@ -20,15 +20,11 @@ export function TemplateInfo({ title, description, githubUrl, isLoading, infoDat
 
   return (
     <>
-      <div className={cn('grid mt-8 items-center')}>
+      <div className={cn('mt-8 grid items-center')}>
         <div
-          className={cn(
-            'text-header-lg flex items-center gap-3',
-            '[&>svg]:w-[1.2em] [&>svg]:h-[1.2em] [&>svg]:opacity-50',
-            {
-              '[&>svg]:opacity-20': isLoading,
-            },
-          )}
+          className={cn('flex items-center gap-3 text-header-lg', '[&>svg]:size-[1.2em] [&>svg]:opacity-50', {
+            '[&>svg]:opacity-20': isLoading,
+          })}
         >
           <PackageIcon />
           <h2
@@ -40,10 +36,10 @@ export function TemplateInfo({ title, description, githubUrl, isLoading, infoDat
           </h2>
         </div>
       </div>
-      <div className="grid lg:grid-cols-[1fr_1fr] gap-x-24">
+      <div className="grid gap-x-24 lg:grid-cols-[1fr_1fr]">
         <div className="grid">
           <p
-            className={cn('mb-4 text-ui-md text-neutral4 mt-2 leading-7', {
+            className={cn('mt-2 mb-4 text-ui-md leading-7 text-neutral4', {
               'bg-surface4 rounded-lg ': isLoading,
             })}
           >
@@ -52,19 +48,19 @@ export function TemplateInfo({ title, description, githubUrl, isLoading, infoDat
 
           {/* Git Branch Notice */}
           {!isLoading && templateSlug && (
-            <div className={cn('bg-surface2 border border-surface4 rounded-lg p-4 mb-4', 'flex items-start gap-3')}>
-              <div className="shrink-0 mt-0.5">
-                <InfoIcon className="w-[1.1em] h-[1.1em] text-blue-500" />
+            <div className={cn('mb-4 rounded-lg border border-surface4 bg-surface2 p-4', 'flex items-start gap-3')}>
+              <div className="mt-0.5 shrink-0">
+                <InfoIcon className="size-[1.1em] text-blue-500" />
               </div>
               <div className="flex-1 space-y-2">
                 <div className="flex items-center gap-2">
-                  <GitBranchIcon className="w-[1em] h-[1em] text-neutral4" />
+                  <GitBranchIcon className="size-[1em] text-neutral4" />
                   <span className="text-ui-md font-medium text-neutral5">A new Git branch will be created</span>
                 </div>
-                <div className="text-ui-sm text-neutral4 space-y-1">
+                <div className="space-y-1 text-ui-sm text-neutral4">
                   <div>
                     <span className="font-medium">Branch name:</span>{' '}
-                    <code className="bg-surface3 px-1.5 py-0.5 rounded text-ui-sm font-mono">{branchName}</code>
+                    <code className="rounded bg-surface3 px-1.5 py-0.5 font-mono text-ui-sm">{branchName}</code>
                   </div>
                   <div>
                     This ensures safe installation with easy rollback if needed. Your main branch remains unchanged.
@@ -79,7 +75,7 @@ export function TemplateInfo({ title, description, githubUrl, isLoading, infoDat
               href={githubUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="flex items-center gap-2 mt-auto text-neutral3 text-ui-md hover:text-neutral5"
+              className="mt-auto flex items-center gap-2 text-ui-md text-neutral3 hover:text-neutral5"
             >
               <GithubIcon />
               {githubUrl?.split('/')?.pop()}

--- a/packages/playground/src/domains/templates/template-installation.tsx
+++ b/packages/playground/src/domains/templates/template-installation.tsx
@@ -69,7 +69,7 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
   }));
 
   return (
-    <Container className="space-y-6 text-neutral3 mb-8 content-center">
+    <Container className="mb-8 content-center space-y-6 text-neutral3">
       {/* Header */}
       <div className="text-center">
         <h3 className="text-lg font-semibold text-neutral5">{getPhaseMessage()}</h3>
@@ -80,7 +80,7 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
 
       {/* Progress Bar */}
       {hasSteps && totalSteps > 0 && !['error'].includes(phase) && (
-        <div className="max-w-[30rem] w-full mx-auto px-6">
+        <div className="max-w-120 mx-auto w-full px-6">
           <ProcessStepProgressBar steps={steps} />
         </div>
       )}
@@ -89,8 +89,8 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
       {error && phase === 'error' && (
         <div
           className={cn(
-            'rounded-lg text-neutral5 p-6 flex items-center gap-3 text-ui-md bg-red-500/10',
-            '[&>svg]:w-6 [&>svg]:h-6 [&>svg]:opacity-70 [&>svg]:text-red-500',
+            'flex items-center gap-3 rounded-lg bg-red-500/10 p-6 text-ui-md text-neutral5',
+            '[&>svg]:size-6 [&>svg]:text-red-500 [&>svg]:opacity-70',
           )}
         >
           <OctagonXIcon />
@@ -103,7 +103,7 @@ export function TemplateInstallation({ name, streamResult, runId, workflowInfo }
 
       {/* Simple loading state for initialization */}
       {!hasSteps && phase === 'initializing' && (
-        <div className="text-center text-sm text-neutral3 grid gap-4 justify-items-center">
+        <div className="grid justify-items-center gap-4 text-center text-sm text-neutral3">
           <Spinner />
           <p>This may take some time...</p>
         </div>

--- a/packages/playground/src/domains/templates/template-success.tsx
+++ b/packages/playground/src/domains/templates/template-success.tsx
@@ -14,10 +14,10 @@ type TemplateSuccessProps = {
 
 export function TemplateSuccess({ name, installedEntities }: TemplateSuccessProps) {
   return (
-    <Container className={cn('grid items-center justify-items-center gap-4 content-center', '[&>svg]:w-8 [&>svg]:h-8')}>
+    <Container className={cn('grid content-center items-center justify-items-center gap-4', '[&>svg]:size-8')}>
       <PackageOpenIcon />
       <h2 className="text-header-md">Done!</h2>
-      <p className="text-ui-md text-center text-neutral3 ">
+      <p className="text-center text-ui-md text-neutral3 ">
         The <b className="text-neutral4">{name}</b> template has been successfully installed.
         {installedEntities && installedEntities.length > 0 && (
           <>

--- a/packages/playground/src/domains/templates/templates-list.tsx
+++ b/packages/playground/src/domains/templates/templates-list.tsx
@@ -35,7 +35,7 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
     return (
       <div className={cn('grid gap-y-4', className)}>
         {Array.from({ length: 5 }).map((_, index) => (
-          <div key={index} className="h-16 bg-surface3 animate-pulse rounded-lg" />
+          <div key={index} className="h-16 animate-pulse rounded-lg bg-surface3" />
         ))}
       </div>
     );
@@ -50,7 +50,7 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
         return (
           <article
             className={cn(
-              'border border-border1 rounded-lg overflow-hidden w-full grid grid-cols-[1fr_auto] bg-surface3 transition-colors hover:bg-surface4',
+              'grid w-full grid-cols-[1fr_auto] overflow-hidden rounded-lg border border-border1 bg-surface3 transition-colors hover:bg-surface4',
             )}
             key={template.slug}
           >
@@ -63,24 +63,22 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
               {template.imageURL && (
                 <div className={cn('overflow-hidden')}>
                   <div
-                    className="w-full h-full bg-cover thumb transition-scale duration-150"
+                    className="thumb transition-scale size-full bg-cover duration-150"
                     style={{
                       backgroundImage: `url(${template.imageURL})`,
                     }}
                   />
                 </div>
               )}
-              <div
-                className={cn('grid py-3 px-6 w-full gap-0.5', '[&_svg]:w-[1em] [&_svg]:h-[1em] [&_svg]:text-neutral3')}
-              >
+              <div className={cn('grid w-full gap-0.5 px-6 py-3', '[&_svg]:size-[1em] [&_svg]:text-neutral3')}>
                 <h2 className="text-ui-lg text-neutral5">{template.title}</h2>
                 <p className="text-ui-md text-neutral4 transition-colors duration-500">{template.description}</p>
-                <div className="hidden 2xl:flex text-neutral3 text-ui-md flex-wrap items-center gap-4 mt-3">
+                <div className="mt-3 hidden flex-wrap items-center gap-4 text-ui-md text-neutral3 2xl:flex">
                   {hasMetaInfo && (
                     <ul
                       className={cn(
-                        'flex gap-4 text-ui-md text-neutral3 m-0 p-0 list-none',
-                        '[&>li]:flex [&>li]:items-center [&>li]:gap-0.5 text-neutral4',
+                        'm-0 flex list-none gap-4 p-0 text-ui-md text-neutral3',
+                        'text-neutral4 [&>li]:flex [&>li]:items-center [&>li]:gap-0.5',
                       )}
                     >
                       {template?.agents && template.agents.length > 0 && (
@@ -111,7 +109,7 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
                     </ul>
                   )}
                   {hasMetaInfo && template.supportedProviders && <small>|</small>}
-                  <div className="flex items-center text-neutral3 gap-4">
+                  <div className="flex items-center gap-4 text-neutral3">
                     {template.supportedProviders.map(provider => (
                       <span key={provider} className="">
                         {provider}
@@ -123,11 +121,11 @@ export function TemplatesList({ templates, linkComponent, className, isLoading }
             </LinkComponent>
             <a
               href={template.githubUrl}
-              className={cn('group items-center gap-2 text-ui-md ml-auto pr-4 hidden', 'lg:flex')}
+              className={cn('group ml-auto hidden items-center gap-2 pr-4 text-ui-md', 'lg:flex')}
               target="_blank"
               rel="noopener noreferrer"
             >
-              <span className="flex items-center gap-2 px-2 py-1 rounded bg-surface1 group-hover:bg-surface2 text-neutral3 transition-colors group-hover:text-neutral5">
+              <span className="flex items-center gap-2 rounded bg-surface1 px-2 py-1 text-neutral3 transition-colors group-hover:bg-surface2 group-hover:text-neutral5">
                 <GithubIcon /> {getRepoName(template.githubUrl)}
               </span>
             </a>

--- a/packages/playground/src/domains/templates/templates-tools.tsx
+++ b/packages/playground/src/domains/templates/templates-tools.tsx
@@ -34,8 +34,8 @@ export function TemplatesTools({
     return (
       <div
         className={cn(
-          'h-[6.5rem] flex items-center gap-8',
-          '[&>div]:bg-surface3 [&>div]:w-48 [&>div]:h-8 [&>div]:animate-pulse',
+          'h-26 flex items-center gap-8',
+          '[&>div]:h-8 [&>div]:w-48 [&>div]:animate-pulse [&>div]:bg-surface3',
           className,
         )}
       >
@@ -45,7 +45,7 @@ export function TemplatesTools({
   }
 
   return (
-    <div className={cn('flex flex-wrap mx-auto sticky top-0 gap-4 bg-surface2 py-8', className)}>
+    <div className={cn('sticky top-0 mx-auto flex flex-wrap gap-4 bg-surface2 py-8', className)}>
       <SearchFieldBlock
         name="search-templates"
         label="Search templates"

--- a/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
+++ b/packages/playground/src/domains/tool-providers/components/integration-tools-section.tsx
@@ -57,7 +57,7 @@ export function IntegrationToolsSection({ selectedToolIds, onSubmitTools }: Inte
             return (
               <Entity key={provider.id} onClick={() => setSelectedProvider(provider)} className="bg-surface2">
                 <div
-                  className="size-11 rounded-lg flex items-center justify-center uppercase shrink-0"
+                  className="flex size-11 shrink-0 items-center justify-center rounded-lg uppercase"
                   style={{ backgroundColor: bg, color: text }}
                 >
                   {provider.name[0]}

--- a/packages/playground/src/domains/tool-providers/components/manage-connection-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/manage-connection-list.tsx
@@ -31,7 +31,7 @@ export const ManageConnectionList = ({
           {connections.map(connection => (
             <Entity
               key={connection.connectionId}
-              className="relative items-center rounded-lg px-2 py-2 transition-colors hover:bg-surface4"
+              className="relative items-center rounded-lg p-2 transition-colors hover:bg-surface4"
             >
               <EntityContent className="min-w-0">
                 <button

--- a/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/selected-tool-list.tsx
@@ -52,7 +52,7 @@ export function SelectedToolList({ providerId, selectedTools, onToggle }: Select
                   }
                 : undefined
             }
-            className={cn('flex items-start gap-3 rounded-md px-3 py-2.5 bg-surface4', onToggle && 'cursor-pointer')}
+            className={cn('flex items-start gap-3 rounded-md bg-surface4 px-3 py-2.5', onToggle && 'cursor-pointer')}
           >
             {onToggle && (
               <div className="pt-0.5">
@@ -64,12 +64,12 @@ export function SelectedToolList({ providerId, selectedTools, onToggle }: Select
               </div>
             )}
 
-            <div className="flex flex-col gap-1 min-w-0">
-              <Txt variant="ui-sm" className="text-neutral6 font-medium">
+            <div className="flex min-w-0 flex-col gap-1">
+              <Txt variant="ui-sm" className="font-medium text-neutral6">
                 {tool.slug}
               </Txt>
               {tool.description && (
-                <Txt variant="ui-sm" className="text-neutral3 line-clamp-2">
+                <Txt variant="ui-sm" className="line-clamp-2 text-neutral3">
                   {tool.description}
                 </Txt>
               )}

--- a/packages/playground/src/domains/tool-providers/components/tool-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/tool-list.tsx
@@ -33,8 +33,8 @@ export function ToolList({ providerId, toolkit, selectedIds, onToggle }: ToolLis
   const tools = data?.data ?? [];
 
   return (
-    <div className="grid grid-rows-[auto_1fr] h-full overflow-hidden">
-      <div className="px-3 py-2.5 border-b border-border1">
+    <div className="grid h-full grid-rows-[auto_1fr] overflow-hidden">
+      <div className="border-b border-border1 px-3 py-2.5">
         <InputGroup variant="outline" size="sm">
           <InputGroupAddon align="inline-start">
             <SearchIcon />
@@ -101,15 +101,15 @@ export function ToolList({ providerId, toolkit, selectedIds, onToggle }: ToolLis
                     </div>
                   )}
 
-                  <div className="flex flex-col gap-1 min-w-0">
+                  <div className="flex min-w-0 flex-col gap-1">
                     <div className="flex items-center gap-2">
-                      <Txt variant="ui-sm" className="text-neutral6 font-medium">
+                      <Txt variant="ui-sm" className="font-medium text-neutral6">
                         {tool.name}
                       </Txt>
                       {toolkit === undefined && tool.toolkit && <Badge>{tool.toolkit}</Badge>}
                     </div>
                     {tool.description && (
-                      <Txt variant="ui-sm" className="text-neutral3 line-clamp-2">
+                      <Txt variant="ui-sm" className="line-clamp-2 text-neutral3">
                         {tool.description}
                       </Txt>
                     )}

--- a/packages/playground/src/domains/tool-providers/components/tool-provider-dialog.tsx
+++ b/packages/playground/src/domains/tool-providers/components/tool-provider-dialog.tsx
@@ -77,8 +77,8 @@ export function ToolProviderDialog({ provider, onClose, selectedToolIds, onSubmi
         )}
       </SideDialog.Header>
 
-      <div className="grid grid-cols-[220px_1fr] h-full overflow-hidden">
-        <div className="border-r border-border1 overflow-hidden">
+      <div className="grid h-full grid-cols-[220px_1fr] overflow-hidden">
+        <div className="overflow-hidden border-r border-border1">
           {provider && (
             <ToolkitList
               providerId={provider.id}

--- a/packages/playground/src/domains/tool-providers/components/toolkit-list.tsx
+++ b/packages/playground/src/domains/tool-providers/components/toolkit-list.tsx
@@ -34,10 +34,10 @@ export function ToolkitList({ providerId, selectedToolkit, onSelectToolkit, sele
           type="button"
           onClick={() => onSelectToolkit(undefined)}
           className={cn(
-            'text-left px-3 py-2 rounded-md text-ui-sm',
+            'rounded-md px-3 py-2 text-left text-ui-sm',
             transitions.colors,
             selectedToolkit === undefined
-              ? 'bg-surface4 text-neutral6 font-medium'
+              ? 'bg-surface4 font-medium text-neutral6'
               : 'text-neutral3 hover:bg-surface4 hover:text-neutral5',
           )}
         >
@@ -48,16 +48,16 @@ export function ToolkitList({ providerId, selectedToolkit, onSelectToolkit, sele
           type="button"
           onClick={() => onSelectToolkit(SELECTED_TOOLKIT_SENTINEL)}
           className={cn(
-            'text-left px-3 py-2 rounded-md text-ui-sm flex items-center justify-between gap-2',
+            'flex items-center justify-between gap-2 rounded-md px-3 py-2 text-left text-ui-sm',
             transitions.colors,
             selectedToolkit === SELECTED_TOOLKIT_SENTINEL
-              ? 'bg-surface4 text-neutral6 font-medium'
+              ? 'bg-surface4 font-medium text-neutral6'
               : 'text-neutral3 hover:bg-surface4 hover:text-neutral5',
           )}
         >
           Selected
           {selectedCount > 0 && (
-            <span className="text-ui-xs tabular-nums bg-surface3 rounded-full px-1.5 py-0.5 min-w-[1.25rem] text-center">
+            <span className="min-w-5 rounded-full bg-surface3 px-1.5 py-0.5 text-center text-ui-xs tabular-nums">
               {selectedCount}
             </span>
           )}
@@ -69,10 +69,10 @@ export function ToolkitList({ providerId, selectedToolkit, onSelectToolkit, sele
             type="button"
             onClick={() => onSelectToolkit(toolkit.slug)}
             className={cn(
-              'text-left px-3 py-2 rounded-md text-ui-sm truncate',
+              'truncate rounded-md px-3 py-2 text-left text-ui-sm',
               transitions.colors,
               selectedToolkit === toolkit.slug
-                ? 'bg-surface4 text-neutral6 font-medium'
+                ? 'bg-surface4 font-medium text-neutral6'
                 : 'text-neutral3 hover:bg-surface4 hover:text-neutral5',
             )}
             title={toolkit.name}

--- a/packages/playground/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.tsx
@@ -47,16 +47,16 @@ const ToolExecutorContent = ({
 
   return (
     <MainContentContent hasLeftServiceColumn={true} className="relative">
-      <div className="bg-surface2 border-r border-border1 w-80 flex flex-col">
+      <div className="flex w-80 flex-col border-r border-border1 bg-surface2">
         <ToolInformation toolDescription={toolDescription} toolId={toolId} toolType={toolType} />
-        <div className="flex-1 overflow-hidden border-t border-border1 flex flex-col">
+        <div className="flex flex-1 flex-col overflow-hidden border-t border-border1">
           <Tabs defaultTab="input-data" value={selectedTab} onValueChange={setSelectedTab}>
             <TabList>
               <Tab value="input-data">Input Data</Tab>
               {requestContextSchema && <Tab value="request-context">Request Context</Tab>}
             </TabList>
           </Tabs>
-          <div className={cn('p-5 overflow-y-auto', selectedTab !== 'input-data' && 'hidden')}>
+          <div className={cn('overflow-y-auto p-5', selectedTab !== 'input-data' && 'hidden')}>
             <DynamicForm
               isSubmitLoading={isExecutingTool}
               schema={zodInputSchema}
@@ -67,7 +67,7 @@ const ToolExecutorContent = ({
             />
           </div>
           {requestContextSchema && (
-            <div className={cn('p-5 overflow-y-auto', selectedTab !== 'request-context' && 'hidden')}>
+            <div className={cn('overflow-y-auto p-5', selectedTab !== 'request-context' && 'hidden')}>
               <RequestContextSchemaForm requestContextSchema={requestContextSchema} />
             </div>
           )}
@@ -76,7 +76,7 @@ const ToolExecutorContent = ({
       <div className="absolute top-4 right-4 z-10">
         <CopyButton content={code} tooltip="Copy JSON result to clipboard" />
       </div>
-      <div className="p-5 h-full relative overflow-x-auto overflow-y-auto">
+      <div className="relative h-full overflow-auto p-5">
         <CodeMirror value={errorString || code} editable={true} theme={theme} extensions={[jsonLanguage]} />
       </div>
     </MainContentContent>

--- a/packages/playground/src/domains/tools/components/ToolInformation.tsx
+++ b/packages/playground/src/domains/tools/components/ToolInformation.tsx
@@ -13,17 +13,17 @@ export const ToolInformation = ({ toolDescription, toolId, toolType }: ToolInfor
   const ToolIconComponent = ToolIconMap[toolType || 'tool'];
 
   return (
-    <div className="p-5 border-b border-border1">
-      <div className="text-neutral6 flex gap-2">
+    <div className="border-b border-border1 p-5">
+      <div className="flex gap-2 text-neutral6">
         <div>
-          <Icon size="lg" className="bg-surface4 rounded-md p-1">
+          <Icon size="lg" className="rounded-md bg-surface4 p-1">
             <ToolIconComponent />
           </Icon>
         </div>
 
-        <div className="flex gap-4 justify-between w-full min-w-0">
+        <div className="flex w-full min-w-0 justify-between gap-4">
           <div>
-            <Txt variant="header-md" as="h2" className="font-medium truncate">
+            <Txt variant="header-md" as="h2" className="truncate font-medium">
               {toolId}
             </Txt>
             <Txt variant="ui-sm" className="text-neutral3">

--- a/packages/playground/src/domains/tools/components/ToolPanel.tsx
+++ b/packages/playground/src/domains/tools/components/ToolPanel.tsx
@@ -76,7 +76,7 @@ export const ToolPanel = ({ toolId }: ToolPanelProps) => {
   if (isLoading) {
     return (
       <div className="p-6">
-        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="mb-4 h-8 w-48" />
         <Skeleton className="h-32 w-full" />
       </div>
     );
@@ -86,7 +86,7 @@ export const ToolPanel = ({ toolId }: ToolPanelProps) => {
 
   if (!tool)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="header-md" className="text-neutral3">
           Tool not found
         </Txt>
@@ -95,7 +95,7 @@ export const ToolPanel = ({ toolId }: ToolPanelProps) => {
 
   if (!canExecuteTool)
     return (
-      <div className="py-12 text-center px-6">
+      <div className="px-6 py-12 text-center">
         <Txt variant="ui-sm" className="text-neutral3">
           You don't have permission to execute tools.
         </Txt>

--- a/packages/playground/src/domains/traces/components/score-data-panel.tsx
+++ b/packages/playground/src/domains/traces/components/score-data-panel.tsx
@@ -22,7 +22,7 @@ function isCodeBasedScorer(score?: ScoreRowData): boolean {
 function buildDialogTitle(sectionTitle: string, icon: React.ReactNode, score: ScoreRowData) {
   return (
     <>
-      <span className="flex items-center gap-1.5 text-neutral2 uppercase tracking-widest [&>svg]:size-3.5">
+      <span className="flex items-center gap-1.5 tracking-widest text-neutral2 uppercase [&>svg]:size-3.5">
         {icon}
         {sectionTitle}
       </span>
@@ -101,7 +101,7 @@ export function ScoreDataPanel({ score, onClose, onPrevious, onNext }: ScoreData
             )}
           </DataKeysAndValues>
 
-          <div className="mt-6 mb-6 flex justify-end ">
+          <div className="my-6 flex justify-end ">
             <Button size="sm" onClick={() => setDatasetDialogOpen(true)}>
               <Icon>
                 <SaveIcon />
@@ -110,18 +110,18 @@ export function ScoreDataPanel({ score, onClose, onPrevious, onNext }: ScoreData
             </Button>
           </div>
 
-          <div className="text-neutral4 mb-6">
+          <div className="mb-6 text-neutral4">
             <div
               className={cn(
-                'text-neutral2 text-ui-lg flex gap-2 items-baseline',
-                '[&>svg]:w-5 [&>svg]:h-5 [&>svg]:translate-y-1',
+                'flex items-baseline gap-2 text-ui-lg text-neutral2',
+                '[&>svg]:size-5 [&>svg]:translate-y-1',
               )}
             >
               <GaugeIcon />
               <span className="">Score:</span>
               <b className="font-mono text-neutral3">{`${score.score == null || Number.isNaN(score.score) ? 'n/a' : score.score}`}</b>
             </div>
-            <div className="text-ui-smd font-mono mt-2">
+            <div className="mt-2 font-mono text-ui-smd">
               {score.reason ||
                 (isCodeBased ? 'N/A — code-based scorer does not generate a reason' : 'N/A — step not configured')}
             </div>

--- a/packages/playground/src/domains/traces/components/span-scores-list.tsx
+++ b/packages/playground/src/domains/traces/components/span-scores-list.tsx
@@ -35,13 +35,13 @@ export function SpanScoresList({ scoresData, isLoadingScoresData, onPageChange, 
 
             return (
               <DataList.RowButton key={score.id} onClick={() => onScoreSelect?.(score)}>
-                <DataList.Cell height="compact" className="font-mono text-neutral3 text-ui-smd">
+                <DataList.Cell height="compact" className="font-mono text-ui-smd text-neutral3">
                   {getShortId(score?.id) || 'n/a'}
                 </DataList.Cell>
-                <DataList.Cell height="compact" className="text-neutral2 text-ui-smd">
+                <DataList.Cell height="compact" className="text-ui-smd text-neutral2">
                   {isTodayDate ? 'Today' : format(createdAtDate, 'MMM dd')}
                 </DataList.Cell>
-                <DataList.Cell height="compact" className="font-mono text-neutral3 text-ui-smd">
+                <DataList.Cell height="compact" className="font-mono text-ui-smd text-neutral3">
                   {format(createdAtDate, 'h:mm:ss aaa')}
                 </DataList.Cell>
                 <DataList.Cell height="compact" className="text-ui-smd">

--- a/packages/playground/src/domains/traces/components/span-scoring.tsx
+++ b/packages/playground/src/domains/traces/components/span-scoring.tsx
@@ -70,7 +70,7 @@ export function SpanScoring({
   }
 
   return (
-    <div className="grid grid-cols-[3fr_1fr] gap-4 items-start">
+    <div className="grid grid-cols-[3fr_1fr] items-start gap-4">
       <div className="grid gap-2">
         <SelectFieldBlock
           name="select-scorer"
@@ -87,7 +87,7 @@ export function SpanScoring({
           disabled={isWaiting}
         />
         {selectedScorerDescription && (
-          <TextAndIcon className="text-neutral3 text-ui-sm">
+          <TextAndIcon className="text-ui-sm text-neutral3">
             <InfoIcon /> {selectedScorerDescription}
           </TextAndIcon>
         )}

--- a/packages/playground/src/domains/voice/components/voice-call-button.tsx
+++ b/packages/playground/src/domains/voice/components/voice-call-button.tsx
@@ -17,7 +17,7 @@ export const VoiceCallButton = ({ voiceCall }: VoiceCallButtonProps) => {
         data-testid="voice-call-button"
         onClick={() => voiceCall.start()}
       >
-        <Phone className="h-5 w-5 text-neutral3 hover:text-neutral6" />
+        <Phone className="size-5 text-neutral3 hover:text-neutral6" />
       </Button>
     );
   }
@@ -25,7 +25,7 @@ export const VoiceCallButton = ({ voiceCall }: VoiceCallButtonProps) => {
   if (voiceCall.status === 'connecting') {
     return (
       <Button variant="default" size="icon-md" type="button" tooltip="Connecting…" data-testid="voice-call-button">
-        <Loader2 className="h-5 w-5 text-neutral3 animate-spin" />
+        <Loader2 className="size-5 animate-spin text-neutral3" />
       </Button>
     );
   }
@@ -39,7 +39,7 @@ export const VoiceCallButton = ({ voiceCall }: VoiceCallButtonProps) => {
       data-testid="voice-call-button"
       onClick={() => voiceCall.stop()}
     >
-      <PhoneOff className="h-5 w-5 text-red-500" />
+      <PhoneOff className="size-5 text-red-500" />
     </Button>
   );
 };

--- a/packages/playground/src/domains/voice/components/voice-call-panel.tsx
+++ b/packages/playground/src/domains/voice/components/voice-call-panel.tsx
@@ -29,21 +29,21 @@ export const VoiceCallPanel = ({ voiceCall }: VoiceCallPanelProps) => {
   return (
     <div
       data-testid="voice-call-panel"
-      className="max-w-3xl w-full mx-auto mb-2 rounded-[16px] border border-border2/40 bg-surface3 px-4 py-3"
+      className="mx-auto mb-2 w-full max-w-3xl rounded-[16px] border border-border2/40 bg-surface3 px-4 py-3"
     >
       <div className="flex items-center gap-2">
         <span
           className={cn(
-            'h-2 w-2 rounded-full',
+            'size-2 rounded-full',
             voiceCall.status === 'connecting' && 'bg-neutral3',
-            voiceCall.status === 'active' && voiceCall.agentState === 'speaking' && 'bg-accent1 animate-pulse',
+            voiceCall.status === 'active' && voiceCall.agentState === 'speaking' && 'animate-pulse bg-accent1',
             voiceCall.status === 'active' && voiceCall.agentState !== 'speaking' && 'bg-green-500',
           )}
         />
         <span className="text-ui-sm text-neutral4">{stateLabel}</span>
       </div>
       {lastUserCaption && (
-        <p className="mt-2 text-ui-sm text-neutral3 truncate" data-testid="voice-caption-user">
+        <p className="mt-2 truncate text-ui-sm text-neutral3" data-testid="voice-caption-user">
           {lastUserCaption.text}
         </p>
       )}

--- a/packages/playground/src/domains/workflows/components/workflow-entity-header.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-entity-header.tsx
@@ -38,7 +38,7 @@ export const WorkflowEntityHeader = ({ workflowId }: WorkflowEntityHeaderProps) 
           </Badge>
 
           {workflow?.isProcessorWorkflow && (
-            <Badge icon={<Cpu className="h-3 w-3" />} className="bg-violet-500/20 text-violet-400">
+            <Badge icon={<Cpu className="size-3" />} className="bg-violet-500/20 text-violet-400">
               Processor
             </Badge>
           )}

--- a/packages/playground/src/domains/workflows/components/workflow-information.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-information.tsx
@@ -57,7 +57,7 @@ function NewWorkflowRunButton({ workflowId, onClick }: { workflowId: string; onC
   const { Link, paths } = useLinkComponent();
 
   return (
-    <div className="flex-none border-b border-border1/50 px-4 py-4">
+    <div className="flex-none border-b border-border1/50 p-4">
       <Button
         as={Link}
         href={`${paths.workflowLink(workflowId)}/graph`}
@@ -104,7 +104,7 @@ function RunWorkflowSidebar({ runId, observeWorkflowStream, ...props }: RunWorkf
 function RecentWorkflowRunsSection({ workflowId, activeRunId }: { workflowId: string; activeRunId?: string }) {
   return (
     <section className="min-h-0 min-w-0 flex-1 overflow-hidden rounded-studio-panel border border-border1/50 bg-surface3">
-      <ScrollArea className="h-full w-full" viewPortClassName="h-full" mask={{ top: false }}>
+      <ScrollArea className="size-full" viewPortClassName="h-full" mask={{ top: false }}>
         <WorkflowRecentRuns workflowId={workflowId} runId={activeRunId} />
       </ScrollArea>
     </section>
@@ -169,7 +169,7 @@ export function WorkflowInformation({ workflowId, initialRunId }: WorkflowInform
   }
 
   if (!workflowId) {
-    return <div data-testid="workflow-information-panel" className="flex h-full min-h-0 w-full flex-col gap-2 p-2" />;
+    return <div data-testid="workflow-information-panel" className="flex size-full min-h-0 flex-col gap-2 p-2" />;
   }
 
   const resetToNewRun = () => {
@@ -181,7 +181,7 @@ export function WorkflowInformation({ workflowId, initialRunId }: WorkflowInform
   };
 
   return (
-    <div data-testid="workflow-information-panel" className="flex h-full min-h-0 w-full flex-col gap-2 p-2">
+    <div data-testid="workflow-information-panel" className="flex size-full min-h-0 flex-col gap-2 p-2">
       <WorkflowInformationTopSection
         newRunButton={
           showNewRunButton ? <NewWorkflowRunButton workflowId={workflowId} onClick={resetToNewRun} /> : undefined

--- a/packages/playground/src/domains/workflows/components/workflow-layout.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-layout.tsx
@@ -31,8 +31,8 @@ export const WorkflowLayout = ({ workflowId, children, leftSlot, rightSlot }: Wo
   // slots move into edge drawers and the main content takes the full width.
   if (isMobile) {
     return (
-      <div className="relative h-full w-full overflow-hidden">
-        <div className="h-full w-full min-w-0 overflow-y-auto">{children}</div>
+      <div className="relative size-full overflow-hidden">
+        <div className="size-full min-w-0 overflow-y-auto">{children}</div>
         {leftSlot && (
           <PanelDrawer direction="left" label="Open left panel">
             {leftSlot}
@@ -49,14 +49,14 @@ export const WorkflowLayout = ({ workflowId, children, leftSlot, rightSlot }: Wo
 
   return (
     <div
-      className="relative h-full min-h-0 w-full min-w-0 overflow-hidden"
+      className="relative size-full min-h-0 min-w-0 overflow-hidden"
       style={{ '--workflow-left-panel-width': `${leftSlot ? leftPanelWidth : 0}px` } as CSSProperties}
     >
       <div className="absolute inset-0 min-w-0 overflow-y-auto">{children}</div>
 
       {leftSlot && (
         <Group
-          className="pointer-events-none absolute inset-0 z-10 h-full min-h-0 w-full min-w-0 bg-transparent"
+          className="pointer-events-none absolute inset-0 z-10 size-full min-h-0 min-w-0 bg-transparent"
           defaultLayout={defaultLayout}
           onLayoutChange={onLayoutChange}
         >
@@ -80,7 +80,7 @@ export const WorkflowLayout = ({ workflowId, children, leftSlot, rightSlot }: Wo
 
       {rightSlot && (
         <Group
-          className="pointer-events-none absolute inset-0 z-10 h-full min-h-0 w-full min-w-0 bg-transparent"
+          className="pointer-events-none absolute inset-0 z-10 size-full min-h-0 min-w-0 bg-transparent"
           defaultLayout={defaultLayout}
           onLayoutChange={onLayoutChange}
         >

--- a/packages/playground/src/domains/workflows/components/workflow-step-detail.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-step-detail.tsx
@@ -19,16 +19,16 @@ export function WorkflowStepDetailContent() {
   }
 
   return (
-    <div className="flex flex-col h-full" data-testid="workflow-step-detail-panel">
+    <div className="flex h-full flex-col" data-testid="workflow-step-detail-panel">
       {/* Header with title and close button */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-border1 bg-surface1">
+      <div className="flex items-center justify-between border-b border-border1 bg-surface1 px-4 py-3">
         <div className="flex items-center gap-2">
-          {stepDetail.type === 'map-config' && <List className="w-4 h-4" style={{ color: BADGE_COLORS.map }} />}
+          {stepDetail.type === 'map-config' && <List className="size-4" style={{ color: BADGE_COLORS.map }} />}
           {stepDetail.type === 'nested-graph' && (
-            <WorkflowIcon className="w-4 h-4" style={{ color: BADGE_COLORS.workflow }} />
+            <WorkflowIcon className="size-4" style={{ color: BADGE_COLORS.workflow }} />
           )}
           <div className="flex flex-col">
-            <Txt variant="ui-md" className="text-neutral6 font-medium">
+            <Txt variant="ui-md" className="font-medium text-neutral6">
               {stepDetail.type === 'map-config' ? `${stepDetail.stepName} Config` : `${stepDetail.stepName} Workflow`}
             </Txt>
             {stepDetail.type === 'map-config' && stepDetail.stepId && stepDetail.stepId !== stepDetail.stepName && (
@@ -40,17 +40,17 @@ export function WorkflowStepDetailContent() {
         </div>
         <button
           onClick={closeStepDetail}
-          className="p-1 hover:bg-surface3 rounded transition-colors"
+          className="rounded p-1 transition-colors hover:bg-surface3"
           aria-label="Close"
         >
-          <X className="w-4 h-4 text-neutral3" />
+          <X className="size-4 text-neutral3" />
         </button>
       </div>
 
       <div className="flex-1 overflow-auto">
         {stepDetail.type === 'map-config' && stepDetail.mapConfig && <CodeDialogContent data={stepDetail.mapConfig} />}
         {stepDetail.type === 'nested-graph' && stepDetail.nestedGraph && (
-          <div className="h-full min-h-[400px]">
+          <div className="min-h-100 h-full">
             <ReactFlowProvider key={`nested-graph-${stepDetail.nestedGraph.fullStep}`}>
               <WorkflowNestedGraph
                 stepGraph={stepDetail.nestedGraph.stepGraph}
@@ -77,7 +77,7 @@ export function WorkflowStepDetailPanel() {
   }
 
   return (
-    <div className="h-full w-[400px] max-w-[45%] shrink-0 border-l border-border1 bg-surface2">
+    <div className="w-100 h-full max-w-[45%] shrink-0 border-l border-border1 bg-surface2">
       <WorkflowStepDetailContent />
     </div>
   );

--- a/packages/playground/src/domains/workflows/components/workflow-tracing-run-options.tsx
+++ b/packages/playground/src/domains/workflows/components/workflow-tracing-run-options.tsx
@@ -87,7 +87,7 @@ export const WorkflowTracingRunOptions = ({
         onChange={handleChange}
         theme={theme}
         extensions={[jsonLanguage]}
-        className={cn('overflow-y-scroll bg-surface3 rounded-lg overflow-hidden p-3', editorClassName)}
+        className={cn('overflow-hidden overflow-y-scroll rounded-lg bg-surface3 p-3', editorClassName)}
       />
 
       <div className="flex items-center justify-end">

--- a/packages/playground/src/domains/workflows/runs/workflow-run-details.tsx
+++ b/packages/playground/src/domains/workflows/runs/workflow-run-details.tsx
@@ -34,9 +34,9 @@ export const WorkflowRunDetail = ({
 
   if (isLoadingRunExecutionResult) {
     return (
-      <div className="p-4 space-y-4">
+      <div className="space-y-4 p-4">
         <div className="flex items-start gap-3">
-          <Skeleton className="h-5 w-5 shrink-0 rounded-full" />
+          <Skeleton className="size-5 shrink-0 rounded-full" />
           <div className="min-w-0 flex-1 space-y-2">
             <Skeleton className="h-4 w-24" />
             <Skeleton className="h-3 w-40" />
@@ -66,7 +66,7 @@ export const WorkflowRunDetail = ({
   if (!runSnapshot || !runId) {
     return (
       <div className="p-4">
-        <Txt variant="ui-md" className="text-neutral6 text-center">
+        <Txt variant="ui-md" className="text-center text-neutral6">
           No previous run
         </Txt>
       </div>
@@ -78,7 +78,7 @@ export const WorkflowRunDetail = ({
 
   if (runId) {
     return (
-      <div className="h-full grid grid-rows-[1fr_auto]">
+      <div className="grid h-full grid-rows-[1fr_auto]">
         <WorkflowTrigger
           {...triggerProps}
           paramsRunId={runId}

--- a/packages/playground/src/domains/workflows/runs/workflow-run-list.tsx
+++ b/packages/playground/src/domains/workflows/runs/workflow-run-list.tsx
@@ -75,7 +75,7 @@ export const WorkflowRecentRuns = ({ workflowId, runId }: WorkflowRecentRunsProp
         </div>
       ) : (
         <div>
-          <div className="px-5 pb-2 pt-3 text-left">
+          <div className="px-5 pt-3 pb-2 text-left">
             <Txt as="h2" variant="ui-md" className="text-neutral3">
               Recent runs
             </Txt>
@@ -126,7 +126,7 @@ export const WorkflowRecentRuns = ({ workflowId, runId }: WorkflowRecentRunsProp
                 })}
 
                 {isFetchingNextPage && (
-                  <li className="flex justify-center items-center py-2">
+                  <li className="flex items-center justify-center py-2">
                     <Icon>
                       <Spinner />
                     </Icon>

--- a/packages/playground/src/domains/workflows/workflow-layout.tsx
+++ b/packages/playground/src/domains/workflows/workflow-layout.tsx
@@ -21,7 +21,7 @@ export const WorkflowLayout = ({ children }: { children: React.ReactNode }) => {
   if (!workflowId) {
     return (
       <div className="flex h-full flex-col items-center justify-center">
-        <Txt variant="ui-md" className="text-neutral6 text-center">
+        <Txt variant="ui-md" className="text-center text-neutral6">
           No workflow ID provided
         </Txt>
       </div>

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-card-badges.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-card-badges.tsx
@@ -27,7 +27,7 @@ export const WorkflowCardBadges = ({ indicators, className }: WorkflowCardIndica
                 tabIndex={0}
                 aria-label={indicator.label}
                 data-testid={`workflow-card-indicator-${indicator.id}`}
-                className="inline-flex h-5 w-5 shrink-0 items-center justify-center text-neutral5 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1"
+                className="inline-flex size-5 shrink-0 items-center justify-center text-neutral5 focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden"
               >
                 <Icon size="sm">
                   <IndicatorIcon className="text-current" style={{ color: indicator.color }} />

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-card-status-icon.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-card-status-icon.tsx
@@ -12,13 +12,13 @@ export const WorkflowCardStatusIcon = ({ displayStatus, hasStep }: WorkflowCardS
   const strokeWidth = 2;
 
   return (
-    <Icon size="sm" className="inline-flex h-5 w-5 shrink-0 items-center justify-center">
+    <Icon size="sm" className="inline-flex size-5 shrink-0 items-center justify-center">
       {displayStatus === 'tripwire' && <ShieldAlert className="text-amber-400" strokeWidth={strokeWidth} />}
       {displayStatus === 'failed' && <CircleX className="text-accent2" strokeWidth={strokeWidth} />}
       {displayStatus === 'success' && <CircleCheck className="text-accent1" strokeWidth={strokeWidth} />}
       {displayStatus === 'suspended' && <PauseIcon className="text-accent3" strokeWidth={strokeWidth} />}
       {displayStatus === 'waiting' && <HourglassIcon className="text-accent5" strokeWidth={strokeWidth} />}
-      {displayStatus === 'running' && <Loader2 className="text-accent6 animate-spin" strokeWidth={strokeWidth} />}
+      {displayStatus === 'running' && <Loader2 className="animate-spin text-accent6" strokeWidth={strokeWidth} />}
       {!displayStatus && !hasStep && <CircleDashed className="text-neutral2" strokeWidth={strokeWidth} />}
     </Icon>
   );

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-condition-card-view.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-condition-card-view.tsx
@@ -37,7 +37,7 @@ export const WorkflowConditionCardView = ({
       data-workflow-step-status={previousDisplayStatus ?? 'idle'}
       data-testid="workflow-condition-node"
       style={accentColor ? { borderLeftColor: accentColor } : undefined}
-      className={cn('bg-surface3 rounded-lg w-dropdown-max-height border border-border1', accentColor && 'border-l-4')}
+      className={cn('w-dropdown-max-height rounded-lg border border-border1 bg-surface3', accentColor && 'border-l-4')}
     >
       <Collapsible
         open={!isCollapsible ? true : isOpen}
@@ -47,11 +47,11 @@ export const WorkflowConditionCardView = ({
           }
         }}
       >
-        <div className="flex items-center gap-1 w-full px-3 py-2">
+        <div className="flex w-full items-center gap-1 px-3 py-2">
           {isCollapsible && (
             <CollapsibleTrigger
               aria-label={isOpen ? 'Collapse condition' : 'Expand condition'}
-              className="inline-flex h-5 w-5 items-center justify-center rounded-full text-neutral3 hover:text-neutral5 focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1"
+              className="inline-flex size-5 items-center justify-center rounded-full text-neutral3 hover:text-neutral5 focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden"
             >
               <Icon>
                 <ChevronDown
@@ -84,7 +84,7 @@ export const WorkflowConditionCardView = ({
                   {condition.ref?.step ? (
                     <div className="flex items-center gap-1">
                       <WorkflowCardBadges indicators={conjIndicators} />
-                      <Txt variant="ui-xs" className=" text-neutral3 flex-1">
+                      <Txt variant="ui-xs" className=" flex-1 text-neutral3">
                         {typeof condition.ref.step === 'string' ? condition.ref.step : condition.ref.step.id}'s{' '}
                         {condition.ref.path}{' '}
                         {Object.entries(condition.query).map(([key, value]) => `${key} ${String(value)}`)}

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-condition-code.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-condition-code.tsx
@@ -23,7 +23,7 @@ export const WorkflowConditionCode = ({ condition, onOpen }: WorkflowConditionCo
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre
           className={cn(
-            'relative font-mono p-3 w-full cursor-pointer rounded-lg text-xs bg-surface4! whitespace-pre-wrap wrap-break-word',
+            'relative w-full cursor-pointer rounded-lg bg-surface4! p-3 font-mono text-xs wrap-break-word whitespace-pre-wrap',
             className,
           )}
           onClick={onOpen}
@@ -31,7 +31,7 @@ export const WorkflowConditionCode = ({ condition, onOpen }: WorkflowConditionCo
         >
           {tokens.map((line, i) => (
             <div key={i} {...getLineProps({ line })}>
-              <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
+              <span className="mr-2 inline-block text-neutral3">{i + 1}</span>
               {line.map((token, key) => (
                 <span key={key} {...getTokenProps({ token })} />
               ))}
@@ -51,7 +51,7 @@ export interface WorkflowConditionDialogProps {
 
 export const WorkflowConditionDialog = ({ open, onOpenChange, condition }: WorkflowConditionDialogProps) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
-    <DialogContent className="max-w-[30rem]">
+    <DialogContent className="max-w-120">
       <DialogHeader>
         <DialogTitle className="sr-only">Condition Function</DialogTitle>
         <DialogDescription>View the condition function code</DialogDescription>
@@ -62,7 +62,7 @@ export const WorkflowConditionDialog = ({ open, onOpenChange, condition }: Workf
             <Highlight theme={themes.oneDark} code={String(condition.fnString).trim()} language="javascript">
               {({ className, style, tokens, getLineProps, getTokenProps }) => (
                 <pre
-                  className={`${className} relative font-mono text-sm overflow-x-auto p-3 w-full rounded-lg mt-2 dark:bg-zinc-800`}
+                  className={`${className} relative mt-2 w-full overflow-x-auto rounded-lg p-3 font-mono text-sm dark:bg-zinc-800`}
                   style={{
                     ...style,
                     backgroundColor: '#121212',
@@ -71,7 +71,7 @@ export const WorkflowConditionDialog = ({ open, onOpenChange, condition }: Workf
                 >
                   {tokens.map((line, i) => (
                     <div key={i} {...getLineProps({ line })}>
-                      <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
+                      <span className="mr-2 inline-block text-neutral3">{i + 1}</span>
                       {line.map((token, key) => (
                         <span key={key} {...getTokenProps({ token })} />
                       ))}

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-edge-data-button.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-edge-data-button.tsx
@@ -35,11 +35,11 @@ export const WorkflowEdgeDataButton = ({ previousStepId, output, label }: Workfl
       </Button>
 
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
-        <DialogContent className="max-w-3xl w-full">
+        <DialogContent className="w-full max-w-3xl">
           <DialogHeader>
             <DialogTitle>Step output</DialogTitle>
           </DialogHeader>
-          <DialogBody className="max-h-[700px] overflow-auto">
+          <DialogBody className="max-h-175 overflow-auto">
             <div className="min-w-0 rounded-lg border border-border1 bg-surface2 p-3">
               <Txt variant="ui-sm" className="mb-2 block text-neutral5">
                 {dataLabel}

--- a/packages/playground/src/domains/workflows/workflow/components/workflow-step-card-view.tsx
+++ b/packages/playground/src/domains/workflows/workflow/components/workflow-step-card-view.tsx
@@ -13,8 +13,8 @@ const WorkflowForEachProgress = ({ foreachProgress }: Pick<WorkflowStepCardViewP
   }
 
   return (
-    <div className="px-3 pb-2 flex items-center gap-2">
-      <div className="flex-1 h-1.5 bg-surface1 rounded-full overflow-hidden">
+    <div className="flex items-center gap-2 px-3 pb-2">
+      <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface1">
         <div
           className={cn(
             'h-full rounded-full transition-all duration-300',
@@ -27,7 +27,7 @@ const WorkflowForEachProgress = ({ foreachProgress }: Pick<WorkflowStepCardViewP
           }}
         />
       </div>
-      <Txt variant="ui-xs" className="text-neutral3 whitespace-nowrap">
+      <Txt variant="ui-xs" className="whitespace-nowrap text-neutral3">
         {foreachProgress.completedCount} / {foreachProgress.totalCount}
       </Txt>
     </div>
@@ -37,12 +37,12 @@ const WorkflowForEachProgress = ({ foreachProgress }: Pick<WorkflowStepCardViewP
 const WorkflowSleepDetails = ({ duration, date }: Pick<WorkflowStepCardViewProps, 'duration' | 'date'>) => (
   <>
     {duration && (
-      <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+      <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
         sleeps for <strong>{duration}ms</strong>
       </Txt>
     )}
     {date && (
-      <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+      <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
         sleeps until <strong>{new Date(date).toLocaleString()}</strong>
       </Txt>
     )}
@@ -89,7 +89,7 @@ export const WorkflowStepCardView = ({
       onMouseLeave={() => onHoverChange?.(false)}
       style={accentColor ? { borderLeftColor: accentColor } : undefined}
       className={cn(
-        'bg-surface3 rounded-lg w-[274px] border border-border1 transition-colors hover:border-neutral6',
+        'w-[274px] rounded-lg border border-border1 bg-surface3 transition-colors hover:border-neutral6',
         accentColor && 'border-l-4',
         isHovered && !isSelected && 'border-neutral6',
         isWaiting && !isSelected && 'border-accent3',
@@ -100,7 +100,7 @@ export const WorkflowStepCardView = ({
         <WorkflowCardBadges indicators={indicators} className="shrink-0" />
         <WorkflowCardStatusIcon displayStatus={displayStatus} hasStep={hasStep} />
         <div className="min-w-0 flex-1">
-          <Txt variant="ui-sm" className="block truncate text-neutral6 font-medium" title={label}>
+          <Txt variant="ui-sm" className="block truncate font-medium text-neutral6" title={label}>
             {label}
           </Txt>
         </div>
@@ -111,7 +111,7 @@ export const WorkflowStepCardView = ({
       </div>
 
       {description && (
-        <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+        <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
           {description}
         </Txt>
       )}

--- a/packages/playground/src/domains/workflows/workflow/workflow-after-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-after-node.tsx
@@ -25,15 +25,15 @@ export function WorkflowAfterNode({ data }: NodeProps<AfterNode>) {
     <Collapsible
       open={open}
       onOpenChange={setOpen}
-      className={cn('bg-surface4 rounded-md w-[274px] flex flex-col p-2 gap-2')}
+      className={cn('flex w-[274px] flex-col gap-2 rounded-md bg-surface4 p-2')}
     >
       <Handle type="target" position={Position.Top} style={{ visibility: 'hidden' }} />
 
-      <CollapsibleTrigger className="flex items-center justify-between w-full">
+      <CollapsibleTrigger className="flex w-full items-center justify-between">
         <Badge icon={<BADGE_ICONS.after className="text-current" style={{ color: BADGE_COLORS.after }} />}>AFTER</Badge>
         <Icon>
           <ChevronDown
-            className={cn('transition-transform text-neutral3', {
+            className={cn('text-neutral3 transition-transform', {
               'transform rotate-180': open,
             })}
           />
@@ -41,8 +41,8 @@ export function WorkflowAfterNode({ data }: NodeProps<AfterNode>) {
       </CollapsibleTrigger>
       <CollapsibleContent className="flex flex-col gap-2">
         {steps.map(step => (
-          <div className="text-sm bg-surface5 flex items-center gap-1.5 rounded-sm  p-2" key={step}>
-            <Footprints className="text-current w-4 h-4" />
+          <div className="flex items-center gap-1.5 rounded-sm bg-surface5 p-2  text-sm" key={step}>
+            <Footprints className="size-4 text-current" />
             <Txt variant="ui-xs" className="text-neutral6 capitalize">
               {step}
             </Txt>

--- a/packages/playground/src/domains/workflows/workflow/workflow-boundary-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-boundary-node.tsx
@@ -13,7 +13,7 @@ export const WorkflowBoundaryNode = ({ data }: NodeProps<WorkflowBoundaryNodeTyp
       <div
         data-workflow-boundary-node
         data-testid={`workflow-boundary-${data.boundaryRole}`}
-        className="flex h-14 w-14 items-center justify-center rounded-full border border-border1 bg-surface3 text-neutral5"
+        className="flex size-14 items-center justify-center rounded-full border border-border1 bg-surface3 text-neutral5"
       >
         <Txt variant="ui-xs" className="font-medium">
           {data.label}

--- a/packages/playground/src/domains/workflows/workflow/workflow-card.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-card.tsx
@@ -13,14 +13,14 @@ export const WorkflowCard = ({ header, children, footer }: WorkflowCardProps) =>
   const [expanded, setExpanded] = useState(false);
   return (
     <div className="rounded-lg border border-border1 bg-surface4">
-      <button className="py-1 px-2 flex items-center gap-3 justify-between w-full" onClick={() => setExpanded(s => !s)}>
+      <button className="flex w-full items-center justify-between gap-3 px-2 py-1" onClick={() => setExpanded(s => !s)}>
         <div className="w-full">{header}</div>
         <Icon>
-          <ChevronDownIcon className={cn('text-neutral3 transition-transform -rotate-90', expanded && 'rotate-0')} />
+          <ChevronDownIcon className={cn('-rotate-90 text-neutral3 transition-transform', expanded && 'rotate-0')} />
         </Icon>
       </button>
-      {children && expanded && <div className="border-t border-border1 max-h-[400px] overflow-y-auto">{children}</div>}
-      {footer && <div className="py-1 px-2 border-t border-border1">{footer}</div>}
+      {children && expanded && <div className="max-h-100 overflow-y-auto border-t border-border1">{children}</div>}
+      {footer && <div className="border-t border-border1 px-2 py-1">{footer}</div>}
     </div>
   );
 };

--- a/packages/playground/src/domains/workflows/workflow/workflow-clock.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-clock.tsx
@@ -21,7 +21,7 @@ export const Clock = ({ startedAt, endedAt }: ClockProps) => {
   const timeDiff = endedAt ? endedAt - startedAt : time - startedAt;
 
   return (
-    <Txt variant="ui-xs" className="font-mono text-neutral3 whitespace-nowrap">
+    <Txt variant="ui-xs" className="font-mono whitespace-nowrap text-neutral3">
       {toSigFigs(timeDiff, 3)}ms
     </Txt>
   );

--- a/packages/playground/src/domains/workflows/workflow/workflow-code-dialog-content.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-code-dialog-content.tsx
@@ -42,11 +42,11 @@ export const CodeDialogContent = ({
   if (typeof data !== 'string') {
     const content = JSON.stringify(data, null, 2);
     return (
-      <div className="max-h-[500px] overflow-auto relative">
-        <div className="absolute right-2 top-2 bg-surface4 rounded-full z-10">
+      <div className="max-h-125 relative overflow-auto">
+        <div className="absolute top-2 right-2 z-10 rounded-full bg-surface4">
           <CopyButton content={content} />
         </div>
-        <div className="bg-surface4 rounded-lg p-4">
+        <div className="rounded-lg bg-surface4 p-4">
           <CodeMirror value={content} theme={theme} extensions={[jsonLanguage, EditorView.lineWrapping]} />
         </div>
       </div>
@@ -65,11 +65,11 @@ export const CodeDialogContent = ({
   }
 
   return (
-    <div className="max-h-[500px] overflow-auto relative">
-      <div className="absolute right-2 top-2 bg-surface4 rounded-full z-10">
+    <div className="max-h-125 relative overflow-auto">
+      <div className="absolute top-2 right-2 z-10 rounded-full bg-surface4">
         <CopyButton content={data} />
       </div>
-      <div className="bg-surface4 rounded-lg p-4">
+      <div className="rounded-lg bg-surface4 p-4">
         <CodeMirror value={displayContent} theme={theme} extensions={extensions} />
       </div>
     </div>

--- a/packages/playground/src/domains/workflows/workflow/workflow-condition-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-condition-node.tsx
@@ -61,10 +61,10 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
         data-workflow-step-status={previousDisplayStatus}
         data-testid="workflow-condition-node"
         className={cn(
-          'bg-surface3 rounded-lg w-dropdown-max-height border border-border1',
+          'w-dropdown-max-height rounded-lg border border-border1 bg-surface3',
           previousDisplayStatus === 'success' && nextStep && 'bg-accent1Darker',
           previousDisplayStatus === 'failed' && nextStep && 'bg-accent2Darker',
-          previousDisplayStatus === 'tripwire' && nextStep && 'bg-amber-950/40 border-amber-500/30',
+          previousDisplayStatus === 'tripwire' && nextStep && 'border-amber-500/30 bg-amber-950/40',
           !previousStep && Boolean(nextStep?.status) && 'bg-accent1Darker',
         )}
       >
@@ -76,7 +76,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
             }
           }}
         >
-          <CollapsibleTrigger className="flex items-center justify-between w-full px-3 py-2">
+          <CollapsibleTrigger className="flex w-full items-center justify-between px-3 py-2">
             <Badge
               icon={
                 IconComponent ? (
@@ -89,7 +89,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
             {isCollapsible && (
               <Icon>
                 <ChevronDown
-                  className={cn('transition-transform text-neutral3', {
+                  className={cn('text-neutral3 transition-transform', {
                     'transform rotate-180': open,
                   })}
                 />
@@ -125,7 +125,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                       {({ className, style, tokens, getLineProps, getTokenProps }) => (
                         <pre
                           className={cn(
-                            'relative font-mono p-3 w-full cursor-pointer rounded-lg text-xs bg-surface4! whitespace-pre-wrap wrap-break-word',
+                            'relative w-full cursor-pointer rounded-lg bg-surface4! p-3 font-mono text-xs wrap-break-word whitespace-pre-wrap',
                             className,
                             previousDisplayStatus === 'success' && nextStep && 'bg-accent1Dark!',
                             previousDisplayStatus === 'failed' && nextStep && 'bg-accent2Dark!',
@@ -136,7 +136,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                         >
                           {tokens.map((line, i) => (
                             <div key={i} {...getLineProps({ line })}>
-                              <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
+                              <span className="mr-2 inline-block text-neutral3">{i + 1}</span>
                               {line.map((token, key) => (
                                 <span key={key} {...getTokenProps({ token })} />
                               ))}
@@ -147,7 +147,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                     </Highlight>
 
                     <Dialog open={openDialog} onOpenChange={setOpenDialog}>
-                      <DialogContent className="max-w-[30rem]">
+                      <DialogContent className="max-w-120">
                         <DialogHeader>
                           <DialogTitle className="sr-only">Condition Function</DialogTitle>
                           <DialogDescription>View the condition function code</DialogDescription>
@@ -161,7 +161,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                             >
                               {({ className, style, tokens, getLineProps, getTokenProps }) => (
                                 <pre
-                                  className={`${className} relative font-mono text-sm overflow-x-auto p-3 w-full rounded-lg mt-2 dark:bg-zinc-800`}
+                                  className={`${className} relative mt-2 w-full overflow-x-auto rounded-lg p-3 font-mono text-sm dark:bg-zinc-800`}
                                   style={{
                                     ...style,
                                     backgroundColor: '#121212',
@@ -170,7 +170,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                                 >
                                   {tokens.map((line, i) => (
                                     <div key={i} {...getLineProps({ line })}>
-                                      <span className="inline-block mr-2 text-neutral3">{i + 1}</span>
+                                      <span className="mr-2 inline-block text-neutral3">{i + 1}</span>
                                       {line.map((token, key) => (
                                         <span key={key} {...getTokenProps({ token })} />
                                       ))}
@@ -190,7 +190,7 @@ export function WorkflowConditionNode({ data }: NodeProps<ConditionNode>) {
                       <div className="flex items-center gap-1">
                         {conjBadge}
 
-                        <Txt variant="ui-xs" className=" text-neutral3 flex-1">
+                        <Txt variant="ui-xs" className=" flex-1 text-neutral3">
                           {(condition.ref.step as any).id || condition.ref.step}'s {condition.ref.path}{' '}
                           {Object.entries(condition.query).map(([key, value]) => `${key} ${String(value)}`)}
                         </Txt>

--- a/packages/playground/src/domains/workflows/workflow/workflow-default-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-default-node.tsx
@@ -83,18 +83,18 @@ export function WorkflowDefaultNode({
         data-workflow-step-status={displayStatus ?? 'idle'}
         data-testid="workflow-default-node"
         className={cn(
-          'bg-surface3 rounded-lg w-[274px] border border-border1',
+          'w-[274px] rounded-lg border border-border1 bg-surface3',
           hasSpecialBadge ? 'pt-0' : 'pt-2',
           displayStatus === 'success' && 'bg-accent1Darker',
           displayStatus === 'failed' && 'bg-accent2Darker',
-          displayStatus === 'tripwire' && 'bg-amber-950/40 border-amber-500/30',
+          displayStatus === 'tripwire' && 'border-amber-500/30 bg-amber-950/40',
           displayStatus === 'suspended' && 'bg-accent3Darker',
           displayStatus === 'waiting' && 'bg-accent5Darker',
           displayStatus === 'running' && 'bg-accent6Darker',
         )}
       >
         {hasSpecialBadge && (
-          <div className="px-3 pt-2 pb-1 flex gap-1.5 flex-wrap">
+          <div className="flex flex-wrap gap-1.5 px-3 pt-2 pb-1">
             {isSleepNode && (
               <Badge
                 icon={
@@ -135,27 +135,27 @@ export function WorkflowDefaultNode({
             {displayStatus === 'success' && <CheckIcon className="text-accent1" />}
             {displayStatus === 'suspended' && <PauseIcon className="text-accent3" />}
             {displayStatus === 'waiting' && <HourglassIcon className="text-accent5" />}
-            {displayStatus === 'running' && <Loader2 className="text-accent6 animate-spin" />}
+            {displayStatus === 'running' && <Loader2 className="animate-spin text-accent6" />}
             {!step && <CircleDashed className="text-neutral2" />}
           </Icon>
 
           <Txt
             variant="ui-lg"
-            className="text-neutral6 font-medium inline-flex items-center gap-1 justify-between w-full"
+            className="inline-flex w-full items-center justify-between gap-1 font-medium text-neutral6"
           >
             {label} {step?.startedAt && <Clock startedAt={step.startedAt} endedAt={step.endedAt} />}
           </Txt>
         </div>
 
         {description && (
-          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+          <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
             {description}
           </Txt>
         )}
 
         {isForEachNode && step?.foreachProgress && (
-          <div className="px-3 pb-2 flex items-center gap-2">
-            <div className="flex-1 h-1.5 bg-surface1 rounded-full overflow-hidden">
+          <div className="flex items-center gap-2 px-3 pb-2">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface1">
               <div
                 className={cn(
                   'h-full rounded-full transition-all duration-300',
@@ -166,19 +166,19 @@ export function WorkflowDefaultNode({
                 }}
               />
             </div>
-            <Txt variant="ui-xs" className="text-neutral3 whitespace-nowrap">
+            <Txt variant="ui-xs" className="whitespace-nowrap text-neutral3">
               {step.foreachProgress.completedCount} / {step.foreachProgress.totalCount}
             </Txt>
           </div>
         )}
         {duration && (
-          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+          <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
             sleeps for <strong>{duration}ms</strong>
           </Txt>
         )}
 
         {date && (
-          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+          <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
             sleeps until <strong>{new Date(date).toLocaleString()}</strong>
           </Txt>
         )}

--- a/packages/playground/src/domains/workflows/workflow/workflow-graph-inner.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-graph-inner.tsx
@@ -62,7 +62,7 @@ export function WorkflowGraphInner({ workflow }: WorkflowGraphInnerProps) {
       ref={graphRef}
       tabIndex={-1}
       data-testid="workflow-graph-viewport"
-      className="w-full h-full bg-surface2 outline-none"
+      className="size-full bg-surface2 outline-none"
     >
       <ReactFlow
         nodes={nodes}

--- a/packages/playground/src/domains/workflows/workflow/workflow-input-data.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-input-data.tsx
@@ -92,7 +92,7 @@ export const WorkflowInputData = ({
   );
 
   const defaultHeading = (
-    <Txt as="span" variant="ui-md" className={cn('text-neutral5 font-semibold', headingClassName)}>
+    <Txt as="span" variant="ui-md" className={cn('font-semibold text-neutral5', headingClassName)}>
       {heading ?? (withoutSubmit ? 'Run input' : 'Trigger a run')}
     </Txt>
   );
@@ -109,7 +109,7 @@ export const WorkflowInputData = ({
   const body = (
     <>
       {!hideInputTypeLabel && (
-        <div className="flex justify-between gap-3 py-3 px-5">
+        <div className="flex justify-between gap-3 px-5 py-3">
           <Txt as="p" variant="ui-sm" className="text-neutral3">
             {inputTypeLabel}
           </Txt>
@@ -195,7 +195,7 @@ export const WorkflowInputData = ({
   return (
     <Collapsible defaultOpen>
       <CollapsibleTrigger className="flex w-full items-center gap-2 pb-3 text-left">
-        <ChevronRight className="h-4 w-4 shrink-0 text-neutral3" />
+        <ChevronRight className="size-4 shrink-0 text-neutral3" />
         {headingSlot ?? defaultHeading}
       </CollapsibleTrigger>
 
@@ -322,12 +322,12 @@ const WorkflowJsonInput = ({
   return (
     <div className="flex flex-col gap-4">
       {errors.length > 0 && (
-        <div className="border border-accent2 rounded-lg p-2">
-          <Txt as="p" variant="ui-md" className="text-accent2 font-semibold">
+        <div className="rounded-lg border border-accent2 p-2">
+          <Txt as="p" variant="ui-md" className="font-semibold text-accent2">
             {errors.length} errors found
           </Txt>
 
-          <ul className="list-disc list-inside">
+          <ul className="list-inside list-disc">
             {errors.map((error, idx) => (
               <li key={idx} className="text-ui-sm text-accent2">
                 {error}
@@ -338,7 +338,7 @@ const WorkflowJsonInput = ({
       )}
 
       <div>
-        <Txt as="label" variant="ui-sm" className="text-neutral3 pb-1 block">
+        <Txt as="label" variant="ui-sm" className="block pb-1 text-neutral3">
           Input data
         </Txt>
         <CodeEditor data={data} onChange={setInputData} editable={!isReadOnly} />
@@ -441,11 +441,11 @@ const WorkflowProcessorInput = ({
   return (
     <div className="flex flex-col gap-4">
       {errors.length > 0 && (
-        <div className="border border-accent2 rounded-lg p-2">
-          <Txt as="p" variant="ui-md" className="text-accent2 font-semibold">
+        <div className="rounded-lg border border-accent2 p-2">
+          <Txt as="p" variant="ui-md" className="font-semibold text-accent2">
             {errors.length} errors found
           </Txt>
-          <ul className="list-disc list-inside">
+          <ul className="list-inside list-disc">
             {errors.map((error, idx) => (
               <li key={idx} className="text-ui-sm text-accent2">
                 {error}
@@ -486,7 +486,7 @@ const WorkflowProcessorInput = ({
           placeholder="Enter a test message..."
           rows={4}
           disabled={isReadOnly}
-          className="w-full bg-transparent border border-border1 rounded-md p-3 text-ui-sm text-neutral6 placeholder:text-neutral3 focus:outline-hidden focus:ring-2 focus:ring-accent1 disabled:opacity-50"
+          className="w-full rounded-md border border-border1 bg-transparent p-3 text-ui-sm text-neutral6 placeholder:text-neutral3 focus:ring-2 focus:ring-accent1 focus:outline-hidden disabled:opacity-50"
         />
       </div>
 

--- a/packages/playground/src/domains/workflows/workflow/workflow-input-type-toggle.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-input-type-toggle.tsx
@@ -37,7 +37,7 @@ export function WorkflowInputTypeToggle({
       role="radiogroup"
       aria-label="Input type"
       className={cn(
-        'grid grid-flow-col auto-cols-fr gap-1 border border-border1 bg-surface3',
+        'grid auto-cols-fr grid-flow-col gap-1 border border-border1 bg-surface3',
         compact ? 'h-5 w-auto rounded-md p-0.5' : 'w-full rounded-lg p-1',
       )}
     >
@@ -56,7 +56,7 @@ export function WorkflowInputTypeToggle({
             className={cn(
               'flex items-center justify-center rounded-md transition-colors',
               compact ? 'gap-0.5 px-1 py-0' : 'gap-2 px-3 py-1.5',
-              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent1',
+              'focus-visible:ring-2 focus-visible:ring-accent1 focus-visible:outline-none',
               isActive ? 'bg-surface5 text-neutral5' : 'text-neutral3 hover:text-neutral4',
               disabled && 'cursor-not-allowed opacity-50',
             )}

--- a/packages/playground/src/domains/workflows/workflow/workflow-loop-result-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-loop-result-node.tsx
@@ -17,13 +17,13 @@ export function WorkflowLoopResultNode({ data }: NodeProps<LoopResultNode>) {
     <div
       data-testid="workflow-loop-result-node"
       data-workflow-step-status={result ? 'success' : 'failed'}
-      className={cn('bg-surface4 rounded-md w-[274px]')}
+      className={cn('w-[274px] rounded-md bg-surface4')}
       data-workflow-node
     >
       <Handle type="target" position={Position.Top} style={{ visibility: 'hidden' }} />
       <div className="p-2">
-        <div className="text-sm bg-surface5 flex items-center gap-1.5 rounded-sm  p-2">
-          {result ? <CircleCheck className="text-current w-4 h-4" /> : <CircleX className="text-current w-4 h-4" />}
+        <div className="flex items-center gap-1.5 rounded-sm bg-surface5 p-2  text-sm">
+          {result ? <CircleCheck className="size-4 text-current" /> : <CircleX className="size-4 text-current" />}
           <Txt variant="ui-xs" className="text-neutral6 capitalize">
             {String(result)}
           </Txt>

--- a/packages/playground/src/domains/workflows/workflow/workflow-map-config-dialog.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-map-config-dialog.tsx
@@ -26,7 +26,7 @@ export function WorkflowMapConfigDialog({ stepName, mapConfig }: WorkflowMapConf
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-4xl w-full">
+        <DialogContent className="w-full max-w-4xl">
           <DialogHeader>
             <DialogTitle>{stepName} config</DialogTitle>
             <DialogDescription>View the map configuration for this step</DialogDescription>

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-graph-dialog.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-graph-dialog.tsx
@@ -29,12 +29,12 @@ export function WorkflowNestedGraphDialog({ stepName, fullStep, stepGraph }: Wor
       </Button>
 
       <Dialog open={open} onOpenChange={setOpen}>
-        <DialogContent className="max-w-4xl w-full z-10">
+        <DialogContent className="z-10 w-full max-w-4xl">
           <DialogHeader>
             <DialogTitle>{stepName} workflow</DialogTitle>
             <DialogDescription>View the nested workflow graph for this step</DialogDescription>
           </DialogHeader>
-          <DialogBody className="min-h-[500px]">
+          <DialogBody className="min-h-125">
             <ReactFlowProvider key={fullStep}>
               <WorkflowNestedGraph stepGraph={stepGraph} open={open} workflowName={fullStep} />
             </ReactFlowProvider>

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-graph.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-graph.tsx
@@ -34,7 +34,7 @@ export function WorkflowNestedGraph({ stepGraph, open, workflowName }: WorkflowN
   }, [open]);
 
   return (
-    <div className="w-full h-full relative bg-surface1">
+    <div className="relative size-full bg-surface1">
       {isMounted ? (
         <ReactFlow
           nodes={nodes}
@@ -53,7 +53,7 @@ export function WorkflowNestedGraph({ stepGraph, open, workflowName }: WorkflowN
           <Background variant={BackgroundVariant.Lines} gap={12} size={0.5} />
         </ReactFlow>
       ) : (
-        <div className="w-full h-full flex items-center justify-center">
+        <div className="flex size-full items-center justify-center">
           <Spinner />
         </div>
       )}

--- a/packages/playground/src/domains/workflows/workflow/workflow-nested-node.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-nested-node.tsx
@@ -83,18 +83,18 @@ export function WorkflowNestedNode({
         data-workflow-node
         data-workflow-step-status={displayStatus}
         className={cn(
-          'bg-surface3 rounded-lg w-[274px] border border-border1',
+          'w-[274px] rounded-lg border border-border1 bg-surface3',
           hasSpecialBadge ? 'pt-0' : 'pt-2',
           displayStatus === 'success' && 'bg-accent1Darker',
           displayStatus === 'failed' && 'bg-accent2Darker',
-          displayStatus === 'tripwire' && 'bg-amber-950/40 border-amber-500/30',
+          displayStatus === 'tripwire' && 'border-amber-500/30 bg-amber-950/40',
           displayStatus === 'suspended' && 'bg-accent3Darker',
           displayStatus === 'waiting' && 'bg-accent5Darker',
           displayStatus === 'running' && 'bg-accent6Darker',
         )}
       >
         {hasSpecialBadge && (
-          <div className="px-3 pt-2 pb-1 flex gap-1.5 flex-wrap">
+          <div className="flex flex-wrap gap-1.5 px-3 pt-2 pb-1">
             {canSuspend && (
               <Badge icon={<BADGE_ICONS.suspend className="text-current" style={{ color: BADGE_COLORS.suspend }} />}>
                 SUSPEND/RESUME
@@ -127,27 +127,27 @@ export function WorkflowNestedNode({
             {displayStatus === 'tripwire' && <ShieldAlert className="text-amber-400" />}
             {displayStatus === 'suspended' && <PauseIcon className="text-accent3" />}
             {displayStatus === 'waiting' && <HourglassIcon className="text-accent5" />}
-            {displayStatus === 'running' && <Loader2 className="text-accent6 animate-spin" />}
+            {displayStatus === 'running' && <Loader2 className="animate-spin text-accent6" />}
             {!step && <CircleDashed className="text-neutral2" />}
           </Icon>
 
           <Txt
             variant="ui-lg"
-            className="text-neutral6 font-medium inline-flex items-center gap-1 justify-between w-full"
+            className="inline-flex w-full items-center justify-between gap-1 font-medium text-neutral6"
           >
             {label} {step?.startedAt && <Clock startedAt={step.startedAt} endedAt={step.endedAt} />}
           </Txt>
         </div>
 
         {description && (
-          <Txt variant="ui-sm" className="text-neutral3 px-3 pb-2">
+          <Txt variant="ui-sm" className="px-3 pb-2 text-neutral3">
             {description}
           </Txt>
         )}
 
         {isForEachNode && step?.foreachProgress && (
-          <div className="px-3 pb-2 flex items-center gap-2">
-            <div className="flex-1 h-1.5 bg-surface1 rounded-full overflow-hidden">
+          <div className="flex items-center gap-2 px-3 pb-2">
+            <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-surface1">
               <div
                 className={cn(
                   'h-full rounded-full transition-all duration-300',
@@ -158,7 +158,7 @@ export function WorkflowNestedNode({
                 }}
               />
             </div>
-            <Txt variant="ui-xs" className="text-neutral3 whitespace-nowrap">
+            <Txt variant="ui-xs" className="whitespace-nowrap text-neutral3">
               {step.foreachProgress.completedCount} / {step.foreachProgress.totalCount}
             </Txt>
           </div>

--- a/packages/playground/src/domains/workflows/workflow/workflow-status.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-status.tsx
@@ -48,9 +48,9 @@ export const WorkflowStatus = ({ stepId, status, result, tripwire }: WorkflowSta
             {status === 'tripwire' && <ShieldAlert className="text-amber-400" />}
             {status === 'suspended' && <CirclePause className="text-accent3" />}
             {status === 'waiting' && <HourglassIcon className="text-accent5" />}
-            {status === 'running' && <Loader2 className="text-accent6 animate-spin" />}
+            {status === 'running' && <Loader2 className="animate-spin text-accent6" />}
           </Icon>
-          <Txt as="span" variant="ui-lg" className="text-neutral6 font-medium">
+          <Txt as="span" variant="ui-lg" className="font-medium text-neutral6">
             {stepId.charAt(0).toUpperCase() + stepId.slice(1)}
           </Txt>
         </div>
@@ -79,12 +79,12 @@ interface TripwireDetailsProps {
 
 const TripwireDetails = ({ tripwire, isExpanded, onToggleExpand, hasMetadata }: TripwireDetailsProps) => {
   return (
-    <div className="rounded-lg border border-amber-500/30 bg-amber-950/20 overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-amber-500/30 bg-amber-950/20">
       {/* Header */}
       <div className="flex items-start gap-3 p-4">
-        <ShieldAlert className="w-5 h-5 text-amber-400 mt-0.5 shrink-0" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-amber-200 mb-1">Content Blocked</p>
+        <ShieldAlert className="mt-0.5 size-5 shrink-0 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <p className="mb-1 text-sm font-medium text-amber-200">Content Blocked</p>
           <p className="text-sm text-amber-300/90">{tripwire.reason || 'Tripwire triggered'}</p>
         </div>
       </div>
@@ -94,18 +94,18 @@ const TripwireDetails = ({ tripwire, isExpanded, onToggleExpand, hasMetadata }: 
         <>
           <button
             onClick={onToggleExpand}
-            className="w-full flex items-center gap-2 px-4 py-2 text-xs text-amber-400/70 hover:text-amber-400 hover:bg-amber-900/20 transition-colors border-t border-amber-500/20"
+            className="flex w-full items-center gap-2 border-t border-amber-500/20 px-4 py-2 text-xs text-amber-400/70 transition-colors hover:bg-amber-900/20 hover:text-amber-400"
           >
-            {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            {isExpanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
             <span>Details</span>
           </button>
 
           {isExpanded && (
-            <div className="px-4 pb-4 space-y-3 border-t border-amber-500/20 bg-amber-950/10">
+            <div className="space-y-3 border-t border-amber-500/20 bg-amber-950/10 px-4 pb-4">
               {/* Retry indicator */}
               {tripwire.retry !== undefined && (
                 <div className="flex items-center gap-2 pt-3">
-                  <RefreshCw className="w-3.5 h-3.5 text-amber-400/60" />
+                  <RefreshCw className="size-3.5 text-amber-400/60" />
                   <span className="text-xs text-amber-300/70">
                     Retry:{' '}
                     {tripwire.retry ? (
@@ -120,10 +120,10 @@ const TripwireDetails = ({ tripwire, isExpanded, onToggleExpand, hasMetadata }: 
               {/* Processor ID */}
               {tripwire.processorId && (
                 <div className="flex items-center gap-2">
-                  <Tag className="w-3.5 h-3.5 text-amber-400/60" />
+                  <Tag className="size-3.5 text-amber-400/60" />
                   <span className="text-xs text-amber-300/70">
                     Processor:{' '}
-                    <code className="px-1.5 py-0.5 rounded bg-amber-900/30 text-amber-200 font-mono">
+                    <code className="rounded bg-amber-900/30 px-1.5 py-0.5 font-mono text-amber-200">
                       {tripwire.processorId}
                     </code>
                   </span>
@@ -133,8 +133,8 @@ const TripwireDetails = ({ tripwire, isExpanded, onToggleExpand, hasMetadata }: 
               {/* Custom metadata */}
               {tripwire.metadata !== undefined && tripwire.metadata !== null && (
                 <div className="pt-1">
-                  <p className="text-xs text-amber-400/60 mb-1.5">Metadata:</p>
-                  <pre className="text-xs text-amber-200/80 bg-amber-900/30 rounded p-2 overflow-x-auto font-mono">
+                  <p className="mb-1.5 text-xs text-amber-400/60">Metadata:</p>
+                  <pre className="overflow-x-auto rounded bg-amber-900/30 p-2 font-mono text-xs text-amber-200/80">
                     {String(JSON.stringify(tripwire.metadata, null, 2))}
                   </pre>
                 </div>

--- a/packages/playground/src/domains/workflows/workflow/workflow-step-action-bar.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-step-action-bar.tsx
@@ -265,7 +265,7 @@ export const WorkflowStepActionBar = ({
               <DialogTitle>Time travel to {stepKey}</DialogTitle>
               <DialogDescription>Time travel to a specific workflow step</DialogDescription>
             </DialogHeader>
-            <DialogBody className="max-h-[600px]">
+            <DialogBody className="max-h-150">
               <WorkflowTimeTravelForm stepKey={stepKey} closeModal={() => setIsTimeTravelOpen(false)} />
             </DialogBody>
           </DialogContent>
@@ -280,7 +280,7 @@ export const WorkflowStepActionBar = ({
                 <DialogTitle>Run step {stepKey}</DialogTitle>
                 <DialogDescription>Run a specific workflow step</DialogDescription>
               </DialogHeader>
-              <DialogBody className="max-h-[600px]">
+              <DialogBody className="max-h-150">
                 <WorkflowTimeTravelForm
                   stepKey={stepKey}
                   closeModal={() => setIsPerStepRunOpen(false)}
@@ -298,7 +298,7 @@ export const WorkflowStepActionBar = ({
                 <DialogTitle>Continue run {stepKey}</DialogTitle>
                 <DialogDescription>Continue the workflow run from this step</DialogDescription>
               </DialogHeader>
-              <DialogBody className="max-h-[600px]">
+              <DialogBody className="max-h-150">
                 <WorkflowTimeTravelForm
                   stepKey={stepKey}
                   closeModal={() => setIsContinueRunOpen(false)}

--- a/packages/playground/src/domains/workflows/workflow/workflow-steps-status.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-steps-status.tsx
@@ -29,7 +29,7 @@ export function WorkflowStepsStatus({ steps, workflowResult }: WorkflowStepsStat
   }
 
   return (
-    <div className="flex flex-col gap-2 pt-5 border-t border-border1">
+    <div className="flex flex-col gap-2 border-t border-border1 pt-5">
       <Txt variant="ui-xs" className="text-neutral3">
         Status
       </Txt>

--- a/packages/playground/src/domains/workflows/workflow/workflow-suspended-overlay.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-suspended-overlay.tsx
@@ -42,7 +42,7 @@ export function WorkflowSuspendedOverlay() {
     <div
       key={runId}
       data-testid="workflow-suspended-overlay"
-      className="absolute top-2 right-2 z-20 w-[380px] max-w-[calc(100%-1rem)] max-h-[calc(100%-1rem)] overflow-y-auto rounded-lg shadow-lg animate-in fade-in-0 slide-in-from-top-2 zoom-in-95 duration-300"
+      className="w-95 absolute top-2 right-2 z-20 max-h-[calc(100%-1rem)] max-w-[calc(100%-1rem)] animate-in overflow-y-auto rounded-lg shadow-lg duration-300 fade-in-0 zoom-in-95 slide-in-from-top-2"
     >
       <WorkflowSuspendedSteps
         suspendedSteps={suspendedSteps}

--- a/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-suspended-steps.tsx
@@ -62,7 +62,7 @@ export function WorkflowSuspendedSteps({
   return (
     <div className="space-y-5 rounded-lg border border-border1 bg-surface4 p-5" data-testid="workflow-suspended-steps">
       <div className="flex items-center justify-between gap-3">
-        <Txt as="p" variant="ui-md" className="flex items-center gap-2 text-neutral6 font-semibold">
+        <Txt as="p" variant="ui-md" className="flex items-center gap-2 font-semibold text-neutral6">
           <Icon>
             <CirclePause />
           </Icon>
@@ -108,7 +108,7 @@ function SuspendedStepCard({ step, stepSchema, description, isStreaming, onResum
   return (
     <div className="space-y-5">
       <div className="space-y-2">
-        <Txt as="p" variant="ui-md" className="text-neutral6 font-medium truncate">
+        <Txt as="p" variant="ui-md" className="truncate font-medium text-neutral6">
           {step.stepId}
         </Txt>
         {description && (
@@ -129,17 +129,17 @@ function SuspendedStepCard({ step, stepSchema, description, isStreaming, onResum
 
           <Collapsible open={isPayloadOpen} onOpenChange={setIsPayloadOpen}>
             <CollapsibleTrigger className="flex w-full items-center justify-between gap-2 rounded-lg border border-border1 bg-surface3 px-3 py-2.5">
-              <span className="flex items-center gap-2 min-w-0">
+              <span className="flex min-w-0 items-center gap-2">
                 <Icon>
                   <ChevronRight
-                    className={cn('transition-transform text-neutral3', { 'transform rotate-90': isPayloadOpen })}
+                    className={cn('text-neutral3 transition-transform', { 'transform rotate-90': isPayloadOpen })}
                   />
                 </Icon>
-                <Txt as="span" variant="ui-md" className="text-neutral6 truncate">
+                <Txt as="span" variant="ui-md" className="truncate text-neutral6">
                   {getPayloadLabel(step.suspendPayload, step.stepId)}
                 </Txt>
               </span>
-              <Txt as="span" variant="ui-sm" className="text-neutral3 shrink-0">
+              <Txt as="span" variant="ui-sm" className="shrink-0 text-neutral3">
                 {formatPayloadSize(step.suspendPayload)}
               </Txt>
             </CollapsibleTrigger>

--- a/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-time-travel-form.tsx
@@ -82,7 +82,7 @@ const JsonField = ({
   return (
     <>
       {isExampleOpen && (
-        <div className="border border-border1 rounded-lg bg-surface3 p-3 space-y-2">
+        <div className="space-y-2 rounded-lg border border-border1 bg-surface3 p-3">
           <div className="flex items-center gap-2">
             <Txt as="p" variant="ui-sm" className="text-neutral3">
               Example {label}
@@ -107,12 +107,12 @@ const JsonField = ({
             value={exampleCode}
             theme={theme}
             extensions={[jsonLanguage]}
-            className="h-[150px] w-full overflow-y-scroll bg-surface3 rounded-lg overflow-scroll p-3"
+            className="h-[150px] w-full overflow-scroll overflow-y-scroll rounded-lg bg-surface3 p-3"
           />
         </div>
       )}
-      <Collapsible className="border border-border1 rounded-lg bg-surface3" open={isOpen} onOpenChange={setIsOpen}>
-        <div className="flex items-center justify-between w-full px-3">
+      <Collapsible className="rounded-lg border border-border1 bg-surface3" open={isOpen} onOpenChange={setIsOpen}>
+        <div className="flex w-full items-center justify-between px-3">
           <div>
             <Txt as="label" variant="ui-md" className="text-neutral3">
               {label}
@@ -179,7 +179,7 @@ const JsonField = ({
             onChange={onChange}
             theme={theme}
             extensions={[jsonLanguage]}
-            className="h-[260px] overflow-y-scroll bg-surface3 rounded-lg overflow-hidden p-3"
+            className="h-65 overflow-hidden overflow-y-scroll rounded-lg bg-surface3 p-3"
           />
 
           {fieldError && (

--- a/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-timeline.tsx
@@ -33,7 +33,7 @@ const StepStatusIcon = ({ status }: { status: Step['status'] }) => (
     {status === 'suspended' && <CirclePause className="text-accent3" />}
     {status === 'waiting' && <HourglassIcon className="text-accent5" />}
     {status === 'skipped' && <HourglassIcon className="text-icon3" />}
-    {status === 'running' && <Loader2 className="text-accent6 animate-spin" />}
+    {status === 'running' && <Loader2 className="animate-spin text-accent6" />}
   </Icon>
 );
 
@@ -151,7 +151,7 @@ const WorkflowTimelineRow = ({
         onSelectStep(row.stepId);
       }}
       className={cn(
-        'grid grid-cols-[auto_auto_auto_minmax(0,10rem)_minmax(0,1fr)_auto_5rem] items-center gap-2 rounded-md border border-transparent px-2 py-1 text-left transition-colors focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-accent1',
+        'grid grid-cols-[auto_auto_auto_minmax(0,10rem)_minmax(0,1fr)_auto_5rem] items-center gap-2 rounded-md border border-transparent px-2 py-1 text-left transition-colors focus-visible:ring-1 focus-visible:ring-accent1 focus-visible:outline-hidden',
         canSelect && 'cursor-pointer',
         canSelect && 'hover:bg-surface4',
         canSelect && isHovered && !isSelected && 'border-neutral6 bg-surface4',
@@ -186,7 +186,7 @@ const WorkflowTimelineRow = ({
       <Txt
         as="span"
         variant="ui-sm"
-        className="block min-w-0 max-w-full justify-self-stretch overflow-hidden text-ellipsis whitespace-nowrap text-left text-neutral6"
+        className="block max-w-full min-w-0 justify-self-stretch truncate text-left text-neutral6"
       >
         {titleCase(row.stepId)}
       </Txt>
@@ -286,7 +286,7 @@ export function WorkflowTimeline() {
               onClick={() => setIsCollapsed(collapsed => !collapsed)}
               className="rounded-md p-1 text-neutral3 transition-colors hover:bg-surface4 hover:text-neutral6"
             >
-              <ChevronDown className={cn('h-4 w-4 transition-transform', isCollapsed && '-rotate-90')} />
+              <ChevronDown className={cn('size-4 transition-transform', isCollapsed && '-rotate-90')} />
             </button>
           </div>
           {!isCollapsed && (

--- a/packages/playground/src/domains/workflows/workflow/workflow-trigger.tsx
+++ b/packages/playground/src/domains/workflows/workflow/workflow-trigger.tsx
@@ -76,9 +76,9 @@ export interface WorkflowTriggerProps {
 function DebugModeSwitch() {
   const { debugMode, setDebugMode } = useContext(WorkflowRunContext);
   return (
-    <label className="flex shrink-0 items-center gap-2 cursor-pointer">
+    <label className="flex shrink-0 cursor-pointer items-center gap-2">
       <Switch checked={debugMode} onCheckedChange={setDebugMode} aria-label="Debug" />
-      <Txt variant="ui-xs" className="text-neutral3 whitespace-nowrap">
+      <Txt variant="ui-xs" className="whitespace-nowrap text-neutral3">
         Debug
       </Txt>
     </label>
@@ -152,7 +152,7 @@ function InitialWorkflowHeader({ workflow, workflowId }: { workflow: GetWorkflow
       <Icon className="shrink-0 text-neutral4">
         <WorkflowIcon />
       </Icon>
-      <Txt as="span" variant="ui-md" className="text-neutral5 font-semibold truncate">
+      <Txt as="span" variant="ui-md" className="truncate font-semibold text-neutral5">
         {workflow.name ?? workflowId}
       </Txt>
       <CopyButton content={workflow.name ?? workflowId} variant="ghost" className="shrink-0" />
@@ -302,7 +302,7 @@ export function WorkflowTrigger({
 
   if (isLoading) {
     return (
-      <ScrollArea className="h-[calc(100vh-126px)] pt-2 px-4 pb-4 text-xs">
+      <ScrollArea className="h-[calc(100vh-126px)] px-4 pt-2 pb-4 text-xs">
         <div className="space-y-4">
           <Skeleton className="h-10" />
           <Skeleton className="h-10" />
@@ -329,10 +329,10 @@ export function WorkflowTrigger({
   );
 
   return (
-    <div className="h-full pt-3 overflow-y-auto">
+    <div className="h-full overflow-y-auto pt-3">
       <div className={`border-b border-border1/50`}>
         {isSuspendedSteps && isStreamingWorkflow && (
-          <div className="py-2 px-5 flex items-center gap-2 bg-surface5 -mt-5 border-b border-border1">
+          <div className="-mt-5 flex items-center gap-2 border-b border-border1 bg-surface5 px-5 py-2">
             <Icon>
               <Loader2 className="animate-spin text-neutral6" />
             </Icon>
@@ -370,7 +370,7 @@ export function WorkflowTrigger({
         )}
 
         {!canExecuteWorkflow && (
-          <Txt variant="ui-sm" className="text-neutral3 py-2 px-5">
+          <Txt variant="ui-sm" className="px-5 py-2 text-neutral3">
             You don't have permission to execute workflows.
           </Txt>
         )}
@@ -401,13 +401,13 @@ export function WorkflowTrigger({
         )}
 
         {isPausedDebug && (
-          <div className="px-5 pb-4 pt-3">
+          <div className="px-5 pt-3 pb-4">
             <WorkflowDebugStepControls isStreaming={isStreamingWorkflow} />
           </div>
         )}
 
         {(streamResultToUse?.status === 'running' || isSuspendedSteps || isPausedDebug) && (
-          <div data-testid="workflow-cancel-action" className="px-5 pb-4 pt-3">
+          <div data-testid="workflow-cancel-action" className="px-5 pt-3 pb-4">
             <WorkflowCancelButton
               status={isSuspendedSteps ? 'suspended' : streamResultToUse?.status}
               cancelMessage={cancelResponse?.message ?? null}

--- a/packages/playground/src/domains/workflows/workflow/zoom-slider.tsx
+++ b/packages/playground/src/domains/workflows/workflow/zoom-slider.tsx
@@ -23,7 +23,7 @@ export const ZoomSlider = forwardRef<HTMLDivElement, Omit<PanelProps, 'children'
         <Minus />
       </Button>
       <Slider
-        className="w-[140px]"
+        className="w-35"
         value={[zoom]}
         min={0.01}
         max={1}

--- a/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
+++ b/packages/playground/src/domains/workspace/components/add-skill-dialog.tsx
@@ -190,16 +190,16 @@ export function AddSkillDialog({
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-4xl h-[80vh] flex flex-col">
+      <DialogContent className="flex h-[80vh] max-w-4xl flex-col">
         <DialogHeader>
           <DialogTitle>Add Skill</DialogTitle>
           <DialogDescription>Search and install skills from the community registry</DialogDescription>
         </DialogHeader>
 
-        <DialogBody className="flex-1 flex flex-col gap-4 overflow-hidden max-h-none">
+        <DialogBody className="flex max-h-none flex-1 flex-col gap-4 overflow-hidden">
           {/* Search Input */}
           <div className="relative">
-            <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-neutral3" />
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-neutral3" />
             <Input
               placeholder="Search skills..."
               value={searchQuery}
@@ -208,24 +208,24 @@ export function AddSkillDialog({
             />
           </div>
 
-          <div className="flex flex-1 gap-4 min-h-0">
+          <div className="flex min-h-0 flex-1 gap-4">
             {/* Skills List */}
-            <div className="w-1/2 flex flex-col min-h-0">
-              <div className="text-xs font-medium text-neutral4 uppercase tracking-wide mb-2">
+            <div className="flex min-h-0 w-1/2 flex-col">
+              <div className="mb-2 text-xs font-medium tracking-wide text-neutral4 uppercase">
                 {hasSearchResults ? 'Search Results' : 'Popular Skills'}
               </div>
-              <ScrollArea className="flex-1 border border-border1 rounded-lg">
+              <ScrollArea className="flex-1 rounded-lg border border-border1">
                 {isLoadingPopular || isSearching ? (
                   <div className="flex items-center justify-center py-8">
-                    <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                    <Loader2 className="size-6 animate-spin text-neutral3" />
                   </div>
                 ) : displaySkills.length === 0 ? (
                   <div className="flex flex-col items-center justify-center py-8 text-neutral4">
-                    <Package className="h-8 w-8 mb-2" />
+                    <Package className="mb-2 size-8" />
                     <p className="text-sm">{hasSearchResults ? 'No skills found' : 'No skills available'}</p>
                   </div>
                 ) : (
-                  <div className="p-2 space-y-1">
+                  <div className="space-y-1 p-2">
                     {displaySkills.map(skill => {
                       const skillUniqueId = getSkillUniqueId(skill);
                       const installedId = getInstalledSkillId(skill);
@@ -239,26 +239,26 @@ export function AddSkillDialog({
                           key={skillUniqueId}
                           onClick={() => setSelectedSkill(skill)}
                           className={cn(
-                            'w-full text-left px-3 py-2 rounded-md transition-colors',
+                            'w-full rounded-md px-3 py-2 text-left transition-colors',
                             'hover:bg-surface4',
-                            selectedSkillUniqueId === skillUniqueId && 'bg-surface5 border border-accent1',
+                            selectedSkillUniqueId === skillUniqueId && 'border border-accent1 bg-surface5',
                           )}
                         >
                           <div className="flex items-start justify-between gap-2">
                             <div className="min-w-0 flex-1">
                               <div className="flex items-center gap-2">
-                                <span className="font-medium text-sm text-neutral6 truncate">{skill.name}</span>
+                                <span className="truncate text-sm font-medium text-neutral6">{skill.name}</span>
                                 {isInstalled && (
-                                  <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-medium bg-accent1/20 text-accent1">
-                                    <Check className="h-2.5 w-2.5" />
+                                  <span className="inline-flex items-center gap-1 rounded bg-accent1/20 px-1.5 py-0.5 text-[10px] font-medium text-accent1">
+                                    <Check className="size-2.5" />
                                     Installed
                                   </span>
                                 )}
                               </div>
-                              <div className="text-xs text-neutral4 truncate">{skill.topSource}</div>
+                              <div className="truncate text-xs text-neutral4">{skill.topSource}</div>
                             </div>
-                            <div className="flex items-center gap-1 text-xs text-neutral3 shrink-0">
-                              <Download className="h-3 w-3" />
+                            <div className="flex shrink-0 items-center gap-1 text-xs text-neutral3">
+                              <Download className="size-3" />
                               <span>{skill.installs.toLocaleString()}</span>
                             </div>
                           </div>
@@ -271,31 +271,31 @@ export function AddSkillDialog({
             </div>
 
             {/* Preview Panel */}
-            <div className="w-1/2 flex flex-col min-h-0">
-              <div className="text-xs font-medium text-neutral4 uppercase tracking-wide mb-2">Preview</div>
-              <div className="flex-1 border border-border1 rounded-lg overflow-hidden flex flex-col">
+            <div className="flex min-h-0 w-1/2 flex-col">
+              <div className="mb-2 text-xs font-medium tracking-wide text-neutral4 uppercase">Preview</div>
+              <div className="flex flex-1 flex-col overflow-hidden rounded-lg border border-border1">
                 {!selectedSkill ? (
-                  <div className="flex flex-col items-center justify-center h-full text-neutral4">
-                    <Package className="h-8 w-8 mb-2" />
+                  <div className="flex h-full flex-col items-center justify-center text-neutral4">
+                    <Package className="mb-2 size-8" />
                     <p className="text-sm">Select a skill to preview</p>
                   </div>
                 ) : (
                   <>
                     {/* Skill Header */}
-                    <div className="p-4 border-b border-border1 bg-surface3">
+                    <div className="border-b border-border1 bg-surface3 p-4">
                       <div className="flex items-start gap-3">
-                        <div className="p-2 rounded-lg bg-surface5">
-                          <SkillIcon className="h-5 w-5 text-neutral4" />
+                        <div className="rounded-lg bg-surface5 p-2">
+                          <SkillIcon className="size-5 text-neutral4" />
                         </div>
-                        <div className="flex-1 min-w-0">
-                          <h3 className="font-semibold text-neutral6 truncate">{selectedSkill.name}</h3>
-                          <div className="flex items-center gap-3 mt-1 text-xs text-neutral4">
+                        <div className="min-w-0 flex-1">
+                          <h3 className="truncate font-semibold text-neutral6">{selectedSkill.name}</h3>
+                          <div className="mt-1 flex items-center gap-3 text-xs text-neutral4">
                             <span className="flex items-center gap-1">
-                              <Github className="h-3 w-3" />
+                              <Github className="size-3" />
                               {selectedSkill.topSource}
                             </span>
                             <span className="flex items-center gap-1">
-                              <Download className="h-3 w-3" />
+                              <Download className="size-3" />
                               {selectedSkill.installs.toLocaleString()} installs
                             </span>
                           </div>
@@ -305,10 +305,10 @@ export function AddSkillDialog({
                             href={`https://github.com/${parsedSource.owner}/${parsedSource.repo}`}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-neutral4 hover:text-neutral5 transition-colors"
+                            className="text-neutral4 transition-colors hover:text-neutral5"
                             title="View on GitHub"
                           >
-                            <ExternalLink className="h-4 w-4" />
+                            <ExternalLink className="size-4" />
                           </a>
                         )}
                       </div>
@@ -316,8 +316,8 @@ export function AddSkillDialog({
 
                     {/* Skill Content */}
                     {isLoadingPreview ? (
-                      <div className="flex-1 flex items-center justify-center">
-                        <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+                      <div className="flex flex-1 items-center justify-center">
+                        <Loader2 className="size-6 animate-spin text-neutral3" />
                       </div>
                     ) : previewContent ? (
                       <ScrollArea className="flex-1">
@@ -326,17 +326,17 @@ export function AddSkillDialog({
                         </div>
                       </ScrollArea>
                     ) : (
-                      <div className="flex-1 flex flex-col items-center justify-center text-neutral4">
-                        <Package className="h-8 w-8 mb-2" />
+                      <div className="flex flex-1 flex-col items-center justify-center text-neutral4">
+                        <Package className="mb-2 size-8" />
                         <p className="text-sm">Preview unavailable</p>
                         {skillsUrl && (
                           <a
                             href={skillsUrl}
                             target="_blank"
                             rel="noopener noreferrer"
-                            className="text-xs mt-2 text-accent1 hover:underline flex items-center gap-1"
+                            className="mt-2 flex items-center gap-1 text-xs text-accent1 hover:underline"
                           >
-                            View on skills.sh <ExternalLink className="h-3 w-3" />
+                            View on skills.sh <ExternalLink className="size-3" />
                           </a>
                         )}
                       </div>
@@ -349,19 +349,19 @@ export function AddSkillDialog({
 
           {/* Install Actions */}
           {selectedSkill && (
-            <div className="flex flex-col gap-3 pt-4 border-t border-border1">
+            <div className="flex flex-col gap-3 border-t border-border1 pt-4">
               {/* Mount picker - only shown when multiple writable mounts exist */}
               {writableMounts && writableMounts.length > 1 && (
-                <div className="flex items-center gap-3 p-3 rounded-lg bg-surface3 border border-border1">
-                  <Folder className="h-4 w-4 text-icon4 shrink-0" />
-                  <label htmlFor="mount-select" className="text-sm text-icon5 whitespace-nowrap font-medium">
+                <div className="flex items-center gap-3 rounded-lg border border-border1 bg-surface3 p-3">
+                  <Folder className="text-icon4 size-4 shrink-0" />
+                  <label htmlFor="mount-select" className="text-icon5 text-sm font-medium whitespace-nowrap">
                     Install to
                   </label>
                   <select
                     id="mount-select"
                     value={selectedMount ?? ''}
                     onChange={e => setSelectedMount(e.target.value)}
-                    className="flex-1 text-sm px-3 py-1.5 rounded-md border border-border1 bg-surface2 text-icon6"
+                    className="text-icon6 flex-1 rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-sm"
                   >
                     {writableMounts.map(m => {
                       const name = m.displayName ?? m.name ?? m.provider ?? 'unknown';
@@ -383,7 +383,7 @@ export function AddSkillDialog({
                   (() => {
                     const skillPath = installedSkillPaths[selectedSkill.name]!;
                     const mount = writableMounts.find(m => skillPath.startsWith(m.path + '/') || skillPath === m.path);
-                    return mount ? <span className="text-xs text-icon4">Installed at {mount.path}</span> : null;
+                    return mount ? <span className="text-icon4 text-xs">Installed at {mount.path}</span> : null;
                   })()}
                 <Button variant="default" onClick={() => handleOpenChange(false)}>
                   Cancel
@@ -396,17 +396,17 @@ export function AddSkillDialog({
                 >
                   {isInstalling ? (
                     <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      <Loader2 className="mr-2 size-4 animate-spin" />
                       Installing...
                     </>
                   ) : isSelectedSkillInstalled ? (
                     <>
-                      <Check className="h-4 w-4 mr-2" />
+                      <Check className="mr-2 size-4" />
                       Already Installed
                     </>
                   ) : (
                     <>
-                      <Download className="h-4 w-4 mr-2" />
+                      <Download className="mr-2 size-4" />
                       Install
                     </>
                   )}

--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -68,32 +68,32 @@ function getMountIcon(mount: FileEntry['mount']) {
     case 'aws-s3':
     case 's3':
       // S3 or S3-compatible storage
-      return <AmazonIcon className="h-4 w-4 text-[#FF9900]" />;
+      return <AmazonIcon className="size-4 text-[#FF9900]" />;
     case 'google-cloud':
     case 'google-cloud-storage':
     case 'gcs':
-      return <GoogleIcon className="h-4 w-4" />;
+      return <GoogleIcon className="size-4" />;
     case 'azure-blob':
     case 'azure':
-      return <AzureIcon className="h-4 w-4 text-[#0078D4]" />;
+      return <AzureIcon className="size-4 text-[#0078D4]" />;
     case 'cloudflare':
     case 'cloudflare-r2':
     case 'r2':
-      return <Cloud className="h-4 w-4 text-[#F38020]" />;
+      return <Cloud className="size-4 text-[#F38020]" />;
     case 'minio':
-      return <HardDrive className="h-4 w-4 text-red-400" />;
+      return <HardDrive className="size-4 text-red-400" />;
     case 'database':
-      return <Database className="h-4 w-4 text-emerald-400" />;
+      return <Database className="size-4 text-emerald-400" />;
     case 'local':
     case 'folder':
-      return <Folder className="h-4 w-4 text-amber-400" />;
+      return <Folder className="size-4 text-amber-400" />;
     case 'hard-drive':
-      return <HardDrive className="h-4 w-4 text-slate-400" />;
+      return <HardDrive className="size-4 text-slate-400" />;
     case 'cloud':
-      return <Cloud className="h-4 w-4 text-sky-400" />;
+      return <Cloud className="size-4 text-sky-400" />;
     default:
       // Default to cloud icon for unknown providers
-      return <Cloud className="h-4 w-4 text-neutral4" />;
+      return <Cloud className="size-4 text-neutral4" />;
   }
 }
 
@@ -105,7 +105,7 @@ function getFileIcon(entry: FileEntry, isOpen = false) {
     if (mount) {
       return getMountIcon(mount);
     }
-    return isOpen ? <FolderOpen className="h-4 w-4 text-amber-400" /> : <Folder className="h-4 w-4 text-amber-400" />;
+    return isOpen ? <FolderOpen className="size-4 text-amber-400" /> : <Folder className="size-4 text-amber-400" />;
   }
 
   const ext = name.split('.').pop()?.toLowerCase();
@@ -114,21 +114,21 @@ function getFileIcon(entry: FileEntry, isOpen = false) {
     case 'tsx':
     case 'js':
     case 'jsx':
-      return <FileCode className="h-4 w-4 text-blue-400" />;
+      return <FileCode className="size-4 text-blue-400" />;
     case 'json':
-      return <FileJson className="h-4 w-4 text-yellow-400" />;
+      return <FileJson className="size-4 text-yellow-400" />;
     case 'md':
     case 'mdx':
-      return <FileText className="h-4 w-4 text-neutral4" />;
+      return <FileText className="size-4 text-neutral4" />;
     case 'png':
     case 'jpg':
     case 'jpeg':
     case 'gif':
     case 'svg':
     case 'webp':
-      return <Image className="h-4 w-4 text-purple-400" />;
+      return <Image className="size-4 text-purple-400" />;
     default:
-      return <File className="h-4 w-4 text-neutral4" />;
+      return <File className="size-4 text-neutral4" />;
   }
 }
 
@@ -197,22 +197,22 @@ function Breadcrumb({ path, onNavigate }: BreadcrumbProps) {
   const parts = isRoot ? [] : path.split('/').filter(Boolean);
 
   return (
-    <div className="flex items-center gap-1 text-sm overflow-x-auto">
+    <div className="flex items-center gap-1 overflow-x-auto text-sm">
       <button
         onClick={() => onNavigate('.')}
-        className="p-1 rounded hover:bg-surface4 text-neutral5 hover:text-neutral6 transition-colors"
+        className="rounded p-1 text-neutral5 transition-colors hover:bg-surface4 hover:text-neutral6"
         aria-label="Workspace root"
       >
-        <FolderOpen className="h-4 w-4" />
+        <FolderOpen className="size-4" />
       </button>
       {parts.map((part, index) => {
         const partPath = parts.slice(0, index + 1).join('/');
         return (
           <div key={partPath} className="flex items-center">
-            <ChevronRight className="h-4 w-4 text-neutral3" />
+            <ChevronRight className="size-4 text-neutral3" />
             <button
               onClick={() => onNavigate(partPath)}
-              className="px-2 py-1 rounded hover:bg-surface4 text-neutral5 hover:text-neutral6 transition-colors truncate max-w-[150px]"
+              className="max-w-[150px] truncate rounded px-2 py-1 text-neutral5 transition-colors hover:bg-surface4 hover:text-neutral6"
               title={part}
             >
               {part}
@@ -268,14 +268,14 @@ export function FileBrowser({
   };
 
   return (
-    <div className="rounded-lg border border-border1 overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-border1">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 bg-surface3 border-b border-border1">
+      <div className="flex items-center justify-between border-b border-border1 bg-surface3 px-4 py-2">
         <Breadcrumb path={currentPath} onNavigate={onNavigate} />
         <div className="flex items-center gap-1">
           {onRefresh && (
             <Button variant="ghost" size="md" onClick={onRefresh} disabled={isLoading} aria-label="Refresh files">
-              <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+              <RefreshCw className={`size-4 ${isLoading ? 'animate-spin' : ''}`} />
             </Button>
           )}
           {onCreateDirectory && (
@@ -292,33 +292,33 @@ export function FileBrowser({
                 }
               }}
             >
-              {isCreatingDirectory ? <Loader2 className="h-4 w-4 animate-spin" /> : <FolderPlus className="h-4 w-4" />}
+              {isCreatingDirectory ? <Loader2 className="size-4 animate-spin" /> : <FolderPlus className="size-4" />}
             </Button>
           )}
           {onUpload && (
             <Button variant="ghost" size="md" onClick={onUpload} aria-label="Upload files">
-              <Upload className="h-4 w-4" />
+              <Upload className="size-4" />
             </Button>
           )}
         </div>
       </div>
 
       {/* File List */}
-      <div className="max-h-[400px] overflow-auto">
+      <div className="max-h-100 overflow-auto">
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+            <Loader2 className="size-6 animate-spin text-neutral3" />
           </div>
         ) : error ? (
-          <div className="py-12 px-4 text-center">
-            <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-red-500/10 mb-4">
-              <AlertCircle className="h-6 w-6 text-red-400" />
+          <div className="px-4 py-12 text-center">
+            <div className="mb-4 inline-flex size-12 items-center justify-center rounded-full bg-red-500/10">
+              <AlertCircle className="size-6 text-red-400" />
             </div>
-            <p className="text-sm text-neutral6 font-medium mb-1">Failed to load directory</p>
-            <p className="text-xs text-neutral4 max-w-sm mx-auto">{getErrorMessage(error)}</p>
+            <p className="mb-1 text-sm font-medium text-neutral6">Failed to load directory</p>
+            <p className="mx-auto max-w-sm text-xs text-neutral4">{getErrorMessage(error)}</p>
           </div>
         ) : sortedEntries.length === 0 ? (
-          <div className="py-12 text-center text-neutral4 text-sm">
+          <div className="py-12 text-center text-sm text-neutral4">
             {isRoot ? 'Workspace is empty' : 'Directory is empty'}
           </div>
         ) : (
@@ -332,9 +332,9 @@ export function FileBrowser({
                       const parentPath = currentPath.split('/').slice(0, -1).join('/') || '.';
                       onNavigate(parentPath);
                     }}
-                    className="w-full flex items-center gap-3 px-4 py-2 hover:bg-surface4 transition-colors text-left"
+                    className="flex w-full items-center gap-3 px-4 py-2 text-left transition-colors hover:bg-surface4"
                   >
-                    <FolderOpen className="h-4 w-4 text-amber-400" />
+                    <FolderOpen className="size-4 text-amber-400" />
                     <span className="text-sm text-neutral5">..</span>
                   </button>
                 </li>
@@ -345,19 +345,19 @@ export function FileBrowser({
 
                 return (
                   <li key={entry.name} className="group">
-                    <div className="flex items-center hover:bg-surface4 transition-colors">
+                    <div className="flex items-center transition-colors hover:bg-surface4">
                       <button
                         onClick={() => handleEntryClick(entry)}
-                        className="flex-1 flex items-center gap-3 px-4 py-2 text-left"
+                        className="flex flex-1 items-center gap-3 px-4 py-2 text-left"
                       >
                         {getFileIcon(entry)}
-                        <span className="text-sm text-neutral6 flex-1 truncate">{entry.name}</span>
+                        <span className="flex-1 truncate text-sm text-neutral6">{entry.name}</span>
                         {/* Mount error indicator */}
                         {entry.mount && isError && (
                           <Tooltip>
                             <TooltipTrigger asChild>
                               <span tabIndex={0} className="flex items-center">
-                                <AlertCircle className="h-4 w-4 text-red-400" />
+                                <AlertCircle className="size-4 text-red-400" />
                               </span>
                             </TooltipTrigger>
                             <TooltipContent className="max-w-xs">
@@ -373,7 +373,7 @@ export function FileBrowser({
                               <TooltipTrigger asChild>
                                 <span
                                   tabIndex={0}
-                                  className={`text-xs px-1.5 py-0.5 rounded ${isError ? 'text-red-400 bg-red-400/10' : 'text-neutral3 bg-surface4'}`}
+                                  className={`rounded px-1.5 py-0.5 text-xs ${isError ? 'bg-red-400/10 text-red-400' : 'bg-surface4 text-neutral3'}`}
                                 >
                                   {mountLabel}
                                 </span>
@@ -382,7 +382,7 @@ export function FileBrowser({
                             </Tooltip>
                           ) : (
                             <span
-                              className={`text-xs px-1.5 py-0.5 rounded ${isError ? 'text-red-400 bg-red-400/10' : 'text-neutral3 bg-surface4'}`}
+                              className={`rounded px-1.5 py-0.5 text-xs ${isError ? 'bg-red-400/10 text-red-400' : 'bg-surface4 text-neutral3'}`}
                             >
                               {mountLabel}
                             </span>
@@ -395,9 +395,9 @@ export function FileBrowser({
                         <button
                           onClick={() => handleDelete(entry)}
                           aria-label={`Delete ${entry.name}`}
-                          className="p-2 opacity-0 group-hover:opacity-100 hover:text-red-400 text-neutral3 transition-all"
+                          className="p-2 text-neutral3 opacity-0 transition-all group-hover:opacity-100 hover:text-red-400"
                         >
-                          <Trash2 className="h-3.5 w-3.5" />
+                          <Trash2 className="size-3.5" />
                         </button>
                       )}
                     </div>
@@ -432,7 +432,7 @@ export function FileBrowser({
                 }
               }}
             >
-              {isDeleting ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
+              {isDeleting ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
               Delete
             </AlertDialog.Action>
           </AlertDialog.Footer>
@@ -530,9 +530,9 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
   const language = getLanguageFromExtension(ext);
 
   return (
-    <div className="rounded-lg border border-border1 overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-border1">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-2 bg-surface3 border-b border-border1">
+      <div className="flex items-center justify-between border-b border-border1 bg-surface3 px-4 py-2">
         <div className="flex items-center gap-2">
           {getFileIcon({ name: fileName, type: 'file' })}
           <span className="text-sm font-medium text-neutral6">{fileName}</span>
@@ -548,23 +548,23 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
       </div>
 
       {/* Content */}
-      <div className="max-h-[500px] overflow-auto h-full" style={{ backgroundColor: 'black' }}>
+      <div className="max-h-125 h-full overflow-auto" style={{ backgroundColor: 'black' }}>
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
-            <Loader2 className="h-6 w-6 animate-spin text-neutral3" />
+            <Loader2 className="size-6 animate-spin text-neutral3" />
           </div>
         ) : isImage ? (
-          <div className="p-4 flex items-center justify-center">
+          <div className="flex items-center justify-center p-4">
             <img
               src={`data:${mimeType || 'image/png'};base64,${btoa(content)}`}
               alt={fileName}
-              className="max-w-full max-h-[400px] object-contain"
+              className="max-h-100 max-w-full object-contain"
             />
           </div>
         ) : language ? (
           <HighlightedCode content={content} language={language} />
         ) : (
-          <pre className="p-4 text-sm text-neutral5 whitespace-pre-wrap font-mono overflow-x-auto">{content}</pre>
+          <pre className="overflow-x-auto p-4 font-mono text-sm whitespace-pre-wrap text-neutral5">{content}</pre>
         )}
       </div>
     </div>

--- a/packages/playground/src/domains/workspace/components/reference-viewer-dialog.tsx
+++ b/packages/playground/src/domains/workspace/components/reference-viewer-dialog.tsx
@@ -38,7 +38,7 @@ export function ReferenceViewerDialog({
 
       {/* Dialog */}
       <div
-        className="relative w-full max-w-4xl max-h-[85vh] mx-4 bg-surface2 rounded-xl border border-border1 shadow-2xl flex flex-col overflow-hidden"
+        className="relative mx-4 flex max-h-[85vh] w-full max-w-4xl flex-col overflow-hidden rounded-xl border border-border1 bg-surface2 shadow-2xl"
         role="dialog"
         aria-modal="true"
         aria-labelledby="reference-viewer-title"
@@ -47,10 +47,10 @@ export function ReferenceViewerDialog({
         }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between px-6 py-4 border-b border-border1 bg-surface3">
+        <div className="flex items-center justify-between border-b border-border1 bg-surface3 px-6 py-4">
           <div className="flex items-center gap-3">
-            <div className="p-1.5 rounded bg-surface5">
-              <FileText className="h-4 w-4 text-neutral4" />
+            <div className="rounded bg-surface5 p-1.5">
+              <FileText className="size-4 text-neutral4" />
             </div>
             <div>
               <h2 id="reference-viewer-title" className="text-base font-medium text-neutral6">
@@ -61,17 +61,15 @@ export function ReferenceViewerDialog({
           </div>
           <div className="flex items-center gap-2">
             <Button size="md" variant="default" onClick={handleCopy} disabled={!content || isLoading}>
-              <Icon>
-                {isCopied ? <Check className="h-3.5 w-3.5 text-green-400" /> : <Copy className="h-3.5 w-3.5" />}
-              </Icon>
+              <Icon>{isCopied ? <Check className="size-3.5 text-green-400" /> : <Copy className="size-3.5" />}</Icon>
               {isCopied ? 'Copied!' : 'Copy'}
             </Button>
             <button
               onClick={() => onOpenChange(false)}
               aria-label="Close reference viewer"
-              className="p-2 rounded-lg hover:bg-surface4 text-neutral3 hover:text-neutral5 transition-colors"
+              className="rounded-lg p-2 text-neutral3 transition-colors hover:bg-surface4 hover:text-neutral5"
             >
-              <X className="h-4 w-4" />
+              <X className="size-4" />
             </button>
           </div>
         </div>
@@ -80,15 +78,15 @@ export function ReferenceViewerDialog({
         <div className="flex-1 overflow-auto p-6">
           {isLoading ? (
             <div className="flex items-center justify-center py-12">
-              <div className="h-6 w-6 border-2 border-accent1 border-t-transparent rounded-full animate-spin" />
+              <div className="size-6 animate-spin rounded-full border-2 border-accent1 border-t-transparent" />
             </div>
           ) : error ? (
             <div className="flex flex-col items-center justify-center py-12 text-center">
-              <p className="text-red-400 mb-2">Failed to load reference</p>
+              <p className="mb-2 text-red-400">Failed to load reference</p>
               <p className="text-sm text-neutral3">{error}</p>
             </div>
           ) : content ? (
-            <pre className="whitespace-pre-wrap text-sm text-neutral5 font-mono bg-surface3 p-4 rounded-lg overflow-auto">
+            <pre className="overflow-auto rounded-lg bg-surface3 p-4 font-mono text-sm whitespace-pre-wrap text-neutral5">
               {content}
             </pre>
           ) : (

--- a/packages/playground/src/domains/workspace/components/search-panel.tsx
+++ b/packages/playground/src/domains/workspace/components/search-panel.tsx
@@ -23,17 +23,17 @@ type SearchMode = 'vector' | 'bm25' | 'hybrid';
 const modeConfig: Record<SearchMode, { label: string; icon: React.ReactNode; color: string }> = {
   bm25: {
     label: 'Keyword',
-    icon: <FileText className="h-3.5 w-3.5" />,
+    icon: <FileText className="size-3.5" />,
     color: 'bg-blue-500/10 text-blue-400 border-blue-500/30',
   },
   vector: {
     label: 'Semantic',
-    icon: <Sparkles className="h-3.5 w-3.5" />,
+    icon: <Sparkles className="size-3.5" />,
     color: 'bg-purple-500/10 text-purple-400 border-purple-500/30',
   },
   hybrid: {
     label: 'Hybrid',
-    icon: <Zap className="h-3.5 w-3.5" />,
+    icon: <Zap className="size-3.5" />,
     color: 'bg-amber-500/10 text-amber-400 border-amber-500/30',
   },
 };
@@ -78,16 +78,16 @@ export function SearchWorkspacePanel({
     <div className="rounded-lg bg-surface4">
       {/* Search Form */}
       <form onSubmit={handleSearch} className="p-4">
-        <div className="flex gap-3 items-center">
+        <div className="flex items-center gap-3">
           {/* Query Input */}
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral3" />
+          <div className="relative flex-1">
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-neutral3" />
             <Input
               value={query}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setQuery(e.target.value)}
               placeholder="Search workspace files..."
               variant="outline"
-              className="pl-9 h-10"
+              className="h-10 pl-9"
             />
           </div>
 
@@ -100,20 +100,20 @@ export function SearchWorkspacePanel({
               max={50}
               value={topK}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => setTopK(parseInt(e.target.value) || 5)}
-              className="w-14 h-10 text-center bg-surface2 border-border1"
+              className="h-10 w-14 border-border1 bg-surface2 text-center"
               title="Number of results"
             />
           </div>
 
           {/* Search Button */}
           <Button type="submit" disabled={isSearching || !query.trim()} size="lg" className="h-10 px-4">
-            {isSearching ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Search'}
+            {isSearching ? <Loader2 className="size-4 animate-spin" /> : 'Search'}
           </Button>
         </div>
 
         {/* Mode Selection */}
         {availableModes.length > 0 && (
-          <div className="flex gap-2 mt-3">
+          <div className="mt-3 flex gap-2">
             {availableModes.map(m => {
               const config = modeConfig[m];
               const isActive = mode === m;
@@ -123,8 +123,8 @@ export function SearchWorkspacePanel({
                   type="button"
                   onClick={() => setMode(m)}
                   className={`
-                    inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium border transition-colors
-                    ${isActive ? config.color : 'bg-surface2 text-neutral4 border-transparent hover:bg-surface3'}
+                    inline-flex items-center gap-1.5 rounded border px-2.5 py-1 text-xs font-medium transition-colors
+                    ${isActive ? config.color : 'border-transparent bg-surface2 text-neutral4 hover:bg-surface3'}
                   `}
                 >
                   {config.icon}
@@ -139,20 +139,20 @@ export function SearchWorkspacePanel({
       {/* Results */}
       {searchResults && (
         <div className="border-t border-border1">
-          <div className="px-4 py-2 flex items-center justify-between text-xs">
+          <div className="flex items-center justify-between px-4 py-2 text-xs">
             <span className="text-neutral4">
               {searchResults.results.length} result{searchResults.results.length !== 1 ? 's' : ''} for "
               <span className="text-neutral6">{searchResults.query}</span>"
             </span>
-            <span className={`px-1.5 py-0.5 rounded ${modeConfig[searchResults.mode].color}`}>
+            <span className={`rounded px-1.5 py-0.5 ${modeConfig[searchResults.mode].color}`}>
               {modeConfig[searchResults.mode].label}
             </span>
           </div>
 
           {searchResults.results.length === 0 ? (
-            <div className="px-4 py-8 text-center text-neutral4 text-sm">No results found. Try a different query.</div>
+            <div className="px-4 py-8 text-center text-sm text-neutral4">No results found. Try a different query.</div>
           ) : (
-            <ul className="max-h-[320px] overflow-auto">
+            <ul className="max-h-80 overflow-auto">
               {searchResults.results.map((result, index) => (
                 <WorkspaceSearchResultItem
                   key={`${result.id}-${index}`}
@@ -181,22 +181,22 @@ function WorkspaceSearchResultItem({ result, rank, onClick }: WorkspaceSearchRes
 
   return (
     <li className="border-t border-border1 first:border-t-0">
-      <button onClick={onClick} className="w-full px-4 py-3 text-left hover:bg-surface5 transition-colors flex gap-3">
-        <span className="text-xs text-neutral3 tabular-nums w-4 shrink-0">{rank}</span>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
-            <FolderOpen className="h-3.5 w-3.5 text-neutral4 shrink-0" />
-            <span className="font-mono text-sm text-neutral6 truncate">{fileId}</span>
-            <div className="flex items-center gap-1.5 shrink-0">
-              <div className="w-12 h-1 rounded-full bg-surface2 overflow-hidden">
+      <button onClick={onClick} className="flex w-full gap-3 px-4 py-3 text-left transition-colors hover:bg-surface5">
+        <span className="w-4 shrink-0 text-xs text-neutral3 tabular-nums">{rank}</span>
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex items-center gap-2">
+            <FolderOpen className="size-3.5 shrink-0 text-neutral4" />
+            <span className="truncate font-mono text-sm text-neutral6">{fileId}</span>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <div className="h-1 w-12 overflow-hidden rounded-full bg-surface2">
                 <div className="h-full rounded-full bg-accent1" style={{ width: `${scorePercent}%` }} />
               </div>
               <span className="text-ui-xs text-neutral3 tabular-nums">{result.score.toFixed(2)}</span>
             </div>
           </div>
-          <p className="text-xs text-neutral4 line-clamp-2">{result.content}</p>
+          <p className="line-clamp-2 text-xs text-neutral4">{result.content}</p>
           {result.lineRange && (
-            <p className="text-xs text-neutral3 mt-1">
+            <p className="mt-1 text-xs text-neutral3">
               Lines {result.lineRange.start}–{result.lineRange.end}
             </p>
           )}
@@ -233,18 +233,18 @@ export function SearchSkillsPanel({ onSearch, results, isSearching, onResultClic
       {/* Search Form */}
       <form onSubmit={handleSearch} className="space-y-3">
         <div className="flex gap-2">
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-neutral3" />
+          <div className="relative flex-1">
+            <Search className="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-neutral3" />
             <input
               type="text"
               value={query}
               onChange={e => setQuery(e.target.value)}
               placeholder="Search across skills..."
-              className="w-full pl-10 pr-4 py-2 rounded-lg bg-surface3 border border-border1 text-sm text-neutral6 placeholder:text-neutral3 focus:outline-hidden focus:ring-2 focus:ring-accent1"
+              className="w-full rounded-lg border border-border1 bg-surface3 py-2 pr-4 pl-10 text-sm text-neutral6 placeholder:text-neutral3 focus:ring-2 focus:ring-accent1 focus:outline-hidden"
             />
           </div>
           <Button type="submit" disabled={!query.trim() || isSearching}>
-            {isSearching ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Search'}
+            {isSearching ? <Loader2 className="size-4 animate-spin" /> : 'Search'}
           </Button>
         </div>
 
@@ -254,7 +254,7 @@ export function SearchSkillsPanel({ onSearch, results, isSearching, onResultClic
             <select
               value={topK}
               onChange={e => setTopK(Number(e.target.value))}
-              className="px-2 py-1 rounded bg-surface3 border border-border1 text-neutral5"
+              className="rounded border border-border1 bg-surface3 px-2 py-1 text-neutral5"
             >
               <option value={3}>3</option>
               <option value={5}>5</option>
@@ -263,7 +263,7 @@ export function SearchSkillsPanel({ onSearch, results, isSearching, onResultClic
             </select>
           </label>
 
-          <label className="flex items-center gap-2 text-neutral4 cursor-pointer">
+          <label className="flex cursor-pointer items-center gap-2 text-neutral4">
             <input
               type="checkbox"
               checked={includeReferences}
@@ -302,28 +302,28 @@ function SkillSearchResultCard({ result, onClick }: { result: SkillSearchResult;
   return (
     <button
       onClick={onClick}
-      className="w-full p-4 rounded-lg bg-surface3 border border-border1 hover:border-accent1/50 text-left transition-colors"
+      className="w-full rounded-lg border border-border1 bg-surface3 p-4 text-left transition-colors hover:border-accent1/50"
     >
       <div className="flex items-start gap-3">
-        <div className="p-1.5 rounded bg-surface5 shrink-0 mt-0.5">
+        <div className="mt-0.5 shrink-0 rounded bg-surface5 p-1.5">
           {isReference ? (
-            <FileText className="h-3.5 w-3.5 text-neutral4" />
+            <FileText className="size-3.5 text-neutral4" />
           ) : (
-            <SkillIcon className="h-3.5 w-3.5 text-neutral4" />
+            <SkillIcon className="size-3.5 text-neutral4" />
           )}
         </div>
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-1">
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex items-center gap-2">
             <span className="font-medium text-neutral6">{result.skillName}</span>
             <span className="text-xs text-neutral3">{result.source}</span>
             <span className="ml-auto text-xs text-neutral3">Score: {result.score.toFixed(3)}</span>
           </div>
-          <p className="text-sm text-neutral4 line-clamp-3 whitespace-pre-wrap">
+          <p className="line-clamp-3 text-sm whitespace-pre-wrap text-neutral4">
             {result.content.slice(0, 300)}
             {result.content.length > 300 && '...'}
           </p>
           {result.lineRange && (
-            <p className="text-xs text-neutral3 mt-2">
+            <p className="mt-2 text-xs text-neutral3">
               Lines {result.lineRange.start}–{result.lineRange.end}
             </p>
           )}

--- a/packages/playground/src/domains/workspace/components/skill-actions.tsx
+++ b/packages/playground/src/domains/workspace/components/skill-actions.tsx
@@ -14,7 +14,7 @@ export interface SkillUpdateButtonProps {
 export function SkillUpdateButton({ skillName, onUpdate, isUpdating }: SkillUpdateButtonProps) {
   return (
     <Button variant="ghost" size="icon-md" disabled={isUpdating} tooltip={`Update ${skillName}`} onClick={onUpdate}>
-      {isUpdating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+      {isUpdating ? <Loader2 className="size-4 animate-spin" /> : <Download className="size-4" />}
     </Button>
   );
 }
@@ -33,7 +33,7 @@ export function SkillRemoveButton({ skillName, onRemove, isRemoving }: SkillRemo
     <AlertDialog>
       <AlertDialog.Trigger asChild>
         <Button variant="ghost" size="icon-md" disabled={isRemoving} tooltip={`Remove ${skillName}`}>
-          {isRemoving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Trash2 className="h-4 w-4" />}
+          {isRemoving ? <Loader2 className="size-4 animate-spin" /> : <Trash2 className="size-4" />}
         </Button>
       </AlertDialog.Trigger>
       <AlertDialog.Content>

--- a/packages/playground/src/domains/workspace/components/skill-detail.tsx
+++ b/packages/playground/src/domains/workspace/components/skill-detail.tsx
@@ -29,19 +29,19 @@ function getSourceInfo(source: SkillSource): { icon: React.ReactNode; label: str
   switch (source.type) {
     case 'external':
       return {
-        icon: <Package className="h-3.5 w-3.5" />,
+        icon: <Package className="size-3.5" />,
         label: 'External Package',
         path: source.packagePath,
       };
     case 'local':
       return {
-        icon: <Home className="h-3.5 w-3.5" />,
+        icon: <Home className="size-3.5" />,
         label: 'Local Project',
         path: source.projectPath,
       };
     case 'managed':
       return {
-        icon: <Server className="h-3.5 w-3.5" />,
+        icon: <Server className="size-3.5" />,
         label: 'Managed',
         path: source.mastraPath,
       };
@@ -66,28 +66,28 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
   };
 
   return (
-    <div className="space-y-6 min-w-0 overflow-hidden">
+    <div className="min-w-0 space-y-6 overflow-hidden">
       {/* Header */}
       <div className="flex items-start gap-4">
-        <div className="p-3 rounded-lg bg-surface5">
-          <SkillIcon className="h-6 w-6 text-neutral4" />
+        <div className="rounded-lg bg-surface5 p-3">
+          <SkillIcon className="size-6 text-neutral4" />
         </div>
         <div className="flex-1">
           <h1 className="text-xl font-semibold text-neutral6">{skill.name}</h1>
-          <p className="text-sm text-neutral4 mt-1">{skill.description}</p>
+          <p className="mt-1 text-sm text-neutral4">{skill.description}</p>
         </div>
       </div>
 
       {/* Metadata */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
         <MetadataCard label="Source" value={sourceInfo.label} icon={sourceInfo.icon} />
-        <MetadataCard label="Path" value={skill.path} icon={<FolderOpen className="h-3.5 w-3.5" />} />
+        <MetadataCard label="Path" value={skill.path} icon={<FolderOpen className="size-3.5" />} />
         {skill.license && <MetadataCard label="License" value={skill.license} />}
         {skill.compatibility != null && <MetadataCard label="Compatibility" value={skill.compatibility} />}
         <MetadataCard
           label="References"
           value={`${skill.references.length} files`}
-          icon={<FileText className="h-3.5 w-3.5" />}
+          icon={<FileText className="size-3.5" />}
         />
       </div>
 
@@ -102,16 +102,16 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
               e.stopPropagation();
               setShowRawInstructions(!showRawInstructions);
             }}
-            className="flex items-center gap-1.5 px-2 py-1 rounded text-xs text-neutral4 hover:text-neutral5 hover:bg-surface4 transition-colors"
+            className="flex items-center gap-1.5 rounded px-2 py-1 text-xs text-neutral4 transition-colors hover:bg-surface4 hover:text-neutral5"
             title={showRawInstructions ? 'Show rendered' : 'Show source'}
           >
-            {showRawInstructions ? <Eye className="h-3.5 w-3.5" /> : <FileCode2 className="h-3.5 w-3.5" />}
+            {showRawInstructions ? <Eye className="size-3.5" /> : <FileCode2 className="size-3.5" />}
             {showRawInstructions ? 'Rendered' : 'Source'}
           </button>
         }
       >
         {showRawInstructions ? (
-          <div style={{ backgroundColor: 'black' }} className="rounded-lg overflow-x-auto w-0 min-w-full">
+          <div style={{ backgroundColor: 'black' }} className="w-0 min-w-full overflow-x-auto rounded-lg">
             <SyntaxHighlighter
               language="markdown"
               style={coldarkDark}
@@ -142,9 +142,9 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
               <button
                 key={ref}
                 onClick={() => onReferenceClick?.(ref)}
-                className="flex items-center gap-2 w-full px-3 py-2 rounded hover:bg-surface4 text-left transition-colors"
+                className="flex w-full items-center gap-2 rounded px-3 py-2 text-left transition-colors hover:bg-surface4"
               >
-                <FileText className="h-4 w-4 text-neutral3" />
+                <FileText className="size-4 text-neutral3" />
                 <span className="text-sm text-neutral5">{ref}</span>
               </button>
             ))}
@@ -161,8 +161,8 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
         >
           <div className="space-y-1">
             {skill.scripts.map(script => (
-              <div key={script} className="flex items-center gap-2 px-3 py-2 rounded bg-surface3">
-                <Code className="h-4 w-4 text-neutral3" />
+              <div key={script} className="flex items-center gap-2 rounded bg-surface3 px-3 py-2">
+                <Code className="size-4 text-neutral3" />
                 <span className="text-sm text-neutral5">{script}</span>
               </div>
             ))}
@@ -179,8 +179,8 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
         >
           <div className="space-y-1">
             {skill.assets.map(asset => (
-              <div key={asset} className="flex items-center gap-2 px-3 py-2 rounded bg-surface3">
-                <Image className="h-4 w-4 text-neutral3" />
+              <div key={asset} className="flex items-center gap-2 rounded bg-surface3 px-3 py-2">
+                <Image className="size-4 text-neutral3" />
                 <span className="text-sm text-neutral5">{asset}</span>
               </div>
             ))}
@@ -189,9 +189,9 @@ export function SkillDetail({ skill, rawSkillMd, onReferenceClick }: SkillDetail
       )}
 
       {/* Path */}
-      <div className="pt-4 border-t border-border1">
+      <div className="border-t border-border1 pt-4">
         <p className="text-xs text-neutral3">
-          Path: <code className="px-1 py-0.5 rounded bg-surface4">{skill.path}</code>
+          Path: <code className="rounded bg-surface4 px-1 py-0.5">{skill.path}</code>
         </p>
       </div>
     </div>
@@ -231,11 +231,11 @@ function formatDisplayValue(value: unknown): string {
 function MetadataCard({ label, value, icon }: { label: string; value: unknown; icon?: React.ReactNode }) {
   const displayValue = formatDisplayValue(value);
   return (
-    <div className="p-3 rounded-lg bg-surface3">
-      <p className="text-xs text-neutral3 mb-1">{label}</p>
+    <div className="rounded-lg bg-surface3 p-3">
+      <p className="mb-1 text-xs text-neutral3">{label}</p>
       <div className="flex items-center gap-1.5">
         {icon && <span className="text-neutral4">{icon}</span>}
-        <p className="text-sm font-medium text-neutral5 truncate" title={displayValue}>
+        <p className="truncate text-sm font-medium text-neutral5" title={displayValue}>
           {displayValue}
         </p>
       </div>
@@ -257,19 +257,19 @@ function CollapsibleSection({
   children: React.ReactNode;
 }) {
   return (
-    <div className="border border-border1 rounded-lg overflow-hidden min-w-0">
-      <div className="flex items-center bg-surface3 hover:bg-surface4 transition-colors">
-        <button onClick={onToggle} className="flex items-center gap-2 flex-1 px-4 py-3">
+    <div className="min-w-0 overflow-hidden rounded-lg border border-border1">
+      <div className="flex items-center bg-surface3 transition-colors hover:bg-surface4">
+        <button onClick={onToggle} className="flex flex-1 items-center gap-2 px-4 py-3">
           {isExpanded ? (
-            <ChevronDown className="h-4 w-4 text-neutral3" />
+            <ChevronDown className="size-4 text-neutral3" />
           ) : (
-            <ChevronRight className="h-4 w-4 text-neutral3" />
+            <ChevronRight className="size-4 text-neutral3" />
           )}
           <span className="text-sm font-medium text-neutral5">{title}</span>
         </button>
         {headerAction && <div className="pr-3">{headerAction}</div>}
       </div>
-      {isExpanded && <div className="p-4 bg-surface2 overflow-x-auto w-0 min-w-full">{children}</div>}
+      {isExpanded && <div className="w-0 min-w-full overflow-x-auto bg-surface2 p-4">{children}</div>}
     </div>
   );
 }

--- a/packages/playground/src/domains/workspace/components/skills-table.tsx
+++ b/packages/playground/src/domains/workspace/components/skills-table.tsx
@@ -71,7 +71,7 @@ export function SkillsTable({
         <div className="flex items-center gap-4">
           <Button variant="default" size="sm" onClick={onAddSkill}>
             <Icon>
-              <Plus className="h-4 w-4" />
+              <Plus className="size-4" />
             </Icon>
             Add Skill
           </Button>
@@ -79,12 +79,12 @@ export function SkillsTable({
       )}
 
       {hasUndiscoveredAgentSkills && (
-        <div className="flex items-start gap-3 p-3 rounded-lg bg-amber-500/10 border border-amber-500/20">
-          <AlertTriangle className="h-5 w-5 text-amber-500 shrink-0 mt-0.5" />
+        <div className="flex items-start gap-3 rounded-lg border border-amber-500/20 bg-amber-500/10 p-3">
+          <AlertTriangle className="mt-0.5 size-5 shrink-0 text-amber-500" />
           <div className="text-sm">
             <p className="font-medium text-amber-500">Skills installed but not discovered</p>
-            <p className="text-neutral4 mt-1">
-              You have skills in <code className="px-1 py-0.5 rounded bg-surface4 text-xs">.agents/skills</code> that
+            <p className="mt-1 text-neutral4">
+              You have skills in <code className="rounded bg-surface4 px-1 py-0.5 text-xs">.agents/skills</code> that
               aren&apos;t being discovered. Add this path to your workspace skills configuration to see them.
             </p>
           </div>
@@ -136,7 +136,7 @@ export function SkillsTable({
                   {rowContent}
                 </DataList.RowButton>
                 <DataList.Cell className="py-0">
-                  <div className="flex items-center justify-end gap-1 pl-2 w-full pr-3">
+                  <div className="flex w-full items-center justify-end gap-1 pr-3 pl-2">
                     {isDownloaded(skill) && (
                       <>
                         {onUpdateSkill && (
@@ -173,12 +173,12 @@ interface SkillsNotConfiguredProps {
 function SkillsNotConfigured({ onAddSkill }: SkillsNotConfiguredProps) {
   return (
     <div className="grid place-items-center py-16">
-      <div className="flex flex-col items-center text-center max-w-md">
-        <div className="p-4 rounded-full bg-surface4 mb-4">
-          <SkillIcon className="h-8 w-8 text-neutral3" />
+      <div className="flex max-w-md flex-col items-center text-center">
+        <div className="mb-4 rounded-full bg-surface4 p-4">
+          <SkillIcon className="size-8 text-neutral3" />
         </div>
-        <h2 className="text-lg font-medium text-neutral6 mb-2">Skills Not Configured</h2>
-        <p className="text-sm text-neutral4 mb-6">
+        <h2 className="mb-2 text-lg font-medium text-neutral6">Skills Not Configured</h2>
+        <p className="mb-6 text-sm text-neutral4">
           No skills are configured in the workspace. Add SKILL.md files to your skills directory to discover and manage
           agent skills.
         </p>
@@ -186,14 +186,14 @@ function SkillsNotConfigured({ onAddSkill }: SkillsNotConfiguredProps) {
           {onAddSkill && (
             <Button size="lg" variant="default" onClick={onAddSkill}>
               <Icon>
-                <Plus className="h-4 w-4" />
+                <Plus className="size-4" />
               </Icon>
               Add Skill from skills.sh
             </Button>
           )}
           <Button size="lg" variant="default" as="a" href="https://mastra.ai/en/docs/workspace/skills" target="_blank">
             <Icon>
-              <BookOpen className="h-4 w-4" />
+              <BookOpen className="size-4" />
             </Icon>
             Learn about Skills
           </Button>

--- a/packages/playground/src/lib/ai-ui/attachments/attach-file-popover.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attach-file-popover.tsx
@@ -73,13 +73,13 @@ export const AttachFilePopover = () => {
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button variant="default" size="icon-md" type="button" tooltip="Add attachment">
-          <PlusIcon className="h-5 w-5 text-neutral3 hover:text-neutral6" />
+          <PlusIcon className="size-5 text-neutral3 hover:text-neutral6" />
         </Button>
       </PopoverTrigger>
       <PopoverContent align="start" className="w-80 p-4">
         <form onSubmit={handleSubmit} className="flex flex-row items-end gap-2">
           <div className="w-full space-y-1">
-            <Label htmlFor="url-attachment" className="text-neutral3 text-ui-md">
+            <Label htmlFor="url-attachment" className="text-ui-md text-neutral3">
               Public URL
             </Label>
             <Input
@@ -107,7 +107,7 @@ export const AttachFilePopover = () => {
           <button
             type="button"
             onClick={openFilePicker}
-            className="w-full h-28 border border-border1 rounded-lg text-neutral3 border-dashed flex flex-col items-center justify-center gap-2 hover:bg-surface2 active:bg-surface3"
+            className="flex h-28 w-full flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border1 text-neutral3 hover:bg-surface2 active:bg-surface3"
           >
             <CloudUpload className="size-8" />
             <Txt variant="ui-lg">Add a local file</Txt>

--- a/packages/playground/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attachment-preview-dialog.tsx
@@ -111,7 +111,7 @@ export const ImageEntry = ({ src }: ImageEntryProps) => {
   return (
     <>
       <button onClick={() => setOpen(true)} type="button" className={ctaClassName}>
-        <img src={src} className="object-cover aspect-ratio max-h-[140px] max-w-[320px]" alt="Preview" />
+        <img src={src} className="aspect-ratio max-h-35 max-w-80 object-cover" alt="Preview" />
       </button>
       <ImagePreviewDialog src={src} open={open} onOpenChange={setOpen} />
     </>
@@ -168,7 +168,7 @@ interface TxtPreviewDialogProps {
 export const TxtPreviewDialog = ({ data, open, onOpenChange }: TxtPreviewDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-4xl h-[80vh]">
+      <DialogContent className="h-[80vh] max-w-4xl">
         <DialogHeader>
           <DialogTitle>Text preview</DialogTitle>
           <DialogDescription>Preview of the text file</DialogDescription>

--- a/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
+++ b/packages/playground/src/lib/ai-ui/attachments/attachment.tsx
@@ -16,7 +16,7 @@ const ComposerTxtAttachment = ({ file }: { file: File }) => {
   const { isLoading, text } = useLoadBrowserFile(file);
 
   return (
-    <div className="flex items-center justify-center h-full w-full">
+    <div className="flex size-full items-center justify-center">
       {isLoading ? <Spinner /> : <TxtEntry data={text} />}
     </div>
   );
@@ -44,7 +44,7 @@ const ComposerPdfAttachment = ({ attachment }: { attachment: ComposerAttachment 
   }, [attachment]);
 
   return (
-    <div className="flex items-center justify-center h-full w-full">
+    <div className="flex size-full items-center justify-center">
       {state.isLoading ? (
         <Spinner />
       ) : (
@@ -78,7 +78,7 @@ const AttachmentThumbnail = ({ attachment }: { attachment: ComposerAttachment })
       <TooltipProvider>
         <Tooltip>
           <TooltipTrigger asChild>
-            <div className="overflow-hidden size-16 rounded-lg bg-surface3 border border-border1 ">
+            <div className="size-16 overflow-hidden rounded-lg border border-border1 bg-surface3 ">
               {attachment.kind === 'image' ? (
                 <ImageAttachmentThumbnail attachment={attachment} />
               ) : attachment.kind === 'pdf' ? (
@@ -104,7 +104,7 @@ const AttachmentThumbnail = ({ attachment }: { attachment: ComposerAttachment })
         type="button"
         tooltip="Remove file"
         onClick={() => remove(attachment.id)}
-        className="absolute -right-2 -top-2 text-neutral3 hover:text-neutral6 bg-surface1 hover:bg-surface2"
+        className="absolute -top-2 -right-2 bg-surface1 text-neutral3 hover:bg-surface2 hover:text-neutral6"
       >
         <Icon>
           <X />
@@ -120,8 +120,8 @@ export const ComposerAttachments = () => {
   if (attachments.length === 0) return null;
 
   return (
-    <div className="absolute bottom-full inset-x-0 px-2" data-attachments-row>
-      <div className="max-w-3xl w-full mx-auto overflow-x-auto">
+    <div className="absolute inset-x-0 bottom-full px-2" data-attachments-row>
+      <div className="mx-auto w-full max-w-3xl overflow-x-auto">
         <div className="flex flex-row items-center gap-4 px-3 pt-3 pb-1">
           {attachments.map(att => (
             <AttachmentThumbnail key={att.id} attachment={att} />

--- a/packages/playground/src/lib/ai-ui/components/bracket-overlay.tsx
+++ b/packages/playground/src/lib/ai-ui/components/bracket-overlay.tsx
@@ -214,7 +214,7 @@ function HighlightBlock({ highlight, visible }: { highlight: HighlightPosition; 
 
   return (
     <div
-      className="absolute left-0 right-0 transition-opacity duration-200"
+      className="absolute inset-x-0 transition-opacity duration-200"
       style={{
         top: highlight.top,
         height: highlight.height,

--- a/packages/playground/src/lib/ai-ui/messages/dataset-save-action.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/dataset-save-action.tsx
@@ -101,7 +101,7 @@ function DatasetSaveDialog({
           <DialogTitle>Save to Dataset</DialogTitle>
           <DialogDescription>Save as a dataset item for evaluation.</DialogDescription>
         </DialogHeader>
-        <DialogBody className="py-1 space-y-4">
+        <DialogBody className="space-y-4 py-1">
           <div className="grid gap-2">
             <Label htmlFor="ds-target">Dataset</Label>
             <Select
@@ -114,7 +114,7 @@ function DatasetSaveDialog({
               </SelectTrigger>
               <SelectContent>
                 {datasets.length === 0 ? (
-                  <div className="px-2 py-4 text-sm text-neutral4 text-center">No datasets available</div>
+                  <div className="px-2 py-4 text-center text-sm text-neutral4">No datasets available</div>
                 ) : (
                   datasets.map(dataset => (
                     <SelectItem key={dataset.id} value={dataset.id}>
@@ -128,12 +128,7 @@ function DatasetSaveDialog({
 
           <div className="grid gap-2">
             <Label>Input (JSON)</Label>
-            <CodeEditor
-              value={input}
-              onChange={onInputChange}
-              showCopyButton={false}
-              className="min-h-[120px] max-h-[240px]"
-            />
+            <CodeEditor value={input} onChange={onInputChange} showCopyButton={false} className="min-h-30 max-h-60" />
           </div>
 
           <div className="grid gap-2">
@@ -142,7 +137,7 @@ function DatasetSaveDialog({
               value={groundTruth}
               onChange={setGroundTruth}
               showCopyButton={false}
-              className="min-h-[80px] max-h-[160px]"
+              className="max-h-40 min-h-20"
             />
           </div>
         </DialogBody>
@@ -201,7 +196,7 @@ function DatasetSaveActionInner({ messageText }: DatasetSaveActionProps) {
         className="bg-transparent text-neutral3 hover:text-neutral6"
         onClick={handleClick}
       >
-        <DatabaseIcon className="h-4 w-4" />
+        <DatabaseIcon className="size-4" />
       </Button>
       <DatasetSaveDialog
         open={dialogOpen}
@@ -268,9 +263,9 @@ function SaveFullConversationInner() {
         type="button"
         onClick={handleClick}
         disabled={isFetching}
-        className="flex items-center gap-1.5 text-neutral3 hover:text-neutral5 transition-colors mx-auto py-3 text-ui-xs leading-ui-xs cursor-pointer disabled:opacity-50"
+        className="mx-auto flex cursor-pointer items-center gap-1.5 py-3 text-ui-xs leading-ui-xs text-neutral3 transition-colors hover:text-neutral5 disabled:opacity-50"
       >
-        {isFetching ? <Spinner className="h-3.5 w-3.5" /> : <DatabaseIcon className="h-3.5 w-3.5" />}
+        {isFetching ? <Spinner className="size-3.5" /> : <DatabaseIcon className="size-3.5" />}
         Save full conversation to dataset
       </button>
       <DatasetSaveDialog

--- a/packages/playground/src/lib/ai-ui/messages/message-row.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/message-row.tsx
@@ -159,9 +159,9 @@ const AssistantActionBar = ({
   onReadAloud?: (text: string) => void;
   onStopSpeaking?: () => void;
 }) => (
-  <div className="flex gap-1 items-center transition-all relative">
+  <div className="relative flex items-center gap-1 transition-all">
     {modelMetadata && (
-      <div className="flex items-center gap-1 pr-2 text-icon5 text-ui-xs leading-ui-xs">
+      <div className="text-icon5 flex items-center gap-1 pr-2 text-ui-xs leading-ui-xs">
         <ProviderLogo providerId={modelMetadata.modelProvider} size={14} />
         <span>
           {modelMetadata.modelProvider}/{modelMetadata.modelId}
@@ -232,7 +232,7 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
       return (
         <div
           ref={ref}
-          className={cn('w-full flex items-end pb-4 pt-2 flex-col', className)}
+          className={cn('flex w-full flex-col items-end pt-2 pb-4', className)}
           {...rootProps}
           data-message-id={message.id}
           data-message-pending={isPending ? 'true' : undefined}
@@ -240,8 +240,8 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
           <DatasetSaveAction messageText={getTextFromParts(message)} />
           <div
             className={cn(
-              'max-w-[max(366px,70%)] break-words px-4 py-2 text-neutral6 text-ui-lg leading-ui-lg rounded-xl bg-surface3',
-              isPending && 'opacity-60 animate-pulse',
+              'max-w-[max(366px,70%)] rounded-xl bg-surface3 px-4 py-2 text-ui-lg leading-ui-lg break-words text-neutral6',
+              isPending && 'animate-pulse opacity-60',
             )}
           >
             <MessageFactory message={dbMessage} {...userRenderers} status={messageStatusRenderers} />
@@ -254,11 +254,11 @@ export const MessageRow = forwardRef<HTMLDivElement, MessageRowProps>(
 
     return (
       <div ref={ref} className={cn('max-w-full', className)} {...rootProps} data-message-id={message.id}>
-        <div className="text-neutral6 text-ui-lg leading-ui-lg pt-2">
+        <div className="pt-2 text-ui-lg leading-ui-lg text-neutral6">
           <MessageFactory message={dbMessage} {...assistantRenderers} status={messageStatusRenderers} />
         </div>
         {showActionBar && (
-          <div className="h-6 pt-4 flex gap-2 items-center">
+          <div className="flex h-6 items-center gap-2 pt-4">
             <AssistantActionBar
               text={getTextFromParts(message)}
               modelMetadata={modelMetadata}

--- a/packages/playground/src/lib/ai-ui/messages/observation-marker.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/observation-marker.tsx
@@ -72,13 +72,13 @@ const ObservationStartMarker = ({ data }: { data: DataOmObservationStartPart['da
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-1.5 px-2 py-1 my-1 rounded-md',
-        'bg-accent1/10 border border-accent1/20 text-accent1',
+        'my-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1',
+        'border border-accent1/20 bg-accent1/10 text-accent1',
         'text-ui-xs leading-ui-xs',
       )}
       data-testid="om-observation-start"
     >
-      <Loader2 className="h-3 w-3 animate-spin" />
+      <Loader2 className="size-3 animate-spin" />
       <span>Observing {tokensK}k tokens...</span>
     </div>
   );
@@ -100,13 +100,13 @@ const ObservationEndMarker = ({ data }: { data: DataOmObservationEndPart['data']
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-1.5 px-2 py-1 my-1 rounded-md',
-        'bg-green-500/10 border border-green-500/20 text-green-600 dark:text-green-400',
+        'my-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1',
+        'border border-green-500/20 bg-green-500/10 text-green-600 dark:text-green-400',
         'text-ui-xs leading-ui-xs',
       )}
       data-testid="om-observation-end"
     >
-      <CheckCircle2 className="h-3 w-3" />
+      <CheckCircle2 className="size-3" />
       <span>
         Observed {tokensK}k tokens → {compressionRatio}% compression ({durationSec}s)
         {extractedCount > 0 ? ` · ${extractedCount} extracted` : ''}
@@ -125,14 +125,14 @@ const ObservationFailedMarker = ({ data }: { data: DataOmObservationFailedPart['
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-1.5 px-2 py-1 my-1 rounded-md',
-        'bg-red-500/10 border border-red-500/20 text-red-600 dark:text-red-400',
+        'my-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1',
+        'border border-red-500/20 bg-red-500/10 text-red-600 dark:text-red-400',
         'text-ui-xs leading-ui-xs',
       )}
       data-testid="om-observation-failed"
       title={data.error}
     >
-      <XCircle className="h-3 w-3" />
+      <XCircle className="size-3" />
       <span>Observation failed ({tokensK}k tokens)</span>
     </div>
   );
@@ -148,14 +148,14 @@ const BufferingStartMarker = ({ data }: { data: DataOmBufferingStartPart['data']
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-1.5 px-2 py-1 my-1 rounded-md',
-        'bg-purple-500/10 border border-dashed border-purple-500/40 text-purple-600 dark:text-purple-400',
+        'my-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1',
+        'border border-dashed border-purple-500/40 bg-purple-500/10 text-purple-600 dark:text-purple-400',
         'text-ui-xs leading-ui-xs',
       )}
       data-testid="om-buffering-start"
     >
-      <Loader2 className="h-3 w-3 animate-spin" />
-      <CloudCog className="h-3 w-3" />
+      <Loader2 className="size-3 animate-spin" />
+      <CloudCog className="size-3" />
       <span>
         {label} ~{tokensK}k tokens...
       </span>
@@ -177,13 +177,13 @@ const BufferingEndMarker = ({ data }: { data: DataOmBufferingEndPart['data'] }) 
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-1.5 px-2 py-1 my-1 rounded-md',
-        'bg-purple-500/10 border border-dashed border-purple-500/40 text-purple-600 dark:text-purple-400',
+        'my-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1',
+        'border border-dashed border-purple-500/40 bg-purple-500/10 text-purple-600 dark:text-purple-400',
         'text-ui-xs leading-ui-xs',
       )}
       data-testid="om-buffering-end"
     >
-      <CloudCog className="h-3 w-3" />
+      <CloudCog className="size-3" />
       <span>
         Buffered {tokensK}k tokens → {compressionRatio}% compression ({durationSec}s)
         {extractedCount > 0 ? ` · ${extractedCount} extracted` : ''}
@@ -200,14 +200,14 @@ const BufferingFailedMarker = ({ data }: { data: DataOmBufferingFailedPart['data
   return (
     <div
       className={cn(
-        'inline-flex items-center gap-1.5 px-2 py-1 my-1 rounded-md',
-        'bg-red-500/10 border border-dashed border-red-500/40 text-red-600 dark:text-red-400',
+        'my-1 inline-flex items-center gap-1.5 rounded-md px-2 py-1',
+        'border border-dashed border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400',
         'text-ui-xs leading-ui-xs',
       )}
       data-testid="om-buffering-failed"
       title={data.error}
     >
-      <XCircle className="h-3 w-3" />
+      <XCircle className="size-3" />
       <span>Buffering failed</span>
     </div>
   );
@@ -221,8 +221,8 @@ export const ObservationIndicator = ({ part }: { part: OmObservationMarkerPart }
   if (part.type === 'data-om-observation-start') {
     return (
       <span className="inline-flex items-center gap-1 text-accent1" title="Observing...">
-        <Brain className="h-3 w-3" />
-        <Loader2 className="h-2.5 w-2.5 animate-spin" />
+        <Brain className="size-3" />
+        <Loader2 className="size-2.5 animate-spin" />
       </span>
     );
   }
@@ -230,7 +230,7 @@ export const ObservationIndicator = ({ part }: { part: OmObservationMarkerPart }
   if (part.type === 'data-om-observation-end') {
     return (
       <span className="inline-flex items-center text-green-500" title="Observation complete">
-        <Brain className="h-3 w-3" />
+        <Brain className="size-3" />
       </span>
     );
   }
@@ -238,7 +238,7 @@ export const ObservationIndicator = ({ part }: { part: OmObservationMarkerPart }
   if (part.type === 'data-om-observation-failed') {
     return (
       <span className="inline-flex items-center text-red-500" title={`Observation failed: ${part.data.error}`}>
-        <Brain className="h-3 w-3" />
+        <Brain className="size-3" />
       </span>
     );
   }

--- a/packages/playground/src/lib/ai-ui/messages/reasoning-streaming-line.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/reasoning-streaming-line.tsx
@@ -14,10 +14,10 @@ export interface ReasoningStreamingLineProps {
 export const ReasoningStreamingLine = ({ text }: ReasoningStreamingLineProps) => (
   <Txt
     variant="ui-md"
-    className="whitespace-pre-wrap leading-relaxed text-neutral4 max-w-[80%] flex items-center gap-2"
+    className="flex max-w-[80%] items-center gap-2 leading-relaxed whitespace-pre-wrap text-neutral4"
     as="div"
   >
-    <Loader2 className="animate-spin size-4 text-neutral3" />
+    <Loader2 className="size-4 animate-spin text-neutral3" />
     <Shimmer>{text}</Shimmer>
   </Txt>
 );

--- a/packages/playground/src/lib/ai-ui/messages/reasoning.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/reasoning.tsx
@@ -28,8 +28,8 @@ export const Reasoning = ({ text, redacted }: ReasoningProps) => {
       </button>
 
       {!isCollapsed ? (
-        <div className="rounded-lg bg-surface4 p-2 border border-border-1">
-          <pre className="whitespace-pre-wrap text-ui-sm leading-ui-sm text-neutral6">{body}</pre>
+        <div className="border-border-1 rounded-lg border bg-surface4 p-2">
+          <pre className="text-ui-sm leading-ui-sm whitespace-pre-wrap text-neutral6">{body}</pre>
         </div>
       ) : null}
     </div>

--- a/packages/playground/src/lib/ai-ui/messages/renderers/in-message-attachment.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/renderers/in-message-attachment.tsx
@@ -14,7 +14,7 @@ export interface InMessageAttachmentProps {
  * placeholder chip for media the browser cannot preview (video, gs://, s3://).
  */
 export const InMessageAttachment = ({ type, contentType, src, data, name }: InMessageAttachmentProps) => (
-  <div className="h-full w-full overflow-hidden rounded-lg">
+  <div className="size-full overflow-hidden rounded-lg">
     {type === 'image' ? (
       <ImageEntry src={src ?? ''} />
     ) : type === 'file' ? (

--- a/packages/playground/src/lib/ai-ui/messages/signal-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/signal-badge.tsx
@@ -105,13 +105,13 @@ export const SignalBadge = ({ signal: value }: SignalBadgeProps) => {
     return (
       <div className="my-2 max-w-[80%] rounded-lg border border-border1 bg-surface2 px-4 py-3 text-neutral5">
         <div className="flex items-start gap-3">
-          <Database className="mt-0.5 h-4 w-4 shrink-0 text-icon3" />
+          <Database className="text-icon3 mt-0.5 size-4 shrink-0" />
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-ui-sm leading-ui-sm font-medium text-neutral6">{state.id}</p>
               {state.mode ? <Pill>{state.mode}</Pill> : null}
             </div>
-            {text ? <p className="mt-2 whitespace-pre-wrap break-words text-ui-sm leading-ui-md">{text}</p> : null}
+            {text ? <p className="mt-2 text-ui-sm leading-ui-md break-words whitespace-pre-wrap">{text}</p> : null}
           </div>
         </div>
       </div>
@@ -128,7 +128,7 @@ export const SignalBadge = ({ signal: value }: SignalBadgeProps) => {
     return (
       <div className={`my-2 max-w-[80%] rounded-lg border px-4 py-3 ${toneClass}`}>
         <div className="flex items-start gap-3">
-          <Bell className="mt-0.5 h-4 w-4 shrink-0" />
+          <Bell className="mt-0.5 size-4 shrink-0" />
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-ui-sm leading-ui-sm font-medium text-neutral6">{getNotificationTitle(value)}</p>
@@ -136,7 +136,7 @@ export const SignalBadge = ({ signal: value }: SignalBadgeProps) => {
               {status ? <Pill>{status}</Pill> : null}
               {pending ? <Pill>{`${pending} pending`}</Pill> : null}
             </div>
-            {text ? <p className="mt-2 whitespace-pre-wrap break-words text-ui-sm leading-ui-md">{text}</p> : null}
+            {text ? <p className="mt-2 text-ui-sm leading-ui-md break-words whitespace-pre-wrap">{text}</p> : null}
           </div>
         </div>
       </div>
@@ -147,10 +147,10 @@ export const SignalBadge = ({ signal: value }: SignalBadgeProps) => {
     return (
       <div className="my-2 max-w-[80%] rounded-lg border border-border1 bg-surface2 px-4 py-3 text-neutral5">
         <div className="flex items-start gap-3">
-          <Radio className="mt-0.5 h-4 w-4 shrink-0 text-icon3" />
+          <Radio className="text-icon3 mt-0.5 size-4 shrink-0" />
           <div className="min-w-0 flex-1">
             <p className="text-ui-sm leading-ui-sm font-medium text-neutral6">{value.tagName ?? 'Signal'}</p>
-            {text ? <p className="mt-2 whitespace-pre-wrap break-words text-ui-sm leading-ui-md">{text}</p> : null}
+            {text ? <p className="mt-2 text-ui-sm leading-ui-md break-words whitespace-pre-wrap">{text}</p> : null}
           </div>
         </div>
       </div>

--- a/packages/playground/src/lib/ai-ui/messages/system-reminder-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/system-reminder-badge.tsx
@@ -17,27 +17,27 @@ export const SystemReminderBadge = ({ text }: SystemReminderBadgeProps) => {
   const title = reminder.path || reminder.type || 'System reminder';
 
   return (
-    <div className="rounded-lg border border-border1 bg-surface2 overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-border1 bg-surface2">
       <button
         type="button"
         onClick={() => setIsExpanded(value => !value)}
-        className="w-full flex items-start gap-3 px-4 py-3 text-left hover:bg-surface3 transition-colors"
+        className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface3"
       >
-        <FileText className="w-4 h-4 text-icon3 mt-0.5 shrink-0" />
+        <FileText className="text-icon3 mt-0.5 size-4 shrink-0" />
         <div className="min-w-0 flex-1">
           <p className="text-ui-sm leading-ui-sm font-medium text-neutral6">System reminder</p>
-          <p className="text-ui-xs leading-ui-xs text-neutral4 break-all mt-1">{title}</p>
+          <p className="mt-1 text-ui-xs leading-ui-xs break-all text-neutral4">{title}</p>
         </div>
         {isExpanded ? (
-          <ChevronDown className="w-4 h-4 text-icon3 shrink-0" />
+          <ChevronDown className="text-icon3 size-4 shrink-0" />
         ) : (
-          <ChevronRight className="w-4 h-4 text-icon3 shrink-0" />
+          <ChevronRight className="text-icon3 size-4 shrink-0" />
         )}
       </button>
 
       {isExpanded && reminder.body && (
-        <div className="border-t border-border1 px-4 py-3 bg-surface1">
-          <pre className="whitespace-pre-wrap break-words text-ui-xs leading-ui-md text-neutral5 font-mono">
+        <div className="border-t border-border1 bg-surface1 px-4 py-3">
+          <pre className="font-mono text-ui-xs leading-ui-md break-words whitespace-pre-wrap text-neutral5">
             {reminder.body}
           </pre>
         </div>

--- a/packages/playground/src/lib/ai-ui/messages/tripwire-notice.tsx
+++ b/packages/playground/src/lib/ai-ui/messages/tripwire-notice.tsx
@@ -13,12 +13,12 @@ export const TripwireNotice = ({ reason, tripwire }: TripwireNoticeProps) => {
   const hasMetadata = tripwire && (tripwire.retry !== undefined || tripwire.metadata || tripwire.processorId);
 
   return (
-    <div className="rounded-lg border border-amber-500/30 bg-amber-950/20 overflow-hidden">
+    <div className="overflow-hidden rounded-lg border border-amber-500/30 bg-amber-950/20">
       {/* Header */}
       <div className="flex items-start gap-3 p-4">
-        <ShieldAlert className="w-5 h-5 text-amber-400 mt-0.5 shrink-0" />
-        <div className="flex-1 min-w-0">
-          <p className="text-sm font-medium text-amber-200 mb-1">Content Blocked</p>
+        <ShieldAlert className="mt-0.5 size-5 shrink-0 text-amber-400" />
+        <div className="min-w-0 flex-1">
+          <p className="mb-1 text-sm font-medium text-amber-200">Content Blocked</p>
           <p className="text-sm text-amber-300/90">{reason}</p>
         </div>
       </div>
@@ -28,18 +28,18 @@ export const TripwireNotice = ({ reason, tripwire }: TripwireNoticeProps) => {
         <>
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="w-full flex items-center gap-2 px-4 py-2 text-xs text-amber-400/70 hover:text-amber-400 hover:bg-amber-900/20 transition-colors border-t border-amber-500/20"
+            className="flex w-full items-center gap-2 border-t border-amber-500/20 px-4 py-2 text-xs text-amber-400/70 transition-colors hover:bg-amber-900/20 hover:text-amber-400"
           >
-            {isExpanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            {isExpanded ? <ChevronDown className="size-3.5" /> : <ChevronRight className="size-3.5" />}
             <span>Details</span>
           </button>
 
           {isExpanded && (
-            <div className="px-4 pb-4 space-y-3 border-t border-amber-500/20 bg-amber-950/10">
+            <div className="space-y-3 border-t border-amber-500/20 bg-amber-950/10 px-4 pb-4">
               {/* Retry indicator */}
               {tripwire.retry !== undefined && (
                 <div className="flex items-center gap-2 pt-3">
-                  <RefreshCw className="w-3.5 h-3.5 text-amber-400/60" />
+                  <RefreshCw className="size-3.5 text-amber-400/60" />
                   <span className="text-xs text-amber-300/70">
                     Retry:{' '}
                     {tripwire.retry ? (
@@ -54,10 +54,10 @@ export const TripwireNotice = ({ reason, tripwire }: TripwireNoticeProps) => {
               {/* Processor ID */}
               {tripwire.processorId && (
                 <div className="flex items-center gap-2">
-                  <Tag className="w-3.5 h-3.5 text-amber-400/60" />
+                  <Tag className="size-3.5 text-amber-400/60" />
                   <span className="text-xs text-amber-300/70">
                     Processor:{' '}
-                    <code className="px-1.5 py-0.5 rounded bg-amber-900/30 text-amber-200 font-mono">
+                    <code className="rounded bg-amber-900/30 px-1.5 py-0.5 font-mono text-amber-200">
                       {tripwire.processorId}
                     </code>
                   </span>
@@ -67,8 +67,8 @@ export const TripwireNotice = ({ reason, tripwire }: TripwireNoticeProps) => {
               {/* Custom metadata */}
               {tripwire.metadata !== undefined && tripwire.metadata !== null && (
                 <div className="pt-1">
-                  <p className="text-xs text-amber-400/60 mb-1.5">Metadata:</p>
-                  <pre className="text-xs text-amber-200/80 bg-amber-900/30 rounded p-2 overflow-x-auto font-mono">
+                  <p className="mb-1.5 text-xs text-amber-400/60">Metadata:</p>
+                  <pre className="overflow-x-auto rounded bg-amber-900/30 p-2 font-mono text-xs text-amber-200/80">
                     {String(JSON.stringify(tripwire.metadata, null, 2))}
                   </pre>
                 </div>

--- a/packages/playground/src/lib/ai-ui/task-panel.tsx
+++ b/packages/playground/src/lib/ai-ui/task-panel.tsx
@@ -6,9 +6,9 @@ import type { ReactNode } from 'react';
 import { useChatTasks } from './chat/chat-context';
 
 const statusIcon: Record<TaskItem['status'], ReactNode> = {
-  completed: <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-500" />,
-  in_progress: <Loader2 className="h-3.5 w-3.5 shrink-0 text-yellow-500 animate-spin" />,
-  pending: <Circle className="h-3.5 w-3.5 shrink-0 text-neutral4" />,
+  completed: <CheckCircle2 className="size-3.5 shrink-0 text-green-500" />,
+  in_progress: <Loader2 className="size-3.5 shrink-0 animate-spin text-yellow-500" />,
+  pending: <Circle className="size-3.5 shrink-0 text-neutral4" />,
 };
 
 const statusTextClass: Record<TaskItem['status'], string> = {
@@ -39,21 +39,21 @@ export const TaskPanel = () => {
 
   return (
     <div className="px-2 pb-1" data-testid="task-panel">
-      <div className="max-w-3xl w-full mx-auto">
+      <div className="mx-auto w-full max-w-3xl">
         <div className="rounded-2xl border border-border2/40 bg-surface3 px-3 py-2.5">
           {/* Header */}
-          <div className="flex items-center gap-2 mb-2">
-            <ListChecks className="h-4 w-4 shrink-0 text-accent6" />
+          <div className="mb-2 flex items-center gap-2">
+            <ListChecks className="size-4 shrink-0 text-accent6" />
             <span className="text-ui-sm leading-ui-sm font-medium text-neutral6">Tasks</span>
-            <span className="text-ui-xs leading-ui-xs text-neutral4 ml-auto tabular-nums">
+            <span className="ml-auto text-ui-xs leading-ui-xs text-neutral4 tabular-nums">
               {completed}/{total} completed
             </span>
           </div>
 
           {/* Progress bar */}
-          <div className="h-1 w-full rounded-full bg-surface4 mb-2.5">
+          <div className="mb-2.5 h-1 w-full rounded-full bg-surface4">
             <div
-              className="h-full rounded-full transition-all duration-300 bg-accent6"
+              className="h-full rounded-full bg-accent6 transition-all duration-300"
               style={{ width: `${total > 0 ? (completed / total) * 100 : 0}%` }}
             />
           </div>

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -142,11 +142,11 @@ export const Thread = ({
   return (
     <ComposerAttachmentsProvider>
       <MessageScrollerProvider>
-        <div className="group/thread grid grid-rows-[1fr_auto] h-full overflow-y-auto" data-testid="thread-wrapper">
+        <div className="group/thread grid h-full grid-rows-[1fr_auto] overflow-y-auto" data-testid="thread-wrapper">
           <MessageScroller>
             <MessageScrollerViewport
               ref={areaRef}
-              className="overflow-y-scroll h-full"
+              className="h-full overflow-y-scroll"
               style={{ overflowAnchor: 'none' }}
             >
               {isEmpty ? (
@@ -157,7 +157,7 @@ export const Thread = ({
                   <div
                     ref={messagesContainerRef}
                     data-testid="thread-message-column"
-                    className="relative max-w-3xl w-full mx-auto px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
+                    className="relative mx-auto w-full max-w-3xl px-4 pb-7 group-has-[[data-attachments-row]]/thread:pb-24"
                   >
                     <BracketOverlay containerRef={messagesContainerRef} />
                     <MessageScrollerContent className="flex flex-col gap-6 py-6">
@@ -197,7 +197,7 @@ export const Thread = ({
           </MessageScroller>
 
           {showThumbnailInChat && agentId && threadId && (
-            <div className="mb-2 max-w-3xl w-full mx-auto px-4">
+            <div className="mx-auto mb-2 w-full max-w-3xl px-4">
               <BrowserThumbnail agentName={agentName} />
             </div>
           )}
@@ -283,14 +283,14 @@ const Composer = ({
           void submit();
         }}
       >
-        <div className="max-w-3xl w-full mx-auto pb-2">
+        <div className="mx-auto w-full max-w-3xl pb-2">
           <ComposerAttachments />
         </div>
 
         <VoiceCallPanel voiceCall={voiceCall} />
 
         <div
-          className="relative overflow-hidden bg-surface3 rounded-[22px] border border-border2/40 mt-auto max-w-3xl w-full mx-auto transition-colors duration-normal focus-within:border-border2 @container"
+          className="duration-normal @container relative mx-auto mt-auto w-full max-w-3xl overflow-hidden rounded-[22px] border border-border2/40 bg-surface3 transition-colors focus-within:border-border2"
           onClick={e => {
             if (e.target === e.currentTarget) textareaRef.current?.focus();
           }}
@@ -304,7 +304,7 @@ const Composer = ({
                 ref={textareaRef}
                 value={text}
                 autoFocus={false}
-                className="field-sizing-content min-h-17 w-full text-ui-lg leading-ui-lg placeholder:text-neutral3 text-neutral6 bg-transparent focus:outline-hidden resize-none outline-hidden disabled:cursor-not-allowed disabled:opacity-50 px-3 pt-3 pb-2"
+                className="min-h-17 field-sizing-content w-full resize-none bg-transparent px-3 pt-3 pb-2 text-ui-lg leading-ui-lg text-neutral6 outline-hidden placeholder:text-neutral3 focus:outline-hidden disabled:cursor-not-allowed disabled:opacity-50"
                 placeholder={canExecuteAgent ? 'Enter your message...' : "You don't have permission to execute agents"}
                 onChange={e => {
                   setThreadInput(e.target.value);
@@ -347,7 +347,7 @@ const Composer = ({
 };
 
 const ComposerGradientColumn = ({ className }: { className?: string }) => (
-  <div className={cn('flex h-full w-full flex-col -space-y-3', className)}>
+  <div className={cn('flex size-full flex-col -space-y-3', className)}>
     <div className="w-full flex-1 bg-accent1 blur-xl" />
     <div className="w-full flex-1 bg-accent1Dark blur-xl" />
     <div className="w-full flex-1 bg-accent1 blur-xl" />
@@ -361,7 +361,7 @@ const ComposerSendingGradient = ({ pulseKey }: { pulseKey: number }) => {
     <div
       key={pulseKey}
       aria-hidden
-      className="composer-sending pointer-events-none absolute -left-[10%] top-0 z-0 flex h-10 w-[120%] transform-gpu"
+      className="composer-sending pointer-events-none absolute top-0 left-[-10%] z-0 flex h-10 w-[120%] transform-gpu"
     >
       <ComposerGradientColumn />
       <ComposerGradientColumn className="-translate-y-2" />
@@ -387,7 +387,7 @@ const SpeechInput = ({ agentId, onTranscript }: { agentId?: string; onTranscript
       tooltip={isListening ? 'Stop dictation' : 'Start dictation'}
       onClick={() => (isListening ? stop() : start())}
     >
-      {isListening ? <CircleStopIcon /> : <Mic className="h-5 w-5 text-neutral3 hover:text-neutral6" />}
+      {isListening ? <CircleStopIcon /> : <Mic className="size-5 text-neutral3 hover:text-neutral6" />}
     </Button>
   );
 };
@@ -418,12 +418,12 @@ const ComposerActionRow = ({
   voiceCall,
 }: ComposerActionRowProps) => {
   return (
-    <div className="flex flex-wrap-reverse justify-between items-center gap-2 px-1.5 pb-1.5">
+    <div className="flex flex-wrap-reverse items-center justify-between gap-2 px-1.5 pb-1.5">
       {((showModelSwitcher && agentId) || runOptionsSlot) && (
-        <div className="flex items-center gap-1.5 shrink-0 max-w-full">
+        <div className="flex max-w-full shrink-0 items-center gap-1.5">
           {showModelSwitcher && agentId && (
             <>
-              <div className="rounded-full bg-surface3 border border-border1 transition-colors duration-normal focus-within:border-border2">
+              <div className="duration-normal rounded-full border border-border1 bg-surface3 transition-colors focus-within:border-border2">
                 <ComposerModelSwitcher agentId={agentId} />
               </div>
               <ComposerModelSettings agentId={agentId} />
@@ -485,7 +485,7 @@ const ComposerSendButton = ({
         className="rounded-full border border-border1 bg-surface5"
         disabled={!canExecute || isEmpty}
       >
-        <ArrowUp className="h-6 w-6 text-neutral3 hover:text-neutral6" />
+        <ArrowUp className="size-6 text-neutral3 hover:text-neutral6" />
       </Button>
       {isRunning && (
         <Button variant="default" size="icon-md" type="button" tooltip="Cancel" onClick={onCancel}>

--- a/packages/playground/src/lib/ai-ui/tools/badges/agent-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/agent-badge.tsx
@@ -87,7 +87,7 @@ export const AgentBadge = ({
 
   let suspendPayloadSlot =
     typeof suspendPayload === 'string' ? (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{suspendPayload}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{suspendPayload}</pre>
     ) : (
       <CodeEditor data={suspendPayload} data-testid="tool-suspend-payload" />
     );
@@ -142,7 +142,7 @@ export const AgentBadge = ({
 
       {suspendPayloadSlot !== undefined && suspendPayload && (
         <div>
-          <p className="font-medium pb-2">Agent suspend payload</p>
+          <p className="pb-2 font-medium">Agent suspend payload</p>
           {suspendPayloadSlot}
         </div>
       )}

--- a/packages/playground/src/lib/ai-ui/tools/badges/ask-user-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/ask-user-badge.tsx
@@ -91,7 +91,7 @@ export const AskUserBadge = ({ toolCallId, suspendPayload, result }: AskUserBadg
         </div>
 
         <div className="flex flex-col gap-4 p-4">
-          <Txt as="p" variant="ui-xs" className="uppercase tracking-wide text-neutral3">
+          <Txt as="p" variant="ui-xs" className="tracking-wide text-neutral3 uppercase">
             Question
           </Txt>
           <Txt as="p" variant="ui-lg" className="text-neutral6">

--- a/packages/playground/src/lib/ai-ui/tools/badges/background-task-metadata-dialog.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/background-task-metadata-dialog.tsx
@@ -63,20 +63,20 @@ const BackgroundTaskMetadata = ({
     argSlot = <CodeEditor data={formattedArgs} />;
   } catch {
     argSlot = (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{args as unknown as string}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{args as unknown as string}</pre>
     );
   }
 
   const resultSlot =
     typeof result === 'string' ? (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{result}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{result}</pre>
     ) : (
       <CodeEditor data={result} />
     );
 
   const suspendPayloadSlot =
     typeof suspendPayload === 'string' ? (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{suspendPayload}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{suspendPayload}</pre>
     ) : (
       <CodeEditor data={suspendPayload as Record<string, unknown> | Record<string, unknown>[] | undefined} />
     );
@@ -92,7 +92,7 @@ const BackgroundTaskMetadata = ({
         <DialogBody className="space-y-4">
           <div className="space-y-2">
             <Txt className="text-neutral3">Background Task Duration</Txt>
-            <Txt className="text-neutral6 text-ui-md">{toSigFigs(timeDiff, 3)}ms</Txt>
+            <Txt className="text-ui-md text-neutral6">{toSigFigs(timeDiff, 3)}ms</Txt>
           </div>
 
           <div className="space-y-2">
@@ -139,9 +139,9 @@ export const BackgroundTaskMetadataDialogTrigger = ({ backgroundTask }: Backgrou
         onClick={() => setIsOpen(s => !s)}
       >
         {backgroundTask.completedAt || backgroundTask.suspendedAt ? (
-          <Share2 className="text-neutral3 size-5" />
+          <Share2 className="size-5 text-neutral3" />
         ) : (
-          <Loader2Icon className="text-neutral3 size-5 animate-spin" />
+          <Loader2Icon className="size-5 animate-spin text-neutral3" />
         )}
       </Button>
 

--- a/packages/playground/src/lib/ai-ui/tools/badges/badge-wrapper.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/badge-wrapper.tsx
@@ -31,7 +31,7 @@ export const BadgeWrapper = ({
 
   return (
     <div className="mb-4" data-testid={dataTestId}>
-      <div className="flex flex-row gap-2 items-center justify-between">
+      <div className="flex flex-row items-center justify-between gap-2">
         <button
           onClick={collapsible ? () => setIsCollapsed(s => !s) : undefined}
           className="flex items-center gap-2 disabled:cursor-not-allowed"
@@ -48,7 +48,7 @@ export const BadgeWrapper = ({
 
       {!isCollapsed && (
         <div className="pt-2">
-          <div className="p-4 rounded-lg bg-surface2 flex flex-col gap-4">{children}</div>
+          <div className="flex flex-col gap-4 rounded-lg bg-surface2 p-4">{children}</div>
         </div>
       )}
     </div>

--- a/packages/playground/src/lib/ai-ui/tools/badges/code-mode-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/code-mode-badge.tsx
@@ -104,7 +104,7 @@ export const CodeModeBadge = ({
     >
       <div className="space-y-4">
         <div>
-          <p className="font-medium pb-2">Program</p>
+          <p className="pb-2 font-medium">Program</p>
           <div data-testid="code-mode-program">
             <CodeBlock code={formattedCode} lang="typescript" />
           </div>
@@ -112,10 +112,10 @@ export const CodeModeBadge = ({
 
         {error && (
           <div>
-            <p className="font-medium pb-2">Error</p>
+            <p className="pb-2 font-medium">Error</p>
             <pre
               data-testid="code-mode-error"
-              className="whitespace-pre-wrap break-words bg-surface4 p-4 rounded-md text-error font-mono text-sm"
+              className="rounded-md bg-surface4 p-4 font-mono text-sm break-words whitespace-pre-wrap text-error"
             >
               {error.name ? `${error.name}: ` : ''}
               {error.message}
@@ -126,9 +126,9 @@ export const CodeModeBadge = ({
 
         {hasResultValue && (
           <div>
-            <p className="font-medium pb-2">Result</p>
+            <p className="pb-2 font-medium">Result</p>
             {typeof result!.result === 'string' ? (
-              <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto" data-testid="code-mode-result">
+              <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre" data-testid="code-mode-result">
                 {result!.result as string}
               </pre>
             ) : (
@@ -139,10 +139,10 @@ export const CodeModeBadge = ({
 
         {logs.length > 0 && (
           <div>
-            <p className="font-medium pb-2">Logs</p>
+            <p className="pb-2 font-medium">Logs</p>
             <pre
               data-testid="code-mode-logs"
-              className="whitespace-pre-wrap break-words bg-black p-3 rounded-md text-neutral-300 font-mono text-sm overflow-x-auto"
+              className="overflow-x-auto rounded-md bg-black p-3 font-mono text-sm break-words whitespace-pre-wrap text-neutral-300"
             >
               {logs.join('\n')}
             </pre>

--- a/packages/playground/src/lib/ai-ui/tools/badges/file-tree-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/file-tree-badge.tsx
@@ -131,15 +131,15 @@ export const FileTreeBadge = ({
   return (
     <div className="mb-4" data-testid="file-tree-badge">
       {/* Header row */}
-      <div className="flex items-center gap-2 flex-wrap">
-        <button onClick={() => setIsCollapsed(s => !s)} className="flex items-center gap-2 min-w-0" type="button">
+      <div className="flex flex-wrap items-center gap-2">
+        <button onClick={() => setIsCollapsed(s => !s)} className="flex min-w-0 items-center gap-2" type="button">
           <Icon>
             <ChevronUpIcon className={cn('transition-all', isCollapsed ? 'rotate-90' : 'rotate-180')} />
           </Icon>
           <Badge icon={<FolderTree className="text-accent6" size={16} />}>
-            List Files <span className="text-neutral6 font-normal ml-1">{path}</span>
+            List Files <span className="ml-1 font-normal text-neutral6">{path}</span>
             {argsDisplay.length > 0 && (
-              <span className="text-neutral4 font-normal ml-1">({argsDisplay.join(', ')})</span>
+              <span className="ml-1 font-normal text-neutral4">({argsDisplay.join(', ')})</span>
             )}
           </Badge>
         </button>
@@ -148,7 +148,7 @@ export const FileTreeBadge = ({
         {wsMeta?.filesystem && (
           <Link
             href={wsMeta.id ? `/workspaces/${wsMeta.id}?path=${encodeURIComponent(path)}` : '/workspaces'}
-            className="flex items-center gap-1.5 text-xs text-neutral6 px-1.5 py-0.5 rounded bg-surface3 border border-border1 hover:bg-surface4 hover:border-border2 transition-colors"
+            className="flex items-center gap-1.5 rounded border border-border1 bg-surface3 px-1.5 py-0.5 text-xs text-neutral6 transition-colors hover:border-border2 hover:bg-surface4"
           >
             <HardDrive className="size-3" />
             <span>{wsMeta.name || wsMeta.filesystem.name}</span>
@@ -156,7 +156,7 @@ export const FileTreeBadge = ({
         )}
 
         {/* Summary - show in header when collapsed */}
-        {isCollapsed && hasResult && summary && <span className="text-neutral6 text-xs">{summary}</span>}
+        {isCollapsed && hasResult && summary && <span className="text-xs text-neutral6">{summary}</span>}
       </div>
 
       {/* Content area */}
@@ -164,9 +164,9 @@ export const FileTreeBadge = ({
         <div className="pt-2">
           {/* Approval UI - styled like ToolBadge/BadgeWrapper when awaiting approval */}
           {toolApprovalMetadata && !toolCalled && (
-            <div className="p-4 rounded-lg bg-surface2 flex flex-col gap-4">
+            <div className="flex flex-col gap-4 rounded-lg bg-surface2 p-4">
               <div>
-                <p className="font-medium pb-2">Tool arguments</p>
+                <p className="pb-2 font-medium">Tool arguments</p>
                 <CodeEditor data={parsedArgs as Record<string, unknown>} data-testid="tool-args" />
               </div>
               <ToolApprovalButtons
@@ -181,10 +181,10 @@ export const FileTreeBadge = ({
 
           {/* Tree output panel - custom UI after tool has been called */}
           {toolCalled && treeOutput && (
-            <div className="rounded-md border border-border1 bg-surface2 overflow-hidden">
+            <div className="overflow-hidden rounded-md border border-border1 bg-surface2">
               {/* Panel header with summary and copy button */}
-              <div className="flex items-center justify-between px-3 py-1.5 border-b border-border1 bg-surface3">
-                {summary && <span className="text-neutral6 text-xs">{summary}</span>}
+              <div className="flex items-center justify-between border-b border-border1 bg-surface3 px-3 py-1.5">
+                {summary && <span className="text-xs text-neutral6">{summary}</span>}
                 <Button variant="default" size="icon-sm" tooltip="Copy tree" onClick={onCopy} disabled={!treeOutput}>
                   <span className="grid">
                     <span
@@ -204,7 +204,7 @@ export const FileTreeBadge = ({
               </div>
 
               {/* Tree content */}
-              <pre className="p-3 text-xs font-mono text-mastra-el-6 overflow-x-auto whitespace-pre max-h-dropdown-max-height overflow-y-auto">
+              <pre className="text-mastra-el-6 max-h-dropdown-max-height overflow-auto p-3 font-mono text-xs whitespace-pre">
                 {treeOutput}
               </pre>
             </div>

--- a/packages/playground/src/lib/ai-ui/tools/badges/loading-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/loading-badge.tsx
@@ -6,7 +6,7 @@ export const LoadingBadge = () => {
   return (
     <BadgeWrapper
       icon={<Spinner className="text-neutral3" />}
-      title={<Skeleton className="ml-2 w-12 h-2" />}
+      title={<Skeleton className="ml-2 h-2 w-12" />}
       collapsible={false}
     />
   );

--- a/packages/playground/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/network-choice-metadata-dialog.tsx
@@ -41,13 +41,13 @@ const NetworkChoiceMetadata = ({ selectionReason, open, onOpenChange, input }: N
         <DialogBody className="space-y-4">
           <div className="space-y-2">
             <Txt className="text-neutral3">Selection Reason</Txt>
-            <div className="text-neutral6 text-ui-md">{selectionReason}</div>
+            <div className="text-ui-md text-neutral6">{selectionReason}</div>
           </div>
 
           {inputSlot && (
             <div className="space-y-2">
               <Txt className="text-neutral3">Input</Txt>
-              <div className="text-neutral6 text-ui-md">{inputSlot}</div>
+              <div className="text-ui-md text-neutral6">{inputSlot}</div>
             </div>
           )}
         </DialogBody>
@@ -69,7 +69,7 @@ export const NetworkChoiceMetadataDialogTrigger = ({
   return (
     <>
       <Button variant="default" size="icon-md" tooltip="Show selection reason" onClick={() => setIsOpen(s => !s)}>
-        <Share2 className="text-neutral3 size-5" />
+        <Share2 className="size-5 text-neutral3" />
       </Button>
 
       <NetworkChoiceMetadata

--- a/packages/playground/src/lib/ai-ui/tools/badges/observation-marker-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/observation-marker-badge.tsx
@@ -134,25 +134,25 @@ const ExtractedValuesPanel = ({
   if (entries.length === 0 && failures.length === 0) return null;
 
   return (
-    <div className="mt-2 pt-2 border-t border-neutral-700">
+    <div className="mt-2 border-t border-neutral-700 pt-2">
       <button
         onClick={onToggle}
-        className="flex items-center gap-1 text-[10px] font-medium text-foreground uppercase tracking-wide hover:opacity-80 transition-opacity"
+        className="text-foreground flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase transition-opacity hover:opacity-80"
       >
-        {isExpanded ? <ChevronDown className="w-2.5 h-2.5" /> : <ChevronRight className="w-2.5 h-2.5" />}
+        {isExpanded ? <ChevronDown className="size-2.5" /> : <ChevronRight className="size-2.5" />}
         Extractions ({entries.length}){failures.length > 0 ? ` · ${failures.length} failed` : ''}
       </button>
       {isExpanded && (
         <div className="mt-1 space-y-2">
           {entries.map(([slug, value]) => (
             <div key={slug} className="rounded border border-neutral-700/60 bg-black/5 p-2 dark:bg-white/5">
-              <div className="text-[10px] font-medium uppercase tracking-wide text-foreground/70">{slug}</div>
+              <div className="text-foreground/70 text-[10px] font-medium tracking-wide uppercase">{slug}</div>
               {isStructuredExtractedValue(value) ? (
-                <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap break-words text-[11px] text-foreground/80">
+                <pre className="text-foreground/80 mt-1 max-h-40 overflow-auto text-[11px] break-words whitespace-pre-wrap">
                   {formatExtractedValue(value)}
                 </pre>
               ) : (
-                <div className="mt-1 text-[11px] text-foreground/80 [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[10px]">
+                <div className="text-foreground/80 mt-1 text-[11px] [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[10px]">
                   <MarkdownRenderer>{formatExtractedValue(value)}</MarkdownRenderer>
                 </div>
               )}
@@ -160,7 +160,7 @@ const ExtractedValuesPanel = ({
           ))}
           {failures.map(failure => (
             <div key={failure.slug} className="rounded border border-red-500/20 bg-red-500/5 p-2 text-red-700">
-              <div className="text-[10px] font-medium uppercase tracking-wide">{failure.slug}</div>
+              <div className="text-[10px] font-medium tracking-wide uppercase">{failure.slug}</div>
               <div className="mt-1 text-[11px]">{failure.error}</div>
             </div>
           ))}
@@ -245,10 +245,10 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
         data-om-type={isReflection ? 'reflection' : 'observation'}
       >
         <div
-          className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md ${bgColor} ${textColor} text-xs font-medium my-1`}
+          className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 ${bgColor} ${textColor} my-1 text-xs font-medium`}
         >
-          <Loader2 className="w-3 h-3 animate-spin" />
-          {isReflection ? <Brain className="w-3 h-3" /> : <ObservationIcon className="w-3 h-3" />}
+          <Loader2 className="size-3 animate-spin" />
+          {isReflection ? <Brain className="size-3" /> : <ObservationIcon className="size-3" />}
           <span>
             {actionLabel}
             {tokensToObserve ? ` ~${formatTokens(tokensToObserve)} tokens` : '...'}
@@ -293,10 +293,10 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
         <div className="my-1">
           <button
             onClick={handleToggle}
-            className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md ${completeBgColor} ${completeTextColor} text-xs font-medium ${completeHoverBgColor} transition-colors cursor-pointer`}
+            className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 ${completeBgColor} ${completeTextColor} text-xs font-medium ${completeHoverBgColor} cursor-pointer transition-colors`}
           >
-            {isExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-            {isReflection ? <Brain className="w-3 h-3" /> : <ObservationIcon className="w-3 h-3" />}
+            {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+            {isReflection ? <Brain className="size-3" /> : <ObservationIcon className="size-3" />}
             <span>
               {completedLabel} {tokensObserved ? formatTokens(tokensObserved) : '?'}→
               {observationTokens ? formatTokens(observationTokens) : '?'} tokens
@@ -305,7 +305,7 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
           </button>
           {isExpanded && (
             <div
-              className={`mt-1 ml-6 p-2 rounded-md ${expandedBgColor} text-xs space-y-1.5 border ${expandedBorderColor}`}
+              className={`mt-1 ml-6 rounded-md p-2 ${expandedBgColor} space-y-1.5 border text-xs ${expandedBorderColor}`}
             >
               {/* Stats row - all green */}
               <div className={`flex gap-4 text-[11px] ${labelColor}`}>
@@ -315,7 +315,7 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
                 {durationMs && <span>Duration: {(durationMs / 1000).toFixed(2)}s</span>}
               </div>
               {observations && (
-                <div className={`mt-1 pt-1 border-t border-neutral-700`}>
+                <div className={`mt-1 border-t border-neutral-700 pt-1`}>
                   {/* If there's no currentTask or suggestedResponse, show observations directly without collapsible wrapper */}
                   {!currentTask && !suggestedResponse ? (
                     <ObservationRenderer observations={observations} maxHeight="500px" />
@@ -323,12 +323,12 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
                     <>
                       <button
                         onClick={() => setIsObservationsExpanded(!isObservationsExpanded)}
-                        className="flex items-center gap-1 text-[10px] font-medium text-foreground uppercase tracking-wide hover:opacity-80 transition-opacity"
+                        className="text-foreground flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase transition-opacity hover:opacity-80"
                       >
                         {isObservationsExpanded ? (
-                          <ChevronDown className="w-2.5 h-2.5" />
+                          <ChevronDown className="size-2.5" />
                         ) : (
-                          <ChevronRight className="w-2.5 h-2.5" />
+                          <ChevronRight className="size-2.5" />
                         )}
                         {isReflection ? 'Reflections' : 'Observations'}
                       </button>
@@ -342,40 +342,32 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
                 </div>
               )}
               {currentTask && (
-                <div className={`mt-2 pt-2 border-t border-neutral-700`}>
+                <div className={`mt-2 border-t border-neutral-700 pt-2`}>
                   <button
                     onClick={() => setIsTaskExpanded(!isTaskExpanded)}
-                    className="flex items-center gap-1 text-[10px] font-medium text-foreground uppercase tracking-wide hover:opacity-80 transition-opacity"
+                    className="text-foreground flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase transition-opacity hover:opacity-80"
                   >
-                    {isTaskExpanded ? (
-                      <ChevronDown className="w-2.5 h-2.5" />
-                    ) : (
-                      <ChevronRight className="w-2.5 h-2.5" />
-                    )}
+                    {isTaskExpanded ? <ChevronDown className="size-2.5" /> : <ChevronRight className="size-2.5" />}
                     Current Task
                   </button>
                   {isTaskExpanded && (
-                    <div className="mt-1 text-[11px] text-foreground [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[10px]">
+                    <div className="text-foreground mt-1 text-[11px] [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[10px]">
                       <MarkdownRenderer>{currentTask}</MarkdownRenderer>
                     </div>
                   )}
                 </div>
               )}
               {suggestedResponse && (
-                <div className={`mt-2 pt-2 border-t border-neutral-700`}>
+                <div className={`mt-2 border-t border-neutral-700 pt-2`}>
                   <button
                     onClick={() => setIsResponseExpanded(!isResponseExpanded)}
-                    className="flex items-center gap-1 text-[10px] font-medium text-foreground uppercase tracking-wide hover:opacity-80 transition-opacity"
+                    className="text-foreground flex items-center gap-1 text-[10px] font-medium tracking-wide uppercase transition-opacity hover:opacity-80"
                   >
-                    {isResponseExpanded ? (
-                      <ChevronDown className="w-2.5 h-2.5" />
-                    ) : (
-                      <ChevronRight className="w-2.5 h-2.5" />
-                    )}
+                    {isResponseExpanded ? <ChevronDown className="size-2.5" /> : <ChevronRight className="size-2.5" />}
                     Suggested Response
                   </button>
                   {isResponseExpanded && (
-                    <div className="mt-1 text-[11px] text-foreground/80 italic [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[10px]">
+                    <div className="text-foreground/80 mt-1 text-[11px] italic [&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[10px]">
                       <MarkdownRenderer>{suggestedResponse}</MarkdownRenderer>
                     </div>
                   )}
@@ -404,8 +396,8 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
         data-om-state={state}
         data-om-type={isReflection ? 'reflection' : 'observation'}
       >
-        <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-yellow-500/10 text-yellow-600 text-xs font-medium my-1">
-          <Unplug className="w-3 h-3" />
+        <div className="my-1 inline-flex items-center gap-1.5 rounded-md bg-yellow-500/10 px-2 py-1 text-xs font-medium text-yellow-600">
+          <Unplug className="size-3" />
           <span>
             {disconnectedLabel}
             {tokensToObserve ? ` (~${formatTokens(tokensToObserve)} tokens)` : ''}
@@ -428,15 +420,15 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
         <div className="my-1">
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-red-500/10 text-red-600 text-xs font-medium hover:bg-red-500/20 transition-colors cursor-pointer"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md bg-red-500/10 px-2 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-500/20"
           >
-            {isExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-            <XCircle className="w-3 h-3" />
+            {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+            <XCircle className="size-3" />
             <span>{failedLabel}</span>
           </button>
 
           {isExpanded && error && (
-            <div className="mt-1 ml-4 p-2 rounded-md bg-red-500/5 text-red-700 text-xs border border-red-500/10">
+            <div className="mt-1 ml-4 rounded-md border border-red-500/10 bg-red-500/5 p-2 text-xs text-red-700">
               <span className="font-medium">Error:</span> {error}
             </div>
           )}
@@ -497,7 +489,7 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
 
           {isExpanded && (
             <div
-              className={`mt-2 ml-6 rounded-lg ${bufferExpandedBgColor} p-4 text-xs space-y-2 border ${bufferExpandedBorderColor}`}
+              className={`mt-2 ml-6 rounded-lg ${bufferExpandedBgColor} space-y-2 border p-4 text-xs ${bufferExpandedBorderColor}`}
             >
               {observations && <ObservationRenderer observations={observations} maxHeight="240px" />}
               <ExtractedValuesPanel
@@ -526,15 +518,15 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
         <div className="my-1">
           <button
             onClick={() => setIsExpanded(!isExpanded)}
-            className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-red-500/10 text-red-600 text-xs font-medium hover:bg-red-500/20 transition-colors cursor-pointer border border-dashed border-red-400/40"
+            className="inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-dashed border-red-400/40 bg-red-500/10 px-2 py-1 text-xs font-medium text-red-600 transition-colors hover:bg-red-500/20"
           >
-            {isExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-            <XCircle className="w-3 h-3" />
+            {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+            <XCircle className="size-3" />
             <span>{failedLabel}</span>
           </button>
 
           {isExpanded && error && (
-            <div className="mt-1 ml-4 p-2 rounded-md bg-red-500/5 text-red-700 text-xs border border-red-500/10">
+            <div className="mt-1 ml-4 rounded-md border border-red-500/10 bg-red-500/5 p-2 text-xs text-red-700">
               <span className="font-medium">Error:</span> {error}
             </div>
           )}
@@ -575,10 +567,10 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
         <div className="my-1">
           <button
             onClick={handleToggle}
-            className={`inline-flex items-center gap-1.5 px-2 py-1 rounded-md ${completeBgColor} ${completeTextColor} text-xs font-medium ${completeHoverBgColor} transition-colors cursor-pointer`}
+            className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 ${completeBgColor} ${completeTextColor} text-xs font-medium ${completeHoverBgColor} cursor-pointer transition-colors`}
           >
-            {isExpanded ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-            {isReflection ? <Brain className="w-3 h-3" /> : <ObservationIcon className="w-3 h-3" />}
+            {isExpanded ? <ChevronDown className="size-3" /> : <ChevronRight className="size-3" />}
+            {isReflection ? <Brain className="size-3" /> : <ObservationIcon className="size-3" />}
             <span>
               {activatedLabel} {tokensActivated ? formatTokens(tokensActivated) : '?'}→
               {observationTokens ? formatTokens(observationTokens) : '?'} tokens
@@ -587,7 +579,7 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
           </button>
           {isExpanded && (
             <div
-              className={`mt-1 ml-6 p-2 rounded-md ${expandedBgColor} text-xs space-y-1.5 border ${expandedBorderColor}`}
+              className={`mt-1 ml-6 rounded-md p-2 ${expandedBgColor} space-y-1.5 border text-xs ${expandedBorderColor}`}
             >
               {/* Stats row */}
               <div className={`flex gap-4 text-[11px] ${labelColor}`}>
@@ -596,7 +588,7 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
                 {compressionRatio && compressionRatio > 1 && <span>Compression: {compressionRatio}x</span>}
               </div>
               {observations && (
-                <div className="mt-1 pt-1 border-t border-neutral-700">
+                <div className="mt-1 border-t border-neutral-700 pt-1">
                   <ObservationRenderer observations={observations} maxHeight="500px" />
                 </div>
               )}
@@ -615,8 +607,8 @@ export const ObservationMarkerBadge = ({ toolName, args, metadata }: Observation
       data-om-state={state}
       data-om-type={isReflection ? 'reflection' : 'observation'}
     >
-      <div className="inline-flex items-center gap-1.5 px-2 py-1 rounded-md bg-gray-500/10 text-gray-600 text-xs font-medium my-1">
-        <Brain className="w-3 h-3" />
+      <div className="my-1 inline-flex items-center gap-1.5 rounded-md bg-gray-500/10 px-2 py-1 text-xs font-medium text-gray-600">
+        <Brain className="size-3" />
         <span>{toolName}</span>
       </div>
     </div>

--- a/packages/playground/src/lib/ai-ui/tools/badges/observation-renderer.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/observation-renderer.tsx
@@ -242,7 +242,7 @@ function ObservationItem({
   const borderColor = observation.priority ? PRIORITY_BORDER[observation.priority] : 'border-l-transparent';
 
   return (
-    <div className={cn('py-0.5', observation.isNested && 'ml-4 border-l border-border/50 pl-2')}>
+    <div className={cn('py-0.5', observation.isNested && 'border-border/50 ml-4 border-l pl-2')}>
       <div
         className={cn(
           'flex items-start gap-1.5 text-xs',
@@ -258,7 +258,7 @@ function ObservationItem({
           className={cn(
             'flex-1',
             priorityColor,
-            '[&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_code]:text-[10px]',
+            '[&_code]:rounded [&_code]:bg-black/10 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[10px]',
           )}
         >
           <MarkdownRenderer>{observation.content}</MarkdownRenderer>
@@ -266,7 +266,7 @@ function ObservationItem({
         {observation.time && (
           <span
             className={cn(
-              'shrink-0 font-mono text-[10px] ml-2',
+              'ml-2 shrink-0 font-mono text-[10px]',
               useInheritedTextColor ? 'opacity-60' : 'text-muted-foreground',
             )}
           >
@@ -293,7 +293,7 @@ function DateBlock({ block, useInheritedTextColor }: { block: ParsedDateBlock; u
     <div className="mb-2">
       <div
         className={cn(
-          'flex items-center gap-2 mb-1 sticky top-0 backdrop-blur-sm pt-1 pb-1',
+          'sticky top-0 mb-1 flex items-center gap-2 py-1 backdrop-blur-sm',
           useInheritedTextColor ? 'bg-transparent' : 'bg-background/95',
         )}
       >
@@ -332,8 +332,8 @@ function ThreadSection({
       {showThreadId && thread.threadId !== 'default' && (
         <div
           className={cn(
-            'text-[10px] font-mono mb-1 px-1 py-0.5 rounded inline-block',
-            useInheritedTextColor ? 'opacity-60 bg-current/10' : 'text-muted-foreground bg-muted/50',
+            'mb-1 inline-block rounded px-1 py-0.5 font-mono text-[10px]',
+            useInheritedTextColor ? 'bg-current/10 opacity-60' : 'text-muted-foreground bg-muted/50',
           )}
         >
           Thread {thread.threadId}
@@ -373,11 +373,11 @@ export function ObservationRenderer({
     parsed.threads.length > 1 || (parsed.threads.length === 1 && parsed.threads[0].threadId !== 'default');
 
   if (parsed.threads.length === 0 && !parsed.currentTask && !parsed.suggestedResponse) {
-    return <div className={cn('text-xs text-muted-foreground italic', className)}>No observations</div>;
+    return <div className={cn('text-muted-foreground text-xs italic', className)}>No observations</div>;
   }
 
   return (
-    <div className={cn('text-sm overflow-hidden', className)}>
+    <div className={cn('overflow-hidden text-sm', className)}>
       <div
         className={cn('wrap-break-word', maxHeight && 'overflow-y-auto pr-1')}
         style={maxHeight ? { maxHeight } : undefined}
@@ -393,18 +393,18 @@ export function ObservationRenderer({
       </div>
 
       {showCurrentTask && parsed.currentTask && (
-        <div className="mt-2 pt-2 border-t border-border">
-          <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1">Current Task</div>
-          <div className="text-xs text-foreground whitespace-pre-wrap">{parsed.currentTask}</div>
+        <div className="border-border mt-2 border-t pt-2">
+          <div className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wide uppercase">Current Task</div>
+          <div className="text-foreground text-xs whitespace-pre-wrap">{parsed.currentTask}</div>
         </div>
       )}
 
       {showSuggestedResponse && parsed.suggestedResponse && (
-        <div className="mt-2 pt-2 border-t border-border">
-          <div className="text-[10px] font-medium text-muted-foreground uppercase tracking-wide mb-1">
+        <div className="border-border mt-2 border-t pt-2">
+          <div className="text-muted-foreground mb-1 text-[10px] font-medium tracking-wide uppercase">
             Suggested Response
           </div>
-          <div className="text-xs text-foreground/80 italic whitespace-pre-wrap">{parsed.suggestedResponse}</div>
+          <div className="text-foreground/80 text-xs whitespace-pre-wrap italic">{parsed.suggestedResponse}</div>
         </div>
       )}
     </div>

--- a/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
@@ -102,13 +102,13 @@ const TerminalBlock = ({ command, content, maxHeight = '20rem', onCopy, isCopied
   }, [content]);
 
   return (
-    <div className="rounded-md border border-border1 overflow-hidden">
+    <div className="overflow-hidden rounded-md border border-border1">
       {/* Terminal header with command */}
       {command && (
-        <div className="px-3 py-2 bg-surface3 border-b border-border1 flex items-center justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
-            <span className="text-neutral6 text-xs shrink-0">$</span>
-            <code className="text-xs text-neutral-300 font-mono truncate">{command}</code>
+        <div className="flex items-center justify-between gap-2 border-b border-border1 bg-surface3 px-3 py-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <span className="shrink-0 text-xs text-neutral6">$</span>
+            <code className="truncate font-mono text-xs text-neutral-300">{command}</code>
           </div>
           {onCopy && (
             <Button variant="default" size="icon-sm" tooltip="Copy output" onClick={onCopy} className="shrink-0">
@@ -134,7 +134,7 @@ const TerminalBlock = ({ command, content, maxHeight = '20rem', onCopy, isCopied
       <pre
         ref={contentRef}
         style={{ maxHeight }}
-        className="overflow-x-auto overflow-y-auto p-3 text-sm text-neutral-300 font-mono whitespace-pre-wrap bg-black"
+        className="overflow-auto bg-black p-3 font-mono text-sm whitespace-pre-wrap text-neutral-300"
       >
         {content || <span className="text-neutral6 italic">No output</span>}
       </pre>
@@ -245,8 +245,8 @@ export const SandboxExecutionBadge = ({
   return (
     <div className="mb-4" data-testid="sandbox-execution-badge">
       {/* Header row */}
-      <div className="flex items-center gap-2 justify-between">
-        <button onClick={() => setIsCollapsed(s => !s)} className="flex items-center gap-2 min-w-0" type="button">
+      <div className="flex items-center justify-between gap-2">
+        <button onClick={() => setIsCollapsed(s => !s)} className="flex min-w-0 items-center gap-2" type="button">
           <Icon>
             <ChevronUpIcon className={cn('transition-all', isCollapsed ? 'rotate-90' : 'rotate-180')} />
           </Icon>
@@ -254,10 +254,10 @@ export const SandboxExecutionBadge = ({
           {execMeta?.sandbox && (
             <Link
               href={execMeta.id ? `/workspaces/${execMeta.id}` : '/workspaces'}
-              className="flex items-center gap-1.5 text-xs text-neutral6 px-1.5 py-0.5 rounded bg-surface3 border border-border1 hover:bg-surface4 hover:border-border2 transition-colors"
+              className="flex items-center gap-1.5 rounded border border-border1 bg-surface3 px-1.5 py-0.5 text-xs text-neutral6 transition-colors hover:border-border2 hover:bg-surface4"
               onClick={(e: React.MouseEvent) => e.stopPropagation()}
             >
-              <span className={cn('w-1.5 h-1.5 rounded-full', getStatusColor(execMeta.sandbox.status))} />
+              <span className={cn('size-1.5 rounded-full', getStatusColor(execMeta.sandbox.status))} />
               <span>{execMeta.sandbox.name || execMeta.sandbox.provider}</span>
             </Link>
           )}
@@ -268,10 +268,10 @@ export const SandboxExecutionBadge = ({
           {isRunning ? (
             <>
               <span className="flex items-center gap-1.5 text-xs text-accent6">
-                <span className="w-1.5 h-1.5 bg-accent6 rounded-full animate-pulse" />
+                <span className="size-1.5 animate-pulse rounded-full bg-accent6" />
                 <span className="animate-pulse">running</span>
               </span>
-              <span className="text-neutral6 text-xs tabular-nums">{elapsedTime}ms</span>
+              <span className="text-xs text-neutral6 tabular-nums">{elapsedTime}ms</span>
             </>
           ) : (
             <>
@@ -279,15 +279,15 @@ export const SandboxExecutionBadge = ({
                 (exitSuccess ? (
                   <CheckIcon className="text-green-400" size={14} />
                 ) : wasKilled ? (
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-orange-500/20 text-orange-400">
+                  <span className="rounded bg-orange-500/20 px-1.5 py-0.5 text-[10px] font-medium text-orange-400">
                     killed
                   </span>
                 ) : (
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-medium bg-red-500/20 text-red-400">
+                  <span className="rounded bg-red-500/20 px-1.5 py-0.5 text-[10px] font-medium text-red-400">
                     exit {exitCode}
                   </span>
                 ))}
-              {executionTime !== undefined && <span className="text-neutral6 text-xs">{executionTime}ms</span>}
+              {executionTime !== undefined && <span className="text-xs text-neutral6">{executionTime}ms</span>}
             </>
           )}
         </div>

--- a/packages/playground/src/lib/ai-ui/tools/badges/tool-approval-buttons.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/tool-approval-buttons.tsx
@@ -67,8 +67,8 @@ export const ToolApprovalButtons = ({
   if (toolApprovalMetadata && !toolCalled) {
     return (
       <div>
-        <p className="font-medium pb-2">Approval required</p>
-        <div className="flex gap-2 items-center">
+        <p className="pb-2 font-medium">Approval required</p>
+        <div className="flex items-center gap-2">
           <Button
             onClick={handleApprove}
             disabled={isRunning || !!toolCallApprovalStatus}

--- a/packages/playground/src/lib/ai-ui/tools/badges/tool-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/tool-badge.tsx
@@ -44,19 +44,19 @@ export const ToolBadge = ({
     const { __mastraMetadata: _, _background, ...formattedArgs } = typeof args === 'object' ? args : JSON.parse(args);
     argSlot = <JsonCodeBlock value={formattedArgs} testId="tool-args" />;
   } catch {
-    argSlot = <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{args as string}</pre>;
+    argSlot = <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{args as string}</pre>;
   }
 
   let resultSlot =
     typeof result === 'string' ? (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{result}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{result}</pre>
     ) : (
       <JsonCodeBlock value={result} testId="tool-result" />
     );
 
   let suspendPayloadSlot =
     typeof suspendPayload === 'string' ? (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{suspendPayload}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{suspendPayload}</pre>
     ) : (
       <CodeEditor data={suspendPayload} data-testid="tool-suspend-payload" />
     );
@@ -93,28 +93,28 @@ export const ToolBadge = ({
       <div className="space-y-4">
         {withoutArgs ? null : (
           <div>
-            <p className="font-medium pb-2">Tool arguments</p>
+            <p className="pb-2 font-medium">Tool arguments</p>
             {argSlot}
           </div>
         )}
 
         {suspendPayloadSlot !== undefined && suspendPayload && (
           <div>
-            <p className="font-medium pb-2">Tool suspend payload</p>
+            <p className="pb-2 font-medium">Tool suspend payload</p>
             {suspendPayloadSlot}
           </div>
         )}
 
         {resultSlot !== undefined && result && (
           <div>
-            <p className="font-medium pb-2">Tool result</p>
+            <p className="pb-2 font-medium">Tool result</p>
             {resultSlot}
           </div>
         )}
 
         {toolOutput.length > 0 && (
           <div>
-            <p className="font-medium pb-2">Tool output</p>
+            <p className="pb-2 font-medium">Tool output</p>
 
             <div className="h-40 overflow-y-auto">
               <CodeEditor data={toolOutput} data-testid="tool-output" />

--- a/packages/playground/src/lib/ai-ui/tools/badges/workflow-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/workflow-badge.tsx
@@ -66,7 +66,7 @@ export const WorkflowBadge = ({
 
   let suspendPayloadSlot =
     typeof suspendPayload === 'string' ? (
-      <pre className="whitespace-pre bg-surface4 p-4 rounded-md overflow-x-auto">{suspendPayload}</pre>
+      <pre className="overflow-x-auto rounded-md bg-surface4 p-4 whitespace-pre">{suspendPayload}</pre>
     ) : (
       <CodeEditor data={suspendPayload} data-testid="tool-suspend-payload" />
     );
@@ -100,7 +100,7 @@ export const WorkflowBadge = ({
 
       {suspendPayloadSlot !== undefined && suspendPayload && (
         <div>
-          <p className="font-medium pb-2">Workflow suspend payload</p>
+          <p className="pb-2 font-medium">Workflow suspend payload</p>
           {suspendPayloadSlot}
         </div>
       )}
@@ -139,7 +139,7 @@ const WorkflowBadgeExtended = ({ workflowId, workflow, runId }: WorkflowBadgeExt
         )}
       </div>
 
-      <div className="rounded-md overflow-hidden h-[60vh] w-full">
+      <div className="h-[60vh] w-full overflow-hidden rounded-md">
         <WorkflowSelectedStepProvider>
           <WorkflowStepDetailProvider>
             <WorkflowGraph workflowId={workflowId} workflow={workflow!} />

--- a/packages/playground/src/lib/command/navigation-command.tsx
+++ b/packages/playground/src/lib/command/navigation-command.tsx
@@ -71,7 +71,7 @@ const resultIconClassName =
   'mt-0.5 flex size-4 min-w-4 max-w-4 basis-4 shrink-0 items-center justify-center text-neutral3 transition-colors duration-150 ease-out group-data-[selected=true]:text-neutral6 [&>svg]:!size-4 [&>svg]:shrink-0';
 
 const CommandPath = ({ children }: { children: React.ReactNode }) => (
-  <span className="max-w-[13rem] truncate rounded-md border border-border1 bg-surface4/70 px-1.5 py-0.5 font-mono text-[10px] leading-none text-neutral3">
+  <span className="max-w-52 truncate rounded-md border border-border1 bg-surface4/70 px-1.5 py-0.5 font-mono text-[10px] leading-none text-neutral3">
     {children}
   </span>
 );
@@ -98,9 +98,9 @@ const NavigationCommandItem = ({
       <span className={resultIconClassName}>{icon}</span>
       <span className="flex min-w-0 flex-1 flex-col gap-1">
         <span className="flex min-w-0 items-center gap-2">
-          <span className="truncate text-ui-smd font-medium leading-ui-sm text-neutral6">{title}</span>
+          <span className="truncate text-ui-smd leading-ui-sm font-medium text-neutral6">{title}</span>
           {badge && (
-            <span className="shrink-0 rounded-md border border-border1 bg-surface4/60 px-1.5 py-0.5 text-[10px] font-medium uppercase leading-none text-neutral3">
+            <span className="shrink-0 rounded-md border border-border1 bg-surface4/60 px-1.5 py-0.5 text-[10px] leading-none font-medium text-neutral3 uppercase">
               {badge}
             </span>
           )}
@@ -190,7 +190,7 @@ const CommandRail = ({
   activeScope: CommandScope;
   onScopeChange: (scope: CommandScope) => void;
 }) => (
-  <aside className="navigation-command-surface navigation-command-surface-rail flex min-h-0 max-h-[min(14rem,32dvh)] flex-col overflow-hidden rounded-2xl border border-border1 bg-surface2 p-3 shadow-[0_8px_24px_-20px_rgb(0_0_0_/_0.55)] md:h-full md:max-h-none">
+  <aside className="navigation-command-surface navigation-command-surface-rail flex max-h-[min(14rem,32dvh)] min-h-0 flex-col overflow-hidden rounded-2xl border border-border1 bg-surface2 p-3 shadow-[0_8px_24px_-20px_rgb(0_0_0_/_0.55)] md:h-full md:max-h-none">
     <ScrollArea className="-m-1 min-h-0 flex-1 p-1" viewPortClassName="pr-1">
       <div className="flex flex-col gap-1">
         {scopeOptions.map(option => (
@@ -557,7 +557,7 @@ const EvaluationResults = ({
 };
 
 const CommandFooter = () => (
-  <div className="navigation-command-footer pointer-events-none absolute inset-x-0 bottom-0 z-20 flex items-end justify-between gap-3 px-4 pb-2 pt-5 text-ui-xs text-neutral3">
+  <div className="navigation-command-footer pointer-events-none absolute inset-x-0 bottom-0 z-20 flex items-end justify-between gap-3 px-4 pt-5 pb-2 text-ui-xs text-neutral3">
     <span className="truncate">Studio search</span>
     <span className="flex shrink-0 items-center gap-1.5">
       <Kbd className="min-w-5 px-1 text-[10px]">↑</Kbd>
@@ -694,11 +694,11 @@ export const NavigationCommand = () => {
       overlayClassName="bg-surface1/40 backdrop-blur-none"
       contentClassName="navigation-command-popup max-w-[min(56rem,calc(100vw-2rem))] overflow-visible border-none bg-transparent p-0 shadow-none backdrop-blur-none sm:max-w-[min(56rem,calc(100vw-2rem))]"
       commandClassName={cn(
-        'h-[min(42rem,calc(100dvh-2rem))] min-h-[min(30rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] gap-2 overflow-visible rounded-none bg-transparent text-neutral4 shadow-none backdrop-blur-none',
+        'h-[min(42rem,calc(100dvh-2rem))] max-h-[calc(100dvh-2rem)] min-h-[min(30rem,calc(100dvh-2rem))] gap-2 overflow-visible rounded-none bg-transparent text-neutral4 shadow-none backdrop-blur-none',
         '[&_[data-slot=command-input-wrapper]]:h-14 [&_[data-slot=command-input-wrapper]]:shrink-0 [&_[data-slot=command-input-wrapper]]:rounded-xl [&_[data-slot=command-input-wrapper]]:border [&_[data-slot=command-input-wrapper]]:border-border1 [&_[data-slot=command-input-wrapper]]:bg-surface3 [&_[data-slot=command-input-wrapper]]:px-4 [&_[data-slot=command-input-wrapper]]:shadow-[0_6px_18px_-16px_rgb(0_0_0_/_0.55)]',
-        '[&_[data-slot=command-input-wrapper]]:pr-11 [&_[data-slot=command-input-wrapper]]:transition-[border-color,box-shadow] [&_[data-slot=command-input-wrapper]]:duration-150 [&_[data-slot=command-input-wrapper]]:ease-out [&_[data-slot=command-input-wrapper]:focus-within]:border-border1 [&_[data-slot=command-input-wrapper]:focus-within]:bg-surface3 [&_[data-slot=command-input-wrapper]:focus-within]:shadow-[0_8px_22px_-18px_rgb(0_0_0_/_0.6)] [&_[data-slot=command-input-wrapper]_svg]:text-neutral4',
+        '[&_[data-slot=command-input-wrapper]]:pr-11 [&_[data-slot=command-input-wrapper]]:transition-[border-color,box-shadow] [&_[data-slot=command-input-wrapper]]:duration-150 [&_[data-slot=command-input-wrapper]]:ease-out [&_[data-slot=command-input-wrapper]_svg]:text-neutral4 [&_[data-slot=command-input-wrapper]:focus-within]:border-border1 [&_[data-slot=command-input-wrapper]:focus-within]:bg-surface3 [&_[data-slot=command-input-wrapper]:focus-within]:shadow-[0_8px_22px_-18px_rgb(0_0_0_/_0.6)]',
         '**:[[cmdk-input]]:h-full **:[[cmdk-input]]:text-ui-md',
-        '**:[[cmdk-group]]:p-0 **:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:pb-2 **:[[cmdk-group-heading]]:pt-3',
+        '**:[[cmdk-group-heading]]:px-3 **:[[cmdk-group-heading]]:pt-3 **:[[cmdk-group-heading]]:pb-2 **:[[cmdk-group]]:p-0',
         '**:[[cmdk-item]]:px-3 **:[[cmdk-item]]:py-2.5',
       )}
     >

--- a/packages/playground/src/lib/form/components/array-element-wrapper.tsx
+++ b/packages/playground/src/lib/form/components/array-element-wrapper.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 
 export const ArrayElementWrapper: React.FC<ArrayElementWrapperProps> = ({ children, onRemove }) => {
   return (
-    <div className="pl-4 border-l border-border1">
+    <div className="border-l border-border1 pl-4">
       {children}
       <Button onClick={onRemove} type="button">
         <Icon size="sm">

--- a/packages/playground/src/lib/form/components/array-wrapper.tsx
+++ b/packages/playground/src/lib/form/components/array-wrapper.tsx
@@ -8,8 +8,8 @@ import React from 'react';
 export const ArrayWrapper: React.FC<ArrayWrapperProps> = ({ label, children, onAddItem }) => {
   return (
     <div>
-      <div className="flex gap-2 justify-between">
-        <Txt as="h3" variant="ui-sm" className="text-neutral3 pb-2 flex items-center gap-1">
+      <div className="flex justify-between gap-2">
+        <Txt as="h3" variant="ui-sm" className="flex items-center gap-1 pb-2 text-neutral3">
           <Icon size="sm">
             <Brackets />
           </Icon>
@@ -23,7 +23,7 @@ export const ArrayWrapper: React.FC<ArrayWrapperProps> = ({ label, children, onA
               <button
                 onClick={onAddItem}
                 type="button"
-                className="text-neutral3 bg-surface3 rounded-md p-1 hover:bg-surface4 hover:text-neutral6 h-icon-sm w-icon-sm"
+                className="h-icon-sm w-icon-sm rounded-md bg-surface3 p-1 text-neutral3 hover:bg-surface4 hover:text-neutral6"
               >
                 <Icon size="sm">
                   <PlusIcon />

--- a/packages/playground/src/lib/form/components/date-field.tsx
+++ b/packages/playground/src/lib/form/components/date-field.tsx
@@ -43,7 +43,7 @@ export const DateField: React.FC<AutoFormFieldProps> = ({ inputProps, field, err
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button id={id} variant="default" size="lg" className={cn('w-full', error ? 'border-accent2' : '')}>
-          <CalendarIcon className="h-4 w-4" />
+          <CalendarIcon className="size-4" />
           {value ? (
             <span className="text-white">{format(value, 'PPP')}</span>
           ) : (
@@ -51,7 +51,7 @@ export const DateField: React.FC<AutoFormFieldProps> = ({ inputProps, field, err
           )}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0 bg-surface4" align="start">
+      <PopoverContent className="w-auto bg-surface4 p-0" align="start">
         <DatePicker mode="single" selected={value} onSelect={handleSelect} month={value} onMonthChange={setValue} />
         {value && (
           <div className="p-3 pt-0">

--- a/packages/playground/src/lib/form/components/field-wrapper.tsx
+++ b/packages/playground/src/lib/form/components/field-wrapper.tsx
@@ -10,7 +10,7 @@ export const FieldWrapper: React.FC<FieldWrapperProps> = ({ label, children, id,
   return (
     <div className="pb-4 last:pb-0">
       {!isDisabled && (
-        <Txt as="label" variant="ui-sm" className="text-neutral3 pb-1 block" htmlFor={id}>
+        <Txt as="label" variant="ui-sm" className="block pb-1 text-neutral3" htmlFor={id}>
           {label}
           {field.required && <span className="text-accent2"> *</span>}
         </Txt>

--- a/packages/playground/src/lib/form/components/object-wrapper.tsx
+++ b/packages/playground/src/lib/form/components/object-wrapper.tsx
@@ -14,7 +14,7 @@ export const ObjectWrapper: React.FC<ObjectWrapperProps> = ({ label, children })
     <div className="">
       <div className="flex items-center">
         {hasLabel && (
-          <Txt as="h3" variant="ui-sm" className="text-neutral3 flex items-center gap-1 pb-2">
+          <Txt as="h3" variant="ui-sm" className="flex items-center gap-1 pb-2 text-neutral3">
             <Icon size="sm">
               <Braces />
             </Icon>
@@ -31,7 +31,7 @@ export const ObjectWrapper: React.FC<ObjectWrapperProps> = ({ label, children })
       </div>
 
       {isOpen && (
-        <div className={hasLabel ? 'flex flex-col gap-1 *:border-dashed *:border-l *:border-l-border1 *:pl-4' : ''}>
+        <div className={hasLabel ? 'flex flex-col gap-1 *:border-l *:border-dashed *:border-l-border1 *:pl-4' : ''}>
           {children}
         </div>
       )}

--- a/packages/playground/src/lib/form/components/record-field.tsx
+++ b/packages/playground/src/lib/form/components/record-field.tsx
@@ -73,8 +73,8 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field })
     <div className="space-y-3">
       {pairs.map(pair => (
         <div key={pair.id} className="relative space-y-2 rounded-lg border p-4">
-          <Button type="button" className="absolute right-2 top-2" onClick={() => removePair(pair.id)}>
-            <TrashIcon className="h-4 w-4" />
+          <Button type="button" className="absolute top-2 right-2" onClick={() => removePair(pair.id)}>
+            <TrashIcon className="size-4" />
           </Button>
 
           <div className="space-y-2 pt-6">
@@ -94,7 +94,7 @@ export const RecordField: React.FC<AutoFormFieldProps> = ({ inputProps, field })
         </div>
       ))}
       <Button type="button" className="w-full" onClick={addPair}>
-        <Plus className="mr-2 h-4 w-4" />
+        <Plus className="mr-2 size-4" />
         Add Key-Value Pair
       </Button>
     </div>

--- a/packages/playground/src/lib/route-header/route-header.tsx
+++ b/packages/playground/src/lib/route-header/route-header.tsx
@@ -39,7 +39,7 @@ export function RouteHeader() {
                 as={linkable ? Link : 'span'}
                 to={linkable ? def.to : undefined}
                 isCurrent={isCurrent}
-                className={isCurrent ? 'max-w-[28rem]' : 'max-w-[18rem]'}
+                className={isCurrent ? 'max-w-md' : 'max-w-2xs'}
               >
                 {IconComponent && (
                   <Icon>
@@ -64,7 +64,7 @@ export function RouteHeader() {
             variant="ghost"
             size="sm"
             aria-label={docs.label ?? 'Documentation'}
-            className="min-w-0 max-w-[14rem]"
+            className="max-w-56 min-w-0"
           >
             <DocsIcon />
             <span className="min-w-0 truncate">{docs.label ?? 'Documentation'}</span>

--- a/packages/playground/src/pages/agent-builder/agents/create.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/create.tsx
@@ -32,7 +32,7 @@ export default function AgentBuilderCreate() {
 
   return (
     <>
-      <div className="absolute top-3 left-3 md:top-6 md:left-6 z-10">
+      <div className="absolute top-3 left-3 z-10 md:top-6 md:left-6">
         <Button
           size="icon-sm"
           variant="ghost"

--- a/packages/playground/src/pages/agent-builder/agents/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/edit.tsx
@@ -252,7 +252,7 @@ const ProfileSlot = () => {
   // Both buttons are already accessible from the mobile 3-dots menu, so we
   // hide them in the profile panel on mobile to avoid duplication.
   const heroActions = (
-    <div className="hidden lg:flex items-center gap-2" data-testid="agent-builder-hero-actions-desktop">
+    <div className="hidden items-center gap-2 lg:flex" data-testid="agent-builder-hero-actions-desktop">
       {capabilities?.enabled && (
         <span style={{ viewTransitionName: 'agent-visibility-select' }}>
           <VisibilitySelect agentId={agentId} />
@@ -326,7 +326,7 @@ const ProfileSlot = () => {
 };
 
 const AgentBuilderAgentEditSkeleton = () => (
-  <div className="h-screen w-screen flex items-center justify-center">
+  <div className="flex h-screen w-screen items-center justify-center">
     <Spinner />
   </div>
 );

--- a/packages/playground/src/pages/agent-builder/agents/index.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/index.tsx
@@ -75,7 +75,7 @@ export default function AgentBuilderAgentsPage() {
       return (
         <div className="flex items-center justify-center pt-16">
           <EmptyState
-            iconSlot={<AgentIcon className="h-8 w-8 text-neutral3" />}
+            iconSlot={<AgentIcon className="size-8 text-neutral3" />}
             titleSlot="No agents yet"
             descriptionSlot="Start building your first agent with the Agent Builder."
             actionSlot={

--- a/packages/playground/src/pages/agent-builder/agents/view.tsx
+++ b/packages/playground/src/pages/agent-builder/agents/view.tsx
@@ -108,7 +108,7 @@ const ViewTopBarSlot = () => {
 };
 
 const AgentBuilderAgentViewSkeleton = () => (
-  <div className="h-screen w-screen flex items-center justify-center">
+  <div className="flex h-screen w-screen items-center justify-center">
     <Spinner />
   </div>
 );

--- a/packages/playground/src/pages/agent-builder/favorite/index.tsx
+++ b/packages/playground/src/pages/agent-builder/favorite/index.tsx
@@ -86,7 +86,7 @@ export default function AgentBuilderFavoritePage() {
         return (
           <div className="flex items-center justify-center pt-16">
             <EmptyState
-              iconSlot={<StarIcon className="h-8 w-8 text-neutral3" />}
+              iconSlot={<StarIcon className="size-8 text-neutral3" />}
               titleSlot="No favorite agents yet"
               descriptionSlot="Star agents to keep them here for quick access."
             />
@@ -103,7 +103,7 @@ export default function AgentBuilderFavoritePage() {
       return (
         <div className="flex items-center justify-center pt-16">
           <EmptyState
-            iconSlot={<SparklesIcon className="h-8 w-8 text-neutral3" />}
+            iconSlot={<SparklesIcon className="size-8 text-neutral3" />}
             titleSlot="No favorite skills yet"
             descriptionSlot="Star skills to keep them here for quick access."
           />
@@ -131,7 +131,7 @@ export default function AgentBuilderFavoritePage() {
           </div>
           <div className="flex items-center gap-4">
             {features.skills && (
-              <div className="flex rounded-lg border border-border1 overflow-hidden">
+              <div className="flex overflow-hidden rounded-lg border border-border1">
                 <button
                   onClick={() => setTab('agents')}
                   className={`px-3 py-1.5 text-xs font-medium transition-colors ${
@@ -150,7 +150,7 @@ export default function AgentBuilderFavoritePage() {
                 </button>
               </div>
             )}
-            <div className="flex-1 max-w-120">
+            <div className="max-w-120 flex-1">
               <ListSearch onSearch={setSearch} label="Filter favorites" placeholder="Filter by name or description" />
             </div>
           </div>

--- a/packages/playground/src/pages/agent-builder/index.tsx
+++ b/packages/playground/src/pages/agent-builder/index.tsx
@@ -8,7 +8,7 @@ export const AgentBuilderRoot = () => {
 
   if (isLoading) {
     return (
-      <div className="h-screen flex items-center justify-center">
+      <div className="flex h-screen items-center justify-center">
         <Spinner />
       </div>
     );

--- a/packages/playground/src/pages/agent-builder/infrastructure/index.tsx
+++ b/packages/playground/src/pages/agent-builder/infrastructure/index.tsx
@@ -15,7 +15,7 @@ const StatusBadge = ({ ok, label }: { ok: boolean; label: string }) => (
     data-slot="infrastructure-status-badge"
     data-ok={ok ? 'true' : 'false'}
   >
-    <span className={`h-1.5 w-1.5 rounded-full ${ok ? 'bg-accent3' : 'bg-neutral3'}`} aria-hidden="true" />
+    <span className={`size-1.5 rounded-full ${ok ? 'bg-accent3' : 'bg-neutral3'}`} aria-hidden="true" />
     {label}
   </span>
 );
@@ -71,7 +71,7 @@ export const AgentBuilderInfrastructure = () => {
         </PageHeader>
       </PageLayout.TopArea>
 
-      <PageLayout.MainArea className="flex flex-col gap-5 mt-6">
+      <PageLayout.MainArea className="mt-6 flex flex-col gap-5">
         <SectionCard
           title="Agent Builder Infrastructure"
           description="Deployment-level defaults Agent Builder applies when users create or run builder agents."
@@ -105,7 +105,7 @@ export const AgentBuilderInfrastructure = () => {
                 ) : (
                   <ul className="flex flex-col gap-2">
                     {data.channels.providers.map(provider => (
-                      <li key={provider.id} className="rounded-md border border-border1 px-3 py-3">
+                      <li key={provider.id} className="rounded-md border border-border1 p-3">
                         <div className="flex items-start justify-between gap-3">
                           <div className="flex flex-col gap-1">
                             <Txt variant="ui-sm" className="font-medium">
@@ -143,7 +143,7 @@ export const AgentBuilderInfrastructure = () => {
                 {!data.browser.provider ? (
                   <EmptyRow message="No browser configured." />
                 ) : (
-                  <div className="rounded-md border border-border1 px-3 py-3">
+                  <div className="rounded-md border border-border1 p-3">
                     <div className="flex items-start justify-between gap-3">
                       <div className="flex flex-col gap-1">
                         <Txt variant="ui-sm" className="font-medium">
@@ -174,7 +174,7 @@ export const AgentBuilderInfrastructure = () => {
                     External skill registries available to import skills into the workspace.
                   </Txt>
                 </div>
-                <div className="rounded-md border border-border1 px-3 py-3">
+                <div className="rounded-md border border-border1 p-3">
                   <div className="flex items-start justify-between gap-3">
                     <div className="flex flex-col gap-1">
                       <Txt variant="ui-sm" className="font-medium">
@@ -205,7 +205,7 @@ export const AgentBuilderInfrastructure = () => {
                 {!data.workspace.type ? (
                   <EmptyRow message="No workspace configured." />
                 ) : (
-                  <div className="rounded-md border border-border1 px-3 py-3">
+                  <div className="rounded-md border border-border1 p-3">
                     <div className="flex items-start justify-between gap-3">
                       <Txt variant="ui-sm" className="font-medium">
                         {data.workspace.workspaceId ?? data.workspace.name ?? 'Inline workspace'}

--- a/packages/playground/src/pages/agent-builder/library/index.tsx
+++ b/packages/playground/src/pages/agent-builder/library/index.tsx
@@ -74,7 +74,7 @@ export default function AgentBuilderLibraryPage() {
         return (
           <div className="flex items-center justify-center pt-16">
             <EmptyState
-              iconSlot={<LibraryIcon className="h-8 w-8 text-neutral3" />}
+              iconSlot={<LibraryIcon className="size-8 text-neutral3" />}
               titleSlot="No public agents yet"
               descriptionSlot="Mark an agent as Public to share it with the team library."
             />
@@ -98,7 +98,7 @@ export default function AgentBuilderLibraryPage() {
       return (
         <div className="flex items-center justify-center pt-16">
           <EmptyState
-            iconSlot={<SparklesIcon className="h-8 w-8 text-neutral3" />}
+            iconSlot={<SparklesIcon className="size-8 text-neutral3" />}
             titleSlot="No public skills yet"
             descriptionSlot="Mark a skill as Public to share it with the team library."
           />
@@ -131,7 +131,7 @@ export default function AgentBuilderLibraryPage() {
           </div>
           <div className="flex items-center gap-4">
             {features.skills && (
-              <div className="flex rounded-lg border border-border1 overflow-hidden">
+              <div className="flex overflow-hidden rounded-lg border border-border1">
                 <button
                   onClick={() => setTab('agents')}
                   className={`px-3 py-1.5 text-xs font-medium transition-colors ${
@@ -150,7 +150,7 @@ export default function AgentBuilderLibraryPage() {
                 </button>
               </div>
             )}
-            <div className="flex-1 max-w-120">
+            <div className="max-w-120 flex-1">
               <ListSearch onSearch={setSearch} label="Filter library" placeholder="Filter by name or description" />
             </div>
           </div>

--- a/packages/playground/src/pages/agent-builder/skills/create.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/create.tsx
@@ -21,7 +21,7 @@ export default function AgentBuilderSkillsCreate() {
   }
   return (
     <>
-      <div className="absolute top-3 left-3 md:top-6 md:left-6 z-10">
+      <div className="absolute top-3 left-3 z-10 md:top-6 md:left-6">
         <Button
           size="icon-sm"
           variant="ghost"

--- a/packages/playground/src/pages/agent-builder/skills/edit.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/edit.tsx
@@ -46,7 +46,7 @@ export default function AgentBuilderSkillsEdit() {
 }
 
 const AgentBuilderSkillEditSkeleton = () => (
-  <div className="h-screen w-screen flex items-center justify-center">
+  <div className="flex h-screen w-screen items-center justify-center">
     <Spinner />
   </div>
 );
@@ -138,7 +138,7 @@ const AgentBuilderSkillEditReady = ({ id, initialUserMessage }: ReadyProps) => {
         <AutosaveIndicator status={autosave.status} lastError={autosave.lastError} onRetry={autosave.retry} />
       }
       primaryAction={
-        <div className="hidden lg:flex items-center gap-2">
+        <div className="hidden items-center gap-2 lg:flex">
           <VisibilitySelectConnected skillId={id} />
         </div>
       }

--- a/packages/playground/src/pages/agent-builder/skills/index.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/index.tsx
@@ -80,7 +80,7 @@ export default function AgentBuilderSkillsPage() {
       return (
         <div className="flex items-center justify-center pt-16">
           <EmptyState
-            iconSlot={<SparklesIcon className="h-8 w-8 text-neutral3" />}
+            iconSlot={<SparklesIcon className="size-8 text-neutral3" />}
             titleSlot="No skills yet"
             descriptionSlot="Create your first skill to give agents new capabilities."
             actionSlot={
@@ -120,7 +120,7 @@ export default function AgentBuilderSkillsPage() {
               <PageHeader.Description>Skills you've created.</PageHeader.Description>
             </PageHeader>
             {skills.length > 0 && canWriteSkills && (
-              <div className="w-full shrink-0 flex flex-col items-stretch gap-2 md:w-auto md:flex-row md:items-center">
+              <div className="flex w-full shrink-0 flex-col items-stretch gap-2 md:w-auto md:flex-row md:items-center">
                 {enabledRegistry && (
                   <Button
                     variant="default"

--- a/packages/playground/src/pages/agent-builder/skills/view.tsx
+++ b/packages/playground/src/pages/agent-builder/skills/view.tsx
@@ -37,7 +37,7 @@ export default function AgentBuilderSkillsView() {
 }
 
 const AgentBuilderSkillViewSkeleton = () => (
-  <div className="h-screen w-screen flex items-center justify-center">
+  <div className="flex h-screen w-screen items-center justify-center">
     <Spinner />
   </div>
 );
@@ -99,7 +99,7 @@ const AgentBuilderSkillViewPage = ({ skill }: PageProps) => {
       </div>
 
       {/* Body */}
-      <div className="flex-1 min-h-0 overflow-y-auto bg-surface1">
+      <div className="min-h-0 flex-1 overflow-y-auto bg-surface1">
         <div className="mx-auto w-full max-w-[80ch] px-4 pt-6 pb-10 md:px-10">
           <h1 className="text-display-md text-neutral6">{skill.name}</h1>
           {skill.description && (

--- a/packages/playground/src/pages/agents/agent-evaluate/index.tsx
+++ b/packages/playground/src/pages/agents/agent-evaluate/index.tsx
@@ -90,13 +90,13 @@ function AgentEvaluate() {
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <Spinner className="h-6 w-6" />
+        <Spinner className="size-6" />
       </div>
     );
   }
 
   if (!codeAgent) {
-    return <div className="text-center py-4">Agent not found</div>;
+    return <div className="py-4 text-center">Agent not found</div>;
   }
 
   return (

--- a/packages/playground/src/pages/agents/agent-playground/index.tsx
+++ b/packages/playground/src/pages/agents/agent-playground/index.tsx
@@ -133,13 +133,13 @@ function AgentPlayground() {
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <Spinner className="h-6 w-6" />
+        <Spinner className="size-6" />
       </div>
     );
   }
 
   if (!codeAgent) {
-    return <div className="text-center py-4">Agent not found</div>;
+    return <div className="py-4 text-center">Agent not found</div>;
   }
 
   return (

--- a/packages/playground/src/pages/agents/agent-review/index.tsx
+++ b/packages/playground/src/pages/agents/agent-review/index.tsx
@@ -32,13 +32,13 @@ function AgentReview() {
   if (isLoading) {
     return (
       <div className="flex h-full items-center justify-center">
-        <Spinner className="h-6 w-6" />
+        <Spinner className="size-6" />
       </div>
     );
   }
 
   if (!codeAgent) {
-    return <div className="text-center py-4">Agent not found</div>;
+    return <div className="py-4 text-center">Agent not found</div>;
   }
 
   const handleCreateScorer = (items: Array<{ input: unknown; output: unknown }>) => {

--- a/packages/playground/src/pages/agents/agent/index.tsx
+++ b/packages/playground/src/pages/agents/agent/index.tsx
@@ -99,7 +99,7 @@ function Agent({ view = 'chat' }: { view?: 'chat' | 'settings' }) {
   }
 
   if (!agent) {
-    return <div className="text-center py-4">Agent not found</div>;
+    return <div className="py-4 text-center">Agent not found</div>;
   }
 
   if (!isSettingsView && !threadId) {

--- a/packages/playground/src/pages/agents/agent/session.tsx
+++ b/packages/playground/src/pages/agents/agent/session.tsx
@@ -53,7 +53,7 @@ function AgentSession() {
   }
 
   if (!agent) {
-    return <div className="text-center py-4">Agent not found</div>;
+    return <div className="py-4 text-center">Agent not found</div>;
   }
 
   const actualThreadId = isNewThread ? newThreadId : (threadId ?? newThreadId);
@@ -83,7 +83,7 @@ function AgentSession() {
                     <ActivatedSkillsProvider>
                       <MainContentLayout>
                         <SessionHeader />
-                        <div className="grid overflow-y-auto relative h-full pt-6">
+                        <div className="relative grid h-full overflow-y-auto pt-6">
                           <AgentChat
                             key={actualThreadId}
                             agentId={agentId!}
@@ -117,7 +117,7 @@ export default AgentSession;
 const AgentSessionLoadingSkeleton = () => (
   <MainContentLayout>
     <SessionHeader />
-    <div className="grid overflow-y-auto relative h-full pt-6" data-testid="agent-session-skeleton" aria-busy="true">
+    <div className="relative grid h-full overflow-y-auto pt-6" data-testid="agent-session-skeleton" aria-busy="true">
       <AgentChatLoadingSkeleton />
     </div>
   </MainContentLayout>

--- a/packages/playground/src/pages/cms/agents/create-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/create-layout.tsx
@@ -24,7 +24,7 @@ function CreateLayoutWrapper() {
         <Button variant="primary" onClick={() => void handlePublish()} disabled={isSubmitting || !canPublish}>
           {isSubmitting ? (
             <>
-              <Spinner className="h-4 w-4" />
+              <Spinner className="size-4" />
               Creating...
             </>
           ) : (

--- a/packages/playground/src/pages/cms/agents/edit-layout.tsx
+++ b/packages/playground/src/pages/cms/agents/edit-layout.tsx
@@ -281,7 +281,7 @@ function EditLayoutWrapper() {
                 <Button onClick={() => void handleSaveDraft()} disabled={!isDirty || isSavingDraft || isSubmitting}>
                   {isSavingDraft ? (
                     <>
-                      <Spinner className="h-4 w-4" />
+                      <Spinner className="size-4" />
                       Saving...
                     </>
                   ) : (
@@ -302,7 +302,7 @@ function EditLayoutWrapper() {
                 >
                   {isSubmitting ? (
                     <>
-                      <Spinner className="h-4 w-4" />
+                      <Spinner className="size-4" />
                       Publishing...
                     </>
                   ) : (
@@ -320,7 +320,7 @@ function EditLayoutWrapper() {
 
       {isNotFound ? (
         <>
-          <div className="flex items-center justify-center h-full text-neutral3">Agent not found</div>
+          <div className="flex h-full items-center justify-center text-neutral3">Agent not found</div>
           <div className="hidden">
             <EditFormContent
               agentId={agentId ?? ''}

--- a/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
+++ b/packages/playground/src/pages/cms/prompt-blocks/edit/index.tsx
@@ -244,12 +244,12 @@ function CmsPromptBlocksEditPage() {
       <MainContentLayout className="grid-rows-[1fr]">
         <AgentEditLayout
           leftSlot={
-            <div className="flex items-center justify-center h-full">
+            <div className="flex h-full items-center justify-center">
               <Spinner className="size-8" />
             </div>
           }
         >
-          <div className="flex items-center justify-center h-full">
+          <div className="flex h-full items-center justify-center">
             <Spinner className="size-8" />
           </div>
         </AgentEditLayout>
@@ -261,9 +261,9 @@ function CmsPromptBlocksEditPage() {
     return (
       <MainContentLayout className="grid-rows-[1fr]">
         <AgentEditLayout
-          leftSlot={<div className="flex items-center justify-center h-full text-neutral3">Prompt block not found</div>}
+          leftSlot={<div className="flex h-full items-center justify-center text-neutral3">Prompt block not found</div>}
         >
-          <div className="flex items-center justify-center h-full text-neutral3">Prompt block not found</div>
+          <div className="flex h-full items-center justify-center text-neutral3">Prompt block not found</div>
         </AgentEditLayout>
       </MainContentLayout>
     );

--- a/packages/playground/src/pages/cms/scorers/edit/index.tsx
+++ b/packages/playground/src/pages/cms/scorers/edit/index.tsx
@@ -244,12 +244,12 @@ function CmsScorersEditPage() {
       <MainContentLayout className="grid-rows-[1fr]">
         <AgentEditLayout
           leftSlot={
-            <div className="flex items-center justify-center h-full">
+            <div className="flex h-full items-center justify-center">
               <Spinner className="size-8" />
             </div>
           }
         >
-          <div className="flex items-center justify-center h-full">
+          <div className="flex h-full items-center justify-center">
             <Spinner className="size-8" />
           </div>
         </AgentEditLayout>
@@ -261,9 +261,9 @@ function CmsScorersEditPage() {
     return (
       <MainContentLayout className="grid-rows-[1fr]">
         <AgentEditLayout
-          leftSlot={<div className="flex items-center justify-center h-full text-neutral3">Scorer not found</div>}
+          leftSlot={<div className="flex h-full items-center justify-center text-neutral3">Scorer not found</div>}
         >
-          <div className="flex items-center justify-center h-full text-neutral3">Scorer not found</div>
+          <div className="flex h-full items-center justify-center text-neutral3">Scorer not found</div>
         </AgentEditLayout>
       </MainContentLayout>
     );

--- a/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/experiments/index.tsx
@@ -40,9 +40,9 @@ function CompareDatasetExperimentsPage() {
     return (
       <MainContentLayout>
         <MainContentContent>
-          <div className="text-neutral4 text-center py-8">
+          <div className="py-8 text-center text-neutral4">
             <p>Select two experiments to compare.</p>
-            <p className="text-sm mt-2">
+            <p className="mt-2 text-sm">
               Use the URL format: /datasets/{'{datasetId}'}/experiments?baseline={'{experimentIdA}'}&contender=
               {'{experimentIdB}'}
             </p>
@@ -55,7 +55,7 @@ function CompareDatasetExperimentsPage() {
   return (
     <MainContentLayout>
       <MainContentContent>
-        <div className="max-w-[100rem] w-full px-12 mx-auto grid content-start ">
+        <div className="max-w-400 mx-auto grid w-full content-start px-12 ">
           <MainHeader>
             <MainHeader.Column>
               <MainHeader.Title>

--- a/packages/playground/src/pages/datasets/dataset/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/index.tsx
@@ -123,7 +123,7 @@ function DatasetPage() {
         <PageLayout.TopArea>
           <PageLayout.Row>
             <PageLayout.Column>
-              {dataset?.description && <p className="text-ui-smd text-neutral3 mb-1">{dataset.description}</p>}
+              {dataset?.description && <p className="mb-1 text-ui-smd text-neutral3">{dataset.description}</p>}
               <DataKeysAndValues numOfCol={2}>
                 <DataKeysAndValues.Key>Created at</DataKeysAndValues.Key>
                 <DataKeysAndValues.Value>

--- a/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/compare/index.tsx
@@ -67,7 +67,7 @@ function DatasetItemsComparePage() {
     return (
       <MainContentLayout>
         <MainContentContent>
-          <div className="text-neutral4 text-center py-8">
+          <div className="py-8 text-center text-neutral4">
             <p>Select at least two items to compare.</p>
           </div>
         </MainContentContent>
@@ -86,7 +86,7 @@ function DatasetItemsComparePage() {
 
       <div className="h-full overflow-hidden px-[3vw] pb-4">
         <div
-          className={cn('grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full', {
+          className={cn('max-w-560 mx-auto grid h-full grid-rows-[auto_1fr] gap-6', {
             'grid-rows-[auto_auto_1fr]': isDiffView,
           })}
         >
@@ -138,7 +138,7 @@ function DatasetItemsComparePage() {
                     setSearchParams({ items: newIds.join(',') });
                   }}
                 />
-                {idx == 0 && <div className={cn('bg-surface5 w-[3px] shrink-0 mx-[1.5vw]')}></div>}
+                {idx == 0 && <div className={cn('mx-[1.5vw] w-[3px] shrink-0 bg-surface5')}></div>}
               </Fragment>
             ))}
           </Columns>
@@ -200,9 +200,9 @@ function CompareItemColumn({
       {showContent && (
         <Column.Content>
           {isLoading ? (
-            <div className="text-neutral4 text-sm">Loading...</div>
+            <div className="text-sm text-neutral4">Loading...</div>
           ) : !item ? (
-            <div className="text-neutral4 text-sm">Item {itemId.slice(0, 8)} not found</div>
+            <div className="text-sm text-neutral4">Item {itemId.slice(0, 8)} not found</div>
           ) : (
             <>
               <DatasetItemHeader item={item} />

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -284,7 +284,7 @@ function DatasetItemPage() {
     return (
       <MainContentLayout>
         <MainContentContent>
-          <div className="text-neutral3 p-4">Item not found</div>
+          <div className="p-4 text-neutral3">Item not found</div>
         </MainContentContent>
       </MainContentLayout>
     );
@@ -294,7 +294,7 @@ function DatasetItemPage() {
     <>
       <MainContentLayout>
         <div className="h-full overflow-hidden px-6 pb-4">
-          <div className="grid gap-6 max-w-[60rem] mx-auto grid-rows-[auto_1fr] h-full">
+          <div className="max-w-240 mx-auto grid h-full grid-rows-[auto_1fr] gap-6">
             <MainHeader>
               <MainHeader.Column>
                 <MainHeader.Title>
@@ -382,7 +382,7 @@ function DatasetItemPage() {
                 ) : displayItem ? (
                   <DatasetItemContent item={displayItem} Link={FrameworkLink} />
                 ) : (
-                  <div className="text-neutral4 text-sm">Item data not available</div>
+                  <div className="text-sm text-neutral4">Item data not available</div>
                 )}
               </Column>
               {!isEditing && (

--- a/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/versions/index.tsx
@@ -88,7 +88,7 @@ function DatasetItemVersionsComparePage() {
     return (
       <MainContentLayout>
         <MainContentContent>
-          <div className="text-neutral4 text-center py-8">
+          <div className="py-8 text-center text-neutral4">
             <p>Select at least two versions to compare.</p>
           </div>
         </MainContentContent>
@@ -107,7 +107,7 @@ function DatasetItemVersionsComparePage() {
 
       <div className="h-full overflow-hidden px-[3vw] pb-4">
         <div
-          className={cn('grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full', {
+          className={cn('max-w-560 mx-auto grid h-full grid-rows-[auto_1fr] gap-6', {
             'grid-rows-[auto_auto_1fr]': isDiffView,
           })}
         >
@@ -162,7 +162,7 @@ function DatasetItemVersionsComparePage() {
                     setSearchParams({ ids: newVersions.join(',') });
                   }}
                 />
-                {idx === 0 && <div className={cn('bg-surface5 w-[3px] shrink-0 mx-[1.5vw]')} />}
+                {idx === 0 && <div className={cn('mx-[1.5vw] w-[3px] shrink-0 bg-surface5')} />}
               </Fragment>
             ))}
           </Columns>
@@ -234,8 +234,8 @@ function CompareVersionColumn({
 
   return (
     <Column>
-      <Column.Toolbar className="grid gap-4 grid-cols-[auto_1fr]">
-        <HistoryIcon className="w-6 h-6 opacity-50" />
+      <Column.Toolbar className="grid grid-cols-[auto_1fr] gap-4">
+        <HistoryIcon className="size-6 opacity-50" />
         <Select
           name={`compare-version-${idx}`}
           value={String(datasetVersion)}
@@ -257,9 +257,9 @@ function CompareVersionColumn({
       {showContent && (
         <Column.Content>
           {isLoading ? (
-            <div className="text-neutral4 text-sm">Loading...</div>
+            <div className="text-sm text-neutral4">Loading...</div>
           ) : !version || !displayItem ? (
-            <div className="text-neutral4 text-sm">Version {datasetVersion} not found</div>
+            <div className="text-sm text-neutral4">Version {datasetVersion} not found</div>
           ) : (
             <DatasetItemContent item={displayItem} Link={Link} />
           )}

--- a/packages/playground/src/pages/datasets/dataset/versions/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/versions/index.tsx
@@ -70,7 +70,7 @@ function DatasetCompareVersionsPage() {
     return (
       <MainContentLayout>
         <MainContentContent>
-          <div className="text-neutral4 text-center py-8">
+          <div className="py-8 text-center text-neutral4">
             <p>Select at least two versions to compare.</p>
           </div>
         </MainContentContent>
@@ -93,7 +93,7 @@ function DatasetCompareVersionsPage() {
   return (
     <MainContentLayout>
       <div className="h-full overflow-hidden px-[3vw] pb-4">
-        <div className="grid gap-6 max-w-[140rem] mx-auto grid-rows-[auto_1fr] h-full">
+        <div className="max-w-560 mx-auto grid h-full grid-rows-[auto_1fr] gap-6">
           <MainHeader>
             <MainHeader.Column>
               <MainHeader.Title>

--- a/packages/playground/src/pages/integrations/components/existing-connections-panel.tsx
+++ b/packages/playground/src/pages/integrations/components/existing-connections-panel.tsx
@@ -115,7 +115,7 @@ export function ExistingConnectionsPanel({
   onDisconnect,
 }: ExistingConnectionsPanelProps) {
   return (
-    <div className="space-y-2 border rounded p-4">
+    <div className="space-y-2 rounded border p-4">
       <h2 className="text-lg font-semibold">Existing connections</h2>
       {!providerId || !toolkit ? (
         <p className="text-gray-500">Pick a provider and toolkit to list connections.</p>

--- a/packages/playground/src/pages/integrations/components/provider-toolkit-selector.tsx
+++ b/packages/playground/src/pages/integrations/components/provider-toolkit-selector.tsx
@@ -38,14 +38,14 @@ export function ProviderToolkitSelector({
   onConnect,
 }: ProviderToolkitSelectorProps) {
   return (
-    <div className="space-y-4 border rounded p-4">
+    <div className="space-y-4 rounded border p-4">
       <div className="space-y-1">
         <label className="block font-medium" htmlFor="provider-select">
           Provider
         </label>
         <select
           id="provider-select"
-          className="border rounded px-2 py-1 w-full"
+          className="w-full rounded border px-2 py-1"
           value={providerId}
           onChange={event => onProviderChange(event.target.value)}
           disabled={providersLoading}
@@ -67,7 +67,7 @@ export function ProviderToolkitSelector({
         </label>
         <select
           id="toolkit-select"
-          className="border rounded px-2 py-1 w-full"
+          className="w-full rounded border px-2 py-1"
           value={toolkit}
           onChange={event => onToolkitChange(event.target.value)}
           disabled={!providerId || toolkitsLoading}
@@ -90,7 +90,7 @@ export function ProviderToolkitSelector({
         <input
           id="label-input"
           type="text"
-          className="border rounded px-2 py-1 w-full"
+          className="w-full rounded border px-2 py-1"
           placeholder="My personal Gmail"
           value={label}
           onChange={event => onLabelChange(event.target.value)}
@@ -100,7 +100,7 @@ export function ProviderToolkitSelector({
 
       <button
         type="button"
-        className="bg-blue-600 text-white rounded px-4 py-2 disabled:opacity-50"
+        className="rounded bg-blue-600 px-4 py-2 text-white disabled:opacity-50"
         onClick={onConnect}
         disabled={!providerId || !toolkit || authorizePending}
       >

--- a/packages/playground/src/pages/integrations/index.tsx
+++ b/packages/playground/src/pages/integrations/index.tsx
@@ -54,7 +54,7 @@ export default function IntegrationsPage() {
   };
 
   return (
-    <div className="p-6 max-w-3xl space-y-6 text-sm">
+    <div className="max-w-3xl space-y-6 p-6 text-sm">
       <h1 className="text-2xl font-semibold">Integrations</h1>
       <p className="text-gray-500">
         Minimal page to verify the ToolProvider backend. Pick a provider and toolkit, then connect.

--- a/packages/playground/src/pages/mcps/[serverId]/index.tsx
+++ b/packages/playground/src/pages/mcps/[serverId]/index.tsx
@@ -9,7 +9,7 @@ export const McpServerPage = () => {
   const server = mcpServers.find(server => server.id === serverId);
 
   return (
-    <div className="h-full w-full overflow-hidden">
+    <div className="size-full overflow-hidden">
       <MCPDetail isLoading={isLoading} server={server} />
     </div>
   );

--- a/packages/playground/src/pages/mcps/tool/index.tsx
+++ b/packages/playground/src/pages/mcps/tool/index.tsx
@@ -11,7 +11,7 @@ const MCPServerToolExecutor = () => {
   if (!mcpTool) return null;
 
   return (
-    <div className="h-full w-full overflow-y-auto">
+    <div className="size-full overflow-y-auto">
       <MCPToolPanel toolId={toolId!} serverId={serverId!} />
     </div>
   );

--- a/packages/playground/src/pages/metrics/index.tsx
+++ b/packages/playground/src/pages/metrics/index.tsx
@@ -331,7 +331,7 @@ function MetricsContent() {
           />
         </div>
       ) : (
-        <div className="grid gap-8 content-start pb-10">
+        <div className="grid content-start gap-8 pb-10">
           {isInMemory && (
             <Notice variant="info" title="Metrics are not persisted">
               <Notice.Message>

--- a/packages/playground/src/pages/processors/processor/index.tsx
+++ b/packages/playground/src/pages/processors/processor/index.tsx
@@ -36,14 +36,14 @@ export function Processor() {
   if (isLoading) {
     return (
       <div className="p-6">
-        <Skeleton className="h-8 w-48 mb-4" />
+        <Skeleton className="mb-4 h-8 w-48" />
         <Skeleton className="h-32 w-full" />
       </div>
     );
   }
 
   return (
-    <div className="h-full w-full overflow-y-hidden">
+    <div className="size-full overflow-y-hidden">
       <ProcessorPanel processorId={processorId!} />
     </div>
   );

--- a/packages/playground/src/pages/resources/index.tsx
+++ b/packages/playground/src/pages/resources/index.tsx
@@ -51,7 +51,7 @@ export default function Resources() {
   return (
     <PageLayout width="narrow">
       <PageLayout.MainArea>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 max-w-3xl">
+        <div className="grid max-w-3xl grid-cols-1 gap-4 sm:grid-cols-2">
           {resources.map(resource => (
             <a
               key={resource.href}
@@ -60,13 +60,13 @@ export default function Resources() {
               className="group flex flex-col gap-3 rounded-lg border border-border1 bg-surface2 p-5 transition-colors hover:border-accent1 hover:bg-surface3"
             >
               <div className="flex items-center gap-2.5">
-                <resource.icon className="h-5 w-5 text-icon3 group-hover:text-accent1 transition-colors" />
+                <resource.icon className="text-icon3 size-5 transition-colors group-hover:text-accent1" />
                 <span className="text-ui-md font-medium text-text1">{resource.title}</span>
                 {resource.external && (
-                  <ExternalLinkIcon className="h-3.5 w-3.5 text-icon3 ml-auto opacity-0 group-hover:opacity-100 transition-opacity" />
+                  <ExternalLinkIcon className="text-icon3 ml-auto size-3.5 opacity-0 transition-opacity group-hover:opacity-100" />
                 )}
               </div>
-              <p className="text-ui-sm text-text3 leading-relaxed">{resource.description}</p>
+              <p className="text-text3 text-ui-sm leading-relaxed">{resource.description}</p>
             </a>
           ))}
         </div>

--- a/packages/playground/src/pages/settings/index.tsx
+++ b/packages/playground/src/pages/settings/index.tsx
@@ -21,8 +21,8 @@ function ThemeOptionLabel({ option }: { option: (typeof THEME_OPTIONS)[number] }
   const { Icon } = option;
 
   return (
-    <span className="inline-flex min-w-0 max-w-full items-center gap-2">
-      <Icon aria-hidden="true" className="h-4 w-4 shrink-0 opacity-70" />
+    <span className="inline-flex max-w-full min-w-0 items-center gap-2">
+      <Icon aria-hidden="true" className="size-4 shrink-0 opacity-70" />
       <span className="min-w-0 truncate">{option.label}</span>
     </span>
   );
@@ -34,7 +34,7 @@ export const StudioSettingsPage = () => {
 
   return (
     <PageLayout width="narrow">
-      <PageLayout.MainArea className="flex flex-col gap-5 mt-6">
+      <PageLayout.MainArea className="mt-6 flex flex-col gap-5">
         <SectionCard title="Theme" description="Customize the appearance of the studio.">
           <SettingsRow label="Theme mode" htmlFor="theme">
             <Select
@@ -44,7 +44,7 @@ export const StudioSettingsPage = () => {
               }}
             >
               <SelectTrigger id="theme" className="w-full sm:w-48">
-                <SelectValue className="inline-flex min-w-0 max-w-full items-center" />
+                <SelectValue className="inline-flex max-w-full min-w-0 items-center" />
               </SelectTrigger>
               <SelectContent>
                 {THEME_OPTIONS.map(option => (

--- a/packages/playground/src/pages/templates/index.tsx
+++ b/packages/playground/src/pages/templates/index.tsx
@@ -73,7 +73,7 @@ export default function Templates() {
         </HeaderTitle>
       </Header>
 
-      <div className={cn('overflow-y-auto w-full h-full px-8 pb-12 z-10')}>
+      <div className={cn('z-10 size-full overflow-y-auto px-8 pb-12')}>
         <TemplatesTools
           selectedTag={selectedTag}
           onTagChange={value => handleFilterChange(value, 'tag')}
@@ -84,13 +84,13 @@ export default function Templates() {
           searchTerm={searchTerm}
           onSearchChange={handleSearch}
           onReset={isFiltered ? handleReset : undefined}
-          className="max-w-[80rem]"
+          className="max-w-7xl"
           isLoading={isLoading}
         />
         <TemplatesList
           templates={filteredTemplates}
           linkComponent={Link}
-          className="max-w-[80rem] mx-auto"
+          className="mx-auto max-w-7xl"
           isLoading={isLoading}
         />
       </div>

--- a/packages/playground/src/pages/templates/template/index.tsx
+++ b/packages/playground/src/pages/templates/template/index.tsx
@@ -327,8 +327,8 @@ export default function Template() {
 
   return (
     <MainContentLayout>
-      <div className={cn('w-full lg:px-12 h-full overflow-y-scroll')}>
-        <div className="p-6 w-full max-w-[80rem] mx-auto grid gap-y-4">
+      <div className={cn('size-full overflow-y-scroll lg:px-12')}>
+        <div className="mx-auto grid w-full max-w-7xl gap-y-4 p-6">
           <TemplateInfo
             isLoading={isLoadingTemplate}
             title={template?.title}

--- a/packages/playground/src/pages/tools/agent-tool/index.tsx
+++ b/packages/playground/src/pages/tools/agent-tool/index.tsx
@@ -5,7 +5,7 @@ const AgentTool = () => {
   const { toolId, agentId } = useParams();
 
   return (
-    <div className="h-full w-full overflow-y-auto">
+    <div className="size-full overflow-y-auto">
       <AgentToolPanel toolId={toolId!} agentId={agentId!} />
     </div>
   );

--- a/packages/playground/src/pages/tools/tool/index.tsx
+++ b/packages/playground/src/pages/tools/tool/index.tsx
@@ -5,7 +5,7 @@ const Tool = () => {
   const { toolId } = useParams();
 
   return (
-    <div className="h-full w-full overflow-y-hidden">
+    <div className="size-full overflow-y-hidden">
       <ToolPanel toolId={toolId!} />
     </div>
   );

--- a/packages/playground/src/pages/traces/index.tsx
+++ b/packages/playground/src/pages/traces/index.tsx
@@ -289,7 +289,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
         onStartTextFilter={setAutoFocusFilterFieldId}
         hiddenFieldIds={hiddenCreatorFieldIds}
       />
-      <div className="flex h-form-default items-center gap-2 ml-auto">
+      <div className="ml-auto flex h-form-default items-center gap-2">
         {!branchesUnsupported && (
           <>
             <Switch
@@ -310,9 +310,9 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
           tooltip={autoRefetchTraces ? 'Auto-refetch ON' : 'Auto-refetch OFF'}
         >
           {autoRefetchTraces ? (
-            <RefreshCw className={`h-4 w-4 ${isRefetchingTraces ? 'animate-spin' : ''}`} />
+            <RefreshCw className={`size-4 ${isRefetchingTraces ? 'animate-spin' : ''}`} />
           ) : (
-            <CircleSlash2 className="h-4 w-4" />
+            <CircleSlash2 className="size-4" />
           )}
         </Button>
       </div>
@@ -339,7 +339,7 @@ export default function TracesPage({ scopedEntityId, scopedEntityType }: TracesP
   const pageTopArea = (
     <PageLayout.TopArea>
       <PageLayout.Row>
-        <PageLayout.Column className="flex flex-wrap items-start justify-start gap-2 w-full">
+        <PageLayout.Column className="flex w-full flex-wrap items-start justify-start gap-2">
           {toolbarControls}
         </PageLayout.Column>
       </PageLayout.Row>

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -208,7 +208,7 @@ export default function TracePage() {
 
       <div
         className={cn(
-          'grid h-full min-h-0 gap-4 overflow-hidden items-start mt-4',
+          'mt-4 grid h-full min-h-0 items-start gap-4 overflow-hidden',
           featuredSpanId ? 'grid-cols-[2fr_3fr]' : 'grid-cols-[1fr]',
         )}
       >
@@ -226,7 +226,7 @@ export default function TracePage() {
         {featuredSpanId && !isTraceLoading && (
           <div
             className={cn(
-              'grid gap-4 max-h-full min-h-0 overflow-auto',
+              'grid max-h-full min-h-0 gap-4 overflow-auto',
               featuredScore ? 'grid-rows-[1fr_1fr]' : 'grid-rows-[1fr]',
             )}
           >

--- a/packages/playground/src/pages/workflows/schedule.tsx
+++ b/packages/playground/src/pages/workflows/schedule.tsx
@@ -18,7 +18,7 @@ import { useLinkComponent } from '@/lib/framework';
 function MetaItem({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1">
-      <Txt variant="ui-xs" className="text-neutral4 uppercase tracking-wide">
+      <Txt variant="ui-xs" className="tracking-wide text-neutral4 uppercase">
         {label}
       </Txt>
       <div className="text-ui-md">{children}</div>
@@ -105,8 +105,8 @@ export default function SchedulePage() {
       </PageLayout.TopArea>
 
       {schedule ? (
-        <div className="grid gap-6 h-full overflow-hidden grid-cols-[minmax(0,20rem)_1fr]">
-          <div className="flex flex-col gap-4 border border-border1 rounded-md p-4 h-fit">
+        <div className="grid h-full grid-cols-[minmax(0,20rem)_1fr] gap-6 overflow-hidden">
+          <div className="flex h-fit flex-col gap-4 rounded-md border border-border1 p-4">
             <MetaItem label={agentId ? 'Agent' : 'Workflow'}>
               {workflowId ? (
                 <Link to={paths.workflowLink(workflowId)} className="text-accent1 hover:underline">
@@ -122,7 +122,7 @@ export default function SchedulePage() {
             </MetaItem>
             <MetaItem label="Cron">
               <code className="font-mono text-ui-md">{schedule.cron}</code>
-              {schedule.timezone ? <span className="text-neutral4 ml-2 text-ui-sm">{schedule.timezone}</span> : null}
+              {schedule.timezone ? <span className="ml-2 text-ui-sm text-neutral4">{schedule.timezone}</span> : null}
             </MetaItem>
             <MetaItem label="Status">
               <ScheduleStatusText status={schedule.status} />

--- a/packages/playground/src/pages/workflows/workflow/index.tsx
+++ b/packages/playground/src/pages/workflows/workflow/index.tsx
@@ -30,7 +30,7 @@ const WorkflowContent = ({ workflowId, workflow, isLoading }: WorkflowContentPro
         </div>
       </div>
       {stepDetail && (
-        <div className="w-[420px] min-h-0 overflow-hidden border-l border-border1">
+        <div className="w-105 min-h-0 overflow-hidden border-l border-border1">
           <WorkflowStepDetailContent />
         </div>
       )}

--- a/packages/playground/src/pages/workspace/index.tsx
+++ b/packages/playground/src/pages/workspace/index.tsx
@@ -372,26 +372,26 @@ export default function Workspace() {
           <div className="relative">
             <button
               onClick={() => setShowWorkspaceDropdown(!showWorkspaceDropdown)}
-              className="flex items-center gap-2 px-3 py-2 text-sm border border-border1 rounded-lg bg-surface2 hover:bg-surface3 transition-colors w-full max-w-md"
+              className="flex w-full max-w-md items-center gap-2 rounded-lg border border-border1 bg-surface2 px-3 py-2 text-sm transition-colors hover:bg-surface3"
             >
               {selectedWorkspace?.source === 'agent' ? (
-                <Bot className="h-4 w-4 text-accent1" />
+                <Bot className="size-4 text-accent1" />
               ) : (
-                <Server className="h-4 w-4 text-neutral4" />
+                <Server className="size-4 text-neutral4" />
               )}
-              <span className="flex-1 text-left truncate">
+              <span className="flex-1 truncate text-left">
                 {selectedWorkspace?.name ?? 'Select workspace'}
                 {selectedWorkspace?.source === 'agent' && selectedWorkspace.agentName && (
-                  <span className="text-neutral4 ml-1">({selectedWorkspace.agentName})</span>
+                  <span className="ml-1 text-neutral4">({selectedWorkspace.agentName})</span>
                 )}
               </span>
               <ChevronDown
-                className={`h-4 w-4 text-neutral4 transition-transform ${showWorkspaceDropdown ? 'rotate-180' : ''}`}
+                className={`size-4 text-neutral4 transition-transform ${showWorkspaceDropdown ? 'rotate-180' : ''}`}
               />
             </button>
 
             {showWorkspaceDropdown && (
-              <div className="absolute z-50 mt-1 w-full max-w-md bg-surface2 border border-border1 rounded-lg shadow-lg overflow-hidden">
+              <div className="absolute z-50 mt-1 w-full max-w-md overflow-hidden rounded-lg border border-border1 bg-surface2 shadow-lg">
                 {workspaces.map(workspace => (
                   <button
                     key={workspace.id}
@@ -399,35 +399,35 @@ export default function Workspace() {
                       setSelectedWorkspaceId(workspace.id);
                       setShowWorkspaceDropdown(false);
                     }}
-                    className={`flex items-center gap-3 px-3 py-2 w-full text-left hover:bg-surface3 transition-colors ${
+                    className={`flex w-full items-center gap-3 px-3 py-2 text-left transition-colors hover:bg-surface3 ${
                       selectedWorkspace?.id === workspace.id ? 'bg-surface3' : ''
                     }`}
                   >
                     {workspace.source === 'agent' ? (
-                      <Bot className="h-4 w-4 text-accent1 shrink-0" />
+                      <Bot className="size-4 shrink-0 text-accent1" />
                     ) : (
-                      <Server className="h-4 w-4 text-neutral4 shrink-0" />
+                      <Server className="size-4 shrink-0 text-neutral4" />
                     )}
-                    <div className="flex-1 min-w-0">
-                      <div className="text-sm font-medium text-neutral6 truncate">{workspace.name}</div>
-                      <div className="text-xs text-neutral4 truncate">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-medium text-neutral6">{workspace.name}</div>
+                      <div className="truncate text-xs text-neutral4">
                         {workspace.source === 'agent' ? `Agent: ${workspace.agentName}` : 'Global workspace'}
                       </div>
                     </div>
-                    <div className="flex gap-1 shrink-0">
+                    <div className="flex shrink-0 gap-1">
                       {workspace.safety?.readOnly && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400">
+                        <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] text-amber-400">
                           Read-only
                         </span>
                       )}
                       {workspace.capabilities.hasFilesystem && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface4 text-neutral4">FS</span>
+                        <span className="rounded bg-surface4 px-1.5 py-0.5 text-[10px] text-neutral4">FS</span>
                       )}
                       {workspace.capabilities.hasSandbox && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface4 text-neutral4">Sandbox</span>
+                        <span className="rounded bg-surface4 px-1.5 py-0.5 text-[10px] text-neutral4">Sandbox</span>
                       )}
                       {workspace.capabilities.hasSkills && (
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-surface4 text-neutral4">Skills</span>
+                        <span className="rounded bg-surface4 px-1.5 py-0.5 text-[10px] text-neutral4">Skills</span>
                       )}
                     </div>
                   </button>
@@ -441,16 +441,16 @@ export default function Workspace() {
         {workspaces.length === 1 && selectedWorkspace && (
           <div className="flex items-center gap-2 text-sm text-neutral4">
             {selectedWorkspace.source === 'agent' ? (
-              <Bot className="h-4 w-4 text-accent1" />
+              <Bot className="size-4 text-accent1" />
             ) : (
-              <Server className="h-4 w-4" />
+              <Server className="size-4" />
             )}
             <span>{selectedWorkspace.name}</span>
             {selectedWorkspace.source === 'agent' && selectedWorkspace.agentName && (
               <span className="text-neutral3">({selectedWorkspace.agentName})</span>
             )}
             {isReadOnly && (
-              <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-400">Read-only</span>
+              <span className="rounded bg-amber-500/20 px-1.5 py-0.5 text-[10px] text-amber-400">Read-only</span>
             )}
           </div>
         )}
@@ -483,16 +483,16 @@ export default function Workspace() {
             <TabList>
               {hasFilesystem && (
                 <Tab value="files">
-                  <FileText className="h-4 w-4" />
+                  <FileText className="size-4" />
                   Files
                 </Tab>
               )}
               {hasSkills && (
                 <Tab value="skills">
-                  <Wand2 className="h-4 w-4" />
+                  <Wand2 className="size-4" />
                   Skills
                   {isSkillsConfigured && skills.length > 0 && (
-                    <span className="text-xs px-1.5 py-0.5 rounded bg-surface4 text-neutral4">{skills.length}</span>
+                    <span className="rounded bg-surface4 px-1.5 py-0.5 text-xs text-neutral4">{skills.length}</span>
                   )}
                 </Tab>
               )}
@@ -500,7 +500,7 @@ export default function Workspace() {
 
             {hasFilesystem && (
               <TabContent value="files" className="pb-8">
-                <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
                   <FileBrowser
                     entries={files}
                     currentPath={currentPath}
@@ -605,15 +605,15 @@ function WorkspaceSearchPanel({
   const searchSkills = useSearchWorkspaceSkills();
 
   return (
-    <div className="border border-border1 rounded-lg p-4 bg-surface2 space-y-4">
+    <div className="space-y-4 rounded-lg border border-border1 bg-surface2 p-4">
       {canSearchFiles && (
         <div>
-          <h3 className="text-sm font-medium text-neutral5 mb-3 flex items-center gap-2">
-            <FileText className="h-4 w-4" />
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-medium text-neutral5">
+            <FileText className="size-4" />
             Search Indexed Files
           </h3>
           {showInitWarning && (
-            <p className="text-xs text-amber-400 mb-3">
+            <p className="mb-3 text-xs text-amber-400">
               File search requires <code className="text-amber-300">workspace.init()</code> to index files from your
               configured <code className="text-amber-300">autoIndexPaths</code>.
             </p>
@@ -638,8 +638,8 @@ function WorkspaceSearchPanel({
 
       {canSearchSkills && (
         <div>
-          <h3 className="text-sm font-medium text-neutral5 mb-3 flex items-center gap-2">
-            <Wand2 className="h-4 w-4" />
+          <h3 className="mb-3 flex items-center gap-2 text-sm font-medium text-neutral5">
+            <Wand2 className="size-4" />
             Search Skills
           </h3>
           <SearchSkillsPanel

--- a/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
+++ b/packages/playground/src/pages/workspace/skills/[skillName]/index.tsx
@@ -79,8 +79,8 @@ export default function WorkspaceSkillDetailPage() {
     return (
       <MainContentLayout>
         {agentCrumbs && <RouteHeaderCrumbs crumbs={agentCrumbs} />}
-        <div className="grid place-items-center h-full">
-          <div className="h-8 w-8 border-2 border-accent1 border-t-transparent rounded-full animate-spin" />
+        <div className="grid h-full place-items-center">
+          <div className="size-8 animate-spin rounded-full border-2 border-accent1 border-t-transparent" />
         </div>
       </MainContentLayout>
     );
@@ -114,9 +114,9 @@ export default function WorkspaceSkillDetailPage() {
     return (
       <MainContentLayout>
         {agentCrumbs && <RouteHeaderCrumbs crumbs={agentCrumbs} />}
-        <div className="grid place-items-center h-full">
+        <div className="grid h-full place-items-center">
           <div className="text-center">
-            <p className="text-red-400 mb-2">Failed to load skill</p>
+            <p className="mb-2 text-red-400">Failed to load skill</p>
             <p className="text-sm text-neutral3">{error instanceof Error ? error.message : 'Skill not found'}</p>
           </div>
         </div>
@@ -127,8 +127,8 @@ export default function WorkspaceSkillDetailPage() {
   return (
     <MainContentLayout>
       {agentCrumbs && <RouteHeaderCrumbs crumbs={agentCrumbs} />}
-      <div className="grid overflow-y-auto overflow-x-hidden h-full">
-        <div className="max-w-[100rem] px-[3rem] mx-auto py-8 h-full w-full overflow-x-hidden">
+      <div className="grid h-full overflow-x-hidden overflow-y-auto">
+        <div className="max-w-400 mx-auto size-full overflow-x-hidden px-12 py-8">
           <SkillDetail skill={skill} rawSkillMd={rawSkillMdData?.content} onReferenceClick={setViewingReference} />
         </div>
       </div>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5257,6 +5257,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@10.6.0(jiti@2.7.0))
+      eslint-plugin-tailwindcss:
+        specifier: ^4.1.0
+        version: 4.1.0(eslint@10.6.0(jiti@2.7.0))(tailwindcss@4.2.2)(typescript@6.0.3)
       jsdom:
         specifier: ^27
         version: 27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0)
@@ -16375,6 +16378,10 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@pkgr/core@0.3.6':
+    resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   '@playwright/test@1.60.0':
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
@@ -22680,6 +22687,17 @@ packages:
       eslint: '>=8'
       storybook: ^10.4.2
 
+  eslint-plugin-tailwindcss@4.1.0:
+    resolution: {integrity: sha512-Z76UU7IhUuxrBAZ6tVZic+jwK2DXohrc4JhRF/I3k0c6sJmWAio+OJsIdvHjVitcnGPg16T4606cqE4vhV97fQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      eslint: ^9.0.0 || ^10.0.0
+      tailwindcss: ^4.0.0
+      typescript: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   eslint-plugin-testing-library@7.16.2:
     resolution: {integrity: sha512-8gleGnQXK2ZA3hHwjCwpYTZvM+9VsrJ+/9kDI8CjqAQGAdMQOdn/rJNu7ZySENuiWlGKQWyZJ4ZjEg2zamaRHw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -26930,6 +26948,12 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
+  postcss-nested@7.0.2:
+    resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
+    engines: {node: '>=18.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
   postcss-nesting@13.0.2:
     resolution: {integrity: sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==}
     engines: {node: '>=18'}
@@ -28922,6 +28946,10 @@ packages:
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
+  synckit@0.11.13:
+    resolution: {integrity: sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+
   tabbable@6.4.0:
     resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
 
@@ -28932,6 +28960,11 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
+
+  tailwind-api-utils@1.0.3:
+    resolution: {integrity: sha512-KpzUHkH1ug1sq4394SLJX38ZtpeTiqQ1RVyFTTSY2XuHsNSTWUkRo108KmyyrMWdDbQrLYkSHaNKj/a3bmA4sQ==}
+    peerDependencies:
+      tailwindcss: ^3.3.0 || ^4.0.0 || ^4.0.0-beta
 
   tailwind-merge@3.5.0:
     resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
@@ -40069,6 +40102,8 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@pkgr/core@0.3.6': {}
+
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
@@ -47320,6 +47355,20 @@ snapshots:
       - supports-color
       - typescript
 
+  eslint-plugin-tailwindcss@4.1.0(eslint@10.6.0(jiti@2.7.0))(tailwindcss@4.2.2)(typescript@6.0.3):
+    dependencies:
+      '@typescript-eslint/utils': 8.59.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.6.0(jiti@2.7.0)
+      postcss: 8.5.15
+      postcss-nested: 7.0.2(postcss@8.5.15)
+      synckit: 0.11.13
+      tailwind-api-utils: 1.0.3(tailwindcss@4.2.2)
+      tailwindcss: 4.2.2
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-plugin-testing-library@7.16.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
       '@typescript-eslint/scope-manager': 8.59.2
@@ -52652,6 +52701,11 @@ snapshots:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
 
+  postcss-nested@7.0.2(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 7.1.1
+
   postcss-nesting@13.0.2(postcss@8.5.15):
     dependencies:
       '@csstools/selector-resolve-nested': 3.1.0(postcss-selector-parser@7.1.1)
@@ -55268,6 +55322,10 @@ snapshots:
 
   symbol-tree@3.2.4: {}
 
+  synckit@0.11.13:
+    dependencies:
+      '@pkgr/core': 0.3.6
+
   tabbable@6.4.0: {}
 
   table-layout@4.1.1:
@@ -55276,6 +55334,13 @@ snapshots:
       wordwrapjs: 5.1.1
 
   tagged-tag@1.0.0: {}
+
+  tailwind-api-utils@1.0.3(tailwindcss@4.2.2):
+    dependencies:
+      enhanced-resolve: 5.24.2
+      jiti: 2.7.0
+      local-pkg: 1.1.2
+      tailwindcss: 4.2.2
 
   tailwind-merge@3.5.0: {}
 


### PR DESCRIPTION
Adds eslint-plugin-tailwindcss to the Playground package using its Tailwind v4 stylesheet, then applies the recommended autofixes across existing utility classes. The no-custom-classname rule remains disabled because it still reports valid v4 infinite-spacing utilities, imported theme tokens, and intentional CSS hooks.

Equivalent shorthand changes exposed several brittle class-string assertions, so those assertions were removed while preserving their behavior-focused coverage. Package-wide lint reports zero errors, every changed file passes ESLint with zero warnings, all 216 test files pass (1,466 tests, 2 skipped), and typecheck plus the production build pass.