### PR TITLE
feat(cli): add `mastra env vars pull` so pulled env files include environment-scoped vars

### DIFF
--- a/.changeset/hot-games-say.md
+++ b/.changeset/hot-games-say.md
@@ -1,0 +1,11 @@
+---
+'mastra': minor
+---
+
+Added `mastra env vars pull [environment]` to download the full set of env vars an environment actually deploys with — vars stored on the environment (for example, added in the dashboard's environment editor) merged with project-level vars. Managed vars from attached databases are listed as comments (names only) since their values are platform-managed secrets.
+
+```bash
+mastra env vars pull staging --output .env.staging
+```
+
+Previously the only pull command, `mastra server env pull`, silently read project-level vars only, so vars added through the dashboard were missing from the pulled file. That command now prints a note about its scope and points to `mastra env vars pull`.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -352,6 +352,21 @@ mastra env restart <env>
 
 `<env>` can be an environment name, slug, or ID. Fails with a conflict error if the environment has never been deployed.
 
+### `mastra env vars pull`
+
+Pulls an environment's env vars into a local env file (default: `.env`). The file contains the merged set a deploy actually runs with: vars stored on the environment (for example, added in the dashboard's environment editor) plus project-level vars, with project values winning on conflict. Managed vars injected by attached databases are listed as comments (names only) since their values are platform-managed secrets.
+
+```bash
+mastra env vars pull
+mastra env vars pull <env> --output .env.staging
+```
+
+`<env>` can be an environment name, slug, or ID, and can be omitted when the project has exactly one environment. The file is written with `0600` permissions.
+
+#### `-o, --output`
+
+File to write. Defaults to `.env`.
+
 ### `mastra env db`
 
 Manages databases attached to a project on Mastra platform. Databases are provisioned from a managed provider (for example Turso or Neon) and inject their connection env vars into deploys automatically.

