### PR TITLE
feat(mcp): complete the OAuth authorization-code loop for HTTP MCP servers

### DIFF
--- a/.changeset/mcp-oauth-auth-loop.md
+++ b/.changeset/mcp-oauth-auth-loop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+Complete the OAuth authorization-code loop in MCPClient for HTTP MCP servers. Connections rejected with an authorization error now surface a `needs-auth` state (readable via `getServerAuthState()`), and the new `authenticate(serverName)` method runs the interactive flow end to end: it captures the authorization code on a local loopback callback server (exported as `createOAuthCallbackServer` for hosts with custom redirect handling), exchanges it for tokens, and reconnects.

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -54,7 +54,7 @@ Visit [MCPClient](/reference/tools/mcp-client) for a full list of configuration 
 
 :::tip Authentication
 
-For connecting to OAuth-protected MCP servers, see the [OAuth Authentication](/reference/tools/mcp-client#oauth-authentication) section.
+For connecting to OAuth-protected MCP servers — including completing the browser-based authorization flow with `authenticate()` — see the [OAuth Authentication](/reference/tools/mcp-client#oauth-authentication) section.
 
 :::
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -311,6 +311,22 @@ const instructionsByServer = mcp.getServerInstructions()
 console.log(instructionsByServer.db)
 ```
 
+### `authenticate()`
+
+Runs the interactive OAuth authorization-code flow for a server configured with an `MCPOAuthClientProvider` whose redirect URL points at a loopback address. Starts a local callback server, delivers the authorization URL through the provider's `onRedirectToAuthorization` callback, waits for the browser to return the authorization code, exchanges it for tokens, and reconnects. See [Interactive browser authentication](#interactive-browser-authentication).
+
+```typescript prettier:false
+async authenticate(serverName: string, options?: { timeoutMs?: number }): Promise<void>
+```
+
+### `getServerAuthState()`
+
+Returns the OAuth authorization state of a configured server: `'needs-auth'` after a connection attempt was rejected with an authorization error, `'authorized'` once the server accepted the provider's credentials, or `undefined` for servers without an `authProvider` or that haven't attempted a connection yet.
+
+```typescript prettier:false
+getServerAuthState(serverName: string): 'needs-auth' | 'authorized' | undefined
+```
+
 ### `disconnect()`
 
 Disconnects from all MCP servers and cleans up resources.
@@ -922,6 +938,64 @@ const client = new MCPClient({
     },
   },
 })
+```
+
+### Interactive browser authentication
+
+When a server rejects a connection because authorization is required, the client records a `'needs-auth'` state instead of failing outright. Calling `authenticate()` then completes the flow end to end: it starts a one-shot callback server on the provider's loopback redirect URL (falling back to the next sequential ports when it is in use), lets the SDK run discovery and dynamic client registration, delivers the authorization URL through `onRedirectToAuthorization` — open it in the user's browser — and finishes the token exchange once the browser returns the authorization code:
+
+```typescript
+import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp'
+
+const oauthProvider = new MCPOAuthClientProvider({
+  redirectUrl: 'http://127.0.0.1:5533/oauth/callback',
+  clientMetadata: {
+    redirect_uris: ['http://127.0.0.1:5533/oauth/callback'],
+    client_name: 'My MCP Client',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+  },
+  onRedirectToAuthorization: url => {
+    // Open the user's browser at the consent page
+    console.log(`Please visit: ${url}`)
+  },
+})
+
+const mcp = new MCPClient({
+  servers: {
+    protectedServer: {
+      url: new URL('https://mcp.example.com/mcp'),
+      authProvider: oauthProvider,
+    },
+  },
+})
+
+try {
+  await mcp.listTools()
+} catch {
+  if (mcp.getServerAuthState('protectedServer') === 'needs-auth') {
+    await mcp.authenticate('protectedServer')
+  }
+}
+```
+
+Concurrent `authenticate()` calls for the same server join the pending flow; different servers authenticate independently. With valid stored tokens the call simply reconnects without opening a browser.
+
+Hosts with custom redirect handling (for example a web app with an HTTPS redirect URL) can capture the authorization code themselves with the exported `createOAuthCallbackServer` helper, which binds a one-shot loopback server, validates the OAuth `state` parameter, and resolves with the code:
+
+```typescript
+import { createOAuthCallbackServer, getCallbackUrlCandidates } from '@mastra/mcp'
+
+const server = await createOAuthCallbackServer({
+  redirectUrl: 'http://127.0.0.1:5533/oauth/callback',
+  state: expectedState,
+})
+
+// server.url reflects any port fallback — use it as the redirect_uri.
+// getCallbackUrlCandidates() lists every URL the helper may bind, so all
+// of them can be registered as redirect_uris during client registration.
+const { code } = await server.waitForCode()
+await server.close()
 ```
 
 ### Quick Token Provider

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -327,6 +327,14 @@ Returns the OAuth authorization state of a configured server: `'needs-auth'` aft
 getServerAuthState(serverName: string): 'needs-auth' | 'authorized' | undefined
 ```
 
+### `cancelAuthentication()`
+
+Cancels an in-progress `authenticate()` flow for a server, so an abandoned browser authorization does not leave the client waiting indefinitely. It aborts the flow (including its setup phase, before the callback server binds), closes the local callback server if one is listening, and returns the server to `'needs-auth'`. The pending `authenticate()` call rejects. Returns `true` if a flow was cancelled, or `false` when no flow was in progress.
+
+```typescript prettier:false
+async cancelAuthentication(serverName: string): Promise<boolean>
+```
+
 ### `disconnect()`
 
 Disconnects from all MCP servers and cleans up resources.
@@ -981,7 +989,7 @@ try {
 
 Concurrent `authenticate()` calls for the same server join the pending flow; different servers authenticate independently. With valid stored tokens the call simply reconnects without opening a browser.
 
-Hosts with custom redirect handling (for example a web app with an HTTPS redirect URL) can capture the authorization code themselves with the exported `createOAuthCallbackServer` helper, which binds a one-shot loopback server, validates the OAuth `state` parameter, and resolves with the code:
+Hosts that drive the flow themselves can capture the authorization code with the exported `createOAuthCallbackServer` helper, which binds a one-shot loopback server, validates the OAuth `state` parameter, and resolves with the code. It creates a plain HTTP server, so it is only for local loopback redirects. Web applications that use an HTTPS redirect URL must host their own callback endpoint and drive the provider directly rather than using this helper:
 
 ```typescript
 import { createOAuthCallbackServer, getCallbackUrlCandidates } from '@mastra/mcp'
@@ -994,8 +1002,12 @@ const server = await createOAuthCallbackServer({
 // server.url reflects any port fallback — use it as the redirect_uri.
 // getCallbackUrlCandidates() lists every URL the helper may bind, so all
 // of them can be registered as redirect_uris during client registration.
-const { code } = await server.waitForCode()
-await server.close()
+try {
+  const { code } = await server.waitForCode()
+  // Exchange the code here.
+} finally {
+  await server.close()
+}
 ```
 
 ### Quick Token Provider

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -529,6 +529,13 @@ export class InternalMastraMCPClient extends MastraBase {
    * transport that started the authorization flow so finishAuth can complete it.
    */
   private markNeedsAuth(transport: StreamableHTTPClientTransport | SSEClientTransport): void {
+    // A prior connect() may have left a pending transport that never completed
+    // finishAuth. Close the superseded one before replacing it so its event
+    // stream and session resources are released rather than abandoned.
+    const superseded = this.pendingAuthTransport;
+    if (superseded && superseded !== transport) {
+      void superseded.close().catch(() => {});
+    }
     this.pendingAuthTransport = transport;
     this._authState = 'needs-auth';
     this.log('debug', 'Server requires OAuth authorization before connecting.');

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -471,7 +471,8 @@ export class InternalMastraMCPClient extends MastraBase {
 
         // A 401 means the flow continues on this transport via finishAuth, not on a
         // fallback: the SDK has already run discovery and redirected to authorization.
-        if (error instanceof UnauthorizedError) {
+        // Guarded on authProvider so servers without one never carry an auth state.
+        if (authProvider && error instanceof UnauthorizedError) {
           this.markNeedsAuth(streamableTransport);
           throw error;
         }
@@ -504,7 +505,7 @@ export class InternalMastraMCPClient extends MastraBase {
         this.transport = sseTransport;
         this.log('debug', 'Successfully connected using deprecated HTTP+SSE transport.');
       } catch (sseError) {
-        if (sseError instanceof UnauthorizedError) {
+        if (authProvider && sseError instanceof UnauthorizedError) {
           this.markNeedsAuth(sseTransport);
           throw sseError;
         }

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -44,6 +44,7 @@ import {
 
 import { asyncExitHook, gracefulExit } from 'exit-hook';
 import { getMastraToolStrictMeta } from '../shared/mastra-tool-meta';
+import { UnauthorizedError } from '../shared/oauth-types';
 import { ElicitationClientActions } from './actions/elicitation';
 import { ProgressClientActions } from './actions/progress';
 import { PromptClientActions } from './actions/prompt';
@@ -78,6 +79,17 @@ export type {
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
 const DEFAULT_INSTRUCTIONS_MAX_LENGTH = 512;
+
+/**
+ * OAuth authorization state of an MCP server connection.
+ *
+ * - `needs-auth`: the server rejected the connection with a 401 and interactive
+ *   authorization is required (see MCPClient.authenticate)
+ * - `authorized`: the server accepted the configured authProvider's credentials
+ *
+ * Servers without an authProvider never carry an auth state.
+ */
+export type MCPServerAuthState = 'needs-auth' | 'authorized';
 
 // Per MCP spec, only fallback to SSE for these status codes
 const SSE_FALLBACK_STATUS_CODES = [400, 404, 405];
@@ -217,6 +229,8 @@ export class InternalMastraMCPClient extends MastraBase {
   private enableProgressTracking?: boolean;
   private serverConfig: MastraMCPServerDefinition;
   private transport?: Transport;
+  private pendingAuthTransport?: StreamableHTTPClientTransport | SSEClientTransport;
+  private _authState?: MCPServerAuthState;
   private operationContextStore = new AsyncLocalStorage<RequestContext | null>();
   private exitHookUnsubscribe?: () => void;
   private sigTermHandler?: () => void;
@@ -436,15 +450,17 @@ export class InternalMastraMCPClient extends MastraBase {
     let shouldTrySSE = url.pathname.endsWith(`/sse`);
 
     if (!shouldTrySSE) {
+      // Constructed outside the try so an UnauthorizedError can keep a handle on the
+      // transport that started the authorization flow (finishAuth must run on it).
+      const streamableTransport = new StreamableHTTPClientTransport(url, {
+        requestInit,
+        reconnectionOptions: this.serverConfig.reconnectionOptions,
+        authProvider: authProvider,
+        fetch,
+      });
       try {
         // Try Streamable HTTP transport first
         this.log('debug', 'Trying Streamable HTTP transport...');
-        const streamableTransport = new StreamableHTTPClientTransport(url, {
-          requestInit,
-          reconnectionOptions: this.serverConfig.reconnectionOptions,
-          authProvider: authProvider,
-          fetch,
-        });
         await this.client.connect(streamableTransport, {
           timeout: connectTimeout ?? DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC,
         });
@@ -452,6 +468,13 @@ export class InternalMastraMCPClient extends MastraBase {
         this.log('debug', 'Successfully connected using Streamable HTTP transport.');
       } catch (error: any) {
         this.log('debug', `Streamable HTTP transport failed: ${error}`);
+
+        // A 401 means the flow continues on this transport via finishAuth, not on a
+        // fallback: the SDK has already run discovery and redirected to authorization.
+        if (error instanceof UnauthorizedError) {
+          this.markNeedsAuth(streamableTransport);
+          throw error;
+        }
 
         // @modelcontextprotocol/sdk 1.24.0+ throws StreamableHTTPError with 'code' property
         // Older @modelcontextprotocol/sdk: fallback to SSE (legacy behavior)
@@ -465,28 +488,82 @@ export class InternalMastraMCPClient extends MastraBase {
 
     if (shouldTrySSE) {
       this.log('debug', 'Falling back to deprecated HTTP+SSE transport...');
-      try {
-        // Fallback to SSE transport
-        // If fetch is provided, ensure it's also in eventSourceInit for the EventSource connection
-        // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream
-        const sseEventSourceInit = { ...eventSourceInit, fetch };
+      // Fallback to SSE transport
+      // If fetch is provided, ensure it's also in eventSourceInit for the EventSource connection
+      // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream
+      const sseEventSourceInit = { ...eventSourceInit, fetch };
 
-        const sseTransport = new SSEClientTransport(url, {
-          requestInit,
-          eventSourceInit: sseEventSourceInit,
-          authProvider,
-          fetch,
-        });
+      const sseTransport = new SSEClientTransport(url, {
+        requestInit,
+        eventSourceInit: sseEventSourceInit,
+        authProvider,
+        fetch,
+      });
+      try {
         await this.client.connect(sseTransport, { timeout: this.serverConfig.timeout ?? this.timeout });
         this.transport = sseTransport;
         this.log('debug', 'Successfully connected using deprecated HTTP+SSE transport.');
       } catch (sseError) {
+        if (sseError instanceof UnauthorizedError) {
+          this.markNeedsAuth(sseTransport);
+          throw sseError;
+        }
         this.log(
           'error',
           `Failed to connect with SSE transport after failing to connect to Streamable HTTP transport first. SSE error: ${sseError}`,
         );
         throw new Error('Could not connect to server with any available HTTP transport');
       }
+    }
+
+    // Reaching here means a transport connected; any earlier authorization requirement is satisfied.
+    this.pendingAuthTransport = undefined;
+    if (authProvider) {
+      this._authState = 'authorized';
+    }
+  }
+
+  /**
+   * Records that the server rejected the connection with a 401 and keeps the
+   * transport that started the authorization flow so finishAuth can complete it.
+   */
+  private markNeedsAuth(transport: StreamableHTTPClientTransport | SSEClientTransport): void {
+    this.pendingAuthTransport = transport;
+    this._authState = 'needs-auth';
+    this.log('debug', 'Server requires OAuth authorization before connecting.');
+  }
+
+  /**
+   * OAuth authorization state of this server connection, when it has an authProvider.
+   *
+   * @internal
+   */
+  get authState(): MCPServerAuthState | undefined {
+    return this._authState;
+  }
+
+  /**
+   * Completes a pending OAuth authorization-code flow.
+   *
+   * Exchanges the authorization code captured at the redirect URI on the same
+   * transport that started the flow, then leaves the client ready to connect().
+   *
+   * @param authorizationCode - The authorization code captured at the redirect URI
+   * @throws {Error} If no authorization flow is pending for this server
+   *
+   * @internal
+   */
+  async finishAuth(authorizationCode: string): Promise<void> {
+    const pending = this.pendingAuthTransport;
+    if (!pending) {
+      throw new Error('No OAuth authorization is pending for this server. Call connect() first.');
+    }
+    this.pendingAuthTransport = undefined;
+    try {
+      await pending.finishAuth(authorizationCode);
+    } finally {
+      // The pending transport only ran the token exchange; the next connect() builds a fresh one.
+      void pending.close().catch(() => {});
     }
   }
 

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -14,13 +14,20 @@ import type {
   ResourceTemplate,
 } from '@modelcontextprotocol/sdk/types.js';
 import equal from 'fast-deep-equal';
+import type { OAuthClientInformationFull } from '../shared/oauth-types';
+import { UnauthorizedError } from '../shared/oauth-types';
 import { InternalMastraMCPClient } from './client';
-import type { MastraMCPServerDefinition } from './client';
+import type { MastraMCPServerDefinition, MCPServerAuthState } from './client';
 import { isReconnectableMCPError } from './error-utils';
+import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server';
+import { MCPOAuthClientProvider } from './oauth-provider';
 import { MCPClientServerProxy } from './server-proxy';
 
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
+
+// Hostnames authenticate() accepts for the provider's redirect URL (RFC 8252 loopback redirection)
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]']);
 
 /**
  * Configuration options for creating an MCPClient instance.
@@ -74,6 +81,7 @@ export class MCPClient extends MastraBase {
   private defaultTimeout: number;
   private mcpClientsById = new Map<string, InternalMastraMCPClient>();
   private disconnectPromise: Promise<void> | null = null;
+  private authFlowsByServer = new Map<string, Promise<void>>();
 
   /**
    * Creates a new MCPClient instance for managing MCP server connections.
@@ -787,6 +795,116 @@ To fix this you have three different options:
   }
 
   /**
+   * Runs the interactive OAuth authorization-code flow for a server.
+   *
+   * Requires the server to be configured with an MCPOAuthClientProvider whose
+   * redirect URL points at a loopback address. The flow:
+   *
+   * 1. Starts a loopback callback server on the redirect URL's port (falling
+   *    back to the next sequential ports when it is in use)
+   * 2. Attempts a connection so the SDK runs discovery and dynamic client
+   *    registration, delivering the authorization URL through the provider's
+   *    `onRedirectToAuthorization` callback — the host directs the user there
+   * 3. Waits for the browser to deliver the authorization code, validates the
+   *    OAuth state, exchanges the code for tokens, and reconnects
+   *
+   * Concurrent calls for the same server join the pending flow; different
+   * servers authenticate independently. Hosts with custom redirect handling
+   * (e.g. a web app with an HTTPS redirect URL) should drive
+   * MCPOAuthClientProvider directly instead.
+   *
+   * @param serverName - The name of the server to authenticate (must match a key in `servers`)
+   * @param options.timeoutMs - How long to wait for the browser callback (default 5 minutes)
+   * @throws {Error} If the server has no MCPOAuthClientProvider or its redirect URL is not loopback
+   *
+   * @example
+   * ```typescript
+   * if (mcp.getServerAuthState('weatherServer') === 'needs-auth') {
+   *   await mcp.authenticate('weatherServer');
+   * }
+   * ```
+   */
+  public async authenticate(serverName: string, options?: { timeoutMs?: number }): Promise<void> {
+    const pendingFlow = this.authFlowsByServer.get(serverName);
+    if (pendingFlow) {
+      return pendingFlow;
+    }
+
+    const flow = this.runAuthorizationFlow(serverName, options).finally(() => {
+      this.authFlowsByServer.delete(serverName);
+    });
+    this.authFlowsByServer.set(serverName, flow);
+    return flow;
+  }
+
+  /**
+   * OAuth authorization state of a configured server.
+   *
+   * Returns `undefined` for servers without an authProvider and for servers
+   * that have not attempted a connection yet.
+   */
+  public getServerAuthState(serverName: string): MCPServerAuthState | undefined {
+    return this.mcpClientsById.get(serverName)?.authState;
+  }
+
+  private async runAuthorizationFlow(serverName: string, options?: { timeoutMs?: number }): Promise<void> {
+    const config = this.getServerConfig(serverName);
+    const provider = config.authProvider;
+    if (!(provider instanceof MCPOAuthClientProvider)) {
+      throw new Error(
+        `Cannot authenticate MCP server ${serverName}: it is not configured with an MCPOAuthClientProvider.`,
+      );
+    }
+
+    const redirectUrl = new URL(provider.redirectUrl.toString());
+    if (redirectUrl.protocol !== 'http:' || !LOOPBACK_HOSTNAMES.has(redirectUrl.hostname)) {
+      throw new Error(
+        `Cannot authenticate MCP server ${serverName}: the provider's redirect URL must be a loopback address, got ${redirectUrl.origin}.`,
+      );
+    }
+
+    const state = await provider.beginAuthorizationSession();
+    const callbackServer = await createOAuthCallbackServer({ redirectUrl, state });
+    try {
+      // Point the authorization request at the callback URL that actually
+      // bound, and register every fallback candidate during dynamic client
+      // registration so a future fallback port still matches a registered URI.
+      provider.applyResolvedRedirectUrl(callbackServer.url, getCallbackUrlCandidates(redirectUrl));
+
+      // Discard a stored client registration that does not cover the bound
+      // callback URL — the authorization server would reject its redirect_uri.
+      const clientInfo = (await provider.clientInformation()) as Partial<OAuthClientInformationFull> | undefined;
+      if (clientInfo?.redirect_uris && !clientInfo.redirect_uris.includes(callbackServer.url.toString())) {
+        await provider.invalidateCredentials('client');
+      }
+
+      const client = await this.getClientForServer(serverName);
+      try {
+        // With valid stored tokens this simply connects; otherwise the SDK
+        // delivers the authorization URL and throws UnauthorizedError.
+        await client.connect();
+        return;
+      } catch (error) {
+        if (!(error instanceof UnauthorizedError)) {
+          throw this.handleConnectError(serverName, error);
+        }
+      }
+
+      const { code } = await callbackServer.waitForCode(options);
+      await client.finishAuth(code);
+
+      try {
+        await client.connect();
+      } catch (error) {
+        throw error instanceof UnauthorizedError ? error : this.handleConnectError(serverName, error);
+      }
+    } finally {
+      provider.endAuthorizationSession();
+      await callbackServer.close();
+    }
+  }
+
+  /**
    * Returns instructions advertised by connected MCP servers during initialize.
    *
    * Servers that have not connected yet, or did not advertise instructions,
@@ -1106,7 +1224,11 @@ To fix this you have three different options:
     );
     this.logger.trackException(mastraError);
     this.logger.error('MCPClient errored connecting to MCP server:', { error: mastraError.toString() });
-    this.mcpClientsById.delete(name);
+    // Keep the client when authorization is required: it carries the needs-auth
+    // state and the pending transport that authenticate() completes.
+    if (!(error instanceof UnauthorizedError)) {
+      this.mcpClientsById.delete(name);
+    }
     return mastraError;
   }
 

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -27,8 +27,13 @@ import { MCPClientServerProxy } from './server-proxy';
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 
-// Hostnames authenticate() accepts for the provider's redirect URL (RFC 8252 loopback redirection)
-const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]']);
+// Whether a hostname is a loopback address authenticate() accepts for the
+// provider's redirect URL (RFC 8252 loopback redirection). Kept in sync with the
+// mastracode config parser, which accepts any 127.0.0.0/8 host, so a config that
+// parses (e.g. 127.0.0.2) does not later fail here.
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.');
+}
 
 /**
  * Configuration options for creating an MCPClient instance.
@@ -761,6 +766,18 @@ To fix this you have three different options:
       try {
         mcpClientInstances.delete(this.id);
 
+        // Tear down any in-flight authorization: each callback server owns a live
+        // loopback HTTP port, and closing it rejects the flow's waitForCode. Await
+        // the flow settlements so a disconnect during authentication does not leave
+        // a bound port or a dangling promise keeping the process alive.
+        const pendingFlows = Array.from(this.authFlowsByServer.values());
+        await Promise.allSettled(
+          Array.from(this.authCallbackServersByServer.values()).map(server => server.close()),
+        );
+        await Promise.allSettled(pendingFlows);
+        this.authCallbackServersByServer.clear();
+        this.authFlowsByServer.clear();
+
         // Disconnect all clients in the cache
         await Promise.allSettled(Array.from(this.mcpClientsById.values()).map(client => client.disconnect()));
         this.mcpClientsById.clear();
@@ -862,7 +879,7 @@ To fix this you have three different options:
     }
 
     const redirectUrl = new URL(provider.redirectUrl.toString());
-    if (redirectUrl.protocol !== 'http:' || !LOOPBACK_HOSTNAMES.has(redirectUrl.hostname)) {
+    if (redirectUrl.protocol !== 'http:' || !isLoopbackHostname(redirectUrl.hostname)) {
       throw new Error(
         `Cannot authenticate MCP server ${serverName}: the provider's redirect URL must be a loopback address, got ${redirectUrl.origin}.`,
       );

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -20,6 +20,7 @@ import { InternalMastraMCPClient } from './client';
 import type { MastraMCPServerDefinition, MCPServerAuthState } from './client';
 import { isReconnectableMCPError } from './error-utils';
 import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server';
+import type { OAuthCallbackServer } from './oauth-callback-server';
 import { MCPOAuthClientProvider } from './oauth-provider';
 import { MCPClientServerProxy } from './server-proxy';
 
@@ -82,6 +83,7 @@ export class MCPClient extends MastraBase {
   private mcpClientsById = new Map<string, InternalMastraMCPClient>();
   private disconnectPromise: Promise<void> | null = null;
   private authFlowsByServer = new Map<string, Promise<void>>();
+  private authCallbackServersByServer = new Map<string, OAuthCallbackServer>();
 
   /**
    * Creates a new MCPClient instance for managing MCP server connections.
@@ -868,6 +870,7 @@ To fix this you have three different options:
 
     const state = await provider.beginAuthorizationSession();
     const callbackServer = await createOAuthCallbackServer({ redirectUrl, state });
+    this.authCallbackServersByServer.set(serverName, callbackServer);
     try {
       // Point the authorization request at the callback URL that actually
       // bound, and register every fallback candidate during dynamic client
@@ -902,9 +905,33 @@ To fix this you have three different options:
         throw error instanceof UnauthorizedError ? error : this.handleConnectError(serverName, error);
       }
     } finally {
+      this.authCallbackServersByServer.delete(serverName);
       provider.endAuthorizationSession();
       await callbackServer.close();
     }
+  }
+
+  /**
+   * Cancels a pending {@link authenticate} flow for a server.
+   *
+   * Tears down the loopback callback server immediately — the pending
+   * authenticate() call rejects, and the server remains in the `needs-auth`
+   * state so the flow can be retried right away. Useful when the user closed
+   * the browser without completing consent, which the host cannot observe.
+   *
+   * @param serverName - The name of the server whose flow to cancel
+   * @returns `true` if a pending flow was cancelled, `false` when no flow was pending
+   */
+  public async cancelAuthentication(serverName: string): Promise<boolean> {
+    const callbackServer = this.authCallbackServersByServer.get(serverName);
+    const pendingFlow = this.authFlowsByServer.get(serverName);
+    if (!callbackServer || !pendingFlow) {
+      return false;
+    }
+
+    await callbackServer.close();
+    await pendingFlow.catch(() => undefined);
+    return true;
   }
 
   /**

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -808,10 +808,13 @@ To fix this you have three different options:
    * 3. Waits for the browser to deliver the authorization code, validates the
    *    OAuth state, exchanges the code for tokens, and reconnects
    *
-   * Concurrent calls for the same server join the pending flow; different
-   * servers authenticate independently. Hosts with custom redirect handling
-   * (e.g. a web app with an HTTPS redirect URL) should drive
-   * MCPOAuthClientProvider directly instead.
+   * Concurrent calls for the same server join the pending flow (the joiner's
+   * options are ignored — the pending flow keeps its own timeout); different
+   * servers authenticate independently. Each server needs its own provider
+   * instance: the flow pins session state on the provider, so sharing one
+   * MCPOAuthClientProvider across servers is not supported. Hosts with custom
+   * redirect handling (e.g. a web app with an HTTPS redirect URL) should
+   * drive MCPOAuthClientProvider directly instead.
    *
    * @param serverName - The name of the server to authenticate (must match a key in `servers`)
    * @param options.timeoutMs - How long to wait for the browser callback (default 5 minutes)

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -27,12 +27,18 @@ import { MCPClientServerProxy } from './server-proxy';
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 
+// Matches the entire 127.0.0.0/8 range in dotted-quad form. `URL` normalizes
+// IPv4 hosts to four octets (so `127.1` becomes `127.0.0.1`), so anchoring the
+// pattern is enough — and it rejects lookalikes like `127.evil.com` that a
+// prefix check would wrongly accept and leak the authorization code to.
+const LOOPBACK_IPV4 = /^127\.(?:\d{1,3})\.(?:\d{1,3})\.(?:\d{1,3})$/;
+
 // Whether a hostname is a loopback address authenticate() accepts for the
 // provider's redirect URL (RFC 8252 loopback redirection). Kept in sync with the
 // mastracode config parser, which accepts any 127.0.0.0/8 host, so a config that
 // parses (e.g. 127.0.0.2) does not later fail here.
 function isLoopbackHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.');
+  return hostname === 'localhost' || hostname === '[::1]' || hostname === '::1' || LOOPBACK_IPV4.test(hostname);
 }
 
 /**
@@ -89,6 +95,13 @@ export class MCPClient extends MastraBase {
   private disconnectPromise: Promise<void> | null = null;
   private authFlowsByServer = new Map<string, Promise<void>>();
   private authCallbackServersByServer = new Map<string, OAuthCallbackServer>();
+  /**
+   * Per-server abort controllers for in-flight authorization flows. Created
+   * synchronously at the start of {@link runAuthorizationFlow} — before the
+   * callback server exists — so cancel/disconnect can interrupt the setup phase
+   * (discovery, registration, port binding) and not just the waitForCode wait.
+   */
+  private authAbortControllersByServer = new Map<string, AbortController>();
 
   /**
    * Creates a new MCPClient instance for managing MCP server connections.
@@ -771,10 +784,17 @@ To fix this you have three different options:
         // the flow settlements so a disconnect during authentication does not leave
         // a bound port or a dangling promise keeping the process alive.
         const pendingFlows = Array.from(this.authFlowsByServer.values());
+        // Abort first so flows still in their setup phase (no callback server
+        // bound yet) unblock instead of parking on waitForCode and deadlocking
+        // the awaited settlement below.
+        for (const controller of this.authAbortControllersByServer.values()) {
+          controller.abort();
+        }
         await Promise.allSettled(
           Array.from(this.authCallbackServersByServer.values()).map(server => server.close()),
         );
         await Promise.allSettled(pendingFlows);
+        this.authAbortControllersByServer.clear();
         this.authCallbackServersByServer.clear();
         this.authFlowsByServer.clear();
 
@@ -870,9 +890,21 @@ To fix this you have three different options:
   }
 
   private async runAuthorizationFlow(serverName: string, options?: { timeoutMs?: number }): Promise<void> {
+    // Register the abort controller synchronously, before the first await, so a
+    // cancel/disconnect during the setup phase (discovery, registration, port
+    // binding) can interrupt the flow rather than letting it park on waitForCode.
+    const abortController = new AbortController();
+    this.authAbortControllersByServer.set(serverName, abortController);
+    const throwIfAborted = () => {
+      if (abortController.signal.aborted) {
+        throw new Error(`Authentication for MCP server ${serverName} was cancelled.`);
+      }
+    };
+
     const config = this.getServerConfig(serverName);
     const provider = config.authProvider;
     if (!(provider instanceof MCPOAuthClientProvider)) {
+      this.authAbortControllersByServer.delete(serverName);
       throw new Error(
         `Cannot authenticate MCP server ${serverName}: it is not configured with an MCPOAuthClientProvider.`,
       );
@@ -880,13 +912,29 @@ To fix this you have three different options:
 
     const redirectUrl = new URL(provider.redirectUrl.toString());
     if (redirectUrl.protocol !== 'http:' || !isLoopbackHostname(redirectUrl.hostname)) {
+      this.authAbortControllersByServer.delete(serverName);
       throw new Error(
         `Cannot authenticate MCP server ${serverName}: the provider's redirect URL must be a loopback address, got ${redirectUrl.origin}.`,
       );
     }
 
     const state = await provider.beginAuthorizationSession();
+    // A cancel that arrived during beginAuthorizationSession() has no callback
+    // server to close yet, so bail here before binding a port and parking.
+    if (abortController.signal.aborted) {
+      provider.endAuthorizationSession();
+      this.authAbortControllersByServer.delete(serverName);
+      throwIfAborted();
+    }
     const callbackServer = await createOAuthCallbackServer({ redirectUrl, state });
+    // A cancel during port binding: close the freshly-bound server and bail
+    // before we ever wait for a code that will never arrive.
+    if (abortController.signal.aborted) {
+      provider.endAuthorizationSession();
+      this.authAbortControllersByServer.delete(serverName);
+      await callbackServer.close();
+      throwIfAborted();
+    }
     this.authCallbackServersByServer.set(serverName, callbackServer);
     try {
       // Point the authorization request at the callback URL that actually
@@ -923,6 +971,7 @@ To fix this you have three different options:
       }
     } finally {
       this.authCallbackServersByServer.delete(serverName);
+      this.authAbortControllersByServer.delete(serverName);
       provider.endAuthorizationSession();
       await callbackServer.close();
     }
@@ -940,13 +989,16 @@ To fix this you have three different options:
    * @returns `true` if a pending flow was cancelled, `false` when no flow was pending
    */
   public async cancelAuthentication(serverName: string): Promise<boolean> {
-    const callbackServer = this.authCallbackServersByServer.get(serverName);
     const pendingFlow = this.authFlowsByServer.get(serverName);
-    if (!callbackServer || !pendingFlow) {
+    if (!pendingFlow) {
       return false;
     }
 
-    await callbackServer.close();
+    // Abort first so a flow still in its setup phase (no callback server bound
+    // yet) is interrupted before it can park on waitForCode; then close the
+    // callback server if one exists, which rejects an in-progress waitForCode.
+    this.authAbortControllersByServer.get(serverName)?.abort();
+    await this.authCallbackServersByServer.get(serverName)?.close();
     await pendingFlow.catch(() => undefined);
     return true;
   }

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -14,4 +14,5 @@ export type {
 export * from './client';
 export * from './configuration';
 export * from './oauth-provider';
+export * from './oauth-callback-server';
 export { MCPClientServerProxy } from './server-proxy';

--- a/packages/mcp/src/client/oauth-callback-server.test.ts
+++ b/packages/mcp/src/client/oauth-callback-server.test.ts
@@ -92,22 +92,28 @@ describe('createOAuthCallbackServer', () => {
     await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
   });
 
-  it('rejects on state mismatch', async () => {
+  it('ignores requests without a matching state so they cannot settle the flow', async () => {
     const server = await startCallbackServer();
+    const pending = server.waitForCode();
 
-    const pending = expect(server.waitForCode()).rejects.toThrow(/state mismatch/);
-    const response = await fetch(`${server.url}?code=auth-code-123&state=wrong-state`);
+    // Neither a forged code nor a forged denial (the state authenticates the
+    // redirect) may settle the pending flow.
+    const forgedCode = await fetch(`${server.url}?code=forged-code&state=wrong-state`);
+    expect(forgedCode.status).toBe(400);
+    const forgedDenial = await fetch(`${server.url}?error=access_denied`);
+    expect(forgedDenial.status).toBe(400);
 
-    expect(response.status).toBe(400);
-    await pending;
+    const genuine = await fetch(`${server.url}?code=auth-code-123&state=${STATE}`);
+    expect(genuine.status).toBe(200);
+    await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
   });
 
-  it('rejects on an OAuth error response, including the description', async () => {
+  it('rejects on a state-matching OAuth error response, including the description', async () => {
     const server = await startCallbackServer();
 
     const pending = expect(server.waitForCode()).rejects.toThrow(/access_denied.*User denied the request/);
     const response = await fetch(
-      `${server.url}?error=access_denied&error_description=${encodeURIComponent('User denied the request')}`,
+      `${server.url}?error=access_denied&error_description=${encodeURIComponent('User denied the request')}&state=${STATE}`,
     );
 
     expect(response.status).toBe(400);
@@ -155,6 +161,20 @@ describe('createOAuthCallbackServer', () => {
     } finally {
       await closeServer(blocker);
     }
+  });
+
+  it('binds the hostname from the redirect URL', async () => {
+    const port = await getFreePort();
+    callbackServer = await createOAuthCallbackServer({
+      redirectUrl: `http://localhost:${port}/oauth/callback`,
+      state: STATE,
+    });
+
+    const pending = callbackServer.waitForCode();
+    const response = await fetch(`http://localhost:${port}/oauth/callback?code=auth-code-123&state=${STATE}`);
+
+    expect(response.status).toBe(200);
+    await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
   });
 
   it('releases the port on close', async () => {

--- a/packages/mcp/src/client/oauth-callback-server.test.ts
+++ b/packages/mcp/src/client/oauth-callback-server.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the loopback OAuth callback server.
+ *
+ * Uses real HTTP requests against the bound port — no mocks — since the
+ * helper's whole job is correct socket-level behavior (binding, fallback,
+ * one-shot semantics, releasing the port).
+ */
+
+import { createServer } from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import type { OAuthCallbackServer } from './oauth-callback-server.js';
+import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server.js';
+
+const STATE = 'expected-state';
+
+/**
+ * Finds a port that is currently free by binding an ephemeral port and
+ * releasing it. Keeps tests independent of hardcoded port availability.
+ */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to probe for a free port'));
+        return;
+      }
+      probe.close(() => resolve(address.port));
+    });
+  });
+}
+
+function occupyPort(port: number): Promise<HttpServer> {
+  return new Promise((resolve, reject) => {
+    const blocker = createServer();
+    blocker.once('error', reject);
+    blocker.listen(port, '127.0.0.1', () => resolve(blocker));
+  });
+}
+
+function closeServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('getCallbackUrlCandidates', () => {
+  it('returns the preferred URL followed by sequential fallback ports', () => {
+    const candidates = getCallbackUrlCandidates('http://127.0.0.1:5533/oauth/callback');
+
+    expect(candidates).toHaveLength(11);
+    expect(candidates[0]!.toString()).toBe('http://127.0.0.1:5533/oauth/callback');
+    expect(candidates.map(url => Number(url.port))).toEqual([
+      5533, 5534, 5535, 5536, 5537, 5538, 5539, 5540, 5541, 5542, 5543,
+    ]);
+    expect(candidates.every(url => url.pathname === '/oauth/callback')).toBe(true);
+  });
+});
+
+describe('createOAuthCallbackServer', () => {
+  let callbackServer: OAuthCallbackServer | undefined;
+
+  afterEach(async () => {
+    await callbackServer?.close().catch(() => {});
+    callbackServer = undefined;
+  });
+
+  async function startCallbackServer(): Promise<OAuthCallbackServer> {
+    const port = await getFreePort();
+    callbackServer = await createOAuthCallbackServer({
+      redirectUrl: `http://127.0.0.1:${port}/oauth/callback`,
+      state: STATE,
+    });
+    return callbackServer;
+  }
+
+  it('captures the authorization code from the callback request', async () => {
+    const server = await startCallbackServer();
+
+    const pending = server.waitForCode();
+    const response = await fetch(`${server.url}?code=auth-code-123&state=${STATE}`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('close this tab');
+    expect(body).not.toContain('auth-code-123');
+    await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
+  });
+
+  it('rejects on state mismatch', async () => {
+    const server = await startCallbackServer();
+
+    const pending = expect(server.waitForCode()).rejects.toThrow(/state mismatch/);
+    const response = await fetch(`${server.url}?code=auth-code-123&state=wrong-state`);
+
+    expect(response.status).toBe(400);
+    await pending;
+  });
+
+  it('rejects on an OAuth error response, including the description', async () => {
+    const server = await startCallbackServer();
+
+    const pending = expect(server.waitForCode()).rejects.toThrow(/access_denied.*User denied the request/);
+    const response = await fetch(
+      `${server.url}?error=access_denied&error_description=${encodeURIComponent('User denied the request')}`,
+    );
+
+    expect(response.status).toBe(400);
+    await pending;
+  });
+
+  it('rejects when no callback arrives before the timeout', async () => {
+    const server = await startCallbackServer();
+
+    await expect(server.waitForCode({ timeoutMs: 50 })).rejects.toThrow(/Timed out waiting for OAuth callback/);
+  });
+
+  it('is one-shot: subsequent callback requests receive 410', async () => {
+    const server = await startCallbackServer();
+
+    const pending = server.waitForCode();
+    await fetch(`${server.url}?code=auth-code-123&state=${STATE}`);
+    await pending;
+
+    const replay = await fetch(`${server.url}?code=another-code&state=${STATE}`);
+    expect(replay.status).toBe(410);
+  });
+
+  it('rejects pending waitForCode when closed before a code arrives', async () => {
+    const server = await startCallbackServer();
+
+    const pending = server.waitForCode();
+    await server.close();
+
+    await expect(pending).rejects.toThrow(/closed before receiving an authorization code/);
+  });
+
+  it('falls back to the next port when the preferred port is in use', async () => {
+    const preferredPort = await getFreePort();
+    const blocker = await occupyPort(preferredPort);
+
+    try {
+      callbackServer = await createOAuthCallbackServer({
+        redirectUrl: `http://127.0.0.1:${preferredPort}/oauth/callback`,
+        state: STATE,
+      });
+
+      expect(callbackServer.port).toBe(preferredPort + 1);
+      expect(callbackServer.url.toString()).toBe(`http://127.0.0.1:${preferredPort + 1}/oauth/callback`);
+    } finally {
+      await closeServer(blocker);
+    }
+  });
+
+  it('releases the port on close', async () => {
+    const server = await startCallbackServer();
+    const { port } = server;
+
+    await server.close();
+    callbackServer = undefined;
+
+    const reclaimed = await occupyPort(port);
+    await closeServer(reclaimed);
+  });
+});

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -47,7 +47,10 @@ export interface OAuthCallbackServerOptions {
   /**
    * The redirect URL the authorization server will send the browser back to.
    * Its port is the preferred port to bind; if that port is in use, the next
-   * sequential ports are tried (see getCallbackUrlCandidates).
+   * sequential ports are tried (see getCallbackUrlCandidates). The server
+   * binds the URL's hostname — prefer the literal `127.0.0.1` over
+   * `localhost` (RFC 8252 §8.3) so the browser and server agree on the
+   * address family.
    *
    * @example 'http://127.0.0.1:5533/oauth/callback'
    */
@@ -55,8 +58,10 @@ export interface OAuthCallbackServerOptions {
 
   /**
    * The OAuth state parameter issued for this authorization request.
-   * Callback requests with a different state are rejected (CSRF protection
-   * per OAuth 2.1).
+   * The state authenticates the redirect (CSRF protection per OAuth 2.1):
+   * callback requests without a matching state receive an error response and
+   * never settle the flow, so a stray local request cannot abort or spoof a
+   * pending authorization.
    */
   state: string;
 }
@@ -95,9 +100,9 @@ export interface OAuthCallbackServer {
   /**
    * Waits for the browser to deliver the authorization code.
    *
-   * Resolves once with the code and state from the first callback request.
-   * Rejects on timeout, on an OAuth error response (`error` /
-   * `error_description` query params), on a state mismatch, or when the
+   * Resolves once with the code and state from the first state-matching
+   * callback request. Rejects on timeout, on a state-matching OAuth error
+   * response (`error` / `error_description` query params), or when the
    * server is closed before a code arrives.
    */
   waitForCode(options?: { timeoutMs?: number }): Promise<OAuthCallbackResult>;
@@ -130,7 +135,7 @@ export function getCallbackUrlCandidates(redirectUrl: string | URL): URL[] {
   return candidates;
 }
 
-function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException | null> {
+function listen(server: HttpServer, port: number, hostname: string): Promise<NodeJS.ErrnoException | null> {
   return new Promise((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
       server.off('listening', onListening);
@@ -147,7 +152,7 @@ function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException
 
     server.once('error', onError);
     server.once('listening', onListening);
-    server.listen(port, '127.0.0.1');
+    server.listen(port, hostname);
   });
 }
 
@@ -155,10 +160,12 @@ function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException
  * Starts a one-shot loopback HTTP server that captures the OAuth
  * authorization code.
  *
- * The server binds 127.0.0.1 on the redirect URL's port, falling back to the
- * next sequential ports when it is in use (see getCallbackUrlCandidates).
- * The first request on the callback path settles the outcome; subsequent
- * requests receive 410 Gone. The response pages never echo the
+ * The server binds the redirect URL's hostname on its port, falling back to
+ * the next sequential ports when it is in use (see getCallbackUrlCandidates).
+ * The first state-matching request on the callback path settles the outcome;
+ * subsequent requests receive 410 Gone. Requests whose state does not match
+ * receive an error response without settling, so only the genuine redirect
+ * can complete or abort the flow. The response pages never echo the
  * authorization code.
  *
  * @example
@@ -220,17 +227,22 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
       res.end(html);
     };
 
+    // The state authenticates the redirect: the callback port is predictable,
+    // so anything local can reach it, and the authorization server echoes the
+    // state on both success and error redirects (RFC 6749 §4.1.2). Requests
+    // without the expected state are not this flow's redirect and must not
+    // settle the one-shot outcome.
+    const state = url.searchParams.get('state');
+    if (state !== options.state) {
+      respond(400, ERROR_HTML);
+      return;
+    }
+
     const error = url.searchParams.get('error');
     if (error) {
       const description = url.searchParams.get('error_description');
       respond(400, ERROR_HTML);
       settle({ error: new Error(`Authorization failed: ${error}${description ? ` (${description})` : ''}`) });
-      return;
-    }
-
-    if (url.searchParams.get('state') !== options.state) {
-      respond(400, ERROR_HTML);
-      settle({ error: new Error('Authorization failed: state mismatch') });
       return;
     }
 
@@ -242,12 +254,17 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
     }
 
     respond(200, SUCCESS_HTML);
-    settle({ result: { code, state: options.state } });
+    settle({ result: { code, state } });
   });
+
+  // Bind the hostname the redirect URL names (brackets stripped for IPv6
+  // literals) so e.g. http://localhost or http://[::1] redirects actually
+  // reach the server rather than an unbound 127.0.0.1 socket.
+  const hostname = candidates[0]!.hostname.replace(/^\[|\]$/g, '');
 
   let boundUrl: URL | undefined;
   for (const candidate of candidates) {
-    const error = await listen(server, Number(candidate.port));
+    const error = await listen(server, Number(candidate.port), hostname);
     if (!error) {
       boundUrl = candidate;
       break;

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -264,14 +264,19 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
   const hostname = candidates[0]!.hostname.replace(/^\[|\]$/g, '');
 
   let boundUrl: URL | undefined;
+  let boundPort: number | undefined;
   for (const candidate of candidates) {
-    const error = await listen(server, Number(candidate.port), hostname);
+    const candidatePort = Number(candidate.port);
+    const error = await listen(server, candidatePort, hostname);
     if (!error) {
       boundUrl = candidate;
+      // Preserve the port we actually listened on. Reading URL.port back would
+      // return '' for the default 80/443, losing the effective port.
+      boundPort = candidatePort;
       break;
     }
   }
-  if (!boundUrl) {
+  if (!boundUrl || boundPort === undefined) {
     const firstPort = Number(candidates[0]!.port);
     const lastPort = Number(candidates[candidates.length - 1]!.port);
     throw new Error(`Failed to start OAuth callback server: ports ${firstPort}-${lastPort} are all in use`);
@@ -279,7 +284,7 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
 
   return {
     url: boundUrl,
-    port: Number(boundUrl.port),
+    port: boundPort,
 
     waitForCode({ timeoutMs = DEFAULT_CALLBACK_TIMEOUT_MS } = {}) {
       let timer: NodeJS.Timeout | undefined;

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -1,0 +1,285 @@
+/**
+ * Loopback OAuth Callback Server for MCP Client
+ *
+ * Provides a one-shot local HTTP server that captures the OAuth authorization
+ * code delivered to a loopback redirect URL (RFC 8252). Hosts use it together
+ * with MCPOAuthClientProvider to complete the authorization-code flow for
+ * OAuth-protected MCP servers.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+ */
+
+import { createServer } from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+
+/**
+ * How many sequential ports to try after the preferred port when it is in use.
+ */
+const CALLBACK_PORT_FALLBACK_RANGE = 10;
+
+/**
+ * Default time to wait for the browser to deliver the authorization code.
+ */
+const DEFAULT_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>Authentication complete</title></head>
+  <body style="font-family: system-ui, sans-serif; text-align: center; padding-top: 4rem;">
+    <h1>Authentication complete</h1>
+    <p>You can close this tab and return to your application.</p>
+  </body>
+</html>`;
+
+const ERROR_HTML = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>Authentication failed</title></head>
+  <body style="font-family: system-ui, sans-serif; text-align: center; padding-top: 4rem;">
+    <h1>Authentication failed</h1>
+    <p>You can close this tab and retry from your application.</p>
+  </body>
+</html>`;
+
+/**
+ * Options for creating an OAuth callback server.
+ */
+export interface OAuthCallbackServerOptions {
+  /**
+   * The redirect URL the authorization server will send the browser back to.
+   * Its port is the preferred port to bind; if that port is in use, the next
+   * sequential ports are tried (see getCallbackUrlCandidates).
+   *
+   * @example 'http://127.0.0.1:5533/oauth/callback'
+   */
+  redirectUrl: string | URL;
+
+  /**
+   * The OAuth state parameter issued for this authorization request.
+   * Callback requests with a different state are rejected (CSRF protection
+   * per OAuth 2.1).
+   */
+  state: string;
+}
+
+/**
+ * The authorization code captured from the OAuth callback.
+ */
+export interface OAuthCallbackResult {
+  /**
+   * The authorization code to exchange for tokens.
+   */
+  code: string;
+
+  /**
+   * The state parameter echoed back by the authorization server.
+   */
+  state: string;
+}
+
+/**
+ * A running loopback OAuth callback server.
+ */
+export interface OAuthCallbackServer {
+  /**
+   * The callback URL that is actually bound (reflects any port fallback).
+   * Use this — not the preferred redirect URL — as the redirect_uri for the
+   * authorization request.
+   */
+  url: URL;
+
+  /**
+   * The port the server is listening on.
+   */
+  port: number;
+
+  /**
+   * Waits for the browser to deliver the authorization code.
+   *
+   * Resolves once with the code and state from the first callback request.
+   * Rejects on timeout, on an OAuth error response (`error` /
+   * `error_description` query params), on a state mismatch, or when the
+   * server is closed before a code arrives.
+   */
+  waitForCode(options?: { timeoutMs?: number }): Promise<OAuthCallbackResult>;
+
+  /**
+   * Stops the server and releases the port. Rejects any pending waitForCode.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Returns the candidate callback URLs for a redirect URL: the URL itself on
+ * its preferred port, followed by the sequential fallback-port variants that
+ * createOAuthCallbackServer will try when the preferred port is in use.
+ *
+ * This is the single source of the candidate list: register all of these as
+ * redirect_uris during dynamic client registration so a fallback-bound
+ * callback URL always matches a registered URI.
+ */
+export function getCallbackUrlCandidates(redirectUrl: string | URL): URL[] {
+  const base = new URL(redirectUrl.toString());
+  const preferredPort = base.port ? Number(base.port) : base.protocol === 'https:' ? 443 : 80;
+
+  const candidates: URL[] = [];
+  for (let offset = 0; offset <= CALLBACK_PORT_FALLBACK_RANGE; offset++) {
+    const candidate = new URL(base.toString());
+    candidate.port = String(preferredPort + offset);
+    candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException | null> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening);
+      if (error.code === 'EADDRINUSE') {
+        resolve(error);
+      } else {
+        reject(error);
+      }
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve(null);
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+/**
+ * Starts a one-shot loopback HTTP server that captures the OAuth
+ * authorization code.
+ *
+ * The server binds 127.0.0.1 on the redirect URL's port, falling back to the
+ * next sequential ports when it is in use (see getCallbackUrlCandidates).
+ * The first request on the callback path settles the outcome; subsequent
+ * requests receive 410 Gone. The response pages never echo the
+ * authorization code.
+ *
+ * @example
+ * ```typescript
+ * const callbackServer = await createOAuthCallbackServer({
+ *   redirectUrl: 'http://127.0.0.1:5533/oauth/callback',
+ *   state: expectedState,
+ * });
+ * try {
+ *   // Direct the user to the authorization URL, then:
+ *   const { code } = await callbackServer.waitForCode();
+ *   await transport.finishAuth(code);
+ * } finally {
+ *   await callbackServer.close();
+ * }
+ * ```
+ */
+export async function createOAuthCallbackServer(options: OAuthCallbackServerOptions): Promise<OAuthCallbackServer> {
+  const candidates = getCallbackUrlCandidates(options.redirectUrl);
+  const callbackPath = candidates[0]!.pathname;
+
+  let settled = false;
+  let resolveCode: (result: OAuthCallbackResult) => void;
+  let rejectCode: (error: Error) => void;
+  const codePromise = new Promise<OAuthCallbackResult>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+  // The rejection is consumed by waitForCode; this guard keeps an unconsumed
+  // rejection (e.g. close() before waitForCode) from surfacing as unhandled.
+  codePromise.catch(() => {});
+
+  const settle = (outcome: { result: OAuthCallbackResult } | { error: Error }) => {
+    if (settled) return;
+    settled = true;
+    if ('result' in outcome) {
+      resolveCode(outcome.result);
+    } else {
+      rejectCode(outcome.error);
+    }
+  };
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '', 'http://localhost');
+    if (url.pathname !== callbackPath) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    if (settled) {
+      res.statusCode = 410;
+      res.end('Callback already handled');
+      return;
+    }
+
+    const respond = (statusCode: number, html: string) => {
+      res.statusCode = statusCode;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.end(html);
+    };
+
+    const error = url.searchParams.get('error');
+    if (error) {
+      const description = url.searchParams.get('error_description');
+      respond(400, ERROR_HTML);
+      settle({ error: new Error(`Authorization failed: ${error}${description ? ` (${description})` : ''}`) });
+      return;
+    }
+
+    if (url.searchParams.get('state') !== options.state) {
+      respond(400, ERROR_HTML);
+      settle({ error: new Error('Authorization failed: state mismatch') });
+      return;
+    }
+
+    const code = url.searchParams.get('code');
+    if (!code) {
+      respond(400, ERROR_HTML);
+      settle({ error: new Error('Authorization failed: missing authorization code') });
+      return;
+    }
+
+    respond(200, SUCCESS_HTML);
+    settle({ result: { code, state: options.state } });
+  });
+
+  let boundUrl: URL | undefined;
+  for (const candidate of candidates) {
+    const error = await listen(server, Number(candidate.port));
+    if (!error) {
+      boundUrl = candidate;
+      break;
+    }
+  }
+  if (!boundUrl) {
+    const firstPort = Number(candidates[0]!.port);
+    const lastPort = Number(candidates[candidates.length - 1]!.port);
+    throw new Error(`Failed to start OAuth callback server: ports ${firstPort}-${lastPort} are all in use`);
+  }
+
+  return {
+    url: boundUrl,
+    port: Number(boundUrl.port),
+
+    waitForCode({ timeoutMs = DEFAULT_CALLBACK_TIMEOUT_MS } = {}) {
+      let timer: NodeJS.Timeout | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out waiting for OAuth callback after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+        timer.unref?.();
+      });
+      return Promise.race([codePromise, timeout]).finally(() => clearTimeout(timer));
+    },
+
+    close() {
+      settle({ error: new Error('OAuth callback server closed before receiving an authorization code') });
+      return new Promise<void>((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -109,6 +109,7 @@ export interface OAuthCallbackServer {
 
   /**
    * Stops the server and releases the port. Rejects any pending waitForCode.
+   * Idempotent: closing an already-closed server resolves immediately.
    */
   close(): Promise<void>;
 }
@@ -295,7 +296,15 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
     close() {
       settle({ error: new Error('OAuth callback server closed before receiving an authorization code') });
       return new Promise<void>((resolve, reject) => {
-        server.close(error => (error ? reject(error) : resolve()));
+        server.close(error => {
+          // Closing twice is fine (e.g. an explicit cancel followed by the
+          // flow's own cleanup); only real errors propagate.
+          if (error && (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
       });
     },
   };

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -426,12 +426,10 @@ describe('MCPClient OAuth authorization flow', () => {
     const secondMcpServer = await startProtectedMcpServer(ports.secondMcpPort, authServer);
     cleanups.push(() => secondMcpServer.close());
 
-    const firstMcp = track(
-      createClient(mcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
-    );
-    const secondMcp = track(
-      createClient(secondMcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
-    );
+    const firstProvider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const secondProvider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const firstMcp = track(createClient(mcpServer.url, firstProvider));
+    const secondMcp = track(createClient(secondMcpServer.url, secondProvider));
 
     await Promise.all([firstMcp.authenticate('fixture'), secondMcp.authenticate('fixture')]);
 
@@ -441,6 +439,10 @@ describe('MCPClient OAuth authorization flow', () => {
     // bound two different ports.
     const boundPorts = authServer.authorizeRedirectUris.map(uri => new URL(uri).port);
     expect(new Set(boundPorts).size).toBe(2);
+    // Fallback binding must not drift the providers' preferred redirect URL:
+    // the next flow starts from the preferred port again.
+    expect(firstProvider.redirectUrl.toString()).toBe(callbackUrl);
+    expect(secondProvider.redirectUrl.toString()).toBe(callbackUrl);
   });
 
   it('returns to needs-auth when the user denies authorization', async () => {

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -529,6 +529,29 @@ describe('MCPClient OAuth authorization flow', () => {
     expect(mcp.getServerAuthState('fixture')).toBe('authorized');
   });
 
+  it('disconnect cancels a pending flow: the callback port is released and the flow settles', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    let authorizationReached: (() => void) | undefined;
+    const reachedAuthorization = new Promise<void>(resolve => {
+      authorizationReached = resolve;
+    });
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: () => {
+        authorizationReached?.();
+      },
+    });
+    const mcp = createClient(mcpServer.url, provider);
+
+    const flow = mcp.authenticate('fixture');
+    await reachedAuthorization;
+
+    // Disconnecting mid-flow must close the callback server and settle the
+    // pending authentication rather than leaving a bound port or a live promise.
+    await mcp.disconnect();
+    await expect(flow).rejects.toThrow(/closed before receiving an authorization code/);
+  });
+
   it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
     const mcp = track(
       new MCPClient({

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -552,6 +552,83 @@ describe('MCPClient OAuth authorization flow', () => {
     await expect(flow).rejects.toThrow(/closed before receiving an authorization code/);
   });
 
+  it('cancels a flow still in its setup phase before the callback server binds', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+
+    // Gate beginAuthorizationSession so the flow parks in setup — before the
+    // callback server is created and stored — which is the window CodeRabbit
+    // flagged as a deadlock/missed-cancellation risk.
+    let reachSetup: (() => void) | undefined;
+    const inSetup = new Promise<void>(resolve => {
+      reachSetup = resolve;
+    });
+    let releaseSetup: (() => void) | undefined;
+    const setupGate = new Promise<void>(resolve => {
+      releaseSetup = resolve;
+    });
+    const originalBegin = provider.beginAuthorizationSession.bind(provider);
+    provider.beginAuthorizationSession = async () => {
+      reachSetup?.();
+      await setupGate;
+      return originalBegin();
+    };
+
+    const mcp = track(createClient(mcpServer.url, provider));
+    const flow = mcp.authenticate('fixture');
+    await inSetup;
+
+    // Cancel while still in setup: no callback server exists yet, but abort must
+    // be recorded so that once setup unblocks the flow bails at the signal check
+    // instead of proceeding to park on waitForCode.
+    const cancelPromise = mcp.cancelAuthentication('fixture');
+    releaseSetup?.();
+    const cancelled = await Promise.race([
+      cancelPromise.then(() => 'cancelled' as const),
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 2_000)),
+    ]);
+    expect(cancelled).toBe('cancelled');
+    await expect(flow).rejects.toThrow(/cancelled/);
+    // Cancellation during setup happens before the 401 handshake runs, so the
+    // auth state was never advanced — the only guarantee is it is not authorized.
+    expect(mcp.getServerAuthState('fixture')).not.toBe('authorized');
+  });
+
+  it('disconnect does not deadlock on a flow still in its setup phase', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+
+    let reachSetup: (() => void) | undefined;
+    const inSetup = new Promise<void>(resolve => {
+      reachSetup = resolve;
+    });
+    let releaseSetup: (() => void) | undefined;
+    const setupGate = new Promise<void>(resolve => {
+      releaseSetup = resolve;
+    });
+    const originalBegin = provider.beginAuthorizationSession.bind(provider);
+    provider.beginAuthorizationSession = async () => {
+      reachSetup?.();
+      await setupGate;
+      return originalBegin();
+    };
+
+    const mcp = createClient(mcpServer.url, provider);
+    const flow = mcp.authenticate('fixture');
+    await inSetup;
+
+    // disconnect() aborts the setup-phase flow first, then awaits its settlement.
+    // Without the abort it would block forever on waitForCode.
+    const disconnectPromise = mcp.disconnect();
+    releaseSetup?.();
+    const disconnected = await Promise.race([
+      disconnectPromise.then(() => 'done' as const),
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 2_000)),
+    ]);
+    expect(disconnected).toBe('done');
+    await expect(flow).rejects.toThrow();
+  });
+
   it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
     const mcp = track(
       new MCPClient({
@@ -563,5 +640,16 @@ describe('MCPClient OAuth authorization flow', () => {
     );
 
     await expect(mcp.authenticate('fixture')).rejects.toThrow(/not configured with an MCPOAuthClientProvider/);
+  });
+
+  it('rejects a redirect URL whose hostname only looks like loopback', async () => {
+    const { mcpServer } = await setup();
+    // 127.evil.com is not a loopback address; a naive startsWith('127.') check
+    // would wrongly accept it and bind the callback server for an attacker host.
+    const provider = createProvider({ callbackUrl: 'http://127.evil.com:9999/oauth/callback' });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.authenticate('fixture')).rejects.toThrow(/loopback address/);
+    expect(mcp.getServerAuthState('fixture')).not.toBe('authorized');
   });
 });

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -465,6 +465,70 @@ describe('MCPClient OAuth authorization flow', () => {
     expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
   });
 
+  it('cancels a pending flow: the authenticate call rejects and the server returns to needs-auth', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    // The "browser" reaches the authorization URL but the redirect never comes
+    // back (the user closed the tab), so the flow is left waiting for the code.
+    let authorizationReached: (() => void) | undefined;
+    const reachedAuthorization = new Promise<void>(resolve => {
+      authorizationReached = resolve;
+    });
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: () => {
+        authorizationReached?.();
+      },
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    const flow = mcp.authenticate('fixture');
+    await reachedAuthorization;
+
+    const cancelled = await mcp.cancelAuthentication('fixture');
+    expect(cancelled).toBe(true);
+
+    await expect(flow).rejects.toThrow(/closed before receiving an authorization code/);
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+  });
+
+  it('cancelAuthentication returns false when no flow is pending', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.cancelAuthentication('fixture')).resolves.toBe(false);
+  });
+
+  it('can authenticate again after a cancelled flow', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    let authorizationReached: (() => void) | undefined;
+    const reachedAuthorization = new Promise<void>(resolve => {
+      authorizationReached = resolve;
+    });
+    // First attempt stalls at the authorization URL; the retry drives the
+    // browser through to completion.
+    let driveOnRedirect = false;
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: url => {
+        if (driveOnRedirect) {
+          return driveBrowser(url);
+        }
+        authorizationReached?.();
+      },
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    const stalledFlow = mcp.authenticate('fixture');
+    await reachedAuthorization;
+    await mcp.cancelAuthentication('fixture');
+    await expect(stalledFlow).rejects.toThrow(/closed before receiving an authorization code/);
+
+    driveOnRedirect = true;
+    await mcp.authenticate('fixture');
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+  });
+
   it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
     const mcp = track(
       new MCPClient({

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -1,0 +1,478 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import type { IncomingMessage, Server as HttpServer, ServerResponse } from 'node:http';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createOAuthMiddleware } from '../server/oauth-middleware.js';
+import type { OAuthMiddlewareResult } from '../server/oauth-middleware.js';
+import { MCPServer } from '../server/server.js';
+import { MCPClient } from './configuration.js';
+import { getCallbackUrlCandidates } from './oauth-callback-server.js';
+import { MCPOAuthClientProvider, InMemoryOAuthStorage } from './oauth-provider.js';
+
+// =============================================================================
+// Fake OAuth authorization server
+//
+// Implements just enough of OAuth 2.1 for the MCP SDK's client flow: RFC 8414
+// metadata discovery, RFC 7591 dynamic client registration, the authorization
+// code grant with PKCE (S256), and the refresh token grant. Tokens are opaque
+// random strings shared with the protected MCP server via `validTokens`.
+// =============================================================================
+
+interface ClientRegistration {
+  client_id: string;
+  redirect_uris: string[];
+}
+
+interface FakeAuthorizationServer {
+  url: string;
+  /** Every dynamic client registration received, in order. */
+  registrations: ClientRegistration[];
+  /** The redirect_uri of every authorization request received, in order. */
+  authorizeRedirectUris: string[];
+  /** How many refresh_token grants the token endpoint served. */
+  refreshGrantCount: number;
+  /** Access tokens currently accepted by the protected MCP server. */
+  validTokens: Set<string>;
+  /** When true, the authorization endpoint denies with error=access_denied. */
+  denyAuthorization: boolean;
+  close(): Promise<void>;
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, statusCode: number, payload: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+async function startFakeAuthorizationServer(port: number): Promise<FakeAuthorizationServer> {
+  const url = `http://127.0.0.1:${port}`;
+  const clientsById = new Map<string, ClientRegistration>();
+  const pendingCodes = new Map<string, { codeChallenge: string; redirectUri: string }>();
+  const refreshTokens = new Set<string>();
+
+  const state: FakeAuthorizationServer = {
+    url,
+    registrations: [],
+    authorizeRedirectUris: [],
+    refreshGrantCount: 0,
+    validTokens: new Set(),
+    denyAuthorization: false,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close(error => (error ? reject(error) : resolve()));
+      }),
+  };
+
+  const httpServer: HttpServer = createServer(async (req, res) => {
+    const requestUrl = new URL(req.url ?? '', url);
+
+    if (requestUrl.pathname === '/.well-known/oauth-authorization-server') {
+      sendJson(res, 200, {
+        issuer: url,
+        authorization_endpoint: `${url}/authorize`,
+        token_endpoint: `${url}/token`,
+        registration_endpoint: `${url}/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        token_endpoint_auth_methods_supported: ['none'],
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/register' && req.method === 'POST') {
+      const metadata = JSON.parse(await readBody(req));
+      const registration: ClientRegistration = {
+        client_id: `client-${randomUUID()}`,
+        redirect_uris: metadata.redirect_uris,
+      };
+      clientsById.set(registration.client_id, registration);
+      state.registrations.push(registration);
+      sendJson(res, 201, {
+        ...metadata,
+        client_id: registration.client_id,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        token_endpoint_auth_method: 'none',
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/authorize') {
+      const clientId = requestUrl.searchParams.get('client_id') ?? '';
+      const redirectUri = requestUrl.searchParams.get('redirect_uri') ?? '';
+      const oauthState = requestUrl.searchParams.get('state') ?? '';
+      const codeChallenge = requestUrl.searchParams.get('code_challenge') ?? '';
+
+      const client = clientsById.get(clientId);
+      if (!client || !client.redirect_uris.includes(redirectUri)) {
+        sendJson(res, 400, { error: 'invalid_request', error_description: 'Unknown client or redirect_uri' });
+        return;
+      }
+
+      state.authorizeRedirectUris.push(redirectUri);
+      const location = new URL(redirectUri);
+      if (state.denyAuthorization) {
+        location.searchParams.set('error', 'access_denied');
+      } else {
+        const code = `code-${randomUUID()}`;
+        pendingCodes.set(code, { codeChallenge, redirectUri });
+        location.searchParams.set('code', code);
+      }
+      location.searchParams.set('state', oauthState);
+      res.writeHead(302, { Location: location.toString() });
+      res.end();
+      return;
+    }
+
+    if (requestUrl.pathname === '/token' && req.method === 'POST') {
+      const params = new URLSearchParams(await readBody(req));
+      const grantType = params.get('grant_type');
+
+      if (grantType === 'authorization_code') {
+        const pending = pendingCodes.get(params.get('code') ?? '');
+        const verifier = params.get('code_verifier') ?? '';
+        const challenge = createHash('sha256').update(verifier).digest('base64url');
+        if (!pending || pending.codeChallenge !== challenge) {
+          sendJson(res, 400, { error: 'invalid_grant' });
+          return;
+        }
+        pendingCodes.delete(params.get('code')!);
+      } else if (grantType === 'refresh_token') {
+        if (!refreshTokens.has(params.get('refresh_token') ?? '')) {
+          sendJson(res, 400, { error: 'invalid_grant' });
+          return;
+        }
+        state.refreshGrantCount += 1;
+      } else {
+        sendJson(res, 400, { error: 'unsupported_grant_type' });
+        return;
+      }
+
+      const accessToken = `access-${randomUUID()}`;
+      const refreshToken = `refresh-${randomUUID()}`;
+      state.validTokens.add(accessToken);
+      refreshTokens.add(refreshToken);
+      sendJson(res, 200, {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: refreshToken,
+      });
+      return;
+    }
+
+    sendJson(res, 404, { error: 'not_found' });
+  });
+
+  await new Promise<void>(resolve => httpServer.listen(port, '127.0.0.1', resolve));
+  return state;
+}
+
+// =============================================================================
+// OAuth-protected MCP server (resource server)
+// =============================================================================
+
+async function startProtectedMcpServer(
+  port: number,
+  authServer: FakeAuthorizationServer,
+): Promise<{ url: string; close(): Promise<void> }> {
+  const url = `http://127.0.0.1:${port}`;
+
+  const mcpServer = new MCPServer({
+    id: `oauth-flow-test-server-${port}`,
+    name: 'OAuth Flow Test Server',
+    version: '1.0.0',
+    tools: {},
+  });
+
+  const oauthMiddleware = createOAuthMiddleware({
+    oauth: {
+      resource: `${url}/mcp`,
+      authorizationServers: [authServer.url],
+      validateToken: async token =>
+        authServer.validTokens.has(token)
+          ? { valid: true }
+          : { valid: false, error: 'invalid_token', errorDescription: 'Token not recognized' },
+    },
+    mcpPath: '/mcp',
+  });
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const requestUrl = new URL(req.url ?? '', url);
+    const result: OAuthMiddlewareResult = await oauthMiddleware(req, res, requestUrl);
+    if (!result.proceed) {
+      return;
+    }
+    await mcpServer.startHTTP({ url: requestUrl, httpPath: '/mcp', req, res });
+  });
+
+  await new Promise<void>(resolve => httpServer.listen(port, '127.0.0.1', resolve));
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close(error => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+// =============================================================================
+// Test harness
+// =============================================================================
+
+// Each test gets its own port block: reusing ports across tests would let
+// undici's keep-alive pool hand a later test a stale socket to a restarted server.
+let portCursor = 19100 + Math.floor(Math.random() * 2000);
+function allocatePortBlock(): { authPort: number; mcpPort: number; secondMcpPort: number; callbackUrl: string } {
+  const base = portCursor;
+  portCursor += 20;
+  return {
+    authPort: base,
+    mcpPort: base + 1,
+    secondMcpPort: base + 2,
+    callbackUrl: `http://127.0.0.1:${base + 3}/oauth/callback`,
+  };
+}
+
+/**
+ * Simulates the user's browser: follows the authorization URL to the fake
+ * authorization server and delivers its redirect to the loopback callback.
+ */
+async function driveBrowser(authorizationUrl: URL): Promise<void> {
+  const response = await fetch(authorizationUrl, { redirect: 'manual' });
+  const location = response.headers.get('location');
+  if (!location) {
+    throw new Error(`Authorization endpoint did not redirect (status ${response.status})`);
+  }
+  await fetch(location);
+}
+
+function createProvider(options: {
+  callbackUrl: string;
+  storage?: InMemoryOAuthStorage;
+  onRedirectToAuthorization?: (url: URL) => void | Promise<void>;
+}): MCPOAuthClientProvider {
+  return new MCPOAuthClientProvider({
+    redirectUrl: options.callbackUrl,
+    clientMetadata: {
+      redirect_uris: [options.callbackUrl],
+      client_name: 'OAuth Flow Test Client',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    },
+    storage: options.storage,
+    onRedirectToAuthorization: options.onRedirectToAuthorization,
+  });
+}
+
+function createClient(serverUrl: string, provider: MCPOAuthClientProvider): MCPClient {
+  return new MCPClient({
+    id: `oauth-flow-test-${randomUUID()}`,
+    servers: {
+      fixture: {
+        url: new URL(`${serverUrl}/mcp`),
+        authProvider: provider,
+      },
+    },
+  });
+}
+
+describe('MCPClient OAuth authorization flow', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  const setup = async () => {
+    const ports = allocatePortBlock();
+    const authServer = await startFakeAuthorizationServer(ports.authPort);
+    const mcpServer = await startProtectedMcpServer(ports.mcpPort, authServer);
+    cleanups.push(() => mcpServer.close(), () => authServer.close());
+    return { authServer, mcpServer, ports, callbackUrl: ports.callbackUrl };
+  };
+
+  const track = (mcp: MCPClient) => {
+    cleanups.push(() => mcp.disconnect());
+    return mcp;
+  };
+
+  afterEach(async () => {
+    while (cleanups.length) {
+      await cleanups.pop()!().catch(() => {});
+    }
+  });
+
+  it('marks the server as needs-auth when the connection is rejected with a 401', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const authorizationUrls: URL[] = [];
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: url => void authorizationUrls.push(url) });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.reconnectServer('fixture')).rejects.toThrow();
+
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+    // The SDK delivered the authorization URL through the provider.
+    expect(authorizationUrls).toHaveLength(1);
+  });
+
+  it('authenticates end to end: registration, consent, code exchange, connect', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    const storage = new InMemoryOAuthStorage();
+    const provider = createProvider({ callbackUrl, storage, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await mcp.authenticate('fixture');
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    await expect(mcp.listTools()).resolves.toBeDefined();
+
+    // Dynamic client registration registered every callback-port candidate,
+    // so a future fallback-bound port still matches a registered URI.
+    expect(authServer.registrations).toHaveLength(1);
+    expect(authServer.registrations[0]!.redirect_uris).toEqual(
+      getCallbackUrlCandidates(callbackUrl).map(candidate => candidate.toString()),
+    );
+
+    // Tokens were persisted through the provider's storage.
+    const tokens = await provider.tokens();
+    expect(tokens?.access_token).toBeDefined();
+    expect(authServer.validTokens.has(tokens!.access_token)).toBe(true);
+  });
+
+  it('reconnects with persisted tokens without a new browser flow', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const storage = new InMemoryOAuthStorage();
+    const provider = createProvider({ callbackUrl, storage, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+    await mcp.authenticate('fixture');
+    await mcp.disconnect();
+
+    // A fresh client sharing the same storage must connect silently.
+    const silentProvider = createProvider({
+      callbackUrl,
+      storage,
+      onRedirectToAuthorization: () => {
+        throw new Error('Browser flow must not run when stored tokens are valid');
+      },
+    });
+    const secondMcp = track(createClient(mcpServer.url, silentProvider));
+
+    await secondMcp.reconnectServer('fixture');
+    expect(secondMcp.getServerAuthState('fixture')).toBe('authorized');
+  });
+
+  it('refreshes an invalidated access token without a new browser flow', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    let browserRuns = 0;
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: url => {
+        browserRuns += 1;
+        return driveBrowser(url);
+      },
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+    await mcp.authenticate('fixture');
+
+    // Invalidate the access token server-side; the refresh token stays valid.
+    const tokens = await provider.tokens();
+    authServer.validTokens.delete(tokens!.access_token);
+
+    await mcp.reconnectServer('fixture');
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(authServer.refreshGrantCount).toBe(1);
+    expect(browserRuns).toBe(1);
+  });
+
+  it('re-registers when the stored client registration does not cover the callback URL', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    // Simulate a registration from an older configuration whose redirect_uris
+    // no longer include the callback URL.
+    await provider.saveClientInformation({
+      client_id: 'stale-client',
+      redirect_uris: ['http://127.0.0.1:9999/oauth/callback'],
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await mcp.authenticate('fixture');
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(authServer.registrations).toHaveLength(1);
+    expect(authServer.registrations[0]!.client_id).not.toBe('stale-client');
+  });
+
+  it('joins concurrent authenticate calls for the same server into one flow', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await Promise.all([mcp.authenticate('fixture'), mcp.authenticate('fixture')]);
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(authServer.authorizeRedirectUris).toHaveLength(1);
+  });
+
+  it('authenticates different servers concurrently, falling back to a free callback port', async () => {
+    const { authServer, mcpServer, ports, callbackUrl } = await setup();
+    const secondMcpServer = await startProtectedMcpServer(ports.secondMcpPort, authServer);
+    cleanups.push(() => secondMcpServer.close());
+
+    const firstMcp = track(
+      createClient(mcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
+    );
+    const secondMcp = track(
+      createClient(secondMcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
+    );
+
+    await Promise.all([firstMcp.authenticate('fixture'), secondMcp.authenticate('fixture')]);
+
+    expect(firstMcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(secondMcp.getServerAuthState('fixture')).toBe('authorized');
+    // Both providers prefer the same callback port, so the flows must have
+    // bound two different ports.
+    const boundPorts = authServer.authorizeRedirectUris.map(uri => new URL(uri).port);
+    expect(new Set(boundPorts).size).toBe(2);
+  });
+
+  it('returns to needs-auth when the user denies authorization', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    authServer.denyAuthorization = true;
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.authenticate('fixture')).rejects.toThrow(/access_denied/);
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+  });
+
+  it('returns to needs-auth when the browser never delivers a code', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    // The "browser" never visits the authorization URL.
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: () => {} });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.authenticate('fixture', { timeoutMs: 300 })).rejects.toThrow(/Timed out/);
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+  });
+
+  it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
+    const mcp = track(
+      new MCPClient({
+        id: `oauth-flow-test-${randomUUID()}`,
+        servers: {
+          fixture: { url: new URL('http://127.0.0.1:1/mcp') },
+        },
+      }),
+    );
+
+    await expect(mcp.authenticate('fixture')).rejects.toThrow(/not configured with an MCPOAuthClientProvider/);
+  });
+});

--- a/packages/mcp/src/client/oauth-provider.ts
+++ b/packages/mcp/src/client/oauth-provider.ts
@@ -163,6 +163,7 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
 
   private _clientInfo?: OAuthClientInformation;
   private _sessionState?: string;
+  private _sessionRedirectUrl?: string | URL;
 
   constructor(options: MCPOAuthClientProviderOptions) {
     this._redirectUrl = options.redirectUrl;
@@ -209,14 +210,22 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
    */
   async beginAuthorizationSession(): Promise<string> {
     this._sessionState = await this.generateState();
+    this._sessionRedirectUrl = this._redirectUrl;
     return this._sessionState;
   }
 
   /**
-   * Clears the pinned authorization state (see beginAuthorizationSession).
+   * Clears the pinned authorization state (see beginAuthorizationSession) and
+   * restores the configured redirect URL if applyResolvedRedirectUrl rebased
+   * it to a fallback port during the session, so the next flow starts from
+   * the preferred port again.
    */
   endAuthorizationSession(): void {
     this._sessionState = undefined;
+    if (this._sessionRedirectUrl !== undefined) {
+      this._redirectUrl = this._sessionRedirectUrl;
+      this._sessionRedirectUrl = undefined;
+    }
   }
 
   /**

--- a/packages/mcp/src/client/oauth-provider.ts
+++ b/packages/mcp/src/client/oauth-provider.ts
@@ -155,13 +155,14 @@ export interface MCPOAuthClientProviderOptions {
  * ```
  */
 export class MCPOAuthClientProvider implements OAuthClientProvider {
-  private readonly _redirectUrl: string | URL;
-  private readonly _clientMetadata: OAuthClientMetadata;
+  private _redirectUrl: string | URL;
+  private _clientMetadata: OAuthClientMetadata;
   private readonly storage: OAuthStorage;
   private readonly onRedirect?: (url: URL) => void | Promise<void>;
   private readonly generateState: () => string | Promise<string>;
 
   private _clientInfo?: OAuthClientInformation;
+  private _sessionState?: string;
 
   constructor(options: MCPOAuthClientProviderOptions) {
     this._redirectUrl = options.redirectUrl;
@@ -188,9 +189,54 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
 
   /**
    * Returns a OAuth2 state parameter.
+   *
+   * While an authorization session is active (see beginAuthorizationSession),
+   * the pinned session state is returned so a callback server can validate
+   * the redirect against a known value.
    */
   async state(): Promise<string> {
-    return this.generateState();
+    return this._sessionState ?? this.generateState();
+  }
+
+  /**
+   * Pins the OAuth state parameter for the next authorization request.
+   *
+   * Hosts driving an interactive authorization flow (e.g. MCPClient.authenticate)
+   * call this before triggering the flow so the loopback callback server knows
+   * which state value to expect. Call endAuthorizationSession once the flow settles.
+   *
+   * @returns The pinned state value, generated with the configured stateGenerator
+   */
+  async beginAuthorizationSession(): Promise<string> {
+    this._sessionState = await this.generateState();
+    return this._sessionState;
+  }
+
+  /**
+   * Clears the pinned authorization state (see beginAuthorizationSession).
+   */
+  endAuthorizationSession(): void {
+    this._sessionState = undefined;
+  }
+
+  /**
+   * Points the provider at the callback URL that is actually bound.
+   *
+   * Loopback callback servers may bind a fallback port when the preferred one
+   * is in use. Call this before triggering authorization so the authorization
+   * request's redirect_uri matches the listening server, and so dynamic client
+   * registration registers every candidate callback URL (see
+   * getCallbackUrlCandidates) rather than only the preferred one.
+   *
+   * @param redirectUrl - The callback URL that is actually bound
+   * @param registeredRedirectUris - The redirect URIs to register during dynamic client registration
+   */
+  applyResolvedRedirectUrl(redirectUrl: string | URL, registeredRedirectUris: (string | URL)[]): void {
+    this._redirectUrl = redirectUrl;
+    this._clientMetadata = {
+      ...this._clientMetadata,
+      redirect_uris: registeredRedirectUris.map(uri => uri.toString()),
+    };
   }
 
   /**


### PR DESCRIPTION
> [!NOTE]
> Draft — segment 1 of 2. A follow-up PR wires this into Mastra Code (zero-config provisioning, browser open, and an Authenticate action in the `/mcp` selector).

## Summary

Completes the OAuth authorization-code loop in `@mastra/mcp` so hosts can authenticate HTTP MCP servers that require a browser login.

`MCPOAuthClientProvider` already handled discovery, PKCE, dynamic client registration, and token storage/refresh — but nothing closed the loop: when a server answered 401, the SDK redirected to authorization and threw `UnauthorizedError`, and no code path ever captured the authorization code or called `transport.finishAuth`. Servers requiring interactive OAuth simply could not connect (#18175, #13997).

This PR adds the missing half:

- **`createOAuthCallbackServer`** — a one-shot loopback HTTP server (`node:http`, RFC 8252) that captures the authorization code. State-authenticated: requests without the expected `state` get a 400 and cannot settle or abort a pending flow. Sequential port fallback when the preferred port is in use, with `getCallbackUrlCandidates` as the single source of the candidate list so dynamic client registration covers every fallback port.
- **`MCPClient.authenticate(serverName)`** — orchestrates the full flow: connect attempt → SDK runs discovery/DCR and delivers the authorization URL via the provider's `onRedirectToAuthorization` → loopback server captures the code → `transport.finishAuth(code)` → reconnect. Concurrent calls for the same server join the pending flow; different servers authenticate independently. Stale client registrations that don't cover the bound callback URL are discarded and re-registered.
- **`MCPClient.getServerAuthState(serverName)`** — exposes `needs-auth` / `authorized` so hosts can render an "authentication required" state and offer an explicit authenticate action instead of failing opaquely.

The trigger stays host-driven: a 401 marks the server as needing auth, and the host decides when to start the browser flow — no surprise browser windows.

Closes #18175
Closes #13997

## Test plan

- New `oauth-flow.test.ts`: end-to-end tests driving the real MCP SDK against an in-process OAuth 2.1 authorization server (RFC 8414 metadata, RFC 7591 registration, PKCE-verified token endpoint) and a real `MCPServer` behind the existing OAuth middleware — covering needs-auth detection, the full authenticate flow, token persistence and refresh, stale-registration recovery, same-server flow joining, cross-server concurrency with port fallback, denied consent, and callback timeout.
- New `oauth-callback-server.test.ts`: socket-level tests over real HTTP requests — code capture, one-shot semantics, forged-request rejection (state mismatch cannot settle the flow), hostname binding, port fallback, and port release.
- Full `test:client` suite: 102 passed. `tsc --noEmit` and `eslint` clean.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If an MCP server asks you to “log in with OAuth,” this PR makes your MCP app open a browser, catch the login code in a tiny local web server, then reconnect to the MCP server. It also saves tokens so you usually don’t have to log in again, and can refresh them when they expire.

## What changed

- Completed the OAuth **authorization-code flow for HTTP MCP servers**:
  - **Host-driven authentication:** a **401** connection response marks the server as `needs-auth`; the host then calls `authenticate()` to start the browser flow.
  - Supports interactive code exchange, token persistence, reconnect, and **token refresh**.

- Added `createOAuthCallbackServer`:
  - A secure one-shot **loopback HTTP callback server** that validates the OAuth `state`.
  - **Port fallback**: tries the preferred callback port first, then sequential alternatives.
  - Tight loopback binding/validation (accepts **127.0.0.0/8** and **::1**, rejects lookalike hostnames).
  - Correct handling for denial/error responses, missing codes, **replay protection** (`410 Gone`), **timeouts**, and **cancellation**.
  - Ensures proper shutdown via `try/finally` and exports it via the client index for host/custom redirect handling.

- Added `MCPClient.authenticate(serverName)`:
  - Runs the end-to-end interactive flow: discover/register as needed, start the callback server, exchange authorization code for tokens, **persist tokens**, then **reconnect**.
  - **Coalesces concurrent** `authenticate()` calls per server into the same in-flight flow.
  - Handles **stale registration recovery** (re-registration when redirect/callback coverage no longer matches).
  - Adds robust **cancellation, timeout, and teardown** behavior (including interrupting OAuth setup before the callback server binds).
  - Surfaces OAuth connection failures through auth state instead of hard-failing, enabling a “detect then authenticate” flow.

- Added `MCPClient.getServerAuthState(serverName)`:
  - Exposes per-server OAuth state: `'needs-auth' | 'authorized' | undefined`.

- Added `MCPClient.cancelAuthentication(serverName)`:
  - Aborts an in-progress interactive flow, closes any loopback callback server, and returns the server back to a retryable auth state.

- Updated OAuth provider session behavior (`MCPOAuthClientProvider`):
  - **Pins OAuth `state`** and the session redirect URL during an active authorization session, then restores configuration after completion.
  - Rebases resolved redirect URLs and updates dynamic client registration redirect URIs accordingly.

- Documentation + tests:
  - Documented the new interactive APIs, recommended flow (“check `needs-auth`, then call `authenticate()`”), and cancellation behavior.
  - Added comprehensive integration tests for OAuth flows, callback security, concurrency, port fallback, denied consent, cancellation/disconnect, timeouts, token refresh, and stale registration recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->