### PR TITLE
Use model capabilities for goal scorer structured output

### DIFF
--- a/.changeset/quiet-goals-inject.md
+++ b/.changeset/quiet-goals-inject.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Use model capability data to select native structured output or JSON prompt injection for goal judges, while preserving fallback retries for unexpected provider failures.
+Add `jsonPromptInjection: 'auto'` to select native structured output when model capability data confirms support and inline JSON prompt injection otherwise. Goal judges use this shared automatic path while preserving fallback retries for unexpected provider failures.

--- a/.changeset/quiet-goals-inject.md
+++ b/.changeset/quiet-goals-inject.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Use model capability data to select native structured output or JSON prompt injection for goal judges, while preserving fallback retries for unexpected provider failures.

--- a/.changeset/quiet-goals-inject.md
+++ b/.changeset/quiet-goals-inject.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Add `jsonPromptInjection: 'auto'` to select native structured output when model capability data confirms support and inline JSON prompt injection otherwise. Goal judges use this shared automatic path while preserving fallback retries for unexpected provider failures.
+Add `jsonPromptInjection: 'auto'` to select native structured output when model capability data confirms support and inline JSON prompt injection otherwise. Scorer judges use this automatic path by default while preserving explicit `jsonPromptInjection` overrides and fallback retries for unexpected provider failures.

--- a/docs/src/content/en/docs/agents/structured-output.mdx
+++ b/docs/src/content/en/docs/agents/structured-output.mdx
@@ -207,9 +207,9 @@ If your tools aren't being called when structured output is enabled, or you rece
 
 When your model doesn't support tools and structured output together, you have three options:
 
-1. **Use `jsonPromptInjection: true`** - Injects the schema into the prompt instead of using the API's `response_format` parameter
-1. **Use a separate structuring model** - Pass a `model` to `structuredOutput` to use a second LLM for structuring
-1. **Use `prepareStep`** - Handle tools and structured output in separate steps
+1. **Use `jsonPromptInjection`**: Set it to `'auto'` to select native structured output when supported and inline prompt injection otherwise, or choose an explicit injection mode
+1. **Use a separate structuring model**: Pass a `model` to `structuredOutput` to use a second LLM for structuring
+1. **Use `prepareStep`**: Handle tools and structured output in separate steps
 
 Each approach is detailed in the sections below.
 
@@ -219,9 +219,7 @@ Structured output support varies across LLMs due to differences in their APIs. T
 
 ### `jsonPromptInjection`
 
-By default, Mastra passes the schema to the model provider using the `response_format` API parameter. Most model providers have built-in support for this, which reliably enforces the schema.
-
-If your model provider doesn't support `response_format`, you'll get an error from the API. When this happens, set `jsonPromptInjection: true`. This adds the schema to the system prompt instead, instructing the model to output JSON. This is less reliable than the API parameter approach.
+By default, Mastra passes the schema to the model provider using the `response_format` API parameter. Set `jsonPromptInjection: 'auto'` to let Mastra choose the mode from its model capability data. Mastra uses native structured output for supported models and inline prompt injection for unsupported models or models without capability data.
 
 ```typescript
 import { z } from 'zod'
@@ -234,12 +232,19 @@ const response = await testAgent.generate('Help me plan my day.', {
         activities: z.array(z.string()),
       }),
     ),
-    jsonPromptInjection: true,
+    jsonPromptInjection: 'auto',
   },
 })
 
 console.log(response.object)
 ```
+
+Use an explicit mode when you need to override the capability-based choice:
+
+- `false` or omitted: Use the provider's native structured output.
+- `'inline'`: Add the schema instructions to the latest user message.
+- `true` or `'system'`: Add the schema instructions to the system message.
+- `'auto'`: Use native structured output when the model supports it. Otherwise, use inline prompt injection.
 
 :::note[Gemini 2.5 with tools]
 

--- a/docs/src/content/en/reference/agents/generate.mdx
+++ b/docs/src/content/en/reference/agents/generate.mdx
@@ -438,10 +438,10 @@ const result = await agent.generate('message for agent')
                 parameters: [
                   {
                     name: 'jsonPromptInjection',
-                    type: 'boolean',
+                    type: "boolean | 'system' | 'inline' | 'auto'",
                     isOptional: true,
                     description:
-                      'Injects system prompt into the main agent instructing it to return structured output, useful for when a model does not natively support structured outputs.',
+                      "Controls how the JSON schema reaches the model. Set to 'auto' to use native structured output when supported and inline prompt injection otherwise.",
                   },
                 ],
               },

