### PR TITLE
chore(docs): Guide for 'Building a coding agent'

### DIFF
--- a/docs/src/content/en/guides/guide/chef-michel.mdx
+++ b/docs/src/content/en/guides/guide/chef-michel.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Guide: How to build an AI chef assistant"
+title: "Guide: Building an AI chef assistant"
 description: Guide on creating a Chef Assistant agent in Mastra to help users cook meals with available ingredients.
 ---
 
 import Steps from "@site/src/components/Steps";
 import StepItem from "@site/src/components/StepItem";
 
-# How to build an AI chef assistant
+# Building an AI chef assistant
 
 In this guide, you'll create a "Chef Assistant" agent that helps users cook meals with available ingredients.
 

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -112,11 +112,8 @@ The response should identify the Acme support portal, its development status, an
 
 Create `src/mastra/coding-agent-controller.ts`. The controller owns the interactive session, exposes UI events, and pauses workspace tools for approval.
 
-**Beta:** `AgentController` is a beta feature and may change in minor releases.
-
 ```typescript title="src/mastra/coding-agent-controller.ts"
 import { AgentController } from '@mastra/core/agent-controller'
-
 import { codingAgent, projectPath } from './agents/coding-agent'
 
 export async function createCodingAgentSession() {
@@ -166,13 +163,13 @@ Create `src/coding-agent-tui.ts`. The UI renders assistant message updates, show
 import { pathToFileURL } from 'node:url'
 import {
   Editor,
+  matchesKey,
   ProcessTerminal,
   Text,
   TUI,
   type EditorTheme,
   type Terminal,
 } from '@earendil-works/pi-tui'
-
 import { createCodingAgentSession } from './mastra/coding-agent-controller'
 
 const plain = (text: string) => text
@@ -257,12 +254,14 @@ export async function startCodingAgentTui(terminal: Terminal = new ProcessTermin
   tui.addChild(output)
   tui.addChild(editor)
   tui.setFocus(editor)
-  tui.start()
 
   let stopPromise: Promise<void> | undefined
+  let removeInputListener = () => {}
+
   const stop = () => {
     stopPromise ??= (async () => {
-      process.off('SIGINT', handleSigint)
+      process.off('SIGINT', handleExit)
+      removeInputListener()
       session.abort()
       unsubscribe()
       tui.stop()
@@ -271,10 +270,20 @@ export async function startCodingAgentTui(terminal: Terminal = new ProcessTermin
     return stopPromise
   }
 
-  const handleSigint = () => {
-    void stop().then(() => process.exit(0))
+  const handleExit = () => {
+    void stop().catch(error => {
+      console.error(error)
+      process.exitCode = 1
+    })
   }
-  process.once('SIGINT', handleSigint)
+
+  removeInputListener = tui.addInputListener(data => {
+    if (!matchesKey(data, 'ctrl+c')) return
+    handleExit()
+    return { consume: true }
+  })
+  process.once('SIGINT', handleExit)
+  tui.start()
 
   return { stop }
 }

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -15,7 +15,7 @@ In this guide, you'll build a coding agent that works inside your local Mastra p
 
 ## Create the coding agent
 
-Create `src/mastra/agents/coding-agent.ts`. The prompt describes the current project and maps the prompt's generic tool names to the tools supplied by the default workspace.
+Create `src/mastra/agents/coding-agent.ts`. The prompt describes the current workspace and maps the prompt's generic tool names to the tools supplied by the default workspace.
 
 ```typescript title="src/mastra/agents/coding-agent.ts"
 import { basename } from 'node:path'
