### PR TITLE
fix(core): preserve reasoning in durable agent messages

### DIFF
--- a/.changeset/fix-durable-agent-preserve-reasoning.md
+++ b/.changeset/fix-durable-agent-preserve-reasoning.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `DurableAgent` losing reasoning items on turns that include tool calls, which caused OpenAI reasoning models like `gpt-5-mini` to fail on the next turn. Reasoning is now preserved and replayed correctly on subsequent turns.
+
+Fixes #19365.

--- a/packages/core/src/agent/durable/__tests__/durable-agent-reasoning-tool-preservation.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-reasoning-tool-preservation.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Regression test for #19365:
+ *
+ * DurableAgent crashes on the second turn when using OpenAI reasoning models
+ * (e.g. gpt-5-mini) with tools because reasoning parts — including the
+ * empty-reasoning-with-itemId marker — are discarded when the assistant
+ * message is reconstructed inside the durable llm-execution step.
+ *
+ * When the model emits a `reasoning-start` with `providerMetadata.openai.itemId`
+ * followed by a `tool-call` (with its own `providerMetadata.openai.itemId`), the
+ * regular Agent path preserves both via `buildMessagesFromChunks`. The durable
+ * path only preserves the tool-call, so the next request to OpenAI contains a
+ * `function_call` referencing a reasoning item that was never sent, producing:
+ *
+ *   Item 'fc_...' of type 'function_call' was provided without its
+ *   required 'reasoning' item: 'rs_...'
+ *
+ * These tests drive a full durable stream through a two-turn tool cycle and
+ * inspect the AI SDK prompt seen on turn 2 to prove the reasoning part
+ * (and its itemId) are preserved before the follow-up call.
+ */
+
+import type { LanguageModelV2 } from '@ai-sdk/provider-v5';
+import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { z } from 'zod';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { createTool } from '../../../tools';
+import { Agent } from '../../agent';
+import { createDurableAgent } from '../create-durable-agent';
+
+const REASONING_ITEM_ID = 'rs_test_19365_reasoning';
+const TOOL_CALL_ITEM_ID = 'fc_test_19365_toolcall';
+
+/**
+ * Extract all assistant-message content parts from an AI SDK prompt captured
+ * inside a mock model's `doStream`. Used to assert what the durable step
+ * actually replays back to the model on the next turn.
+ */
+function assistantPartsFromPrompt(prompt: unknown): Array<Record<string, any>> {
+  const messages = prompt as Array<{ role: string; content: any }>;
+  return messages
+    .filter(m => m.role === 'assistant')
+    .flatMap(m => (Array.isArray(m.content) ? (m.content as Array<Record<string, any>>) : []));
+}
+
+/**
+ * Two-turn model that mimics an OpenAI reasoning model:
+ *  - turn 1: empty reasoning span carrying openai.itemId, followed by a tool-call
+ *  - turn 2: plain text response
+ */
+function createReasoningThenToolModel(finalText: string, prompts: unknown[]) {
+  let callCount = 0;
+  return new MockLanguageModelV2({
+    doStream: async (options: any) => {
+      prompts.push(options.prompt);
+      callCount++;
+      if (callCount === 1) {
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-0', modelId: 'gpt-5-mini', timestamp: new Date(0) },
+            {
+              type: 'reasoning-start',
+              id: 'reasoning-1',
+              providerMetadata: {
+                openai: {
+                  itemId: REASONING_ITEM_ID,
+                  reasoningEncryptedContent: null,
+                },
+              },
+            },
+            { type: 'reasoning-end', id: 'reasoning-1' },
+            {
+              type: 'tool-call',
+              toolCallId: 'call-1',
+              toolName: 'echo',
+              input: JSON.stringify({ text: 'hello' }),
+              providerExecuted: false,
+              providerMetadata: {
+                openai: {
+                  itemId: TOOL_CALL_ITEM_ID,
+                },
+              },
+            },
+            {
+              type: 'finish',
+              finishReason: 'tool-calls',
+              usage: { inputTokens: 15, outputTokens: 10, totalTokens: 25 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      }
+      return {
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-1', modelId: 'gpt-5-mini', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: finalText },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'finish',
+            finishReason: 'stop',
+            usage: { inputTokens: 20, outputTokens: 15, totalTokens: 35 },
+          },
+        ]),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+      };
+    },
+  });
+}
+
+describe('DurableAgent — reasoning + tool call preservation (#19365)', () => {
+  let pubsub: EventEmitterPubSub;
+
+  beforeEach(() => {
+    pubsub = new EventEmitterPubSub();
+  });
+
+  afterEach(async () => {
+    await pubsub.close();
+  });
+
+  it('preserves an empty reasoning part with openai.itemId when a tool-call follows in the same step', async () => {
+    const prompts: unknown[] = [];
+    const model = createReasoningThenToolModel('done', prompts);
+
+    const echoTool = createTool({
+      id: 'echo',
+      description: 'Echo the input',
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({ echoed: z.string() }),
+      execute: async ({ text }) => ({ echoed: text }),
+    });
+
+    const baseAgent = new Agent({
+      id: 'durable-reasoning-tool-agent',
+      name: 'Durable Reasoning Tool Agent',
+      instructions: 'Use the echo tool.',
+      model: model as LanguageModelV2,
+      tools: { echo: echoTool },
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const { output, cleanup } = await durableAgent.stream('Echo hello.', { maxSteps: 4 });
+    await output.consumeStream();
+
+    // Two model calls: reasoning+tool-call, then final text.
+    expect(prompts).toHaveLength(2);
+
+    // The second prompt is what actually gets sent back to OpenAI on turn 2.
+    // The reasoning part (with its itemId) MUST appear before the tool-call
+    // or OpenAI rejects the request with the "required 'reasoning' item" error.
+    const assistantParts = assistantPartsFromPrompt(prompts[1]);
+    expect(assistantParts.length).toBeGreaterThan(0);
+
+    const reasoningParts = assistantParts.filter(p => p.type === 'reasoning');
+    const toolCallParts = assistantParts.filter(p => p.type === 'tool-call');
+
+    expect(reasoningParts.length).toBeGreaterThan(0);
+    expect(reasoningParts[0]?.providerOptions?.openai?.itemId).toBe(REASONING_ITEM_ID);
+
+    expect(toolCallParts.length).toBeGreaterThan(0);
+    expect(toolCallParts[0]?.providerOptions?.openai?.itemId).toBe(TOOL_CALL_ITEM_ID);
+
+    // Reasoning must precede the tool-call within the assistant turn.
+    const reasoningIndex = assistantParts.findIndex(p => p.type === 'reasoning');
+    const toolCallIndex = assistantParts.findIndex(p => p.type === 'tool-call');
+    expect(reasoningIndex).toBeGreaterThanOrEqual(0);
+    expect(toolCallIndex).toBeGreaterThan(reasoningIndex);
+
+    cleanup();
+  });
+
+  it('preserves reasoning text content and ordering when reasoning precedes a tool-call in the same step', async () => {
+    const prompts: unknown[] = [];
+    let callCount = 0;
+    const model = new MockLanguageModelV2({
+      doStream: async (options: any) => {
+        prompts.push(options.prompt);
+        callCount++;
+        if (callCount === 1) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'gpt-5-mini', timestamp: new Date(0) },
+              {
+                type: 'reasoning-start',
+                id: 'reasoning-1',
+                providerMetadata: {
+                  openai: { itemId: 'rs_test_second_case', reasoningEncryptedContent: null },
+                },
+              },
+              { type: 'reasoning-delta', id: 'reasoning-1', delta: 'Thinking about the answer' },
+              { type: 'reasoning-delta', id: 'reasoning-1', delta: ' step by step.' },
+              { type: 'reasoning-end', id: 'reasoning-1' },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-2',
+                toolName: 'echo',
+                input: JSON.stringify({ text: 'hi' }),
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+              },
+            ]),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'id-1', modelId: 'gpt-5-mini', timestamp: new Date(0) },
+            { type: 'text-start', id: 'text-2' },
+            { type: 'text-delta', id: 'text-2', delta: 'done' },
+            { type: 'text-end', id: 'text-2' },
+            {
+              type: 'finish',
+              finishReason: 'stop',
+              usage: { inputTokens: 15, outputTokens: 5, totalTokens: 20 },
+            },
+          ]),
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const echoTool = createTool({
+      id: 'echo',
+      description: 'Echo the input',
+      inputSchema: z.object({ text: z.string() }),
+      outputSchema: z.object({ echoed: z.string() }),
+      execute: async ({ text }) => ({ echoed: text }),
+    });
+
+    const baseAgent = new Agent({
+      id: 'durable-reasoning-text-agent',
+      name: 'Durable Reasoning Text Agent',
+      instructions: 'Think, then use the echo tool.',
+      model: model as LanguageModelV2,
+      tools: { echo: echoTool },
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+
+    const { output, cleanup } = await durableAgent.stream('Echo hi.', { maxSteps: 4 });
+    await output.consumeStream();
+
+    expect(prompts).toHaveLength(2);
+
+    // Inspect the second-turn prompt — the reasoning content and ordering
+    // (reasoning before tool-call) must be preserved from turn 1.
+    const assistantParts = assistantPartsFromPrompt(prompts[1]);
+
+    const reasoningParts = assistantParts.filter(p => p.type === 'reasoning');
+    const toolCallParts = assistantParts.filter(p => p.type === 'tool-call');
+
+    expect(reasoningParts.length).toBeGreaterThan(0);
+    expect(reasoningParts[0]?.text ?? reasoningParts[0]?.reasoning).toContain('Thinking about the answer');
+    expect(reasoningParts[0]?.providerOptions?.openai?.itemId).toBe('rs_test_second_case');
+
+    expect(toolCallParts.length).toBeGreaterThan(0);
+
+    const reasoningIndex = assistantParts.findIndex(p => p.type === 'reasoning');
+    const toolCallIndex = assistantParts.findIndex(p => p.type === 'tool-call');
+    expect(toolCallIndex).toBeGreaterThan(reasoningIndex);
+
+    cleanup();
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -1436,10 +1436,26 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // OpenAI reasoning models fail on the next turn with
             // "Item 'fc_...' of type 'function_call' was provided without
             // its required 'reasoning' item" (#19365).
+            //
+            // Mirror the regular Agent's buildResponseModelMetadata so the
+            // persisted assistant message carries the same content.metadata
+            // (modelId/provider): prefer the static model, fall back to the
+            // response-metadata chunk.
+            const responseModelId = currentModel.modelId ?? responseMetadata?.modelId;
+            const responseModelMetadata =
+              responseModelId || currentModel.provider
+                ? {
+                    metadata: {
+                      ...(responseModelId ? { modelId: responseModelId } : {}),
+                      ...(currentModel.provider ? { provider: currentModel.provider } : {}),
+                    },
+                  }
+                : undefined;
             const builtMessages = buildMessagesFromChunks({
               chunks: collectedChunks,
               messageId: currentMessageId,
               tools: currentTools,
+              responseModelMetadata,
             });
             if (builtMessages.length > 0) {
               for (const msg of builtMessages) {

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -9,6 +9,7 @@ import { buildLlmPromptArgs } from '../../../../loop/shared/build-llm-prompt-arg
 import { composeStepInput } from '../../../../loop/shared/compose-step-input';
 import { injectBackgroundTaskPrompt } from '../../../../loop/shared/inject-background-task-prompt';
 import { buildMemoryHeaders, mergeLlmCallHeaders } from '../../../../loop/shared/merge-llm-call-headers';
+import { buildMessagesFromChunks } from '../../../../loop/workflows/agentic-execution/build-messages-from-chunks';
 import type { Mastra } from '../../../../mastra';
 import type {
   SpanType,
@@ -31,7 +32,6 @@ import type { CoreTool } from '../../../../tools/types';
 import { PUBSUB_SYMBOL } from '../../../../workflows/constants';
 import { createStep } from '../../../../workflows/workflow';
 import { MessageList } from '../../../message-list';
-import type { MastraDBMessage } from '../../../message-list';
 import { TripWire } from '../../../trip-wire';
 import { isSupportedLanguageModel } from '../../../utils';
 import { DurableStepIds } from '../../constants';
@@ -851,10 +851,14 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             });
             modelSpanTracker?.startInference?.();
 
-            // Collect chunks for the processLLMResponse hook (pairs with
-            // processLLMRequest — lets processors like ResponseCache persist
-            // the model's response). Only populated when there's no cache hit.
-            const collectedChunks: Array<{ type: string; payload: unknown }> = [];
+            // Collect chunks for post-stream message building (via
+            // buildMessagesFromChunks) and for the processLLMResponse hook
+            // (pairs with processLLMRequest — lets processors like
+            // ResponseCache persist the model's response). Always populated
+            // so reasoning/text/tool parts are reconstructed in stream order,
+            // including empty reasoning spans that carry providerMetadata
+            // (e.g. OpenAI itemId) required by subsequent turns (#19365).
+            const collectedChunks: Array<{ type: string; payload: unknown; metadata?: Record<string, unknown> }> = [];
 
             // 10. Execute LLM call (or replay cached response)
             let modelResult: ReturnType<typeof execute>;
@@ -1084,16 +1088,17 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
                   }
                 }
 
-                // Collect every chunk for post-stream processLLMResponse hook.
-                // Skipped on cache hit because the processor already handled
-                // the original response, and skipped when no request/response
-                // processors exist to avoid buffering the entire stream in memory.
-                if (!cachedResponse && requestStepRunner) {
-                  collectedChunks.push({
-                    type: rawChunk.type,
-                    payload: 'payload' in rawChunk ? rawChunk.payload : undefined,
-                  });
-                }
+                // Collect every chunk for post-stream message building and the
+                // processLLMResponse hook. Always collect — reasoning parts
+                // (including empty spans with providerMetadata carrying
+                // OpenAI itemIds) are required to correctly reconstruct the
+                // assistant message and preserve pairing with subsequent
+                // tool-calls (#19365).
+                collectedChunks.push({
+                  type: rawChunk.type,
+                  payload: 'payload' in rawChunk ? rawChunk.payload : undefined,
+                  metadata: (rawChunk as { metadata?: Record<string, unknown> }).metadata,
+                });
 
                 // Process different chunk types — always from the raw chunk so
                 // internal state (tool args, finish reason, usage, metadata) is
@@ -1423,40 +1428,23 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               }
             }
 
-            // 12. Add assistant response to message list
-            if (textDeltas.length > 0 || toolCalls.length > 0) {
-              const parts: any[] = [];
-
-              if (textDeltas.length > 0) {
-                parts.push({
-                  type: 'text' as const,
-                  text: textDeltas.join(''),
-                });
+            // 12. Add assistant response to message list.
+            // Build parts from the full chunk sequence via the same helper
+            // the regular Agent uses, so reasoning spans (including empty
+            // reasoning with providerMetadata.openai.itemId) are preserved
+            // alongside text and tool-calls in stream order. Without this
+            // OpenAI reasoning models fail on the next turn with
+            // "Item 'fc_...' of type 'function_call' was provided without
+            // its required 'reasoning' item" (#19365).
+            const builtMessages = buildMessagesFromChunks({
+              chunks: collectedChunks,
+              messageId: currentMessageId,
+              tools: currentTools,
+            });
+            if (builtMessages.length > 0) {
+              for (const msg of builtMessages) {
+                messageList.add(msg, 'response');
               }
-
-              for (const tc of toolCalls) {
-                parts.push({
-                  type: 'tool-invocation' as const,
-                  toolInvocation: {
-                    state: 'call' as const,
-                    toolCallId: tc.toolCallId,
-                    toolName: tc.toolName,
-                    args: tc.args,
-                  },
-                });
-              }
-
-              const assistantMessage: MastraDBMessage = {
-                id: currentMessageId,
-                role: 'assistant' as const,
-                content: {
-                  format: 2,
-                  parts,
-                },
-                createdAt: new Date(),
-              };
-
-              messageList.add(assistantMessage, 'response');
 
               // Sync the updated messageList to the in-process registry so
               // downstream steps (e.g. tool-call.ts's doFlush()) see the

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -10,6 +10,7 @@ import { composeStepInput } from '../../../../loop/shared/compose-step-input';
 import { injectBackgroundTaskPrompt } from '../../../../loop/shared/inject-background-task-prompt';
 import { buildMemoryHeaders, mergeLlmCallHeaders } from '../../../../loop/shared/merge-llm-call-headers';
 import { buildMessagesFromChunks } from '../../../../loop/workflows/agentic-execution/build-messages-from-chunks';
+import type { CollectedChunk } from '../../../../loop/workflows/agentic-execution/build-messages-from-chunks';
 import type { Mastra } from '../../../../mastra';
 import type {
   SpanType,
@@ -858,7 +859,7 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
             // so reasoning/text/tool parts are reconstructed in stream order,
             // including empty reasoning spans that carry providerMetadata
             // (e.g. OpenAI itemId) required by subsequent turns (#19365).
-            const collectedChunks: Array<{ type: string; payload: unknown; metadata?: Record<string, unknown> }> = [];
+            const collectedChunks: CollectedChunk[] = [];
 
             // 10. Execute LLM call (or replay cached response)
             let modelResult: ReturnType<typeof execute>;


### PR DESCRIPTION
## Description

`DurableAgent` could fail on the LLM step following a tool call when using OpenAI reasoning models because reasoning parts were dropped while reconstructing assistant messages between durable steps.

The durable LLM step rebuilt assistant messages from text and tool-call accumulators only. As a result, reasoning parts and their provider metadata were missing from the serialized message history, leaving OpenAI `function_call` items without their required reasoning items on the next turn.

This change makes the durable path collect the full ordered chunk stream and reuse `buildMessagesFromChunks`, the same message builder used by the regular `Agent` path. This preserves reasoning spans, including empty reasoning parts carrying `providerMetadata.openai.itemId`, across the durable round-trip.

The regression tests exercise a two-turn durable tool cycle and verify the actual provider-facing prompt on the second turn. Both tests fail on `main` and pass with this fix.

## Related issue(s)

Fixes #19365

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

DurableAgent used to “replay” what the model said between durable steps using only the visible text and tool-call info. For OpenAI reasoning models, that accidentally dropped the model’s hidden reasoning markers (including required item IDs), so the next request could be rejected. Now it replays the full ordered stream (including reasoning—even empty—and its OpenAI `itemId`) when building the next prompt.

## Changes

- Updated `createDurableLLMExecutionStep` to buffer the complete streamed chunk sequence and reconstruct assistant message parts using `buildMessagesFromChunks`, instead of manually assembling messages from only `textDeltas` and `toolCalls`.
- Ensured durable replay preserves OpenAI reasoning parts across turns, including empty reasoning spans and `providerMetadata.openai.itemId`, and keeps reasoning parts ordered before the corresponding `tool-call`.
- Added a regression test for `#19365` covering a two-turn durable tool cycle:
  - Verifies turn 2’s prompt includes an empty `reasoning` part with the expected `openai.itemId` before the subsequent `tool-call`.
  - Verifies reasoning text deltas and ordering are preserved when reasoning precedes a tool-call in the same step.
- Added a patch changeset for `@mastra/core` (`fix-durable-agent-preserve-reasoning.md`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->