### PR TITLE
fix(mastracode): keep TUI responsive during streamed tools

### DIFF
--- a/.changeset/honest-eagles-sink.md
+++ b/.changeset/honest-eagles-sink.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved Mastra Code responsiveness while tool inputs and command output stream.

--- a/mastracode/tui/package.json
+++ b/mastracode/tui/package.json
@@ -81,6 +81,7 @@
     "prepack": "tsx ../../scripts/generate-package-docs.ts",
     "render-smoke:install": "node scripts/install-render-smoke-settings.mjs",
     "render-smoke:server": "node scripts/render-smoke-server.mjs",
+    "render-smoke:uninstall": "node scripts/uninstall-render-smoke-settings.mjs",
     "test": "vitest",
     "lint": "eslint .",
     "e2e:list": "tsx e2e-list.ts",

--- a/mastracode/tui/package.json
+++ b/mastracode/tui/package.json
@@ -79,6 +79,8 @@
     "check": "tsc --noEmit",
     "build:lib": "tsup --silent --config tsup.config.ts",
     "prepack": "tsx ../../scripts/generate-package-docs.ts",
+    "render-smoke:install": "node scripts/install-render-smoke-settings.mjs",
+    "render-smoke:server": "node scripts/render-smoke-server.mjs",
     "test": "vitest",
     "lint": "eslint .",
     "e2e:list": "tsx e2e-list.ts",

--- a/mastracode/tui/package.json
+++ b/mastracode/tui/package.json
@@ -118,7 +118,7 @@
     "cli-highlight": "^2.1.11",
     "execa": "^9.6.1",
     "fastest-levenshtein": "^1.0.16",
-    "partial-json": "^0.1.7",
+    "jsonriver": "^1.1.1",
     "posthog-node": "^5.37.0",
     "strip-ansi": "^7.2.0",
     "tokenx": "^1.3.0",

--- a/mastracode/tui/package.json
+++ b/mastracode/tui/package.json
@@ -99,7 +99,7 @@
     "@ai-sdk/openai-compatible": "^2.0.56",
     "@ast-grep/napi": "^0.42.0",
     "@aws-sdk/credential-providers": "^3.864.0",
-    "@earendil-works/pi-tui": "^0.79.4",
+    "@earendil-works/pi-tui": "0.80.6",
     "@mastra/agent-browser": "workspace:*",
     "@mastra/code-sdk": "workspace:^",
     "@mastra/core": "workspace:*",

--- a/mastracode/tui/scripts/README.md
+++ b/mastracode/tui/scripts/README.md
@@ -17,6 +17,18 @@ The installer is idempotent and nondestructive:
 - preserves the current active model pack and mode defaults
 - writes a timestamped backup before changing an existing settings file
 
+Uninstall the provider and model pack from global Mastra Code settings:
+
+```sh
+pnpm --filter mastracode render-smoke:uninstall
+```
+
+The uninstaller refuses to remove Render Smoke while it is selected in `models.activeModelPackId` or `models.modeDefaults`. Switch to another model pack first, or force removal and clear those references:
+
+```sh
+RENDER_SMOKE_UNINSTALL_FORCE=1 pnpm --filter mastracode render-smoke:uninstall
+```
+
 Start the mock server:
 
 ```sh

--- a/mastracode/tui/scripts/README.md
+++ b/mastracode/tui/scripts/README.md
@@ -1,0 +1,50 @@
+# Mastra Code scripts
+
+## Render Smoke
+
+Render Smoke is a local OpenAI-compatible streaming mock used to stress-test Mastra Code TUI rendering with large streamed tool arguments.
+
+Install the provider and model pack into global Mastra Code settings:
+
+```sh
+pnpm --filter mastracode render-smoke:install
+```
+
+The installer is idempotent and nondestructive:
+
+- adds/updates the `Render Smoke` custom provider
+- adds/updates the `Render Smoke` custom model pack
+- preserves the current active model pack and mode defaults
+- writes a timestamped backup before changing an existing settings file
+
+Start the mock server:
+
+```sh
+pnpm --filter mastracode render-smoke:server
+```
+
+Default endpoint:
+
+```txt
+http://localhost:8787/v1
+```
+
+Useful environment overrides:
+
+```sh
+PORT=8787 LARGE_SIZE=60000 CHUNK_SIZE=48 DELAY_MS=25 pnpm --filter mastracode render-smoke:server
+```
+
+Prompts to send from Mastra Code after selecting the Render Smoke pack:
+
+```txt
+write a large file
+edit a large file
+run command output
+```
+
+Routes:
+
+- `write` streams a large `write_file` call with `.ts` content.
+- `edit` streams a large `string_replace_lsp` call with `.ts` `old_string` and `new_string` args.
+- `command` / `output` streams a large `execute_command.command` argument.

--- a/mastracode/tui/scripts/README.md
+++ b/mastracode/tui/scripts/README.md
@@ -7,7 +7,7 @@ Render Smoke is a local OpenAI-compatible streaming mock used to stress-test Mas
 Install the provider and model pack into global Mastra Code settings:
 
 ```sh
-pnpm --filter mastracode render-smoke:install
+pnpm --filter ./mastracode/tui render-smoke:install
 ```
 
 The installer is idempotent and nondestructive:
@@ -20,19 +20,19 @@ The installer is idempotent and nondestructive:
 Uninstall the provider and model pack from global Mastra Code settings:
 
 ```sh
-pnpm --filter mastracode render-smoke:uninstall
+pnpm --filter ./mastracode/tui render-smoke:uninstall
 ```
 
 The uninstaller refuses to remove Render Smoke while it is selected in `models.activeModelPackId` or `models.modeDefaults`. Switch to another model pack first, or force removal and clear those references:
 
 ```sh
-RENDER_SMOKE_UNINSTALL_FORCE=1 pnpm --filter mastracode render-smoke:uninstall
+RENDER_SMOKE_UNINSTALL_FORCE=1 pnpm --filter ./mastracode/tui render-smoke:uninstall
 ```
 
 Start the mock server:
 
 ```sh
-pnpm --filter mastracode render-smoke:server
+pnpm --filter ./mastracode/tui render-smoke:server
 ```
 
 Default endpoint:
@@ -43,8 +43,16 @@ http://localhost:8787/v1
 
 Useful environment overrides:
 
+For realistic/manual TUI testing, use a slower stream that is close to the pace of real chats:
+
 ```sh
-PORT=8787 LARGE_SIZE=60000 CHUNK_SIZE=48 DELAY_MS=25 pnpm --filter mastracode render-smoke:server
+PORT=8787 LARGE_SIZE=60000 CHUNK_SIZE=16 DELAY_MS=100 pnpm --filter ./mastracode/tui render-smoke:server
+```
+
+For faster stress testing, increase chunk size and reduce delay:
+
+```sh
+PORT=8787 LARGE_SIZE=60000 CHUNK_SIZE=48 DELAY_MS=25 pnpm --filter ./mastracode/tui render-smoke:server
 ```
 
 Prompts to send from Mastra Code after selecting the Render Smoke pack:

--- a/mastracode/tui/scripts/install-render-smoke-settings.mjs
+++ b/mastracode/tui/scripts/install-render-smoke-settings.mjs
@@ -2,10 +2,9 @@
 import { existsSync } from 'node:fs';
 import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import { homedir } from 'node:os';
+import { getAppDataDir } from '@mastra/code-sdk/utils/project';
 
-const SETTINGS_PATH =
-  process.env.MASTRACODE_SETTINGS_PATH || join(homedir(), 'Library/Application Support/mastracode/settings.json');
+const SETTINGS_PATH = process.env.MASTRACODE_SETTINGS_PATH || join(getAppDataDir(), 'settings.json');
 const PROVIDER_NAME = 'Render Smoke';
 const PROVIDER_URL = process.env.RENDER_SMOKE_URL || 'http://localhost:8787/v1';
 const PROVIDER_API_KEY = process.env.RENDER_SMOKE_API_KEY || 'test';

--- a/mastracode/tui/scripts/install-render-smoke-settings.mjs
+++ b/mastracode/tui/scripts/install-render-smoke-settings.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { copyFile, mkdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+const SETTINGS_PATH =
+  process.env.MASTRACODE_SETTINGS_PATH || join(homedir(), 'Library/Application Support/mastracode/settings.json');
+const PROVIDER_NAME = 'Render Smoke';
+const PROVIDER_URL = process.env.RENDER_SMOKE_URL || 'http://localhost:8787/v1';
+const PROVIDER_API_KEY = process.env.RENDER_SMOKE_API_KEY || 'test';
+const MODEL_ID = 'render-smoke';
+const PACK_MODEL_ID = `${MODEL_ID}/${MODEL_ID}`;
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+async function readSettings() {
+  if (!existsSync(SETTINGS_PATH)) return {};
+  return JSON.parse(await readFile(SETTINGS_PATH, 'utf8'));
+}
+
+async function backupSettingsIfPresent() {
+  if (!existsSync(SETTINGS_PATH)) return null;
+  const backupPath = `${SETTINGS_PATH}.backup-render-smoke-${timestamp()}`;
+  await copyFile(SETTINGS_PATH, backupPath);
+  return backupPath;
+}
+
+function addRenderSmokeProvider(settings) {
+  settings.customProviders ??= [];
+  const existing = settings.customProviders.find(provider => provider?.name === PROVIDER_NAME);
+  if (existing) {
+    let changed = false;
+    if (existing.url !== PROVIDER_URL) {
+      existing.url = PROVIDER_URL;
+      changed = true;
+    }
+    if (existing.apiKey !== PROVIDER_API_KEY) {
+      existing.apiKey = PROVIDER_API_KEY;
+      changed = true;
+    }
+    if (!Array.isArray(existing.models)) {
+      existing.models = [MODEL_ID];
+      changed = true;
+    } else if (!existing.models.includes(MODEL_ID)) {
+      existing.models.push(MODEL_ID);
+      changed = true;
+    }
+    return changed;
+  }
+
+  settings.customProviders.push({
+    name: PROVIDER_NAME,
+    url: PROVIDER_URL,
+    apiKey: PROVIDER_API_KEY,
+    models: [MODEL_ID],
+  });
+  return true;
+}
+
+function addRenderSmokePack(settings) {
+  settings.customModelPacks ??= [];
+  const existing = settings.customModelPacks.find(pack => pack?.name === PROVIDER_NAME);
+  if (existing) {
+    const nextModels = { build: PACK_MODEL_ID, plan: PACK_MODEL_ID, fast: PACK_MODEL_ID };
+    if (JSON.stringify(existing.models) === JSON.stringify(nextModels)) return false;
+    existing.models = nextModels;
+    return true;
+  }
+
+  settings.customModelPacks.push({
+    name: PROVIDER_NAME,
+    models: {
+      build: PACK_MODEL_ID,
+      plan: PACK_MODEL_ID,
+      fast: PACK_MODEL_ID,
+    },
+    createdAt: new Date().toISOString(),
+  });
+  return true;
+}
+
+const before = await readSettings();
+const settings = structuredClone(before);
+const providerChanged = addRenderSmokeProvider(settings);
+const packChanged = addRenderSmokePack(settings);
+const changed = providerChanged || packChanged;
+
+if (!changed) {
+  console.log(`Render Smoke settings already installed at ${SETTINGS_PATH}`);
+  console.log('No changes made.');
+  process.exit(0);
+}
+
+await mkdir(dirname(SETTINGS_PATH), { recursive: true });
+const backupPath = await backupSettingsIfPresent();
+await writeFile(SETTINGS_PATH, `${JSON.stringify(settings, null, 2)}\n`);
+
+console.log(`Installed Render Smoke settings at ${SETTINGS_PATH}`);
+if (backupPath) console.log(`Backup written to ${backupPath}`);
+console.log('Preserved existing activeModelPackId and modeDefaults.');
+console.log(`Provider: ${PROVIDER_NAME} -> ${PROVIDER_URL}`);
+console.log(`Model pack: custom:${PROVIDER_NAME} (${PACK_MODEL_ID})`);

--- a/mastracode/tui/scripts/render-smoke-server.mjs
+++ b/mastracode/tui/scripts/render-smoke-server.mjs
@@ -1,0 +1,211 @@
+#!/usr/bin/env node
+import http from 'node:http';
+
+const PORT = Number(process.env.PORT || 8787);
+const DELAY_MS = Number(process.env.DELAY_MS || 25);
+const CHUNK_SIZE = Number(process.env.CHUNK_SIZE || 48);
+const LARGE_SIZE = Number(process.env.LARGE_SIZE || 60_000);
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function sse(res, value) {
+  res.write(`data: ${JSON.stringify(value)}\n\n`);
+}
+
+function chunkString(value, size) {
+  const chunks = [];
+  for (let i = 0; i < value.length; i += size) chunks.push(value.slice(i, i + size));
+  return chunks;
+}
+
+function getMessageText(message) {
+  return [message?.content]
+    .flat()
+    .map(part => {
+      if (typeof part === 'string') return part;
+      if (part && typeof part === 'object' && 'text' in part) return part.text;
+      return '';
+    })
+    .join('\n');
+}
+
+function getPrompt(messages = []) {
+  const latestUserMessage = [...messages].reverse().find(message => message?.role === 'user');
+  return getMessageText(latestUserMessage ?? messages.at(-1)).toLowerCase();
+}
+
+function makeLargeTypeScriptContent(label) {
+  const lines = [
+    `type RenderSmokeRow = { id: number; label: string; enabled: boolean };`,
+    `export const renderSmokeRows: RenderSmokeRow[] = [`,
+  ];
+  let size = lines.join('\n').length;
+  for (let i = 0; size < LARGE_SIZE; i++) {
+    const line = `  { id: ${i}, label: '${label}_${String(i).padStart(5, '0')}', enabled: ${i % 2 === 0} },`;
+    lines.push(line);
+    size += line.length + 1;
+  }
+  lines.push(`];`);
+  lines.push(`export function getRenderSmokeLabel(id: number): string | undefined {`);
+  lines.push(`  return renderSmokeRows.find(row => row.id === id)?.label;`);
+  lines.push(`}`);
+  return lines.join('\n');
+}
+
+function makeLargeCommand() {
+  const parts = [`node -e "`];
+  let size = parts.join('').length;
+  for (let i = 0; size < LARGE_SIZE; i++) {
+    const part = `console.log('ARG_STREAM_${String(i).padStart(5, '0')}');`;
+    parts.push(part);
+    size += part.length;
+  }
+  parts.push(`"`);
+  return parts.join('');
+}
+
+async function streamToolCall(res, { id, toolName, args }) {
+  const created = Math.floor(Date.now() / 1000);
+  const callId = `call_${Math.random().toString(36).slice(2)}`;
+  const argumentsJson = JSON.stringify(args);
+
+  sse(res, {
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: 'render-smoke',
+    choices: [
+      {
+        index: 0,
+        delta: {
+          role: 'assistant',
+          tool_calls: [{ index: 0, id: callId, type: 'function', function: { name: toolName, arguments: '' } }],
+        },
+        finish_reason: null,
+      },
+    ],
+  });
+
+  for (const part of chunkString(argumentsJson, CHUNK_SIZE)) {
+    sse(res, {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'render-smoke',
+      choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: part } }] }, finish_reason: null }],
+    });
+    if (DELAY_MS > 0) await sleep(DELAY_MS);
+  }
+
+  sse(res, {
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: 'render-smoke',
+    choices: [{ index: 0, delta: {}, finish_reason: 'tool_calls' }],
+  });
+  res.write('data: [DONE]\n\n');
+}
+
+async function streamText(res, text) {
+  const id = `chatcmpl_${Math.random().toString(36).slice(2)}`;
+  const created = Math.floor(Date.now() / 1000);
+  sse(res, {
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: 'render-smoke',
+    choices: [{ index: 0, delta: { role: 'assistant' }, finish_reason: null }],
+  });
+  for (const part of chunkString(text, 80)) {
+    sse(res, {
+      id,
+      object: 'chat.completion.chunk',
+      created,
+      model: 'render-smoke',
+      choices: [{ index: 0, delta: { content: part }, finish_reason: null }],
+    });
+    await sleep(1);
+  }
+  sse(res, {
+    id,
+    object: 'chat.completion.chunk',
+    created,
+    model: 'render-smoke',
+    choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+  });
+  res.write('data: [DONE]\n\n');
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'GET' && (req.url === '/v1/models' || req.url === '/models')) {
+    res.setHeader('content-type', 'application/json');
+    res.end(JSON.stringify({ object: 'list', data: [{ id: 'render-smoke', object: 'model', created: 0, owned_by: 'local' }] }));
+    return;
+  }
+
+  if (req.method !== 'POST' || !req.url?.endsWith('/chat/completions')) {
+    res.statusCode = 404;
+    res.end('not found');
+    return;
+  }
+
+  let body = '';
+  for await (const chunk of req) body += chunk;
+  const request = JSON.parse(body || '{}');
+  const prompt = getPrompt(request.messages);
+
+  res.writeHead(200, {
+    'content-type': 'text/event-stream; charset=utf-8',
+    'cache-control': 'no-cache, no-transform',
+    connection: 'keep-alive',
+    'x-accel-buffering': 'no',
+  });
+
+  const id = `chatcmpl_${Math.random().toString(36).slice(2)}`;
+  if (prompt.includes('write')) {
+    await streamToolCall(res, {
+      id,
+      toolName: 'write_file',
+      args: {
+        path: 'tmp/render-smoke-large.ts',
+        content: makeLargeTypeScriptContent('WRITE_STREAM'),
+        overwrite: true,
+      },
+    });
+  } else if (prompt.includes('edit')) {
+    await streamToolCall(res, {
+      id,
+      toolName: 'string_replace_lsp',
+      args: {
+        path: 'tmp/render-smoke-large.ts',
+        old_string: makeLargeTypeScriptContent('OLD_STREAM'),
+        new_string: makeLargeTypeScriptContent('NEW_STREAM'),
+      },
+    });
+  } else if (prompt.includes('command') || prompt.includes('output')) {
+    await streamToolCall(res, {
+      id,
+      toolName: 'execute_command',
+      args: {
+        command: makeLargeCommand(),
+        timeout: 30,
+        cwd: null,
+        tail: 200,
+        background: false,
+      },
+    });
+  } else {
+    await streamText(res, 'Render Smoke ready. Send a prompt containing write, edit, command, or output.');
+  }
+
+  res.end();
+});
+
+server.listen(PORT, () => {
+  console.log(`Mastra Code Render Smoke mock listening on http://localhost:${PORT}/v1`);
+  console.log('Prompts: "write", "edit", or "command output"');
+  console.log(`LARGE_SIZE=${LARGE_SIZE} CHUNK_SIZE=${CHUNK_SIZE} DELAY_MS=${DELAY_MS}`);
+});