--- a/docs/src/content/en/reference/evals/create-scorer.mdx
+++ b/docs/src/content/en/reference/evals/create-scorer.mdx
@@ -86,13 +86,6 @@ const scorer = createScorer({
             description: 'System prompt/instructions for the LLM.',
           },
           {
-            name: 'jsonPromptInjection',
-            type: 'boolean',
-            isOptional: true,
-            description:
-              "When true, inject the JSON schema into the prompt instead of using the provider's native `response_format` API. Set this for models that don't support native structured output (e.g. some Groq Llama models) to avoid a wasted 400 call.",
-          },
-          {
             name: 'inputProcessors',
             type: 'Processor[]',
             isOptional: true,

--- a/docs/src/content/en/reference/evals/create-scorer.mdx
+++ b/docs/src/content/en/reference/evals/create-scorer.mdx
@@ -86,6 +86,13 @@ const scorer = createScorer({
             description: 'System prompt/instructions for the LLM.',
           },
           {
+            name: 'jsonPromptInjection',
+            type: "boolean | 'system' | 'inline' | 'auto'",
+            isOptional: true,
+            description:
+              "Controls how the judge's structured output schema reaches the model. Defaults to 'auto', which uses native structured output when supported and inline prompt injection otherwise. Explicit values override automatic routing.",
+          },
+          {
             name: 'inputProcessors',
             type: 'Processor[]',
             isOptional: true,

--- a/docs/src/content/en/reference/streaming/agents/stream.mdx
+++ b/docs/src/content/en/reference/streaming/agents/stream.mdx
@@ -414,10 +414,10 @@ const stream = await agent.stream('message for agent')
                 parameters: [
                   {
                     name: 'jsonPromptInjection',
-                    type: 'boolean',
+                    type: "boolean | 'system' | 'inline' | 'auto'",
                     isOptional: true,
                     description:
-                      'Injects system prompt into the main agent instructing it to return structured output, useful for when a model does not natively support structured outputs.',
+                      "Controls how the JSON schema reaches the model. Set to 'auto' to use native structured output when supported and inline prompt injection otherwise.",
                   },
                 ],
               },

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -134,9 +134,15 @@ export class SessionRunEngine {
       if (chunk.type === 'abort') {
         aborted = true;
       }
+      if (chunk.type === 'finish') {
+        // A goal chunk may follow the model's finish chunk. Finalize the current
+        // message, but keep consuming the stream so late lifecycle chunks reach
+        // session listeners.
+        result ??= this.finishStreamState(state);
+        continue;
+      }
       if (
         result ||
-        chunk.type === 'finish' ||
         chunk.type === 'error' ||
         chunk.type === 'abort' ||
         chunk.type === 'tool-call-suspended' ||

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -134,15 +134,9 @@ export class SessionRunEngine {
       if (chunk.type === 'abort') {
         aborted = true;
       }
-      if (chunk.type === 'finish') {
-        // A goal chunk may follow the model's finish chunk. Finalize the current
-        // message, but keep consuming the stream so late lifecycle chunks reach
-        // session listeners.
-        result ??= this.finishStreamState(state);
-        continue;
-      }
       if (
         result ||
+        chunk.type === 'finish' ||
         chunk.type === 'error' ||
         chunk.type === 'abort' ||
         chunk.type === 'tool-call-suspended' ||

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3091,7 +3091,17 @@ export class Session<TState = unknown> {
       } catch (error) {
         throw error;
       }
-      void result.accepted.catch(() => {});
+      // Idle signals can wake a new run whose output is not attached to the session. Process it here so
+      // late chunks, including goal evaluations emitted after `finish`, still reach session listeners.
+      void result.accepted
+        .then(accepted => {
+          if (accepted.action === 'wake') {
+            void this.runEngine.processStream(accepted.output, requestContextInput).catch(error => {
+              this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+            });
+          }
+        })
+        .catch(() => {});
       return { accepted: true as const, runId: undefined };
     });
 

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3032,6 +3032,7 @@ export class Session<TState = unknown> {
     const signal = createSignal(
       'content' in input ? { type: 'user', tagName: 'user', contents: input.content } : input,
     );
+    const shouldForwardGoalEvaluations = signal.attributes?.type === 'goal';
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
         const thread = await this.thread.create();
@@ -3091,15 +3092,21 @@ export class Session<TState = unknown> {
       } catch (error) {
         throw error;
       }
-      // Idle signals can wake a new run whose output is not attached to the session. Process it here so
-      // late chunks, including goal evaluations emitted after `finish`, still reach session listeners.
       void result.accepted
         .then(accepted => {
-          if (accepted.action === 'wake') {
-            void this.runEngine.processStream(accepted.output, requestContextInput).catch(error => {
-              this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
-            });
-          }
+          if (accepted.action !== 'wake' || !shouldForwardGoalEvaluations) return;
+          // Goal evaluations are emitted after the model's finish chunk and are not forwarded by
+          // the per-thread subscription. Read only those lifecycle chunks from the owned wake output;
+          // processing the whole output here would duplicate message and suspension events.
+          void (async () => {
+            for await (const chunk of accepted.output.fullStream) {
+              if (chunk.type === 'goal') {
+                this.emit({ type: 'goal_evaluation', payload: chunk.payload });
+              }
+            }
+          })().catch(error => {
+            this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
+          });
         })
         .catch(() => {});
       return { accepted: true as const, runId: undefined };

--- a/packages/core/src/agent/__tests__/goal.test.ts
+++ b/packages/core/src/agent/__tests__/goal.test.ts
@@ -34,6 +34,33 @@ function singleStepModel(text = 'Working on it.') {
   });
 }
 
+function goalJudgeModel(
+  decisions: Array<{ decision: 'done' | 'continue' | 'waiting'; reason: string }>,
+  spyStream?: (props: any) => void,
+) {
+  let call = 0;
+  return new MockLanguageModelV2({
+    doStream: async props => {
+      spyStream?.(props);
+      const decision = decisions[Math.min(call, decisions.length - 1)];
+      call++;
+      const text = JSON.stringify(decision);
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: `judge-${call}`, modelId: 'mock-judge-id', timestamp: new Date(0) },
+          { type: 'text-start', id: 'text-1' },
+          { type: 'text-delta', id: 'text-1', delta: text },
+          { type: 'text-end', id: 'text-1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+        ]),
+      };
+    },
+  });
+}
+
 function makeAgent(goal?: GoalConfig) {
   const agent = new Agent({
     id: 'goal-agent',
@@ -53,11 +80,22 @@ describe('resolveEffectiveGoalSettings', () => {
       judgeModelId: undefined,
       maxRuns: DEFAULT_GOAL_MAX_RUNS,
       prompt: DEFAULT_GOAL_JUDGE_PROMPT,
+      maxSteps: undefined,
     });
 
     expect(
-      resolveEffectiveGoalSettings(undefined, { judgeModelId: 'agent-judge', maxRuns: 10, prompt: 'agent-prompt' }),
-    ).toEqual({ judgeModelId: 'agent-judge', maxRuns: 10, prompt: 'agent-prompt' });
+      resolveEffectiveGoalSettings(undefined, {
+        judgeModelId: 'agent-judge',
+        maxRuns: 10,
+        prompt: 'agent-prompt',
+        maxSteps: 20,
+      }),
+    ).toEqual({
+      judgeModelId: 'agent-judge',
+      maxRuns: 10,
+      prompt: 'agent-prompt',
+      maxSteps: 20,
+    });
   });
 
   it('lets the ThreadState record override agent config', () => {
@@ -75,6 +113,7 @@ describe('resolveEffectiveGoalSettings', () => {
       judgeModelId: 'record-judge',
       maxRuns: 3,
       prompt: 'record-prompt',
+      maxSteps: undefined,
     });
   });
 
@@ -84,6 +123,7 @@ describe('resolveEffectiveGoalSettings', () => {
       judgeModelId: 'agent-judge',
       maxRuns: 7,
       prompt: DEFAULT_GOAL_JUDGE_PROMPT,
+      maxSteps: undefined,
     });
   });
 });
