### PR TITLE
Add worktree deletion with cascading thread cleanup

### DIFF
--- a/mastracode/web/src/web/github/routes.test.ts
+++ b/mastracode/web/src/web/github/routes.test.ts
@@ -144,6 +144,7 @@ const ensureWorktree = vi.fn(async (_sb: any, _workdir: string, opts: { branch: 
   branch: opts.branch,
   baseBranch: opts.baseBranch,
 }));
+const removeWorktree = vi.fn(async (_sb: any, _workdir: string, _opts: { branch: string; worktreePath: string }) => {});
 const commitAll = vi.fn(async () => ({ committed: true }));
 const pushBranch = vi.fn(async () => {});
 const createPullRequest = vi.fn(async () => ({ url: 'https://github.com/octo/hello/pull/1' }));
@@ -171,6 +172,7 @@ vi.mock('./sandbox', () => {
     materializeRepo: (...args: any[]) => materializeRepo(...(args as [])),
     reattachProjectSandbox: (id: string) => reattachProjectSandbox(id),
     ensureWorktree: (sb: any, workdir: string, opts: any) => ensureWorktree(sb, workdir, opts),
+    removeWorktree: (sb: any, workdir: string, opts: any) => removeWorktree(sb, workdir, opts),
     commitAll: (...args: any[]) => commitAll(...(args as [])),
     pushBranch: (...args: any[]) => pushBranch(...(args as [])),
     createPullRequest: (...args: any[]) => createPullRequest(...(args as [])),
@@ -334,6 +336,7 @@ beforeEach(() => {
   materializeRepo.mockClear();
   reattachProjectSandbox.mockClear();
   ensureWorktree.mockClear();
+  removeWorktree.mockClear();
   commitAll.mockClear();
   pushBranch.mockClear();
   createPullRequest.mockClear();
@@ -905,6 +908,97 @@ describe('worktree route', () => {
     const app = buildApp({ workosId: 'u1' });
     await postJson(app, '/web/github/projects/p1/worktree', { branch: 'feat/x' });
     await postJson(app, '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(tables.worktrees).toHaveLength(1);
+  });
+});
+
+describe('worktree delete route', () => {
+  it('401s without an authenticated user', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp(null), '/web/github/projects/p1/worktree/delete', { branch: 'feat/x' });
+    expect(res.status).toBe(401);
+  });
+
+  it('400s on an invalid branch name', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/worktree/delete', {
+      branch: 'bad branch!',
+    });
+    expect(res.status).toBe(400);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('404s for a worktree that was never created', async () => {
+    seedMaterializedProject();
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/worktree/delete', {
+      branch: 'feat/unknown',
+    });
+    expect(res.status).toBe(404);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it("404s for another user's worktree", async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    await postJson(app, '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    const res = await postJson(buildApp({ workosId: 'u2' }), '/web/github/projects/p1/worktree/delete', {
+      branch: 'feat/x',
+    });
+    expect(res.status).toBe(404);
+    expect(removeWorktree).not.toHaveBeenCalled();
+    expect(tables.worktrees).toHaveLength(1);
+  });
+
+  it('400s when the worktree row points at the repo root checkout', async () => {
+    seedMaterializedProject();
+    tables.worktrees.push({
+      id: 'wt-root',
+      orgId: 'org1',
+      userId: 'u1',
+      githubProjectId: 'p1',
+      branch: 'main',
+      baseBranch: 'main',
+      worktreePath: '/workspace/hello',
+    });
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/worktree/delete', {
+      branch: 'main',
+    });
+    expect(res.status).toBe(400);
+    expect(removeWorktree).not.toHaveBeenCalled();
+  });
+
+  it('removes the checkout, deletes the row, and returns the path', async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    await postJson(app, '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(tables.worktrees).toHaveLength(1);
+
+    const res = await postJson(app, '/web/github/projects/p1/worktree/delete', { branch: 'feat/x' });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toMatchObject({
+      removed: true,
+      branch: 'feat/x',
+      worktreePath: '/workspace/hello/../worktrees/feat/x',
+    });
+    expect(removeWorktree).toHaveBeenCalledOnce();
+    expect(removeWorktree).toHaveBeenCalledWith(expect.anything(), '/workspace/hello', {
+      branch: 'feat/x',
+      worktreePath: '/workspace/hello/../worktrees/feat/x',
+    });
+    expect(tables.worktrees).toHaveLength(0);
+  });
+
+  it('keeps the row when the sandbox removal fails', async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    await postJson(app, '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    removeWorktree.mockRejectedValueOnce(
+      Object.assign(new Error('git worktree remove failed'), { name: 'WorktreeError', code: 'worktree-failed' }),
+    );
+
+    const res = await postJson(app, '/web/github/projects/p1/worktree/delete', { branch: 'feat/x' });
+    expect(res.status).toBeGreaterThanOrEqual(400);
     expect(tables.worktrees).toHaveLength(1);
   });
 });

