### PR TITLE
Fix file-based agent instructions hot reload

### DIFF
--- a/.changeset/silent-mugs-fly.md
+++ b/.changeset/silent-mugs-fly.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix file-based agent `instructions.md` hot reload in dev.

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -56,7 +56,10 @@ vi.mock('@mastra/deployer/build', () => {
       }),
       off: vi.fn(),
     }),
+    discoverFsAgents: vi.fn().mockResolvedValue([]),
     getWatcherInputOptions: vi.fn().mockResolvedValue({ plugins: [] }),
+    prepareFsAgentsEntry: vi.fn(),
+    writeFsAgentsEntry: vi.fn(),
   };
 });
 
@@ -129,6 +132,72 @@ describe('DevBundler', () => {
           },
           expect.objectContaining({ sourcemap: false }),
         );
+      } finally {
+        await remove(tmpDir);
+      }
+    });
+
+    it('watches file-based agent instructions and regenerates the wrapper when source changes before rebuilds', async () => {
+      const devBundler = new DevBundler();
+      const { createWatcher, discoverFsAgents, prepareFsAgentsEntry, writeFsAgentsEntry } = await import(
+        '@mastra/deployer/build'
+      );
+      vi.mocked(discoverFsAgents).mockResolvedValue([
+        {
+          name: 'weather',
+          configPath: '/project/src/mastra/agents/weather/config.ts',
+          instructionsPath: '/project/src/mastra/agents/weather/instructions.md',
+          workspacePath: undefined,
+          workspaceSeedDir: undefined,
+          memoryPath: undefined,
+          tools: [],
+          skills: [],
+          inputProcessors: [],
+          outputProcessors: [],
+          scorers: [],
+          subagents: [],
+        },
+      ] as any);
+      const nextEntry = {
+        entryFile: '/project/.mastra/.mastra-fs-agents-entry.mjs',
+        standalone: false,
+        toolPaths: [],
+        agentCount: 1,
+        workflowCount: 0,
+        hasStorage: false,
+        hasObservability: false,
+        hasLogger: false,
+        hasServer: false,
+        hasStudio: false,
+        moduleSource: 'next source',
+      };
+      vi.mocked(prepareFsAgentsEntry).mockResolvedValue(nextEntry);
+
+      const tmpDir = '.test-tmp';
+      await devBundler.watch('test-entry.js', tmpDir, [], {
+        mastraDir: '/project/src/mastra',
+        userEntryFile: '/project/src/mastra/index.ts',
+        outputDirectory: '/project/.mastra',
+        preparedEntry: {
+          ...nextEntry,
+          moduleSource: 'old source',
+        },
+      });
+
+      try {
+        const input = vi.mocked(createWatcher).mock.calls[0]![0] as any;
+        const plugin = input.plugins.find((candidate: any) => candidate?.name === 'fs-routing-watcher');
+        const addWatchFile = vi.fn();
+
+        await plugin.buildStart.call({ addWatchFile });
+
+        expect(addWatchFile).toHaveBeenCalledWith('/project/src/mastra/agents/weather/instructions.md');
+        expect(prepareFsAgentsEntry).toHaveBeenCalledWith(
+          '/project/src/mastra',
+          '/project/src/mastra/index.ts',
+          '/project/.mastra',
+        );
+        expect(writeFsAgentsEntry).toHaveBeenCalledWith(nextEntry);
       } finally {
         await remove(tmpDir);
       }

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -56,7 +56,10 @@ vi.mock('@mastra/deployer/build', () => {
       }),
       off: vi.fn(),
     }),
+    discoverFsAgents: vi.fn().mockResolvedValue([]),
     getWatcherInputOptions: vi.fn().mockResolvedValue({ plugins: [] }),
+    prepareFsAgentsEntry: vi.fn(),
+    writeFsAgentsEntry: vi.fn(),
   };
 });
 
@@ -129,6 +132,71 @@ describe('DevBundler', () => {
           },
           expect.objectContaining({ sourcemap: false }),
         );
