### PR TITLE
feat(voice-google): add Cloud STT v2 support to listen()

### DIFF
--- a/.changeset/tall-papayas-exist.md
+++ b/.changeset/tall-papayas-exist.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-google': minor
+---
+
+Added Cloud Speech-to-Text v2 support to `GoogleVoice.listen()`. Pass `{ v2: true }` in options to use the v2 API, which supports additional audio formats like AAC-in-MP4 (iOS Safari) via `autoDecodingConfig` or `explicitDecodingConfig`. The v1 path remains the default — no breaking changes.

--- a/docs/src/content/en/reference/voice/google.mdx
+++ b/docs/src/content/en/reference/voice/google.mdx
@@ -195,7 +195,9 @@ Returns: `Promise<NodeJS.ReadableStream>`
 
 ### `listen()`
 
-Converts speech to text using Google Cloud Speech-to-Text service.
+Converts speech to text using Google Cloud Speech-to-Text service. Supports both v1 (default) and v2 APIs. The v2 API adds support for AAC-in-MP4 audio (iOS Safari) via auto-decoding.
+
+#### v1 (default)
 
 <PropertiesTable
   content={[
@@ -207,25 +209,76 @@ Converts speech to text using Google Cloud Speech-to-Text service.
   },
   {
     name: 'options',
-    type: 'object',
-    description: 'Recognition options',
+    type: 'GoogleListenOptionsV1',
+    description: 'v1 recognition options',
     isOptional: true,
     properties: [
       {
-        type: 'object',
+        type: 'GoogleListenOptionsV1',
         parameters: [
-          {
-            name: 'stream',
-            type: 'boolean',
-            description: 'Whether to use streaming recognition',
-            isOptional: true,
-          },
           {
             name: 'config',
             type: 'IRecognitionConfig',
-            description: 'Recognition configuration from Google Cloud Speech-to-Text API',
+            description: 'v1 recognition configuration from Google Cloud Speech-to-Text API',
             isOptional: true,
             defaultValue: "{ encoding: 'LINEAR16', languageCode: 'en-US' }",
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+#### v2
+
+Pass `v2: true` to use the Cloud Speech-to-Text v2 API, which supports additional audio formats like AAC-in-MP4 (iOS Safari).
+
+```typescript
+const transcript = await voice.listen(iosSafariAacStream, {
+  v2: true,
+  config: {
+    autoDecodingConfig: {},
+  },
+})
+```
+
+<PropertiesTable
+  content={[
+  {
+    name: 'audioStream',
+    type: 'NodeJS.ReadableStream',
+    description: 'Audio stream to transcribe',
+    isOptional: false,
+  },
+  {
+    name: 'options',
+    type: 'GoogleListenOptionsV2',
+    description: 'v2 recognition options',
+    isOptional: false,
+    properties: [
+      {
+        type: 'GoogleListenOptionsV2',
+        parameters: [
+          {
+            name: 'v2',
+            type: 'true',
+            description: 'Enables the v2 API path',
+            isOptional: false,
+          },
+          {
+            name: 'config',
+            type: 'v2.IRecognitionConfig',
+            description:
+              "v2 recognition configuration. Defaults to auto-decoding with `languageCodes: ['en-US']` and `model: 'long'`. Set `autoDecodingConfig: {}` to auto-detect the audio format, or use `explicitDecodingConfig` to specify an encoding like `MP4_AAC`, `M4A_AAC`, or `MOV_AAC`.",
+            isOptional: true,
+          },
+          {
+            name: 'recognizer',
+            type: 'string',
+            description:
+              "v2 recognizer resource path. Defaults to `projects/{project}/locations/global/recognizers/_` where `{project}` is resolved from the constructor `project` option, `GOOGLE_CLOUD_PROJECT`, or the client's default project.",
+            isOptional: true,
           },
         ],
       },

--- a/voice/google/src/index.test.ts
+++ b/voice/google/src/index.test.ts
@@ -10,6 +10,11 @@ vi.mock('@google-cloud/speech', () => ({
   SpeechClient: vi.fn().mockImplementation(() => ({
     recognize: vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'test' }] }] }]),
   })),
+  v2: {
+    SpeechClient: vi.fn().mockImplementation(() => ({
+      recognize: vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'test v2' }] }] }]),
+    })),
+  },
 }));
 
 vi.mock('@google-cloud/text-to-speech', () => ({
@@ -137,6 +142,188 @@ describe('GoogleVoice Unit Tests', () => {
         speaker: 'en-US-Studio-O',
       });
       expect(voice.speaker).toBe('en-US-Studio-O');
+    });
+  });
+
+  describe('listen v1 (default)', () => {
+    it('should call v1 recognize by default', async () => {
+      const voice = new GoogleVoice();
+      const mockRecognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'hello' }] }] }]);
+      (voice as any).speechClient = { recognize: mockRecognize };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      const result = await voice.listen(audioStream);
+      expect(result).toBe('hello');
+      expect(mockRecognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ encoding: 'LINEAR16', languageCode: 'en-US' }),
+          audio: expect.objectContaining({ content: expect.any(String) }),
+        }),
+      );
+    });
+
+    it('should pass custom v1 config', async () => {
+      const voice = new GoogleVoice();
+      const mockRecognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'bonjour' }] }] }]);
+      (voice as any).speechClient = { recognize: mockRecognize };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, { config: { encoding: 'FLAC', languageCode: 'fr-FR' } });
+      expect(mockRecognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ encoding: 'FLAC', languageCode: 'fr-FR' }),
+        }),
+      );
+    });
+  });
+
+  describe('listen v2', () => {
+    it('should call v2 recognize when v2: true', async () => {
+      const voice = new GoogleVoice();
+      const mockV1Recognize = vi.fn();
+      const mockV2Recognize = vi
+        .fn()
+        .mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'v2 hello' }] }] }]);
+      (voice as any).speechClient = { recognize: mockV1Recognize };
+      (voice as any).speechClientV2 = {
+        recognize: mockV2Recognize,
+        getProjectId: vi.fn().mockResolvedValue('test-project'),
+      };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      const result = await voice.listen(audioStream, { v2: true });
+      expect(result).toBe('v2 hello');
+      expect(mockV2Recognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recognizer: 'projects/test-project/locations/global/recognizers/_',
+          config: expect.objectContaining({ autoDecodingConfig: {}, languageCodes: ['en-US'] }),
+          content: expect.any(Buffer),
+        }),
+      );
+      expect(mockV1Recognize).not.toHaveBeenCalled();
+    });
+
+    it('should use project from constructor for recognizer', async () => {
+      const voice = new GoogleVoice({ vertexAI: true, project: 'my-vertex-project' });
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      (voice as any).speechClientV2 = { recognize: mockV2Recognize };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, { v2: true });
+      expect(mockV2Recognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recognizer: 'projects/my-vertex-project/locations/global/recognizers/_',
+        }),
+      );
+    });
+
+    it('should use autoDecodingConfig by default when no decoding config specified', async () => {
+      const voice = new GoogleVoice();
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      (voice as any).speechClientV2 = {
+        recognize: mockV2Recognize,
+        getProjectId: vi.fn().mockResolvedValue('test-project'),
+      };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, { v2: true, config: { languageCodes: ['fr-FR'] } });
+      expect(mockV2Recognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ autoDecodingConfig: {}, languageCodes: ['fr-FR'] }),
+        }),
+      );
+    });
+
+    it('should default languageCodes to en-US and model to long', async () => {
+      const voice = new GoogleVoice();
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      (voice as any).speechClientV2 = {
+        recognize: mockV2Recognize,
+        getProjectId: vi.fn().mockResolvedValue('test-project'),
+      };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, { v2: true });
+      expect(mockV2Recognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: expect.objectContaining({ languageCodes: ['en-US'], model: 'long' }),
+        }),
+      );
+    });
+
+    it('should pass explicit decoding config without adding auto', async () => {
+      const voice = new GoogleVoice();
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      (voice as any).speechClientV2 = {
+        recognize: mockV2Recognize,
+        getProjectId: vi.fn().mockResolvedValue('test-project'),
+      };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, {
+        v2: true,
+        config: { explicitDecodingConfig: { encoding: 'MP4_AAC', sampleRateHertz: 44100, audioChannelCount: 1 } },
+      });
+      const call = mockV2Recognize.mock.calls[0][0];
+      expect(call.config.explicitDecodingConfig).toEqual({
+        encoding: 'MP4_AAC',
+        sampleRateHertz: 44100,
+        audioChannelCount: 1,
+      });
+      expect(call.config.autoDecodingConfig).toBeUndefined();
+    });
+
+    it('should accept a custom recognizer path', async () => {
+      const voice = new GoogleVoice();
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      (voice as any).speechClientV2 = { recognize: mockV2Recognize };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, {
+        v2: true,
+        recognizer: 'projects/my-project/locations/global/recognizers/my-recognizer',
+      });
+      expect(mockV2Recognize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recognizer: 'projects/my-project/locations/global/recognizers/my-recognizer',
+        }),
+      );
+    });
+
+    it('should not mutate caller config object', async () => {
+      const voice = new GoogleVoice();
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      (voice as any).speechClientV2 = {
+        recognize: mockV2Recognize,
+        getProjectId: vi.fn().mockResolvedValue('test-project'),
+      };
+
+      const callerConfig = { languageCodes: ['ja-JP'] };
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, { v2: true, config: callerConfig });
+      // Caller's original object should not have autoDecodingConfig added
+      expect(callerConfig).toEqual({ languageCodes: ['ja-JP'] });
+    });
+
+    it('should lazily construct v2 client', async () => {
+      const voice = new GoogleVoice();
+      expect((voice as any).speechClientV2).toBeUndefined();
+
+      const mockV2Recognize = vi.fn().mockResolvedValue([{ results: [{ alternatives: [{ transcript: 'ok' }] }] }]);
+      let constructed = false;
+      (voice as any).getV2SpeechClient = () => {
+        constructed = true;
+        const mock = {
+          recognize: mockV2Recognize,
+          getProjectId: vi.fn().mockResolvedValue('test-project'),
+        };
+        (voice as any).speechClientV2 = mock;
+        return mock;
+      };
+
+      const audioStream = Readable.from([Buffer.from('fake audio')]);
+      await voice.listen(audioStream, { v2: true });
+      expect(constructed).toBe(true);
     });
   });
 });

