### PR TITLE
fix(core): persist processor data chunks

### DIFF
--- a/.changeset/jolly-ears-spend.md
+++ b/.changeset/jolly-ears-spend.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed custom data chunks emitted by processors so they are saved with thread messages unless marked transient.

--- a/docs/src/content/en/reference/processors/processor-interface.mdx
+++ b/docs/src/content/en/reference/processors/processor-interface.mdx
@@ -646,7 +646,7 @@ processLLMRequest?(
     name: 'writer',
     type: 'ProcessorStreamWriter',
     description:
-      'Stream writer for emitting custom data chunks during streaming. Use `writer.custom()` to send transient UI signals.',
+      'Stream writer for emitting custom data chunks during streaming. Call `writer.custom()` to emit a `data-*` chunk.',
     isOptional: true,
   },
   {
@@ -865,7 +865,7 @@ processAPIError?(args: ProcessAPIErrorArgs): Promise<ProcessAPIErrorResult | voi
     name: 'writer',
     type: 'ProcessorStreamWriter',
     description:
-      'Stream writer for emitting custom data chunks during streaming. Use `writer.custom()` to send transient UI signals.',
+      'Stream writer for emitting custom data chunks during streaming. Call `writer.custom()` to emit a `data-*` chunk.',
     isOptional: true,
   },
   {
@@ -1501,6 +1501,18 @@ await writer.custom({
   data: { level: 'warn', reason: 'Possibly unsafe' },
 })
 ```
+
+When memory is configured, custom `data-*` chunks emitted from `processOutputStream` or `processOutputResult` are saved as parts of the assistant message. Set `transient: true` on the chunk object to stream it without saving it to memory:
+
+```typescript {4}
+await writer.custom({
+  type: 'data-progress',
+  data: { status: 'Processing' },
+  transient: true,
+})
+```
+
+Pass `transient` as a property of the chunk, not as the second argument to `writer.custom()`. The second argument contains writer options such as `messageId`.
 
 By default, processors **don't** see `data-*` chunks in `processOutputStream` so they don't accidentally process tool telemetry or their own output. Opt in by setting `processDataParts: true` on the processor:
 

--- a/packages/core/src/loop/workflows/stream.ts
+++ b/packages/core/src/loop/workflows/stream.ts
@@ -55,14 +55,34 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
           })
         : undefined;
 
-      // Create a ProcessorStreamWriter so output processors can emit custom chunks back to the stream
-      const dataChunkStreamWriter = {
-        custom: async (data: { type: string }) => {
-          safeEnqueue(controller, data as ChunkType<OUTPUT>);
-        },
-      };
-
       const outputWriter = async (chunk: ChunkType<OUTPUT>, options?: { messageId?: string }) => {
+        const responseMessageId = options?.messageId ?? messageId;
+        const dataChunkStreamWriter = {
+          custom: async (
+            data: { type: string; data?: unknown; transient?: boolean },
+            writerOptions?: { messageId?: string },
+          ) => {
+            const emittedMessageId = writerOptions?.messageId ?? responseMessageId;
+            if (data.type.startsWith('data-') && emittedMessageId && !data.transient) {
+              messageList.add(
+                {
+                  id: emittedMessageId,
+                  role: 'assistant',
+                  content: {
+                    format: 2,
+                    parts: [{ type: data.type as `data-${string}`, data: data.data }],
+                  },
+                  createdAt: new Date(),
+                  threadId: _internal?.threadId,
+                  resourceId: _internal?.resourceId,
+                },
+                'response',
+              );
+            }
+            safeEnqueue(controller, data as ChunkType<OUTPUT>);
+          },
+        };
+
         // Handle data-* chunks (custom data chunks from writer.custom())
         // These need to be persisted to storage, not just streamed
         // Transient chunks are streamed to the client but not saved to the DB
@@ -109,7 +129,6 @@ export function workflowLoopStream<Tools extends ToolSet = ToolSet, OUTPUT = und
           }
 
           // If a processor rewrote the chunk to a non-data type, skip persistence
-          const responseMessageId = options?.messageId ?? messageId;
           if (
             typeof processedChunk.type === 'string' &&
             processedChunk.type.startsWith('data-') &&

--- a/packages/core/src/processors/output-processor-data-chunks.test.ts
+++ b/packages/core/src/processors/output-processor-data-chunks.test.ts
@@ -3,8 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { Agent } from '../agent';
 import { MessageList } from '../agent/message-list';
+import { MockMemory } from '../memory/mock';
 import { createTool } from '../tools';
-import type { Processor } from './index';
+import type { Processor, ProcessOutputResultArgs, ProcessOutputStreamArgs } from './index';
 
 /**
  * Creates a mock model that calls `toolName` on the first turn,
@@ -61,6 +62,154 @@ function createToolCallingModel(toolName: string) {
 }
 
 describe('Output Processor Data Chunks (#13341)', () => {
+  it('persists custom chunks emitted by output processors to memory', async () => {
+    const memory = new MockMemory();
+    const threadId = 'processor-custom-chunks-thread';
+    const resourceId = 'processor-custom-chunks-resource';
+    let emittedStreamChunk = false;
+
+    class CustomChunkEmitter {
+      readonly id = 'custom-chunk-emitter';
+      readonly name = 'Custom Chunk Emitter';
+
+      async processOutputStream({ part, writer }: ProcessOutputStreamArgs) {
+        if (part.type === 'text-delta' && !emittedStreamChunk) {
+          emittedStreamChunk = true;
+          await writer?.custom({ type: 'data-stream-reference', data: { source: 'stream' } });
+          await writer?.custom({
+            type: 'data-stream-transient',
+            data: { status: 'streaming' },
+            transient: true,
+          });
+        }
+        return part;
+      }
+
+      async processOutputResult({ messages, writer }: ProcessOutputResultArgs) {
+        await writer?.custom({ type: 'data-result-reference', data: { source: 'result' } });
+        await writer?.custom({ type: 'data-transient-status', data: { status: 'done' }, transient: true });
+        return messages;
+      }
+    }
+
+    const model = new MockLanguageModelV2({
+      doStream: async () => ({
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Done!' },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+          },
+        ]),
+        rawCall: { rawPrompt: [], rawSettings: {} },
+        warnings: [],
+      }),
+    });
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent',
+      model: model as any,
+      memory,
+      outputProcessors: [new CustomChunkEmitter()],
+    });
+
+    const stream = await agent.stream('Hello', {
+      memory: { thread: threadId, resource: resourceId },
+    });
+    const streamedTypes: string[] = [];
+    for await (const chunk of stream.fullStream) {
+      streamedTypes.push(chunk.type);
+    }
+
+    const recalled = await memory.recall({ threadId, resourceId });
+    const persistedParts = recalled.messages.flatMap(message => message.content.parts);
+
+    expect(streamedTypes).toContain('data-stream-reference');
+    expect(streamedTypes).toContain('data-stream-transient');
+    expect(streamedTypes).toContain('data-result-reference');
+    expect(streamedTypes).toContain('data-transient-status');
+    expect(persistedParts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'data-stream-reference', data: { source: 'stream' } }),
+        expect.objectContaining({ type: 'data-result-reference', data: { source: 'result' } }),
+      ]),
+    );
+    const persistedTypes = persistedParts.map(part => part.type);
+    expect(persistedTypes).not.toContain('data-stream-transient');
+    expect(persistedTypes).not.toContain('data-transient-status');
+  });
+
+  it('persists custom chunks emitted while processing tool data chunks', async () => {
+    const memory = new MockMemory();
+    const threadId = 'processor-derived-chunk-thread';
+    const resourceId = 'processor-derived-chunk-resource';
+
+    class DerivedChunkEmitter implements Processor {
+      readonly id = 'derived-chunk-emitter';
+      readonly name = 'Derived Chunk Emitter';
+      readonly processDataParts = true;
+
+      async processOutputStream({ part, writer }: ProcessOutputStreamArgs) {
+        if (part.type === 'data-tool-status') {
+          await writer?.custom({ type: 'data-processor-status', data: { source: 'processor' } });
+          await writer?.custom({
+            type: 'data-processor-transient',
+            data: { source: 'processor' },
+            transient: true,
+          });
+        }
+        return part;
+      }
+    }
+
+    const tool = createTool({
+      id: 'customDataTool',
+      description: 'Emits custom data',
+      inputSchema: z.object({ text: z.string() }),
+      execute: async (inputData, { writer }) => {
+        await writer?.custom({ type: 'data-tool-status', data: { source: 'tool' } });
+        return `Processed: ${inputData.text}`;
+      },
+    });
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'Test agent',
+      model: createToolCallingModel('customDataTool') as any,
+      tools: { customDataTool: tool },
+      memory,
+      outputProcessors: [new DerivedChunkEmitter()],
+    });
+
+    const stream = await agent.stream('Call the tool', {
+      maxSteps: 5,
+      memory: { thread: threadId, resource: resourceId },
+    });
+    const streamedTypes: string[] = [];
+    for await (const chunk of stream.fullStream) {
+      streamedTypes.push(chunk.type);
+    }
+
+    const recalled = await memory.recall({ threadId, resourceId });
+    const persistedParts = recalled.messages.flatMap(message => message.content.parts);
+
+    expect(streamedTypes).toContain('data-processor-status');
+    expect(streamedTypes).toContain('data-processor-transient');
+    expect(persistedParts).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'data-processor-status', data: { source: 'processor' } }),
+      ]),
+    );
+    expect(persistedParts.map(part => part.type)).not.toContain('data-processor-transient');
+  });
+
   it('should receive data-* chunks from tool execute in processOutputStream', async () => {
     const capturedChunkTypes: string[] = [];
     const capturedDataChunks: any[] = [];

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -54,6 +54,25 @@ export function createDestructurableOutput<OUTPUT = undefined>(
   }) as MastraModelOutput<OUTPUT>;
 }
 
+function persistProcessorDataChunk(
+  messageList: MessageList,
+  messageId: string,
+  chunk: { type: string; data?: unknown; transient?: boolean },
+): void {
+  if (!chunk.type.startsWith('data-') || chunk.transient) return;
+
+  const message: MastraDBMessage = {
+    id: messageId,
+    role: 'assistant',
+    content: {
+      format: 2,
+      parts: [{ type: chunk.type as `data-${string}`, data: chunk.data }],
+    },
+    createdAt: new Date(),
+  };
+  messageList.add(message, 'response');
+}
+
 type PromiseResults<OUTPUT = undefined> = Pick<
   LLMStepResult<OUTPUT>,
   | 'text'
@@ -383,7 +402,13 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
               // Create a ProcessorStreamWriter from the controller so processOutputStream can emit custom chunks
               const streamWriter = {
-                custom: async (data: { type: string }) => controller.enqueue(data as ChunkType<OUTPUT>),
+                custom: async (
+                  data: { type: string; data?: unknown; transient?: boolean },
+                  writerOptions?: { messageId?: string },
+                ) => {
+                  persistProcessorDataChunk(self.messageList, writerOptions?.messageId ?? self.messageId, data);
+                  controller.enqueue(data as ChunkType<OUTPUT>);
+                },
               };
 
               const {
@@ -905,7 +930,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                   // Must use both #emitChunk (for fullStream/EventEmitter consumers) and
                   // controller.enqueue (for raw stream consumers) to ensure visibility.
                   const outputResultWriter = {
-                    custom: async (data: { type: string }) => {
+                    custom: async (
+                      data: { type: string; data?: unknown; transient?: boolean },
+                      writerOptions?: { messageId?: string },
+                    ) => {
+                      persistProcessorDataChunk(self.messageList, writerOptions?.messageId ?? self.messageId, data);
                       self.#emitChunk(data as ChunkType<OUTPUT>);
                       controller.enqueue(data as ChunkType<OUTPUT>);
                     },

--- a/packages/core/src/workflows/processor-step.test.ts
+++ b/packages/core/src/workflows/processor-step.test.ts
@@ -307,7 +307,9 @@ describe('createStep with Processor', () => {
       expect(messageList.markResponseMessageBoundary).toHaveBeenCalledTimes(1);
       expect(messageList.addSignal).toHaveBeenCalledWith(expect.objectContaining({ tagName: 'system-reminder' }));
       expect(rotateResponseMessageId).toHaveBeenCalledTimes(1);
-      expect(writer).toHaveBeenCalledWith(expect.objectContaining({ type: 'data-signal', transient: true }));
+      expect(writer).toHaveBeenCalledWith(expect.objectContaining({ type: 'data-signal', transient: true }), {
+        messageId: 'response-2',
+      });
     });
 
     it('should provide sendSignal when phase is inputStep and messageList is synthesized', async () => {

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -32,7 +32,7 @@ import {
   resolveObservabilityContext,
 } from '../observability';
 import { executeWithContext } from '../observability/utils';
-import type { OutputResult, Processor, ProcessorStreamWriter } from '../processors';
+import type { OutputResult, Processor, ProcessorStreamWriter, ProcessorStreamWriterOptions } from '../processors';
 import { ProcessorRunner, ProcessorState } from '../processors/runner';
 import { createProcessorSendSignal } from '../processors/send-signal';
 import {
@@ -980,8 +980,8 @@ function createStepFromProcessor<TProcessorId extends string>(
       // This enables processors to stream data-* parts to the UI in real-time
       const processorWriter: ProcessorStreamWriter | undefined = outputWriter
         ? {
-            custom: async <T extends { type: string }>(data: T) => {
-              await outputWriter(data as any);
+            custom: async <T extends { type: string }>(data: T, options?: ProcessorStreamWriterOptions) => {
+              await outputWriter(data as any, { messageId: options?.messageId ?? currentMessageId });
             },
           }
         : undefined;


### PR DESCRIPTION
Custom data chunks emitted from output processors were streamed to clients but skipped by message persistence, so data such as trace references disappeared from thread history.

Previously, this streamed the chunk without saving it:

\`\`\`ts
await writer.custom({
  type: 'data-trace-context',
  data: { traceId, spanId },
})
\`\`\`

With this change, the same chunk is stored with the assistant message. Chunks explicitly marked with \`transient: true\` remain stream-only.

This also preserves response message IDs through processor workflows, covers direct and tool-derived processor chunks with regression tests, and documents persistence and transient usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When an AI response processor adds “custom data chunks,” those chunks now get saved into the conversation (as part of the assistant message) instead of only being sent to the client during streaming. Chunks marked `transient: true` still stream live, but they’re not saved.

## What changed

- Persist non-transient custom `data-*` chunks emitted by output processors onto the assistant message parts in `MessageList` (durable storage), rather than streaming only.
- Keep message identity consistent by threading `messageId` through processor/workflow writer paths so the processor persistence logic can reuse the correct IDs.
- Apply the same persistence behavior to both:
  - direct processor-emitted custom chunks (during output streaming and final output processing), and
  - custom chunks produced while processing tool/data parts (with `transient: true` still remaining stream-only).
- Update documentation to clarify `writer.custom()` behavior and how `memory` affects persistence (saved unless `transient: true`).

## Tests & documentation

- Added regression tests covering persistence and recall for custom chunks from `processOutputStream` / `processOutputResult`, plus tool-derived processor chunks via `processDataParts`, including verification of `transient: true` behavior.
- Updated processor interface reference docs to reflect the persistence/transient rules and the `writer.custom()` output shape expectations.
- Added a patch changeset for `@mastra/core` describing the persistence fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->