### PR TITLE
fix(core): retract unresumable ask_user prompts when the suspended run fails

### DIFF
--- a/.changeset/hip-moles-brake.md
+++ b/.changeset/hip-moles-brake.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed answering an ask_user question failing with a misleading "could not find a suspended run" error when the suspended run died before its state was saved (for example when persisting the suspended snapshot failed). The unresumable question is now retracted, a late answer is ignored, and the original error is surfaced instead.

--- a/.changeset/twenty-eggs-guess.md
+++ b/.changeset/twenty-eggs-guess.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed a stuck ask_user question box after the underlying run failed: the prompt is now dismissed automatically instead of accepting an answer that could never be delivered.

--- a/mastracode/tui/src/tui/__tests__/ask-question-cancellation.test.ts
+++ b/mastracode/tui/src/tui/__tests__/ask-question-cancellation.test.ts
@@ -1,0 +1,159 @@
+/**
+ * When a run dies after `tool_suspended` was emitted (e.g. persisting the
+ * suspended snapshot failed with `RangeError: Invalid string length`), the
+ * session cancels the parked suspension via `tool_suspension_cancelled` because
+ * the answer could never be resumed. The TUI must retract the rendered prompt
+ * out-of-band — the serialized event queue is parked on the question's own
+ * promise, so the cancellation cannot arrive through the normal dispatch path.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { handleAskQuestion } from '../handlers/prompts.js';
+import type { EventHandlerContext } from '../handlers/types.js';
+import type { TUIState } from '../state.js';
+
+function createMockState(): { state: TUIState; emitSessionEvent: (event: any) => void } {
+  const chatContainer = {
+    children: [] as any[],
+    addChild: vi.fn(function (this: any, child: any) {
+      this.children.push(child);
+    }),
+    invalidate: vi.fn(),
+  };
+  chatContainer.addChild = chatContainer.addChild.bind(chatContainer);
+
+  const listeners = new Set<(event: any) => void>();
+  const session = {
+    respondToToolSuspension: vi.fn(),
+    subscribe: vi.fn((listener: (event: any) => void) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    }),
+  };
+
+  const state = {
+    options: { inlineQuestions: true, controller: {} as any },
+    controller: { session },
+    session,
+    chatContainer,
+    ui: { requestRender: vi.fn() },
+    activeInlineQuestion: undefined,
+    activeInlinePlanApproval: undefined,
+    pendingInlineQuestions: [],
+    lastAskUserComponent: undefined,
+    pendingAskUserComponents: new Map(),
+    pendingApprovalDismiss: null,
+  } as unknown as TUIState;
+
+  return {
+    state,
+    emitSessionEvent: event => {
+      for (const listener of [...listeners]) listener(event);
+    },
+  };
+}
+
+function createMockContext(state: TUIState): EventHandlerContext {
+  return {
+    state,
+    showInfo: vi.fn(),
+    showError: vi.fn(),
+    showFormattedError: vi.fn(),
+    updateStatusLine: vi.fn(),
+    notify: vi.fn(),
+    handleSlashCommand: vi.fn(),
+    addUserMessage: vi.fn(),
+    addChildBeforeFollowUps: vi.fn(),
+    fireMessage: vi.fn(),
+    queueFollowUpMessage: vi.fn(),
+    renderExistingMessages: vi.fn(),
+    renderClearedTasksInline: vi.fn(),
+    renderCompletedTasksInline: vi.fn(),
+    renderTaskDeltaInline: vi.fn(),
+    refreshModelAuthStatus: vi.fn(),
+    startGoal: vi.fn(),
+  } as unknown as EventHandlerContext;
+}
+
+describe('ask_user prompt retraction on tool_suspension_cancelled', () => {
+  let state: TUIState;
+  let ctx: EventHandlerContext;
+  let emitSessionEvent: (event: any) => void;
+
+  beforeEach(() => {
+    const mock = createMockState();
+    state = mock.state;
+    emitSessionEvent = mock.emitSessionEvent;
+    ctx = createMockContext(state);
+  });
+
+  it('retracts the active question and resolves without answering', async () => {
+    const promise = handleAskQuestion(ctx, 'q1', 'Your name?');
+
+    const component = state.activeInlineQuestion!;
+    expect(component).toBeDefined();
+
+    emitSessionEvent({
+      type: 'tool_suspension_cancelled',
+      toolCallId: 'q1',
+      toolName: 'ask_user',
+      reason: 'Invalid string length',
+    });
+
+    await promise;
+
+    expect(state.activeInlineQuestion).toBeUndefined();
+    expect((component as any).answered).toBe(true);
+    expect(state.session.respondToToolSuspension).not.toHaveBeenCalled();
+
+    // Late input on the dismissed component must not submit an answer.
+    component.handleInput('y');
+    component.handleInput('\r');
+    expect(state.session.respondToToolSuspension).not.toHaveBeenCalled();
+  });
+
+  it('ignores cancellations for other toolCallIds', async () => {
+    const promise = handleAskQuestion(ctx, 'q1', 'Your name?');
+    const component = state.activeInlineQuestion!;
+
+    emitSessionEvent({
+      type: 'tool_suspension_cancelled',
+      toolCallId: 'other',
+      toolName: 'ask_user',
+      reason: 'Invalid string length',
+    });
+
+    expect(state.activeInlineQuestion).toBe(component);
+
+    component.handleInput('A');
+    component.handleInput('\r');
+    await promise;
+    expect(state.session.respondToToolSuspension).toHaveBeenCalledWith({ toolCallId: 'q1', resumeData: 'A' });
+  });
+
+  it('drops a queued question that is cancelled before activation', async () => {
+    const p1 = handleAskQuestion(ctx, 'q1', 'First?');
+    const p2 = handleAskQuestion(ctx, 'q2', 'Second?');
+
+    const firstComponent = state.activeInlineQuestion!;
+    expect(state.pendingInlineQuestions).toHaveLength(1);
+
+    // Second question is retracted while still queued.
+    emitSessionEvent({
+      type: 'tool_suspension_cancelled',
+      toolCallId: 'q2',
+      toolName: 'ask_user',
+      reason: 'Invalid string length',
+    });
+    await p2;
+
+    // Answering the first question must not activate the cancelled second one.
+    firstComponent.handleInput('A');
+    firstComponent.handleInput('\r');
+    await p1;
+
+    expect(state.activeInlineQuestion).toBeUndefined();
+    expect(state.session.respondToToolSuspension).toHaveBeenCalledTimes(1);
+    expect(state.session.respondToToolSuspension).toHaveBeenCalledWith({ toolCallId: 'q1', resumeData: 'A' });
+  });
+});

--- a/mastracode/tui/src/tui/components/ask-question-inline.ts
+++ b/mastracode/tui/src/tui/components/ask-question-inline.ts
@@ -592,6 +592,19 @@ export class AskQuestionInlineComponent extends Container implements Focusable {
     this.onCancel?.();
   }
 
+  /**
+   * Retract the question without invoking any submit/cancel callback. Used when
+   * the underlying tool suspension was cancelled (the suspended run died, e.g.
+   * its snapshot failed to persist), so an answer could never be delivered.
+   */
+  dismiss(): void {
+    if (this.answered) return;
+    this.answered = true;
+    this.focused = false;
+
+    this.borderedBox.setCancelled();
+  }
+
   handleInput(data: string): void {
     if (this.answered) return;
 

--- a/mastracode/tui/src/tui/handlers/prompts.ts
+++ b/mastracode/tui/src/tui/handlers/prompts.ts
@@ -42,6 +42,28 @@ export async function handleAskQuestion(
   const { state } = ctx;
 
   return new Promise(resolve => {
+    // The suspended run can die after the question is rendered (e.g. persisting
+    // the suspended snapshot failed), in which case the session cancels the
+    // suspension because the answer could never be resumed. That cancellation
+    // must bypass the TUI's serialized event queue — the queue is parked on
+    // this very promise — so listen on the session directly and retract the
+    // prompt out-of-band.
+    let cancelled = false;
+    let retract: () => void = () => {};
+    const unsubscribeCancel =
+      state.session.subscribe?.(event => {
+        if (event.type !== 'tool_suspension_cancelled' || event.toolCallId !== toolCallId) return;
+        if (cancelled) return;
+        cancelled = true;
+        unsubscribeCancel();
+        retract();
+        resolve();
+      }) ?? (() => {});
+    const finish = () => {
+      unsubscribeCancel();
+      resolve();
+    };
+
     if (state.options.inlineQuestions) {
       // Look up the streaming component created for THIS tool call. Using the
       // per-toolCallId map (instead of the single lastAskUserComponent field)
@@ -50,7 +72,23 @@ export async function handleAskQuestion(
       const askUserComponent = state.pendingAskUserComponents?.get(toolCallId) ?? state.lastAskUserComponent;
       state.pendingAskUserComponents?.delete(toolCallId);
 
+      let shownComponent: AskQuestionInlineComponent | undefined = askUserComponent;
+      retract = () => {
+        shownComponent?.dismiss();
+        if (state.activeInlineQuestion === shownComponent) {
+          state.activeInlineQuestion = undefined;
+          processNextInlineQuestion(state);
+        }
+        state.ui.requestRender();
+      };
+
       const activate = () => {
+        // Retracted while waiting in the queue — skip activation and let the
+        // next queued question take the slot.
+        if (cancelled) {
+          processNextInlineQuestion(state);
+          return;
+        }
         try {
           let questionComponent: AskQuestionInlineComponent;
 
@@ -67,19 +105,19 @@ export async function handleAskQuestion(
               onSubmit: answer => {
                 state.activeInlineQuestion = undefined;
                 state.session.respondToToolSuspension({ toolCallId, resumeData: answer });
-                resolve();
+                finish();
                 processNextInlineQuestion(state);
               },
               onSubmitMulti: answers => {
                 state.activeInlineQuestion = undefined;
                 state.session.respondToToolSuspension({ toolCallId, resumeData: answers });
-                resolve();
+                finish();
                 processNextInlineQuestion(state);
               },
               onCancel: () => {
                 state.activeInlineQuestion = undefined;
                 state.session.respondToToolSuspension({ toolCallId, resumeData: '(skipped)' });
-                resolve();
+                finish();
                 processNextInlineQuestion(state);
               },
             });
@@ -96,19 +134,19 @@ export async function handleAskQuestion(
                 onSubmit: answer => {
                   state.activeInlineQuestion = undefined;
                   state.session.respondToToolSuspension({ toolCallId, resumeData: answer });
-                  resolve();
+                  finish();
                   processNextInlineQuestion(state);
                 },
                 onSubmitMulti: answers => {
                   state.activeInlineQuestion = undefined;
                   state.session.respondToToolSuspension({ toolCallId, resumeData: answers });
-                  resolve();
+                  finish();
                   processNextInlineQuestion(state);
                 },
                 onCancel: () => {
                   state.activeInlineQuestion = undefined;
                   state.session.respondToToolSuspension({ toolCallId, resumeData: '(skipped)' });
-                  resolve();
+                  finish();
                   processNextInlineQuestion(state);
                 },
               },
@@ -118,6 +156,7 @@ export async function handleAskQuestion(
           }
 
           // Store as active question
+          shownComponent = questionComponent;
           state.activeInlineQuestion = questionComponent;
 
           state.ui.requestRender();
@@ -131,7 +170,7 @@ export async function handleAskQuestion(
           // Don't let ask_user errors crash the process — skip the question
           state.activeInlineQuestion = undefined;
           state.session.respondToToolSuspension({ toolCallId, resumeData: '(skipped)' });
-          resolve();
+          finish();
           processNextInlineQuestion(state);
         }
       };
@@ -143,6 +182,10 @@ export async function handleAskQuestion(
         activate();
       }
     } else {
+      retract = () => {
+        state.ui.hideOverlay();
+        state.ui.requestRender();
+      };
       // Dialog mode: Show overlay. Multiline opt-in matches the inline branch.
       const dialog = new AskQuestionDialogComponent({
         question,
@@ -153,17 +196,17 @@ export async function handleAskQuestion(
         onSubmit: answer => {
           state.ui.hideOverlay();
           state.session.respondToToolSuspension({ toolCallId, resumeData: answer });
-          resolve();
+          finish();
         },
         onSubmitMulti: answers => {
           state.ui.hideOverlay();
           state.session.respondToToolSuspension({ toolCallId, resumeData: answers });
-          resolve();
+          finish();
         },
         onCancel: () => {
           state.ui.hideOverlay();
           state.session.respondToToolSuspension({ toolCallId, resumeData: '(skipped)' });
-          resolve();
+          finish();
         },
       });
       showModalOverlay(state.ui, dialog, { widthPercent: 0.7 });

--- a/packages/core/src/agent-controller/__tests__/agent-controller-ask-user-snapshot-failure.test.ts
+++ b/packages/core/src/agent-controller/__tests__/agent-controller-ask-user-snapshot-failure.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Repro for the "sendStreamResume() could not find a suspended run" failure
+ * reported when answering an ask_user question.
+ *
+ * Models the real-world failure: persisting the suspended workflow snapshot
+ * throws (`RangeError: Invalid string length` from serializing an oversized
+ * snapshot). The TUI has already rendered the question from the
+ * `tool_suspended` event, so the user answers — but the run never reached a
+ * valid persisted suspended state, so the resume lookup fails.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { Agent } from '../../agent';
+import { Mastra } from '../../mastra';
+import { InMemoryStore } from '../../storage';
+import { MastraLanguageModelV2Mock } from '../../test-utils/llm-mock';
+import { askUserTool } from '../../tools/builtin/ask-user';
+
+import { AgentController } from '../agent-controller';
+import { createMockWorkspace } from '../test-utils';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+function createAskUserToolCallStream(input: string, toolCallId = 'call-1') {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({ type: 'response-metadata', id: 'id-0', modelId: 'mock', timestamp: new Date(0) });
+      controller.enqueue({
+        type: 'tool-call',
+        toolCallId,
+        toolName: 'ask_user',
+        input,
+        providerExecuted: false,
+      });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'tool-calls',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      });
+      controller.close();
+    },
+  });
+}
+
+function createTextStream() {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue({ type: 'stream-start', warnings: [] });
+      controller.enqueue({ type: 'response-metadata', id: 'id-1', modelId: 'mock', timestamp: new Date(0) });
+      controller.enqueue({ type: 'text-start', id: 'text-1' });
+      controller.enqueue({ type: 'text-delta', id: 'text-1', delta: 'Thanks!' });
+      controller.enqueue({ type: 'text-end', id: 'text-1' });
+      controller.enqueue({
+        type: 'finish',
+        finishReason: 'stop',
+        usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      });
+      controller.close();
+    },
+  });
+}
+
+async function buildController(id: string) {
+  const agent = new Agent({
+    id: `agent-${id}`,
+    name: `Agent ${id}`,
+    instructions: 'You ask the user questions.',
+    model: new MastraLanguageModelV2Mock({
+      doStream: (() => {
+        let callCount = 0;
+        return async () => {
+          callCount++;
+          return {
+            stream:
+              callCount === 1
+                ? createAskUserToolCallStream(JSON.stringify({ question: 'Your name?' }))
+                : createTextStream(),
+          };
+        };
+      })(),
+    }),
+    tools: { ask_user: askUserTool },
+  });
+
+  const storage = new InMemoryStore();
+  const mastra = new Mastra({ agents: { [`agent-${id}`]: agent }, logger: false, storage });
+  const registeredAgent = mastra.getAgent(`agent-${id}`);
+
+  const controller = new AgentController({
+    workspace: createMockWorkspace(),
+    id: `controller-${id}`,
+    storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent: registeredAgent }],
+    initialState: { yolo: true } as any,
+  });
+
+  await controller.init();
+  const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+  await session.thread.create();
+  return { controller, session, storage };
+}
+
+describe('AgentController: ask_user with suspended-snapshot persistence failure', () => {
+  it('cancels the parked suspension so answering does not fail with "could not find a suspended run"', async () => {
+    const { session, storage } = await buildController('snapfail');
+
+    // Fail suspended-snapshot persistence the way an oversized snapshot does in
+    // real storage adapters that JSON.stringify the snapshot.
+    const workflowsStore = await storage.getStore('workflows');
+    const realPersist = workflowsStore!.persistWorkflowSnapshot.bind(workflowsStore);
+    vi.spyOn(workflowsStore!, 'persistWorkflowSnapshot').mockImplementation(async args => {
+      if ((args.snapshot as any)?.status === 'suspended') {
+        throw new RangeError('Invalid string length');
+      }
+      return realPersist(args);
+    });
+
+    const events: any[] = [];
+    session.subscribe(event => {
+      events.push(event);
+    });
+
+    await session.sendMessage({ content: 'Ask my name' });
+
+    // The TUI-facing suspension event still fires — the user sees the question.
+    const suspendEvent = events.find(e => e.type === 'tool_suspended');
+    expect(suspendEvent).toBeDefined();
+
+    // The run then dies on the failed snapshot persist. The primary error must
+    // surface and the unresumable suspension must be retracted.
+    await vi.waitFor(() => {
+      expect(events.some(e => e.type === 'error' && e.error?.message === 'Invalid string length')).toBe(true);
+      expect(events.some(e => e.type === 'tool_suspension_cancelled')).toBe(true);
+    });
+
+    const cancelEvent = events.find(e => e.type === 'tool_suspension_cancelled');
+    expect(cancelEvent.toolCallId).toBe(suspendEvent.toolCallId);
+    expect(cancelEvent.toolName).toBe('ask_user');
+    expect(cancelEvent.reason).toBe('Invalid string length');
+
+    // Both the resume bookkeeping and the UI-facing display state are cleared.
+    expect(session.suspensions.hasPending()).toBe(false);
+    expect(session.displayState.get().pendingSuspensions.size).toBe(0);
+
+    events.length = 0;
+
+    // A late answer (the user hit Enter anyway) is a no-op instead of failing
+    // with the misleading "could not find a suspended run" error.
+    await session.respondToToolSuspension({ toolCallId: suspendEvent.toolCallId, resumeData: 'Ada' });
+    expect(events.some(e => e.type === 'error')).toBe(false);
+  });
+});