@@ -56,7 +56,7 @@ export const codingAgent = createCodingAgent({
 // highlight-end
 ```
 
-Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` sets the directory that the workspace can access. Any configuration you pass to the factory takes precedence over its defaults.
+Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` sets the directory that the workspace can access. In this development-server example, `process.cwd()` resolves to `src/mastra/public`, so the agent is limited to that workspace directory. Any configuration you pass to the factory takes precedence over its defaults.
 
 ## Register the coding agent
 
@@ -75,7 +75,7 @@ export const mastra = new Mastra({
 
 ## Add a workspace file
 
-When you run the development server, its working directory is `src/mastra/public`. Add a file there for the agent to inspect:
+When you run the development server, its working directory is `src/mastra/public`. Add a file there for the agent to inspect. Files in the [public folder](/docs/deployment/mastra-server#public-folder) are served as static assets, so use only non-sensitive test data and don't store source code, credentials, or private project context there.
 
 ```md title="src/mastra/public/project-notes.md"
 # Project notes

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -3,9 +3,15 @@ title: "Guide: Building a coding agent"
 description: Build and run your own interactive coding agent with Mastra.
 ---
 
+import { VideoPlayer } from '@site/src/components/video-player'
+
 # Building a coding agent
 
 In this guide, you'll build a small coding-agent application in the same category as Mastra Code, Claude Code, or Codex. You'll create the coding agent with `buildBasePrompt()` and `createCodingAgent()`, wrap it in an `AgentController` for interactive sessions and tool approvals, and run the controller in a terminal UI built with pi-tui.
+
+The video below shows the coding agent you'll build in action.
+
+<VideoPlayer src="https://res.cloudinary.com/mastra-assets/video/upload/v1784018138/coding-agent-demo_a8p4vf.mp4" />
 
 ## Prerequisites
 

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -32,9 +32,8 @@ Create `src/mastra/agents/coding-agent.ts`. The prompt describes the current pro
 import { basename } from 'node:path'
 import { buildBasePrompt, createCodingAgent } from '@mastra/core/coding-agent'
 
-// highlight-next-line
 export const projectPath = process.cwd()
-const model = '__GATEWAY_OPENAI_MODEL_MINI__'
+const model = '__GATEWAY_OPENAI_MODEL__'
 
 const instructions = buildBasePrompt({
   projectPath,
@@ -155,7 +154,9 @@ export async function createCodingAgentSession() {
 }
 ```
 
-This example uses one mode and disables the controller's additional built-in tools so the agent exposes only its workspace capabilities. It also omits storage, so the conversation lasts only for the current process. You can add storage later when you want to resume sessions.
+This example uses one mode and disables the controller's additional built-in tools so the introductory UI can focus on workspace execution. This is a tutorial simplification, not a production recommendation. In a production application, enable the built-in tools your product needs and implement their UI flows: interactive tools such as `ask_user` and `submit_plan` suspend until your interface resumes them, while task and subagent tools have their own lifecycle events. See [tool approvals and suspensions](/docs/agent-controller/tool-approvals).
+
+The example also omits storage, so the conversation lasts only for the current process. You can add storage later when you want to resume sessions.
 
 ## Build the terminal UI
 

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -1,0 +1,122 @@
+---
+title: "Guide: Building a coding agent"
+description: Build a coding agent that can inspect and edit files in a local Mastra workspace.
+---
+
+# Building a coding agent
+
+In this guide, you'll build a coding agent that works inside your local Mastra project. You'll learn how to create coding instructions with [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt), configure an agent with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent), and register it with Mastra.
+
+## Prerequisites
+
+- Node.js `v22.13.0` or later installed
+- An API key from a supported [Model Provider](/models)
+- An existing Mastra project. Follow the [installation guide](/guides/getting-started/quickstart) if needed.
+
+## Create the coding agent
+
+Create `src/mastra/agents/coding-agent.ts`. The prompt describes the current project and maps the prompt's generic tool names to the tools supplied by the default workspace.
+
+```typescript title="src/mastra/agents/coding-agent.ts"
+import { basename } from 'node:path'
+import { buildBasePrompt, createCodingAgent } from '@mastra/core/coding-agent'
+
+const projectPath = process.cwd()
+const model = '__GATEWAY_OPENAI_MODEL_MINI__'
+
+// highlight-start
+const instructions = buildBasePrompt({
+  projectPath,
+  projectName: basename(projectPath),
+  platform: process.platform,
+  date: new Date().toISOString().slice(0, 10),
+  mode: 'build',
+  modelId: model,
+  productName: 'My Coding Agent',
+  coAuthorName: 'My Coding Agent',
+  coAuthorEmail: 'coding-agent@example.com',
+  toolGuidance: `# Workspace tools
+- Use mastra_workspace_read_file for view.
+- Use mastra_workspace_list_files for find_files.
+- Use mastra_workspace_grep for search_content.
+- Use mastra_workspace_execute_command for execute_command.
+- Use mastra_workspace_write_file, mastra_workspace_edit_file, and mastra_workspace_file_stat for writing, editing, and inspecting file metadata.
+- Use only the workspace tools provided to you. Do not attempt unavailable capabilities.`,
+})
+// highlight-end
+
+// highlight-start
+export const codingAgent = createCodingAgent({
+  id: 'coding-agent',
+  name: 'Coding Agent',
+  model,
+  instructions,
+  basePath: projectPath,
+})
+// highlight-end
+```
+
+Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` sets the directory that the workspace can access. Any configuration you pass to the factory takes precedence over its defaults.
+
+## Register the coding agent
+
+Register the returned agent like any other Mastra agent in `src/mastra/index.ts`.
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+// highlight-next-line
+import { codingAgent } from './agents/coding-agent'
+
+export const mastra = new Mastra({
+  // highlight-next-line
+  agents: { codingAgent },
+})
+```
+
+## Add a workspace file
+
+When you run the development server, its working directory is `src/mastra/public`. Add a file there for the agent to inspect:
+
+```md title="src/mastra/public/project-notes.md"
+# Project notes
+
+Name: Acme support portal
+Status: In development
+Owner: Platform team
+```
+
+## Test the coding agent
+
+Start the development server:
+
+```bash npm2yarn
+npm run dev
+```
+
+Open [Studio](/docs/studio/overview), select **Coding Agent**, and enter:
+
+```text
+Inspect project-notes.md and report the project name, status, and owner. Do not modify files.
+```
+
+The agent reads `project-notes.md` from the configured workspace and reports what it finds without changing the file. Model wording may vary, but the response should resemble:
+
+```md
+- Project name: Acme support portal
+- Status: In development
+- Owner: Platform team
+```
+
+## Next steps
+
+You can extend this coding agent to:
+
+- Add project-specific instructions for testing and code style
+- Supply extra agent tools for services outside the local workspace
+- Configure a different `basePath` for a dedicated project directory
+
+Learn more:
+
+- [`createCodingAgent()` reference](/reference/coding-agent/create-coding-agent)
+- [`buildBasePrompt()` reference](/reference/coding-agent/build-base-prompt)
+- [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -1,11 +1,11 @@
 ---
 title: "Guide: Building a coding agent"
-description: Build a coding agent that can inspect and edit files in a local Mastra workspace.
+description: Build the foundation for your own interactive coding agent with Mastra.
 ---
 
 # Building a coding agent
 
-In this guide, you'll build a coding agent that works inside your local Mastra project. You'll learn how to create coding instructions with [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt), configure an agent with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent), and register it with Mastra.
+In this guide, you'll build the foundation for your own interactive coding agent—an application in the same category as Mastra Code, Claude Code, or Codex. You'll create branded coding instructions with [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt), configure the agent and its local workspace with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent), and register it with Mastra. After testing the agent's core behavior in Studio, you'll see how to connect it to a terminal UI or another application.
 
 ## Prerequisites
 
@@ -56,7 +56,7 @@ export const codingAgent = createCodingAgent({
 // highlight-end
 ```
 
-Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` sets the directory that the workspace can access. In this development-server example, `process.cwd()` resolves to `src/mastra/public`, so the agent is limited to that workspace directory. Any configuration you pass to the factory takes precedence over its defaults.
+Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` scopes the filesystem tools and sets the initial working directory for commands. It isn't an operating-system security boundary: the default local sandbox runs commands directly on the host without isolation, so commands can access paths outside that directory. In this development-server example, `process.cwd()` resolves to `src/mastra/public`, so the filesystem tools use that directory. Any configuration you pass to the factory takes precedence over its defaults.
 
 ## Register the coding agent
 
@@ -107,16 +107,29 @@ The agent reads `project-notes.md` from the configured workspace and reports wha
 - Owner: Platform team
 ```
 
+## Take the agent beyond Studio
+
+Studio is a convenient place to verify the agent, but it isn't the required interface. `createCodingAgent()` returns a standard Mastra `Agent`, so you can connect the same agent to a terminal, desktop, or web application.
+
+A terminal UI can collect the user's input and conversation history, pass them to [`codingAgent.stream()`](/reference/streaming/agents/stream), render `textStream` as it arrives, and inspect `fullStream` to display tool activity. Set `basePath` to the project the user opens. If the terminal process starts in that project directory, the existing `process.cwd()` value already provides that path.
+
+The default local workspace is intended for trusted local development. It exposes file-writing tools and host command execution without isolation. Before accepting untrusted prompts or distributing the agent to other users, add [sandbox isolation](/docs/workspace/sandbox) and a [tool permission or approval policy](/docs/agents/agent-approval). When you use the `Agent` directly, your application owns these safety controls.
+
+You can import the agent directly into a Node.js terminal application. If the interface runs as a separate process, keep the agent registered with Mastra and call it through the [Client SDK Agents API](/reference/client-js/agents). In that architecture, the server controls `basePath` and can access only projects available on its filesystem. Selecting a directory in a remote client doesn't upload or mount it, so your server must map each user to an available project and validate that mapping.
+
+For a richer collaborative product with persistent sessions, tool approvals, modes, and UI event state, see the [AgentController overview](/docs/agent-controller/overview). AgentController is currently a beta feature; the direct `Agent` streaming path remains available when you want to build the application runtime yourself.
+
 ## Next steps
 
-You can extend this coding agent to:
+You can extend this foundation to:
 
 - Add project-specific instructions for testing and code style
 - Supply extra agent tools for services outside the local workspace
-- Configure a different `basePath` for a dedicated project directory
+- Build a terminal interface that shows streaming text and workspace tool activity
 
 Learn more:
 
 - [`createCodingAgent()` reference](/reference/coding-agent/create-coding-agent)
 - [`buildBasePrompt()` reference](/reference/coding-agent/build-base-prompt)
+- [`Agent.stream()` reference](/reference/streaming/agents/stream)
 - [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -1,28 +1,40 @@
 ---
 title: "Guide: Building a coding agent"
-description: Build the foundation for your own interactive coding agent with Mastra.
+description: Build and run your own interactive coding agent with Mastra.
 ---
 
 # Building a coding agent
 
-In this guide, you'll build the foundation for your own interactive coding agent, an application in the same category as Mastra Code, Claude Code, or Codex. You'll create branded coding instructions with [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt), configure the agent and its local workspace with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent), and register it with Mastra. After testing the agent's core behavior in Studio, you'll see how to connect it to a terminal UI or another application.
+In this guide, you'll build a small coding-agent application in the same category as Mastra Code, Claude Code, or Codex. You'll create the coding agent with `buildBasePrompt()` and `createCodingAgent()`, wrap it in an `AgentController` for interactive sessions and tool approvals, and run the controller in a terminal UI built with pi-tui.
 
 ## Prerequisites
 
-- Node.js `v22.13.0` or later installed
+- Node.js `v22.19.0` or later installed
 - An API key from a supported [Model Provider](/models)
 - An existing Mastra project. Follow the [installation guide](/guides/getting-started/quickstart) if needed.
 
+## Install the terminal dependencies
+
+Install [pi-tui](https://github.com/earendil-works/pi/tree/main/packages/tui) and `tsx`:
+
+```bash npm2yarn
+npm install @earendil-works/pi-tui
+npm install --save-dev tsx
+```
+
+pi-tui provides the terminal renderer and input editor. `tsx` runs the TypeScript entry point directly.
+
 ## Create the coding agent
 
-Create `src/mastra/agents/coding-agent.ts`. The prompt describes the current workspace and maps the prompt's generic tool names to the tools supplied by the default workspace.
+Create `src/mastra/agents/coding-agent.ts`. The prompt describes the current project and maps the prompt's generic tool names to the tools supplied by the default workspace.
 
 ```typescript title="src/mastra/agents/coding-agent.ts"
 import { basename } from 'node:path'
 import { buildBasePrompt, createCodingAgent } from '@mastra/core/coding-agent'
 
-const projectPath = process.cwd()
-const model = '__GATEWAY_OPENAI_MODEL__'
+// highlight-next-line
+export const projectPath = process.cwd()
+const model = '__GATEWAY_OPENAI_MODEL_MINI__'
 
 const instructions = buildBasePrompt({
   projectPath,
@@ -52,11 +64,13 @@ export const codingAgent = createCodingAgent({
 })
 ```
 
-Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` scopes the filesystem tools and sets the initial working directory for commands. It isn't an operating-system security boundary: the default local sandbox runs commands directly on the host without isolation, so commands can access paths outside that directory. In this development-server example, `process.cwd()` resolves to `src/mastra/public`, so the filesystem tools use that directory. Any configuration you pass to the factory takes precedence over its defaults.
+Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` scopes the filesystem tools and sets the initial working directory for commands. Any configuration you pass to the factory takes precedence over its defaults.
+
+The default local sandbox runs commands directly on the host without isolation, so `basePath` isn't an operating-system security boundary. This example adds per-tool-call approval in the terminal, but you should still run it only against a trusted local project.
 
 ## Register the coding agent
 
-Register the returned agent like any other Mastra agent in `src/mastra/index.ts`.
+Register the returned agent like any other Mastra agent in `src/mastra/index.ts`. Registration also makes the underlying agent available in Studio and through the Mastra server.
 
 ```typescript title="src/mastra/index.ts"
 import { Mastra } from '@mastra/core/mastra'
@@ -69,9 +83,9 @@ export const mastra = new Mastra({
 })
 ```
 
-## Add a workspace file
+## Test the coding agent
 
-When you run the development server, its working directory is `src/mastra/public`. Add a file there for the agent to inspect. Files in the [public folder](/docs/deployment/mastra-server#public-folder) are served as static assets, so use only non-sensitive test data and don't store source code, credentials, or private project context there.
+Before adding the terminal interface, verify the underlying agent in Studio. When the development server starts, its working directory is `src/mastra/public`, so add a non-sensitive file there for the agent to inspect:
 
 ```md title="src/mastra/public/project-notes.md"
 # Project notes
@@ -80,8 +94,6 @@ Name: Acme support portal
 Status: In development
 Owner: Platform team
 ```
-
-## Test the coding agent
 
 Start the development server:
 
@@ -95,37 +107,215 @@ Open [Studio](/docs/studio/overview), select **Coding Agent**, and enter:
 Inspect project-notes.md and report the project name, status, and owner. Do not modify files.
 ```
 
-The agent reads `project-notes.md` from the configured workspace and reports what it finds without changing the file. Model wording may vary, but the response should resemble:
+The response should identify the Acme support portal, its development status, and the Platform team without changing the file. Model wording may vary.
 
-```md
-- Project name: Acme support portal
-- Status: In development
-- Owner: Platform team
+## Create the agent controller
+
+Create `src/mastra/coding-agent-controller.ts`. The controller owns the interactive session, exposes UI events, and pauses workspace tools for approval.
+
+**Beta:** `AgentController` is a beta feature and may change in minor releases.
+
+```typescript title="src/mastra/coding-agent-controller.ts"
+import { AgentController } from '@mastra/core/agent-controller'
+
+import { codingAgent, projectPath } from './agents/coding-agent'
+
+export async function createCodingAgentSession() {
+  const workspace = await codingAgent.getWorkspace()
+
+  if (!workspace) {
+    throw new Error('The coding agent requires a workspace.')
+  }
+
+  const controller = new AgentController({
+    id: 'coding-agent-controller',
+    agent: codingAgent,
+    workspace,
+    modes: [{ id: 'build', name: 'Build', metadata: { default: true } }],
+    disableBuiltinTools: [
+      'ask_user',
+      'submit_plan',
+      'task_write',
+      'task_update',
+      'task_complete',
+      'task_check',
+      'subagent',
+    ],
+  })
+
+  await controller.init()
+
+  const session = await controller.createSession({
+    id: 'local-session',
+    ownerId: 'local-user',
+    resourceId: projectPath,
+  })
+
+  return { controller, session }
+}
 ```
 
-## Take the agent beyond Studio
+This example uses one mode and disables the controller's additional built-in tools so the agent exposes only its workspace capabilities. It also omits storage, so the conversation lasts only for the current process. You can add storage later when you want to resume sessions.
 
-Studio is a convenient place to verify the agent, but it isn't the required interface. `createCodingAgent()` returns a standard Mastra `Agent`, so you can connect the same agent to a terminal, desktop, or web application.
+## Build the terminal UI
 
-A terminal UI can collect the user's input and conversation history, pass them to [`codingAgent.stream()`](/reference/streaming/agents/stream), render `textStream` as it arrives, and inspect `fullStream` to display tool activity. Set `basePath` to the project the user opens. If the terminal process starts in that project directory, the existing `process.cwd()` value already provides that path.
+Create `src/coding-agent-tui.ts`. The UI renders assistant message updates, shows tool activity, and asks the user to approve or decline each workspace tool call.
 
-The default local workspace is intended for trusted local development. It exposes file-writing tools and host command execution without isolation. Before accepting untrusted prompts or distributing the agent to other users, add [sandbox isolation](/docs/workspace/sandbox) and a [tool permission or approval policy](/docs/agents/agent-approval). When you use the `Agent` directly, your application owns these safety controls.
+```typescript title="src/coding-agent-tui.ts"
+import { pathToFileURL } from 'node:url'
+import {
+  Editor,
+  ProcessTerminal,
+  Text,
+  TUI,
+  type EditorTheme,
+  type Terminal,
+} from '@earendil-works/pi-tui'
 
-You can import the agent directly into a Node.js terminal application. If the interface runs as a separate process, keep the agent registered with Mastra and call it through the [Client SDK Agents API](/reference/client-js/agents). In that architecture, the server controls `basePath` and can access only projects available on its filesystem. Selecting a directory in a remote client doesn't upload or mount it, so your server must map each user to an available project and validate that mapping.
+import { createCodingAgentSession } from './mastra/coding-agent-controller'
 
-For a richer collaborative product with persistent sessions, tool approvals, modes, and UI event state, see the [AgentController overview](/docs/agent-controller/overview). AgentController is currently a beta feature; the direct `Agent` streaming path remains available when you want to build the application runtime yourself.
+const plain = (text: string) => text
+const editorTheme: EditorTheme = {
+  borderColor: plain,
+  selectList: {
+    selectedPrefix: plain,
+    selectedText: plain,
+    description: plain,
+    scrollInfo: plain,
+    noMatch: plain,
+  },
+}
+
+function getText(message: { content: Array<{ type: string; text?: string }> }) {
+  return message.content
+    .filter(part => part.type === 'text')
+    .map(part => part.text ?? '')
+    .join('')
+}
+
+export async function startCodingAgentTui(terminal: Terminal = new ProcessTerminal()) {
+  const { controller, session } = await createCodingAgentSession()
+  const tui = new TUI(terminal)
+  const output = new Text('Ask me to inspect or change this project.', 1, 0)
+  const editor = new Editor(tui, editorTheme)
+
+  let busy = false
+  let pendingApproval: { toolCallId: string; toolName: string } | undefined
+
+  const showError = (error: unknown) => {
+    output.setText(`Error: ${error instanceof Error ? error.message : String(error)}`)
+    busy = false
+    tui.requestRender()
+  }
+
+  const unsubscribe = session.subscribe(event => {
+    if (event.type === 'message_update' && event.message.role === 'assistant') {
+      output.setText(getText(event.message))
+    } else if (event.type === 'tool_start') {
+      output.setText(`Running ${event.toolName}...`)
+    } else if (event.type === 'tool_approval_required') {
+      pendingApproval = { toolCallId: event.toolCallId, toolName: event.toolName }
+      output.setText(`Allow ${event.toolName}? Enter y or n.`)
+    } else if (event.type === 'agent_end') {
+      busy = false
+    } else if (event.type === 'error') {
+      showError(event.error)
+      return
+    }
+
+    tui.requestRender()
+  })
+
+  editor.onSubmit = value => {
+    if (pendingApproval) {
+      const answer = value.trim().toLowerCase()
+      if (answer !== 'y' && answer !== 'n') {
+        output.setText(`Allow ${pendingApproval.toolName}? Enter y or n.`)
+        tui.requestRender()
+        return
+      }
+
+      const approval = pendingApproval
+      pendingApproval = undefined
+      session.respondToToolApproval({
+        toolCallId: approval.toolCallId,
+        decision: answer === 'y' ? 'approve' : 'decline',
+      })
+      return
+    }
+
+    if (busy || !value.trim()) return
+
+    busy = true
+    output.setText('Thinking...')
+    tui.requestRender()
+    void session.sendMessage({ content: value.trim() }).catch(showError)
+  }
+
+  tui.addChild(new Text('My Coding Agent', 1, 0))
+  tui.addChild(output)
+  tui.addChild(editor)
+  tui.setFocus(editor)
+  tui.start()
+
+  let stopPromise: Promise<void> | undefined
+  const stop = () => {
+    stopPromise ??= (async () => {
+      process.off('SIGINT', handleSigint)
+      session.abort()
+      unsubscribe()
+      tui.stop()
+      await controller.destroy()
+    })()
+    return stopPromise
+  }
+
+  const handleSigint = () => {
+    void stop().then(() => process.exit(0))
+  }
+  process.once('SIGINT', handleSigint)
+
+  return { stop }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await startCodingAgentTui()
+}
+```
+
+The optional `Terminal` parameter supports automated tests while using `ProcessTerminal` during normal execution. The UI intentionally renders only the latest response; the `Session` still maintains the conversation context for follow-up prompts.
+
+## Run the coding agent
+
+Start the terminal application from the project root so `process.cwd()` points to the project you want the agent to use:
+
+```bash npm2yarn
+npx tsx src/coding-agent-tui.ts
+```
+
+Enter this prompt:
+
+```text
+Inspect package.json and report the package name and available scripts. Do not modify files.
+```
+
+When the controller asks whether to allow `mastra_workspace_read_file`, enter `y`. The agent reads `package.json` and reports what it finds. Model wording varies, but the response should include the package name and its scripts without changing the file.
+
+Press **Ctrl+C** to close the application and destroy the controller.
 
 ## Next steps
 
 You can extend this foundation to:
 
-- Add project-specific instructions for testing and code style
-- Supply extra agent tools for services outside the local workspace
-- Build a terminal interface that shows streaming text and workspace tool activity
+- Add storage to persist and resume controller sessions
+- Add more modes with different instructions and workspace-tool allowlists
+- Replace the latest-response component with a transcript that renders tool calls and results
+- Add sandbox isolation before accepting untrusted prompts or distributing the application
 
 Learn more:
 
 - [`createCodingAgent()` reference](/reference/coding-agent/create-coding-agent)
 - [`buildBasePrompt()` reference](/reference/coding-agent/build-base-prompt)
-- [`Agent.stream()` reference](/reference/streaming/agents/stream)
+- [AgentController overview](/docs/agent-controller/overview)
+- [`AgentController` reference](/reference/agent-controller/agent-controller-class)
 - [Workspace overview](/docs/workspace/overview)

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -203,6 +203,7 @@ export async function startCodingAgentTui(terminal: Terminal = new ProcessTermin
   const showError = (error: unknown) => {
     output.setText(`Error: ${error instanceof Error ? error.message : String(error)}`)
     busy = false
+    pendingApproval = undefined
     tui.requestRender()
   }
 

--- a/docs/src/content/en/guides/guide/coding-agent.mdx
+++ b/docs/src/content/en/guides/guide/coding-agent.mdx
@@ -5,7 +5,7 @@ description: Build the foundation for your own interactive coding agent with Mas
 
 # Building a coding agent
 
-In this guide, you'll build the foundation for your own interactive coding agent—an application in the same category as Mastra Code, Claude Code, or Codex. You'll create branded coding instructions with [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt), configure the agent and its local workspace with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent), and register it with Mastra. After testing the agent's core behavior in Studio, you'll see how to connect it to a terminal UI or another application.
+In this guide, you'll build the foundation for your own interactive coding agent, an application in the same category as Mastra Code, Claude Code, or Codex. You'll create branded coding instructions with [`buildBasePrompt()`](/reference/coding-agent/build-base-prompt), configure the agent and its local workspace with [`createCodingAgent()`](/reference/coding-agent/create-coding-agent), and register it with Mastra. After testing the agent's core behavior in Studio, you'll see how to connect it to a terminal UI or another application.
 
 ## Prerequisites
 
@@ -22,9 +22,8 @@ import { basename } from 'node:path'
 import { buildBasePrompt, createCodingAgent } from '@mastra/core/coding-agent'
 
 const projectPath = process.cwd()
-const model = '__GATEWAY_OPENAI_MODEL_MINI__'
+const model = '__GATEWAY_OPENAI_MODEL__'
 
-// highlight-start
 const instructions = buildBasePrompt({
   projectPath,
   projectName: basename(projectPath),
@@ -43,9 +42,7 @@ const instructions = buildBasePrompt({
 - Use mastra_workspace_write_file, mastra_workspace_edit_file, and mastra_workspace_file_stat for writing, editing, and inspecting file metadata.
 - Use only the workspace tools provided to you. Do not attempt unavailable capabilities.`,
 })
-// highlight-end
 
-// highlight-start
 export const codingAgent = createCodingAgent({
   id: 'coding-agent',
   name: 'Coding Agent',
@@ -53,7 +50,6 @@ export const codingAgent = createCodingAgent({
   instructions,
   basePath: projectPath,
 })
-// highlight-end
 ```
 
 Replace the branding values with the name and co-author details for your agent. `createCodingAgent()` supplies a local filesystem and sandbox workspace, along with defaults for recovering from transient provider errors. The `basePath` scopes the filesystem tools and sets the initial working directory for commands. It isn't an operating-system security boundary: the default local sandbox runs commands directly on the host without isolation, so commands can access paths outside that directory. In this development-server example, `process.cwd()` resolves to `src/mastra/public`, so the filesystem tools use that directory. Any configuration you pass to the factory takes precedence over its defaults.

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -266,6 +266,11 @@ const sidebars = {
           items: [
             {
               type: 'doc',
+              id: 'guide/coding-agent',
+              label: 'Workspace: Coding Agent',
+            },
+            {
+              type: 'doc',
               id: 'guide/dev-assistant',
               label: 'Workspace: Dev Assistant',
             },

--- a/docs/src/content/en/guides/sidebars.js
+++ b/docs/src/content/en/guides/sidebars.js
@@ -266,11 +266,6 @@ const sidebars = {
           items: [
             {
               type: 'doc',
-              id: 'guide/coding-agent',
-              label: 'Workspace: Coding Agent',
-            },
-            {
-              type: 'doc',
               id: 'guide/dev-assistant',
               label: 'Workspace: Dev Assistant',
             },
@@ -285,6 +280,11 @@ const sidebars = {
               label: 'Filesystem: Docs Manager',
             },
           ],
+        },
+        {
+          type: 'doc',
+          id: 'guide/coding-agent',
+          label: 'Building a Coding Agent',
         },
         {
           type: 'doc',


### PR DESCRIPTION
## Description

Adds a tutorial on how to use `createCodingAgent()`, `buildBasePrompt()`, and `AgentController` together with pi-tui to build a simple coding agent.


https://github.com/user-attachments/assets/2e202aa3-e844-4d05-9656-c8689c03e8e1



## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a beginner-friendly tutorial that shows how to build a small coding agent and run it in the terminal (including asking for approval before it executes tools). It also adds a video demo so you can see the agent working.

## Summary
- Added a new MDX guide for building an interactive coding agent with `createCodingAgent()`, `buildBasePrompt()`, and `AgentController`, wired to `pi-tui` for a terminal UI.
- The guide covers setup (prereqs + installing `pi-tui`/`tsx`), creating the agent, scoping tools with `basePath`, registering the agent in Mastra, and managing an interactive session with tool-approval flow via `disableBuiltinTools`.
- Includes instructions and “Learn more” reference links for running the example with `npx tsx`.
- Added the guide to the docs Guides sidebar under “Building a Coding Agent”.
- Updated the “Chef Assistant” guide page title/description to match the “Building an AI chef assistant” framing.
- Added a video demo to the coding-agent guide (embedded via `VideoPlayer`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->