### PR TITLE
Give agents Linear tools when the project's org has Linear connected

### DIFF
--- a/.changeset/little-cobras-raise.md
+++ b/.changeset/little-cobras-raise.md
@@ -1,0 +1,15 @@
+---
+'@mastra/code-sdk': minor
+---
+
+Added support for async `extraTools` providers in `MastraCodeConfig`. The `extraTools` option now accepts an async function that receives the request context, so tools can be resolved per session (for example, only exposing an integration tool when the current project has that integration connected).
+
+```ts
+const mastraCode = await createMastraCode({
+  extraTools: async ({ requestContext }) => {
+    const controller = requestContext.get('controller');
+    if (!(await hasLinearConnection(controller?.resourceId))) return {};
+    return { linear_get_issue: linearGetIssueTool };
+  },
+});
+```

--- a/mastracode/sdk/src/agents/extra-tools.test.ts
+++ b/mastracode/sdk/src/agents/extra-tools.test.ts
@@ -42,7 +42,7 @@ function makeRequestContext(
 }
 
 describe('createDynamicTools – extraTools', () => {
-  it('should include extraTools in the returned tool set', () => {
+  it('should include extraTools in the returned tool set', async () => {
     const myCustomTool = createTool({
       id: 'my_custom_tool',
       description: 'A custom tool provided via extraTools',
@@ -51,7 +51,7 @@ describe('createDynamicTools – extraTools', () => {
     });
 
     const getDynamicTools = createDynamicTools(undefined, { my_custom_tool: myCustomTool });
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     // The extra tool must be present alongside the built-in tools
     expect(tools).toHaveProperty('my_custom_tool');
@@ -61,7 +61,7 @@ describe('createDynamicTools – extraTools', () => {
     expect(tools).toHaveProperty('request_access');
   });
 
-  it('should not overwrite built-in tools with extraTools of the same name', () => {
+  it('should not overwrite built-in tools with extraTools of the same name', async () => {
     const sneakyTool = createTool({
       id: 'request_access',
       description: 'Trying to overwrite the built-in request_access tool',
@@ -70,13 +70,13 @@ describe('createDynamicTools – extraTools', () => {
     });
 
     const getDynamicTools = createDynamicTools(undefined, { request_access: sneakyTool });
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     // Built-in request_access should NOT be replaced by the extra tool
     expect(tools.request_access).not.toBe(sneakyTool);
   });
 
-  it('should include pluginTools without overwriting existing dynamic tools', () => {
+  it('should include pluginTools without overwriting existing dynamic tools', async () => {
     const pluginTool = createTool({
       id: 'plugin_tool',
       description: 'Tool from plugin',
@@ -94,13 +94,13 @@ describe('createDynamicTools – extraTools', () => {
       plugin_tool: pluginTool,
       request_access: sneakyPluginTool,
     });
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     expect(tools.plugin_tool).toBe(pluginTool);
     expect(tools.request_access).not.toBe(sneakyPluginTool);
   });
 
-  it('should let extraTools win over pluginTools for embedding overrides', () => {
+  it('should let extraTools win over pluginTools for embedding overrides', async () => {
     const extraTool = createTool({
       id: 'shared_tool',
       description: 'Extra tool',
@@ -117,12 +117,12 @@ describe('createDynamicTools – extraTools', () => {
     const getDynamicTools = createDynamicTools(undefined, { shared_tool: extraTool }, undefined, undefined, {
       shared_tool: pluginTool,
     });
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     expect(tools.shared_tool).toBe(extraTool);
   });
 
-  it('should return extraTools even when no MCP manager is provided', () => {
+  it('should return extraTools even when no MCP manager is provided', async () => {
     const toolA = createTool({
       id: 'tool_a',
       description: 'Tool A',
@@ -137,13 +137,13 @@ describe('createDynamicTools – extraTools', () => {
     });
 
     const getDynamicTools = createDynamicTools(undefined, { tool_a: toolA, tool_b: toolB });
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     expect(tools).toHaveProperty('tool_a');
     expect(tools).toHaveProperty('tool_b');
   });
 
-  it('should support extraTools as a function that receives requestContext', () => {
+  it('should support extraTools as a function that receives requestContext', async () => {
     const myCustomTool = createTool({
       id: 'dynamic_tool',
       description: 'A dynamically provided tool',
@@ -158,12 +158,52 @@ describe('createDynamicTools – extraTools', () => {
       return { dynamic_tool: myCustomTool };
     });
 
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
     expect(tools).toHaveProperty('dynamic_tool');
     expect(tools.dynamic_tool).toBe(myCustomTool);
   });
 
-  it('should support extraTools function that conditionally returns empty', () => {
+  it('should support an async extraTools function and stay sync otherwise', async () => {
+    const asyncTool = createTool({
+      id: 'async_tool',
+      description: 'A tool provided by an async provider (e.g. after a DB lookup)',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'async' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, async () => {
+      await Promise.resolve();
+      return { async_tool: asyncTool };
+    });
+
+    const result = getDynamicTools({ requestContext: makeRequestContext() });
+    // Async providers make the tool set a promise…
+    expect(result).toHaveProperty('then');
+    const tools = await result;
+    expect(tools.async_tool).toBe(asyncTool);
+    expect(tools).toHaveProperty('request_access');
+
+    // …while sync providers keep the tool set synchronous.
+    const syncResult = createDynamicTools(undefined, () => ({}))({ requestContext: makeRequestContext() });
+    expect(syncResult).not.toHaveProperty('then');
+  });
+
+  it('should apply disabledTools and deny policies to async extraTools results', async () => {
+    const asyncTool = createTool({
+      id: 'blocked_async_tool',
+      description: 'Should be removed by disabledTools',
+      inputSchema: z.object({}),
+      execute: async () => ({ result: 'blocked' }),
+    });
+
+    const getDynamicTools = createDynamicTools(undefined, async () => ({ blocked_async_tool: asyncTool }), [
+      'blocked_async_tool',
+    ]);
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
+    expect(tools).not.toHaveProperty('blocked_async_tool');
+  });
+
+  it('should support extraTools function that conditionally returns empty', async () => {
     const myCustomTool = createTool({
       id: 'conditional_tool',
       description: 'A conditionally provided tool',
@@ -178,13 +218,13 @@ describe('createDynamicTools – extraTools', () => {
       return { conditional_tool: myCustomTool };
     });
 
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
     expect(tools).not.toHaveProperty('conditional_tool');
   });
 
-  it('should return only built-in tools when extraTools is undefined', () => {
+  it('should return only built-in tools when extraTools is undefined', async () => {
     const getDynamicTools = createDynamicTools(undefined, undefined);
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     // Should have built-in non-workspace tools but nothing extra
     // Note: workspace tools (view, search_content, etc.) are provided by the workspace, not createDynamicTools
@@ -200,7 +240,7 @@ describe('createDynamicTools – extraTools', () => {
       getStore: vi.fn(async (name: string) => (name === 'notifications' ? notificationStore : undefined)),
     };
     const getDynamicTools = createDynamicTools(undefined, undefined, undefined, storage as any);
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     expect(tools).toHaveProperty(MC_TOOLS.NOTIFICATION_INBOX);
     await expect(
@@ -237,7 +277,7 @@ describe('createDynamicTools – extraTools', () => {
       persisted: Promise.resolve(),
     }));
     const getDynamicTools = createDynamicTools(undefined, undefined, undefined, storage as any);
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
 
     await expect(
       tools[MC_TOOLS.NOTIFICATION_INBOX]?.execute?.(
@@ -264,13 +304,13 @@ describe('createDynamicTools – extraTools', () => {
 });
 
 describe('getToolCategory – extra tools', () => {
-  it('should categorize unknown/extra tools as "mcp"', () => {
+  it('should categorize unknown/extra tools as "mcp"', async () => {
     expect(getToolCategory('my_custom_tool')).toBe('mcp');
     expect(getToolCategory('tool_a')).toBe('mcp');
     expect(getToolCategory('some_random_extra_tool')).toBe('mcp');
   });
 
-  it('should still categorize built-in tools correctly', () => {
+  it('should still categorize built-in tools correctly', async () => {
     expect(getToolCategory(MC_TOOLS.VIEW)).toBe('read');
     expect(getToolCategory(MC_TOOLS.SEARCH_CONTENT)).toBe('read');
     expect(getToolCategory(MC_TOOLS.FIND_FILES)).toBe('read');
@@ -280,7 +320,7 @@ describe('getToolCategory – extra tools', () => {
     expect(getToolCategory(MC_TOOLS.EXECUTE_COMMAND)).toBe('execute');
   });
 
-  it('should return null for always-allowed tools', () => {
+  it('should return null for always-allowed tools', async () => {
     expect(getToolCategory('ask_user')).toBeNull();
     expect(getToolCategory('task_write')).toBeNull();
     expect(getToolCategory('task_update')).toBeNull();
@@ -290,9 +330,9 @@ describe('getToolCategory – extra tools', () => {
 });
 
 describe('createDynamicTools – denied tool filtering', () => {
-  it('should omit tools with a per-tool deny policy', () => {
+  it('should omit tools with a per-tool deny policy', async () => {
     const getDynamicTools = createDynamicTools();
-    const tools = getDynamicTools({
+    const tools = await getDynamicTools({
       requestContext: makeRequestContext({
         permissionRules: { categories: {}, tools: { request_access: 'deny' } },
       }),
@@ -301,7 +341,7 @@ describe('createDynamicTools – denied tool filtering', () => {
     expect(tools).not.toHaveProperty('request_access');
   });
 
-  it('should omit multiple denied tools', () => {
+  it('should omit multiple denied tools', async () => {
     const myTool = createTool({
       id: 'my_tool',
       description: 'A custom tool',
@@ -310,7 +350,7 @@ describe('createDynamicTools – denied tool filtering', () => {
     });
 
     const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool });
-    const tools = getDynamicTools({
+    const tools = await getDynamicTools({
       requestContext: makeRequestContext({
         permissionRules: {
           categories: {},
@@ -323,9 +363,9 @@ describe('createDynamicTools – denied tool filtering', () => {
     expect(tools).not.toHaveProperty('my_tool');
   });
 
-  it('should keep tools with allow or ask policies', () => {
+  it('should keep tools with allow or ask policies', async () => {
     const getDynamicTools = createDynamicTools();
-    const tools = getDynamicTools({
+    const tools = await getDynamicTools({
       requestContext: makeRequestContext({
         permissionRules: {
           categories: {},
@@ -337,7 +377,7 @@ describe('createDynamicTools – denied tool filtering', () => {
     expect(tools).toHaveProperty('request_access');
   });
 
-  it('should also deny extraTools when they have a deny policy', () => {
+  it('should also deny extraTools when they have a deny policy', async () => {
     const myTool = createTool({
       id: 'my_tool',
       description: 'A custom tool',
@@ -346,7 +386,7 @@ describe('createDynamicTools – denied tool filtering', () => {
     });
 
     const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool });
-    const tools = getDynamicTools({
+    const tools = await getDynamicTools({
       requestContext: makeRequestContext({
         permissionRules: { categories: {}, tools: { my_tool: 'deny' } },
       }),
@@ -357,19 +397,19 @@ describe('createDynamicTools – denied tool filtering', () => {
 });
 
 describe('createDynamicTools – disabledTools filtering', () => {
-  it('should omit disabled built-in tools', () => {
+  it('should omit disabled built-in tools', async () => {
     const unfilteredTools = createDynamicTools()({ requestContext: makeRequestContext() });
     expect(unfilteredTools).toHaveProperty('request_access');
 
     const getDynamicTools = createDynamicTools(undefined, undefined, ['request_access']);
 
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
     expect(tools).not.toHaveProperty('request_access');
     // web_search is provided by the Anthropic model mock and should survive filtering
     expect(tools).toHaveProperty('web_search');
   });
 
-  it('should omit disabled extraTools', () => {
+  it('should omit disabled extraTools', async () => {
     const myTool = createTool({
       id: 'my_tool',
       description: 'A custom tool',
@@ -378,13 +418,13 @@ describe('createDynamicTools – disabledTools filtering', () => {
     });
 
     const getDynamicTools = createDynamicTools(undefined, { my_tool: myTool }, ['my_tool']);
-    const tools = getDynamicTools({ requestContext: makeRequestContext() });
+    const tools = await getDynamicTools({ requestContext: makeRequestContext() });
     expect(tools).not.toHaveProperty('my_tool');
   });
 });
 
 describe('buildToolGuidance – denied tool filtering', () => {
-  it('should omit guidance for denied tools', () => {
+  it('should omit guidance for denied tools', async () => {
     const guidance = buildToolGuidance('build', {
       deniedTools: new Set([MC_TOOLS.EXECUTE_COMMAND]),
     });
@@ -395,7 +435,7 @@ describe('buildToolGuidance – denied tool filtering', () => {
     expect(guidance).toContain(`**${MC_TOOLS.NOTIFICATION_INBOX}**`);
   });
 
-  it('should omit multiple denied tools from guidance', () => {
+  it('should omit multiple denied tools from guidance', async () => {
     const guidance = buildToolGuidance('build', {
       deniedTools: new Set([MC_TOOLS.EXECUTE_COMMAND, MC_TOOLS.WRITE_FILE, 'subagent']),
     });
@@ -408,7 +448,7 @@ describe('buildToolGuidance – denied tool filtering', () => {
     expect(guidance).toContain(`**${MC_TOOLS.STRING_REPLACE_LSP}**`);
   });
 
-  it('should include all tools when no denied set is provided', () => {
+  it('should include all tools when no denied set is provided', async () => {
     const guidance = buildToolGuidance('build');
 
     expect(guidance).toContain(`**${MC_TOOLS.EXECUTE_COMMAND}**`);

--- a/mastracode/sdk/src/agents/tools.test.ts
+++ b/mastracode/sdk/src/agents/tools.test.ts
@@ -24,7 +24,7 @@ function createRequestContext(state: Record<string, unknown>, modeId: string = '
 }
 
 describe('createDynamicTools', () => {
-  it('merges extra tools into the exposed tool map', () => {
+  it('merges extra tools into the exposed tool map', async () => {
     const customTool = {
       description: 'custom',
       async execute() {
@@ -36,7 +36,7 @@ describe('createDynamicTools', () => {
       custom_tool: customTool,
     });
 
-    const allowedTools = getDynamicTools({
+    const allowedTools = await getDynamicTools({
       requestContext: createRequestContext({
         projectPath: process.cwd(),
       }),

--- a/mastracode/sdk/src/agents/tools.ts
+++ b/mastracode/sdk/src/agents/tools.ts
@@ -90,7 +90,9 @@ export function createToolHooks(hookManager?: HookManager): ToolHooks | undefine
 
 type DynamicToolProvider =
   | Record<string, ToolLike | undefined>
-  | ((ctx: { requestContext: RequestContext }) => Record<string, ToolLike | undefined>);
+  | ((ctx: {
+      requestContext: RequestContext;
+    }) => Record<string, ToolLike | undefined> | Promise<Record<string, ToolLike | undefined>>);
 
 export function createDynamicTools(
   mcpManager?: McpManager,
@@ -99,7 +101,11 @@ export function createDynamicTools(
   storage?: MastraCompositeStore,
   pluginTools?: Record<string, ToolLike>,
 ) {
-  return function getDynamicTools({ requestContext }: { requestContext: RequestContext }) {
+  return function getDynamicTools({
+    requestContext,
+  }: {
+    requestContext: RequestContext;
+  }): Record<string, ToolLike> | Promise<Record<string, ToolLike>> {
     const ctx = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeComposedState> | undefined;
     const state = ctx?.getState();
 
@@ -136,40 +142,52 @@ export function createDynamicTools(
       Object.assign(tools, mcpTools);
     }
 
-    if (extraTools) {
-      const resolved = typeof extraTools === 'function' ? extraTools({ requestContext }) : extraTools;
-      for (const [name, tool] of Object.entries(resolved)) {
-        if (tool && !(name in tools)) {
-          tools[name] = tool;
+    const finish = (resolvedExtra: Record<string, ToolLike | undefined> | undefined) => {
+      if (resolvedExtra) {
+        for (const [name, tool] of Object.entries(resolvedExtra)) {
+          if (tool && !(name in tools)) {
+            tools[name] = tool;
+          }
         }
       }
-    }
 
-    if (pluginTools) {
-      for (const [name, tool] of Object.entries(pluginTools)) {
-        if (!(name in tools)) {
-          tools[name] = tool;
+      if (pluginTools) {
+        for (const [name, tool] of Object.entries(pluginTools)) {
+          if (!(name in tools)) {
+            tools[name] = tool;
+          }
         }
       }
-    }
 
-    // Remove tools explicitly disabled via config so the model never sees them.
-    if (disabledTools?.length) {
-      for (const toolName of disabledTools) {
-        delete tools[toolName];
-      }
-    }
-
-    // Remove tools that have a per-tool 'deny' policy so the model never sees them.
-    const permissionRules = state?.permissionRules;
-    if (permissionRules?.tools) {
-      for (const [name, policy] of Object.entries(permissionRules.tools)) {
-        if (policy === 'deny') {
-          delete tools[name];
+      // Remove tools explicitly disabled via config so the model never sees them.
+      if (disabledTools?.length) {
+        for (const toolName of disabledTools) {
+          delete tools[toolName];
         }
       }
+
+      // Remove tools that have a per-tool 'deny' policy so the model never sees them.
+      const permissionRules = state?.permissionRules;
+      if (permissionRules?.tools) {
+        for (const [name, policy] of Object.entries(permissionRules.tools)) {
+          if (policy === 'deny') {
+            delete tools[name];
+          }
+        }
+      }
+
+      return tools;
+    };
+
+    if (typeof extraTools === 'function') {
+      const resolved = extraTools({ requestContext });
+      // Stay synchronous for sync providers; only go async when the provider does.
+      if (resolved && typeof (resolved as PromiseLike<unknown>).then === 'function') {
+        return Promise.resolve(resolved).then(finish);
+      }
+      return finish(resolved as Record<string, ToolLike | undefined>);
     }
 
-    return tools;
+    return finish(extraTools);
   };
 }

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -54,6 +54,7 @@ import { getStaticallyLoadedInstructionPaths } from './agents/prompts/agent-inst
 // import { planSubagent } from './agents/subagents/plan.js';
 import { attachOMThreadStatePersistence, restoreOMThreadStateForCurrentThread } from './agents/thread-caveman-state.js';
 import { createDynamicTools, createToolHooks } from './agents/tools.js';
+import type { ToolLike } from './agents/tools.js';
 
 import { getDynamicWorkspace, getGoalJudgeTools } from './agents/workspace.js';
 import { AuthStorage } from './auth/storage.js';
@@ -172,18 +173,10 @@ export interface MastraCodeConfig {
   modes?: AgentControllerMode[];
   /** Override or extend subagent definitions. Default: explore/plan/execute */
   subagents?: AgentControllerSubagent[];
-  /** Extra tools merged into the dynamic tool set. Can be a static record or a function that receives requestContext. */
+  /** Extra tools merged into the dynamic tool set. Can be a static record or a (sync or async) function that receives requestContext. */
   extraTools?:
-    | Record<
-        string,
-        { execute?: (input: unknown, context?: unknown) => Promise<unknown> | unknown; [key: string]: unknown }
-      >
-    | ((ctx: {
-        requestContext: RequestContext;
-      }) => Record<
-        string,
-        { execute?: (input: unknown, context?: unknown) => Promise<unknown> | unknown; [key: string]: unknown }
-      >);
+    | Record<string, ToolLike>
+    | ((ctx: { requestContext: RequestContext }) => Record<string, ToolLike> | Promise<Record<string, ToolLike>>);
   /** Tools removed from the dynamic tool set before exposure to the model */
   disabledTools?: string[];
   /** Custom storage config instead of auto-detected default */

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -30,6 +30,7 @@
 import { Mastra } from '@mastra/core/mastra';
 import { prepareAgentControllerMount } from '@mastra/code-sdk';
 import { buildAuthRoutes, createWebAuthGate, createWebAuthProvider, isWebAuthEnabled } from '../web/auth.js';
+import { buildLinearAgentTools } from '../web/linear/agent-tools.js';
 import { handleServerError } from '../web/server-error.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from '../web/spa-static.js';
 import {
@@ -91,6 +92,9 @@ const prepared = await prepareAgentControllerMount({
   ...(process.env.APP_DATABASE_URL
     ? { storage: { backend: 'pg', connectionString: process.env.APP_DATABASE_URL } }
     : {}),
+  // Linear tools are resolved per session: exposed only when the session's
+  // project belongs to an org with an active Linear connection.
+  ...(linearReady ? { extraTools: buildLinearAgentTools } : {}),
   buildApiRoutes: ({ controller, authStorage }) => [
     // Public WorkOS `/auth/*` routes (login/callback/logout/me). Folded in as
     // `apiRoutes` (not plain Hono routes) because the entry can't touch the Hono

--- a/mastracode/web/src/web/linear/agent-tools.test.ts
+++ b/mastracode/web/src/web/linear/agent-tools.test.ts
@@ -51,9 +51,11 @@ vi.mock('./config', () => ({
 }));
 
 const fetchLinearIssueDetail = vi.fn();
+const createLinearIssueComment = vi.fn();
 const refreshLinearAccessToken = vi.fn();
 vi.mock('./client', () => ({
   fetchLinearIssueDetail: (...args: any[]) => fetchLinearIssueDetail(...(args as [])),
+  createLinearIssueComment: (...args: any[]) => createLinearIssueComment(...(args as [])),
   refreshLinearAccessToken: (...args: any[]) => refreshLinearAccessToken(...(args as [])),
 }));
 
@@ -107,15 +109,17 @@ beforeEach(() => {
   featureEnabled = true;
   clearLinearAgentToolCaches();
   fetchLinearIssueDetail.mockReset();
+  createLinearIssueComment.mockReset();
   refreshLinearAccessToken.mockReset();
 });
 
 describe('buildLinearAgentTools — exposure gating', () => {
-  it('exposes linear_get_issue when the project org has a Linear connection', async () => {
+  it('exposes the Linear tools when the project org has a Linear connection', async () => {
     seedProject();
     seedConnection();
     const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
     expect(tools).toHaveProperty('linear_get_issue');
+    expect(tools).toHaveProperty('linear_create_comment');
   });
 
   it('exposes nothing when the org has not connected Linear', async () => {
@@ -215,5 +219,52 @@ describe('linear_get_issue — execute', () => {
     const tool = await getTool();
     const result = await (tool.execute as any)({ issue: 'ENG-42' });
     expect(result).toEqual({ error: 'Failed to fetch Linear issue: Linear API request failed (502)' });
+  });
+});
+
+describe('linear_create_comment — execute', () => {
+  async function getTool() {
+    seedProject();
+    seedConnection();
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    return tools.linear_create_comment!;
+  }
+
+  it('posts a comment and returns its URL', async () => {
+    createLinearIssueComment.mockResolvedValue({
+      id: 'comment-1',
+      url: 'https://linear.app/acme/issue/ENG-42#comment-1',
+    });
+    const tool = await getTool();
+    const result = await (tool.execute as any)({ issue: ' ENG-42 ', body: 'Investigated: root cause is X.' });
+    expect(createLinearIssueComment).toHaveBeenCalledWith('linear-token', 'ENG-42', 'Investigated: root cause is X.');
+    expect(result).toEqual({ posted: true, url: 'https://linear.app/acme/issue/ENG-42#comment-1' });
+  });
+
+  it('returns a not-found error for unknown issues', async () => {
+    createLinearIssueComment.mockResolvedValue(null);
+    const tool = await getTool();
+    const result = await (tool.execute as any)({ issue: 'ENG-999', body: 'Hello' });
+    expect(result).toEqual({ error: 'Linear issue "ENG-999" was not found in this workspace.' });
+  });
+
+  it('surfaces reauth-required as a tool error instead of throwing', async () => {
+    connections.length = 0;
+    seedProject();
+    seedConnection({ expiresAt: new Date(Date.now() - 1000), refreshToken: null });
+
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    const result = await (tools.linear_create_comment!.execute as any)({ issue: 'ENG-42', body: 'Hello' });
+
+    expect(result).toEqual({
+      error: 'Linear authorization expired. Reconnect Linear to keep syncing intake issues.',
+    });
+  });
+
+  it('maps post failures to a tool error', async () => {
+    createLinearIssueComment.mockRejectedValue(new Error('Linear did not accept the comment.'));
+    const tool = await getTool();
+    const result = await (tool.execute as any)({ issue: 'ENG-42', body: 'Hello' });
+    expect(result).toEqual({ error: 'Failed to post Linear comment: Linear did not accept the comment.' });
   });
 });

--- a/mastracode/web/src/web/linear/agent-tools.test.ts
+++ b/mastracode/web/src/web/linear/agent-tools.test.ts
@@ -9,6 +9,8 @@ vi.mock('drizzle-orm', () => ({
 // In-memory tables, keyed by the drizzle table object passed to `.from()`.
 let projects: Array<Record<string, any>> = [];
 let connections: Array<Record<string, any>> = [];
+/** When true, every select throws — simulates a transient app-db outage. */
+let dbShouldFail = false;
 
 function rowsFor(table: any): Array<Record<string, any>> {
   // The github_projects table has a `repoFullName` column; linear_connections doesn't.
@@ -30,7 +32,10 @@ vi.mock('../github/db', () => ({
   getAppDb: () => ({
     select: (_projection?: any) => ({
       from: (table: any) => ({
-        where: async (cond: any) => rowsFor(table).filter(row => matches(table, row, cond)),
+        where: async (cond: any) => {
+          if (dbShouldFail) throw new Error('connection refused');
+          return rowsFor(table).filter(row => matches(table, row, cond));
+        },
       }),
     }),
     update: (table: any) => ({
@@ -61,7 +66,7 @@ vi.mock('./client', () => ({
 
 import { buildLinearAgentTools, clearLinearAgentToolCaches, invalidateLinearConnectionCache } from './agent-tools';
 
-const PROJECT_ID = 'project-1';
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
 const ORG_ID = 'org-1';
 
 function requestContextFor(resourceId: string | undefined): RequestContext {
@@ -107,6 +112,7 @@ const issueDetail = {
 beforeEach(() => {
   projects = [];
   connections = [];
+  dbShouldFail = false;
   featureEnabled = true;
   clearLinearAgentToolCaches();
   fetchLinearIssueDetail.mockReset();
@@ -162,6 +168,19 @@ describe('buildLinearAgentTools — exposure gating', () => {
   it('exposes nothing when there is no controller context', async () => {
     const tools = await buildLinearAgentTools({ requestContext: requestContextFor(undefined) });
     expect(tools).toEqual({});
+  });
+
+  it('does not cache a transient database failure as "not a project"', async () => {
+    seedProject();
+    seedConnection();
+
+    dbShouldFail = true;
+    expect(await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) })).toEqual({});
+
+    // Database recovers: the next request must retry the lookup and get tools.
+    dbShouldFail = false;
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toHaveProperty('linear_get_issue');
   });
 
   it('sees a fresh connection immediately after cache invalidation', async () => {

--- a/mastracode/web/src/web/linear/agent-tools.test.ts
+++ b/mastracode/web/src/web/linear/agent-tools.test.ts
@@ -82,6 +82,7 @@ function seedConnection(overrides: Record<string, any> = {}): void {
     accessToken: 'linear-token',
     refreshToken: 'linear-refresh',
     expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    scope: 'read,comments:create',
     ...overrides,
   });
 }
@@ -120,6 +121,22 @@ describe('buildLinearAgentTools — exposure gating', () => {
     const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
     expect(tools).toHaveProperty('linear_get_issue');
     expect(tools).toHaveProperty('linear_create_comment');
+  });
+
+  it('withholds linear_create_comment when the connection scope is read-only', async () => {
+    seedProject();
+    seedConnection({ scope: 'read' });
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toHaveProperty('linear_get_issue');
+    expect(tools).not.toHaveProperty('linear_create_comment');
+  });
+
+  it('treats legacy connections without a recorded scope as read-only', async () => {
+    seedProject();
+    seedConnection({ scope: null });
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toHaveProperty('linear_get_issue');
+    expect(tools).not.toHaveProperty('linear_create_comment');
   });
 
   it('exposes nothing when the org has not connected Linear', async () => {

--- a/mastracode/web/src/web/linear/agent-tools.test.ts
+++ b/mastracode/web/src/web/linear/agent-tools.test.ts
@@ -1,0 +1,219 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+vi.mock('drizzle-orm', () => ({
+  eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+}));
+
+// In-memory tables, keyed by the drizzle table object passed to `.from()`.
+let projects: Array<Record<string, any>> = [];
+let connections: Array<Record<string, any>> = [];
+
+function rowsFor(table: any): Array<Record<string, any>> {
+  // The github_projects table has a `repoFullName` column; linear_connections doesn't.
+  return 'repoFullName' in table ? projects : connections;
+}
+
+function matches(table: any, row: any, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'eq') {
+    for (const [jsKey, col] of Object.entries(table)) {
+      if ((col as any)?.name === cond.column) return row[jsKey] === cond.value;
+    }
+    return false;
+  }
+  return true;
+}
+
+vi.mock('../github/db', () => ({
+  getAppDb: () => ({
+    select: (_projection?: any) => ({
+      from: (table: any) => ({
+        where: async (cond: any) => rowsFor(table).filter(row => matches(table, row, cond)),
+      }),
+    }),
+    update: (table: any) => ({
+      set: (vals: any) => ({
+        where: async (cond: any) => {
+          for (const row of rowsFor(table)) {
+            if (matches(table, row, cond)) Object.assign(row, vals);
+          }
+        },
+      }),
+    }),
+  }),
+}));
+
+let featureEnabled = true;
+vi.mock('./config', () => ({
+  isLinearFeatureEnabled: () => featureEnabled,
+}));
+
+const fetchLinearIssueDetail = vi.fn();
+const refreshLinearAccessToken = vi.fn();
+vi.mock('./client', () => ({
+  fetchLinearIssueDetail: (...args: any[]) => fetchLinearIssueDetail(...(args as [])),
+  refreshLinearAccessToken: (...args: any[]) => refreshLinearAccessToken(...(args as [])),
+}));
+
+import { buildLinearAgentTools, clearLinearAgentToolCaches, invalidateLinearConnectionCache } from './agent-tools';
+
+const PROJECT_ID = 'project-1';
+const ORG_ID = 'org-1';
+
+function requestContextFor(resourceId: string | undefined): RequestContext {
+  const ctx = new RequestContext();
+  if (resourceId !== undefined) {
+    ctx.set('controller', { resourceId });
+  }
+  return ctx;
+}
+
+function seedProject(): void {
+  projects.push({ id: PROJECT_ID, orgId: ORG_ID, repoFullName: 'acme/app' });
+}
+
+function seedConnection(overrides: Record<string, any> = {}): void {
+  connections.push({
+    orgId: ORG_ID,
+    accessToken: 'linear-token',
+    refreshToken: 'linear-refresh',
+    expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    ...overrides,
+  });
+}
+
+const issueDetail = {
+  id: 'uuid-1',
+  identifier: 'ENG-42',
+  title: 'Fix intake sync',
+  description: 'It syncs the wrong way.',
+  url: 'https://linear.app/acme/issue/ENG-42',
+  state: 'Todo',
+  stateType: 'unstarted',
+  priorityLabel: 'High',
+  assignee: 'ada',
+  team: 'ENG',
+  labels: ['bug'],
+  createdAt: '2026-07-01T00:00:00Z',
+  updatedAt: '2026-07-02T00:00:00Z',
+  comments: [{ author: 'grace', body: 'Repro attached.', createdAt: '2026-07-01T12:00:00Z' }],
+};
+
+beforeEach(() => {
+  projects = [];
+  connections = [];
+  featureEnabled = true;
+  clearLinearAgentToolCaches();
+  fetchLinearIssueDetail.mockReset();
+  refreshLinearAccessToken.mockReset();
+});
+
+describe('buildLinearAgentTools — exposure gating', () => {
+  it('exposes linear_get_issue when the project org has a Linear connection', async () => {
+    seedProject();
+    seedConnection();
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toHaveProperty('linear_get_issue');
+  });
+
+  it('exposes nothing when the org has not connected Linear', async () => {
+    seedProject();
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toEqual({});
+  });
+
+  it('exposes nothing when the feature is disabled', async () => {
+    featureEnabled = false;
+    seedProject();
+    seedConnection();
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toEqual({});
+  });
+
+  it('exposes nothing for resources that are not GitHub projects', async () => {
+    seedConnection();
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor('local-default') });
+    expect(tools).toEqual({});
+  });
+
+  it('exposes nothing when there is no controller context', async () => {
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(undefined) });
+    expect(tools).toEqual({});
+  });
+
+  it('sees a fresh connection immediately after cache invalidation', async () => {
+    seedProject();
+    expect(await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) })).toEqual({});
+
+    // Org connects Linear (OAuth callback invalidates the cached check).
+    seedConnection();
+    invalidateLinearConnectionCache(ORG_ID);
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    expect(tools).toHaveProperty('linear_get_issue');
+  });
+});
+
+describe('linear_get_issue — execute', () => {
+  async function getTool() {
+    seedProject();
+    seedConnection();
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    return tools.linear_get_issue!;
+  }
+
+  it('returns the full issue detail for an identifier', async () => {
+    fetchLinearIssueDetail.mockResolvedValue(issueDetail);
+    const tool = await getTool();
+    const result = await (tool.execute as any)({ issue: ' ENG-42 ' });
+    expect(fetchLinearIssueDetail).toHaveBeenCalledWith('linear-token', 'ENG-42');
+    expect(result).toEqual(issueDetail);
+  });
+
+  it('returns a not-found error for unknown issues', async () => {
+    fetchLinearIssueDetail.mockResolvedValue(null);
+    const tool = await getTool();
+    const result = await (tool.execute as any)({ issue: 'ENG-999' });
+    expect(result).toEqual({ error: 'Linear issue "ENG-999" was not found in this workspace.' });
+  });
+
+  it('refreshes an expired token before fetching', async () => {
+    connections.length = 0;
+    seedProject();
+    seedConnection({ expiresAt: new Date(Date.now() - 1000) });
+    refreshLinearAccessToken.mockResolvedValue({
+      accessToken: 'linear-token-2',
+      refreshToken: 'linear-refresh-2',
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000),
+    });
+    fetchLinearIssueDetail.mockResolvedValue(issueDetail);
+
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    const result = await (tools.linear_get_issue!.execute as any)({ issue: 'ENG-42' });
+
+    expect(refreshLinearAccessToken).toHaveBeenCalledWith('linear-refresh');
+    expect(fetchLinearIssueDetail).toHaveBeenCalledWith('linear-token-2', 'ENG-42');
+    expect(result).toEqual(issueDetail);
+  });
+
+  it('surfaces reauth-required as a tool error instead of throwing', async () => {
+    connections.length = 0;
+    seedProject();
+    seedConnection({ expiresAt: new Date(Date.now() - 1000), refreshToken: null });
+
+    const tools = await buildLinearAgentTools({ requestContext: requestContextFor(PROJECT_ID) });
+    const result = await (tools.linear_get_issue!.execute as any)({ issue: 'ENG-42' });
+
+    expect(result).toEqual({
+      error: 'Linear authorization expired. Reconnect Linear to keep syncing intake issues.',
+    });
+  });
+
+  it('maps fetch failures to a tool error', async () => {
+    fetchLinearIssueDetail.mockRejectedValue(new Error('Linear API request failed (502)'));
+    const tool = await getTool();
+    const result = await (tool.execute as any)({ issue: 'ENG-42' });
+    expect(result).toEqual({ error: 'Failed to fetch Linear issue: Linear API request failed (502)' });
+  });
+});

--- a/mastracode/web/src/web/linear/agent-tools.ts
+++ b/mastracode/web/src/web/linear/agent-tools.ts
@@ -1,0 +1,131 @@
+/**
+ * Linear tools exposed to the coding agent.
+ *
+ * Wired into the agent through the SDK's async `extraTools` provider: on each
+ * tool-set resolution we map the session's resourceId (which is the GitHub
+ * project id in the web app) to its owning WorkOS org and only expose the
+ * Linear tools when that org has a Linear connection. Projects whose org never
+ * connected Linear (or when the feature is disabled) see no Linear tools at
+ * all — the model is never shown tools it can't use.
+ *
+ * Tenancy mirrors the Linear API routes: everything is scoped by the org that
+ * owns the project, and tokens are refreshed through the same shared
+ * connection helpers the routes use.
+ */
+
+import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
+import type { RequestContext } from '@mastra/core/request-context';
+import { createTool } from '@mastra/core/tools';
+import { eq } from 'drizzle-orm';
+import { z } from 'zod';
+
+import { getAppDb } from '../github/db';
+import { githubProjects } from '../github/schema';
+import { fetchLinearIssueDetail } from './client';
+import { isLinearFeatureEnabled } from './config';
+import { getFreshLinearAccessToken, LinearReauthRequiredError, loadLinearConnection } from './connection';
+
+/**
+ * A project's org never changes, so the resourceId → orgId mapping is cached
+ * forever. `null` marks resource ids that aren't GitHub projects (e.g. local
+ * default resources) so we don't re-query them on every tool-set resolution.
+ */
+const orgIdByResourceId = new Map<string, string | null>();
+
+/** Re-check "is Linear connected" for an org at most this often. */
+const CONNECTION_TTL_MS = 60_000;
+const connectionCheckByOrg = new Map<string, { connected: boolean; checkedAt: number }>();
+
+async function resolveOrgId(resourceId: string): Promise<string | null> {
+  const cached = orgIdByResourceId.get(resourceId);
+  if (cached !== undefined) return cached;
+  let orgId: string | null = null;
+  try {
+    const [row] = await getAppDb()
+      .select({ orgId: githubProjects.orgId })
+      .from(githubProjects)
+      .where(eq(githubProjects.id, resourceId));
+    orgId = row?.orgId ?? null;
+  } catch {
+    // Non-UUID resource ids (local/dev resources) make the uuid comparison
+    // throw — treat them as "not a project" rather than failing tool resolution.
+    orgId = null;
+  }
+  orgIdByResourceId.set(resourceId, orgId);
+  return orgId;
+}
+
+async function isLinearConnected(orgId: string): Promise<boolean> {
+  const cached = connectionCheckByOrg.get(orgId);
+  if (cached && Date.now() - cached.checkedAt < CONNECTION_TTL_MS) return cached.connected;
+  const connected = (await loadLinearConnection(orgId)) !== null;
+  connectionCheckByOrg.set(orgId, { connected, checkedAt: Date.now() });
+  return connected;
+}
+
+/** Test hook: clear the org/connection caches between specs. */
+export function clearLinearAgentToolCaches(): void {
+  orgIdByResourceId.clear();
+  connectionCheckByOrg.clear();
+}
+
+/**
+ * Drop the cached connection check for an org. Called by the OAuth callback
+ * after a connection is persisted so the tools show up on the very next run
+ * instead of after the TTL lapses.
+ */
+export function invalidateLinearConnectionCache(orgId: string): void {
+  connectionCheckByOrg.delete(orgId);
+}
+
+function createLinearGetIssueTool(orgId: string) {
+  return createTool({
+    id: 'linear_get_issue',
+    description:
+      "Fetch a Linear issue's full details — title, description, state, assignee, labels, priority, and discussion comments. Use this whenever you're working on a Linear issue (e.g. ENG-123) to get its complete context.",
+    inputSchema: z.object({
+      issue: z.string().min(1).describe('The Linear issue identifier (e.g. "ENG-123") or issue UUID.'),
+    }),
+    execute: async ({ issue }: { issue: string }) => {
+      const connection = await loadLinearConnection(orgId);
+      if (!connection) {
+        return { error: 'Linear is not connected for this project. Connect Linear in Settings to fetch issues.' };
+      }
+      try {
+        const accessToken = await getFreshLinearAccessToken(connection);
+        const detail = await fetchLinearIssueDetail(accessToken, issue.trim());
+        if (!detail) {
+          return { error: `Linear issue "${issue}" was not found in this workspace.` };
+        }
+        return detail;
+      } catch (err) {
+        if (err instanceof LinearReauthRequiredError) {
+          return { error: err.message };
+        }
+        return { error: `Failed to fetch Linear issue: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    },
+  });
+}
+
+/**
+ * Async `extraTools` provider: expose Linear tools only when the session's
+ * project belongs to an org with an active Linear connection.
+ */
+export async function buildLinearAgentTools({
+  requestContext,
+}: {
+  requestContext: RequestContext;
+}): Promise<Record<string, ReturnType<typeof createLinearGetIssueTool>>> {
+  if (!isLinearFeatureEnabled()) return {};
+
+  const ctx = requestContext.get('controller') as AgentControllerRequestContext | undefined;
+  const resourceId = ctx?.resourceId;
+  if (!resourceId) return {};
+
+  const orgId = await resolveOrgId(resourceId);
+  if (!orgId) return {};
+  if (!(await isLinearConnected(orgId))) return {};
+
+  return { linear_get_issue: createLinearGetIssueTool(orgId) };
+}

--- a/mastracode/web/src/web/linear/agent-tools.ts
+++ b/mastracode/web/src/web/linear/agent-tools.ts
@@ -21,7 +21,7 @@ import { z } from 'zod';
 
 import { getAppDb } from '../github/db';
 import { githubProjects } from '../github/schema';
-import { fetchLinearIssueDetail } from './client';
+import { createLinearIssueComment, fetchLinearIssueDetail } from './client';
 import { isLinearFeatureEnabled } from './config';
 import { getFreshLinearAccessToken, LinearReauthRequiredError, loadLinearConnection } from './connection';
 
@@ -108,6 +108,37 @@ function createLinearGetIssueTool(orgId: string) {
   });
 }
 
+function createLinearCommentTool(orgId: string) {
+  return createTool({
+    id: 'linear_create_comment',
+    description:
+      'Post a comment on a Linear issue (e.g. to report investigation findings, link a PR, or ask a clarifying question). The comment is posted as the connected Linear integration, so make clear it comes from the agent.',
+    inputSchema: z.object({
+      issue: z.string().min(1).describe('The Linear issue identifier (e.g. "ENG-123") or issue UUID.'),
+      body: z.string().min(1).describe('The comment body, as Linear-flavored markdown.'),
+    }),
+    execute: async ({ issue, body }: { issue: string; body: string }) => {
+      const connection = await loadLinearConnection(orgId);
+      if (!connection) {
+        return { error: 'Linear is not connected for this project. Connect Linear in Settings to post comments.' };
+      }
+      try {
+        const accessToken = await getFreshLinearAccessToken(connection);
+        const comment = await createLinearIssueComment(accessToken, issue.trim(), body);
+        if (!comment) {
+          return { error: `Linear issue "${issue}" was not found in this workspace.` };
+        }
+        return { posted: true, url: comment.url };
+      } catch (err) {
+        if (err instanceof LinearReauthRequiredError) {
+          return { error: err.message };
+        }
+        return { error: `Failed to post Linear comment: ${err instanceof Error ? err.message : String(err)}` };
+      }
+    },
+  });
+}
+
 /**
  * Async `extraTools` provider: expose Linear tools only when the session's
  * project belongs to an org with an active Linear connection.
@@ -116,7 +147,7 @@ export async function buildLinearAgentTools({
   requestContext,
 }: {
   requestContext: RequestContext;
-}): Promise<Record<string, ReturnType<typeof createLinearGetIssueTool>>> {
+}): Promise<Record<string, ReturnType<typeof createLinearGetIssueTool> | ReturnType<typeof createLinearCommentTool>>> {
   if (!isLinearFeatureEnabled()) return {};
 
   const ctx = requestContext.get('controller') as AgentControllerRequestContext | undefined;
@@ -127,5 +158,8 @@ export async function buildLinearAgentTools({
   if (!orgId) return {};
   if (!(await isLinearConnected(orgId))) return {};
 
-  return { linear_get_issue: createLinearGetIssueTool(orgId) };
+  return {
+    linear_get_issue: createLinearGetIssueTool(orgId),
+    linear_create_comment: createLinearCommentTool(orgId),
+  };
 }

--- a/mastracode/web/src/web/linear/agent-tools.ts
+++ b/mastracode/web/src/web/linear/agent-tools.ts
@@ -47,21 +47,29 @@ interface ConnectionCheck {
 }
 const connectionCheckByOrg = new Map<string, ConnectionCheck>();
 
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 async function resolveOrgId(resourceId: string): Promise<string | null> {
   const cached = orgIdByResourceId.get(resourceId);
   if (cached !== undefined) return cached;
-  let orgId: string | null = null;
+  // Non-UUID resource ids (local/dev resources) would make the uuid column
+  // comparison throw — they're definitively "not a project", so cache that.
+  if (!UUID_PATTERN.test(resourceId)) {
+    orgIdByResourceId.set(resourceId, null);
+    return null;
+  }
+  let row: { orgId: string } | undefined;
   try {
-    const [row] = await getAppDb()
+    [row] = await getAppDb()
       .select({ orgId: githubProjects.orgId })
       .from(githubProjects)
       .where(eq(githubProjects.id, resourceId));
-    orgId = row?.orgId ?? null;
   } catch {
-    // Non-UUID resource ids (local/dev resources) make the uuid comparison
-    // throw — treat them as "not a project" rather than failing tool resolution.
-    orgId = null;
+    // Transient database failure: skip the tools for this request but don't
+    // cache the miss, so the next request retries the lookup.
+    return null;
   }
+  const orgId = row?.orgId ?? null;
   orgIdByResourceId.set(resourceId, orgId);
   return orgId;
 }
@@ -140,8 +148,7 @@ function createLinearCommentTool(orgId: string) {
       }
       if (!canPostLinearComments(connection)) {
         return {
-          error:
-            'The Linear connection does not have comment permissions. Reconnect Linear in Settings to grant them.',
+          error: 'The Linear connection does not have comment permissions. Reconnect Linear in Settings to grant them.',
         };
       }
       try {

--- a/mastracode/web/src/web/linear/agent-tools.ts
+++ b/mastracode/web/src/web/linear/agent-tools.ts
@@ -23,7 +23,12 @@ import { getAppDb } from '../github/db';
 import { githubProjects } from '../github/schema';
 import { createLinearIssueComment, fetchLinearIssueDetail } from './client';
 import { isLinearFeatureEnabled } from './config';
-import { getFreshLinearAccessToken, LinearReauthRequiredError, loadLinearConnection } from './connection';
+import {
+  canPostLinearComments,
+  getFreshLinearAccessToken,
+  LinearReauthRequiredError,
+  loadLinearConnection,
+} from './connection';
 
 /**
  * A project's org never changes, so the resourceId → orgId mapping is cached
@@ -32,9 +37,15 @@ import { getFreshLinearAccessToken, LinearReauthRequiredError, loadLinearConnect
  */
 const orgIdByResourceId = new Map<string, string | null>();
 
-/** Re-check "is Linear connected" for an org at most this often. */
+/** Re-check the org's Linear connection (and its scopes) at most this often. */
 const CONNECTION_TTL_MS = 60_000;
-const connectionCheckByOrg = new Map<string, { connected: boolean; checkedAt: number }>();
+interface ConnectionCheck {
+  connected: boolean;
+  /** Whether the granted OAuth scope allows posting issue comments. */
+  canComment: boolean;
+  checkedAt: number;
+}
+const connectionCheckByOrg = new Map<string, ConnectionCheck>();
 
 async function resolveOrgId(resourceId: string): Promise<string | null> {
   const cached = orgIdByResourceId.get(resourceId);
@@ -55,12 +66,17 @@ async function resolveOrgId(resourceId: string): Promise<string | null> {
   return orgId;
 }
 
-async function isLinearConnected(orgId: string): Promise<boolean> {
+async function checkLinearConnection(orgId: string): Promise<ConnectionCheck> {
   const cached = connectionCheckByOrg.get(orgId);
-  if (cached && Date.now() - cached.checkedAt < CONNECTION_TTL_MS) return cached.connected;
-  const connected = (await loadLinearConnection(orgId)) !== null;
-  connectionCheckByOrg.set(orgId, { connected, checkedAt: Date.now() });
-  return connected;
+  if (cached && Date.now() - cached.checkedAt < CONNECTION_TTL_MS) return cached;
+  const connection = await loadLinearConnection(orgId);
+  const check: ConnectionCheck = {
+    connected: connection !== null,
+    canComment: connection !== null && canPostLinearComments(connection),
+    checkedAt: Date.now(),
+  };
+  connectionCheckByOrg.set(orgId, check);
+  return check;
 }
 
 /** Test hook: clear the org/connection caches between specs. */
@@ -122,6 +138,12 @@ function createLinearCommentTool(orgId: string) {
       if (!connection) {
         return { error: 'Linear is not connected for this project. Connect Linear in Settings to post comments.' };
       }
+      if (!canPostLinearComments(connection)) {
+        return {
+          error:
+            'The Linear connection does not have comment permissions. Reconnect Linear in Settings to grant them.',
+        };
+      }
       try {
         const accessToken = await getFreshLinearAccessToken(connection);
         const comment = await createLinearIssueComment(accessToken, issue.trim(), body);
@@ -156,10 +178,14 @@ export async function buildLinearAgentTools({
 
   const orgId = await resolveOrgId(resourceId);
   if (!orgId) return {};
-  if (!(await isLinearConnected(orgId))) return {};
+  const check = await checkLinearConnection(orgId);
+  if (!check.connected) return {};
 
   return {
     linear_get_issue: createLinearGetIssueTool(orgId),
-    linear_create_comment: createLinearCommentTool(orgId),
+    // Only offered when the granted OAuth scope allows posting comments —
+    // connections made before `comments:create` was requested are read-only
+    // until the org reconnects Linear.
+    ...(check.canComment ? { linear_create_comment: createLinearCommentTool(orgId) } : {}),
   };
 }

--- a/mastracode/web/src/web/linear/client.ts
+++ b/mastracode/web/src/web/linear/client.ts
@@ -338,6 +338,19 @@ export interface LinearIssueDetail extends LinearIssue {
 }
 
 const ISSUE_COMMENTS_PAGE_SIZE = 50;
+/** Hard stop for comment pagination so a misbehaving cursor can't loop forever. */
+const ISSUE_COMMENTS_MAX_PAGES = 20;
+
+interface IssueCommentNode {
+  body: string;
+  createdAt: string;
+  user: { name: string } | null;
+}
+
+interface IssueCommentsPage {
+  nodes: IssueCommentNode[];
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+}
 
 interface IssueDetailQueryData {
   issue: {
@@ -353,8 +366,41 @@ interface IssueDetailQueryData {
     assignee: { name: string } | null;
     team: { key: string } | null;
     labels: { nodes: Array<{ name: string }> };
-    comments: { nodes: Array<{ body: string; createdAt: string; user: { name: string } | null }> };
+    comments: IssueCommentsPage;
   } | null;
+}
+
+interface IssueCommentsQueryData {
+  issue: { comments: IssueCommentsPage } | null;
+}
+
+/** Follow `comments.pageInfo` until exhausted so long discussions aren't truncated. */
+async function fetchRemainingIssueComments(
+  accessToken: string,
+  issueId: string,
+  firstPage: IssueCommentsPage,
+): Promise<IssueCommentNode[]> {
+  const nodes = [...firstPage.nodes];
+  let { hasNextPage, endCursor } = firstPage.pageInfo;
+  for (let page = 1; hasNextPage && endCursor && page < ISSUE_COMMENTS_MAX_PAGES; page++) {
+    const data = await linearGraphql<IssueCommentsQueryData>(
+      accessToken,
+      `query IssueComments($id: String!, $first: Int!, $after: String!) {
+        issue(id: $id) {
+          comments(first: $first, after: $after) {
+            nodes { body createdAt user { name } }
+            pageInfo { hasNextPage endCursor }
+          }
+        }
+      }`,
+      { id: issueId, first: ISSUE_COMMENTS_PAGE_SIZE, after: endCursor },
+    );
+    const comments = data.issue?.comments;
+    if (!comments) break;
+    nodes.push(...comments.nodes);
+    ({ hasNextPage, endCursor } = comments.pageInfo);
+  }
+  return nodes;
 }
 
 /**
@@ -384,7 +430,10 @@ export async function fetchLinearIssueDetail(
           assignee { name }
           team { key }
           labels { nodes { name } }
-          comments(first: $commentsFirst) { nodes { body createdAt user { name } } }
+          comments(first: $commentsFirst) {
+            nodes { body createdAt user { name } }
+            pageInfo { hasNextPage endCursor }
+          }
         }
       }`,
       { id: idOrIdentifier, commentsFirst: ISSUE_COMMENTS_PAGE_SIZE },
@@ -397,9 +446,8 @@ export async function fetchLinearIssueDetail(
   }
   const issue = data.issue;
   if (!issue) return null;
-  const comments = [...issue.comments.nodes].sort(
-    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
-  );
+  const allComments = await fetchRemainingIssueComments(accessToken, issue.id, issue.comments);
+  const comments = allComments.sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
   return {
     id: issue.id,
     identifier: issue.identifier,

--- a/mastracode/web/src/web/linear/client.ts
+++ b/mastracode/web/src/web/linear/client.ts
@@ -55,7 +55,9 @@ export function buildLinearAuthorizeUrl(state: string, redirectUri: string): str
   url.searchParams.set('client_id', config.clientId);
   url.searchParams.set('redirect_uri', redirectUri);
   url.searchParams.set('response_type', 'code');
-  url.searchParams.set('scope', 'read');
+  // `comments:create` lets the agent's linear_create_comment tool post
+  // comments; everything else the integration does is read-only.
+  url.searchParams.set('scope', 'read,comments:create');
   url.searchParams.set('state', state);
   url.searchParams.set('prompt', 'consent');
   return url.toString();
@@ -72,6 +74,8 @@ export interface LinearTokenSet {
   refreshToken: string | null;
   /** Null when Linear reported no `expires_in`. */
   expiresAt: Date | null;
+  /** Scopes granted to the token as reported by Linear; null when omitted. */
+  scope: string | null;
 }
 
 /** POST to Linear's token endpoint and normalize the response. */
@@ -92,7 +96,12 @@ async function requestLinearTokens(params: Record<string, string>, label: string
     (err as { status?: number }).status = res.status;
     throw err;
   }
-  const body = (await res.json()) as { access_token?: string; refresh_token?: string; expires_in?: number };
+  const body = (await res.json()) as {
+    access_token?: string;
+    refresh_token?: string;
+    expires_in?: number;
+    scope?: string;
+  };
   if (!body.access_token) {
     throw new Error(`Linear ${label} returned no access token.`);
   }
@@ -100,6 +109,7 @@ async function requestLinearTokens(params: Record<string, string>, label: string
     accessToken: body.access_token,
     refreshToken: body.refresh_token ?? null,
     expiresAt: typeof body.expires_in === 'number' ? new Date(Date.now() + body.expires_in * 1000) : null,
+    scope: body.scope ?? null,
   };
 }
 
@@ -129,7 +139,16 @@ async function linearGraphql<T>(accessToken: string, query: string, variables?: 
     body: JSON.stringify({ query, variables }),
   });
   if (!res.ok) {
-    const err = new Error(`Linear API request failed (${res.status})`);
+    // Linear returns GraphQL errors (validation, missing scopes, …) with a
+    // 400 status — surface the actual message instead of just the code.
+    let detail: string | null = null;
+    try {
+      const errBody = (await res.json()) as { errors?: Array<{ message?: string }> };
+      detail = errBody.errors?.[0]?.message ?? null;
+    } catch {
+      // Non-JSON error body; fall back to the status code alone.
+    }
+    const err = new Error(`Linear API request failed (${res.status})${detail ? `: ${detail}` : ''}`);
     (err as { status?: number }).status = res.status;
     throw err;
   }

--- a/mastracode/web/src/web/linear/client.ts
+++ b/mastracode/web/src/web/linear/client.ts
@@ -402,3 +402,54 @@ export async function fetchLinearIssueDetail(
     })),
   };
 }
+
+/** The comment created by {@link createLinearIssueComment}. */
+export interface LinearCreatedComment {
+  id: string;
+  url: string;
+}
+
+interface IssueIdQueryData {
+  issue: { id: string } | null;
+}
+
+interface CommentCreateMutationData {
+  commentCreate: { success: boolean; comment: { id: string; url: string } | null };
+}
+
+/**
+ * Post a comment on an issue. `idOrIdentifier` accepts both the Linear UUID
+ * and the human key (`ENG-123`) — the identifier is resolved to a UUID first
+ * because `commentCreate` only accepts UUIDs. Returns `null` when the issue
+ * doesn't exist.
+ */
+export async function createLinearIssueComment(
+  accessToken: string,
+  idOrIdentifier: string,
+  body: string,
+): Promise<LinearCreatedComment | null> {
+  let issueId: string;
+  try {
+    const data = await linearGraphql<IssueIdQueryData>(
+      accessToken,
+      `query IssueId($id: String!) { issue(id: $id) { id } }`,
+      { id: idOrIdentifier },
+    );
+    if (!data.issue) return null;
+    issueId = data.issue.id;
+  } catch (err) {
+    if (err instanceof Error && /entity not found/i.test(err.message)) return null;
+    throw err;
+  }
+  const data = await linearGraphql<CommentCreateMutationData>(
+    accessToken,
+    `mutation CommentCreate($input: CommentCreateInput!) {
+      commentCreate(input: $input) { success comment { id url } }
+    }`,
+    { input: { issueId, body } },
+  );
+  if (!data.commentCreate.success || !data.commentCreate.comment) {
+    throw new Error('Linear did not accept the comment.');
+  }
+  return data.commentCreate.comment;
+}

--- a/mastracode/web/src/web/linear/client.ts
+++ b/mastracode/web/src/web/linear/client.ts
@@ -303,3 +303,102 @@ export async function listActiveLinearIssues(
     nextCursor: pageInfo.hasNextPage ? pageInfo.endCursor : null,
   };
 }
+
+export interface LinearIssueComment {
+  author: string | null;
+  body: string;
+  createdAt: string;
+}
+
+/** Full issue payload for agent context: everything in {@link LinearIssue} plus description and discussion. */
+export interface LinearIssueDetail extends LinearIssue {
+  /** Markdown body of the issue, or `null` when empty. */
+  description: string | null;
+  /** Discussion comments, oldest first. */
+  comments: LinearIssueComment[];
+}
+
+const ISSUE_COMMENTS_PAGE_SIZE = 50;
+
+interface IssueDetailQueryData {
+  issue: {
+    id: string;
+    identifier: string;
+    title: string;
+    description: string | null;
+    url: string;
+    priorityLabel: string;
+    createdAt: string;
+    updatedAt: string;
+    state: { name: string; type: string };
+    assignee: { name: string } | null;
+    team: { key: string } | null;
+    labels: { nodes: Array<{ name: string }> };
+    comments: { nodes: Array<{ body: string; createdAt: string; user: { name: string } | null }> };
+  } | null;
+}
+
+/**
+ * Fetch one issue with its description and comments. `idOrIdentifier` accepts
+ * both the Linear UUID and the human key (`ENG-123`). Returns `null` when the
+ * issue doesn't exist (Linear reports it as an "Entity not found" error).
+ */
+export async function fetchLinearIssueDetail(
+  accessToken: string,
+  idOrIdentifier: string,
+): Promise<LinearIssueDetail | null> {
+  let data: IssueDetailQueryData;
+  try {
+    data = await linearGraphql<IssueDetailQueryData>(
+      accessToken,
+      `query IssueDetail($id: String!, $commentsFirst: Int!) {
+        issue(id: $id) {
+          id
+          identifier
+          title
+          description
+          url
+          priorityLabel
+          createdAt
+          updatedAt
+          state { name type }
+          assignee { name }
+          team { key }
+          labels { nodes { name } }
+          comments(first: $commentsFirst) { nodes { body createdAt user { name } } }
+        }
+      }`,
+      { id: idOrIdentifier, commentsFirst: ISSUE_COMMENTS_PAGE_SIZE },
+    );
+  } catch (err) {
+    // Linear surfaces unknown ids/identifiers as a GraphQL "Entity not found"
+    // error rather than a null node — map that to "issue doesn't exist".
+    if (err instanceof Error && /entity not found/i.test(err.message)) return null;
+    throw err;
+  }
+  const issue = data.issue;
+  if (!issue) return null;
+  const comments = [...issue.comments.nodes].sort(
+    (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime(),
+  );
+  return {
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    description: issue.description?.trim() ? issue.description : null,
+    url: issue.url,
+    state: issue.state.name,
+    stateType: issue.state.type,
+    priorityLabel: issue.priorityLabel,
+    assignee: issue.assignee?.name ?? null,
+    team: issue.team?.key ?? null,
+    labels: issue.labels.nodes.map(label => label.name),
+    createdAt: issue.createdAt,
+    updatedAt: issue.updatedAt,
+    comments: comments.map(comment => ({
+      author: comment.user?.name ?? null,
+      body: comment.body,
+      createdAt: comment.createdAt,
+    })),
+  };
+}

--- a/mastracode/web/src/web/linear/connection.ts
+++ b/mastracode/web/src/web/linear/connection.ts
@@ -81,7 +81,20 @@ export async function getFreshLinearAccessToken(connection: LinearConnectionRow)
   const existing = inflightRefreshes.get(connection.orgId);
   if (existing) return existing;
 
-  const refreshToken = connection.refreshToken;
+  // The caller may hold a stale row: another request could have refreshed and
+  // rotated the refresh token since this row was loaded. Reload before
+  // refreshing so we don't burn the rotated token and force a false reauth.
+  const latest = await loadLinearConnection(connection.orgId);
+  if (!latest) throw new LinearReauthRequiredError();
+
+  const concurrent = inflightRefreshes.get(connection.orgId);
+  if (concurrent) return concurrent;
+
+  const latestExpired = latest.expiresAt !== null && latest.expiresAt.getTime() - TOKEN_REFRESH_SKEW_MS <= Date.now();
+  if (!latestExpired) return latest.accessToken;
+  if (!latest.refreshToken) throw new LinearReauthRequiredError();
+
+  const refreshToken = latest.refreshToken;
   const refresh = (async () => {
     try {
       const tokens = await refreshLinearAccessToken(refreshToken);

--- a/mastracode/web/src/web/linear/connection.ts
+++ b/mastracode/web/src/web/linear/connection.ts
@@ -46,9 +46,21 @@ export async function persistLinearTokens(orgId: string, tokens: LinearTokenSet)
       accessToken: tokens.accessToken,
       refreshToken: tokens.refreshToken,
       expiresAt: tokens.expiresAt,
+      // Refresh responses may omit scope; keep the recorded grant in that case.
+      ...(tokens.scope !== null ? { scope: tokens.scope } : {}),
       updatedAt: new Date(),
     })
     .where(eq(linearConnections.orgId, orgId));
+}
+
+/**
+ * Whether the connection's token can post issue comments. Legacy rows without
+ * a recorded scope were minted with `read` only, so they count as read-only
+ * until the org reconnects Linear.
+ */
+export function canPostLinearComments(connection: LinearConnectionRow): boolean {
+  const scopes = (connection.scope ?? '').split(/[\s,]+/).filter(Boolean);
+  return scopes.some(scope => scope === 'comments:create' || scope === 'write' || scope === 'admin');
 }
 
 /**

--- a/mastracode/web/src/web/linear/connection.ts
+++ b/mastracode/web/src/web/linear/connection.ts
@@ -1,0 +1,90 @@
+/**
+ * Org-scoped Linear connection loading and OAuth token lifecycle.
+ *
+ * Shared between the Linear API routes (intake UI) and the Linear agent tools
+ * (issue context for factory runs). Both surfaces resolve the same org-owned
+ * connection row and need the same proactive refresh + single-flight rotation
+ * semantics, so the logic lives here rather than in either consumer.
+ */
+
+import { eq } from 'drizzle-orm';
+
+import { getAppDb } from '../github/db';
+import { refreshLinearAccessToken } from './client';
+import type { LinearTokenSet } from './client';
+import { linearConnections } from './schema';
+import type { LinearConnectionRow } from './schema';
+
+/** Load the org's Linear connection, or `null` when not connected. */
+export async function loadLinearConnection(orgId: string): Promise<LinearConnectionRow | null> {
+  const [row] = await getAppDb().select().from(linearConnections).where(eq(linearConnections.orgId, orgId));
+  return row ?? null;
+}
+
+/** Refresh this many ms before the recorded expiry to absorb clock skew. */
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+
+/**
+ * In-flight refreshes keyed by org. Linear rotates refresh tokens, so two
+ * concurrent refreshes with the same token would invalidate each other —
+ * single-flight ensures one exchange per org and shares the result.
+ */
+const inflightRefreshes = new Map<string, Promise<string>>();
+
+/** Thrown when the org's Linear authorization can no longer be renewed. */
+export class LinearReauthRequiredError extends Error {
+  constructor() {
+    super('Linear authorization expired. Reconnect Linear to keep syncing intake issues.');
+  }
+}
+
+/** Persist a rotated token set on the org's connection row. */
+export async function persistLinearTokens(orgId: string, tokens: LinearTokenSet): Promise<void> {
+  await getAppDb()
+    .update(linearConnections)
+    .set({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+      expiresAt: tokens.expiresAt,
+      updatedAt: new Date(),
+    })
+    .where(eq(linearConnections.orgId, orgId));
+}
+
+/**
+ * Return a usable access token for the connection, proactively refreshing it
+ * when the recorded expiry is past (or imminent). Throws
+ * `LinearReauthRequiredError` when the token is expired and cannot be
+ * refreshed — the org has to go through the OAuth flow again.
+ */
+export async function getFreshLinearAccessToken(connection: LinearConnectionRow): Promise<string> {
+  const expired = connection.expiresAt !== null && connection.expiresAt.getTime() - TOKEN_REFRESH_SKEW_MS <= Date.now();
+  if (!expired) return connection.accessToken;
+
+  if (!connection.refreshToken) {
+    // Legacy row from before refresh-token support: nothing to renew with.
+    throw new LinearReauthRequiredError();
+  }
+
+  const existing = inflightRefreshes.get(connection.orgId);
+  if (existing) return existing;
+
+  const refreshToken = connection.refreshToken;
+  const refresh = (async () => {
+    try {
+      const tokens = await refreshLinearAccessToken(refreshToken);
+      await persistLinearTokens(connection.orgId, tokens);
+      return tokens.accessToken;
+    } catch (err) {
+      const status = (err as { status?: number }).status;
+      // invalid_grant surfaces as 400/401: the refresh token was revoked or
+      // already rotated away. Terminal for this connection.
+      if (status === 400 || status === 401) throw new LinearReauthRequiredError();
+      throw err;
+    } finally {
+      inflightRefreshes.delete(connection.orgId);
+    }
+  })();
+  inflightRefreshes.set(connection.orgId, refresh);
+  return refresh;
+}

--- a/mastracode/web/src/web/linear/routes.ts
+++ b/mastracode/web/src/web/linear/routes.ts
@@ -201,6 +201,7 @@ export function buildLinearRoutes(options: MountLinearRoutesOptions = {}): ApiRo
               accessToken: tokens.accessToken,
               refreshToken: tokens.refreshToken,
               expiresAt: tokens.expiresAt,
+              scope: tokens.scope,
               workspaceName: workspace.name,
               workspaceUrlKey: workspace.urlKey,
             })
@@ -211,6 +212,7 @@ export function buildLinearRoutes(options: MountLinearRoutesOptions = {}): ApiRo
                 accessToken: tokens.accessToken,
                 refreshToken: tokens.refreshToken,
                 expiresAt: tokens.expiresAt,
+                scope: tokens.scope,
                 workspaceName: workspace.name,
                 workspaceUrlKey: workspace.urlKey,
                 updatedAt: new Date(),

--- a/mastracode/web/src/web/linear/routes.ts
+++ b/mastracode/web/src/web/linear/routes.ts
@@ -13,7 +13,6 @@
 
 import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
-import { eq } from 'drizzle-orm';
 import type { Context } from 'hono';
 
 import { ensureWebAuthUser, webAuthTenant } from '../auth';
@@ -26,13 +25,16 @@ import {
   fetchLinearWorkspace,
   listActiveLinearIssues,
   listLinearProjects,
-  refreshLinearAccessToken,
 } from './client';
-import type { LinearTokenSet } from './client';
 import { getIntakeConfig } from '../intake/store';
+import { invalidateLinearConnectionCache } from './agent-tools';
 import { getLinearFeatureDiagnostics, isLinearFeatureEnabled } from './config';
+import {
+  getFreshLinearAccessToken as getFreshAccessToken,
+  LinearReauthRequiredError,
+  loadLinearConnection as loadConnection,
+} from './connection';
 import { linearConnections } from './schema';
-import type { LinearConnectionRow } from './schema';
 
 type RouteContext = Context;
 
@@ -85,80 +87,6 @@ function parseAfterCursor(raw: string | undefined): string | undefined | null {
   if (raw === undefined || raw === '') return undefined;
   if (raw.length > 512 || !/^[\w+/=.:-]+$/.test(raw)) return null;
   return raw;
-}
-
-/** Load the org's Linear connection, or `null` when not connected. */
-async function loadConnection(orgId: string): Promise<LinearConnectionRow | null> {
-  const [row] = await getAppDb().select().from(linearConnections).where(eq(linearConnections.orgId, orgId));
-  return row ?? null;
-}
-
-/** Refresh this many ms before the recorded expiry to absorb clock skew. */
-const TOKEN_REFRESH_SKEW_MS = 60_000;
-
-/**
- * In-flight refreshes keyed by org. Linear rotates refresh tokens, so two
- * concurrent refreshes with the same token would invalidate each other —
- * single-flight ensures one exchange per org and shares the result.
- */
-const inflightRefreshes = new Map<string, Promise<string>>();
-
-/** Thrown when the org's Linear authorization can no longer be renewed. */
-class LinearReauthRequiredError extends Error {
-  constructor() {
-    super('Linear authorization expired. Reconnect Linear to keep syncing intake issues.');
-  }
-}
-
-/** Persist a rotated token set on the org's connection row. */
-async function persistTokens(orgId: string, tokens: LinearTokenSet): Promise<void> {
-  await getAppDb()
-    .update(linearConnections)
-    .set({
-      accessToken: tokens.accessToken,
-      refreshToken: tokens.refreshToken,
-      expiresAt: tokens.expiresAt,
-      updatedAt: new Date(),
-    })
-    .where(eq(linearConnections.orgId, orgId));
-}
-
-/**
- * Return a usable access token for the connection, proactively refreshing it
- * when the recorded expiry is past (or imminent). Throws
- * `LinearReauthRequiredError` when the token is expired and cannot be
- * refreshed — the org has to go through the OAuth flow again.
- */
-async function getFreshAccessToken(connection: LinearConnectionRow): Promise<string> {
-  const expired = connection.expiresAt !== null && connection.expiresAt.getTime() - TOKEN_REFRESH_SKEW_MS <= Date.now();
-  if (!expired) return connection.accessToken;
-
-  if (!connection.refreshToken) {
-    // Legacy row from before refresh-token support: nothing to renew with.
-    throw new LinearReauthRequiredError();
-  }
-
-  const existing = inflightRefreshes.get(connection.orgId);
-  if (existing) return existing;
-
-  const refreshToken = connection.refreshToken;
-  const refresh = (async () => {
-    try {
-      const tokens = await refreshLinearAccessToken(refreshToken);
-      await persistTokens(connection.orgId, tokens);
-      return tokens.accessToken;
-    } catch (err) {
-      const status = (err as { status?: number }).status;
-      // invalid_grant surfaces as 400/401: the refresh token was revoked or
-      // already rotated away. Terminal for this connection.
-      if (status === 400 || status === 401) throw new LinearReauthRequiredError();
-      throw err;
-    } finally {
-      inflightRefreshes.delete(connection.orgId);
-    }
-  })();
-  inflightRefreshes.set(connection.orgId, refresh);
-  return refresh;
 }
 
 /** Map a Linear read failure to the API response for the SPA. */
@@ -293,6 +221,8 @@ export function buildLinearRoutes(options: MountLinearRoutesOptions = {}): ApiRo
           return c.redirect('/?linear=error');
         }
 
+        // Let the agent tools see the new connection immediately.
+        invalidateLinearConnectionCache(orgId);
         return c.redirect('/?linear=connected');
       },
     }),

--- a/mastracode/web/src/web/linear/schema.ts
+++ b/mastracode/web/src/web/linear/schema.ts
@@ -22,8 +22,13 @@ export const linearConnections = pgTable(
     orgId: text('org_id').notNull(),
     /** Stable WorkOS user id of whoever connected it (audit only). */
     userId: text('user_id').notNull(),
-    /** Linear OAuth access token (workspace-scoped, `read`). Server-side only. */
+    /** Linear OAuth access token (workspace-scoped). Server-side only. */
     accessToken: text('access_token').notNull(),
+    /**
+     * Scopes Linear granted to the token (e.g. `read,comments:create`). Null
+     * for connections created before scope tracking — treated as read-only.
+     */
+    scope: text('scope'),
     /**
      * Linear OAuth refresh token. Linear access tokens expire (24h) and refresh
      * tokens rotate on every exchange, so this is rewritten after each refresh.
@@ -65,5 +70,6 @@ CREATE TABLE IF NOT EXISTS linear_connections (
 );
 ALTER TABLE linear_connections ADD COLUMN IF NOT EXISTS refresh_token text;
 ALTER TABLE linear_connections ADD COLUMN IF NOT EXISTS expires_at timestamptz;
+ALTER TABLE linear_connections ADD COLUMN IF NOT EXISTS scope text;
 CREATE UNIQUE INDEX IF NOT EXISTS linear_connections_org_unique ON linear_connections (org_id);
 `;

--- a/mastracode/web/src/web/ui/domains/factory/IntakePage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/IntakePage.tsx
@@ -298,11 +298,11 @@ function linearIssueBranch(issue: LinearIssue): string {
 }
 
 function linearIssuePrompt(issue: LinearIssue): string {
-  return `Use the understand-issue skill to investigate Linear issue ${issue.identifier}: "${issue.title}" (${issue.url}).`;
+  return `Use the understand-issue skill to investigate Linear issue ${issue.identifier}: "${issue.title}" (${issue.url}). Start by fetching the issue's full details (description and comments) with the linear_get_issue tool.`;
 }
 
 function linearIssueCustomPrompt(issue: LinearIssue, instructions: string): string {
-  return `Regarding Linear issue ${issue.identifier}: "${issue.title}" (${issue.url}). ${instructions}`;
+  return `Regarding Linear issue ${issue.identifier}: "${issue.title}" (${issue.url}) — fetch its full details with the linear_get_issue tool. ${instructions}`;
 }
 
 function LinearIssueList() {

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -493,6 +493,7 @@ describe('Factory Intake page — Linear source', () => {
     expect(captured.messages).toHaveLength(1);
     expect(captured.messages[0]!.message).toContain('understand-issue skill');
     expect(captured.messages[0]!.message).toContain('https://linear.app/acme/issue/ENG-42');
+    expect(captured.messages[0]!.message).toContain('linear_get_issue');
   });
 });
 


### PR DESCRIPTION
## Summary

When a project's org has connected Linear, agents now get Linear tools injected into their tool set, so runs kicked off from the Intake page can pull full issue context and reply on the issue:

- **`linear_get_issue`** — fetches the full issue (description, comments, state, assignee, labels, priority) by identifier (e.g. `ENG-123`) or UUID. Intake kickoff prompts now point the agent at this tool.
- **`linear_create_comment`** — posts a markdown comment on an issue, so the agent can report findings/updates back to Linear.

Tools are provided dynamically per request: the provider resolves the project's org, checks the org's Linear connection (cached with a short TTL), and returns an empty set when Linear isn't connected — agents on unconnected projects never see the tools.

## How it works

- **SDK (`@mastra/code-sdk`, minor):** `extraTools` can now be an async function receiving `requestContext`, enabling context-aware tool injection.
- **Web:** Linear token/connection helpers extracted into a shared `connection.ts` module (reused by routes and the tools provider); the Linear client gains an issue-detail query and a comment-create mutation; `buildLinearAgentTools` is wired into the web Mastra entry as the `extraTools` provider.
- **OAuth scope:** the authorize URL now requests `read,comments:create`, and the granted scope is persisted on the connection. `linear_create_comment` is only exposed when the token can actually post comments — existing read-only connections keep `linear_get_issue` until the org reconnects Linear in Settings.
- **Errors:** non-200 Linear GraphQL failures now surface Linear's actual error message instead of just the status code; reauth/API failures are returned as tool results rather than thrown.

## Test plan

- 42 Linear agent-tools + routes tests (connection gating, scope gating incl. legacy scope-less rows, tool execution, comment posting, not-found, reauth, API failure)
- 392 web MSW tests + 313 unit tests passing; SDK tests cover sync/async `extraTools` providers
- Typecheck + prettier clean across web and sdk
- Manual: verified read-only connections hide the comment tool; reconnecting Linear grants `comments:create` and enables posting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If your project is connected to Linear, the agent can now look up Linear issues and (when allowed) leave comments on them. It only turns these features on for the right projects and handles OAuth token refresh automatically so it keeps working.

## Summary
- Added async, request-context-aware SDK `extraTools` support (tool providers can be async and receive `requestContext`).
- Introduced Linear agent tools:
  - `linear_get_issue` to fetch full issue details plus complete discussion comments (paginated with a hard cap of 20 pages).
  - `linear_create_comment` to post Markdown comments to an issue (requires OAuth scope `comments:create`).
- Injected Linear tools dynamically per request/session only when Linear is connected and permitted; non-connected/unauthorized projects don’t receive the tools.
- Implemented Linear OAuth handling end-to-end: scope persistence, fresh access token retrieval with refresh, single-flight refresh to avoid rotation races, and standardized error responses (including reauth-required cases).
- Added org/connection caching for tool gating, with explicit cache invalidation on OAuth callback; transient DB failures are not cached as “not a project” (so tools recover without restart).
- Extracted reusable Linear connection/token lifecycle helpers and improved GraphQL error surfacing.
- Updated intake prompts and UI tests to guide agents to start by calling `linear_get_issue`.
- Added/updated comprehensive tests covering SDK tool injection (sync+async), Linear tools, routes, gating by connection + scope, token refresh behavior, cache invalidation, and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->