### PR TITLE
feat(core): scoped agent controller sessions for parallel worktree runs

### DIFF
--- a/.changeset/big-parrots-tickle.md
+++ b/.changeset/big-parrots-tickle.md
@@ -1,0 +1,26 @@
+---
+'@mastra/core': minor
+---
+
+Added session scoping to `AgentController` so independent sessions can run in parallel over the same resource (for example one session per git worktree).
+
+Previously `createSession()` was get-or-create by `resourceId` alone, so two callers sharing a resource always resolved to the same session — with one run loop, one thread binding, and shared mode/model/state. Passing the new `scope` option creates an independent session per scope:
+
+```ts
+// Two independent sessions over the same resource:
+const a = await controller.createSession({
+  resourceId: 'repo-123',
+  scope: '/worktrees/feature-a',
+  tags: { projectPath: '/worktrees/feature-a' },
+});
+const b = await controller.createSession({
+  resourceId: 'repo-123',
+  scope: '/worktrees/feature-b',
+  tags: { projectPath: '/worktrees/feature-b' },
+});
+
+// Look up a scoped session later:
+const session = await controller.getSessionByResource('repo-123', '/worktrees/feature-a');
+```
+
+Calls with the same `resourceId` and `scope` still resume the same session (get-or-create), and unscoped sessions behave exactly as before.