--- a/packages/cli/src/commands/env/env-file.ts
+++ b/packages/cli/src/commands/env/env-file.ts
@@ -1,0 +1,47 @@
+/**
+ * Serialize env vars into `.env` file content, quoting/escaping values so the
+ * file is safe to `source` and skipping keys that aren't valid shell
+ * identifiers. Managed var names (platform-injected secrets whose values are
+ * never exposed) are listed as comments so users know they exist without
+ * round-tripping secrets into local files.
+ */
+export function serializeEnvFile(
+  envVars: Record<string, string>,
+  opts: { header: string; managedVarNames?: string[] },
+): { content: string; written: number; skipped: number } {
+  const shellSafeKey = /^[A-Za-z_][A-Za-z0-9_]*$/;
+  const lines = [`# ${opts.header}`, ''];
+  let skipped = 0;
+  let written = 0;
+
+  for (const key of Object.keys(envVars).sort()) {
+    if (!shellSafeKey.test(key)) {
+      lines.push(`# Skipped unsafe key: ${key.replace(/[^\w.-]/g, '?')}`);
+      skipped++;
+      continue;
+    }
+    const value = envVars[key]!;
+    // Always quote values to prevent shell metacharacter interpretation when sourced
+    const escaped = value
+      .replace(/\\/g, '\\\\')
+      .replace(/\r/g, '\\r')
+      .replace(/\n/g, '\\n')
+      .replace(/\t/g, '\\t')
+      .replace(/"/g, '\\"')
+      .replace(/\$/g, '\\$')
+      .replace(/`/g, '\\`');
+    lines.push(`${key}="${escaped}"`);
+    written++;
+  }
+
+  if (opts.managedVarNames && opts.managedVarNames.length > 0) {
+    lines.push('');
+    lines.push('# Managed by the Mastra platform — values are injected at deploy time:');
+    for (const name of [...opts.managedVarNames].sort()) {
+      lines.push(`# ${name}`);
+    }
+  }
+
+  lines.push(''); // trailing newline
+  return { content: lines.join('\n'), written, skipped };
+}

--- a/packages/cli/src/commands/env/env.ts
+++ b/packages/cli/src/commands/env/env.ts
@@ -12,6 +12,7 @@ import {
   restartEnvironment,
 } from './platform-api.js';
 import { resolveProject } from './resolve-project.js';
+import { registerEnvVarsCommands } from './vars.js';
 
 /**
  * Shape returned by `mastra env list --json` and `mastra env create --json`.
@@ -118,6 +119,9 @@ export function registerEnvCommands(program: Command): Command {
     .option(...PROJECT_OPTION)
     .option('--json', 'Output as JSON')
     .action(wrapAction(listDeploysAction));
+
+  // Env vars: mastra env vars ...
+  registerEnvVarsCommands(env);
 
   return env;
 }

--- a/packages/cli/src/commands/env/vars.test.ts
+++ b/packages/cli/src/commands/env/vars.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { Environment } from './platform-api.js';
+
+const mockGetToken = vi.fn();
+
+vi.mock('../auth/credentials.js', () => ({
+  getToken: mockGetToken,
+}));
+
+const mockResolveCurrentOrg = vi.fn();
+
+vi.mock('../auth/orgs.js', () => ({
+  resolveCurrentOrg: mockResolveCurrentOrg,
+}));
+
+const mockResolveProject = vi.fn();
+
+vi.mock('./resolve-project.js', () => ({
+  resolveProject: mockResolveProject,
+}));
+
+const mockFetchEnvironments = vi.fn();
+
+vi.mock('./platform-api.js', () => ({
+  fetchEnvironments: mockFetchEnvironments,
+}));
+
+const mockGetServerProjectEnv = vi.fn();
+
+vi.mock('../server/platform-api.js', () => ({
+  getServerProjectEnv: mockGetServerProjectEnv,
+}));
+
+const mockWriteFile = vi.fn();
+const mockChmod = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  writeFile: mockWriteFile,
+  chmod: mockChmod,
+}));
+
+function environment(overrides: Partial<Environment>): Environment {
+  return {
+    id: 'env-1',
+    projectId: 'proj-1',
+    name: 'Production',
+    slug: 'my-app',
+    type: 'production',
+    region: null,
+    branch: null,
+    instanceUrl: null,
+    customServerUrl: null,
+    observabilityProjectId: null,
+    envVars: null,
+    createdAt: '2026-07-01T00:00:00.000Z',
+    updatedAt: '2026-07-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  mockGetToken.mockResolvedValue('tok');
+  mockResolveCurrentOrg.mockResolvedValue({ orgId: 'org-1', orgName: 'Org' });
+  mockResolveProject.mockResolvedValue({ id: 'proj-1', name: 'My App', slug: 'my-app', organizationId: 'org-1' });
+  mockGetServerProjectEnv.mockResolvedValue({});
+  mockWriteFile.mockResolvedValue(undefined);
+  mockChmod.mockResolvedValue(undefined);
+});
+
+describe('envVarsPullAction', () => {
+  it('writes both environment-scoped and project-scoped vars (regression: pull read project scope only)', async () => {
+    // Joel's repro: vars added through the UI land on the environment row;
+    // the initial-deploy vars live on the project row. Pull must merge both.
+    mockGetServerProjectEnv.mockResolvedValue({ A: '1' });
+    mockFetchEnvironments.mockResolvedValue([environment({ envVars: { B: '2' } })]);
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await envVarsPullAction(undefined, {});
+
+    expect(mockWriteFile).toHaveBeenCalledTimes(1);
+    const [filePath, content, options] = mockWriteFile.mock.calls[0]!;
+    expect(filePath).toContain('.env');
+    expect(content).toContain('A="1"');
+    expect(content).toContain('B="2"');
+    expect(options).toEqual({ encoding: 'utf-8', mode: 0o600 });
+    expect(mockChmod).toHaveBeenCalledWith(filePath, 0o600);
+    expect(spy.mock.calls.some(c => String(c[0]).includes('Pulled 2 variable(s)'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('project-scoped values win over environment-scoped values (matches deploy-time merge)', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ SHARED: 'project' });
+    mockFetchEnvironments.mockResolvedValue([environment({ envVars: { SHARED: 'environment' } })]);
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await envVarsPullAction(undefined, {});
+
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('SHARED="project"');
+    expect(content).not.toContain('SHARED="environment"');
+    spy.mockRestore();
+  });
+
+  it('lists managed var names as comments without values', async () => {
+    mockFetchEnvironments.mockResolvedValue([
+      environment({ envVars: { B: '2' }, managedEnvVarNames: ['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN'] }),
+    ]);
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await envVarsPullAction(undefined, {});
+
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('# TURSO_DATABASE_URL');
+    expect(content).toContain('# TURSO_AUTH_TOKEN');
+    expect(content).not.toMatch(/^TURSO_DATABASE_URL=/m);
+    expect(content).not.toMatch(/^TURSO_AUTH_TOKEN=/m);
+    spy.mockRestore();
+  });
+
+  it('selects the environment by name, slug, or id', async () => {
+    mockFetchEnvironments.mockResolvedValue([
+      environment({ id: 'env-1', slug: 'my-app', envVars: { PROD: '1' } }),
+      environment({ id: 'env-2', name: 'Staging', slug: 'my-app-staging', type: 'staging', envVars: { STAGE: '1' } }),
+    ]);
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await envVarsPullAction('my-app-staging', {});
+
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('STAGE="1"');
+    expect(content).not.toContain('PROD=');
+    spy.mockRestore();
+  });
+
+  it('requires an environment argument when the project has more than one', async () => {
+    mockFetchEnvironments.mockResolvedValue([
+      environment({ id: 'env-1', slug: 'my-app' }),
+      environment({ id: 'env-2', slug: 'my-app-staging' }),
+    ]);
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await expect(envVarsPullAction(undefined, {})).rejects.toThrow(/my-app-staging/);
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when the named environment does not exist', async () => {
+    mockFetchEnvironments.mockResolvedValue([environment({})]);
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await expect(envVarsPullAction('nope', {})).rejects.toThrow('Environment not found: nope');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('throws when the project has no environments', async () => {
+    mockFetchEnvironments.mockResolvedValue([]);
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await expect(envVarsPullAction(undefined, {})).rejects.toThrow('No environments found');
+    expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+
+  it('writes to a custom output file', async () => {
+    mockFetchEnvironments.mockResolvedValue([environment({ envVars: { FOO: 'bar' } })]);
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await envVarsPullAction(undefined, { output: '.env.production' });
+
+    const [filePath] = mockWriteFile.mock.calls[0]!;
+    expect(filePath).toContain('.env.production');
+    expect(spy.mock.calls.some(c => String(c[0]).includes('.env.production'))).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('escapes special characters and skips unsafe keys like the legacy pull', async () => {
+    mockFetchEnvironments.mockResolvedValue([
+      environment({ envVars: { TOKEN: 'price=$100`cmd`\nline2', 'bad-key': 'nope' } }),
+    ]);
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+
+    const { envVarsPullAction } = await import('./vars.js');
+    await envVarsPullAction(undefined, {});
+
+    const [, content] = mockWriteFile.mock.calls[0]!;
+    expect(content).toContain('TOKEN="price=\\$100\\`cmd\\`\\nline2"');
+    expect(content).not.toContain('bad-key=');
+    expect(content).toContain('# Skipped unsafe key');
+    spy.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/env/vars.ts
+++ b/packages/cli/src/commands/env/vars.ts
@@ -1,0 +1,96 @@
+import { chmod, writeFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import type { Command } from 'commander';
+import { getToken } from '../auth/credentials.js';
+import { resolveCurrentOrg } from '../auth/orgs.js';
+import { getServerProjectEnv } from '../server/platform-api.js';
+import { wrapAction } from '../utils.js';
+import { serializeEnvFile } from './env-file.js';
+import type { Environment } from './platform-api.js';
+import { fetchEnvironments } from './platform-api.js';
+import { resolveProject } from './resolve-project.js';
+
+export function registerEnvVarsCommands(env: Command): void {
+  const vars = env.command('vars').description("Manage an environment's variables");
+
+  vars
+    .command('pull')
+    .description('Pull the merged env vars (environment + project scope) into a local env file')
+    .argument('[environment]', 'Environment name, slug, or ID (optional when the project has exactly one)')
+    .option('--project <project>', 'Project name, slug, or ID (default: linked project)')
+    .option('-o, --output <file>', 'File to write (default: .env)')
+    .action(wrapAction(envVarsPullAction));
+}
+
+function pickEnvironment(environments: Environment[], envArg: string | undefined): Environment {
+  if (environments.length === 0) {
+    throw new Error('No environments found for this project. Deploy first with `mastra deploy`.');
+  }
+
+  if (!envArg) {
+    if (environments.length === 1) return environments[0]!;
+    const slugs = environments.map(e => e.slug).join(', ');
+    throw new Error(`Multiple environments found (${slugs}). Specify one: mastra env vars pull <environment>`);
+  }
+
+  const env = environments.find(e => e.id === envArg || e.name === envArg || e.slug === envArg);
+  if (!env) {
+    throw new Error(`Environment not found: ${envArg}`);
+  }
+  return env;
+}
+
+/**
+ * Pull the full set of env vars that a deploy of the target environment
+ * actually runs with — the environment row's vars (e.g. added via the UI
+ * editor) merged with the project-scoped vars, with project values winning on
+ * conflict, matching the platform's deploy-time merge precedence. Managed
+ * vars (platform-injected secrets) are listed as comments, names only.
+ *
+ * The legacy `mastra server env pull` reads only the project scope; this is
+ * the unified-surface replacement that fixes UI-added vars silently missing
+ * from pulled files.
+ */
+export async function envVarsPullAction(
+  envArg: string | undefined,
+  options: { project?: string; output?: string },
+): Promise<void> {
+  const token = await getToken();
+  const { orgId } = await resolveCurrentOrg(token);
+  const project = await resolveProject(token, orgId, options.project);
+
+  const [environments, projectVars] = await Promise.all([
+    fetchEnvironments(token, orgId, project.id),
+    getServerProjectEnv(token, orgId, project.id),
+  ]);
+  const environment = pickEnvironment(environments, envArg);
+
+  // Same precedence as the platform's deploy-time merge: environment row
+  // vars first, project-scoped vars override on conflict.
+  const merged = { ...(environment.envVars ?? {}), ...projectVars };
+
+  const { content, written, skipped } = serializeEnvFile(merged, {
+    header: `Pulled from Mastra environment ${environment.slug} — do not edit manually`,
+    managedVarNames: environment.managedEnvVarNames,
+  });
+
+  const target = options.output ?? '.env';
+  const outputPath = resolve(target);
+  await writeFile(outputPath, content, { encoding: 'utf-8', mode: 0o600 });
+  await chmod(outputPath, 0o600);
+
+  if (written === 0) {
+    console.info(`\n  No env vars set on ${environment.slug}. Wrote empty ${target}.\n`);
+  } else {
+    console.info(
+      `\n  Pulled ${written} variable(s) from ${environment.slug} to ${target}.${skipped > 0 ? ` Skipped ${skipped} unsafe key(s).` : ''}\n`,
+    );
+  }
+  const managedCount = environment.managedEnvVarNames?.length ?? 0;
+  if (managedCount > 0) {
+    console.info(
+      `  ${managedCount} managed variable name(s) listed as comments — values are injected at deploy time.\n`,
+    );
+  }
+}

--- a/packages/cli/src/commands/server/env.test.ts
+++ b/packages/cli/src/commands/server/env.test.ts
@@ -291,4 +291,15 @@ describe('envPullAction', () => {
     expect(spy.mock.calls.some(c => String(c[0]).includes('Skipped 2 unsafe key(s)'))).toBe(true);
     spy.mockRestore();
   });
+
+  it('notes that only project-level variables were pulled and points at `mastra env vars pull`', async () => {
+    mockGetServerProjectEnv.mockResolvedValue({ A: '1' });
+    const spy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const { envPullAction } = await import('./env.js');
+    await envPullAction(undefined, {});
+    const out = spy.mock.calls.map(c => c[0]).join('\n');
+    expect(out).toContain('project-level variables only');
+    expect(out).toContain('mastra env vars pull');
+    spy.mockRestore();
+  });
 });

