### PR TITLE
feat(voice-google): expose full Cloud TTS request surface in speak()

### DIFF
--- a/.changeset/rich-rice-argue.md
+++ b/.changeset/rich-rice-argue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/voice-google': minor
+---
+
+Expose full Cloud TTS request surface in `GoogleVoice.speak()`. You can now pass `options.input` (for SSML, markup, custom pronunciations, multi-speaker markup) and `options.voice` (for modelName, multi-speaker voice config) to access the complete `ISynthesizeSpeechRequest` proto. Existing text-only usage is unchanged.

--- a/.changeset/rich-rice-argue.md
+++ b/.changeset/rich-rice-argue.md
@@ -2,4 +2,23 @@
 '@mastra/voice-google': minor
 ---
 
-Expose full Cloud TTS request surface in `GoogleVoice.speak()`. You can now pass `options.input` (for SSML, markup, custom pronunciations, multi-speaker markup) and `options.voice` (for modelName, multi-speaker voice config) to access the complete `ISynthesizeSpeechRequest` proto. Existing text-only usage is unchanged.
+Added support for SSML, custom pronunciations, multi-speaker markup, and Gemini-TTS model selection in `GoogleVoice.speak()`. Existing text-only usage is unchanged.
+
+**New `options.input` fields:** pass `ssml`, `markup`, `customPronunciations`, `multiSpeakerMarkup`, or `prompt` (for Gemini-TTS style steering) directly to the Google Cloud TTS API.
+
+**New `options.voice` fields:** set `modelName` (e.g. `gemini-2.5-flash-preview-tts`) or `multiSpeakerVoiceConfig` alongside the default `name` and `languageCode`.
+
+```ts
+// SSML with custom pronunciations
+await voice.speak('Give Metacam to the patient.', {
+  input: {
+    ssml: '<speak>Give <phoneme alphabet="ipa" ph="mɛtəˈkæm">Metacam</phoneme>.</speak>',
+  },
+});
+
+// Gemini-TTS with prompt-driven styling
+await voice.speak('Hello!', {
+  voice: { name: 'Kore', modelName: 'gemini-2.5-flash-preview-tts' },
+  input: { prompt: 'Warm, calm tone.' },
+});
+```

--- a/docs/src/content/en/reference/voice/google.mdx
+++ b/docs/src/content/en/reference/voice/google.mdx
@@ -17,12 +17,25 @@ import { GoogleVoice } from '@mastra/voice-google'
 // Initialize with default configuration (uses GOOGLE_API_KEY environment variable)
 const voice = new GoogleVoice()
 
-// Text-to-Speech
+// Text-to-Speech (plain text)
 const audioStream = await voice.speak('Hello, world!', {
   languageCode: 'en-US',
   audioConfig: {
     audioEncoding: 'LINEAR16',
   },
+})
+
+// Text-to-Speech with SSML
+const ssmlStream = await voice.speak('ignored', {
+  input: {
+    ssml: '<speak>Take <say-as interpret-as="unit">5 mg</say-as> daily.</speak>',
+  },
+})
+
+// Text-to-Speech with Gemini-TTS model
+const geminiStream = await voice.speak('Hello from Gemini TTS!', {
+  voice: { name: 'Kore', modelName: 'gemini-2.5-flash-preview-tts' },
+  input: { prompt: 'Warm, calm tone.' },
 })
 
 // Speech-to-Text
