### PR TITLE
fix(ai-sdk): support A2A and resumed sub-agent streams in handleChatStream

### DIFF
--- a/.changeset/sharp-gifts-end.md
+++ b/.changeset/sharp-gifts-end.md
@@ -3,3 +3,5 @@
 ---
 
 Fixed a crash in the AI SDK stream transformer when a supervisor agent delegates to a remote A2A agent (A2AAgent) through chatRoute() or handleChatStream. A2A sub-agent streams do not emit a start chunk and use a flat finish payload, which caused the UI stream to end with "Cannot read properties of undefined" errors. The remote agent's answer now streams to the client correctly.
+
+The same guard now also covers resumed sub-agent streams, which skip the start chunk as well and could crash or corrupt the delegation state on tool calls and structured output.

--- a/.changeset/sharp-gifts-end.md
+++ b/.changeset/sharp-gifts-end.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed a crash in the AI SDK stream transformer when a supervisor agent delegates to a remote A2A agent (A2AAgent) through chatRoute() or handleChatStream. A2A sub-agent streams do not emit a start chunk and use a flat finish payload, which caused the UI stream to end with "Cannot read properties of undefined" errors. The remote agent's answer now streams to the client correctly.

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-a2a-stream.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-a2a-stream.test.ts
@@ -94,6 +94,26 @@ describe('transformAgent A2A sub-agent streams', () => {
     });
   });
 
+  it('handles tool-call and object chunks without a start chunk (resumed streams)', () => {
+    // Resumed Agent streams also skip the `start` chunk (core's
+    // loop/workflows/stream.ts only emits it when there is no resumeContext).
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'resumed-run';
+
+    const toolCall = transformAgent(
+      makePayload('tool-call', runId, { toolCallId: 'call-1', toolName: 'weather', args: { city: 'Paris' } }),
+      bufferedSteps,
+    );
+    expect(toolCall?.data.toolCalls).toEqual([{ toolCallId: 'call-1', toolName: 'weather', args: { city: 'Paris' } }]);
+
+    const objectChunk = transformAgent(
+      { type: 'object', runId: 'resumed-run-object', object: { answer: 42 } } as any,
+      bufferedSteps,
+    );
+    expect(objectChunk?.data.object).toEqual({ answer: 42 });
+    expect(objectChunk?.data.toolCalls).toEqual([]);
+  });
+
   it('still prefers the regular Agent finish payload shape', () => {
     const bufferedSteps = new Map<string, any>();
     const runId = 'agent-run';

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-a2a-stream.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-a2a-stream.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+
+import { transformAgent } from '../transformers';
+
+/**
+ * Regression test for A2AAgent sub-agent delegation through handleChatStream.
+ *
+ * A2AAgent remote streams differ from regular Agent streams in two ways:
+ *
+ * 1. They never emit a `start` chunk — the first chunks are
+ *    `text-start` / `text-delta` — so the buffered run state for the runId
+ *    does not exist when the first content chunk arrives.
+ * 2. Their `finish` chunk carries a flat `{ finishReason, usage }` payload
+ *    instead of the regular Agent shape `{ stepResult: { reason }, output: { usage } }`.
+ *
+ * Both previously crashed transformAgent ("Cannot read properties of
+ * undefined (reading 'text')" and "... (reading 'reason')"), killing the UI
+ * stream with an error chunk.
+ */
+describe('transformAgent A2A sub-agent streams', () => {
+  function makePayload(type: string, runId: string, payload: any) {
+    return { type, runId, payload } as any;
+  }
+
+  const EMPTY_USAGE = { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined };
+
+  it('handles a full A2A-shaped stream without a start chunk', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'a2a-run';
+
+    // No `start` chunk — A2A streams begin with text-start/text-delta.
+    const firstDelta = transformAgent(
+      makePayload('text-delta', runId, { id: 'text-1', text: 'Shipment ord_1003 ' }),
+      bufferedSteps,
+    );
+
+    expect(firstDelta).toMatchObject({
+      type: 'data-tool-agent',
+      id: runId,
+      data: { text: 'Shipment ord_1003 ', status: 'running' },
+    });
+
+    transformAgent(makePayload('text-delta', runId, { id: 'text-1', text: 'is in transit.' }), bufferedSteps);
+
+    // Flat A2A finish payload: no stepResult / output wrappers.
+    const finish = transformAgent(
+      makePayload('finish', runId, { finishReason: 'stop', usage: EMPTY_USAGE }),
+      bufferedSteps,
+    );
+
+    expect(finish).toMatchObject({
+      type: 'data-tool-agent',
+      id: runId,
+      data: {
+        text: 'Shipment ord_1003 is in transit.',
+        finishReason: 'stop',
+        usage: EMPTY_USAGE,
+        status: 'finished',
+      },
+    });
+  });
+
+  it('handles reasoning-delta, source, and file chunks without a start chunk', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'a2a-run';
+
+    const reasoning = transformAgent(makePayload('reasoning-delta', runId, { text: 'thinking' }), bufferedSteps);
+    expect(reasoning?.data.reasoning).toEqual(['thinking']);
+
+    const source = transformAgent(
+      makePayload('source', 'a2a-run-source', { id: 'src-1', url: 'https://example.com' }),
+      bufferedSteps,
+    );
+    expect(source?.data.sources).toEqual([{ id: 'src-1', url: 'https://example.com' }]);
+
+    const file = transformAgent(
+      makePayload('file', 'a2a-run-file', { name: 'report.txt', content: 'hello' }),
+      bufferedSteps,
+    );
+    expect(file?.data.files).toEqual([{ name: 'report.txt', content: 'hello' }]);
+  });
+
+  it('handles a finish chunk arriving without any prior chunks', () => {
+    const bufferedSteps = new Map<string, any>();
+
+    const finish = transformAgent(
+      makePayload('finish', 'a2a-finish-only', { finishReason: 'stop', usage: EMPTY_USAGE }),
+      bufferedSteps,
+    );
+
+    expect(finish).toMatchObject({
+      type: 'data-tool-agent',
+      data: { finishReason: 'stop', status: 'finished' },
+    });
+  });
+
+  it('still prefers the regular Agent finish payload shape', () => {
+    const bufferedSteps = new Map<string, any>();
+    const runId = 'agent-run';
+
+    transformAgent(makePayload('start', runId, { id: 'agent-1' }), bufferedSteps);
+    transformAgent(makePayload('text-delta', runId, { id: 'text-1', text: 'Done.' }), bufferedSteps);
+
+    const usage = { inputTokens: 10, outputTokens: 5, totalTokens: 15 };
+    const finish = transformAgent(
+      makePayload('finish', runId, {
+        stepResult: { reason: 'tool-calls', warnings: ['w'] },
+        output: { usage },
+        response: { modelId: 'test-model' },
+      }),
+      bufferedSteps,
+    );
+
+    expect(finish).toMatchObject({
+      type: 'data-tool-agent',
+      data: {
+        text: 'Done.',
+        finishReason: 'tool-calls',
+        usage,
+        warnings: ['w'],
+        status: 'finished',
+        response: { modelId: 'test-model' },
+      },
+    });
+  });
+});

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -675,23 +675,37 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       hasChanged = true;
       break;
     }
