### PR TITLE
fix(observability): price Bedrock inference profiles

### DIFF
--- a/.changeset/small-dots-yawn.md
+++ b/.changeset/small-dots-yawn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed cost estimation for Amazon Bedrock inference profiles, including geographic prefixes and versioned model IDs.

--- a/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
+++ b/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
@@ -5,3 +5,6 @@
 {"i":"openrouter-gpt-5-mini","p":"openrouter","m":"gpt-5-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2.5e-8},"it":{"c":2.5e-7},"ot":{"c":2e-6}}}]}}}
 {"i":"openrouter-anthropic-claude-sonnet-4-6","p":"openrouter","m":"claude-sonnet-4-6","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3e-7},"icwt":{"c":0.00000375},"it":{"c":0.000003},"ot":{"c":0.000015}}}]}}}
 {"i":"openrouter-gemini-2-5-flash","p":"openrouter","m":"gemini-2-5-flash","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":1e-6},"ot":{"c":3e-6}}}]}}}
+{"i":"amazon-bedrock-claude-sonnet-4-6","p":"amazon-bedrock","m":"claude-sonnet-4-6","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3.3e-7},"icwt":{"c":4.125e-6},"it":{"c":3.3e-6},"ot":{"c":1.65e-5}}}]}}}
+{"i":"amazon-bedrock-claude-sonnet-4-5","p":"amazon-bedrock","m":"claude-sonnet-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":3e-6},"ot":{"c":1.5e-5}}}]}}}
+{"i":"amazon-bedrock-amazon-nova-pro","p":"amazon-bedrock","m":"amazon-nova-pro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":8e-7},"ot":{"c":3.2e-6}}}]}}}

--- a/observability/mastra/src/metrics/auto-extract.test.ts
+++ b/observability/mastra/src/metrics/auto-extract.test.ts
@@ -644,4 +644,42 @@ describe('AutoExtractedMetrics', () => {
       'openrouter-anthropic-claude-sonnet-4-6',
     );
   });
+
+  it('should estimate costs for Bedrock inference-profile model ids', () => {
+    setup();
+    const span = createMockSpan({
+      type: SpanType.MODEL_GENERATION,
+      endTime: new Date('2026-01-01T00:00:01Z'),
+      attributes: {
+        provider: 'amazon-bedrock',
+        model: 'us.anthropic.claude-sonnet-4-6',
+        responseModel: 'us.anthropic.claude-sonnet-4-6',
+        usage: {
+          inputTokens: 1_150,
+          outputTokens: 100,
+          inputDetails: { text: 1_000, cacheRead: 100, cacheWrite: 50 },
+          outputDetails: { text: 100 },
+        },
+      },
+    });
+
+    vi.spyOn(PricingRegistry, 'getGlobal').mockReturnValue(pricingRegistry);
+
+    emitAutoExtractedMetrics(span, createMetricsContext(span));
+
+    const costContexts = emittedMetrics.flatMap(event => (event.metric.costContext ? [event.metric.costContext] : []));
+    expect(costContexts).toHaveLength(6);
+    expect(costContexts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          costMetadata: expect.objectContaining({ pricing_id: 'amazon-bedrock-claude-sonnet-4-6' }),
+        }),
+      ]),
+    );
+    expect(costContexts).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ costMetadata: expect.objectContaining({ error: 'no_matching_model' }) }),
+      ]),
+    );
+  });
 });

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -450,4 +450,56 @@ describe('estimateCosts', () => {
       },
     });
   });