--- a/packages/cli/src/commands/server/env.ts
+++ b/packages/cli/src/commands/server/env.ts
@@ -2,6 +2,7 @@ import { chmod, readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 
 import { getToken, getCurrentOrgId } from '../auth/credentials.js';
+import { serializeEnvFile } from '../env/env-file.js';
 import { loadProjectConfig } from '../studio/project-config.js';
 import { parseEnvFile } from './deploy.js';
 import { fetchServerProjects, getServerProjectEnv, updateServerProjectEnv } from './platform-api.js';
@@ -149,37 +150,16 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
   const projectId = await resolveProjectId(opts, { token, orgId });
 
   const envVars = await getServerProjectEnv(token, orgId, projectId);
-  const keys = Object.keys(envVars);
 
   const target = file ?? '.env';
-  const shellSafeKey = /^[A-Za-z_][A-Za-z0-9_]*$/;
-  const lines = ['# Pulled from Mastra Server — do not edit manually', ''];
-  let skipped = 0;
-  for (const key of keys.sort()) {
-    if (!shellSafeKey.test(key)) {
-      lines.push(`# Skipped unsafe key: ${key.replace(/[^\w.-]/g, '?')}`);
-      skipped++;
-      continue;
-    }
-    const value = envVars[key]!;
-    // Always quote values to prevent shell metacharacter interpretation when sourced
-    const escaped = value
-      .replace(/\\/g, '\\\\')
-      .replace(/\r/g, '\\r')
-      .replace(/\n/g, '\\n')
-      .replace(/\t/g, '\\t')
-      .replace(/"/g, '\\"')
-      .replace(/\$/g, '\\$')
-      .replace(/`/g, '\\`');
-    lines.push(`${key}="${escaped}"`);
-  }
-  lines.push(''); // trailing newline
+  const { content, written, skipped } = serializeEnvFile(envVars, {
+    header: 'Pulled from Mastra Server — do not edit manually',
+  });
 
   const outputPath = resolve(target);
-  await writeFile(outputPath, lines.join('\n'), { encoding: 'utf-8', mode: 0o600 });
+  await writeFile(outputPath, content, { encoding: 'utf-8', mode: 0o600 });
   await chmod(outputPath, 0o600);
 
-  const written = keys.length - skipped;
   if (written === 0) {
     console.info(`\n  No environment variables set in the project. Wrote empty ${target}.\n`);
   } else {
@@ -187,4 +167,7 @@ export async function envPullAction(file: string | undefined, opts: { config?: s
       `\n  Pulled ${written} variable(s) to ${target}.${skipped > 0 ? ` Skipped ${skipped} unsafe key(s).` : ''}\n`,
     );
   }
+  console.info(
+    '  Note: this reads project-level variables only — environment-scoped vars (e.g. added in the UI) are not included. Use `mastra env vars pull` for the full set.\n',
+  );
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -432,7 +432,9 @@ serverEnvCommand
 
 serverEnvCommand
   .command('pull [file]')
-  .description('Pull environment variables into a local .env file (default: .env)')
+  .description(
+    'Pull project-level environment variables into a local .env file (default: .env) — use `mastra env vars pull` to include environment-scoped vars',
+  )
   .option('-c, --config <file>', 'Project config file path (default: .mastra-project.json)')
   .option('--project <id>', 'Project ID or slug (overrides linked project when MASTRA_PROJECT_ID is unset)')
   .action(wrapAction(envPullAction));


### PR DESCRIPTION
Pulling env vars into a local file only ever returned the project-scoped var set (`mastra server env pull` reads `getServerProjectEnv`). Vars added through the dashboard's environment editor are stored on the environment row, so they were silently missing from pulled files — you'd only get roughly the vars from the initial deploy.

This adds `mastra env vars pull [environment]` to the unified `mastra env` group. It writes the merged set a deploy actually runs with — environment row vars plus project-level vars, project winning on conflict to match the platform's deploy-time merge — and lists managed vars (e.g. from attached databases) as comments, names only, so platform-managed secrets don't round-trip into local files.

```bash
mastra env vars pull
mastra env vars pull staging --output .env.staging
```

The legacy `mastra server env pull` keeps its behavior but now says it reads project-level variables only and points at the new command. Both commands share one env-file serializer.

Test plan: new regression tests in `packages/cli/src/commands/env/vars.test.ts` cover the merged read (project `{A: '1'}` + environment `{B: '2'}` → both written), conflict precedence, managed-name comments, environment resolution, and escaping; `packages/cli/src/commands/server/env.test.ts` covers the legacy scope notice. Full CLI suite (627 tests), typecheck, and eslint pass. CLI reference docs updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds a command to download all environment settings into a local `.env` file. It combines project and environment settings safely, while listing secret-managed settings without exposing their values.

## What changed

- Added `mastra env vars pull [environment]`.
- Supports environment selection by name, slug, or ID.
- Merges environment and project variables, with project values taking precedence.
- Supports custom output paths and writes files with `0600` permissions.
- Safely serializes values, skips unsafe keys, and reports skipped variables.
- Lists managed variable names as comments without writing secret values.
- Shared env-file serialization with `mastra server env pull`.
- Clarified that `mastra server env pull` only retrieves project-level variables and directs users to the new command for full coverage.
- Added regression tests and updated CLI documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->