### PR TITLE
fix(core): approving parallel tool calls now works in any order

### DIFF
--- a/.changeset/silly-papayas-jog.md
+++ b/.changeset/silly-papayas-jog.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed parallel tool calls that require approval so every suspended call is visible and resumable in any order. When one agent step parks several tool calls (for example two sub-agent delegations that each need approval), listSuspendedRuns() now lists all of them instead of only the first, and approving or declining a specific tool call resumes that exact call — approving the second card no longer fails just because it was answered before the first.

--- a/packages/core/src/agent/__tests__/parallel-delegation-approval.test.ts
+++ b/packages/core/src/agent/__tests__/parallel-delegation-approval.test.ts
@@ -214,17 +214,14 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
       memory: { resource: 'rep_approval', thread: 'thread-wrong-target' },
     });
 
-    const approvals = await collectApprovals(stream);
-    const [{ toolCalls }] = (await supervisor.listSuspendedRuns()).runs;
-    const suspendedToolCallIds = new Set(toolCalls.map(toolCall => toolCall.toolCallId));
-    const phantomApproval = approvals.find(approval => !suspendedToolCallIds.has(approval.toolCallId));
+    await collectApprovals(stream);
+    const bogusToolCallId = 'sup-tc-nonexistent';
 
-    expect(phantomApproval).toBeDefined();
     let resumeError: unknown;
     try {
       const resumed = await supervisor.approveToolCall({
         runId: stream.runId,
-        toolCallId: phantomApproval!.toolCallId,
+        toolCallId: bogusToolCallId,
       });
       for await (const _chunk of resumed.fullStream) {
         // Drain the stream so unintended tool execution cannot leak into later tests.
@@ -235,12 +232,62 @@ describe('parallel sub-agent delegation (suspend/resume)', () => {
 
     expect(resumeError).toMatchObject({ id: 'AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED' });
     await expect(
-      supervisor.resumeGenerate({ approved: true }, { runId: stream.runId, toolCallId: phantomApproval!.toolCallId }),
+      supervisor.resumeGenerate({ approved: true }, { runId: stream.runId, toolCallId: bogusToolCallId }),
     ).rejects.toMatchObject({ id: 'AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED' });
     await expect(
       supervisor.resumeGenerate({ approved: true }, { runId: stream.runId, toolCallId: '' }),
     ).rejects.toMatchObject({ id: 'AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED' });
     expect(processedOrders).toEqual([]);
+  }, 30_000);
+
+  it('surfaces BOTH suspended delegations in listSuspendedRuns', async () => {
+    processedOrders.length = 0;
+    const supervisor = buildSupervisorAgent();
+
+    const stream = await supervisor.stream('Process both orders in parallel.', {
+      maxSteps: 6,
+      memory: { resource: 'rep_approval', thread: 'thread-surface' },
+    });
+
+    const approvals = await collectApprovals(stream);
+    expect(approvals.length).toBe(2);
+
+    const [{ toolCalls }] = (await supervisor.listSuspendedRuns()).runs;
+    const suspendedToolCallIds = toolCalls.map(toolCall => toolCall.toolCallId).sort();
+    expect(suspendedToolCallIds).toEqual(['sup-tc-A', 'sup-tc-B']);
+    for (const toolCall of toolCalls) {
+      expect(toolCall.toolName).toBe('agent-subAgent');
+      expect(toolCall.requiresApproval).toBe(true);
+    }
+  });
+
+  it('approving the delegations OUT OF ORDER (B first) processes both orders correctly', async () => {
+    processedOrders.length = 0;
+    const supervisor = buildSupervisorAgent();
+
+    const stream = await supervisor.stream('Process both orders in parallel.', {
+      maxSteps: 6,
+      memory: { resource: 'rep_approval', thread: 'thread-out-of-order' },
+    });
+
+    const approvals = await collectApprovals(stream);
+    const runId = stream.runId;
+    expect(approvals.length).toBe(2);
+
+    // Approve the SECOND emitted card first — the field failure ("approve the
+    // bottom card") that previously resumed the wrong delegation.
+    const outOfOrder = [...approvals].reverse();
+    const resumeErrors: string[] = [];
+    for (const a of outOfOrder) {
+      const resumed = await supervisor.approveToolCall({ runId, toolCallId: a.toolCallId });
+      for await (const chunk of resumed.fullStream) {
+        if (chunk.type === 'tool-error') resumeErrors.push(JSON.stringify((chunk as any).payload ?? chunk));
+      }
+    }
+
+    expect(resumeErrors).toEqual([]);
+    // Approval order must map to execution order: B was approved first.
+    expect(processedOrders).toEqual([ORDER_B, ORDER_A]);
   });
 
   it('approving both parallel delegations one at a time processes BOTH orders', async () => {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -83,6 +83,7 @@ import { resolveAgentSkills, mergeWorkspaceSkills } from '../skills/agent-skills
 import type { AgentSkillsInput, SkillInput } from '../skills/types';
 import { InMemoryStore } from '../storage';
 import type { GoalObjectiveRecord } from '../storage/domains/thread-state/base';
+import type { WorkflowsStorage } from '../storage/domains/workflows/base';
 import { ChunkFrom } from '../stream';
 import type { MastraAgentNetworkStream } from '../stream';
 import type { FullOutput, MastraModelOutput } from '../stream/base/output';
@@ -6310,12 +6311,8 @@ export class Agent<
 
   #getSuspendedToolCalls(existingSnapshot: WorkflowRunState | null | undefined): AgentRunToolCall[] {
     const toolCalls: AgentRunToolCall[] = [];
-    for (const key in existingSnapshot?.context) {
-      const step = existingSnapshot?.context[key];
-      if (step?.status !== 'suspended') continue;
-      const payload = step.suspendPayload;
-      if (!payload) continue;
 
+    const collectFromPayload = (payload: Record<string, any>, stepKey: string) => {
       if (payload.requireToolApproval) {
         toolCalls.push({
           toolCallId: payload.requireToolApproval.toolCallId,
@@ -6325,12 +6322,97 @@ export class Agent<
         });
       } else if (payload.toolCallSuspended || payload.toolName || payload.toolCallId) {
         toolCalls.push({
-          toolCallId: payload.toolCallId ?? this.#findResumeLabelForStep(existingSnapshot, key),
+          toolCallId: payload.toolCallId ?? this.#findResumeLabelForStep(existingSnapshot, stepKey),
           toolName: payload.toolName,
           requiresApproval: false,
           suspendPayload: payload.toolCallSuspended,
         });
       }
+    };
+
+    for (const key in existingSnapshot?.context) {
+      const step = existingSnapshot?.context[key];
+      if (step?.status !== 'suspended') continue;
+      const payload = step.suspendPayload;
+      if (!payload) continue;
+
+      // A foreach step (e.g. parallel tool calls in the agentic loop) can park several
+      // iterations at once, but its step-level suspendPayload only carries the first
+      // suspended iteration. The full set lives in `__workflow_meta.foreachOutput`,
+      // where each suspended entry keeps its own per-iteration payload — surface every
+      // one of them so all pending tool calls are discoverable and resumable.
+      const suspendedIterations = this.#getSuspendedForeachIterations(payload);
+      if (suspendedIterations.length > 0) {
+        for (const iteration of suspendedIterations) {
+          collectFromPayload(iteration.suspendPayload, key);
+        }
+      } else {
+        collectFromPayload(payload, key);
+      }
+    }
+
+    return toolCalls;
+  }
+
+  #getSuspendedForeachIterations(
+    payload: Record<string, any>,
+  ): { status: 'suspended'; suspendPayload: Record<string, any> }[] {
+    const foreachOutput = payload.__workflow_meta?.foreachOutput;
+    if (!Array.isArray(foreachOutput)) return [];
+    return foreachOutput.filter(
+      (entry: any): entry is { status: 'suspended'; suspendPayload: Record<string, any> } =>
+        entry?.status === 'suspended' && !!entry.suspendPayload,
+    );
+  }
+
+  /**
+   * Like `#getSuspendedToolCalls`, but follows nested-workflow suspensions into their own
+   * persisted snapshots. The agentic loop nests execution (`agentic-loop` →
+   * `executionWorkflow` → foreach over `toolCallStep`), and only the nested run's snapshot
+   * carries the per-iteration `foreachOutput` with EVERY parked tool call — the payload
+   * that bubbles up to the parent only carries the first one. Nested snapshots are stored
+   * under the parent step's id as the workflow name.
+   */
+  async #getSuspendedToolCallsDeep(
+    existingSnapshot: WorkflowRunState | null | undefined,
+    workflowsStore: WorkflowsStorage | undefined,
+    depth = 0,
+  ): Promise<AgentRunToolCall[]> {
+    if (!workflowsStore || depth >= 5) {
+      return this.#getSuspendedToolCalls(existingSnapshot);
+    }
+
+    const toolCalls: AgentRunToolCall[] = [];
+    for (const key in existingSnapshot?.context) {
+      const step = existingSnapshot?.context[key];
+      if (step?.status !== 'suspended') continue;
+      const payload = step.suspendPayload;
+      if (!payload) continue;
+
+      const nestedRunId = payload.__workflow_meta?.runId;
+      if (nestedRunId && this.#getSuspendedForeachIterations(payload).length === 0) {
+        let nestedSnapshot: WorkflowRunState | null = null;
+        try {
+          nestedSnapshot = await workflowsStore.loadWorkflowSnapshot({ workflowName: key, runId: nestedRunId });
+        } catch {
+          // Fall through to the shallow payload below.
+        }
+        if (nestedSnapshot) {
+          const nestedToolCalls = await this.#getSuspendedToolCallsDeep(nestedSnapshot, workflowsStore, depth + 1);
+          if (nestedToolCalls.length > 0) {
+            toolCalls.push(...nestedToolCalls);
+            continue;
+          }
+        }
+      }
+
+      // Reuse the shallow logic for this single step by scoping it to a one-step snapshot.
+      toolCalls.push(
+        ...this.#getSuspendedToolCalls({
+          ...existingSnapshot,
+          context: { [key]: step },
+        } as WorkflowRunState),
+      );
     }
 
     return toolCalls;
@@ -6349,21 +6431,24 @@ export class Agent<
   }) {
     if (toolCallId === undefined) return;
 
-    const isTargetSuspended = (currentSnapshot: WorkflowRunState) =>
-      this.#getSuspendedToolCalls(currentSnapshot).some(toolCall => toolCall.toolCallId === toolCallId);
+    const effectiveMastra = this.#mastra ?? (await this.#getOrCreateEphemeralMastra());
+    const workflowsStore = await effectiveMastra?.getStorage()?.getStore('workflows');
 
-    let isSuspended = isTargetSuspended(snapshot);
+    const isTargetSuspended = async (currentSnapshot: WorkflowRunState) =>
+      (await this.#getSuspendedToolCallsDeep(currentSnapshot, workflowsStore)).some(
+        toolCall => toolCall.toolCallId === toolCallId,
+      );
+
+    let isSuspended = await isTargetSuspended(snapshot);
     if (!isSuspended) {
       // A resume stream can expose the next suspension just before its snapshot is
       // persisted. Briefly poll after authorization so an immediate response to
       // that newly surfaced tool call is not rejected based on the prior snapshot.
-      const effectiveMastra = this.#mastra ?? (await this.#getOrCreateEphemeralMastra());
-      const workflowsStore = await effectiveMastra?.getStorage()?.getStore('workflows');
       const deadline = Date.now() + 2000;
       while (!isSuspended && workflowsStore && Date.now() < deadline) {
         await new Promise(resolve => setTimeout(resolve, 25));
         const latestSnapshot = await workflowsStore.loadWorkflowSnapshot({ workflowName: 'agentic-loop', runId });
-        isSuspended = latestSnapshot ? isTargetSuspended(latestSnapshot) : false;
+        isSuspended = latestSnapshot ? await isTargetSuspended(latestSnapshot) : false;
       }
     }
 
@@ -7578,7 +7663,7 @@ export class Agent<
         threadId: runThreadId,
         resourceId: runResourceId,
         suspendedAt: run.updatedAt,
-        toolCalls: this.#getSuspendedToolCalls(snapshot),
+        toolCalls: await this.#getSuspendedToolCallsDeep(snapshot, workflowsStore),
       });
     }
 

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -120,6 +120,17 @@ export class StepExecutor extends MastraBase {
     let suspendDataToUse =
       params.stepResults[step.id]?.status === 'suspended' ? params.stepResults[step.id]?.suspendPayload : undefined;
 
+    // A suspended foreach step's step-level suspendPayload only carries the FIRST suspended
+    // iteration's payload. When resuming a specific iteration, use that iteration's own payload
+    // from `__workflow_meta.foreachOutput` so parallel suspensions don't read a sibling's data
+    // (e.g. another tool call's suspended run id).
+    if (suspendDataToUse && typeof params.foreachIdx === 'number') {
+      const iterationResult = suspendDataToUse.__workflow_meta?.foreachOutput?.[params.foreachIdx];
+      if (iterationResult?.status === 'suspended' && iterationResult.suspendPayload) {
+        suspendDataToUse = iterationResult.suspendPayload;
+      }
+    }
+
     // Filter out internal workflow metadata before exposing to step code
     if (suspendDataToUse && '__workflow_meta' in suspendDataToUse) {
       const { __workflow_meta, ...userSuspendData } = suspendDataToUse;

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -135,6 +135,18 @@ export async function executeStep(
   let suspendDataToUse =
     stepResults[step.id]?.status === 'suspended' ? stepResults[step.id]?.suspendPayload : undefined;
 
+  // A suspended foreach step's step-level suspendPayload only carries the FIRST suspended
+  // iteration's payload. When resuming a specific iteration, use that iteration's own payload
+  // from `__workflow_meta.foreachOutput` so parallel suspensions don't read a sibling's data
+  // (e.g. another tool call's suspended run id).
+  const foreachIndex = executionContext.foreachIndex;
+  if (suspendDataToUse && foreachIndex !== undefined) {
+    const iterationResult = suspendDataToUse.__workflow_meta?.foreachOutput?.[foreachIndex];
+    if (iterationResult?.status === 'suspended' && iterationResult.suspendPayload) {
+      suspendDataToUse = iterationResult.suspendPayload;
+    }
+  }
+
   // Filter out internal workflow metadata before exposing to step code
   if (suspendDataToUse && '__workflow_meta' in suspendDataToUse) {
     const { __workflow_meta, ...userSuspendData } = suspendDataToUse;


### PR DESCRIPTION
## Summary

When a single agent step emits multiple tool calls that suspend for approval (for example two parallel sub-agent delegations that each require sign-off), only the first suspension was usable:

- `listSuspendedRuns()` reported just one pending tool call, so the other approval cards pointed at tool calls the framework considered non-existent — answering them failed with `AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED` even though the card was real.
- Resuming a specific tool call fed it the *first* suspended iteration's saved state instead of its own, so a targeted approval could act on a sibling's suspended run.

The workflow snapshot already stores every parked iteration's suspend payload (`__workflow_meta.foreachOutput`) with its resume label — the data was written but never read. This PR fixes the read side:

- **Discovery**: `listSuspendedRuns()` and targeted-resume validation walk each suspended foreach iteration (following nested execution-workflow snapshots), so every pending tool call is visible.
- **Resume routing**: the default and evented step executors hand a resumed iteration its own per-index suspend payload instead of the first suspended sibling's.

No engine scheduling behavior changes — this only reads state the engines already persist.

## Test plan

- New regression tests: `listSuspendedRuns()` surfaces both parallel delegations; approving cards out of order (second card first) executes both tools correctly and in approval order.
- Updated fail-closed test to target a genuinely unknown tool call id.
- Full `packages/core` unit suite passes (12k+ tests); `pnpm build:core` and typecheck clean.
- Only failures are the pre-existing stale-recording e2e files failing on every PR today.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When several tasks ask for approval at the same time, the system now remembers which approval belongs to which task. This lets people approve them in any order without losing or mixing up work.

## What changed

- Discover all suspended tool calls across parallel and nested workflow executions.
- Show every pending approval in `listSuspendedRuns()`, rather than only the first one.
- Validate approvals against the complete set of suspended tool calls.
- Resume each parallel iteration with its own saved suspension payload.
- Add regression coverage for parallel delegations, out-of-order approvals, and invalid tool-call IDs.
- Add a patch changeset for `@mastra/core`.

Core tests, build, and typecheck pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->