### PR TITLE
fix(cli): deploy/env usability papercuts — wrong-target deploy guard, actionable preflight, field-level 400s

### DIFF
--- a/.changeset/wise-pugs-argue.md
+++ b/.changeset/wise-pugs-argue.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fix three deploy/env usability papercuts: `mastra deploy staging` now fails fast with "Did you mean: mastra deploy --env staging" instead of silently deploying to production, the preflight block message names the exact unblock command (`mastra env db create --kind turso`/`neon` based on the missing variable), and 400 validation errors now show the field name and valid options instead of a bare "invalid fields".

--- a/packages/cli/src/commands/auth/client.ts
+++ b/packages/cli/src/commands/auth/client.ts
@@ -49,9 +49,30 @@ export function throwApiError(message: string, status: number, detail?: string):
 export function extractApiErrorDetail(error: unknown): string | undefined {
   if (!error || typeof error !== 'object') return undefined;
   const o = error as Record<string, unknown>;
-  if (typeof o.detail === 'string' && o.detail.trim()) return o.detail;
-  if (typeof o.message === 'string' && o.message.trim()) return o.message;
-  return undefined;
+
+  let detail: string | undefined;
+  if (typeof o.detail === 'string' && o.detail.trim()) detail = o.detail;
+  else if (typeof o.message === 'string' && o.message.trim()) detail = o.message;
+  else if (typeof o.error === 'string' && o.error.trim()) detail = o.error;
+
+  // Validation errors (400) carry the useful part in errors[] — field name plus
+  // message (e.g. the valid-options enum for a bad --region). Without this the
+  // user only sees "The request body contains invalid fields".
+  const fieldErrors = Array.isArray(o.errors)
+    ? o.errors
+        .map(e => {
+          if (!e || typeof e !== 'object') return '';
+          const fe = e as Record<string, unknown>;
+          const field = typeof fe.field === 'string' ? fe.field : '';
+          const message = typeof fe.message === 'string' ? fe.message : '';
+          return [field, message].filter(Boolean).join(' — ');
+        })
+        .filter(Boolean)
+        .join('; ')
+    : '';
+
+  if (detail && fieldErrors) return `${detail}: ${fieldErrors}`;
+  return detail ?? (fieldErrors || undefined);
 }
 
 // Shared mutable token state — updated by refreshes so all callers see the latest.

--- a/packages/cli/src/commands/db/platform-api.test.ts
+++ b/packages/cli/src/commands/db/platform-api.test.ts
@@ -99,6 +99,31 @@ describe('attachDatabase', () => {
       'TURSO_DATABASE_URL is already set on this project',
     );
   });
