### PR TITLE
feat(core): formalize clearTopic on PubSub, clean up workflow.events.v2 topics at run end

### DIFF
--- a/.changeset/forty-grapes-create.md
+++ b/.changeset/forty-grapes-create.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': minor
+---
+
+Workflow run event topics are now cleaned up automatically. The evented workflow engine deletes each run's `workflow.events.v2.<runId>` pub/sub topic shortly after the run reaches a terminal state (success, failure, or cancellation), so persistent transports like Redis Streams no longer accumulate streams from finished workflow runs (#19123).
+
+`clearTopic` is now part of the `PubSub` base class with a default no-op implementation. Custom transports that retain messages per topic should override it to delete that state:
+
+```typescript
+import { PubSub } from '@mastra/core/events';
+
+class CustomPubSub extends PubSub {
+  async clearTopic(topic: string): Promise<void> {
+    // delete retained state for the topic
+  }
+}
+```
+
+Callers no longer need to probe for the method before calling it — `CachingPubSub` and the durable-agent runtime now forward `clearTopic` unconditionally.

--- a/docs/src/content/en/reference/pubsub/base.mdx
+++ b/docs/src/content/en/reference/pubsub/base.mdx
@@ -106,6 +106,16 @@ Waits for any in-flight deliveries to settle. Call this before shutdown to avoid
 await pubsub.flush()
 ```
 
+#### `clearTopic(topic)`
+
+Deletes all retained state for a topic — cached history, persistent stream entries, and consumer groups — once no more events will be published to it. Mastra's run lifecycles (durable agents and the evented workflow engine) call this automatically when a run reaches a terminal state, so per-run topics don't accumulate on transports that retain messages.
+
+The default implementation is a no-op: transports that retain nothing per topic (such as `EventEmitterPubSub`) have nothing to clear. Backends that persist messages, like [`RedisStreamsPubSub`](/reference/pubsub/redis-streams), override it. The contract is best-effort — implementations log failures rather than throwing, because callers invoke it fire-and-forget at cleanup boundaries.
+
+```typescript
+await pubsub.clearTopic('workflow.events.v2.run-123')
+```
+
 ### Replay methods
 
 These methods support resuming a stream after a disconnect. The default implementations fall back to a regular `subscribe`, so backends without history support behave as live-only. [`CachingPubSub`](/reference/pubsub/caching-pubsub) overrides them to replay cached events.

--- a/docs/src/content/en/reference/pubsub/caching-pubsub.mdx
+++ b/docs/src/content/en/reference/pubsub/caching-pubsub.mdx
@@ -138,6 +138,14 @@ const events = await pubsub.getHistory('my-topic', 0)
 
 Returns: `Promise<Event[]>`
 
+### `clearTopic(topic)`
+
+Removes the topic's cached events and offset counter, and forwards the call to the inner pub/sub so persistent transports (such as [`RedisStreamsPubSub`](/reference/pubsub/redis-streams)) can delete their retained state too. Mastra's run lifecycles call this automatically when a run finishes.
+
+```typescript
+await pubsub.clearTopic('my-topic')
+```
+
 ## Functions
 
 ### `withCaching(pubsub, cache, options?)`

--- a/docs/src/content/en/reference/pubsub/redis-streams.mdx
+++ b/docs/src/content/en/reference/pubsub/redis-streams.mdx
@@ -152,7 +152,7 @@ await pubsub.flush()
 
 ### `clearTopic(topic)`
 
-Deletes a topic's stream and every consumer group on it, freeing the memory a finished topic would otherwise hold. The durable-agent runtime calls this automatically when a run's cleanup fires; call it yourself only once nothing will read the topic again. It's best-effort and never throws — failures are logged at warn level. A subscriber still attached when the stream is deleted recovers on its own but misses the deleted entries.
+Deletes a topic's stream and every consumer group on it, freeing the memory a finished topic would otherwise hold. Mastra's run lifecycles — durable agents and the evented workflow engine — call this automatically when a run reaches a terminal state; call it yourself only once nothing will read the topic again. It's best-effort and never throws — failures are logged at warn level. A subscriber still attached when the stream is deleted recovers on its own but misses the deleted entries.
 
 Automatic cleanup requires `@mastra/core` and `@mastra/redis-streams` versions that both support `clearTopic`: the runtime routes the call through its caching layer, so upgrade the two packages together to get end-of-run stream deletion.
 

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2492,6 +2492,13 @@ export class DurableAgent<
    * Clear retained pubsub state for a run's topic (cached history and, for
    * persistent transports, the underlying stream). Fire-and-forget: the
    * `clearTopic` contract is best-effort and non-throwing.
+   *
+   * Unlike the evented workflow engine's per-run topic cleanup, this needs no
+   * restart guard: cleanup timers arm only on terminal outcomes
+   * (FINISH/ERROR/ABORT — never SUSPENDED), `resume()` rejects runs whose
+   * snapshot isn't `suspended`, `untilIdle` continuations mint a fresh runId
+   * per segment, and cross-process `recover()` can't race a dead process's
+   * timer. No supported flow re-engages a runId after its timer is armed.
    */
   #clearPubsubTopic(runId: string): void {
     void this.pubsub.clearTopic(AGENT_STREAM_TOPIC(runId));

--- a/packages/core/src/agent/durable/durable-agent.ts
+++ b/packages/core/src/agent/durable/durable-agent.ts
@@ -2489,14 +2489,12 @@ export class DurableAgent<
   }
 
   /**
-   * Clear cached pubsub events for a run's topic.
-   * Only effective when pubsub supports clearTopic (e.g. CachingPubSub).
+   * Clear retained pubsub state for a run's topic (cached history and, for
+   * persistent transports, the underlying stream). Fire-and-forget: the
+   * `clearTopic` contract is best-effort and non-throwing.
    */
   #clearPubsubTopic(runId: string): void {
-    const pubsub = this.pubsub;
-    if ('clearTopic' in pubsub && typeof (pubsub as any).clearTopic === 'function') {
-      void (pubsub as any).clearTopic(AGENT_STREAM_TOPIC(runId));
-    }
+    void this.pubsub.clearTopic(AGENT_STREAM_TOPIC(runId));
   }
 
   /**

--- a/packages/core/src/events/caching-pubsub.test.ts
+++ b/packages/core/src/events/caching-pubsub.test.ts
@@ -464,6 +464,27 @@ describe('CachingPubSub', () => {
       // PubSub base class's no-op clearTopic; forwarding must resolve cleanly.
       await expect(cachingPubsub.clearTopic('no-inner-hook')).resolves.toBeUndefined();
     });
+
+    it('does not reject when the cache or inner transport fails', async () => {
+      // The base-class contract says clearTopic is best-effort and
+      // non-throwing: callers (DurableAgent, WorkflowEventProcessor) invoke
+      // it fire-and-forget, so a rejection here would surface as an
+      // unhandledRejection. Failures must be logged, not thrown.
+      class FailingInner extends PubSub {
+        override clearTopic = vi.fn(async (_topic: string) => {
+          throw new Error('inner delete failed');
+        });
+        async publish(): Promise<void> {}
+        async subscribe(): Promise<void> {}
+        async unsubscribe(): Promise<void> {}
+        async flush(): Promise<void> {}
+      }
+      const logger = { error: vi.fn() };
+      const wrapped = new CachingPubSub(new FailingInner(), cache, { logger: logger as any });
+
+      await expect(wrapped.clearTopic('failing-topic')).resolves.toBeUndefined();
+      expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('failing-topic'), expect.any(Error));
+    });
   });
 
   describe('flush', () => {

--- a/packages/core/src/events/caching-pubsub.test.ts
+++ b/packages/core/src/events/caching-pubsub.test.ts
@@ -459,8 +459,9 @@ describe('CachingPubSub', () => {
       expect(inner.clearTopic).toHaveBeenCalledWith('some-topic');
     });
 
-    it('does not throw when the inner transport has no clearTopic', async () => {
-      // EventEmitterPubSub has no clearTopic; the probe must skip it cleanly.
+    it('does not throw when the inner transport does not override clearTopic', async () => {
+      // EventEmitterPubSub retains nothing per topic and relies on the
+      // PubSub base class's no-op clearTopic; forwarding must resolve cleanly.
       await expect(cachingPubsub.clearTopic('no-inner-hook')).resolves.toBeUndefined();
     });
   });

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -318,7 +318,15 @@ export class CachingPubSub extends PubSub {
   override async clearTopic(topic: string): Promise<void> {
     const cacheKey = this.getCacheKey(topic);
     const counterKey = this.getCounterKey(topic);
-    await Promise.all([this.cache.delete(cacheKey), this.cache.delete(counterKey), this.inner.clearTopic(topic)]);
+    try {
+      await Promise.all([this.cache.delete(cacheKey), this.cache.delete(counterKey), this.inner.clearTopic(topic)]);
+    } catch (error) {
+      // Honor the base-class contract: clearTopic is best-effort and callers
+      // invoke it fire-and-forget, so a cache failure must not become an
+      // unhandled rejection. A failed delete means retained state may leak
+      // until the transport-level TTL backstop, so make it visible.
+      this.logError(`[CachingPubSub] Failed to clear topic ${topic}`, error);
+    }
   }
 
   /**

--- a/packages/core/src/events/caching-pubsub.ts
+++ b/packages/core/src/events/caching-pubsub.ts
@@ -313,18 +313,12 @@ export class CachingPubSub extends PubSub {
    * Call this when a stream completes to free memory. The forward matters for
    * persistent inner transports (e.g. Redis Streams): without it, wrapping a
    * pubsub in `CachingPubSub` silently turns `clearTopic` into a cache-only
-   * no-op and the inner stream leaks forever. The hook is optional on the
-   * `PubSub` contract, so probe for it before calling.
+   * no-op and the inner stream leaks forever.
    */
-  async clearTopic(topic: string): Promise<void> {
+  override async clearTopic(topic: string): Promise<void> {
     const cacheKey = this.getCacheKey(topic);
     const counterKey = this.getCounterKey(topic);
-    const inner = this.inner as PubSub & { clearTopic?: (topic: string) => Promise<void> };
-    await Promise.all([
-      this.cache.delete(cacheKey),
-      this.cache.delete(counterKey),
-      typeof inner.clearTopic === 'function' ? inner.clearTopic(topic) : undefined,
-    ]);
+    await Promise.all([this.cache.delete(cacheKey), this.cache.delete(counterKey), this.inner.clearTopic(topic)]);
   }
 
   /**

--- a/packages/core/src/events/event-emitter/event-emitter.test.ts
+++ b/packages/core/src/events/event-emitter/event-emitter.test.ts
@@ -191,6 +191,22 @@ describe('EventEmitterPubSub', () => {
     });
   });
 
+  describe('clearTopic', () => {
+    it('resolves via the PubSub base no-op and leaves subscriptions intact', async () => {
+      // EventEmitterPubSub retains nothing per topic, so it relies on the
+      // base class's default clearTopic. Run lifecycles call it
+      // fire-and-forget on every transport; it must resolve cleanly and
+      // must not tear down live subscriptions.
+      const cb = vi.fn();
+      await pubsub.subscribe('tasks', cb);
+
+      await expect(pubsub.clearTopic('tasks')).resolves.toBeUndefined();
+
+      await pubsub.publish('tasks', makeEvent());
+      expect(cb).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('publish', () => {
     it('auto-generates id and createdAt', async () => {
       const cb = vi.fn();

--- a/packages/core/src/events/pubsub.ts
+++ b/packages/core/src/events/pubsub.ts
@@ -35,6 +35,27 @@ export abstract class PubSub {
   abstract flush(): Promise<void>;
 
   /**
+   * Delete all retained state for a topic (cached history, persistent stream
+   * entries, consumer groups) once no more events will be published to it.
+   *
+   * Called by run lifecycles (durable agents, the evented workflow engine)
+   * when a run reaches a terminal state, so per-run topics don't accumulate
+   * forever on transports that retain messages (e.g. Redis Streams).
+   *
+   * Default implementation is a no-op: transports that don't retain anything
+   * per topic (e.g. plain EventEmitter delivery) have nothing to clear.
+   *
+   * Best-effort contract: implementations should not throw — callers invoke
+   * this fire-and-forget at cleanup boundaries, so failures should be logged
+   * by the implementation rather than rejected.
+   *
+   * @param topic - The topic whose retained state should be deleted
+   */
+  clearTopic(_topic: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  /**
    * Delivery modes this PubSub implementation supports.
    *
    * Defaults to `['pull']` for backward compatibility — third-party

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -107,10 +107,50 @@ export class WorkflowEventProcessor extends EventProcessor {
   // an entry mid-retry, but low enough to bound memory.
   private static readonly DELIVERY_ATTEMPTS_MAX_ENTRIES = 1024;
 
-  constructor({ mastra, stepExecutionStrategy }: { mastra: Mastra; stepExecutionStrategy?: StepExecutionStrategy }) {
+  // How long after a run reaches a terminal state before its
+  // `workflow.events.v2.<runId>` topic is cleared from the pubsub. The
+  // terminal `workflow-finish` watch event is published to that same topic,
+  // so deletion must lag long enough for attached watchers/streams to drain
+  // it. Mirrors DurableAgent's cleanupTimeoutMs default. 0 disables cleanup.
+  private readonly topicCleanupDelayMs: number;
+  private static readonly DEFAULT_TOPIC_CLEANUP_DELAY_MS = 30_000;
+
+  constructor({
+    mastra,
+    stepExecutionStrategy,
+    topicCleanupDelayMs,
+  }: {
+    mastra: Mastra;
+    stepExecutionStrategy?: StepExecutionStrategy;
+    topicCleanupDelayMs?: number;
+  }) {
     super({ mastra });
     this.stepExecutor = new StepExecutor({ mastra });
     this.stepExecutionStrategy = stepExecutionStrategy;
+    this.topicCleanupDelayMs = topicCleanupDelayMs ?? WorkflowEventProcessor.DEFAULT_TOPIC_CLEANUP_DELAY_MS;
+  }
+
+  /**
+   * Schedule deletion of a finished run's `workflow.events.v2.<runId>` topic.
+   *
+   * Per-run watch topics are written by every step of a run; on transports
+   * that retain messages (e.g. Redis Streams) they would otherwise live
+   * forever once the run ends. Deletion is delayed so subscribers still
+   * draining the terminal `workflow-finish` event aren't cut off, and
+   * fire-and-forget because topic cleanup must never affect run completion.
+   *
+   * Best-effort by design: if the process exits before the timer fires, the
+   * transport-level idle TTL (e.g. `streamIdleTtlMs`) is the backstop.
+   */
+  private scheduleRunTopicCleanup(runId: string): void {
+    if (this.topicCleanupDelayMs <= 0) return;
+    const timer = setTimeout(() => {
+      this.mastra.pubsub.clearTopic(`workflow.events.v2.${runId}`).catch(err => {
+        this.mastra.getLogger()?.warn('Failed to clear workflow events topic', { runId, error: err });
+      });
+    }, this.topicCleanupDelayMs);
+    // Don't let a pending cleanup timer keep a short-lived process alive.
+    timer.unref?.();
   }
 
   /**
@@ -535,6 +575,13 @@ export class WorkflowEventProcessor extends EventProcessor {
     // Clean up abort controller and parent-child tracking
     this.cleanupRun(runId);
 
+    // A per-step run publishes `workflow.end` while merely paused — it will
+    // keep writing to its watch topic when the next step executes, so only
+    // truly terminal runs get their topic cleared.
+    if (!perStep) {
+      this.scheduleRunTopicCleanup(runId);
+    }
+
     // handle nested workflow
     if (parentWorkflow) {
       // get the step from the parent workflow and process it if it's a loop
@@ -720,6 +767,9 @@ export class WorkflowEventProcessor extends EventProcessor {
 
     // Clean up abort controller and parent-child tracking
     this.cleanupRun(runId);
+
+    // 'failed' is terminal: the run stops writing to its watch topic.
+    this.scheduleRunTopicCleanup(runId);
 
     const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -115,6 +115,22 @@ export class WorkflowEventProcessor extends EventProcessor {
   private readonly topicCleanupDelayMs: number;
   private static readonly DEFAULT_TOPIC_CLEANUP_DELAY_MS = 30_000;
 
+  // Pending per-run topic cleanup timers, so a run restarted in this process
+  // (timeTravel/restart reuse the runId) cancels its own pending deletion.
+  private readonly pendingTopicCleanups = new Map<string, ReturnType<typeof setTimeout>>();
+
+  // Statuses under which a run is still (or again) writing to its watch
+  // topic. If the run was restarted via timeTravel/restart after its terminal
+  // end, deletion must be skipped — the new execution reschedules cleanup
+  // when it reaches its own terminal state.
+  private static readonly ACTIVE_RUN_STATUSES: ReadonlySet<string> = new Set([
+    'running',
+    'pending',
+    'waiting',
+    'suspended',
+    'paused',
+  ]);
+
   constructor({
     mastra,
     stepExecutionStrategy,
@@ -141,16 +157,49 @@ export class WorkflowEventProcessor extends EventProcessor {
    *
    * Best-effort by design: if the process exits before the timer fires, the
    * transport-level idle TTL (e.g. `streamIdleTtlMs`) is the backstop.
+   *
+   * A finished run can be re-executed under the same runId (`timeTravel`,
+   * `restart`), so deletion is double-guarded: a restart processed by this
+   * process cancels the pending timer directly, and when the timer fires we
+   * re-check the run's persisted status — a restart may have been picked up
+   * by a different worker process — and skip deletion while the run is
+   * active again.
    */
-  private scheduleRunTopicCleanup(runId: string): void {
+  private scheduleRunTopicCleanup(workflowId: string, runId: string): void {
     if (this.topicCleanupDelayMs <= 0) return;
+    this.cancelRunTopicCleanup(runId);
     const timer = setTimeout(() => {
-      this.mastra.pubsub.clearTopic(`workflow.events.v2.${runId}`).catch(err => {
-        this.mastra.getLogger()?.warn('Failed to clear workflow events topic', { runId, error: err });
-      });
+      this.pendingTopicCleanups.delete(runId);
+      void this.clearRunTopicUnlessActive(workflowId, runId);
     }, this.topicCleanupDelayMs);
     // Don't let a pending cleanup timer keep a short-lived process alive.
     timer.unref?.();
+    this.pendingTopicCleanups.set(runId, timer);
+  }
+
+  private cancelRunTopicCleanup(runId: string): void {
+    const timer = this.pendingTopicCleanups.get(runId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.pendingTopicCleanups.delete(runId);
+    }
+  }
+
+  private async clearRunTopicUnlessActive(workflowId: string, runId: string): Promise<void> {
+    try {
+      const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
+      if (workflowsStore) {
+        const snapshot = await workflowsStore.loadWorkflowSnapshot({ workflowName: workflowId, runId });
+        const status = typeof snapshot === 'string' ? undefined : snapshot?.status;
+        // Run was restarted (possibly by another worker process) after the
+        // terminal end that scheduled this cleanup: it is writing to its
+        // topic again, and its own terminal end will reschedule deletion.
+        if (status && WorkflowEventProcessor.ACTIVE_RUN_STATUSES.has(status)) return;
+      }
+      await this.mastra.pubsub.clearTopic(`workflow.events.v2.${runId}`);
+    } catch (err) {
+      this.mastra.getLogger()?.warn('Failed to clear workflow events topic', { workflowId, runId, error: err });
+    }
   }
 
   /**
@@ -375,6 +424,10 @@ export class WorkflowEventProcessor extends EventProcessor {
     const initialState = (arguments[0] as any).initialState ?? state ?? {};
     const resolvedFormat = format ?? this.runFormats.get(runId);
     this.runFormats.set(runId, resolvedFormat);
+    // The run is starting (or restarting via timeTravel/restart under the
+    // same runId): any topic cleanup pending from a previous terminal end
+    // must not fire while the run is writing to its topic again.
+    this.cancelRunTopicCleanup(runId);
     // Create abort controller for this workflow run
     this.getOrCreateAbortController(runId);
 
@@ -579,7 +632,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     // keep writing to its watch topic when the next step executes, so only
     // truly terminal runs get their topic cleared.
     if (!perStep) {
-      this.scheduleRunTopicCleanup(runId);
+      this.scheduleRunTopicCleanup(_workflowId, runId);
     }
 
     // handle nested workflow
@@ -769,7 +822,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     this.cleanupRun(runId);
 
     // 'failed' is terminal: the run stops writing to its watch topic.
-    this.scheduleRunTopicCleanup(runId);
+    this.scheduleRunTopicCleanup(workflowId, runId);
 
     const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -629,7 +629,7 @@ export class WorkflowEventProcessor extends EventProcessor {
       perStep,
       stepResults,
       state,
-      workflowId: _workflowId,
+      workflowId,
     } = args;
 
     // Extract final state from stepResults or args
@@ -642,7 +642,7 @@ export class WorkflowEventProcessor extends EventProcessor {
     // keep writing to its watch topic when the next step executes, so only
     // truly terminal runs get their topic cleared.
     if (!perStep) {
-      this.scheduleRunTopicCleanup(_workflowId, runId);
+      this.scheduleRunTopicCleanup(workflowId, runId);
     }
 
     // handle nested workflow

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -187,6 +187,16 @@ export class WorkflowEventProcessor extends EventProcessor {
 
   private async clearRunTopicUnlessActive(workflowId: string, runId: string): Promise<void> {
     try {
+      // Without a storage backend there is no way to observe a cross-process
+      // restart, so we delete unconditionally — the in-process timer
+      // cancellation in processWorkflowStart still covers same-process
+      // restarts. The status check below is also not atomic with the delete:
+      // a restart persisting `running` between the read and the DEL can still
+      // lose its topic. That window is milliseconds (vs. the full cleanup
+      // delay without this guard) and self-heals — persistent transports
+      // recover subscribers on the next publish (e.g. Redis NOGROUP
+      // recreation). Closing it fully would require distributed locking,
+      // which best-effort topic cleanup does not justify.
       const workflowsStore = await this.mastra.getStorage()?.getStore('workflows');
       if (workflowsStore) {
         const snapshot = await workflowsStore.loadWorkflowSnapshot({ workflowName: workflowId, runId });

--- a/packages/core/src/workflows/evented/workflow-event-processor/topic-cleanup.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/topic-cleanup.test.ts
@@ -149,6 +149,11 @@ describe('WorkflowEventProcessor per-run topic cleanup', () => {
       })
       .catch(() => {});
 
+    // Force the persisted status terminal so the fire-time status guard would
+    // NOT protect the topic. Only the in-process timer cancellation can
+    // prevent deletion here — this isolates the layer under test.
+    await persistRunStatus(mastra, 'success');
+
     await new Promise(resolve => setTimeout(resolve, 80));
     expect(clearTopicSpy).not.toHaveBeenCalled();
 

--- a/packages/core/src/workflows/evented/workflow-event-processor/topic-cleanup.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/topic-cleanup.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitterPubSub } from '../../../events/event-emitter';
+import { Mastra } from '../../../mastra';
+import { MockStore } from '../../../storage/mock';
+import { WorkflowEventProcessor } from './index';
+
+class TestWorkflowEventProcessor extends WorkflowEventProcessor {
+  callProcessWorkflowEnd(args: any) {
+    return this.processWorkflowEnd(args);
+  }
+  callProcessWorkflowFail(args: any) {
+    return this.processWorkflowFail(args);
+  }
+}
+
+function setup(topicCleanupDelayMs?: number) {
+  const pubsub = new EventEmitterPubSub();
+  const mastra = new Mastra({
+    logger: false,
+    storage: new MockStore(),
+    workflows: {} as any,
+    pubsub,
+  });
+  const processor = new TestWorkflowEventProcessor({ mastra, topicCleanupDelayMs });
+  const clearTopicSpy = vi.spyOn(pubsub, 'clearTopic');
+  return { mastra, processor, clearTopicSpy };
+}
+
+const baseArgs = {
+  workflowId: 'wf',
+  runId: 'run-1',
+  executionPath: [],
+  resumeSteps: [],
+  stepResults: {},
+  activeStepsPath: {},
+  requestContext: {},
+  prevResult: { status: 'success' },
+};
+
+describe('WorkflowEventProcessor per-run topic cleanup', () => {
+  it('clears the workflow.events.v2 topic after a terminal workflow.end', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(10);
+
+    await processor.callProcessWorkflowEnd({ ...baseArgs });
+
+    // Deletion is delayed so watchers can drain the terminal event first.
+    expect(clearTopicSpy).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(clearTopicSpy).toHaveBeenCalledWith('workflow.events.v2.run-1');
+    });
+
+    await mastra.shutdown();
+  });
+
+  it('clears the workflow.events.v2 topic after workflow.fail', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(10);
+
+    await processor.callProcessWorkflowFail({
+      ...baseArgs,
+      prevResult: { status: 'failed', error: 'boom' },
+    });
+
+    await vi.waitFor(() => {
+      expect(clearTopicSpy).toHaveBeenCalledWith('workflow.events.v2.run-1');
+    });
+
+    await mastra.shutdown();
+  });
+
+  it('does not clear the topic for a per-step (paused) workflow.end', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(10);
+
+    await processor.callProcessWorkflowEnd({ ...baseArgs, perStep: true });
+
+    // The run is only paused: it keeps writing to its topic when the next
+    // step executes, so cleanup must not be scheduled.
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(clearTopicSpy).not.toHaveBeenCalled();
+
+    await mastra.shutdown();
+  });
+
+  it('disables topic cleanup when topicCleanupDelayMs is 0', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(0);
+
+    await processor.callProcessWorkflowEnd({ ...baseArgs });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(clearTopicSpy).not.toHaveBeenCalled();
+
+    await mastra.shutdown();
+  });
+});

--- a/packages/core/src/workflows/evented/workflow-event-processor/topic-cleanup.test.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/topic-cleanup.test.ts
@@ -11,6 +11,18 @@ class TestWorkflowEventProcessor extends WorkflowEventProcessor {
   callProcessWorkflowFail(args: any) {
     return this.processWorkflowFail(args);
   }
+  callProcessWorkflowStart(args: any) {
+    return this.processWorkflowStart(args);
+  }
+}
+
+async function persistRunStatus(mastra: Mastra, status: string) {
+  const workflowsStore = await mastra.getStorage()!.getStore('workflows');
+  await workflowsStore!.persistWorkflowSnapshot({
+    workflowName: 'wf',
+    runId: 'run-1',
+    snapshot: { status, context: {}, activePaths: [], timestamp: Date.now(), value: {}, runId: 'run-1' } as any,
+  });
 }
 
 function setup(topicCleanupDelayMs?: number) {
@@ -86,6 +98,58 @@ describe('WorkflowEventProcessor per-run topic cleanup', () => {
     await processor.callProcessWorkflowEnd({ ...baseArgs });
 
     await new Promise(resolve => setTimeout(resolve, 50));
+    expect(clearTopicSpy).not.toHaveBeenCalled();
+
+    await mastra.shutdown();
+  });
+
+  it('skips deletion when the run is active again at fire time (cross-process restart)', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(10);
+
+    await processor.callProcessWorkflowEnd({ ...baseArgs });
+    // Simulate a timeTravel/restart picked up by a different worker process:
+    // the local timer is still pending, but shared storage says the run is
+    // executing again.
+    await persistRunStatus(mastra, 'running');
+
+    await new Promise(resolve => setTimeout(resolve, 60));
+    expect(clearTopicSpy).not.toHaveBeenCalled();
+
+    await mastra.shutdown();
+  });
+
+  it('proceeds with deletion when the persisted status is terminal', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(10);
+
+    await persistRunStatus(mastra, 'failed');
+    await processor.callProcessWorkflowFail({
+      ...baseArgs,
+      prevResult: { status: 'failed', error: 'boom' },
+    });
+
+    await vi.waitFor(() => {
+      expect(clearTopicSpy).toHaveBeenCalledWith('workflow.events.v2.run-1');
+    });
+
+    await mastra.shutdown();
+  });
+
+  it('cancels a pending cleanup when the run restarts in-process', async () => {
+    const { mastra, processor, clearTopicSpy } = setup(30);
+
+    await processor.callProcessWorkflowEnd({ ...baseArgs });
+
+    // A timeTravel/restart re-enters through processWorkflowStart with the
+    // same runId. The minimal workflow here may make later phases of start
+    // throw — the cancellation happens first and is what's under test.
+    await processor
+      .callProcessWorkflowStart({
+        ...baseArgs,
+        workflow: { id: 'wf', options: {}, stepGraph: [] },
+      })
+      .catch(() => {});
+
+    await new Promise(resolve => setTimeout(resolve, 80));
     expect(clearTopicSpy).not.toHaveBeenCalled();
 
     await mastra.shutdown();


### PR DESCRIPTION
## Summary

Follow-up to #19138, completing the fix for #19123.

Finished workflow runs leave their `workflow.events.v2.<runId>` pub/sub topics behind forever. On persistent transports like Redis Streams, every workflow run permanently adds a stream that is never deleted — the same class of unbounded memory growth that #19123 reported for agent streams (measured at 538MB in a week in the original report). #19138 fixed the `agent.stream.<runId>` half; this PR fixes the workflow half and hardens the contract that made the first leak possible.

### 1. `clearTopic` is now part of the `PubSub` base class

Previously `clearTopic` was an informal, duck-typed hook: callers probed `'clearTopic' in pubsub` before calling. That pattern is exactly what caused the original leak — `CachingPubSub` wrapped every transport and silently failed to forward the call. It is now declared on the abstract base with a default no-op (matching the existing pattern for `getHistory` / `subscribeWithReplay` / `subscribeFromOffset`), and the probes in `CachingPubSub` and `DurableAgent` are removed. Future wrappers can't repeat the bug. Non-breaking: transports that retain nothing per topic inherit the no-op.

### 2. The evented workflow engine now cleans up its per-run topics

`WorkflowEventProcessor` schedules deletion of `workflow.events.v2.<runId>` when a run reaches a terminal state (`processWorkflowEnd` and `processWorkflowFail`, covering success/failure/cancellation):

- **Delayed** (default 30s, mirroring `DurableAgent.cleanupTimeoutMs`) so watchers still draining the terminal `workflow-finish` event — which is published to that same topic — aren't cut off.
- **Skipped for per-step pauses**: a paused run keeps writing to its topic when the next step executes.
- **Fire-and-forget** with a warn log on failure; topic cleanup can never affect run completion. Timer is `unref`'d so it doesn't pin short-lived processes.
- **Restart-safe**: re-running a finished run under the same `runId` (timeTravel/restart) cancels the pending cleanup timer in-process, and at fire time the run's persisted status is re-checked so a restart picked up by a *different* worker process also can't have its topic deleted mid-flight. The new execution's own terminal end reschedules cleanup. The residual status-read→delete race is milliseconds wide and self-heals on persistent transports (e.g. Redis NOGROUP group recreation); closing it fully would need distributed locking, which best-effort cleanup doesn't justify (documented in code). `DurableAgent`'s `agent.stream.<runId>` cleanup needs no equivalent guard — its timers arm only on terminal outcomes, `resume()` rejects non-suspended runs, and `untilIdle` continuations mint fresh runIds (also documented in code).
- `topicCleanupDelayMs` on the processor constructor controls the delay (0 disables). Note: Mastra constructs the processor internally without exposing this option today, so it is effectively internal/test-facing — the default applies everywhere. The transport-level idle TTL such as `streamIdleTtlMs` remains the backstop for crashed processes.

## Test plan

- New `topic-cleanup.test.ts` (7 tests): topic cleared after terminal `workflow.end` and `workflow.fail`, not cleared for per-step pauses, disabled at `topicCleanupDelayMs: 0`, skipped when the persisted run status is active again at fire time (cross-process restart), still cleared when the persisted status is terminal, and cancelled when the run restarts in-process (with a terminal persisted status, so the fire-time guard cannot mask a broken cancellation — verified red with the cancel disabled).
- New base-contract test: default `clearTopic` resolves and leaves live subscriptions intact on `EventEmitterPubSub`.
- Updated `CachingPubSub` tests for unconditional forwarding.
- Full `src/events/`, `src/agent/durable/`, and evented workflow suites pass (one pre-existing e2e failure reproduces on `main` without these changes).
- `pnpm --filter ./packages/core typecheck` and `lint` clean; docs remark lint clean.

Fixes #19123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Finished workflow runs were leaving behind stored data forever, which could eventually fill Redis. This PR adds a standard way to delete topic data and automatically cleans up workflow topics after successful or failed runs, while preserving paused runs and allowing cleanup to be disabled or delayed.

## What changed

- Added `PubSub.clearTopic(topic)` with a default no-op implementation.
- Updated `CachingPubSub` and durable agents to forward cleanup calls unconditionally.
- Added delayed cleanup for `workflow.events.v2.<runId>` topics:
  - Runs after terminal success or failure.
  - Defaults to a 30-second delay.
  - Skips per-step pauses.
  - Can be disabled with `topicCleanupDelayMs: 0`.
  - Uses an unref’d timer and logs failures without affecting run completion.
- Documented `clearTopic` across PubSub implementations.
- Added tests covering cleanup timing, failures, pauses, disabled cleanup, subscriptions, and base-class behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