-    case 'finish':
+    case 'finish': {
+      // Not all sub-agent streams emit a `start` chunk before their first
+      // content chunk (e.g. A2AAgent remote streams), so the run state may
+      // not exist yet.
+      const finishRun = ensureAgentRunState(bufferedSteps, payload.runId!);
+      // Regular Agent streams emit `{ stepResult, output }`; A2AAgent remote
+      // streams emit a flat `{ finishReason, usage }` payload.
+      const finishPayload = payload.payload as {
+        stepResult?: { reason?: string; warnings?: unknown };
+        output?: { usage?: unknown };
+        finishReason?: string;
+        usage?: unknown;
+        response?: Record<string, unknown>;
+      };
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
-        finishReason: payload.payload.stepResult.reason,
-        usage: payload.payload?.output?.usage,
-        warnings: payload.payload?.stepResult?.warnings,
-        steps: bufferedSteps.get(payload.runId!)!.steps,
+        ...finishRun,
+        finishReason: finishPayload.stepResult?.reason ?? finishPayload.finishReason ?? null,
+        usage: finishPayload.output?.usage ?? finishPayload.usage,
+        warnings: finishPayload.stepResult?.warnings,
+        steps: finishRun.steps,
         status: 'finished',
         response: {
-          ...bufferedSteps.get(payload.runId!).response,
-          ...(payload.payload.response || {}),
+          ...finishRun.response,
+          ...(finishPayload.response || {}),
         },
       });
       hasChanged = true;
       break;
+    }
     case 'text-delta': {
-      const prevData = bufferedSteps.get(payload.runId!)!;
+      const prevData = ensureAgentRunState(bufferedSteps, payload.runId!);
       bufferedSteps.set(payload.runId!, {
         ...prevData,
         text: `${prevData.text}${payload.payload.text}`,
@@ -699,27 +713,33 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       hasChanged = true;
       break;
     }
-    case 'reasoning-delta':
+    case 'reasoning-delta': {
+      const reasoningRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
-        reasoning: [...bufferedSteps.get(payload.runId)!.reasoning, payload.payload.text],
+        ...reasoningRun,
+        reasoning: [...reasoningRun.reasoning, payload.payload.text],
       });
       hasChanged = true;
       break;
-    case 'source':
+    }
+    case 'source': {
+      const sourceRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
-        sources: [...bufferedSteps.get(payload.runId)!.sources, payload.payload],
+        ...sourceRun,
+        sources: [...sourceRun.sources, payload.payload],
       });
       hasChanged = true;
       break;
