### PR TITLE
fix(voice-speechify): pair Simba 3 models with their curated voices

### DIFF
--- a/.changeset/fast-dingos-like.md
+++ b/.changeset/fast-dingos-like.md
@@ -1,0 +1,25 @@
+---
+'@mastra/voice-speechify': patch
+---
+
+Fixed voice selection for the Simba 3 models. Speechify's `simba-3.2` and `simba-3.0` serve a curated voice set only (`beatrice_32`, `dominic_32`, `edmund_32`, `geffen_32`, `harper_32`, `hugh_32`, `imogen_32`, `wyatt_32`), so pairing them with a classic catalog voice like `george` failed with an API error.
+
+- Added the curated Simba 3 voices to the voice list, so they type-check as `speaker` and appear in `getSpeakers()`
+- The default speaker now follows the configured model: `harper_32` for Simba 3 models, `george` otherwise
+
+```typescript
+import { SpeechifyVoice } from '@mastra/voice-speechify';
+
+// Works out of the box now — defaults to the harper_32 voice
+const voice = new SpeechifyVoice({
+  speechModel: { name: 'simba-3.2' },
+});
+
+// Or pick a curated voice explicitly
+new SpeechifyVoice({
+  speechModel: { name: 'simba-3.2' },
+  speaker: 'imogen_32',
+});
+```
+
+When overriding the model per request, pass a matching speaker too: `voice.speak('Hi', { model: 'simba-3.2', speaker: 'harper_32' })`.

--- a/docs/src/content/en/reference/voice/speechify.mdx
+++ b/docs/src/content/en/reference/voice/speechify.mdx
@@ -23,12 +23,12 @@ const voice = new SpeechifyVoice({
     name: 'simba-3.2',
     apiKey: 'your-api-key',
   },
-  speaker: 'george', // Default voice
+  speaker: 'harper_32', // Default voice (simba-3.2 serves the curated Simba 3 voices only)
 })
 
 // Convert text to speech
 const audioStream = await voice.speak('Hello, world!', {
-  speaker: 'henry', // Override default voice
+  speaker: 'imogen_32', // Override default voice
 })
 ```
 
@@ -67,9 +67,10 @@ const audioStream = await voice.speak('Hello, world!', {
   {
     name: 'speaker',
     type: 'SpeechifyVoiceId',
-    description: 'Default voice ID to use for speech synthesis',
+    description:
+      'Default voice ID to use for speech synthesis. The Simba 3 models serve a curated voice set only (harper_32, imogen_32, ...); the classic catalog voices (george, henry, ...) work with simba-english and simba-multilingual',
     isOptional: true,
-    defaultValue: "'george'",
+    defaultValue: "'harper_32' for Simba 3 models, otherwise 'george'",
   },
 ]}
 />
@@ -159,5 +160,7 @@ This method isn't supported by Speechify and will throw an error. Speechify does
 - The default model is 'simba-english'
 - 'simba-3.2' is Speechify's latest streaming model with the lowest latency and richest expressivity, and the recommended model for English
 - 'simba-3.2' and 'simba-3.0' are currently English only; use 'simba-multilingual' for non-English or mixed-language input
+- 'simba-3.2' and 'simba-3.0' serve a curated voice set only: 'beatrice\_32', 'dominic\_32', 'edmund\_32', 'geffen\_32', 'harper\_32', 'hugh\_32', 'imogen\_32', 'wyatt\_32'. Classic catalog voices such as 'george' return an error on these models
+- The default speaker follows the configured model: 'harper\_32' for the Simba 3 models, otherwise 'george'
 - Speech-to-text functionality isn't supported
 - Additional audio stream options can be passed through the speak() method's options parameter

--- a/voice/speechify/README.md
+++ b/voice/speechify/README.md
@@ -26,7 +26,7 @@ const voice = new SpeechifyVoice({
     name: 'simba-3.2', // Optional, defaults to 'simba-english'
     apiKey: 'your-api-key', // Optional, can use SPEECHIFY_API_KEY env var
   },
-  speaker: 'george', // Optional, defaults to 'george'
+  speaker: 'harper_32', // Optional, defaults to a voice that matches the model
 });
 
 // List available speakers
@@ -34,7 +34,7 @@ const speakers = await voice.getSpeakers();
 
 // Generate speech
 const stream = await voice.speak('Hello world', {
-  speaker: 'george', // Optional, defaults to constructor speaker
+  speaker: 'harper_32', // Optional, defaults to constructor speaker
   // Additional Speechify options
   audioFormat: 'mp3',
 });
@@ -66,10 +66,10 @@ new SpeechifyVoice({
 - `simba-english`: The default model, optimized for English.
 - `simba-multilingual`: Optimized for non-English or mixed-language input.
 
-The model can also be overridden per request:
+The model can also be overridden per request. When overriding to a Simba 3 model, pass a matching speaker too:
 
 ```typescript
