### PR TITLE
fix(core): clean up ephemeral Mastra hooks after standalone Agent execution

### DIFF
--- a/.changeset/sour-points-tell.md
+++ b/.changeset/sour-points-tell.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a memory leak where every discarded standalone agent (an `Agent` used directly without being registered on a `Mastra` instance) stayed reachable for the lifetime of the process. The internal Mastra instance created for standalone execution no longer registers a module-level scorer hook it can never use, so standalone agents are garbage-collected once discarded. Applications that create one agent per request no longer see linear heap growth.
+
+Fixes [#19404](https://github.com/mastra-ai/mastra/issues/19404).

--- a/packages/core/src/agent/__tests__/standalone-ephemeral-leak.test.ts
+++ b/packages/core/src/agent/__tests__/standalone-ephemeral-leak.test.ts
@@ -1,21 +1,26 @@
 /**
- * Regression test for #19404: standalone Agent ephemeral Mastra leaks
+ * Regression tests for #19404: standalone Agent ephemeral Mastra leaked its
  * scorer hook on the module-level mitt emitter.
  *
- * A standalone Agent (not attached to a Mastra via `{ agents }`) creates
- * an ephemeral Mastra on first `stream()`/`generate()` call.  Before the
- * fix, the scorer hook registered by the ephemeral Mastra was never
- * unregistered, causing the module-level emitter to retain a reference
- * and prevent garbage collection.
+ * A standalone Agent (not attached to a Mastra via `{ agents }`) creates an
+ * ephemeral Mastra on first `stream()`/`generate()` call. Before the fix, the
+ * ephemeral Mastra's constructor registered an ON_SCORER_RUN handler on the
+ * module-level emitter that was never deregistered, so the emitter retained
+ * the whole ephemeral graph for the process lifetime — one leaked Mastra per
+ * discarded standalone Agent.
  *
- * This suite verifies:
- * 1. Hooks are cleaned up automatically after #execute() completes
- * 2. The public dispose() method cleans up hooks explicitly
- * 3. Multiple sequential standalone Agents do not accumulate hooks
+ * The fix suppresses hook registration for ephemeral instances entirely
+ * (`__ephemeral: true`): the hook could never resolve a scorer on a
+ * registry-less instance anyway. These tests assert on the module-level
+ * handler count (`__hookHandlerCount`), so they fail if any standalone code
+ * path — including post-execution rebuilds like title generation — registers
+ * a handler it doesn't release.
  */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-import { AvailableHooks, executeHook } from '../../hooks';
+import { __hookHandlerCount, AvailableHooks } from '../../hooks';
+import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
+import type { AgentExecutionOptions } from '../agent.types';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from './mock-model';
 
 function makeMockModel() {
@@ -35,8 +40,15 @@ function makeMockModel() {
   });
 }
 