--- a/voice/google/src/index.ts
+++ b/voice/google/src/index.ts
@@ -1,6 +1,6 @@
 import { PassThrough } from 'node:stream';
 
-import { SpeechClient } from '@google-cloud/speech';
+import { SpeechClient, v2 } from '@google-cloud/speech';
 import type { google as SpeechTypes } from '@google-cloud/speech/build/protos/protos';
 import { TextToSpeechClient } from '@google-cloud/text-to-speech';
 import type { google as TextToSpeechTypes } from '@google-cloud/text-to-speech/build/protos/protos';
@@ -120,6 +120,22 @@ const buildAuthOptions = (
   return options;
 };
 
+type V2RecognitionConfig = SpeechTypes.cloud.speech.v2.IRecognitionConfig;
+
+export interface GoogleListenOptionsV1 {
+  stream?: boolean;
+  config?: SpeechTypes.cloud.speech.v1.IRecognitionConfig;
+}
+
+export interface GoogleListenOptionsV2 {
+  stream?: boolean;
+  v2: true;
+  config?: V2RecognitionConfig;
+  recognizer?: string;
+}
+
+export type GoogleListenOptions = GoogleListenOptionsV1 | GoogleListenOptionsV2;
+
 const DEFAULT_VOICE = 'en-US-Casual-K';
 
 /**
@@ -161,6 +177,8 @@ const DEFAULT_VOICE = 'en-US-Casual-K';
 export class GoogleVoice extends MastraVoice {
   private ttsClient: TextToSpeechClient;
   private speechClient: SpeechClient;
+  private speechClientV2?: v2.SpeechClient;
+  private readonly speechOptionsV2: GoogleClientOptions;
   private readonly vertexAI: boolean;
   private readonly project?: string;
   private readonly location: string;
@@ -225,6 +243,14 @@ export class GoogleVoice extends MastraVoice {
 
     this.ttsClient = new TextToSpeechClient(ttsOptions);
     this.speechClient = new SpeechClient(speechOptions);
+    this.speechOptionsV2 = speechOptions;
+  }
+
+  private getV2SpeechClient(): v2.SpeechClient {
+    if (!this.speechClientV2) {
+      this.speechClientV2 = new v2.SpeechClient(this.speechOptionsV2);
+    }
+    return this.speechClientV2;
   }
 
   /**
@@ -330,16 +356,17 @@ export class GoogleVoice extends MastraVoice {
   }
 
   /**
-   * Converts speech to text
+   * Converts speech to text using Cloud Speech-to-Text v1 or v2.
+   *
+   * Pass `{ v2: true }` in options to use the v2 API, which supports additional
+   * audio formats like AAC-in-MP4 (iOS Safari) via `autoDecodingConfig` or
+   * `explicitDecodingConfig`. The v1 path remains the default.
+   *
    * @param {NodeJS.ReadableStream} audioStream - Audio stream to transcribe. Default encoding is LINEAR16.
-   * @param {Object} [options] - Recognition options
-   * @param {SpeechTypes.cloud.speech.v1.IRecognitionConfig} [options.config] - Recognition configuration
+   * @param {GoogleListenOptions} [options] - Recognition options
    * @returns {Promise<string>} Transcribed text
    */
