### PR TITLE
fix(temporal): propagate activity timeout to worker bundle

### DIFF
--- a/.changeset/late-badgers-juggle.md
+++ b/.changeset/late-badgers-juggle.md
@@ -1,0 +1,5 @@
+---
+'@mastra/temporal': patch
+---
+
+Fixed Temporal workflows to apply the configured activity start-to-close timeout in generated worker bundles.

--- a/workflows/temporal/src/__tests__/integration/prebuild.test.ts
+++ b/workflows/temporal/src/__tests__/integration/prebuild.test.ts
@@ -96,6 +96,7 @@ describe('Temporal prebuild integration', () => {
       const { createWorkflow, createStep } = init({
         client: undefined,
         taskQueue: 'mastra',
+        startToCloseTimeout: '5 minutes',
       });
 
       const step1 = createStep({
@@ -167,6 +168,7 @@ describe('Temporal prebuild integration', () => {
     expect(workflowSource).toContain('.then("step4")');
     expect(workflowSource).not.toContain('export const mastra');
     expect(workflowSource).not.toContain('createStep({');
+    expect(workflowSource).toContain("startToCloseTimeout: '5 minutes'");
 
     expect(activitiesSource).toContain('function createStep(args)');
     expect(activitiesSource).toContain('const step1 = createStep({');
@@ -229,7 +231,7 @@ describe('Temporal prebuild integration', () => {
         step4: { result: 'test-step1-inner-step2|test-step1-inner-step3|final' },
       },
     });
-    expect(proxyActivities).toHaveBeenCalledWith({ startToCloseTimeout: '1 minute' });
+    expect(proxyActivities).toHaveBeenCalledWith({ startToCloseTimeout: '5 minutes' });
     expect(executeChild).toHaveBeenCalledWith('innerWorkflow', { args: [{ inputData: { value: 'test-step1' } }] });
     expect(sleep).toHaveBeenCalledWith(1000);
   });

--- a/workflows/temporal/src/transforms/__fixtures__/workflow/weather-workflow/output.js
+++ b/workflows/temporal/src/transforms/__fixtures__/workflow/weather-workflow/output.js
@@ -164,15 +164,13 @@ class TemporalExecutionEngine {
     }
   }
 }
-function createWorkflow(workflowId) {
+function createWorkflow(workflowId, options) {
   const stepFlow = [];
   let autoId = 0;
   const nextId = prefix => `${prefix}_${autoId++}`;
   const workflow = async startArgs => {
     const engine = new TemporalExecutionEngine({
-      options: {
-        startToCloseTimeout: '1 minute'
-      }
+      options
     });
     return engine.execute({
       workflowId,

--- a/workflows/temporal/src/transforms/temporal-workflow-runtime.d.ts
+++ b/workflows/temporal/src/transforms/temporal-workflow-runtime.d.ts
@@ -35,4 +35,4 @@ export class TemporalExecutionEngine {
   }): Promise<WorkflowExecutionResult>;
 }
 
-export function createWorkflow(workflowId: string): WorkflowRuntime;
+export function createWorkflow(workflowId: string, options?: { startToCloseTimeout?: string }): WorkflowRuntime;

--- a/workflows/temporal/src/transforms/temporal-workflow-runtime.mjs
+++ b/workflows/temporal/src/transforms/temporal-workflow-runtime.mjs
@@ -143,17 +143,13 @@ export class TemporalExecutionEngine {
   }
 }
 
-export function createWorkflow(workflowId) {
+export function createWorkflow(workflowId, options) {
   const stepFlow = [];
   let autoId = 0;
   const nextId = prefix => `${prefix}_${autoId++}`;
 
   const workflow = async startArgs => {
-    const engine = new TemporalExecutionEngine({
-      options: {
-        startToCloseTimeout: '1 minute',
-      },
-    });
+    const engine = new TemporalExecutionEngine({ options });
 
     return engine.execute({
       workflowId,

--- a/workflows/temporal/src/transforms/temporal-workflow-runtime.test.ts
+++ b/workflows/temporal/src/transforms/temporal-workflow-runtime.test.ts
@@ -45,6 +45,16 @@ describe('temporal workflow runtime helper module', () => {
     });
   });
 
+  it('uses the configured activity timeout', async () => {
+    proxyActivities.mockReturnValue({});
+
+    const { createWorkflow } = await import('./temporal-workflow-runtime.mjs');
+    const workflow = createWorkflow('weather-workflow', { startToCloseTimeout: '5 minutes' }).commit();
+    await workflow({ inputData: { city: 'SF' } });
+
+    expect(proxyActivities).toHaveBeenCalledWith({ startToCloseTimeout: '5 minutes' });
+  });
+
   it('executes child workflow entries through executeChild', async () => {
     proxyActivities.mockReturnValue({});
     executeChild.mockResolvedValue({ result: { city: 'SF', child: true } });

--- a/workflows/temporal/src/transforms/workflows.test.ts
+++ b/workflows/temporal/src/transforms/workflows.test.ts
@@ -108,6 +108,22 @@ describe('workflow transform', () => {
     expect(output).toContain('log');
     expect(output).toContain('sleep');
     expect(output).toContain('class TemporalExecutionEngine');
-    expect(output).toContain('function createWorkflow(workflowId)');
+    expect(output).toContain('function createWorkflow(workflowId, options)');
+  });
+
+  it('injects the configured activity timeout into transformed workflows', async () => {
+    const output = await transform(`
+      import { init } from '@mastra/temporal';
+
+      const { createWorkflow } = init({
+        client: undefined,
+        taskQueue: 'mastra',
+        startToCloseTimeout: '5 minutes',
+      });
+
+      export const weatherWorkflow = createWorkflow({ id: 'weather-workflow' }).then('fetch-weather');
+    `);
+
+    expect(output).toMatch(/createWorkflow\('weather-workflow',\s*\{\s*startToCloseTimeout: '5 minutes'\s*\}\)/);
   });
 });

--- a/workflows/temporal/src/transforms/workflows.ts
+++ b/workflows/temporal/src/transforms/workflows.ts
@@ -85,6 +85,43 @@ function createTemporalWorkflowHelperStatements(): t.Statement[] {
   });
 }
 
+function getTemporalWorkflowRuntimeOptions(program: t.Program): t.ObjectExpression | undefined {
+  for (const statement of program.body) {
+    const declarationStatement = t.isVariableDeclaration(statement)
+      ? statement
+      : t.isExportNamedDeclaration(statement) && t.isVariableDeclaration(statement.declaration)
+        ? statement.declaration
+        : null;
+
+    if (!declarationStatement) {
+      continue;
+    }
+
+    for (const declaration of declarationStatement.declarations) {
+      if (!isWorkflowHelperDestructure(declaration) || !t.isCallExpression(declaration.init)) {
+        continue;
+      }
+
+      const [temporalParams] = declaration.init.arguments;
+      if (!temporalParams || !t.isObjectExpression(temporalParams)) {
+        continue;
+      }
+
+      for (const property of temporalParams.properties) {
+        if (
+          t.isObjectProperty(property) &&
+          getObjectPropertyName(property) === 'startToCloseTimeout' &&
+          t.isExpression(property.value)
+        ) {
+          return t.objectExpression([
+            t.objectProperty(t.identifier('startToCloseTimeout'), t.cloneNode(property.value, true)),
+          ]);
+        }
+      }
+    }
+  }
+}
+
 /**
  * Walks a chained workflow expression like `createWorkflow(...).then(...).commit()`
  * back to its root `createWorkflow(...)` call while preserving method order.
@@ -373,10 +410,16 @@ function createTemporalWorkflowStatements(
   includeCommit: boolean,
   stepBindings: Map<string, string>,
   workflowBindings: Map<string, string>,
+  runtimeOptions?: t.ObjectExpression,
 ): t.Statement[] {
   // Start from `createWorkflow(<static id>)` and rebuild the chain one call at a time
   // using normalized arguments from `rewriteChainMethod`.
-  let expression: t.Expression = t.callExpression(t.identifier('createWorkflow'), [t.cloneNode(workflowId, true)]);
+  const createWorkflowArgs = [t.cloneNode(workflowId, true)];
+  if (runtimeOptions) {
+    createWorkflowArgs.push(t.cloneNode(runtimeOptions, true));
+  }
+
+  let expression: t.Expression = t.callExpression(t.identifier('createWorkflow'), createWorkflowArgs);
 
   for (const method of methods) {
     const rewrittenMethod = rewriteChainMethod(method, filePath, exportName, stepBindings, workflowBindings);
@@ -482,6 +525,7 @@ interface WorkflowTransformState {
   stepBindings: Map<string, string>;
   workflowBindings: Map<string, string>;
   workflowExports: TemporalWorkflowExport[];
+  runtimeOptions?: t.ObjectExpression;
 }
 
 function createWorkflowTransformState(program: t.Program, filePath: string): WorkflowTransformState {
@@ -494,6 +538,7 @@ function createWorkflowTransformState(program: t.Program, filePath: string): Wor
     stepBindings: collectStepBindings(program),
     workflowBindings: collectWorkflowBindings(program, filePath),
     workflowExports: [],
+    runtimeOptions: getTemporalWorkflowRuntimeOptions(program),
   };
 }
 
@@ -674,6 +719,7 @@ function rewriteWorkflowVariableDeclaration(
         state.committedWorkflowNames.has(declaration.id.name),
         state.stepBindings,
         state.workflowBindings,
+        state.runtimeOptions,
       ),
     );
   }


### PR DESCRIPTION
The startToCloseTimeout option passed to init was retained only on the client-side workflow, so generated worker bundles always used the one-minute default.

This change extracts the configured timeout during the workflow transform and passes it into the generated Temporal runtime while preserving the existing default when the option is omitted. Regression coverage exercises the transform output, runtime behavior, and full prebuild path.

Tested with the Temporal package test suite, typecheck, lint, and filtered dependency build.

Fixes #19340

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Temporal workflows now use the activity timeout you configure instead of always using a one-minute limit. If you don’t configure one, the existing one-minute default remains.

## What changed

- Extracts `startToCloseTimeout` during workflow transformation.
- Passes the configured timeout into generated workflow runtimes and `proxyActivities`.
- Updates runtime declarations and fixtures to support workflow options.
- Adds regression coverage for transformation output, runtime behavior, and the full prebuild path.
- Adds a patch changeset for `@mastra/temporal`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->