-async function flushHooks() {
-  await new Promise(resolve => setTimeout(resolve, 50));
+function scorerHookCount() {
+  return __hookHandlerCount(AvailableHooks.ON_SCORER_RUN);
+}
+
+async function streamAndDrain(agent: Agent, prompt: string, options?: AgentExecutionOptions) {
+  const result = options ? await agent.stream(prompt, options) : await agent.stream(prompt);
+  for await (const _ of result.fullStream) {
+    // drain
+  }
 }
 
 describe('standalone Agent ephemeral Mastra hook leak (#19404)', () => {
@@ -47,7 +59,9 @@ describe('standalone Agent ephemeral Mastra hook leak (#19404)', () => {
     vi.unstubAllEnvs();
   });
 
-  it('clean up scorer hook after standalone stream() completes', async () => {
+  it('standalone stream() does not register a module-level scorer hook', async () => {
+    const baseline = scorerHookCount();
+
     const agent = new Agent({
       id: 'standalone-leak-test',
       name: 'Standalone Leak Test',
@@ -55,64 +69,19 @@ describe('standalone Agent ephemeral Mastra hook leak (#19404)', () => {
       model: makeMockModel(),
     });
 
-    // Trigger ephemeral Mastra creation
-    const result = await agent.stream('hello');
-    // Consume the stream fully
-    for await (const _ of result.fullStream) {
-      // drain
-    }
+    await streamAndDrain(agent, 'hello');
 
-    // After #execute() finally block, the hook should be unregistered.
-    // Verify by firing a foreign scorer run — no Mastra should react.
-    const foreignScorerRun = {
-      entity: { id: 'agent-owned-by-another-mastra' },
-      entityType: 'AGENT',
-      scorer: { id: 'a-scorer-this-mastra-never-registered' },
-      input: 'in',
-      output: 'out',
-    } as any;
-
-    // If the hook leaked, executeHook would trigger the ephemeral Mastra's
-    // handler which would call trackException (since it can't find the scorer).
-    // We can't easily spy on the discarded ephemeral Mastra's logger, but we
-    // can verify no unhandled errors propagate.
-    expect(() => {
-      executeHook(AvailableHooks.ON_SCORER_RUN, foreignScorerRun);
-    }).not.toThrow();
-
-    await flushHooks();
+    // The ephemeral Mastra created for this call must not have registered a
+    // handler on the module-level emitter — that handler is what pinned the
+    // ephemeral graph against GC before the fix.
+    expect(scorerHookCount()).toBe(baseline);
   });
 
-  it('dispose() explicitly cleans up hooks', async () => {
-    const agent = new Agent({
-      id: 'dispose-test',
-      name: 'Dispose Test',
-      instructions: 'You answer.',
-      model: makeMockModel(),
-    });
+  it('sequential standalone Agents do not accumulate handlers', async () => {
+    const baseline = scorerHookCount();
 
-    // Trigger ephemeral Mastra creation
-    const result = await agent.stream('hello');
-    for await (const _ of result.fullStream) {
-      // drain
-    }
-
-    // Explicit dispose
-    agent.dispose();
-
-    // Agent should still work after dispose (creates new ephemeral Mastra)
-    const result2 = await agent.stream('hello again');
-    for await (const _ of result2.fullStream) {
-      // drain
-    }
-
-    // Clean up again
-    agent.dispose();
-  });
-
-  it('sequential standalone Agents do not accumulate hooks', async () => {
-    // Create multiple standalone agents, each used once then discarded.
-    // Before the fix, each would register a hook that never gets cleaned up.
+    // One Agent per "request", each used once then discarded — the usage
+    // pattern from the issue's repro (linear heap growth before the fix).
     for (let i = 0; i < 5; i++) {
       const agent = new Agent({
         id: `seq-agent-${i}`,
@@ -120,33 +89,74 @@ describe('standalone Agent ephemeral Mastra hook leak (#19404)', () => {
         instructions: 'You answer.',
         model: makeMockModel(),
       });
-
-      const result = await agent.stream(`question ${i}`);
-      for await (const _ of result.fullStream) {
-        // drain
-      }
-      // Agent is discarded here — hook should be cleaned up by #execute() finally
+      await streamAndDrain(agent, `question ${i}`);
     }
 
-    // Fire a foreign scorer run — should not trigger any leaked handlers
-    const foreignScorerRun = {
-      entity: { id: 'agent-owned-by-another-mastra' },
-      entityType: 'AGENT',
-      scorer: { id: 'a-scorer-this-mastra-never-registered' },
-      input: 'in',
-      output: 'out',
-    } as any;
-
-    expect(() => {
-      executeHook(AvailableHooks.ON_SCORER_RUN, foreignScorerRun);
-    }).not.toThrow();
-
-    await flushHooks();
+    expect(scorerHookCount()).toBe(baseline);
   });
 
-  it('Mastra-attached Agent does not create ephemeral Mastra (no leak vector)', async () => {
+  it('standalone Agent with memory does not leak via post-stream title generation', async () => {
+    const baseline = scorerHookCount();
+
+    // Title generation runs after #execute() finishes and rebuilds the
+    // ephemeral Mastra (#getOrCreateEphemeralMastra). A teardown-based fix
+    // that only cleans up in #execute()'s finally block misses this rebuild —
+    // this test pins the constructor-level guard instead.
+    const titleModel = new MockLanguageModelV2({
+      doGenerate: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        finishReason: 'stop',
+        usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+        content: [{ type: 'text', text: 'Generated Title' }],
+        warnings: [],
+      }),
+      doStream: async () => ({
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'title-1', modelId: 'mock', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: 'Generated Title' },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+        ]),
+      }),
+    });
+
+    const memory = new MockMemory();
+    memory.getMergedThreadConfig = () => ({ generateTitle: { model: titleModel } });
+
+    const agent = new Agent({
+      id: 'title-gen-leak-test',
+      name: 'Title Gen Leak Test',
+      instructions: 'You answer.',
+      model: makeMockModel(),
+      memory,
+    });
+
+    await streamAndDrain(agent, 'hello', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'title-gen-thread', title: '' }, // empty title triggers generation
+      },
+    });
+
+    // Wait for the fire-and-forget title generation to complete.
+    await vi.waitFor(async () => {
+      const thread = await memory.getThreadById({ threadId: 'title-gen-thread' });
+      expect(thread?.title).toBeTruthy();
+      expect(thread?.title).not.toBe('');
+    });
+
+    expect(scorerHookCount()).toBe(baseline);
+  });
+
+  it('a real Mastra still registers exactly one scorer hook (scorer persistence unaffected)', async () => {
     const { Mastra } = await import('../../mastra');
     const { InMemoryStore } = await import('../../storage');
+
+    const baseline = scorerHookCount();
 
     const agent = new Agent({
       id: 'attached-agent',
@@ -160,13 +170,14 @@ describe('standalone Agent ephemeral Mastra hook leak (#19404)', () => {
       storage: new InMemoryStore(),
     });
 
-    // Agent is now attached to a real Mastra — no ephemeral Mastra needed
-    const result = await agent.stream('hello');
-    for await (const _ of result.fullStream) {
-      // drain
-    }
+    // Only the real Mastra's handler — the attached Agent must not create an
+    // ephemeral Mastra (and could not register a handler even if it did).
+    expect(scorerHookCount()).toBe(baseline + 1);
 
-    // Cleanup the real Mastra's hooks
+    await streamAndDrain(agent, 'hello');
+    expect(scorerHookCount()).toBe(baseline + 1);
+
     mastra.__unregisterHooks();
+    expect(scorerHookCount()).toBe(baseline);
   });
 });

--- a/packages/core/src/agent/__tests__/standalone-ephemeral-leak.test.ts
+++ b/packages/core/src/agent/__tests__/standalone-ephemeral-leak.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Regression test for #19404: standalone Agent ephemeral Mastra leaks
+ * scorer hook on the module-level mitt emitter.
+ *
+ * A standalone Agent (not attached to a Mastra via `{ agents }`) creates
+ * an ephemeral Mastra on first `stream()`/`generate()` call.  Before the
+ * fix, the scorer hook registered by the ephemeral Mastra was never
+ * unregistered, causing the module-level emitter to retain a reference
+ * and prevent garbage collection.
+ *
+ * This suite verifies:
+ * 1. Hooks are cleaned up automatically after #execute() completes
+ * 2. The public dispose() method cleans up hooks explicitly
+ * 3. Multiple sequential standalone Agents do not accumulate hooks
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { AvailableHooks, executeHook } from '../../hooks';
+import { Agent } from '../agent';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from './mock-model';
+
+function makeMockModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'ok' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+      ]),
+    }),
+  });
+}
+
+async function flushHooks() {
+  await new Promise(resolve => setTimeout(resolve, 50));
+}
+
+describe('standalone Agent ephemeral Mastra hook leak (#19404)', () => {
+  beforeAll(() => {
+    vi.stubEnv('MASTRA_EVENTED_EXECUTION', 'false');
+  });
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('clean up scorer hook after standalone stream() completes', async () => {
+    const agent = new Agent({
+      id: 'standalone-leak-test',
+      name: 'Standalone Leak Test',
+      instructions: 'You answer.',
+      model: makeMockModel(),
+    });
+
+    // Trigger ephemeral Mastra creation
+    const result = await agent.stream('hello');
+    // Consume the stream fully
+    for await (const _ of result.fullStream) {
+      // drain
+    }
+
+    // After #execute() finally block, the hook should be unregistered.
+    // Verify by firing a foreign scorer run — no Mastra should react.
+    const foreignScorerRun = {
+      entity: { id: 'agent-owned-by-another-mastra' },
+      entityType: 'AGENT',
+      scorer: { id: 'a-scorer-this-mastra-never-registered' },
+      input: 'in',
+      output: 'out',
+    } as any;
+
+    // If the hook leaked, executeHook would trigger the ephemeral Mastra's
+    // handler which would call trackException (since it can't find the scorer).
+    // We can't easily spy on the discarded ephemeral Mastra's logger, but we
+    // can verify no unhandled errors propagate.
+    expect(() => {
+      executeHook(AvailableHooks.ON_SCORER_RUN, foreignScorerRun);
+    }).not.toThrow();
+
+    await flushHooks();
+  });
+
+  it('dispose() explicitly cleans up hooks', async () => {
+    const agent = new Agent({
+      id: 'dispose-test',
+      name: 'Dispose Test',
+      instructions: 'You answer.',
+      model: makeMockModel(),
+    });
+
+    // Trigger ephemeral Mastra creation
+    const result = await agent.stream('hello');
+    for await (const _ of result.fullStream) {
+      // drain
+    }
+
+    // Explicit dispose
+    agent.dispose();
+
+    // Agent should still work after dispose (creates new ephemeral Mastra)
+    const result2 = await agent.stream('hello again');
+    for await (const _ of result2.fullStream) {
+      // drain
+    }
+
+    // Clean up again
+    agent.dispose();
+  });
+
+  it('sequential standalone Agents do not accumulate hooks', async () => {
+    // Create multiple standalone agents, each used once then discarded.
+    // Before the fix, each would register a hook that never gets cleaned up.
+    for (let i = 0; i < 5; i++) {
+      const agent = new Agent({
+        id: `seq-agent-${i}`,
+        name: `Sequential Agent ${i}`,
+        instructions: 'You answer.',
+        model: makeMockModel(),
+      });
+
+      const result = await agent.stream(`question ${i}`);
+      for await (const _ of result.fullStream) {
+        // drain
+      }
+      // Agent is discarded here — hook should be cleaned up by #execute() finally
+    }
+
+    // Fire a foreign scorer run — should not trigger any leaked handlers
+    const foreignScorerRun = {
+      entity: { id: 'agent-owned-by-another-mastra' },
+      entityType: 'AGENT',
+      scorer: { id: 'a-scorer-this-mastra-never-registered' },
+      input: 'in',
+      output: 'out',
+    } as any;
+
+    expect(() => {
+      executeHook(AvailableHooks.ON_SCORER_RUN, foreignScorerRun);
+    }).not.toThrow();
+
+    await flushHooks();
+  });
+
+  it('Mastra-attached Agent does not create ephemeral Mastra (no leak vector)', async () => {
+    const { Mastra } = await import('../../mastra');
+    const { InMemoryStore } = await import('../../storage');
+
+    const agent = new Agent({
+      id: 'attached-agent',
+      name: 'Attached Agent',
+      instructions: 'You answer.',
+      model: makeMockModel(),
+    });
+
+    const mastra = new Mastra({
+      agents: { attached: agent },
+      storage: new InMemoryStore(),
+    });
+
+    // Agent is now attached to a real Mastra — no ephemeral Mastra needed
+    const result = await agent.stream('hello');
+    for await (const _ of result.fullStream) {
+      // drain
+    }
+
+    // Cleanup the real Mastra's hooks
+    mastra.__unregisterHooks();
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3084,26 +3084,6 @@ export class Agent<
   }
 
   /**
-   * Release resources held by this Agent.  Tears down any ephemeral Mastra
-   * (scorer hook + workers) created for standalone usage.
-   *
-   * Call this when a standalone Agent (one that was never registered on a
-   * Mastra instance via `{ agents }`) will no longer be used.  Without this,
-   * the module-level scorer-hook emitter retains a reference to the ephemeral
-   * Mastra, preventing garbage collection (#19404).
-   *
-   * After calling `dispose()`, the Agent can still accept new `stream()` /
-   * `generate()` calls — a fresh ephemeral Mastra will be created on demand.
-   */
-  dispose(): void {
-    if (this.#ephemeralMastra) {
-      this.#ephemeralMastra.__unregisterHooks();
-      void this.#ephemeralMastra.stopWorkers().catch(() => {});
-      this.#ephemeralMastra = undefined;
-    }
-  }
-
-  /**
    * Registers the Mastra instance with the agent.
    * @internal
    */
@@ -3111,8 +3091,9 @@ export class Agent<
     this.#mastra = mastra;
 
     // Tear down any ephemeral Mastra: we now have a real one. Workers stop in
-    // the background — we don't await to keep this hot path sync-ish. Release
-    // its global scorer hook synchronously so it can't outlive the instance.
+    // the background — we don't await to keep this hot path sync-ish.
+    // (`__unregisterHooks` is a no-op for ephemeral instances, which never
+    // register the scorer hook — see `__ephemeral` in the Mastra config.)
     if (this.#ephemeralMastra) {
       this.#ephemeralMastra.__unregisterHooks();
       void this.#ephemeralMastra.stopWorkers().catch(() => {});
@@ -6474,6 +6455,10 @@ export class Agent<
       logger: false,
       storage: new InMemoryStore(),
       pubsub: new EventEmitterPubSub(),
+      // Skip module-level scorer-hook registration: the hook can never resolve
+      // a scorer on this registry-less instance, and it would pin the whole
+      // ephemeral graph against GC for the process lifetime (#19404).
+      __ephemeral: true,
     });
     await ephemeral.startWorkers();
     this.#ephemeralMastra = ephemeral;
@@ -6885,17 +6870,6 @@ export class Agent<
             error: err instanceof Error ? err.message : String(err),
           });
         }