-  async listen(
-    audioStream: NodeJS.ReadableStream,
-    options?: { stream?: boolean; config?: SpeechTypes.cloud.speech.v1.IRecognitionConfig },
-  ): Promise<string> {
+  async listen(audioStream: NodeJS.ReadableStream, options?: GoogleListenOptions): Promise<string> {
     const chunks: Buffer[] = [];
     for await (const chunk of audioStream) {
       if (typeof chunk === 'string') {
@@ -350,7 +377,15 @@ export class GoogleVoice extends MastraVoice {
     }
     const buffer = Buffer.concat(chunks);
 
-    let request = {
+    if (options && 'v2' in options && options.v2) {
+      return this.recognizeV2(buffer, options);
+    }
+
+    return this.recognizeV1(buffer, options as GoogleListenOptionsV1 | undefined);
+  }
+
+  private async recognizeV1(buffer: Buffer, options?: GoogleListenOptionsV1): Promise<string> {
+    const request = {
       config: {
         encoding: 'LINEAR16',
         languageCode: 'en-US',
@@ -361,12 +396,51 @@ export class GoogleVoice extends MastraVoice {
       },
     };
     const [response] = await this.speechClient.recognize(request as SpeechTypes.cloud.speech.v1.IRecognizeRequest);
+    return this.extractTranscription(response?.results);
+  }
 
-    if (!response.results || response.results.length === 0) {
+  private async recognizeV2(buffer: Buffer, options: GoogleListenOptionsV2): Promise<string> {
+    const config: V2RecognitionConfig = { ...options.config };
+    // Default to auto-decoding if neither decoding config is specified
+    if (!config.autoDecodingConfig && !config.explicitDecodingConfig) {
+      config.autoDecodingConfig = {};
+    }
+    if (!config.languageCodes || config.languageCodes.length === 0) {
+      config.languageCodes = ['en-US'];
+    }
+    if (!config.model) {
+      config.model = 'long';
+    }
+
+    let recognizer = options.recognizer;
+    if (!recognizer) {
+      const project = this.project || (await this.getV2SpeechClient().getProjectId());
+      recognizer = `projects/${project}/locations/global/recognizers/_`;
+    }
+
+    const request: SpeechTypes.cloud.speech.v2.IRecognizeRequest = {
+      recognizer,
+      config,
+      content: buffer,
+    };
+
+    const client = this.getV2SpeechClient();
+    const [response] = await client.recognize(request);
+    return this.extractTranscription(response?.results);
+  }
+
+  private extractTranscription(
+    results:
+      | SpeechTypes.cloud.speech.v1.ISpeechRecognitionResult[]
+      | SpeechTypes.cloud.speech.v2.ISpeechRecognitionResult[]
+      | null
+      | undefined,
+  ): string {
+    if (!results || results.length === 0) {
       throw new Error('No transcription results returned');
     }
 
-    const transcription = response.results
+    const transcription = results
       .map((result: any) => {
         if (!result.alternatives || result.alternatives.length === 0) {
           return '';


### PR DESCRIPTION
## Description

Add an opt-in Cloud Speech-to-Text v2 code path to `GoogleVoice.listen()`, enabling transcription of AAC-in-MP4 audio (the only format iOS Safari's MediaRecorder produces). Pass `{ v2: true }` to use the v2 API; the v1 path remains the default with no breaking changes.

- Import `v2.SpeechClient` from `@google-cloud/speech` (already shipped in the pinned `^6.7.1` dep)
- Add exported `GoogleListenOptionsV1`, `GoogleListenOptionsV2`, and `GoogleListenOptions` discriminated union types
- Lazily construct `v2.SpeechClient` on first v2 call to avoid overhead for v1-only users
- Split `listen()` into `recognizeV1()` and `recognizeV2()` private methods with shared `extractTranscription()`
- Default v2 config to `autoDecodingConfig`, `languageCodes: ['en-US']`, and `model: 'long'` (v2 requires all three)
- Resolve `recognizer` path from `this.project` or `client.getProjectId()` instead of invalid `projects/-` wildcard
- Clone caller's config to avoid mutation side effects
- Add 10 unit tests covering v1 default path, v2 routing, project resolution, defaults, explicit decoding, custom recognizer, no-mutation, and lazy construction
- Update reference docs for `listen()` with v2 options, code example, and `PropertiesTable`

## Related Issue(s)

Fixes #19401

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Google voice transcription can now optionally understand more recording types, including iPhone Safari audio. The old transcription method remains the default, so existing users are unaffected.

## What changed

- Added opt-in Google Speech-to-Text v2 support via `{ v2: true }`.
- Added typed v1/v2 listening options and v2 configuration support.
- Added automatic and explicit audio decoding configurations.
- Added recognizer resource resolution from the configured project, with support for custom recognizers.
- Added lazy v2 client initialization.
- Preserved existing v1 behavior by default.
- Added shared transcript extraction and improved empty-result handling.
- Added unit tests covering v1/v2 routing, defaults, configuration cloning, recognizers, and lazy initialization.
- Updated Google Voice reference documentation and added a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->