### PR TITLE
chore(docs): Add redirects for common hallucinated URLs

### DIFF
--- a/docs/vercel.json
+++ b/docs/vercel.json
@@ -956,6 +956,66 @@
       "permanent": true
     },
     {
+      "source": "/docs/agents/input-processors",
+      "destination": "/docs/agents/processors",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/model-providers",
+      "destination": "/models",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/model-usage",
+      "destination": "/models",
+      "permanent": true
+    },
+    {
+      "source": "/docs/frameworks/ai-sdk",
+      "destination": "/models",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/using-with-agents-and-tools",
+      "destination": "/docs/workflows/agents-and-tools",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/using-agents-and-tools",
+      "destination": "/docs/workflows/agents-and-tools",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/steps",
+      "destination": "/reference/workflows/step",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/agents",
+      "destination": "/docs/workflows/agents-and-tools",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/flow-control",
+      "destination": "/docs/workflows/control-flow",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/running-evals",
+      "destination": "/docs/evals/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/scorers/custom-scorers",
+      "destination": "/docs/evals/custom-scorers",
+      "permanent": true
+    },
+    {
+      "source": "/docs/scorers/creating-custom-scorers",
+      "destination": "/docs/evals/custom-scorers",
+      "permanent": true
+    },
+    {
       "source": "/docs/agents/channels/llms.txt",
       "destination": "/docs/capabilities/channels/overview/llms.txt",
       "permanent": true
@@ -1628,6 +1688,66 @@
     {
       "source": "/docs/agents/file-based-agents/llms.txt",
       "destination": "/docs/getting-started/file-based-agents/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/input-processors/llms.txt",
+      "destination": "/docs/agents/processors/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/model-providers/llms.txt",
+      "destination": "/models/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/model-usage/llms.txt",
+      "destination": "/models/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/frameworks/ai-sdk/llms.txt",
+      "destination": "/models/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/using-with-agents-and-tools/llms.txt",
+      "destination": "/docs/workflows/agents-and-tools/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/using-agents-and-tools/llms.txt",
+      "destination": "/docs/workflows/agents-and-tools/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/steps/llms.txt",
+      "destination": "/reference/workflows/step/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/agents/llms.txt",
+      "destination": "/docs/workflows/agents-and-tools/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/flow-control/llms.txt",
+      "destination": "/docs/workflows/control-flow/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/running-evals/llms.txt",
+      "destination": "/docs/evals/overview/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/scorers/custom-scorers/llms.txt",
+      "destination": "/docs/evals/custom-scorers/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/docs/scorers/creating-custom-scorers/llms.txt",
+      "destination": "/docs/evals/custom-scorers/llms.txt",
       "permanent": true
     }
   ]

--- a/docs/vercel.redirects.json
+++ b/docs/vercel.redirects.json
@@ -939,6 +939,66 @@
       "source": "/docs/agents/file-based-agents",
       "destination": "/docs/getting-started/file-based-agents",
       "permanent": true
+    },
+    {
+      "source": "/docs/agents/input-processors",
+      "destination": "/docs/agents/processors",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/model-providers",
+      "destination": "/models",
+      "permanent": true
+    },
+    {
+      "source": "/docs/agents/model-usage",
+      "destination": "/models",
+      "permanent": true
+    },
+    {
+      "source": "/docs/frameworks/ai-sdk",
+      "destination": "/models",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/using-with-agents-and-tools",
+      "destination": "/docs/workflows/agents-and-tools",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/using-agents-and-tools",
+      "destination": "/docs/workflows/agents-and-tools",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/steps",
+      "destination": "/reference/workflows/step",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/agents",
+      "destination": "/docs/workflows/agents-and-tools",
+      "permanent": true
+    },
+    {
+      "source": "/docs/workflows/flow-control",
+      "destination": "/docs/workflows/control-flow",
+      "permanent": true
+    },
+    {
+      "source": "/docs/evals/running-evals",
+      "destination": "/docs/evals/overview",
+      "permanent": true
+    },
+    {
+      "source": "/docs/scorers/custom-scorers",
+      "destination": "/docs/evals/custom-scorers",
+      "permanent": true
+    },
+    {
+      "source": "/docs/scorers/creating-custom-scorers",
+      "destination": "/docs/evals/custom-scorers",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## Description

Add redirects for URLs that LLMs like to hallucinate

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some documentation links point to old or made-up pages. This change sends visitors and AI tools to the correct newer pages instead.

## Summary

- Added permanent redirects for legacy documentation URLs covering:
  - Inputs, processors, models, and providers
  - Agents, tools, and workflows
  - Evaluations and scorers
  - Framework documentation
- Added matching `llms.txt` redirects in `docs/vercel.json`.
- Updated `docs/vercel.redirects.json` with the same redirect mappings.
- Documentation-only change; no public code APIs were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->