### PR TITLE
Add MC GitHub webhook infrastructure

### DIFF
--- a/.changeset/github-webhook-infrastructure.md
+++ b/.changeset/github-webhook-infrastructure.md
@@ -1,0 +1,5 @@
+---
+"mastracode-web": patch
+---
+
+Add a GitHub App webhook endpoint that verifies delivery signatures and logs normalized issue and pull request event metadata.

--- a/.changeset/github-webhook-infrastructure.md
+++ b/.changeset/github-webhook-infrastructure.md
@@ -1,5 +1,0 @@
----
-"mastracode-web": patch
----
-
-Add a GitHub App webhook endpoint that verifies delivery signatures and logs normalized issue and pull request event metadata.

--- a/mastracode/web/src/web/auth.test.ts
+++ b/mastracode/web/src/web/auth.test.ts
@@ -94,6 +94,7 @@ function buildApp() {
   const app = new Hono();
   const enabled = mountWebAuth(app, { redirectUri: 'http://localhost:4111/auth/callback' });
   app.get('*', c => c.text('ok'));
+  app.post('*', c => c.text('ok'));
   return { app, enabled };
 }
 
@@ -161,6 +162,25 @@ describe('mountWebAuth gate (enabled)', () => {
     const { app } = buildApp();
 
     const res = await app.request('/web/projects', { headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: 'unauthorized' });
+  });
+
+  it('lets unauthenticated GitHub webhook deliveries reach the route handler', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const { app } = buildApp();
+
+    const res = await app.request('/web/github/webhook', { method: 'POST', headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('ok');
+    expect(mockAuthenticate).not.toHaveBeenCalled();
+  });
+
+  it('does not bypass auth for non-POST GitHub webhook requests', async () => {
+    mockAuthenticate.mockResolvedValue(null);
+    const { app } = buildApp();
+
+    const res = await app.request('/web/github/webhook', { method: 'GET', headers: { Accept: 'application/json' } });
     expect(res.status).toBe(401);
     expect(await res.json()).toEqual({ error: 'unauthorized' });
   });

--- a/mastracode/web/src/web/auth.ts
+++ b/mastracode/web/src/web/auth.ts
@@ -508,6 +508,9 @@ export function createWebAuthGate(provider: MastraAuthWorkos) {
     if (path.startsWith('/auth/')) {
       return next();
     }
+    if (c.req.method === 'POST' && path === '/web/github/webhook') {
+      return next();
+    }
     // The SPA sign-in page and the static bundle it needs must be reachable
     // while signed out; no user is stashed, so `/api/*` stays protected.
     if (path === '/signin' || path.startsWith('/assets/')) {

--- a/mastracode/web/src/web/github/config.ts
+++ b/mastracode/web/src/web/github/config.ts
@@ -54,6 +54,11 @@ export function getGithubFeatureDiagnostics(): GithubFeatureDiagnostics {
   };
 }
 
+/** Secret used by GitHub to sign webhook deliveries. */
+export function getGithubWebhookSecret(): string | undefined {
+  return process.env.GITHUB_APP_WEBHOOK_SECRET || undefined;
+}
+
 /**
  * Secret used to sign the OAuth/install `state`. Falls back to a per-process
  * random secret when no explicit one is configured (state is short-lived).

--- a/mastracode/web/src/web/github/routes.test.ts
+++ b/mastracode/web/src/web/github/routes.test.ts
@@ -422,9 +422,13 @@ describe('webhook route', () => {
 
   it('rejects invalid signatures without logging', async () => {
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const req = signedGithubWebhookRequest('issues', { action: 'opened' }, {
-      headers: { 'x-hub-signature-256': 'sha256=0000000000000000000000000000000000000000000000000000000000000000' },
-    });
+    const req = signedGithubWebhookRequest(
+      'issues',
+      { action: 'opened' },
+      {
+        headers: { 'x-hub-signature-256': 'sha256=0000000000000000000000000000000000000000000000000000000000000000' },
+      },
+    );
 
     const res = await buildApp(null).request(req);
 
@@ -449,7 +453,9 @@ describe('webhook route', () => {
 
   it('rejects malformed JSON after signature verification', async () => {
     const body = '{';
-    const signature = `sha256=${createHmac('sha256', process.env.GITHUB_APP_WEBHOOK_SECRET ?? '').update(body).digest('hex')}`;
+    const signature = `sha256=${createHmac('sha256', process.env.GITHUB_APP_WEBHOOK_SECRET ?? '')
+      .update(body)
+      .digest('hex')}`;
     const res = await buildApp(null).request('/web/github/webhook', {
       method: 'POST',
       headers: {

--- a/mastracode/web/src/web/github/routes.test.ts
+++ b/mastracode/web/src/web/github/routes.test.ts
@@ -1,3 +1,4 @@
+import { createHmac } from 'node:crypto';
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as AuthModule from '../auth';
@@ -188,6 +189,7 @@ let featureEnabled = true;
 vi.mock('./config', () => ({
   isGithubFeatureEnabled: () => featureEnabled,
   getGithubFeatureDiagnostics: () => ({}),
+  getGithubWebhookSecret: () => process.env.GITHUB_APP_WEBHOOK_SECRET || undefined,
   signState: (orgId: string, userId: string) => `state.${orgId}.${userId}`,
   verifyState: (state: string | undefined) => {
     if (!state?.startsWith('state.')) return null;
@@ -330,6 +332,7 @@ beforeEach(() => {
   featureEnabled = true;
   sandboxEnabled = true;
   cookieUser = null;
+  process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-webhook-secret';
   // No Postgres in these unit tests: keep the project lock purely in-process.
   process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
   ensureProjectSandbox.mockClear();
@@ -345,8 +348,131 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  delete process.env.GITHUB_APP_WEBHOOK_SECRET;
   delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
   vi.clearAllMocks();
+});
+
+function signedGithubWebhookRequest(event: string, payload: Record<string, unknown>, init?: RequestInit): Request {
+  const body = JSON.stringify(payload);
+  const secret = process.env.GITHUB_APP_WEBHOOK_SECRET ?? '';
+  const signature = `sha256=${createHmac('sha256', secret).update(body).digest('hex')}`;
+  const headers = new Headers({
+    'content-type': 'application/json',
+    'x-github-event': event,
+    'x-github-delivery': 'delivery-1',
+    'x-hub-signature-256': signature,
+  });
+  new Headers(init?.headers).forEach((value, key) => headers.set(key, value));
+  return new Request('http://localhost/web/github/webhook', { ...init, method: 'POST', headers, body });
+}
+
+describe('webhook route', () => {
+  it('accepts a valid signed issues event and logs normalized metadata', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const res = await buildApp(null).request(
+      signedGithubWebhookRequest('issues', {
+        action: 'opened',
+        repository: { full_name: 'octo/hello' },
+        issue: { number: 12 },
+        sender: { login: 'ada' },
+        installation: { id: 99 },
+      }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[GitHub Webhook]', {
+      event: 'issues',
+      action: 'opened',
+      deliveryId: 'delivery-1',
+      repository: 'octo/hello',
+      issueNumber: 12,
+      pullRequestNumber: undefined,
+      sender: 'ada',
+      installationId: 99,
+    });
+  });
+
+  it('accepts a valid signed PR review comment event and logs normalized PR metadata', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const res = await buildApp(null).request(
+      signedGithubWebhookRequest('pull_request_review_comment', {
+        action: 'created',
+        repository: { full_name: 'octo/hello' },
+        pull_request: { number: 34 },
+        sender: { login: 'grace' },
+        installation: { id: 99 },
+      }),
+    );
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(logSpy).toHaveBeenCalledWith('[GitHub Webhook]', {
+      event: 'pull_request_review_comment',
+      action: 'created',
+      deliveryId: 'delivery-1',
+      repository: 'octo/hello',
+      issueNumber: undefined,
+      pullRequestNumber: 34,
+      sender: 'grace',
+      installationId: 99,
+    });
+  });
+
+  it('rejects invalid signatures without logging', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const req = signedGithubWebhookRequest('issues', { action: 'opened' }, {
+      headers: { 'x-hub-signature-256': 'sha256=0000000000000000000000000000000000000000000000000000000000000000' },
+    });
+
+    const res = await buildApp(null).request(req);
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toMatchObject({ error: 'unauthorized' });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['x-github-event', 400, { error: 'bad_request', message: 'Missing x-github-event header' }],
+    ['x-github-delivery', 400, { error: 'bad_request', message: 'Missing x-github-delivery header' }],
+    ['x-hub-signature-256', 401, { error: 'unauthorized', message: 'Missing x-hub-signature-256 header' }],
+  ] as const)('rejects missing %s header', async (missingHeader, expectedStatus, expectedBody) => {
+    const req = signedGithubWebhookRequest('issues', { action: 'opened' });
+    req.headers.delete(missingHeader);
+
+    const res = await buildApp(null).request(req);
+
+    expect(res.status).toBe(expectedStatus);
+    expect(await res.json()).toEqual(expectedBody);
+  });
+
+  it('rejects malformed JSON after signature verification', async () => {
+    const body = '{';
+    const signature = `sha256=${createHmac('sha256', process.env.GITHUB_APP_WEBHOOK_SECRET ?? '').update(body).digest('hex')}`;
+    const res = await buildApp(null).request('/web/github/webhook', {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-github-event': 'issues',
+        'x-github-delivery': 'delivery-1',
+        'x-hub-signature-256': signature,
+      },
+      body,
+    });
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'bad_request', message: 'Malformed JSON payload' });
+  });
+
+  it('accepts and ignores a valid unsupported event', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const res = await buildApp(null).request(signedGithubWebhookRequest('installation', { action: 'created' }));
+
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ ok: true, ignored: true });
+    expect(logSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('status route', () => {

--- a/mastracode/web/src/web/github/routes.ts
+++ b/mastracode/web/src/web/github/routes.ts
@@ -46,6 +46,7 @@ import {
 import { getGithubFeatureDiagnostics, isGithubFeatureEnabled, signState, verifyState } from './config';
 import { getAppDb } from './db';
 import { withProjectLock } from './project-lock';
+import { handleGithubWebhook } from './webhook';
 import {
   commitAll,
   computeSandboxWorkdir,
@@ -217,6 +218,17 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions = {}): ApiRo
   if (!isGithubFeatureEnabled()) {
     return routes;
   }
+
+  routes.push(
+    registerApiRoute('/web/github/webhook', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        const result = await handleGithubWebhook(loose(c));
+        return c.json(result.body, result.status);
+      },
+    }),
+  );
 
   const redirectUri = options.redirectUri ?? `${(options.baseUrl ?? '').replace(/\/$/, '')}/auth/github/callback`;
 

--- a/mastracode/web/src/web/github/webhook.ts
+++ b/mastracode/web/src/web/github/webhook.ts
@@ -60,7 +60,8 @@ async function parseGithubWebhook(c: Context): Promise<ParsedGithubWebhook | Git
 
   if (!event) return { status: 400, body: { error: 'bad_request', message: 'Missing x-github-event header' } };
   if (!deliveryId) return { status: 400, body: { error: 'bad_request', message: 'Missing x-github-delivery header' } };
-  if (!signature) return { status: 401, body: { error: 'unauthorized', message: 'Missing x-hub-signature-256 header' } };
+  if (!signature)
+    return { status: 401, body: { error: 'unauthorized', message: 'Missing x-hub-signature-256 header' } };
 
   const rawBody = await c.req.text();
   if (!verifySignature(rawBody, signature, secret)) {

--- a/mastracode/web/src/web/github/webhook.ts
+++ b/mastracode/web/src/web/github/webhook.ts
@@ -1,0 +1,126 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { Context } from 'hono';
+import { getGithubWebhookSecret } from './config';
+
+const SUPPORTED_GITHUB_WEBHOOK_EVENTS = new Set([
+  'issues',
+  'pull_request',
+  'pull_request_review',
+  'pull_request_review_comment',
+]);
+
+export interface GithubWebhookMetadata {
+  event: string;
+  action?: string;
+  deliveryId: string;
+  repository?: string;
+  issueNumber?: number;
+  pullRequestNumber?: number;
+  sender?: string;
+  installationId?: number;
+}
+
+export interface ParsedGithubWebhook {
+  event: string;
+  deliveryId: string;
+  payload: Record<string, unknown>;
+}
+
+export type GithubWebhookResult =
+  | { status: 202; body: { ok: true; ignored?: true } }
+  | { status: 400; body: { error: 'bad_request'; message: string } }
+  | { status: 401; body: { error: 'unauthorized'; message: string } };
+
+function normalizeHeader(value: string | undefined | null): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function verifySignature(rawBody: string, signature: string, secret: string): boolean {
+  if (!signature.startsWith('sha256=')) return false;
+  const signatureHex = signature.slice('sha256='.length);
+  if (!/^[a-fA-F0-9]{64}$/.test(signatureHex)) return false;
+
+  const expectedHex = createHmac('sha256', secret).update(rawBody).digest('hex');
+  const received = Buffer.from(signatureHex, 'hex');
+  const expected = Buffer.from(expectedHex, 'hex');
+  return received.length === expected.length && timingSafeEqual(received, expected);
+}
+
+async function parseGithubWebhook(c: Context): Promise<ParsedGithubWebhook | GithubWebhookResult> {
+  const secret = getGithubWebhookSecret();
+  if (!secret) {
+    return { status: 401, body: { error: 'unauthorized', message: 'GitHub webhook secret is not configured' } };
+  }
+
+  const event = normalizeHeader(c.req.header('x-github-event'));
+  const deliveryId = normalizeHeader(c.req.header('x-github-delivery'));
+  const signature = normalizeHeader(c.req.header('x-hub-signature-256'));
+
+  if (!event) return { status: 400, body: { error: 'bad_request', message: 'Missing x-github-event header' } };
+  if (!deliveryId) return { status: 400, body: { error: 'bad_request', message: 'Missing x-github-delivery header' } };
+  if (!signature) return { status: 401, body: { error: 'unauthorized', message: 'Missing x-hub-signature-256 header' } };
+
+  const rawBody = await c.req.text();
+  if (!verifySignature(rawBody, signature, secret)) {
+    return { status: 401, body: { error: 'unauthorized', message: 'Invalid GitHub webhook signature' } };
+  }
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(rawBody);
+  } catch {
+    return { status: 400, body: { error: 'bad_request', message: 'Malformed JSON payload' } };
+  }
+
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return { status: 400, body: { error: 'bad_request', message: 'Payload must be a JSON object' } };
+  }
+
+  return { event, deliveryId, payload: payload as Record<string, unknown> };
+}
+
+function getObject(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
+}
+
+function getString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function getNumber(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+export function normalizeGithubWebhookMetadata(parsed: ParsedGithubWebhook): GithubWebhookMetadata {
+  const { event, deliveryId, payload } = parsed;
+  const repository = getObject(payload.repository);
+  const issue = getObject(payload.issue);
+  const pullRequest = getObject(payload.pull_request);
+  const sender = getObject(payload.sender);
+  const installation = getObject(payload.installation);
+
+  return {
+    event,
+    action: getString(payload.action),
+    deliveryId,
+    repository: getString(repository?.full_name),
+    issueNumber: getNumber(issue?.number),
+    pullRequestNumber: getNumber(pullRequest?.number),
+    sender: getString(sender?.login),
+    installationId: getNumber(installation?.id),
+  };
+}
+
+export async function handleGithubWebhook(c: Context): Promise<GithubWebhookResult> {
+  const parsed = await parseGithubWebhook(c);
+  if ('status' in parsed) return parsed;
+
+  if (!SUPPORTED_GITHUB_WEBHOOK_EVENTS.has(parsed.event)) {
+    return { status: 202, body: { ok: true, ignored: true } };
+  }
+
+  console.log('[GitHub Webhook]', normalizeGithubWebhookMetadata(parsed));
+  return { status: 202, body: { ok: true } };
+}


### PR DESCRIPTION
## Summary
This is the first incremental PR toward MC triage. It only adds the GitHub webhook plumbing needed for future triage work.

- Add a public GitHub App webhook endpoint for MastraCode Web at `POST /web/github/webhook`.
- Verify `x-hub-signature-256` against the raw request body before parsing JSON.
- Accept and log compact metadata for issue and pull request webhook events.
- Let valid but unsupported signed GitHub events return an ignored success response.
- Allow unauthenticated GitHub webhook deliveries through the global WorkOS gate while keeping non-POST webhook requests protected.

## Not included in this PR
- No issue triage logic.
- No agent actions.
- No persistence, queues, or idempotency table.
- No background jobs or GitHub write-back behavior.

Those pieces will be added in follow-up incremental PRs.

## Test plan
- `cd mastracode/web && pnpm vitest run src/web/auth.test.ts src/web/github/routes.test.ts`
- `cd mastracode/web && pnpm check`
- `git diff --check`
- Live verified through ngrok to local port 4111 with real `issues` and `pull_request` deliveries from `mastra-ai/mastra`, then closed/cleaned up temporary test artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds a secure front door for GitHub notifications, checking that messages really came from GitHub before accepting them. It records basic details for supported issue and pull request events while safely ignoring events it does not handle yet.

## What changed

- Added `POST /web/github/webhook`.
- Verifies `x-hub-signature-256` using the raw request body and HMAC-SHA256.
- Handles missing headers, invalid signatures, malformed JSON, missing secrets, and unsupported events with structured responses.
- Logs compact metadata for supported issue and pull request review comment events.
- Returns `202` for valid but unsupported signed events.
- Exempts only the webhook `POST` route from the global WorkOS authentication gate; other methods remain protected.
- Added webhook secret configuration via `GITHUB_APP_WEBHOOK_SECRET`.
- Added comprehensive routing, authentication, signature, parsing, logging, and response tests.

Triage, agent actions, persistence, queues, idempotency, background jobs, and GitHub write-back are not included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->