-const stream = await voice.speak('Hello world', { model: 'simba-3.2' });
+const stream = await voice.speak('Hello world', { model: 'simba-3.2', speaker: 'harper_32' });
 ```
 
 ## Available Speakers
@@ -79,3 +79,10 @@ You can get a list of available speakers:
 ```typescript
 const speakers = await voice.getSpeakers();
 ```
+
+Voice availability depends on the model:
+
+- `simba-3.2` and `simba-3.0` serve a curated voice set only: `beatrice_32`, `dominic_32`, `edmund_32`, `geffen_32`, `harper_32`, `hugh_32`, `imogen_32`, `wyatt_32`. `simba-3.2` also accepts cloned voices approved by Speechify.
+- `simba-english` and `simba-multilingual` serve the full classic catalog (`george`, `henry`, `carly`, ...) and self-serve cloned voices.
+
+The default speaker follows the configured model: `harper_32` for the Simba 3 models, otherwise `george`.

--- a/voice/speechify/src/index.ts
+++ b/voice/speechify/src/index.ts
@@ -4,16 +4,20 @@ import { MastraVoice } from '@internal/voice';
 import { Speechify } from '@speechify/api-sdk';
 import type { AudioStreamRequest, VoiceModelName } from '@speechify/api-sdk';
 
-import { SPEECHIFY_VOICES } from './voices';
+import { SIMBA_3_VOICES, SPEECHIFY_VOICES } from './voices';
 import type { SpeechifyVoiceId } from './voices';
 
 /**
  * Models accepted by the Speechify API. Extends the SDK's `VoiceModelName`
  * with the Simba 3 generation models, which the API accepts but the SDK's
  * type union does not yet include. `simba-3.0` and `simba-3.2` are
- * currently English only.
+ * currently English only and serve only the curated `SIMBA_3_VOICES`
+ * (plus, on `simba-3.2`, cloned voices approved by Speechify) — the
+ * classic catalog voices return an error on them.
  */
 type SpeechifyModel = VoiceModelName | 'simba-3.0' | 'simba-3.2';
+
+const isSimba3Model = (model: string | undefined) => model === 'simba-3.0' || model === 'simba-3.2';
 
 interface SpeechifyConfig {
   name?: SpeechifyModel;
@@ -24,12 +28,15 @@ export class SpeechifyVoice extends MastraVoice {
   private client: Speechify;
 
   constructor({ speechModel, speaker }: { speechModel?: SpeechifyConfig; speaker?: SpeechifyVoiceId } = {}) {
+    const modelName = speechModel?.name ?? 'simba-english';
     super({
       speechModel: {
-        name: speechModel?.name ?? 'simba-english',
+        name: modelName,
         apiKey: speechModel?.apiKey ?? process.env.SPEECHIFY_API_KEY,
       },
-      speaker: speaker ?? 'george',
+      // The Simba 3 models serve only the curated SIMBA_3_VOICES, so the
+      // default speaker has to follow the configured model.
+      speaker: speaker ?? (isSimba3Model(modelName) ? 'harper_32' : 'george'),
     });
 
     const apiKey = speechModel?.apiKey ?? process.env.SPEECHIFY_API_KEY;
@@ -41,7 +48,7 @@ export class SpeechifyVoice extends MastraVoice {
   }
 
   async getSpeakers() {
-    return SPEECHIFY_VOICES.map(voice => ({
+    return [...SIMBA_3_VOICES, ...SPEECHIFY_VOICES].map(voice => ({
       voiceId: voice,
       name: voice,
     }));

--- a/voice/speechify/src/models.test.ts
+++ b/voice/speechify/src/models.test.ts
@@ -59,6 +59,59 @@ describe('SpeechifyVoice model support', () => {
     const voice = new SpeechifyVoice({ speechModel: { apiKey: 'test-key' } });
     await drain(await voice.speak('Hello'));
 
-    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'simba-english' }));
+    expect(audioStreamMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'simba-english', voiceId: 'george' }),
+    );
+  });
+});
+
+describe('SpeechifyVoice Simba 3 voice pairing', () => {
+  beforeEach(() => {
+    audioStreamMock.mockReset();
+    audioStreamMock.mockResolvedValue(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new Uint8Array([1, 2, 3]));
+          controller.close();
+        },
+      }),
+    );
+  });
+
+  it('accepts a curated Simba 3 voice as the constructor speaker', async () => {
+    const voice = new SpeechifyVoice({
+      speechModel: { name: 'simba-3.2', apiKey: 'test-key' },
+      speaker: 'harper_32',
+    });
+    await drain(await voice.speak('Hello'));
+
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'simba-3.2', voiceId: 'harper_32' }));
+  });
+
+  it('defaults the speaker to harper_32 when a Simba 3 model is configured', async () => {
+    const voice = new SpeechifyVoice({ speechModel: { name: 'simba-3.2', apiKey: 'test-key' } });
+    await drain(await voice.speak('Hello'));
+
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ voiceId: 'harper_32' }));
+  });
+
+  it('keeps an explicit speaker over the model-based default', async () => {
+    const voice = new SpeechifyVoice({
+      speechModel: { name: 'simba-3.0', apiKey: 'test-key' },
+      speaker: 'wyatt_32',
+    });
+    await drain(await voice.speak('Hello'));
+
+    expect(audioStreamMock).toHaveBeenCalledWith(expect.objectContaining({ voiceId: 'wyatt_32' }));
+  });
+
+  it('lists the curated Simba 3 voices in getSpeakers', async () => {
+    const voice = new SpeechifyVoice({ speechModel: { apiKey: 'test-key' } });
+    const speakers = await voice.getSpeakers();
+    const ids = speakers.map(s => s.voiceId);
+
+    expect(ids).toContain('harper_32');
+    expect(ids).toContain('wyatt_32');
+    expect(ids).toContain('george');
   });
 });

--- a/voice/speechify/src/voices.ts
+++ b/voice/speechify/src/voices.ts
@@ -1,3 +1,20 @@
+/**
+ * Curated voices served by the Simba 3 generation models (`simba-3.0` and
+ * `simba-3.2`). The classic catalog voices in `SPEECHIFY_VOICES` are not
+ * served by those models and return an error. `simba-3.2` additionally
+ * accepts cloned voices manually approved by Speechify.
+ */
+export const SIMBA_3_VOICES = [
+  'beatrice_32',
+  'dominic_32',
+  'edmund_32',
+  'geffen_32',
+  'harper_32',
+  'hugh_32',
+  'imogen_32',
+  'wyatt_32',
+] as const;
+
 export const SPEECHIFY_VOICES = [
   'henry',
   'bwyneth',
@@ -708,4 +725,4 @@ export const SPEECHIFY_VOICES = [
   'michal',
 ] as const;
 
-export type SpeechifyVoiceId = (typeof SPEECHIFY_VOICES)[number];
+export type SpeechifyVoiceId = (typeof SPEECHIFY_VOICES)[number] | (typeof SIMBA_3_VOICES)[number];


### PR DESCRIPTION
Fixes #19414

Follow-up to #19411. Speechify's `simba-3.2` and `simba-3.0` serve a curated voice set only (`beatrice_32`, `dominic_32`, `edmund_32`, `geffen_32`, `harper_32`, `hugh_32`, `imogen_32`, `wyatt_32` — see the [models docs](https://docs.speechify.ai/build/guides/concepts/models)), so the examples #19411 shipped that pair `simba-3.2` with `george` fail with a 400, and a valid Simba 3 voice couldn't even be set through the typed `speaker` option.

This adds the curated voices to the `SpeechifyVoiceId` union and `getSpeakers()`, makes the default speaker follow the configured model, and fixes the README/reference examples.

```typescript
// Works out of the box now — defaults to the harper_32 voice
const voice = new SpeechifyVoice({
  speechModel: { name: 'simba-3.2' },
});

// Curated voices now type-check
new SpeechifyVoice({
  speechModel: { name: 'simba-3.2' },
  speaker: 'imogen_32',
});
```

The classic default (`george` on `simba-english`) is unchanged. No runtime voice validation was added on purpose: `simba-3.2` also accepts Speechify-approved cloned voices whose keys we can't know, so the API stays the source of truth.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Simba 3 needs a special set of voices, but it previously used voices that Speechify rejected. This update adds the right voices, chooses a compatible default, and updates examples so Simba 3 works correctly.

## What changed

- Added eight curated Simba 3 voices to `SpeechifyVoiceId` and `getSpeakers()`.
- Defaults to `harper_32` for `simba-3.0` and `simba-3.2`.
- Preserves `george` as the default for other models, including `simba-english`.
- Added tests covering curated voices, defaults, overrides, and speaker listing.
- Updated README, reference documentation, examples, and changeset notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->