### PR TITLE
fix: increase renovate node heap

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -90,6 +90,7 @@ jobs:
           docker-user: '${{ steps.id.outputs.user }}:${{ steps.id.outputs.group }}'
           token: ${{ secrets.RENOVATE_PAT  }}
         env:
+          NODE_OPTIONS: --max-old-space-size=8192
           LOG_LEVEL: ${{ github.event.inputs.logLevel }}
           RENOVATE_REPOSITORIES: ${{ github.repository }}
           # This enables the cache -- if this is set, it's not necessary to add it to renovate.json.


### PR DESCRIPTION
Renovate has been failing to generate the pnpm lockfile artifact on security update branches because Node runs out of heap.\n\nThis gives the self-hosted Renovate workflow an 8 GB Node heap, matching the setting we already use in other large CI jobs.\n\nNo package changes, so no changeset is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Renovate gets more memory to prevent failures while creating lockfiles for security updates.

## Changes

- Increased Node.js heap allocation to 8 GB in the self-hosted Renovate workflow.
- No package changes or changeset included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->