### PR TITLE
fix(braintrust): show real tool name instead of unknown_tool in Messages tab

### DIFF
--- a/.changeset/orange-showers-roll.md
+++ b/.changeset/orange-showers-roll.md
@@ -1,0 +1,5 @@
+---
+'@mastra/braintrust': patch
+---
+
+Fixed tool calls showing as `unknown_tool` in the Braintrust Messages tab. Tool spans (`TOOL_CALL`, `MCP_TOOL_CALL`, and `PROVIDER_TOOL_CALL`) are now converted to OpenAI chat messages with the real tool name and paired result, so Braintrust renders them correctly.

--- a/observability/braintrust/src/formatter.ts
+++ b/observability/braintrust/src/formatter.ts
@@ -168,7 +168,7 @@ function convertContentPart(part: AISDKContentPart | null | undefined): string |
 /**
  * Serializes tool result data to a string for OpenAI format.
  */
-function serializeToolResult(resultData: unknown): string {
+export function serializeToolResult(resultData: unknown): string {
   if (typeof resultData === 'string') {
     return resultData;
   }

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -537,6 +537,119 @@ describe('BraintrustExporter', () => {
     });
   });
 
+  describe('Tool span chat shaping (unknown_tool fix)', () => {
+    it('shapes TOOL_CALL input/output as OpenAI messages with the real tool name', async () => {
+      const toolSpan = createMockSpan({
+        id: 'tool-span-1',
+        name: "tool: 'getWeather'",
+        type: SpanType.TOOL_CALL,
+        isRoot: true,
+        entityName: 'getWeather',
+        input: { city: 'Paris' },
+        output: { temperatureC: 21, conditions: 'Sunny' },
+        attributes: { toolId: 'getWeather' },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      expect(mockLogger.startSpan).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: expect.objectContaining({
+            input: [
+              {
+                role: 'assistant',
+                content: '',
+                tool_calls: [
+                  {
+                    id: 'tool-span-1',
+                    type: 'function',
+                    function: { name: 'getWeather', arguments: '{"city":"Paris"}' },
+                  },
+                ],
+              },
+            ],
+            output: {
+              role: 'tool',
+              content: '{"temperatureC":21,"conditions":"Sunny"}',
+              tool_call_id: 'tool-span-1',
+            },
+          }),
+        }),
+      );
+    });
+
+    it('falls back to the name inside the span name when entityName is missing', async () => {
+      const toolSpan = createMockSpan({
+        id: 'tool-span-3',
+        name: "tool: 'searchDocs'",
+        type: SpanType.TOOL_CALL,
+        isRoot: true,
+        input: { q: 'mastra' },
+        attributes: {},
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: toolSpan,
+      });
+
+      const call = mockLogger.startSpan.mock.calls.at(-1)![0];
+      expect(call.event.input[0].tool_calls[0].function.name).toBe('searchDocs');
+    });
+
+    it('chat-shapes MCP_TOOL_CALL spans and pairs call/result with the same id', async () => {
+      const mcpSpan = createMockSpan({
+        id: 'mcp-span-1',
+        name: "mcp_tool: 'read_file' on 'fs-server'",
+        type: SpanType.MCP_TOOL_CALL,
+        isRoot: true,
+        entityName: 'read_file',
+        input: { path: '/tmp/a.txt' },
+        output: 'file contents',
+        attributes: { mcpServer: 'fs-server' },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: mcpSpan,
+      });
+
+      const call = mockLogger.startSpan.mock.calls.at(-1)![0];
+      expect(call.event.input[0].tool_calls[0].function.name).toBe('read_file');
+      expect(call.event.output).toEqual({
+        role: 'tool',
+        content: 'file contents',
+        tool_call_id: 'mcp-span-1',
+      });
+    });
+
+    it('chat-shapes PROVIDER_TOOL_CALL spans', async () => {
+      const providerSpan = createMockSpan({
+        id: 'provider-span-1',
+        name: "provider_tool: 'code_execution'",
+        type: SpanType.PROVIDER_TOOL_CALL,
+        isRoot: true,
+        entityName: 'code_execution',
+        input: { code: 'print("hello")' },
+        output: { stdout: 'hello' },
+        attributes: { toolType: 'provider-tool', toolCallId: 'srvtoolu_123' },
+      });
+
+      await exporter.exportTracingEvent({
+        type: TracingEventType.SPAN_STARTED,
+        exportedSpan: providerSpan,
+      });
+
+      const call = mockLogger.startSpan.mock.calls.at(-1)![0];
+      expect(call.event.input[0].tool_calls[0].function.name).toBe('code_execution');
+      expect(call.event.input[0].tool_calls[0].id).toBe('srvtoolu_123');
+      expect(call.event.output.tool_call_id).toBe('srvtoolu_123');
+    });
+  });
+
   describe('LLM Generation Attributes', () => {
     it('should handle LLM generation with full attributes', async () => {
       const traceId = 'trace-id';
@@ -1429,7 +1542,7 @@ describe('BraintrustExporter', () => {
       });
 
       expect(mockSpan.log).toHaveBeenCalledWith({
-        output: { result: 42 },
+        output: { role: 'tool', content: '{"result":42}', tool_call_id: 'tool-span' },
         metadata: {
           spanType: 'tool_call',
           toolId: 'calc',
@@ -2692,6 +2805,8 @@ function createMockSpan({
   errorInfo,
   tags,
   traceId,
+  entityName,
+  entityId,
 }: {
   id: string;
   name: string;
@@ -2704,6 +2819,8 @@ function createMockSpan({
   errorInfo?: any;
   tags?: string[];
   traceId?: string;
+  entityName?: string;
+  entityId?: string;
 }): AnyExportedSpan {
   const mockSpan = {
     id,
@@ -2715,6 +2832,8 @@ function createMockSpan({
     output,
     errorInfo,
     tags,
+    entityName,
+    entityId,
     startTime: new Date(),
     endTime: undefined,
     traceId: traceId ?? (isRoot ? id : 'parent-trace-id'),

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -514,7 +514,16 @@ export class BraintrustExporter extends TrackingExporter<
 
   private toToolCallInput(span: AnyExportedSpan): OpenAIMessage[] {
     const args = span.input;
-    const argsString = typeof args === 'string' ? args : JSON.stringify(args ?? {});
+    let argsString: string;
+    if (typeof args === 'string') {
+      argsString = args;
+    } else {
+      try {
+        argsString = JSON.stringify(args ?? {});
+      } catch {
+        argsString = '[unserializable result]';
+      }
+    }
     return [
       {
         role: 'assistant',

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -13,7 +13,8 @@ import { TrackingExporter } from '@mastra/observability';
 import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import { initLogger, currentSpan } from 'braintrust';
 import type { Span, Logger } from 'braintrust';
-import { removeNullish, convertAISDKMessage } from './formatter';
+import { removeNullish, convertAISDKMessage, serializeToolResult } from './formatter';
+import type { OpenAIMessage } from './formatter';
 import { formatUsageMetrics } from './metrics';
 import { reconstructThreadOutput } from './thread-reconstruction';
 import type { ThreadData, ThreadStepData, PendingToolResult } from './thread-reconstruction';
@@ -490,15 +491,67 @@ export class BraintrustExporter extends TrackingExporter<
     return output;
   }
 
+  private isToolSpan(span: AnyExportedSpan): boolean {
+    return (
+      span.type === SpanType.TOOL_CALL ||
+      span.type === SpanType.MCP_TOOL_CALL ||
+      span.type === SpanType.PROVIDER_TOOL_CALL
+    );
+  }
+
+  private getToolName(span: AnyExportedSpan): string {
+    if (span.entityName) {
+      return span.entityName;
+    }
+    const match = /'([^']+)'/.exec(span.name);
+    return match?.[1] ?? span.name;
+  }
+
+  private getToolCallId(span: AnyExportedSpan): string {
+    const attrs = span.attributes as { toolCallId?: string } | undefined;
+    return attrs?.toolCallId ?? (span.input as { toolCallId?: string } | undefined)?.toolCallId ?? span.id;
+  }
+
+  private toToolCallInput(span: AnyExportedSpan): OpenAIMessage[] {
+    const args = span.input;
+    const argsString = typeof args === 'string' ? args : JSON.stringify(args ?? {});
+    return [
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: this.getToolCallId(span),
+            type: 'function',
+            function: {
+              name: this.getToolName(span),
+              arguments: argsString,
+            },
+          },
+        ],
+      },
+    ];
+  }
+
+  private toToolCallOutput(span: AnyExportedSpan): OpenAIMessage {
+    return {
+      role: 'tool',
+      content: serializeToolResult(span.output),
+      tool_call_id: this.getToolCallId(span),
+    };
+  }
+
   private buildSpanPayload(span: AnyExportedSpan, isCreate = true): Record<string, any> {
     const payload: Record<string, any> = {};
 
+    const isToolType = this.isToolSpan(span);
+
     if (span.input !== undefined) {
-      payload.input = this.transformInput(span.input, span.type);
+      payload.input = isToolType ? this.toToolCallInput(span) : this.transformInput(span.input, span.type);
     }
 
     if (span.output !== undefined) {
-      payload.output = this.transformOutput(span.output, span.type);
+      payload.output = isToolType ? this.toToolCallOutput(span) : this.transformOutput(span.output, span.type);
     }
 
     if (isCreate && span.isRootSpan && span.tags?.length) {


### PR DESCRIPTION
## Description

Tool spans (`TOOL_CALL`, `MCP_TOOL_CALL`, `PROVIDER_TOOL_CALL`) were logged to Braintrust with raw args/result objects. Braintrust's Messages renderer expects OpenAI chat-message format with `function.name` — without it, every tool call was labelled `unknown_tool`. This PR chat-shapes tool span input/output into proper OpenAI messages so the real tool name is shown.

## Before
<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/8678a9d8-6ee8-4f77-802e-8ae592600fac" />

## After
<img width="1918" height="983" alt="image" src="https://github.com/user-attachments/assets/8bccaaa4-3533-4ec5-b2d8-55559f36f4cc" />

## Related Issue(s)

Fixes #19308

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Braintrust was showing tool calls as `unknown_tool` because the exporter wasn’t formatting tool spans into the “tool message” structure Braintrust expects. This PR updates the exporter to carry over the real tool name, call id, and the call input/output in the correct OpenAI-style message shape.

## What changed
- Converts `TOOL_CALL`, `MCP_TOOL_CALL`, and `PROVIDER_TOOL_CALL` spans into OpenAI-compatible chat messages, including:
  - `tool_calls[]` with `function.name`
  - paired tool result messages with `role: 'tool'` and `tool_call_id`
- Resolves tool names from `entityName`, falling back to the span’s `name` when `entityName` is missing.
- Resolves tool call ids from `attributes.toolCallId`, then `input.toolCallId`, then falls back to `span.id`.
- Uses `serializeToolResult` to shape tool span inputs/outputs into the expected OpenAI-like structures.
- Exports `serializeToolResult` for reuse.
- Adds safer serialization in tool input shaping by adding error handling around `JSON.stringify` (matching existing `serializeToolResult` behavior) to avoid exporter crashes for values like circular references or `BigInt`.
- Extends tests and the `createMockSpan` helper to include `entityName`/`entityId`, and adds coverage ensuring MCP/provider tool call shaping and the “unknown_tool” fix work correctly, including update-log formatting for tool spans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->