@@ -123,8 +163,16 @@ describe('Agent objective methods', () => {
     expect(await agent.updateObjectiveOptions({ threadId: THREAD, judgeModelId: 'j' })).toBeUndefined();
 
     await agent.setObjective('Goal', { threadId: THREAD, resourceId: RESOURCE });
-    const updated = await agent.updateObjectiveOptions({ threadId: THREAD, judgeModelId: 'new-judge', maxRuns: 12 });
-    expect(updated).toMatchObject({ judgeModelId: 'new-judge', maxRuns: 12, objective: 'Goal' });
+    const updated = await agent.updateObjectiveOptions({
+      threadId: THREAD,
+      judgeModelId: 'new-judge',
+      maxRuns: 12,
+    });
+    expect(updated).toMatchObject({
+      judgeModelId: 'new-judge',
+      maxRuns: 12,
+      objective: 'Goal',
+    });
   });
 
   it('no-ops without storage', async () => {
@@ -203,6 +251,124 @@ describe('in-loop goal scoring', () => {
 
     const record = await agent.getObjective({ threadId: THREAD });
     expect(record?.status).toBe('done');
+    expect(record?.runsUsed).toBe(1);
+  });
+
+  it('direct agent goal loop completes with built-in scorer without manual continuation', async () => {
+    const agent = makeAgent({
+      judge: goalJudgeModel([
+        { decision: 'continue', reason: 'need one more pass' },
+        { decision: 'done', reason: 'goal satisfied' },
+      ]) as any,
+      maxRuns: 5,
+    });
+    await agent.setObjective('Reach the goal', { threadId: THREAD, resourceId: RESOURCE });
+
+    const goalChunks: any[] = [];
+    const stream = await agent.stream('go', {
+      memory: { resource: RESOURCE, thread: { id: THREAD } },
+      maxSteps: 10,
+    });
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'goal') goalChunks.push(chunk);
+    }
+
+    const resultChunks = goalChunks.filter(c => !c.payload.pending);
+    expect(resultChunks.map(c => c.payload.status)).toEqual(['active', 'done']);
+    expect(resultChunks[resultChunks.length - 1].payload).toMatchObject({
+      objective: 'Reach the goal',
+      iteration: 2,
+      passed: true,
+      status: 'done',
+      maxRunsReached: false,
+    });
+
+    const record = await agent.getObjective({ threadId: THREAD });
+    expect(record?.status).toBe('done');
+    expect(record?.runsUsed).toBe(2);
+  });
+
+  it('goal judge activity observation does not block structured-output fallback', async () => {
+    const streamCalls: any[] = [];
+    const generateCalls: any[] = [];
+    const judge = new MockLanguageModelV2({
+      doStream: async props => {
+        streamCalls.push(props);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          warnings: [],
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: `judge-stream-${streamCalls.length}`,
+              modelId: 'mock-judge-id',
+              timestamp: new Date(0),
+            },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 } },
+          ]),
+        };
+      },
+      doGenerate: async props => {
+        generateCalls.push(props);
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
+          content: [{ type: 'text', text: '{"decision":"done","reason":"generated fallback"}' }],
+          warnings: [],
+        };
+      },
+    });
+    const agent = makeAgent({ judge: judge as any, maxRuns: 5 });
+    await agent.setObjective('Reach the goal', { threadId: THREAD, resourceId: RESOURCE });
+
+    const goalChunks: any[] = [];
+    const stream = await agent.stream('go', {
+      memory: { resource: RESOURCE, thread: { id: THREAD } },
+      maxSteps: 10,
+    });
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'goal') goalChunks.push(chunk);
+    }
+
+    expect(streamCalls.length).toBeGreaterThan(0);
+    expect(generateCalls.length).toBeGreaterThan(0);
+    expect(goalChunks.filter(c => !c.payload.pending).at(-1)?.payload).toMatchObject({
+      status: 'done',
+      reason: 'generated fallback',
+    });
+  });
+
+  it('direct agent goal loop pauses actionably when built-in scorer returns waiting', async () => {
+    const agent = makeAgent({
+      judge: goalJudgeModel([{ decision: 'waiting', reason: 'waiting for your review' }]) as any,
+      maxRuns: 5,
+    });
+    await agent.setObjective('Reach the goal', { threadId: THREAD, resourceId: RESOURCE });
+
+    const goalChunks: any[] = [];
+    const stream = await agent.stream('go', {
+      memory: { resource: RESOURCE, thread: { id: THREAD } },
+      maxSteps: 10,
+    });
+    for await (const chunk of stream.fullStream) {
+      if (chunk.type === 'goal') goalChunks.push(chunk);
+    }
+
+    const resultChunks = goalChunks.filter(c => !c.payload.pending);
+    expect(resultChunks).toHaveLength(1);
+    expect(resultChunks[0].payload).toMatchObject({
+      objective: 'Reach the goal',
+      iteration: 1,
+      passed: false,
+      status: 'active',
+      waitingForUser: true,
+      reason: 'waiting for your review',
+    });
+
+    const record = await agent.getObjective({ threadId: THREAD });
+    expect(record?.status).toBe('active');
     expect(record?.runsUsed).toBe(1);
   });
 

--- a/packages/core/src/agent/__tests__/goal.test.ts
+++ b/packages/core/src/agent/__tests__/goal.test.ts
@@ -290,10 +290,10 @@ describe('in-loop goal scoring', () => {
 
   it('goal judge activity observation does not block structured-output fallback', async () => {
     const streamCalls: any[] = [];
-    const generateCalls: any[] = [];
     const judge = new MockLanguageModelV2({
       doStream: async props => {
         streamCalls.push(props);
+        const fallbackText = '{"decision":"done","reason":"stream fallback"}';
         return {
           rawCall: { rawPrompt: null, rawSettings: {} },
           warnings: [],
@@ -305,18 +305,15 @@ describe('in-loop goal scoring', () => {
               modelId: 'mock-judge-id',
               timestamp: new Date(0),
             },
-            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 0, totalTokens: 1 } },
+            ...(streamCalls.length > 1
+              ? [
+                  { type: 'text-start' as const, id: 'text-1' },
+                  { type: 'text-delta' as const, id: 'text-1', delta: fallbackText },
+                  { type: 'text-end' as const, id: 'text-1' },
+                ]
+              : []),
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
           ]),
-        };
-      },
-      doGenerate: async props => {
-        generateCalls.push(props);
-        return {
-          rawCall: { rawPrompt: null, rawSettings: {} },
-          finishReason: 'stop',
-          usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 },
-          content: [{ type: 'text', text: '{"decision":"done","reason":"generated fallback"}' }],
-          warnings: [],
         };
       },
     });
@@ -332,11 +329,10 @@ describe('in-loop goal scoring', () => {
       if (chunk.type === 'goal') goalChunks.push(chunk);
     }
 
-    expect(streamCalls.length).toBeGreaterThan(0);
-    expect(generateCalls.length).toBeGreaterThan(0);
+    expect(streamCalls).toHaveLength(2);
     expect(goalChunks.filter(c => !c.payload.pending).at(-1)?.payload).toMatchObject({
       status: 'done',
-      reason: 'generated fallback',
+      reason: 'stream fallback',
     });
   });
 

--- a/packages/core/src/agent/durable/__tests__/durable-agent-goal.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-goal.test.ts
@@ -20,6 +20,7 @@ import { MockMemory } from '../../../memory/mock';
 import { InMemoryStore } from '../../../storage';
 import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
