### PR TITLE
fix(playground): keep trace panels independently scrollable

### DIFF
--- a/.changeset/sunny-breads-kiss.md
+++ b/.changeset/sunny-breads-kiss.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed trace detail pages so long timelines and span details scroll independently within the viewport.

--- a/.changeset/tender-lizards-push.md
+++ b/.changeset/tender-lizards-push.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed data panel content so it scrolls correctly inside constrained layouts.

--- a/packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
+++ b/packages/playground-ui/src/ds/components/DataPanel/data-panel-content.tsx
@@ -7,7 +7,7 @@ export interface DataPanelContentProps {
 
 export function DataPanelContent({ children, ref }: DataPanelContentProps) {
   return (
-    <div ref={ref} className="flex-1 overflow-y-auto p-4">
+    <div ref={ref} className="min-h-0 flex-1 overflow-y-auto p-4">
       {children}
     </div>
   );

--- a/packages/playground/e2e/tests/traces/$traceId/page.spec.ts
+++ b/packages/playground/e2e/tests/traces/$traceId/page.spec.ts
@@ -1,9 +1,85 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
 import { test, expect } from '@playwright/test';
 import type { Page } from '@playwright/test';
 import { resetStorage } from '../../__utils__/reset-storage';
 import { expectBreadcrumbLink, expectCurrentBreadcrumb, expectRouteDocsLink } from '../../__utils__/route-header';
 
 const FAKE_TRACE_ID = 'trace-does-not-exist';
+const LONG_TRACE_ID = 'trace-with-many-spans';
+const ROOT_SPAN_ID = 'root-span';
+const SELECTED_SPAN_ID = 'span-60';
+const TRACE_STARTED_AT_MS = Date.parse('2026-07-14T08:00:00.000Z');
+
+type TraceLightResponse = Awaited<ReturnType<MastraClient['getTraceLight']>>;
+type TraceLightSpan = TraceLightResponse['spans'][number];
+type SpanResponse = Awaited<ReturnType<MastraClient['getSpan']>>;
+
+const rootSpan: TraceLightSpan = {
+  traceId: LONG_TRACE_ID,
+  spanId: ROOT_SPAN_ID,
+  parentSpanId: null,
+  name: 'agent run',
+  spanType: SpanType.AGENT_RUN,
+  isEvent: false,
+  startedAt: new Date('2026-07-14T08:00:00.000Z'),
+  endedAt: new Date('2026-07-14T08:01:00.000Z'),
+  createdAt: new Date('2026-07-14T08:00:00.000Z'),
+  updatedAt: new Date('2026-07-14T08:01:00.000Z'),
+};
+
+function createChildSpan(index: number): TraceLightSpan {
+  const spanId = `span-${index}`;
+  const startedAt = new Date(TRACE_STARTED_AT_MS + index * 500);
+
+  return {
+    traceId: LONG_TRACE_ID,
+    spanId,
+    parentSpanId: ROOT_SPAN_ID,
+    name: `tool call ${index}`,
+    spanType: SpanType.TOOL_CALL,
+    isEvent: false,
+    startedAt,
+    endedAt: new Date(startedAt.getTime() + 250),
+    createdAt: new Date('2026-07-14T08:00:00.000Z'),
+    updatedAt: new Date('2026-07-14T08:01:00.000Z'),
+  };
+}
+
+const longTraceResponse: TraceLightResponse = {
+  traceId: LONG_TRACE_ID,
+  spans: [rootSpan, ...Array.from({ length: 60 }, (_, index) => createChildSpan(index + 1))],
+};
+
+const selectedSpanResponse: SpanResponse = {
+  span: {
+    traceId: LONG_TRACE_ID,
+    spanId: SELECTED_SPAN_ID,
+    parentSpanId: ROOT_SPAN_ID,
+    name: 'tool call 60',
+    spanType: SpanType.TOOL_CALL,
+    isEvent: false,
+    startedAt: new Date('2026-07-14T08:00:59.000Z'),
+    endedAt: new Date('2026-07-14T08:00:59.500Z'),
+    createdAt: new Date('2026-07-14T08:00:59.000Z'),
+    updatedAt: new Date('2026-07-14T08:00:59.500Z'),
+    input: {
+      messages: Array.from({ length: 40 }, (_, index) => ({
+        role: 'user',
+        content: `Long trace input line ${index + 1}`,
+      })),
+    },
+    output: {
+      chunks: Array.from({ length: 40 }, (_, index) => `Long trace output line ${index + 1}`),
+    },
+    metadata: Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`metadata-${index + 1}`, `value-${index + 1}`]),
+    ),
+    attributes: Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`attribute-${index + 1}`, `value-${index + 1}`]),
+    ),
+  },
+};
 
 async function mockTraceResponse(page: Page, status: number, body: unknown = { error: 'mock' }) {
   // Match the lightweight trace endpoint (traces/:traceId/light) used by the trace detail page,
@@ -20,6 +96,23 @@ async function mockTraceResponse(page: Page, status: number, body: unknown = { e
       status,
       contentType: 'application/json',
       body: JSON.stringify(body),
+    });
+  });
+}
+
+async function mockLongTrace(page: Page) {
+  await page.route(`**/api/observability/traces/${LONG_TRACE_ID}/light`, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(longTraceResponse),
+    });
+  });
+  await page.route(`**/api/observability/traces/${LONG_TRACE_ID}/spans/${SELECTED_SPAN_ID}`, async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(selectedSpanResponse),
     });
   });
 }