--- a/mastracode/tui/scripts/render-smoke-server.mjs
+++ b/mastracode/tui/scripts/render-smoke-server.mjs
@@ -67,7 +67,9 @@ function makeLargeCommand() {
 }
 
 function makeQuotedCommand() {
-  const parts = [`if [ -f package.json ]; then echo "quoted if then fi ${'TEXT '.repeat(40)}" && printf 'single quoted && || ; ${'MORE '.repeat(40)}' || echo fallback; fi > /tmp/render-smoke-command.txt && node -e "`];
+  const parts = [
+    `if [ -f package.json ]; then echo "quoted if then fi ${'TEXT '.repeat(40)}" && printf 'single quoted && || ; ${'MORE '.repeat(40)}' || echo fallback; fi > /tmp/render-smoke-command.txt && node -e "`,
+  ];
   let size = parts.join('').length;
   for (let i = 0; size < LARGE_SIZE; i++) {
     const part = `console.log('QUOTED_COMMAND_${String(i).padStart(5, '0')} && || if then fi');`;
@@ -106,7 +108,9 @@ async function streamToolCall(res, { id, toolName, args }) {
       object: 'chat.completion.chunk',
       created,
       model: 'render-smoke',
-      choices: [{ index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: part } }] }, finish_reason: null }],
+      choices: [
+        { index: 0, delta: { tool_calls: [{ index: 0, function: { arguments: part } }] }, finish_reason: null },
+      ],
     });
     if (DELAY_MS > 0) await sleep(DELAY_MS);
   }
