### PR TITLE
docs(platform): document unified single-command deploy, environments, and CLI-managed databases

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-platform/configuration.mdx
@@ -5,13 +5,13 @@ description: Configuration options and settings for the Mastra platform, includi
 
 # Configuration
 
-When you deploy to the Mastra platform, the CLI generates a `.mastra-project.json` config file and reads environment variables from your local `.env` files.
+When you deploy to the Mastra platform, the CLI generates a `.mastra-project.json` config file and resolves environment variables from the platform and, optionally, your local `.env` files.
 
-This page explains both mechanisms and how they differ between Studio and Server deployments.
+This page explains both mechanisms.
 
 ## Project config
 
-The `.mastra-project.json` file is auto-generated on your first Studio or Server deploy. It links your local project to a platform project. The [GitHub integration](/docs/mastra-platform/github) writes the same file into linked repositories.
+The `.mastra-project.json` file is auto-generated on your first [`mastra deploy`](/docs/mastra-platform/deploy). It links your local project to a platform project. The [GitHub integration](/docs/mastra-platform/github) writes the same file into linked repositories.
 
 Commit it to your version control so that subsequent deploys (including from CI) target the correct project.
 
@@ -33,18 +33,19 @@ Your file will look something like this:
 
 ## Environment variables
 
-The CLI reads from `.env` and `.env.local` files in your project directory during deploy. Variables from `.env.local` override those in `.env`.
+A local env file is optional. [`mastra deploy`](/docs/mastra-platform/deploy) resolves variables from three sources:
 
-You can set environment variables like so:
+- **Managed variables**: Injected by platform resources like [hosted databases](/docs/mastra-platform/database). The platform defines these, and you can't edit them.
+- **Stored variables**: Saved on the project or environment through the dashboard. Used as-is on every deploy with no local file needed.
+- **Local env files**: An explicit `--env-file`, or ambient `.env` and `.env.local` files, layered on top at deploy time. Variables from `.env.local` override those in `.env`.
 
-- **Studio**: Environment variables are read from your local `.env` files and bundled into the deploy artifact. To update them, redeploy.
-- **Server**: On the first deploy, the CLI automatically seeds environment variables from your local `.env` files. After that, manage them per-project through the dashboard or API.
-
-To pin the deploy to a specific env file (instead of relying on the default selection), pass `--env-file`:
+To pin the deploy to a specific env file instead of relying on the default selection, pass `--env-file`:
 
 ```bash
-mastra studio deploy --env-file .env.production --yes
+mastra deploy --env-file .env.production --yes
 ```
+
+Review and sanitize local env files before deploying to avoid uploading development-only or personal secrets.
 
 ### Observability
 
@@ -61,19 +62,13 @@ The following environment variables configure the Observability product on the M
 
 ## Multiple environments
 
-A platform project maps to a single deployed instance with one set of env vars. Platform projects don't have built-in `staging` vs `production` slots. To run the same codebase across multiple environments, create one project per environment and use the matching `.mastra-project.json` file for each deploy.
+A single project runs the same codebase across multiple [environments](/docs/mastra-platform/environments), such as `production` and `staging`. Each environment has its own URL, its own stored variables, and its own deploy history. One `.mastra-project.json` file covers all of them:
 
 ```bash
-# Create and deploy each environment for the first time.
-mastra studio deploy --project "my-app-staging" --env-file .env.staging --yes
-mastra studio deploy --project "my-app-production" --env-file .env.production --yes
-
-# For subsequent deploys, restore the matching .mastra-project.json file before deploying.
-cp .mastra-project.staging.json .mastra-project.json
-mastra studio deploy --env-file .env.staging --yes
-
-cp .mastra-project.production.json .mastra-project.json
-mastra studio deploy --env-file .env.production --yes
+mastra deploy --env production --yes
+mastra deploy --env staging --env-file .env.staging --yes
 ```
 
-Each project has its own Studio URL and can send observability data to the Mastra platform. When using [`MastraPlatformExporter`](/docs/observability/integrations/exporters/mastra-platform), set `MASTRA_PROJECT_ID` and `MASTRA_PLATFORM_ACCESS_TOKEN` per environment so traces route to the matching platform project.
+:::note
+Earlier platform versions required one project per environment. Environments replace that pattern, so keep one project and deploy to named environments instead.
+:::

--- a/docs/src/content/en/docs/mastra-platform/configuration.mdx
+++ b/docs/src/content/en/docs/mastra-platform/configuration.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Configuration | Mastra platform"
-description: Configuration options and settings for the Mastra platform, including Studio and Server deployments.
+description: How Mastra platform deploys resolve their target project through .mastra-project.json and their environment variables across managed, stored, and local sources.
 ---
 
 # Configuration

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -24,7 +24,7 @@ Use a hosted database when your project needs durable storage that's managed by 
 
 ## Providers
 
-Hosted databases are available through three providers. Pick one when you attach a database, then wire its injected variables into the matching Mastra storage adapter in your code.
+Hosted databases are available through two providers today — Turso and Postgres — with MongoDB coming soon. Pick one when you attach a database, then wire its injected variables into the matching Mastra storage adapter in your code.
 
 Each provider injects a fixed set of variable names — for example, a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Those names must be unique within each environment, which means an environment can use at most one database per provider. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
 

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -26,7 +26,7 @@ Use a hosted database when your project needs durable storage that's managed by 
 
 Hosted databases are available through three providers. Pick one when you attach a database, then wire its injected variables into the matching Mastra storage adapter in your code.
 
-Each provider injects a fixed set of variable names, and those names must be unique across the project. In practice this means one database per provider — for example, a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
+Each provider injects a fixed set of variable names — for example, a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Those names must be unique within each environment, which means an environment can use at most one database per provider. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
 
 For most agent-focused projects, **Turso** is the simplest starting point. It provides a lightweight, SQLite-compatible engine well suited to agent memory, conversation history, and per-tenant isolation. Choose **Postgres** when your workload needs full SQL, relational schemas, or structured application data beyond Mastra runtime state. **MongoDB** (_coming soon_) will add document storage and built-in vector search for workloads that don't map cleanly to SQL.
 