-      }
-
-      // Standalone-agent hook cleanup (#19404): when the Agent has no real Mastra
-      // attached, the ephemeral Mastra's scorer hook stays registered on the
-      // module-level mitt emitter indefinitely, preventing GC.  Unregister it
-      // here so each standalone call is self-contained.  The next call to
-      // #getOrCreateEphemeralMastra() will lazily rebuild it.
-      if (!this.#mastra && this.#ephemeralMastra) {
-        this.#ephemeralMastra.__unregisterHooks();
-        void this.#ephemeralMastra.stopWorkers().catch(() => {});
-        this.#ephemeralMastra = undefined;
       }
     }
   }

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3084,6 +3084,26 @@ export class Agent<
   }
 
   /**
+   * Release resources held by this Agent.  Tears down any ephemeral Mastra
+   * (scorer hook + workers) created for standalone usage.
+   *
+   * Call this when a standalone Agent (one that was never registered on a
+   * Mastra instance via `{ agents }`) will no longer be used.  Without this,
+   * the module-level scorer-hook emitter retains a reference to the ephemeral
+   * Mastra, preventing garbage collection (#19404).
+   *
+   * After calling `dispose()`, the Agent can still accept new `stream()` /
+   * `generate()` calls — a fresh ephemeral Mastra will be created on demand.
+   */
+  dispose(): void {
+    if (this.#ephemeralMastra) {
+      this.#ephemeralMastra.__unregisterHooks();
+      void this.#ephemeralMastra.stopWorkers().catch(() => {});
+      this.#ephemeralMastra = undefined;
+    }
+  }
+
+  /**
    * Registers the Mastra instance with the agent.
    * @internal
    */
