### PR TITLE
MC Web: restructure sidebar into Factory Sessions and User Sessions

### DIFF
--- a/mastracode/web/e2e/web-ui/msw-server.ts
+++ b/mastracode/web/e2e/web-ui/msw-server.ts
@@ -1,3 +1,4 @@
+import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
 /**
@@ -5,5 +6,11 @@ import { setupServer } from 'msw/node';
  * (`vitest.setup.ts`) starts it with `onUnhandledRequest: 'error'` so any
  * request that isn't explicitly stubbed fails the test loudly. Register
  * per-test handlers with `server.use(...)`.
+ *
+ * `/auth/me` has a default handler because the auth state is ambient (read by
+ * the user-sessions plumbing wherever the provider stack renders): auth is
+ * reported disabled — the local-dev default — so user sessions fall back to
+ * the fixed local resourceId. Tests that exercise authenticated flows override
+ * it with `server.use(...)`.
  */
-export const server = setupServer();
+export const server = setupServer(http.get('*/auth/me', () => HttpResponse.json(null, { status: 404 })));

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -21,6 +21,7 @@ export const queryKeys = {
   intakeConfig: () => ['intake', 'config'] as const,
   workItems: (githubProjectId: string | undefined) => ['factory', 'work-items', githubProjectId ?? null] as const,
   workspaces: (projectId: string | undefined) => ['workspaces', projectId ?? null] as const,
+  userSessions: (projectId: string | undefined) => ['user-sessions', projectId ?? null] as const,
   providers: () => ['providers'] as const,
   customProviders: () => ['custom-providers'] as const,
   modelPacks: (resourceId: string | undefined) => ['model-packs', resourceId ?? null] as const,

--- a/mastracode/web/src/web/auth.test.ts
+++ b/mastracode/web/src/web/auth.test.ts
@@ -295,7 +295,7 @@ describe('mountWebAuth /auth routes (enabled)', () => {
     expect(await res.json()).toEqual({ authenticated: true, user: { email: 'user@example.com', name: 'User' } });
   });
 
-  it('/auth/me surfaces the organization id to the SPA', async () => {
+  it('/auth/me surfaces the organization id and stable user id to the SPA', async () => {
     mockAuthenticate.mockResolvedValue({
       workosId: 'user_1',
       email: 'user@example.com',
@@ -307,7 +307,7 @@ describe('mountWebAuth /auth routes (enabled)', () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({
       authenticated: true,
-      user: { email: 'user@example.com', name: 'User', organizationId: 'org_a' },
+      user: { email: 'user@example.com', name: 'User', organizationId: 'org_a', userId: 'user_1' },
     });
   });
 });

--- a/mastracode/web/src/web/auth.ts
+++ b/mastracode/web/src/web/auth.ts
@@ -411,7 +411,7 @@ export function registerAuthRoutes(app: Hono<any>, provider: MastraAuthWorkos, r
     }
     return c.json({
       authenticated: true,
-      user: { email: user.email, name: user.name, organizationId: user.organizationId },
+      user: { userId: getWebAuthUserId(user), email: user.email, name: user.name, organizationId: user.organizationId },
     });
   });
 }
@@ -488,7 +488,12 @@ export function buildAuthRoutes(provider: MastraAuthWorkos, redirectUri: string 
         }
         return c.json({
           authenticated: true,
-          user: { email: user.email, name: user.name, organizationId: user.organizationId },
+          user: {
+            userId: getWebAuthUserId(user),
+            email: user.email,
+            name: user.name,
+            organizationId: user.organizationId,
+          },
         });
       },
     }),

--- a/mastracode/web/src/web/ui/Sidebar.tsx
+++ b/mastracode/web/src/web/ui/Sidebar.tsx
@@ -8,7 +8,7 @@ import { useApiConfig } from '../../shared/api/config';
 import { redirectToLogout, useWebAuth } from './domains/auth';
 import { ThreadList, useChatConnection, useChatTranscript } from './domains/chat';
 import { FactorySection } from './domains/factory';