@@ -44,6 +44,8 @@ A database is attached at one of two scopes:
 - **Environment scope**: Attached to a single environment. Use this to isolate data between environments, for example separate production and staging databases.
 
 The scope is set when you attach the database and shown in `mastra env db list`.
+
+The two scopes can't overlap for the same provider. Because a project-scoped database already injects its variables into every environment, attaching an environment-scoped database of the same provider is rejected with a variable name conflict. To move from a shared database to per-environment databases, detach the project-scoped database first, then attach one database per environment. Environment-scoped databases on different environments never conflict — each deploy only receives the variables for its own environment.
 
 ## Attach with the CLI
 

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Hosted databases | Mastra platform"
-description: Provision managed Turso (LibSQL) and Postgres databases from your platform project settings and connect them to your Mastra project with no manual configuration.
+description: Provision managed Turso (LibSQL) and Postgres databases from the CLI or your platform project settings and connect them to your Mastra project with no manual configuration.
 ---
 
 import Steps from "@site/src/components/Steps";
@@ -24,7 +24,7 @@ Use a hosted database when your project needs durable storage that's managed by 
 
 ## Providers
 
-Hosted databases are available through three providers. Pick one when you attach a database from project settings. Mastra provisions it with the provider, stores credentials securely, and injects connection details as runtime environment variables when the database is ready. Wire those variables into the matching Mastra storage adapter in your code.
+Hosted databases are available through three providers. Pick one when you attach a database, then wire its injected variables into the matching Mastra storage adapter in your code.
 
 Each provider injects a fixed set of variable names, and those names must be unique across the project. In practice this means one database per provider — for example, a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
 

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -8,7 +8,11 @@ import StepItem from "@site/src/components/StepItem";
 
 # Hosted databases
 
-From your [platform](/docs/mastra-platform/overview) project settings, provision a fully managed database and attach it to your project. Mastra creates it with your provider, stores credentials securely, and injects connection details as runtime environment variables when the database is ready, so there are no connection strings to copy or configure.
+Provision a fully managed database from the CLI or your [platform](/docs/mastra-platform/overview) project settings and attach it to your project. Mastra creates it with your provider, stores credentials securely, and injects connection details as runtime environment variables when the database is ready, so there are no connection strings to copy or configure.
+
+```bash
+mastra env db create --kind turso
+```
 
 ## When to use hosted databases
 
@@ -22,7 +26,7 @@ Use a hosted database when your project needs durable storage that's managed by 
 
 Hosted databases are available through three providers. Pick one when you attach a database from project settings. Mastra provisions it with the provider, stores credentials securely, and injects connection details as runtime environment variables when the database is ready. Wire those variables into the matching Mastra storage adapter in your code.
 
-You can attach one database per provider to a project. This keeps environment variable names unambiguous — for example, a project has a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
+Each provider injects a fixed set of variable names, and those names must be unique across the project. In practice this means one database per provider — for example, a single `DATABASE_URL` for Postgres and separate `TURSO_*` variables for Turso. Attach Turso and Postgres to the same project when you need separate stores for different workloads.
 
 For most agent-focused projects, **Turso** is the simplest starting point. It provides a lightweight, SQLite-compatible engine well suited to agent memory, conversation history, and per-tenant isolation. Choose **Postgres** when your workload needs full SQL, relational schemas, or structured application data beyond Mastra runtime state. **MongoDB** (_coming soon_) will add document storage and built-in vector search for workloads that don't map cleanly to SQL.
 
@@ -32,7 +36,45 @@ For most agent-focused projects, **Turso** is the simplest starting point. It pr
 | **PostgreSQL** | Serverless Postgres | Relational workloads, structured data |
 | **MongoDB** | Document and vector search | Document storage, vector search (_coming soon_) |
 
-## Attach a database
+## Database scope
+
+A database is attached at one of two scopes:
+
+- **Project scope**: The default. One database shared by all of the project's [environments](/docs/mastra-platform/environments). Its variables are injected into every deploy.
+- **Environment scope**: Attached to a single environment. Use this to isolate data between environments, for example separate production and staging databases.
+
+The scope is set when you attach the database and shown in `mastra env db list`.
+
+## Attach with the CLI
+
+Create and attach a database in one command. The CLI polls until it's ready, which takes a few seconds:
+
+```bash
+# Shared by all environments
+mastra env db create --kind turso
+
+# Scoped to the staging environment
+mastra env db create staging --kind turso
+```
+
+Supported kinds are `turso` and `neon` (Postgres). Useful flags:
+
+- `--name <name>`: Database name. Defaults to a name derived from the project slug.
+- `--region <region>`: Provider region ID for project-scoped databases (for example `fra`). Environment-scoped databases are placed near the environment's region automatically, and an explicit `--region` is ignored.
+- `--no-wait`: Return immediately instead of polling. Check progress later with `mastra env db show`.
+- `--json`: Machine-readable output.
+
+Inspect and manage attached databases:
+
+```bash
+mastra env db list
+mastra env db show <database>
+mastra env db detach <database>
+```
+
+`mastra env db list` shows each database's kind, status, scope, and injected variable names. `mastra env db show` prints connection instructions with secret values masked; pass `--show-secrets` to reveal them. Creating and detaching databases requires the admin role in your organization.
+
+## Attach from project settings
 
 <Steps>
   <StepItem>
@@ -59,9 +101,7 @@ For most agent-focused projects, **Turso** is the simplest starting point. It pr
   </StepItem>
 </Steps>
 