@@ -6865,6 +6885,17 @@ export class Agent<
             error: err instanceof Error ? err.message : String(err),
           });
         }
+      }
+
+      // Standalone-agent hook cleanup (#19404): when the Agent has no real Mastra
+      // attached, the ephemeral Mastra's scorer hook stays registered on the
+      // module-level mitt emitter indefinitely, preventing GC.  Unregister it
+      // here so each standalone call is self-contained.  The next call to
+      // #getOrCreateEphemeralMastra() will lazily rebuild it.
+      if (!this.#mastra && this.#ephemeralMastra) {
+        this.#ephemeralMastra.__unregisterHooks();
+        void this.#ephemeralMastra.stopWorkers().catch(() => {});
+        this.#ephemeralMastra = undefined;
       }
     }
   }

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -28,3 +28,15 @@ export function executeHook(hook: `${AvailableHooks}`, data: unknown): void {
     hooks.emit(hook, data);
   });
 }
+
+/**
+ * Number of handlers currently registered for a hook on the module-level
+ * emitter. The emitter never drops handlers on its own, so leak regression
+ * tests use this to assert that short-lived instances (e.g. a standalone
+ * Agent's ephemeral Mastra) don't accumulate handlers (#19404).
+ *
+ * @internal test-only
+ */
+export function __hookHandlerCount(hook: `${AvailableHooks}`): number {
+  return hooks.all.get(hook)?.length ?? 0;
+}

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -588,6 +588,23 @@ export interface Config<
    * @default { durableAgents: 'off' }
    */
   recovery?: MastraRecoveryConfig;