+import { createEventedAgent } from '../create-evented-agent';
 
 function createTextModel(text: string) {
   return new MockLanguageModelV2({
@@ -42,7 +43,7 @@ function createTextModel(text: string) {
   });
 }
 
-async function drain(stream: ReadableStream<any>) {
+async function drain(stream: AsyncIterable<any>) {
   const out: any[] = [];
   for await (const c of stream) out.push(c);
   return out;
@@ -57,6 +58,33 @@ describe('DurableAgent goal step', () => {
 
   afterEach(async () => {
     await pubsub.close();
+  });
+
+  it('durable wrappers expose the wrapped agent goal config', () => {
+    const passingScorer = {
+      id: 'goal-scorer',
+      name: 'Goal Scorer',
+      run: vi.fn().mockResolvedValue({ score: 1, reason: 'Goal achieved' }),
+    };
+
+    const baseAgent = new Agent({
+      id: 'goal-wrapper-agent',
+      name: 'Goal Wrapper Agent',
+      instructions: 'noop',
+      model: createTextModel('done') as LanguageModelV2,
+      memory: new MockMemory(),
+      goal: {
+        judge: 'mock-judge',
+        maxRuns: 5,
+        scorer: passingScorer as any,
+      },
+    });
+
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    const eventedAgent = createEventedAgent({ agent: baseAgent, pubsub });
+
+    expect(durableAgent.__getGoalConfig()?.scorer).toBe(passingScorer);
+    expect(eventedAgent.__getGoalConfig()?.scorer).toBe(passingScorer);
   });
 
   it('goal config is stored on the run registry entry', async () => {
@@ -90,6 +118,118 @@ describe('DurableAgent goal step', () => {
     expect(registryEntry.goal).toBeDefined();
     expect(registryEntry.goal?.scorer).toBe(passingScorer);
     expect(registryEntry.goal?.maxRuns).toBe(5);
+  });
+
+  it('evented idle signal wake emits goal chunk when scorer passes', async () => {
+    const passingScorer = {
+      id: 'goal-scorer',
+      name: 'Goal Scorer',
+      run: vi.fn().mockResolvedValue({ score: 1, reason: 'Goal achieved' }),
+    };
+
+    const THREAD = 'evented-signal-goal-thread';
+    const RESOURCE = 'user-1';
+
+    const baseAgent = new Agent({
+      id: 'evented-signal-goal-agent',
+      name: 'Evented Signal Goal Agent',
+      instructions: 'You are a helpful agent.',
+      model: createTextModel('I have completed the goal.') as LanguageModelV2,
+      memory: new MockMemory(),
+      goal: {
+        judge: 'mock-judge',
+        maxRuns: 5,
+        scorer: passingScorer as any,
+      },
+    });
+    const eventedAgent = createEventedAgent({ agent: baseAgent, pubsub });
+    new Mastra({
+      agents: { 'evented-signal-goal-agent': eventedAgent as any },
+      logger: false,
+      storage: new InMemoryStore(),
+      pubsub,
+    });
+
+    const setResult = await eventedAgent.setObjective('Implement feature X', {
+      threadId: THREAD,
+      resourceId: RESOURCE,
+    });
+    expect(setResult).toBeDefined();
+
+    const signalResult = await eventedAgent.sendSignal(
+      { type: 'user-message', contents: 'Implement feature X' },
+      {
+        threadId: THREAD,
+        resourceId: RESOURCE,
+        ifIdle: { streamOptions: { maxSteps: 3, memory: { thread: THREAD, resource: RESOURCE } } },
+      },
+    );
+
+    const accepted = await signalResult.accepted;
+    expect(accepted).toMatchObject({ action: 'wake' });
+    if (accepted.action !== 'wake') throw new Error('Expected signal wake');
+    const chunks = await drain(accepted.output.fullStream as AsyncIterable<any>);
+
+    const goalChunks = chunks.filter((c: any) => c.type === 'goal' && !c.payload?.pending);
+    expect(goalChunks.length).toBeGreaterThan(0);
+    expect(goalChunks[0].payload).toMatchObject({
+      objective: 'Implement feature X',
+      passed: true,
+      status: 'done',
+    });
+  });
+
+  it('evented wrapper stops the loop and emits goal chunk when scorer passes', async () => {
+    const passingScorer = {
+      id: 'goal-scorer',
+      name: 'Goal Scorer',
+      run: vi.fn().mockResolvedValue({ score: 1, reason: 'Goal achieved' }),
+    };
+
+    const THREAD = 'evented-goal-thread';
+    const RESOURCE = 'user-1';
+
+    const baseAgent = new Agent({
+      id: 'evented-goal-pass-agent',
+      name: 'Evented Goal Pass Agent',
+      instructions: 'You are a helpful agent.',
+      model: createTextModel('I have completed the goal.') as LanguageModelV2,
+      memory: new MockMemory(),
+      goal: {
+        judge: 'mock-judge',
+        maxRuns: 5,
+        scorer: passingScorer as any,
+      },
+    });
+    const eventedAgent = createEventedAgent({ agent: baseAgent, pubsub });
+    new Mastra({
+      agents: { 'evented-goal-pass-agent': eventedAgent as any },
+      logger: false,
+      storage: new InMemoryStore(),
+      pubsub,
+    });
+
+    const setResult = await eventedAgent.setObjective('Implement feature X', {
+      threadId: THREAD,
+      resourceId: RESOURCE,
+    });
+    expect(setResult).toBeDefined();
+
+    const { output, cleanup } = await eventedAgent.stream('Implement feature X', {
+      maxSteps: 3,
+      memory: { thread: THREAD, resource: RESOURCE },
+      untilIdle: true,
+    });
+    const chunks = await drain(output.fullStream);
+    cleanup();
+
+    const goalChunks = chunks.filter((c: any) => c.type === 'goal' && !c.payload?.pending);
+    expect(goalChunks.length).toBeGreaterThan(0);
+    expect(goalChunks[0].payload).toMatchObject({
+      objective: 'Implement feature X',
+      passed: true,
+      status: 'done',
+    });
   });
 
   it('stops the loop and emits goal chunk when scorer passes', async () => {

--- a/packages/core/src/agent/durable/types.ts
+++ b/packages/core/src/agent/durable/types.ts
@@ -137,7 +137,7 @@ export interface SerializableStructuredOutput {
   /** JSON Schema representation of the output schema */
   schema?: JSONSchema7;
   /** Whether to use JSON prompt injection instead of native response format */
-  jsonPromptInjection?: boolean | 'system' | 'inline';
+  jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
   /** Whether to use the parent agent's model for structuring */
   useAgent?: boolean;
   /** Model config for a dedicated structuring model (if different from the main model) */

--- a/packages/core/src/agent/durable/workflows/steps/goal.ts
+++ b/packages/core/src/agent/durable/workflows/steps/goal.ts
@@ -140,10 +140,15 @@ export function createDurableGoalStep() {
       };
 
       const registryEntry = globalRunRegistry.get(state.runId);
-      const goal = registryEntry?.goal;
+      // This is shared agent configuration (judge, scorer, tools, defaults), not per-goal state.
+      // The objective and its progress are isolated by thread and loaded from storage below.
+      let goalConfig = registryEntry?.goal;
+      if (!goalConfig && initData.agentId) {
+        goalConfig = (mastra as any)?.getAgent?.(initData.agentId)?.__getGoalConfig?.();
+      }
 
-      // No goal configured → nothing to do.
-      if (!goal) return state;
+      // No goal mode configured → nothing to do.
+      if (!goalConfig) return state;
 
       // Same gating as isTaskComplete: skip background results, mid-tool-loop
       // continuations, and working-memory-only iterations.
@@ -179,10 +184,10 @@ export function createDurableGoalStep() {
       }
 
       const effective = resolveEffectiveGoalSettings(record, {
-        judgeModelId: typeof goal.judge === 'string' ? goal.judge : undefined,
-        maxRuns: goal.maxRuns,
-        prompt: goal.prompt,
-        maxSteps: goal.maxSteps,
+        judgeModelId: typeof goalConfig.judge === 'string' ? goalConfig.judge : undefined,
+        maxRuns: goalConfig.maxRuns,
+        prompt: goalConfig.prompt,
+        maxSteps: goalConfig.maxSteps,
       });
 
       // Defensive budget guard.
@@ -221,9 +226,10 @@ export function createDurableGoalStep() {
         return nextState;
       }
 
-      // Determine the judge model config. A non-string agent `goal.judge` (a
+      // Determine the judge model config. A non-string agent `goalConfig.judge` (a
       // resolved model or a model-resolver function) takes precedence.
-      const nonStringAgentJudge = goal.judge && typeof goal.judge !== 'string' ? goal.judge : undefined;
+      const nonStringAgentJudge =
+        goalConfig.judge && typeof goalConfig.judge !== 'string' ? goalConfig.judge : undefined;
 
       let judgeModelConfig: unknown = nonStringAgentJudge ?? effective.judgeModelId;
       if (typeof judgeModelConfig === 'function') {
@@ -268,37 +274,43 @@ export function createDurableGoalStep() {
         const observeJudgeStream = (stream: { fullStream?: AsyncIterable<ChunkType> }) => {
           if (!stream.fullStream) return;
           void (async () => {
-            let streamedText = '';
-            let lastReason = '';
-            for await (const chunk of stream.fullStream!) {
-              if (chunk.type === 'text-delta') {
-                streamedText += (chunk as any).payload?.text ?? '';
-                const reason = extractPartialReasonFromStructuredText(streamedText);
-                if (reason && reason !== lastReason) {
-                  lastReason = reason;
-                  emitJudgeActivity({ type: 'reason', message: reason });
+            try {
+              let streamedText = '';
+              let lastReason = '';
+              for await (const chunk of stream.fullStream!) {
+                if (chunk.type === 'text-delta') {
+                  streamedText += (chunk as any).payload?.text ?? '';
+                  const reason = extractPartialReasonFromStructuredText(streamedText);
+                  if (reason && reason !== lastReason) {
+                    lastReason = reason;
+                    emitJudgeActivity({ type: 'reason', message: reason });
+                  }
+                } else if (chunk.type === 'tool-call') {
+                  emitJudgeActivity(
+                    {
+                      type: 'tool-call',
+                      name: (chunk as any).payload?.toolName,
+                      message: (chunk as any).payload?.toolName,
+                    },
+                    (chunk as any).payload?.args,
+                  );
                 }
-              } else if (chunk.type === 'tool-call') {
-                emitJudgeActivity(
-                  {
-                    type: 'tool-call',
-                    name: (chunk as any).payload?.toolName,
-                    message: (chunk as any).payload?.toolName,
-                  },
-                  (chunk as any).payload?.args,
-                );
               }
+            } catch {
+              // The scorer owns structured-output fallback and error reporting.
+              // Judge activity streaming is best-effort UI feedback and must not
+              // turn a recoverable scorer stream failure into an unhandled rejection.
             }
           })();
         };
 
         // Resolve the scorer.
         let scorer: MastraScorer<any, any, any, any> | undefined;
-        if (goal.scorer) {
+        if (goalConfig.scorer) {
           scorer =
-            typeof goal.scorer === 'string'
-              ? (mastra?.getScorer?.(goal.scorer as any) as MastraScorer<any, any, any, any> | undefined)
-              : goal.scorer;
+            typeof goalConfig.scorer === 'string'
+              ? (mastra?.getScorer?.(goalConfig.scorer as any) as MastraScorer<any, any, any, any> | undefined)
+              : goalConfig.scorer;
         }
         if (!scorer) {
           const judgeModel = (
@@ -308,9 +320,11 @@ export function createDurableGoalStep() {
           ) as MastraLanguageModel;
 
           const goalTools: ToolsInput | undefined =
-            typeof goal.tools === 'function'
-              ? ((await (goal.tools as (args: any) => unknown)({ requestContext, mastra })) as ToolsInput | undefined)
-              : goal.tools;
+            typeof goalConfig.tools === 'function'
+              ? ((await (goalConfig.tools as (args: any) => unknown)({ requestContext, mastra })) as
+                  | ToolsInput
+                  | undefined)
+              : goalConfig.tools;
 
           scorer = createGoalScorer({
             mastra,

--- a/packages/core/src/agent/durable/workflows/steps/goal.ts
+++ b/packages/core/src/agent/durable/workflows/steps/goal.ts
@@ -144,7 +144,7 @@ export function createDurableGoalStep() {
       // The objective and its progress are isolated by thread and loaded from storage below.
       let goalConfig = registryEntry?.goal;
       if (!goalConfig && initData.agentId) {
-        goalConfig = (mastra as any)?.getAgent?.(initData.agentId)?.__getGoalConfig?.();
+        goalConfig = (mastra as any)?.getAgentById?.(initData.agentId)?.__getGoalConfig?.();
       }
 
       // No goal mode configured → nothing to do.

--- a/packages/core/src/agent/goal/scorer.test.ts
+++ b/packages/core/src/agent/goal/scorer.test.ts
@@ -169,6 +169,39 @@ describe('createGoalScorer tool support', () => {
   });
 });
 
+describe('createGoalScorer JSON prompt injection', () => {
+  async function runWithInjectedJson(decision: 'done' | 'continue' | 'waiting', reason: string) {
+    const streamCalls: any[] = [];
+    const model = createMockModel({
+      mockText: { decision, reason },
+      version: 'v2',
+      spyStream: props => streamCalls.push(props),
+    });
+    const scorer = createGoalScorer({ judgeModel: model as any });
+
+    const result = await scorer.run({
+      input: { originalTask: 'do the thing', currentText: 'I did the thing' },
+      output: 'I did the thing',
+    } as any);
+
+    expect(JSON.stringify(streamCalls[0]?.prompt)).toContain('Return your response as JSON matching this schema');
+    expect(streamCalls.every(call => call.responseFormat === undefined)).toBe(true);
+    return result;
+  }
+
+  it('parses JSON prompt injection text through the structured output pipeline', async () => {
+    const result = await runWithInjectedJson('done', 'all requirements met');
+    expect(result.score).toBe(1);
+    expect(result.reason).toBe('all requirements met');
+  });
+
+  it('preserves the waiting score when JSON prompt injection text returns waiting', async () => {
+    const result = await runWithInjectedJson('waiting', 'waiting for approval');
+    expect(result.score).toBe(GOAL_SCORE_WAITING);
+    expect(result.reason).toBe('waiting for approval');
+  });
+});
+
 describe('createGoalScorer tri-state decision → score mapping', () => {
   it('maps "done" to score 1 (goal complete)', async () => {
     const result = await runWithDecision('done', 'all requirements met');

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -379,9 +379,10 @@ export type StructuredOutputOptionsBase<OUTPUT = {}> = {
    * Whether to use prompt injection instead of native response format to coerce the LLM to respond with JSON text.
    * true and 'system' inject JSON instructions into the leading system message.
    * 'inline' appends JSON instructions to the latest user message.
+   * 'auto' uses native structured output when supported and inline injection otherwise.
    * false or omitted uses the provider's native response format.
    */
-  jsonPromptInjection?: boolean | 'system' | 'inline';
+  jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
 
   /**
    * Optional logger instance for structured logging

--- a/packages/core/src/agent/utils.ts
+++ b/packages/core/src/agent/utils.ts
@@ -22,7 +22,8 @@ function isStructuredOutputFormatError(error: unknown): boolean {
     JSONParseError.isInstance(error) ||
     NoObjectGeneratedError.isInstance(error) ||
     TypeValidationError.isInstance(error) ||
-    (error instanceof MastraError && error.id === 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED')
+    (error instanceof MastraError &&
+      (error.id === 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED' || error.id === 'STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED'))
   );
 }
 
@@ -68,7 +69,7 @@ export async function tryGenerateWithJsonFallback<OUTPUT>(
     if (!isStructuredOutputFormatError(error)) throw error;
 
     console.warn('Error in tryGenerateWithJsonFallback. Attempting fallback.', error);
-    return await agent.generate(prompt, {
+    const result = await agent.generate(prompt, {
       ...options,
       structuredOutput: {
         ...options.structuredOutput,
@@ -79,6 +80,15 @@ export async function tryGenerateWithJsonFallback<OUTPUT>(
             : true,
       },
     });
+    if (result.object === undefined) {
+      throw new MastraError({
+        id: 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: 'structuredOutput object is undefined',
+      });
+    }
+    return result;
   }
 }
 
@@ -130,6 +140,15 @@ export async function tryStreamWithJsonFallback<OUTPUT extends {}>(
       },
     });
     void onStream?.(result as unknown as Awaited<ReturnType<Agent['stream']>>);
+    const object = await result.object;
+    if (object === undefined) {
+      throw new MastraError({
+        id: 'STRUCTURED_OUTPUT_OBJECT_UNDEFINED',
+        domain: ErrorDomain.AGENT,
+        category: ErrorCategory.USER,
+        text: 'structuredOutput object is undefined',
+      });
+    }
     return result;
   }
 }

--- a/packages/core/src/evals/base.test.ts
+++ b/packages/core/src/evals/base.test.ts
@@ -293,6 +293,33 @@ describe('createScorer', () => {
       }
     });
 
+    it('uses automatic structured output routing by default', async () => {
+      const streamSpy = vi.spyOn(Agent.prototype, 'stream');
+      try {
+        const model = createMockModel({ mockText: { score: 1 }, version: 'v2' });
+
+        const scorer = createScorer({
+          id: 'automatic-json-routing-scorer',
+          name: 'automatic-json-routing-scorer',
+          description: 'Verifies the default structured output routing',
+          judge: {
+            model,
+            instructions: 'Test instructions',
+          },
+        }).generateScore({
+          description: 'score',
+          createPrompt: () => 'score this',
+        });
+
+        await scorer.run(testData.scoringInput);
+
+        const [, options] = (streamSpy.mock.calls[0] ?? []) as any[];
+        expect(options?.structuredOutput?.jsonPromptInjection).toBe('auto');
+      } finally {
+        streamSpy.mockRestore();
+      }
+    });
+
     it('forwards judge memory to the internal judge agent run', async () => {
       const streamSpy = vi
         .spyOn(Agent.prototype, 'stream')
@@ -777,9 +804,9 @@ describe('createScorer', () => {
 
         const result = await scorer.run(testData.scoringInput);
 
-        // Two stream calls: the failed first attempt + the jsonPromptInjection retry.
+        // Two stream calls: automatic routing first, then the existing fallback retry.
         expect(streamSpy).toHaveBeenCalledTimes(2);
-        expect(((streamSpy.mock.calls as any)[0]?.[1] as any)?.structuredOutput?.jsonPromptInjection).toBeFalsy();
+        expect(((streamSpy.mock.calls as any)[0]?.[1] as any)?.structuredOutput?.jsonPromptInjection).toBe('auto');
         expect(((streamSpy.mock.calls as any)[1]?.[1] as any)?.structuredOutput?.jsonPromptInjection).toBe(true);
         // The scorer recovered and produced the retried score.
         expect(result.score).toBe(1);

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -5,7 +5,6 @@ import type { MastraDBMessage, MastraMessagePart, MastraToolInvocationPart } fro
 import type { AgentMemoryOption, ToolsInput } from '../agent/types';
 import { tryStreamWithJsonFallback } from '../agent/utils';
 import { ErrorCategory, ErrorDomain, getErrorFromUnknown, MastraError } from '../error';
-import { modelSupportsStructuredOutput } from '../llm/model/provider-registry';
 import { resolveModelConfig } from '../llm/model/resolve-model';
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import { noopLogger } from '../logger';
@@ -74,10 +73,6 @@ type ScorerTypeShortcuts = {
  * grading text alone. Tools run in the judge agent's own tool-call loop and the
  * judge still returns the step's structured output at the end.
  */
-function selectJsonPromptInjection(capability: boolean | undefined): 'inline' | undefined {
-  return capability === true ? undefined : 'inline';
-}
-
 export interface ScorerJudgeConfig {
   model: MastraModelConfig;
   instructions: string;
@@ -956,7 +951,7 @@ class MastraScorer<
       this.#mastra,
     );
     const judgeModel = resolvedModel.modelId;
-    const jsonPromptInjection = selectJsonPromptInjection(modelSupportsStructuredOutput(judgeModel));
+    const jsonPromptInjection = 'auto' as const;
 
     const judge = new Agent({
       id: 'judge',

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -76,6 +76,11 @@ type ScorerTypeShortcuts = {
 export interface ScorerJudgeConfig {
   model: MastraModelConfig;
   instructions: string;
+  /**
+   * Controls how the judge's structured output schema reaches the model.
+   * Defaults to automatic capability-based routing.
+   */
+  jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
   /** Optional tools the judge agent may call while evaluating (e.g. readonly verification tools). */
   tools?: ToolsInput;
   /** Optional memory instance for the internal judge agent. */
@@ -907,6 +912,8 @@ class MastraScorer<
     const prompt = await originalStep.createPrompt(context);
     const modelConfig = originalStep.judge?.model ?? this.config.judge?.model;
     const instructions = originalStep.judge?.instructions ?? this.config.judge?.instructions;
+    const jsonPromptInjection =
+      originalStep.judge?.jsonPromptInjection ?? this.config.judge?.jsonPromptInjection ?? 'auto';
     // Step-level tools override scorer-level tools. When present, the judge agent
     // can call them (in its own tool-call loop) before producing the step output.
     const tools = originalStep.judge?.tools ?? this.config.judge?.tools;
@@ -951,7 +958,6 @@ class MastraScorer<
       this.#mastra,
     );
     const judgeModel = resolvedModel.modelId;
-    const jsonPromptInjection = 'auto' as const;
 
     const judge = new Agent({
       id: 'judge',

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -5,6 +5,7 @@ import type { MastraDBMessage, MastraMessagePart, MastraToolInvocationPart } fro
 import type { AgentMemoryOption, ToolsInput } from '../agent/types';
 import { tryStreamWithJsonFallback } from '../agent/utils';
 import { ErrorCategory, ErrorDomain, getErrorFromUnknown, MastraError } from '../error';
+import { modelSupportsStructuredOutput } from '../llm/model/provider-registry';
 import { resolveModelConfig } from '../llm/model/resolve-model';
 import type { MastraModelConfig } from '../llm/model/shared.types';
 import { noopLogger } from '../logger';
@@ -73,10 +74,13 @@ type ScorerTypeShortcuts = {
  * grading text alone. Tools run in the judge agent's own tool-call loop and the
  * judge still returns the step's structured output at the end.
  */
+function selectJsonPromptInjection(capability: boolean | undefined): 'inline' | undefined {
+  return capability === true ? undefined : 'inline';
+}
+
 export interface ScorerJudgeConfig {
   model: MastraModelConfig;
   instructions: string;
-  jsonPromptInjection?: boolean;
   /** Optional tools the judge agent may call while evaluating (e.g. readonly verification tools). */
   tools?: ToolsInput;
   /** Optional memory instance for the internal judge agent. */
@@ -908,7 +912,6 @@ class MastraScorer<
     const prompt = await originalStep.createPrompt(context);
     const modelConfig = originalStep.judge?.model ?? this.config.judge?.model;
     const instructions = originalStep.judge?.instructions ?? this.config.judge?.instructions;
-    const jsonPromptInjection = originalStep.judge?.jsonPromptInjection ?? this.config.judge?.jsonPromptInjection;
     // Step-level tools override scorer-level tools. When present, the judge agent
     // can call them (in its own tool-call loop) before producing the step output.
     const tools = originalStep.judge?.tools ?? this.config.judge?.tools;
@@ -953,6 +956,7 @@ class MastraScorer<
       this.#mastra,
     );
     const judgeModel = resolvedModel.modelId;
+    const jsonPromptInjection = selectJsonPromptInjection(modelSupportsStructuredOutput(judgeModel));
 
     const judge = new Agent({
       id: 'judge',

--- a/packages/core/src/loop/test-utils/aimock/scenarios/goal-default-scorer-json-fallback.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/goal-default-scorer-json-fallback.scenario.test.ts
@@ -1,0 +1,64 @@
+import { createOpenAI } from '@ai-sdk/openai-v5';
+import { it, expect } from 'vitest';
+import { MockMemory } from '../../../../memory/mock';
+import { describeForAllEngines, runLoopScenario, useLoopScenarioAimock } from '../aimock-scenario';
+import { SCENARIO_MODEL_ID } from '../types';
+
+const getMock = useLoopScenarioAimock();
+
+describeForAllEngines(
+  'AIMock loop scenario: default goal scorer JSON fallback',
+  engine => {
+    it('completes when the default goal scorer falls back to JSON text', async () => {
+      const llm = getMock();
+      const openai = createOpenAI({
+        apiKey: 'aimock-test-key',
+        baseURL: `${llm.url.replace(/\/+$/, '')}/v1`,
+      });
+      const memory = new MockMemory();
+      const THREAD = 'goal-json-fallback-thread-1';
+      const RESOURCE = 'user-1';
+
+      const { agent, chunks } = await runLoopScenario({
+        engine,
+        llm,
+        prompt: 'Implement feature X',
+        memory,
+        threadId: THREAD,
+        resourceId: RESOURCE,
+        goal: {
+          judge: openai(SCENARIO_MODEL_ID),
+          maxRuns: 5,
+        },
+        objective: 'Implement feature X',
+        collectChunks: true,
+        fixtures: llm => {
+          llm.on({ endpoint: 'chat', sequenceIndex: 0 }, { content: 'I have implemented feature X.' });
+          llm.on({ endpoint: 'chat', sequenceIndex: 1 }, { content: 'not-json' });
+          llm.on(
+            { endpoint: 'chat', sequenceIndex: 2 },
+            { content: JSON.stringify({ decision: 'done', reason: 'Goal achieved' }) },
+          );
+        },
+      });
+
+      const goalChunks = chunks?.filter((chunk: any) => chunk.type === 'goal') ?? [];
+      const pendingChunks = goalChunks.filter((chunk: any) => chunk.payload?.pending);
+      const resultChunks = goalChunks.filter((chunk: any) => !chunk.payload?.pending);
+
+      expect(pendingChunks.length).toBeGreaterThan(0);
+      expect(resultChunks.length).toBeGreaterThan(0);
+      const finalGoalChunk = resultChunks[resultChunks.length - 1] as any;
+      expect(finalGoalChunk.payload).toMatchObject({
+        objective: 'Implement feature X',
+        passed: true,
+        status: 'done',
+      });
+
+      const record = await agent.getObjective({ threadId: THREAD });
+      expect(record?.status).toBe('done');
+      expect(record?.runsUsed).toBe(1);
+    });
+  },
+  { skip: ['durable'] },
+);

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
@@ -47,6 +47,7 @@ async function runGoalStep(
     throwingScorer?: boolean;
     throwMessage?: string;
     throwingToolsResolver?: string;
+    undefinedJudgeResolver?: boolean;
     dbMessages?: any[];
     useMemory?: boolean;
   },
@@ -122,7 +123,9 @@ async function runGoalStep(
 
   const step = createGoalStep({
     goal: {
-      judge: createMockModel({ objectGenerationMode: 'json', mockText: { decision, reason: `r:${decision}` } }) as any,
+      judge: opts?.undefinedJudgeResolver
+        ? () => undefined
+        : (createMockModel({ objectGenerationMode: 'json', mockText: { decision, reason: `r:${decision}` } }) as any),
       ...(opts?.throwingScorer ? { scorer: throwingScorer } : {}),
       // A `goal.tools` resolver that throws exercises a resolution-time judge
       // failure (before scoring) — the default scorer resolves tools eagerly.
@@ -262,6 +265,19 @@ describe('goal step waiting semantics', () => {
     expect(chunk.payload.reason).toBe('r:waiting');
     // It scored the waiting signal (visible on the per-scorer result).
     expect(chunk.payload.results.some((r: any) => r.score === GOAL_SCORE_WAITING)).toBe(true);
+  });
+
+  it('falls back to the objective judge when a dynamic judge resolver returns undefined', async () => {
+    const fallbackJudge = createMockModel({
+      objectGenerationMode: 'json',
+      mockText: { decision: 'done', reason: 'fallback judge resolved' },
+    });
+    const { record, chunk } = await runGoalStep('done', makeRecord({ judgeModelId: fallbackJudge as any }), {
+      undefinedJudgeResolver: true,
+    });
+
+    expect(record.status).toBe('done');
+    expect(chunk.payload.reason).toBe('fallback judge resolved');
   });
 
   it('marks the objective done and stops the loop on a done decision', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -181,7 +181,8 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
       // judge configured) → no-op.
       let judgeModelConfig: unknown = nonStringAgentJudge ?? effective.judgeModelId;
       if (typeof judgeModelConfig === 'function') {
-        judgeModelConfig = await (judgeModelConfig as (args: any) => unknown)({ requestContext, mastra });
+        judgeModelConfig =
+          (await (judgeModelConfig as (args: any) => unknown)({ requestContext, mastra })) ?? effective.judgeModelId;
       }
       if (!judgeModelConfig) {
         return inputData;

--- a/packages/core/src/processor-provider/providers/index.ts
+++ b/packages/core/src/processor-provider/providers/index.ts
@@ -18,7 +18,9 @@ import { UnicodeNormalizer } from '../../processors/processors/unicode-normalize
 import type { ProcessorProvider, ProcessorPhase } from '../types';
 
 // Reusable schema fragments
-const structuredOutputOptionsSchema = z.object({ jsonPromptInjection: z.boolean().optional() }).optional();
+const structuredOutputOptionsSchema = z
+  .object({ jsonPromptInjection: z.union([z.boolean(), z.enum(['system', 'inline', 'auto'])]).optional() })
+  .optional();
 const providerOptionsSchema = z.record(z.string(), z.any()).optional();
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/processors/processors/structured-output.ts
+++ b/packages/core/src/processors/processors/structured-output.ts
@@ -45,7 +45,7 @@ export class StructuredOutputProcessor<OUTPUT extends {}> implements Processor<'
   private errorStrategy: 'strict' | 'warn' | 'fallback';
   private fallbackValue?: OUTPUT;
   private isStructuringAgentStreamStarted = false;
-  private jsonPromptInjection?: boolean | 'system' | 'inline';
+  private jsonPromptInjection?: boolean | 'system' | 'inline' | 'auto';
   private providerOptions?: ProviderOptions;
   private logger?: IMastraLogger;
 

--- a/packages/core/src/stream/aisdk/v5/execute.test.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.test.ts
@@ -2,7 +2,7 @@ import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { coreFeatures } from '../../../features';
-import { execute } from './execute';
+import { execute, resolveJsonPromptInjection } from './execute';
 import { testUsage } from './test-utils';
 
 const inputMessages = [{ role: 'user' as const, content: [{ type: 'text' as const, text: 'Summarize the plan.' }] }];
@@ -21,6 +21,13 @@ async function readStream(stream: ReadableStream) {
 }
 
 describe('execute structured output prompt handling', () => {
+  it('resolves automatic prompt injection from tri-state capability data', () => {
+    expect(resolveJsonPromptInjection('auto', true)).toBeUndefined();
+    expect(resolveJsonPromptInjection('auto', false)).toBe('inline');
+    expect(resolveJsonPromptInjection('auto', undefined)).toBe('inline');
+    expect(resolveJsonPromptInjection('system', undefined)).toBe('system');
+  });
+
   it('advertises inline JSON prompt injection support', () => {
     expect(coreFeatures.has('json-prompt-injection:inline')).toBe(true);
   });

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -5,6 +5,7 @@ import type { IdGenerator, ToolChoice, ToolSet } from '@internal/ai-sdk-v5';
 import { prepareJsonSchemaForOpenAIStrictMode } from '@mastra/schema-compat';
 import type { StructuredOutputOptions } from '../../../agent/types';
 import type { ModelMethodType } from '../../../llm/model/model.loop.types';
+import { modelSupportsStructuredOutput } from '../../../llm/model/provider-registry';
 import type { MastraLanguageModel, SharedProviderOptions } from '../../../llm/model/shared.types';
 import type { LoopOptions } from '../../../loop/types';
 import { getResponseFormat } from '../../base/schema';
@@ -12,6 +13,17 @@ import type { LanguageModelV2StreamResult, OnResult } from '../../types';
 import { prepareToolsAndToolChoice } from './compat';
 import type { ModelSpecVersion } from './compat';
 import { AISDKV5InputStream } from './input';
+
+type JsonPromptInjection = StructuredOutputOptions<unknown>['jsonPromptInjection'];
+type ResolvedJsonPromptInjection = Exclude<JsonPromptInjection, 'auto'>;
+
+export function resolveJsonPromptInjection(
+  value: JsonPromptInjection,
+  capability: boolean | undefined,
+): ResolvedJsonPromptInjection {
+  if (value !== 'auto') return value;
+  return capability === true ? undefined : 'inline';
+}
 
 function buildJsonInstruction(schema: unknown) {
   return `Return your response as JSON matching this schema:\n\n${JSON.stringify(schema)}\n\nReturn only valid JSON. Do not include markdown or explanatory text.`;
@@ -135,7 +147,12 @@ export function execute<OUTPUT = undefined>({
 
   let prompt = inputMessages;
   const jsonPromptInjection = structuredOutput?.jsonPromptInjection;
-  const injectionMode = jsonPromptInjection === true ? 'system' : jsonPromptInjection;
+  const modelRoute = `${model.provider.split('.')[0]}/${model.modelId}`;
+  const resolvedJsonPromptInjection = resolveJsonPromptInjection(
+    jsonPromptInjection,
+    jsonPromptInjection === 'auto' ? modelSupportsStructuredOutput(modelRoute) : undefined,
+  );
+  const injectionMode = resolvedJsonPromptInjection === true ? 'system' : resolvedJsonPromptInjection;
 
   // For direct mode (no model provided for structuring agent), inject JSON schema instruction if opting out of native response format with jsonPromptInjection
   if (structuredOutputMode === 'direct' && responseFormat?.type === 'json' && injectionMode) {

--- a/packages/core/src/stream/base/output-format-handlers.test.ts
+++ b/packages/core/src/stream/base/output-format-handlers.test.ts
@@ -210,6 +210,51 @@ describe('output-format-handlers', () => {
       expect(objectResultChunk?.object).toEqual({ name: 'John', age: 30 });
     });
 
+    it('should extract final JSON object from mixed prompt-injection text', async () => {
+      const schema = z.object({
+        decision: z.enum(['done', 'continue', 'waiting']),
+        reason: z.string(),
+      });
+
+      const transformer = createObjectStreamTransformer({
+        structuredOutput: { schema, jsonPromptInjection: true },
+      });
+
+      const streamParts: ChunkType<typeof schema>[] = [
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: 'I will inspect the files first.\n' },
+        },
+        {
+          type: 'text-delta',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: { id: 'text-1', text: '{"decision":"done","reason":"verified with tools"}' },
+        },
+        {
+          type: 'finish',
+          runId: 'test-run',
+          from: ChunkFrom.AGENT,
+          payload: {
+            stepResult: { reason: 'stop' },
+            output: { usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } },
+            metadata: {},
+            messages: { all: [], user: [], nonUser: [] },
+          },
+        },
+      ];
+
+      // @ts-expect-error - web/stream readable stream type error
+      const stream = convertArrayToReadableStream(streamParts).pipeThrough(transformer);
+      const chunks = await convertAsyncIterableToArray(stream);
+
+      const objectResultChunk = chunks.find(c => c?.type === 'object-result');
+      expect(objectResultChunk).toBeDefined();
+      expect(objectResultChunk?.object).toEqual({ decision: 'done', reason: 'verified with tools' });
+    });
+
     it('should validate on text-end chunk', async () => {
       const schema = z.object({
         name: z.string(),

--- a/packages/core/src/stream/base/output-format-handlers.ts
+++ b/packages/core/src/stream/base/output-format-handlers.ts
@@ -78,6 +78,53 @@ export function escapeUnescapedControlCharsInJsonStrings(text: string): string {
   return result;
 }
 
+function extractBalancedJsonObject(text: string): string | undefined {
+  const trimmed = text.trim();
+  if (trimmed.startsWith('{') || trimmed.startsWith('[')) return undefined;
+
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  let lastBalanced: string | undefined;
+
+  for (let i = 0; i < text.length; i++) {
+    const char = text[i];
+
+    if (escaped) {
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaped = true;
+      continue;
+    }
+
+    if (char === '"') {
+      inString = !inString;
+      continue;
+    }
+
+    if (inString) continue;
+
+    if (char === '{') {
+      if (depth === 0) start = i;
+      depth++;
+      continue;
+    }
+
+    if (char === '}' && depth > 0) {
+      depth--;
+      if (depth === 0 && start !== -1) {
+        lastBalanced = text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return lastBalanced;
+}
+
 interface ProcessPartialChunkParams {
   /** Text accumulated from streaming so far */
   accumulatedText: string;
@@ -289,6 +336,11 @@ abstract class BaseFormatHandler<OUTPUT = undefined> {
         // No complete code block yet - just remove the opening ```json prefix
         processedText = trimmedStart.replace(/^```json\s*\n?/, '');
       }
+    }
+
+    const extractedObject = extractBalancedJsonObject(processedText);
+    if (extractedObject) {
+      processedText = extractedObject;
     }
 
     // LLMs often output actual newlines/tabs inside JSON strings instead of


### PR DESCRIPTION
## Summary

Adds `jsonPromptInjection: 'auto'` and resolves it at the shared structured-output execution boundary using the capability introduced by #19440.

- use native structured output for models known to support it
- use inline JSON prompt injection for models known not to support it or absent from capability data
- keep existing `true`, `false`, `system`, and `inline` behavior backward compatible
- route goal judges through the same automatic path instead of a goal-specific selector
- never select system-message injection from automatic routing
- preserve native-to-injection retries for unexpected provider failures
- recover structured goal output across tool-heavy judge runs and late session goal events

## Test plan

- `pnpm exec vitest run packages/core/src/stream/aisdk/v5/execute.test.ts packages/core/src/agent/goal/scorer.test.ts packages/core/src/agent/durable/__tests__/durable-agent-goal.test.ts --reporter=dot --bail 1`
- `pnpm --filter ./packages/core check`

## Stack

1. #19440: capability tracking
2. **This PR:** automatic structured-output routing and goal scorer consumer
3. #19441: headless MastraCode goal API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The PR helps Mastra choose the best way to get structured answers from different AI models. It uses native support when available and safely adds JSON instructions when it is not, including for goal scoring and durable agents.

## What changed

- Added `jsonPromptInjection: 'auto'` routing:
  - Uses native structured output for capable models.
  - Falls back to inline JSON prompt injection otherwise.
  - Preserves existing `true`, `false`, `system`, and `inline` modes.
- Enabled automatic routing by default for scorer judges and goal evaluations.
- Preserved retries from native structured output to prompt injection after provider or schema failures.
- Improved JSON extraction from streamed text containing surrounding commentary or tool output.
- Improved goal evaluation handling for:
  - Tool-heavy judge runs.
  - Late goal lifecycle events.
  - Durable and evented agents.
  - Missing goal configuration and unresolved judge models.
  - Waiting decisions and structured-output fallback.
- Expanded public and durable-agent types and provider schemas to support `'auto'`.
- Updated structured-output, agent, scorer, and streaming documentation.
- Added execution, scorer, goal, durable-agent, streaming, and fallback regression tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->