+
+  it('surfaces field-level validation errors on 400 (e.g. bad --region)', async () => {
+    mockPlatformFetch.mockResolvedValue(
+      jsonResponse(400, {
+        detail: 'The request body contains invalid fields',
+        errors: [{ field: 'regionId', message: 'Invalid option: expected one of "ams"|"arn"|"fra"' }],
+      }),
+    );
+
+    const { attachDatabase } = await import('./platform-api.js');
+    await expect(
+      attachDatabase('tok', 'org-1', 'proj-1', { kind: 'turso', name: 'db', regionId: 'eu' }),
+    ).rejects.toThrow(
+      'The request body contains invalid fields: regionId — Invalid option: expected one of "ams"|"arn"|"fra"',
+    );
+  });
+
+  it('leaves plain-detail 400s unchanged', async () => {
+    mockPlatformFetch.mockResolvedValue(jsonResponse(400, { detail: 'Provider is unavailable' }));
+
+    const { attachDatabase } = await import('./platform-api.js');
+    await expect(attachDatabase('tok', 'org-1', 'proj-1', { kind: 'turso', name: 'db' })).rejects.toThrow(
+      /^Provider is unavailable$/,
+    );
+  });
 });
 
 describe('detachDatabase', () => {

--- a/packages/cli/src/commands/db/platform-api.ts
+++ b/packages/cli/src/commands/db/platform-api.ts
@@ -1,5 +1,5 @@
 import { withPollingRetries } from '../../utils/polling.js';
-import { authHeaders, platformFetch, throwApiError } from '../auth/client.js';
+import { authHeaders, extractApiErrorDetail, platformFetch, throwApiError } from '../auth/client.js';
 
 export type DatabaseKind = 'turso' | 'neon' | 'mongodb';
 export type DatabaseStatus = 'provisioning' | 'ready' | 'failed' | 'deleting' | 'deleted';
@@ -52,8 +52,7 @@ function getApiUrl(): string {
 
 async function readErrorDetail(resp: Response): Promise<string | undefined> {
   try {
-    const err = (await resp.json()) as { detail?: string; error?: string };
-    return err.detail ?? err.error;
+    return extractApiErrorDetail(await resp.json());
   } catch {
     return undefined;
   }

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -289,6 +289,34 @@ describe('preflightBuildOutput', () => {
       expect(issue?.message).toContain('TURSO_DATABASE_URL is not set');
     });
 
+    it('names the exact db create command in the hard-error fix (kind-specific)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: false, managedEnvVarNames: [] });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.fix).toContain('mastra env db create --kind turso');
+    });
+
+    it('names the exact db create command when preflight runs without platform context (lint path)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'DATABASE_URL' }] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.fix).toContain('mastra env db create --kind neon');
+    });
+
+    it('falls back to a bare db create command for unmapped guard vars', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'MY_CUSTOM_DB_URL' }] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.fix).toContain('mastra env db create');
+      expect(issue?.fix).not.toContain('--kind');
+    });
+
     it('warns (not errors) on guarded misses when platform context lacks managedEnvVarNames (older platform)', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [guardedDetection] });

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -1,8 +1,10 @@
 import type { Dirent } from 'node:fs';
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
+
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
+import { DB_ENV_VAR_NAMES } from './db/platform-api.js';
 
 /* ------------------------------------------------------------------ */
 /*  Types                                                             */