+      } finally {
+        await remove(tmpDir);
+      }
+    });
+
+    it('watches file-based agent instructions and regenerates the wrapper when source changes before rebuilds', async () => {
+      const devBundler = new DevBundler();
+      const { createWatcher, discoverFsAgents, prepareFsAgentsEntry, writeFsAgentsEntry } =
+        await import('@mastra/deployer/build');
+      vi.mocked(discoverFsAgents).mockResolvedValue([
+        {
+          name: 'weather',
+          configPath: '/project/src/mastra/agents/weather/config.ts',
+          instructionsPath: '/project/src/mastra/agents/weather/instructions.md',
+          workspacePath: undefined,
+          workspaceSeedDir: undefined,
+          memoryPath: undefined,
+          tools: [],
+          skills: [],
+          inputProcessors: [],
+          outputProcessors: [],
+          scorers: [],
+          subagents: [],
+        },
+      ] as any);
+      const nextEntry = {
+        entryFile: '/project/.mastra/.mastra-fs-agents-entry.mjs',
+        standalone: false,
+        toolPaths: [],
+        agentCount: 1,
+        workflowCount: 0,
+        hasStorage: false,
+        hasObservability: false,
+        hasLogger: false,
+        hasServer: false,
+        hasStudio: false,
+        moduleSource: 'next source',
+      };
+      vi.mocked(prepareFsAgentsEntry).mockResolvedValue(nextEntry);
+
+      const tmpDir = '.test-tmp';
+      await devBundler.watch('test-entry.js', tmpDir, [], {
+        mastraDir: '/project/src/mastra',
+        userEntryFile: '/project/src/mastra/index.ts',
+        outputDirectory: '/project/.mastra',
+        preparedEntry: {
+          ...nextEntry,
+          moduleSource: 'old source',
+        },
+      });
+
+      try {
+        const input = vi.mocked(createWatcher).mock.calls[0]![0] as any;
+        const plugin = input.plugins.find((candidate: any) => candidate?.name === 'fs-routing-watcher');
+        const addWatchFile = vi.fn();
+
+        await plugin.buildStart.call({ addWatchFile });
+
+        expect(addWatchFile).toHaveBeenCalledWith('/project/src/mastra/agents/weather/instructions.md');
+        expect(prepareFsAgentsEntry).toHaveBeenCalledWith(
+          '/project/src/mastra',
+          '/project/src/mastra/index.ts',
+          '/project/.mastra',
+        );
+        expect(writeFsAgentsEntry).toHaveBeenCalledWith(nextEntry);
       } finally {
         await remove(tmpDir);
       }

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -2,13 +2,34 @@ import { writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { FileService } from '@mastra/deployer';
-import { createWatcher, getWatcherInputOptions } from '@mastra/deployer/build';
+import {
+  createWatcher,
+  discoverFsAgents,
+  getWatcherInputOptions,
+  prepareFsAgentsEntry,
+  writeFsAgentsEntry,
+} from '@mastra/deployer/build';
+import type { DiscoveredFsAgent, PrepareFsAgentsEntryResult } from '@mastra/deployer/build';
 import { Bundler } from '@mastra/deployer/bundler';
 import * as fsExtra from 'fs-extra';
 import type { InputPluginOption, RollupWatcherEvent } from 'rollup';
 
 import { devLogger } from '../../utils/dev-logger.js';
 import { shouldSkipDotenvLoading } from '../utils.js';
+
+interface FsRoutingWatchOptions {
+  mastraDir: string;
+  userEntryFile: string | undefined;
+  outputDirectory: string;
+  preparedEntry: PrepareFsAgentsEntryResult;
+}
+
+function collectInstructionPaths(agents: DiscoveredFsAgent[]): string[] {
+  return agents.flatMap(agent => [
+    ...(agent.instructionsPath ? [agent.instructionsPath] : []),
+    ...collectInstructionPaths(agent.subagents),
+  ]);
+}
 
 export class DevBundler extends Bundler {
   private customEnvFile?: string;
@@ -59,6 +80,7 @@ export class DevBundler extends Bundler {
     entryFile: string,
     outputDirectory: string,
     toolsPaths: (string | string[])[],
+    fsRoutingWatchOptions?: FsRoutingWatchOptions,
   ): ReturnType<typeof createWatcher> {
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);
@@ -89,6 +111,8 @@ export class DevBundler extends Bundler {
 
     await this.writePackageJson(outputDir, new Map(), {});
 
+    let lastFsAgentsModuleSource = fsRoutingWatchOptions?.preparedEntry.moduleSource;
+
     const watcher = await createWatcher(
       {
         ...inputOptions,
@@ -111,6 +135,29 @@ export class DevBundler extends Bundler {
             buildStart() {
               for (const envFile of envFiles) {
                 this.addWatchFile(resolve(envFile));
+              }
+            },
+          },
+          {
+            name: 'fs-routing-watcher',
+            async buildStart() {
+              if (!fsRoutingWatchOptions?.preparedEntry.moduleSource) {
+                return;
+              }
+
+              const agents = await discoverFsAgents(fsRoutingWatchOptions.mastraDir);
+              for (const instructionsPath of collectInstructionPaths(agents)) {
+                this.addWatchFile(resolve(instructionsPath));
+              }
+
+              const nextEntry = await prepareFsAgentsEntry(
+                fsRoutingWatchOptions.mastraDir,
+                fsRoutingWatchOptions.userEntryFile,
+                fsRoutingWatchOptions.outputDirectory,
+              );
+              if (nextEntry.moduleSource !== lastFsAgentsModuleSource) {
+                await writeFsAgentsEntry(nextEntry);
+                lastFsAgentsModuleSource = nextEntry.moduleSource;
               }
             },
           },

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -549,7 +549,12 @@ export async function dev({
     await mirrorFsAgentWorkspaces(mastraDir, join(dotMastraPath, 'output'));
   }
 
-  const watcher = await bundler.watch(entryFile, dotMastraPath, discoveredTools);
+  const watcher = await bundler.watch(entryFile, dotMastraPath, discoveredTools, {
+    mastraDir,
+    userEntryFile,
+    outputDirectory: dotMastraPath,
+    preparedEntry: fsAgents,
+  });
 
   await startServer(
     join(dotMastraPath, 'output'),

--- a/packages/deployer/src/build/fs-routing/codegen.ts
+++ b/packages/deployer/src/build/fs-routing/codegen.ts
@@ -168,8 +168,8 @@ async function emitAgentEntry(
  * 5. re-exports everything from the user's entry so this module is a drop-in
  *    replacement for the original `#mastra` target.
  *
- * `instructions.md` contents are inlined at codegen time so no markdown loader
- * plugin is required in the bundler graph.
+ * `instructions.md` is read into the generated wrapper. In dev, the CLI watcher
+ * regenerates that wrapper when the markdown file changes.
  *
  * @param userEntry slash-normalized absolute path to the user's mastra entry.
  * @param agents discovered fs-routed agents (absolute, slash-normalized paths).


### PR DESCRIPTION
## Summary
- Watches discovered file-based agent `instructions.md` files during `mastra dev`.
- Regenerates the generated file-based agent wrapper before rebuilds so updated instructions are picked up.
- Skips wrapper writes when the generated module source is unchanged to avoid rebuild loops.

## Why
File-based agent `instructions.md` was read into the generated wrapper at codegen time, so edits were not reflected during dev reloads. This keeps the existing wrapper-based design and avoids adding broad markdown loader behavior.

## Test plan
- `pnpm --filter ./packages/cli exec vitest run src/commands/dev/DevBundler.test.ts`
- `pnpm --filter ./packages/deployer exec vitest run src/build/fs-routing/fs-routing.test.ts`
- `pnpm test:cli`
- `pnpm --filter ./packages/cli typecheck`
- `pnpm build:cli`
- Linked `/Users/ehindero/Desktop/code/mastra-demos/mastra-dev-reload` to this worktree's `packages/cli` and confirmed editing `src/mastra/agents/weather/instructions.md` triggers bundling and server restart without getting stuck.

## Notes
The watcher-only approach can produce two quick rebuild/restart cycles for a single `instructions.md` edit because the generated wrapper is itself in Rollup's graph. In manual testing it settled back to ready and did not loop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

During `mastra dev`, if you edit an agent’s `instructions.md`, the dev server now notices the change, regenerates the generated wrapper code, and then reloads—so you see updates right away. It also avoids “rebuild loops” by not rewriting the generated file when the generated result hasn’t actually changed.

## What changed

- Added a new `fs-routing-watcher` Rollup watcher plugin that watches discovered filesystem-agent `instructions.md` files.
- On watcher startup (`buildStart`), it discovers filesystem agents under `mastraDir`, registers watches for each `instructions.md`, regenerates the filesystem agents wrapper entry, and writes it only when the generated source changed.
- Updated `DevBundler.watch` to accept optional `fsRoutingWatchOptions` and to use helper logic to collect instruction paths for the watcher.
- Updated the `dev()` command bundler initialization to pass the additional dev context needed for fs-routing preparation (including the prepared fs-routed entry).
- Adjusted generated-wrapper documentation to reflect dev-time regeneration behavior when `instructions.md` changes.
- Added/expanded tests to verify watcher registration and wrapper regeneration behavior, plus CLI/dev bundling coverage.
- Added a patch Changeset noting the `instructions.md` hot-reload fix for file-based agents in development.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->