### PR TITLE
feat(voice-speechify): add support for Simba 3.2 and Simba 3.0 models

### DIFF
--- a/.changeset/solid-apples-end.md
+++ b/.changeset/solid-apples-end.md
@@ -1,0 +1,19 @@
+---
+'@mastra/voice-speechify': minor
+---
+
+Added support for Speechify's Simba 3.2 and Simba 3.0 text-to-speech models. Simba 3.2 is Speechify's latest streaming model with lower latency and richer expressivity, and is the recommended model for English speech.
+
+```typescript
+import { SpeechifyVoice } from '@mastra/voice-speechify';
+
+// Set as the default model
+const voice = new SpeechifyVoice({
+  speechModel: { name: 'simba-3.2' },
+});
+
+// Or override per request
+const stream = await voice.speak('Hello world', { model: 'simba-3.2' });
+```
+
+Note: `simba-3.2` and `simba-3.0` are currently English only. The default model remains `simba-english`.

--- a/docs/src/content/en/reference/voice/speechify.mdx
+++ b/docs/src/content/en/reference/voice/speechify.mdx
@@ -20,7 +20,7 @@ const voice = new SpeechifyVoice()
 // Initialize with custom configuration
 const voice = new SpeechifyVoice({
   speechModel: {
-    name: 'simba-english',
+    name: 'simba-3.2',
     apiKey: 'your-api-key',
   },
   speaker: 'george', // Default voice
@@ -48,8 +48,9 @@ const audioStream = await voice.speak('Hello, world!', {
         parameters: [
           {
             name: 'name',
-            type: 'VoiceModelName',
-            description: 'The Speechify model to use',
+            type: 'SpeechifyModel',
+            description:
+              "The Speechify model to use ('simba-3.2', 'simba-3.0', 'simba-english', or 'simba-multilingual')",
             isOptional: true,
             defaultValue: "'simba-english'",
           },
@@ -105,7 +106,7 @@ Converts text to speech using the configured speech model and voice.
           },
           {
             name: 'model',
-            type: 'VoiceModelName',
+            type: 'SpeechifyModel',
             description: 'Override the default model for this request',
             isOptional: true,
             defaultValue: "Constructor's model value",
@@ -156,5 +157,7 @@ This method isn't supported by Speechify and will throw an error. Speechify does
 
 - Speechify requires an API key for authentication
 - The default model is 'simba-english'
+- 'simba-3.2' is Speechify's latest streaming model with the lowest latency and richest expressivity, and the recommended model for English
+- 'simba-3.2' and 'simba-3.0' are currently English only; use 'simba-multilingual' for non-English or mixed-language input
 - Speech-to-text functionality isn't supported
 - Additional audio stream options can be passed through the speak() method's options parameter

--- a/voice/speechify/README.md
+++ b/voice/speechify/README.md
@@ -23,7 +23,7 @@ import { SpeechifyVoice } from '@mastra/voice-speechify';
 
 const voice = new SpeechifyVoice({
   speechModel: {
-    name: 'simba-english', // Optional, defaults to 'simba-english'
+    name: 'simba-3.2', // Optional, defaults to 'simba-english'
     apiKey: 'your-api-key', // Optional, can use SPEECHIFY_API_KEY env var
   },
   speaker: 'george', // Optional, defaults to 'george'
@@ -49,7 +49,7 @@ The `SpeechifyVoice` constructor accepts the following options:
 
 ```typescript
 interface SpeechifyConfig {
-  name?: string; // Optional Speechify model name (default: 'simba-english')
+  name?: SpeechifyModel; // Optional Speechify model name (default: 'simba-english')
   apiKey?: string; // Optional API key (can also use env var)
 }
 
@@ -57,6 +57,19 @@ new SpeechifyVoice({
   speechModel?: SpeechifyConfig,
   speaker?: string // Optional default speaker ID
 })
+```
+
+## Available Models
+
+- `simba-3.2`: Speechify's latest streaming-native model with the lowest latency and richest expressivity. Recommended for English. Currently English only.
+- `simba-3.0`: The earlier Simba 3 model, still available. Currently English only.
+- `simba-english`: The default model, optimized for English.
+- `simba-multilingual`: Optimized for non-English or mixed-language input.
+
+The model can also be overridden per request:
+
+```typescript
+const stream = await voice.speak('Hello world', { model: 'simba-3.2' });
 ```
 
 ## Available Speakers

--- a/voice/speechify/src/index.ts
+++ b/voice/speechify/src/index.ts
@@ -7,8 +7,16 @@ import type { AudioStreamRequest, VoiceModelName } from '@speechify/api-sdk';
 import { SPEECHIFY_VOICES } from './voices';
 import type { SpeechifyVoiceId } from './voices';
 
+/**
+ * Models accepted by the Speechify API. Extends the SDK's `VoiceModelName`
+ * with the Simba 3 generation models, which the API accepts but the SDK's
+ * type union does not yet include. `simba-3.0` and `simba-3.2` are
+ * currently English only.
+ */
+type SpeechifyModel = VoiceModelName | 'simba-3.0' | 'simba-3.2';
+
 interface SpeechifyConfig {
-  name?: VoiceModelName;
+  name?: SpeechifyModel;
   apiKey?: string;
 }
 
@@ -55,15 +63,19 @@ export class SpeechifyVoice extends MastraVoice {
     input: string | NodeJS.ReadableStream,
     options?: {
       speaker?: string;
-    } & Omit<AudioStreamRequest, 'voiceId' | 'input'>,
+      model?: SpeechifyModel;
+    } & Omit<AudioStreamRequest, 'voiceId' | 'input' | 'model'>,
   ): Promise<NodeJS.ReadableStream> {
     const text = typeof input === 'string' ? input : await this.streamToString(input);
 
+    const { speaker, model, ...streamOptions } = options ?? {};
     const request: AudioStreamRequest = {
+      ...streamOptions,
       input: text,
-      model: (options?.model || this.speechModel?.name) as VoiceModelName,
-      voiceId: (options?.speaker || this.speaker) as SpeechifyVoiceId,
-      ...options,
+      // The SDK sends `model` to the API verbatim, so casting the wider
+      // SpeechifyModel union into its narrower VoiceModelName is safe.
+      model: (model || this.speechModel?.name) as VoiceModelName,
+      voiceId: (speaker || this.speaker) as SpeechifyVoiceId,
     };
 
     const webStream = await this.client.audioStream(request);
@@ -108,4 +120,4 @@ export class SpeechifyVoice extends MastraVoice {
   }
 }
 
-export type { SpeechifyConfig, SpeechifyVoiceId };
+export type { SpeechifyConfig, SpeechifyModel, SpeechifyVoiceId };

--- a/voice/speechify/src/models.test.ts
+++ b/voice/speechify/src/models.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { SpeechifyVoice } from './index';
+
+const { audioStreamMock } = vi.hoisted(() => ({
+  audioStreamMock: vi.fn(),
+}));
+
+vi.mock('@speechify/api-sdk', () => ({
+  Speechify: class {
+    audioStream = audioStreamMock;
+  },
+}));
+
+async function drain(stream: NodeJS.ReadableStream): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return Buffer.concat(chunks);
+}
+
+describe('SpeechifyVoice model support', () => {
+  beforeEach(() => {
+    audioStreamMock.mockReset();
+    audioStreamMock.mockResolvedValue(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      }),
+    );
+  });
+
+  it('passes simba-3.2 from the constructor config to the API', async () => {
+    const voice = new SpeechifyVoice({ speechModel: { name: 'simba-3.2', apiKey: 'test-key' } });
+    const audio = await drain(await voice.speak('Hello'));
+
+    expect(audio.length).toBeGreaterThan(0);
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'simba-3.2' }));
+  });
+
+  it('passes simba-3.2 as a per-request override', async () => {
+    const voice = new SpeechifyVoice({ speechModel: { apiKey: 'test-key' } });
+    await drain(await voice.speak('Hello', { model: 'simba-3.2' }));
+
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'simba-3.2' }));
+  });
+
+  it('accepts simba-3.0', async () => {
+    const voice = new SpeechifyVoice({ speechModel: { name: 'simba-3.0', apiKey: 'test-key' } });
+    await drain(await voice.speak('Hello'));
+
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'simba-3.0' }));
+  });
+
+  it('still defaults to simba-english', async () => {
+    const voice = new SpeechifyVoice({ speechModel: { apiKey: 'test-key' } });
+    await drain(await voice.speak('Hello'));
+
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'simba-english' }));
+  });
+});