-:::note
-Hosted databases are created from your platform project settings. No CLI or public API currently provisions them.
-:::
+Databases attached from project settings are project-scoped. Use the [CLI](#attach-with-the-cli) to attach an environment-scoped database.
 
 ## Connect from your code
 

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -45,7 +45,7 @@ A database is attached at one of two scopes:
 
 The scope is set when you attach the database and shown in `mastra env db list`.
 
-The two scopes can't overlap for the same provider. Because a project-scoped database already injects its variables into every environment, attaching an environment-scoped database of the same provider is rejected with a variable name conflict. To move from a shared database to per-environment databases, detach the project-scoped database first, then attach one database per environment. Environment-scoped databases on different environments never conflict — each deploy only receives the variables for its own environment.
+The two scopes can't overlap for the same provider. Because a project-scoped database already injects its variables into every environment, attaching an environment-scoped database of the same provider is rejected with a variable name conflict. To move from a shared database to per-environment databases, delete the project-scoped database first, then attach one database per environment. Deleting a database destroys it with the provider along with all of its data — export anything you need to keep before switching scopes. Environment-scoped databases on different environments never conflict — each deploy only receives the variables for its own environment.
 
 ## Attach with the CLI
 
@@ -71,10 +71,10 @@ Inspect and manage attached databases:
 ```bash
 mastra env db list
 mastra env db show <database>
-mastra env db detach <database>
+mastra env db delete <database>
 ```
 
-`mastra env db list` shows each database's kind, status, scope, and injected variable names. `mastra env db show` prints connection instructions with secret values masked; pass `--show-secrets` to reveal them. Creating and detaching databases requires the admin role in your organization.
+`mastra env db list` shows each database's kind, status, scope, and injected variable names. `mastra env db show` prints connection instructions with secret values masked; pass `--show-secrets` to reveal them. `mastra env db delete` permanently deletes the database and all of its data with the provider. Creating and deleting databases requires the admin role in your organization.
 
 ## Attach from project settings
 
@@ -173,4 +173,4 @@ Treat connection credentials as secrets. The auth token (`TURSO_AUTH_TOKEN`) and
 ## Manage a database
 
 - **View connection details**: Open a `ready` database in your project settings to see its environment variables and a copy-pasteable code snippet.
-- **Detach**: Removing a database from a project deletes it with the provider and clears its injected environment variables. This is irreversible, so ensure you no longer need the data.
+- **Delete**: Removing a database from a project deletes it with the provider and clears its injected environment variables. This is irreversible, so ensure you no longer need the data.

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -1,0 +1,150 @@
+---
+title: "Deploy | Mastra platform"
+description: Deploy your Mastra application to the Mastra platform with a single command. Build, validate, provision, and ship to any environment with mastra deploy.
+---
+
+import Steps from "@site/src/components/Steps";
+import StepItem from "@site/src/components/StepItem";
+
+# Deploy to Mastra platform
+
+[`mastra deploy`](/reference/cli/mastra#mastra-deploy) is the single command for shipping a Mastra application to the [Mastra platform](/docs/mastra-platform/overview). One command builds your project, validates it before anything ships, creates the platform project and environment on your first run, deploys, streams build logs, and prints your public URL once the deploy is serving traffic.
+
+```bash
+mastra deploy
+```
+
+:::note
+This page covers the unified deploy flow. The earlier split commands, [`mastra server deploy`](/docs/mastra-platform/server) and [`mastra studio deploy`](/docs/mastra-platform/studio), still work but `mastra deploy` is the recommended path.
+:::
+
+## Before you begin
+
+You'll need a [Mastra application](/docs/getting-started/installation) and a [Mastra platform](https://projects.mastra.ai) account. If you're not authenticated, the CLI prompts you to log in on first use.
+
+A local `.env` file is optional. Environment variables stored on the platform are used as-is at deploy time, and managed resources like [hosted databases](/docs/mastra-platform/database) inject their own variables. Pass `--env-file` only when you want to layer local values on top.
+
+## Your first deploy
+
+<Steps>
+  <StepItem>
+    From your project directory, run:
+
+    ```bash
+    mastra deploy
+    ```
+
+    On the first run the CLI prompts you to create the platform project (named after your `package.json`) and the `production` environment. Accept the prompts, or pass `--yes` to accept defaults without confirmation.
+  </StepItem>
+
+  <StepItem>
+    The CLI runs a preflight check before anything ships. If your storage falls back to a local file path, the deploy is blocked with a message like:
+
+    ```
+    [LOCAL_STORAGE_PATH] file:./mastra.db will be used at runtime because TURSO_DATABASE_URL is not set
+    ```
+
+    Local file storage doesn't survive on the platform's ephemeral filesystem. Attach a [hosted database](/docs/mastra-platform/database) that provides the missing variables:
+
+    ```bash
+    mastra env db create --kind turso
+    ```
+
+    Provisioning takes a few seconds. The database's connection variables are injected into your deploys automatically, so there is nothing to copy into an `.env` file.
+  </StepItem>
+
+  <StepItem>
+    Run `mastra deploy` again. Preflight passes, the build uploads, and the CLI streams build logs until the deploy is live. Expect the full build and deploy to take between 30 seconds and a few minutes. The success message prints only when the new version is serving traffic.
+  </StepItem>
+
+  <StepItem>
+    Verify your deployment at the URL printed by the CLI. Append `/api/agents` to confirm it returns a JSON list of your agents.
+
+    :::warning
+    Set up [authentication](/docs/server/auth) before exposing your endpoints publicly.
+    :::
+  </StepItem>
+</Steps>
+
+The first deploy writes a `.mastra-project.json` file linking your directory to the platform project. Commit it so later deploys, CI runs, and [`mastra env`](/docs/mastra-platform/environments) commands target the same project without extra flags.
+
+## Deploy to another environment
+
+`mastra deploy` targets the `production` environment by default. Pass `--env` to target a different one. If the environment doesn't exist yet, the CLI offers to create it:
+
+```bash
+mastra deploy --env staging
+```
+
+Each environment gets its own URL, its own environment variables, and optionally its own [hosted database](/docs/mastra-platform/database). See [Environments](/docs/mastra-platform/environments) for the full model.
+
+## Choose a region
+
+Pass `--region` when a deploy creates a new environment to control where it runs. Use the `us` or `eu` shorthand:
+
+```bash
+mastra deploy --env production --region eu
+```
+
+The region is fixed when the environment is created. Databases attached to an environment are placed near that environment's region automatically.
+
+## Preflight checks
+
+Preflight validates the built output before anything ships, and only flags issues in your own code:
+
+- **Local storage paths**: A hard block. File-backed storage (for example `file:./mastra.db`) is lost on every deploy. Preflight passes when the path is guarded by an environment variable that is set locally, stored on the platform, or provided by a managed database:
+
+  ```ts title="src/mastra/storage.ts"
+  import { LibSQLStore } from '@mastra/libsql'
+
+  export const storage = new LibSQLStore({
+    // Uses the hosted database when deployed, a local file during development
+    url: process.env.TURSO_DATABASE_URL ?? 'file:./mastra.db',
+    authToken: process.env.TURSO_AUTH_TOKEN,
+  })
+  ```
+
+- **Missing environment variables**: A warning for variables your code reads but no source provides. Variables referenced only by library code are excluded.
+
+The recommended response to a preflight block is to fix the cause, usually by attaching a hosted database or storing the variable on the platform. `--skip-preflight` exists as an escape hatch but skips the checks that prevent broken deploys.
+
+Run the same checks without deploying:
+
+```bash
+mastra lint --preflight
+```
+
+## Environment variables
+
+Deploys resolve environment variables from three sources:
+
+1. **Managed variables**: Injected by platform resources like hosted databases (for example `TURSO_DATABASE_URL`). Always present, never defined by you.
+1. **Stored variables**: Saved on the project or environment through the dashboard. Used as-is on every deploy with no local file needed.
+1. **Local env files**: An explicit `--env-file`, or ambient `.env` / `.env.local` files, layered on top at deploy time.
+
+```bash
+mastra deploy --env staging --env-file .env.staging
+```
+
+To change variables on a running service without a redeploy, update them in the dashboard and run [`mastra env restart`](/reference/cli/mastra#mastra-env-restart).
+
+## Project resolution
+
+Every deploy resolves its target project in this order:
+
+1. The `MASTRA_PROJECT_ID` environment variable
+1. The `--project <name|slug|id>` flag
+1. The `.mastra-project.json` file in the current directory
+
+In CI, set `MASTRA_PROJECT_ID` and `MASTRA_API_TOKEN` and pass `--yes`:
+
+```bash
+mastra deploy --env production --yes
+```
+
+## Related
+
+- [Environments](/docs/mastra-platform/environments)
+- [Hosted databases](/docs/mastra-platform/database)
+- [`mastra deploy` CLI reference](/reference/cli/mastra#mastra-deploy)
+- [Configuration](/docs/mastra-platform/configuration)

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -50,7 +50,7 @@ A local `.env` file is optional. Environment variables stored on the platform ar
     mastra env db create --kind turso
     ```
 
-    Provisioning takes a few seconds. The database's connection variables are injected into your deploys automatically, so there is nothing to copy into an `.env` file.
+    Provisioning takes a few seconds. The database's connection variables are injected into your deploys automatically, with nothing to copy into an `.env` file.
   </StepItem>
 
   <StepItem>
@@ -118,9 +118,9 @@ mastra lint --preflight
 
 Deploys resolve environment variables from three sources:
 
-1. **Managed variables**: Injected by platform resources like hosted databases (for example `TURSO_DATABASE_URL`). Always present, never defined by you.
-1. **Stored variables**: Saved on the project or environment through the dashboard. Used as-is on every deploy with no local file needed.
-1. **Local env files**: An explicit `--env-file`, or ambient `.env` / `.env.local` files, layered on top at deploy time.
+- **Managed variables**: Injected by platform resources like hosted databases (for example `TURSO_DATABASE_URL`). The platform defines these, and you can't edit them.
+- **Stored variables**: Saved on the project or environment through the dashboard. Used as-is on every deploy with no local file needed.
+- **Local env files**: An explicit `--env-file`, or ambient `.env` and `.env.local` files, layered on top at deploy time.
 
 ```bash
 mastra deploy --env staging --env-file .env.staging

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -38,13 +38,22 @@ A local `.env` file is optional. Environment variables stored on the platform ar
   </StepItem>
 
   <StepItem>
-    The CLI runs a preflight check before anything ships. Storage that points at a local file path blocks the deploy, because local files don't survive on the platform's ephemeral filesystem:
+    The CLI runs a preflight check before anything ships. Storage that would fall back to a local file path blocks the deploy, because local files don't survive on the platform's ephemeral filesystem:
 
     ```
-    [LOCAL_STORAGE_PATH] Build contains a host-local storage URL: file:./mastra.db
+    [LOCAL_STORAGE_PATH] file:./mastra.db will be used at runtime because TURSO_DATABASE_URL is not set
     ```
 
-    Fix it in two steps. First, guard the local path with an environment variable so the file is only used during local development:
+    Attach a [hosted database](/docs/mastra-platform/database) that provides the missing variables:
+
+    ```bash
+    mastra env db create --kind turso
+    ```
+
+    Provisioning takes a few seconds. The database's connection variables are injected into your deploys automatically, with nothing to copy into an `.env` file.
+
+    :::note
+    If preflight reports a hard-coded local path instead (`Build contains a host-local storage URL`), guard it with an environment variable first so the file is only used during local development:
 
     ```ts title="src/mastra/index.ts"
     new LibSQLStore({
@@ -54,13 +63,7 @@ A local `.env` file is optional. Environment variables stored on the platform ar
     })
     ```
 
-    Then attach a [hosted database](/docs/mastra-platform/database) that provides those variables:
-
-    ```bash
-    mastra env db create --kind turso
-    ```
-
-    Provisioning takes a few seconds. The database's connection variables are injected into your deploys automatically, with nothing to copy into an `.env` file.
+    :::
   </StepItem>
 
   <StepItem>

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -38,13 +38,23 @@ A local `.env` file is optional. Environment variables stored on the platform ar
   </StepItem>
 
   <StepItem>
-    The CLI runs a preflight check before anything ships. If your storage falls back to a local file path, the deploy is blocked with a message like:
+    The CLI runs a preflight check before anything ships. Storage that points at a local file path blocks the deploy, because local files don't survive on the platform's ephemeral filesystem:
 
     ```
-    [LOCAL_STORAGE_PATH] file:./mastra.db will be used at runtime because TURSO_DATABASE_URL is not set
+    [LOCAL_STORAGE_PATH] Build contains a host-local storage URL: file:./mastra.db
     ```
 
-    Local file storage doesn't survive on the platform's ephemeral filesystem. Attach a [hosted database](/docs/mastra-platform/database) that provides the missing variables:
+    Fix it in two steps. First, guard the local path with an environment variable so the file is only used during local development:
+
+    ```ts title="src/mastra/index.ts"
+    new LibSQLStore({
+      // Uses the hosted database when deployed, a local file during development
+      url: process.env.TURSO_DATABASE_URL ?? 'file:./mastra.db',
+      authToken: process.env.TURSO_AUTH_TOKEN,
+    })
+    ```
+
+    Then attach a [hosted database](/docs/mastra-platform/database) that provides those variables:
 
     ```bash
     mastra env db create --kind turso
@@ -108,11 +118,13 @@ Preflight validates the built output before anything ships, and only flags issue
 
 The recommended response to a preflight block is to fix the cause, usually by attaching a hosted database or storing the variable on the platform. `--skip-preflight` exists as an escape hatch but skips the checks that prevent broken deploys.
 
-Run the same checks without deploying:
+Run the checks without deploying:
 
 ```bash
 mastra lint --preflight
 ```
+
+`mastra lint` only sees your local env files. Variables stored on the platform or injected by managed databases aren't visible to it, so a deploy can pass preflight where lint still reports an error.
 
 ## Environment variables
 

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -20,7 +20,7 @@ This page covers the unified deploy flow. The earlier split commands, [`mastra s
 
 ## Before you begin
 
-You'll need a [Mastra application](/docs/getting-started/installation) and a [Mastra platform](https://projects.mastra.ai) account. If you're not authenticated, the CLI prompts you to log in on first use.
+You'll need a [Mastra application](/guides/getting-started/quickstart) and a [Mastra platform](https://projects.mastra.ai) account. If you're not authenticated, the CLI prompts you to log in on first use.
 
 A local `.env` file is optional. Environment variables stored on the platform are used as-is at deploy time, and managed resources like [hosted databases](/docs/mastra-platform/database) inject their own variables. Pass `--env-file` only when you want to layer local values on top.
 

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -83,7 +83,7 @@ mastra env db create staging --kind turso --name my-project-staging-db
 
 Each environment then reads and writes only its own database.
 
-An environment can only use one database per provider. If the project already has a shared project-scoped database of the same provider, attaching an environment-scoped one is rejected with a variable name conflict — detach the shared database with `mastra env db detach` first. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
+An environment can only use one database per provider. If the project already has a shared project-scoped database of the same provider, attaching an environment-scoped one is rejected with a variable name conflict — delete the shared database with `mastra env db delete` first. Deleting a database destroys it with the provider along with all of its data, so export anything you need to keep. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
 
 ## Delete an environment
 

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -23,13 +23,13 @@ Or let a deploy create it, which prompts for confirmation:
 mastra deploy --env staging
 ```
 
-`mastra env create` defaults to the `staging` type. Pass `--type` to set `production`, `staging`, or `preview` explicitly, and `--region` to choose where the environment runs:
+`mastra env create` defaults to the `staging` type. Pass `--type` to set `staging` or `preview` explicitly, and `--region` to choose where the environment runs:
 
 ```bash
-mastra env create eu-prod --type production --region eu
+mastra env create eu-preview --type preview --region eu
 ```
 
-The region is fixed at creation. Databases attached to an environment are placed near the environment's region automatically.
+Each project has a single `production` environment, created by your first deploy. The region is fixed at creation. Databases attached to an environment are placed near the environment's region automatically. The number of environments per project depends on your plan.
 
 ## List environments
 

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -57,6 +57,14 @@ Variables are applied when a deploy starts. To apply changed variables to a runn
 mastra env restart staging
 ```
 
+To see the full set an environment's deploys actually run with — environment-scoped and project-scoped values merged, with managed variables listed by name — pull them into a local env file:
+
+```bash
+mastra env vars pull staging --output .env.staging
+```
+
+Managed variable values are injected at deploy time and never written to the file; they appear as name-only comments.
+
 :::note
 Environment variables don't override managed database variables. To point an environment at a different database, attach an [environment-scoped database](/docs/mastra-platform/database#attach-with-the-cli) instead.
 :::

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -74,13 +74,16 @@ Each row shows the deploy status, environment, timestamp, and which deploy is cu
 
 ## Isolate an environment's data
 
-By default a hosted database attached to the project is shared by all environments. To isolate production data from staging data, attach a database scoped to a single environment:
+By default a hosted database attached to the project is shared by all environments. To isolate production data from staging data, attach a separate database to each environment instead:
 
 ```bash
-mastra env db create staging --kind turso
+mastra env db create production --kind turso --name my-project-production-db
+mastra env db create staging --kind turso --name my-project-staging-db
 ```
 
-Each environment then reads and writes only its own database. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
+Each environment then reads and writes only its own database.
+
+An environment can only use one database per provider. If the project already has a shared project-scoped database of the same provider, attaching an environment-scoped one is rejected with a variable name conflict — detach the shared database with `mastra env db detach` first. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
 
 ## Delete an environment
 

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -1,0 +1,95 @@
+---
+title: "Environments | Mastra platform"
+description: Run the same Mastra project across production, staging, and preview environments with isolated URLs, environment variables, regions, and databases.
+---
+
+# Environments
+
+Every platform project contains one or more environments. An environment is an isolated deployment target with its own URL, its own environment variables, its own deploy history, and optionally its own [hosted database](/docs/mastra-platform/database). Use environments to run `production`, `staging`, and preview versions of the same codebase inside a single project.
+
+Your first [`mastra deploy`](/docs/mastra-platform/deploy) creates the `production` environment. Create more with the CLI or by deploying to a name that doesn't exist yet.
+
+## Create an environment
+
+Create an environment explicitly:
+
+```bash
+mastra env create staging
+```
+
+Or let a deploy create it, which prompts for confirmation:
+
+```bash
+mastra deploy --env staging
+```
+
+`mastra env create` defaults to the `staging` type. Pass `--type` to set `production`, `staging`, or `preview` explicitly, and `--region` to choose where the environment runs:
+
+```bash
+mastra env create eu-prod --type production --region eu
+```
+
+The region is fixed at creation. Databases attached to an environment are placed near the environment's region automatically.
+
+## List environments
+
+```bash
+mastra env list
+```
+
+The output shows each environment's name, region, active deploy status, and the managed environment variables injected by attached databases. Pass `--json` for machine-readable output in CI.
+
+All `mastra env` commands resolve their project from `MASTRA_PROJECT_ID`, the `--project` flag, or the `.mastra-project.json` file written by your first deploy, in that order. Run them from your project directory and you never need to name the project.
+
+## Environment variables
+
+An environment resolves its variables from three scopes:
+
+1. **Managed variables**: Injected by attached [hosted databases](/docs/mastra-platform/database) (for example `TURSO_DATABASE_URL`). The platform defines these, and you can't edit them.
+1. **Environment variables**: Stored on one environment through the dashboard. Use these for values that differ between environments, like API keys for staging vs production services.
+1. **Project variables**: Stored on the project and shared by all environments.
+
+Variables are applied when a deploy starts. To apply changed variables to a running service without a full redeploy:
+
+```bash
+mastra env restart staging
+```
+
+:::note
+Environment variables don't override managed database variables. To point an environment at a different database, attach an [environment-scoped database](/docs/mastra-platform/database#attach-with-the-cli) instead.
+:::
+
+## Deploy history
+
+List deploys across all environments, or filter to one:
+
+```bash
+mastra env deploys
+mastra env deploys staging
+```
+
+Each row shows the deploy status, environment, timestamp, and which deploy is currently active. A deploy transitions through **queued → uploading → building → deploying → running**, and the platform reports **running** only when the new version is serving traffic.
+
+## Isolate an environment's data
+
+By default a hosted database attached to the project is shared by all environments. For real isolation between production and staging data, attach a database scoped to a single environment:
+
+```bash
+mastra env db create staging --kind turso
+```
+
+Each environment then reads and writes only its own database. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
+
+## Delete an environment
+
+```bash
+mastra env delete staging
+```
+
+The CLI asks for confirmation before deleting. Deleting an environment removes its deploys and stored variables.
+
+## Related
+
+- [Deploy](/docs/mastra-platform/deploy)
+- [Hosted databases](/docs/mastra-platform/database)
+- [`mastra env` CLI reference](/reference/cli/mastra#mastra-env)

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -45,9 +45,11 @@ All `mastra env` commands resolve their project from `MASTRA_PROJECT_ID`, the `-
 
 An environment resolves its variables from three scopes:
 
-1. **Managed variables**: Injected by attached [hosted databases](/docs/mastra-platform/database) (for example `TURSO_DATABASE_URL`). The platform defines these, and you can't edit them.
-1. **Environment variables**: Stored on one environment through the dashboard. Use these for values that differ between environments, like API keys for staging vs production services.
-1. **Project variables**: Stored on the project and shared by all environments.
+- **Managed variables**: Injected by attached [hosted databases](/docs/mastra-platform/database) (for example `TURSO_DATABASE_URL`). The platform defines these, and you can't edit them.
+- **Environment-scoped variables**: Stored on one environment through the dashboard. Use these for values that differ between environments, like API keys for staging and production services.
+- **Project-scoped variables**: Stored on the project and shared by all environments.
+
+Environment-scoped and project-scoped variables together are the stored variables described on the [Deploy](/docs/mastra-platform/deploy#environment-variables) page.
 
 Variables are applied when a deploy starts. To apply changed variables to a running service without a full redeploy:
 
@@ -72,7 +74,7 @@ Each row shows the deploy status, environment, timestamp, and which deploy is cu
 
 ## Isolate an environment's data
 
-By default a hosted database attached to the project is shared by all environments. For real isolation between production and staging data, attach a database scoped to a single environment:
+By default a hosted database attached to the project is shared by all environments. To isolate production data from staging data, attach a database scoped to a single environment:
 
 ```bash
 mastra env db create staging --kind turso

--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -26,7 +26,7 @@ Choose the path that matches what you want to do:
 - **Deploy Server**: Use [Server](/docs/mastra-platform/server) to run your Mastra application as a production API server. Start here when
   you’re ready to serve agents, tools, and workflows from the cloud.
 
-## Key Concepts
+## Key concepts
 
 **Projects** are the shared parent entity across all products. A single project can have Observability, a Studio deployment, and a Server deployment. Projects belong to an **Organization**, which is the multi-tenant container for your team.
 

--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -11,9 +11,9 @@ The [Mastra platform](https://projects.mastra.ai) provides three products for de
 - [**Studio**](/docs/mastra-platform/studio): A hosted visual environment for testing agents, running workflows, and inspecting traces. Starting with Studio also gives you Observability.
 - [**Server**](/docs/mastra-platform/server): A production deployment target that runs your Mastra application as an API server. Starting with Server also gives you Observability.
 
-You can deploy Studio and Server from the CLI or connect a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
+Deploy with a single command, [`mastra deploy`](/docs/mastra-platform/deploy), or connect a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
 
-You can also provision [**Hosted databases**](/docs/mastra-platform/database) from your project settings to persist your application data with no manual configuration.
+Each project can run multiple [**Environments**](/docs/mastra-platform/environments) (for example `production` and `staging`) and provision [**Hosted databases**](/docs/mastra-platform/database) from the CLI or project settings to persist application data with no manual configuration.
 
 ## Get started
 
@@ -40,8 +40,8 @@ Your Mastra application is built from three building blocks:
 
 Develop your project locally with [`mastra dev`](/reference/cli/mastra#mastra-dev) and open [Studio](/docs/studio/overview) to test your agents, workflows, and tools in a visual environment.
 
-Once you're ready to deploy your application to production, use [`mastra studio deploy`](/reference/cli/mastra#mastra-studio-deploy) and [`mastra server deploy`](/reference/cli/mastra#mastra-server-deploy) to push your application to the cloud.
+Once you're ready to deploy your application to production, run [`mastra deploy`](/reference/cli/mastra#mastra-deploy) to push your application to the cloud.
 
-Follow the [Studio on Mastra platform](/docs/mastra-platform/studio) and [Server on Mastra platform](/docs/mastra-platform/server) docs for step-by-step instructions.
+Follow the [Deploy](/docs/mastra-platform/deploy) docs for step-by-step instructions.
 
 If you host your Mastra application on your own infrastructure, you can still send observability data to Mastra platform using the [MastraPlatformExporter](/docs/observability/integrations/exporters/mastra-platform).

--- a/docs/src/content/en/docs/mastra-platform/server.mdx
+++ b/docs/src/content/en/docs/mastra-platform/server.mdx
@@ -13,6 +13,10 @@ Server on Mastra platform is a production deployment target that runs your Mastr
 You get a stable API endpoint, environment variable management, custom domain support, and deploy history out of the box.
 
 :::note
+`mastra server deploy` is the earlier split deploy path. New projects should use the unified [`mastra deploy`](/docs/mastra-platform/deploy) command, which adds preflight validation, environments, and CLI-managed databases.
+:::
+
+:::note
 
 Server deploy provisions hosted storage automatically. If you override storage with [LibSQLStore](/reference/storage/libsql) and a file URL, switch to a remotely hosted database because Mastra platform uses an ephemeral filesystem.
 

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Studio | Mastra platform"
-description: Deploy and host Studio on Mastra platform for a shared visual environment for your Mastra application.
+description: Deploy and host Studio on Mastra platform for a shared visual workspace for your Mastra application.
 ---
 
 import Steps from "@site/src/components/Steps";
@@ -8,7 +8,7 @@ import StepItem from "@site/src/components/StepItem";
 
 # Studio on Mastra platform
 
-Studio on Mastra platform is a hosted visual environment for testing agents, running workflows, and inspecting traces. Use it when you want to share Studio with your team without hosting the Studio UI yourself.
+Studio on Mastra platform is a hosted visual workspace for testing agents, running workflows, and inspecting traces. Use it when you want to share Studio with your team without hosting the Studio UI yourself.
 
 You can deploy Studio from the CLI as shown below, or link a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
 

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -54,7 +54,7 @@ See the [`mastra studio deploy` CLI reference](/reference/cli/mastra#mastra-stud
 
 ## Environment files
 
-The deploy bundles environment variables from a `.env` or `.env.*` file in the project directory. If no env file is present, the deploy errors with `No env file found for deploy.` after the build step. Add at least an empty `.env` file before running the command.
+A local env file is optional. When a `.env` or `.env.*` file is present in the project directory, the deploy bundles its environment variables.
 
 When multiple env files are present, the CLI prompts you to pick one. To select non-interactively, pass `--env-file`:
 
@@ -62,7 +62,7 @@ When multiple env files are present, the CLI prompts you to pick one. To select 
 mastra studio deploy --env-file .env.production --yes
 ```
 
-This is also how you target multiple environments from a single codebase: maintain one env file per environment, such as `.env.staging` and `.env.production`, and pass the right one to each deploy. Each environment still requires its own Mastra platform project. See [Configuration](/docs/mastra-platform/configuration) for the multi-environment pattern.
+To run the same codebase across `production` and `staging`, use the unified [`mastra deploy --env`](/docs/mastra-platform/deploy#deploy-to-another-environment) command instead. [Environments](/docs/mastra-platform/environments) replace the earlier pattern of one project per environment.
 
 ## Create a new project non-interactively
 

--- a/docs/src/content/en/docs/mastra-platform/studio.mdx
+++ b/docs/src/content/en/docs/mastra-platform/studio.mdx
@@ -12,6 +12,10 @@ Studio on Mastra platform is a hosted visual environment for testing agents, run
 
 You can deploy Studio from the CLI as shown below, or link a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
 
+:::note
+`mastra studio deploy` is the earlier split deploy path. New projects should use the unified [`mastra deploy`](/docs/mastra-platform/deploy) command, which adds preflight validation, environments, and CLI-managed databases.
+:::
+
 ## Quickstart
 
 <Steps>

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -1004,6 +1004,22 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'mastra-platform/deploy',
+          label: 'Deploy',
+          customProps: {
+            tags: ['new'],
+          },
+        },
+        {
+          type: 'doc',
+          id: 'mastra-platform/environments',
+          label: 'Environments',
+          customProps: {
+            tags: ['new'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'mastra-platform/observability',
           label: 'Observability',
         },

--- a/docs/src/content/en/guides/migrations/mastra-cloud.mdx
+++ b/docs/src/content/en/guides/migrations/mastra-cloud.mdx
@@ -267,7 +267,7 @@ mastra studio deploy
 
 The CLI builds your project, uploads the artifact, and deploys it. On first deploy, a `.mastra-project.json` file is created to link your local project to the platform. Commit this file to your repository.
 
-The deploy requires a `.env` or `.env.*` file in the project directory. If none exists the CLI errors with `No env file found for deploy.` after the build completes — add at least an empty `.env` before running the command.
+A local env file is optional. When a `.env` or `.env.*` file is present in the project directory, the deploy bundles its environment variables.
 
 To create a new platform project in one non-interactive step (instead of running `mastra studio projects create` separately), pass a name with `--project` and accept defaults with `--yes`:
 
@@ -279,21 +279,14 @@ See [Studio deployment](/docs/studio/deployment#mastra-platform) for details.
 
 ### Multiple environments
 
-Mastra platform projects don't have a built-in concept of named environments (for example `staging` vs `production`). To deploy the same codebase to multiple environments, create one project per environment and pair each deploy with the matching env file using `--env-file`.
-
-The pattern below uses one `.env.<env>` file per environment, deploys to a project named `my-app-<env>`, and overrides `.mastra-project.json` per deploy with `MASTRA_ORG_ID` and `MASTRA_PROJECT_ID`:
+A single Mastra platform project runs the same codebase across multiple named [environments](/docs/mastra-platform/environments), such as `production` and `staging`. Deploy to each with the unified [`mastra deploy`](/docs/mastra-platform/deploy) command:
 
 ```bash
-# First deploy of each environment — creates the project
-mastra studio deploy --project "my-app-staging" --env-file .env.staging --yes
-mastra studio deploy --project "my-app-production" --env-file .env.production --yes
-
-# Subsequent deploys (CI/CD) — target the existing project
-MASTRA_PROJECT_ID="<staging-id>" mastra studio deploy --env-file .env.staging --yes
-MASTRA_PROJECT_ID="<production-id>" mastra studio deploy --env-file .env.production --yes
+mastra deploy --env production --yes
+mastra deploy --env staging --env-file .env.staging --yes
 ```
 
-Each environment ends up with its own Studio URL and its own observability data. Send `MASTRA_PLATFORM_ACCESS_TOKEN` and `MASTRA_PROJECT_ID` per environment so `MastraPlatformExporter` routes traces to the correct project.
+Each environment gets its own URL, its own environment variables, and its own deploy history.
 
 ## Deploy Server (optional)
 

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -358,7 +358,7 @@ Manages databases attached to a project on Mastra platform. Databases are provis
 
 A database is either **environment-scoped** (its env vars only go to one environment) or **shared** (project-scoped: its env vars go to all environments). Pass the environment argument to work with environment-scoped databases; omit it for shared databases.
 
-Creating and detaching databases requires the `admin` role in the organization.
+Creating and deleting databases requires the `admin` role in the organization.
 
 ### `mastra env db list`
 
@@ -422,12 +422,12 @@ Print secret connection values instead of masking them.
 
 Emit machine-readable JSON. Secret values are masked unless `--show-secrets` is passed.
 
-### `mastra env db detach`
+### `mastra env db delete`
 
-Detaches a database from the project. The CLI prompts for confirmation unless `--yes` is passed. After detaching, deploys no longer receive the database's env vars.
+Permanently deletes a database with the provider, including all of its data. This cannot be undone. The CLI prompts for confirmation unless `--yes` is passed. After deletion, deploys no longer receive the database's env vars.
 
 ```bash
-mastra env db detach <database>
+mastra env db delete <database>
 ```
 
 #### `-y, --yes`


### PR DESCRIPTION
## Summary

Documents the unified deploy experience for the platform launch: `mastra deploy` as the single front door, environments as a first-class concept, and CLI-provisioned hosted databases. Before this PR, the platform docs still taught the split `mastra studio deploy` / `mastra server deploy` paths, claimed no CLI could provision databases, and recommended a one-project-per-environment workaround that the unified flow makes obsolete.

### New pages

- **Deploy** (`mastra-platform/deploy.mdx`) — the front door: quickstart from fresh scaffold through the preflight block → `mastra env db create` → redeploy loop, deploy lifecycle, preflight checks, env var sources, project resolution.
- **Environments** (`mastra-platform/environments.mdx`) — creating/listing environments, deploying with `--env`, restart, deploy history, env var scoping, per-environment data isolation with the database scoping rules.

### Updated pages

- **Hosted databases** — CLI provisioning (`mastra env db create/list/show/detach`), project vs environment scope, the same-provider scope-conflict rule (env-scoped + project-scoped of the same provider is rejected; detach first), region placement authority.
- **Configuration** — removed the one-project-per-environment workaround; documents `.mastra-project.json` as auto-generated by first `mastra deploy`; local `.env` is optional.
- **Overview** — "Going to production" now leads with `mastra deploy`.
- **Studio / Server** — marked as the earlier split deploy path, pointing at unified deploy; Studio described as a workspace (not an "environment").
- **Migration guide** (mastra-cloud) — removed stale "empty `.env` required" claim; multi-env pattern now uses `mastra deploy --env`.
- **Sidebar** — Deploy and Environments added; order now Overview → Deploy → Observability → Environments → Databases → Configuration → Studio → Server → GitHub.

All command examples reflect behavior verified live against production (fresh-scaffold E2E runs on 07-09/07-10: provisioning, scoping, region placement, isolation, RBAC errors). The database scoping rules were verified against the platform source (`assertNoEnvCollisions`) — there is no precedence/shadowing; conflicting scopes are rejected.

## Test plan

- [x] `pnpm validate` — 566 files pass, sidebars valid, all docs linked
- [x] `pnpm lint:prose` — vale + remark clean
- [x] prettier clean
- [x] Local `docusaurus start` — all new/updated pages render, links resolve
- [x] Fresh-scaffold read-through of the Deploy quickstart verbatim against production (issue 34 acceptance item — tracked before undraft)

Docs-only change; no changeset needed.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR explains how to deploy Mastra projects in one simple workflow using `mastra deploy`. It also documents separate environments and command-line database management so teams can safely run isolated deployments.

## Summary

- Added Deploy and Environments documentation covering:
  - `mastra deploy` provisioning, preflight checks, project resolution, regions, and environment targeting
  - Environment variables from managed, stored, and local sources
  - Environment creation, restart, deletion, deploy history, and isolation
  - Environment-specific hosted databases and scope conflicts
- Updated Hosted databases documentation with CLI provisioning, provider availability, attachment scopes, and database deletion guidance.
- Updated Overview, Configuration, Studio, Server, and migration documentation to reflect unified deployment and optional local `.env` files.
- Updated the CLI reference from `mastra env db detach` to `mastra env db delete`, including data-loss warnings and confirmation behavior.
- Added the new pages to the platform sidebar.
- Incorporated fresh-scaffold and production verification, correcting command examples, provider availability, preflight guidance, environment limits, variable retrieval, and links.
- Documentation validation, formatting, prose linting, rendering, link checks, and scaffold verification were completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->