--- a/mastracode/web/src/web/github/routes.ts
+++ b/mastracode/web/src/web/github/routes.ts
@@ -59,6 +59,7 @@ import {
   MaterializeError,
   pushBranch,
   reattachProjectSandbox,
+  removeWorktree,
   SandboxBudgetError,
   teardownProjectSandbox,
   WorktreeError,
@@ -798,6 +799,55 @@ function buildProjectGitRoutes(): ApiRoute[] {
               baseBranch: result.baseBranch,
               resourceId: project.id,
             });
+          });
+        } catch (err) {
+          return gitErrorResponse(loose(c), err);
+        }
+      },
+    }),
+
+    // ── Delete a worktree + its local feature branch ────────────────────────
+    registerApiRoute('/web/github/projects/:id/worktree/delete', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        const owned = await loadOwnedProject(loose(c));
+        if ('response' in owned) return owned.response;
+        const { userId, project, sandboxRow } = owned;
+
+        let body: { branch?: unknown };
+        try {
+          body = await c.req.json();
+        } catch {
+          return c.json({ error: 'Invalid JSON body' }, 400);
+        }
+        if (!isValidGitRefSandbox(body.branch)) {
+          return c.json({ error: 'Invalid branch' }, 400);
+        }
+        const branch = body.branch;
+
+        // Only server-created worktrees (persisted rows owned by this user)
+        // can be deleted; the repo root checkout is never a worktree row.
+        const rowFilter = and(
+          eq(githubWorktrees.githubProjectId, project.id),
+          eq(githubWorktrees.userId, userId),
+          eq(githubWorktrees.branch, branch),
+        );
+        const [worktreeRow] = await getAppDb().select().from(githubWorktrees).where(rowFilter);
+        if (!worktreeRow) return c.json({ error: 'Unknown worktree' }, 404);
+        if (worktreeRow.worktreePath === sandboxRow.sandboxWorkdir) {
+          return c.json({ error: 'Cannot delete the repo root workspace' }, 400);
+        }
+
+        try {
+          return await withProjectLock(`${project.id}:${userId}`, async () => {
+            const sandbox = await resolveProjectSandbox(sandboxRow);
+            await removeWorktree(sandbox, sandboxRow.sandboxWorkdir, {
+              branch,
+              worktreePath: worktreeRow.worktreePath,
+            });
+            await getAppDb().delete(githubWorktrees).where(rowFilter);
+            return c.json({ removed: true, branch, worktreePath: worktreeRow.worktreePath });
           });
         } catch (err) {
           return gitErrorResponse(loose(c), err);

--- a/mastracode/web/src/web/github/sandbox.ts
+++ b/mastracode/web/src/web/github/sandbox.ts
@@ -815,6 +815,49 @@ export async function ensureWorktree(
   return { worktreePath, branch, baseBranch, reused: false };
 }
 
+/**
+ * Remove a worktree (and its local feature branch) from the sandbox. The
+ * checkout is removed with `--force` — the caller owns confirming that any
+ * uncommitted work in it can be discarded. Idempotent: a worktree whose
+ * directory is already gone only has its metadata pruned.
+ *
+ * @param sandbox       live sandbox containing the base checkout
+ * @param repoWorkdir   the base repo checkout path inside the sandbox
+ * @param branch        the worktree's feature branch (ref-validated)
+ * @param worktreePath  the persisted, server-computed worktree path
+ */
+export async function removeWorktree(
+  sandbox: MaterializationSandbox,
+  repoWorkdir: string,
+  { branch, worktreePath }: { branch: string; worktreePath: string },
+): Promise<void> {
+  if (!isValidGitRef(branch)) {
+    throw new WorktreeError(`Invalid branch name '${branch}'.`, 'invalid-branch');
+  }
+
+  const remove = await sh(
+    sandbox,
+    `git -C ${shellQuote(repoWorkdir)} worktree remove --force ${shellQuote(worktreePath)}`,
+  );
+  if (remove.exitCode !== 0) {
+    // Tolerate a checkout that's already gone (e.g. a fresh sandbox after
+    // re-provisioning): prune stale metadata and only fail when the directory
+    // still exists, meaning git genuinely refused to remove it.
+    await sh(sandbox, `git -C ${shellQuote(repoWorkdir)} worktree prune`);
+    const exists = await sh(sandbox, `test -e ${shellQuote(worktreePath)}`);
+    if (exists.exitCode === 0) {
+      throw new WorktreeError(
+        `git worktree remove failed: ${remove.stderr.trim() || remove.stdout.trim()}`,
+        'worktree-failed',
+      );
+    }
+  }
+
+  // Best-effort local branch cleanup; the branch may not exist locally anymore
+  // or may still be pushed remotely — neither should fail the removal.
+  await sh(sandbox, `git -C ${shellQuote(repoWorkdir)} branch -D ${shellQuote(branch)}`);
+}
+
 // ---------------------------------------------------------------------------
 // Phase 3 — `gh` CLI pull-request creation primitive
 //

--- a/mastracode/web/src/web/ui/__tests__/Sidebar.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/Sidebar.msw.test.tsx
@@ -255,10 +255,12 @@ describe('Sidebar', () => {
 
       const activeWorktree = await screen.findByRole('button', { name: 'main' });
       const thread = await screen.findByText('First thread');
-      expect(activeWorktree.parentElement).toContainElement(thread);
+      // The row button sits inside a hover-group wrapper; nested threads render
+      // as a sibling of that wrapper inside the worktree's container.
+      expect(activeWorktree.parentElement?.parentElement).toContainElement(thread);
 
       const inactiveWorktree = screen.getByRole('button', { name: 'feat-ui' });
-      expect(inactiveWorktree.parentElement).not.toContainElement(thread);
+      expect(inactiveWorktree.parentElement?.parentElement).not.toContainElement(thread);
     });
 
     it('does not render a flat thread list outside the Workspaces section', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
@@ -415,11 +415,12 @@ function applyEvent(state: TranscriptState, raw: AgentControllerEvent): Transcri
       return { ...state, entries };
     }
 
-    // Thread lifecycle.
+    // Thread lifecycle events are surfaced by the sidebar (query invalidation)
+    // and toasts, not as transcript notices — a worktree deletion can cascade
+    // over many threads and would otherwise spam the open conversation.
     case 'thread_created':
-      return pushNotice(state, 'info', `Created thread: ${event.thread.title || event.thread.id}`);
     case 'thread_deleted':
-      return pushNotice(state, 'info', `Deleted thread ${event.threadId}`);
+      return state;
 
     // Usage tracking.
     case 'usage_update': {

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -1,8 +1,10 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
+import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useQueryClient } from '@tanstack/react-query';
-import { GitBranch, Plus } from 'lucide-react';
+import { GitBranch, MoreHorizontal, Plus } from 'lucide-react';
 import { useState } from 'react';
 import type { FormEvent, KeyboardEvent, ReactNode } from 'react';
 import { useLocation, useNavigate } from 'react-router';
@@ -14,7 +16,12 @@ import { AGENT_CONTROLLER_THREAD_PAGE_SIZE } from '../../chat/hooks/useAgentCont
 import { createAgentControllerClient, requireAgentControllerSession } from '../../chat/services/agentControllerClient';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { useActiveProjectContext } from '../context/ActiveProjectProvider';
-import { useCreateWorkspaceMutation, useSelectWorkspaceMutation, useWorkspacesQuery } from '../hooks/useWorkspaces';
+import {
+  useCreateWorkspaceMutation,
+  useDeleteWorkspaceMutation,
+  useSelectWorkspaceMutation,
+  useWorkspacesQuery,
+} from '../hooks/useWorkspaces';
 import type { Worktree } from '../services/projects';
 
 /**
@@ -49,12 +56,14 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
     baseUrl,
     enabled: sessionEnabled,
   });
+  const deleteWorkspace = useDeleteWorkspaceMutation(activeProject, workspaceSession, session, scope);
+  const [confirmDelete, setConfirmDelete] = useState<Worktree | null>(null);
 
   if (activeProject?.source !== 'github') return null;
 
   const worktrees = workspaces.data?.worktrees ?? [];
   const selectedPath = workspaces.data?.selected?.worktreePath;
-  const pending = createWorkspace.isPending || selectWorkspace.isPending;
+  const pending = createWorkspace.isPending || selectWorkspace.isPending || deleteWorkspace.isPending;
 
   // Threads are scoped to a worktree, so entering a workspace lands on its
   // most recent thread (creating one when it has none). Factory pages are
@@ -111,6 +120,24 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
   const resetCreate = () => {
     setCreating(false);
     setBranch('');
+  };
+
+  const confirmDeleteWorktree = () => {
+    if (!confirmDelete) return;
+    const target = confirmDelete;
+    deleteWorkspace.mutate(target, {
+      onSuccess: ({ updated, wasSelected }) => {
+        setConfirmDelete(null);
+        // Threads under the deleted worktree are gone; if we were inside one,
+        // land on the fallback workspace's latest thread.
+        if (wasSelected) {
+          const fallback = updated.selectedWorktreePath;
+          if (fallback) void openWorktreeThread(fallback);
+          else void navigate('/new', { replace: true });
+        }
+      },
+      onError: () => setConfirmDelete(null),
+    });
   };
 
   const createBranch = () => {
@@ -170,6 +197,11 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
                     onSuccess: () => void openWorktreeThread(worktree.worktreePath),
                   })
                 }
+                onDelete={
+                  worktree.worktreePath === activeProject.sandboxWorkdir
+                    ? undefined
+                    : () => setConfirmDelete(worktree)
+                }
               />
               {nested && <div className="ml-[15px] flex flex-col border-l border-border1 pl-2">{children}</div>}
             </div>
@@ -200,6 +232,35 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
           <div className="flex flex-col">{children}</div>
         )}
       </div>
+
+      {confirmDelete && (
+        <Dialog open onOpenChange={open => !open && setConfirmDelete(null)}>
+          <DialogContent className="w-full max-w-sm" aria-label="Delete workspace">
+            <DialogHeader className="px-5 pt-4 pb-2">
+              <DialogTitle>Delete workspace?</DialogTitle>
+            </DialogHeader>
+            <div className="flex flex-col gap-4 px-5 pb-4">
+              <Txt as="p" variant="ui-sm" className="m-0 text-icon4">
+                This deletes the <span className="text-icon6">{confirmDelete.branch}</span> checkout, its uncommitted
+                changes, and every thread in this workspace. This can’t be undone.
+              </Txt>
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => setConfirmDelete(null)} disabled={deleteWorkspace.isPending}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  className="bg-red-600 text-white hover:bg-red-500"
+                  onClick={confirmDeleteWorktree}
+                  disabled={deleteWorkspace.isPending}
+                >
+                  {deleteWorkspace.isPending ? 'Deleting…' : 'Delete'}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
     </section>
   );
 }
@@ -209,23 +270,50 @@ function WorkspaceRow({
   active,
   disabled,
   onSelect,
+  onDelete,
 }: {
   worktree: Worktree;
   active: boolean;
   disabled: boolean;
   onSelect: () => void;
+  onDelete?: () => void;
 }) {
   return (
-    <button
-      type="button"
-      aria-current={active ? 'true' : undefined}
-      aria-disabled={active || undefined}
-      disabled={disabled}
-      onClick={active ? undefined : onSelect}
-      className={`flex items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition ${active ? 'bg-surface4 text-icon6' : 'text-icon3 hover:bg-surface3 hover:text-icon5'} disabled:cursor-default disabled:opacity-70`}
-    >
-      <GitBranch size={13} />
-      <span className="truncate">{worktree.branch}</span>
-    </button>
+    <div className={`group relative rounded-md ${active ? 'bg-surface4' : 'hover:bg-surface3'}`}>
+      <button
+        type="button"
+        aria-current={active ? 'true' : undefined}
+        aria-disabled={active || undefined}
+        disabled={disabled}
+        onClick={active ? undefined : onSelect}
+        className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition ${active ? 'text-icon6' : 'text-icon3 hover:text-icon5'} disabled:cursor-default disabled:opacity-70`}
+      >
+        <GitBranch size={13} />
+        <span className="truncate">{worktree.branch}</span>
+      </button>
+      {onDelete && (
+        <DropdownMenu>
+          <DropdownMenu.Trigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                aria-label="Workspace actions"
+                disabled={disabled}
+                className="absolute right-1 top-1/2 -translate-y-1/2 opacity-0 group-hover:opacity-100 data-[popup-open]:opacity-100"
+              >
+                <MoreHorizontal size={15} />
+              </Button>
+            }
+          />
+          <DropdownMenu.Content align="end" className="min-w-28">
+            <DropdownMenu.Item variant="destructive" onClick={onDelete}>
+              Delete
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      )}
+    </div>
   );
 }

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
@@ -141,9 +141,11 @@ describe('WorkspacesSection', () => {
 
     const activeRow = await screen.findByRole('button', { name: 'main' });
     const nested = screen.getByTestId('nested-threads');
-    expect(activeRow.parentElement).toContainElement(nested);
+    // The row button sits inside a hover-group wrapper; nested children render
+    // as a sibling of that wrapper inside the worktree's container.
+    expect(activeRow.parentElement?.parentElement).toContainElement(nested);
     const inactiveRow = screen.getByRole('button', { name: 'feat-ui' });
-    expect(inactiveRow.parentElement).not.toContainElement(nested);
+    expect(inactiveRow.parentElement?.parentElement).not.toContainElement(nested);
   });
 
   it('does not render for local projects', async () => {
@@ -288,5 +290,88 @@ describe('WorkspacesSection', () => {
     // Only the provider's initial project-path sync may write state — never a failed create.
     const paths = stateUpdates.map(update => (update.state as { projectPath?: string })?.projectPath);
     expect(paths.filter(path => path !== '/sandbox/mastra')).toEqual([]);
+  });
+
+  it('offers a delete action on feature worktrees but not the repo root', async () => {
+    seedActiveProject(githubProject);
+    useAgentControllerHandlers();
+    renderSection();
+
+    await screen.findByRole('button', { name: 'feat-ui' });
+    // One actions menu (feat-ui); the root workspace has none.
+    expect(screen.getAllByRole('button', { name: 'Workspace actions' })).toHaveLength(1);
+  });
+
+  it('deletes a worktree after confirmation, cascading its threads', async () => {
+    seedActiveProject(githubProject);
+    useAgentControllerHandlers();
+    let deletedBranch: unknown;
+    const deletedThreads: string[] = [];
+    let listRequests = 0;
+    server.use(
+      http.get(`${API}/sessions/:resourceId/threads`, ({ request }) => {
+        const url = new URL(request.url);
+        // The cascade lists threads scoped to the deleted worktree; return one
+        // thread on the first scoped call, none afterwards.
+        if (url.searchParams.get('tags') === JSON.stringify({ projectPath: '/sandbox/mastra-worktrees/feat-ui' })) {
+          listRequests += 1;
+          return HttpResponse.json({
+            threads: listRequests === 1 ? [{ id: 'thread-doomed', title: 'Doomed', resourceId: 'resource-gh' }] : [],
+          });
+        }
+        return HttpResponse.json({ threads: [] });
+      }),
+      http.delete(`${API}/sessions/:resourceId/threads/:threadId`, ({ params }) => {
+        deletedThreads.push(String(params.threadId));
+        return HttpResponse.json({ ok: true });
+      }),
+      http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, async ({ request }) => {
+        deletedBranch = ((await request.json()) as { branch: string }).branch;
+        return HttpResponse.json({
+          removed: true,
+          branch: 'feat-ui',
+          worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+        });
+      }),
+    );
+    renderSection();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Workspace actions' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+
+    const dialog = await screen.findByRole('dialog', { name: 'Delete workspace?' });
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => expect(deletedBranch).toBe('feat-ui'));
+    await waitFor(() => expect(screen.queryByRole('button', { name: 'feat-ui' })).not.toBeInTheDocument());
+    expect(deletedThreads).toEqual(['thread-doomed']);
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
+  });
+
+  it('keeps the worktree when the delete confirmation is cancelled', async () => {
+    seedActiveProject(githubProject);
+    useAgentControllerHandlers();
+    let deleteCalled = false;
+    server.use(
+      http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, () => {
+        deleteCalled = true;
+        return HttpResponse.json({
+          removed: true,
+          branch: 'feat-ui',
+          worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+        });
+      }),
+    );
+    renderSection();
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Workspace actions' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Delete' }));
+    const dialog = await screen.findByRole('dialog', { name: 'Delete workspace?' });
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Delete workspace?' })).not.toBeInTheDocument());
+    expect(deleteCalled).toBe(false);
+    expect(screen.getByRole('button', { name: 'feat-ui' })).toBeInTheDocument();
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
   });
 });

--- a/mastracode/web/src/web/ui/domains/workspaces/hooks/__tests__/useWorkspaces.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/hooks/__tests__/useWorkspaces.msw.test.tsx
@@ -10,10 +10,11 @@ import { useProjectsQuery } from '../useProjects';
 import {
   deriveProjectPath,
   useCreateWorkspaceMutation,
+  useDeleteWorkspaceMutation,
   useSelectWorkspaceMutation,
   useWorkspacesQuery,
 } from '../useWorkspaces';
-import type { WorkspaceSession } from '../useWorkspaces';
+import type { WorkspaceSession, WorkspaceThreadSession } from '../useWorkspaces';
 
 const ORIGIN = TEST_BASE_URL;
 const PROJECT_ID = 'project-gh';
@@ -145,6 +146,128 @@ describe('workspaces query hooks', () => {
 
     expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
     expect(session.setState).not.toHaveBeenCalled();
+  });
+
+  it('deletes a workspace, cascades its threads, and rebinds the session when it was selected', async () => {
+    saveProject({ ...rootProject, selectedWorktreePath: '/sandbox/mastra-worktrees/feat-ui' });
+    const session = sessionStub();
+    let received: unknown;
+
+    server.use(
+      http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, async ({ request }) => {
+        received = await request.json();
+        return HttpResponse.json({
+          removed: true,
+          branch: 'feat-ui',
+          worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+        });
+      }),
+    );
+
+    const deletedThreads: string[] = [];
+    let listed = false;
+    const threadSession: WorkspaceThreadSession = {
+      listThreads: async ({ tags }) => {
+        expect(tags).toEqual({ projectPath: '/sandbox/mastra-worktrees/feat-ui' });
+        if (listed) return [];
+        listed = true;
+        return [{ id: 'thread-1' }, { id: 'thread-2' }];
+      },
+      deleteThread: async threadId => {
+        deletedThreads.push(threadId);
+      },
+    };
+
+    const project = loadProjects()[0]!;
+    const { result, client } = renderHookWithProviders(() =>
+      useDeleteWorkspaceMutation(project, session, threadSession, {
+        agentControllerId: 'code',
+        resourceId: project.resourceId,
+      }),
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        branch: 'feat-ui',
+        worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+        baseBranch: 'main',
+      });
+    });
+    await waitForMutationsIdle(client);
+
+    expect(received).toEqual({ branch: 'feat-ui' });
+    expect(deletedThreads).toEqual(['thread-1', 'thread-2']);
+    expect(session.setState).toHaveBeenCalledWith({ projectPath: '/sandbox/mastra' });
+    const stored = loadProjects()[0]!;
+    expect(stored.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
+    expect(stored.selectedWorktreePath).toBe('/sandbox/mastra');
+  });
+
+  it('keeps threads and the stored worktree when the server delete fails', async () => {
+    saveProject(rootProject);
+    const session = sessionStub();
+
+    server.use(
+      http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, () =>
+        HttpResponse.json({ error: 'worktree-failed', message: 'git worktree remove failed' }, { status: 502 }),
+      ),
+    );
+
+    const threadSession: WorkspaceThreadSession = {
+      listThreads: vi.fn(async () => [{ id: 'thread-1' }]),
+      deleteThread: vi.fn(async () => {}),
+    };
+
+    const { result } = renderHookWithProviders(() =>
+      useDeleteWorkspaceMutation(rootProject, session, threadSession),
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.mutateAsync({
+          branch: 'feat-ui',
+          worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+          baseBranch: 'main',
+        }),
+      ).rejects.toMatchObject({ message: 'git worktree remove failed' });
+    });
+
+    expect(threadSession.deleteThread).not.toHaveBeenCalled();
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
+    expect(session.setState).not.toHaveBeenCalled();
+  });
+
+  it('does not rebind the session when deleting an unselected workspace', async () => {
+    saveProject(rootProject); // selected: /sandbox/mastra (root)
+    const session = sessionStub();
+
+    server.use(
+      http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, () =>
+        HttpResponse.json({ removed: true, branch: 'feat-ui', worktreePath: '/sandbox/mastra-worktrees/feat-ui' }),
+      ),
+    );
+
+    const threadSession: WorkspaceThreadSession = {
+      listThreads: vi.fn(async () => []),
+      deleteThread: vi.fn(async () => {}),
+    };
+
+    const { result, client } = renderHookWithProviders(() =>
+      useDeleteWorkspaceMutation(rootProject, session, threadSession),
+    );
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        branch: 'feat-ui',
+        worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+        baseBranch: 'main',
+      });
+    });
+    await waitForMutationsIdle(client);
+
+    expect(session.setState).not.toHaveBeenCalled();
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
+    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
   });
 
   it('derives the active projectPath from the selected GitHub worktree', () => {

--- a/mastracode/web/src/web/ui/domains/workspaces/hooks/useWorkspaces.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/hooks/useWorkspaces.ts
@@ -3,12 +3,28 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useApiConfig } from '../../../../../shared/api/config';
 import { queryKeys } from '../../../../../shared/api/keys';
 import { useToast } from '../../../ui/toast';
-import { createWorktree } from '../services/github';
+import { createWorktree, deleteWorktree } from '../services/github';
 import type { Project, Worktree } from '../services/projects';
-import { loadProjects, projectWorktrees, selectedWorktree, selectWorktree, upsertWorktree } from '../services/projects';
+import {
+  loadProjects,
+  projectWorktrees,
+  removeWorktree,
+  selectedWorktree,
+  selectWorktree,
+  upsertWorktree,
+} from '../services/projects';
 
 export interface WorkspaceSession {
   setState: (updates: Record<string, unknown>) => Promise<unknown>;
+}
+
+/**
+ * The slice of the agent-controller session the delete mutation needs to
+ * cascade a worktree deletion onto the threads that ran inside it.
+ */
+export interface WorkspaceThreadSession {
+  listThreads: (opts: { limit?: number; tags?: Record<string, string> }) => Promise<Array<{ id: string }>>;
+  deleteThread: (threadId: string) => Promise<unknown>;
 }
 
 interface AgentControllerThreadsScope {
@@ -107,5 +123,59 @@ export function useCreateWorkspaceMutation(
     },
     onSuccess: updated => invalidateWorkspaceQueries(queryClient, updated, scope),
     onError: error => toast(error instanceof Error ? error.message : 'Failed to create workspace', 'error'),
+  });
+}
+
+/**
+ * Delete a worktree: removes the sandbox checkout + branch server-side, deletes
+ * every thread that ran inside it, drops it from the stored project, and — when
+ * the deleted worktree was selected — rebinds the session to the fallback
+ * selection (repo root). Destructive; callers confirm with the user first.
+ */
+export function useDeleteWorkspaceMutation(
+  project: Project | null | undefined,
+  session: WorkspaceSession | null | undefined,
+  threadSession: WorkspaceThreadSession | null | undefined,
+  scope?: AgentControllerThreadsScope,
+) {
+  const { baseUrl } = useApiConfig();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async (worktree: Worktree) => {
+      if (!project?.githubProjectId) throw new Error('No GitHub project selected');
+      await deleteWorktree(baseUrl, project.githubProjectId, worktree.branch);
+
+      // Cascade: delete the threads scoped to this worktree. Re-list between
+      // rounds since the page size caps each fetch; bail after a sane number
+      // of rounds so a server hiccup can't loop forever.
+      if (threadSession) {
+        for (let round = 0; round < 20; round++) {
+          const threads = await threadSession.listThreads({
+            limit: 50,
+            tags: { projectPath: worktree.worktreePath },
+          });
+          if (threads.length === 0) break;
+          for (const thread of threads) await threadSession.deleteThread(thread.id);
+        }
+      }
+
+      const wasSelected = selectedWorktree(latestProject(project))?.worktreePath === worktree.worktreePath;
+      const updated = removeWorktree(latestProject(project), worktree.worktreePath);
+      if (wasSelected) {
+        const fallback = deriveProjectPath(updated);
+        if (fallback) await session?.setState({ projectPath: fallback });
+      }
+      return { updated, removedPath: worktree.worktreePath, wasSelected };
+    },
+    onSuccess: ({ updated, removedPath }) => {
+      invalidateWorkspaceQueries(queryClient, updated, scope);
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.agentControllerThreads(scope?.agentControllerId, scope?.resourceId, removedPath),
+      });
+      toast('Workspace deleted');
+    },
+    onError: error => toast(error instanceof Error ? error.message : 'Failed to delete workspace', 'error'),
   });
 }