--- a/.changeset/lucky-moons-attack.md
+++ b/.changeset/lucky-moons-attack.md
@@ -1,0 +1,20 @@
+---
+'@mastra/client-js': patch
+'@mastra/server': patch
+'mastra': patch
+---
+
+Added an optional session scope to the agent controller API so clients can address independent sessions that share one resource (for example one session per git worktree).
+
+Session routes now accept a `sessionScope` query parameter, and `AgentController.session()` in the client accepts a scope that travels on every request:
+
+```ts
+const controller = client.getAgentController('code');
+
+// Address the worktree's own session instead of the shared one:
+const session = controller.session('repo-123', '/worktrees/feature-a');
+await session.create({ tags: { projectPath: '/worktrees/feature-a' } });
+await session.sendMessage('hello');
+```
+
+Requests without a scope behave exactly as before.

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -319,20 +319,34 @@ export interface AgentControllerSubscription {
 
 /**
  * A session bound to a `resourceId` within one agent controller. Sessions are
- * get-or-create on the server, so re-creating the same resourceId resumes the
- * existing conversation rather than forking it.
+ * get-or-create on the server, so re-creating the same resourceId (and scope)
+ * resumes the existing conversation rather than forking it.
+ *
+ * Pass a `scope` to address an independent session over the same resourceId:
+ * two sessions with the same resourceId but different scopes have their own
+ * run loop, thread binding, and mode/model/state (e.g. one session per git
+ * worktree, with the worktree path as the scope). The scope travels on every
+ * request as a `sessionScope` query param.
  */
 export class AgentControllerSession extends BaseResource {
   constructor(
     options: ClientOptions,
     private readonly controllerId: string,
     private readonly resourceId: string,
+    private readonly scope?: string,
   ) {
     super(options);
   }
 
   private base() {
     return `/agent-controller/${encodeURIComponent(this.controllerId)}/sessions/${encodeURIComponent(this.resourceId)}`;
+  }
+
+  /** Append this session's scope (if any) as a `sessionScope` query param. */
+  private url(path: string): string {
+    if (this.scope === undefined) return path;
+    const sep = path.includes('?') ? '&' : '?';
+    return `${path}${sep}sessionScope=${encodeURIComponent(this.scope)}`;
   }
 
   /**
@@ -345,7 +359,7 @@ export class AgentControllerSession extends BaseResource {
   create(options?: { tags?: Record<string, string> }): Promise<CreateAgentControllerSessionResponse> {
     return this.request(`/agent-controller/${encodeURIComponent(this.controllerId)}/sessions`, {
       method: 'POST',
-      body: { resourceId: this.resourceId, tags: options?.tags },
+      body: { resourceId: this.resourceId, tags: options?.tags, sessionScope: this.scope },
     });
   }
 
@@ -354,7 +368,7 @@ export class AgentControllerSession extends BaseResource {
    * message arrives here as `message_*` events, not on the sendMessage call.
    */
   async subscribe(options: SubscribeAgentControllerSessionOptions): Promise<AgentControllerSubscription> {
-    const response = (await this.request(`${this.base()}/stream`, { stream: true })) as Response;
+    const response = (await this.request(this.url(`${this.base()}/stream`), { stream: true })) as Response;
     if (!response.body) {
       throw new Error('No response body for agent controller session stream');
     }
@@ -405,17 +419,17 @@ export class AgentControllerSession extends BaseResource {
 
   /** Send a user message. The reply streams over `subscribe()`. */
   async sendMessage(message: string): Promise<void> {
-    await this.request(`${this.base()}/messages`, { method: 'POST', body: { message } });
+    await this.request(this.url(`${this.base()}/messages`), { method: 'POST', body: { message } });
   }
 
   /** Abort the in-flight run for this session. */
   async abort(): Promise<void> {
-    await this.request(`${this.base()}/abort`, { method: 'POST' });
+    await this.request(this.url(`${this.base()}/abort`), { method: 'POST' });
   }
 
   /** Approve or decline a pending tool call (`tool_approval_required`). */
   async approveTool(toolCallId: string, approved: boolean): Promise<void> {
-    await this.request(`${this.base()}/tool-approval`, {
+    await this.request(this.url(`${this.base()}/tool-approval`), {
       method: 'POST',
       body: { toolCallId, approved },
     });
@@ -427,7 +441,7 @@ export class AgentControllerSession extends BaseResource {
    * `request_access`, and a {@link PlanResume} for `submit_plan`.
    */
   async respondToToolSuspension(toolCallId: string, resumeData: string | string[] | PlanResume): Promise<void> {
-    await this.request(`${this.base()}/tool-suspension`, {
+    await this.request(this.url(`${this.base()}/tool-suspension`), {
       method: 'POST',
       body: { toolCallId, resumeData },
     });
@@ -435,27 +449,27 @@ export class AgentControllerSession extends BaseResource {
 
   /** Inject a message into the in-flight run without starting a new turn. */
   async steer(message: string): Promise<void> {
-    await this.request(`${this.base()}/steer`, { method: 'POST', body: { message } });
+    await this.request(this.url(`${this.base()}/steer`), { method: 'POST', body: { message } });
   }
 
   /** Get the current mode, model, and thread (for initial UI hydration). */
   state(): Promise<AgentControllerSessionState> {
-    return this.request(this.base());
+    return this.request(this.url(this.base()));
   }
 
   /** Merge key-value pairs into the session state. Existing keys not in the payload are preserved. */
   async setState(updates: Record<string, unknown>): Promise<void> {
-    await this.request(`${this.base()}/state`, { method: 'PUT', body: { state: updates } });
+    await this.request(this.url(`${this.base()}/state`), { method: 'PUT', body: { state: updates } });
   }
 
   /** Switch the active mode (e.g. `build`, `plan`). */
   async switchMode(modeId: string): Promise<void> {
-    await this.request(`${this.base()}/mode`, { method: 'POST', body: { modeId } });
+    await this.request(this.url(`${this.base()}/mode`), { method: 'POST', body: { modeId } });
   }
 
   /** Switch the model. Defaults to thread scope. */
   async switchModel(modelId: string, options?: { scope?: 'global' | 'thread'; modeId?: string }): Promise<void> {
-    await this.request(`${this.base()}/model`, {
+    await this.request(this.url(`${this.base()}/model`), {
       method: 'POST',
       body: { modelId, scope: options?.scope, modeId: options?.modeId },
     });
@@ -477,18 +491,20 @@ export class AgentControllerSession extends BaseResource {
     if (opts.limit != null) params.set('limit', String(opts.limit));
     if (opts.tags && Object.keys(opts.tags).length > 0) params.set('tags', JSON.stringify(opts.tags));
     const query = params.toString() ? `?${params.toString()}` : '';
-    const body = await this.request<{ threads: AgentControllerThreadInfo[] }>(`${this.base()}/threads${query}`);
+    const body = await this.request<{ threads: AgentControllerThreadInfo[] }>(
+      this.url(`${this.base()}/threads${query}`),
+    );
     return body.threads;
   }
 
   /** Switch the session to an existing thread (rebinds stream + state). */
   async switchThread(threadId: string): Promise<void> {
-    await this.request(`${this.base()}/thread`, { method: 'POST', body: { threadId } });
+    await this.request(this.url(`${this.base()}/thread`), { method: 'POST', body: { threadId } });
   }
 
   /** Create a new thread (unbinds previous, binds the new one). */
   async createThread(title?: string): Promise<AgentControllerThreadInfo> {
-    return this.request(`${this.base()}/threads`, {
+    return this.request(this.url(`${this.base()}/threads`), {
       method: 'POST',
       body: { title },
     });
@@ -496,14 +512,14 @@ export class AgentControllerSession extends BaseResource {
 
   /** Delete a thread. If it's the active thread the session unbinds. */
   async deleteThread(threadId: string): Promise<void> {
-    await this.request(`${this.base()}/threads/${encodeURIComponent(threadId)}`, {
+    await this.request(this.url(`${this.base()}/threads/${encodeURIComponent(threadId)}`), {
       method: 'DELETE',
     });
   }
 
   /** Rename a thread. */
   async renameThread(threadId: string, title: string): Promise<void> {
-    await this.request(`${this.base()}/threads/${encodeURIComponent(threadId)}`, {
+    await this.request(this.url(`${this.base()}/threads/${encodeURIComponent(threadId)}`), {
       method: 'PUT',
       body: { title },
     });
@@ -511,7 +527,7 @@ export class AgentControllerSession extends BaseResource {
 
   /** Clone a thread (and its messages). The session binds to the clone. */
   async cloneThread(options?: { sourceThreadId?: string; title?: string }): Promise<AgentControllerThreadInfo> {
-    return this.request(`${this.base()}/threads/clone`, {
+    return this.request(this.url(`${this.base()}/threads/clone`), {
       method: 'POST',
       body: options ?? {},
     });
@@ -521,7 +537,7 @@ export class AgentControllerSession extends BaseResource {
   async listMessages(threadId: string, limit?: number): Promise<AgentControllerMessage[]> {
     const params = limit != null ? `?limit=${limit}` : '';
     const body = await this.request<{ messages: AgentControllerMessage[] }>(
-      `${this.base()}/threads/${encodeURIComponent(threadId)}/messages${params}`,
+      this.url(`${this.base()}/threads/${encodeURIComponent(threadId)}/messages${params}`),
     );
     return body.messages;
   }
@@ -531,18 +547,18 @@ export class AgentControllerSession extends BaseResource {
    * if a run is active it queues for after completion.
    */
   async followUp(message: string): Promise<void> {
-    await this.request(`${this.base()}/follow-up`, { method: 'POST', body: { message } });
+    await this.request(this.url(`${this.base()}/follow-up`), { method: 'POST', body: { message } });
   }
 
   /** Get the observational memory record for this session's thread. */
   async getOMRecord(): Promise<unknown> {
-    const body = await this.request<{ record: unknown }>(`${this.base()}/om`);
+    const body = await this.request<{ record: unknown }>(this.url(`${this.base()}/om`));
     return body.record;
   }
 
   /** Change the session's resource identity. */
   async setResourceId(newResourceId: string): Promise<void> {
-    await this.request(`${this.base()}/resource`, {
+    await this.request(this.url(`${this.base()}/resource`), {
       method: 'POST',
       body: { newResourceId },
     });
@@ -550,13 +566,13 @@ export class AgentControllerSession extends BaseResource {
 
   /** Get known resource IDs for this session. */
   async getResourceIds(): Promise<string[]> {
-    const body = await this.request<{ resourceIds: string[] }>(`${this.base()}/resources`);
+    const body = await this.request<{ resourceIds: string[] }>(this.url(`${this.base()}/resources`));
     return body.resourceIds;
   }
 
   /** Get the current goal for this session's thread. */
   async getGoal(): Promise<AgentControllerGoalRecord | undefined> {
-    const body = await this.request<{ goal?: AgentControllerGoalRecord }>(`${this.base()}/goal`);
+    const body = await this.request<{ goal?: AgentControllerGoalRecord }>(this.url(`${this.base()}/goal`));
     return body.goal;
   }
 
@@ -565,7 +581,7 @@ export class AgentControllerSession extends BaseResource {
     objective: string,
     options?: { judgeModelId?: string; maxRuns?: number },
   ): Promise<AgentControllerGoalRecord | undefined> {
-    const body = await this.request<{ goal?: AgentControllerGoalRecord }>(`${this.base()}/goal`, {
+    const body = await this.request<{ goal?: AgentControllerGoalRecord }>(this.url(`${this.base()}/goal`), {
       method: 'POST',
       body: { objective, ...options },
     });
@@ -578,7 +594,7 @@ export class AgentControllerSession extends BaseResource {
     maxRuns?: number;
     status?: 'active' | 'paused' | 'done';
   }): Promise<AgentControllerGoalRecord | undefined> {
-    const body = await this.request<{ goal?: AgentControllerGoalRecord }>(`${this.base()}/goal`, {
+    const body = await this.request<{ goal?: AgentControllerGoalRecord }>(this.url(`${this.base()}/goal`), {
       method: 'PUT',
       body: options,
     });
@@ -587,7 +603,7 @@ export class AgentControllerSession extends BaseResource {
 
   /** Clear the current goal. */
   async clearGoal(): Promise<void> {
-    await this.request(`${this.base()}/goal`, { method: 'DELETE' });
+    await this.request(this.url(`${this.base()}/goal`), { method: 'DELETE' });
   }
 
   // ---------------------------------------------------------------------------
@@ -596,12 +612,12 @@ export class AgentControllerSession extends BaseResource {
 
   /** Get the current permission rules (per-category and per-tool policies). */
   async getPermissions(): Promise<PermissionRules> {
-    return this.request(`${this.base()}/permissions`);
+    return this.request(this.url(`${this.base()}/permissions`));
   }
 
   /** Set the approval policy for a tool category. */
   async setPermissionForCategory(category: ToolCategory, policy: PermissionPolicy): Promise<void> {
-    await this.request(`${this.base()}/permissions/category`, {
+    await this.request(this.url(`${this.base()}/permissions/category`), {
       method: 'PUT',
       body: { category, policy },
     });
@@ -609,7 +625,7 @@ export class AgentControllerSession extends BaseResource {
 
   /** Set the approval policy for a specific tool. */
   async setPermissionForTool(toolName: string, policy: PermissionPolicy): Promise<void> {
-    await this.request(`${this.base()}/permissions/tool`, {
+    await this.request(this.url(`${this.base()}/permissions/tool`), {
       method: 'PUT',
       body: { toolName, policy },
     });
@@ -621,7 +637,7 @@ export class AgentControllerSession extends BaseResource {
    * or is persisted for later.
    */
   async sendNotification(input: SendNotificationInput): Promise<SendNotificationResult> {
-    return this.request(`${this.base()}/notifications`, {
+    return this.request(this.url(`${this.base()}/notifications`), {
       method: 'POST',
       body: input,
     });
@@ -658,9 +674,13 @@ export class AgentController extends BaseResource {
     return this.request(`${this.basePath()}/workspace`);
   }
 
-  /** Scope to a session bound to `resourceId` (e.g. a user or conversation id). */
-  session(resourceId: string): AgentControllerSession {
-    return new AgentControllerSession(this.options, this.controllerId, resourceId);
+  /**
+   * Scope to a session bound to `resourceId` (e.g. a user or conversation id).
+   * Pass `scope` to address an independent session over the same resourceId
+   * (e.g. one session per git worktree, with the worktree path as the scope).
+   */
+  session(resourceId: string, scope?: string): AgentControllerSession {
+    return new AgentControllerSession(this.options, this.controllerId, resourceId, scope);
   }
 }
 

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -91400,6 +91400,7 @@ export type PostAgentControllerControllerIdSessions_Body = {
         [key: string]: string;
       }
     | undefined;
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessions_Response = {
@@ -91435,6 +91436,10 @@ export interface PostAgentControllerControllerIdSessions_RouteContract {
 export type GetAgentControllerControllerIdSessionsResourceId_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type GetAgentControllerControllerIdSessionsResourceId_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type GetAgentControllerControllerIdSessionsResourceId_Response = {
@@ -91475,13 +91480,17 @@ export type GetAgentControllerControllerIdSessionsResourceId_Request = Simplify<
   (GetAgentControllerControllerIdSessionsResourceId_PathParams extends never
     ? {}
     : { params: GetAgentControllerControllerIdSessionsResourceId_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (GetAgentControllerControllerIdSessionsResourceId_QueryParams extends never
+      ? {}
+      : {} extends GetAgentControllerControllerIdSessionsResourceId_QueryParams
+        ? { query?: GetAgentControllerControllerIdSessionsResourceId_QueryParams }
+        : { query: GetAgentControllerControllerIdSessionsResourceId_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface GetAgentControllerControllerIdSessionsResourceId_RouteContract {
   pathParams: GetAgentControllerControllerIdSessionsResourceId_PathParams;
-  queryParams: never;
+  queryParams: GetAgentControllerControllerIdSessionsResourceId_QueryParams;
   body: never;
   request: GetAgentControllerControllerIdSessionsResourceId_Request;
   response: GetAgentControllerControllerIdSessionsResourceId_Response;
@@ -91498,6 +91507,7 @@ export type GetAgentControllerControllerIdSessionsResourceIdThreads_PathParams =
 
 export type GetAgentControllerControllerIdSessionsResourceIdThreads_QueryParams = {
   limit?: number | undefined;
+  sessionScope?: string | undefined;
   tags?:
     | (
         | {
@@ -91550,6 +91560,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdThreads_PathParams 
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdThreads_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdThreads_Body = {
   title?: string | undefined;
 };
@@ -91566,7 +91580,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdThreads_Request = S
   (PostAgentControllerControllerIdSessionsResourceIdThreads_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdThreads_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdThreads_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdThreads_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdThreads_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdThreads_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdThreads_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdThreads_Body
@@ -91576,7 +91594,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdThreads_Request = S
 
 export interface PostAgentControllerControllerIdSessionsResourceIdThreads_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdThreads_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdThreads_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdThreads_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdThreads_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdThreads_Response;
@@ -91592,6 +91610,10 @@ export type DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_P
   threadId: string;
 };
 
+export type DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Response = {
   ok: boolean;
 };
@@ -91600,13 +91622,17 @@ export type DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_R
   (DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_PathParams extends never
     ? {}
     : { params: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams extends never
+      ? {}
+      : {} extends DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams
+        ? { query?: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams }
+        : { query: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_RouteContract {
   pathParams: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_PathParams;
-  queryParams: never;
+  queryParams: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams;
   body: never;
   request: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Request;
   response: DeleteAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Response;
@@ -91622,6 +91648,10 @@ export type PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Path
   threadId: string;
 };
 
+export type PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Body = {
   title: string;
 };
@@ -91634,7 +91664,11 @@ export type PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Requ
   (PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_PathParams extends never
     ? {}
     : { params: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams extends never
+      ? {}
+      : {} extends PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams
+        ? { query?: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams }
+        : { query: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams }) &
     (PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Body extends never
       ? {}
       : {} extends PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Body
@@ -91644,7 +91678,7 @@ export type PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Requ
 
 export interface PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_RouteContract {
   pathParams: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_PathParams;
-  queryParams: never;
+  queryParams: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_QueryParams;
   body: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Body;
   request: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Request;
   response: PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId_Response;
@@ -91657,6 +91691,10 @@ export interface PutAgentControllerControllerIdSessionsResourceIdThreadsThreadId
 export type PostAgentControllerControllerIdSessionsResourceIdThreadsClone_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PostAgentControllerControllerIdSessionsResourceIdThreadsClone_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Body = {
@@ -91676,7 +91714,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Reques
   (PostAgentControllerControllerIdSessionsResourceIdThreadsClone_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdThreadsClone_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdThreadsClone_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Body
@@ -91686,7 +91728,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Reques
 
 export interface PostAgentControllerControllerIdSessionsResourceIdThreadsClone_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdThreadsClone_Response;
@@ -91704,6 +91746,7 @@ export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessa
 
 export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessages_QueryParams = {
   limit?: number | undefined;
+  sessionScope?: string | undefined;
 };
 
 export type GetAgentControllerControllerIdSessionsResourceIdThreadsThreadIdMessages_Response = {
@@ -91747,17 +91790,25 @@ export type GetAgentControllerControllerIdSessionsResourceIdStream_PathParams = 
   resourceId: string;
 };
 
+export type GetAgentControllerControllerIdSessionsResourceIdStream_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type GetAgentControllerControllerIdSessionsResourceIdStream_Request = Simplify<
   (GetAgentControllerControllerIdSessionsResourceIdStream_PathParams extends never
     ? {}
     : { params: GetAgentControllerControllerIdSessionsResourceIdStream_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (GetAgentControllerControllerIdSessionsResourceIdStream_QueryParams extends never
+      ? {}
+      : {} extends GetAgentControllerControllerIdSessionsResourceIdStream_QueryParams
+        ? { query?: GetAgentControllerControllerIdSessionsResourceIdStream_QueryParams }
+        : { query: GetAgentControllerControllerIdSessionsResourceIdStream_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface GetAgentControllerControllerIdSessionsResourceIdStream_RouteContract {
   pathParams: GetAgentControllerControllerIdSessionsResourceIdStream_PathParams;
-  queryParams: never;
+  queryParams: GetAgentControllerControllerIdSessionsResourceIdStream_QueryParams;
   body: never;
   request: GetAgentControllerControllerIdSessionsResourceIdStream_Request;
   response: unknown;
@@ -91772,6 +91823,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdMessages_PathParams
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdMessages_Body = {
   message: string;
 };
@@ -91784,7 +91839,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdMessages_Request = 
   (PostAgentControllerControllerIdSessionsResourceIdMessages_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdMessages_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdMessages_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdMessages_Body
@@ -91794,7 +91853,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdMessages_Request = 
 
 export interface PostAgentControllerControllerIdSessionsResourceIdMessages_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdMessages_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdMessages_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdMessages_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdMessages_Response;
@@ -91809,6 +91868,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdSteer_PathParams = 
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdSteer_Body = {
   message: string;
 };
@@ -91821,7 +91884,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdSteer_Request = Sim
   (PostAgentControllerControllerIdSessionsResourceIdSteer_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdSteer_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdSteer_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdSteer_Body
@@ -91831,7 +91898,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdSteer_Request = Sim
 
 export interface PostAgentControllerControllerIdSessionsResourceIdSteer_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdSteer_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdSteer_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdSteer_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdSteer_Response;
@@ -91846,6 +91913,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_PathParams
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_Body = {
   message: string;
 };
@@ -91858,7 +91929,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_Request = 
   (PostAgentControllerControllerIdSessionsResourceIdFollowUp_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdFollowUp_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdFollowUp_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdFollowUp_Body
@@ -91868,7 +91943,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_Request = 
 
 export interface PostAgentControllerControllerIdSessionsResourceIdFollowUp_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdFollowUp_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdFollowUp_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdFollowUp_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdFollowUp_Response;
@@ -91883,6 +91958,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdAbort_PathParams = 
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdAbort_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdAbort_Response = {
   ok: boolean;
 };
@@ -91891,13 +91970,17 @@ export type PostAgentControllerControllerIdSessionsResourceIdAbort_Request = Sim
   (PostAgentControllerControllerIdSessionsResourceIdAbort_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdAbort_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdAbort_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdAbort_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdAbort_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdAbort_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface PostAgentControllerControllerIdSessionsResourceIdAbort_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdAbort_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdAbort_QueryParams;
   body: never;
   request: PostAgentControllerControllerIdSessionsResourceIdAbort_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdAbort_Response;
@@ -91910,6 +91993,10 @@ export interface PostAgentControllerControllerIdSessionsResourceIdAbort_RouteCon
 export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_Body = {
@@ -91925,7 +92012,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_Reques
   (PostAgentControllerControllerIdSessionsResourceIdToolApproval_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdToolApproval_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdToolApproval_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdToolApproval_Body
@@ -91935,7 +92026,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_Reques
 
 export interface PostAgentControllerControllerIdSessionsResourceIdToolApproval_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdToolApproval_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdToolApproval_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdToolApproval_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdToolApproval_Response;
@@ -91948,6 +92039,10 @@ export interface PostAgentControllerControllerIdSessionsResourceIdToolApproval_R
 export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Body = {
@@ -91963,7 +92058,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Requ
   (PostAgentControllerControllerIdSessionsResourceIdToolSuspension_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdToolSuspension_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdToolSuspension_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Body
@@ -91973,7 +92072,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Requ
 
 export interface PostAgentControllerControllerIdSessionsResourceIdToolSuspension_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Response;
@@ -91988,6 +92087,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdMode_PathParams = {
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdMode_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdMode_Body = {
   modeId: string;
 };
@@ -92000,7 +92103,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdMode_Request = Simp
   (PostAgentControllerControllerIdSessionsResourceIdMode_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdMode_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdMode_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdMode_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdMode_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdMode_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdMode_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdMode_Body
@@ -92010,7 +92117,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdMode_Request = Simp
 
 export interface PostAgentControllerControllerIdSessionsResourceIdMode_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdMode_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdMode_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdMode_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdMode_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdMode_Response;
@@ -92023,6 +92130,10 @@ export interface PostAgentControllerControllerIdSessionsResourceIdMode_RouteCont
 export type PostAgentControllerControllerIdSessionsResourceIdModel_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PostAgentControllerControllerIdSessionsResourceIdModel_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdModel_Body = {
@@ -92039,7 +92150,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdModel_Request = Sim
   (PostAgentControllerControllerIdSessionsResourceIdModel_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdModel_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdModel_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdModel_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdModel_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdModel_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdModel_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdModel_Body
@@ -92049,7 +92164,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdModel_Request = Sim
 
 export interface PostAgentControllerControllerIdSessionsResourceIdModel_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdModel_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdModel_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdModel_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdModel_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdModel_Response;
@@ -92064,6 +92179,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdThread_PathParams =
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdThread_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdThread_Body = {
   threadId: string;
 };
@@ -92076,7 +92195,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdThread_Request = Si
   (PostAgentControllerControllerIdSessionsResourceIdThread_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdThread_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdThread_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdThread_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdThread_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdThread_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdThread_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdThread_Body
@@ -92086,7 +92209,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdThread_Request = Si
 
 export interface PostAgentControllerControllerIdSessionsResourceIdThread_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdThread_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdThread_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdThread_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdThread_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdThread_Response;
@@ -92099,6 +92222,10 @@ export interface PostAgentControllerControllerIdSessionsResourceIdThread_RouteCo
 export type PostAgentControllerControllerIdSessionsResourceIdNotifications_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PostAgentControllerControllerIdSessionsResourceIdNotifications_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdNotifications_Body = {
@@ -92133,7 +92260,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdNotifications_Reque
   (PostAgentControllerControllerIdSessionsResourceIdNotifications_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdNotifications_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdNotifications_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdNotifications_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdNotifications_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdNotifications_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdNotifications_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdNotifications_Body
@@ -92143,7 +92274,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdNotifications_Reque
 
 export interface PostAgentControllerControllerIdSessionsResourceIdNotifications_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdNotifications_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdNotifications_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdNotifications_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdNotifications_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdNotifications_Response;
@@ -92187,6 +92318,10 @@ export type GetAgentControllerControllerIdSessionsResourceIdOm_PathParams = {
   resourceId: string;
 };
 
+export type GetAgentControllerControllerIdSessionsResourceIdOm_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type GetAgentControllerControllerIdSessionsResourceIdOm_Response = {
   record?: any | undefined;
 };
@@ -92195,13 +92330,17 @@ export type GetAgentControllerControllerIdSessionsResourceIdOm_Request = Simplif
   (GetAgentControllerControllerIdSessionsResourceIdOm_PathParams extends never
     ? {}
     : { params: GetAgentControllerControllerIdSessionsResourceIdOm_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (GetAgentControllerControllerIdSessionsResourceIdOm_QueryParams extends never
+      ? {}
+      : {} extends GetAgentControllerControllerIdSessionsResourceIdOm_QueryParams
+        ? { query?: GetAgentControllerControllerIdSessionsResourceIdOm_QueryParams }
+        : { query: GetAgentControllerControllerIdSessionsResourceIdOm_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface GetAgentControllerControllerIdSessionsResourceIdOm_RouteContract {
   pathParams: GetAgentControllerControllerIdSessionsResourceIdOm_PathParams;
-  queryParams: never;
+  queryParams: GetAgentControllerControllerIdSessionsResourceIdOm_QueryParams;
   body: never;
   request: GetAgentControllerControllerIdSessionsResourceIdOm_Request;
   response: GetAgentControllerControllerIdSessionsResourceIdOm_Response;
@@ -92216,6 +92355,10 @@ export type PostAgentControllerControllerIdSessionsResourceIdResource_PathParams
   resourceId: string;
 };
 
+export type PostAgentControllerControllerIdSessionsResourceIdResource_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type PostAgentControllerControllerIdSessionsResourceIdResource_Body = {
   newResourceId: string;
 };
@@ -92228,7 +92371,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdResource_Request = 
   (PostAgentControllerControllerIdSessionsResourceIdResource_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdResource_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdResource_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdResource_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdResource_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdResource_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdResource_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdResource_Body
@@ -92238,7 +92385,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdResource_Request = 
 
 export interface PostAgentControllerControllerIdSessionsResourceIdResource_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdResource_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdResource_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdResource_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdResource_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdResource_Response;
@@ -92253,6 +92400,10 @@ export type GetAgentControllerControllerIdSessionsResourceIdResources_PathParams
   resourceId: string;
 };
 
+export type GetAgentControllerControllerIdSessionsResourceIdResources_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type GetAgentControllerControllerIdSessionsResourceIdResources_Response = {
   resourceIds: string[];
 };
@@ -92261,13 +92412,17 @@ export type GetAgentControllerControllerIdSessionsResourceIdResources_Request = 
   (GetAgentControllerControllerIdSessionsResourceIdResources_PathParams extends never
     ? {}
     : { params: GetAgentControllerControllerIdSessionsResourceIdResources_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (GetAgentControllerControllerIdSessionsResourceIdResources_QueryParams extends never
+      ? {}
+      : {} extends GetAgentControllerControllerIdSessionsResourceIdResources_QueryParams
+        ? { query?: GetAgentControllerControllerIdSessionsResourceIdResources_QueryParams }
+        : { query: GetAgentControllerControllerIdSessionsResourceIdResources_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface GetAgentControllerControllerIdSessionsResourceIdResources_RouteContract {
   pathParams: GetAgentControllerControllerIdSessionsResourceIdResources_PathParams;
-  queryParams: never;
+  queryParams: GetAgentControllerControllerIdSessionsResourceIdResources_QueryParams;
   body: never;
   request: GetAgentControllerControllerIdSessionsResourceIdResources_Request;
   response: GetAgentControllerControllerIdSessionsResourceIdResources_Response;
@@ -92280,6 +92435,10 @@ export interface GetAgentControllerControllerIdSessionsResourceIdResources_Route
 export type GetAgentControllerControllerIdSessionsResourceIdGoal_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type GetAgentControllerControllerIdSessionsResourceIdGoal_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type GetAgentControllerControllerIdSessionsResourceIdGoal_Response = {
@@ -92302,13 +92461,17 @@ export type GetAgentControllerControllerIdSessionsResourceIdGoal_Request = Simpl
   (GetAgentControllerControllerIdSessionsResourceIdGoal_PathParams extends never
     ? {}
     : { params: GetAgentControllerControllerIdSessionsResourceIdGoal_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (GetAgentControllerControllerIdSessionsResourceIdGoal_QueryParams extends never
+      ? {}
+      : {} extends GetAgentControllerControllerIdSessionsResourceIdGoal_QueryParams
+        ? { query?: GetAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }
+        : { query: GetAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface GetAgentControllerControllerIdSessionsResourceIdGoal_RouteContract {
   pathParams: GetAgentControllerControllerIdSessionsResourceIdGoal_PathParams;
-  queryParams: never;
+  queryParams: GetAgentControllerControllerIdSessionsResourceIdGoal_QueryParams;
   body: never;
   request: GetAgentControllerControllerIdSessionsResourceIdGoal_Request;
   response: GetAgentControllerControllerIdSessionsResourceIdGoal_Response;
@@ -92321,6 +92484,10 @@ export interface GetAgentControllerControllerIdSessionsResourceIdGoal_RouteContr
 export type PostAgentControllerControllerIdSessionsResourceIdGoal_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PostAgentControllerControllerIdSessionsResourceIdGoal_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdGoal_Body = {
@@ -92349,7 +92516,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdGoal_Request = Simp
   (PostAgentControllerControllerIdSessionsResourceIdGoal_PathParams extends never
     ? {}
     : { params: PostAgentControllerControllerIdSessionsResourceIdGoal_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PostAgentControllerControllerIdSessionsResourceIdGoal_QueryParams extends never
+      ? {}
+      : {} extends PostAgentControllerControllerIdSessionsResourceIdGoal_QueryParams
+        ? { query?: PostAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }
+        : { query: PostAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }) &
     (PostAgentControllerControllerIdSessionsResourceIdGoal_Body extends never
       ? {}
       : {} extends PostAgentControllerControllerIdSessionsResourceIdGoal_Body
@@ -92359,7 +92530,7 @@ export type PostAgentControllerControllerIdSessionsResourceIdGoal_Request = Simp
 
 export interface PostAgentControllerControllerIdSessionsResourceIdGoal_RouteContract {
   pathParams: PostAgentControllerControllerIdSessionsResourceIdGoal_PathParams;
-  queryParams: never;
+  queryParams: PostAgentControllerControllerIdSessionsResourceIdGoal_QueryParams;
   body: PostAgentControllerControllerIdSessionsResourceIdGoal_Body;
   request: PostAgentControllerControllerIdSessionsResourceIdGoal_Request;
   response: PostAgentControllerControllerIdSessionsResourceIdGoal_Response;
@@ -92372,6 +92543,10 @@ export interface PostAgentControllerControllerIdSessionsResourceIdGoal_RouteCont
 export type PutAgentControllerControllerIdSessionsResourceIdGoal_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PutAgentControllerControllerIdSessionsResourceIdGoal_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PutAgentControllerControllerIdSessionsResourceIdGoal_Body = {
@@ -92400,7 +92575,11 @@ export type PutAgentControllerControllerIdSessionsResourceIdGoal_Request = Simpl
   (PutAgentControllerControllerIdSessionsResourceIdGoal_PathParams extends never
     ? {}
     : { params: PutAgentControllerControllerIdSessionsResourceIdGoal_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PutAgentControllerControllerIdSessionsResourceIdGoal_QueryParams extends never
+      ? {}
+      : {} extends PutAgentControllerControllerIdSessionsResourceIdGoal_QueryParams
+        ? { query?: PutAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }
+        : { query: PutAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }) &
     (PutAgentControllerControllerIdSessionsResourceIdGoal_Body extends never
       ? {}
       : {} extends PutAgentControllerControllerIdSessionsResourceIdGoal_Body
@@ -92410,7 +92589,7 @@ export type PutAgentControllerControllerIdSessionsResourceIdGoal_Request = Simpl
 
 export interface PutAgentControllerControllerIdSessionsResourceIdGoal_RouteContract {
   pathParams: PutAgentControllerControllerIdSessionsResourceIdGoal_PathParams;
-  queryParams: never;
+  queryParams: PutAgentControllerControllerIdSessionsResourceIdGoal_QueryParams;
   body: PutAgentControllerControllerIdSessionsResourceIdGoal_Body;
   request: PutAgentControllerControllerIdSessionsResourceIdGoal_Request;
   response: PutAgentControllerControllerIdSessionsResourceIdGoal_Response;
@@ -92425,6 +92604,10 @@ export type DeleteAgentControllerControllerIdSessionsResourceIdGoal_PathParams =
   resourceId: string;
 };
 
+export type DeleteAgentControllerControllerIdSessionsResourceIdGoal_QueryParams = {
+  sessionScope?: string | undefined;
+};
+
 export type DeleteAgentControllerControllerIdSessionsResourceIdGoal_Response = {
   ok: boolean;
 };
@@ -92433,13 +92616,17 @@ export type DeleteAgentControllerControllerIdSessionsResourceIdGoal_Request = Si
   (DeleteAgentControllerControllerIdSessionsResourceIdGoal_PathParams extends never
     ? {}
     : { params: DeleteAgentControllerControllerIdSessionsResourceIdGoal_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (DeleteAgentControllerControllerIdSessionsResourceIdGoal_QueryParams extends never
+      ? {}
+      : {} extends DeleteAgentControllerControllerIdSessionsResourceIdGoal_QueryParams
+        ? { query?: DeleteAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }
+        : { query: DeleteAgentControllerControllerIdSessionsResourceIdGoal_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface DeleteAgentControllerControllerIdSessionsResourceIdGoal_RouteContract {
   pathParams: DeleteAgentControllerControllerIdSessionsResourceIdGoal_PathParams;
-  queryParams: never;
+  queryParams: DeleteAgentControllerControllerIdSessionsResourceIdGoal_QueryParams;
   body: never;
   request: DeleteAgentControllerControllerIdSessionsResourceIdGoal_Request;
   response: DeleteAgentControllerControllerIdSessionsResourceIdGoal_Response;
@@ -92452,6 +92639,10 @@ export interface DeleteAgentControllerControllerIdSessionsResourceIdGoal_RouteCo
 export type GetAgentControllerControllerIdSessionsResourceIdPermissions_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type GetAgentControllerControllerIdSessionsResourceIdPermissions_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type GetAgentControllerControllerIdSessionsResourceIdPermissions_Response = {
@@ -92471,13 +92662,17 @@ export type GetAgentControllerControllerIdSessionsResourceIdPermissions_Request 
   (GetAgentControllerControllerIdSessionsResourceIdPermissions_PathParams extends never
     ? {}
     : { params: GetAgentControllerControllerIdSessionsResourceIdPermissions_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (GetAgentControllerControllerIdSessionsResourceIdPermissions_QueryParams extends never
+      ? {}
+      : {} extends GetAgentControllerControllerIdSessionsResourceIdPermissions_QueryParams
+        ? { query?: GetAgentControllerControllerIdSessionsResourceIdPermissions_QueryParams }
+        : { query: GetAgentControllerControllerIdSessionsResourceIdPermissions_QueryParams }) &
     (never extends never ? {} : {} extends never ? { body?: never } : { body: never })
 >;
 
 export interface GetAgentControllerControllerIdSessionsResourceIdPermissions_RouteContract {
   pathParams: GetAgentControllerControllerIdSessionsResourceIdPermissions_PathParams;
-  queryParams: never;
+  queryParams: GetAgentControllerControllerIdSessionsResourceIdPermissions_QueryParams;
   body: never;
   request: GetAgentControllerControllerIdSessionsResourceIdPermissions_Request;
   response: GetAgentControllerControllerIdSessionsResourceIdPermissions_Response;
@@ -92490,6 +92685,10 @@ export interface GetAgentControllerControllerIdSessionsResourceIdPermissions_Rou
 export type PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_Body = {
@@ -92505,7 +92704,11 @@ export type PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_
   (PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_PathParams extends never
     ? {}
     : { params: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_QueryParams extends never
+      ? {}
+      : {} extends PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_QueryParams
+        ? { query?: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_QueryParams }
+        : { query: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_QueryParams }) &
     (PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_Body extends never
       ? {}
       : {} extends PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_Body
@@ -92515,7 +92718,7 @@ export type PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_
 
 export interface PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_RouteContract {
   pathParams: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_PathParams;
-  queryParams: never;
+  queryParams: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_QueryParams;
   body: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_Body;
   request: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_Request;
   response: PutAgentControllerControllerIdSessionsResourceIdPermissionsCategory_Response;
@@ -92528,6 +92731,10 @@ export interface PutAgentControllerControllerIdSessionsResourceIdPermissionsCate
 export type PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Body = {
@@ -92543,7 +92750,11 @@ export type PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Requ
   (PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_PathParams extends never
     ? {}
     : { params: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_QueryParams extends never
+      ? {}
+      : {} extends PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_QueryParams
+        ? { query?: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_QueryParams }
+        : { query: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_QueryParams }) &
     (PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Body extends never
       ? {}
       : {} extends PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Body
@@ -92553,7 +92764,7 @@ export type PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Requ
 
 export interface PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_RouteContract {
   pathParams: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_PathParams;
-  queryParams: never;
+  queryParams: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_QueryParams;
   body: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Body;
   request: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Request;
   response: PutAgentControllerControllerIdSessionsResourceIdPermissionsTool_Response;
@@ -92566,6 +92777,10 @@ export interface PutAgentControllerControllerIdSessionsResourceIdPermissionsTool
 export type PutAgentControllerControllerIdSessionsResourceIdState_PathParams = {
   controllerId: string;
   resourceId: string;
+};
+
+export type PutAgentControllerControllerIdSessionsResourceIdState_QueryParams = {
+  sessionScope?: string | undefined;
 };
 
 export type PutAgentControllerControllerIdSessionsResourceIdState_Body = {
@@ -92582,7 +92797,11 @@ export type PutAgentControllerControllerIdSessionsResourceIdState_Request = Simp
   (PutAgentControllerControllerIdSessionsResourceIdState_PathParams extends never
     ? {}
     : { params: PutAgentControllerControllerIdSessionsResourceIdState_PathParams }) &
-    (never extends never ? {} : {} extends never ? { query?: never } : { query: never }) &
+    (PutAgentControllerControllerIdSessionsResourceIdState_QueryParams extends never
+      ? {}
+      : {} extends PutAgentControllerControllerIdSessionsResourceIdState_QueryParams
+        ? { query?: PutAgentControllerControllerIdSessionsResourceIdState_QueryParams }
+        : { query: PutAgentControllerControllerIdSessionsResourceIdState_QueryParams }) &
     (PutAgentControllerControllerIdSessionsResourceIdState_Body extends never
       ? {}
       : {} extends PutAgentControllerControllerIdSessionsResourceIdState_Body
@@ -92592,7 +92811,7 @@ export type PutAgentControllerControllerIdSessionsResourceIdState_Request = Simp
 
 export interface PutAgentControllerControllerIdSessionsResourceIdState_RouteContract {
   pathParams: PutAgentControllerControllerIdSessionsResourceIdState_PathParams;
-  queryParams: never;
+  queryParams: PutAgentControllerControllerIdSessionsResourceIdState_QueryParams;
   body: PutAgentControllerControllerIdSessionsResourceIdState_Body;
   request: PutAgentControllerControllerIdSessionsResourceIdState_Request;
   response: PutAgentControllerControllerIdSessionsResourceIdState_Response;

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -29,8 +29,15 @@ export const queryKeys = {
     ['agent-controller', agentControllerId ?? null, 'models'] as const,
   agentControllerModes: (agentControllerId: string | undefined) =>
     ['agent-controller', agentControllerId ?? null, 'modes'] as const,
-  agentControllerSession: (agentControllerId: string | undefined, resourceId: string | undefined) =>
-    ['agent-controller', agentControllerId ?? null, 'sessions', resourceId ?? null] as const,
+  // Sessions are scoped per worktree (projectPath), so every session-derived key
+  // includes the projectPath — two worktrees over the same resourceId are
+  // independent sessions with independent state.
+  agentControllerSession: (
+    agentControllerId: string | undefined,
+    resourceId: string | undefined,
+    projectPath: string | undefined,
+  ) =>
+    ['agent-controller', agentControllerId ?? null, 'sessions', resourceId ?? null, projectPath ?? null] as const,
   // Keep connection state outside agentControllerSession: mutation hooks invalidate that prefix,
   // and a sync refetch would bump dataUpdatedAt and wipe the live transcript.
   agentControllerConnection: (
@@ -38,22 +45,34 @@ export const queryKeys = {
     resourceId: string | undefined,
     projectPath: string | undefined,
   ) => ['agent-controller', agentControllerId ?? null, 'connection', resourceId ?? null, projectPath ?? null] as const,
-  agentControllerSettings: (agentControllerId: string | undefined, resourceId: string | undefined) =>
-    [...queryKeys.agentControllerSession(agentControllerId, resourceId), 'settings'] as const,
-  agentControllerPermissions: (agentControllerId: string | undefined, resourceId: string | undefined) =>
-    [...queryKeys.agentControllerSession(agentControllerId, resourceId), 'permissions'] as const,
+  agentControllerSettings: (
+    agentControllerId: string | undefined,
+    resourceId: string | undefined,
+    projectPath: string | undefined,
+  ) => [...queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath), 'settings'] as const,
+  agentControllerPermissions: (
+    agentControllerId: string | undefined,
+    resourceId: string | undefined,
+    projectPath: string | undefined,
+  ) => [...queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath), 'permissions'] as const,
   agentControllerThreads: (
     agentControllerId: string | undefined,
     resourceId: string | undefined,
     projectPath: string | undefined,
-  ) => [...queryKeys.agentControllerSession(agentControllerId, resourceId), 'threads', projectPath ?? null] as const,
+  ) => [...queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath), 'threads'] as const,
+  // Thread ids are unique across the resource, so messages are keyed by threadId
+  // alone (no projectPath) — caches survive worktree switches and seeding does
+  // not need to know the thread's scope.
   agentControllerThreadMessages: (
     agentControllerId: string | undefined,
     resourceId: string | undefined,
     threadId: string | undefined,
   ) =>
     [
-      ...queryKeys.agentControllerSession(agentControllerId, resourceId),
+      'agent-controller',
+      agentControllerId ?? null,
+      'sessions',
+      resourceId ?? null,
       'threads',
       threadId ?? null,
       'messages',

--- a/mastracode/web/src/web/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Composer.tsx
@@ -41,8 +41,8 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
   const { busy, localUser, reset } = useChatTranscript();
   const { composerCommandName, clearComposerCommand, runComposerCommand } = useChatCommands();
 
-  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
-  const createThreadMutation = useCreateAgentControllerThreadMutation({ ...hookArgs, projectPath });
+  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, projectPath, baseUrl, enabled: sessionEnabled };
+  const createThreadMutation = useCreateAgentControllerThreadMutation(hookArgs);
   const sendMutation = useSendAgentControllerMessageMutation(hookArgs);
   const steerMutation = useSteerAgentControllerMutation(hookArgs);
   const abortMutation = useAbortAgentControllerMutation(hookArgs);

--- a/mastracode/web/src/web/ui/domains/chat/components/GoalPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/GoalPanel.tsx
@@ -18,9 +18,9 @@ const goalBar = 'flex shrink-0 items-center gap-2.5 border-b border-border1 bg-a
  * stays uncluttered by default.
  */
 export function GoalPanel() {
-  const { resourceId, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { transcript } = useChatTranscript();
-  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
+  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, projectPath, baseUrl, enabled: sessionEnabled };
   const pauseGoalMutation = usePauseAgentControllerGoalMutation(hookArgs);
   const resumeGoalMutation = useResumeAgentControllerGoalMutation(hookArgs);
   const clearGoalMutation = useClearAgentControllerGoalMutation(hookArgs);

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -567,9 +567,9 @@ function NotificationSummaryCard({ entry }: { entry: NotificationSummaryEntry })
 // ---------------------------------------------------------------------------
 
 export function Transcript() {
-  const { resourceId, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { transcript, resolvePrompt } = useChatTranscript();
-  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
+  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, projectPath, baseUrl, enabled: sessionEnabled };
   const approveMutation = useApproveAgentControllerToolMutation(hookArgs);
   const respondMutation = useRespondAgentControllerSuspensionMutation(hookArgs);
 

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatModelsProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatModelsProvider.tsx
@@ -12,11 +12,12 @@ interface ChatModelsProviderProps {
 }
 
 export function ChatModelsProvider({ children }: ChatModelsProviderProps) {
-  const { resourceId, baseUrl, sessionEnabled } = useChatSessionContext();
+  const { resourceId, projectPath, baseUrl, sessionEnabled } = useChatSessionContext();
   const { state } = useChatConnection();
   const switchModelMutation = useSwitchAgentControllerModelMutation({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    projectPath,
     baseUrl,
     enabled: sessionEnabled,
   });

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatModesProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatModesProvider.tsx
@@ -13,17 +13,19 @@ interface ChatModesProviderProps {
 }
 
 export function ChatModesProvider({ children }: ChatModesProviderProps) {
-  const { resourceId, baseUrl, sessionEnabled } = useChatSessionContext();
+  const { resourceId, projectPath, baseUrl, sessionEnabled } = useChatSessionContext();
   const { state } = useChatConnection();
   const modesQuery = useAgentControllerModes({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    projectPath,
     baseUrl,
     enabled: sessionEnabled,
   });
   const switchModeMutation = useSwitchAgentControllerModeMutation({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    projectPath,
     baseUrl,
     enabled: sessionEnabled,
   });

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatPermissionsProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatPermissionsProvider.tsx
@@ -14,11 +14,12 @@ interface ChatPermissionsProviderProps {
 }
 
 export function ChatPermissionsProvider({ children }: ChatPermissionsProviderProps) {
-  const { resourceId, baseUrl, sessionEnabled } = useChatSessionContext();
+  const { resourceId, projectPath, baseUrl, sessionEnabled } = useChatSessionContext();
   const [pendingPermissionCategory, setPendingPermissionCategory] = useState<ToolCategory | null>(null);
   const hookArgs = {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    projectPath,
     baseUrl,
     enabled: sessionEnabled,
   };

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -30,10 +30,11 @@ export function ChatSessionProvider({ children, threadId }: { children: ReactNod
 }
 
 function ChatSessionBoundary({ children, threadId }: { children: ReactNode; threadId?: string }) {
-  const { resourceId, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const messagesQuery = useAgentControllerThreadMessages({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    projectPath,
     threadId,
     baseUrl,
     enabled: sessionEnabled && Boolean(threadId),

--- a/mastracode/web/src/web/ui/domains/chat/context/useRunPaletteCommand.ts
+++ b/mastracode/web/src/web/ui/domains/chat/context/useRunPaletteCommand.ts
@@ -25,12 +25,12 @@ const TOOL_CATEGORIES: ToolCategory[] = ['read', 'edit', 'execute', 'mcp', 'othe
 
 export function useRunPaletteCommand(setComposerCommandName: Dispatch<SetStateAction<string | undefined>>) {
   const { activeProject } = useActiveProjectContext();
-  const { resourceId, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { transcript, localUser, pushNotice } = useChatTranscript();
   const { activeModeId } = useChatModes();
   const { activeModelId, setModel } = useChatModels();
 
-  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
+  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, projectPath, baseUrl, enabled: sessionEnabled };
   const clearGoalMutation = useClearAgentControllerGoalMutation(hookArgs);
   const pauseGoalMutation = usePauseAgentControllerGoalMutation(hookArgs);
   const resumeGoalMutation = useResumeAgentControllerGoalMutation(hookArgs);

--- a/mastracode/web/src/web/ui/domains/chat/hooks/__tests__/useAgentControllerMutationCache.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/__tests__/useAgentControllerMutationCache.msw.test.tsx
@@ -127,7 +127,9 @@ describe('agent-controller mutation hooks cache behavior', () => {
     );
 
     const { result, client } = renderHookWithProviders(() => {
-      const settingsQuery = useAgentControllerSettings(hookArgs);
+      // Settings are session-scoped, so the query must carry the same projectPath
+      // scope as the mutation for invalidation to reach it.
+      const settingsQuery = useAgentControllerSettings({ ...hookArgs, projectPath: '/sandbox/mastra' });
       const threadsQuery = useAgentControllerThreads({ ...hookArgs, projectPath: '/sandbox/mastra' });
       const createThread = useCreateAgentControllerThreadMutation({ ...hookArgs, projectPath: '/sandbox/mastra' });
       return { settingsQuery, threadsQuery, createThread };

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerConnection.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerConnection.ts
@@ -28,7 +28,7 @@ export function useAgentControllerConnection({
   const [sseConnectionState, setSseConnectionState] = useState<SseConnectionState>('never');
   const sseConnected = sseConnectionState === 'connected';
   const hasEverConnected = sseConnectionState !== 'never';
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
   const initQuery = useAgentControllerSessionInit({ agentControllerId, resourceId, projectPath, baseUrl, enabled });
   const syncQuery = useAgentControllerSessionSync({
     agentControllerId,

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerGoalMutations.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerGoalMutations.ts
@@ -6,19 +6,24 @@ import { createAgentControllerClient, requireAgentControllerSession } from '../s
 interface AgentControllerGoalMutationArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
 
-function useSessionInvalidation({ agentControllerId, resourceId }: AgentControllerGoalMutationArgs) {
+function toClientArgs({ agentControllerId, resourceId, projectPath, baseUrl, enabled }: AgentControllerGoalMutationArgs) {
+  return { agentControllerId, resourceId, scope: projectPath, baseUrl, enabled };
+}
+
+function useSessionInvalidation({ agentControllerId, resourceId, projectPath }: AgentControllerGoalMutationArgs) {
   const queryClient = useQueryClient();
   return async () => {
     await Promise.all([
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId, projectPath),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath),
         exact: true,
       }),
     ]);
@@ -26,7 +31,7 @@ function useSessionInvalidation({ agentControllerId, resourceId }: AgentControll
 }
 
 export function useSetAgentControllerGoalMutation(args: AgentControllerGoalMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (objective: string) => requireAgentControllerSession(session).setGoal(objective),
@@ -35,7 +40,7 @@ export function useSetAgentControllerGoalMutation(args: AgentControllerGoalMutat
 }
 
 export function usePauseAgentControllerGoalMutation(args: AgentControllerGoalMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: () => requireAgentControllerSession(session).updateGoal({ status: 'paused' }),
@@ -44,7 +49,7 @@ export function usePauseAgentControllerGoalMutation(args: AgentControllerGoalMut
 }
 
 export function useResumeAgentControllerGoalMutation(args: AgentControllerGoalMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: () => requireAgentControllerSession(session).updateGoal({ status: 'active' }),
@@ -53,7 +58,7 @@ export function useResumeAgentControllerGoalMutation(args: AgentControllerGoalMu
 }
 
 export function useClearAgentControllerGoalMutation(args: AgentControllerGoalMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: () => requireAgentControllerSession(session).clearGoal(),

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerModels.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerModels.ts
@@ -6,6 +6,7 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 interface UseAgentControllerModelsArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -13,10 +14,17 @@ interface UseAgentControllerModelsArgs {
 export function useAgentControllerModels({
   agentControllerId,
   resourceId,
+  projectPath,
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerModelsArgs) {
-  const { controller } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { controller } = createAgentControllerClient({
+    agentControllerId,
+    resourceId,
+    scope: projectPath,
+    baseUrl,
+    enabled,
+  });
 
   return useQuery({
     queryKey: queryKeys.agentControllerModels(agentControllerId),

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerModes.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerModes.ts
@@ -6,6 +6,7 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 interface UseAgentControllerModesArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -13,10 +14,17 @@ interface UseAgentControllerModesArgs {
 export function useAgentControllerModes({
   agentControllerId,
   resourceId,
+  projectPath,
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerModesArgs) {
-  const { controller } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { controller } = createAgentControllerClient({
+    agentControllerId,
+    resourceId,
+    scope: projectPath,
+    baseUrl,
+    enabled,
+  });
 
   return useQuery({
     queryKey: queryKeys.agentControllerModes(agentControllerId),

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerPermissionMutations.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerPermissionMutations.ts
@@ -7,6 +7,7 @@ import { createAgentControllerClient, requireAgentControllerSession } from '../s
 interface AgentControllerPermissionMutationArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -14,18 +15,19 @@ interface AgentControllerPermissionMutationArgs {
 export function useSetPermissionForCategoryMutation({
   agentControllerId,
   resourceId,
+  projectPath,
   baseUrl = '',
   enabled = true,
 }: AgentControllerPermissionMutationArgs) {
   const queryClient = useQueryClient();
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useMutation({
     mutationFn: ({ category, policy }: { category: ToolCategory; policy: PermissionPolicy }) =>
       requireAgentControllerSession(session).setPermissionForCategory(category, policy),
     onSuccess: () =>
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerPermissions(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerPermissions(agentControllerId, resourceId, projectPath),
       }),
   });
 }

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerPermissions.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerPermissions.ts
@@ -6,6 +6,7 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 interface UseAgentControllerPermissionsArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -13,13 +14,14 @@ interface UseAgentControllerPermissionsArgs {
 export function useAgentControllerPermissions({
   agentControllerId,
   resourceId,
+  projectPath,
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerPermissionsArgs) {
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useQuery({
-    queryKey: queryKeys.agentControllerPermissions(agentControllerId, resourceId),
+    queryKey: queryKeys.agentControllerPermissions(agentControllerId, resourceId, projectPath),
     queryFn: () => session!.getPermissions(),
     enabled: enabled && Boolean(session),
   });

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerRunMutations.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerRunMutations.ts
@@ -7,19 +7,24 @@ import { createAgentControllerClient, requireAgentControllerSession } from '../s
 interface AgentControllerRunMutationArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
 
-function useSessionInvalidation({ agentControllerId, resourceId }: AgentControllerRunMutationArgs) {
+function toClientArgs({ agentControllerId, resourceId, projectPath, baseUrl, enabled }: AgentControllerRunMutationArgs) {
+  return { agentControllerId, resourceId, scope: projectPath, baseUrl, enabled };
+}
+
+function useSessionInvalidation({ agentControllerId, resourceId, projectPath }: AgentControllerRunMutationArgs) {
   const queryClient = useQueryClient();
   return async () => {
     await Promise.all([
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId, projectPath),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath),
         exact: true,
       }),
     ]);
@@ -27,7 +32,7 @@ function useSessionInvalidation({ agentControllerId, resourceId }: AgentControll
 }
 
 export function useSendAgentControllerMessageMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (text: string) => requireAgentControllerSession(session).sendMessage(text),
@@ -36,7 +41,7 @@ export function useSendAgentControllerMessageMutation(args: AgentControllerRunMu
 }
 
 export function useSteerAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (text: string) => requireAgentControllerSession(session).steer(text),
@@ -45,7 +50,7 @@ export function useSteerAgentControllerMutation(args: AgentControllerRunMutation
 }
 
 export function useFollowUpAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (text: string) => requireAgentControllerSession(session).followUp(text),
@@ -54,7 +59,7 @@ export function useFollowUpAgentControllerMutation(args: AgentControllerRunMutat
 }
 
 export function useAbortAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: () => requireAgentControllerSession(session).abort(),
@@ -63,7 +68,7 @@ export function useAbortAgentControllerMutation(args: AgentControllerRunMutation
 }
 
 export function useApproveAgentControllerToolMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: ({ toolCallId, approved }: { toolCallId: string; approved: boolean }) =>
@@ -73,7 +78,7 @@ export function useApproveAgentControllerToolMutation(args: AgentControllerRunMu
 }
 
 export function useRespondAgentControllerSuspensionMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: ({ toolCallId, resumeData }: { toolCallId: string; resumeData: string | string[] | PlanResume }) =>

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerSessionInit.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerSessionInit.ts
@@ -18,7 +18,7 @@ export function useAgentControllerSessionInit({
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerSessionInitArgs) {
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useQuery({
     queryKey: [...queryKeys.agentControllerConnection(agentControllerId, resourceId, projectPath), 'init'],

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerSessionSync.ts
@@ -26,7 +26,7 @@ export function useAgentControllerSessionSync({
   enabled = true,
   sseConnected,
 }: UseAgentControllerSessionSyncArgs) {
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useQuery({
     queryKey: [...queryKeys.agentControllerConnection(agentControllerId, resourceId, projectPath), 'state'],

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerSettings.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerSettings.ts
@@ -6,6 +6,7 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 interface UseAgentControllerSettingsArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -13,13 +14,14 @@ interface UseAgentControllerSettingsArgs {
 export function useAgentControllerSettings({
   agentControllerId,
   resourceId,
+  projectPath,
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerSettingsArgs) {
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useQuery({
-    queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId),
+    queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId, projectPath),
     queryFn: async () => {
       const state = await session!.state();
       return state.settings ?? null;

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerStateMutations.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerStateMutations.ts
@@ -6,29 +6,30 @@ import { createAgentControllerClient, requireAgentControllerSession } from '../s
 interface AgentControllerMutationArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
 
-export function useSetAgentControllerStateMutation({
-  agentControllerId,
-  resourceId,
-  baseUrl = '',
-  enabled = true,
-}: AgentControllerMutationArgs) {
+function toClientArgs({ agentControllerId, resourceId, projectPath, baseUrl, enabled }: AgentControllerMutationArgs) {
+  return { agentControllerId, resourceId, scope: projectPath, baseUrl, enabled };
+}
+
+export function useSetAgentControllerStateMutation(args: AgentControllerMutationArgs) {
+  const { agentControllerId, resourceId, projectPath } = args;
   const queryClient = useQueryClient();
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient(toClientArgs(args));
 
   return useMutation({
     mutationFn: (updates: Record<string, unknown>) => requireAgentControllerSession(session).setState(updates),
     onSuccess: async (_data, updates) => {
       await Promise.all([
         queryClient.invalidateQueries({
-          queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId),
+          queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath),
         }),
         'settings' in updates
           ? queryClient.invalidateQueries({
-              queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId),
+              queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId, projectPath),
             })
           : Promise.resolve(),
       ]);
@@ -38,14 +39,14 @@ export function useSetAgentControllerStateMutation({
 
 export function useSwitchAgentControllerModeMutation(args: AgentControllerMutationArgs) {
   const queryClient = useQueryClient();
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
 
   return useMutation({
     mutationFn: (modeId: string) => requireAgentControllerSession(session).switchMode(modeId),
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: queryKeys.agentControllerSession(args.agentControllerId, args.resourceId),
+          queryKey: queryKeys.agentControllerSession(args.agentControllerId, args.resourceId, args.projectPath),
         }),
         queryClient.invalidateQueries({
           queryKey: ['agent-controller', args.agentControllerId, 'connection', args.resourceId],
@@ -56,14 +57,14 @@ export function useSwitchAgentControllerModeMutation(args: AgentControllerMutati
 
 export function useSwitchAgentControllerModelMutation(args: AgentControllerMutationArgs) {
   const queryClient = useQueryClient();
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
 
   return useMutation({
     mutationFn: (modelId: string) => requireAgentControllerSession(session).switchModel(modelId),
     onSuccess: () =>
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: queryKeys.agentControllerSession(args.agentControllerId, args.resourceId),
+          queryKey: queryKeys.agentControllerSession(args.agentControllerId, args.resourceId, args.projectPath),
         }),
         queryClient.invalidateQueries({
           queryKey: ['agent-controller', args.agentControllerId, 'connection', args.resourceId],

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreadMessages.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreadMessages.ts
@@ -6,6 +6,7 @@ import { createAgentControllerClient } from '../services/agentControllerClient';
 interface UseAgentControllerThreadMessagesArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   threadId?: string;
   baseUrl?: string;
   enabled?: boolean;
@@ -14,11 +15,12 @@ interface UseAgentControllerThreadMessagesArgs {
 export function useAgentControllerThreadMessages({
   agentControllerId,
   resourceId,
+  projectPath,
   threadId,
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerThreadMessagesArgs) {
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useQuery({
     queryKey: queryKeys.agentControllerThreadMessages(agentControllerId, resourceId, threadId),

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreadMutations.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreadMutations.ts
@@ -11,6 +11,16 @@ interface AgentControllerThreadMutationArgs {
   enabled?: boolean;
 }
 
+function toClientArgs({
+  agentControllerId,
+  resourceId,
+  projectPath,
+  baseUrl,
+  enabled,
+}: AgentControllerThreadMutationArgs) {
+  return { agentControllerId, resourceId, scope: projectPath, baseUrl, enabled };
+}
+
 function useThreadMutationInvalidation({
   agentControllerId,
   resourceId,
@@ -23,10 +33,10 @@ function useThreadMutationInvalidation({
         queryKey: queryKeys.agentControllerThreads(agentControllerId, resourceId, projectPath),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerSettings(agentControllerId, resourceId, projectPath),
       }),
       queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId),
+        queryKey: queryKeys.agentControllerSession(agentControllerId, resourceId, projectPath),
         exact: true,
       }),
     ]);
@@ -34,7 +44,7 @@ function useThreadMutationInvalidation({
 }
 
 export function useCreateAgentControllerThreadMutation(args: AgentControllerThreadMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateThreads = useThreadMutationInvalidation(args);
 
   return useMutation({
@@ -44,7 +54,7 @@ export function useCreateAgentControllerThreadMutation(args: AgentControllerThre
 }
 
 export function useDeleteAgentControllerThreadMutation(args: AgentControllerThreadMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateThreads = useThreadMutationInvalidation(args);
 
   return useMutation({
@@ -54,7 +64,7 @@ export function useDeleteAgentControllerThreadMutation(args: AgentControllerThre
 }
 
 export function useRenameAgentControllerThreadMutation(args: AgentControllerThreadMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateThreads = useThreadMutationInvalidation(args);
 
   return useMutation({
@@ -65,7 +75,7 @@ export function useRenameAgentControllerThreadMutation(args: AgentControllerThre
 }
 
 export function useCloneAgentControllerThreadMutation(args: AgentControllerThreadMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
   const invalidateThreads = useThreadMutationInvalidation(args);
 
   return useMutation({
@@ -76,7 +86,7 @@ export function useCloneAgentControllerThreadMutation(args: AgentControllerThrea
 }
 
 export function useSwitchAgentControllerThreadMutation(args: AgentControllerThreadMutationArgs) {
-  const { session } = createAgentControllerClient(args);
+  const { session } = createAgentControllerClient(toClientArgs(args));
 
   return useMutation({
     mutationFn: async (threadId: string) => {

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreads.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerThreads.ts
@@ -20,7 +20,7 @@ export function useAgentControllerThreads({
   baseUrl = '',
   enabled = true,
 }: UseAgentControllerThreadsArgs) {
-  const { session } = createAgentControllerClient({ agentControllerId, resourceId, baseUrl, enabled });
+  const { session } = createAgentControllerClient({ agentControllerId, resourceId, scope: projectPath, baseUrl, enabled });
 
   return useQuery({
     queryKey: queryKeys.agentControllerThreads(agentControllerId, resourceId, projectPath),

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useGlobalShortcuts.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useGlobalShortcuts.ts
@@ -9,11 +9,12 @@ import { useAbortAgentControllerMutation } from './useAgentControllerRunMutation
 export function useGlobalShortcuts() {
   const overlays = useOverlays();
   const { projects } = useActiveProjectContext();
-  const { resourceId, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { busy } = useChatTranscript();
   const abortMutation = useAbortAgentControllerMutation({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    projectPath,
     baseUrl,
     enabled: sessionEnabled,
   });

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useRouteThreadSync.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useRouteThreadSync.ts
@@ -34,6 +34,7 @@ export function useRouteThreadSync() {
   const { session } = createAgentControllerClient({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    scope: projectPath,
     baseUrl,
     enabled: sessionEnabled,
   });

--- a/mastracode/web/src/web/ui/domains/chat/services/agentControllerClient.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/agentControllerClient.ts
@@ -6,6 +6,12 @@ export type AgentControllerSession = ReturnType<AgentController['session']>;
 export interface CreateAgentControllerClientArgs {
   agentControllerId: string;
   resourceId: string;
+  /**
+   * Per-worktree session scope (the worktree's project path). Sessions sharing
+   * a resourceId but scoped differently are independent server-side sessions,
+   * so the client cache must be keyed by scope too.
+   */
+  scope?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -18,8 +24,8 @@ type AgentControllerClientEntry = {
 
 const clientCache = new Map<string, AgentControllerClientEntry>();
 
-const cacheKey = (agentControllerId: string, resourceId: string, baseUrl: string) =>
-  JSON.stringify([baseUrl, agentControllerId, resourceId]);
+const cacheKey = (agentControllerId: string, resourceId: string, baseUrl: string, scope: string | undefined) =>
+  JSON.stringify([baseUrl, agentControllerId, resourceId, scope ?? null]);
 
 export function requireAgentControllerSession(session: AgentControllerSession | null) {
   if (!session) throw new Error('Agent controller session is not available');
@@ -29,18 +35,20 @@ export function requireAgentControllerSession(session: AgentControllerSession | 
 export function createAgentControllerClient({
   agentControllerId,
   resourceId,
+  scope,
   baseUrl = '',
   enabled = true,
 }: CreateAgentControllerClientArgs) {
   if (!enabled) return { client: null, controller: null, session: null };
 
-  const key = cacheKey(agentControllerId, resourceId, baseUrl);
+  const normalizedScope = scope || undefined;
+  const key = cacheKey(agentControllerId, resourceId, baseUrl, normalizedScope);
   const cached = clientCache.get(key);
   if (cached) return cached;
 
   const client = new MastraClient({ baseUrl, credentials: 'include' });
   const controller = client.getAgentController(agentControllerId);
-  const session = controller.session(resourceId);
+  const session = controller.session(resourceId, normalizedScope);
   const entry = { client, controller, session };
   clientCache.set(key, entry);
   return entry;

--- a/mastracode/web/src/web/ui/domains/factory/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/web/ui/domains/factory/hooks/useStartFactoryRun.ts
@@ -4,9 +4,7 @@ import { useNavigate } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
 import { queryKeys } from '../../../../../shared/api/keys';
-import { useSendAgentControllerMessageMutation } from '../../chat/hooks/useAgentControllerRunMutations';
-import { useSetAgentControllerStateMutation } from '../../chat/hooks/useAgentControllerStateMutations';
-import { useCreateAgentControllerThreadMutation } from '../../chat/hooks/useAgentControllerThreadMutations';
+import { createAgentControllerClient, requireAgentControllerSession } from '../../chat/services/agentControllerClient';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 // Deep imports (not the workspaces barrel) to avoid provider/component cycles.
 import { useActiveProjectContext } from '../../workspaces/context/ActiveProjectProvider';
@@ -26,9 +24,10 @@ export interface StartFactoryRunInput {
  * item's branch, create a fresh thread in that workspace, send the kickoff
  * prompt, and navigate to the new thread.
  *
- * Mirrors the Composer's `/new` flow (create thread → send → seed message
- * cache → navigate) on top of the WorkspacesSection worktree flow (create
- * worktree → select it → point the session's `projectPath` at it).
+ * Sessions are scoped per worktree, so the run targets the NEW worktree's own
+ * session (created here with its `projectPath` tag) instead of repointing the
+ * currently active one — parallel Factory runs over the same project stay
+ * independent and never abort each other.
  */
 export function useStartFactoryRun() {
   const { activeProject, resourceId, sessionEnabled } = useActiveProjectContext();
@@ -36,21 +35,31 @@ export function useStartFactoryRun() {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
-  const setStateMutation = useSetAgentControllerStateMutation(hookArgs);
-  const workspaceSession = { setState: (updates: Record<string, unknown>) => setStateMutation.mutateAsync(updates) };
-  const createWorkspace = useCreateWorkspaceMutation(activeProject, workspaceSession, {
+  const createWorkspace = useCreateWorkspaceMutation(activeProject, {
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
   });
-  const createThread = useCreateAgentControllerThreadMutation(hookArgs);
-  const send = useSendAgentControllerMessageMutation(hookArgs);
 
   const mutation = useMutation({
     mutationFn: async ({ branch, threadTitle, prompt }: StartFactoryRunInput) => {
       const updatedProject = await createWorkspace.mutateAsync(branch);
-      const thread = await createThread.mutateAsync(threadTitle);
-      await send.mutateAsync(prompt);
+      const projectPath = deriveProjectPath(updatedProject);
+      if (!projectPath) throw new Error('Could not resolve the new worktree path');
+
+      // Address the new worktree's own session; create it up front so a
+      // brand-new scope is seeded with its projectPath tag before the thread
+      // is created in it.
+      const { session } = createAgentControllerClient({
+        agentControllerId: AGENT_CONTROLLER_ID,
+        resourceId,
+        scope: projectPath,
+        baseUrl,
+        enabled: sessionEnabled,
+      });
+      const scopedSession = requireAgentControllerSession(session);
+      await scopedSession.create({ tags: { projectPath } });
+      const thread = await scopedSession.createThread(threadTitle);
+      await scopedSession.sendMessage(prompt);
 
       // Seed the thread's message cache so the prompt renders immediately when
       // the thread page mounts, before the server transcript catches up.
@@ -63,9 +72,9 @@ export function useStartFactoryRun() {
         message,
       ]);
       // The thread now exists under the new worktree's project path; refresh
-      // that thread list (createThread invalidated the pre-switch path).
+      // its thread list so the sidebar shows it once the UI lands there.
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, resourceId, deriveProjectPath(updatedProject)),
+        queryKey: queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, resourceId, projectPath),
       });
       return thread.id;
     },

--- a/mastracode/web/src/web/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/SettingsPanel.tsx
@@ -47,11 +47,11 @@ const TABS: { id: Tab; label: string; icon: LucideIcon }[] = [
 export function SettingsPanel({ onClose }: SettingsPanelProps) {
   const [tab, setTab] = useState<Tab>('general');
   const { theme, setTheme } = useTheme();
-  const { resourceId, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
   const { activeModelId, setModel } = useChatModels();
   const { permissions, pendingPermissionCategory, setPermissionForCategory } = useChatPermissions();
   const { toast } = useToast();
-  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, baseUrl, enabled: sessionEnabled };
+  const hookArgs = { agentControllerId: AGENT_CONTROLLER_ID, resourceId, projectPath, baseUrl, enabled: sessionEnabled };
   const modelsQuery = useAgentControllerModels(hookArgs);
   const settingsQuery = useAgentControllerSettings(hookArgs);
   const setStateMutation = useSetAgentControllerStateMutation(hookArgs);

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -11,12 +11,12 @@ import { useLocation, useNavigate } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
 import { queryKeys } from '../../../../../shared/api/keys';
-import { useSetAgentControllerStateMutation } from '../../chat/hooks/useAgentControllerStateMutations';
 import { AGENT_CONTROLLER_THREAD_PAGE_SIZE } from '../../chat/hooks/useAgentControllerThreads';
 import { createAgentControllerClient, requireAgentControllerSession } from '../../chat/services/agentControllerClient';
 import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
 import { useActiveProjectContext } from '../context/ActiveProjectProvider';
 import {
+  deriveProjectPath,
   useCreateWorkspaceMutation,
   useDeleteWorkspaceMutation,
   useSelectWorkspaceMutation,
@@ -37,26 +37,21 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
   const [creating, setCreating] = useState(false);
   const [branch, setBranch] = useState('');
   const workspaces = useWorkspacesQuery(activeProject);
+  const projectPath = deriveProjectPath(activeProject);
   const scope = { agentControllerId: AGENT_CONTROLLER_ID, resourceId };
-  const setStateMutation = useSetAgentControllerStateMutation({
-    agentControllerId: AGENT_CONTROLLER_ID,
-    resourceId,
-    baseUrl,
-    enabled: sessionEnabled,
-  });
-  const workspaceSession = { setState: (updates: Record<string, unknown>) => setStateMutation.mutateAsync(updates) };
-  const selectWorkspace = useSelectWorkspaceMutation(activeProject, workspaceSession, scope);
-  const createWorkspace = useCreateWorkspaceMutation(activeProject, workspaceSession, scope);
+  const selectWorkspace = useSelectWorkspaceMutation(activeProject, scope);
+  const createWorkspace = useCreateWorkspaceMutation(activeProject, scope);
   const navigate = useNavigate();
   const location = useLocation();
   const queryClient = useQueryClient();
   const { session } = createAgentControllerClient({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
+    scope: projectPath || undefined,
     baseUrl,
     enabled: sessionEnabled,
   });
-  const deleteWorkspace = useDeleteWorkspaceMutation(activeProject, workspaceSession, session, scope);
+  const deleteWorkspace = useDeleteWorkspaceMutation(activeProject, session, scope);
   const [confirmDelete, setConfirmDelete] = useState<Worktree | null>(null);
 
   if (activeProject?.source !== 'github') return null;
@@ -71,7 +66,18 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
   const openWorktreeThread = async (worktreePath: string) => {
     if (location.pathname.startsWith('/factory')) return;
     try {
-      const chatSession = requireAgentControllerSession(session);
+      // Address the target worktree's own session (sessions are scoped per
+      // worktree). Create it up front so a brand-new scope is seeded with its
+      // projectPath tag before any thread is created in it.
+      const { session: targetSession } = createAgentControllerClient({
+        agentControllerId: AGENT_CONTROLLER_ID,
+        resourceId,
+        scope: worktreePath,
+        baseUrl,
+        enabled: sessionEnabled,
+      });
+      const chatSession = requireAgentControllerSession(targetSession);
+      await chatSession.create({ tags: { projectPath: worktreePath } });
       const threadsKey = queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, resourceId, worktreePath);
       const threads = await queryClient.fetchQuery({
         queryKey: threadsKey,
@@ -101,8 +107,8 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
       }
       // Empty worktree: leave the stale thread route before creating, so the
       // route-thread sync can't race the create call and error on the old
-      // thread. The workspace switch already rebound the session to this
-      // worktree, so the new thread is tagged with its projectPath.
+      // thread. The scoped session is pinned to this worktree, so the new
+      // thread is tagged with its projectPath.
       if (location.pathname.startsWith('/threads/')) void navigate('/new', { replace: true });
       const created = await chatSession.createThread();
       // A fresh thread has no messages; seed the cache to skip the skeleton.

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
@@ -89,6 +89,12 @@ function useAgentControllerHandlers(): { stateUpdates: Array<Record<string, unkn
     }),
     http.get(`${API}/sessions/:resourceId/permissions`, () => HttpResponse.json({ categories: {}, tools: {} })),
     http.get(`${API}/sessions/:resourceId/threads`, () => HttpResponse.json({ threads: [] })),
+    // Entering an empty worktree creates a thread; handle it here so tests
+    // that don't care about the create flow still settle deterministically
+    // (tests that count creates register their own handler on top).
+    http.post(`${API}/sessions/:resourceId/threads`, () =>
+      HttpResponse.json({ id: 'thread-generic', title: 'New thread', resourceId: 'resource-gh' }),
+    ),
     http.get(`${API}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
     http.get(`${API}/sessions/:resourceId/stream`, () => sse()),
   );
@@ -168,6 +174,8 @@ describe('WorkspacesSection', () => {
       expect(stateUpdates).toContainEqual({ state: { projectPath: '/sandbox/mastra-worktrees/feat-ui' } }),
     );
     await waitFor(() => expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-ui'));
+    // Let the open-thread flow settle so its requests can't leak into later tests.
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/threads/thread-generic'));
   });
 
   it('opens the most recent thread of the new worktree when switching workspaces', async () => {
@@ -268,6 +276,8 @@ describe('WorkspacesSection', () => {
     await waitFor(() =>
       expect(stateUpdates).toContainEqual({ state: { projectPath: '/sandbox/mastra-worktrees/feat-new' } }),
     );
+    // Let the open-thread flow settle so its requests can't leak into later tests.
+    await waitFor(() => expect(screen.getByTestId('location')).toHaveTextContent('/threads/thread-generic'));
   });
 
   it('shows an error and keeps the current selection when create fails', async () => {

--- a/mastracode/web/src/web/ui/domains/workspaces/hooks/__tests__/useWorkspaces.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/hooks/__tests__/useWorkspaces.msw.test.tsx
@@ -14,7 +14,7 @@ import {
   useSelectWorkspaceMutation,
   useWorkspacesQuery,
 } from '../useWorkspaces';
-import type { WorkspaceSession, WorkspaceThreadSession } from '../useWorkspaces';
+import type { WorkspaceThreadSession } from '../useWorkspaces';
 
 const ORIGIN = TEST_BASE_URL;
 const PROJECT_ID = 'project-gh';
@@ -40,10 +40,6 @@ function saveProject(project: Project) {
   saveProjects([project]);
 }
 
-function sessionStub() {
-  return { setState: vi.fn<WorkspaceSession['setState']>().mockResolvedValue(undefined) };
-}
-
 describe('workspaces query hooks', () => {
   it('reads GitHub project worktrees through React Query', async () => {
     saveProject(rootProject);
@@ -54,14 +50,13 @@ describe('workspaces query hooks', () => {
     expect(result.current.data?.worktrees.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
   });
 
-  it('selects a workspace, persists it, rebinds the session projectPath, and refreshes projects consumers', async () => {
+  it('selects a workspace, persists it, and refreshes projects consumers', async () => {
     saveProject(rootProject);
-    const session = sessionStub();
 
     const { result, client } = renderHookWithProviders(() => {
       const projects = useProjectsQuery();
       const workspaces = useWorkspacesQuery(rootProject);
-      const selectWorkspace = useSelectWorkspaceMutation(rootProject, session, {
+      const selectWorkspace = useSelectWorkspaceMutation(rootProject, {
         agentControllerId: 'code',
         resourceId: rootProject.resourceId,
       });
@@ -75,7 +70,6 @@ describe('workspaces query hooks', () => {
     });
     await waitForMutationsIdle(client);
 
-    expect(session.setState).toHaveBeenCalledWith({ projectPath: '/sandbox/mastra-worktrees/feat-ui' });
     expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-ui');
     await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('feat-ui'));
     await waitFor(() =>
@@ -85,7 +79,6 @@ describe('workspaces query hooks', () => {
 
   it('creates a workspace, persists it, selects it, and refetches the workspaces query', async () => {
     saveProject(rootProject);
-    const session = sessionStub();
     let received: unknown;
 
     server.use(
@@ -102,7 +95,7 @@ describe('workspaces query hooks', () => {
 
     const { result, client } = renderHookWithProviders(() => {
       const workspaces = useWorkspacesQuery(rootProject);
-      const createWorkspace = useCreateWorkspaceMutation(rootProject, session, {
+      const createWorkspace = useCreateWorkspaceMutation(rootProject, {
         agentControllerId: 'code',
         resourceId: rootProject.resourceId,
       });
@@ -117,7 +110,6 @@ describe('workspaces query hooks', () => {
     await waitForMutationsIdle(client);
 
     expect(received).toEqual({ branch: 'feat-new' });
-    expect(session.setState).toHaveBeenCalledWith({ projectPath: '/sandbox/mastra-worktrees/feat-new' });
     await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('feat-new'));
     expect(result.current.workspaces.data?.worktrees.map(worktree => worktree.branch)).toEqual([
       'main',
@@ -128,7 +120,6 @@ describe('workspaces query hooks', () => {
 
   it('keeps the current selection when creating a workspace fails', async () => {
     saveProject(rootProject);
-    const session = sessionStub();
 
     server.use(
       http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree`, () =>
@@ -136,7 +127,7 @@ describe('workspaces query hooks', () => {
       ),
     );
 
-    const { result } = renderHookWithProviders(() => useCreateWorkspaceMutation(rootProject, session));
+    const { result } = renderHookWithProviders(() => useCreateWorkspaceMutation(rootProject));
 
     await act(async () => {
       await expect(result.current.mutateAsync('bad branch')).rejects.toMatchObject({
@@ -145,12 +136,10 @@ describe('workspaces query hooks', () => {
     });
 
     expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
-    expect(session.setState).not.toHaveBeenCalled();
   });
 
-  it('deletes a workspace, cascades its threads, and rebinds the session when it was selected', async () => {
+  it('deletes a workspace, cascades its threads, and falls back the stored selection when it was selected', async () => {
     saveProject({ ...rootProject, selectedWorktreePath: '/sandbox/mastra-worktrees/feat-ui' });
-    const session = sessionStub();
     let received: unknown;
 
     server.use(
@@ -180,7 +169,7 @@ describe('workspaces query hooks', () => {
 
     const project = loadProjects()[0]!;
     const { result, client } = renderHookWithProviders(() =>
-      useDeleteWorkspaceMutation(project, session, threadSession, {
+      useDeleteWorkspaceMutation(project, threadSession, {
         agentControllerId: 'code',
         resourceId: project.resourceId,
       }),
@@ -197,7 +186,6 @@ describe('workspaces query hooks', () => {
 
     expect(received).toEqual({ branch: 'feat-ui' });
     expect(deletedThreads).toEqual(['thread-1', 'thread-2']);
-    expect(session.setState).toHaveBeenCalledWith({ projectPath: '/sandbox/mastra' });
     const stored = loadProjects()[0]!;
     expect(stored.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
     expect(stored.selectedWorktreePath).toBe('/sandbox/mastra');
@@ -205,7 +193,6 @@ describe('workspaces query hooks', () => {
 
   it('keeps threads and the stored worktree when the server delete fails', async () => {
     saveProject(rootProject);
-    const session = sessionStub();
 
     server.use(
       http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, () =>
@@ -218,9 +205,7 @@ describe('workspaces query hooks', () => {
       deleteThread: vi.fn(async () => {}),
     };
 
-    const { result } = renderHookWithProviders(() =>
-      useDeleteWorkspaceMutation(rootProject, session, threadSession),
-    );
+    const { result } = renderHookWithProviders(() => useDeleteWorkspaceMutation(rootProject, threadSession));
 
     await act(async () => {
       await expect(
@@ -234,12 +219,10 @@ describe('workspaces query hooks', () => {
 
     expect(threadSession.deleteThread).not.toHaveBeenCalled();
     expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
-    expect(session.setState).not.toHaveBeenCalled();
   });
 
-  it('does not rebind the session when deleting an unselected workspace', async () => {
+  it('keeps the stored selection when deleting an unselected workspace', async () => {
     saveProject(rootProject); // selected: /sandbox/mastra (root)
-    const session = sessionStub();
 
     server.use(
       http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, () =>
@@ -252,9 +235,7 @@ describe('workspaces query hooks', () => {
       deleteThread: vi.fn(async () => {}),
     };
 
-    const { result, client } = renderHookWithProviders(() =>
-      useDeleteWorkspaceMutation(rootProject, session, threadSession),
-    );
+    const { result, client } = renderHookWithProviders(() => useDeleteWorkspaceMutation(rootProject, threadSession));
 
     await act(async () => {
       await result.current.mutateAsync({
@@ -265,7 +246,6 @@ describe('workspaces query hooks', () => {
     });
     await waitForMutationsIdle(client);
 
-    expect(session.setState).not.toHaveBeenCalled();
     expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
     expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
   });

--- a/mastracode/web/src/web/ui/domains/workspaces/hooks/useWorkspaces.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/hooks/useWorkspaces.ts
@@ -14,10 +14,6 @@ import {
   upsertWorktree,
 } from '../services/projects';
 
-export interface WorkspaceSession {
-  setState: (updates: Record<string, unknown>) => Promise<unknown>;
-}
-
 /**
  * The slice of the agent-controller session the delete mutation needs to
  * cascade a worktree deletion onto the threads that ran inside it.
@@ -81,28 +77,21 @@ export function useWorkspacesQuery(project: Project | null | undefined) {
   });
 }
 
-export function useSelectWorkspaceMutation(
-  project: Project | null | undefined,
-  session: WorkspaceSession | null | undefined,
-  scope?: AgentControllerThreadsScope,
-) {
+export function useSelectWorkspaceMutation(project: Project | null | undefined, scope?: AgentControllerThreadsScope) {
   const queryClient = useQueryClient();
   return useMutation({
+    // Sessions are scoped per worktree, so selecting a worktree only updates
+    // the stored project — the UI re-derives the scope and addresses that
+    // worktree's own session (no rebinding of the previous session's state).
     mutationFn: async (worktreePath: string) => {
       if (!project) throw new Error('No active project');
-      const updated = selectWorktree(latestProject(project), worktreePath);
-      await session?.setState({ projectPath: worktreePath });
-      return updated;
+      return selectWorktree(latestProject(project), worktreePath);
     },
     onSuccess: updated => invalidateWorkspaceQueries(queryClient, updated, scope),
   });
 }
 
-export function useCreateWorkspaceMutation(
-  project: Project | null | undefined,
-  session: WorkspaceSession | null | undefined,
-  scope?: AgentControllerThreadsScope,
-) {
+export function useCreateWorkspaceMutation(project: Project | null | undefined, scope?: AgentControllerThreadsScope) {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -117,9 +106,7 @@ export function useCreateWorkspaceMutation(
         worktreePath: result.worktreePath,
         baseBranch: result.baseBranch,
       };
-      const updated = selectWorktree(upsertWorktree(latestProject(project), worktree), worktree.worktreePath);
-      await session?.setState({ projectPath: worktree.worktreePath });
-      return updated;
+      return selectWorktree(upsertWorktree(latestProject(project), worktree), worktree.worktreePath);
     },
     onSuccess: updated => invalidateWorkspaceQueries(queryClient, updated, scope),
     onError: error => toast(error instanceof Error ? error.message : 'Failed to create workspace', 'error'),
@@ -129,12 +116,12 @@ export function useCreateWorkspaceMutation(
 /**
  * Delete a worktree: removes the sandbox checkout + branch server-side, deletes
  * every thread that ran inside it, drops it from the stored project, and — when
- * the deleted worktree was selected — rebinds the session to the fallback
- * selection (repo root). Destructive; callers confirm with the user first.
+ * the deleted worktree was selected — falls back to the repo-root selection
+ * (the UI re-derives the scope and addresses that worktree's own session).
+ * Destructive; callers confirm with the user first.
  */
 export function useDeleteWorkspaceMutation(
   project: Project | null | undefined,
-  session: WorkspaceSession | null | undefined,
   threadSession: WorkspaceThreadSession | null | undefined,
   scope?: AgentControllerThreadsScope,
 ) {
@@ -163,10 +150,6 @@ export function useDeleteWorkspaceMutation(
 
       const wasSelected = selectedWorktree(latestProject(project))?.worktreePath === worktree.worktreePath;
       const updated = removeWorktree(latestProject(project), worktree.worktreePath);
-      if (wasSelected) {
-        const fallback = deriveProjectPath(updated);
-        if (fallback) await session?.setState({ projectPath: fallback });
-      }
       return { updated, removedPath: worktree.worktreePath, wasSelected };
     },
     onSuccess: ({ updated, removedPath }) => {

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -5850,6 +5850,7 @@ export const API_ROUTE_METADATA = {
     "queryParams": [],
     "bodyParams": [
       "resourceId",
+      "sessionScope",
       "tags"
     ],
     "hasQuery": false,
@@ -5865,9 +5866,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -5882,6 +5885,7 @@ export const API_ROUTE_METADATA = {
     ],
     "queryParams": [
       "limit",
+      "sessionScope",
       "tags"
     ],
     "bodyParams": [],
@@ -5899,11 +5903,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "title"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -5917,9 +5923,11 @@ export const API_ROUTE_METADATA = {
       "resourceId",
       "threadId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -5933,11 +5941,13 @@ export const API_ROUTE_METADATA = {
       "resourceId",
       "threadId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "title"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -5950,12 +5960,14 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "sourceThreadId",
       "title"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -5970,7 +5982,8 @@ export const API_ROUTE_METADATA = {
       "threadId"
     ],
     "queryParams": [
-      "limit"
+      "limit",
+      "sessionScope"
     ],
     "bodyParams": [],
     "hasQuery": true,
@@ -5987,11 +6000,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "message"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6004,11 +6019,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "message"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6021,11 +6038,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "message"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6038,9 +6057,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -6053,12 +6074,14 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "approved",
       "toolCallId"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6071,12 +6094,14 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "resumeData",
       "toolCallId"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6089,11 +6114,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "modeId"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6106,13 +6133,15 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "modeId",
       "modelId",
       "scope"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6125,11 +6154,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "threadId"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6142,7 +6173,9 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "attributes",
       "coalesceKey",
@@ -6155,7 +6188,7 @@ export const API_ROUTE_METADATA = {
       "sourceId",
       "summary"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6182,9 +6215,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -6197,11 +6232,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "newResourceId"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6214,9 +6251,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "object-property",
@@ -6230,9 +6269,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -6245,13 +6286,15 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "judgeModelId",
       "maxRuns",
       "objective"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6264,13 +6307,15 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "judgeModelId",
       "maxRuns",
       "status"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6283,9 +6328,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -6298,9 +6345,11 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": false,
     "responseShape": {
       "kind": "single"
@@ -6313,12 +6362,14 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "category",
       "policy"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6331,12 +6382,14 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "policy",
       "toolName"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"
@@ -6349,11 +6402,13 @@ export const API_ROUTE_METADATA = {
       "controllerId",
       "resourceId"
     ],
-    "queryParams": [],
+    "queryParams": [
+      "sessionScope"
+    ],
     "bodyParams": [
       "state"
     ],
-    "hasQuery": false,
+    "hasQuery": true,
     "hasBody": true,
     "responseShape": {
       "kind": "single"

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -56,6 +56,15 @@ import type {
   ToolCategory,
 } from './types';
 
+/**
+ * Registry key for the session map: a bare resourceId when unscoped, otherwise
+ * resourceId + scope joined by NUL (which cannot appear in either value), so a
+ * scoped session can never collide with an unscoped one or another scope.
+ */
+function sessionRegistryKey(resourceId: string, scope?: string): string {
+  return scope === undefined ? resourceId : `${resourceId}\u0000${scope}`;
+}
+
 function validateModes(modes: AgentControllerMode[]): void {
   const modeIds = new Set<string>();
 
@@ -189,14 +198,20 @@ export class AgentController<TState = {}> {
    */
   readonly #defaultMode: AgentControllerMode;
   /**
-   * Live sessions created by {@link createSession}, keyed by resourceId. A
-   * resourceId maps to exactly one session per AgentController (get-or-create). Stores
-   * the in-flight creation promise so concurrent calls share one session. Lets
-   * AgentController-external callers (e.g. notification delivery) resolve "the session
-   * that owns this resource" so a woken run uses that session's model/mode/state
-   * instead of an arbitrary one.
+   * Live sessions created by {@link createSession}, keyed by resourceId plus an
+   * optional caller-provided scope (see {@link sessionRegistryKey}). A
+   * (resourceId, scope) pair maps to exactly one session per AgentController
+   * (get-or-create). Stores the in-flight creation promise so concurrent calls
+   * share one session. Lets AgentController-external callers (e.g. notification
+   * delivery) resolve "the session that owns this resource" so a woken run uses
+   * that session's model/mode/state instead of an arbitrary one.
    */
   readonly #sessionsByResource = new Map<string, Promise<Session<TState>>>();
+  /**
+   * The scope each live session was created under, so re-keying operations
+   * (e.g. {@link setResourceId}) preserve the session's registry scope.
+   */
+  readonly #sessionScopes = new WeakMap<Session<TState>, string>();
   private availableModelsCache: AvailableModel[] | null = null;
   private availableModelsCacheTime: number = 0;
   readonly #instructions?: string;
@@ -333,6 +348,7 @@ export class AgentController<TState = {}> {
     resourceId,
     ownerId,
     id,
+    scope,
     tags,
     workspace,
     browser,
@@ -341,6 +357,15 @@ export class AgentController<TState = {}> {
     resourceId?: string;
     id?: string;
     ownerId?: string;
+    /**
+     * Optional isolation scope within a resourceId. Two `createSession` calls
+     * with the same resourceId but different scopes get two independent
+     * sessions (own run loop, thread binding, mode/model/state) instead of
+     * resolving to the same one. Memory/threads still belong to the shared
+     * resourceId. Used by hosts that run parallel sessions over one resource —
+     * e.g. one session per git worktree, with the worktree path as the scope.
+     */
+    scope?: string;
     /**
      * Arbitrary string tags that scope this session. Each tag is seeded into the
      * session's state and used to filter initial thread selection: a thread is a
@@ -357,13 +382,15 @@ export class AgentController<TState = {}> {
     const effectiveResourceId = resourceId ?? this.config.resourceId ?? this.config.id;
     const effectiveSessionId = id ?? this.config.id;
     const effectiveOwnerId = ownerId ?? this.config.id;
+    const registryKey = sessionRegistryKey(effectiveResourceId, scope);
 
-    // Get-or-create: a resourceId maps to exactly one durable session per
-    // AgentController. Asking for the same resource twice returns the same session, so
-    // a user/thread always resumes their own session and notification delivery
-    // reuses it rather than spawning a split-brain duplicate. Cache the in-flight
-    // promise so concurrent calls for the same resource resolve to one session.
-    const existing = this.#sessionsByResource.get(effectiveResourceId);
+    // Get-or-create: a (resourceId, scope) pair maps to exactly one durable
+    // session per AgentController. Asking for the same resource+scope twice returns
+    // the same session, so a user/thread always resumes their own session and
+    // notification delivery reuses it rather than spawning a split-brain
+    // duplicate. Cache the in-flight promise so concurrent calls for the same
+    // resource+scope resolve to one session.
+    const existing = this.#sessionsByResource.get(registryKey);
     if (existing) {
       return existing;
     }
@@ -373,13 +400,15 @@ export class AgentController<TState = {}> {
       browser,
       requestContext,
     });
-    this.#sessionsByResource.set(effectiveResourceId, creation);
+    this.#sessionsByResource.set(registryKey, creation);
     try {
-      return await creation;
+      const session = await creation;
+      if (scope !== undefined) this.#sessionScopes.set(session, scope);
+      return session;
     } catch (error) {
       // Don't cache a failed creation — let the next call retry.
-      if (this.#sessionsByResource.get(effectiveResourceId) === creation) {
-        this.#sessionsByResource.delete(effectiveResourceId);
+      if (this.#sessionsByResource.get(registryKey) === creation) {
+        this.#sessionsByResource.delete(registryKey);
       }
       throw error;
     }
@@ -531,13 +560,14 @@ export class AgentController<TState = {}> {
   }
 
   /**
-   * Resolve a live session by resourceId, if one was created for it via
-   * {@link createSession}. Returns `undefined` when no session owns the
-   * resource. Used by notification delivery to run woken signals as the session
-   * that owns the target thread, rather than an arbitrary session.
+   * Resolve a live session by resourceId (and optional scope), if one was
+   * created for it via {@link createSession}. Returns `undefined` when no
+   * session owns the resource. Used by notification delivery to run woken
+   * signals as the session that owns the target thread, rather than an
+   * arbitrary session.
    */
-  async getSessionByResource(resourceId: string): Promise<Session<TState> | undefined> {
-    return this.#sessionsByResource.get(resourceId);
+  async getSessionByResource(resourceId: string, scope?: string): Promise<Session<TState> | undefined> {
+    return this.#sessionsByResource.get(sessionRegistryKey(resourceId, scope));
   }
 
   // ===========================================================================
@@ -1239,20 +1269,22 @@ export class AgentController<TState = {}> {
     // Re-key the resource registry so this session is the one resolved for its
     // new resourceId (and is no longer resolved for the old one). This session
     // becomes the authoritative owner of the target resource, replacing any
-    // prior session registered there.
-    const dropPreviousResource = this.#dropSessionFromRegistry(previousResourceId, session);
-    this.#sessionsByResource.set(resourceId, Promise.resolve(session));
+    // prior session registered there. The session keeps its creation scope, so
+    // a scoped session re-keys under the same scope on the new resource.
+    const scope = this.#sessionScopes.get(session);
+    const dropPreviousResource = this.#dropSessionFromRegistry(sessionRegistryKey(previousResourceId, scope), session);
+    this.#sessionsByResource.set(sessionRegistryKey(resourceId, scope), Promise.resolve(session));
     await releasePreviousThreadLock;
     await dropPreviousResource;
   }
 
-  /** Remove `resourceId` from the registry only if it still resolves to `session`. */
-  async #dropSessionFromRegistry(resourceId: string, session: Session<TState>): Promise<void> {
-    const pending = this.#sessionsByResource.get(resourceId);
+  /** Remove `registryKey` from the registry only if it still resolves to `session`. */
+  async #dropSessionFromRegistry(registryKey: string, session: Session<TState>): Promise<void> {
+    const pending = this.#sessionsByResource.get(registryKey);
     if (!pending) return;
     const resolved = await pending.catch(() => undefined);
-    if (resolved === session && this.#sessionsByResource.get(resourceId) === pending) {
-      this.#sessionsByResource.delete(resourceId);
+    if (resolved === session && this.#sessionsByResource.get(registryKey) === pending) {
+      this.#sessionsByResource.delete(registryKey);
     }
   }
 

--- a/packages/core/src/agent-controller/session-isolation.test.ts
+++ b/packages/core/src/agent-controller/session-isolation.test.ts
@@ -323,4 +323,84 @@ describe('AgentController session registry', () => {
     expect(await controller.getSessionByResource('user-a-renamed')).toBe(a);
     expect(await controller.getSessionByResource('user-a')).toBeUndefined();
   });
+
+  it('creates independent sessions for the same resourceId under different scopes', async () => {
+    const controller = createController(new InMemoryStore());
+    await controller.init();
+
+    const a = await controller.createSession({
+      id: 'user-a::wt-a',
+      ownerId: 'test-owner',
+      resourceId: 'user-a',
+      scope: '/worktrees/a',
+      tags: { projectPath: '/worktrees/a' },
+    });
+    const b = await controller.createSession({
+      id: 'user-a::wt-b',
+      ownerId: 'test-owner',
+      resourceId: 'user-a',
+      scope: '/worktrees/b',
+      tags: { projectPath: '/worktrees/b' },
+    });
+
+    expect(b).not.toBe(a);
+    // Each scoped session has its own thread binding and mode/model state.
+    expect(a.thread.getId()).not.toBe(b.thread.getId());
+    await a.mode.switch({ modeId: 'plan' });
+    expect(a.mode.get()).toBe('plan');
+    expect(b.mode.get()).toBe('build');
+  });
+
+  it('returns the same session for the same resourceId and scope (get-or-create)', async () => {
+    const controller = createController(new InMemoryStore());
+    await controller.init();
+
+    const first = await controller.createSession({
+      id: 'user-a::wt-a',
+      ownerId: 'test-owner',
+      resourceId: 'user-a',
+      scope: '/worktrees/a',
+    });
+    const second = await controller.createSession({
+      id: 'user-a::wt-a',
+      ownerId: 'test-owner',
+      resourceId: 'user-a',
+      scope: '/worktrees/a',
+    });
+
+    expect(second).toBe(first);
+  });
+
+  it('resolves scoped sessions independently via getSessionByResource', async () => {
+    const controller = createController(new InMemoryStore());
+    await controller.init();
+
+    const unscoped = await controller.createSession({ id: 'user-a', ownerId: 'test-owner', resourceId: 'user-a' });
+    const scoped = await controller.createSession({
+      id: 'user-a::wt-a',
+      ownerId: 'test-owner',
+      resourceId: 'user-a',
+      scope: '/worktrees/a',
+    });
+
+    expect(await controller.getSessionByResource('user-a')).toBe(unscoped);
+    expect(await controller.getSessionByResource('user-a', '/worktrees/a')).toBe(scoped);
+    expect(await controller.getSessionByResource('user-a', '/worktrees/other')).toBeUndefined();
+  });
+
+  it('keeps the scope when a scoped session is re-keyed to a new resourceId', async () => {
+    const controller = createController(new InMemoryStore());
+    await controller.init();
+
+    const a = await controller.createSession({
+      id: 'user-a::wt-a',
+      ownerId: 'test-owner',
+      resourceId: 'user-a',
+      scope: '/worktrees/a',
+    });
+    controller.setResourceId(a, { resourceId: 'user-a-renamed' });
+
+    expect(await controller.getSessionByResource('user-a-renamed', '/worktrees/a')).toBe(a);
+    expect(await controller.getSessionByResource('user-a', '/worktrees/a')).toBeUndefined();
+  });
 });

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -100,6 +100,81 @@ describe('agent-controller routes', () => {
     });
   });
 
+  describe('scoped sessions (sessionScope)', () => {
+    // One resourceId can be shared across git worktrees; a `sessionScope`
+    // addresses an independent session per scope so parallel worktrees don't
+    // collide on one run loop / thread binding.
+    it('creates independent sessions for the same resourceId under different scopes', async () => {
+      const a = (await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+        sessionScope: '/repo/worktree-a',
+        tags: { projectPath: '/repo/worktree-a' },
+      } as any)) as { threadId?: string };
+      const b = (await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+        sessionScope: '/repo/worktree-b',
+        tags: { projectPath: '/repo/worktree-b' },
+      } as any)) as { threadId?: string };
+
+      expect(a.threadId).toBeDefined();
+      expect(b.threadId).toBeDefined();
+      expect(b.threadId).not.toBe(a.threadId);
+
+      // Get-or-create still holds within one scope.
+      const aAgain = (await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+        sessionScope: '/repo/worktree-a',
+        tags: { projectPath: '/repo/worktree-a' },
+      } as any)) as { threadId?: string };
+      expect(aAgain.threadId).toBe(a.threadId);
+    });
+
+    it('routes with a sessionScope address the scoped session, not the unscoped one', async () => {
+      await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+      } as any);
+      await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+        sessionScope: '/repo/worktree-a',
+        tags: { projectPath: '/repo/worktree-a' },
+      } as any);
+
+      // Switch the scoped session's mode; the unscoped session must not move.
+      await SWITCH_AGENT_CONTROLLER_MODE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+        sessionScope: '/repo/worktree-a',
+        modeId: 'plan',
+      } as any);
+
+      const scoped = (await GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+        sessionScope: '/repo/worktree-a',
+      } as any)) as { modeId: string };
+      const unscoped = (await GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-wt',
+      } as any)) as { modeId: string };
+
+      expect(scoped.modeId).toBe('plan');
+      expect(unscoped.modeId).toBe('build');
+    });
+  });
+
   describe('ABORT_AGENT_CONTROLLER_SESSION_ROUTE', () => {
     it('acks an abort on an idle session', async () => {
       const res = await ABORT_AGENT_CONTROLLER_SESSION_ROUTE.handler({

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -64,10 +64,15 @@ function getAgentControllerOrThrow(
 async function getSession(
   controller: AgentController<any>,
   resourceId: string,
-  tags?: Record<string, string>,
+  options?: { tags?: Record<string, string>; scope?: string },
 ): Promise<Session<any>> {
   await controller.init();
-  return controller.createSession({ resourceId, id: resourceId, ownerId: controller.id, tags });
+  const { tags, scope } = options ?? {};
+  // Scoped sessions are independent sessions over the same resource (e.g. one
+  // per git worktree), so qualify the stable session id with the scope to keep
+  // their identities distinct as well.
+  const id = scope ? `${resourceId}::${scope}` : resourceId;
+  return controller.createSession({ resourceId, id, ownerId: controller.id, tags, scope });
 }
 
 // ---------------------------------------------------------------------------
@@ -76,10 +81,18 @@ async function getSession(
 
 const controllerIdPathParams = z.object({ controllerId: z.string() });
 const sessionPathParams = z.object({ controllerId: z.string(), resourceId: z.string() });
+/**
+ * Optional session scope (mirrors `AgentController.createSession`'s `scope`):
+ * requests with the same resourceId but different scopes address independent
+ * sessions (e.g. one per git worktree). Sent as a `sessionScope` query param
+ * on session routes; named to avoid colliding with the model-switch `scope`.
+ */
+const sessionScopeQuerySchema = z.object({ sessionScope: z.string().optional() });
 
 const createSessionBodySchema = z.object({
   resourceId: z.string(),
   tags: z.record(z.string(), z.string()).optional(),
+  sessionScope: z.string().optional(),
 });
 const sendMessageBodySchema = z.object({ message: z.string() });
 const steerBodySchema = z.object({ message: z.string() });
@@ -108,7 +121,7 @@ const cloneThreadBodySchema = z.object({
   sourceThreadId: z.string().optional(),
   title: z.string().optional(),
 });
-const listMessagesQuerySchema = z.object({ limit: z.coerce.number().optional() });
+const listMessagesQuerySchema = z.object({ limit: z.coerce.number().optional(), sessionScope: z.string().optional() });
 /**
  * `tags` arrives as a JSON-encoded object in the query string (query params are
  * flat strings). It scopes the listing to threads whose metadata matches every
@@ -117,6 +130,7 @@ const listMessagesQuerySchema = z.object({ limit: z.coerce.number().optional() }
  */
 const listThreadsQuerySchema = z.object({
   limit: z.coerce.number().optional(),
+  sessionScope: z.string().optional(),
   tags: z
     .preprocess(value => {
       if (typeof value !== 'string' || value.length === 0) return undefined;
@@ -296,10 +310,10 @@ export const CREATE_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, tags }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, tags }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId, tags);
+      const session = await getSession(controller, resourceId, { tags, scope: sessionScope });
       return {
         controllerId,
         resourceId,
@@ -337,15 +351,16 @@ export const STREAM_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   streamFormat: 'sse' as const,
   sseFlushOnConnect: true,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   summary: 'Stream controller session events',
   description: 'Subscribes to a session\u2019s event bus and streams events to the client over SSE.',
   tags: ['AgentController', 'Streaming'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId, abortSignal }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, abortSignal }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
 
       let cleanedUp = false;
       let heartbeat: ReturnType<typeof setTimeout> | undefined;
@@ -421,6 +436,7 @@ export const SEND_AGENT_CONTROLLER_MESSAGE_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/messages',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: sendMessageBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Send a message to a controller session',
@@ -428,10 +444,10 @@ export const SEND_AGENT_CONTROLLER_MESSAGE_ROUTE = createRoute({
   tags: ['AgentController', 'Streaming'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, message, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       // Forward the server middleware's requestContext so identity injected in
       // `server.middleware` reaches dynamic instructions and tools (same as the
       // plain agent message route).
@@ -448,16 +464,17 @@ export const ABORT_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/abort',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: ackResponseSchema,
   summary: 'Abort a controller session run',
   description: 'Aborts the in-flight run for the session, if any.',
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       session.abort();
       return { ok: true };
     } catch (error) {
@@ -471,6 +488,7 @@ export const AGENT_CONTROLLER_TOOL_APPROVAL_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/tool-approval',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: toolApprovalBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Respond to a controller tool approval',
@@ -478,10 +496,10 @@ export const AGENT_CONTROLLER_TOOL_APPROVAL_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, toolCallId, approved, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, toolCallId, approved, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       // Resolve the parked approval gate so the session's own run loop drives the
       // continuation and emits its events to subscribers (the open SSE stream).
       // Calling approveToolCall/declineToolCall directly would bypass the gate,
@@ -500,6 +518,7 @@ export const AGENT_CONTROLLER_TOOL_SUSPENSION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/tool-suspension',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: toolSuspensionBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Respond to a suspended controller tool',
@@ -508,10 +527,10 @@ export const AGENT_CONTROLLER_TOOL_SUSPENSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, toolCallId, resumeData, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, toolCallId, resumeData, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.respondToToolSuspension({ toolCallId, resumeData, requestContext });
       return { ok: true };
     } catch (error) {
@@ -525,6 +544,7 @@ export const STEER_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/steer',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: steerBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Steer the in-flight run',
@@ -532,10 +552,10 @@ export const STEER_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, message, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       void session.steer({ content: message, requestContext });
       return { ok: true };
     } catch (error) {
@@ -549,6 +569,7 @@ export const SWITCH_AGENT_CONTROLLER_MODE_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/mode',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: switchModeBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Switch the session mode',
@@ -556,10 +577,10 @@ export const SWITCH_AGENT_CONTROLLER_MODE_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, modeId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, modeId }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.mode.switch({ modeId });
       return { ok: true };
     } catch (error) {
@@ -573,6 +594,7 @@ export const SWITCH_AGENT_CONTROLLER_MODEL_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/model',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: switchModelBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Switch the session model',
@@ -580,10 +602,10 @@ export const SWITCH_AGENT_CONTROLLER_MODEL_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, modelId, scope, modeId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, modelId, scope, modeId }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.model.switch({ modelId, scope, modeId });
       return { ok: true };
     } catch (error) {
@@ -597,6 +619,7 @@ export const SWITCH_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/thread',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: switchThreadBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Switch the session thread',
@@ -604,10 +627,10 @@ export const SWITCH_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, threadId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, threadId }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.thread.switch({ threadId });
       return { ok: true };
     } catch (error) {
@@ -621,16 +644,17 @@ export const GET_AGENT_CONTROLLER_SESSION_STATE_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: sessionStateResponseSchema,
   summary: 'Get session state',
   description: 'Returns the current mode, model, and thread for the session (for initial UI hydration).',
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const ds = session.displayState.get();
       const om = ds.omProgress;
       const reflectionSavings =
@@ -705,10 +729,10 @@ export const LIST_AGENT_CONTROLLER_THREADS_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId, limit, tags }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, limit, tags }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const threads = await session.thread.list();
       // A thread's metadata mixes the session scoping tags (stamped at creation,
       // e.g. `projectPath`) with internal session bookkeeping that
@@ -764,6 +788,7 @@ export const SEND_AGENT_CONTROLLER_NOTIFICATION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/notifications',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: sendNotificationBodySchema,
   responseSchema: z.object({
     accepted: z.boolean(),
@@ -781,6 +806,7 @@ export const SEND_AGENT_CONTROLLER_NOTIFICATION_ROUTE = createRoute({
     mastra,
     controllerId,
     resourceId,
+    sessionScope,
     source,
     kind,
     summary,
@@ -794,7 +820,7 @@ export const SEND_AGENT_CONTROLLER_NOTIFICATION_ROUTE = createRoute({
   }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const result = await session.sendNotificationSignal({
         source,
         kind,
@@ -828,6 +854,7 @@ export const CREATE_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/threads',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: createThreadBodySchema,
   responseSchema: threadResponseSchema,
   summary: 'Create a new thread',
@@ -835,10 +862,10 @@ export const CREATE_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, title }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, title }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const thread = await session.thread.create({ title });
       return {
         id: thread.id,
@@ -858,16 +885,17 @@ export const DELETE_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/threads/:threadId',
   responseType: 'json' as const,
   pathParamSchema: threadPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: ackResponseSchema,
   summary: 'Delete a thread',
   description: 'Deletes a thread. If the deleted thread is the active one, the session is unbound.',
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, threadId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, threadId }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.thread.delete({ threadId });
       return { ok: true };
     } catch (error) {
@@ -881,6 +909,7 @@ export const RENAME_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/threads/:threadId',
   responseType: 'json' as const,
   pathParamSchema: threadPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: renameThreadBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Rename a thread',
@@ -888,10 +917,10 @@ export const RENAME_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, threadId, title }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, threadId, title }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       // Ensure the thread is the active one (switch if not)
       if (session.thread.getId() !== threadId) {
         await session.thread.switch({ threadId });
@@ -909,6 +938,7 @@ export const CLONE_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/threads/clone',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: cloneThreadBodySchema,
   responseSchema: threadResponseSchema,
   summary: 'Clone a thread',
@@ -916,10 +946,10 @@ export const CLONE_AGENT_CONTROLLER_THREAD_ROUTE = createRoute({
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, sourceThreadId, title }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, sourceThreadId, title }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const thread = await session.thread.clone({ sourceThreadId, title });
       return {
         id: thread.id,
@@ -946,10 +976,10 @@ export const LIST_AGENT_CONTROLLER_THREAD_MESSAGES_ROUTE = createRoute({
   tags: ['AgentController', 'Threads'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId, threadId, limit }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, threadId, limit }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const messages = await session.thread.listMessages({ threadId, limit });
       return {
         messages: messages.map(m => ({
@@ -974,6 +1004,7 @@ export const FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/follow-up',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: followUpBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Queue a follow-up message',
@@ -982,10 +1013,10 @@ export const FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, message, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       void session.followUp({ content: message, requestContext });
       return { ok: true };
     } catch (error) {
@@ -1067,16 +1098,17 @@ export const GET_AGENT_CONTROLLER_OM_RECORD_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/om',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: omRecordResponseSchema,
   summary: 'Get observational memory record',
   description: 'Returns the current observational memory record for the session\u2019s thread/resource.',
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const record = await controller.getObservationalMemoryRecord(session);
       return { record: record ?? undefined };
     } catch (error) {
@@ -1094,6 +1126,7 @@ export const SET_AGENT_CONTROLLER_RESOURCE_ID_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/resource',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: z.object({ newResourceId: z.string() }),
   responseSchema: ackResponseSchema,
   summary: 'Change the session resource ID',
@@ -1101,10 +1134,10 @@ export const SET_AGENT_CONTROLLER_RESOURCE_ID_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, newResourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, newResourceId }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await controller.setResourceId(session, { resourceId: newResourceId });
       return { ok: true };
     } catch (error) {
@@ -1118,16 +1151,17 @@ export const GET_AGENT_CONTROLLER_RESOURCE_IDS_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/resources',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: z.object({ resourceIds: z.array(z.string()) }),
   summary: 'Get known resource IDs',
   description: 'Lists the resource IDs known to this session (from threads).',
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const resourceIds = await controller.getKnownResourceIds(session);
       return { resourceIds };
     } catch (error) {
@@ -1172,16 +1206,17 @@ export const GET_AGENT_CONTROLLER_GOAL_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/goal',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: goalResponseSchema,
   summary: 'Get the current goal',
   description: 'Returns the active/paused/done goal objective for the session\u2019s thread, if any.',
   tags: ['AgentController', 'Goals'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const threadId = session.thread.getId();
       if (!threadId) return { goal: undefined };
       const agent = getAgentForSession(controller, session);
@@ -1198,6 +1233,7 @@ export const SET_AGENT_CONTROLLER_GOAL_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/goal',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: setGoalBodySchema,
   responseSchema: goalResponseSchema,
   summary: 'Set a goal',
@@ -1206,10 +1242,10 @@ export const SET_AGENT_CONTROLLER_GOAL_ROUTE = createRoute({
   tags: ['AgentController', 'Goals'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, objective, judgeModelId, maxRuns }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, objective, judgeModelId, maxRuns }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const threadId = session.thread.getId();
       if (!threadId) throw new HTTPException(400, { message: 'session has no active thread' });
       const agent = getAgentForSession(controller, session);
@@ -1231,6 +1267,7 @@ export const UPDATE_AGENT_CONTROLLER_GOAL_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/goal',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: updateGoalBodySchema,
   responseSchema: goalResponseSchema,
   summary: 'Update goal options',
@@ -1238,10 +1275,10 @@ export const UPDATE_AGENT_CONTROLLER_GOAL_ROUTE = createRoute({
   tags: ['AgentController', 'Goals'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, judgeModelId, maxRuns, status }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, judgeModelId, maxRuns, status }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const threadId = session.thread.getId();
       if (!threadId) throw new HTTPException(400, { message: 'session has no active thread' });
       const agent = getAgentForSession(controller, session);
@@ -1263,16 +1300,17 @@ export const CLEAR_AGENT_CONTROLLER_GOAL_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/goal',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: ackResponseSchema,
   summary: 'Clear the goal',
   description: 'Removes the active goal from the session\u2019s thread.',
   tags: ['AgentController', 'Goals'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const threadId = session.thread.getId();
       if (!threadId) throw new HTTPException(400, { message: 'session has no active thread' });
       const agent = getAgentForSession(controller, session);
@@ -1293,16 +1331,17 @@ export const GET_AGENT_CONTROLLER_PERMISSIONS_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/permissions',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   responseSchema: permissionRulesResponseSchema,
   summary: 'Get permission rules',
   description: 'Returns the current permission rules (per-category and per-tool policies) for the session.',
   tags: ['AgentController', 'Permissions'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:read',
-  handler: async ({ mastra, controllerId, resourceId }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       const rules = session.permissions.getRules();
       return {
         categories: rules.categories as Record<string, 'allow' | 'ask' | 'deny'> | undefined,
@@ -1319,6 +1358,7 @@ export const SET_AGENT_CONTROLLER_CATEGORY_PERMISSION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/permissions/category',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: setCategoryPermissionBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Set permission for a tool category',
@@ -1326,10 +1366,10 @@ export const SET_AGENT_CONTROLLER_CATEGORY_PERMISSION_ROUTE = createRoute({
   tags: ['AgentController', 'Permissions'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, category, policy }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, category, policy }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.permissions.setForCategory({ category, policy });
       return { ok: true };
     } catch (error) {
@@ -1343,6 +1383,7 @@ export const SET_AGENT_CONTROLLER_TOOL_PERMISSION_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/permissions/tool',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: setToolPermissionBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Set permission for a specific tool',
@@ -1351,10 +1392,10 @@ export const SET_AGENT_CONTROLLER_TOOL_PERMISSION_ROUTE = createRoute({
   tags: ['AgentController', 'Permissions'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, toolName, policy }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, toolName, policy }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.permissions.setForTool({ toolName, policy });
       return { ok: true };
     } catch (error) {
@@ -1374,6 +1415,7 @@ export const SET_AGENT_CONTROLLER_SESSION_STATE_ROUTE = createRoute({
   path: '/agent-controller/:controllerId/sessions/:resourceId/state',
   responseType: 'json' as const,
   pathParamSchema: sessionPathParams,
+  queryParamSchema: sessionScopeQuerySchema,
   bodySchema: setSessionStateBodySchema,
   responseSchema: ackResponseSchema,
   summary: 'Set session state',
@@ -1382,10 +1424,10 @@ export const SET_AGENT_CONTROLLER_SESSION_STATE_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, state }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, state }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId);
+      const session = await getSession(controller, resourceId, { scope: sessionScope });
       await session.state.set(state as Record<string, unknown>);
       return { ok: true };
     } catch (error) {


### PR DESCRIPTION
Starting multiple runs from the Intake page didn't give you independent sessions — they all shared one server-side session, so each new run repointed the workspace and the earlier run stopped streaming. You couldn't switch between parallel worktrees and watch each agent keep working.

The cause: agent controller sessions were get-or-create by resourceId alone, and every worktree of a project shares the same resourceId. This adds an optional session scope so callers can address independent sessions over the same resource — one per git worktree, with the worktree path as the scope.

```ts
const controller = client.getAgentController('code');

// Each worktree addresses its own session:
const a = controller.session('repo-123', '/worktrees/feature-a');
const b = controller.session('repo-123', '/worktrees/feature-b');
// a and b have independent run loops, thread bindings, mode/model/state
```

Core keys the session registry by resourceId + scope, server session routes accept a `sessionScope` query param, client-js carries the scope on every request, and the web app keys its client cache and session query keys by the worktree projectPath. Unscoped callers behave exactly as before.

Test plan: new core session-isolation tests for scoped sessions (independent threads, get-or-create per scope, scope preserved on re-key), new server tests for `sessionScope` on session routes, and updated web MSW tests for scope-aware caching. Full suites pass: core 378, server 1862, client-js 551, web ui 375, web e2e 89; typechecks clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Each worktree now gets its own independent agent session, so parallel coding runs no longer interfere with one another. Existing callers that do not specify a worktree continue to behave as before.

## What changed

- Added optional session scoping by worktree path across core, server, JavaScript client, and web UI.
- Updated server routes and generated route types to accept and propagate `sessionScope`.
- Updated client requests and caching keys to include the session scope.
- Scoped web hooks, mutations, settings, permissions, threads, modes, models, goals, and state operations by `projectPath`.
- Updated workspace and factory flows to create and use worktree-specific sessions.
- Removed workspace-session rebinding in favor of scoped controller sessions.
- Added coverage for session isolation, scoped server behavior, caching, and workspace flows.
- Preserved backward-compatible behavior for unscoped callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->