+
+  it('resolves Bedrock inference-profile ids and prices all Anthropic token meters', () => {
+    const costs = estimateCosts(
+      {
+        provider: 'amazon-bedrock',
+        model: 'us.anthropic.claude-sonnet-4-6',
+        usage: {
+          inputTokens: 1_150,
+          outputTokens: 100,
+          inputDetails: { text: 1_000, cacheRead: 100, cacheWrite: 50 },
+          outputDetails: { text: 100 },
+        },
+      },
+      pricingRegistry,
+    );
+
+    const expectedCosts = new Map([
+      [TokenMetrics.INPUT_TEXT, 0.0033],
+      [TokenMetrics.INPUT_CACHE_READ, 0.000033],
+      [TokenMetrics.INPUT_CACHE_WRITE, 0.00020625],
+      [TokenMetrics.OUTPUT_TEXT, 0.00165],
+    ]);
+    for (const [metric, estimatedCost] of expectedCosts) {
+      expect(costs.get(metric)).toMatchObject({
+        provider: 'amazon-bedrock',
+        model: 'claude-sonnet-4-6',
+        costMetadata: { pricing_id: 'amazon-bedrock-claude-sonnet-4-6' },
+      });
+      expect(costs.get(metric)?.estimatedCost).toBeCloseTo(estimatedCost);
+    }
+  });
+
+  it.each([
+    ['anthropic.claude-sonnet-4-6-v1', 'amazon-bedrock-claude-sonnet-4-6', 0.0033],
+    ['global.anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon-bedrock-claude-sonnet-4-5', 0.003],
+    ['us.amazon.nova-pro-v1:0', 'amazon-bedrock-amazon-nova-pro', 0.0008],
+  ])('resolves Bedrock model id %s', (model, pricingId, estimatedCost) => {
+    const costs = estimateCosts(
+      {
+        provider: 'amazon-bedrock',
+        model,
+        usage: { inputTokens: 1_000 },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toMatchObject({
+      provider: 'amazon-bedrock',
+      costMetadata: { pricing_id: pricingId },
+    });
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.estimatedCost).toBeCloseTo(estimatedCost);
+  });
 });

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -485,6 +485,8 @@ describe('estimateCosts', () => {
   it.each([
     ['anthropic.claude-sonnet-4-6-v1', 'amazon-bedrock-claude-sonnet-4-6', 0.0033],
     ['global.anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon-bedrock-claude-sonnet-4-5', 0.003],
+    ['jp.anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon-bedrock-claude-sonnet-4-5', 0.003],
+    ['au.anthropic.claude-sonnet-4-5-20250929-v1:0', 'amazon-bedrock-claude-sonnet-4-5', 0.003],
     ['us.amazon.nova-pro-v1:0', 'amazon-bedrock-amazon-nova-pro', 0.0008],
   ])('resolves Bedrock model id %s', (model, pricingId, estimatedCost) => {
     const costs = estimateCosts(

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -5,7 +5,7 @@ import { PricingModel, PricingTier } from './pricing-model';
 import type { PricingMeter, PricingConditionOperator, PricingConditionField } from './types';
 
 const DATA_FILE_NAME = 'pricing-data.jsonl';
-const BEDROCK_GEOGRAPHY_PREFIXES = new Set(['global', 'us', 'eu', 'apac']);
+const BEDROCK_GEOGRAPHY_PREFIXES = new Set(['global', 'us', 'eu', 'apac', 'jp', 'au']);
 
 type MinifiedMeterKey = 'it' | 'ot' | 'icrt' | 'icwt' | 'iat' | 'oat' | 'ort';
 type MinifiedConditionFieldKey = 'tit';

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -5,6 +5,7 @@ import { PricingModel, PricingTier } from './pricing-model';
 import type { PricingMeter, PricingConditionOperator, PricingConditionField } from './types';
 
 const DATA_FILE_NAME = 'pricing-data.jsonl';
+const BEDROCK_GEOGRAPHY_PREFIXES = new Set(['global', 'us', 'eu', 'apac']);
 
 type MinifiedMeterKey = 'it' | 'ot' | 'icrt' | 'icwt' | 'iat' | 'oat' | 'ort';
 type MinifiedConditionFieldKey = 'tit';
@@ -74,7 +75,7 @@ export class PricingRegistry {
 
   get(args: { provider: string; model: string }): PricingModel | null {
     // Try all model name variants in order of preference
-    const variants = getModelVariants(args.model);
+    const variants = getModelVariants(args.model, normalizeProvider(args.provider));
     for (const variant of variants) {
       const key = makePricingKey({ provider: args.provider, model: variant });
       const match = this.pricingModels.get(key);
@@ -199,11 +200,14 @@ function normalizeProvider(provider: string): string {
  *    same with dots flattened, e.g. "google/gemini-2.5-flash" → "gemini-2-5-flash"
  *    (covers OpenRouter entries stored without the vendor prefix, including
  *    dotted versions)
+ * 5. For Bedrock, geographic and vendor prefixes dropped and Bedrock version suffixes
+ *    stripped, e.g. "us.anthropic.claude-sonnet-4-5-20250929-v1:0" →
+ *    "claude-sonnet-4-5"
  *
  * Each variant is also tried with its date suffix stripped.
  * The Set dedupes so non-prefixed inputs do not pay for redundant lookups.
  */
-function getModelVariants(model: string): string[] {
+function getModelVariants(model: string, provider: string): string[] {
   const variants = new Set<string>();
   const add = (v: string) => {
     variants.add(v);
@@ -222,6 +226,25 @@ function getModelVariants(model: string): string[] {
     const withoutVendor = model.substring(slashIndex + 1);
     add(withoutVendor);
     add(withoutVendor.replace(/\./g, '-'));
+  }
+
+  if (provider === 'amazon-bedrock') {
+    const addBedrockVariant = (v: string) => {
+      add(v);
+      add(v.replace(/-(?:v)?\d+(?::\d+)?$/, ''));
+    };
+    const segments = model.split('.');
+    const withoutGeography = BEDROCK_GEOGRAPHY_PREFIXES.has(segments[0] ?? '') ? segments.slice(1).join('.') : model;
+
+    addBedrockVariant(withoutGeography);
+    addBedrockVariant(withoutGeography.replace(/\./g, '-'));
+
+    const vendorSeparator = withoutGeography.indexOf('.');
+    if (vendorSeparator !== -1) {
+      const withoutVendor = withoutGeography.substring(vendorSeparator + 1);
+      addBedrockVariant(withoutVendor);
+      addBedrockVariant(withoutVendor.replace(/\./g, '-'));
+    }
   }
 
   return [...variants];


### PR DESCRIPTION
Bedrock inference-profile IDs currently fail pricing lookup when they include geography, vendor, date, or version segments. This leaves model spans with `no_matching_model` even when the embedded model has catalog pricing.

```text
Before: us.anthropic.claude-sonnet-4-6 -> no_matching_model
After:  us.anthropic.claude-sonnet-4-6 -> amazon-bedrock-claude-sonnet-4-6
```

This adds Bedrock-specific model normalization without changing other providers. The regression coverage exercises span metric extraction, cache token meters, dated Anthropic IDs, and Amazon Nova IDs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Amazon Bedrock can report model IDs that include extra “where/which/vendor/when/version” pieces, so the pricing system can’t recognize the real underlying model. This PR teaches the pricing lookup to normalize those IDs so cost calculations work instead of showing “unknown.”

## What changed

- Normalized Amazon Bedrock inference-profile/model IDs during pricing lookups by stripping geography prefixes (including Japan/Australia), vendor/date/version segments, and generating both dotted and dash-flattened model variants.
- Added/extended Bedrock pricing fixture coverage (Claude Sonnet 4.6, Claude Sonnet 4.5, Amazon Nova Pro).
- Added regression tests ensuring pricing is correctly resolved and used for:
  - Span metric extraction
  - Cache token meters (read/write) and token meter cost estimation
  - Dated Anthropic-style Bedrock IDs
  - Amazon Nova model IDs
  - Multiple inference-profile/model ID formats
- Added a patch changeset for `@mastra/observability` documenting the Bedrock inference-profile cost estimation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->