-import { ProjectSwitcher, useActiveProjectContext, WorkspacesSection } from './domains/workspaces';
+import { ProjectSwitcher, useActiveProjectContext, UserSessionsSection, WorkspacesSection } from './domains/workspaces';
 import { useOverlays } from './lib/overlays';
 
 /**
@@ -16,10 +16,11 @@ import { useOverlays } from './lib/overlays';
  * (`useActiveProjectContext`, focused chat hooks, `useOverlays`), so nothing is
  * wired through props here.
  *
- * Threads are scoped to the worktree they run in. GitHub projects nest the
- * thread list under the main-branch workspace inside the Workspaces section —
- * feature worktrees hold a single conversation, so they show no thread list;
- * local projects (no worktrees) keep the flat list.
+ * Everything runs in a worktree branched from the repo's HEAD. GitHub projects
+ * show the Factory menu (Board + org-level factory Sessions) and the current
+ * user's personal User Sessions; each worktree holds a single conversation, so
+ * there is no nested thread list. Local projects (no worktrees) keep the flat
+ * thread list.
  */
 export function Sidebar() {
   const overlays = useOverlays();
@@ -32,11 +33,13 @@ export function Sidebar() {
       className={`fixed inset-y-0 left-0 z-40 flex h-full w-[82vw] max-w-[300px] shrink-0 flex-col gap-4 border-r border-border1 bg-surface2 p-3 shadow-lg transition-transform duration-200 md:static md:z-auto md:w-full md:max-w-none md:translate-x-0 md:border-r-0 md:bg-transparent md:shadow-none ${open ? 'translate-x-0' : '-translate-x-full'}`}
     >
       <ProjectSwitcher />
-      <FactorySection />
       {isGithubProject ? (
-        <WorkspacesSection>
-          <ThreadList />
-        </WorkspacesSection>
+        <>
+          <FactorySection>
+            <WorkspacesSection />
+          </FactorySection>
+          <UserSessionsSection />
+        </>
       ) : (
         <ThreadList />
       )}

--- a/mastracode/web/src/web/ui/__tests__/Sidebar.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/Sidebar.msw.test.tsx
@@ -246,33 +246,32 @@ describe('Sidebar', () => {
   });
 
   describe('when a GitHub project is active', () => {
-    it('nests the thread list under the active worktree inside the Workspaces section', async () => {
+    it('nests the factory Sessions list under the Factory menu, without the repo root', async () => {
       seedProject(githubProject);
       useAuthHandler();
       useGithubStatusHandler();
       useAgentControllerHandlers();
       renderSidebar();
 
-      const activeWorktree = await screen.findByRole('button', { name: 'main' });
-      const thread = await screen.findByText('First thread');
-      // The row button sits inside a hover-group wrapper; nested threads render
-      // as a sibling of that wrapper inside the worktree's container.
-      expect(activeWorktree.parentElement?.parentElement).toContainElement(thread);
-
-      const inactiveWorktree = screen.getByRole('button', { name: 'feat-ui' });
-      expect(inactiveWorktree.parentElement?.parentElement).not.toContainElement(thread);
+      const factory = await screen.findByRole('navigation', { name: 'Factory' });
+      expect(await within(factory).findByText('Sessions')).toBeInTheDocument();
+      // Only feature worktrees are sessions: the repo-root checkout is not one.
+      expect(within(factory).getByRole('button', { name: 'feat-ui' })).toBeInTheDocument();
+      expect(within(factory).queryByRole('button', { name: 'main' })).not.toBeInTheDocument();
     });
 
-    it('does not render a flat thread list outside the Workspaces section', async () => {
+    it('renders the User Sessions section and no thread list', async () => {
       seedProject(githubProject);
       useAuthHandler();
       useGithubStatusHandler();
       useAgentControllerHandlers();
       renderSidebar();
 
-      const workspaces = await screen.findByRole('region', { name: 'Workspaces' });
-      const thread = await screen.findByText('First thread');
-      expect(workspaces).toContainElement(thread);
+      expect(await screen.findByRole('region', { name: 'User sessions' })).toBeInTheDocument();
+      // Each worktree holds a single conversation, so GitHub projects have no
+      // thread list — neither nested nor flat.
+      await screen.findByRole('button', { name: 'feat-ui' });
+      expect(screen.queryByText('First thread')).not.toBeInTheDocument();
     });
   });
 

--- a/mastracode/web/src/web/ui/domains/auth/index.ts
+++ b/mastracode/web/src/web/ui/domains/auth/index.ts
@@ -1,4 +1,11 @@
 export { SignInPage } from './components/SignInPage';
 export { useWebAuth } from './hooks/useWebAuth';
-export { fetchAuthState, loginUrl, logoutUrl, redirectToLogin, redirectToLogout } from './services/auth';
+export {
+  fetchAuthState,
+  loginUrl,
+  logoutUrl,
+  redirectToLogin,
+  redirectToLogout,
+  userSessionResourceId,
+} from './services/auth';
 export type { WebAuthState } from './services/auth';

--- a/mastracode/web/src/web/ui/domains/auth/services/auth.ts
+++ b/mastracode/web/src/web/ui/domains/auth/services/auth.ts
@@ -19,7 +19,21 @@ export interface WebAuthState {
   /** Whether the server has WorkOS auth configured. */
   authEnabled: boolean;
   authenticated: boolean;
-  user?: { email?: string; name?: string };
+  user?: { userId?: string; email?: string; name?: string };
+}
+
+/**
+ * The user-session resourceId used when auth is disabled (local dev): there is
+ * only one operator, so a fixed id keeps their sessions stable across reloads.
+ */
+export const LOCAL_USER_RESOURCE_ID = 'local-user';
+
+/**
+ * The resourceId under which a user's personal (non-factory) sessions live:
+ * the stable WorkOS user id, or a fixed local id when auth is disabled.
+ */
+export function userSessionResourceId(state: WebAuthState | undefined): string {
+  return state?.user?.userId ?? LOCAL_USER_RESOURCE_ID;
 }
 
 /**
@@ -60,7 +74,10 @@ export async function fetchAuthState(baseUrl: string): Promise<WebAuthState> {
     if (!res.ok) {
       return { authEnabled: true, authenticated: false };
     }
-    const data = (await res.json()) as { authenticated?: boolean; user?: { email?: string; name?: string } | null };
+    const data = (await res.json()) as {
+      authenticated?: boolean;
+      user?: { userId?: string; email?: string; name?: string } | null;
+    };
     return {
       authEnabled: true,
       authenticated: Boolean(data.authenticated),

--- a/mastracode/web/src/web/ui/domains/chat/Chat.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/Chat.tsx
@@ -28,11 +28,18 @@ export default function Chat() {
 
 function ChatSessionRouteProvider({ children }: { children: ReactNode }) {
   const { pathname } = useLocation();
-  const threadId = pathname.startsWith('/threads/')
-    ? decodeURIComponent(pathname.slice('/threads/'.length))
-    : undefined;
+  const userScoped = pathname.startsWith('/user/threads/');
+  const threadId = userScoped
+    ? decodeURIComponent(pathname.slice('/user/threads/'.length))
+    : pathname.startsWith('/threads/')
+      ? decodeURIComponent(pathname.slice('/threads/'.length))
+      : undefined;
 
-  return <ChatSessionProvider threadId={threadId}>{children}</ChatSessionProvider>;
+  return (
+    <ChatSessionProvider threadId={threadId} userScoped={userScoped}>
+      {children}
+    </ChatSessionProvider>
+  );
 }
 
 function ChatShell() {

--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/ModesSelection.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/ModesSelection.tsx
@@ -2,12 +2,19 @@ import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
 
 import { useChatModes } from '../../context/useChatModes';
+import { useChatSessionContext } from '../../context/useChatSessionContext';
 
-/** Session mode buttons; switches modes through the agent controller. */
+/**
+ * Session mode buttons; switches modes through the agent controller. Only
+ * shown for personal (user) sessions — factory sessions are driven by the
+ * factory's own run prompts, so mode switching is hidden there.
+ */
 export function ModesSelection() {
+  const { kind } = useChatSessionContext();
   const { modes, activeModeId, setMode } = useChatModes();
   const selectedModeId = activeModeId ?? modes[0]?.id;
 
+  if (kind === 'factory') return null;
   if (modes.length === 0) return null;
 
   return (

--- a/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
@@ -41,11 +41,11 @@ export function ThreadList() {
 
   if (!activeProject) return null;
 
-  // Feature worktrees hold a single conversation: show its title for context,
-  // but no "Threads" header/count, no rename/clone/delete actions, and no way
-  // to create more threads.
-  const readOnly =
-    activeProject.source === 'github' && Boolean(projectPath) && projectPath !== activeProject.sandboxWorkdir;
+  // Worktrees hold a single conversation: show its title for context, but no
+  // "Threads" header/count, no rename/clone/delete actions, and no way to
+  // create more threads. Every GitHub chat target is a worktree (the repo
+  // root is not a workspace), so any GitHub project path is read-only here.
+  const readOnly = activeProject.source === 'github' && Boolean(projectPath);
 
   const threads = threadsQuery.data ?? [];
   const activeThreadId = routeThreadId;

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/ThreadList.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/ThreadList.msw.test.tsx
@@ -224,14 +224,16 @@ describe('ThreadList', () => {
     expect(screen.queryByRole('button', { name: 'Thread actions' })).not.toBeInTheDocument();
   });
 
-  it('given a main-branch workspace is active on a GitHub project, then the full thread controls render', async () => {
+  it('given a GitHub project, then the list is read-only even when the repo-root path was persisted as selected', async () => {
+    // Legacy projects could persist the repo root as the selected worktree;
+    // it is no longer a workspace, so GitHub lists never expose thread controls.
     seedProject({ ...worktreeProject, selectedWorktreePath: '/sandbox/mastra' });
     useAgentControllerHandlers([threadOne]);
     renderThreadList();
 
     expect(await screen.findByText('First thread')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'New thread' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Thread actions' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'New thread' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Thread actions' })).not.toBeInTheDocument();
   });
 
   it('when a thread is clicked, then the app navigates to its page and the sidebar closes', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionContext.ts
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionContext.ts
@@ -5,6 +5,15 @@ export interface ChatSessionContextApi {
   sessionEnabled: boolean;
   projectPath?: string;
   baseUrl: string;
+  /**
+   * 'factory' — org-scoped session bound to a factory worktree of a GitHub
+   * project (runs are driven by the factory; modes are hidden).
+   * 'user' — personal session (a `user/` worktree opened via
+   * /user/threads/*, or a local project chat); modes stay available.
+   */
+  kind: 'factory' | 'user';
+  /** Route prefix this session's threads are addressed under. */
+  threadBasePath: '/threads' | '/user/threads';
 }
 
 export const ChatSessionContext = createContext<ChatSessionContextApi | null>(null);

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -3,24 +3,64 @@ import type { ReactNode } from 'react';
 
 import { useApiConfig } from '../../../../../shared/api/config';
 import { SkeletonRows } from '../../../ui';
-// Deep imports (not the workspaces barrel): the barrel re-exports components
-// that consume this chat context, so importing it here would create a cycle.
+// Deep imports (not the domain barrels): the barrels re-export components
+// that consume this chat context, so importing them here would create cycles.
+import { useWebAuth } from '../../auth/hooks/useWebAuth';
+import { userSessionResourceId } from '../../auth/services/auth';
 import { useActiveProjectContext } from '../../workspaces/context/ActiveProjectProvider';
 import { deriveProjectPath } from '../../workspaces/hooks/useWorkspaces';
+import { findUserSessionByThreadId } from '../../workspaces/services/projects';
 import { useAgentControllerThreadMessages } from '../hooks/useAgentControllerThreadMessages';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 import { ChatModelsProvider } from './ChatModelsProvider';
 import { ChatModesProvider } from './ChatModesProvider';
 import { ChatPermissionsProvider } from './ChatPermissionsProvider';
 import { ChatSessionContext } from './ChatSessionContext';
+import type { ChatSessionContextApi } from './ChatSessionContext';
 import { ChatTranscriptProvider } from './ChatTranscriptProvider';
 import { useChatSessionContext } from './useChatSessionContext';
 
-export function ChatSessionProvider({ children, threadId }: { children: ReactNode; threadId?: string }) {
+export function ChatSessionProvider({
+  children,
+  threadId,
+  userScoped = false,
+}: {
+  children: ReactNode;
+  threadId?: string;
+  /** True for /user/threads/* routes: bind to the user's personal session. */
+  userScoped?: boolean;
+}) {
   const { activeProject, resourceId, sessionEnabled } = useActiveProjectContext();
+  const auth = useWebAuth();
   const { baseUrl } = useApiConfig();
-  const projectPath = deriveProjectPath(activeProject);
-  const sessionContextValue = { resourceId, sessionEnabled, projectPath, baseUrl };
+
+  let sessionContextValue: ChatSessionContextApi;
+  if (userScoped) {
+    // Personal session: resourceId is the logged-in user, scope is the
+    // user-session worktree that owns the route's thread.
+    const userSession = threadId ? findUserSessionByThreadId(threadId) : undefined;
+    sessionContextValue = {
+      resourceId: userSessionResourceId(auth.data),
+      sessionEnabled: !auth.isPending && Boolean(userSession),
+      projectPath: userSession?.worktree.worktreePath,
+      baseUrl,
+      kind: 'user',
+      threadBasePath: '/user/threads',
+    };
+  } else {
+    const projectPath = deriveProjectPath(activeProject);
+    const isGithubProject = activeProject?.source === 'github';
+    sessionContextValue = {
+      resourceId,
+      // GitHub projects have no repo-root session anymore — without a factory
+      // worktree there is nothing to bind a session to.
+      sessionEnabled: sessionEnabled && (!isGithubProject || Boolean(projectPath)),
+      projectPath,
+      baseUrl,
+      kind: isGithubProject ? 'factory' : 'user',
+      threadBasePath: '/threads',
+    };
+  }
 
   return (
     <ChatSessionContext.Provider value={sessionContextValue}>

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useRouteThreadSync.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useRouteThreadSync.ts
@@ -12,7 +12,7 @@ import { useSwitchAgentControllerThreadMutation } from './useAgentControllerThre
 import { useAgentControllerThreads } from './useAgentControllerThreads';
 
 export function useRouteThreadSync() {
-  const { resourceId, sessionEnabled, projectPath, baseUrl } = useChatSessionContext();
+  const { resourceId, sessionEnabled, projectPath, baseUrl, threadBasePath } = useChatSessionContext();
   const { status, state } = useChatConnection();
   const { transcript, reset, syncState, pushNotice } = useChatTranscript();
   const threadsQuery = useAgentControllerThreads({
@@ -66,7 +66,7 @@ export function useRouteThreadSync() {
           : Promise.resolve();
         void warm.finally(() => {
           if (!isLatestRequest()) return;
-          void navigate(`/threads/${latest.id}`, { replace: true });
+          void navigate(`${threadBasePath}/${latest.id}`, { replace: true });
         });
         return;
       }

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -339,7 +339,10 @@ describe('Factory sidebar section', () => {
 
     const nav = await screen.findByRole('navigation', { name: 'Factory' });
     expect(within(nav).getByText('Factory')).toBeInTheDocument();
-    expect(within(nav).getByRole('link', { name: /Board/ })).toHaveAttribute('href', '/factory/board');
+    // The Board link appears once the GitHub status query resolves as connected.
+    expect(await within(nav).findByRole('link', { name: /Board/ })).toHaveAttribute('href', '/factory/board');
+    // The factory Sessions list is nested under the same menu.
+    expect(within(nav).getByRole('region', { name: 'Factory sessions' })).toBeInTheDocument();
   });
 
   it('given a local project, when the app renders, then the Factory section is hidden', async () => {
@@ -349,11 +352,14 @@ describe('Factory sidebar section', () => {
     expect(screen.queryByRole('navigation', { name: 'Factory' })).not.toBeInTheDocument();
   });
 
-  it('given GitHub is not connected, when the app renders, then the Factory section is hidden', async () => {
+  it('given GitHub is not connected, when the app renders, then the Board link is hidden but Sessions remain', async () => {
     renderAt('/new', githubProject, notConnectedStatus);
 
-    expect(await screen.findByText('What do you want to work on?')).toBeInTheDocument();
-    await waitFor(() => expect(screen.queryByRole('navigation', { name: 'Factory' })).not.toBeInTheDocument());
+    // Sessions work off the project's own worktrees, so the Factory menu stays;
+    // only the Board (which needs the GitHub integration) disappears.
+    const nav = await screen.findByRole('navigation', { name: 'Factory' });
+    expect(within(nav).getByRole('region', { name: 'Factory sessions' })).toBeInTheDocument();
+    await waitFor(() => expect(within(nav).queryByRole('link', { name: /Board/ })).not.toBeInTheDocument());
   });
 });
 

--- a/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
@@ -1,23 +1,26 @@
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { SquareKanban } from 'lucide-react';
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { NavLink } from 'react-router';
 
 import { useOverlays } from '../../../lib/overlays';
 import { useActiveProjectContext, useGithubStatusQuery } from '../../workspaces';
 
 /**
- * Sidebar navigation for the Factory pages. Factory data comes from GitHub, so
- * the section only renders for GitHub-backed projects (mirroring
- * WorkspacesSection) while the GitHub feature is enabled and connected.
+ * The Factory menu: Board navigation plus whatever the caller nests under it
+ * (the factory Sessions list). Factory work is GitHub-backed, so the section
+ * only renders for GitHub projects; the Board link additionally requires the
+ * GitHub integration to be enabled and connected, while the nested sessions
+ * work off the project's own worktrees.
  */
-export function FactorySection() {
+export function FactorySection({ children }: { children?: ReactNode }) {
   const { activeProject } = useActiveProjectContext();
   const isGithubProject = activeProject?.source === 'github';
   const { data: status } = useGithubStatusQuery(isGithubProject);
 
   if (!isGithubProject) return null;
-  if (!status?.enabled || !status.connected) return null;
+
+  const showBoard = Boolean(status?.enabled && status.connected);
 
   return (
     <nav className="flex flex-col gap-2" aria-label="Factory">
@@ -26,9 +29,12 @@ export function FactorySection() {
           Factory
         </Txt>
       </div>
-      <div className="flex flex-col gap-1">
-        <FactoryLink to="/factory/board" icon={SquareKanban} label="Board" />
-      </div>
+      {showBoard && (
+        <div className="flex flex-col gap-1">
+          <FactoryLink to="/factory/board" icon={SquareKanban} label="Board" />
+        </div>
+      )}
+      {children && <div className="flex flex-col gap-2 pl-2">{children}</div>}
     </nav>
   );
 }

--- a/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/UserSessionsSection.tsx
@@ -1,0 +1,306 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@mastra/playground-ui/components/Dialog';
+import { Input } from '@mastra/playground-ui/components/Input';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { useState } from 'react';
+import type { FormEvent, KeyboardEvent } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
+import { useApiConfig } from '../../../../../shared/api/config';
+import { queryKeys } from '../../../../../shared/api/keys';
+import { useToast } from '../../../ui/toast';
+import { useWebAuth } from '../../auth/hooks/useWebAuth';
+import { userSessionResourceId } from '../../auth/services/auth';
+import { createAgentControllerClient, requireAgentControllerSession } from '../../chat/services/agentControllerClient';
+import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
+import { useActiveProjectContext } from '../context/ActiveProjectProvider';
+import { useWorkspaceActivity } from '../hooks/useWorkspaceActivity';
+import { useWorkspaceAttention } from '../hooks/useWorkspaceAttention';
+import { createWorktree, deleteWorktree } from '../services/github';
+import type { Project, Worktree } from '../services/projects';
+import {
+  loadProjects,
+  removeWorktree,
+  upsertWorktree,
+  USER_SESSION_BRANCH_PREFIX,
+  userSessionWorktrees,
+} from '../services/projects';
+import { WorkspaceRow } from './WorkspacesSection';
+
+function latestProject(project: Project): Project {
+  return loadProjects().find(stored => stored.id === project.id) ?? project;
+}
+
+function sessionLabel(worktree: Worktree): string {
+  return worktree.branch.startsWith(USER_SESSION_BRANCH_PREFIX)
+    ? worktree.branch.slice(USER_SESSION_BRANCH_PREFIX.length)
+    : worktree.branch;
+}
+
+/**
+ * Personal (non-factory) sessions for the current user on a GitHub project.
+ *
+ * Each session is its own worktree branched from the repo's HEAD (branch
+ * `user/<name>`), holding exactly one conversation under the user's own
+ * resourceId — so a user can run several personal sessions in parallel
+ * without touching the org-level factory sessions. Opening a session
+ * navigates to `/user/threads/<threadId>`, where the chat binds to the
+ * user-scoped session (and modes stay available).
+ */
+export function UserSessionsSection() {
+  const { baseUrl } = useApiConfig();
+  const { activeProject } = useActiveProjectContext();
+  const auth = useWebAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+  const [creating, setCreating] = useState(false);
+  const [name, setName] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState<Worktree | null>(null);
+
+  const isGithubProject = activeProject?.source === 'github';
+  const userResourceId = userSessionResourceId(auth.data);
+
+  const sessionsQuery = useQuery({
+    queryKey: queryKeys.userSessions(activeProject?.id),
+    queryFn: async (): Promise<Worktree[]> => {
+      if (!activeProject) throw new Error('User sessions require an active project');
+      return userSessionWorktrees(latestProject(activeProject));
+    },
+    enabled: isGithubProject,
+    initialData:
+      isGithubProject && activeProject ? () => userSessionWorktrees(latestProject(activeProject)) : undefined,
+  });
+  const worktrees = sessionsQuery.data ?? [];
+
+  const runningByPath = useWorkspaceActivity({
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceId: userResourceId,
+    projectPath: worktrees[0]?.worktreePath,
+    worktreePaths: worktrees.map(worktree => worktree.worktreePath),
+    baseUrl,
+    enabled: isGithubProject && !auth.isPending && worktrees.length > 0,
+  });
+  const { attentionByPath, clearAttention } = useWorkspaceAttention(runningByPath);
+
+  const invalidate = () => {
+    void queryClient.invalidateQueries({ queryKey: queryKeys.userSessions(activeProject?.id) });
+    void queryClient.invalidateQueries({ queryKey: queryKeys.projects() });
+  };
+
+  // Seed (or address) the user's own session for a worktree: sessions are
+  // scoped per worktree, under the user's resourceId rather than the org's.
+  const userSessionFor = (worktreePath: string) => {
+    const { session } = createAgentControllerClient({
+      agentControllerId: AGENT_CONTROLLER_ID,
+      resourceId: userResourceId,
+      scope: worktreePath,
+      baseUrl,
+    });
+    return requireAgentControllerSession(session);
+  };
+
+  const createSession = useMutation({
+    mutationFn: async (rawName: string) => {
+      if (!activeProject?.githubProjectId) throw new Error('No GitHub project selected');
+      const slug = rawName.trim().toLowerCase().replace(/\s+/g, '-');
+      if (!slug) throw new Error('Session name is required');
+      // A fresh worktree branched from the repo's HEAD (server defaults the
+      // base branch), owned by this user.
+      const result = await createWorktree(
+        baseUrl,
+        activeProject.githubProjectId,
+        `${USER_SESSION_BRANCH_PREFIX}${slug}`,
+      );
+      const chatSession = userSessionFor(result.worktreePath);
+      await chatSession.create({ tags: { projectPath: result.worktreePath } });
+      const thread = await chatSession.createThread();
+      upsertWorktree(latestProject(activeProject), {
+        branch: result.branch,
+        worktreePath: result.worktreePath,
+        baseBranch: result.baseBranch,
+        threadId: thread.id,
+      });
+      // A fresh thread has no messages; seed the cache to skip the skeleton.
+      queryClient.setQueryData(
+        queryKeys.agentControllerThreadMessages(AGENT_CONTROLLER_ID, userResourceId, thread.id),
+        [],
+      );
+      return thread.id;
+    },
+    onSuccess: threadId => {
+      setCreating(false);
+      setName('');
+      invalidate();
+      void navigate(`/user/threads/${threadId}`);
+    },
+  });
+
+  const deleteSession = useMutation({
+    mutationFn: async (worktree: Worktree) => {
+      if (!activeProject?.githubProjectId) throw new Error('No GitHub project selected');
+      await deleteWorktree(baseUrl, activeProject.githubProjectId, worktree.branch);
+      // Cascade: delete the user's threads scoped to this worktree. Re-list
+      // between rounds (page-size cap); bail after a sane number of rounds.
+      const chatSession = userSessionFor(worktree.worktreePath);
+      for (let round = 0; round < 20; round++) {
+        const threads = await chatSession.listThreads({ limit: 50, tags: { projectPath: worktree.worktreePath } });
+        if (threads.length === 0) break;
+        for (const thread of threads) await chatSession.deleteThread(thread.id);
+      }
+      removeWorktree(latestProject(activeProject), worktree.worktreePath);
+      return worktree;
+    },
+    onSuccess: worktree => {
+      setConfirmDelete(null);
+      invalidate();
+      toast('Session deleted');
+      if (worktree.threadId && location.pathname === `/user/threads/${worktree.threadId}`) {
+        void navigate('/new', { replace: true });
+      }
+    },
+    onError: error => {
+      setConfirmDelete(null);
+      toast(error instanceof Error ? error.message : 'Failed to delete session', 'error');
+    },
+  });
+
+  if (!isGithubProject) return null;
+
+  const pending = createSession.isPending || deleteSession.isPending;
+
+  const openSession = async (worktree: Worktree) => {
+    clearAttention(worktree.worktreePath);
+    if (worktree.threadId) {
+      void navigate(`/user/threads/${worktree.threadId}`);
+      return;
+    }
+    // Legacy user worktree without a recorded thread: create one now so the
+    // route can resolve back to this worktree.
+    try {
+      const chatSession = userSessionFor(worktree.worktreePath);
+      await chatSession.create({ tags: { projectPath: worktree.worktreePath } });
+      const thread = await chatSession.createThread();
+      if (activeProject) upsertWorktree(latestProject(activeProject), { ...worktree, threadId: thread.id });
+      invalidate();
+      void navigate(`/user/threads/${thread.id}`);
+    } catch (error) {
+      toast(error instanceof Error ? error.message : 'Failed to open session', 'error');
+    }
+  };
+
+  const resetCreate = () => {
+    setCreating(false);
+    setName('');
+  };
+
+  const submitCreate = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (name.trim()) createSession.mutate(name);
+  };
+
+  const onCreateKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') resetCreate();
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      if (name.trim()) createSession.mutate(name);
+    }
+  };
+
+  return (
+    <section className="flex flex-col gap-2" aria-label="User sessions">
+      <div className="flex items-center justify-between px-1">
+        <Txt as="span" variant="ui-xs" className="text-icon3 uppercase tracking-wide">
+          User Sessions
+        </Txt>
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          aria-label="New user session"
+          onClick={() => setCreating(true)}
+          disabled={creating || pending}
+        >
+          <Plus size={15} />
+        </Button>
+      </div>
+
+      <div className="flex flex-col gap-1">
+        {worktrees.map(worktree => {
+          const active = Boolean(worktree.threadId) && location.pathname === `/user/threads/${worktree.threadId}`;
+          return (
+            <WorkspaceRow
+              key={worktree.worktreePath}
+              worktree={worktree}
+              label={sessionLabel(worktree)}
+              active={active}
+              running={runningByPath[worktree.worktreePath] === true}
+              attention={attentionByPath[worktree.worktreePath] === true}
+              disabled={pending}
+              onSeen={() => clearAttention(worktree.worktreePath)}
+              onSelect={() => void openSession(worktree)}
+              onDelete={() => setConfirmDelete(worktree)}
+            />
+          );
+        })}
+
+        {worktrees.length === 0 && !creating && (
+          <Txt as="p" variant="ui-xs" className="m-0 px-2 py-1 text-icon3">
+            No sessions yet
+          </Txt>
+        )}
+
+        {creating && (
+          <form aria-label="Create user session" className="flex flex-col gap-1" onSubmit={submitCreate}>
+            <Input
+              aria-label="Session name"
+              autoFocus
+              value={name}
+              onChange={event => setName(event.target.value)}
+              onKeyDown={onCreateKeyDown}
+              placeholder="session-name"
+              disabled={createSession.isPending}
+              className="h-8 text-xs"
+            />
+            {createSession.error && (
+              <Txt as="p" variant="ui-xs" className="m-0 text-red-400">
+                {createSession.error instanceof Error ? createSession.error.message : 'Failed to create session'}
+              </Txt>
+            )}
+          </form>
+        )}
+      </div>
+
+      {confirmDelete && (
+        <Dialog open onOpenChange={open => !open && setConfirmDelete(null)}>
+          <DialogContent className="w-full max-w-sm" aria-label="Delete user session">
+            <DialogHeader className="px-5 pt-4 pb-2">
+              <DialogTitle>Delete session?</DialogTitle>
+            </DialogHeader>
+            <div className="flex flex-col gap-4 px-5 pb-4">
+              <Txt as="p" variant="ui-sm" className="m-0 text-icon4">
+                This deletes the <span className="text-icon6">{sessionLabel(confirmDelete)}</span> session, its checkout
+                with any uncommitted changes, and its conversation. This can’t be undone.
+              </Txt>
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => setConfirmDelete(null)} disabled={deleteSession.isPending}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="primary"
+                  className="bg-red-600 text-white hover:bg-red-500"
+                  onClick={() => deleteSession.mutate(confirmDelete)}
+                  disabled={deleteSession.isPending}
+                >
+                  {deleteSession.isPending ? 'Deleting…' : 'Delete'}
+                </Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      )}
+    </section>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -6,7 +6,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 import { useQueryClient } from '@tanstack/react-query';
 import { GitBranch, MoreHorizontal, Plus } from 'lucide-react';
 import { useState } from 'react';
-import type { FormEvent, KeyboardEvent, ReactNode } from 'react';
+import type { FormEvent, KeyboardEvent } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
@@ -27,15 +27,12 @@ import { useWorkspaceAttention } from '../hooks/useWorkspaceAttention';
 import type { Worktree } from '../services/projects';
 
 /**
- * Sidebar section listing a GitHub project's worktrees.
- *
- * Threads are scoped to the worktree they run in, so callers can pass the
- * thread list as `children`; it renders nested under the active worktree row
- * (or after the list when no worktree is selected yet). Feature worktrees
- * hold a single conversation, so the thread list renders read-only for them
- * (title only — no rename/clone/delete or new-thread controls).
+ * Factory sessions: a GitHub project's feature worktrees, rendered as the
+ * "Sessions" subsection of the Factory menu. Each worktree holds a single
+ * factory-run conversation, so selecting one opens its thread directly —
+ * there is no nested thread list.
  */
-export function WorkspacesSection({ children }: { children?: ReactNode }) {
+export function WorkspacesSection() {
   const { baseUrl } = useApiConfig();
   const { activeProject, resourceId, sessionEnabled } = useActiveProjectContext();
   const [creating, setCreating] = useState(false);
@@ -185,10 +182,10 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
   };
 
   return (
-    <section className="flex flex-col gap-2" aria-label="Workspaces">
+    <section className="flex flex-col gap-2" aria-label="Factory sessions">
       <div className="flex items-center justify-between px-1">
         <Txt as="span" variant="ui-xs" className="text-icon3 uppercase tracking-wide">
-          Workspaces
+          Sessions
         </Txt>
         <Button
           variant="ghost"
@@ -204,28 +201,23 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
       <div className="flex flex-col gap-1">
         {worktrees.map(worktree => {
           const active = worktree.worktreePath === selectedPath;
-          const nested = active && Boolean(children);
           return (
-            <div key={worktree.worktreePath} className="flex flex-col gap-1">
-              <WorkspaceRow
-                worktree={worktree}
-                active={active}
-                running={runningByPath[worktree.worktreePath] === true}
-                attention={attentionByPath[worktree.worktreePath] === true}
-                disabled={pending}
-                onSeen={() => clearAttention(worktree.worktreePath)}
-                onSelect={() => {
-                  clearAttention(worktree.worktreePath);
-                  selectWorkspace.mutate(worktree.worktreePath, {
-                    onSuccess: () => void openWorktreeThread(worktree.worktreePath),
-                  });
-                }}
-                onDelete={
-                  worktree.worktreePath === activeProject.sandboxWorkdir ? undefined : () => setConfirmDelete(worktree)
-                }
-              />
-              {nested && <div className="ml-[15px] flex flex-col border-l border-border1 pl-2">{children}</div>}
-            </div>
+            <WorkspaceRow
+              key={worktree.worktreePath}
+              worktree={worktree}
+              active={active}
+              running={runningByPath[worktree.worktreePath] === true}
+              attention={attentionByPath[worktree.worktreePath] === true}
+              disabled={pending}
+              onSeen={() => clearAttention(worktree.worktreePath)}
+              onSelect={() => {
+                clearAttention(worktree.worktreePath);
+                selectWorkspace.mutate(worktree.worktreePath, {
+                  onSuccess: () => void openWorktreeThread(worktree.worktreePath),
+                });
+              }}
+              onDelete={() => setConfirmDelete(worktree)}
+            />
           );
         })}
 
@@ -247,10 +239,6 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
               </Txt>
             )}
           </form>
-        )}
-
-        {Boolean(children) && !worktrees.some(worktree => worktree.worktreePath === selectedPath) && (
-          <div className="flex flex-col">{children}</div>
         )}
       </div>
 
@@ -286,8 +274,9 @@ export function WorkspacesSection({ children }: { children?: ReactNode }) {
   );
 }
 
-function WorkspaceRow({
+export function WorkspaceRow({
   worktree,
+  label,
   active,
   running,
   attention,
@@ -297,6 +286,8 @@ function WorkspaceRow({
   onDelete,
 }: {
   worktree: Worktree;
+  /** Display name; defaults to the worktree's branch. */
+  label?: string;
   active: boolean;
   running: boolean;
   /** A run finished here and the user hasn't opened the workspace since. */
@@ -310,6 +301,7 @@ function WorkspaceRow({
   // the already-active row can't be re-selected, so clicking it just clears
   // the done indicator.
   const onClick = active ? (attention ? onSeen : undefined) : onSelect;
+  const name = label ?? worktree.branch;
   return (
     <div className={`group relative rounded-md ${active ? 'bg-surface4' : 'hover:bg-surface3'}`}>
       <button
@@ -321,18 +313,18 @@ function WorkspaceRow({
         className={`flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-xs transition ${active ? 'text-icon6' : 'text-icon3 hover:text-icon5'} disabled:cursor-default disabled:opacity-70`}
       >
         <GitBranch size={13} />
-        <span className="truncate">{worktree.branch}</span>
+        <span className="truncate">{name}</span>
         {running ? (
           <span
             role="status"
-            aria-label={`Agent working in ${worktree.branch}`}
+            aria-label={`Agent working in ${name}`}
             title="Agent working"
             className="ml-auto size-2 shrink-0 animate-pulse rounded-full bg-accent1 group-hover:opacity-0"
           />
         ) : attention ? (
           <span
             role="status"
-            aria-label={`Agent finished in ${worktree.branch}`}
+            aria-label={`Agent finished in ${name}`}
             title="Agent finished — open to dismiss"
             className="ml-auto size-2 shrink-0 rounded-full bg-accent1 group-hover:opacity-0"
           />

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
@@ -1,15 +1,18 @@
 /**
- * BDD coverage for the propless `WorkspacesSection`.
+ * BDD coverage for the propless `WorkspacesSection` (factory Sessions).
  *
  * The section reads the active project from `useActiveProjectContext` and the
  * agent session from focused chat hooks, so the spec renders it inside the real
  * provider stack and asserts worktree selection through the MSW-captured
  * session-state requests instead of a session spy.
+ *
+ * Factory sessions are feature worktrees only: the persisted fixture includes
+ * a legacy repo-root entry and a `user/` personal-session worktree, and the
+ * specs assert both stay out of the list.
  */
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
-import type { ReactNode } from 'react';
 import { MemoryRouter, useLocation } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
@@ -44,10 +47,19 @@ const githubProject: Project = {
   resourceId: 'resource-gh',
   gitBranch: 'main',
   worktrees: [
+    // Legacy repo-root entry persisted by older builds — never a workspace.
     { branch: 'main', worktreePath: '/sandbox/mastra', baseBranch: 'main' },
     { branch: 'feat-ui', worktreePath: '/sandbox/mastra-worktrees/feat-ui', baseBranch: 'main' },
+    { branch: 'feat-api', worktreePath: '/sandbox/mastra-worktrees/feat-api', baseBranch: 'main' },
+    // Personal user session — listed by the User Sessions section instead.
+    {
+      branch: 'user/alice-notes',
+      worktreePath: '/sandbox/mastra-worktrees/user-alice-notes',
+      baseBranch: 'main',
+      threadId: 'thread-user',
+    },
   ],
-  selectedWorktreePath: '/sandbox/mastra',
+  selectedWorktreePath: '/sandbox/mastra-worktrees/feat-api',
   createdAt: 1,
 };
 
@@ -121,13 +133,13 @@ function LocationProbe() {
   return <span data-testid="location">{location.pathname}</span>;
 }
 
-function renderSection(children?: ReactNode, initialPath = '/') {
+function renderSection(initialPath = '/') {
   return renderWithProviders(
     <MemoryRouter initialEntries={[initialPath]}>
       <ToastProvider>
         <ActiveProjectProvider>
           <ChatSessionProvider>
-            <WorkspacesSection>{children}</WorkspacesSection>
+            <WorkspacesSection />
             <LocationProbe />
           </ChatSessionProvider>
         </ActiveProjectProvider>
@@ -136,43 +148,23 @@ function renderSection(children?: ReactNode, initialPath = '/') {
   );
 }
 
+/** The hover-group container of a worktree row, for targeting its actions menu. */
+function rowContainer(name: string): HTMLElement {
+  return screen.getByRole('button', { name }).parentElement as HTMLElement;
+}
+
 describe('WorkspacesSection', () => {
-  it('lists GitHub worktrees and marks the selected one active', async () => {
+  it('lists factory worktrees, hides the repo root and user sessions, and marks the selected one active', async () => {
     seedActiveProject(githubProject);
     useAgentControllerHandlers();
 
     renderSection();
 
-    expect(await screen.findByText('Workspaces')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'main' })).toHaveAttribute('aria-current', 'true');
+    expect(await screen.findByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'feat-api' })).toHaveAttribute('aria-current', 'true');
     expect(screen.getByRole('button', { name: 'feat-ui' })).not.toHaveAttribute('aria-current');
-  });
-
-  it('nests children under the active worktree row', async () => {
-    seedActiveProject(githubProject);
-    useAgentControllerHandlers();
-
-    renderSection(<div data-testid="nested-threads">Threads</div>);
-
-    const activeRow = await screen.findByRole('button', { name: 'main' });
-    const nested = screen.getByTestId('nested-threads');
-    // The row button sits inside a hover-group wrapper; nested children render
-    // as a sibling of that wrapper inside the worktree's container.
-    expect(activeRow.parentElement?.parentElement).toContainElement(nested);
-    const inactiveRow = screen.getByRole('button', { name: 'feat-ui' });
-    expect(inactiveRow.parentElement?.parentElement).not.toContainElement(nested);
-  });
-
-  it('given a feature worktree is active, then children nest under its row', async () => {
-    seedActiveProject({ ...githubProject, selectedWorktreePath: '/sandbox/mastra-worktrees/feat-ui' });
-    useAgentControllerHandlers();
-
-    renderSection(<div data-testid="nested-threads">Threads</div>);
-
-    const activeRow = await screen.findByRole('button', { name: 'feat-ui' });
-    expect(activeRow).toHaveAttribute('aria-current', 'true');
-    const nested = screen.getByTestId('nested-threads');
-    expect(activeRow.parentElement?.parentElement).toContainElement(nested);
+    expect(screen.queryByRole('button', { name: 'main' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'user/alice-notes' })).not.toBeInTheDocument();
   });
 
   it('does not render for local projects', async () => {
@@ -181,7 +173,7 @@ describe('WorkspacesSection', () => {
 
     renderSection();
 
-    await waitFor(() => expect(screen.queryByText('Workspaces')).not.toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Sessions')).not.toBeInTheDocument());
   });
 
   it('shows an activity indicator on workspaces with an active thread', async () => {
@@ -193,7 +185,12 @@ describe('WorkspacesSection', () => {
       http.get(`${API}/sessions/:resourceId/threads`, () =>
         HttpResponse.json({
           threads: [
-            { id: 'thread-main', title: 'Main work', tags: { projectPath: '/sandbox/mastra' }, state: 'idle' },
+            {
+              id: 'thread-api',
+              title: 'API work',
+              tags: { projectPath: '/sandbox/mastra-worktrees/feat-api' },
+              state: 'idle',
+            },
             {
               id: 'thread-feat',
               title: 'Feature work',
@@ -208,7 +205,7 @@ describe('WorkspacesSection', () => {
     renderSection();
 
     expect(await screen.findByRole('status', { name: 'Agent working in feat-ui' })).toBeInTheDocument();
-    expect(screen.queryByRole('status', { name: 'Agent working in main' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('status', { name: 'Agent working in feat-api' })).not.toBeInTheDocument();
   });
 
   it('given a run that finishes, then the dot turns solid and chimes, and opening the workspace dismisses it', async () => {
@@ -306,7 +303,7 @@ describe('WorkspacesSection', () => {
         }),
       ),
     );
-    renderSection(undefined, '/threads/thread-test');
+    renderSection('/threads/thread-test');
 
     await userEvent.click(await screen.findByRole('button', { name: 'feat-ui' }));
 
@@ -325,7 +322,7 @@ describe('WorkspacesSection', () => {
         }),
       ),
     );
-    renderSection(undefined, '/new');
+    renderSection('/new');
 
     await userEvent.click(await screen.findByRole('button', { name: 'feat-ui' }));
 
@@ -342,7 +339,7 @@ describe('WorkspacesSection', () => {
         return HttpResponse.json({ id: 'thread-fresh', title: 'New thread', resourceId: 'resource-gh' });
       }),
     );
-    renderSection(undefined, '/threads/thread-test');
+    renderSection('/threads/thread-test');
 
     await userEvent.click(await screen.findByRole('button', { name: 'feat-ui' }));
 
@@ -353,7 +350,7 @@ describe('WorkspacesSection', () => {
   it('stays on non-thread routes when switching workspaces', async () => {
     seedActiveProject(githubProject);
     useAgentControllerHandlers();
-    renderSection(undefined, '/factory/board');
+    renderSection('/factory/board');
 
     await userEvent.click(await screen.findByRole('button', { name: 'feat-ui' }));
 
@@ -410,21 +407,21 @@ describe('WorkspacesSection', () => {
     await userEvent.type(within(form).getByRole('textbox', { name: 'Branch name' }), 'bad branch{Enter}');
 
     expect(await screen.findAllByText('branch name is invalid')).not.toHaveLength(0);
-    expect(screen.getByRole('button', { name: 'main' })).toHaveAttribute('aria-current', 'true');
-    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
+    expect(screen.getByRole('button', { name: 'feat-api' })).toHaveAttribute('aria-current', 'true');
+    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-api');
     // Only the provider's initial project-path sync may write state — never a failed create.
     const paths = stateUpdates.map(update => (update.state as { projectPath?: string })?.projectPath);
-    expect(paths.filter(path => path !== '/sandbox/mastra')).toEqual([]);
+    expect(paths.filter(path => path !== '/sandbox/mastra-worktrees/feat-api')).toEqual([]);
   });
 
-  it('offers a delete action on feature worktrees but not the repo root', async () => {
+  it('offers a delete action on every factory worktree', async () => {
     seedActiveProject(githubProject);
     useAgentControllerHandlers();
     renderSection();
 
     await screen.findByRole('button', { name: 'feat-ui' });
-    // One actions menu (feat-ui); the root workspace has none.
-    expect(screen.getAllByRole('button', { name: 'Workspace actions' })).toHaveLength(1);
+    // One actions menu per factory worktree (feat-ui, feat-api).
+    expect(screen.getAllByRole('button', { name: 'Workspace actions' })).toHaveLength(2);
   });
 
   it('deletes a worktree after confirmation, cascading its threads', async () => {
@@ -461,7 +458,8 @@ describe('WorkspacesSection', () => {
     );
     renderSection();
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Workspace actions' }));
+    await screen.findByRole('button', { name: 'feat-ui' });
+    await userEvent.click(within(rowContainer('feat-ui')).getByRole('button', { name: 'Workspace actions' }));
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Delete' }));
 
     const dialog = await screen.findByRole('dialog', { name: 'Delete workspace?' });
@@ -470,7 +468,10 @@ describe('WorkspacesSection', () => {
     await waitFor(() => expect(deletedBranch).toBe('feat-ui'));
     await waitFor(() => expect(screen.queryByRole('button', { name: 'feat-ui' })).not.toBeInTheDocument());
     expect(deletedThreads).toEqual(['thread-doomed']);
-    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
+    // The user-session worktree survives; the legacy repo-root entry is
+    // dropped for good when the worktree list is rewritten.
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['feat-api', 'user/alice-notes']);
+    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-api');
   });
 
   it('keeps the worktree when the delete confirmation is cancelled', async () => {
@@ -489,7 +490,8 @@ describe('WorkspacesSection', () => {
     );
     renderSection();
 
-    await userEvent.click(await screen.findByRole('button', { name: 'Workspace actions' }));
+    await screen.findByRole('button', { name: 'feat-ui' });
+    await userEvent.click(within(rowContainer('feat-ui')).getByRole('button', { name: 'Workspace actions' }));
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Delete' }));
     const dialog = await screen.findByRole('dialog', { name: 'Delete workspace?' });
     await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }));
@@ -497,6 +499,11 @@ describe('WorkspacesSection', () => {
     await waitFor(() => expect(screen.queryByRole('dialog', { name: 'Delete workspace?' })).not.toBeInTheDocument());
     expect(deleteCalled).toBe(false);
     expect(screen.getByRole('button', { name: 'feat-ui' })).toBeInTheDocument();
-    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual([
+      'main',
+      'feat-ui',
+      'feat-api',
+      'user/alice-notes',
+    ]);
   });
 });

--- a/mastracode/web/src/web/ui/domains/workspaces/context/__tests__/ActiveProjectProvider.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/context/__tests__/ActiveProjectProvider.msw.test.tsx
@@ -153,7 +153,9 @@ describe('ActiveProjectProvider', () => {
         sandboxId: 'sbx_1',
         sandboxWorkdir: '/workspace/hello',
       });
-      expect(stored?.worktrees).toEqual([{ branch: 'main', worktreePath: '/workspace/hello', baseBranch: 'main' }]);
+      // The repo-root checkout is not a workspace, so materialization seeds no
+      // worktrees — sessions only exist once created explicitly.
+      expect(stored?.worktrees ?? []).toEqual([]);
     });
 
     it('given materialization fails, when a GitHub project is selected, then it is NOT activated and the error is exposed', async () => {

--- a/mastracode/web/src/web/ui/domains/workspaces/hooks/__tests__/useWorkspaces.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/hooks/__tests__/useWorkspaces.msw.test.tsx
@@ -20,6 +20,9 @@ const ORIGIN = TEST_BASE_URL;
 const PROJECT_ID = 'project-gh';
 const GITHUB_PROJECT_ID = 'github-project-1';
 
+// The persisted shape intentionally includes a legacy repo-root entry (older
+// builds stored it) and a personal user-session worktree: neither is a
+// factory workspace, so both must be filtered out of the workspaces data.
 const rootProject: Project = {
   id: PROJECT_ID,
   name: 'Mastra',
@@ -31,8 +34,15 @@ const rootProject: Project = {
   worktrees: [
     { branch: 'main', worktreePath: '/sandbox/mastra', baseBranch: 'main' },
     { branch: 'feat-ui', worktreePath: '/sandbox/mastra-worktrees/feat-ui', baseBranch: 'main' },
+    { branch: 'feat-api', worktreePath: '/sandbox/mastra-worktrees/feat-api', baseBranch: 'main' },
+    {
+      branch: 'user/alice-notes',
+      worktreePath: '/sandbox/mastra-worktrees/user-alice-notes',
+      baseBranch: 'main',
+      threadId: 'thread-user',
+    },
   ],
-  selectedWorktreePath: '/sandbox/mastra',
+  selectedWorktreePath: '/sandbox/mastra-worktrees/feat-ui',
   createdAt: 1,
 };
 
@@ -41,13 +51,13 @@ function saveProject(project: Project) {
 }
 
 describe('workspaces query hooks', () => {
-  it('reads GitHub project worktrees through React Query', async () => {
+  it('reads factory worktrees only: legacy repo-root and user/ session entries are excluded', async () => {
     saveProject(rootProject);
 
     const { result } = renderHookWithProviders(() => useWorkspacesQuery(rootProject));
 
-    await waitFor(() => expect(result.current.data?.selected?.branch).toBe('main'));
-    expect(result.current.data?.worktrees.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
+    await waitFor(() => expect(result.current.data?.selected?.branch).toBe('feat-ui'));
+    expect(result.current.data?.worktrees.map(worktree => worktree.branch)).toEqual(['feat-ui', 'feat-api']);
   });
 
   it('selects a workspace, persists it, and refreshes projects consumers', async () => {
@@ -63,17 +73,17 @@ describe('workspaces query hooks', () => {
       return { projects, workspaces, selectWorkspace };
     });
 
-    await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('main'));
+    await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('feat-ui'));
 
     await act(async () => {
-      await result.current.selectWorkspace.mutateAsync('/sandbox/mastra-worktrees/feat-ui');
+      await result.current.selectWorkspace.mutateAsync('/sandbox/mastra-worktrees/feat-api');
     });
     await waitForMutationsIdle(client);
 
-    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-ui');
-    await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('feat-ui'));
+    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-api');
+    await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('feat-api'));
     await waitFor(() =>
-      expect(result.current.projects.data[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-ui'),
+      expect(result.current.projects.data[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-api'),
     );
   });
 
@@ -112,8 +122,8 @@ describe('workspaces query hooks', () => {
     expect(received).toEqual({ branch: 'feat-new' });
     await waitFor(() => expect(result.current.workspaces.data?.selected?.branch).toBe('feat-new'));
     expect(result.current.workspaces.data?.worktrees.map(worktree => worktree.branch)).toEqual([
-      'main',
       'feat-ui',
+      'feat-api',
       'feat-new',
     ]);
   });
@@ -135,11 +145,11 @@ describe('workspaces query hooks', () => {
       });
     });
 
-    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
+    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-ui');
   });
 
   it('deletes a workspace, cascades its threads, and falls back the stored selection when it was selected', async () => {
-    saveProject({ ...rootProject, selectedWorktreePath: '/sandbox/mastra-worktrees/feat-ui' });
+    saveProject(rootProject); // selected: feat-ui
     let received: unknown;
 
     server.use(
@@ -187,8 +197,9 @@ describe('workspaces query hooks', () => {
     expect(received).toEqual({ branch: 'feat-ui' });
     expect(deletedThreads).toEqual(['thread-1', 'thread-2']);
     const stored = loadProjects()[0]!;
-    expect(stored.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
-    expect(stored.selectedWorktreePath).toBe('/sandbox/mastra');
+    // User-session worktrees survive but never become the selection.
+    expect(stored.worktrees?.map(worktree => worktree.branch)).toEqual(['feat-api', 'user/alice-notes']);
+    expect(stored.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-api');
   });
 
   it('keeps threads and the stored worktree when the server delete fails', async () => {
@@ -218,15 +229,20 @@ describe('workspaces query hooks', () => {
     });
 
     expect(threadSession.deleteThread).not.toHaveBeenCalled();
-    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main', 'feat-ui']);
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual([
+      'main',
+      'feat-ui',
+      'feat-api',
+      'user/alice-notes',
+    ]);
   });
 
   it('keeps the stored selection when deleting an unselected workspace', async () => {
-    saveProject(rootProject); // selected: /sandbox/mastra (root)
+    saveProject(rootProject); // selected: feat-ui
 
     server.use(
       http.post(`${ORIGIN}/web/github/projects/${GITHUB_PROJECT_ID}/worktree/delete`, () =>
-        HttpResponse.json({ removed: true, branch: 'feat-ui', worktreePath: '/sandbox/mastra-worktrees/feat-ui' }),
+        HttpResponse.json({ removed: true, branch: 'feat-api', worktreePath: '/sandbox/mastra-worktrees/feat-api' }),
       ),
     );
 
@@ -239,24 +255,31 @@ describe('workspaces query hooks', () => {
 
     await act(async () => {
       await result.current.mutateAsync({
-        branch: 'feat-ui',
-        worktreePath: '/sandbox/mastra-worktrees/feat-ui',
+        branch: 'feat-api',
+        worktreePath: '/sandbox/mastra-worktrees/feat-api',
         baseBranch: 'main',
       });
     });
     await waitForMutationsIdle(client);
 
-    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['main']);
-    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra');
+    expect(loadProjects()[0]?.worktrees?.map(worktree => worktree.branch)).toEqual(['feat-ui', 'user/alice-notes']);
+    expect(loadProjects()[0]?.selectedWorktreePath).toBe('/sandbox/mastra-worktrees/feat-ui');
   });
 
-  it('derives the active projectPath from the selected GitHub worktree', () => {
-    expect(deriveProjectPath(rootProject)).toBe('/sandbox/mastra');
-    expect(deriveProjectPath({ ...rootProject, selectedWorktreePath: '/sandbox/mastra-worktrees/feat-ui' })).toBe(
-      '/sandbox/mastra-worktrees/feat-ui',
+  it('derives the active projectPath from the selected factory worktree, with no repo-root fallback', () => {
+    expect(deriveProjectPath(rootProject)).toBe('/sandbox/mastra-worktrees/feat-ui');
+    expect(deriveProjectPath({ ...rootProject, selectedWorktreePath: '/sandbox/mastra-worktrees/feat-api' })).toBe(
+      '/sandbox/mastra-worktrees/feat-api',
     );
-    expect(deriveProjectPath({ ...rootProject, worktrees: [], selectedWorktreePath: undefined })).toBe(
-      '/sandbox/mastra',
-    );
+    // No factory worktree yet: nothing to chat in, so no project path.
+    expect(deriveProjectPath({ ...rootProject, worktrees: [], selectedWorktreePath: undefined })).toBe('');
+    // A user-session worktree is never the project selection.
+    expect(
+      deriveProjectPath({
+        ...rootProject,
+        worktrees: rootProject.worktrees!.filter(w => w.branch.startsWith('user/')),
+        selectedWorktreePath: undefined,
+      }),
+    ).toBe('');
   });
 });

--- a/mastracode/web/src/web/ui/domains/workspaces/hooks/useWorkspaces.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/hooks/useWorkspaces.ts
@@ -6,8 +6,8 @@ import { useToast } from '../../../ui/toast';
 import { createWorktree, deleteWorktree } from '../services/github';
 import type { Project, Worktree } from '../services/projects';
 import {
+  factoryWorktrees,
   loadProjects,
-  projectWorktrees,
   removeWorktree,
   selectedWorktree,
   selectWorktree,
@@ -39,7 +39,10 @@ function latestProject(project: Project): Project {
 
 export function deriveProjectPath(project: Project | null | undefined): string {
   if (!project) return '';
-  if (project.source === 'github') return selectedWorktree(project)?.worktreePath ?? project.sandboxWorkdir ?? '';
+  // The repo-root checkout is not a chat target: everything runs in a
+  // worktree branched from HEAD, so a GitHub project without a selected
+  // workspace has no project path (and no enabled chat session).
+  if (project.source === 'github') return selectedWorktree(project)?.worktreePath ?? '';
   return project.path ?? '';
 }
 
@@ -59,7 +62,9 @@ function invalidateWorkspaceQueries(
 function workspacesData(project: Project): WorkspacesData {
   const current = latestProject(project);
   return {
-    worktrees: projectWorktrees(current),
+    // Factory workspaces only: user-session worktrees are listed by the
+    // User Sessions section, and the repo root is not a workspace at all.
+    worktrees: factoryWorktrees(current),
     selected: selectedWorktree(current),
   };
 }
@@ -116,8 +121,9 @@ export function useCreateWorkspaceMutation(project: Project | null | undefined, 
 /**
  * Delete a worktree: removes the sandbox checkout + branch server-side, deletes
  * every thread that ran inside it, drops it from the stored project, and — when
- * the deleted worktree was selected — falls back to the repo-root selection
- * (the UI re-derives the scope and addresses that worktree's own session).
+ * the deleted worktree was selected — falls back to the first remaining factory
+ * workspace (the UI re-derives the scope and addresses that worktree's own
+ * session), or to no selection when none remain.
  * Destructive; callers confirm with the user first.
  */
 export function useDeleteWorkspaceMutation(

--- a/mastracode/web/src/web/ui/domains/workspaces/index.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/index.ts
@@ -3,6 +3,7 @@ export { EmptyProjectState } from './components/EmptyProjectState';
 export { GithubConnectModal } from './components/GithubConnectModal';
 export { ProjectsModal } from './components/ProjectsModal';
 export { ProjectSwitcher } from './components/ProjectSwitcher';
+export { UserSessionsSection } from './components/UserSessionsSection';
 export { WorkspacesSection } from './components/WorkspacesSection';
 export { useActiveProject } from './hooks/useActiveProject';
 export { ActiveProjectProvider, useActiveProjectContext } from './context/ActiveProjectProvider';

--- a/mastracode/web/src/web/ui/domains/workspaces/services/projects.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/services/projects.ts
@@ -19,16 +19,36 @@ const ACTIVE_KEY = 'mastracode-active-project';
 
 /**
  * A workspace (git worktree) inside a GitHub project's sandbox. Each worktree
- * is a distinct branch checked out at its own path. A repo's worktrees share
- * one session resourceId (and that id is shared with the TUI); their threads
+ * is a distinct branch checked out at its own path, created from the repo's
+ * HEAD (default) branch. The repo-root checkout is never a workspace itself —
+ * it only serves as the source that worktrees branch from. Factory worktrees
+ * share the project's session resourceId (shared with the TUI); their threads
  * are partitioned per workspace by the `projectPath` tag (the worktree path).
- * The project root is itself the first worktree (the default branch);
- * additional ones are created via "New workspace".
+ * User-session worktrees use the `user/` branch prefix and run under the
+ * signed-in user's own resourceId.
  */
 export interface Worktree {
   branch: string;
   worktreePath: string;
   baseBranch: string;
+  /**
+   * The single conversation held by this worktree, when known. User-session
+   * worktrees always persist it (the `/user/threads/:threadId` route resolves
+   * the session scope from it); factory worktrees may leave it unset.
+   */
+  threadId?: string;
+}
+
+/**
+ * Branch prefix that marks a worktree as a personal user session rather than
+ * a factory workspace. User sessions are worktrees too (branched from HEAD),
+ * but they live under the user's resourceId and are listed separately.
+ */
+export const USER_SESSION_BRANCH_PREFIX = 'user/';
+
+/** Whether a worktree is a personal user session (by branch prefix). */
+export function isUserSessionWorktree(worktree: Worktree): boolean {
+  return worktree.branch.startsWith(USER_SESSION_BRANCH_PREFIX);
 }
 
 export interface Project {
@@ -52,16 +72,17 @@ export interface Project {
   sandboxId?: string;
   sandboxWorkdir?: string;
   /**
-   * Workspaces (git worktrees) for a GitHub project. The first entry is the
-   * repo root on its default branch; additional entries are feature-branch
-   * worktrees created via "New workspace". Each carries its own resourceId so
-   * its threads are isolated. Absent/empty for local projects.
+   * Workspaces (git worktrees) for a GitHub project: factory feature-branch
+   * worktrees created via "New workspace" plus `user/`-prefixed personal
+   * session worktrees, all branched from the repo's HEAD. The repo-root
+   * checkout is never listed. Absent/empty for local projects.
    */
   worktrees?: Worktree[];
   /**
-   * Currently selected worktree for a GitHub project (by worktreePath). The
-   * session binds to this worktree's path + resourceId. Falls back to the repo
-   * root when unset.
+   * Currently selected factory worktree for a GitHub project (by
+   * worktreePath). The session binds to this worktree's path + resourceId.
+   * Falls back to the first factory worktree when unset; no selection when
+   * the project has no factory worktree yet.
    */
   selectedWorktreePath?: string;
   /**
@@ -201,49 +222,75 @@ export function updateProject(project: Project): void {
 /**
  * Merge a server `MaterializeResult` (from the `/ensure` route) into a stored
  * GitHub project and persist it: records the session `resourceId` plus the
- * sandbox binding, and seeds the root worktree (default branch at the sandbox
- * workdir) when the project has none yet.
+ * sandbox binding. The repo-root checkout is not a workspace, so no worktree
+ * is seeded — workspaces only exist once created explicitly.
  */
 export function applyMaterializeResult(project: Project, result: MaterializeResult): Project {
-  const merged: Project = {
+  const updated: Project = {
     ...project,
     resourceId: result.resourceId,
     sandboxId: result.sandboxId,
     sandboxWorkdir: result.sandboxWorkdir,
   };
-  const updated: Project =
-    merged.worktrees && merged.worktrees.length > 0 ? merged : { ...merged, worktrees: projectWorktrees(merged) };
   updateProject(updated);
   return updated;
 }
 
 /**
- * The worktree list for a project, normalizing legacy projects: a GitHub
- * project always has at least the repo-root worktree (its default branch), and
- * a pre-`worktrees` project with an `activeBranch` gets that folded in.
+ * Every session worktree for a project (factory workspaces + user sessions).
+ * The repo-root checkout is never a workspace: legacy projects that persisted
+ * it as their first worktree get it filtered out here, and a pre-`worktrees`
+ * project with an `activeBranch` gets that folded in.
  */
 export function projectWorktrees(project: Project): Worktree[] {
   if (project.source !== 'github') return [];
-  if (project.worktrees && project.worktrees.length > 0) return project.worktrees;
-
-  // Migrate legacy shape: synthesize the root worktree, plus the previously
-  // persisted active feature worktree if one existed.
-  const rootBranch = project.gitBranch ?? 'main';
-  const rootPath = project.sandboxWorkdir ?? '';
-  const list: Worktree[] = [{ branch: rootBranch, worktreePath: rootPath, baseBranch: rootBranch }];
-  if (project.activeBranch && project.activeWorktreePath && project.activeBranch !== rootBranch) {
-    list.push({
-      branch: project.activeBranch,
-      worktreePath: project.activeWorktreePath,
-      baseBranch: rootBranch,
-    });
+  const persisted = project.worktrees ?? [];
+  if (persisted.length > 0) {
+    // Drop legacy repo-root entries (default branch at the sandbox workdir).
+    return persisted.filter(w => w.worktreePath !== project.sandboxWorkdir);
   }
-  return list;
+
+  // Migrate legacy shape: fold in the previously persisted active feature
+  // worktree if one existed. No root entry — HEAD is not a workspace.
+  const rootBranch = project.gitBranch ?? 'main';
+  if (project.activeBranch && project.activeWorktreePath && project.activeBranch !== rootBranch) {
+    return [{ branch: project.activeBranch, worktreePath: project.activeWorktreePath, baseBranch: rootBranch }];
+  }
+  return [];
 }
 
-/** The currently selected worktree for a project, or the repo root by default. */
+/** Factory workspaces only (excludes `user/` personal-session worktrees). */
+export function factoryWorktrees(project: Project): Worktree[] {
+  return projectWorktrees(project).filter(w => !isUserSessionWorktree(w));
+}
+
+/** Personal user-session worktrees only (`user/` branch prefix). */
+export function userSessionWorktrees(project: Project): Worktree[] {
+  return projectWorktrees(project).filter(isUserSessionWorktree);
+}
+
+/**
+ * Resolve the user-session worktree that holds the given thread, searching
+ * every stored project. Used by the `/user/threads/:threadId` route to rebind
+ * the user-scoped session (resourceId = user id, scope = worktree path) on
+ * deep links and reloads.
+ */
+export function findUserSessionByThreadId(threadId: string): { project: Project; worktree: Worktree } | undefined {
+  for (const project of loadProjects()) {
+    const worktree = userSessionWorktrees(project).find(w => w.threadId === threadId);
+    if (worktree) return { project, worktree };
+  }
+  return undefined;
+}
+
+/**
+ * The currently selected factory workspace, falling back to the first one.
+ * User-session worktrees are never the project selection — they are opened
+ * through their own routes. Undefined when the project has no factory
+ * workspace yet (nothing to chat in until one is created).
+ */
 export function selectedWorktree(project: Project): Worktree | undefined {
-  const list = projectWorktrees(project);
+  const list = factoryWorktrees(project);
   if (list.length === 0) return undefined;
   const match = project.selectedWorktreePath
     ? list.find(w => w.worktreePath === project.selectedWorktreePath)
@@ -265,16 +312,16 @@ export function upsertWorktree(project: Project, worktree: Worktree): Project {
 
 /**
  * Remove a worktree from a project and persist. If the removed worktree was
- * selected, selection falls back to the repo root (first worktree). Returns the
- * updated project.
+ * selected, selection falls back to the first remaining factory workspace (or
+ * none — the repo root is not a workspace). Returns the updated project.
  */
 export function removeWorktree(project: Project, worktreePath: string): Project {
   const remaining = projectWorktrees(project).filter(w => w.worktreePath !== worktreePath);
+  const fallback = remaining.find(w => !isUserSessionWorktree(w))?.worktreePath;
   const updated: Project = {
     ...project,
     worktrees: remaining,
-    selectedWorktreePath:
-      project.selectedWorktreePath === worktreePath ? remaining[0]?.worktreePath : project.selectedWorktreePath,
+    selectedWorktreePath: project.selectedWorktreePath === worktreePath ? fallback : project.selectedWorktreePath,
   };
   updateProject(updated);
   return updated;

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -82,6 +82,9 @@ export function createAppRoutes(): RouteObject[] {
           children: [
             { path: 'new', element: <NewPage /> },
             { path: 'threads/:threadId', element: <ThreadPage /> },
+            // Personal (non-factory) sessions: same thread page, but the
+            // session provider binds to the user's own resourceId + worktree.
+            { path: 'user/threads/:threadId', element: <ThreadPage /> },
             { path: 'factory/board', element: <BoardPage /> },
             // Legacy Factory pages, folded into the Board.
             { path: 'factory/intake', element: <Navigate to="/factory/board" replace /> },


### PR DESCRIPTION
## Summary

Restructures the Mastra Code web sidebar around two kinds of worktree-driven sessions, and removes the repo-root/main-branch checkout as a chat target entirely. Every conversation now lives in its own worktree branched from the repo's HEAD.

### Factory Sessions (nested under the Factory menu)
- The workspace list moves inside the **Factory** nav as a "Sessions" subsection, alongside the Board link.
- Only feature worktrees appear — the repo-root checkout is no longer a workspace, and `user/`-prefixed personal worktrees are excluded.
- The Factory menu now renders for any GitHub project; only the Board link is gated on GitHub connectivity.
- Mode selection (Build, etc.) is hidden in factory sessions — these are org-level sessions run by the factory.

### User Sessions (new sidebar section)
- Personal chat sessions for the signed-in user, each backed by its own worktree branched from HEAD under the `user/` prefix.
- Scoped to the user's own stable identity: `/auth/me` now exposes the WorkOS `userId`, which the SPA uses as the session `resourceId` (instead of the org/project resource).
- New `/user/threads/:threadId` route; `ChatSessionContext` gains a `kind: 'factory' | 'user'` descriptor so chat components (modes, thread lists, navigation) adapt per session type.
- Modes remain available in user sessions.

### Why
Factory sessions are org-level runs coordinated by the factory board; user sessions are an individual's parallel conversations. Splitting them by resourceId and worktree keeps thread partitions isolated, lets multiple user sessions run in parallel, and removes the special-cased main-branch workspace that previously anchored the thread list.

## Test plan
- [x] 399 web MSW tests passing (`pnpm exec vitest run --config e2e/web-ui/vitest.config.ts`)
- [x] 368 web unit tests passing (`pnpm exec vitest run`)
- [x] `pnpm check` (tsc for server + UI) clean
- [x] Prettier clean
- [x] Updated specs: Sidebar nesting, Factory section gating, ThreadList read-only behavior, project materialization no longer seeding a repo-root worktree, `/auth/me` userId exposure

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The sidebar now separates shared project work into **Factory Sessions** and personal conversations into **User Sessions**. Personal sessions use the signed-in user’s identity and have their own URLs, while the repository checkout is no longer treated as a chat workspace.

## Summary

- Added Factory Sessions for feature worktrees only, excluding the repo root and `user/` worktrees.
- Added User Sessions backed by personal `user/` worktrees, user-scoped resources, and `/user/threads/:threadId` routes.
- Added session context metadata to distinguish factory and user sessions; factory sessions hide mode selection.
- Exposed `userId` through `/auth/me` and used it to derive user-session resource IDs.
- Updated the sidebar and Factory navigation:
  - Factory navigation remains available for GitHub projects.
  - Board visibility remains gated by GitHub connectivity.
  - User Sessions appear separately from Factory Sessions.
- Added creation, deletion, legacy-session migration, thread backfilling, navigation, and cache handling for User Sessions.
- Updated worktree selection, persistence, deletion fallback, and filtering behavior.
- Updated MSW, UI, hook, authentication, and routing tests to cover the new session model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->