### PR TITLE
Fix stale worktree bases, garbled tool output, and OM failures in Mastra Code web

### DIFF
--- a/mastracode/web/docker-compose.yml
+++ b/mastracode/web/docker-compose.yml
@@ -12,7 +12,10 @@
 # src/web/.env.example.
 services:
   app-db:
-    image: postgres:18
+    # pgvector build of the official postgres image — agent memory (recall +
+    # observational memory) stores embeddings in this database and needs the
+    # `vector` extension available.
+    image: pgvector/pgvector:pg18
     container_name: mastracode-web-db
     ports:
       - '54329:5432'

--- a/mastracode/web/src/web/github/routes.test.ts
+++ b/mastracode/web/src/web/github/routes.test.ts
@@ -899,6 +899,14 @@ describe('worktree route', () => {
     expect(json.resourceId).toBe('p1');
     expect(reattachProjectSandbox).toHaveBeenCalledWith('sb-1');
     expect(ensureWorktree).toHaveBeenCalledOnce();
+    // A freshly minted install token + repo name are passed through so the
+    // worktree forks from the latest fetched origin/<base>, not local state.
+    expect(ensureWorktree).toHaveBeenCalledWith(expect.anything(), '/workspace/hello', {
+      branch: 'feat/x',
+      baseBranch: 'main',
+      token: 'install-token',
+      repoFullName: 'octo/hello',
+    });
     expect(tables.worktrees).toHaveLength(1);
     expect(tables.worktrees[0]).toMatchObject({ githubProjectId: 'p1', branch: 'feat/x', userId: 'u1' });
   });

