### PR TITLE
fix(cli): rename `env db detach` to `env db delete` — the operation destroys data

### DIFF
--- a/.changeset/proud-doors-vanish.md
+++ b/.changeset/proud-doors-vanish.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Rename `mastra env db detach` to `mastra env db delete` and make the confirmation prompt state that the database and all of its data are permanently deleted with the provider. The old name described a non-destructive unlink, but the operation deprovisions the Turso/Neon database — data included. The `detach` name is reserved for a future true non-destructive detach.

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -358,7 +358,7 @@ Manages databases attached to a project on Mastra platform. Databases are provis
 
 A database is either **environment-scoped** (its env vars only go to one environment) or **shared** (project-scoped: its env vars go to all environments). Pass the environment argument to work with environment-scoped databases; omit it for shared databases.
 
-Creating and detaching databases requires the `admin` role in the organization.
+Creating and deleting databases requires the `admin` role in the organization.
 
 ### `mastra env db list`
 
@@ -422,12 +422,12 @@ Print secret connection values instead of masking them.
 
 Emit machine-readable JSON. Secret values are masked unless `--show-secrets` is passed.
 
-### `mastra env db detach`
+### `mastra env db delete`
 
-Detaches a database from the project. The CLI prompts for confirmation unless `--yes` is passed. After detaching, deploys no longer receive the database's env vars.
+Permanently deletes a database with the provider, including all of its data. This cannot be undone. The CLI prompts for confirmation unless `--yes` is passed. After deletion, deploys no longer receive the database's env vars.
 
 ```bash
-mastra env db detach <database>
+mastra env db delete <database>
 ```
 
 #### `-y, --yes`