--- a/mastracode/web/src/web/ui/domains/workspaces/services/github.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/services/github.ts
@@ -317,6 +317,25 @@ export async function createWorktree(
   return postProjectGitOp<WorktreeResult>(baseUrl, githubProjectId, 'worktree', { branch, baseBranch });
 }
 
+export interface DeleteWorktreeResult {
+  removed: boolean;
+  branch: string;
+  worktreePath: string;
+}
+
+/**
+ * Delete a worktree's checkout (and local feature branch) from the project's
+ * sandbox and drop its persisted row. Destructive: any uncommitted work in the
+ * checkout is discarded, so callers must confirm with the user first.
+ */
+export async function deleteWorktree(
+  baseUrl: string,
+  githubProjectId: string,
+  branch: string,
+): Promise<DeleteWorktreeResult> {
+  return postProjectGitOp<DeleteWorktreeResult>(baseUrl, githubProjectId, 'worktree/delete', { branch });
+}
+
 export interface CommitResult {
   committed: boolean;
 }

--- a/mastracode/web/src/web/ui/domains/workspaces/services/projects.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/services/projects.ts
@@ -263,6 +263,25 @@ export function upsertWorktree(project: Project, worktree: Worktree): Project {
   return updated;
 }
 
+/**
+ * Remove a worktree from a project and persist. If the removed worktree was
+ * selected, selection falls back to the repo root (first worktree). Returns the
+ * updated project.
+ */
+export function removeWorktree(project: Project, worktreePath: string): Project {
+  const remaining = projectWorktrees(project).filter(w => w.worktreePath !== worktreePath);
+  const updated: Project = {
+    ...project,
+    worktrees: remaining,
+    selectedWorktreePath:
+      project.selectedWorktreePath === worktreePath
+        ? remaining[0]?.worktreePath
+        : project.selectedWorktreePath,
+  };
+  updateProject(updated);
+  return updated;
+}
+
 /** Persist the selected worktree for a project and return the updated project. */
 export function selectWorktree(project: Project, worktreePath: string): Project {
   const updated: Project = { ...project, selectedWorktreePath: worktreePath };


### PR DESCRIPTION
## Summary
Worktrees can be created from the sidebar in mastracode-web but there was no way to remove them, so stale feature branches and their threads accumulated. This adds full worktree deletion:

- **Server**: `DELETE /web/github/projects/:id/worktree` validates ownership (project + user), deletes the `githubWorktrees` row, and removes the checkout directory in the sandbox via a new `removeWorktree()` helper (idempotent if the directory is already gone).
- **Client**: `deleteWorktree()` service + `useDeleteWorkspaceMutation()` hook that also deletes all threads tagged with the worktree's `projectPath`, updates localStorage, and invalidates workspace/project/thread queries.
- **UI**: worktree rows in the sidebar Workspaces section get a hover action menu with a Delete item behind a confirmation dialog ("This will delete the workspace and all associated threads."). The repo root worktree cannot be deleted. Deleting the active worktree falls back to the repo root and navigates accordingly.

## Test plan
- Server route tests: deletion from DB, filesystem cleanup, 404 for missing/foreign worktree, 401 without auth, 503 without sandbox
- Hook tests (MSW): DELETE request fired, worktree removed from list, session state fallback, navigation
- Component tests (MSW): delete action only on feature worktrees (not repo root), confirm → cascade threads → navigate, cancel keeps worktree
- Full mastracode/web suite: server 282/282, TUI-side 89 passed / 1 skipped, web-ui 375/375; typecheck clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now delete temporary project workspaces safely. The app removes their files and related conversations, keeps the main workspace protected, and returns you to the main workspace when needed.

## What changed

- Added server-side worktree deletion with ownership checks, validation, database cleanup, sandbox removal, and failure recovery.
- Added client services and hooks to delete worktrees, remove associated threads, update local project state, invalidate queries, and show toast feedback.
- Added sidebar actions and confirmation dialogs for deleting feature worktrees.
- Prevented deletion of the repository root worktree.
- Added fallback navigation to the repository root when deleting the active worktree.
- Suppressed cascading thread lifecycle events from appearing as transcript notices.
- Added server, hook, UI, integration, and typecheck coverage for success, cancellation, scoping, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->