@@ -162,25 +175,39 @@ Converts text to speech using Google Cloud Text-to-Speech service.
     isOptional: true,
     properties: [
       {
-        type: 'object',
+        type: 'GoogleSpeakOptions',
         parameters: [
           {
             name: 'speaker',
             type: 'string',
-            description: 'Voice ID to use for this request',
+            description: 'Voice ID to use for this request.',
             isOptional: true,
           },
           {
             name: 'languageCode',
             type: 'string',
             description:
-              "Language code for the voice (e.g., 'en-US'). Defaults to the language code from the speaker ID or 'en-US'",
+              "Language code for the voice (e.g., 'en-US'). Defaults to the language code derived from the speaker ID, or 'en-US'.",
+            isOptional: true,
+          },
+          {
+            name: 'input',
+            type: "ISynthesizeSpeechRequest['input']",
+            description:
+              'Rich input object passed through to the Google Cloud TTS API. Supports `ssml`, `markup`, `prompt` (Gemini-TTS style steering), `customPronunciations`, and `multiSpeakerMarkup`. When provided without `text`, `ssml`, or `markup`, the positional `input` argument is used as the `text` field automatically.',
+            isOptional: true,
+          },
+          {
+            name: 'voice',
+            type: "ISynthesizeSpeechRequest['voice']",
+            description:
+              "Voice configuration merged on top of defaults (`name` and `languageCode`). Supports `modelName` (e.g., `'gemini-2.5-flash-preview-tts'`) and `multiSpeakerVoiceConfig`.",
             isOptional: true,
           },
           {
             name: 'audioConfig',
             type: "ISynthesizeSpeechRequest['audioConfig']",
-            description: 'Audio configuration options from Google Cloud Text-to-Speech API',
+            description: 'Audio configuration options from Google Cloud Text-to-Speech API.',
             isOptional: true,
             defaultValue: "{ audioEncoding: 'LINEAR16' }",
           },

--- a/docs/src/content/en/reference/voice/google.mdx
+++ b/docs/src/content/en/reference/voice/google.mdx
@@ -194,7 +194,7 @@ Converts text to speech using Google Cloud Text-to-Speech service.
             name: 'input',
             type: "ISynthesizeSpeechRequest['input']",
             description:
-              'Rich input object passed through to the Google Cloud TTS API. Supports `ssml`, `markup`, `prompt` (Gemini-TTS style steering), `customPronunciations`, and `multiSpeakerMarkup`. When provided without `text`, `ssml`, or `markup`, the positional `input` argument is used as the `text` field automatically.',
+              'Rich input object passed through to the Google Cloud TTS API. Supports `ssml`, `markup`, `prompt` (Gemini-TTS style steering), `customPronunciations`, and `multiSpeakerMarkup`. When provided without `text`, `ssml`, `markup`, or `multiSpeakerMarkup`, the positional `input` argument is used as the `text` field automatically.',
             isOptional: true,
           },
           {

--- a/voice/google/src/index.test.ts
+++ b/voice/google/src/index.test.ts
@@ -145,6 +145,122 @@ describe('GoogleVoice Unit Tests', () => {
     });
   });
 
+  describe('speak', () => {
+    it('should build a text-only request by default', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      await voice.speak('Hello');
+      expect(mockSynthesize).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { text: 'Hello' },
+          voice: expect.objectContaining({ name: 'en-US-Casual-K', languageCode: 'en-US' }),
+          audioConfig: { audioEncoding: 'LINEAR16' },
+        }),
+      );
+    });
+
+    it('should pass SSML via options.input', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      const ssml = '<speak>Hello <break time="200ms"/> world</speak>';
+      await voice.speak('ignored', { input: { ssml } });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.input.ssml).toBe(ssml);
+      expect(call.input.text).toBeUndefined();
+    });
+
+    it('should populate text from positional input when options.input has no text/ssml/markup', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      await voice.speak('Hello world', {
+        input: { customPronunciations: { pronunciations: [] } },
+      });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.input.text).toBe('Hello world');
+      expect(call.input.customPronunciations).toEqual({ pronunciations: [] });
+    });
+
+    it('should merge caller voice fields on top of defaults', async () => {
+      const voice = new GoogleVoice({ speaker: 'en-US-Studio-O' });
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      await voice.speak('Hi', {
+        voice: { modelName: 'gemini-2.5-flash-tts' },
+      });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.voice.modelName).toBe('gemini-2.5-flash-tts');
+      expect(call.voice.name).toBe('en-US-Studio-O');
+      expect(call.voice.languageCode).toBe('en-US');
+    });
+
+    it('should allow caller voice fields to override defaults', async () => {
+      const voice = new GoogleVoice({ speaker: 'en-US-Studio-O' });
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      await voice.speak('Hi', {
+        voice: { name: 'custom-voice', languageCode: 'fr-FR' },
+      });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.voice.name).toBe('custom-voice');
+      expect(call.voice.languageCode).toBe('fr-FR');
+    });
+
+    it('should pass custom audioConfig', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      await voice.speak('Hi', { audioConfig: { audioEncoding: 'MP3' } });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.audioConfig).toEqual({ audioEncoding: 'MP3' });
+    });
+
+    it('should not inject text when input uses multiSpeakerMarkup', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      const multiSpeakerMarkup = { turns: [{ speaker: 'R', text: 'Hi' }] };
+      await voice.speak('ignored', { input: { multiSpeakerMarkup } });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.input.multiSpeakerMarkup).toEqual(multiSpeakerMarkup);
+      expect(call.input.text).toBeUndefined();
+    });
+
+    it('should not mutate caller input object', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      const callerInput = { customPronunciations: { pronunciations: [] } };
+      await voice.speak('Hi', { input: callerInput });
+      expect(callerInput).toEqual({ customPronunciations: { pronunciations: [] } });
+    });
+
+    it('should handle stream input with rich options', async () => {
+      const voice = new GoogleVoice();
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      const textStream = Readable.from(['Hello', ' stream']);
+      await voice.speak(textStream, {
+        input: { customPronunciations: { pronunciations: [] } },
+        voice: { modelName: 'gemini-2.5-flash-tts' },
+      });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.input.text).toBe('Hello stream');
+      expect(call.voice.modelName).toBe('gemini-2.5-flash-tts');
+    });
+  });
+
   describe('listen v1 (default)', () => {
     it('should call v1 recognize by default', async () => {
       const voice = new GoogleVoice();

--- a/voice/google/src/index.test.ts
+++ b/voice/google/src/index.test.ts
@@ -200,6 +200,20 @@ describe('GoogleVoice Unit Tests', () => {
       expect(call.voice.languageCode).toBe('en-US');
     });
 
+    it('should derive languageCode from non-en-US default speaker', async () => {
+      const voice = new GoogleVoice({ speaker: 'cmn-CN-Standard-A' });
+      const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);
+      (voice as any).ttsClient = { synthesizeSpeech: mockSynthesize };
+
+      await voice.speak('Hi', {
+        voice: { modelName: 'gemini-2.5-flash-tts' },
+      });
+      const call = mockSynthesize.mock.calls[0][0];
+      expect(call.voice.name).toBe('cmn-CN-Standard-A');
+      expect(call.voice.languageCode).toBe('cmn-CN');
+      expect(call.voice.modelName).toBe('gemini-2.5-flash-tts');
+    });
+
     it('should allow caller voice fields to override defaults', async () => {
       const voice = new GoogleVoice({ speaker: 'en-US-Studio-O' });
       const mockSynthesize = vi.fn().mockResolvedValue([{ audioContent: Buffer.from('audio') }]);

--- a/voice/google/src/index.ts
+++ b/voice/google/src/index.ts
@@ -327,7 +327,7 @@ export class GoogleVoice extends MastraVoice {
    */
   async speak(input: string | NodeJS.ReadableStream, options?: GoogleSpeakOptions): Promise<NodeJS.ReadableStream> {
     const defaultVoiceName = options?.speaker || this.speaker;
-    const defaultLanguageCode = options?.languageCode || options?.speaker?.split('-').slice(0, 2).join('-') || 'en-US';
+    const defaultLanguageCode = options?.languageCode || defaultVoiceName?.split('-').slice(0, 2).join('-') || 'en-US';
 
     const requestInput: ISynthesizeSpeechRequest['input'] = options?.input
       ? { ...options.input }

--- a/voice/google/src/index.ts
+++ b/voice/google/src/index.ts
@@ -136,6 +136,16 @@ export interface GoogleListenOptionsV2 {
 
 export type GoogleListenOptions = GoogleListenOptionsV1 | GoogleListenOptionsV2;
 
+type ISynthesizeSpeechRequest = TextToSpeechTypes.cloud.texttospeech.v1.ISynthesizeSpeechRequest;
+
+export interface GoogleSpeakOptions {
+  speaker?: string;
+  languageCode?: string;
+  input?: ISynthesizeSpeechRequest['input'];
+  voice?: ISynthesizeSpeechRequest['voice'];
+  audioConfig?: ISynthesizeSpeechRequest['audioConfig'];
+}
+
 const DEFAULT_VOICE = 'en-US-Casual-K';
 
 /**
@@ -304,29 +314,43 @@ export class GoogleVoice extends MastraVoice {
   }
 
   /**
-   * Converts text to speech
+   * Converts text to speech.
+   *
+   * When `input` is a string or stream, builds a text-only request (existing behaviour).
+   * Pass `options.input` to send richer proto fields (ssml, markup, prompt,
+   * customPronunciations, multiSpeakerMarkup) and `options.voice` for fields
+   * like modelName or multiSpeakerVoiceConfig.
+   *
    * @param {string | NodeJS.ReadableStream} input - Text or stream to convert to speech
-   * @param {Object} [options] - Speech synthesis options
-   * @param {string} [options.speaker] - Voice ID to use
-   * @param {string} [options.languageCode] - Language code for the voice
-   * @param {TextToSpeechTypes.cloud.texttospeech.v1.ISynthesizeSpeechRequest['audioConfig']} [options.audioConfig] - Audio configuration options
-   * @returns {Promise<NodeJS.ReadableStream>} Stream of synthesized audio. Default encoding is LINEAR16.
+   * @param {GoogleSpeakOptions} [options] - Speech synthesis options
+   * @returns {Promise<NodeJS.ReadableStream>} Stream of synthesised audio. Default encoding is LINEAR16.
    */
-  async speak(
-    input: string | NodeJS.ReadableStream,
-    options?: {
-      speaker?: string;
-      languageCode?: string;
-      audioConfig?: TextToSpeechTypes.cloud.texttospeech.v1.ISynthesizeSpeechRequest['audioConfig'];
-    },
-  ): Promise<NodeJS.ReadableStream> {
-    const text = typeof input === 'string' ? input : await this.streamToString(input);
+  async speak(input: string | NodeJS.ReadableStream, options?: GoogleSpeakOptions): Promise<NodeJS.ReadableStream> {
+    const defaultVoiceName = options?.speaker || this.speaker;
+    const defaultLanguageCode = options?.languageCode || options?.speaker?.split('-').slice(0, 2).join('-') || 'en-US';
 
-    const request: TextToSpeechTypes.cloud.texttospeech.v1.ISynthesizeSpeechRequest = {
-      input: { text },
+    const requestInput: ISynthesizeSpeechRequest['input'] = options?.input
+      ? { ...options.input }
+      : { text: typeof input === 'string' ? input : await this.streamToString(input) };
+
+    // When the caller provides a rich input object but no explicit text field,
+    // populate it from the positional `input` argument for convenience.
+    if (
+      options?.input &&
+      !options.input.text &&
+      !options.input.ssml &&
+      !options.input.markup &&
+      !options.input.multiSpeakerMarkup
+    ) {
+      requestInput!.text = typeof input === 'string' ? input : await this.streamToString(input);
+    }
+
+    const request: ISynthesizeSpeechRequest = {
+      input: requestInput,
       voice: {
-        name: options?.speaker || this.speaker,
-        languageCode: options?.languageCode || options?.speaker?.split('-').slice(0, 2).join('-') || 'en-US',
+        name: defaultVoiceName,
+        languageCode: defaultLanguageCode,
+        ...options?.voice,
       },
       audioConfig: options?.audioConfig || { audioEncoding: 'LINEAR16' },
     };


### PR DESCRIPTION
## Description

Widens `GoogleVoice.speak()` to accept the full `ISynthesizeSpeechRequest` proto surface — SSML, custom pronunciations, Gemini-TTS model selection, multi-speaker markup, and prompt-driven styling — while keeping existing text-only usage unchanged.

- Add `GoogleSpeakOptions` interface with optional `input` and `voice` fields that pass through to `TextToSpeechClient.synthesizeSpeech()`
- When `options.input` is provided with `ssml`, `markup`, or `multiSpeakerMarkup`, skip auto-populating the `text` field from the positional argument
- When `options.input` has only additive fields (e.g. `customPronunciations`), auto-populate `text` from the positional `input` for convenience
- Merge caller-supplied `voice` fields (e.g. `modelName`, `multiSpeakerVoiceConfig`) on top of defaults (`name`, `languageCode`)
- Add 9 unit tests covering SSML, custom pronunciations, voice merge/override, audioConfig, multiSpeakerMarkup, immutability, and stream input
- Update reference docs with SSML and Gemini-TTS usage examples and new `input`/`voice` option documentation

## Related Issue(s)

Fixes #19209

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Google Voice can now take more “rich instructions” for what to say—like SSML, pronunciation rules, multiple speakers, and Gemini-style prompts—while still working the same way for the simple “just a string” case.

## Changes
- Expanded `GoogleVoice.speak()` by introducing `GoogleSpeakOptions` and widening the `options` shape to pass through Google Cloud TTS `input` and `voice` fields (including `voice.modelName`, `input.prompt`, `input.ssml`/`input.markup`, `input.customPronunciations`, `input.multiSpeakerMarkup`, and `voice.multiSpeakerVoiceConfig`).
- Preserved backward compatibility for text-only calls (string input and readable-stream input).
- When `options.input` is provided:
  - clone/pass-through is used (caller objects aren’t mutated),
  - positional `input` text is only filled in if no text-bearing field (`text`/`ssml`/`markup`/`multiSpeakerMarkup`) was supplied.
- Merged caller-supplied voice settings on top of defaults:
  - default `voice.name` comes from the effective speaker (with `this.speaker` fallback),
  - `languageCode` is derived from the effective speaker (including non-English locales like `cmn-CN`),
  - caller `voice` fields can override defaults.
- Added/updated unit tests covering:
  - request construction for plain text and rich `input` shapes (SSML/markup/multi-speaker/custom pronunciations/prompt),
  - `audioConfig` passthrough,
  - immutability (no mutation of caller-provided `options.input`),
  - stream input handling (chunk concatenation into `input.text`),
  - locale/languageCode derivation behavior.
- Updated the reference documentation with the new `GoogleSpeakOptions` options schema and added usage examples (SSML + Gemini-TTS model selection).
- Added a minor release changeset documenting the new `speak()` request capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->