### PR TITLE
fix(playground): improve sandbox command contrast

### DIFF
--- a/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/sandbox-execution-badge.tsx
@@ -108,7 +108,7 @@ const TerminalBlock = ({ command, content, maxHeight = '20rem', onCopy, isCopied
         <div className="px-3 py-2 bg-surface3 border-b border-border1 flex items-center justify-between gap-2">
           <div className="flex items-center gap-2 min-w-0">
             <span className="text-neutral6 text-xs shrink-0">$</span>
-            <code className="text-xs text-neutral-300 font-mono truncate">{command}</code>
+            <code className="text-xs text-neutral5 font-mono truncate">{command}</code>
           </div>
           {onCopy && (
             <Button variant="default" size="icon-sm" tooltip="Copy output" onClick={onCopy} className="shrink-0">


### PR DESCRIPTION
Use the Playground UI neutral5 semantic token for sandbox command text so the color adapts with the active theme.

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The sandbox command text now uses a theme-aware color so it stays easier to read, especially in light mode.

## Changes

- Replaced `text-neutral-300` with `text-neutral5` for sandbox command text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->