@@ -71,6 +164,74 @@ test.describe('Trace detail page', () => {
       // Page shell still renders - the panels themselves depend on server data that may not exist.
       await expectCurrentBreadcrumb(page, 'trace');
       await expectBreadcrumbLink(page, 'Traces', '/observability');
+    });
+  });
+
+  test.describe('when a span near the end of a long trace is opened', () => {
+    /**
+     * FEATURE: Independent trace panel scrolling.
+     * USER STORY: A user can inspect a deep span without scrolling the whole trace page back and forth.
+     * BEHAVIOR UNDER TEST: Timeline and span details stay within the viewport and scroll independently.
+     * DATA FLOW: Typed client responses are fulfilled at the network boundary and rendered by the real trace page.
+     * PERSISTENCE: The selected span remains encoded in the URL; no additional state must persist.
+     * DOWNSTREAM EFFECT: Scrolling span details does not move the selected timeline position.
+     */
+    test('keeps the timeline and span details independently scrollable within the page', async ({ page }) => {
+      await page.setViewportSize({ width: 1280, height: 800 });
+      await mockLongTrace(page);
+      // Warm the mocked trace query, then remount the route with the final span selected through the URL.
+      await page.goto(`/traces/${LONG_TRACE_ID}`);
+      await expect(page.getByRole('button', { name: 'tool call 60', exact: true })).toBeAttached();
+      await page.getByRole('navigation', { name: 'Main' }).getByRole('link', { name: 'Traces' }).click();
+      await expect(page).toHaveURL(/\/observability$/);
+      await page.evaluate(url => {
+        window.history.pushState(null, '', url);
+        window.dispatchEvent(new PopStateEvent('popstate'));
+      }, `/traces/${LONG_TRACE_ID}?spanId=${SELECTED_SPAN_ID}`);
+      await expect(page).toHaveURL(new RegExp(`spanId=${SELECTED_SPAN_ID}`));
+
+      const timelinePanel = page.locator('section').filter({
+        has: page.getByRole('heading', { name: 'Trace Timeline', exact: true }),
+      });
+      const spanDetailsPanel = page.locator('section').filter({
+        has: page.getByRole('heading', { name: `Span # ${SELECTED_SPAN_ID}`, exact: true }),
+      });
+      const pageLayout = page.locator('main').filter({ has: timelinePanel });
+      const timelineContent = timelinePanel.locator(':scope > div').last();
+      const spanDetailsContent = spanDetailsPanel.locator(':scope > div').last();
+
+      await expect(timelinePanel).toBeVisible();
+      await expect(spanDetailsPanel).toBeVisible();
+      await timelinePanel.getByRole('button', { name: 'tool call 60', exact: true }).scrollIntoViewIfNeeded();
+      await expect
+        .poll(() => timelineContent.evaluate(element => element.scrollHeight > element.clientHeight))
+        .toBe(true);
+      await expect.poll(() => timelineContent.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
+      await expect
+        .poll(() => spanDetailsContent.evaluate(element => element.scrollHeight > element.clientHeight))
+        .toBe(true);
+
+      const [pageLayoutBox, timelinePanelBox, spanDetailsPanelBox] = await Promise.all([
+        pageLayout.boundingBox(),
+        timelinePanel.boundingBox(),
+        spanDetailsPanel.boundingBox(),
+      ]);
+      if (!pageLayoutBox || !timelinePanelBox || !spanDetailsPanelBox) {
+        throw new Error('Expected the trace page and both data panels to have measurable bounds');
+      }
+
+      const pageLayoutBottom = pageLayoutBox.y + pageLayoutBox.height;
+      expect(timelinePanelBox.y + timelinePanelBox.height).toBeLessThanOrEqual(pageLayoutBottom);
+      expect(spanDetailsPanelBox.y + spanDetailsPanelBox.height).toBeLessThanOrEqual(pageLayoutBottom);
+      expect(await page.evaluate(() => document.scrollingElement?.scrollTop ?? 0)).toBe(0);
+
+      const timelineScrollTop = await timelineContent.evaluate(element => element.scrollTop);
+      await spanDetailsContent.evaluate(element => {
+        element.scrollTop = element.scrollHeight;
+      });
+
+      await expect.poll(() => spanDetailsContent.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
+      expect(await timelineContent.evaluate(element => element.scrollTop)).toBe(timelineScrollTop);
     });
   });
 

--- a/packages/playground/e2e/tests/traces/$traceId/page.spec.ts
+++ b/packages/playground/e2e/tests/traces/$traceId/page.spec.ts
@@ -210,6 +210,7 @@ test.describe('Trace detail page', () => {
       await expect
         .poll(() => spanDetailsContent.evaluate(element => element.scrollHeight > element.clientHeight))
         .toBe(true);
+      await expect.poll(() => pageLayout.evaluate(element => element.scrollHeight === element.clientHeight)).toBe(true);
 
       const [pageLayoutBox, timelinePanelBox, spanDetailsPanelBox] = await Promise.all([
         pageLayout.boundingBox(),

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -195,7 +195,7 @@ export default function TracePage() {
   }
 
   return (
-    <PageLayout>
+    <PageLayout height="full" className="grid-rows-[auto_minmax(0,1fr)] content-normal overflow-hidden">
       {traceHeaderActions}
       {traceTopAreaSharedContent && <PageLayout.TopArea>{traceTopAreaSharedContent}</PageLayout.TopArea>}
 
@@ -208,7 +208,7 @@ export default function TracePage() {
 
       <div
         className={cn(
-          'grid h-full min-h-0 gap-4 overflow-hidden items-start mt-4',
+          'mt-4 grid h-full min-h-0 items-stretch gap-4 overflow-hidden',
           featuredSpanId ? 'grid-cols-[2fr_3fr]' : 'grid-cols-[1fr]',
         )}
       >
@@ -226,7 +226,7 @@ export default function TracePage() {
         {featuredSpanId && !isTraceLoading && (
           <div
             className={cn(
-              'grid gap-4 max-h-full min-h-0 overflow-auto',
+              'grid h-full max-h-full min-h-0 gap-4 overflow-auto',
               featuredScore ? 'grid-rows-[1fr_1fr]' : 'grid-rows-[1fr]',
             )}
           >

--- a/packages/playground/src/pages/traces/trace/index.tsx
+++ b/packages/playground/src/pages/traces/trace/index.tsx
@@ -195,7 +195,7 @@ export default function TracePage() {
   }
 
   return (
-    <PageLayout height="full" className="grid-rows-[auto_minmax(0,1fr)] content-normal overflow-hidden">
+    <PageLayout height="full" className="grid-rows-[auto_minmax(0,1fr)] content-normal">
       {traceHeaderActions}
       {traceTopAreaSharedContent && <PageLayout.TopArea>{traceTopAreaSharedContent}</PageLayout.TopArea>}
 
@@ -208,7 +208,7 @@ export default function TracePage() {
 
       <div
         className={cn(
-          'mt-4 grid h-full min-h-0 items-stretch gap-4 overflow-hidden',
+          'mt-4 grid min-h-0 items-stretch gap-4 overflow-hidden',
           featuredSpanId ? 'grid-cols-[2fr_3fr]' : 'grid-cols-[1fr]',
         )}
       >


### PR DESCRIPTION
Fixes #19185.

Long traces could make the trace page grow beyond Studio's viewport. Opening a deep span moved the whole Studio content area and hid both panel headers. This keeps the trace layout within the viewport and lets the timeline and span details scroll independently. The containment is scoped to this route and does not add an outer overflow-hidden.

Inspired by the [mastra-studio-ui-enhancements](https://github.com/berrydev-ai/mastra-studio-ui-enhancements) repository shared by @coderberry and its [integration gist](https://gist.github.com/coderberry/34571e742029186b98df7a9d3ea9a5b2). Thanks for reporting this and sharing the initial direction.

Before, using a 61-span reproduction on main:

<img width="1280" height="800" alt="Current main after revealing the final span, with both trace panel headers above the viewport" src="https://github.com/user-attachments/assets/5e8c7d71-a460-4f68-b7e0-05b3df1f5d2b" />

The page moved to reveal span 60, pushing both panel headers out of view.

After:

<img width="1280" height="800" alt="Fixed trace route with both panel headers visible and the timeline scrolled to span 60" src="https://github.com/user-attachments/assets/0c4968db-a694-47b2-a82c-5ded4805cb38" />

Both headers remain visible and the timeline scrolls to the selected span.

After scrolling the span details:

<img width="1280" height="800" alt="Fixed trace route with the details panel scrolled while the timeline remains on span 60" src="https://github.com/user-attachments/assets/35828fcc-9e29-4064-bcc5-ae4789c44024" />

Only the details panel moves. The timeline stays at the same position.

A focused Chromium regression covers the overflowing layout and independent scrolling. The playground and playground-ui builds, lint, and typechecks also pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Long trace pages no longer make the whole Studio page grow endlessly. The timeline and span details now fit within the screen and scroll separately.

## What changed

- Constrained the trace detail layout to the available viewport height.
- Added shrinkable grid and flex containers so panels remain within their layout.
- Enabled independent scrolling for the timeline and span details.
- Updated `DataPanelContent` to support constrained scrolling.
- Added deterministic Chromium coverage for long traces with 60 tool-call spans.
- Regression tests verify panel visibility, independent scrolling, and no page-level overflow.
- Added patch changesets for the affected packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->