--- a/packages/cli/src/commands/db/db.ts
+++ b/packages/cli/src/commands/db/db.ts
@@ -10,7 +10,7 @@ import type { DatabaseKind, ProjectDatabase } from './platform-api.js';
 import {
   attachDatabase,
   DB_ENV_VAR_NAMES,
-  detachDatabase,
+  deleteDatabase,
   fetchDatabase,
   fetchDatabaseConnection,
   fetchDatabases,
@@ -48,12 +48,12 @@ export function registerEnvDbCommands(envCommand: Command) {
     .option('--json', 'Output as JSON')
     .action(wrapAction(showDatabaseAction));
 
-  db.command('detach')
-    .description('Detach a database from the project (soft-delete; admin only)')
+  db.command('delete')
+    .description('Permanently delete a database and all its data (admin only)')
     .argument('<database>', 'Database ID or name')
     .option(...PROJECT_OPTION)
     .option('-y, --yes', 'Skip confirmation')
-    .action(wrapAction(detachDatabaseAction));
+    .action(wrapAction(deleteDatabaseAction));
 }
 
 /* ------------------------------------------------------------------ */
@@ -343,10 +343,10 @@ async function showDatabaseAction(dbArg: string, options: { project?: string; sh
 }
 
 /* ------------------------------------------------------------------ */
-/*  mastra env db detach                                               */
+/*  mastra env db delete                                               */
 /* ------------------------------------------------------------------ */
 
-async function detachDatabaseAction(dbArg: string, options: { project?: string; yes?: boolean }) {
+async function deleteDatabaseAction(dbArg: string, options: { project?: string; yes?: boolean }) {
   const token = await getToken();
   const { orgId } = await resolveCurrentOrg(token);
   const project = await resolveProject(token, orgId, options.project);
@@ -355,7 +355,7 @@ async function detachDatabaseAction(dbArg: string, options: { project?: string; 
 
   if (!options.yes) {
     const confirm = await p.confirm({
-      message: `Detach database "${db.name}" (${db.kind}) from ${project.name}? Deploys will no longer receive its env vars.`,
+      message: `Permanently delete database "${db.name}" (${db.kind}) and ALL of its data? This cannot be undone. Deploys for ${project.name} will no longer receive its env vars.`,
     });
 
     if (p.isCancel(confirm) || !confirm) {
@@ -364,6 +364,6 @@ async function detachDatabaseAction(dbArg: string, options: { project?: string; 
     }
   }
 
-  await detachDatabase(token, orgId, project.id, db.id);
-  console.info(`Database "${db.name}" detached.`);
+  await deleteDatabase(token, orgId, project.id, db.id);
+  console.info(`Database "${db.name}" deleted.`);
 }

--- a/packages/cli/src/commands/db/platform-api.test.ts
+++ b/packages/cli/src/commands/db/platform-api.test.ts
@@ -101,12 +101,12 @@ describe('attachDatabase', () => {
   });
 });
 
-describe('detachDatabase', () => {
+describe('deleteDatabase', () => {
   it('resolves on 204', async () => {
     mockPlatformFetch.mockResolvedValue({ ok: true, status: 204 } as unknown as Response);
 
-    const { detachDatabase } = await import('./platform-api.js');
-    await expect(detachDatabase('tok', 'org-1', 'proj-1', 'db-1')).resolves.toBeUndefined();
+    const { deleteDatabase } = await import('./platform-api.js');
+    await expect(deleteDatabase('tok', 'org-1', 'proj-1', 'db-1')).resolves.toBeUndefined();
 
     const [url, init] = mockPlatformFetch.mock.calls[0]!;
     expect(url).toBe('http://localhost:9999/v1/server/projects/proj-1/databases/db-1');
@@ -116,8 +116,8 @@ describe('detachDatabase', () => {
   it('throws a clear admin-role message on 403', async () => {
     mockPlatformFetch.mockResolvedValue(jsonResponse(403, { detail: 'Forbidden' }));
 
-    const { detachDatabase } = await import('./platform-api.js');
-    await expect(detachDatabase('tok', 'org-1', 'proj-1', 'db-1')).rejects.toThrow(
+    const { deleteDatabase } = await import('./platform-api.js');
+    await expect(deleteDatabase('tok', 'org-1', 'proj-1', 'db-1')).rejects.toThrow(
       'You need the admin role in this organization to manage databases.',
     );
   });

--- a/packages/cli/src/commands/db/platform-api.ts
+++ b/packages/cli/src/commands/db/platform-api.ts
@@ -117,14 +117,14 @@ export async function fetchDatabase(
   return data.database;
 }
 
-export async function detachDatabase(token: string, orgId: string, projectId: string, dbId: string): Promise<void> {
+export async function deleteDatabase(token: string, orgId: string, projectId: string, dbId: string): Promise<void> {
   const resp = await platformFetch(`${getApiUrl()}/v1/server/projects/${projectId}/databases/${dbId}`, {
     method: 'DELETE',
     headers: authHeaders(token, orgId),
   });
 
   if (!resp.ok) {
-    await handleFailure(resp, 'Failed to detach database');
+    await handleFailure(resp, 'Failed to delete database');
   }
 }
 


### PR DESCRIPTION
## Summary

`mastra env db detach` permanently deletes the provider database. The platform's delete path deprovisions the Turso/Neon database upstream — all data is destroyed; only the platform row is soft-deleted. The command name and confirmation prompt ("Deploys will no longer receive its env vars.") described a non-destructive unlink, which made the CLI a data-loss trap: a user "detaching" a shared database to move to per-environment databases (the documented migration path) loses production data.

This renames the command to `mastra env db delete` and rewrites the copy to say what actually happens:

- Command: `mastra env db delete <database>` — description "Permanently delete a database and all its data (admin only)"
- Confirm prompt: "Permanently delete database … and ALL of its data? This cannot be undone. …"
- CLI reference docs updated to match

**No `detach` alias, deliberately.** The command shipped days ago on an alpha CLI so the rename is nearly free, and the platform is expected to grow a *true* non-destructive detach (drop the attachment, keep the provider DB) for the shared→per-environment migration path. Reserving the name means "detach" will never mean "destroy data" on any CLI version.

Tracked as deploy-experience-papercuts issue 29 (severity upgraded to high 07-13 after the destructive behavior was confirmed in the platform delete path).

## Test plan

- [x] Unit tests pass (`platform-api` delete tests renamed with the function)
- [x] Typecheck + build clean
- [x] `mastra env db --help` and `mastra env db delete --help` show the new command and honest description
- [ ] Docs PR #19394 will be updated to use `delete` naming + inline data-destruction warnings (depends on this PR)

🤖 Generated with Mastra Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The database command was renamed from `detach` to `delete` because it permanently removes the database and all its data. The CLI, documentation, confirmation prompt, and tests now clearly describe this destructive behavior.

## Changes

- Replaced `mastra env db detach` with `mastra env db delete`.
- Added explicit permanent-deletion warnings and updated success messages.
- Updated CLI reference documentation and changeset.
- Renamed the platform API function and updated lifecycle tests for HTTP 204 and error cases.
- Reserved `detach` for a future non-destructive unlink operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->