--- a/packages/core/src/agent-controller/session-run-engine.ts
+++ b/packages/core/src/agent-controller/session-run-engine.ts
@@ -378,6 +378,23 @@ export class SessionRunEngine {
       case 'error': {
         const streamError = getErrorFromUnknown(chunk.payload.error);
         this.#session.emit({ type: 'error', error: streamError });
+
+        // A run that dies after emitting `tool_suspended` (e.g. persisting the
+        // suspended snapshot failed) leaves its parked suspensions unresumable:
+        // answering them would fail with a misleading "could not find a
+        // suspended run" error that masks this primary failure. Retract them so
+        // the UI dismisses the prompts and the user sees the real error.
+        const failedRunId = chunk.runId ?? this.#session.run.getRunId();
+        if (failedRunId) {
+          for (const { toolCallId, toolName } of this.#session.suspensions.deleteForRun({ runId: failedRunId })) {
+            this.#session.emit({
+              type: 'tool_suspension_cancelled',
+              toolCallId,
+              toolName,
+              reason: streamError.message,
+            });
+          }
+        }
         break;
       }
 

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1051,6 +1051,25 @@ export class SessionSuspensions {
     this.#pending.delete(toolCallId);
   }
 
+  /**
+   * Drop every suspension parked on `runId`, returning the dropped toolCallIds.
+   * Used when a run reaches a terminal failure after emitting `tool_suspended`
+   * (e.g. persisting the suspended snapshot failed): those suspensions can never
+   * be resumed, so keeping them parked would leave the user with prompts whose
+   * answers fail with a misleading "could not find a suspended run" error.
+   * Suspensions parked on other runs are left intact.
+   */
+  deleteForRun({ runId }: { runId: string }): Array<{ toolCallId: string; toolName: string }> {
+    const dropped: Array<{ toolCallId: string; toolName: string }> = [];
+    for (const [toolCallId, suspension] of this.#pending) {
+      if (suspension.runId === runId) {
+        this.#pending.delete(toolCallId);
+        dropped.push({ toolCallId, toolName: suspension.toolName });
+      }
+    }
+    return dropped;
+  }
+
   /** Drop all parked suspensions (e.g. on abort or thread switch). */
   clear(): void {
     this.#pending.clear();
@@ -2270,6 +2289,10 @@ export class SessionDisplayState {
           suspendPayload: event.suspendPayload,
           resumeSchema: event.resumeSchema,
         });