@@ -370,6 +372,18 @@ async function readPreflightMetadata(outputDir: string): Promise<PreflightMetada
  * are absent (e.g. older build, or the plugin wasn't active) the check is
  * silently skipped — no false positives.
  */
+/**
+ * The exact command that unblocks a missing database env var. Kind-specific
+ * when the guarded var maps to a known provider (issue 35-B: the remediation
+ * previously said "attach a managed database" without ever naming the command).
+ */
+export function dbCreateCommandFor(envVarName: string): string {
+  for (const [kind, names] of Object.entries(DB_ENV_VAR_NAMES)) {
+    if (names.includes(envVarName)) return `mastra env db create --kind ${kind}`;
+  }
+  return 'mastra env db create';
+}
+
 async function checkLocalStoragePaths(
   outputDir: string,
   metadata: PreflightMetadata | null,
@@ -441,7 +455,7 @@ async function checkLocalStoragePaths(
           code: 'LOCAL_STORAGE_PATH',
           severity: 'error',
           message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or attach a managed database that provides it.`,
+          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy)}`,
         });
       }
     } else if (hasEnvFile) {
@@ -449,7 +463,7 @@ async function checkLocalStoragePaths(
         code: 'LOCAL_STORAGE_PATH',
         severity: 'error',
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-        fix: `Set ${d.guardedBy} in your env file, or remove the local fallback. If the platform injects it (e.g. a managed database), re-run with --skip-preflight.`,
+        fix: `Set ${d.guardedBy} in your env file, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy)}. If the platform already injects it, re-run with --skip-preflight.`,
       });
     } else {
       issues.push({

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -33,6 +33,7 @@ import { getDeployEnvFiles, loadDeployEnvFromDotenv, readEnvVars, getMastraVersi
 import { createProject } from '../studio/platform-api.js';
 import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
 import { getOverwrittenEnvKeys } from './env-vars.js';
+import { assertDeployDir } from './validate-dir.js';
 
 /**
  * Derive the public studio/server URLs from the environment slug.
@@ -554,6 +555,7 @@ export async function unifiedDeployAction(dir: string | undefined, opts: DeployO
 
 async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
   const targetDir = resolve(dir || process.cwd());
+  await assertDeployDir(dir, targetDir);
   loadDeployEnvFromDotenv(targetDir);
 
   const isHeadless = Boolean(process.env.MASTRA_API_TOKEN);

--- a/packages/cli/src/commands/deploy/validate-dir.test.ts
+++ b/packages/cli/src/commands/deploy/validate-dir.test.ts
@@ -1,0 +1,36 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { assertDeployDir } from './validate-dir.js';
+
+describe('assertDeployDir', () => {
+  it('does nothing when no positional was passed', async () => {
+    await expect(assertDeployDir(undefined, '/nonexistent')).resolves.toBeUndefined();
+  });
+
+  it('accepts an existing directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deploy-dir-'));
+    await expect(assertDeployDir(dir, dir)).resolves.toBeUndefined();
+  });
+
+  it('suggests --env when the positional looks like an environment name', async () => {
+    await expect(assertDeployDir('staging', join(tmpdir(), 'does-not-exist-staging'))).rejects.toThrow(
+      'Did you mean: mastra deploy --env staging',
+    );
+  });
+
+  it('reports a plain missing directory for path-like arguments', async () => {
+    const err = await assertDeployDir('./missing/path', join(tmpdir(), 'does-not-exist-path')).catch(e => e);
+    expect(err.message).toContain('Directory not found: ./missing/path');
+    expect(err.message).not.toContain('--env');
+  });
+
+  it('rejects a file passed as the deploy directory', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'mastra-deploy-file-'));
+    const file = join(dir, 'staging');
+    await writeFile(file, '');
+    await expect(assertDeployDir('staging', file)).rejects.toThrow('Did you mean: mastra deploy --env staging');
+  });
+});

--- a/packages/cli/src/commands/deploy/validate-dir.ts
+++ b/packages/cli/src/commands/deploy/validate-dir.ts
@@ -1,0 +1,22 @@
+import { stat } from 'node:fs/promises';
+
+/**
+ * Guard against `mastra deploy staging` silently deploying to production.
+ *
+ * The deploy signature is `deploy [dir]`, but the rest of the surface teaches
+ * positional environments (`env restart staging`, `env db create staging`),
+ * so users type `mastra deploy staging` expecting to target that environment.
+ * The positional is consumed as a directory, falls back to cwd semantics, and
+ * the deploy targets production. Fail fast when the directory doesn't exist
+ * and point at `--env` when the argument looks like an environment name.
+ */
+export async function assertDeployDir(dirArg: string | undefined, resolvedDir: string): Promise<void> {
+  if (!dirArg) return;
+
+  const stats = await stat(resolvedDir).catch(() => null);
+  if (stats?.isDirectory()) return;
+
+  const looksLikeEnvName = !dirArg.includes('/') && !dirArg.includes('\\') && !dirArg.startsWith('.');
+  const hint = looksLikeEnvName ? ` Did you mean: mastra deploy --env ${dirArg}` : '';
+  throw new Error(`Directory not found: ${dirArg}.${hint}`);
+}

--- a/packages/cli/src/commands/env/platform-api.ts
+++ b/packages/cli/src/commands/env/platform-api.ts
@@ -1,4 +1,4 @@
-import { throwApiError } from '../auth/client.js';
+import { extractApiErrorDetail, throwApiError } from '../auth/client.js';
 
 export interface Project {
   id: string;
@@ -71,7 +71,7 @@ export async function fetchProjects(token: string, orgId: string): Promise<Proje
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
-    throwApiError('Failed to fetch projects', resp.status, (err as { detail?: string }).detail);
+    throwApiError('Failed to fetch projects', resp.status, extractApiErrorDetail(err));
   }
 
   const data = (await resp.json()) as { projects: Project[] };
@@ -88,7 +88,7 @@ export async function fetchEnvironments(token: string, orgId: string, projectId:
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
-    throwApiError('Failed to fetch environments', resp.status, (err as { detail?: string }).detail);
+    throwApiError('Failed to fetch environments', resp.status, extractApiErrorDetail(err));
   }
 
   const data = (await resp.json()) as { environments: Environment[] };
@@ -109,7 +109,7 @@ export async function fetchEnvironmentDeploys(
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
-    throwApiError('Failed to fetch deploys', resp.status, (err as { detail?: string }).detail);
+    throwApiError('Failed to fetch deploys', resp.status, extractApiErrorDetail(err));
   }
 
   const data = (await resp.json()) as { deploys: EnvironmentDeploy[] };
@@ -134,7 +134,7 @@ export async function createEnvironment(
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
-    throwApiError('Failed to create environment', resp.status, (err as { detail?: string }).detail);
+    throwApiError('Failed to create environment', resp.status, extractApiErrorDetail(err));
   }
 
   const data = (await resp.json()) as { environment: Environment };
@@ -161,7 +161,7 @@ export async function restartEnvironment(
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
-    throwApiError('Failed to restart environment', resp.status, (err as { detail?: string }).detail);
+    throwApiError('Failed to restart environment', resp.status, extractApiErrorDetail(err));
   }
 }
 
@@ -176,7 +176,7 @@ export async function deleteEnvironment(token: string, orgId: string, projectId:
 
   if (!resp.ok) {
     const err = await resp.json().catch(() => ({}));
-    throwApiError('Failed to delete environment', resp.status, (err as { detail?: string }).detail);
+    throwApiError('Failed to delete environment', resp.status, extractApiErrorDetail(err));
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the three CLI-side papercuts from the 07-13 fresh-user usability pass of `mastra deploy` + `mastra env` (deploy-experience-papercuts issue 35, items A–C). Shared acceptance goal: a fresh user can go help → deploy → blocked → db create → deploy without reading docs.

### A. `mastra deploy staging` silently targeted PRODUCTION

The deploy signature is `deploy [dir]`, so the positional was consumed as a directory, fell back to cwd, and the deploy targeted production. The rest of the surface teaches positional environments (`env restart staging`, `env db create staging`), so this was a wrong-target production deploy waiting to happen — with `-y` in CI it goes all the way.

Now: when the positional isn't an existing directory, deploy fails fast. If the argument looks like an environment name, the error says `Did you mean: mastra deploy --env staging`. Legitimate directories are unchanged.

### B. Preflight remediation never named the command that unblocks you

The `LOCAL_STORAGE_PATH` block said "…or attach a managed database that provides it" — right advice, no how. The fix now names the exact command, kind-specific by reversing `DB_ENV_VAR_NAMES`: `TURSO_*` → `mastra env db create --kind turso`, `DATABASE_URL` → `--kind neon`, unmapped guard vars → bare `mastra env db create`. The lint-preflight variant (which previously only offered `--skip-preflight`) gets the same command.

### C. CLI swallowed field-level 400 detail

`extractApiErrorDetail` only read top-level `detail`/`error`, dropping the `errors[]` array. The platform's 400 for a bad `--region` is self-documenting (`regionId — Invalid option: expected one of "ams"|"arn"|"fra"|…`) but users saw only "The request body contains invalid fields". Field errors are now appended to the detail. Fixed in the shared `auth/client.ts` helper and adopted by both `db/platform-api.ts` and `env/platform-api.ts` (which had the same gap inline at six call sites).

Items D (help-text discovery) is deferred until #19400 merges (touches the same registration code), and item E (region vocabulary) needs a platform decision — C makes the 400 self-documenting in the meantime.

## Test plan

- [x] New unit tests: positional guard (5), preflight command naming (3), field-level 400 detail (2)
- [x] All 627 CLI tests pass; typecheck clean; build succeeds
- [x] Live check: `mastra deploy staging` from a non-project directory prints `Did you mean: mastra deploy --env staging`

🤖 Generated with Mastra Code


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This makes `mastra deploy` and `mastra env` safer and clearer: mistaken environment names no longer deploy to production, database setup errors explain exactly how to fix them, and API errors show which fields need attention.

## Changes

- Fail fast when `mastra deploy <environment>` is not a valid directory, with guidance to use `--env <environment>`.
- Add database-kind-specific remediation commands such as `mastra env db create --kind turso` or `--kind neon`.
- Preserve detailed 400-response validation errors, including field names and allowed region options, across database and environment API clients.
- Add unit tests covering deploy-directory validation, database preflight commands, and API error formatting.
- Add a patch changeset for the `mastra` package.

## Validation

- All 627 CLI tests pass.
- Typechecking and build succeed.
- Live deploy guard check passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->