### PR TITLE
fix(playground): theme workspace file previews

### DIFF
--- a/packages/playground/src/domains/workspace/components/__tests__/file-viewer.test.tsx
+++ b/packages/playground/src/domains/workspace/components/__tests__/file-viewer.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { ThemeProvider } from '@mastra/playground-ui/components/ThemeProvider';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import '@/index.css';
+import { FileViewer } from '../file-browser';
+
+afterEach(() => {
+  cleanup();
+  window.localStorage.clear();
+});
+
+describe('FileViewer', () => {
+  describe('when the light theme is active', () => {
+    it('renders plain text on the themed surface', () => {
+      render(
+        <ThemeProvider defaultTheme="light" storageKey="file-viewer-plain-text-theme">
+          <div data-testid="surface-reference" className="bg-surface2" />
+          <FileViewer path="hello.txt" content="hello" isLoading={false} />
+        </ThemeProvider>,
+      );
+
+      const content = screen.getByText('hello');
+      const viewerSurface = content.parentElement;
+
+      if (!viewerSurface) {
+        throw new Error('Expected the file content to render inside the viewer surface.');
+      }
+
+      const expectedBackground = getComputedStyle(screen.getByTestId('surface-reference')).backgroundColor;
+      expect(getComputedStyle(viewerSurface).backgroundColor).toBe(expectedBackground);
+      expect(expectedBackground).not.toBe('rgb(0, 0, 0)');
+    });
+
+    it('uses a light syntax-highlighting palette', () => {
+      const { container } = render(
+        <ThemeProvider defaultTheme="light" storageKey="file-viewer-highlight-theme">
+          <FileViewer path="config.json" content={'{"enabled": true}'} isLoading={false} />
+        </ThemeProvider>,
+      );
+      const code = container.querySelector<HTMLElement>('pre code');
+
+      if (!code) {
+        throw new Error('Expected highlighted code to render.');
+      }
+
+      expect(getComputedStyle(code).color).toBe('rgb(17, 27, 39)');
+    });
+  });
+});

--- a/packages/playground/src/domains/workspace/components/file-browser.tsx
+++ b/packages/playground/src/domains/workspace/components/file-browser.tsx
@@ -1,6 +1,7 @@
 import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { useTheme } from '@mastra/playground-ui/components/ThemeProvider';
 import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { AmazonIcon } from '@mastra/playground-ui/icons/AmazonIcon';
 import { AzureIcon } from '@mastra/playground-ui/icons/AzureIcon';
@@ -26,7 +27,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { coldarkDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
+import { coldarkCold, coldarkDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import type { FileEntry } from '../types';
 
 // =============================================================================
@@ -494,10 +495,12 @@ function getLanguageFromExtension(ext?: string): string | null {
  * Highlighted code display component using Prism.
  */
 function HighlightedCode({ content, language }: { content: string; language: string }) {
+  const isDark = useTheme().resolvedTheme === 'dark';
+
   return (
     <SyntaxHighlighter
       language={language}
-      style={coldarkDark}
+      style={isDark ? coldarkDark : coldarkCold}
       customStyle={{
         margin: 0,
         padding: '1rem',
@@ -548,7 +551,7 @@ export function FileViewer({ path, content, isLoading, mimeType, onClose }: File
       </div>
 
       {/* Content */}
-      <div className="max-h-[500px] overflow-auto h-full" style={{ backgroundColor: 'black' }}>
+      <div className="max-h-[500px] overflow-auto h-full bg-surface2">
         {isLoading ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-6 w-6 animate-spin text-neutral3" />


### PR DESCRIPTION
Workspace file previews were rendered on a hardcoded black surface and syntax-highlighted files always used the dark CoLDARK palette. In light mode, that left the preview visually disconnected from the rest of Studio.

Before, plain text and code previews stayed dark. After, the preview uses the semantic `bg-surface2` color and chooses the light or dark syntax palette from the active Studio theme. This keeps dark mode unchanged while making light mode consistent.

I added focused regression coverage for plain text and syntax-highlighted files. I also ran the focused Vitest test, touched-file ESLint, the Playground typecheck and production build, the full Playground lint command, and React Doctor (96/100, no issues).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Playground file previews now match Studio’s light and dark themes instead of always looking black. Tests ensure both plain text backgrounds and highlighted code use the correct light-theme styling.

## Changes

- Replaced the hardcoded black file-preview background with the semantic `bg-surface2` surface.
- Switched syntax highlighting between light and dark palettes based on the active Studio theme.
- Added regression tests for plain-text and syntax-highlighted previews.
- Validated with focused tests, ESLint, typecheck, production build, full Playground lint, and React Doctor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->