--- a/mastracode/web/src/web/github/routes.ts
+++ b/mastracode/web/src/web/github/routes.ts
@@ -776,7 +776,13 @@ function buildProjectGitRoutes(): ApiRoute[] {
         try {
           return await withProjectLock(`${project.id}:${userId}`, async () => {
             const sandbox = await resolveProjectSandbox(sandboxRow);
-            const result = await ensureWorktree(sandbox, sandboxRow.sandboxWorkdir, { branch, baseBranch });
+            const token = await mintInstallationToken(project.installationId);
+            const result = await ensureWorktree(sandbox, sandboxRow.sandboxWorkdir, {
+              branch,
+              baseBranch,
+              token,
+              repoFullName: project.repoFullName,
+            });
 
             await getAppDb()
               .insert(githubWorktrees)

--- a/mastracode/web/src/web/github/sandbox.test.ts
+++ b/mastracode/web/src/web/github/sandbox.test.ts
@@ -640,15 +640,17 @@ describe('computeWorktreePath', () => {
 });
 
 describe('ensureWorktree', () => {
+  const WT_OPTS = { branch: 'feat/x', baseBranch: 'main', token: 'tok', repoFullName: 'octocat/hello' };
+
   // The default FakeSandbox responder returns OK for everything, which would
   // make `test -e <path>/.git` look like the worktree already exists. Use a
   // responder that fails the existence check so the create path runs.
   const notExisting = (script: string): SandboxCommandResult =>
     script.startsWith('test -e') ? { exitCode: 1, stdout: '', stderr: '' } : OK;
 
-  it('creates a branch + worktree from the base branch when none exists', async () => {
+  it('creates a branch + worktree from the freshly fetched origin base when none exists', async () => {
     const sandbox = new FakeSandbox(notExisting);
-    const result = await ensureWorktree(sandbox, '/workspace/hello', { branch: 'feat/x', baseBranch: 'main' });
+    const result = await ensureWorktree(sandbox, '/workspace/hello', WT_OPTS);
 
     expect(result).toEqual({
       worktreePath: '/workspace/worktrees/feat-x-79b4cc55',
@@ -657,27 +659,66 @@ describe('ensureWorktree', () => {
       reused: false,
     });
     const joined = sandbox.calls.join('\n');
-    expect(joined).toContain("git -C '/workspace/hello' fetch origin 'main'");
+    // The base branch is fetched from origin with an explicit refspec so the
+    // fork point is the latest remote state, not the stale local ref.
+    expect(joined).toContain("git -C '/workspace/hello' fetch origin '+refs/heads/main:refs/remotes/origin/main'");
     expect(joined).toContain(
-      "git -C '/workspace/hello' worktree add -B 'feat/x' '/workspace/worktrees/feat-x-79b4cc55' 'main'",
+      "git -C '/workspace/hello' worktree add --no-track -B 'feat/x' '/workspace/worktrees/feat-x-79b4cc55' 'origin/main'",
     );
   });
 
-  it('reuses an existing worktree without running git worktree add', async () => {
+  it('fetches with the install token and scrubs the remote afterwards', async () => {
+    const sandbox = new FakeSandbox(notExisting);
+    await ensureWorktree(sandbox, '/workspace/hello', WT_OPTS);
+
+    const setUrlIdx = sandbox.calls.findIndex(c => c.includes('remote set-url origin') && c.includes('tok'));
+    const fetchIdx = sandbox.calls.findIndex(c => c.includes('fetch origin'));
+    const scrubIdx = sandbox.calls.findIndex(c => c.includes('remote set-url origin') && !c.includes('tok'));
+    expect(setUrlIdx).toBeGreaterThanOrEqual(0);
+    expect(fetchIdx).toBeGreaterThan(setUrlIdx);
+    expect(scrubIdx).toBeGreaterThan(fetchIdx);
+  });
+
+  it('fails instead of forking a stale local ref when the fetch fails', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.startsWith('test -e')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('fetch origin')) return { exitCode: 128, stdout: '', stderr: 'fatal: unable to fetch' };
+      return OK;
+    });
+    const err = await ensureWorktree(sandbox, '/workspace/hello', WT_OPTS).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('pull-failed');
+    expect(sandbox.calls.some(c => c.includes('worktree add'))).toBe(false);
+  });
+
+  it('classifies an egress-blocked fetch failure', async () => {
+    const sandbox = new FakeSandbox(script => {
+      if (script.startsWith('test -e')) return { exitCode: 1, stdout: '', stderr: '' };
+      if (script.includes('fetch origin'))
+        return { exitCode: 128, stdout: '', stderr: 'fatal: unable to access: Could not resolve host: github.com' };
+      return OK;
+    });
+    const err = await ensureWorktree(sandbox, '/workspace/hello', WT_OPTS).catch(e => e);
+    expect(err).toBeInstanceOf(MaterializeError);
+    expect(err.code).toBe('egress-blocked');
+  });
+
+  it('reuses an existing worktree without fetching or running git worktree add', async () => {
     // Default responder => `test -e` returns OK => path exists => reuse.
     const sandbox = new FakeSandbox();
-    const result = await ensureWorktree(sandbox, '/workspace/hello', { branch: 'feat/x', baseBranch: 'main' });
+    const result = await ensureWorktree(sandbox, '/workspace/hello', WT_OPTS);
 
     expect(result.reused).toBe(true);
     expect(result.worktreePath).toBe('/workspace/worktrees/feat-x-79b4cc55');
     expect(sandbox.calls.some(c => c.includes('worktree add'))).toBe(false);
+    expect(sandbox.calls.some(c => c.includes('fetch origin'))).toBe(false);
   });
 
   it('rejects an unsafe branch name before touching the sandbox', async () => {
     const sandbox = new FakeSandbox(notExisting);
     const err = await ensureWorktree(sandbox, '/workspace/hello', {
+      ...WT_OPTS,
       branch: "x'; rm -rf /; '",
-      baseBranch: 'main',
     }).catch(e => e);
     expect(err).toBeInstanceOf(WorktreeError);
     expect(err.code).toBe('invalid-branch');
@@ -687,7 +728,7 @@ describe('ensureWorktree', () => {
   it('rejects an unsafe base branch name', async () => {
     const sandbox = new FakeSandbox(notExisting);
     const err = await ensureWorktree(sandbox, '/workspace/hello', {
-      branch: 'feat/x',
+      ...WT_OPTS,
       baseBranch: 'bad branch',
     }).catch(e => e);
     expect(err).toBeInstanceOf(WorktreeError);
@@ -701,9 +742,7 @@ describe('ensureWorktree', () => {
       if (script.includes('worktree add')) return { exitCode: 1, stdout: '', stderr: 'fatal: branch in use' };
       return OK;
     });
-    const err = await ensureWorktree(sandbox, '/workspace/hello', { branch: 'feat/x', baseBranch: 'main' }).catch(
-      e => e,
-    );
+    const err = await ensureWorktree(sandbox, '/workspace/hello', WT_OPTS).catch(e => e);
     expect(err).toBeInstanceOf(WorktreeError);
     expect(err.code).toBe('worktree-failed');
   });

--- a/mastracode/web/src/web/github/sandbox.ts
+++ b/mastracode/web/src/web/github/sandbox.ts
@@ -769,17 +769,26 @@ export interface EnsureWorktreeResult {
 /**
  * Create (or reuse) a git worktree + branch inside the sandbox for a unit of
  * work. Idempotent: if a worktree already exists at the computed path it is
- * reused. The branch is created from `baseBranch` when it does not yet exist.
+ * reused. The branch is created from the freshly fetched `origin/<baseBranch>`
+ * — never the sandbox's possibly stale local ref — so new worktrees always
+ * start from the latest remote state.
  *
- * @param sandbox      live sandbox containing the base checkout
- * @param repoWorkdir  the base repo checkout path inside the sandbox
- * @param branch       the feature branch (ref-validated server-side)
- * @param baseBranch   the branch to fork from (ref-validated; default's repo branch)
+ * @param sandbox       live sandbox containing the base checkout
+ * @param repoWorkdir   the base repo checkout path inside the sandbox
+ * @param branch        the feature branch (ref-validated server-side)
+ * @param baseBranch    the branch to fork from (ref-validated; defaults to the repo's default branch)
+ * @param token         short-lived installation token used only for the base-branch fetch
+ * @param repoFullName  `owner/repo` used to build the tokenized remote URL
  */
 export async function ensureWorktree(
   sandbox: MaterializationSandbox,
   repoWorkdir: string,
-  { branch, baseBranch }: { branch: string; baseBranch: string },
+  {
+    branch,
+    baseBranch,
+    token,
+    repoFullName,
+  }: { branch: string; baseBranch: string; token: string; repoFullName: string },
 ): Promise<EnsureWorktreeResult> {
   if (!isValidGitRef(branch)) {
     throw new WorktreeError(`Invalid branch name '${branch}'.`, 'invalid-branch');
@@ -797,16 +806,31 @@ export async function ensureWorktree(
     return { worktreePath, branch, baseBranch, reused: true };
   }
 
-  // Make sure the base ref is present locally before forking from it.
-  await sh(sandbox, `git -C ${shellQuote(repoWorkdir)} fetch origin ${shellQuote(baseBranch)}`);
+  // Fetch the latest base ref from origin before forking. The explicit refspec
+  // updates `refs/remotes/origin/<base>` even when the checkout was created as
+  // a single-branch clone. The fetch needs the install token (the resting
+  // remote is tokenless), and a failure is a hard error — silently forking a
+  // stale local ref is worse than failing the request.
+  const baseRef = `origin/${baseBranch}`;
+  await withInstallToken(sandbox, repoWorkdir, repoFullName, token, async () => {
+    const fetch = await sh(
+      sandbox,
+      `git -C ${shellQuote(repoWorkdir)} fetch origin ${shellQuote(`+refs/heads/${baseBranch}:refs/remotes/${baseRef}`)}`,
+    );
+    if (fetch.exitCode !== 0) {
+      throw classifyGitFailure(fetch, 'pull-failed');
+    }
+  });
 
   // Create the worktree. If the branch already exists, check it out into the
-  // worktree; otherwise create it from the base branch. `git worktree add -B`
+  // worktree; otherwise create it from the fetched base. `git worktree add -B`
   // creates-or-resets the branch to the base, which keeps this idempotent for a
   // fresh worktree while still working when the branch already exists remotely.
+  // `--no-track` keeps the feature branch from tracking origin/<base>; pushes
+  // set their own upstream via `push -u`.
   const add = await sh(
     sandbox,
-    `git -C ${shellQuote(repoWorkdir)} worktree add -B ${shellQuote(branch)} ${shellQuote(worktreePath)} ${shellQuote(baseBranch)}`,
+    `git -C ${shellQuote(repoWorkdir)} worktree add --no-track -B ${shellQuote(branch)} ${shellQuote(worktreePath)} ${shellQuote(baseRef)}`,
   );
   if (add.exitCode !== 0) {
     throw new WorktreeError(`git worktree add failed: ${add.stderr.trim() || add.stdout.trim()}`, 'worktree-failed');

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -20,6 +20,7 @@ import {
   useApproveAgentControllerToolMutation,
   useRespondAgentControllerSuspensionMutation,
 } from '../hooks/useAgentControllerRunMutations';
+import { stripSerializedAnsi } from '../services/ansi';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 
 function ToolIcon({ name, size = 14, className }: { name: string; size?: number; className?: string }) {
@@ -216,7 +217,8 @@ function ToolCard({
   }, [forceExpanded]);
   const argsPreview = tool.args !== undefined ? JSON.stringify(tool.args) : tool.argsText;
   const argsPretty = tool.args !== undefined ? stringify(tool.args) : tool.argsText;
-  const resultText = tool.status !== 'running' && tool.result !== undefined ? stringify(tool.result) : undefined;
+  const resultText =
+    tool.status !== 'running' && tool.result !== undefined ? stripSerializedAnsi(stringify(tool.result)) : undefined;
   const edit = editArgs(tool.toolName, tool.args);
 
   return (

--- a/mastracode/web/src/web/ui/domains/chat/services/__tests__/ansi.test.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/__tests__/ansi.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { stripAnsi, stripSerializedAnsi } from '../ansi';
+
+describe('stripAnsi', () => {
+  it('removes color escape sequences from PTY output', () => {
+    expect(stripAnsi('\u001b[1;38m{\u001b[m\n  \u001b[1;34m"title"\u001b[m: \u001b[32m"Fix bug"\u001b[m')).toBe(
+      '{\n  "title": "Fix bug"',
+    );
+  });
+
+  it('removes cursor and erase sequences', () => {
+    expect(stripAnsi('progress\u001b[2K\u001b[1Gdone')).toBe('progressdone');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(stripAnsi('plain output with [brackets] and 100% signs')).toBe(
+      'plain output with [brackets] and 100% signs',
+    );
+  });
+});
+
+describe('stripSerializedAnsi', () => {
+  it('removes JSON-escaped escape sequences from serialized results', () => {
+    expect(stripSerializedAnsi('"\\u001b[32mok\\u001b[m all good"')).toBe('"ok all good"');
+  });
+});

--- a/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -121,6 +121,26 @@ describe('transcript reducer message entries', () => {
     ]);
   });
 
+  it('strips ANSI escape sequences from streamed shell output', () => {
+    const started = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: { type: 'tool_start', toolCallId: 'tool-1', toolName: 'execute_command', args: { command: 'gh pr view' } },
+    });
+
+    const state = transcriptReducer(started, {
+      type: 'event',
+      event: {
+        type: 'shell_output',
+        toolCallId: 'tool-1',
+        output: '\u001b[1;38m{\u001b[m\n  \u001b[1;34m"title"\u001b[m: \u001b[32m"Fix bug"\u001b[m\n',
+      },
+    });
+
+    const entry = state.entries[0];
+    if (!entry || entry.kind !== 'message') throw new Error('expected a message entry');
+    expect(entry.runtimeTools?.['tool-1']?.output).toBe('{\n  "title": "Fix bug"\n');
+  });
+
   it('ignores active mode and model events because focused providers own that state', () => {
     const state = transcriptReducer(initialTranscript, {
       type: 'event',

--- a/mastracode/web/src/web/ui/domains/chat/services/ansi.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/ansi.ts
@@ -1,0 +1,25 @@
+/**
+ * Strip ANSI terminal escape sequences from tool output.
+ *
+ * Sandbox commands run in a PTY, so CLIs like `gh` detect a TTY and emit
+ * color/formatting escapes even when NO_COLOR is set. The web transcript
+ * renders plain text, so these sequences show up as garbage like `[1;38m`.
+ */
+
+// CSI/OSC escape sequences (subset of the well-known ansi-regex pattern).
+// eslint-disable-next-line no-control-regex
+const ANSI_RE =
+  /[\u001b\u009b][[\]()#;?]*(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d/#&.:=?%@~_]*)*)?\u0007|(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~])/g;
+
+// The same sequences after JSON.stringify escapes the ESC byte (`\u001b[1;38m`),
+// as seen when a persisted tool result string is re-serialized for display.
+const ESCAPED_ANSI_RE = /\\u001[bB]\[[0-9;]*[a-zA-Z]/g;
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, '');
+}
+
+/** Strip both raw and JSON-escaped ANSI sequences from serialized text. */
+export function stripSerializedAnsi(text: string): string {
+  return stripAnsi(text).replace(ESCAPED_ANSI_RE, '');
+}

--- a/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
@@ -8,6 +8,7 @@ import type {
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent';
 
 import { toMastraDBMessage } from './agent-controller-message-accumulator';
+import { stripAnsi } from './ansi';
 
 /**
  * Transcript model + reducer.
@@ -307,7 +308,7 @@ function applyEvent(state: TranscriptState, raw: AgentControllerEvent): Transcri
         },
       );
     case 'shell_output':
-      return withTool(state, event.toolCallId, t => ({ ...t, output: t.output + event.output }));
+      return withTool(state, event.toolCallId, t => ({ ...t, output: t.output + stripAnsi(event.output) }));
     case 'tool_update':
       return withTool(state, event.toolCallId, t => ({ ...t, result: event.partialResult }));
     case 'tool_end':


### PR DESCRIPTION
## Summary

Three fixes for the Mastra Code web surface:

**Worktrees now fork from the latest `origin/<base>`.** Creating a new worktree previously branched off whatever local base branch state the repo was materialized with — `git fetch` failed silently on private repos because the remote URL had no token, so worktrees started from stale code. The worktree route now mints a short-lived installation token, fetches the base branch with an explicit refspec (so single-branch clones still update `origin/<base>`), and forks with `worktree add --no-track -B <branch> <path> origin/<base>`. Failed fetches are now hard, classified errors instead of silent stale forks. Existing worktrees are reused untouched.

**Tool output in chat no longer shows ANSI escape garbage.** Sandbox commands run in a PTY, so CLIs like `gh` emit color escapes even with `NO_COLOR` set, which rendered as `[1;38m`-style noise in tool cards. ANSI sequences are stripped as `shell_output` chunks accumulate in the transcript reducer, and JSON-escaped sequences are stripped from serialized tool results at render time so persisted history is clean too.

**Observational memory works against the local app database.** The local docker-compose app DB ran plain `postgres:18`, which doesn't ship the pgvector extension; OM observation buffering then failed with `type "vector" does not exist`. The compose file now uses `pgvector/pgvector:pg18` (same official postgres base, data-volume compatible).

## Test plan

- `mastracode/web` server tests: 180/180 passing (worktree fetch/fork + token-minting specs added)
- `mastracode/web` UI tests: 295/295 passing (new `ansi.test.ts` + reducer spec for stripped shell output)
- Typecheck and prettier clean
- Verified locally: recreated the app DB container on the pgvector image, existing tables intact, `CREATE EXTENSION vector` succeeds (v0.8.5)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes new code workspaces safer and more up to date, cleans strange terminal symbols from command output, and enables the database feature needed for agent memory.

## Changes

- Fetches the latest base branch before creating new Git worktrees, using a short-lived GitHub installation token.
- Prevents stale worktrees when fetching fails and classifies network/egress failures appropriately.
- Keeps existing worktrees unchanged.
- Removes ANSI escape sequences from tool output before storing and displaying transcript history.
- Uses `pgvector/pgvector:pg18` for the local app database to support vector embeddings.
- Adds and updates coverage for worktree fetching, failure handling, ANSI sanitization, and transcript behavior.

## Validation

- Server and UI tests pass.
- Typecheck and formatting are clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->