+        break;
+
+      case 'tool_suspension_cancelled':
+        ds.pendingSuspensions.delete(event.toolCallId);
         break;
 
       // ── Subagent tracking ──────────────────────────────────────────────

--- a/packages/core/src/agent-controller/types.ts
+++ b/packages/core/src/agent-controller/types.ts
@@ -753,6 +753,7 @@ export type AgentControllerEvent =
       suspendPayload: unknown;
       resumeSchema?: string;
     }
+  | { type: 'tool_suspension_cancelled'; toolCallId: string; toolName: string; reason: string }
   | { type: 'tool_update'; toolCallId: string; partialResult: unknown }
   | {
       type: 'tool_end';


### PR DESCRIPTION
When a run errors after it already emitted `tool_suspended` — for example when persisting the suspended workflow snapshot throws `RangeError: Invalid string length` on very large snapshots — the run finishes as `failed` instead of `suspended`. The session-level suspension stayed parked though, so the ask_user question in mastracode remained on screen and answerable. Answering it then surfaced a misleading secondary error instead of the real one:

Before: user answers the question and gets `Agent "Code Agent" sendStreamResume() could not find a suspended run "…" for thread "…"`, with the actual snapshot-persistence failure hidden.

After: the session drops suspensions parked on a run that reached terminal failure and emits a `tool_suspension_cancelled` event. Display state clears the pending suspension, and the mastracode TUI listens for the cancellation out-of-band (its event queue is blocked on the pending question) to dismiss active, queued, or dialog prompts. The user sees the real error, and a late answer is a no-op instead of throwing.

Reproduced and verified with a new core regression test that forces `persistWorkflowSnapshot` to throw during suspension finalization, plus TUI tests covering retraction of active, queued, and unrelated prompts. All 379 agent-controller tests and the ask-question TUI suites pass.

The underlying snapshot bloat that triggers the serialization failure (multi-MB `executionWorkflow` snapshots) is a separate issue — this makes the failure visible and recoverable rather than trapping the user behind a dead prompt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a run crashes while waiting for your answer, the app now closes the question instead of leaving it stuck. Late answers are safely ignored, so you see the real error.

## What changed

- Added `tool_suspension_cancelled` events for suspended prompts belonging to failed runs.
- Cleared cancelled suspensions from session and display state.
- Updated the mastracode TUI to dismiss active, queued, and dialog prompts out-of-band.
- Added regression tests for snapshot persistence failures, late answers, and prompt cancellation behavior.
- Added patch release changesets for `@mastra/core` and `mastracode`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->