### PR DESCRIPTION
Fixes #19410

Speechify's API supports the new Simba 3 generation models, but the `@speechify/api-sdk` `VoiceModelName` type union hasn't caught up yet, so `@mastra/voice-speechify` rejected them at compile time. This widens the accepted model type with a local `SpeechifyModel` union — the SDK passes the model value through to the API verbatim, so no SDK change is needed. `simba-3.2` is Speechify's latest streaming model with lower latency and richer expressivity, and their recommended model for English.

```typescript
const voice = new SpeechifyVoice({
  speechModel: { name: 'simba-3.2' },
});

// or per request
await voice.speak('Hello world', { model: 'simba-3.2' });
```

`simba-3.2` and `simba-3.0` are currently English only. The default model stays `simba-english` so audio output doesn't change for existing users. While widening the `speak()` options type, the `speaker` option no longer leaks into the audio stream request object. Includes unit tests that mock the SDK (the existing test file needs a real `SPEECHIFY_API_KEY`), plus README and reference doc updates.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Speechify can now use newer voice models for faster, higher-quality English speech, while keeping the existing model as the default. You can choose a model once for the voice or change it for an individual request.

## Summary

- Added support for Speechify’s `simba-3.2` and `simba-3.0` models through the exported `SpeechifyModel` type.
- Preserved `simba-english` as the default model.
- Added per-request model overrides in `speak()`.
- Updated request typing to prevent `speaker` and `model` from being sent as audio stream options.
- Added mocked unit tests covering defaults, constructor configuration, and request-level overrides.
- Updated README, reference documentation, and changeset with supported models and language guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->