@@ -154,7 +158,12 @@ async function streamText(res, text) {
 const server = http.createServer(async (req, res) => {
   if (req.method === 'GET' && (req.url === '/v1/models' || req.url === '/models')) {
     res.setHeader('content-type', 'application/json');
-    res.end(JSON.stringify({ object: 'list', data: [{ id: 'render-smoke', object: 'model', created: 0, owned_by: 'local' }] }));
+    res.end(
+      JSON.stringify({
+        object: 'list',
+        data: [{ id: 'render-smoke', object: 'model', created: 0, owned_by: 'local' }],
+      }),
+    );
     return;
   }
 
@@ -222,7 +231,10 @@ const server = http.createServer(async (req, res) => {
       },
     });
   } else {
-    await streamText(res, 'Render Smoke ready. Send a prompt containing write, edit, command, quoted command, shell highlight, or output.');
+    await streamText(
+      res,
+      'Render Smoke ready. Send a prompt containing write, edit, command, quoted command, shell highlight, or output.',
+    );
   }
 
   res.end();

--- a/mastracode/tui/scripts/render-smoke-server.mjs
+++ b/mastracode/tui/scripts/render-smoke-server.mjs
@@ -6,6 +6,19 @@ const DELAY_MS = Number(process.env.DELAY_MS || 25);
 const CHUNK_SIZE = Number(process.env.CHUNK_SIZE || 48);
 const LARGE_SIZE = Number(process.env.LARGE_SIZE || 60_000);
 
+if (!Number.isInteger(PORT) || PORT < 1 || PORT > 65_535) {
+  throw new Error('PORT must be an integer between 1 and 65535');
+}
+if (!Number.isFinite(DELAY_MS) || DELAY_MS < 0) {
+  throw new Error('DELAY_MS must be a non-negative number');
+}
+if (!Number.isInteger(CHUNK_SIZE) || CHUNK_SIZE <= 0) {
+  throw new Error('CHUNK_SIZE must be a positive integer');
+}
+if (!Number.isInteger(LARGE_SIZE) || LARGE_SIZE <= 0) {
+  throw new Error('LARGE_SIZE must be a positive integer');
+}
+
 function sleep(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -240,7 +253,7 @@ const server = http.createServer(async (req, res) => {
   res.end();
 });
 
-server.listen(PORT, () => {
+server.listen(PORT, '127.0.0.1', () => {
   console.log(`Mastra Code Render Smoke mock listening on http://localhost:${PORT}/v1`);
   console.log('Prompts: "write", "edit", "command output", or "quoted command"');
   console.log(`LARGE_SIZE=${LARGE_SIZE} CHUNK_SIZE=${CHUNK_SIZE} DELAY_MS=${DELAY_MS}`);

--- a/mastracode/tui/scripts/render-smoke-server.mjs
+++ b/mastracode/tui/scripts/render-smoke-server.mjs
@@ -66,6 +66,18 @@ function makeLargeCommand() {
   return parts.join('');
 }
 
+function makeQuotedCommand() {
+  const parts = [`if [ -f package.json ]; then echo "quoted if then fi ${'TEXT '.repeat(40)}" && printf 'single quoted && || ; ${'MORE '.repeat(40)}' || echo fallback; fi > /tmp/render-smoke-command.txt && node -e "`];
+  let size = parts.join('').length;
+  for (let i = 0; size < LARGE_SIZE; i++) {
+    const part = `console.log('QUOTED_COMMAND_${String(i).padStart(5, '0')} && || if then fi');`;
+    parts.push(part);
+    size += part.length;
+  }
+  parts.push(`"`);
+  return parts.join('');
+}
+
 async function streamToolCall(res, { id, toolName, args }) {
   const created = Math.floor(Date.now() / 1000);
   const callId = `call_${Math.random().toString(36).slice(2)}`;
@@ -185,6 +197,18 @@ const server = http.createServer(async (req, res) => {
         new_string: makeLargeTypeScriptContent('NEW_STREAM'),
       },
     });
+  } else if (prompt.includes('quoted command') || prompt.includes('shell highlight')) {
+    await streamToolCall(res, {
+      id,
+      toolName: 'execute_command',
+      args: {
+        command: makeQuotedCommand(),
+        timeout: 30,
+        cwd: null,
+        tail: 200,
+        background: false,
+      },
+    });
   } else if (prompt.includes('command') || prompt.includes('output')) {
     await streamToolCall(res, {
       id,
@@ -198,7 +222,7 @@ const server = http.createServer(async (req, res) => {
       },
     });
   } else {
-    await streamText(res, 'Render Smoke ready. Send a prompt containing write, edit, command, or output.');
+    await streamText(res, 'Render Smoke ready. Send a prompt containing write, edit, command, quoted command, shell highlight, or output.');
   }
 
   res.end();
@@ -206,6 +230,6 @@ const server = http.createServer(async (req, res) => {
 
 server.listen(PORT, () => {
   console.log(`Mastra Code Render Smoke mock listening on http://localhost:${PORT}/v1`);
-  console.log('Prompts: "write", "edit", or "command output"');
+  console.log('Prompts: "write", "edit", "command output", or "quoted command"');
   console.log(`LARGE_SIZE=${LARGE_SIZE} CHUNK_SIZE=${CHUNK_SIZE} DELAY_MS=${DELAY_MS}`);
 });

--- a/mastracode/tui/scripts/uninstall-render-smoke-settings.mjs
+++ b/mastracode/tui/scripts/uninstall-render-smoke-settings.mjs
@@ -2,10 +2,9 @@
 import { existsSync } from 'node:fs';
 import { copyFile, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { getAppDataDir } from '@mastra/code-sdk/utils/project';
 
-const SETTINGS_PATH =
-  process.env.MASTRACODE_SETTINGS_PATH || join(homedir(), 'Library/Application Support/mastracode/settings.json');
+const SETTINGS_PATH = process.env.MASTRACODE_SETTINGS_PATH || join(getAppDataDir(), 'settings.json');
 const PROVIDER_NAME = 'Render Smoke';
 const ACTIVE_PACK_ID = `custom:${PROVIDER_NAME}`;
 const MODEL_ID = 'render-smoke';

--- a/mastracode/tui/scripts/uninstall-render-smoke-settings.mjs
+++ b/mastracode/tui/scripts/uninstall-render-smoke-settings.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { copyFile, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const SETTINGS_PATH =
+  process.env.MASTRACODE_SETTINGS_PATH || join(homedir(), 'Library/Application Support/mastracode/settings.json');
+const PROVIDER_NAME = 'Render Smoke';
+const ACTIVE_PACK_ID = `custom:${PROVIDER_NAME}`;
+const MODEL_ID = 'render-smoke';
+const PACK_MODEL_ID = `${MODEL_ID}/${MODEL_ID}`;
+const FORCE = process.env.RENDER_SMOKE_UNINSTALL_FORCE === '1';
+
+function timestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+async function readSettings() {
+  if (!existsSync(SETTINGS_PATH)) return null;
+  return JSON.parse(await readFile(SETTINGS_PATH, 'utf8'));
+}
+
+async function backupSettings() {
+  const backupPath = `${SETTINGS_PATH}.backup-render-smoke-uninstall-${timestamp()}`;
+  await copyFile(SETTINGS_PATH, backupPath);
+  return backupPath;
+}
+
+function getRenderSmokeRefs(settings) {
+  const refs = [];
+  if (settings.models?.activeModelPackId === ACTIVE_PACK_ID) refs.push('models.activeModelPackId');
+  for (const key of ['build', 'plan', 'fast']) {
+    if (settings.models?.modeDefaults?.[key] === PACK_MODEL_ID) refs.push(`models.modeDefaults.${key}`);
+  }
+  return refs;
+}
+
+function removeRenderSmoke(settings) {
+  let changed = false;
+
+  if (Array.isArray(settings.customProviders)) {
+    const nextProviders = settings.customProviders.filter(provider => provider?.name !== PROVIDER_NAME);
+    changed = changed || nextProviders.length !== settings.customProviders.length;
+    settings.customProviders = nextProviders;
+  }
+
+  if (Array.isArray(settings.customModelPacks)) {
+    const nextPacks = settings.customModelPacks.filter(pack => pack?.name !== PROVIDER_NAME);
+    changed = changed || nextPacks.length !== settings.customModelPacks.length;
+    settings.customModelPacks = nextPacks;
+  }
+
+  return changed;
+}
+
+function clearForcedRefs(settings) {
+  let changed = false;
+  if (settings.models?.activeModelPackId === ACTIVE_PACK_ID) {
+    delete settings.models.activeModelPackId;
+    changed = true;
+  }
+  for (const key of ['build', 'plan', 'fast']) {
+    if (settings.models?.modeDefaults?.[key] === PACK_MODEL_ID) {
+      delete settings.models.modeDefaults[key];
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+const settings = await readSettings();
+if (!settings) {
+  console.log(`No Mastra Code settings found at ${SETTINGS_PATH}`);
+  console.log('No changes made.');
+  process.exit(0);
+}
+
+const refs = getRenderSmokeRefs(settings);
+if (refs.length > 0 && !FORCE) {
+  console.error('Render Smoke is still selected in settings:');
+  for (const ref of refs) console.error(`- ${ref}`);
+  console.error('Switch to another model pack first, then rerun uninstall.');
+  console.error('Or run with RENDER_SMOKE_UNINSTALL_FORCE=1 to remove it and clear those references.');
+  process.exit(1);
+}
+
+const removed = removeRenderSmoke(settings);
+const clearedRefs = FORCE && clearForcedRefs(settings);
+const changed = removed || clearedRefs;
+if (!changed) {
+  console.log(`Render Smoke settings are not installed at ${SETTINGS_PATH}`);
+  console.log('No changes made.');
+  process.exit(0);
+}
+
+const backupPath = await backupSettings();
+await writeFile(SETTINGS_PATH, `${JSON.stringify(settings, null, 2)}\n`);
+
+console.log(`Uninstalled Render Smoke settings from ${SETTINGS_PATH}`);
+console.log(`Backup written to ${backupPath}`);
+if (FORCE && refs.length > 0) console.log(`Cleared references: ${refs.join(', ')}`);

--- a/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
+++ b/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
@@ -55,6 +55,21 @@ describe('RenderScheduler', () => {
     vi.useRealTimers();
   });
 
+  it('ignores requests and flushes after disposal', () => {
+    vi.useFakeTimers();
+    const render = vi.fn();
+    const scheduler = new RenderScheduler(render);
+
+    scheduler.request();
+    scheduler.dispose();
+    scheduler.request();
+    scheduler.flush();
+    vi.runAllTimers();
+
+    expect(render).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
   it('uses only the scheduler when one is present', () => {
     const legacyRender = vi.fn();
     const scheduler = { request: vi.fn(), flush: vi.fn() } as unknown as RenderScheduler;

--- a/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
+++ b/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { RenderScheduler, flushRender, requestRender } from '../render-scheduler.js';
+
+describe('RenderScheduler', () => {
+  it('coalesces bursty render requests into one delayed render inside the throttle window', () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const render = vi.fn();
+    const scheduler = new RenderScheduler(render, 80, () => now);
+
+    scheduler.request();
+    expect(render).toHaveBeenCalledTimes(1);
+
+    now += 10;
+    scheduler.request();
+    scheduler.request();
+    scheduler.request();
+    expect(render).toHaveBeenCalledTimes(1);
+
+    vi.advanceTimersByTime(69);
+    expect(render).toHaveBeenCalledTimes(1);
+
+    now += 70;
+    vi.advanceTimersByTime(1);
+    expect(render).toHaveBeenCalledTimes(2);
+
+    scheduler.dispose();
+    vi.useRealTimers();
+  });
+
+  it('flushes immediately and cancels a pending coalesced render', () => {
+    vi.useFakeTimers();
+    let now = 1_000;
+    const render = vi.fn();
+    const scheduler = new RenderScheduler(render, 80, () => now);
+
+    scheduler.request();
+    now += 10;
+    scheduler.request();
+
+    scheduler.flush();
+    expect(render).toHaveBeenCalledTimes(2);
+
+    now += 80;
+    vi.advanceTimersByTime(80);
+    expect(render).toHaveBeenCalledTimes(2);
+
+    scheduler.dispose();
+    vi.useRealTimers();
+  });
+
+  it('falls back to direct ui rendering when no scheduler is present', () => {
+    const render = vi.fn();
+    const state = { ui: { requestRender: render } };
+
+    requestRender(state);
+    flushRender(state);
+
+    expect(render).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
+++ b/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
@@ -10,6 +10,11 @@ describe('RenderScheduler', () => {
     const scheduler = new RenderScheduler(render, 80, () => now);
 
     scheduler.request();
+    scheduler.request();
+    scheduler.request();
+    expect(render).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(0);
     expect(render).toHaveBeenCalledTimes(1);
 
     now += 10;
@@ -40,11 +45,11 @@ describe('RenderScheduler', () => {
     scheduler.request();
 
     scheduler.flush();
-    expect(render).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenCalledTimes(1);
 
     now += 80;
     vi.advanceTimersByTime(80);
-    expect(render).toHaveBeenCalledTimes(2);
+    expect(render).toHaveBeenCalledTimes(1);
 
     scheduler.dispose();
     vi.useRealTimers();

--- a/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
+++ b/mastracode/tui/src/tui/__tests__/render-scheduler.test.ts
@@ -55,6 +55,19 @@ describe('RenderScheduler', () => {
     vi.useRealTimers();
   });
 
+  it('uses only the scheduler when one is present', () => {
+    const legacyRender = vi.fn();
+    const scheduler = { request: vi.fn(), flush: vi.fn() } as unknown as RenderScheduler;
+    const state = { ui: { requestRender: legacyRender }, renderScheduler: scheduler };
+
+    requestRender(state);
+    flushRender(state);
+
+    expect(scheduler.request).toHaveBeenCalledOnce();
+    expect(scheduler.flush).toHaveBeenCalledOnce();
+    expect(legacyRender).not.toHaveBeenCalled();
+  });
+
   it('falls back to direct ui rendering when no scheduler is present', () => {
     const render = vi.fn();
     const state = { ui: { requestRender: render } };

--- a/mastracode/tui/src/tui/__tests__/status-line.test.ts
+++ b/mastracode/tui/src/tui/__tests__/status-line.test.ts
@@ -389,7 +389,7 @@ describe('updateStatusLine', () => {
     expect(rendered).toContain('judge');
     expect(rendered).toContain('openai/gpt-5.4-mini');
     expect(rendered).not.toContain('goal');
-    expect(rendered).not.toContain('claude-sonnet-4-20250514');
+    expect(rendered).not.toContain('anthropic/claude-sonnet-4-20250514');
     expect(chalkRgbMock).toHaveBeenCalledWith(53, 117, 221);
   });
 
@@ -536,7 +536,7 @@ describe('updateStatusLine', () => {
     expect(rendered).toContain('gpt-5.4-mini');
     expect(rendered).not.toContain('observe');
     expect(rendered).not.toContain('━');
-    expect(rendered).not.toContain('claude-sonnet-4-20250514');
+    expect(rendered).not.toContain('anthropic/claude-sonnet-4-20250514');
   });
 
   it('renders one unified context indicator with combined totals and savings', () => {
@@ -583,8 +583,9 @@ describe('updateStatusLine', () => {
     expect(rendered).not.toContain('━━━━━━━━━━');
   });
 
-  it('animates only the message segment while keeping the middle, model, badge, and text static', () => {
+  it('keeps the provider animation active while animating the message segment', () => {
     const state = createState();
+    process.stdout.columns = 200;
     state.controller.listModes.mockReturnValue([
       { id: 'build', name: 'build', metadata: { color: '#00ff00' } },
       { id: 'plan', name: 'plan', metadata: { color: '#0000ff' } },
@@ -600,14 +601,23 @@ describe('updateStatusLine', () => {
 
     updateStatusLine(state);
 
-    expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
+    expect(applyGradientSweepMock).toHaveBeenCalledTimes(2);
+    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual([
+      'anthropic/claude-sonnet-4-20250514',
+      '━━━',
+    ]);
     expect(applyGradientSweepMock).toHaveBeenCalledWith('━━━', 0.5, '#00ff00', 0);
     const rendered = state.statusLine.setText.mock.calls[0]?.[0];
     expect(rendered).toContain('━━<sweep>━━━</sweep>━━━━━  60/120k↓ ');
   });
 
-  it('animates only the memory segment', () => {
+  it('keeps the provider animation active while animating the memory segment', () => {
     const state = createState();
+    process.stdout.columns = 200;
+    state.controller.listModes.mockReturnValue([
+      { id: 'build', name: 'build', metadata: { color: '#00ff00' } },
+      { id: 'plan', name: 'plan', metadata: { color: '#0000ff' } },
+    ]);
     const displayState = state.session.displayState.get();
     state.session.displayState.get.mockReturnValue({ ...displayState, bufferingObservations: true });
     state.gradientAnimator = {
@@ -618,12 +628,21 @@ describe('updateStatusLine', () => {
 
     updateStatusLine(state);
 
-    expect(applyGradientSweepMock).toHaveBeenCalledTimes(1);
+    expect(applyGradientSweepMock).toHaveBeenCalledTimes(2);
+    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual([
+      'anthropic/claude-sonnet-4-20250514',
+      '━━',
+    ]);
     expect(applyGradientSweepMock).toHaveBeenCalledWith('━━', 0.25, '#2563eb', 0.1);
   });
 
-  it('animates both occupied segments independently when both buffers are active', () => {
+  it('keeps the provider animation active while animating both occupied segments', () => {
     const state = createState();
+    process.stdout.columns = 200;
+    state.controller.listModes.mockReturnValue([
+      { id: 'build', name: 'build', metadata: { color: '#00ff00' } },
+      { id: 'plan', name: 'plan', metadata: { color: '#0000ff' } },
+    ]);
     const displayState = state.session.displayState.get();
     state.session.displayState.get.mockReturnValue({
       ...displayState,
@@ -638,7 +657,11 @@ describe('updateStatusLine', () => {
 
     updateStatusLine(state);
 
-    expect(applyGradientSweepMock).toHaveBeenCalledTimes(2);
-    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual(['━━', '━━━']);
+    expect(applyGradientSweepMock).toHaveBeenCalledTimes(3);
+    expect(applyGradientSweepMock.mock.calls.map(call => call[0])).toEqual([
+      'anthropic/claude-sonnet-4-20250514',
+      '━━',
+      '━━━',
+    ]);
   });
 });

--- a/mastracode/tui/src/tui/__tests__/tokens-per-sec.test.ts
+++ b/mastracode/tui/src/tui/__tests__/tokens-per-sec.test.ts
@@ -34,6 +34,7 @@ vi.mock('../handlers/index.js', () => ({
   handleToolInputDelta: vi.fn(),
   handleToolInputEnd: vi.fn(),
   handleToolEnd: vi.fn(),
+  clearPendingShellOutputs: vi.fn(),
   clearToolInputParsers: vi.fn(),
 }));
 
@@ -46,6 +47,7 @@ vi.mock('@mastra/code-sdk/utils/project', () => ({
 }));
 
 import { dispatchEvent } from '../event-dispatch.js';
+import * as handlers from '../handlers/index.js';
 import type { TUIState } from '../state.js';
 
 function createMinimalState(overrides: Partial<TUIState> = {}): TUIState {
@@ -107,6 +109,7 @@ async function decodeStep(
 describe('tokens/sec decode-window calculation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.clearAllMocks();
   });
 
   afterEach(() => {
@@ -231,6 +234,23 @@ describe('tokens/sec decode-window calculation', () => {
     // Step 3: 30 tokens / 1s = 30 instantaneous. EMA = 0.3*30 + 0.7*13 = 18.1 → 18.
     await decodeStep(state, ectx, { startMs: 5000, endMs: 6000, completionTokens: 30 });
     expect(state.tokensPerSec).toBe(18);
+  });
+
+  it('clears pending shell output timers on agent_start and terminal abort/error ends', async () => {
+    const state = createMinimalState();
+    const ectx = createEctx();
+
+    await dispatchEvent({ type: 'agent_start' } as any, ectx, state);
+    expect(handlers.clearPendingShellOutputs).toHaveBeenCalledTimes(1);
+
+    await dispatchEvent({ type: 'agent_end', reason: 'aborted' } as any, ectx, state);
+    expect(handlers.clearPendingShellOutputs).toHaveBeenCalledTimes(2);
+
+    await dispatchEvent({ type: 'agent_end', reason: 'error' } as any, ectx, state);
+    expect(handlers.clearPendingShellOutputs).toHaveBeenCalledTimes(3);
+
+    await dispatchEvent({ type: 'agent_end', reason: 'done' } as any, ectx, state);
+    expect(handlers.clearPendingShellOutputs).toHaveBeenCalledTimes(3);
   });
 
   it('keeps the last rate after agent_end and clears it on the next agent_start', async () => {

--- a/mastracode/tui/src/tui/__tests__/tokens-per-sec.test.ts
+++ b/mastracode/tui/src/tui/__tests__/tokens-per-sec.test.ts
@@ -34,6 +34,7 @@ vi.mock('../handlers/index.js', () => ({
   handleToolInputDelta: vi.fn(),
   handleToolInputEnd: vi.fn(),
   handleToolEnd: vi.fn(),
+  clearToolInputParsers: vi.fn(),
 }));
 
 vi.mock('../state.js', () => ({

--- a/mastracode/tui/src/tui/components/__tests__/custom-editor.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/custom-editor.test.ts
@@ -733,6 +733,22 @@ describe('CustomEditor voice push-to-talk', () => {
     expect(requestRender).toHaveBeenCalledTimes(1); // only the stop's own render
   });
 
+  it('uses only the assigned render callback for listening animation', () => {
+    const fallbackRender = vi.fn();
+    const assignedRender = vi.fn();
+    const editor = new CustomEditor({ requestRender: fallbackRender } as any, {} as any);
+    editor.requestRender = assignedRender;
+
+    editor.setVoiceListening(true);
+    fallbackRender.mockClear();
+    assignedRender.mockClear();
+    vi.advanceTimersByTime(120);
+
+    expect(assignedRender).toHaveBeenCalledOnce();
+    expect(fallbackRender).not.toHaveBeenCalled();
+    editor.setVoiceListening(false);
+  });
+
   it('renders dictated text greyed-out and stops greying once edited', async () => {
     const { theme } = await import('../../theme.js');
     const [r, g, b] = theme

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -110,8 +110,8 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(stripAnsi(output)).toContain('│ const value =');
   });
 
-  it('caps quiet write previews before highlighting large streamed content', () => {
-    const hugeContent = `${'a'.repeat(2_500)}END_SHOULD_NOT_RENDER`;
+  it('shows a rolling tail for large quiet write previews', () => {
+    const hugeContent = `START_SHOULD_NOT_RENDER${'a'.repeat(2_500)}END_SHOULD_RENDER`;
     const component = new ToolExecutionComponentEnhanced(
       'write_file',
       { path: 'src/large.ts', content: hugeContent },
@@ -122,7 +122,9 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     const output = stripAnsi(component.render(120).join('\n'));
     expect(output).toContain('write');
     expect(output).toContain('src/large.ts');
-    expect(output).not.toContain('END_SHOULD_NOT_RENDER');
+    expect(output).toContain('…');
+    expect(output).toContain('END_SHOULD_RENDER');
+    expect(output).not.toContain('START_SHOULD_NOT_RENDER');
   });
 
   it('shows exactly the immediate dirname and filename once continuation paths are available', () => {

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -925,21 +925,23 @@ Test plan:
     expect(output).toContain(theme.fg('toolArgs', '-f'));
   });
 
-  it('shows a rolling tail for large partial quiet shell command footers', () => {
-    const command = `node -e "${'START '.repeat(600)}${'MIDDLE '.repeat(600)}"`;
+  it('shows the full growing shell command while bounding syntax highlighting', () => {
+    const command = `printf START-${'x'.repeat(2_100)}-then-LATEST`;
     const component = new ToolExecutionComponentEnhanced(
       'execute_command',
-      { command },
+      { command: 'printf START-' },
       { quietDisplayMode: 'quiet', collapsedByDefault: true },
       ui,
     );
 
-    component.updateArgs({ command: `${command}${'LATEST '.repeat(20)}` }, true);
+    component.updateArgs({ command }, true);
 
-    const visible = stripAnsi(component.render(100).join('\n'));
-    expect(visible).toContain('…');
+    const output = component.render(100).join('\n');
+    const visible = stripAnsi(output);
+    expect(visible).toContain('START-');
     expect(visible).toContain('LATEST');
-    expect(visible).not.toContain('START');
+    expect(visible).not.toContain('…');
+    expect(output).not.toContain(chalk.blue('then'));
   });
 
   it('keeps shell keywords inside quoted strings highlighted as strings', () => {

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -110,6 +110,21 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(stripAnsi(output)).toContain('│ const value =');
   });
 
+  it('caps quiet write previews before highlighting large streamed content', () => {
+    const hugeContent = `${'a'.repeat(2_500)}END_SHOULD_NOT_RENDER`;
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: 'src/large.ts', content: hugeContent },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 8, collapsedByDefault: true },
+      ui,
+    );
+
+    const output = stripAnsi(component.render(120).join('\n'));
+    expect(output).toContain('write');
+    expect(output).toContain('src/large.ts');
+    expect(output).not.toContain('END_SHOULD_NOT_RENDER');
+  });
+
   it('shows exactly the immediate dirname and filename once continuation paths are available', () => {
     const component = new ToolExecutionComponentEnhanced(
       'view',

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -110,21 +110,25 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(stripAnsi(output)).toContain('│ const value =');
   });
 
-  it('shows a rolling tail for large quiet write previews', () => {
-    const hugeContent = `START_SHOULD_NOT_RENDER${'a'.repeat(2_500)}END_SHOULD_RENDER`;
+  it('shows the latest complete lines for large quiet write previews', () => {
+    const hugeContent = Array.from(
+      { length: 120 },
+      (_, index) => `const row${index} = { id: ${index}, label: 'WRITE_STREAM_${String(index).padStart(5, '0')}' };`,
+    ).join('\n');
     const component = new ToolExecutionComponentEnhanced(
       'write_file',
       { path: 'src/large.ts', content: hugeContent },
-      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 8, collapsedByDefault: true },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
       ui,
     );
 
-    const output = stripAnsi(component.render(120).join('\n'));
-    expect(output).toContain('write');
-    expect(output).toContain('src/large.ts');
-    expect(output).toContain('…');
-    expect(output).toContain('END_SHOULD_RENDER');
-    expect(output).not.toContain('START_SHOULD_NOT_RENDER');
+    const output = component.render(120).join('\n');
+    const visible = stripAnsi(output);
+    expect(output).toContain('\u001b[');
+    expect(visible).toContain('write');
+    expect(visible).toContain('src/large.ts');
+    expect(visible).toContain('WRITE_STREAM_00119');
+    expect(visible).not.toContain('WRITE_STREAM_00000');
   });
 
   it('shows exactly the immediate dirname and filename once continuation paths are available', () => {

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -1005,7 +1005,6 @@ Test plan:
     const footerLines = output.split('\n').filter(line => line.startsWith('│') && line.trim() !== '│');
     expect(output).not.toContain('…');
     expect(output).toContain('--reporter=dot');
-    expect(component.render(60).join('\n')).toContain(theme.fg('toolArgs', '--reporter=dot'));
     expect(footerLines.length).toBeGreaterThan(1);
     expect(footerLines[0]).toContain('│ $ pnpm');
     expect(footerLines[1]).toMatch(/^│   \S/);

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -924,6 +924,23 @@ Test plan:
     expect(output).toContain(theme.fg('toolArgs', '-f'));
   });
 
+  it('shows a rolling tail for large partial quiet shell command footers', () => {
+    const command = `node -e "${'START '.repeat(600)}${'MIDDLE '.repeat(600)}"`;
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    component.updateArgs({ command: `${command}${'LATEST '.repeat(20)}` }, true);
+
+    const visible = stripAnsi(component.render(100).join('\n'));
+    expect(visible).toContain('…');
+    expect(visible).toContain('LATEST');
+    expect(visible).not.toContain('START');
+  });
+
   it('keeps shell keywords inside quoted strings highlighted as strings', () => {
     const command = 'echo "if then fi" && printf \'done\'';
     const component = new ToolExecutionComponentEnhanced(

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -972,6 +972,21 @@ Test plan:
     expect(output).toContain(chalk.white("'done'"));
   });
 
+  it('closes double quotes after an even run of backslashes', () => {
+    const command = 'echo "path\\\\" && then';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(100).join('\n');
+    expect(stripAnsi(output)).toContain(command);
+    expect(output).toContain(chalk.white('"path\\\\"'));
+    expect(output).toContain(chalk.blue('then'));
+  });
+
   it('highlights shell control words and numbers outside quoted strings', () => {
     const command = 'for item in 1 2 3; do echo "while 99"; done';
     const component = new ToolExecutionComponentEnhanced(

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -131,6 +131,18 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(visible).not.toContain('WRITE_STREAM_00000');
   });
 
+  it('keeps the beginning of a growing single-line write preview visible', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: 'src/large.ts', content: `const stableStart = '${'x'.repeat(3_000)}';` },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    const visible = stripAnsi(component.render(120).join('\n'));
+    expect(visible).toContain('const stableStart');
+  });
+
   it('shows old_string while large quiet edit new_string has not streamed yet', () => {
     const oldString = Array.from(
       { length: 80 },

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -868,7 +868,8 @@ Test plan:
 
     const visible = stripAnsi(rendered.join('\n'));
     expect(visible).toContain('This follows up on the');
-    expect(visible).toContain('quiet-mode terminal rendering work.');
+    expect(visible).toContain('quiet-mode');
+    expect(visible).toContain('rendering work.');
     expect(visible).not.toContain('…');
     expect(boxLines.length).toBeGreaterThan(3);
     expect(boxLines.every(line => visibleWidth(line) === topWidth)).toBe(true);

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -131,6 +131,27 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(visible).not.toContain('WRITE_STREAM_00000');
   });
 
+  it('shows old_string while large quiet edit new_string has not streamed yet', () => {
+    const oldString = Array.from(
+      { length: 80 },
+      (_, index) => `const oldRow${index} = { id: ${index}, label: 'OLD_STREAM_${String(index).padStart(5, '0')}' };`,
+    ).join('\n');
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: 'src/large.ts', old_string: oldString },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(120).join('\n');
+    const visible = stripAnsi(output);
+    expect(output).toContain('\u001b[');
+    expect(visible).toContain('edit');
+    expect(visible).toContain('src/large.ts');
+    expect(visible).toContain('OLD_STREAM_00079');
+    expect(visible).not.toContain('OLD_STREAM_00000');
+  });
+
   it('shows exactly the immediate dirname and filename once continuation paths are available', () => {
     const component = new ToolExecutionComponentEnhanced(
       'view',
@@ -529,7 +550,9 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     );
 
     let lines = component.render(100);
-    expect(lines).toHaveLength(1);
+    expect(lines).toHaveLength(3);
+    expect(stripAnsi(lines[1]!)).toContain('old value');
+    expect(stripAnsi(lines[2]!)).toContain('╰──');
 
     component.updateArgs({ path: 'src/example.ts', old_string: 'old value', new_string: 'new value\nmore' });
     lines = component.render(100);

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -957,6 +957,25 @@ Test plan:
     expect(output).toContain(chalk.white("'done'"));
   });
 
+  it('highlights shell control words and numbers outside quoted strings', () => {
+    const command = 'for item in 1 2 3; do echo "while 99"; done';
+    const component = new ToolExecutionComponentEnhanced(
+      'execute_command',
+      { command },
+      { quietDisplayMode: 'quiet', collapsedByDefault: true },
+      ui,
+    );
+
+    const output = component.render(100).join('\n');
+    expect(stripAnsi(output)).toContain(command);
+    expect(output).toContain(chalk.blue('for'));
+    expect(output).toContain(chalk.blue('in'));
+    expect(output).toContain(chalk.white('1'));
+    expect(output).toContain(chalk.white('3'));
+    expect(output).toContain(chalk.white('"while 99"'));
+    expect(output).not.toContain(chalk.blue('while'));
+  });
+
   it('keeps quoted shell strings highlighted after wrapping', () => {
     const command = `echo "${'quoted '.repeat(40)}if then fi"`;
     const component = new ToolExecutionComponentEnhanced(

--- a/mastracode/tui/src/tui/components/custom-editor.ts
+++ b/mastracode/tui/src/tui/components/custom-editor.ts
@@ -168,7 +168,11 @@ export class CustomEditor extends Editor {
   private lastPromptWasInvisible = false;
 
   private requestEditorRender(): void {
-    this.requestRender?.() ?? this.tui.requestRender();
+    if (this.requestRender) {
+      this.requestRender();
+      return;
+    }
+    this.tui.requestRender();
   }
 
   constructor(tui: TUI, theme: EditorTheme) {

--- a/mastracode/tui/src/tui/components/custom-editor.ts
+++ b/mastracode/tui/src/tui/components/custom-editor.ts
@@ -126,6 +126,7 @@ export class CustomEditor extends Editor {
   public onImagePaste?: (image: ClipboardImage) => void;
   public getModeColor?: () => string | undefined;
   public getPromptAnimator?: () => GradientAnimator | undefined;
+  public requestRender?: () => void;
   private pendingBracketedPaste: string | null = null;
 
   /**
@@ -165,6 +166,10 @@ export class CustomEditor extends Editor {
   private _cachedColorFn?: (s: string) => string;
   private promptIcon = DEFAULT_PROMPT_ICON;
   private lastPromptWasInvisible = false;
+
+  private requestEditorRender(): void {
+    this.requestRender?.() ?? this.tui.requestRender();
+  }
 
   constructor(tui: TUI, theme: EditorTheme) {
     super(tui, theme);
@@ -703,7 +708,7 @@ export class CustomEditor extends Editor {
     this.setCursorOffset(this.voicePrefix.length + payload.length);
     // Programmatic insertion mutates editor state but does not repaint on its
     // own, so force a render to show the transcript immediately.
-    this.tui.requestRender();
+    this.requestEditorRender();
   }
 
   /**
@@ -799,13 +804,13 @@ export class CustomEditor extends Editor {
       this.voiceListenPhase = 0;
       this.voiceListenTimer ??= setInterval(() => {
         this.voiceListenPhase += 1;
-        this.tui.requestRender();
+        this.requestEditorRender();
       }, 120);
     } else if (this.voiceListenTimer) {
       clearInterval(this.voiceListenTimer);
       this.voiceListenTimer = null;
     }
-    this.tui.requestRender();
+    this.requestEditorRender();
   }
 
   /**

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -51,8 +51,7 @@ const COMPACT_TOOL_COLOR = mastra.orange;
 const COMPACT_TOOL_ARGS_BG = '#141414';
 const QUIET_TOOL_RAIL = tintHex(COMPACT_TOOL_COLOR, 0.35);
 const QUIET_CODE_PREVIEW_MAX_CHARS = 2_000;
-const QUIET_SHELL_COMMAND_PREVIEW_TRUNCATE_AT_CHARS = 2_000;
-const QUIET_SHELL_COMMAND_PREVIEW_MAX_CHARS = 500;
+const QUIET_SHELL_COMMAND_HIGHLIGHT_MAX_CHARS = 2_000;
 
 function normalizeHexColor(color: string | undefined): string | undefined {
   if (!color || !/^#[0-9a-f]{6}$/i.test(color)) return undefined;
@@ -583,11 +582,14 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     const lines: string[] = [];
     let current = '';
     let currentWidth = 0;
+    let highlightedChars = 0;
     let quote: 'single' | 'double' | undefined;
 
     const pushCurrent = () => {
-      const highlighted = this.highlightQuietShellCommandLine(current, quote);
-      lines.push(highlighted.line);
+      const highlightLength = Math.min(current.length, QUIET_SHELL_COMMAND_HIGHLIGHT_MAX_CHARS - highlightedChars);
+      const highlighted = this.highlightQuietShellCommandLine(current.slice(0, highlightLength), quote);
+      lines.push(highlighted.line + current.slice(highlightLength));
+      highlightedChars += highlightLength;
       quote = highlighted.quote;
       current = '';
       currentWidth = 0;
@@ -764,11 +766,6 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
       this.getLatestCodePreview('old_str') ||
       this.getLatestCodePreview('old_string')
     );
-  }
-
-  private getQuietShellCommandPreview(command: string): string {
-    if (!this.isPartial || command.length <= QUIET_SHELL_COMMAND_PREVIEW_TRUNCATE_AT_CHARS) return command;
-    return `…${command.slice(-QUIET_SHELL_COMMAND_PREVIEW_MAX_CHARS)}`;
   }
 
   private getLatestCodePreview(key: string): string {
@@ -1399,11 +1396,10 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     // Strip "cd $CWD && " from the start since we show cwd in the footer
     const cdPattern = /^cd\s+[^\s]+\s+&&\s+/;
     command = command.replace(cdPattern, '');
-    const displayCommand = this.getQuietShellCommandPreview(command);
 
     // Extract tail value from command (e.g., "| tail -5" or "| tail -n 5")
     let maxStreamLines: number | undefined;
-    const tailMatch = displayCommand.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/);
+    const tailMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/);
     if (tailMatch) {
       maxStreamLines = Math.abs(parseInt(tailMatch[1]!, 10));
     }
@@ -1434,7 +1430,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
         this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
       }
       const footerWrapWidth = Math.max(1, contentWidth - 4);
-      const footerLines = this.wrapQuietShellCommand(displayCommand, footerWrapWidth);
+      const footerLines = this.wrapQuietShellCommand(command, footerWrapWidth);
       const footerSuffixWidth = visibleWidth(footerSuffix);
       footerLines.forEach((footerLine, index) => {
         const prefix = index === 0 ? footerPrompt : '  ';

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -549,14 +549,17 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
     for (let index = 0; index < line.length; index++) {
       const char = line[index]!;
-      const previous = index > 0 ? line[index - 1] : undefined;
 
       if (activeQuote) {
         quoted += char;
-        if (
-          previous !== '\\' &&
-          ((activeQuote === 'single' && char === "'") || (activeQuote === 'double' && char === '"'))
-        ) {
+        let precedingBackslashes = 0;
+        for (let cursor = index - 1; cursor >= 0 && line[cursor] === '\\'; cursor--) {
+          precedingBackslashes++;
+        }
+        const closesQuote =
+          (activeQuote === 'single' && char === "'") ||
+          (activeQuote === 'double' && char === '"' && precedingBackslashes % 2 === 0);
+        if (closesQuote) {
           flushQuoted();
           activeQuote = undefined;
         }

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -520,6 +520,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     if (token === '(' || token === ')' || token === '<' || token === '>') {
       return theme.fg('muted', token);
     }
+    if (/^\d+(?:\.\d+)?$/.test(token)) return chalk.white(token);
     if (SHELL_CONTROL_WORDS.has(token)) return chalk.blue(token);
     return theme.fg('toolArgs', token);
   }
@@ -535,8 +536,9 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
     const flushPlain = () => {
       if (!plain) return;
-      highlighted += plain.replace(/&&|\|\||[|;&()<>]|-{1,2}[a-zA-Z0-9_.=/-]+|\b[a-zA-Z_][a-zA-Z0-9_]*\b/g, token =>
-        this.highlightQuietShellCommandToken(token),
+      highlighted += plain.replace(
+        /&&|\|\||[|;&()<>]|-{1,2}[a-zA-Z0-9_.=/-]+|\b\d+(?:\.\d+)?\b|\b[a-zA-Z_][a-zA-Z0-9_]*\b/g,
+        token => this.highlightQuietShellCommandToken(token),
       );
       plain = '';
     };

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -464,29 +464,10 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
   private getQuietCodePreviewLines(preview: string, maxLineWidth: number): string[] {
     const linePrefix = `  ${chalk.hex(this.getQuietToolRailColor())('│')} `;
-    const isTailPreview = preview.startsWith('…');
     return this.highlightQuietCodePreview(preview)
       .split('\n')
       .slice(-this.quietPreviewLineLimit)
-      .map(line =>
-        isTailPreview
-          ? `${linePrefix}${this.truncatePlainLineFromStart(this.stripAnsi(line), maxLineWidth - visibleWidth(linePrefix))}`
-          : truncateAnsi(`${linePrefix}${line}`, maxLineWidth),
-      );
-  }
-
-  private truncatePlainLineFromStart(line: string, maxWidth: number): string {
-    if (visibleWidth(line) <= maxWidth) return line;
-    const availableWidth = Math.max(0, maxWidth - 1);
-    let result = '';
-    let width = 0;
-    for (const char of [...line].reverse()) {
-      const charWidth = visibleWidth(char);
-      if (width + charWidth > availableWidth) break;
-      result = `${char}${result}`;
-      width += charWidth;
-    }
-    return `…${result}`;
+      .map(line => truncateAnsi(`${linePrefix}${line}`, maxLineWidth));
   }
 
   private isQuietCodePreviewTool(): boolean {
@@ -755,7 +736,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
       case MC_TOOLS.STRING_REPLACE_LSP:
         return this.formatQuietEditPreview();
       case MC_TOOLS.WRITE_FILE:
-        return this.getMultilinePreview('content', QUIET_CODE_PREVIEW_MAX_CHARS, false, 'tail');
+        return this.getLatestCodePreview('content');
       case MC_TOOLS.SEARCH_CONTENT:
         return this.formatSearchDetail();
       case MC_TOOLS.LSP_INSPECT:
@@ -766,10 +747,18 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
   }
 
   private formatQuietEditPreview(): string {
-    return (
-      this.getMultilinePreview('new_str', QUIET_CODE_PREVIEW_MAX_CHARS, false, 'tail') ||
-      this.getMultilinePreview('new_string', QUIET_CODE_PREVIEW_MAX_CHARS, false, 'tail')
-    );
+    return this.getLatestCodePreview('new_str') || this.getLatestCodePreview('new_string');
+  }
+
+  private getLatestCodePreview(key: string): string {
+    const value = this.getFirstStringArg(key);
+    if (!value) return '';
+    const normalized = value.replace(/\r\n/g, '\n').replace(/^\n+|\n+$/g, '');
+    if (!normalized) return '';
+    const lines = normalized.split('\n');
+    const latestLines = lines.slice(-Math.max(1, this.quietPreviewLineLimit)).join('\n');
+    if (latestLines.length <= QUIET_CODE_PREVIEW_MAX_CHARS) return latestLines;
+    return latestLines.slice(-QUIET_CODE_PREVIEW_MAX_CHARS);
   }
 
   private formatQuietErrorPreview(): string {
@@ -929,26 +918,6 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
   private looksLikeViewOutput(output: string): boolean {
     return output.split('\n').some(line => /^\s*\d+[\t→]/.test(line));
-  }
-
-  private getMultilinePreview(
-    key: string,
-    maxLength = 80,
-    includeLineCount = true,
-    truncateFrom: 'head' | 'tail' = 'head',
-  ): string {
-    const value = this.getFirstStringArg(key);
-    if (!value) return '';
-
-    const lines = value.split('\n');
-    const previewText = includeLineCount ? (lines[0] ?? '') : value.replace(/\r\n/g, '\n').replace(/^\n+|\n+$/g, '');
-    const shouldTruncate = Number.isFinite(maxLength) && previewText.length > maxLength;
-    const truncated = shouldTruncate
-      ? truncateFrom === 'tail'
-        ? `…${previewText.slice(-maxLength)}`
-        : `${previewText.slice(0, maxLength)}…`
-      : previewText;
-    return includeLineCount && lines.length > 1 ? `${truncated} (${lines.length} lines)` : truncated;
   }
 
   private stripAnsi(value: string): string {

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -747,7 +747,12 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
   }
 
   private formatQuietEditPreview(): string {
-    return this.getLatestCodePreview('new_str') || this.getLatestCodePreview('new_string');
+    return (
+      this.getLatestCodePreview('new_str') ||
+      this.getLatestCodePreview('new_string') ||
+      this.getLatestCodePreview('old_str') ||
+      this.getLatestCodePreview('old_string')
+    );
   }
 
   private getLatestCodePreview(key: string): string {

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -464,10 +464,29 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
   private getQuietCodePreviewLines(preview: string, maxLineWidth: number): string[] {
     const linePrefix = `  ${chalk.hex(this.getQuietToolRailColor())('│')} `;
+    const isTailPreview = preview.startsWith('…');
     return this.highlightQuietCodePreview(preview)
       .split('\n')
       .slice(-this.quietPreviewLineLimit)
-      .map(line => truncateAnsi(`${linePrefix}${line}`, maxLineWidth));
+      .map(line =>
+        isTailPreview
+          ? `${linePrefix}${this.truncatePlainLineFromStart(this.stripAnsi(line), maxLineWidth - visibleWidth(linePrefix))}`
+          : truncateAnsi(`${linePrefix}${line}`, maxLineWidth),
+      );
+  }
+
+  private truncatePlainLineFromStart(line: string, maxWidth: number): string {
+    if (visibleWidth(line) <= maxWidth) return line;
+    const availableWidth = Math.max(0, maxWidth - 1);
+    let result = '';
+    let width = 0;
+    for (const char of [...line].reverse()) {
+      const charWidth = visibleWidth(char);
+      if (width + charWidth > availableWidth) break;
+      result = `${char}${result}`;
+      width += charWidth;
+    }
+    return `…${result}`;
   }
 
   private isQuietCodePreviewTool(): boolean {
@@ -736,7 +755,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
       case MC_TOOLS.STRING_REPLACE_LSP:
         return this.formatQuietEditPreview();
       case MC_TOOLS.WRITE_FILE:
-        return this.getMultilinePreview('content', QUIET_CODE_PREVIEW_MAX_CHARS, false);
+        return this.getMultilinePreview('content', QUIET_CODE_PREVIEW_MAX_CHARS, false, 'tail');
       case MC_TOOLS.SEARCH_CONTENT:
         return this.formatSearchDetail();
       case MC_TOOLS.LSP_INSPECT:
@@ -748,8 +767,8 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
   private formatQuietEditPreview(): string {
     return (
-      this.getMultilinePreview('new_str', QUIET_CODE_PREVIEW_MAX_CHARS, false) ||
-      this.getMultilinePreview('new_string', QUIET_CODE_PREVIEW_MAX_CHARS, false)
+      this.getMultilinePreview('new_str', QUIET_CODE_PREVIEW_MAX_CHARS, false, 'tail') ||
+      this.getMultilinePreview('new_string', QUIET_CODE_PREVIEW_MAX_CHARS, false, 'tail')
     );
   }
 
@@ -912,16 +931,23 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     return output.split('\n').some(line => /^\s*\d+[\t→]/.test(line));
   }
 
-  private getMultilinePreview(key: string, maxLength = 80, includeLineCount = true): string {
+  private getMultilinePreview(
+    key: string,
+    maxLength = 80,
+    includeLineCount = true,
+    truncateFrom: 'head' | 'tail' = 'head',
+  ): string {
     const value = this.getFirstStringArg(key);
     if (!value) return '';
 
     const lines = value.split('\n');
     const previewText = includeLineCount ? (lines[0] ?? '') : value.replace(/\r\n/g, '\n').replace(/^\n+|\n+$/g, '');
-    const truncated =
-      Number.isFinite(maxLength) && previewText.length > maxLength
-        ? `${previewText.slice(0, maxLength)}…`
-        : previewText;
+    const shouldTruncate = Number.isFinite(maxLength) && previewText.length > maxLength;
+    const truncated = shouldTruncate
+      ? truncateFrom === 'tail'
+        ? `…${previewText.slice(-maxLength)}`
+        : `${previewText.slice(0, maxLength)}…`
+      : previewText;
     return includeLineCount && lines.length > 1 ? `${truncated} (${lines.length} lines)` : truncated;
   }
 

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -513,95 +513,102 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     }
   }
 
-  private tokenizeQuietShellCommand(command: string): Array<{ text: string; color: (value: string) => string }> {
-    const tokens = command.match(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|\s+|&&|\|\||[|;&()<>]|[^\s|;&()<>]+/g) ?? [''];
+  private highlightQuietShellCommandToken(token: string): string {
+    if (token === '&&' || token === '||' || token === '|' || token === ';' || token === '&') {
+      return theme.fg('muted', token);
+    }
+    if (token === '(' || token === ')' || token === '<' || token === '>') {
+      return theme.fg('muted', token);
+    }
+    if (SHELL_CONTROL_WORDS.has(token)) return chalk.blue(token);
+    return theme.fg('toolArgs', token);
+  }
 
-    return tokens.map(token => {
-      if (/^\s+$/.test(token)) return { text: token, color: (value: string) => value };
-      if ((token.startsWith('"') && token.endsWith('"')) || (token.startsWith("'") && token.endsWith("'"))) {
-        return { text: token, color: chalk.white };
+  private highlightQuietShellCommandLine(
+    line: string,
+    quote: 'single' | 'double' | undefined,
+  ): { line: string; quote: 'single' | 'double' | undefined } {
+    let highlighted = '';
+    let plain = '';
+    let quoted = '';
+    let activeQuote = quote;
+
+    const flushPlain = () => {
+      if (!plain) return;
+      highlighted += plain.replace(/&&|\|\||[|;&()<>]|-{1,2}[a-zA-Z0-9_.=/-]+|\b[a-zA-Z_][a-zA-Z0-9_]*\b/g, token =>
+        this.highlightQuietShellCommandToken(token),
+      );
+      plain = '';
+    };
+    const flushQuoted = () => {
+      if (!quoted) return;
+      highlighted += chalk.white(quoted);
+      quoted = '';
+    };
+
+    for (let index = 0; index < line.length; index++) {
+      const char = line[index]!;
+      const previous = index > 0 ? line[index - 1] : undefined;
+
+      if (activeQuote) {
+        quoted += char;
+        if (
+          previous !== '\\' &&
+          ((activeQuote === 'single' && char === "'") || (activeQuote === 'double' && char === '"'))
+        ) {
+          flushQuoted();
+          activeQuote = undefined;
+        }
+        continue;
       }
-      if (token === '&&' || token === '||' || token === '|' || token === ';' || token === '&') {
-        return { text: token, color: (value: string) => theme.fg('muted', value) };
+
+      if (char === "'" || char === '"') {
+        flushPlain();
+        activeQuote = char === "'" ? 'single' : 'double';
+        quoted += char;
+        continue;
       }
-      if (token === '(' || token === ')' || token === '<' || token === '>') {
-        return { text: token, color: (value: string) => theme.fg('muted', value) };
-      }
-      if (SHELL_CONTROL_WORDS.has(token)) {
-        return { text: token, color: chalk.blue };
-      }
-      return { text: token, color: (value: string) => theme.fg('toolArgs', value) };
-    });
+
+      plain += char;
+    }
+
+    flushPlain();
+    flushQuoted();
+    return { line: highlighted, quote: activeQuote };
   }
 
   private wrapQuietShellCommand(command: string, width: number): string[] {
     const lines: string[] = [];
     let current = '';
     let currentWidth = 0;
+    let quote: 'single' | 'double' | undefined;
 
     const pushCurrent = () => {
-      lines.push(current);
+      const highlighted = this.highlightQuietShellCommandLine(current, quote);
+      lines.push(highlighted.line);
+      quote = highlighted.quote;
       current = '';
       currentWidth = 0;
     };
 
-    const takeVisiblePrefix = (text: string, maxWidth: number): string => {
-      let chunk = '';
-      let chunkWidth = 0;
-
-      for (const char of text) {
-        const charWidth = visibleWidth(char);
-        if (chunk && chunkWidth + charWidth > maxWidth) break;
-        chunk += char;
-        chunkWidth += charWidth;
-        if (chunkWidth >= maxWidth) break;
+    for (const char of command) {
+      if (char === '\n') {
+        pushCurrent();
+        continue;
       }
 
-      return chunk;
-    };
-
-    const wrapSourceLine = (sourceLine: string) => {
-      for (const token of this.tokenizeQuietShellCommand(sourceLine)) {
-        let remaining = token.text;
-
-        while (remaining.length > 0) {
-          if (currentWidth === 0 && /^\s+$/.test(remaining)) break;
-
-          const available = width - currentWidth;
-          if (available <= 0) {
-            pushCurrent();
-            continue;
-          }
-
-          const remainingWidth = visibleWidth(remaining);
-          if (remainingWidth <= available) {
-            current += token.color(remaining);
-            currentWidth += remainingWidth;
-            break;
-          }
-
-          if (currentWidth > 0 && !/^\s+$/.test(remaining)) {
-            pushCurrent();
-            continue;
-          }
-
-          const chunk = takeVisiblePrefix(remaining, available);
-          current += token.color(chunk);
-          currentWidth += visibleWidth(chunk);
-          remaining = remaining.slice(chunk.length);
-          pushCurrent();
-        }
+      const charWidth = visibleWidth(char);
+      if (current && currentWidth + charWidth > width) {
+        pushCurrent();
       }
-    };
+      if (!current && /^\s$/.test(char)) continue;
 
-    const sourceLines = command.split('\n');
-    sourceLines.forEach((sourceLine, index) => {
-      wrapSourceLine(sourceLine);
-      if (index < sourceLines.length - 1) pushCurrent();
-    });
+      current += char;
+      currentWidth += charWidth;
+    }
 
-    if (current) lines.push(current);
-    return lines.length ? lines : [''];
+    if (current || lines.length === 0) pushCurrent();
+    return lines;
   }
 
   private wrapPreviewLines(preview: string, firstLineWidth: number, continuationWidth: number): string[] {

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -50,6 +50,7 @@ const CODE_HIGHLIGHT_THEME: HighlightTheme = {
 const COMPACT_TOOL_COLOR = mastra.orange;
 const COMPACT_TOOL_ARGS_BG = '#141414';
 const QUIET_TOOL_RAIL = tintHex(COMPACT_TOOL_COLOR, 0.35);
+const QUIET_CODE_PREVIEW_MAX_CHARS = 2_000;
 
 function normalizeHexColor(color: string | undefined): string | undefined {
   if (!color || !/^#[0-9a-f]{6}$/i.test(color)) return undefined;
@@ -735,7 +736,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
       case MC_TOOLS.STRING_REPLACE_LSP:
         return this.formatQuietEditPreview();
       case MC_TOOLS.WRITE_FILE:
-        return this.getMultilinePreview('content', Number.POSITIVE_INFINITY, false);
+        return this.getMultilinePreview('content', QUIET_CODE_PREVIEW_MAX_CHARS, false);
       case MC_TOOLS.SEARCH_CONTENT:
         return this.formatSearchDetail();
       case MC_TOOLS.LSP_INSPECT:
@@ -747,8 +748,8 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
 
   private formatQuietEditPreview(): string {
     return (
-      this.getMultilinePreview('new_str', Number.POSITIVE_INFINITY, false) ||
-      this.getMultilinePreview('new_string', Number.POSITIVE_INFINITY, false)
+      this.getMultilinePreview('new_str', QUIET_CODE_PREVIEW_MAX_CHARS, false) ||
+      this.getMultilinePreview('new_string', QUIET_CODE_PREVIEW_MAX_CHARS, false)
     );
   }
 

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -775,6 +775,9 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     if (!normalized) return '';
     const lines = normalized.split('\n');
     const latestLines = lines.slice(-Math.max(1, this.quietPreviewLineLimit)).join('\n');
+    if (this.isPartial && (this.toolName === MC_TOOLS.WRITE_FILE || this.toolName === MC_TOOLS.STRING_REPLACE_LSP)) {
+      return latestLines;
+    }
     if (latestLines.length <= QUIET_CODE_PREVIEW_MAX_CHARS) return latestLines;
     return latestLines.slice(-QUIET_CODE_PREVIEW_MAX_CHARS);
   }

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -51,6 +51,8 @@ const COMPACT_TOOL_COLOR = mastra.orange;
 const COMPACT_TOOL_ARGS_BG = '#141414';
 const QUIET_TOOL_RAIL = tintHex(COMPACT_TOOL_COLOR, 0.35);
 const QUIET_CODE_PREVIEW_MAX_CHARS = 2_000;
+const QUIET_SHELL_COMMAND_PREVIEW_TRUNCATE_AT_CHARS = 2_000;
+const QUIET_SHELL_COMMAND_PREVIEW_MAX_CHARS = 500;
 
 function normalizeHexColor(color: string | undefined): string | undefined {
   if (!color || !/^#[0-9a-f]{6}$/i.test(color)) return undefined;
@@ -755,6 +757,11 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     );
   }
 
+  private getQuietShellCommandPreview(command: string): string {
+    if (!this.isPartial || command.length <= QUIET_SHELL_COMMAND_PREVIEW_TRUNCATE_AT_CHARS) return command;
+    return `…${command.slice(-QUIET_SHELL_COMMAND_PREVIEW_MAX_CHARS)}`;
+  }
+
   private getLatestCodePreview(key: string): string {
     const value = this.getFirstStringArg(key);
     if (!value) return '';
@@ -1383,10 +1390,11 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
     // Strip "cd $CWD && " from the start since we show cwd in the footer
     const cdPattern = /^cd\s+[^\s]+\s+&&\s+/;
     command = command.replace(cdPattern, '');
+    const displayCommand = this.getQuietShellCommandPreview(command);
 
     // Extract tail value from command (e.g., "| tail -5" or "| tail -n 5")
     let maxStreamLines: number | undefined;
-    const tailMatch = command.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/);
+    const tailMatch = displayCommand.match(/\|\s*tail\s+(?:-n\s+)?(-?\d+)\s*$/);
     if (tailMatch) {
       maxStreamLines = Math.abs(parseInt(tailMatch[1]!, 10));
     }
@@ -1417,7 +1425,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
         this.contentBox.addChild(new Text(`${border('├')}${border(horizontal)}${border('┤')}`, 0, 0));
       }
       const footerWrapWidth = Math.max(1, contentWidth - 4);
-      const footerLines = this.wrapQuietShellCommand(command, footerWrapWidth);
+      const footerLines = this.wrapQuietShellCommand(displayCommand, footerWrapWidth);
       const footerSuffixWidth = visibleWidth(footerSuffix);
       footerLines.forEach((footerLine, index) => {
         const prefix = index === 0 ? footerPrompt : '  ';

--- a/mastracode/tui/src/tui/event-dispatch.ts
+++ b/mastracode/tui/src/tui/event-dispatch.ts
@@ -40,6 +40,7 @@ import {
   handleToolInputDelta,
   handleToolInputEnd,
   handleToolEnd,
+  clearToolInputParsers,
 } from './handlers/index.js';
 import type { EventHandlerContext } from './handlers/types.js';
 import type { TUIState } from './state.js';
@@ -63,6 +64,7 @@ export async function dispatchEvent(
 ): Promise<void> {
   switch (event.type) {
     case 'agent_start':
+      clearToolInputParsers();
       // Reset tokens/sec at the start of a new turn (not at the end) so the
       // last turn's reading stays visible while idle — short single-step turns
       // would otherwise zero it before it could be read.

--- a/mastracode/tui/src/tui/event-dispatch.ts
+++ b/mastracode/tui/src/tui/event-dispatch.ts
@@ -43,6 +43,7 @@ import {
   clearToolInputParsers,
 } from './handlers/index.js';
 import type { EventHandlerContext } from './handlers/types.js';
+import { flushRender } from './render-scheduler.js';
 import type { TUIState } from './state.js';
 import { getGithubPrSubscriptionsFromMetadata } from './state.js';
 
@@ -199,7 +200,7 @@ export async function dispatchEvent(
       state.previousPlanSnapshot = undefined;
       if (state.taskProgress) {
         state.taskProgress.updateTasks([]);
-        state.ui.requestRender();
+        flushRender(state);
       }
       state.taskToolInsertIndex = -1;
       await ectx.renderExistingMessages();

--- a/mastracode/tui/src/tui/event-dispatch.ts
+++ b/mastracode/tui/src/tui/event-dispatch.ts
@@ -40,6 +40,7 @@ import {
   handleToolInputDelta,
   handleToolInputEnd,
   handleToolEnd,
+  clearPendingShellOutputs,
   clearToolInputParsers,
 } from './handlers/index.js';
 import type { EventHandlerContext } from './handlers/types.js';
@@ -66,6 +67,7 @@ export async function dispatchEvent(
   switch (event.type) {
     case 'agent_start':
       clearToolInputParsers();
+      clearPendingShellOutputs();
       // Reset tokens/sec at the start of a new turn (not at the end) so the
       // last turn's reading stays visible while idle — short single-step turns
       // would otherwise zero it before it could be read.
@@ -94,8 +96,10 @@ export async function dispatchEvent(
       state.decodeStartedAt = 0;
       ectx.updateStatusLine();
       if (event.reason === 'aborted') {
+        clearPendingShellOutputs();
         handleAgentAborted(ectx);
       } else if (event.reason === 'error') {
+        clearPendingShellOutputs();
         handleAgentError(ectx);
       } else {
         handleAgentEnd(ectx);

--- a/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
@@ -1,11 +1,43 @@
+import { Container } from '@earendil-works/pi-tui';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { clearToolInputParsers, handleToolInputDelta, handleToolInputStart, handleToolUpdate } from '../tool.js';
+import {
+  clearPendingShellOutputs,
+  clearToolInputParsers,
+  handleShellOutput,
+  handleToolEnd,
+  handleToolInputDelta,
+  handleToolInputStart,
+  handleToolUpdate,
+} from '../tool.js';
 
 async function flushParser(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
   await new Promise(resolve => setTimeout(resolve, 100));
+}
+
+function createShellOutputContext() {
+  const appendStreamingOutput = vi.fn();
+  const updateResult = vi.fn();
+  const requestRender = vi.fn();
+  const component = { appendStreamingOutput, updateResult };
+  const session = { displayState: { get: () => ({ toolInputBuffers: new Map() }) } };
+  const ctx = {
+    state: {
+      controller: { session },
+      session,
+      pendingTools: new Map([['call-1', component]]),
+      pendingTaskToolIds: new Set(),
+      pendingSubagents: new Map(),
+      pendingAskUserComponents: new Map(),
+      pendingSubmitPlanComponents: new Map(),
+      chatContainer: new Container(),
+      ui: { requestRender },
+    },
+  } as any;
+
+  return { ctx, appendStreamingOutput, updateResult, requestRender };
 }
 
 function createContext(bufferText: string | undefined, toolName = 'view') {
@@ -40,6 +72,49 @@ function createContext(bufferText: string | undefined, toolName = 'view') {
 describe('tool event handlers', () => {
   afterEach(() => {
     clearToolInputParsers();
+    clearPendingShellOutputs();
+    vi.useRealTimers();
+  });
+
+  it('clears pending shell output without appending or rendering before the timer fires', () => {
+    vi.useFakeTimers();
+    const { ctx, appendStreamingOutput, requestRender } = createShellOutputContext();
+
+    handleShellOutput(ctx, 'call-1', 'partial output', 'stdout');
+    clearPendingShellOutputs();
+    vi.advanceTimersByTime(1000);
+
+    expect(appendStreamingOutput).not.toHaveBeenCalled();
+    expect(requestRender).not.toHaveBeenCalled();
+  });
+
+  it('keeps shell-output cleanup safe when no output is pending', () => {
+    expect(() => clearPendingShellOutputs()).not.toThrow();
+  });
+
+  it('flushes pending shell output on normal tool end', () => {
+    vi.useFakeTimers();
+    const { ctx, appendStreamingOutput, updateResult, requestRender } = createShellOutputContext();
+
+    handleShellOutput(ctx, 'call-1', 'hello ', 'stdout');
+    handleShellOutput(ctx, 'call-1', 'world', 'stdout');
+    handleToolEnd(ctx, 'call-1', { content: 'done' }, false);
+
+    expect(appendStreamingOutput).toHaveBeenCalledWith('hello world');
+    expect(updateResult).toHaveBeenCalled();
+    expect(requestRender).toHaveBeenCalled();
+  });
+
+  it('does not append cleared shell output after abort/error lifecycle cleanup', () => {
+    vi.useFakeTimers();
+    const { ctx, appendStreamingOutput, requestRender } = createShellOutputContext();
+
+    handleShellOutput(ctx, 'call-1', 'stale output', 'stderr');
+    clearPendingShellOutputs();
+    vi.advanceTimersByTime(1000);
+
+    expect(appendStreamingOutput).not.toHaveBeenCalled();
+    expect(requestRender).not.toHaveBeenCalled();
   });
 
   it('feeds streamed delta fragments into the pending tool component incrementally', async () => {

--- a/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
@@ -81,6 +81,24 @@ describe('tool event handlers', () => {
     expect(requestRender).toHaveBeenCalledOnce();
   });
 
+  it('does not stream incomplete task_write items into the task progress component', async () => {
+    const { ctx } = createContext('', 'task_write');
+    const updateTasks = vi.fn();
+    ctx.state.taskProgress = { getTasks: () => [], updateTasks };
+
+    handleToolInputDelta(ctx, 'call-1', '{"tasks":[{"id":"task-1","content":"Fix crash","status":"in_progress"');
+    await flushParser();
+
+    expect(updateTasks).not.toHaveBeenCalled();
+
+    handleToolInputDelta(ctx, 'call-1', ',"activeForm":"Fixing crash"}]}');
+    await flushParser();
+
+    expect(updateTasks).toHaveBeenCalledWith([
+      { id: 'task-1', content: 'Fix crash', status: 'in_progress', activeForm: 'Fixing crash' },
+    ]);
+  });
+
   it('ignores deltas for calls without a display-state buffer', () => {
     const { ctx, updateArgs, requestRender } = createContext(undefined);
 

--- a/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
@@ -1,8 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { handleToolInputDelta, handleToolInputStart, handleToolUpdate } from '../tool.js';
+import { clearToolInputParsers, handleToolInputDelta, handleToolInputStart, handleToolUpdate } from '../tool.js';
 
-function createContext(bufferText: string | undefined) {
+async function flushParser(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise(resolve => setTimeout(resolve, 0));
+}
+
+function createContext(bufferText: string | undefined, toolName = 'view') {
   const updateArgs = vi.fn();
   const refresh = vi.fn();
   const requestRender = vi.fn();
@@ -11,7 +17,7 @@ function createContext(bufferText: string | undefined) {
   const toolInputBuffers = new Map<string, { text: string; toolName: string }>();
 
   if (bufferText !== undefined) {
-    toolInputBuffers.set('call-1', { text: bufferText, toolName: 'view' });
+    toolInputBuffers.set('call-1', { text: bufferText, toolName });
   }
 
   const session = { displayState: { get: () => ({ toolInputBuffers }) } };
@@ -28,26 +34,51 @@ function createContext(bufferText: string | undefined) {
     },
   } as any;
 
-  return { ctx, updateArgs, refresh, requestRender };
+  return { ctx, toolInputBuffers, updateArgs, refresh, requestRender };
 }
 
 describe('tool event handlers', () => {
-  it('parses buffered partial tool args into the pending tool component', () => {
-    const { ctx, updateArgs, refresh, requestRender } = createContext('{"path":"src/index.ts","query":"create');
+  afterEach(() => {
+    clearToolInputParsers();
+  });
 
-    handleToolInputDelta(ctx, 'call-1', 'ignored-delta');
+  it('feeds streamed delta fragments into the pending tool component incrementally', async () => {
+    const { ctx, updateArgs, refresh, requestRender } = createContext('');
+
+    handleToolInputDelta(ctx, 'call-1', '{"path":"src/index.ts","query":"create');
+    await flushParser();
 
     expect(updateArgs).toHaveBeenCalledWith({ path: 'src/index.ts', query: 'create' }, false);
     expect(refresh).toHaveBeenCalledOnce();
     expect(requestRender).toHaveBeenCalledOnce();
+
+    handleToolInputDelta(ctx, 'call-1', ' parser"}');
+    await flushParser();
+
+    expect(updateArgs).toHaveBeenLastCalledWith({ path: 'src/index.ts', query: 'create parser' }, false);
+    expect(requestRender).toHaveBeenCalledTimes(2);
   });
 
-  it('uses the canonical display-state buffer instead of the latest delta fragment', () => {
-    const { ctx, updateArgs } = createContext('{"path":"src/index.ts"}');
+  it('does not reparse the canonical display-state buffer on every delta', async () => {
+    const { ctx, updateArgs } = createContext('{"path":"canonical.ts"}');
 
-    handleToolInputDelta(ctx, 'call-1', '{"path":"wrong.ts"}');
+    handleToolInputDelta(ctx, 'call-1', '{"path":"delta.ts"}');
+    await flushParser();
 
-    expect(updateArgs).toHaveBeenCalledWith({ path: 'src/index.ts' }, false);
+    expect(updateArgs).toHaveBeenCalledWith({ path: 'delta.ts' }, false);
+    expect(updateArgs).not.toHaveBeenCalledWith({ path: 'canonical.ts' }, false);
+  });
+
+  it('streams partial ask_user args into the inline question component', async () => {
+    const { ctx, requestRender } = createContext('', 'ask_user');
+    const updateAskArgs = vi.fn();
+    ctx.state.pendingAskUserComponents.set('call-1', { updateArgs: updateAskArgs });
+
+    handleToolInputDelta(ctx, 'call-1', '{"question":"Pick a color","options":[{"label":"Red"');
+    await flushParser();
+
+    expect(updateAskArgs).toHaveBeenCalledWith({ question: 'Pick a color', options: [{ label: 'Red' }] });
+    expect(requestRender).toHaveBeenCalledOnce();
   });
 
   it('ignores deltas for calls without a display-state buffer', () => {
@@ -63,6 +94,7 @@ describe('tool event handlers', () => {
     const component = { updateResult: vi.fn() };
     const requestRender = vi.fn();
     const invalidate = vi.fn();
+    const toolInputBuffers = new Map([['call-1', { text: '', toolName: 'mastra_expert' }]]);
     const ctx = {
       addChildBeforeFollowUps: vi.fn(child => ctx.state.chatContainer.children.push(child)),
       state: {
@@ -76,11 +108,7 @@ describe('tool event handlers', () => {
         seenToolCallIds: new Set(),
         session: {
           displayState: {
-            get: () => ({
-              toolInputBuffers: new Map([
-                ['call-1', { text: '{"question":"Answer from Alexandria"}', toolName: 'mastra_expert' }],
-              ]),
-            }),
+            get: () => ({ toolInputBuffers }),
           },
         },
         chatContainer: { children: [], invalidate },
@@ -89,7 +117,6 @@ describe('tool event handlers', () => {
     } as any;
 
     handleToolInputStart(ctx, 'call-1', 'mastra_expert');
-    handleToolInputDelta(ctx, 'call-1', 'ignored-delta');
     handleToolUpdate(ctx, 'call-1', {
       event: 'tool_start',
       toolName: 'search_content',

--- a/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
@@ -7,13 +7,19 @@ import {
   handleShellOutput,
   handleToolEnd,
   handleToolInputDelta,
+  handleToolInputEnd,
   handleToolInputStart,
   handleToolUpdate,
 } from '../tool.js';
 
+async function flushParserMicrotasks(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await Promise.resolve();
+  }
+}
+
 async function flushParser(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
+  await flushParserMicrotasks();
   await new Promise(resolve => setTimeout(resolve, 100));
 }
 
@@ -115,6 +121,22 @@ describe('tool event handlers', () => {
 
     expect(appendStreamingOutput).not.toHaveBeenCalled();
     expect(requestRender).not.toHaveBeenCalled();
+  });
+
+  it('flushes latest parsed tool args when input streaming ends before the apply timer fires', async () => {
+    vi.useFakeTimers();
+    const { ctx, updateArgs, refresh, requestRender } = createContext('');
+
+    handleToolInputDelta(ctx, 'call-1', '{"path":"src/final.ts","query":"final args"}');
+    await flushParserMicrotasks();
+
+    expect(updateArgs).not.toHaveBeenCalled();
+
+    handleToolInputEnd(ctx, 'call-1');
+
+    expect(updateArgs).toHaveBeenCalledWith({ path: 'src/final.ts', query: 'final args' }, false);
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(requestRender).toHaveBeenCalledOnce();
   });
 
   it('feeds streamed delta fragments into the pending tool component incrementally', async () => {

--- a/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/tool.test.ts
@@ -5,7 +5,7 @@ import { clearToolInputParsers, handleToolInputDelta, handleToolInputStart, hand
 async function flushParser(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
-  await new Promise(resolve => setTimeout(resolve, 0));
+  await new Promise(resolve => setTimeout(resolve, 100));
 }
 
 function createContext(bufferText: string | undefined, toolName = 'view') {

--- a/mastracode/tui/src/tui/handlers/agent-lifecycle.ts
+++ b/mastracode/tui/src/tui/handlers/agent-lifecycle.ts
@@ -10,6 +10,7 @@ import { JudgeDisplayComponent } from '../components/judge-display.js';
 import { GradientAnimator } from '../components/obi-loader.js';
 import { pruneChatContainer } from '../prune-chat.js';
 import { clearPendingUserMessages, removePendingUserMessage } from '../render-messages.js';
+import { flushRender, requestRender } from '../render-scheduler.js';
 
 import type { EventHandlerContext } from './types.js';
 
@@ -28,6 +29,7 @@ export function handleAgentStart(ctx: EventHandlerContext): void {
   if (!state.gradientAnimator) {
     state.gradientAnimator = new GradientAnimator(() => {
       ctx.updateStatusLine();
+      requestRender(state);
     });
   }
   state.gradientAnimator.start();
@@ -64,7 +66,7 @@ export function handleAgentEnd(ctx: EventHandlerContext): void {
   state.pendingTaskToolIds?.clear();
   pruneChatContainer(state);
   ctx.updateStatusLine();
-  state.ui.requestRender();
+  flushRender(state);
 
   ctx.notify('agent_done');
 
@@ -112,7 +114,7 @@ function drainQueuedAction(ctx: EventHandlerContext): boolean {
     const key = nextMessage.content.trim();
     const counts = (state.firedQueuedMessageTexts ??= new Map<string, number>());
     counts.set(key, (counts.get(key) ?? 0) + 1);
-    state.ui.requestRender();
+    flushRender(state);
     ctx.fireMessage(nextMessage.content, nextMessage.images);
     return true;
   }
@@ -173,7 +175,7 @@ export function handleAgentAborted(ctx: EventHandlerContext): void {
   state.pendingTaskToolIds?.clear();
   pruneChatContainer(state);
   ctx.updateStatusLine();
-  state.ui.requestRender();
+  flushRender(state);
 }
 
 export function handleAgentError(ctx: EventHandlerContext): void {
@@ -202,7 +204,7 @@ export function handleAgentError(ctx: EventHandlerContext): void {
   state.pendingTaskToolIds?.clear();
   pruneChatContainer(state);
   ctx.updateStatusLine();
-  state.ui.requestRender();
+  flushRender(state);
 }
 
 // =============================================================================
@@ -265,7 +267,7 @@ export function handleGoalEvaluation(ctx: EventHandlerContext, payload: GoalEval
   // when result is null) and wait for the follow-up chunk with the result.
   if (payload.pending) {
     ctx.updateStatusLine();
-    state.ui.requestRender();
+    flushRender(state);
     return;
   }
 
@@ -276,7 +278,7 @@ export function handleGoalEvaluation(ctx: EventHandlerContext, payload: GoalEval
   state.goalManager.applyEvaluation({ runsUsed: payload.iteration, status: payload.status });
 
   ctx.updateStatusLine();
-  state.ui.requestRender();
+  flushRender(state);
 
   // A final (non-pending) goal chunk completes this judge display. Keep the
   // rendered component in history, but drop the live reference so an in-loop

--- a/mastracode/tui/src/tui/handlers/index.ts
+++ b/mastracode/tui/src/tui/handlers/index.ts
@@ -31,5 +31,6 @@ export {
   handleToolInputDelta,
   handleToolInputEnd,
   handleToolEnd,
+  clearPendingShellOutputs,
   clearToolInputParsers,
 } from './tool.js';

--- a/mastracode/tui/src/tui/handlers/index.ts
+++ b/mastracode/tui/src/tui/handlers/index.ts
@@ -31,4 +31,5 @@ export {
   handleToolInputDelta,
   handleToolInputEnd,
   handleToolEnd,
+  clearToolInputParsers,
 } from './tool.js';

--- a/mastracode/tui/src/tui/handlers/message.ts
+++ b/mastracode/tui/src/tui/handlers/message.ts
@@ -21,6 +21,7 @@ import { TemporalGapComponent } from '../components/temporal-gap.js';
 import { ToolExecutionComponentEnhanced } from '../components/tool-execution-enhanced.js';
 import { UserMessageComponent } from '../components/user-message.js';
 import { addChildBeforeMessageOrFollowUps } from '../render-messages.js';
+import { flushRender, requestRender } from '../render-scheduler.js';
 import { getMarkdownTheme } from '../theme.js';
 
 import { createStaticSubagentComponent } from './tool.js';
@@ -354,7 +355,7 @@ export function handleMessageStart(ctx: EventHandlerContext, message: AgentContr
       });
       reconcileChatBoundarySpacers(state.chatContainer);
     }
-    state.ui.requestRender();
+    flushRender(state);
   }
 }
 
@@ -440,7 +441,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: AgentCont
         notificationSummaryParts.length > 0 ||
         notificationParts.length > 0
       ) {
-        state.ui.requestRender();
+        requestRender(state);
       }
       return;
     }
@@ -543,7 +544,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: AgentCont
     }
   }
 
-  state.ui.requestRender();
+  requestRender(state);
 }
 
 export function handleMessageEnd(ctx: EventHandlerContext, message: AgentControllerMessage): void {
@@ -584,5 +585,5 @@ export function handleMessageEnd(ctx: EventHandlerContext, message: AgentControl
     state.subagentToolCallIds.clear();
     state.currentRunSystemReminderKeys.clear();
   }
-  state.ui.requestRender();
+  flushRender(state);
 }

--- a/mastracode/tui/src/tui/handlers/subagent.ts
+++ b/mastracode/tui/src/tui/handlers/subagent.ts
@@ -4,6 +4,7 @@
  */
 import { insertChatComponentWithBoundarySpacing } from '../chat-boundary-reconciliation.js';
 import { SubagentExecutionComponent } from '../components/subagent-execution.js';
+import { flushRender, requestRender } from '../render-scheduler.js';
 
 import type { EventHandlerContext } from './types.js';
 
@@ -37,7 +38,7 @@ export function handleSubagentStart(
     insertChatComponentWithBoundarySpacing(state.chatContainer, component);
   }
 
-  state.ui.requestRender();
+  flushRender(state);
 }
 
 export function handleSubagentToolStart(
@@ -49,7 +50,7 @@ export function handleSubagentToolStart(
   const component = ctx.state.pendingSubagents.get(toolCallId);
   if (component) {
     component.addToolStart(subToolName, subToolArgs);
-    ctx.state.ui.requestRender();
+    requestRender(ctx.state);
   }
 }
 
@@ -63,7 +64,7 @@ export function handleSubagentToolEnd(
   const component = ctx.state.pendingSubagents.get(toolCallId);
   if (component) {
     component.addToolEnd(subToolName, subToolResult, isError);
-    ctx.state.ui.requestRender();
+    requestRender(ctx.state);
   }
 }
 
@@ -78,6 +79,6 @@ export function handleSubagentEnd(
   if (component) {
     component.finish(isError, durationMs, result);
     ctx.state.pendingSubagents.delete(toolCallId);
-    ctx.state.ui.requestRender();
+    flushRender(ctx.state);
   }
 }

--- a/mastracode/tui/src/tui/handlers/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/tool.test.ts
@@ -16,7 +16,7 @@ import type { EventHandlerContext } from './types.js';
 async function flushParser(): Promise<void> {
   await Promise.resolve();
   await Promise.resolve();
-  await new Promise(resolve => setImmediate(resolve));
+  await new Promise(resolve => setTimeout(resolve, 100));
 }
 
 function visibleChildren(ctx: EventHandlerContext) {

--- a/mastracode/tui/src/tui/handlers/tool.test.ts
+++ b/mastracode/tui/src/tui/handlers/tool.test.ts
@@ -1,11 +1,23 @@
 import { Container } from '@earendil-works/pi-tui';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { reconcileChatBoundarySpacers } from '../chat-boundary-reconciliation.js';
 import { isChatBoundarySpacer } from '../components/chat-boundary-spacer.js';
 
 import type { TUIState } from '../state.js';
-import { handleToolEnd, handleToolInputDelta, handleToolInputStart, handleToolStart } from './tool.js';
+import {
+  clearToolInputParsers,
+  handleToolEnd,
+  handleToolInputDelta,
+  handleToolInputStart,
+  handleToolStart,
+} from './tool.js';
 import type { EventHandlerContext } from './types.js';
+
+async function flushParser(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await new Promise(resolve => setImmediate(resolve));
+}
 
 function visibleChildren(ctx: EventHandlerContext) {
   return ctx.state.chatContainer.children.filter(child => !isChatBoundarySpacer(child));
@@ -47,6 +59,10 @@ function createToolHandlerContext(): EventHandlerContext {
 }
 
 describe('task tool rendering', () => {
+  afterEach(() => {
+    clearToolInputParsers();
+  });
+
   it('keeps successful task tools out of the chat tool list', () => {
     const ctx = createToolHandlerContext();
 
@@ -101,32 +117,37 @@ describe('task tool rendering', () => {
     expect((second as any).render(100).join('\n')).not.toContain('╭──');
   });
 
-  it('marks quiet tool result objects with isError true as failed even when the event flag is false', () => {
+  it('marks quiet tool result objects with isError true as failed even when the event flag is false', async () => {
     const ctx = createToolHandlerContext();
     ctx.state.quietMode = true;
+    const buffers = new Map([['call-1', { toolName: 'string_replace_lsp', text: '' }]]);
+    vi.mocked(ctx.state.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
 
     handleToolInputStart(ctx, 'call-1', 'string_replace_lsp');
     handleToolInputDelta(ctx, 'call-1', '{"path":"src/example.ts","old_string":"missing","new_string":"replacement"}');
+    await flushParser();
     handleToolEnd(ctx, 'call-1', { content: 'The specified text was not found.', isError: true }, false);
 
     const output = stripAnsi(ctx.state.chatContainer.render(100).join('\n'));
     expect(output).toContain('The specified text was not found.');
-    expect(output).toContain('▐edit▌ ✗');
+    expect(output).toContain('▐edit▌src/example.ts▌ ✗');
   });
 
-  it('regroups quiet tools as streamed args arrive', () => {
+  it('regroups quiet tools as streamed args arrive', async () => {
     const ctx = createToolHandlerContext();
     ctx.state.quietMode = true;
     const buffers = new Map([
-      ['call-1', { toolName: 'view', text: '{"path":"src/example.ts","offset":80,"limit":90}' }],
-      ['call-2', { toolName: 'view', text: '{"path":"src/example.ts","offset":1,"limit":25}' }],
+      ['call-1', { toolName: 'view', text: '' }],
+      ['call-2', { toolName: 'view', text: '' }],
     ]);
     vi.mocked(ctx.state.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
 
     handleToolInputStart(ctx, 'call-1', 'view');
-    handleToolInputDelta(ctx, 'call-1', '');
+    handleToolInputDelta(ctx, 'call-1', '{"path":"src/example.ts","offset":80,"limit":90}');
+    await flushParser();
     handleToolInputStart(ctx, 'call-2', 'view');
-    handleToolInputDelta(ctx, 'call-2', '');
+    handleToolInputDelta(ctx, 'call-2', '{"path":"src/example.ts","offset":1,"limit":25}');
+    await flushParser();
 
     const output = stripAnsi(ctx.state.chatContainer.render(120).join('\n'));
     expect(output).toContain('view');
@@ -134,13 +155,14 @@ describe('task tool rendering', () => {
     expect(output).toContain('●───── /example.ts:1-25▌');
   });
 
-  it('streams submit_plan args into a plan box instead of rendering a generic tool', () => {
+  it('streams submit_plan args into a plan box instead of rendering a generic tool', async () => {
     const ctx = createToolHandlerContext();
-    const buffers = new Map([['call-1', { toolName: 'submit_plan', text: '{"path":".mastracode/plans/ship-it.md"}' }]]);
+    const buffers = new Map([['call-1', { toolName: 'submit_plan', text: '' }]]);
     vi.mocked(ctx.state.session.displayState.get).mockReturnValue({ toolInputBuffers: buffers } as any);
 
     handleToolInputStart(ctx, 'call-1', 'submit_plan');
     handleToolInputDelta(ctx, 'call-1', '{"path":".mastracode/plans/ship-it.md"}');
+    await flushParser();
 
     expect(ctx.state.pendingTools.has('call-1')).toBe(false);
     expect(ctx.state.allToolComponents).toHaveLength(0);

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -57,6 +57,13 @@ interface PendingShellOutput {
 
 const pendingShellOutputs = new Map<string, PendingShellOutput>();
 
+export function clearPendingShellOutputs(): void {
+  for (const pending of pendingShellOutputs.values()) {
+    clearTimeout(pending.timer);
+  }
+  pendingShellOutputs.clear();
+}
+
 type JsonObject = Record<string, unknown>;
 
 class AsyncStringQueue implements AsyncIterable<string> {

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -689,15 +689,20 @@ function applyParsedToolArgs(
   requestRender(state);
 }
 
+function flushLatestParsedToolArgs(ctx: EventHandlerContext, toolCallId: string): void {
+  const parser = toolInputParsers.get(toolCallId);
+  if (!parser || parser.closed || !parser.latestArgs) return;
+
+  const buffer = ctx.state.session.displayState.get().toolInputBuffers.get(toolCallId);
+  if (!buffer) return;
+  applyParsedToolArgs(ctx, toolCallId, buffer.toolName, parser.latestArgs);
+}
+
 function scheduleParsedToolArgsApply(ctx: EventHandlerContext, toolCallId: string, parser: ToolInputParserState): void {
   if (parser.applyTimer) return;
   parser.applyTimer = setTimeout(() => {
     parser.applyTimer = undefined;
-    if (parser.closed || !parser.latestArgs) return;
-
-    const buffer = ctx.state.session.displayState.get().toolInputBuffers.get(toolCallId);
-    if (!buffer) return;
-    applyParsedToolArgs(ctx, toolCallId, buffer.toolName, parser.latestArgs);
+    flushLatestParsedToolArgs(ctx, toolCallId);
   }, DEFAULT_RENDER_COALESCE_MS);
 }
 
@@ -741,7 +746,8 @@ export function handleToolInputDelta(ctx: EventHandlerContext, toolCallId: strin
 /**
  * Clean up the input buffer when tool input streaming ends.
  */
-export function handleToolInputEnd(_ctx: EventHandlerContext, toolCallId: string): void {
+export function handleToolInputEnd(ctx: EventHandlerContext, toolCallId: string): void {
+  flushLatestParsedToolArgs(ctx, toolCallId);
   closeToolInputParser(toolCallId);
 }
 

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -112,6 +112,24 @@ function isJsonObject(value: unknown): value is JsonObject {
   return !!value && typeof value === 'object' && !Array.isArray(value);
 }
 
+function isTaskStatus(value: unknown): value is TaskItemInput['status'] {
+  return value === 'pending' || value === 'in_progress' || value === 'completed';
+}
+
+function isRenderableTask(value: unknown): value is TaskItemInput {
+  if (!isJsonObject(value) || !isTaskStatus(value.status)) return false;
+  if (typeof value.content !== 'string' || value.content.length === 0) return false;
+  if (value.status === 'in_progress' && (typeof value.activeForm !== 'string' || value.activeForm.length === 0)) {
+    return false;
+  }
+  return true;
+}
+
+function getRenderableTasks(value: unknown): TaskItemInput[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter(isRenderableTask);
+}
+
 function createToolInputParser(toolCallId: string): ToolInputParserState {
   const queue = new AsyncStringQueue();
   const state: ToolInputParserState = {
@@ -636,8 +654,8 @@ function applyParsedToolArgs(
   }
 
   if (toolName === 'task_write' && state.taskProgress) {
-    const tasks = (partialArgs as { tasks?: TaskItemInput[] }).tasks;
-    if (tasks && tasks.length > 0) {
+    const tasks = getRenderableTasks(partialArgs.tasks);
+    if (tasks.length > 0) {
       const existing = state.taskProgress.getTasks();
       const allExistingDone = existing.length === 0 || existing.every(t => t.status === 'completed');
       if (allExistingDone) {
@@ -647,7 +665,6 @@ function applyParsedToolArgs(
         // Merge only completed items (exclude the last still-streaming one)
         const merged = [...existing];
         for (const task of tasks.slice(0, -1)) {
-          if (!task.content) continue;
           const idx = task.id
             ? merged.findIndex(t => t.id === task.id)
             : merged.findIndex(t => !t.id && t.content === task.content);

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -21,6 +21,7 @@ import type { ApprovalAction } from '../components/tool-approval-dialog.js';
 import { ToolExecutionComponentEnhanced } from '../components/tool-execution-enhanced.js';
 import type { ToolResult } from '../components/tool-execution-enhanced.js';
 import { showModalOverlay } from '../overlay.js';
+import { requestRender, flushRender } from '../render-scheduler.js';
 import { sanitizeAnsiForRendering } from '../sanitize-ansi.js';
 import { getMarkdownTheme } from '../theme.js';
 
@@ -191,7 +192,7 @@ export function createStaticSubagentComponent(
   ctx.addChildBeforeFollowUps(state.streamingComponent);
 
   reconcileToolBoundaries(ctx);
-  state.ui.requestRender();
+  flushRender(state);
   return component;
 }
 
@@ -220,7 +221,7 @@ function handleSubagentProgress(
   }
 
   reconcileToolBoundaries(ctx);
-  state.ui.requestRender();
+  requestRender(state);
   return true;
 }
 
@@ -355,7 +356,7 @@ export function handleToolApprovalRequired(
   // Show the dialog as an overlay
   showModalOverlay(state.ui, dialog, { widthPercent: 0.7 });
   dialog.focused = true;
-  state.ui.requestRender();
+  flushRender(state);
 }
 
 export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, toolName: string, args: unknown): void {
@@ -396,7 +397,7 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
 
     if (toolName === 'submit_plan') {
       ensureSubmitPlanComponent(ctx, toolCallId, args);
-      state.ui.requestRender();
+      flushRender(state);
       return;
     }
 
@@ -413,7 +414,7 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
       state.pendingTaskToolIds?.add(toolCallId);
       state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
       ctx.addChildBeforeFollowUps(state.streamingComponent);
-      state.ui.requestRender();
+      flushRender(state);
       return;
     }
 
@@ -434,7 +435,7 @@ export function handleToolStart(ctx: EventHandlerContext, toolCallId: string, to
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
     ctx.addChildBeforeFollowUps(state.streamingComponent);
 
-    state.ui.requestRender();
+    flushRender(state);
   }
 
   // File modification tracking is handled by the AgentController display state
@@ -454,7 +455,7 @@ export function handleToolUpdate(ctx: EventHandlerContext, toolCallId: string, p
     };
     component.updateResult(result, true);
     reconcileToolBoundaries(ctx);
-    state.ui.requestRender();
+    requestRender(state);
   }
 }
 
@@ -472,7 +473,7 @@ export function handleShellOutput(
   if (component?.appendStreamingOutput) {
     component.appendStreamingOutput(output);
     reconcileToolBoundaries(ctx);
-    state.ui.requestRender();
+    requestRender(state);
   }
 }
 
@@ -504,7 +505,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
   // and ask_user (uses AskQuestionInlineComponent)
   if (toolName === 'submit_plan') {
     ensureSubmitPlanComponent(ctx, toolCallId);
-    state.ui.requestRender();
+    flushRender(state);
   } else if (toolName === 'ask_user') {
     if (state.goalManager?.isActive()) {
       return;
@@ -519,7 +520,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
     ctx.addChildBeforeFollowUps(state.streamingComponent);
 
-    state.ui.requestRender();
+    flushRender(state);
   } else if (isTaskMutationTool(toolName)) {
     // Record position so task_updated can place inline completed/cleared display here
     state.taskToolInsertIndex = state.chatContainer.children.length;
@@ -538,7 +539,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
     // to split the streaming component so getTrailingContentParts doesn't overwrite it)
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
     ctx.addChildBeforeFollowUps(state.streamingComponent);
-    state.ui.requestRender();
+    flushRender(state);
   } else if (toolName !== 'subagent') {
     if (createStaticSubagentComponent(ctx, toolCallId, toolName, {})) {
       return;
@@ -561,7 +562,7 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
     state.streamingComponent = new AssistantMessageComponent(undefined, state.hideThinkingBlock, getMarkdownTheme());
     ctx.addChildBeforeFollowUps(state.streamingComponent);
 
-    state.ui.requestRender();
+    flushRender(state);
   }
 }
 
@@ -628,7 +629,7 @@ function applyParsedToolArgs(
     }
   }
 
-  state.ui.requestRender();
+  requestRender(state);
 }
 
 async function processToolInputParser(
@@ -686,7 +687,7 @@ export function handleToolEnd(ctx: EventHandlerContext, toolCallId: string, resu
       subagentComponent.finish(isError, 0, resultText);
       state.pendingSubagents.delete(toolCallId);
       pluginSubagentToolCallIds.delete(toolCallId);
-      state.ui.requestRender();
+      flushRender(state);
     } else {
       // We'll need to wait for subagent_end to set this
       // Store it temporarily
@@ -722,6 +723,6 @@ export function handleToolEnd(ctx: EventHandlerContext, toolCallId: string, resu
 
     state.pendingTools.delete(toolCallId);
     state.pendingTaskToolIds?.delete(toolCallId);
-    state.ui.requestRender();
+    flushRender(state);
   }
 }

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -21,7 +21,7 @@ import type { ApprovalAction } from '../components/tool-approval-dialog.js';
 import { ToolExecutionComponentEnhanced } from '../components/tool-execution-enhanced.js';
 import type { ToolResult } from '../components/tool-execution-enhanced.js';
 import { showModalOverlay } from '../overlay.js';
-import { requestRender, flushRender } from '../render-scheduler.js';
+import { DEFAULT_RENDER_COALESCE_MS, requestRender, flushRender } from '../render-scheduler.js';
 import { sanitizeAnsiForRendering } from '../sanitize-ansi.js';
 import { getMarkdownTheme } from '../theme.js';
 
@@ -49,6 +49,13 @@ function reconcileToolBoundaries(ctx: EventHandlerContext): void {
 }
 
 const pluginSubagentToolCallIds = new Set<string>();
+
+interface PendingShellOutput {
+  output: string;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingShellOutputs = new Map<string, PendingShellOutput>();
 
 type JsonObject = Record<string, unknown>;
 
@@ -95,6 +102,7 @@ interface ToolInputParserState {
   queue: AsyncStringQueue;
   iterator: AsyncIterableIterator<unknown>;
   latestArgs?: JsonObject;
+  applyTimer?: ReturnType<typeof setTimeout>;
   closed: boolean;
 }
 
@@ -119,6 +127,10 @@ function closeToolInputParser(toolCallId: string): void {
   const parser = toolInputParsers.get(toolCallId);
   if (!parser) return;
   parser.closed = true;
+  if (parser.applyTimer) {
+    clearTimeout(parser.applyTimer);
+    parser.applyTimer = undefined;
+  }
   parser.queue.close();
   toolInputParsers.delete(toolCallId);
 }
@@ -462,19 +474,40 @@ export function handleToolUpdate(ctx: EventHandlerContext, toolCallId: string, p
 /**
  * Handle streaming shell output from execute_command tool.
  */
+function flushPendingShellOutput(ctx: EventHandlerContext, toolCallId: string): void {
+  const pending = pendingShellOutputs.get(toolCallId);
+  if (!pending) return;
+  pendingShellOutputs.delete(toolCallId);
+  clearTimeout(pending.timer);
+
+  const { state } = ctx;
+  const component = state.pendingTools.get(toolCallId);
+  if (component?.appendStreamingOutput) {
+    component.appendStreamingOutput(pending.output);
+    reconcileToolBoundaries(ctx);
+    requestRender(state);
+  }
+}
+
+/**
+ * Handle streaming shell output from execute_command tool.
+ */
 export function handleShellOutput(
   ctx: EventHandlerContext,
   toolCallId: string,
   output: string,
   _stream: 'stdout' | 'stderr',
 ): void {
-  const { state } = ctx;
-  const component = state.pendingTools.get(toolCallId);
-  if (component?.appendStreamingOutput) {
-    component.appendStreamingOutput(output);
-    reconcileToolBoundaries(ctx);
-    requestRender(state);
+  const pending = pendingShellOutputs.get(toolCallId);
+  if (pending) {
+    pending.output += output;
+    return;
   }
+
+  pendingShellOutputs.set(toolCallId, {
+    output,
+    timer: setTimeout(() => flushPendingShellOutput(ctx, toolCallId), DEFAULT_RENDER_COALESCE_MS),
+  });
 }
 
 /**
@@ -632,6 +665,18 @@ function applyParsedToolArgs(
   requestRender(state);
 }
 
+function scheduleParsedToolArgsApply(ctx: EventHandlerContext, toolCallId: string, parser: ToolInputParserState): void {
+  if (parser.applyTimer) return;
+  parser.applyTimer = setTimeout(() => {
+    parser.applyTimer = undefined;
+    if (parser.closed || !parser.latestArgs) return;
+
+    const buffer = ctx.state.session.displayState.get().toolInputBuffers.get(toolCallId);
+    if (!buffer) return;
+    applyParsedToolArgs(ctx, toolCallId, buffer.toolName, parser.latestArgs);
+  }, DEFAULT_RENDER_COALESCE_MS);
+}
+
 async function processToolInputParser(
   ctx: EventHandlerContext,
   toolCallId: string,
@@ -644,9 +689,8 @@ async function processToolInputParser(
       if (!isJsonObject(next.value)) continue;
 
       parser.latestArgs = next.value;
-      const buffer = ctx.state.session.displayState.get().toolInputBuffers.get(toolCallId);
-      if (!buffer || parser.closed) return;
-      applyParsedToolArgs(ctx, toolCallId, buffer.toolName, next.value);
+      if (parser.closed) return;
+      scheduleParsedToolArgsApply(ctx, toolCallId, parser);
     }
   } catch {
     closeToolInputParser(toolCallId);
@@ -678,6 +722,7 @@ export function handleToolInputEnd(_ctx: EventHandlerContext, toolCallId: string
 }
 
 export function handleToolEnd(ctx: EventHandlerContext, toolCallId: string, result: unknown, isError: boolean): void {
+  flushPendingShellOutput(ctx, toolCallId);
   const { state } = ctx;
   // If this is a subagent tool, store the result in the SubagentExecutionComponent
   const subagentComponent = state.pendingSubagents.get(toolCallId);

--- a/mastracode/tui/src/tui/handlers/tool.ts
+++ b/mastracode/tui/src/tui/handlers/tool.ts
@@ -9,7 +9,7 @@
 import { getToolCategory, TOOL_CATEGORIES } from '@mastra/code-sdk/permissions';
 import type { TaskItemInput } from '@mastra/core/signals';
 import { safeStringify } from '@mastra/core/utils';
-import { parse as parsePartialJson } from 'partial-json';
+import { parse as parseJsonRiver } from 'jsonriver';
 
 import { reconcileChatBoundarySpacers } from '../chat-boundary-reconciliation.js';
 import { AskQuestionInlineComponent } from '../components/ask-question-inline.js';
@@ -48,6 +48,85 @@ function reconcileToolBoundaries(ctx: EventHandlerContext): void {
 }
 
 const pluginSubagentToolCallIds = new Set<string>();
+
+type JsonObject = Record<string, unknown>;
+
+class AsyncStringQueue implements AsyncIterable<string> {
+  #chunks: string[] = [];
+  #waiting: ((result: IteratorResult<string>) => void) | undefined;
+  #closed = false;
+
+  push(chunk: string): void {
+    if (this.#closed) return;
+    const waiting = this.#waiting;
+    if (waiting) {
+      this.#waiting = undefined;
+      waiting({ value: chunk, done: false });
+      return;
+    }
+    this.#chunks.push(chunk);
+  }
+
+  close(): void {
+    this.#closed = true;
+    const waiting = this.#waiting;
+    if (waiting) {
+      this.#waiting = undefined;
+      waiting({ value: undefined, done: true });
+    }
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<string> {
+    return {
+      next: () => {
+        const chunk = this.#chunks.shift();
+        if (chunk !== undefined) return Promise.resolve({ value: chunk, done: false });
+        if (this.#closed) return Promise.resolve({ value: undefined, done: true });
+        return new Promise(resolve => {
+          this.#waiting = resolve;
+        });
+      },
+    };
+  }
+}
+
+interface ToolInputParserState {
+  queue: AsyncStringQueue;
+  iterator: AsyncIterableIterator<unknown>;
+  latestArgs?: JsonObject;
+  closed: boolean;
+}
+
+const toolInputParsers = new Map<string, ToolInputParserState>();
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+function createToolInputParser(toolCallId: string): ToolInputParserState {
+  const queue = new AsyncStringQueue();
+  const state: ToolInputParserState = {
+    queue,
+    iterator: parseJsonRiver(queue) as AsyncIterableIterator<unknown>,
+    closed: false,
+  };
+  toolInputParsers.set(toolCallId, state);
+  return state;
+}
+
+function closeToolInputParser(toolCallId: string): void {
+  const parser = toolInputParsers.get(toolCallId);
+  if (!parser) return;
+  parser.closed = true;
+  parser.queue.close();
+  toolInputParsers.delete(toolCallId);
+}
+
+export function clearToolInputParsers(): void {
+  for (const toolCallId of toolInputParsers.keys()) {
+    closeToolInputParser(toolCallId);
+  }
+}
 
 type SubagentProgressEvent =
   | { event: 'text'; text: string }
@@ -403,6 +482,9 @@ export function handleShellOutput(
  */
 export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: string, toolName: string): void {
   const { state } = ctx;
+  closeToolInputParser(toolCallId);
+  const parser = createToolInputParser(toolCallId);
+  void processToolInputParser(ctx, toolCallId, parser);
 
   // Mark as seen so handleMessageUpdate doesn't create a duplicate component
   if (!state.seenToolCallIds.has(toolCallId)) {
@@ -484,92 +566,114 @@ export function handleToolInputStart(ctx: EventHandlerContext, toolCallId: strin
 }
 
 /**
- * Handle an incremental delta of tool call input arguments.
- * Buffers the partial JSON text and attempts to parse it, updating the component's args.
+ * Apply the latest progressive JSON object from the stateful tool-input parser.
  */
-export function handleToolInputDelta(ctx: EventHandlerContext, toolCallId: string, _argsTextDelta: string): void {
+function applyParsedToolArgs(
+  ctx: EventHandlerContext,
+  toolCallId: string,
+  toolName: string,
+  partialArgs: JsonObject,
+): void {
   const { state } = ctx;
-  const ds = state.session.displayState.get();
-  const buffer = ds.toolInputBuffers.get(toolCallId);
-  if (buffer === undefined) return;
 
-  const updatedText = buffer.text;
+  const component = state.pendingTools.get(toolCallId);
+  if (component) {
+    component.updateArgs(partialArgs, false);
+    reconcileToolBoundaries(ctx);
+    component.refresh?.();
+  }
 
+  if (toolName === 'ask_user') {
+    const askComponent = state.pendingAskUserComponents.get(toolCallId);
+    if (askComponent) {
+      try {
+        askComponent.updateArgs(partialArgs);
+      } catch {
+        // Don't crash on malformed partial args
+      }
+    }
+  }
+
+  if (toolName === 'submit_plan') {
+    const planComponent = state.pendingSubmitPlanComponents?.get(toolCallId);
+    if (planComponent) {
+      planComponent.updateArgs(partialArgs);
+    }
+  }
+
+  if (toolName === 'task_write' && state.taskProgress) {
+    const tasks = (partialArgs as { tasks?: TaskItemInput[] }).tasks;
+    if (tasks && tasks.length > 0) {
+      const existing = state.taskProgress.getTasks();
+      const allExistingDone = existing.length === 0 || existing.every(t => t.status === 'completed');
+      if (allExistingDone) {
+        // Old list is done — start fresh, stream new items immediately
+        state.taskProgress.updateTasks(tasks);
+      } else if (tasks.length > 1) {
+        // Merge only completed items (exclude the last still-streaming one)
+        const merged = [...existing];
+        for (const task of tasks.slice(0, -1)) {
+          if (!task.content) continue;
+          const idx = task.id
+            ? merged.findIndex(t => t.id === task.id)
+            : merged.findIndex(t => !t.id && t.content === task.content);
+          if (idx >= 0) {
+            merged[idx] = task;
+          } else {
+            merged.push(task);
+          }
+        }
+        state.taskProgress.updateTasks(merged);
+      }
+    }
+  }
+
+  state.ui.requestRender();
+}
+
+async function processToolInputParser(
+  ctx: EventHandlerContext,
+  toolCallId: string,
+  parser: ToolInputParserState,
+): Promise<void> {
   try {
-    const partialArgs = parsePartialJson(updatedText);
-    if (partialArgs && typeof partialArgs === 'object') {
-      // Update inline tool component if it exists
-      const component = state.pendingTools.get(toolCallId);
-      if (component) {
-        component.updateArgs(partialArgs, false);
-        reconcileToolBoundaries(ctx);
-        component.refresh?.();
-      }
+    while (!parser.closed) {
+      const next = await parser.iterator.next();
+      if (next.done) return;
+      if (!isJsonObject(next.value)) continue;
 
-      // For ask_user, stream partial args into the question component
-      if (buffer.toolName === 'ask_user') {
-        const askComponent = state.pendingAskUserComponents.get(toolCallId);
-        if (askComponent) {
-          try {
-            askComponent.updateArgs(partialArgs);
-          } catch {
-            // Don't crash on malformed partial args
-          }
-        }
-      }
-
-      // For submit_plan, stream the path arg into the inline purple plan box.
-      if (buffer.toolName === 'submit_plan') {
-        const planComponent = state.pendingSubmitPlanComponents?.get(toolCallId);
-        if (planComponent) {
-          planComponent.updateArgs(partialArgs);
-        }
-      }
-
-      // For task_write, stream partial tasks into the pinned TaskProgressComponent.
-      // The last array item is actively being written so its content is unstable.
-      // If all existing pinned items are already completed, the list is stable and
-      // we can stream in new items immediately (including the last one).
-      // Otherwise, exclude the last item to avoid jumpy partial-content matches.
-      if (buffer.toolName === 'task_write' && state.taskProgress) {
-        const tasks = (partialArgs as { tasks?: TaskItemInput[] }).tasks;
-        if (tasks && tasks.length > 0) {
-          const existing = state.taskProgress.getTasks();
-          const allExistingDone = existing.length === 0 || existing.every(t => t.status === 'completed');
-          if (allExistingDone) {
-            // Old list is done — start fresh, stream new items immediately
-            state.taskProgress.updateTasks(tasks);
-          } else if (tasks.length > 1) {
-            // Merge only completed items (exclude the last still-streaming one)
-            const merged = [...existing];
-            for (const task of tasks.slice(0, -1)) {
-              if (!task.content) continue;
-              const idx = task.id
-                ? merged.findIndex(t => t.id === task.id)
-                : merged.findIndex(t => !t.id && t.content === task.content);
-              if (idx >= 0) {
-                merged[idx] = task;
-              } else {
-                merged.push(task);
-              }
-            }
-            state.taskProgress.updateTasks(merged);
-          }
-        }
-      }
-
-      state.ui.requestRender();
+      parser.latestArgs = next.value;
+      const buffer = ctx.state.session.displayState.get().toolInputBuffers.get(toolCallId);
+      if (!buffer || parser.closed) return;
+      applyParsedToolArgs(ctx, toolCallId, buffer.toolName, next.value);
     }
   } catch {
-    // Malformed or incomplete JSON — partial-json throws MalformedJSON for invalid input
+    closeToolInputParser(toolCallId);
   }
+}
+
+/**
+ * Handle an incremental delta of tool call input arguments.
+ * Feeds only the incoming JSON fragment to the stateful parser.
+ */
+export function handleToolInputDelta(ctx: EventHandlerContext, toolCallId: string, argsTextDelta: string): void {
+  const buffer = ctx.state.session.displayState.get().toolInputBuffers.get(toolCallId);
+  if (buffer === undefined) return;
+
+  let parser = toolInputParsers.get(toolCallId);
+  if (!parser) {
+    parser = createToolInputParser(toolCallId);
+    void processToolInputParser(ctx, toolCallId, parser);
+  }
+
+  parser.queue.push(argsTextDelta);
 }
 
 /**
  * Clean up the input buffer when tool input streaming ends.
  */
-export function handleToolInputEnd(_ctx: EventHandlerContext, _toolCallId: string): void {
-  // Buffer cleanup handled by AgentController display state
+export function handleToolInputEnd(_ctx: EventHandlerContext, toolCallId: string): void {
+  closeToolInputParser(toolCallId);
 }
 
 export function handleToolEnd(ctx: EventHandlerContext, toolCallId: string, result: unknown, isError: boolean): void {

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -63,6 +63,7 @@ import {
   renderExistingMessages,
   renderTaskDeltaInline,
 } from './render-messages.js';
+import { flushRender, requestRender } from './render-scheduler.js';
 import {
   setupKeyboardShortcuts,
   buildLayout,
@@ -180,7 +181,7 @@ export class MastraTUI {
         lastNotificationPriority: subscription.lastNotificationPriority,
       }));
       updateStatusLine(this.state);
-      this.state.ui.requestRender();
+      flushRender(this.state);
     });
 
     (options.githubSignals as GithubSignalsWithPollingEvents | undefined)?.onPollingChanged?.(event => {
@@ -190,13 +191,14 @@ export class MastraTUI {
       if (!this.state.githubPrGradientAnimator) {
         this.state.githubPrGradientAnimator = new GradientAnimator(() => {
           updateStatusLine(this.state);
+          requestRender(this.state);
         });
       }
       this.state.githubPrPollingActive = event.running;
       if (event.running) this.state.githubPrGradientAnimator.start();
       else this.state.githubPrGradientAnimator.stop();
       updateStatusLine(this.state);
-      this.state.ui.requestRender();
+      flushRender(this.state);
     });
 
     // Load user preferences
@@ -246,7 +248,7 @@ export class MastraTUI {
     this.state.editor.onImagePaste = image => {
       this.state.pendingImages.push(image);
       this.state.editor.insertTextAtCursor?.('[image] ');
-      this.state.ui.requestRender();
+      flushRender(this.state);
     };
     this.state.editor.getPromptAnimator = () => this.state.gradientAnimator;
 
@@ -288,7 +290,7 @@ export class MastraTUI {
           content: [{ type: 'text', text: msg }],
           createdAt: new Date(),
         });
-        this.state.ui.requestRender();
+        flushRender(this.state);
 
         const allowed = await this.runUserPromptHook(msg);
         if (!allowed) {
@@ -296,7 +298,7 @@ export class MastraTUI {
           if (comp) {
             this.state.chatContainer.removeChild(comp as never);
             this.state.messageComponentsById.delete(messageId);
-            this.state.ui.requestRender();
+            flushRender(this.state);
           }
         } else {
           try {
@@ -401,7 +403,7 @@ export class MastraTUI {
     addUserMessage(this.state, this.createUserSignalMessage(content, images, messageId), {
       ...(isInterjection ? { label: 'steer' } : {}),
     });
-    this.state.ui.requestRender();
+    flushRender(this.state);
     return messageId;
   }
 
@@ -410,7 +412,7 @@ export class MastraTUI {
     if (!component) return;
     this.state.chatContainer.removeChild(component as never);
     this.state.messageComponentsById.delete(messageId);
-    this.state.ui.requestRender();
+    flushRender(this.state);
   }
 
   private remapOptimisticUserMessage(optimisticMessageId: string, signalId: string): void {
@@ -525,7 +527,7 @@ export class MastraTUI {
     this.state.pendingFollowUpMessages.push({ content, images });
     this.state.pendingQueuedActions.push('message');
     updateStatusLine(this.state);
-    this.state.ui.requestRender();
+    flushRender(this.state);
   }
 
   /**
@@ -560,6 +562,7 @@ export class MastraTUI {
     if (this.state.unsubscribe) {
       this.state.unsubscribe();
     }
+    this.state.renderScheduler?.dispose();
     this.state.ui.stop();
   }
 
@@ -684,13 +687,13 @@ export class MastraTUI {
 
   private updateIdleStatusLine(now = Date.now()): void {
     this.state.idleCounter?.setTimingState(this.state, now);
-    this.state.ui.requestRender?.();
+    requestRender(this.state);
   }
 
   private updateActiveStatusTiming(now = Date.now()): void {
     this.state.idleCounter?.setTimingState(this.state, now);
     updateStatusLine(this.state);
-    this.state.ui.requestRender?.();
+    requestRender(this.state);
   }
 
   private startActiveStatusTimingTicker(): void {
@@ -737,7 +740,7 @@ export class MastraTUI {
     }
     if (clearDisplay) {
       this.state.idleCounter?.setTimingState(undefined);
-      this.state.ui.requestRender?.();
+      requestRender(this.state);
     }
   }
 
@@ -1111,7 +1114,7 @@ export class MastraTUI {
         if (isGoalJudgeInputLocked(this.state)) {
           this.state.editor.setText(text);
           showGoalJudgeInputLockInfo(this.state);
-          this.state.ui.requestRender();
+          flushRender(this.state);
           return;
         }
 
@@ -1514,7 +1517,7 @@ export class MastraTUI {
       tool.setQuietModeDisplay?.(enabled ? 'quiet' : 'normal');
       tool.setQuietPreviewLineLimit?.(previewLineLimit);
     }
-    this.state.ui.requestRender();
+    flushRender(this.state);
   }
 
   private parseQuietPreviewLineAnswer(answer: string | null): number {
@@ -1652,7 +1655,7 @@ export class MastraTUI {
       insertChatComponentWithBoundarySpacing(this.state.chatContainer, component);
       this.state.activeInlineQuestion = component;
       component.focused = true;
-      this.state.ui.requestRender();
+      flushRender(this.state);
     });
 
     if (answer === 'Yes') {

--- a/mastracode/tui/src/tui/render-scheduler.ts
+++ b/mastracode/tui/src/tui/render-scheduler.ts
@@ -1,0 +1,65 @@
+export const DEFAULT_RENDER_COALESCE_MS = 80;
+
+export class RenderScheduler {
+  private timer: ReturnType<typeof setTimeout> | undefined;
+  private lastRenderAt = 0;
+  private pending = false;
+
+  constructor(
+    private readonly render: () => void,
+    private readonly intervalMs = DEFAULT_RENDER_COALESCE_MS,
+    private readonly now = () => Date.now(),
+  ) {}
+
+  request(): void {
+    if (this.pending) return;
+
+    const elapsed = this.now() - this.lastRenderAt;
+    if (elapsed >= this.intervalMs) {
+      this.run();
+      return;
+    }
+
+    this.pending = true;
+    this.timer = setTimeout(() => {
+      this.timer = undefined;
+      this.run();
+    }, this.intervalMs - elapsed);
+  }
+
+  flush(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.pending = false;
+    this.run();
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = undefined;
+    }
+    this.pending = false;
+  }
+
+  private run(): void {
+    this.pending = false;
+    this.lastRenderAt = this.now();
+    this.render();
+  }
+}
+
+export interface RenderableState {
+  ui: { requestRender?: () => void };
+  renderScheduler?: RenderScheduler;
+}
+
+export function requestRender(state: RenderableState): void {
+  state.renderScheduler?.request() ?? state.ui.requestRender?.();
+}
+
+export function flushRender(state: RenderableState): void {
+  state.renderScheduler?.flush() ?? state.ui.requestRender?.();
+}

--- a/mastracode/tui/src/tui/render-scheduler.ts
+++ b/mastracode/tui/src/tui/render-scheduler.ts
@@ -15,16 +15,12 @@ export class RenderScheduler {
     if (this.pending) return;
 
     const elapsed = this.now() - this.lastRenderAt;
-    if (elapsed >= this.intervalMs) {
-      this.run();
-      return;
-    }
-
+    const delay = Math.max(0, this.intervalMs - elapsed);
     this.pending = true;
     this.timer = setTimeout(() => {
       this.timer = undefined;
       this.run();
-    }, this.intervalMs - elapsed);
+    }, delay);
   }
 
   flush(): void {

--- a/mastracode/tui/src/tui/render-scheduler.ts
+++ b/mastracode/tui/src/tui/render-scheduler.ts
@@ -53,9 +53,17 @@ export interface RenderableState {
 }
 
 export function requestRender(state: RenderableState): void {
-  state.renderScheduler?.request() ?? state.ui.requestRender?.();
+  if (state.renderScheduler) {
+    state.renderScheduler.request();
+    return;
+  }
+  state.ui.requestRender?.();
 }
 
 export function flushRender(state: RenderableState): void {
-  state.renderScheduler?.flush() ?? state.ui.requestRender?.();
+  if (state.renderScheduler) {
+    state.renderScheduler.flush();
+    return;
+  }
+  state.ui.requestRender?.();
 }

--- a/mastracode/tui/src/tui/render-scheduler.ts
+++ b/mastracode/tui/src/tui/render-scheduler.ts
@@ -4,6 +4,7 @@ export class RenderScheduler {
   private timer: ReturnType<typeof setTimeout> | undefined;
   private lastRenderAt = 0;
   private pending = false;
+  private disposed = false;
 
   constructor(
     private readonly render: () => void,
@@ -12,7 +13,7 @@ export class RenderScheduler {
   ) {}
 
   request(): void {
-    if (this.pending) return;
+    if (this.disposed || this.pending) return;
 
     const elapsed = this.now() - this.lastRenderAt;
     const delay = Math.max(0, this.intervalMs - elapsed);
@@ -24,6 +25,8 @@ export class RenderScheduler {
   }
 
   flush(): void {
+    if (this.disposed) return;
+
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
@@ -33,6 +36,7 @@ export class RenderScheduler {
   }
 
   dispose(): void {
+    this.disposed = true;
     if (this.timer) {
       clearTimeout(this.timer);
       this.timer = undefined;
@@ -42,6 +46,7 @@ export class RenderScheduler {
 
   private run(): void {
     this.pending = false;
+    if (this.disposed) return;
     this.lastRenderAt = this.now();
     this.render();
   }

--- a/mastracode/tui/src/tui/state.ts
+++ b/mastracode/tui/src/tui/state.ts
@@ -40,6 +40,7 @@ import { showError, showInfo } from './display.js';
 
 import { GoalManager } from './goal-manager.js';
 import type { OnboardingInlineComponent } from './onboarding-inline.js';
+import { RenderScheduler } from './render-scheduler.js';
 import { getEditorTheme, mastra, TERM_WIDTH_BUFFER } from './theme.js';
 import { VoiceController } from './voice/voice-controller.js';
 
@@ -165,6 +166,7 @@ export interface TUIState {
 
   // ── TUI framework (set once) ──────────────────────────────────────────
   ui: TUI;
+  renderScheduler?: RenderScheduler;
   chatContainer: Container;
   editorContainer: Container;
   idleCounter?: IdleCounterComponent;
@@ -342,6 +344,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
     });
   }
   const ui = new TUI(terminal);
+  const renderScheduler = new RenderScheduler(() => ui.requestRender());
 
   // Perf profiling removed
 
@@ -349,6 +352,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
   const editorContainer = new Container();
   const footer = new Container();
   const editor = new CustomEditor(ui, getEditorTheme());
+  editor.requestRender = () => renderScheduler.request();
   const result: TUIState = {
     // Core dependencies
     controller: options.controller,
@@ -363,6 +367,7 @@ export function createTUIState(options: MastraTUIOptions): TUIState {
 
     // TUI framework
     ui,
+    renderScheduler,
     chatContainer,
     editorContainer,
     editor,

--- a/mastracode/tui/src/tui/status-line.ts
+++ b/mastracode/tui/src/tui/status-line.ts
@@ -79,7 +79,6 @@ export function updateStatusLine(state: TUIState): void {
   // --- Determine if we're showing observer/reflector instead of main mode ---
   const displayState = state.session.displayState.get();
   const omStatus = displayState.omProgress.status;
-  const isOMBuffering = displayState.bufferingMessages || displayState.bufferingObservations;
   const isJudging = Boolean(state.activeGoalJudge);
   const isObserving = omStatus === 'observing';
   const isReflecting = omStatus === 'reflecting';
@@ -124,7 +123,7 @@ export function updateStatusLine(state: TUIState): void {
     ];
     // Pulse the badge bg brightness opposite to the gradient sweep
     let badgeBrightness = 0.9;
-    if (!isOMBuffering && state.gradientAnimator?.isRunning()) {
+    if (state.gradientAnimator?.isRunning()) {
       const fade = state.gradientAnimator.getFadeProgress();
       const easedFade = fade * fade * (3 - 2 * fade); // smoothstep
       const offset = state.gradientAnimator.getOffset() % 1;
@@ -217,7 +216,7 @@ export function updateStatusLine(state: TUIState): void {
       return theme.fg('dim', id) + theme.fg('error', ' ✗') + theme.fg('muted', envVar ? ` (${envVar})` : ' (no key)');
     }
 
-    if (!isOMBuffering && state.gradientAnimator?.isRunning() && modeColor) {
+    if (state.gradientAnimator?.isRunning() && modeColor) {
       const fade = state.gradientAnimator.getFadeProgress();
       const easedFade = fade * fade * (3 - 2 * fade); // smoothstep
       const text = applyGradientSweep(id, state.gradientAnimator.getOffset(), modeColor, easedFade);
@@ -258,7 +257,7 @@ export function updateStatusLine(state: TUIState): void {
       parseInt(modeColor.slice(5, 7), 16),
     ];
     let sBadgeBrightness = 0.9;
-    if (!isOMBuffering && state.gradientAnimator?.isRunning()) {
+    if (state.gradientAnimator?.isRunning()) {
       const fade = state.gradientAnimator.getFadeProgress();
       if (fade < 1) {
         const offset = state.gradientAnimator.getOffset() % 1;

--- a/patches/@earendil-works__pi-tui@0.80.6.patch
+++ b/patches/@earendil-works__pi-tui@0.80.6.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/utils.js b/dist/utils.js
+index bc550a400f3ac921263a8f2fa1753335b4fded8c..eb17cdc3a91466b812a6eca53a97473abcecfa0c 100644
+--- a/dist/utils.js
++++ b/dist/utils.js
+@@ -212,6 +212,10 @@ export function visibleWidth(str) {
+         }
+         clean = stripped;
+     }
++    // ANSI-styled printable ASCII remains single-column text after normalization.
++    if (isPrintableAscii(clean)) {
++        return clean.length;
++    }
+     // Calculate width
+     let width = 0;
+     for (const { segment } of graphemeSegmenter.segment(clean)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -181,6 +181,7 @@ packageExtensionsChecksum: sha256-/cD8y6AI9CdIuSvELFiNyGPNGS77AbBTfsEAe7m2Qbo=
 
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': eb65c5cbf43c61ce6dcb0c77fa30d9aebcdffa3a70dee1faefc4cde4125f28fa
+  '@earendil-works/pi-tui@0.80.6': 88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b
   tsup@8.5.1: 78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f
 
 importers:
@@ -2276,8 +2277,8 @@ importers:
         specifier: ^3.864.0
         version: 3.1006.0
       '@earendil-works/pi-tui':
-        specifier: ^0.79.4
-        version: 0.79.4
+        specifier: 0.80.6
+        version: 0.80.6(patch_hash=88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b)
       '@mastra/agent-browser':
         specifier: workspace:*
         version: link:../../browser/agent-browser
@@ -12194,8 +12195,8 @@ packages:
   '@duckdb/node-bindings@1.5.2-r.2':
     resolution: {integrity: sha512-A17A6pXB7SEBAm93POdmEG+f4vQWMSujUP8/hNUfDWjaqp4C5mUWFnyuBM4XiB4qyXXH3vbjis2TYsnxAN2xEQ==}
 
-  '@earendil-works/pi-tui@0.79.4':
-    resolution: {integrity: sha512-/ZhfFiHSBMH7AbDrBQIN+UWlJnl9tSEpLYICRGGMzmNfyCqX+30NYacIhyOEaD8R5rS6wJZysAOPU0yNwigbXw==}
+  '@earendil-works/pi-tui@0.80.6':
+    resolution: {integrity: sha512-bSuzS4EVSqEPj/Qr/p9eqCESfKsGuDNbl77EGci8Iaqqt/C/XCBZL1MjXaxSWW1NsT5afjp/Cb0NTPzOLv/aPA==}
     engines: {node: '>=22.19.0'}
 
   '@elastic/elasticsearch@8.19.1':
@@ -24472,9 +24473,9 @@ packages:
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
-  marked@15.0.12:
-    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
-    engines: {node: '>= 18'}
+  marked@18.0.5:
+    resolution: {integrity: sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==}
+    engines: {node: '>= 20'}
     hasBin: true
 
   marky@1.3.0:
@@ -34565,10 +34566,10 @@ snapshots:
       '@duckdb/node-bindings-win32-arm64': 1.5.2-r.2
       '@duckdb/node-bindings-win32-x64': 1.5.2-r.2
 
-  '@earendil-works/pi-tui@0.79.4':
+  '@earendil-works/pi-tui@0.80.6(patch_hash=88572df39a8452647fa073db5bc0907de3f1cb04c52c4559c8cc6e662973818b)':
     dependencies:
       get-east-asian-width: 1.6.0
-      marked: 15.0.12
+      marked: 18.0.5
 
   '@elastic/elasticsearch@8.19.1':
     dependencies:
@@ -47786,7 +47787,7 @@ snapshots:
 
   markdown-table@3.0.4: {}
 
-  marked@15.0.12: {}
+  marked@18.0.5: {}
 
   marky@1.3.0:
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2341,9 +2341,9 @@ importers:
       fastest-levenshtein:
         specifier: ^1.0.16
         version: 1.0.16
-      partial-json:
-        specifier: ^0.1.7
-        version: 0.1.7
+      jsonriver:
+        specifier: ^1.1.1
+        version: 1.1.1
       posthog-node:
         specifier: ^5.37.0
         version: 5.37.0(rxjs@7.8.2)
@@ -23966,6 +23966,9 @@ packages:
     resolution: {integrity: sha512-wy8OTjwsJwQRnQJkKnMJJ9vcytRdBPAgIF/Hy6+s1dAj42BHMKiyL8JzEieIl3JY7idt8eyHwBWTO8mh/+mtwA==}
     hasBin: true
 
+  jsonriver@1.1.1:
+    resolution: {integrity: sha512-w/y/ZvC0YlJxRjySXt6hEji3RltOLAbSiDe3jlWekbIT7qLIOJF+tGNscwTWJZhoNQzi1dItJVMM2jEPZbHSEQ==}
+
   jsonschema@1.2.7:
     resolution: {integrity: sha512-3dFMg9hmI9LdHag/BRIhMefCfbq1hicvYMy8YhZQorAdzOzWz7NjniSpn39yjpzUAMIWtGyyZuH2KNBloH7ZLw==}
 
@@ -25812,9 +25815,6 @@ packages:
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  partial-json@0.1.7:
-    resolution: {integrity: sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA==}
 
   pascal-case@3.1.2:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
@@ -47229,6 +47229,8 @@ snapshots:
 
   jsonrepair@3.15.0: {}
 
+  jsonriver@1.1.1: {}
+
   jsonschema@1.2.7: {}
 
   jsonwebtoken@9.0.3:
@@ -49739,8 +49741,6 @@ snapshots:
       entities: 8.0.0
 
   parseurl@1.3.3: {}
-
-  partial-json@0.1.7: {}
 
   pascal-case@3.1.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,6 +46,7 @@ catalog:
 
 patchedDependencies:
   '@changesets/get-dependents-graph@2.1.4': patches/@changesets__get-dependents-graph@2.1.4.patch
+  '@earendil-works/pi-tui@0.80.6': patches/@earendil-works__pi-tui@0.80.6.patch
   tsup@8.5.1: patches/tsup@8.5.1.patch
 
 packageExtensions:


### PR DESCRIPTION
Large streamed tool arguments and shell output could repeatedly rebuild and rerender expensive TUI previews, making the interface sluggish or appear frozen during file writes, edits, and long shell commands.

This switches streamed tool-argument parsing to incremental `jsonriver` state, coalesces bursty renders and shell output, and keeps quiet-mode previews bounded while still showing a rolling highlighted view of current progress. It also makes parser and shell-output cleanup lifecycle-safe, flushes final streamed args before input teardown, and adds a local Render Smoke provider for reproducing realistic and stress-rate streams.

Before, each incoming fragment could reparse and rerender the growing payload. After, parsing remains incremental and visual updates are applied at a bounded cadence without dropping the final state.

Verified with:

```sh
pnpm --filter ./mastracode/tui exec vitest run src/tui/handlers/__tests__/tool.test.ts src/tui/handlers/tool.test.ts --reporter=dot --bail 1
pnpm --filter ./mastracode/tui check
```

Also manually verified write, edit, and command-argument streaming with the included Render Smoke server at realistic chat speed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When Mastra Code streams tool inputs and shell output, the screen would “jitter” because it tried to re-render too often while data was still arriving. This PR makes the TUI read streamed JSON incrementally and only repaint at the right moments, while also cleaning up partial work safely so interrupted runs don’t leave stale UI.

## What changed
- Tool-argument streaming: replaced `partial-json` with incremental streaming JSON parsing using `jsonriver`, buffering per `toolCallId`, updating the tool UI via coalesced renders, and cleaning up parser state on end/error.
- Render performance: added a `RenderScheduler` plus `requestRender(state)` (coalesced) and `flushRender(state)` (immediate) helpers, and rewired many TUI code paths to use them instead of direct `ui.requestRender()` calls.
- Shell output streaming: buffered streamed shell output per `toolCallId`, coalesced high-frequency updates, and added lifecycle-safe cleanup helpers (`clearPendingShellOutputs`, `clearToolInputParsers`) used across agent/message/tool transitions.
- Render lifecycle hardening: ensured flushes happen at key lifecycle boundaries (start/end/thread changes/subagents/messages), prevented duplicate or post-disposal renders via scheduler disposal, and flushed remaining streamed work before teardown.
- Quiet-mode preview improvements: tightened character/width caps and quote-aware highlighting for large/streaming `write_file`, `string_replace_lsp` (edit), and shell command previews; updated tests to reflect bounded highlighting and rolling preview behavior during streaming.
- Render Smoke local stress tooling: added `render-smoke:*` scripts, a local SSE-based mock server, and installer/uninstaller logic with idempotency and force-uninstall support, enabling realistic streaming-rate reproduction across platforms and invalid configurations.
- Tests & deps: added/updated Vitest suites for render scheduling, parser/shell-output cleanup, and streaming/quiet-preview behavior; bumped `@earendil-works/pi-tui` to `0.80.6`, swapped `partial-json` → `jsonriver`, and added a patch to optimize `visibleWidth` for printable ASCII.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->