### PR TITLE
fix(cli): default scaffold no longer fails deploy preflight (guarded storage path)

### DIFF
--- a/.changeset/silver-moose-lay.md
+++ b/.changeset/silver-moose-lay.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed the default project scaffold failing the deploy preflight check. New projects now read the database URL from TURSO_DATABASE_URL when it is set (for example from a hosted database created with `mastra env db create`) and fall back to a local file during development, so the first `mastra deploy` is no longer blocked by a local storage path error.

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -28,7 +28,7 @@ vi.mock('../auth/orgs.js', () => ({
   resolveCurrentOrg: vi.fn(),
 }));
 
-const { getAPIKey, promptForObservability, writeObservabilityEnv } = await import('./utils');
+const { getAPIKey, promptForObservability, writeObservabilityEnv, writeIndexFile } = await import('./utils');
 const prompts = await import('@clack/prompts');
 const { getToken, loadCredentials } = await import('../auth/credentials.js');
 const { resolveCurrentOrg } = await import('../auth/orgs.js');
@@ -173,6 +173,33 @@ describe('promptForObservability', () => {
     await expect(promptForObservability()).resolves.toEqual({});
 
     expect(selectMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('writeIndexFile', () => {
+  const dirPath = '/mock-project/src/mastra';
+
+  beforeEach(() => {
+    vol.reset();
+    fs.mkdirSync(dirPath, { recursive: true });
+  });
+
+  test('example scaffold guards the local storage path behind TURSO_DATABASE_URL', async () => {
+    await writeIndexFile({
+      dirPath,
+      addExample: true,
+      addWorkflow: true,
+      addAgent: true,
+      addScorers: true,
+    });
+
+    const contents = fs.readFileSync(`${dirPath}/index.ts`, 'utf-8') as string;
+    // Deploy preflight hard-blocks unguarded host-local storage URLs
+    // (LOCAL_STORAGE_PATH). The guarded form deploys clean once a hosted
+    // database provides TURSO_DATABASE_URL, and keeps the local file for dev.
+    expect(contents).toContain('url: process.env.TURSO_DATABASE_URL ?? "file:./mastra.db"');
+    expect(contents).toContain('authToken: process.env.TURSO_AUTH_TOKEN');
+    expect(contents).not.toContain('url: "file:./mastra.db"');
   });
 });
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -560,7 +560,10 @@ export const mastra = new Mastra({
     id: 'composite-storage',
     default: new LibSQLStore({
       id: "mastra-storage",
-      url: "file:./mastra.db",
+      // Uses a hosted database when deployed (mastra env db create --kind turso),
+      // and a local file during development.
+      url: process.env.TURSO_DATABASE_URL ?? "file:./mastra.db",
+      authToken: process.env.TURSO_AUTH_TOKEN,
     }),
     domains: {
       observability: await new DuckDBStore().getStore('observability'),


### PR DESCRIPTION
## Summary

The default scaffold (`create-mastra` / `mastra init` with the example) ships an unguarded local storage URL:

```ts
url: "file:./mastra.db",
```

so the very first thing a brand-new user does after the quickstart — `mastra deploy` — hard-blocks on `LOCAL_STORAGE_PATH` with no way out except editing storage config or `--skip-preflight`.

This changes the scaffold to the documented guarded pattern:

```ts
url: process.env.TURSO_DATABASE_URL ?? "file:./mastra.db",
authToken: process.env.TURSO_AUTH_TOKEN,
```

Preflight already understands this shape (#19071): with nothing providing the var it blocks with an actionable "attach a managed database" message, and after `mastra env db create --kind turso` (managed var names, #19199) it passes silently. Local development is unchanged — no env var means the same local file as before.

This makes the quickstart in the platform docs rewrite (#19394) true verbatim: deploy → blocked with guidance → `env db create` → deploy succeeds, with zero code edits.

## Test plan

- [x] TDD: new `writeIndexFile` test asserting the guarded url + authToken and the absence of the unguarded literal — verified failing against the old template first
- [x] `pnpm test:cli` — 618/618 passing
- [x] `pnpm --filter ./packages/cli typecheck` clean (after building the dep graph)
- [x] prettier clean, changeset included (patch, `mastra`)
- [ ] Fresh-scaffold E2E against production: `create-mastra` → `mastra deploy` (blocked with attach guidance) → `env db create --kind turso` → `mastra deploy` (passes preflight) — will run with the docs quickstart read-through

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

New Mastra projects now automatically use a hosted Turso database when configured, while still using a local database during development. This prevents first-time deployments from failing because of an unsafe local storage setting.

## Changes

- Updated the `create-mastra` / `mastra init` scaffold to use:
  - `TURSO_DATABASE_URL`
  - `TURSO_AUTH_TOKEN`
  - A local `file:./mastra.db` fallback
- Added tests verifying the generated `index.ts` storage configuration.
- Added a patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->