### PR TITLE
fix(deployer): thread transpilePackages through build and dev bundler paths

### DIFF
--- a/.changeset/fix-transpile-packages-threading.md
+++ b/.changeset/fix-transpile-packages-threading.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'mastra': patch
+---
+
+Fix `bundler.transpilePackages` being silently ignored by `mastra build` and `mastra dev`. The option is now threaded through `BundlerOptions`, `analyzeBundle`, and `DevBundler.watch` so non-workspace npm packages that ship TypeScript source can be transpiled as documented.

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -102,6 +102,13 @@ export class DevBundler extends Bundler {
       },
       {
         sourcemap: sourcemapEnabled,
+        bundlerOptions: {
+          enableSourcemap: sourcemapEnabled,
+          enableEsmShim: true,
+          externals: bundlerOptions?.externals ?? true,
+          dynamicPackages: bundlerOptions?.dynamicPackages,
+          transpilePackages: bundlerOptions?.transpilePackages,
+        },
         analysisEntries: [entryFile, devServerAnalysisEntry],
       },
     );

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -269,6 +269,55 @@ describe('external dependency versions', () => {
   }, 15000);
 });
 
+describe('transpilePackages threading (issue #19380)', () => {
+  it('accepts transpilePackages in bundlerOptions without dropping it', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'mastra-transpile-packages-'));
+    tempDirs.push(tempDir);
+
+    const appDir = join(tempDir, 'apps', 'app');
+    const entryFile = join(appDir, 'index.ts');
+    const outputDir = join(appDir, '.mastra', '.build');
+
+    await mkdir(outputDir, { recursive: true });
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test-workspace', version: '1.0.0' }));
+    await writeFile(join(appDir, 'package.json'), JSON.stringify({ name: 'app', version: '1.0.0', type: 'module' }));
+    await writeFile(entryFile, `export const value = 1;`);
+
+    const originalCwd = process.cwd();
+    process.chdir(tempDir);
+    try {
+      // Before the fix, `transpilePackages` was outside the `Pick<BundlerOptions, ...>`
+      // accepted by analyzeBundle's type, and internalBundlerOptions
+      // (packages/deployer/src/bundler/index.ts) never read it off the user's
+      // config at all -- so it was silently dropped before ever reaching
+      // bundleExternals. This call should type-check and succeed without
+      // throwing, and is a regression guard against that field being dropped
+      // again in the future.
+      const result = await analyzeBundle(
+        [entryFile],
+        entryFile,
+        {
+          outputDir,
+          projectRoot: appDir,
+          platform: 'node',
+          isDev: true,
+          bundlerOptions: {
+            externals: [],
+            enableSourcemap: false,
+            transpilePackages: ['some-ts-shipping-package'],
+          },
+        },
+        noopLogger,
+      );
+
+      expect(result).toBeDefined();
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }, 15000);
+});
+
 describe('protocol imports', () => {
   it('should exclude protocol imports from externalDependencies', async () => {
     await mkdir(tempRoot, { recursive: true });

--- a/packages/deployer/src/build/analyze.ts
+++ b/packages/deployer/src/build/analyze.ts
@@ -386,7 +386,7 @@ export async function analyzeBundle(
     projectRoot: string;
     platform: BundlerPlatform;
     isDev?: boolean;
-    bundlerOptions?: Pick<BundlerOptions, 'externals' | 'enableSourcemap' | 'dynamicPackages'> | null;
+    bundlerOptions?: Pick<BundlerOptions, 'externals' | 'enableSourcemap' | 'dynamicPackages' | 'transpilePackages'> | null;
   },
   logger: IMastraLogger,
 ) {

--- a/packages/deployer/src/build/types.ts
+++ b/packages/deployer/src/build/types.ts
@@ -30,6 +30,7 @@ export interface BundlerOptions {
   enableEsmShim: boolean;
   externals: boolean | string[];
   dynamicPackages?: string[];
+  transpilePackages?: string[];
 }
 
 /**

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -319,6 +319,7 @@ export abstract class Bundler extends MastraBundler {
       externals: bundlerOptions.externals ?? [],
       enableEsmShim,
       dynamicPackages: bundlerOptions.dynamicPackages,
+      transpilePackages: bundlerOptions.transpilePackages,
     };
 
     let analyzedBundleInfo;


### PR DESCRIPTION
Fixes #19380

## Problem
`transpilePackages` is a documented `Config['bundler']` option but had no 
effect in either `mastra build` or `mastra dev`.

## Root cause (three structural drop points)
1. `BundlerOptions` (`build/types.ts`) had no `transpilePackages` field, so 
   `internalBundlerOptions` (`bundler/index.ts`) couldn't carry the value 
   even though `getUserBundlerOptions()` already returns it.
2. `analyzeBundle`'s parameter type explicitly `Pick<BundlerOptions, ...>` a 
   fixed list of fields that excluded `transpilePackages` — so it was 
   dropped at this boundary even after fixing (1).
3. `DevBundler.watch` only forwarded `{ sourcemap }` to 
   `getWatcherInputOptions`, never `bundlerOptions` at all — despite 
   `getInputOptions` already accepting and forwarding a full `BundlerOptions` 
   object through to `analyzeBundle`.

All workspace packages are auto-added to the transpile set regardless 
(`bundleExternals.ts`), which is why this was easy to miss — the option 
only matters for non-workspace npm packages that ship TypeScript source, 
where it silently did nothing.

## Fix
- Add `transpilePackages?: string[]` to `BundlerOptions`
- Include `'transpilePackages'` in `analyzeBundle`'s `Pick<...>`
- Forward it in `internalBundlerOptions` (`mastra build` path)
- Build a full `bundlerOptions` object in `DevBundler.watch` instead of 
  only `sourcemap` (`mastra dev` path)

## Tests
Added a regression test in `analyze.test.ts` asserting `analyzeBundle` 
accepts `transpilePackages` in `bundlerOptions` without dropping it 
(type-level regression guard against #19380 recurring).

**Note:** I could not run the full local test suite in this checkout — 
`@mastra/core` fails to build via `turbo` due to a pre-existing, unrelated 
TS 6.0 `baseUrl` deprecation error in `@internal/llm-recorder` (reproduces 
identically on unmodified `main`, confirmed via `git stash`). I verified 
the change instead via isolated `tsc` checks against all four edited files 
(no new errors beyond pre-existing, unrelated `logger` typing gaps) and by 
manually tracing all three drop points end to end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some npm packages contain TypeScript that needs to be converted before Mastra can use it. This change makes `bundler.transpilePackages` work consistently in both `mastra build` and `mastra dev`, and adds a test to prevent the issue from returning.

## Changes

- Added `transpilePackages` to `BundlerOptions`.
- Forwarded the option through build and dev bundling paths.
- Updated `analyzeBundle` to accept the option.
- Added a regression test for option propagation.
- Added a changeset for `@mastra/deployer` and `mastra`.

## Verification

- Isolated TypeScript checks were used.
- Full test execution was blocked by an unrelated TypeScript 6.0 `baseUrl` deprecation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->