-    case 'file':
+    }
+    case 'file': {
+      const fileRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
-        files: [...bufferedSteps.get(payload.runId)!.files, payload.payload],
+        ...fileRun,
+        files: [...fileRun.files, payload.payload],
       });
       hasChanged = true;
       break;
+    }
     case 'tool-call':
       bufferedSteps.set(payload.runId!, {
         ...bufferedSteps.get(payload.runId!),

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -677,8 +677,10 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
     }
     case 'finish': {
       // Not all sub-agent streams emit a `start` chunk before their first
-      // content chunk (e.g. A2AAgent remote streams), so the run state may
-      // not exist yet.
+      // content chunk, so the run state may not exist yet. A2AAgent remote
+      // streams never emit one (see A2AAgentFullStreamChunkBase in
+      // @mastra/core), and resumed Agent streams skip it (`if (!resumeContext)`
+      // in core's loop/workflows/stream.ts).
       const finishRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       // Regular Agent streams emit `{ stepResult, output }`; A2AAgent remote
       // streams emit a flat `{ finishReason, usage }` payload.
@@ -740,17 +742,16 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
       hasChanged = true;
       break;
     }
-    case 'tool-call':
+    case 'tool-call': {
+      const toolCallRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
-        pendingToolCalls: removePendingToolCall(
-          bufferedSteps.get(payload.runId)!.pendingToolCalls,
-          payload.payload.toolCallId,
-        ),
-        toolCalls: [...bufferedSteps.get(payload.runId)!.toolCalls, payload.payload],
+        ...toolCallRun,
+        pendingToolCalls: removePendingToolCall(toolCallRun.pendingToolCalls, payload.payload.toolCallId),
+        toolCalls: [...toolCallRun.toolCalls, payload.payload],
       });
       hasChanged = true;
       break;
+    }
     case 'tool-result': {
       const toolResultRun = ensureAgentRunState(bufferedSteps, payload.runId!);
       bufferedSteps.set(payload.runId!, {
@@ -763,14 +764,14 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
     }
     case 'object-result':
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
+        ...ensureAgentRunState(bufferedSteps, payload.runId!),
         object: payload.object,
       });
       hasChanged = true;
       break;
     case 'object':
       bufferedSteps.set(payload.runId!, {
-        ...bufferedSteps.get(payload.runId!),
+        ...ensureAgentRunState(bufferedSteps, payload.runId!),
         object: payload.object,
       });
       hasChanged = true;


### PR DESCRIPTION
Delegating to a remote A2A agent (an `A2AAgent` in a supervisor's `agents` map, per the A2A docs) works at the agent level, but serving that supervisor through `chatRoute()` / `handleChatStream` kills the UI stream with `{"type":"error","errorText":"Cannot read properties of undefined (reading 'text')"}` and the remote answer never reaches the client.

The cause is that `transformAgent` assumes every sub-agent stream begins with a `start` chunk (which initializes the buffered run state) and finishes with the regular Agent payload shape. Neither holds for `A2AAgent`: its chunk union (`A2AAgentFullStreamChunkBase` in core) has no `start` variant at all, and its `finish` payload is flat (`{ finishReason, usage }`) instead of `{ stepResult: { reason }, output: { usage } }`. Resumed Agent streams also skip the `start` chunk (core only emits it when there is no `resumeContext`), so they hit the same unguarded code paths with a fresh buffered map.

The fix lazily seeds the run state via the existing `ensureAgentRunState()` helper (already used by the tool-call input-streaming cases) in the `finish`, `text-delta`, `reasoning-delta`, `source`, `file`, `tool-call`, `object`, and `object-result` cases, and accepts both finish payload shapes, preferring the regular Agent shape when present.

Before: streaming a supervisor with an A2A sub-agent through `chatRoute()` ends in an error chunk and no answer. After: the remote answer streams to the client and the `data-tool-agent` delegation part renders correctly. Regular Agent streams take the same code paths as before.

Includes regression tests simulating start-less streams (A2A-shaped text/finish, flat finish payload, tool-call and object chunks with no prior state) — 3 of them fail with the reported errors against the previous transformer. Verified with `vitest run src/__tests__` in `client-sdks/ai-sdk` (110/110 passing; the 3 suites failing to load are the pre-existing `ai/test` resolution issue on main), plus `tsc --noEmit` and `eslint`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some agent responses arrive without the usual “starting” message, which could make the chat crash. This PR teaches the stream handler to safely start tracking those responses and understand both response formats.

## What changed

- Added lazy run-state initialization for A2A and resumed sub-agent streams.
- Added support for flat and regular finish payloads.
- Hardened text, reasoning, source, file, tool-call, object, and object-result handling.
- Added regression tests for start-less A2A and resumed streams.
- Added a patch changeset for `@mastra/ai-sdk`.

## Validation

- 110 `client-sdks/ai-sdk` tests passing
- TypeScript compilation passing
- ESLint passing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->