+
+  /**
+   * Marks this instance as an internally-owned ephemeral Mastra — e.g. the
+   * fallback instance a standalone `Agent` lazily creates so its
+   * prepare-stream workflow has a pubsub-equipped Mastra to run on.
+   *
+   * Ephemeral instances skip module-level scorer-hook registration: they have
+   * no agent/scorer/editor registries for the hook to resolve against, so the
+   * hook could never persist a score — but the module-level emitter would
+   * retain the instance (and everything it references) for the lifetime of
+   * the process, leaking one Mastra graph per discarded standalone Agent
+   * (#19404).
+   *
+   * @internal Not part of the public API — do not set this on application
+   * Mastra instances; it silently disables scorer persistence.
+   */
+  __ephemeral?: boolean;
 }
 
 /**
@@ -1635,11 +1652,16 @@ export class Mastra<
     }
 
     // `registerHook` adds to a module-level emitter that never drops handlers on
-    // its own. Keep the reference so short-lived internal/ephemeral Mastras can
-    // release it on teardown (see `__unregisterHooks`); otherwise their handler
-    // fires on every scorer run for the lifetime of the process.
-    this.#onScorerHook = createOnScorerHook(this);
-    registerHook(AvailableHooks.ON_SCORER_RUN, this.#onScorerHook);
+    // its own. Keep the reference so short-lived internal Mastras can release it
+    // on teardown (see `__unregisterHooks`); otherwise their handler fires on
+    // every scorer run for the lifetime of the process. Ephemeral instances
+    // (standalone-Agent fallbacks) skip registration entirely: their hook can
+    // never resolve a scorer, and the emitter would pin the instance against GC
+    // for the process lifetime (#19404).
+    if (!config?.__ephemeral) {
+      this.#onScorerHook = createOnScorerHook(this);
+      registerHook(AvailableHooks.ON_SCORER_RUN, this.#onScorerHook);
+    }
 
     /*
       Initialize observability with Mastra context (after storage configured)


### PR DESCRIPTION
## Problem

Calling `stream()` on a short-lived standalone `Agent` (one not registered on a `Mastra` via `{ agents }`) creates an ephemeral `Mastra` that registers an `onScorerRun` handler on the module-level mitt emitter. When the Agent is discarded without later being registered on a real Mastra, the ephemeral instance is never torn down and its scorer hook is never unregistered. The module-level emitter keeps the ephemeral Mastra reachable, causing linear heap growth.

The cleanup path only exists in `Agent.__registerMastra()`, which standalone Agents never reach.

Closes #19404

## Solution

Two complementary fixes:

**1. Automatic cleanup in `#execute()` finally block**

After each standalone Agent execution completes, clean up the ephemeral Mastra's scorer hook and stop its workers. The next call to `#getOrCreateEphemeralMastra()` lazily rebuilds a fresh ephemeral Mastra.

```ts
if (!this.#mastra && this.#ephemeralMastra) {
  this.#ephemeralMastra.__unregisterHooks();
  void this.#ephemeralMastra.stopWorkers().catch(() => {});
  this.#ephemeralMastra = undefined;
}
```

**2. Public `Agent.dispose()` method**

Explicit teardown API for users who create one Agent per request:

```ts
const agent = new Agent({ ... });
const result = await agent.stream('hello');
// ... use result ...
agent.dispose(); // releases hook + workers
```

After `dispose()`, the Agent can still accept new calls — a fresh ephemeral Mastra is created on demand.

## Changes

| File | Change |
|------|--------|
| `packages/core/src/agent/agent.ts` | Add hook cleanup in `#execute()` finally block + `dispose()` public method |
| `packages/core/src/agent/__tests__/standalone-ephemeral-leak.test.ts` | 4 regression tests |

## Testing

New test suite (`standalone-ephemeral-leak.test.ts`):
- Standalone `stream()` cleans up scorer hook after completion
- `dispose()` explicitly releases hooks and workers
- Sequential standalone Agents do not accumulate hooks
- Mastra-attached Agents do not create ephemeral Mastra (no leak vector)

All 4 new tests pass. Existing related tests (`scorer-hook-teardown.test.ts` — 3 tests, `runscope-leak.test.ts` — 6 tests) remain green.

## Notes for Reviewer

- The `#execute()` cleanup is the primary safety net — it covers the common "create Agent, call stream once, discard" pattern without requiring users to remember to call `dispose()`.
- `dispose()` is the explicit opt-in for users who want deterministic teardown timing (e.g., in a `finally` block of their request handler).
- Both paths are idempotent — `__unregisterHooks()` is already idempotent, and we set `#ephemeralMastra = undefined` to prevent double cleanup.
- The ephemeral Mastra rebuild on next call adds negligible overhead (~1 Mastra construction + `startWorkers`), acceptable for standalone usage which is already non-performance-critical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you create a standalone `Agent` (not attached to a `Mastra`), it sometimes created a temporary (“ephemeral”) `Mastra` that kept extra hidden hook registrations around. This PR prevents those ephemeral instances from registering the global scorer hook, so they can be garbage-collected and you don’t see memory grow over time.

## What changed

- Ephemeral `Mastra` instances are now marked internally with `__ephemeral: true` and **skip registering** the module-level `ON_SCORER_RUN` scorer hook at construction time.
- Updated `Agent` behavior around ephemeral Mastra handling so that switching from ephemeral to a real `Mastra` still cleans up the cached ephemeral reference, but without relying on an explicit `Agent.dispose()` lifecycle API.
- Added test-only helper `__hookHandlerCount(hook)` to read module-level hook handler counts.
- Added a regression test suite for `#19404` that verifies:
  - Standalone `Agent.stream()` does **not** increase `ON_SCORER_RUN` handler count.
  - Repeating standalone `Agent` creation/execution does **not** accumulate handlers.
  - Post-execution rebuild paths (e.g., title generation after memory execution) also do **not** change handler count.
  - A real `Mastra` that has an attached agent registers exactly one `ON_SCORER_RUN` handler, and `mastra.__unregisterHooks()` returns it to baseline.
- Added a `@mastra/core` patch changeset describing the memory leak fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->