### PR TITLE
feat(mastracode): browser-based OAuth authentication for HTTP MCP servers

### DIFF
--- a/.changeset/mastracode-mcp-oauth-surface.md
+++ b/.changeset/mastracode-mcp-oauth-surface.md
@@ -18,3 +18,18 @@ The server manager gains `authenticateServer(name)` and
 `cancelServerAuthentication(name)`, `McpServerStatus` gains an optional
 `needsAuth` flag, and the OAuth `redirectUrl` in MCP server config is now
 optional (it defaults to a stable loopback URL).
+
+```ts
+const server = manager.getServerStatuses().find(s => s.name === 'supabase')
+if (server?.needsAuth) {
+  // Opens the consent page in the browser, completes the OAuth flow, and
+  // resolves with the reconnected server status.
+  const status = await manager.authenticateServer('supabase', {
+    onAuthorizationUrl: url => openInBrowser(url),
+  })
+  console.log(status.connected)
+
+  // Abort an abandoned browser flow and return the server to needs-auth:
+  // await manager.cancelServerAuthentication('supabase')
+}
+```

--- a/.changeset/mastracode-mcp-oauth-surface.md
+++ b/.changeset/mastracode-mcp-oauth-surface.md
@@ -1,0 +1,20 @@
+---
+'@mastra/code-sdk': minor
+'mastracode': minor
+---
+
+Add browser-based OAuth authentication for HTTP MCP servers to Mastra Code.
+
+When an HTTP MCP server rejects a connection with an authorization error, the
+`/mcp` selector now shows a "needs auth" badge and an **Authenticate** action.
+Choosing it opens the provider's consent page in the browser and completes the
+OAuth 2.1 authorization-code flow (PKCE + Dynamic Client Registration) over a
+loopback callback server, persists the tokens, and reconnects — no manual
+configuration required for a bare `{ "url": ... }` server entry. A **Cancel
+authentication** action aborts an in-flight flow and returns the server to the
+needs-auth state.
+
+The server manager gains `authenticateServer(name)` and
+`cancelServerAuthentication(name)`, `McpServerStatus` gains an optional
+`needsAuth` flag, and the OAuth `redirectUrl` in MCP server config is now
+optional (it defaults to a stable loopback URL).

--- a/.changeset/mcp-oauth-auth-loop.md
+++ b/.changeset/mcp-oauth-auth-loop.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': minor
+---
+
+Complete the OAuth authorization-code loop in MCPClient for HTTP MCP servers. Connections rejected with an authorization error now surface a `needs-auth` state (readable via `getServerAuthState()`), and the new `authenticate(serverName)` method runs the interactive flow end to end: it captures the authorization code on a local loopback callback server (exported as `createOAuthCallbackServer` for hosts with custom redirect handling), exchanges it for tokens, and reconnects.

--- a/docs/src/content/en/docs/mcp/overview.mdx
+++ b/docs/src/content/en/docs/mcp/overview.mdx
@@ -54,7 +54,7 @@ Visit [MCPClient](/reference/tools/mcp-client) for a full list of configuration 
 
 :::tip Authentication
 
-For connecting to OAuth-protected MCP servers, see the [OAuth Authentication](/reference/tools/mcp-client#oauth-authentication) section.
+For connecting to OAuth-protected MCP servers — including completing the browser-based authorization flow with `authenticate()` — see the [OAuth Authentication](/reference/tools/mcp-client#oauth-authentication) section.
 
 :::
 

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -311,6 +311,22 @@ const instructionsByServer = mcp.getServerInstructions()
 console.log(instructionsByServer.db)
 ```
 
+### `authenticate()`
+
+Runs the interactive OAuth authorization-code flow for a server configured with an `MCPOAuthClientProvider` whose redirect URL points at a loopback address. Starts a local callback server, delivers the authorization URL through the provider's `onRedirectToAuthorization` callback, waits for the browser to return the authorization code, exchanges it for tokens, and reconnects. See [Interactive browser authentication](#interactive-browser-authentication).
+
+```typescript prettier:false
+async authenticate(serverName: string, options?: { timeoutMs?: number }): Promise<void>
+```
+
+### `getServerAuthState()`
+
+Returns the OAuth authorization state of a configured server: `'needs-auth'` after a connection attempt was rejected with an authorization error, `'authorized'` once the server accepted the provider's credentials, or `undefined` for servers without an `authProvider` or that haven't attempted a connection yet.
+
+```typescript prettier:false
+getServerAuthState(serverName: string): 'needs-auth' | 'authorized' | undefined
+```
+
 ### `disconnect()`
 
 Disconnects from all MCP servers and cleans up resources.
@@ -922,6 +938,64 @@ const client = new MCPClient({
     },
   },
 })
+```
+
+### Interactive browser authentication
+
+When a server rejects a connection because authorization is required, the client records a `'needs-auth'` state instead of failing outright. Calling `authenticate()` then completes the flow end to end: it starts a one-shot callback server on the provider's loopback redirect URL (falling back to the next sequential ports when it is in use), lets the SDK run discovery and dynamic client registration, delivers the authorization URL through `onRedirectToAuthorization` — open it in the user's browser — and finishes the token exchange once the browser returns the authorization code:
+
+```typescript
+import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp'
+
+const oauthProvider = new MCPOAuthClientProvider({
+  redirectUrl: 'http://127.0.0.1:5533/oauth/callback',
+  clientMetadata: {
+    redirect_uris: ['http://127.0.0.1:5533/oauth/callback'],
+    client_name: 'My MCP Client',
+    grant_types: ['authorization_code', 'refresh_token'],
+    response_types: ['code'],
+  },
+  onRedirectToAuthorization: url => {
+    // Open the user's browser at the consent page
+    console.log(`Please visit: ${url}`)
+  },
+})
+
+const mcp = new MCPClient({
+  servers: {
+    protectedServer: {
+      url: new URL('https://mcp.example.com/mcp'),
+      authProvider: oauthProvider,
+    },
+  },
+})
+
+try {
+  await mcp.listTools()
+} catch {
+  if (mcp.getServerAuthState('protectedServer') === 'needs-auth') {
+    await mcp.authenticate('protectedServer')
+  }
+}
+```
+
+Concurrent `authenticate()` calls for the same server join the pending flow; different servers authenticate independently. With valid stored tokens the call simply reconnects without opening a browser.
+
+Hosts with custom redirect handling (for example a web app with an HTTPS redirect URL) can capture the authorization code themselves with the exported `createOAuthCallbackServer` helper, which binds a one-shot loopback server, validates the OAuth `state` parameter, and resolves with the code:
+
+```typescript
+import { createOAuthCallbackServer, getCallbackUrlCandidates } from '@mastra/mcp'
+
+const server = await createOAuthCallbackServer({
+  redirectUrl: 'http://127.0.0.1:5533/oauth/callback',
+  state: expectedState,
+})
+
+// server.url reflects any port fallback — use it as the redirect_uri.
+// getCallbackUrlCandidates() lists every URL the helper may bind, so all
+// of them can be registered as redirect_uris during client registration.
+const { code } = await server.waitForCode()
+await server.close()
 ```
 
 ### Quick Token Provider

--- a/docs/src/content/en/reference/tools/mcp-client.mdx
+++ b/docs/src/content/en/reference/tools/mcp-client.mdx
@@ -327,6 +327,14 @@ Returns the OAuth authorization state of a configured server: `'needs-auth'` aft
 getServerAuthState(serverName: string): 'needs-auth' | 'authorized' | undefined
 ```
 
+### `cancelAuthentication()`
+
+Cancels an in-progress `authenticate()` flow for a server, so an abandoned browser authorization does not leave the client waiting indefinitely. It aborts the flow (including its setup phase, before the callback server binds), closes the local callback server if one is listening, and returns the server to `'needs-auth'`. The pending `authenticate()` call rejects. Returns `true` if a flow was cancelled, or `false` when no flow was in progress.
+
+```typescript prettier:false
+async cancelAuthentication(serverName: string): Promise<boolean>
+```
+
 ### `disconnect()`
 
 Disconnects from all MCP servers and cleans up resources.
@@ -981,7 +989,7 @@ try {
 
 Concurrent `authenticate()` calls for the same server join the pending flow; different servers authenticate independently. With valid stored tokens the call simply reconnects without opening a browser.
 
-Hosts with custom redirect handling (for example a web app with an HTTPS redirect URL) can capture the authorization code themselves with the exported `createOAuthCallbackServer` helper, which binds a one-shot loopback server, validates the OAuth `state` parameter, and resolves with the code:
+Hosts that drive the flow themselves can capture the authorization code with the exported `createOAuthCallbackServer` helper, which binds a one-shot loopback server, validates the OAuth `state` parameter, and resolves with the code. It creates a plain HTTP server, so it is only for local loopback redirects. Web applications that use an HTTPS redirect URL must host their own callback endpoint and drive the provider directly rather than using this helper:
 
 ```typescript
 import { createOAuthCallbackServer, getCallbackUrlCandidates } from '@mastra/mcp'
@@ -994,8 +1002,12 @@ const server = await createOAuthCallbackServer({
 // server.url reflects any port fallback — use it as the redirect_uri.
 // getCallbackUrlCandidates() lists every URL the helper may bind, so all
 // of them can be registered as redirect_uris during client registration.
-const { code } = await server.waitForCode()
-await server.close()
+try {
+  const { code } = await server.waitForCode()
+  // Exchange the code here.
+} finally {
+  await server.close()
+}
 ```
 
 ### Quick Token Provider

--- a/mastracode/sdk/src/mcp/__tests__/config.test.ts
+++ b/mastracode/sdk/src/mcp/__tests__/config.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { classifyServerEntry, expandEnvVars, loadMcpConfig, validateConfig } from '../config.js';
+import { DEFAULT_OAUTH_REDIRECT_URL, classifyServerEntry, expandEnvVars, loadMcpConfig, validateConfig } from '../config.js';
 
 describe('classifyServerEntry', () => {
   it('classifies stdio entry', () => {
@@ -186,6 +186,38 @@ describe('validateConfig', () => {
         clientSecret: 'client-secret',
       },
     });
+  });
+
+  it('applies the default loopback redirect URL when oauth.redirectUrl is omitted', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/mcp',
+          oauth: {},
+        },
+      },
+    });
+
+    expect(result.skippedServers).toBeUndefined();
+    expect((result.mcpServers!['remote'] as { oauth?: { redirectUrl: string } }).oauth?.redirectUrl).toBe(
+      DEFAULT_OAUTH_REDIRECT_URL,
+    );
+  });
+
+  it('rejects a non-string oauth.redirectUrl', () => {
+    const result = validateConfig({
+      mcpServers: {
+        remote: {
+          url: 'https://mcp.example.com/mcp',
+          oauth: { redirectUrl: 42 },
+        },
+      },
+    });
+
+    expect(result.mcpServers).toBeUndefined();
+    expect(result.skippedServers).toEqual([
+      { name: 'remote', reason: 'Invalid OAuth config: "redirectUrl" must be a string' },
+    ]);
   });
 
   it('accepts loopback IPv6 HTTP OAuth redirect URLs', () => {

--- a/mastracode/sdk/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/mcp/__tests__/manager.test.ts
@@ -194,30 +194,37 @@ describe('createMcpManager', () => {
     });
 
     it('uses separate OAuth token storage for the same server name in different projects', async () => {
-      const httpConfig: McpHttpServerConfig = {
-        url: 'https://mcp.example.com/mcp',
-        oauth: {
-          redirectUrl: 'http://localhost:3000/oauth/callback',
-          clientName: 'Remote MCP',
-          scopes: ['mcp:read'],
-          clientId: 'client-id',
-        },
-      };
-      setupConfig({ mcpServers: { remote: httpConfig } });
+      const dataDir = await fs.mkdtemp(join(tmpdir(), 'mc-oauth-test-'));
+      process.env.MASTRA_APP_DATA_DIR = dataDir;
+      try {
+        const httpConfig: McpHttpServerConfig = {
+          url: 'https://mcp.example.com/mcp',
+          oauth: {
+            redirectUrl: 'http://localhost:3000/oauth/callback',
+            clientName: 'Remote MCP',
+            scopes: ['mcp:read'],
+            clientId: 'client-id',
+          },
+        };
+        setupConfig({ mcpServers: { remote: httpConfig } });
 
-      MockedMCPClient.mockImplementation(function (this: any) {
-        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { remote: {} }, errors: {} });
-        this.disconnect = vi.fn().mockResolvedValue(undefined);
-      } as any);
+        MockedMCPClient.mockImplementation(function (this: any) {
+          this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { remote: {} }, errors: {} });
+          this.disconnect = vi.fn().mockResolvedValue(undefined);
+        } as any);
 
-      await createMcpManager('/tmp/project-a').init();
-      await createMcpManager('/tmp/project-b').init();
+        await createMcpManager('/tmp/project-a').init();
+        await createMcpManager('/tmp/project-b').init();
 
-      const firstStoragePath = MockedMCPOAuthClientProvider.mock.calls[0]?.[0]?.storage?.filePath;
-      const secondStoragePath = MockedMCPOAuthClientProvider.mock.calls[1]?.[0]?.storage?.filePath;
-      expect(firstStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
-      expect(secondStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
-      expect(firstStoragePath).not.toBe(secondStoragePath);
+        const firstStoragePath = MockedMCPOAuthClientProvider.mock.calls[0]?.[0]?.storage?.filePath;
+        const secondStoragePath = MockedMCPOAuthClientProvider.mock.calls[1]?.[0]?.storage?.filePath;
+        expect(firstStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
+        expect(secondStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
+        expect(firstStoragePath).not.toBe(secondStoragePath);
+      } finally {
+        delete process.env.MASTRA_APP_DATA_DIR;
+        await fs.rm(dataDir, { recursive: true, force: true });
+      }
     });
 
     it('creates one MCPClient with all servers', async () => {

--- a/mastracode/sdk/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/mcp/__tests__/manager.test.ts
@@ -1,3 +1,6 @@
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { loadMcpConfig } from '../config.js';
@@ -949,6 +952,271 @@ describe('createMcpManager', () => {
       logs.push('injected');
 
       expect(manager.getServerLogs('fs')).not.toContain('injected');
+    });
+  });
+
+  describe('needs-auth status', () => {
+    it('surfaces needsAuth from the client auth state for OAuth-configured servers', async () => {
+      setupConfig({
+        mcpServers: {
+          api: {
+            url: 'https://api.example.com/mcp',
+            oauth: { redirectUrl: 'http://127.0.0.1:1458/oauth/callback' },
+          },
+        },
+      });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: {}, errors: { api: 'Unauthorized' } });
+        this.getServerAuthState = vi.fn().mockReturnValue('needs-auth');
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const statuses = manager.getServerStatuses();
+      expect(statuses[0]!.needsAuth).toBe(true);
+      expect(statuses[0]!.connected).toBe(false);
+    });
+
+    it('flags a bare url server whose connect error is a 401 as needing auth', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({
+          toolsets: {},
+          errors: { api: 'Streamable HTTP error: Error POSTing to endpoint (HTTP 401): invalid_token' },
+        });
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      expect(manager.getServerStatuses()[0]!.needsAuth).toBe(true);
+    });
+
+    it('does not flag non-auth connect failures', async () => {
+      setupConfig({
+        mcpServers: {
+          api: { url: 'https://api.example.com/mcp' },
+          fs: { command: 'npx' },
+        },
+      });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({
+          toolsets: {},
+          // The stdio error mentions 401 to prove the heuristic only applies to HTTP servers
+          errors: { api: 'fetch failed: ECONNREFUSED', fs: 'spawn npx ENOENT after HTTP 401 from registry' },
+        });
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      for (const status of manager.getServerStatuses()) {
+        expect(status.needsAuth).toBeUndefined();
+      }
+    });
+  });
+
+  describe('authenticateServer', () => {
+    function setupAuthenticatingClient(overrides: Record<string, any> = {}) {
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { api: { fetch: {} } }, errors: {} });
+        this.authenticate = vi.fn().mockResolvedValue(undefined);
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+        Object.assign(this, overrides);
+      } as any);
+    }
+
+    it('returns error status for unknown server name', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      setupAuthenticatingClient();
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const result = await manager.authenticateServer('nonexistent');
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('not found in config');
+    });
+
+    it('returns error status for stdio servers', async () => {
+      setupConfig({ mcpServers: { fs: { command: 'npx' } } });
+      setupAuthenticatingClient();
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const result = await manager.authenticateServer('fs');
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('does not support OAuth');
+    });
+
+    it('provisions a zero-config OAuth provider for bare url entries and authenticates', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      setupAuthenticatingClient();
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      // Bare entries get no eager provider — provisioning happens on authenticate
+      expect(MockedMCPOAuthClientProvider).not.toHaveBeenCalled();
+
+      const result = await manager.authenticateServer('api');
+
+      expect(MockedMCPOAuthClientProvider).toHaveBeenCalledTimes(1);
+      const options = MockedMCPOAuthClientProvider.mock.calls[0]![0]!;
+      expect(options.redirectUrl).toBe('http://127.0.0.1:1458/oauth/callback');
+      expect(options.clientMetadata.redirect_uris).toEqual(['http://127.0.0.1:1458/oauth/callback']);
+      expect(options.clientInformation).toBeUndefined();
+
+      // The provider is attached to the live server def so the client sees it
+      const serverDef = (MockedMCPClient.mock.calls[0]![0]! as any).servers['api'];
+      expect(serverDef.authProvider).toBeInstanceOf(mcpMocks.MCPOAuthClientProvider);
+
+      const mockInstance = MockedMCPClient.mock.instances[0] as any;
+      expect(mockInstance.authenticate).toHaveBeenCalledWith('api', undefined);
+      expect(result.connected).toBe(true);
+      expect(result.toolNames).toEqual(['api_fetch']);
+    });
+
+    it('keeps the configured provider for servers with an explicit oauth block', async () => {
+      setupConfig({
+        mcpServers: {
+          api: {
+            url: 'https://api.example.com/mcp',
+            oauth: { redirectUrl: 'http://localhost:3000/oauth/callback' },
+          },
+        },
+      });
+      setupAuthenticatingClient();
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+      expect(MockedMCPOAuthClientProvider).toHaveBeenCalledTimes(1);
+
+      await manager.authenticateServer('api');
+
+      // No second provider — the configured one wins
+      expect(MockedMCPOAuthClientProvider).toHaveBeenCalledTimes(1);
+      expect(MockedMCPOAuthClientProvider.mock.calls[0]![0]!.redirectUrl).toBe('http://localhost:3000/oauth/callback');
+    });
+
+    it('passes timeoutMs through to the client', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      setupAuthenticatingClient();
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      await manager.authenticateServer('api', { timeoutMs: 1000 });
+
+      const mockInstance = MockedMCPClient.mock.instances[0] as any;
+      expect(mockInstance.authenticate).toHaveBeenCalledWith('api', { timeoutMs: 1000 });
+    });
+
+    it('surfaces the authorization URL through onAuthorizationUrl', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      setupAuthenticatingClient({
+        authenticate: vi.fn().mockImplementation(async () => {
+          // Simulate the SDK delivering the authorization URL through the provider
+          const providerOptions = MockedMCPOAuthClientProvider.mock.calls[0]![0]!;
+          providerOptions.onRedirectToAuthorization(new URL('https://auth.example.com/authorize?state=abc'));
+        }),
+      });
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const seenUrls: string[] = [];
+      await manager.authenticateServer('api', { onAuthorizationUrl: url => seenUrls.push(url) });
+
+      expect(seenUrls).toEqual(['https://auth.example.com/authorize?state=abc']);
+    });
+
+    it('returns a needs-auth error status when authentication fails', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      setupAuthenticatingClient({
+        authenticate: vi.fn().mockRejectedValue(new Error('Timed out waiting for the OAuth callback')),
+        getServerAuthState: vi.fn().mockReturnValue('needs-auth'),
+      });
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      const result = await manager.authenticateServer('api');
+      expect(result.connected).toBe(false);
+      expect(result.error).toContain('Timed out');
+      expect(result.needsAuth).toBe(true);
+    });
+  });
+
+  describe('OAuth token storage fingerprint', () => {
+    it('is stable across zero-config provisioning and manager instantiations', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { api: { fetch: {} } }, errors: {} });
+        this.authenticate = vi.fn().mockResolvedValue(undefined);
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      await createMcpManager('/tmp/project-a').init();
+      const firstManager = createMcpManager('/tmp/project-a');
+      await firstManager.init();
+      await firstManager.authenticateServer('api');
+      const firstStoragePath = MockedMCPOAuthClientProvider.mock.calls[0]?.[0]?.storage?.filePath;
+
+      vi.clearAllMocks();
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { api: { fetch: {} } }, errors: {} });
+        this.authenticate = vi.fn().mockResolvedValue(undefined);
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      const secondManager = createMcpManager('/tmp/project-a');
+      await secondManager.init();
+      await secondManager.authenticateServer('api');
+      const secondStoragePath = MockedMCPOAuthClientProvider.mock.calls[0]?.[0]?.storage?.filePath;
+
+      expect(firstStoragePath).toEqual(expect.stringMatching(/mcp-oauth\/[a-f0-9]{16}\.json$/));
+      expect(secondStoragePath).toBe(firstStoragePath);
+    });
+
+    it('eagerly attaches a provider on init when a previous session persisted OAuth state', async () => {
+      const dataDir = await fs.mkdtemp(join(tmpdir(), 'mc-oauth-test-'));
+      process.env.MASTRA_APP_DATA_DIR = dataDir;
+      try {
+        setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+        MockedMCPClient.mockImplementation(function (this: any) {
+          this.listToolsetsWithErrors = vi.fn().mockResolvedValue({ toolsets: { api: { fetch: {} } }, errors: {} });
+          this.authenticate = vi.fn().mockResolvedValue(undefined);
+          this.disconnect = vi.fn().mockResolvedValue(undefined);
+        } as any);
+
+        // Session 1: no persisted state — provider only appears on authenticate
+        const firstManager = createMcpManager('/tmp/project-a');
+        await firstManager.init();
+        expect(MockedMCPOAuthClientProvider).not.toHaveBeenCalled();
+        await firstManager.authenticateServer('api');
+        const storagePath = MockedMCPOAuthClientProvider.mock.calls[0]![0]!.storage.filePath as string;
+
+        // Simulate the provider having persisted tokens to disk
+        await fs.mkdir(dirname(storagePath), { recursive: true });
+        await fs.writeFile(storagePath, JSON.stringify({ tokens: { access_token: 'stored' } }));
+
+        // Session 2: persisted state — provider attaches eagerly so tokens are used
+        MockedMCPOAuthClientProvider.mockClear();
+        const secondManager = createMcpManager('/tmp/project-a');
+        await secondManager.init();
+        expect(MockedMCPOAuthClientProvider).toHaveBeenCalledTimes(1);
+        expect(MockedMCPOAuthClientProvider.mock.calls[0]![0]!.storage.filePath).toBe(storagePath);
+      } finally {
+        delete process.env.MASTRA_APP_DATA_DIR;
+        await fs.rm(dataDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/mastracode/sdk/src/mcp/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/mcp/__tests__/manager.test.ts
@@ -995,6 +995,24 @@ describe('createMcpManager', () => {
       expect(manager.getServerStatuses()[0]!.needsAuth).toBe(true);
     });
 
+    it('flags a bare url server whose connect error carries only the bearer error code', async () => {
+      setupConfig({ mcpServers: { api: { url: 'https://api.example.com/mcp' } } });
+      MockedMCPClient.mockImplementation(function (this: any) {
+        this.listToolsetsWithErrors = vi.fn().mockResolvedValue({
+          toolsets: {},
+          // The SDK flattens 401 bodies without the status code — only the
+          // RFC 6750 bearer error code survives in the message
+          errors: { api: 'Streamable HTTP error: Error POSTing to endpoint: {"error":"invalid_token"}' },
+        });
+        this.disconnect = vi.fn().mockResolvedValue(undefined);
+      } as any);
+
+      const manager = createMcpManager('/tmp/test');
+      await manager.init();
+
+      expect(manager.getServerStatuses()[0]!.needsAuth).toBe(true);
+    });
+
     it('does not flag non-auth connect failures', async () => {
       setupConfig({
         mcpServers: {

--- a/mastracode/sdk/src/mcp/config.ts
+++ b/mastracode/sdk/src/mcp/config.ts
@@ -17,6 +17,16 @@ import * as path from 'node:path';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
 import type { McpConfig, McpHttpOAuthConfig, McpServerConfig, McpSkippedServer } from './types.js';
 
+/**
+ * Default OAuth redirect URL for servers that do not configure one.
+ * Port 1458 is stable across sessions so persisted tokens keep the same
+ * storage fingerprint; it sits clear of the ports the Codex login flow
+ * reserves (1455/1457). When 1458 is busy the callback server falls back
+ * to the next sequential port, which stays covered by the client
+ * registration (see `@mastra/mcp`'s `getCallbackUrlCandidates`).
+ */
+export const DEFAULT_OAUTH_REDIRECT_URL = 'http://127.0.0.1:1458/oauth/callback';
+
 export function loadMcpConfig(projectDir: string, configDirName = DEFAULT_CONFIG_DIR): McpConfig {
   const claudeConfig = loadClaudeSettings(projectDir);
   const globalConfig = loadSingleConfig(getGlobalMcpPath(configDirName));
@@ -202,11 +212,12 @@ function parseOAuthConfig(raw: unknown): { config?: McpHttpOAuthConfig; reason?:
   }
 
   const obj = raw as Record<string, unknown>;
-  if (typeof obj.redirectUrl !== 'string') {
-    return { reason: 'Invalid OAuth config: missing required field "redirectUrl"' };
+  if (obj.redirectUrl !== undefined && typeof obj.redirectUrl !== 'string') {
+    return { reason: 'Invalid OAuth config: "redirectUrl" must be a string' };
   }
+  const rawRedirectUrl = obj.redirectUrl ?? DEFAULT_OAUTH_REDIRECT_URL;
   try {
-    const redirectUrl = new URL(obj.redirectUrl);
+    const redirectUrl = new URL(rawRedirectUrl);
     const isLoopback =
       redirectUrl.hostname === 'localhost' ||
       redirectUrl.hostname.startsWith('127.') ||
@@ -224,7 +235,7 @@ function parseOAuthConfig(raw: unknown): { config?: McpHttpOAuthConfig; reason?:
 
   return {
     config: {
-      redirectUrl: obj.redirectUrl,
+      redirectUrl: rawRedirectUrl,
       clientName: typeof obj.clientName === 'string' ? obj.clientName : undefined,
       scopes: obj.scopes as string[] | undefined,
       clientId: typeof obj.clientId === 'string' ? obj.clientId : undefined,

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -9,8 +9,21 @@ import { MCPClient, MCPOAuthClientProvider } from '@mastra/mcp';
 import type { MastraMCPServerDefinition, OAuthClientInformation, OAuthStorage } from '@mastra/mcp';
 import { DEFAULT_CONFIG_DIR } from '../constants.js';
 import { getAppDataDir } from '../utils/project.js';
-import { loadMcpConfig, getProjectMcpPath, getGlobalMcpPath, getClaudeSettingsPath } from './config.js';
-import type { McpConfig, McpHttpServerConfig, McpServerConfig, McpServerStatus, McpSkippedServer } from './types.js';
+import {
+  DEFAULT_OAUTH_REDIRECT_URL,
+  loadMcpConfig,
+  getProjectMcpPath,
+  getGlobalMcpPath,
+  getClaudeSettingsPath,
+} from './config.js';
+import type {
+  McpConfig,
+  McpHttpOAuthConfig,
+  McpHttpServerConfig,
+  McpServerConfig,
+  McpServerStatus,
+  McpSkippedServer,
+} from './types.js';
 
 const MASTRACODE_MCP_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 
@@ -32,6 +45,16 @@ export interface McpManager {
   reload(): Promise<void>;
   /** Reconnect a single server by name. Returns updated status. */
   reconnectServer(name: string): Promise<McpServerStatus>;
+  /**
+   * Run the OAuth authorization-code flow for an HTTP server, then reconnect it.
+   * Servers without an `oauth` config are provisioned with a zero-config default
+   * (dynamic client registration). The authorization URL is surfaced through
+   * `onAuthorizationUrl` for the caller to open in a browser.
+   */
+  authenticateServer(
+    name: string,
+    options?: { onAuthorizationUrl?: (url: string) => void; timeoutMs?: number },
+  ): Promise<McpServerStatus>;
   /** Disconnect from all MCP servers and clean up. */
   disconnect(): Promise<void>;
   /** Get all tools from connected MCP servers (namespaced as serverName_toolName). */
@@ -93,12 +116,20 @@ class FileOAuthStorage implements OAuthStorage {
   }
 }
 
+/**
+ * Zero-config OAuth defaults for servers with a bare `url` entry. Dynamic
+ * client registration provisions the client, so no `clientId` is needed.
+ */
+const DEFAULT_OAUTH_CONFIG: McpHttpOAuthConfig = { redirectUrl: DEFAULT_OAUTH_REDIRECT_URL };
+
 function getOAuthStoragePath(projectDir: string, name: string, cfg: McpHttpServerConfig): string {
+  // The fingerprint always uses the resolved redirect URL so a bare `url`
+  // entry keeps the same token file before and after zero-config provisioning.
   const key = JSON.stringify({
     projectDir,
     name,
     url: cfg.url,
-    redirectUrl: cfg.oauth?.redirectUrl,
+    redirectUrl: cfg.oauth?.redirectUrl ?? DEFAULT_OAUTH_REDIRECT_URL,
     clientId: cfg.oauth?.clientId,
     scopes: cfg.oauth?.scopes ?? [],
   });
@@ -131,10 +162,14 @@ export function createMcpManager(
 
   let config = applyExtraServers(loadMcpConfig(projectDir, configDirName));
   let client: MCPClient | null = null;
+  let serverDefs: Record<string, MastraMCPServerDefinition> = {};
   let tools: Record<string, any> = {};
   let serverStatuses = new Map<string, McpServerStatus>();
   let stderrLogs = new Map<string, string[]>();
   let initialized = false;
+
+  /** Per-server handlers that receive the OAuth authorization URL during authenticateServer(). */
+  const authUrlHandlers = new Map<string, (url: string) => void>();
 
   const MAX_STDERR_LINES = 200;
 
@@ -174,24 +209,32 @@ export function createMcpManager(
   }
 
   function createOAuthProvider(name: string, cfg: McpHttpServerConfig) {
-    if (!cfg.oauth) return undefined;
+    // Bare `url` entries get no eager provider — auth is provisioned lazily
+    // when the user authenticates — unless a previous session already stored
+    // OAuth state for this server, in which case the provider is needed to
+    // attach the persisted tokens on connect.
+    const oauth = cfg.oauth ?? (existsSync(getOAuthStoragePath(projectDir, name, cfg)) ? DEFAULT_OAUTH_CONFIG : undefined);
+    if (!oauth) return undefined;
 
     return new MCPOAuthClientProvider({
-      redirectUrl: cfg.oauth.redirectUrl,
+      redirectUrl: oauth.redirectUrl,
       clientMetadata: {
-        redirect_uris: [cfg.oauth.redirectUrl],
-        client_name: cfg.oauth.clientName ?? `Mastra Code MCP ${name}`,
+        redirect_uris: [oauth.redirectUrl],
+        client_name: oauth.clientName ?? `Mastra Code MCP ${name}`,
         grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
-        ...(cfg.oauth.scopes?.length ? { scope: cfg.oauth.scopes.join(' ') } : {}),
+        ...(oauth.scopes?.length ? { scope: oauth.scopes.join(' ') } : {}),
       },
-      clientInformation: cfg.oauth.clientId
+      clientInformation: oauth.clientId
         ? ({
-            client_id: cfg.oauth.clientId,
-            ...(cfg.oauth.clientSecret ? { client_secret: cfg.oauth.clientSecret } : {}),
+            client_id: oauth.clientId,
+            ...(oauth.clientSecret ? { client_secret: oauth.clientSecret } : {}),
           } satisfies OAuthClientInformation)
         : undefined,
       storage: new FileOAuthStorage(getOAuthStoragePath(projectDir, name, cfg)),
+      onRedirectToAuthorization: url => {
+        authUrlHandlers.get(name)?.(url.toString());
+      },
     });
   }
 
@@ -231,9 +274,10 @@ export function createMcpManager(
       });
     }
 
+    serverDefs = buildServerDefs(servers);
     client = new MCPClient({
       id: 'mastra-code-mcp',
-      servers: buildServerDefs(servers),
+      servers: serverDefs,
       timeout: MASTRACODE_MCP_TIMEOUT_MS,
     });
 
@@ -264,13 +308,15 @@ export function createMcpManager(
           });
         } else {
           // Server failed — use the real error from listToolsetsWithErrors()
+          const error = errors[name] ?? 'Failed to connect';
           serverStatuses.set(name, {
             name,
             connected: false,
             toolCount: 0,
             toolNames: [],
             transport: getTransport(servers[name]!),
-            error: errors[name] ?? 'Failed to connect',
+            error,
+            ...(serverNeedsAuth(name, servers[name]!, error) ? { needsAuth: true } : {}),
           });
         }
       }
@@ -290,8 +336,118 @@ export function createMcpManager(
           toolNames: [],
           transport: getTransport(servers[name]!),
           error: errMsg,
+          ...(serverNeedsAuth(name, servers[name]!, errMsg) ? { needsAuth: true } : {}),
         });
       }
+    }
+  }
+
+  /**
+   * Whether a failed HTTP server is blocked on OAuth authorization.
+   *
+   * Provider-backed servers report the exact state tracked by `@mastra/mcp`.
+   * Bare `url` entries carry no provider until the user authenticates, so a
+   * 401 in the connect error is the signal that the server wants OAuth.
+   */
+  function serverNeedsAuth(name: string, cfg: McpServerConfig, error?: string): boolean {
+    if (getTransport(cfg) !== 'http') return false;
+    if (client?.getServerAuthState?.(name) === 'needs-auth') return true;
+    if (serverDefs[name]?.authProvider) return false;
+    return error !== undefined && /\b401\b|unauthorized/i.test(error);
+  }
+
+  /**
+   * Runs a single-server connect action (reconnect or authenticate), then
+   * refreshes that server's tools and status from the client.
+   */
+  async function connectSingleServer(
+    name: string,
+    cfg: McpServerConfig,
+    connect: () => Promise<unknown>,
+  ): Promise<McpServerStatus> {
+    const transport = getTransport(cfg);
+
+    // Remove old tools for this server
+    const prefix = `${name}_`;
+    for (const key of Object.keys(tools)) {
+      if (key.startsWith(prefix)) {
+        delete tools[key];
+      }
+    }
+
+    // Clear old logs and mark as connecting
+    stderrLogs.delete(name);
+    serverStatuses.set(name, {
+      name,
+      connected: false,
+      connecting: true,
+      toolCount: 0,
+      toolNames: [],
+      transport,
+    });
+
+    try {
+      await connect();
+
+      // Recapture stderr for the reconnected server
+      captureStderr(name);
+
+      // Fetch updated toolsets to get this server's tools
+      const { toolsets, errors } = await client!.listToolsetsWithErrors();
+      const serverTools = toolsets[name];
+      const serverError = errors[name];
+
+      if (serverError) {
+        const status: McpServerStatus = {
+          name,
+          connected: false,
+          toolCount: 0,
+          toolNames: [],
+          transport,
+          error: serverError,
+          ...(serverNeedsAuth(name, cfg, serverError) ? { needsAuth: true } : {}),
+        };
+        serverStatuses.set(name, status);
+        return status;
+      } else if (serverTools && Object.keys(serverTools).length > 0) {
+        const toolNames = Object.keys(serverTools).map(t => `${name}_${t}`);
+        for (const [toolName, toolConfig] of Object.entries(serverTools)) {
+          tools[`${name}_${toolName}`] = toolConfig;
+        }
+        const status: McpServerStatus = {
+          name,
+          connected: true,
+          toolCount: toolNames.length,
+          toolNames,
+          transport,
+        };
+        serverStatuses.set(name, status);
+        return status;
+      } else {
+        const status: McpServerStatus = {
+          name,
+          connected: false,
+          toolCount: 0,
+          toolNames: [],
+          transport,
+          error: 'Failed to connect',
+        };
+        serverStatuses.set(name, status);
+        return status;
+      }
+    } catch (error) {
+      const errMsg = error instanceof Error ? error.message : String(error);
+      const status: McpServerStatus = {
+        name,
+        connected: false,
+        toolCount: 0,
+        toolNames: [],
+        transport,
+        error: errMsg,
+        ...(serverNeedsAuth(name, cfg, errMsg) ? { needsAuth: true } : {}),
+      };
+      serverStatuses.set(name, status);
+      return status;
     }
   }
 
@@ -361,88 +517,62 @@ export function createMcpManager(
         };
       }
 
-      const transport = getTransport(cfg);
+      // Use MCPClient's per-server reconnect
+      return connectSingleServer(name, cfg, () => client!.reconnectServer(name));
+    },
 
-      // Remove old tools for this server
-      const prefix = `${name}_`;
-      for (const key of Object.keys(tools)) {
-        if (key.startsWith(prefix)) {
-          delete tools[key];
-        }
-      }
-
-      // Clear old logs and mark as connecting
-      stderrLogs.delete(name);
-      serverStatuses.set(name, {
-        name,
-        connected: false,
-        connecting: true,
-        toolCount: 0,
-        toolNames: [],
-        transport,
-      });
-
-      try {
-        // Use MCPClient's per-server reconnect
-        await client.reconnectServer(name);
-
-        // Recapture stderr for the reconnected server
-        captureStderr(name);
-
-        // Fetch updated toolsets to get this server's tools
-        const { toolsets, errors } = await client.listToolsetsWithErrors();
-        const serverTools = toolsets[name];
-        const serverError = errors[name];
-
-        if (serverError) {
-          const status: McpServerStatus = {
-            name,
-            connected: false,
-            toolCount: 0,
-            toolNames: [],
-            transport,
-            error: serverError,
-          };
-          serverStatuses.set(name, status);
-          return status;
-        } else if (serverTools && Object.keys(serverTools).length > 0) {
-          const toolNames = Object.keys(serverTools).map(t => `${name}_${t}`);
-          for (const [toolName, toolConfig] of Object.entries(serverTools)) {
-            tools[`${name}_${toolName}`] = toolConfig;
-          }
-          const status: McpServerStatus = {
-            name,
-            connected: true,
-            toolCount: toolNames.length,
-            toolNames,
-            transport,
-          };
-          serverStatuses.set(name, status);
-          return status;
-        } else {
-          const status: McpServerStatus = {
-            name,
-            connected: false,
-            toolCount: 0,
-            toolNames: [],
-            transport,
-            error: 'Failed to connect',
-          };
-          serverStatuses.set(name, status);
-          return status;
-        }
-      } catch (error) {
-        const errMsg = error instanceof Error ? error.message : String(error);
-        const status: McpServerStatus = {
+    async authenticateServer(name: string, options?: { onAuthorizationUrl?: (url: string) => void; timeoutMs?: number }): Promise<McpServerStatus> {
+      const cfg = config.mcpServers?.[name];
+      if (!cfg) {
+        return {
           name,
           connected: false,
           toolCount: 0,
           toolNames: [],
-          transport,
-          error: errMsg,
+          transport: 'stdio',
+          error: `Server "${name}" not found in config`,
         };
-        serverStatuses.set(name, status);
-        return status;
+      }
+
+      if (!client) {
+        return {
+          name,
+          connected: false,
+          toolCount: 0,
+          toolNames: [],
+          transport: getTransport(cfg),
+          error: 'MCP client not initialized',
+        };
+      }
+
+      if (getTransport(cfg) !== 'http') {
+        return {
+          name,
+          connected: false,
+          toolCount: 0,
+          toolNames: [],
+          transport: 'stdio',
+          error: `Server "${name}" uses stdio transport, which does not support OAuth`,
+        };
+      }
+
+      // Zero-config provisioning: a bare `url` entry gets a provider with the
+      // default redirect URL the first time the user authenticates. Dynamic
+      // client registration takes care of the client credentials.
+      const def = serverDefs[name];
+      if (def?.url && !def.authProvider) {
+        def.authProvider = createOAuthProvider(name, { ...(cfg as McpHttpServerConfig), oauth: DEFAULT_OAUTH_CONFIG });
+      }
+
+      if (options?.onAuthorizationUrl) {
+        authUrlHandlers.set(name, options.onAuthorizationUrl);
+      }
+      try {
+        return await connectSingleServer(name, cfg, () =>
+          client!.authenticate(name, options?.timeoutMs === undefined ? undefined : { timeoutMs: options.timeoutMs }),
+        );
+      } finally {
+        authUrlHandlers.delete(name);
       }
     },
 

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -183,6 +183,18 @@ export function createMcpManager(
   /** Per-server handlers that receive the OAuth authorization URL during authenticateServer(). */
   const authUrlHandlers = new Map<string, (url: string) => void>();
 
+  /**
+   * Servers with an OAuth authorization flow currently in flight. Owned by the
+   * manager (not the TUI) so the state survives a `/mcp` selector being closed
+   * and reopened — the reopened selector reads it back off the server status and
+   * can still offer "Cancel authentication".
+   */
+  const authenticatingServers = new Set<string>();
+
+  /** Overlay the manager-owned `authenticating` flag onto a status snapshot. */
+  const withAuthenticating = (status: McpServerStatus): McpServerStatus =>
+    authenticatingServers.has(status.name) ? { ...status, authenticating: true } : status;
+
   const MAX_STDERR_LINES = 200;
 
   /** Hook into a server's stderr stream and buffer its output. */
@@ -609,12 +621,14 @@ export function createMcpManager(
       if (options?.onAuthorizationUrl) {
         authUrlHandlers.set(name, options.onAuthorizationUrl);
       }
+      authenticatingServers.add(name);
       try {
         return await connectSingleServer(name, cfg, () =>
           client!.authenticate(name, options?.timeoutMs === undefined ? undefined : { timeoutMs: options.timeoutMs }),
         );
       } finally {
         authUrlHandlers.delete(name);
+        authenticatingServers.delete(name);
       }
     },
 
@@ -638,7 +652,7 @@ export function createMcpManager(
     },
 
     getServerStatuses() {
-      return Array.from(serverStatuses.values());
+      return Array.from(serverStatuses.values(), withAuthenticating);
     },
 
     getSkippedServers() {

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -50,6 +50,11 @@ export interface McpManager {
    * Servers without an `oauth` config are provisioned with a zero-config default
    * (dynamic client registration). The authorization URL is surfaced through
    * `onAuthorizationUrl` for the caller to open in a browser.
+   *
+   * Resolves with the resulting {@link McpServerStatus}: a connected status on
+   * success, or a status carrying an `error` message on failure (including
+   * cancellation) — it does not reject. Inspect the returned status rather than
+   * relying on a thrown error.
    */
   authenticateServer(
     name: string,
@@ -223,10 +228,14 @@ export function createMcpManager(
     const oauth = cfg.oauth ?? (existsSync(getOAuthStoragePath(projectDir, name, cfg)) ? DEFAULT_OAUTH_CONFIG : undefined);
     if (!oauth) return undefined;
 
+    // redirectUrl is optional in the user-supplied config; resolve the stable
+    // default here so provider metadata always carries a concrete URL.
+    const redirectUrl = oauth.redirectUrl ?? DEFAULT_OAUTH_REDIRECT_URL;
+
     return new MCPOAuthClientProvider({
-      redirectUrl: oauth.redirectUrl,
+      redirectUrl,
       clientMetadata: {
-        redirect_uris: [oauth.redirectUrl],
+        redirect_uris: [redirectUrl],
         client_name: oauth.clientName ?? `Mastra Code MCP ${name}`,
         grant_types: ['authorization_code', 'refresh_token'],
         response_types: ['code'],
@@ -576,6 +585,25 @@ export function createMcpManager(
       const def = serverDefs[name];
       if (def?.url && !def.authProvider) {
         def.authProvider = createOAuthProvider(name, { ...(cfg as McpHttpServerConfig), oauth: DEFAULT_OAUTH_CONFIG });
+      }
+
+      // authUrlHandlers has a single slot per server, and a concurrent second
+      // attempt would overwrite the first caller's handler (so it never sees the
+      // URL) and its finally would delete the handler out from under the other
+      // in-flight call. The underlying client.authenticate already coalesces
+      // same-server calls into one flow, so reject the duplicate here instead.
+      if (authUrlHandlers.has(name)) {
+        const current = serverStatuses.get(name);
+        return {
+          name,
+          connected: current?.connected ?? false,
+          connecting: current?.connecting,
+          needsAuth: current?.needsAuth,
+          toolCount: current?.toolCount ?? 0,
+          toolNames: current?.toolNames ?? [],
+          transport: current?.transport ?? getTransport(cfg),
+          error: `Authentication for "${name}" is already in progress`,
+        };
       }
 
       if (options?.onAuthorizationUrl) {

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -55,6 +55,13 @@ export interface McpManager {
     name: string,
     options?: { onAuthorizationUrl?: (url: string) => void; timeoutMs?: number },
   ): Promise<McpServerStatus>;
+  /**
+   * Cancel a pending {@link authenticateServer} flow for a server (e.g. the
+   * user closed the browser without completing consent). The pending
+   * authenticate call rejects and the server returns to the `needsAuth` state
+   * so it can be retried. Returns `true` if a flow was cancelled.
+   */
+  cancelServerAuthentication(name: string): Promise<boolean>;
   /** Disconnect from all MCP servers and clean up. */
   disconnect(): Promise<void>;
   /** Get all tools from connected MCP servers (namespaced as serverName_toolName). */
@@ -575,6 +582,13 @@ export function createMcpManager(
       } finally {
         authUrlHandlers.delete(name);
       }
+    },
+
+    async cancelServerAuthentication(name: string): Promise<boolean> {
+      if (!client) {
+        return false;
+      }
+      return client.cancelAuthentication(name);
     },
 
     disconnect,

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -567,6 +567,12 @@ export function createMcpManager(
       // Zero-config provisioning: a bare `url` entry gets a provider with the
       // default redirect URL the first time the user authenticates. Dynamic
       // client registration takes care of the client credentials.
+      //
+      // NOTE: `serverDefs[name]` is the same object reference the MCPClient was
+      // constructed with, and connectHttp reads `authProvider` live off it at
+      // connect time, so mutating it here reaches the already-created client.
+      // If MCPClient ever defensively copies its server config, zero-config auth
+      // would need an explicit "set this server's provider" API instead.
       const def = serverDefs[name];
       if (def?.url && !def.authProvider) {
         def.authProvider = createOAuthProvider(name, { ...(cfg as McpHttpServerConfig), oauth: DEFAULT_OAUTH_CONFIG });

--- a/mastracode/sdk/src/mcp/manager.ts
+++ b/mastracode/sdk/src/mcp/manager.ts
@@ -346,14 +346,15 @@ export function createMcpManager(
    * Whether a failed HTTP server is blocked on OAuth authorization.
    *
    * Provider-backed servers report the exact state tracked by `@mastra/mcp`.
-   * Bare `url` entries carry no provider until the user authenticates, so a
-   * 401 in the connect error is the signal that the server wants OAuth.
+   * Bare `url` entries carry no provider until the user authenticates, so the
+   * signal is a 401 in the connect error — surfaced either as the status text
+   * or as the RFC 6750 `invalid_token` bearer error code in the response body.
    */
   function serverNeedsAuth(name: string, cfg: McpServerConfig, error?: string): boolean {
     if (getTransport(cfg) !== 'http') return false;
     if (client?.getServerAuthState?.(name) === 'needs-auth') return true;
     if (serverDefs[name]?.authProvider) return false;
-    return error !== undefined && /\b401\b|unauthorized/i.test(error);
+    return error !== undefined && /\b401\b|unauthorized|invalid_token/i.test(error);
   }
 
   /**

--- a/mastracode/sdk/src/mcp/types.ts
+++ b/mastracode/sdk/src/mcp/types.ts
@@ -33,7 +33,7 @@ export interface McpHttpServerConfig {
  * OAuth client configuration for an HTTP MCP server.
  */
 export interface McpHttpOAuthConfig {
-  /** Redirect URL controlled by the user/application for OAuth callbacks */
+  /** Redirect URL for OAuth callbacks. Defaults to a stable loopback URL when omitted. */
   redirectUrl: string;
   /** Human-readable OAuth client name */
   clientName?: string;
@@ -88,4 +88,6 @@ export interface McpServerStatus {
   transport: 'stdio' | 'http';
   /** Error message if connection failed */
   error?: string;
+  /** Whether the server rejected the connection pending OAuth authorization */
+  needsAuth?: boolean;
 }

--- a/mastracode/sdk/src/mcp/types.ts
+++ b/mastracode/sdk/src/mcp/types.ts
@@ -90,4 +90,10 @@ export interface McpServerStatus {
   error?: string;
   /** Whether the server rejected the connection pending OAuth authorization */
   needsAuth?: boolean;
+  /**
+   * Whether an OAuth authorization flow is currently in flight for this server.
+   * Owned by the manager so the state survives a selector being closed/reopened;
+   * the UI uses it to keep offering "Cancel authentication" while auth is pending.
+   */
+  authenticating?: boolean;
 }

--- a/mastracode/sdk/src/mcp/types.ts
+++ b/mastracode/sdk/src/mcp/types.ts
@@ -33,8 +33,8 @@ export interface McpHttpServerConfig {
  * OAuth client configuration for an HTTP MCP server.
  */
 export interface McpHttpOAuthConfig {
-  /** Redirect URL for OAuth callbacks. Defaults to a stable loopback URL when omitted. */
-  redirectUrl: string;
+  /** Redirect URL for OAuth callbacks. Defaults to DEFAULT_OAUTH_REDIRECT_URL when omitted. */
+  redirectUrl?: string;
   /** Human-readable OAuth client name */
   clientName?: string;
   /** Optional scopes requested during OAuth */

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -50,6 +50,7 @@ import { loginDialogMaskedInputScenario } from './login-dialog-masked-input.js';
 import { loginPreservesModelPackScenario } from './login-preserves-model-pack.js';
 import { mcpHttpToolCallScenario } from './mcp-http-tool-call.js';
 import { mcpLongRunningToolScenario } from './mcp-long-running-tool.js';
+import { mcpOauthAuthenticateScenario } from './mcp-oauth-authenticate.js';
 import { mcpReloadConfigScenario } from './mcp-reload-config.js';
 import { mcpSelectorReconnectScenario } from './mcp-selector-reconnect.js';
 import { mcpServerConfigScenario } from './mcp-server-config.js';
@@ -207,6 +208,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'modal-and-shell': modalAndShellScenario,
   'mcp-http-tool-call': mcpHttpToolCallScenario,
   'mcp-long-running-tool': mcpLongRunningToolScenario,
+  'mcp-oauth-authenticate': mcpOauthAuthenticateScenario,
   'mcp-reload-config': mcpReloadConfigScenario,
   'mcp-selector-reconnect': mcpSelectorReconnectScenario,
   'mcp-server-config': mcpServerConfigScenario,

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -51,6 +51,7 @@ import { loginPreservesModelPackScenario } from './login-preserves-model-pack.js
 import { mcpHttpToolCallScenario } from './mcp-http-tool-call.js';
 import { mcpLongRunningToolScenario } from './mcp-long-running-tool.js';
 import { mcpOauthAuthenticateScenario } from './mcp-oauth-authenticate.js';
+import { mcpOauthCancelScenario } from './mcp-oauth-cancel.js';
 import { mcpReloadConfigScenario } from './mcp-reload-config.js';
 import { mcpSelectorReconnectScenario } from './mcp-selector-reconnect.js';
 import { mcpServerConfigScenario } from './mcp-server-config.js';
@@ -209,6 +210,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'mcp-http-tool-call': mcpHttpToolCallScenario,
   'mcp-long-running-tool': mcpLongRunningToolScenario,
   'mcp-oauth-authenticate': mcpOauthAuthenticateScenario,
+  'mcp-oauth-cancel': mcpOauthCancelScenario,
   'mcp-reload-config': mcpReloadConfigScenario,
   'mcp-selector-reconnect': mcpSelectorReconnectScenario,
   'mcp-server-config': mcpServerConfigScenario,

--- a/mastracode/tui/e2e/tui/mcp-http-fixture.ts
+++ b/mastracode/tui/e2e/tui/mcp-http-fixture.ts
@@ -47,7 +47,7 @@ export type McpHttpFixtureOptions = {
 
 const requireFromMcpPackage = createRequire(new URL('../../../packages/mcp/package.json', import.meta.url));
 
-async function loadMcpSdk(): Promise<{
+export async function loadMcpSdk(): Promise<{
   McpServer: McpServerConstructor;
   StreamableHTTPServerTransport: StreamableHttpTransportConstructor;
 }> {

--- a/mastracode/tui/e2e/tui/mcp-oauth-authenticate.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-authenticate.ts
@@ -87,7 +87,11 @@ export const mcpOauthAuthenticateScenario = {
     await runtime.waitForScreenText(/Authenticate/i, terminal, 8_000);
     terminal.write('\r');
 
-    // Close the overlay so the printed authorization URL is visible on screen.
+    // Starting the flow auto-opens the "Cancel authentication" sub-menu; the
+    // first Esc closes that sub-menu, the second closes the selector overlay so
+    // the printed authorization URL is visible on screen.
+    await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
+    terminal.write('\x1b');
     terminal.write('\x1b');
     await runtime.waitForScreenTextAbsent(/Manage MCP servers/i, terminal, 8_000);
     await runtime.waitForScreenText(/MCP: To authenticate "oauth_server", open:/i, terminal, 15_000);

--- a/mastracode/tui/e2e/tui/mcp-oauth-authenticate.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-authenticate.ts
@@ -1,0 +1,112 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod/v3';
+import { createGlobalPatchScope } from './global-patches.js';
+import { startMcpOAuthFixtureServer } from './mcp-oauth-fixture.js';
+import type { McE2eInProcessApp, McE2eScenario, McE2eTerminal } from './types.js';
+
+function extractAuthorizationUrl(terminal: McE2eTerminal): string {
+  const view = terminal.serialize().view;
+  const match = view.match(/http:\/\/127\.0\.0\.1:\d+\/authorize\?\S+/);
+  if (!match) {
+    throw new Error(`authorization URL not found on screen:\n${view}`);
+  }
+  return match[0];
+}
+
+export const mcpOauthAuthenticateScenario = {
+  name: 'mcp-oauth-authenticate',
+  description:
+    'Authenticates a bare-url OAuth-protected HTTP MCP server from the /mcp selector, with the harness acting as the browser.',
+  testName: 'authenticates an OAuth MCP server from the interactive selector overlay',
+  projectFixture: 'long-branch',
+  prepare({ projectDir }) {
+    mkdirSync(join(projectDir, '.mastracode'), { recursive: true });
+  },
+  async inProcessApp({ projectDir, startMastraCodeApp }): Promise<McE2eInProcessApp> {
+    const patches = createGlobalPatchScope();
+    // Never spawn a real browser from the e2e run — the harness fetches the URL.
+    patches.setEnv('MASTRA_MCP_OAUTH_NO_BROWSER', '1');
+    const fixtureServer = await startMcpOAuthFixtureServer({
+      name: 'mc-e2e-oauth-mcp',
+      registerTools: server => {
+        server.tool(
+          'oauth_probe',
+          'Return the deterministic MCP OAuth e2e probe payload.',
+          { label: z.string().default('oauth') },
+          input => ({
+            content: [{ type: 'text', text: `MC_MCP_OAUTH_TOOL:${String(input.label)}:ok` }],
+          }),
+        );
+      },
+    });
+
+    writeFileSync(
+      join(projectDir, '.mastracode', 'mcp.json'),
+      JSON.stringify({ mcpServers: { oauth_server: { url: fixtureServer.url } } }, null, 2),
+    );
+
+    try {
+      const app = await startMastraCodeApp({
+        config: {
+          disableHooks: true,
+          disableMcp: false,
+          unixSocketPubSub: false,
+        },
+      });
+
+      return {
+        stop: async () => {
+          try {
+            await patches.stopApp(app.stop);
+          } finally {
+            await fixtureServer.close();
+          }
+        },
+      };
+    } catch (error) {
+      await fixtureServer.close();
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+
+    // Wide terminal so the authorization URL renders unwrapped on one line.
+    terminal.resize(400, 50);
+
+    await runtime.waitForScreenText(/MCP: Failed to connect to "oauth_server"/i, terminal, 15_000);
+
+    terminal.submit('/mcp');
+    await runtime.waitForScreenText(/Manage MCP servers/i, terminal, 8_000);
+    await runtime.waitForScreenText(/oauth_server \[http\] needs auth/i, terminal, 8_000);
+
+    // Open the sub-menu; Authenticate is the first action.
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Authenticate/i, terminal, 8_000);
+    terminal.write('\r');
+
+    // Close the overlay so the printed authorization URL is visible on screen.
+    terminal.write('\x1b');
+    await runtime.waitForScreenTextAbsent(/Manage MCP servers/i, terminal, 8_000);
+    await runtime.waitForScreenText(/MCP: To authenticate "oauth_server", open:/i, terminal, 15_000);
+
+    // Act as the browser: follow the authorize redirect back to the loopback
+    // callback server started by the client's OAuth flow.
+    const authorizationUrl = extractAuthorizationUrl(terminal);
+    const callbackResponse = await fetch(authorizationUrl, { redirect: 'follow' });
+    if (!callbackResponse.ok) {
+      throw new Error(`OAuth callback failed: HTTP ${callbackResponse.status}`);
+    }
+
+    await runtime.waitForScreenText(/MCP: Authenticated "oauth_server" — 1 tool\(s\)/i, terminal, 15_000);
+
+    terminal.submit('/mcp');
+    await runtime.waitForScreenText(/oauth_server \[http\] connected.*1 tools/i, terminal, 8_000);
+    runtime.printScreen('mcp selector after oauth authenticate', terminal);
+    terminal.write('\x1b');
+    await runtime.waitForScreenTextAbsent(/Manage MCP servers/i, terminal, 8_000);
+    terminal.keyCtrlC();
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
@@ -90,6 +90,14 @@ export const mcpOauthCancelScenario = {
     // "Cancel authentication" sub-menu, pre-selected, so Enter backs out.
     await runtime.waitForScreenText(/oauth_server \[http\] authenticating — Enter to cancel/i, terminal, 8_000);
     await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
+
+    // Hold long enough to span several 500ms selector poll cycles. The
+    // authenticating affordance is derived from the in-flight flow, not the
+    // polled `connecting` flag, so it must survive status refreshes from the
+    // manager without reverting the row to needs-auth or dropping the sub-menu.
+    await new Promise(resolve => setTimeout(resolve, 1_600));
+    await runtime.waitForScreenText(/oauth_server \[http\] authenticating — Enter to cancel/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
     terminal.write('\r');
 
     // Cancelling aborts the pending flow and returns the server to needs-auth.

--- a/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
@@ -85,12 +85,10 @@ export const mcpOauthCancelScenario = {
     await runtime.waitForScreenText(/Authenticate/i, terminal, 8_000);
     terminal.write('\r');
 
-    // The authorize endpoint is held open, so the flow parks and the server sits
-    // in the connecting state while the "browser" is nominally open.
-    await runtime.waitForScreenText(/oauth_server \[http\] connecting/i, terminal, 8_000);
-
-    // Re-open the sub-menu on the same server; a mid-OAuth server offers Cancel.
-    terminal.write('\r');
+    // The authorize endpoint is held open, so the flow parks. The selector
+    // surfaces the cancel affordance in the row state and auto-opens the
+    // "Cancel authentication" sub-menu, pre-selected, so Enter backs out.
+    await runtime.waitForScreenText(/oauth_server \[http\] authenticating — Enter to cancel/i, terminal, 8_000);
     await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
     terminal.write('\r');
 

--- a/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
@@ -1,0 +1,104 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { z } from 'zod/v3';
+import { createGlobalPatchScope } from './global-patches.js';
+import { startMcpOAuthFixtureServer } from './mcp-oauth-fixture.js';
+import type { McpOAuthFixture } from './mcp-oauth-fixture.js';
+import type { McE2eInProcessApp, McE2eScenario } from './types.js';
+
+export const mcpOauthCancelScenario = {
+  name: 'mcp-oauth-cancel',
+  description:
+    'Starts authenticating a bare-url OAuth MCP server, then cancels the pending flow from the selector and confirms the server returns to needs-auth.',
+  testName: 'cancels a pending MCP OAuth authentication from the interactive selector overlay',
+  projectFixture: 'long-branch',
+  prepare({ projectDir }) {
+    mkdirSync(join(projectDir, '.mastracode'), { recursive: true });
+  },
+  async inProcessApp({ projectDir, startMastraCodeApp }): Promise<McE2eInProcessApp> {
+    const patches = createGlobalPatchScope();
+    // Never spawn a real browser from the e2e run.
+    patches.setEnv('MASTRA_MCP_OAUTH_NO_BROWSER', '1');
+    // Hold the authorize endpoint open so the client's OAuth flow stays pending,
+    // giving the scenario a deterministic window to cancel before any code is issued.
+    let fixtureServer: McpOAuthFixture | undefined = await startMcpOAuthFixtureServer({
+      name: 'mc-e2e-oauth-cancel-mcp',
+      holdAuthorize: true,
+      registerTools: server => {
+        server.tool(
+          'oauth_probe',
+          'Return the deterministic MCP OAuth e2e probe payload.',
+          { label: z.string().default('oauth') },
+          input => ({
+            content: [{ type: 'text', text: `MC_MCP_OAUTH_TOOL:${String(input.label)}:ok` }],
+          }),
+        );
+      },
+    });
+    const server = fixtureServer;
+
+    writeFileSync(
+      join(projectDir, '.mastracode', 'mcp.json'),
+      JSON.stringify({ mcpServers: { oauth_server: { url: server.url } } }, null, 2),
+    );
+
+    try {
+      const app = await startMastraCodeApp({
+        config: {
+          disableHooks: true,
+          disableMcp: false,
+          unixSocketPubSub: false,
+        },
+      });
+
+      return {
+        stop: async () => {
+          try {
+            await patches.stopApp(app.stop);
+          } finally {
+            // Release any held authorize request before tearing the server down.
+            fixtureServer?.releaseAuthorize();
+            await fixtureServer?.close();
+            fixtureServer = undefined;
+          }
+        },
+      };
+    } catch (error) {
+      server.releaseAuthorize();
+      await server.close();
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    terminal.resize(400, 50);
+
+    await runtime.waitForScreenText(/MCP: Failed to connect to "oauth_server"/i, terminal, 15_000);
+
+    terminal.submit('/mcp');
+    await runtime.waitForScreenText(/Manage MCP servers/i, terminal, 8_000);
+    await runtime.waitForScreenText(/oauth_server \[http\] needs auth/i, terminal, 8_000);
+
+    // Open the sub-menu and start authentication (Authenticate is the first action).
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Authenticate/i, terminal, 8_000);
+    terminal.write('\r');
+
+    // The authorize endpoint is held open, so the flow parks and the server sits
+    // in the connecting state while the "browser" is nominally open.
+    await runtime.waitForScreenText(/oauth_server \[http\] connecting/i, terminal, 8_000);
+
+    // Re-open the sub-menu on the same server; a mid-OAuth server offers Cancel.
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
+    terminal.write('\r');
+
+    // Cancelling aborts the pending flow and returns the server to needs-auth.
+    await runtime.waitForScreenText(/oauth_server \[http\] needs auth/i, terminal, 10_000);
+    runtime.printScreen('mcp selector after cancelling oauth authenticate', terminal);
+    terminal.write('\x1b');
+    await runtime.waitForScreenTextAbsent(/Manage MCP servers/i, terminal, 8_000);
+    terminal.keyCtrlC();
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-cancel.ts
@@ -98,6 +98,22 @@ export const mcpOauthCancelScenario = {
     await new Promise(resolve => setTimeout(resolve, 1_600));
     await runtime.waitForScreenText(/oauth_server \[http\] authenticating — Enter to cancel/i, terminal, 8_000);
     await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
+
+    // Close the selector entirely (Esc closes the sub-menu, Esc closes the
+    // overlay) while the flow is still pending, then reopen /mcp. The reopened
+    // selector is a fresh instance with an empty local set, so it can only know
+    // the flow is still in flight from the manager-owned `authenticating` status
+    // — it must still surface the cancel affordance.
+    terminal.write('\x1b');
+    terminal.write('\x1b');
+    await runtime.waitForScreenTextAbsent(/Manage MCP servers/i, terminal, 8_000);
+    terminal.submit('/mcp');
+    await runtime.waitForScreenText(/Manage MCP servers/i, terminal, 8_000);
+    await runtime.waitForScreenText(/oauth_server \[http\] authenticating — Enter to cancel/i, terminal, 8_000);
+
+    // Open the sub-menu on the still-authenticating server and cancel.
+    terminal.write('\r');
+    await runtime.waitForScreenText(/Cancel authentication/i, terminal, 8_000);
     terminal.write('\r');
 
     // Cancelling aborts the pending flow and returns the server to needs-auth.

--- a/mastracode/tui/e2e/tui/mcp-oauth-fixture.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-fixture.ts
@@ -9,12 +9,25 @@ export type McpOAuthFixture = {
   close: () => Promise<void>;
   /** Streamable HTTP MCP endpoint (requires a Bearer token issued by the fixture). */
   url: string;
+  /**
+   * Release the authorize endpoint when it is being held open (see
+   * `holdAuthorize`). Resolves any in-flight authorize request so the OAuth
+   * flow can complete. No-op when the endpoint is not held.
+   */
+  releaseAuthorize: () => void;
 };
 
 export type McpOAuthFixtureOptions = {
   name: string;
   registerTools: (server: McpFixtureServer) => void;
   version?: string;
+  /**
+   * When true, the authorize endpoint parks the request (holding the browser
+   * "open") instead of redirecting immediately. This keeps the client's OAuth
+   * flow pending so a scenario can exercise cancellation before any code is
+   * issued. Call `releaseAuthorize()` to let a held request complete.
+   */
+  holdAuthorize?: boolean;
 };
 
 function readBody(req: IncomingMessage): Promise<string> {
@@ -49,6 +62,15 @@ export async function startMcpOAuthFixtureServer(options: McpOAuthFixtureOptions
   const pendingCodes = new Map<string, { codeChallenge: string; redirectUri: string }>();
   const refreshTokens = new Set<string>();
   const validTokens = new Set<string>();
+
+  // When `holdAuthorize` is set, in-flight authorize requests wait on this
+  // promise instead of redirecting; `releaseAuthorize()` resolves it.
+  let releaseHeldAuthorize: (() => void) | undefined;
+  const authorizeGate = options.holdAuthorize
+    ? new Promise<void>(resolve => {
+        releaseHeldAuthorize = resolve;
+      })
+    : undefined;
 
   let baseUrl = '';
 
@@ -113,6 +135,11 @@ export async function startMcpOAuthFixtureServer(options: McpOAuthFixtureOptions
         if (!client || !client.redirect_uris.includes(redirectUri)) {
           sendJson(res, 400, { error: 'invalid_request', error_description: 'Unknown client or redirect_uri' });
           return;
+        }
+        // Park the request (browser "open") until released, so a scenario can
+        // cancel the pending OAuth flow before any code is issued.
+        if (authorizeGate) {
+          await authorizeGate;
         }
         const code = `code-${randomUUID()}`;
         pendingCodes.set(code, { codeChallenge: requestUrl.searchParams.get('code_challenge') ?? '', redirectUri });
@@ -209,10 +236,12 @@ export async function startMcpOAuthFixtureServer(options: McpOAuthFixtureOptions
 
   return {
     close: async () => {
+      releaseHeldAuthorize?.();
       await Promise.all([...activeServers].map(server => server.close().catch(() => undefined)));
       activeServers.clear();
       await new Promise<void>(resolve => httpServer.close(() => resolve())).catch(() => undefined);
     },
     url: `${baseUrl}/mcp`,
+    releaseAuthorize: () => releaseHeldAuthorize?.(),
   };
 }

--- a/mastracode/tui/e2e/tui/mcp-oauth-fixture.ts
+++ b/mastracode/tui/e2e/tui/mcp-oauth-fixture.ts
@@ -1,0 +1,218 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { loadMcpSdk } from './mcp-http-fixture.js';
+import type { McpFixtureServer } from './mcp-http-fixture.js';
+
+export type McpOAuthFixture = {
+  close: () => Promise<void>;
+  /** Streamable HTTP MCP endpoint (requires a Bearer token issued by the fixture). */
+  url: string;
+};
+
+export type McpOAuthFixtureOptions = {
+  name: string;
+  registerTools: (server: McpFixtureServer) => void;
+  version?: string;
+};
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, statusCode: number, payload: unknown, headers?: Record<string, string>): void {
+  res.writeHead(statusCode, { 'content-type': 'application/json', ...headers });
+  res.end(JSON.stringify(payload));
+}
+
+/**
+ * OAuth-protected MCP fixture server for e2e scenarios.
+ *
+ * A single `node:http` server acts as both the OAuth 2.1 authorization server
+ * (RFC 8414 metadata, RFC 7591 dynamic client registration, authorization code
+ * grant with PKCE S256) and the protected MCP resource (RFC 9728 metadata,
+ * Bearer-gated streamable HTTP endpoint). The authorize endpoint immediately
+ * redirects back with a code — no login page — so the e2e harness can act as
+ * the browser with a single fetch. All tokens are fake, per-run random strings.
+ */
+export async function startMcpOAuthFixtureServer(options: McpOAuthFixtureOptions): Promise<McpOAuthFixture> {
+  const { McpServer, StreamableHTTPServerTransport } = await loadMcpSdk();
+  const activeServers = new Set<McpFixtureServer>();
+
+  const clientsById = new Map<string, { client_id: string; redirect_uris: string[] }>();
+  const pendingCodes = new Map<string, { codeChallenge: string; redirectUri: string }>();
+  const refreshTokens = new Set<string>();
+  const validTokens = new Set<string>();
+
+  let baseUrl = '';
+
+  const createMcpServer = () => {
+    const server = new McpServer(
+      { name: options.name, version: options.version ?? '1.0.0' },
+      { capabilities: { tools: {} } },
+    );
+    options.registerTools(server);
+    activeServers.add(server);
+    return server;
+  };
+
+  const httpServer = createServer((req: IncomingMessage, res: ServerResponse) => {
+    void (async () => {
+      const requestUrl = new URL(req.url ?? '', baseUrl);
+
+      // --- RFC 9728 protected resource metadata (also served under the /mcp
+      // suffix for clients that derive the well-known path from the MCP URL) ---
+      if (requestUrl.pathname.startsWith('/.well-known/oauth-protected-resource')) {
+        sendJson(res, 200, {
+          resource: `${baseUrl}/mcp`,
+          authorization_servers: [baseUrl],
+          bearer_methods_supported: ['header'],
+        });
+        return;
+      }
+
+      // --- RFC 8414 authorization server metadata ---
+      if (requestUrl.pathname === '/.well-known/oauth-authorization-server') {
+        sendJson(res, 200, {
+          issuer: baseUrl,
+          authorization_endpoint: `${baseUrl}/authorize`,
+          token_endpoint: `${baseUrl}/token`,
+          registration_endpoint: `${baseUrl}/register`,
+          response_types_supported: ['code'],
+          grant_types_supported: ['authorization_code', 'refresh_token'],
+          code_challenge_methods_supported: ['S256'],
+          token_endpoint_auth_methods_supported: ['none'],
+        });
+        return;
+      }
+
+      // --- RFC 7591 dynamic client registration ---
+      if (requestUrl.pathname === '/register' && req.method === 'POST') {
+        const metadata = JSON.parse(await readBody(req));
+        const registration = { client_id: `client-${randomUUID()}`, redirect_uris: metadata.redirect_uris };
+        clientsById.set(registration.client_id, registration);
+        sendJson(res, 201, {
+          ...metadata,
+          client_id: registration.client_id,
+          client_id_issued_at: Math.floor(Date.now() / 1000),
+          token_endpoint_auth_method: 'none',
+        });
+        return;
+      }
+
+      // --- Authorization endpoint: no login page, immediately redirect back ---
+      if (requestUrl.pathname === '/authorize') {
+        const client = clientsById.get(requestUrl.searchParams.get('client_id') ?? '');
+        const redirectUri = requestUrl.searchParams.get('redirect_uri') ?? '';
+        if (!client || !client.redirect_uris.includes(redirectUri)) {
+          sendJson(res, 400, { error: 'invalid_request', error_description: 'Unknown client or redirect_uri' });
+          return;
+        }
+        const code = `code-${randomUUID()}`;
+        pendingCodes.set(code, { codeChallenge: requestUrl.searchParams.get('code_challenge') ?? '', redirectUri });
+        const location = new URL(redirectUri);
+        location.searchParams.set('code', code);
+        location.searchParams.set('state', requestUrl.searchParams.get('state') ?? '');
+        res.writeHead(302, { location: location.toString() });
+        res.end();
+        return;
+      }
+
+      // --- Token endpoint: authorization code (PKCE S256) and refresh grants ---
+      if (requestUrl.pathname === '/token' && req.method === 'POST') {
+        const params = new URLSearchParams(await readBody(req));
+        const grantType = params.get('grant_type');
+        if (grantType === 'authorization_code') {
+          const pending = pendingCodes.get(params.get('code') ?? '');
+          const challenge = createHash('sha256')
+            .update(params.get('code_verifier') ?? '')
+            .digest('base64url');
+          if (!pending || pending.codeChallenge !== challenge) {
+            sendJson(res, 400, { error: 'invalid_grant' });
+            return;
+          }
+          pendingCodes.delete(params.get('code')!);
+        } else if (grantType === 'refresh_token') {
+          if (!refreshTokens.has(params.get('refresh_token') ?? '')) {
+            sendJson(res, 400, { error: 'invalid_grant' });
+            return;
+          }
+        } else {
+          sendJson(res, 400, { error: 'unsupported_grant_type' });
+          return;
+        }
+        const accessToken = `mc-e2e-access-${randomUUID()}`;
+        const refreshToken = `mc-e2e-refresh-${randomUUID()}`;
+        validTokens.add(accessToken);
+        refreshTokens.add(refreshToken);
+        sendJson(res, 200, {
+          access_token: accessToken,
+          token_type: 'Bearer',
+          expires_in: 3600,
+          refresh_token: refreshToken,
+        });
+        return;
+      }
+
+      // --- Bearer-gated MCP endpoint ---
+      if (requestUrl.pathname === '/mcp') {
+        const authorization = req.headers.authorization ?? '';
+        const token = authorization.startsWith('Bearer ') ? authorization.slice('Bearer '.length) : '';
+        if (!validTokens.has(token)) {
+          sendJson(
+            res,
+            401,
+            { error: 'invalid_token' },
+            {
+              'www-authenticate': `Bearer error="invalid_token", resource_metadata="${baseUrl}/.well-known/oauth-protected-resource"`,
+            },
+          );
+          return;
+        }
+
+        const mcpServer = createMcpServer();
+        const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+        await mcpServer.connect(transport);
+        res.on('finish', () => {
+          activeServers.delete(mcpServer);
+          void mcpServer.close().catch(() => undefined);
+        });
+        await transport.handleRequest(req, res);
+        return;
+      }
+
+      sendJson(res, 404, { error: 'not_found' });
+    })().catch(error => {
+      res.writeHead(500, { 'content-type': 'text/plain' });
+      res.end(String(error instanceof Error ? (error.stack ?? error.message) : error));
+    });
+  });
+
+  baseUrl = await new Promise<string>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(0, '127.0.0.1', () => {
+      httpServer.off('error', reject);
+      const address = httpServer.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error(`${options.name} fixture server did not bind to a port`));
+        return;
+      }
+      resolve(`http://127.0.0.1:${(address as AddressInfo).port}`);
+    });
+  });
+
+  return {
+    close: async () => {
+      await Promise.all([...activeServers].map(server => server.close().catch(() => undefined)));
+      activeServers.clear();
+      await new Promise<void>(resolve => httpServer.close(() => resolve())).catch(() => undefined);
+    },
+    url: `${baseUrl}/mcp`,
+  };
+}

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -85,6 +85,7 @@ export type ScenarioName =
   | 'mcp-long-running-tool'
   | 'mcp-reload-config'
   | 'mcp-oauth-authenticate'
+  | 'mcp-oauth-cancel'
   | 'mcp-selector-reconnect'
   | 'mcp-server-config'
   | 'mcp-skipped-validation'

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -84,6 +84,7 @@ export type ScenarioName =
   | 'mcp-http-tool-call'
   | 'mcp-long-running-tool'
   | 'mcp-reload-config'
+  | 'mcp-oauth-authenticate'
   | 'mcp-selector-reconnect'
   | 'mcp-server-config'
   | 'mcp-skipped-validation'

--- a/mastracode/tui/src/tui/commands/mcp.ts
+++ b/mastracode/tui/src/tui/commands/mcp.ts
@@ -90,6 +90,9 @@ export async function handleMcpCommand(ctx: SlashCommandContext, args: string[])
         },
       });
     },
+    onCancelAuthenticateServer: async (name: string) => {
+      return mm.cancelServerAuthentication(name);
+    },
     getServerLogs: (name: string) => {
       return mm.getServerLogs(name);
     },

--- a/mastracode/tui/src/tui/commands/mcp.ts
+++ b/mastracode/tui/src/tui/commands/mcp.ts
@@ -1,5 +1,6 @@
 import { McpSelectorComponent } from '../components/mcp-selector.js';
 import { showInfo } from '../display.js';
+import { openUrlInBrowser } from '../open-url.js';
 import { showModalOverlay } from '../overlay.js';
 import type { SlashCommandContext } from './types.js';
 
@@ -48,8 +49,8 @@ export async function handleMcpCommand(ctx: SlashCommandContext, args: string[])
         `      }\n` +
         `    }\n` +
         `  }\n\n` +
-        `Note: For dynamic auth (token refresh), use a stdio wrapper.\n` +
-        `"headers" only supports static values.`,
+        `Servers that require OAuth can be added with just a "url" —\n` +
+        `authenticate them from the /mcp selector.`,
     );
     return;
   }
@@ -76,6 +77,18 @@ export async function handleMcpCommand(ctx: SlashCommandContext, args: string[])
     },
     onReconnectServer: async (name: string) => {
       return mm.reconnectServer(name);
+    },
+    onAuthenticateServer: async (name: string) => {
+      return mm.authenticateServer(name, {
+        onAuthorizationUrl: (url: string) => {
+          // Always print the URL so headless (or failed-open) environments can
+          // complete the flow manually; opening the browser is best-effort.
+          showInfo(ctx.state, `MCP: To authenticate "${name}", open:\n  ${url}`);
+          if (process.env.MASTRA_MCP_OAUTH_NO_BROWSER !== '1') {
+            openUrlInBrowser(url);
+          }
+        },
+      });
     },
     getServerLogs: (name: string) => {
       return mm.getServerLogs(name);
@@ -125,8 +138,14 @@ function showTextStatus(ctx: SlashCommandContext): void {
   lines.push('');
 
   for (const status of statuses) {
-    const icon = status.connecting ? '⟳' : status.connected ? '\u2713' : '\u2717';
-    const state = status.connecting ? 'connecting...' : status.connected ? 'connected' : `error: ${status.error}`;
+    const icon = status.connecting ? '⟳' : status.connected ? '\u2713' : status.needsAuth ? '\u26a0' : '\u2717';
+    const state = status.connecting
+      ? 'connecting...'
+      : status.connected
+        ? 'connected'
+        : status.needsAuth
+          ? 'needs auth — authenticate via /mcp'
+          : `error: ${status.error}`;
     lines.push(`  ${icon} ${status.name} [${status.transport}] (${state})`);
     if (status.toolNames.length > 0) {
       for (const toolName of status.toolNames) {

--- a/mastracode/tui/src/tui/components/login-dialog.ts
+++ b/mastracode/tui/src/tui/components/login-dialog.ts
@@ -2,41 +2,12 @@
  * Login dialog component - handles OAuth login flow UI
  */
 
-import { spawn } from 'node:child_process';
 import { Box, Container, getKeybindings, Spacer, Text } from '@earendil-works/pi-tui';
 import type { Focusable, TUI } from '@earendil-works/pi-tui';
 import { getOAuthProviders } from '@mastra/code-sdk/auth/index';
+import { openUrlInBrowser } from '../open-url.js';
 import { theme } from '../theme.js';
 import { MaskedInput } from './masked-input.js';
-
-/**
- * Open a URL in the default browser without going through a shell.
- * Only well-formed http(s) URLs are opened; anything else is ignored
- * (the URL is still displayed for the user to open manually).
- */
-function openUrlInBrowser(url: string): void {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    return;
-  }
-  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-    return;
-  }
-
-  const [cmd, args]: [string, string[]] =
-    process.platform === 'darwin'
-      ? ['open', [url]]
-      : process.platform === 'win32'
-        ? ['rundll32', ['url.dll,FileProtocolHandler', url]]
-        : ['xdg-open', [url]];
-
-  const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
-  // Opening the browser is best-effort — the URL is shown in the dialog.
-  child.on('error', () => {});
-  child.unref();
-}
 
 export class LoginDialogComponent extends Box implements Focusable {
   private contentContainer: Container;

--- a/mastracode/tui/src/tui/components/mcp-selector.ts
+++ b/mastracode/tui/src/tui/components/mcp-selector.ts
@@ -29,6 +29,8 @@ export interface McpSelectorOptions {
   onReloadAll: () => Promise<{ statuses: McpServerStatus[]; skipped: McpSkippedServer[] }>;
   /** Callback to reconnect a single server by name — returns updated status */
   onReconnectServer: (name: string) => Promise<McpServerStatus>;
+  /** Callback to run the OAuth flow for a single server by name — returns updated status */
+  onAuthenticateServer: (name: string) => Promise<McpServerStatus>;
   /** Get captured stderr logs for a server */
   getServerLogs: (name: string) => string[];
   /** Show an info message in the chat area */
@@ -58,6 +60,13 @@ const FAILED_ACTIONS: ServerAction[] = [
   { label: 'Reconnect', key: 'reconnect' },
 ];
 
+const NEEDS_AUTH_ACTIONS: ServerAction[] = [
+  { label: 'Authenticate', key: 'authenticate' },
+  { label: 'View error', key: 'error' },
+  { label: 'View logs', key: 'logs' },
+  { label: 'Reconnect', key: 'reconnect' },
+];
+
 const CONNECTING_ACTIONS: ServerAction[] = [{ label: 'Waiting for connection...', key: 'none' }];
 
 // =============================================================================
@@ -72,6 +81,7 @@ export class McpSelectorComponent extends Box implements Focusable {
   private getStatusesCallback: McpSelectorOptions['getStatuses'];
   private onReloadAllCallback: McpSelectorOptions['onReloadAll'];
   private onReconnectServerCallback: McpSelectorOptions['onReconnectServer'];
+  private onAuthenticateServerCallback: McpSelectorOptions['onAuthenticateServer'];
   private getServerLogsCallback: McpSelectorOptions['getServerLogs'];
   private showInfoCallback: McpSelectorOptions['showInfo'];
   private onCloseCallback: () => void;
@@ -107,6 +117,7 @@ export class McpSelectorComponent extends Box implements Focusable {
     this.getStatusesCallback = options.getStatuses;
     this.onReloadAllCallback = options.onReloadAll;
     this.onReconnectServerCallback = options.onReconnectServer;
+    this.onAuthenticateServerCallback = options.onAuthenticateServer;
     this.getServerLogsCallback = options.getServerLogs;
     this.showInfoCallback = options.showInfo;
     this.onCloseCallback = options.onClose;
@@ -165,6 +176,9 @@ export class McpSelectorComponent extends Box implements Focusable {
       } else if (status.connected) {
         icon = theme.fg('success', '✔');
         stateText = theme.fg('success', 'connected');
+      } else if (status.needsAuth) {
+        icon = theme.fg('warning', '⚠');
+        stateText = theme.fg('warning', 'needs auth');
       } else {
         icon = theme.fg('error', '✗');
         stateText = theme.fg('error', 'failed');
@@ -320,6 +334,8 @@ export class McpSelectorComponent extends Box implements Focusable {
       this.subMenuActions = CONNECTING_ACTIONS;
     } else if (status.connected) {
       this.subMenuActions = CONNECTED_ACTIONS;
+    } else if (status.needsAuth) {
+      this.subMenuActions = NEEDS_AUTH_ACTIONS;
     } else {
       this.subMenuActions = FAILED_ACTIONS;
     }
@@ -376,6 +392,11 @@ export class McpSelectorComponent extends Box implements Focusable {
       case 'reconnect': {
         this.subMenuOpen = false;
         this.doReconnectServer(status);
+        break;
+      }
+      case 'authenticate': {
+        this.subMenuOpen = false;
+        this.doAuthenticateServer(status);
         break;
       }
     }
@@ -458,6 +479,64 @@ export class McpSelectorComponent extends Box implements Focusable {
           };
         }
         this.showInfoCallback(`MCP: Failed to reconnect "${name}": ${errMsg}`);
+      })
+      .finally(() => {
+        if (!this._reloading) {
+          this.updateList();
+        }
+      });
+  }
+
+  private doAuthenticateServer(status: McpServerStatus): void {
+    if (status.connecting) return;
+    const name = status.name;
+
+    // Mark this server as connecting while the OAuth flow runs
+    const idx = this.statuses.findIndex(s => s.name === name);
+    if (idx >= 0) {
+      this.statuses[idx] = {
+        name,
+        connected: false,
+        connecting: true,
+        toolCount: 0,
+        toolNames: [],
+        transport: status.transport,
+      };
+    }
+    this.updateList();
+    this.showInfoCallback(`MCP: Authenticating "${name}" — complete the sign-in in your browser.`);
+
+    this.onAuthenticateServerCallback(name)
+      .then((updated: McpServerStatus) => {
+        // If a reload-all started, ignore stale authenticate results
+        if (this._reloading) return;
+        const i = this.statuses.findIndex(s => s.name === name);
+        if (i >= 0) {
+          this.statuses[i] = updated;
+        }
+        if (updated.connected) {
+          this.showInfoCallback(`MCP: Authenticated "${name}" — ${updated.toolCount} tool(s)`);
+        } else {
+          this.showInfoCallback(`MCP: Failed to authenticate "${name}": ${updated.error ?? 'Unknown error'}`);
+        }
+      })
+      .catch((err: unknown) => {
+        if (this._reloading) return;
+        const errMsg = err instanceof Error ? err.message : String(err);
+        const i = this.statuses.findIndex(s => s.name === name);
+        if (i >= 0) {
+          this.statuses[i] = {
+            name,
+            connected: false,
+            connecting: false,
+            toolCount: 0,
+            toolNames: [],
+            transport: status.transport,
+            error: errMsg,
+            needsAuth: true,
+          };
+        }
+        this.showInfoCallback(`MCP: Failed to authenticate "${name}": ${errMsg}`);
       })
       .finally(() => {
         if (!this._reloading) {

--- a/mastracode/tui/src/tui/components/mcp-selector.ts
+++ b/mastracode/tui/src/tui/components/mcp-selector.ts
@@ -180,10 +180,12 @@ export class McpSelectorComponent extends Box implements Focusable {
       if (this._reloading) {
         icon = theme.fg('warning', '⟳');
         stateText = theme.fg('warning', 'reconnecting...');
-      } else if (this._authenticating.has(status.name)) {
+      } else if (this.isAuthenticating(status)) {
         // A flow is in flight for this server. This is authoritative even if a
         // polled status refresh from the manager no longer reports `connecting`,
-        // so the "Enter to cancel" affordance never disappears mid-flow.
+        // so the "Enter to cancel" affordance never disappears mid-flow. The
+        // manager-owned `authenticating` flag also survives close/reopen of the
+        // selector, when the local set has been discarded with the old instance.
         icon = theme.fg('warning', '⟳');
         stateText = theme.fg('warning', 'authenticating — Enter to cancel');
       } else if (status.connecting) {
@@ -246,8 +248,17 @@ export class McpSelectorComponent extends Box implements Focusable {
     this.tui.requestRender();
   }
 
+  /**
+   * Whether an OAuth flow is in flight for this server. True if either the local
+   * set (this selector instance started the flow) or the manager-owned status
+   * flag (survives close/reopen) says so.
+   */
+  private isAuthenticating(status: McpServerStatus): boolean {
+    return status.authenticating === true || this._authenticating.has(status.name);
+  }
+
   private isBusy(): boolean {
-    return this.statuses.some(s => s.connecting) || this._authenticating.size > 0;
+    return this.statuses.some(s => s.connecting || this.isAuthenticating(s)) || this._authenticating.size > 0;
   }
 
   private startPollingIfNeeded(): void {
@@ -349,9 +360,10 @@ export class McpSelectorComponent extends Box implements Focusable {
     const status = this.statuses[this.selectedIndex];
     if (!status) return;
 
-    if (this._authenticating.has(status.name)) {
+    if (this.isAuthenticating(status)) {
       // A server mid-OAuth shows a cancel path (the user may have closed the
-      // browser). Authoritative even if a polled refresh cleared `connecting`.
+      // browser). Authoritative even if a polled refresh cleared `connecting`,
+      // and after a close/reopen via the manager-owned status flag.
       this.subMenuActions = AUTHENTICATING_ACTIONS;
     } else if (status.connecting) {
       this.subMenuActions = CONNECTING_ACTIONS;
@@ -599,7 +611,9 @@ export class McpSelectorComponent extends Box implements Focusable {
   private doCancelAuthentication(status: McpServerStatus): void {
     const name = status.name;
     // Nothing to cancel unless a flow is actually in flight for this server.
-    if (!this._authenticating.has(name)) return;
+    // Accept the manager-owned flag too, so a reopened selector (whose local
+    // set was discarded with the previous instance) can still cancel.
+    if (!this.isAuthenticating(status)) return;
 
     this.showInfoCallback(`MCP: Cancelling authentication for "${name}"...`);
     this.onCancelAuthenticateServerCallback(name)

--- a/mastracode/tui/src/tui/components/mcp-selector.ts
+++ b/mastracode/tui/src/tui/components/mcp-selector.ts
@@ -31,6 +31,8 @@ export interface McpSelectorOptions {
   onReconnectServer: (name: string) => Promise<McpServerStatus>;
   /** Callback to run the OAuth flow for a single server by name — returns updated status */
   onAuthenticateServer: (name: string) => Promise<McpServerStatus>;
+  /** Callback to cancel a pending OAuth flow for a server by name — resolves true if one was cancelled */
+  onCancelAuthenticateServer: (name: string) => Promise<boolean>;
   /** Get captured stderr logs for a server */
   getServerLogs: (name: string) => string[];
   /** Show an info message in the chat area */
@@ -69,6 +71,8 @@ const NEEDS_AUTH_ACTIONS: ServerAction[] = [
 
 const CONNECTING_ACTIONS: ServerAction[] = [{ label: 'Waiting for connection...', key: 'none' }];
 
+const AUTHENTICATING_ACTIONS: ServerAction[] = [{ label: 'Cancel authentication', key: 'cancel-authenticate' }];
+
 // =============================================================================
 // McpSelectorComponent
 // =============================================================================
@@ -82,6 +86,7 @@ export class McpSelectorComponent extends Box implements Focusable {
   private onReloadAllCallback: McpSelectorOptions['onReloadAll'];
   private onReconnectServerCallback: McpSelectorOptions['onReconnectServer'];
   private onAuthenticateServerCallback: McpSelectorOptions['onAuthenticateServer'];
+  private onCancelAuthenticateServerCallback: McpSelectorOptions['onCancelAuthenticateServer'];
   private getServerLogsCallback: McpSelectorOptions['getServerLogs'];
   private showInfoCallback: McpSelectorOptions['showInfo'];
   private onCloseCallback: () => void;
@@ -98,6 +103,10 @@ export class McpSelectorComponent extends Box implements Focusable {
 
   // Loading state during reload
   private _reloading = false;
+
+  // Names of servers with an in-flight OAuth flow (so their sub-menu offers a
+  // cancel path while they show as connecting).
+  private _authenticating = new Set<string>();
 
   // Focusable implementation
   private _focused = false;
@@ -118,6 +127,7 @@ export class McpSelectorComponent extends Box implements Focusable {
     this.onReloadAllCallback = options.onReloadAll;
     this.onReconnectServerCallback = options.onReconnectServer;
     this.onAuthenticateServerCallback = options.onAuthenticateServer;
+    this.onCancelAuthenticateServerCallback = options.onCancelAuthenticateServer;
     this.getServerLogsCallback = options.getServerLogs;
     this.showInfoCallback = options.showInfo;
     this.onCloseCallback = options.onClose;
@@ -331,7 +341,9 @@ export class McpSelectorComponent extends Box implements Focusable {
     if (!status) return;
 
     if (status.connecting) {
-      this.subMenuActions = CONNECTING_ACTIONS;
+      // A server mid-OAuth shows a cancel path (the user may have closed the
+      // browser); other connecting servers just wait.
+      this.subMenuActions = this._authenticating.has(status.name) ? AUTHENTICATING_ACTIONS : CONNECTING_ACTIONS;
     } else if (status.connected) {
       this.subMenuActions = CONNECTED_ACTIONS;
     } else if (status.needsAuth) {
@@ -397,6 +409,11 @@ export class McpSelectorComponent extends Box implements Focusable {
       case 'authenticate': {
         this.subMenuOpen = false;
         this.doAuthenticateServer(status);
+        break;
+      }
+      case 'cancel-authenticate': {
+        this.subMenuOpen = false;
+        this.doCancelAuthentication(status);
         break;
       }
     }
@@ -503,6 +520,7 @@ export class McpSelectorComponent extends Box implements Focusable {
         transport: status.transport,
       };
     }
+    this._authenticating.add(name);
     this.updateList();
     this.showInfoCallback(`MCP: Authenticating "${name}" — complete the sign-in in your browser.`);
 
@@ -539,9 +557,28 @@ export class McpSelectorComponent extends Box implements Focusable {
         this.showInfoCallback(`MCP: Failed to authenticate "${name}": ${errMsg}`);
       })
       .finally(() => {
+        this._authenticating.delete(name);
         if (!this._reloading) {
           this.updateList();
         }
+      });
+  }
+
+  private doCancelAuthentication(status: McpServerStatus): void {
+    const name = status.name;
+    // Nothing to cancel unless a flow is actually in flight for this server.
+    if (!this._authenticating.has(name)) return;
+
+    this.showInfoCallback(`MCP: Cancelling authentication for "${name}"...`);
+    this.onCancelAuthenticateServerCallback(name)
+      .then((cancelled: boolean) => {
+        if (cancelled) {
+          this.showInfoCallback(`MCP: Cancelled authentication for "${name}".`);
+        }
+      })
+      .catch(() => {
+        // The pending authenticate flow's own rejection handler restores the
+        // server's needs-auth status; a failed cancel needs no extra message.
       });
   }
 

--- a/mastracode/tui/src/tui/components/mcp-selector.ts
+++ b/mastracode/tui/src/tui/components/mcp-selector.ts
@@ -180,7 +180,10 @@ export class McpSelectorComponent extends Box implements Focusable {
       if (this._reloading) {
         icon = theme.fg('warning', '⟳');
         stateText = theme.fg('warning', 'reconnecting...');
-      } else if (status.connecting && this._authenticating.has(status.name)) {
+      } else if (this._authenticating.has(status.name)) {
+        // A flow is in flight for this server. This is authoritative even if a
+        // polled status refresh from the manager no longer reports `connecting`,
+        // so the "Enter to cancel" affordance never disappears mid-flow.
         icon = theme.fg('warning', '⟳');
         stateText = theme.fg('warning', 'authenticating — Enter to cancel');
       } else if (status.connecting) {
@@ -243,10 +246,13 @@ export class McpSelectorComponent extends Box implements Focusable {
     this.tui.requestRender();
   }
 
+  private isBusy(): boolean {
+    return this.statuses.some(s => s.connecting) || this._authenticating.size > 0;
+  }
+
   private startPollingIfNeeded(): void {
     if (this.pollTimer) return;
-    const hasConnecting = this.statuses.some(s => s.connecting);
-    if (!hasConnecting) return;
+    if (!this.isBusy()) return;
 
     this.pollTimer = setInterval(() => {
       // Don't refresh while in a detail view or mid-reload
@@ -264,8 +270,8 @@ export class McpSelectorComponent extends Box implements Focusable {
 
       this.updateList();
 
-      // Stop polling when nothing is connecting anymore
-      if (!this.statuses.some(s => s.connecting)) {
+      // Stop polling only when nothing is connecting and no auth flow is pending
+      if (!this.isBusy()) {
         this.stopPolling();
       }
     }, 500);
@@ -343,10 +349,12 @@ export class McpSelectorComponent extends Box implements Focusable {
     const status = this.statuses[this.selectedIndex];
     if (!status) return;
 
-    if (status.connecting) {
+    if (this._authenticating.has(status.name)) {
       // A server mid-OAuth shows a cancel path (the user may have closed the
-      // browser); other connecting servers just wait.
-      this.subMenuActions = this._authenticating.has(status.name) ? AUTHENTICATING_ACTIONS : CONNECTING_ACTIONS;
+      // browser). Authoritative even if a polled refresh cleared `connecting`.
+      this.subMenuActions = AUTHENTICATING_ACTIONS;
+    } else if (status.connecting) {
+      this.subMenuActions = CONNECTING_ACTIONS;
     } else if (status.connected) {
       this.subMenuActions = CONNECTED_ACTIONS;
     } else if (status.needsAuth) {
@@ -430,6 +438,13 @@ export class McpSelectorComponent extends Box implements Focusable {
       .then((result: { statuses: McpServerStatus[]; skipped: McpSkippedServer[] }) => {
         this.statuses = result.statuses;
         this.skipped = result.skipped;
+        // Reload disconnects the client, which cancels any pending auth flow
+        // server-side. Drop authenticating markers for servers that no longer
+        // exist so isBusy() can settle and polling can stop.
+        const liveNames = new Set(result.statuses.map(s => s.name));
+        for (const name of this._authenticating) {
+          if (!liveNames.has(name)) this._authenticating.delete(name);
+        }
         // Clamp selected index in case server count changed
         const total = this.getTotalItems();
         if (this.selectedIndex >= total) {

--- a/mastracode/tui/src/tui/components/mcp-selector.ts
+++ b/mastracode/tui/src/tui/components/mcp-selector.ts
@@ -568,9 +568,13 @@ export class McpSelectorComponent extends Box implements Focusable {
       })
       .finally(() => {
         this._authenticating.delete(name);
-        // The auth flow has ended (connected, failed, or cancelled); close the
-        // auto-opened cancel sub-menu so the row shows its resolved state.
-        this.subMenuOpen = false;
+        // The auth flow has ended (connected, failed, or cancelled). Close the
+        // auto-opened cancel sub-menu so the row shows its resolved state — but
+        // only if the user is still looking at *this* server's sub-menu, so we
+        // don't yank shut a different server's menu they navigated to meanwhile.
+        if (this.subMenuOpen && this.statuses[this.selectedIndex]?.name === name) {
+          this.subMenuOpen = false;
+        }
         if (!this._reloading) {
           this.updateList();
         }

--- a/mastracode/tui/src/tui/components/mcp-selector.ts
+++ b/mastracode/tui/src/tui/components/mcp-selector.ts
@@ -180,6 +180,9 @@ export class McpSelectorComponent extends Box implements Focusable {
       if (this._reloading) {
         icon = theme.fg('warning', '⟳');
         stateText = theme.fg('warning', 'reconnecting...');
+      } else if (status.connecting && this._authenticating.has(status.name)) {
+        icon = theme.fg('warning', '⟳');
+        stateText = theme.fg('warning', 'authenticating — Enter to cancel');
       } else if (status.connecting) {
         icon = theme.fg('warning', '⟳');
         stateText = theme.fg('warning', 'connecting...');
@@ -521,7 +524,14 @@ export class McpSelectorComponent extends Box implements Focusable {
       };
     }
     this._authenticating.add(name);
-    this.updateList();
+    // Surface the cancel path immediately: keep this server selected and open
+    // its sub-menu with "Cancel authentication" pre-selected, so a user who
+    // abandons the browser sign-in can just press Enter to back out.
+    if (idx >= 0) {
+      this.selectedIndex = idx;
+    }
+    this.openSubMenu();
+    this.startPollingIfNeeded();
     this.showInfoCallback(`MCP: Authenticating "${name}" — complete the sign-in in your browser.`);
 
     this.onAuthenticateServerCallback(name)
@@ -558,6 +568,9 @@ export class McpSelectorComponent extends Box implements Focusable {
       })
       .finally(() => {
         this._authenticating.delete(name);
+        // The auth flow has ended (connected, failed, or cancelled); close the
+        // auto-opened cancel sub-menu so the row shows its resolved state.
+        this.subMenuOpen = false;
         if (!this._reloading) {
           this.updateList();
         }

--- a/mastracode/tui/src/tui/open-url.ts
+++ b/mastracode/tui/src/tui/open-url.ts
@@ -1,0 +1,34 @@
+/**
+ * Best-effort browser opening for OAuth and other login flows.
+ */
+
+import { spawn } from 'node:child_process';
+
+/**
+ * Open a URL in the default browser without going through a shell.
+ * Only well-formed http(s) URLs are opened; anything else is ignored
+ * (the URL is still displayed for the user to open manually).
+ */
+export function openUrlInBrowser(url: string): void {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return;
+  }
+
+  const [cmd, args]: [string, string[]] =
+    process.platform === 'darwin'
+      ? ['open', [url]]
+      : process.platform === 'win32'
+        ? ['rundll32', ['url.dll,FileProtocolHandler', url]]
+        : ['xdg-open', [url]];
+
+  const child = spawn(cmd, args, { stdio: 'ignore', detached: true });
+  // Opening the browser is best-effort — the URL is shown to the user as well.
+  child.on('error', () => {});
+  child.unref();
+}

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -529,6 +529,13 @@ export class InternalMastraMCPClient extends MastraBase {
    * transport that started the authorization flow so finishAuth can complete it.
    */
   private markNeedsAuth(transport: StreamableHTTPClientTransport | SSEClientTransport): void {
+    // A prior connect() may have left a pending transport that never completed
+    // finishAuth. Close the superseded one before replacing it so its event
+    // stream and session resources are released rather than abandoned.
+    const superseded = this.pendingAuthTransport;
+    if (superseded && superseded !== transport) {
+      void superseded.close().catch(() => {});
+    }
     this.pendingAuthTransport = transport;
     this._authState = 'needs-auth';
     this.log('debug', 'Server requires OAuth authorization before connecting.');

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -471,7 +471,8 @@ export class InternalMastraMCPClient extends MastraBase {
 
         // A 401 means the flow continues on this transport via finishAuth, not on a
         // fallback: the SDK has already run discovery and redirected to authorization.
-        if (error instanceof UnauthorizedError) {
+        // Guarded on authProvider so servers without one never carry an auth state.
+        if (authProvider && error instanceof UnauthorizedError) {
           this.markNeedsAuth(streamableTransport);
           throw error;
         }
@@ -504,7 +505,7 @@ export class InternalMastraMCPClient extends MastraBase {
         this.transport = sseTransport;
         this.log('debug', 'Successfully connected using deprecated HTTP+SSE transport.');
       } catch (sseError) {
-        if (sseError instanceof UnauthorizedError) {
+        if (authProvider && sseError instanceof UnauthorizedError) {
           this.markNeedsAuth(sseTransport);
           throw sseError;
         }

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -44,6 +44,7 @@ import {
 
 import { asyncExitHook, gracefulExit } from 'exit-hook';
 import { getMastraToolStrictMeta } from '../shared/mastra-tool-meta';
+import { UnauthorizedError } from '../shared/oauth-types';
 import { ElicitationClientActions } from './actions/elicitation';
 import { ProgressClientActions } from './actions/progress';
 import { PromptClientActions } from './actions/prompt';
@@ -78,6 +79,17 @@ export type {
 
 const DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC = 3000;
 const DEFAULT_INSTRUCTIONS_MAX_LENGTH = 512;
+
+/**
+ * OAuth authorization state of an MCP server connection.
+ *
+ * - `needs-auth`: the server rejected the connection with a 401 and interactive
+ *   authorization is required (see MCPClient.authenticate)
+ * - `authorized`: the server accepted the configured authProvider's credentials
+ *
+ * Servers without an authProvider never carry an auth state.
+ */
+export type MCPServerAuthState = 'needs-auth' | 'authorized';
 
 // Per MCP spec, only fallback to SSE for these status codes
 const SSE_FALLBACK_STATUS_CODES = [400, 404, 405];
@@ -217,6 +229,8 @@ export class InternalMastraMCPClient extends MastraBase {
   private enableProgressTracking?: boolean;
   private serverConfig: MastraMCPServerDefinition;
   private transport?: Transport;
+  private pendingAuthTransport?: StreamableHTTPClientTransport | SSEClientTransport;
+  private _authState?: MCPServerAuthState;
   private operationContextStore = new AsyncLocalStorage<RequestContext | null>();
   private exitHookUnsubscribe?: () => void;
   private sigTermHandler?: () => void;
@@ -436,15 +450,17 @@ export class InternalMastraMCPClient extends MastraBase {
     let shouldTrySSE = url.pathname.endsWith(`/sse`);
 
     if (!shouldTrySSE) {
+      // Constructed outside the try so an UnauthorizedError can keep a handle on the
+      // transport that started the authorization flow (finishAuth must run on it).
+      const streamableTransport = new StreamableHTTPClientTransport(url, {
+        requestInit,
+        reconnectionOptions: this.serverConfig.reconnectionOptions,
+        authProvider: authProvider,
+        fetch,
+      });
       try {
         // Try Streamable HTTP transport first
         this.log('debug', 'Trying Streamable HTTP transport...');
-        const streamableTransport = new StreamableHTTPClientTransport(url, {
-          requestInit,
-          reconnectionOptions: this.serverConfig.reconnectionOptions,
-          authProvider: authProvider,
-          fetch,
-        });
         await this.client.connect(streamableTransport, {
           timeout: connectTimeout ?? DEFAULT_SERVER_CONNECT_TIMEOUT_MSEC,
         });
@@ -452,6 +468,13 @@ export class InternalMastraMCPClient extends MastraBase {
         this.log('debug', 'Successfully connected using Streamable HTTP transport.');
       } catch (error: any) {
         this.log('debug', `Streamable HTTP transport failed: ${error}`);
+
+        // A 401 means the flow continues on this transport via finishAuth, not on a
+        // fallback: the SDK has already run discovery and redirected to authorization.
+        if (error instanceof UnauthorizedError) {
+          this.markNeedsAuth(streamableTransport);
+          throw error;
+        }
 
         // @modelcontextprotocol/sdk 1.24.0+ throws StreamableHTTPError with 'code' property
         // Older @modelcontextprotocol/sdk: fallback to SSE (legacy behavior)
@@ -465,28 +488,82 @@ export class InternalMastraMCPClient extends MastraBase {
 
     if (shouldTrySSE) {
       this.log('debug', 'Falling back to deprecated HTTP+SSE transport...');
-      try {
-        // Fallback to SSE transport
-        // If fetch is provided, ensure it's also in eventSourceInit for the EventSource connection
-        // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream
-        const sseEventSourceInit = { ...eventSourceInit, fetch };
+      // Fallback to SSE transport
+      // If fetch is provided, ensure it's also in eventSourceInit for the EventSource connection
+      // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream
+      const sseEventSourceInit = { ...eventSourceInit, fetch };
 
-        const sseTransport = new SSEClientTransport(url, {
-          requestInit,
-          eventSourceInit: sseEventSourceInit,
-          authProvider,
-          fetch,
-        });
+      const sseTransport = new SSEClientTransport(url, {
+        requestInit,
+        eventSourceInit: sseEventSourceInit,
+        authProvider,
+        fetch,
+      });
+      try {
         await this.client.connect(sseTransport, { timeout: this.serverConfig.timeout ?? this.timeout });
         this.transport = sseTransport;
         this.log('debug', 'Successfully connected using deprecated HTTP+SSE transport.');
       } catch (sseError) {
+        if (sseError instanceof UnauthorizedError) {
+          this.markNeedsAuth(sseTransport);
+          throw sseError;
+        }
         this.log(
           'error',
           `Failed to connect with SSE transport after failing to connect to Streamable HTTP transport first. SSE error: ${sseError}`,
         );
         throw new Error('Could not connect to server with any available HTTP transport');
       }
+    }
+
+    // Reaching here means a transport connected; any earlier authorization requirement is satisfied.
+    this.pendingAuthTransport = undefined;
+    if (authProvider) {
+      this._authState = 'authorized';
+    }
+  }
+
+  /**
+   * Records that the server rejected the connection with a 401 and keeps the
+   * transport that started the authorization flow so finishAuth can complete it.
+   */
+  private markNeedsAuth(transport: StreamableHTTPClientTransport | SSEClientTransport): void {
+    this.pendingAuthTransport = transport;
+    this._authState = 'needs-auth';
+    this.log('debug', 'Server requires OAuth authorization before connecting.');
+  }
+
+  /**
+   * OAuth authorization state of this server connection, when it has an authProvider.
+   *
+   * @internal
+   */
+  get authState(): MCPServerAuthState | undefined {
+    return this._authState;
+  }
+
+  /**
+   * Completes a pending OAuth authorization-code flow.
+   *
+   * Exchanges the authorization code captured at the redirect URI on the same
+   * transport that started the flow, then leaves the client ready to connect().
+   *
+   * @param authorizationCode - The authorization code captured at the redirect URI
+   * @throws {Error} If no authorization flow is pending for this server
+   *
+   * @internal
+   */
+  async finishAuth(authorizationCode: string): Promise<void> {
+    const pending = this.pendingAuthTransport;
+    if (!pending) {
+      throw new Error('No OAuth authorization is pending for this server. Call connect() first.');
+    }
+    this.pendingAuthTransport = undefined;
+    try {
+      await pending.finishAuth(authorizationCode);
+    } finally {
+      // The pending transport only ran the token exchange; the next connect() builds a fresh one.
+      void pending.close().catch(() => {});
     }
   }
 

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -14,13 +14,20 @@ import type {
   ResourceTemplate,
 } from '@modelcontextprotocol/sdk/types.js';
 import equal from 'fast-deep-equal';
+import type { OAuthClientInformationFull } from '../shared/oauth-types';
+import { UnauthorizedError } from '../shared/oauth-types';
 import { InternalMastraMCPClient } from './client';
-import type { MastraMCPServerDefinition } from './client';
+import type { MastraMCPServerDefinition, MCPServerAuthState } from './client';
 import { isReconnectableMCPError } from './error-utils';
+import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server';
+import { MCPOAuthClientProvider } from './oauth-provider';
 import { MCPClientServerProxy } from './server-proxy';
 
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
+
+// Hostnames authenticate() accepts for the provider's redirect URL (RFC 8252 loopback redirection)
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]']);
 
 /**
  * Configuration options for creating an MCPClient instance.
@@ -74,6 +81,7 @@ export class MCPClient extends MastraBase {
   private defaultTimeout: number;
   private mcpClientsById = new Map<string, InternalMastraMCPClient>();
   private disconnectPromise: Promise<void> | null = null;
+  private authFlowsByServer = new Map<string, Promise<void>>();
 
   /**
    * Creates a new MCPClient instance for managing MCP server connections.
@@ -787,6 +795,116 @@ To fix this you have three different options:
   }
 
   /**
+   * Runs the interactive OAuth authorization-code flow for a server.
+   *
+   * Requires the server to be configured with an MCPOAuthClientProvider whose
+   * redirect URL points at a loopback address. The flow:
+   *
+   * 1. Starts a loopback callback server on the redirect URL's port (falling
+   *    back to the next sequential ports when it is in use)
+   * 2. Attempts a connection so the SDK runs discovery and dynamic client
+   *    registration, delivering the authorization URL through the provider's
+   *    `onRedirectToAuthorization` callback — the host directs the user there
+   * 3. Waits for the browser to deliver the authorization code, validates the
+   *    OAuth state, exchanges the code for tokens, and reconnects
+   *
+   * Concurrent calls for the same server join the pending flow; different
+   * servers authenticate independently. Hosts with custom redirect handling
+   * (e.g. a web app with an HTTPS redirect URL) should drive
+   * MCPOAuthClientProvider directly instead.
+   *
+   * @param serverName - The name of the server to authenticate (must match a key in `servers`)
+   * @param options.timeoutMs - How long to wait for the browser callback (default 5 minutes)
+   * @throws {Error} If the server has no MCPOAuthClientProvider or its redirect URL is not loopback
+   *
+   * @example
+   * ```typescript
+   * if (mcp.getServerAuthState('weatherServer') === 'needs-auth') {
+   *   await mcp.authenticate('weatherServer');
+   * }
+   * ```
+   */
+  public async authenticate(serverName: string, options?: { timeoutMs?: number }): Promise<void> {
+    const pendingFlow = this.authFlowsByServer.get(serverName);
+    if (pendingFlow) {
+      return pendingFlow;
+    }
+
+    const flow = this.runAuthorizationFlow(serverName, options).finally(() => {
+      this.authFlowsByServer.delete(serverName);
+    });
+    this.authFlowsByServer.set(serverName, flow);
+    return flow;
+  }
+
+  /**
+   * OAuth authorization state of a configured server.
+   *
+   * Returns `undefined` for servers without an authProvider and for servers
+   * that have not attempted a connection yet.
+   */
+  public getServerAuthState(serverName: string): MCPServerAuthState | undefined {
+    return this.mcpClientsById.get(serverName)?.authState;
+  }
+
+  private async runAuthorizationFlow(serverName: string, options?: { timeoutMs?: number }): Promise<void> {
+    const config = this.getServerConfig(serverName);
+    const provider = config.authProvider;
+    if (!(provider instanceof MCPOAuthClientProvider)) {
+      throw new Error(
+        `Cannot authenticate MCP server ${serverName}: it is not configured with an MCPOAuthClientProvider.`,
+      );
+    }
+
+    const redirectUrl = new URL(provider.redirectUrl.toString());
+    if (redirectUrl.protocol !== 'http:' || !LOOPBACK_HOSTNAMES.has(redirectUrl.hostname)) {
+      throw new Error(
+        `Cannot authenticate MCP server ${serverName}: the provider's redirect URL must be a loopback address, got ${redirectUrl.origin}.`,
+      );
+    }
+
+    const state = await provider.beginAuthorizationSession();
+    const callbackServer = await createOAuthCallbackServer({ redirectUrl, state });
+    try {
+      // Point the authorization request at the callback URL that actually
+      // bound, and register every fallback candidate during dynamic client
+      // registration so a future fallback port still matches a registered URI.
+      provider.applyResolvedRedirectUrl(callbackServer.url, getCallbackUrlCandidates(redirectUrl));
+
+      // Discard a stored client registration that does not cover the bound
+      // callback URL — the authorization server would reject its redirect_uri.
+      const clientInfo = (await provider.clientInformation()) as Partial<OAuthClientInformationFull> | undefined;
+      if (clientInfo?.redirect_uris && !clientInfo.redirect_uris.includes(callbackServer.url.toString())) {
+        await provider.invalidateCredentials('client');
+      }
+
+      const client = await this.getClientForServer(serverName);
+      try {
+        // With valid stored tokens this simply connects; otherwise the SDK
+        // delivers the authorization URL and throws UnauthorizedError.
+        await client.connect();
+        return;
+      } catch (error) {
+        if (!(error instanceof UnauthorizedError)) {
+          throw this.handleConnectError(serverName, error);
+        }
+      }
+
+      const { code } = await callbackServer.waitForCode(options);
+      await client.finishAuth(code);
+
+      try {
+        await client.connect();
+      } catch (error) {
+        throw error instanceof UnauthorizedError ? error : this.handleConnectError(serverName, error);
+      }
+    } finally {
+      provider.endAuthorizationSession();
+      await callbackServer.close();
+    }
+  }
+
+  /**
    * Returns instructions advertised by connected MCP servers during initialize.
    *
    * Servers that have not connected yet, or did not advertise instructions,
@@ -1106,7 +1224,11 @@ To fix this you have three different options:
     );
     this.logger.trackException(mastraError);
     this.logger.error('MCPClient errored connecting to MCP server:', { error: mastraError.toString() });
-    this.mcpClientsById.delete(name);
+    // Keep the client when authorization is required: it carries the needs-auth
+    // state and the pending transport that authenticate() completes.
+    if (!(error instanceof UnauthorizedError)) {
+      this.mcpClientsById.delete(name);
+    }
     return mastraError;
   }
 

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -27,8 +27,13 @@ import { MCPClientServerProxy } from './server-proxy';
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 
-// Hostnames authenticate() accepts for the provider's redirect URL (RFC 8252 loopback redirection)
-const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]']);
+// Whether a hostname is a loopback address authenticate() accepts for the
+// provider's redirect URL (RFC 8252 loopback redirection). Kept in sync with the
+// mastracode config parser, which accepts any 127.0.0.0/8 host, so a config that
+// parses (e.g. 127.0.0.2) does not later fail here.
+function isLoopbackHostname(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.');
+}
 
 /**
  * Configuration options for creating an MCPClient instance.
@@ -761,6 +766,18 @@ To fix this you have three different options:
       try {
         mcpClientInstances.delete(this.id);
 
+        // Tear down any in-flight authorization: each callback server owns a live
+        // loopback HTTP port, and closing it rejects the flow's waitForCode. Await
+        // the flow settlements so a disconnect during authentication does not leave
+        // a bound port or a dangling promise keeping the process alive.
+        const pendingFlows = Array.from(this.authFlowsByServer.values());
+        await Promise.allSettled(
+          Array.from(this.authCallbackServersByServer.values()).map(server => server.close()),
+        );
+        await Promise.allSettled(pendingFlows);
+        this.authCallbackServersByServer.clear();
+        this.authFlowsByServer.clear();
+
         // Disconnect all clients in the cache
         await Promise.allSettled(Array.from(this.mcpClientsById.values()).map(client => client.disconnect()));
         this.mcpClientsById.clear();
@@ -862,7 +879,7 @@ To fix this you have three different options:
     }
 
     const redirectUrl = new URL(provider.redirectUrl.toString());
-    if (redirectUrl.protocol !== 'http:' || !LOOPBACK_HOSTNAMES.has(redirectUrl.hostname)) {
+    if (redirectUrl.protocol !== 'http:' || !isLoopbackHostname(redirectUrl.hostname)) {
       throw new Error(
         `Cannot authenticate MCP server ${serverName}: the provider's redirect URL must be a loopback address, got ${redirectUrl.origin}.`,
       );

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -20,6 +20,7 @@ import { InternalMastraMCPClient } from './client';
 import type { MastraMCPServerDefinition, MCPServerAuthState } from './client';
 import { isReconnectableMCPError } from './error-utils';
 import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server';
+import type { OAuthCallbackServer } from './oauth-callback-server';
 import { MCPOAuthClientProvider } from './oauth-provider';
 import { MCPClientServerProxy } from './server-proxy';
 
@@ -82,6 +83,7 @@ export class MCPClient extends MastraBase {
   private mcpClientsById = new Map<string, InternalMastraMCPClient>();
   private disconnectPromise: Promise<void> | null = null;
   private authFlowsByServer = new Map<string, Promise<void>>();
+  private authCallbackServersByServer = new Map<string, OAuthCallbackServer>();
 
   /**
    * Creates a new MCPClient instance for managing MCP server connections.
@@ -868,6 +870,7 @@ To fix this you have three different options:
 
     const state = await provider.beginAuthorizationSession();
     const callbackServer = await createOAuthCallbackServer({ redirectUrl, state });
+    this.authCallbackServersByServer.set(serverName, callbackServer);
     try {
       // Point the authorization request at the callback URL that actually
       // bound, and register every fallback candidate during dynamic client
@@ -902,9 +905,33 @@ To fix this you have three different options:
         throw error instanceof UnauthorizedError ? error : this.handleConnectError(serverName, error);
       }
     } finally {
+      this.authCallbackServersByServer.delete(serverName);
       provider.endAuthorizationSession();
       await callbackServer.close();
     }
+  }
+
+  /**
+   * Cancels a pending {@link authenticate} flow for a server.
+   *
+   * Tears down the loopback callback server immediately — the pending
+   * authenticate() call rejects, and the server remains in the `needs-auth`
+   * state so the flow can be retried right away. Useful when the user closed
+   * the browser without completing consent, which the host cannot observe.
+   *
+   * @param serverName - The name of the server whose flow to cancel
+   * @returns `true` if a pending flow was cancelled, `false` when no flow was pending
+   */
+  public async cancelAuthentication(serverName: string): Promise<boolean> {
+    const callbackServer = this.authCallbackServersByServer.get(serverName);
+    const pendingFlow = this.authFlowsByServer.get(serverName);
+    if (!callbackServer || !pendingFlow) {
+      return false;
+    }
+
+    await callbackServer.close();
+    await pendingFlow.catch(() => undefined);
+    return true;
   }
 
   /**

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -808,10 +808,13 @@ To fix this you have three different options:
    * 3. Waits for the browser to deliver the authorization code, validates the
    *    OAuth state, exchanges the code for tokens, and reconnects
    *
-   * Concurrent calls for the same server join the pending flow; different
-   * servers authenticate independently. Hosts with custom redirect handling
-   * (e.g. a web app with an HTTPS redirect URL) should drive
-   * MCPOAuthClientProvider directly instead.
+   * Concurrent calls for the same server join the pending flow (the joiner's
+   * options are ignored — the pending flow keeps its own timeout); different
+   * servers authenticate independently. Each server needs its own provider
+   * instance: the flow pins session state on the provider, so sharing one
+   * MCPOAuthClientProvider across servers is not supported. Hosts with custom
+   * redirect handling (e.g. a web app with an HTTPS redirect URL) should
+   * drive MCPOAuthClientProvider directly instead.
    *
    * @param serverName - The name of the server to authenticate (must match a key in `servers`)
    * @param options.timeoutMs - How long to wait for the browser callback (default 5 minutes)

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -27,12 +27,18 @@ import { MCPClientServerProxy } from './server-proxy';
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 
+// Matches the entire 127.0.0.0/8 range in dotted-quad form. `URL` normalizes
+// IPv4 hosts to four octets (so `127.1` becomes `127.0.0.1`), so anchoring the
+// pattern is enough — and it rejects lookalikes like `127.evil.com` that a
+// prefix check would wrongly accept and leak the authorization code to.
+const LOOPBACK_IPV4 = /^127\.(?:\d{1,3})\.(?:\d{1,3})\.(?:\d{1,3})$/;
+
 // Whether a hostname is a loopback address authenticate() accepts for the
 // provider's redirect URL (RFC 8252 loopback redirection). Kept in sync with the
 // mastracode config parser, which accepts any 127.0.0.0/8 host, so a config that
 // parses (e.g. 127.0.0.2) does not later fail here.
 function isLoopbackHostname(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '[::1]' || hostname.startsWith('127.');
+  return hostname === 'localhost' || hostname === '[::1]' || hostname === '::1' || LOOPBACK_IPV4.test(hostname);
 }
 
 /**
@@ -89,6 +95,13 @@ export class MCPClient extends MastraBase {
   private disconnectPromise: Promise<void> | null = null;
   private authFlowsByServer = new Map<string, Promise<void>>();
   private authCallbackServersByServer = new Map<string, OAuthCallbackServer>();
+  /**
+   * Per-server abort controllers for in-flight authorization flows. Created
+   * synchronously at the start of {@link runAuthorizationFlow} — before the
+   * callback server exists — so cancel/disconnect can interrupt the setup phase
+   * (discovery, registration, port binding) and not just the waitForCode wait.
+   */
+  private authAbortControllersByServer = new Map<string, AbortController>();
 
   /**
    * Creates a new MCPClient instance for managing MCP server connections.
@@ -771,10 +784,17 @@ To fix this you have three different options:
         // the flow settlements so a disconnect during authentication does not leave
         // a bound port or a dangling promise keeping the process alive.
         const pendingFlows = Array.from(this.authFlowsByServer.values());
+        // Abort first so flows still in their setup phase (no callback server
+        // bound yet) unblock instead of parking on waitForCode and deadlocking
+        // the awaited settlement below.
+        for (const controller of this.authAbortControllersByServer.values()) {
+          controller.abort();
+        }
         await Promise.allSettled(
           Array.from(this.authCallbackServersByServer.values()).map(server => server.close()),
         );
         await Promise.allSettled(pendingFlows);
+        this.authAbortControllersByServer.clear();
         this.authCallbackServersByServer.clear();
         this.authFlowsByServer.clear();
 
@@ -870,9 +890,21 @@ To fix this you have three different options:
   }
 
   private async runAuthorizationFlow(serverName: string, options?: { timeoutMs?: number }): Promise<void> {
+    // Register the abort controller synchronously, before the first await, so a
+    // cancel/disconnect during the setup phase (discovery, registration, port
+    // binding) can interrupt the flow rather than letting it park on waitForCode.
+    const abortController = new AbortController();
+    this.authAbortControllersByServer.set(serverName, abortController);
+    const throwIfAborted = () => {
+      if (abortController.signal.aborted) {
+        throw new Error(`Authentication for MCP server ${serverName} was cancelled.`);
+      }
+    };
+
     const config = this.getServerConfig(serverName);
     const provider = config.authProvider;
     if (!(provider instanceof MCPOAuthClientProvider)) {
+      this.authAbortControllersByServer.delete(serverName);
       throw new Error(
         `Cannot authenticate MCP server ${serverName}: it is not configured with an MCPOAuthClientProvider.`,
       );
@@ -880,13 +912,29 @@ To fix this you have three different options:
 
     const redirectUrl = new URL(provider.redirectUrl.toString());
     if (redirectUrl.protocol !== 'http:' || !isLoopbackHostname(redirectUrl.hostname)) {
+      this.authAbortControllersByServer.delete(serverName);
       throw new Error(
         `Cannot authenticate MCP server ${serverName}: the provider's redirect URL must be a loopback address, got ${redirectUrl.origin}.`,
       );
     }
 
     const state = await provider.beginAuthorizationSession();
+    // A cancel that arrived during beginAuthorizationSession() has no callback
+    // server to close yet, so bail here before binding a port and parking.
+    if (abortController.signal.aborted) {
+      provider.endAuthorizationSession();
+      this.authAbortControllersByServer.delete(serverName);
+      throwIfAborted();
+    }
     const callbackServer = await createOAuthCallbackServer({ redirectUrl, state });
+    // A cancel during port binding: close the freshly-bound server and bail
+    // before we ever wait for a code that will never arrive.
+    if (abortController.signal.aborted) {
+      provider.endAuthorizationSession();
+      this.authAbortControllersByServer.delete(serverName);
+      await callbackServer.close();
+      throwIfAborted();
+    }
     this.authCallbackServersByServer.set(serverName, callbackServer);
     try {
       // Point the authorization request at the callback URL that actually
@@ -923,6 +971,7 @@ To fix this you have three different options:
       }
     } finally {
       this.authCallbackServersByServer.delete(serverName);
+      this.authAbortControllersByServer.delete(serverName);
       provider.endAuthorizationSession();
       await callbackServer.close();
     }
@@ -940,13 +989,16 @@ To fix this you have three different options:
    * @returns `true` if a pending flow was cancelled, `false` when no flow was pending
    */
   public async cancelAuthentication(serverName: string): Promise<boolean> {
-    const callbackServer = this.authCallbackServersByServer.get(serverName);
     const pendingFlow = this.authFlowsByServer.get(serverName);
-    if (!callbackServer || !pendingFlow) {
+    if (!pendingFlow) {
       return false;
     }
 
-    await callbackServer.close();
+    // Abort first so a flow still in its setup phase (no callback server bound
+    // yet) is interrupted before it can park on waitForCode; then close the
+    // callback server if one exists, which rejects an in-progress waitForCode.
+    this.authAbortControllersByServer.get(serverName)?.abort();
+    await this.authCallbackServersByServer.get(serverName)?.close();
     await pendingFlow.catch(() => undefined);
     return true;
   }

--- a/packages/mcp/src/client/index.ts
+++ b/packages/mcp/src/client/index.ts
@@ -14,4 +14,5 @@ export type {
 export * from './client';
 export * from './configuration';
 export * from './oauth-provider';
+export * from './oauth-callback-server';
 export { MCPClientServerProxy } from './server-proxy';

--- a/packages/mcp/src/client/oauth-callback-server.test.ts
+++ b/packages/mcp/src/client/oauth-callback-server.test.ts
@@ -92,22 +92,28 @@ describe('createOAuthCallbackServer', () => {
     await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
   });
 
-  it('rejects on state mismatch', async () => {
+  it('ignores requests without a matching state so they cannot settle the flow', async () => {
     const server = await startCallbackServer();
+    const pending = server.waitForCode();
 
-    const pending = expect(server.waitForCode()).rejects.toThrow(/state mismatch/);
-    const response = await fetch(`${server.url}?code=auth-code-123&state=wrong-state`);
+    // Neither a forged code nor a forged denial (the state authenticates the
+    // redirect) may settle the pending flow.
+    const forgedCode = await fetch(`${server.url}?code=forged-code&state=wrong-state`);
+    expect(forgedCode.status).toBe(400);
+    const forgedDenial = await fetch(`${server.url}?error=access_denied`);
+    expect(forgedDenial.status).toBe(400);
 
-    expect(response.status).toBe(400);
-    await pending;
+    const genuine = await fetch(`${server.url}?code=auth-code-123&state=${STATE}`);
+    expect(genuine.status).toBe(200);
+    await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
   });
 
-  it('rejects on an OAuth error response, including the description', async () => {
+  it('rejects on a state-matching OAuth error response, including the description', async () => {
     const server = await startCallbackServer();
 
     const pending = expect(server.waitForCode()).rejects.toThrow(/access_denied.*User denied the request/);
     const response = await fetch(
-      `${server.url}?error=access_denied&error_description=${encodeURIComponent('User denied the request')}`,
+      `${server.url}?error=access_denied&error_description=${encodeURIComponent('User denied the request')}&state=${STATE}`,
     );
 
     expect(response.status).toBe(400);
@@ -155,6 +161,20 @@ describe('createOAuthCallbackServer', () => {
     } finally {
       await closeServer(blocker);
     }
+  });
+
+  it('binds the hostname from the redirect URL', async () => {
+    const port = await getFreePort();
+    callbackServer = await createOAuthCallbackServer({
+      redirectUrl: `http://localhost:${port}/oauth/callback`,
+      state: STATE,
+    });
+
+    const pending = callbackServer.waitForCode();
+    const response = await fetch(`http://localhost:${port}/oauth/callback?code=auth-code-123&state=${STATE}`);
+
+    expect(response.status).toBe(200);
+    await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
   });
 
   it('releases the port on close', async () => {

--- a/packages/mcp/src/client/oauth-callback-server.test.ts
+++ b/packages/mcp/src/client/oauth-callback-server.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the loopback OAuth callback server.
+ *
+ * Uses real HTTP requests against the bound port — no mocks — since the
+ * helper's whole job is correct socket-level behavior (binding, fallback,
+ * one-shot semantics, releasing the port).
+ */
+
+import { createServer } from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+
+import { describe, it, expect, afterEach } from 'vitest';
+
+import type { OAuthCallbackServer } from './oauth-callback-server.js';
+import { createOAuthCallbackServer, getCallbackUrlCandidates } from './oauth-callback-server.js';
+
+const STATE = 'expected-state';
+
+/**
+ * Finds a port that is currently free by binding an ephemeral port and
+ * releasing it. Keeps tests independent of hardcoded port availability.
+ */
+async function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      if (!address || typeof address === 'string') {
+        reject(new Error('Failed to probe for a free port'));
+        return;
+      }
+      probe.close(() => resolve(address.port));
+    });
+  });
+}
+
+function occupyPort(port: number): Promise<HttpServer> {
+  return new Promise((resolve, reject) => {
+    const blocker = createServer();
+    blocker.once('error', reject);
+    blocker.listen(port, '127.0.0.1', () => resolve(blocker));
+  });
+}
+
+function closeServer(server: HttpServer): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close(error => (error ? reject(error) : resolve()));
+  });
+}
+
+describe('getCallbackUrlCandidates', () => {
+  it('returns the preferred URL followed by sequential fallback ports', () => {
+    const candidates = getCallbackUrlCandidates('http://127.0.0.1:5533/oauth/callback');
+
+    expect(candidates).toHaveLength(11);
+    expect(candidates[0]!.toString()).toBe('http://127.0.0.1:5533/oauth/callback');
+    expect(candidates.map(url => Number(url.port))).toEqual([
+      5533, 5534, 5535, 5536, 5537, 5538, 5539, 5540, 5541, 5542, 5543,
+    ]);
+    expect(candidates.every(url => url.pathname === '/oauth/callback')).toBe(true);
+  });
+});
+
+describe('createOAuthCallbackServer', () => {
+  let callbackServer: OAuthCallbackServer | undefined;
+
+  afterEach(async () => {
+    await callbackServer?.close().catch(() => {});
+    callbackServer = undefined;
+  });
+
+  async function startCallbackServer(): Promise<OAuthCallbackServer> {
+    const port = await getFreePort();
+    callbackServer = await createOAuthCallbackServer({
+      redirectUrl: `http://127.0.0.1:${port}/oauth/callback`,
+      state: STATE,
+    });
+    return callbackServer;
+  }
+
+  it('captures the authorization code from the callback request', async () => {
+    const server = await startCallbackServer();
+
+    const pending = server.waitForCode();
+    const response = await fetch(`${server.url}?code=auth-code-123&state=${STATE}`);
+    const body = await response.text();
+
+    expect(response.status).toBe(200);
+    expect(body).toContain('close this tab');
+    expect(body).not.toContain('auth-code-123');
+    await expect(pending).resolves.toEqual({ code: 'auth-code-123', state: STATE });
+  });
+
+  it('rejects on state mismatch', async () => {
+    const server = await startCallbackServer();
+
+    const pending = expect(server.waitForCode()).rejects.toThrow(/state mismatch/);
+    const response = await fetch(`${server.url}?code=auth-code-123&state=wrong-state`);
+
+    expect(response.status).toBe(400);
+    await pending;
+  });
+
+  it('rejects on an OAuth error response, including the description', async () => {
+    const server = await startCallbackServer();
+
+    const pending = expect(server.waitForCode()).rejects.toThrow(/access_denied.*User denied the request/);
+    const response = await fetch(
+      `${server.url}?error=access_denied&error_description=${encodeURIComponent('User denied the request')}`,
+    );
+
+    expect(response.status).toBe(400);
+    await pending;
+  });
+
+  it('rejects when no callback arrives before the timeout', async () => {
+    const server = await startCallbackServer();
+
+    await expect(server.waitForCode({ timeoutMs: 50 })).rejects.toThrow(/Timed out waiting for OAuth callback/);
+  });
+
+  it('is one-shot: subsequent callback requests receive 410', async () => {
+    const server = await startCallbackServer();
+
+    const pending = server.waitForCode();
+    await fetch(`${server.url}?code=auth-code-123&state=${STATE}`);
+    await pending;
+
+    const replay = await fetch(`${server.url}?code=another-code&state=${STATE}`);
+    expect(replay.status).toBe(410);
+  });
+
+  it('rejects pending waitForCode when closed before a code arrives', async () => {
+    const server = await startCallbackServer();
+
+    const pending = server.waitForCode();
+    await server.close();
+
+    await expect(pending).rejects.toThrow(/closed before receiving an authorization code/);
+  });
+
+  it('falls back to the next port when the preferred port is in use', async () => {
+    const preferredPort = await getFreePort();
+    const blocker = await occupyPort(preferredPort);
+
+    try {
+      callbackServer = await createOAuthCallbackServer({
+        redirectUrl: `http://127.0.0.1:${preferredPort}/oauth/callback`,
+        state: STATE,
+      });
+
+      expect(callbackServer.port).toBe(preferredPort + 1);
+      expect(callbackServer.url.toString()).toBe(`http://127.0.0.1:${preferredPort + 1}/oauth/callback`);
+    } finally {
+      await closeServer(blocker);
+    }
+  });
+
+  it('releases the port on close', async () => {
+    const server = await startCallbackServer();
+    const { port } = server;
+
+    await server.close();
+    callbackServer = undefined;
+
+    const reclaimed = await occupyPort(port);
+    await closeServer(reclaimed);
+  });
+});

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -47,7 +47,10 @@ export interface OAuthCallbackServerOptions {
   /**
    * The redirect URL the authorization server will send the browser back to.
    * Its port is the preferred port to bind; if that port is in use, the next
-   * sequential ports are tried (see getCallbackUrlCandidates).
+   * sequential ports are tried (see getCallbackUrlCandidates). The server
+   * binds the URL's hostname — prefer the literal `127.0.0.1` over
+   * `localhost` (RFC 8252 §8.3) so the browser and server agree on the
+   * address family.
    *
    * @example 'http://127.0.0.1:5533/oauth/callback'
    */
@@ -55,8 +58,10 @@ export interface OAuthCallbackServerOptions {
 
   /**
    * The OAuth state parameter issued for this authorization request.
-   * Callback requests with a different state are rejected (CSRF protection
-   * per OAuth 2.1).
+   * The state authenticates the redirect (CSRF protection per OAuth 2.1):
+   * callback requests without a matching state receive an error response and
+   * never settle the flow, so a stray local request cannot abort or spoof a
+   * pending authorization.
    */
   state: string;
 }
@@ -95,9 +100,9 @@ export interface OAuthCallbackServer {
   /**
    * Waits for the browser to deliver the authorization code.
    *
-   * Resolves once with the code and state from the first callback request.
-   * Rejects on timeout, on an OAuth error response (`error` /
-   * `error_description` query params), on a state mismatch, or when the
+   * Resolves once with the code and state from the first state-matching
+   * callback request. Rejects on timeout, on a state-matching OAuth error
+   * response (`error` / `error_description` query params), or when the
    * server is closed before a code arrives.
    */
   waitForCode(options?: { timeoutMs?: number }): Promise<OAuthCallbackResult>;
@@ -130,7 +135,7 @@ export function getCallbackUrlCandidates(redirectUrl: string | URL): URL[] {
   return candidates;
 }
 
-function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException | null> {
+function listen(server: HttpServer, port: number, hostname: string): Promise<NodeJS.ErrnoException | null> {
   return new Promise((resolve, reject) => {
     const onError = (error: NodeJS.ErrnoException) => {
       server.off('listening', onListening);
@@ -147,7 +152,7 @@ function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException
 
     server.once('error', onError);
     server.once('listening', onListening);
-    server.listen(port, '127.0.0.1');
+    server.listen(port, hostname);
   });
 }
 
@@ -155,10 +160,12 @@ function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException
  * Starts a one-shot loopback HTTP server that captures the OAuth
  * authorization code.
  *
- * The server binds 127.0.0.1 on the redirect URL's port, falling back to the
- * next sequential ports when it is in use (see getCallbackUrlCandidates).
- * The first request on the callback path settles the outcome; subsequent
- * requests receive 410 Gone. The response pages never echo the
+ * The server binds the redirect URL's hostname on its port, falling back to
+ * the next sequential ports when it is in use (see getCallbackUrlCandidates).
+ * The first state-matching request on the callback path settles the outcome;
+ * subsequent requests receive 410 Gone. Requests whose state does not match
+ * receive an error response without settling, so only the genuine redirect
+ * can complete or abort the flow. The response pages never echo the
  * authorization code.
  *
  * @example
@@ -220,17 +227,22 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
       res.end(html);
     };
 
+    // The state authenticates the redirect: the callback port is predictable,
+    // so anything local can reach it, and the authorization server echoes the
+    // state on both success and error redirects (RFC 6749 §4.1.2). Requests
+    // without the expected state are not this flow's redirect and must not
+    // settle the one-shot outcome.
+    const state = url.searchParams.get('state');
+    if (state !== options.state) {
+      respond(400, ERROR_HTML);
+      return;
+    }
+
     const error = url.searchParams.get('error');
     if (error) {
       const description = url.searchParams.get('error_description');
       respond(400, ERROR_HTML);
       settle({ error: new Error(`Authorization failed: ${error}${description ? ` (${description})` : ''}`) });
-      return;
-    }
-
-    if (url.searchParams.get('state') !== options.state) {
-      respond(400, ERROR_HTML);
-      settle({ error: new Error('Authorization failed: state mismatch') });
       return;
     }
 
@@ -242,12 +254,17 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
     }
 
     respond(200, SUCCESS_HTML);
-    settle({ result: { code, state: options.state } });
+    settle({ result: { code, state } });
   });
+
+  // Bind the hostname the redirect URL names (brackets stripped for IPv6
+  // literals) so e.g. http://localhost or http://[::1] redirects actually
+  // reach the server rather than an unbound 127.0.0.1 socket.
+  const hostname = candidates[0]!.hostname.replace(/^\[|\]$/g, '');
 
   let boundUrl: URL | undefined;
   for (const candidate of candidates) {
-    const error = await listen(server, Number(candidate.port));
+    const error = await listen(server, Number(candidate.port), hostname);
     if (!error) {
       boundUrl = candidate;
       break;

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -264,14 +264,19 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
   const hostname = candidates[0]!.hostname.replace(/^\[|\]$/g, '');
 
   let boundUrl: URL | undefined;
+  let boundPort: number | undefined;
   for (const candidate of candidates) {
-    const error = await listen(server, Number(candidate.port), hostname);
+    const candidatePort = Number(candidate.port);
+    const error = await listen(server, candidatePort, hostname);
     if (!error) {
       boundUrl = candidate;
+      // Preserve the port we actually listened on. Reading URL.port back would
+      // return '' for the default 80/443, losing the effective port.
+      boundPort = candidatePort;
       break;
     }
   }
-  if (!boundUrl) {
+  if (!boundUrl || boundPort === undefined) {
     const firstPort = Number(candidates[0]!.port);
     const lastPort = Number(candidates[candidates.length - 1]!.port);
     throw new Error(`Failed to start OAuth callback server: ports ${firstPort}-${lastPort} are all in use`);
@@ -279,7 +284,7 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
 
   return {
     url: boundUrl,
-    port: Number(boundUrl.port),
+    port: boundPort,
 
     waitForCode({ timeoutMs = DEFAULT_CALLBACK_TIMEOUT_MS } = {}) {
       let timer: NodeJS.Timeout | undefined;

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -1,0 +1,285 @@
+/**
+ * Loopback OAuth Callback Server for MCP Client
+ *
+ * Provides a one-shot local HTTP server that captures the OAuth authorization
+ * code delivered to a loopback redirect URL (RFC 8252). Hosts use it together
+ * with MCPOAuthClientProvider to complete the authorization-code flow for
+ * OAuth-protected MCP servers.
+ *
+ * @see https://modelcontextprotocol.io/specification/2025-06-18/basic/authorization
+ */
+
+import { createServer } from 'node:http';
+import type { Server as HttpServer } from 'node:http';
+
+/**
+ * How many sequential ports to try after the preferred port when it is in use.
+ */
+const CALLBACK_PORT_FALLBACK_RANGE = 10;
+
+/**
+ * Default time to wait for the browser to deliver the authorization code.
+ */
+const DEFAULT_CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+
+const SUCCESS_HTML = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>Authentication complete</title></head>
+  <body style="font-family: system-ui, sans-serif; text-align: center; padding-top: 4rem;">
+    <h1>Authentication complete</h1>
+    <p>You can close this tab and return to your application.</p>
+  </body>
+</html>`;
+
+const ERROR_HTML = `<!DOCTYPE html>
+<html>
+  <head><meta charset="utf-8"><title>Authentication failed</title></head>
+  <body style="font-family: system-ui, sans-serif; text-align: center; padding-top: 4rem;">
+    <h1>Authentication failed</h1>
+    <p>You can close this tab and retry from your application.</p>
+  </body>
+</html>`;
+
+/**
+ * Options for creating an OAuth callback server.
+ */
+export interface OAuthCallbackServerOptions {
+  /**
+   * The redirect URL the authorization server will send the browser back to.
+   * Its port is the preferred port to bind; if that port is in use, the next
+   * sequential ports are tried (see getCallbackUrlCandidates).
+   *
+   * @example 'http://127.0.0.1:5533/oauth/callback'
+   */
+  redirectUrl: string | URL;
+
+  /**
+   * The OAuth state parameter issued for this authorization request.
+   * Callback requests with a different state are rejected (CSRF protection
+   * per OAuth 2.1).
+   */
+  state: string;
+}
+
+/**
+ * The authorization code captured from the OAuth callback.
+ */
+export interface OAuthCallbackResult {
+  /**
+   * The authorization code to exchange for tokens.
+   */
+  code: string;
+
+  /**
+   * The state parameter echoed back by the authorization server.
+   */
+  state: string;
+}
+
+/**
+ * A running loopback OAuth callback server.
+ */
+export interface OAuthCallbackServer {
+  /**
+   * The callback URL that is actually bound (reflects any port fallback).
+   * Use this — not the preferred redirect URL — as the redirect_uri for the
+   * authorization request.
+   */
+  url: URL;
+
+  /**
+   * The port the server is listening on.
+   */
+  port: number;
+
+  /**
+   * Waits for the browser to deliver the authorization code.
+   *
+   * Resolves once with the code and state from the first callback request.
+   * Rejects on timeout, on an OAuth error response (`error` /
+   * `error_description` query params), on a state mismatch, or when the
+   * server is closed before a code arrives.
+   */
+  waitForCode(options?: { timeoutMs?: number }): Promise<OAuthCallbackResult>;
+
+  /**
+   * Stops the server and releases the port. Rejects any pending waitForCode.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Returns the candidate callback URLs for a redirect URL: the URL itself on
+ * its preferred port, followed by the sequential fallback-port variants that
+ * createOAuthCallbackServer will try when the preferred port is in use.
+ *
+ * This is the single source of the candidate list: register all of these as
+ * redirect_uris during dynamic client registration so a fallback-bound
+ * callback URL always matches a registered URI.
+ */
+export function getCallbackUrlCandidates(redirectUrl: string | URL): URL[] {
+  const base = new URL(redirectUrl.toString());
+  const preferredPort = base.port ? Number(base.port) : base.protocol === 'https:' ? 443 : 80;
+
+  const candidates: URL[] = [];
+  for (let offset = 0; offset <= CALLBACK_PORT_FALLBACK_RANGE; offset++) {
+    const candidate = new URL(base.toString());
+    candidate.port = String(preferredPort + offset);
+    candidates.push(candidate);
+  }
+  return candidates;
+}
+
+function listen(server: HttpServer, port: number): Promise<NodeJS.ErrnoException | null> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: NodeJS.ErrnoException) => {
+      server.off('listening', onListening);
+      if (error.code === 'EADDRINUSE') {
+        resolve(error);
+      } else {
+        reject(error);
+      }
+    };
+    const onListening = () => {
+      server.off('error', onError);
+      resolve(null);
+    };
+
+    server.once('error', onError);
+    server.once('listening', onListening);
+    server.listen(port, '127.0.0.1');
+  });
+}
+
+/**
+ * Starts a one-shot loopback HTTP server that captures the OAuth
+ * authorization code.
+ *
+ * The server binds 127.0.0.1 on the redirect URL's port, falling back to the
+ * next sequential ports when it is in use (see getCallbackUrlCandidates).
+ * The first request on the callback path settles the outcome; subsequent
+ * requests receive 410 Gone. The response pages never echo the
+ * authorization code.
+ *
+ * @example
+ * ```typescript
+ * const callbackServer = await createOAuthCallbackServer({
+ *   redirectUrl: 'http://127.0.0.1:5533/oauth/callback',
+ *   state: expectedState,
+ * });
+ * try {
+ *   // Direct the user to the authorization URL, then:
+ *   const { code } = await callbackServer.waitForCode();
+ *   await transport.finishAuth(code);
+ * } finally {
+ *   await callbackServer.close();
+ * }
+ * ```
+ */
+export async function createOAuthCallbackServer(options: OAuthCallbackServerOptions): Promise<OAuthCallbackServer> {
+  const candidates = getCallbackUrlCandidates(options.redirectUrl);
+  const callbackPath = candidates[0]!.pathname;
+
+  let settled = false;
+  let resolveCode: (result: OAuthCallbackResult) => void;
+  let rejectCode: (error: Error) => void;
+  const codePromise = new Promise<OAuthCallbackResult>((resolve, reject) => {
+    resolveCode = resolve;
+    rejectCode = reject;
+  });
+  // The rejection is consumed by waitForCode; this guard keeps an unconsumed
+  // rejection (e.g. close() before waitForCode) from surfacing as unhandled.
+  codePromise.catch(() => {});
+
+  const settle = (outcome: { result: OAuthCallbackResult } | { error: Error }) => {
+    if (settled) return;
+    settled = true;
+    if ('result' in outcome) {
+      resolveCode(outcome.result);
+    } else {
+      rejectCode(outcome.error);
+    }
+  };
+
+  const server = createServer((req, res) => {
+    const url = new URL(req.url ?? '', 'http://localhost');
+    if (url.pathname !== callbackPath) {
+      res.statusCode = 404;
+      res.end('Not found');
+      return;
+    }
+    if (settled) {
+      res.statusCode = 410;
+      res.end('Callback already handled');
+      return;
+    }
+
+    const respond = (statusCode: number, html: string) => {
+      res.statusCode = statusCode;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.end(html);
+    };
+
+    const error = url.searchParams.get('error');
+    if (error) {
+      const description = url.searchParams.get('error_description');
+      respond(400, ERROR_HTML);
+      settle({ error: new Error(`Authorization failed: ${error}${description ? ` (${description})` : ''}`) });
+      return;
+    }
+
+    if (url.searchParams.get('state') !== options.state) {
+      respond(400, ERROR_HTML);
+      settle({ error: new Error('Authorization failed: state mismatch') });
+      return;
+    }
+
+    const code = url.searchParams.get('code');
+    if (!code) {
+      respond(400, ERROR_HTML);
+      settle({ error: new Error('Authorization failed: missing authorization code') });
+      return;
+    }
+
+    respond(200, SUCCESS_HTML);
+    settle({ result: { code, state: options.state } });
+  });
+
+  let boundUrl: URL | undefined;
+  for (const candidate of candidates) {
+    const error = await listen(server, Number(candidate.port));
+    if (!error) {
+      boundUrl = candidate;
+      break;
+    }
+  }
+  if (!boundUrl) {
+    const firstPort = Number(candidates[0]!.port);
+    const lastPort = Number(candidates[candidates.length - 1]!.port);
+    throw new Error(`Failed to start OAuth callback server: ports ${firstPort}-${lastPort} are all in use`);
+  }
+
+  return {
+    url: boundUrl,
+    port: Number(boundUrl.port),
+
+    waitForCode({ timeoutMs = DEFAULT_CALLBACK_TIMEOUT_MS } = {}) {
+      let timer: NodeJS.Timeout | undefined;
+      const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out waiting for OAuth callback after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+        timer.unref?.();
+      });
+      return Promise.race([codePromise, timeout]).finally(() => clearTimeout(timer));
+    },
+
+    close() {
+      settle({ error: new Error('OAuth callback server closed before receiving an authorization code') });
+      return new Promise<void>((resolve, reject) => {
+        server.close(error => (error ? reject(error) : resolve()));
+      });
+    },
+  };
+}

--- a/packages/mcp/src/client/oauth-callback-server.ts
+++ b/packages/mcp/src/client/oauth-callback-server.ts
@@ -109,6 +109,7 @@ export interface OAuthCallbackServer {
 
   /**
    * Stops the server and releases the port. Rejects any pending waitForCode.
+   * Idempotent: closing an already-closed server resolves immediately.
    */
   close(): Promise<void>;
 }
@@ -295,7 +296,15 @@ export async function createOAuthCallbackServer(options: OAuthCallbackServerOpti
     close() {
       settle({ error: new Error('OAuth callback server closed before receiving an authorization code') });
       return new Promise<void>((resolve, reject) => {
-        server.close(error => (error ? reject(error) : resolve()));
+        server.close(error => {
+          // Closing twice is fine (e.g. an explicit cancel followed by the
+          // flow's own cleanup); only real errors propagate.
+          if (error && (error as NodeJS.ErrnoException).code !== 'ERR_SERVER_NOT_RUNNING') {
+            reject(error);
+          } else {
+            resolve();
+          }
+        });
       });
     },
   };

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -426,12 +426,10 @@ describe('MCPClient OAuth authorization flow', () => {
     const secondMcpServer = await startProtectedMcpServer(ports.secondMcpPort, authServer);
     cleanups.push(() => secondMcpServer.close());
 
-    const firstMcp = track(
-      createClient(mcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
-    );
-    const secondMcp = track(
-      createClient(secondMcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
-    );
+    const firstProvider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const secondProvider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const firstMcp = track(createClient(mcpServer.url, firstProvider));
+    const secondMcp = track(createClient(secondMcpServer.url, secondProvider));
 
     await Promise.all([firstMcp.authenticate('fixture'), secondMcp.authenticate('fixture')]);
 
@@ -441,6 +439,10 @@ describe('MCPClient OAuth authorization flow', () => {
     // bound two different ports.
     const boundPorts = authServer.authorizeRedirectUris.map(uri => new URL(uri).port);
     expect(new Set(boundPorts).size).toBe(2);
+    // Fallback binding must not drift the providers' preferred redirect URL:
+    // the next flow starts from the preferred port again.
+    expect(firstProvider.redirectUrl.toString()).toBe(callbackUrl);
+    expect(secondProvider.redirectUrl.toString()).toBe(callbackUrl);
   });
 
   it('returns to needs-auth when the user denies authorization', async () => {

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -529,6 +529,29 @@ describe('MCPClient OAuth authorization flow', () => {
     expect(mcp.getServerAuthState('fixture')).toBe('authorized');
   });
 
+  it('disconnect cancels a pending flow: the callback port is released and the flow settles', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    let authorizationReached: (() => void) | undefined;
+    const reachedAuthorization = new Promise<void>(resolve => {
+      authorizationReached = resolve;
+    });
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: () => {
+        authorizationReached?.();
+      },
+    });
+    const mcp = createClient(mcpServer.url, provider);
+
+    const flow = mcp.authenticate('fixture');
+    await reachedAuthorization;
+
+    // Disconnecting mid-flow must close the callback server and settle the
+    // pending authentication rather than leaving a bound port or a live promise.
+    await mcp.disconnect();
+    await expect(flow).rejects.toThrow(/closed before receiving an authorization code/);
+  });
+
   it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
     const mcp = track(
       new MCPClient({

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -552,6 +552,83 @@ describe('MCPClient OAuth authorization flow', () => {
     await expect(flow).rejects.toThrow(/closed before receiving an authorization code/);
   });
 
+  it('cancels a flow still in its setup phase before the callback server binds', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+
+    // Gate beginAuthorizationSession so the flow parks in setup — before the
+    // callback server is created and stored — which is the window CodeRabbit
+    // flagged as a deadlock/missed-cancellation risk.
+    let reachSetup: (() => void) | undefined;
+    const inSetup = new Promise<void>(resolve => {
+      reachSetup = resolve;
+    });
+    let releaseSetup: (() => void) | undefined;
+    const setupGate = new Promise<void>(resolve => {
+      releaseSetup = resolve;
+    });
+    const originalBegin = provider.beginAuthorizationSession.bind(provider);
+    provider.beginAuthorizationSession = async () => {
+      reachSetup?.();
+      await setupGate;
+      return originalBegin();
+    };
+
+    const mcp = track(createClient(mcpServer.url, provider));
+    const flow = mcp.authenticate('fixture');
+    await inSetup;
+
+    // Cancel while still in setup: no callback server exists yet, but abort must
+    // be recorded so that once setup unblocks the flow bails at the signal check
+    // instead of proceeding to park on waitForCode.
+    const cancelPromise = mcp.cancelAuthentication('fixture');
+    releaseSetup?.();
+    const cancelled = await Promise.race([
+      cancelPromise.then(() => 'cancelled' as const),
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 2_000)),
+    ]);
+    expect(cancelled).toBe('cancelled');
+    await expect(flow).rejects.toThrow(/cancelled/);
+    // Cancellation during setup happens before the 401 handshake runs, so the
+    // auth state was never advanced — the only guarantee is it is not authorized.
+    expect(mcp.getServerAuthState('fixture')).not.toBe('authorized');
+  });
+
+  it('disconnect does not deadlock on a flow still in its setup phase', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+
+    let reachSetup: (() => void) | undefined;
+    const inSetup = new Promise<void>(resolve => {
+      reachSetup = resolve;
+    });
+    let releaseSetup: (() => void) | undefined;
+    const setupGate = new Promise<void>(resolve => {
+      releaseSetup = resolve;
+    });
+    const originalBegin = provider.beginAuthorizationSession.bind(provider);
+    provider.beginAuthorizationSession = async () => {
+      reachSetup?.();
+      await setupGate;
+      return originalBegin();
+    };
+
+    const mcp = createClient(mcpServer.url, provider);
+    const flow = mcp.authenticate('fixture');
+    await inSetup;
+
+    // disconnect() aborts the setup-phase flow first, then awaits its settlement.
+    // Without the abort it would block forever on waitForCode.
+    const disconnectPromise = mcp.disconnect();
+    releaseSetup?.();
+    const disconnected = await Promise.race([
+      disconnectPromise.then(() => 'done' as const),
+      new Promise<'timeout'>(resolve => setTimeout(() => resolve('timeout'), 2_000)),
+    ]);
+    expect(disconnected).toBe('done');
+    await expect(flow).rejects.toThrow();
+  });
+
   it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
     const mcp = track(
       new MCPClient({
@@ -563,5 +640,16 @@ describe('MCPClient OAuth authorization flow', () => {
     );
 
     await expect(mcp.authenticate('fixture')).rejects.toThrow(/not configured with an MCPOAuthClientProvider/);
+  });
+
+  it('rejects a redirect URL whose hostname only looks like loopback', async () => {
+    const { mcpServer } = await setup();
+    // 127.evil.com is not a loopback address; a naive startsWith('127.') check
+    // would wrongly accept it and bind the callback server for an attacker host.
+    const provider = createProvider({ callbackUrl: 'http://127.evil.com:9999/oauth/callback' });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.authenticate('fixture')).rejects.toThrow(/loopback address/);
+    expect(mcp.getServerAuthState('fixture')).not.toBe('authorized');
   });
 });

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -465,6 +465,70 @@ describe('MCPClient OAuth authorization flow', () => {
     expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
   });
 
+  it('cancels a pending flow: the authenticate call rejects and the server returns to needs-auth', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    // The "browser" reaches the authorization URL but the redirect never comes
+    // back (the user closed the tab), so the flow is left waiting for the code.
+    let authorizationReached: (() => void) | undefined;
+    const reachedAuthorization = new Promise<void>(resolve => {
+      authorizationReached = resolve;
+    });
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: () => {
+        authorizationReached?.();
+      },
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    const flow = mcp.authenticate('fixture');
+    await reachedAuthorization;
+
+    const cancelled = await mcp.cancelAuthentication('fixture');
+    expect(cancelled).toBe(true);
+
+    await expect(flow).rejects.toThrow(/closed before receiving an authorization code/);
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+  });
+
+  it('cancelAuthentication returns false when no flow is pending', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.cancelAuthentication('fixture')).resolves.toBe(false);
+  });
+
+  it('can authenticate again after a cancelled flow', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    let authorizationReached: (() => void) | undefined;
+    const reachedAuthorization = new Promise<void>(resolve => {
+      authorizationReached = resolve;
+    });
+    // First attempt stalls at the authorization URL; the retry drives the
+    // browser through to completion.
+    let driveOnRedirect = false;
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: url => {
+        if (driveOnRedirect) {
+          return driveBrowser(url);
+        }
+        authorizationReached?.();
+      },
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    const stalledFlow = mcp.authenticate('fixture');
+    await reachedAuthorization;
+    await mcp.cancelAuthentication('fixture');
+    await expect(stalledFlow).rejects.toThrow(/closed before receiving an authorization code/);
+
+    driveOnRedirect = true;
+    await mcp.authenticate('fixture');
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+  });
+
   it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
     const mcp = track(
       new MCPClient({

--- a/packages/mcp/src/client/oauth-flow.test.ts
+++ b/packages/mcp/src/client/oauth-flow.test.ts
@@ -1,0 +1,478 @@
+import { createHash, randomUUID } from 'node:crypto';
+import { createServer } from 'node:http';
+import type { IncomingMessage, Server as HttpServer, ServerResponse } from 'node:http';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import { createOAuthMiddleware } from '../server/oauth-middleware.js';
+import type { OAuthMiddlewareResult } from '../server/oauth-middleware.js';
+import { MCPServer } from '../server/server.js';
+import { MCPClient } from './configuration.js';
+import { getCallbackUrlCandidates } from './oauth-callback-server.js';
+import { MCPOAuthClientProvider, InMemoryOAuthStorage } from './oauth-provider.js';
+
+// =============================================================================
+// Fake OAuth authorization server
+//
+// Implements just enough of OAuth 2.1 for the MCP SDK's client flow: RFC 8414
+// metadata discovery, RFC 7591 dynamic client registration, the authorization
+// code grant with PKCE (S256), and the refresh token grant. Tokens are opaque
+// random strings shared with the protected MCP server via `validTokens`.
+// =============================================================================
+
+interface ClientRegistration {
+  client_id: string;
+  redirect_uris: string[];
+}
+
+interface FakeAuthorizationServer {
+  url: string;
+  /** Every dynamic client registration received, in order. */
+  registrations: ClientRegistration[];
+  /** The redirect_uri of every authorization request received, in order. */
+  authorizeRedirectUris: string[];
+  /** How many refresh_token grants the token endpoint served. */
+  refreshGrantCount: number;
+  /** Access tokens currently accepted by the protected MCP server. */
+  validTokens: Set<string>;
+  /** When true, the authorization endpoint denies with error=access_denied. */
+  denyAuthorization: boolean;
+  close(): Promise<void>;
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => (body += chunk));
+    req.on('end', () => resolve(body));
+    req.on('error', reject);
+  });
+}
+
+function sendJson(res: ServerResponse, statusCode: number, payload: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(payload));
+}
+
+async function startFakeAuthorizationServer(port: number): Promise<FakeAuthorizationServer> {
+  const url = `http://127.0.0.1:${port}`;
+  const clientsById = new Map<string, ClientRegistration>();
+  const pendingCodes = new Map<string, { codeChallenge: string; redirectUri: string }>();
+  const refreshTokens = new Set<string>();
+
+  const state: FakeAuthorizationServer = {
+    url,
+    registrations: [],
+    authorizeRedirectUris: [],
+    refreshGrantCount: 0,
+    validTokens: new Set(),
+    denyAuthorization: false,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close(error => (error ? reject(error) : resolve()));
+      }),
+  };
+
+  const httpServer: HttpServer = createServer(async (req, res) => {
+    const requestUrl = new URL(req.url ?? '', url);
+
+    if (requestUrl.pathname === '/.well-known/oauth-authorization-server') {
+      sendJson(res, 200, {
+        issuer: url,
+        authorization_endpoint: `${url}/authorize`,
+        token_endpoint: `${url}/token`,
+        registration_endpoint: `${url}/register`,
+        response_types_supported: ['code'],
+        grant_types_supported: ['authorization_code', 'refresh_token'],
+        code_challenge_methods_supported: ['S256'],
+        token_endpoint_auth_methods_supported: ['none'],
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/register' && req.method === 'POST') {
+      const metadata = JSON.parse(await readBody(req));
+      const registration: ClientRegistration = {
+        client_id: `client-${randomUUID()}`,
+        redirect_uris: metadata.redirect_uris,
+      };
+      clientsById.set(registration.client_id, registration);
+      state.registrations.push(registration);
+      sendJson(res, 201, {
+        ...metadata,
+        client_id: registration.client_id,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        token_endpoint_auth_method: 'none',
+      });
+      return;
+    }
+
+    if (requestUrl.pathname === '/authorize') {
+      const clientId = requestUrl.searchParams.get('client_id') ?? '';
+      const redirectUri = requestUrl.searchParams.get('redirect_uri') ?? '';
+      const oauthState = requestUrl.searchParams.get('state') ?? '';
+      const codeChallenge = requestUrl.searchParams.get('code_challenge') ?? '';
+
+      const client = clientsById.get(clientId);
+      if (!client || !client.redirect_uris.includes(redirectUri)) {
+        sendJson(res, 400, { error: 'invalid_request', error_description: 'Unknown client or redirect_uri' });
+        return;
+      }
+
+      state.authorizeRedirectUris.push(redirectUri);
+      const location = new URL(redirectUri);
+      if (state.denyAuthorization) {
+        location.searchParams.set('error', 'access_denied');
+      } else {
+        const code = `code-${randomUUID()}`;
+        pendingCodes.set(code, { codeChallenge, redirectUri });
+        location.searchParams.set('code', code);
+      }
+      location.searchParams.set('state', oauthState);
+      res.writeHead(302, { Location: location.toString() });
+      res.end();
+      return;
+    }
+
+    if (requestUrl.pathname === '/token' && req.method === 'POST') {
+      const params = new URLSearchParams(await readBody(req));
+      const grantType = params.get('grant_type');
+
+      if (grantType === 'authorization_code') {
+        const pending = pendingCodes.get(params.get('code') ?? '');
+        const verifier = params.get('code_verifier') ?? '';
+        const challenge = createHash('sha256').update(verifier).digest('base64url');
+        if (!pending || pending.codeChallenge !== challenge) {
+          sendJson(res, 400, { error: 'invalid_grant' });
+          return;
+        }
+        pendingCodes.delete(params.get('code')!);
+      } else if (grantType === 'refresh_token') {
+        if (!refreshTokens.has(params.get('refresh_token') ?? '')) {
+          sendJson(res, 400, { error: 'invalid_grant' });
+          return;
+        }
+        state.refreshGrantCount += 1;
+      } else {
+        sendJson(res, 400, { error: 'unsupported_grant_type' });
+        return;
+      }
+
+      const accessToken = `access-${randomUUID()}`;
+      const refreshToken = `refresh-${randomUUID()}`;
+      state.validTokens.add(accessToken);
+      refreshTokens.add(refreshToken);
+      sendJson(res, 200, {
+        access_token: accessToken,
+        token_type: 'Bearer',
+        expires_in: 3600,
+        refresh_token: refreshToken,
+      });
+      return;
+    }
+
+    sendJson(res, 404, { error: 'not_found' });
+  });
+
+  await new Promise<void>(resolve => httpServer.listen(port, '127.0.0.1', resolve));
+  return state;
+}
+
+// =============================================================================
+// OAuth-protected MCP server (resource server)
+// =============================================================================
+
+async function startProtectedMcpServer(
+  port: number,
+  authServer: FakeAuthorizationServer,
+): Promise<{ url: string; close(): Promise<void> }> {
+  const url = `http://127.0.0.1:${port}`;
+
+  const mcpServer = new MCPServer({
+    id: `oauth-flow-test-server-${port}`,
+    name: 'OAuth Flow Test Server',
+    version: '1.0.0',
+    tools: {},
+  });
+
+  const oauthMiddleware = createOAuthMiddleware({
+    oauth: {
+      resource: `${url}/mcp`,
+      authorizationServers: [authServer.url],
+      validateToken: async token =>
+        authServer.validTokens.has(token)
+          ? { valid: true }
+          : { valid: false, error: 'invalid_token', errorDescription: 'Token not recognized' },
+    },
+    mcpPath: '/mcp',
+  });
+
+  const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+    const requestUrl = new URL(req.url ?? '', url);
+    const result: OAuthMiddlewareResult = await oauthMiddleware(req, res, requestUrl);
+    if (!result.proceed) {
+      return;
+    }
+    await mcpServer.startHTTP({ url: requestUrl, httpPath: '/mcp', req, res });
+  });
+
+  await new Promise<void>(resolve => httpServer.listen(port, '127.0.0.1', resolve));
+  return {
+    url,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close(error => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+// =============================================================================
+// Test harness
+// =============================================================================
+
+// Each test gets its own port block: reusing ports across tests would let
+// undici's keep-alive pool hand a later test a stale socket to a restarted server.
+let portCursor = 19100 + Math.floor(Math.random() * 2000);
+function allocatePortBlock(): { authPort: number; mcpPort: number; secondMcpPort: number; callbackUrl: string } {
+  const base = portCursor;
+  portCursor += 20;
+  return {
+    authPort: base,
+    mcpPort: base + 1,
+    secondMcpPort: base + 2,
+    callbackUrl: `http://127.0.0.1:${base + 3}/oauth/callback`,
+  };
+}
+
+/**
+ * Simulates the user's browser: follows the authorization URL to the fake
+ * authorization server and delivers its redirect to the loopback callback.
+ */
+async function driveBrowser(authorizationUrl: URL): Promise<void> {
+  const response = await fetch(authorizationUrl, { redirect: 'manual' });
+  const location = response.headers.get('location');
+  if (!location) {
+    throw new Error(`Authorization endpoint did not redirect (status ${response.status})`);
+  }
+  await fetch(location);
+}
+
+function createProvider(options: {
+  callbackUrl: string;
+  storage?: InMemoryOAuthStorage;
+  onRedirectToAuthorization?: (url: URL) => void | Promise<void>;
+}): MCPOAuthClientProvider {
+  return new MCPOAuthClientProvider({
+    redirectUrl: options.callbackUrl,
+    clientMetadata: {
+      redirect_uris: [options.callbackUrl],
+      client_name: 'OAuth Flow Test Client',
+      grant_types: ['authorization_code', 'refresh_token'],
+      response_types: ['code'],
+      token_endpoint_auth_method: 'none',
+    },
+    storage: options.storage,
+    onRedirectToAuthorization: options.onRedirectToAuthorization,
+  });
+}
+
+function createClient(serverUrl: string, provider: MCPOAuthClientProvider): MCPClient {
+  return new MCPClient({
+    id: `oauth-flow-test-${randomUUID()}`,
+    servers: {
+      fixture: {
+        url: new URL(`${serverUrl}/mcp`),
+        authProvider: provider,
+      },
+    },
+  });
+}
+
+describe('MCPClient OAuth authorization flow', () => {
+  const cleanups: Array<() => Promise<void>> = [];
+
+  const setup = async () => {
+    const ports = allocatePortBlock();
+    const authServer = await startFakeAuthorizationServer(ports.authPort);
+    const mcpServer = await startProtectedMcpServer(ports.mcpPort, authServer);
+    cleanups.push(() => mcpServer.close(), () => authServer.close());
+    return { authServer, mcpServer, ports, callbackUrl: ports.callbackUrl };
+  };
+
+  const track = (mcp: MCPClient) => {
+    cleanups.push(() => mcp.disconnect());
+    return mcp;
+  };
+
+  afterEach(async () => {
+    while (cleanups.length) {
+      await cleanups.pop()!().catch(() => {});
+    }
+  });
+
+  it('marks the server as needs-auth when the connection is rejected with a 401', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const authorizationUrls: URL[] = [];
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: url => void authorizationUrls.push(url) });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.reconnectServer('fixture')).rejects.toThrow();
+
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+    // The SDK delivered the authorization URL through the provider.
+    expect(authorizationUrls).toHaveLength(1);
+  });
+
+  it('authenticates end to end: registration, consent, code exchange, connect', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    const storage = new InMemoryOAuthStorage();
+    const provider = createProvider({ callbackUrl, storage, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await mcp.authenticate('fixture');
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    await expect(mcp.listTools()).resolves.toBeDefined();
+
+    // Dynamic client registration registered every callback-port candidate,
+    // so a future fallback-bound port still matches a registered URI.
+    expect(authServer.registrations).toHaveLength(1);
+    expect(authServer.registrations[0]!.redirect_uris).toEqual(
+      getCallbackUrlCandidates(callbackUrl).map(candidate => candidate.toString()),
+    );
+
+    // Tokens were persisted through the provider's storage.
+    const tokens = await provider.tokens();
+    expect(tokens?.access_token).toBeDefined();
+    expect(authServer.validTokens.has(tokens!.access_token)).toBe(true);
+  });
+
+  it('reconnects with persisted tokens without a new browser flow', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    const storage = new InMemoryOAuthStorage();
+    const provider = createProvider({ callbackUrl, storage, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+    await mcp.authenticate('fixture');
+    await mcp.disconnect();
+
+    // A fresh client sharing the same storage must connect silently.
+    const silentProvider = createProvider({
+      callbackUrl,
+      storage,
+      onRedirectToAuthorization: () => {
+        throw new Error('Browser flow must not run when stored tokens are valid');
+      },
+    });
+    const secondMcp = track(createClient(mcpServer.url, silentProvider));
+
+    await secondMcp.reconnectServer('fixture');
+    expect(secondMcp.getServerAuthState('fixture')).toBe('authorized');
+  });
+
+  it('refreshes an invalidated access token without a new browser flow', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    let browserRuns = 0;
+    const provider = createProvider({
+      callbackUrl,
+      onRedirectToAuthorization: url => {
+        browserRuns += 1;
+        return driveBrowser(url);
+      },
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+    await mcp.authenticate('fixture');
+
+    // Invalidate the access token server-side; the refresh token stays valid.
+    const tokens = await provider.tokens();
+    authServer.validTokens.delete(tokens!.access_token);
+
+    await mcp.reconnectServer('fixture');
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(authServer.refreshGrantCount).toBe(1);
+    expect(browserRuns).toBe(1);
+  });
+
+  it('re-registers when the stored client registration does not cover the callback URL', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    // Simulate a registration from an older configuration whose redirect_uris
+    // no longer include the callback URL.
+    await provider.saveClientInformation({
+      client_id: 'stale-client',
+      redirect_uris: ['http://127.0.0.1:9999/oauth/callback'],
+    });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await mcp.authenticate('fixture');
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(authServer.registrations).toHaveLength(1);
+    expect(authServer.registrations[0]!.client_id).not.toBe('stale-client');
+  });
+
+  it('joins concurrent authenticate calls for the same server into one flow', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await Promise.all([mcp.authenticate('fixture'), mcp.authenticate('fixture')]);
+
+    expect(mcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(authServer.authorizeRedirectUris).toHaveLength(1);
+  });
+
+  it('authenticates different servers concurrently, falling back to a free callback port', async () => {
+    const { authServer, mcpServer, ports, callbackUrl } = await setup();
+    const secondMcpServer = await startProtectedMcpServer(ports.secondMcpPort, authServer);
+    cleanups.push(() => secondMcpServer.close());
+
+    const firstMcp = track(
+      createClient(mcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
+    );
+    const secondMcp = track(
+      createClient(secondMcpServer.url, createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser })),
+    );
+
+    await Promise.all([firstMcp.authenticate('fixture'), secondMcp.authenticate('fixture')]);
+
+    expect(firstMcp.getServerAuthState('fixture')).toBe('authorized');
+    expect(secondMcp.getServerAuthState('fixture')).toBe('authorized');
+    // Both providers prefer the same callback port, so the flows must have
+    // bound two different ports.
+    const boundPorts = authServer.authorizeRedirectUris.map(uri => new URL(uri).port);
+    expect(new Set(boundPorts).size).toBe(2);
+  });
+
+  it('returns to needs-auth when the user denies authorization', async () => {
+    const { authServer, mcpServer, callbackUrl } = await setup();
+    authServer.denyAuthorization = true;
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: driveBrowser });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.authenticate('fixture')).rejects.toThrow(/access_denied/);
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+  });
+
+  it('returns to needs-auth when the browser never delivers a code', async () => {
+    const { mcpServer, callbackUrl } = await setup();
+    // The "browser" never visits the authorization URL.
+    const provider = createProvider({ callbackUrl, onRedirectToAuthorization: () => {} });
+    const mcp = track(createClient(mcpServer.url, provider));
+
+    await expect(mcp.authenticate('fixture', { timeoutMs: 300 })).rejects.toThrow(/Timed out/);
+    expect(mcp.getServerAuthState('fixture')).toBe('needs-auth');
+  });
+
+  it('rejects authenticate for servers without an MCPOAuthClientProvider', async () => {
+    const mcp = track(
+      new MCPClient({
+        id: `oauth-flow-test-${randomUUID()}`,
+        servers: {
+          fixture: { url: new URL('http://127.0.0.1:1/mcp') },
+        },
+      }),
+    );
+
+    await expect(mcp.authenticate('fixture')).rejects.toThrow(/not configured with an MCPOAuthClientProvider/);
+  });
+});

--- a/packages/mcp/src/client/oauth-provider.ts
+++ b/packages/mcp/src/client/oauth-provider.ts
@@ -163,6 +163,7 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
 
   private _clientInfo?: OAuthClientInformation;
   private _sessionState?: string;
+  private _sessionRedirectUrl?: string | URL;
 
   constructor(options: MCPOAuthClientProviderOptions) {
     this._redirectUrl = options.redirectUrl;
@@ -209,14 +210,22 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
    */
   async beginAuthorizationSession(): Promise<string> {
     this._sessionState = await this.generateState();
+    this._sessionRedirectUrl = this._redirectUrl;
     return this._sessionState;
   }
 
   /**
-   * Clears the pinned authorization state (see beginAuthorizationSession).
+   * Clears the pinned authorization state (see beginAuthorizationSession) and
+   * restores the configured redirect URL if applyResolvedRedirectUrl rebased
+   * it to a fallback port during the session, so the next flow starts from
+   * the preferred port again.
    */
   endAuthorizationSession(): void {
     this._sessionState = undefined;
+    if (this._sessionRedirectUrl !== undefined) {
+      this._redirectUrl = this._sessionRedirectUrl;
+      this._sessionRedirectUrl = undefined;
+    }
   }
 
   /**

--- a/packages/mcp/src/client/oauth-provider.ts
+++ b/packages/mcp/src/client/oauth-provider.ts
@@ -155,13 +155,14 @@ export interface MCPOAuthClientProviderOptions {
  * ```
  */
 export class MCPOAuthClientProvider implements OAuthClientProvider {
-  private readonly _redirectUrl: string | URL;
-  private readonly _clientMetadata: OAuthClientMetadata;
+  private _redirectUrl: string | URL;
+  private _clientMetadata: OAuthClientMetadata;
   private readonly storage: OAuthStorage;
   private readonly onRedirect?: (url: URL) => void | Promise<void>;
   private readonly generateState: () => string | Promise<string>;
 
   private _clientInfo?: OAuthClientInformation;
+  private _sessionState?: string;
 
   constructor(options: MCPOAuthClientProviderOptions) {
     this._redirectUrl = options.redirectUrl;
@@ -188,9 +189,54 @@ export class MCPOAuthClientProvider implements OAuthClientProvider {
 
   /**
    * Returns a OAuth2 state parameter.
+   *
+   * While an authorization session is active (see beginAuthorizationSession),
+   * the pinned session state is returned so a callback server can validate
+   * the redirect against a known value.
    */
   async state(): Promise<string> {
-    return this.generateState();
+    return this._sessionState ?? this.generateState();
+  }
+
+  /**
+   * Pins the OAuth state parameter for the next authorization request.
+   *
+   * Hosts driving an interactive authorization flow (e.g. MCPClient.authenticate)
+   * call this before triggering the flow so the loopback callback server knows
+   * which state value to expect. Call endAuthorizationSession once the flow settles.
+   *
+   * @returns The pinned state value, generated with the configured stateGenerator
+   */
+  async beginAuthorizationSession(): Promise<string> {
+    this._sessionState = await this.generateState();
+    return this._sessionState;
+  }
+
+  /**
+   * Clears the pinned authorization state (see beginAuthorizationSession).
+   */
+  endAuthorizationSession(): void {
+    this._sessionState = undefined;
+  }
+
+  /**
+   * Points the provider at the callback URL that is actually bound.
+   *
+   * Loopback callback servers may bind a fallback port when the preferred one
+   * is in use. Call this before triggering authorization so the authorization
+   * request's redirect_uri matches the listening server, and so dynamic client
+   * registration registers every candidate callback URL (see
+   * getCallbackUrlCandidates) rather than only the preferred one.
+   *
+   * @param redirectUrl - The callback URL that is actually bound
+   * @param registeredRedirectUris - The redirect URIs to register during dynamic client registration
+   */
+  applyResolvedRedirectUrl(redirectUrl: string | URL, registeredRedirectUris: (string | URL)[]): void {
+    this._redirectUrl = redirectUrl;
+    this._clientMetadata = {
+      ...this._clientMetadata,
+      redirect_uris: registeredRedirectUris.map(uri => uri.toString()),
+    };
   }
 
   /**


### PR DESCRIPTION
> **Stacked on #19458.** This PR is based on `main` for tooling reasons (the base branch lives on a fork), so its diff currently includes the `@mastra/mcp` authorization-code loop from #19458. **Review/merge #19458 first**; once it lands, this diff reduces to just the Mastra Code SDK/TUI surface described below.

## Demo

Video walkthrough of the feature (needs-auth badge → Authenticate → browser consent → reconnect, plus Cancel) in the Mastra Discord: https://discord.com/channels/1309558646228779139/1309558648476930100/1526738697528148100

_(Link opens for Mastra Discord members.)_


## What this ships

Browser-based OAuth authentication for HTTP MCP servers in **Mastra Code**. When an HTTP MCP server rejects a connection because authorization is required, the `/mcp` selector now shows a **needs auth** badge and an **Authenticate** action. Choosing it opens the provider's consent page in the browser, completes the OAuth 2.1 authorization-code flow (PKCE + Dynamic Client Registration) over a loopback callback server, persists the tokens, and reconnects — with **zero configuration** required for a bare `{ "url": ... }` server entry. An in-flight flow can be abandoned with a **Cancel authentication** action.

This is the Mastra Code SDK/TUI surface built on top of the `@mastra/mcp` authorization-code loop in #19458, which this PR is stacked on.

## Changes

**`@mastra/code-sdk` (server manager)**
- `authenticateServer(name)` — runs the interactive OAuth flow for an HTTP server, lazily provisioning an OAuth provider (default loopback redirect URL) for a bare `url` entry on first authentication via DCR.
- `cancelServerAuthentication(name)` — aborts a pending flow and returns the server to the needs-auth state.
- `McpServerStatus.needsAuth` — new optional flag surfaced when a server is rejected with an authorization error.
- OAuth `redirectUrl` in MCP server config is now **optional**, defaulting to a stable loopback URL. Token storage stays at the existing `getAppDataDir()/mcp-oauth/` location.

**`mastracode` (TUI)**
- `/mcp` selector: needs-auth badge, **Authenticate** and **Cancel authentication** actions. While a flow runs, the row reads `authenticating — Enter to cancel` and the cancel action is pre-selected; Esc closes the sub-menu but leaves the flow running.
- Shared `openUrlInBrowser` helper (extracted from the login dialog) opens the consent page; `MASTRA_MCP_OAUTH_NO_BROWSER=1` prints the URL instead for headless use.

## Testing

- SDK: manager tests (98 passed, clean HOME) covering needs-auth detection, zero-config provisioning, fingerprint stability, and authenticate/cancel wiring.
- TUI e2e: `mcp-oauth-authenticate` and `mcp-oauth-cancel` scenarios (in-process OAuth fixture server with a hold gate for deterministic cancellation), plus the `mcp-selector-reconnect` regression — all passing.
- Live-verified end to end against real Supabase and Cloudflare MCP servers: 401 → needs-auth badge → Authenticate → browser consent → token exchange → reconnect → real tool calls.

## Notes

- No breaking changes: `redirectUrl` required→optional is a loosening; all other `@mastra/mcp` changes are additive; the `McpManager` interface additions have only an in-package implementer.
- Changeset: `minor` for `@mastra/code-sdk` and `mastracode`.

Closes #18175
Closes #13997




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Some MCP servers only work after you sign in. Mastra Code now notices when login is needed, shows you an **Authenticate** button on the **/mcp** screen, and finishes sign-in for HTTP servers using a browser + automatic token saving. You can also **Cancel authentication** if you want to stop.

## What changed
- Added browser-based **OAuth 2.1 authorization-code flow (PKCE + Dynamic Client Registration)** for **HTTP** MCP servers:
  - Uses a **local loopback callback server** (with fallback callback ports) to capture the authorization code
  - **Persists tokens** so reloading/restarting can reconnect automatically
  - Automatically reconnects the MCP server after successful authorization
- Replaced confusing/silent auth failures with actionable auth state:
  - Added `McpServerStatus.needsAuth` to represent “authorization required”
  - Added manager APIs:
    - `authenticateServer(name, ...)` to run the interactive auth flow
    - `cancelServerAuthentication(name)` to abort an in-flight flow and return to `needsAuth`
- Extended the MCP SDK client with interactive OAuth APIs:
  - `MCPClient.authenticate(serverName, options?)`
  - `MCPClient.getServerAuthState(serverName)` → `'needs-auth' | 'authorized' | undefined`
  - `MCPClient.cancelAuthentication(serverName)`
- Simplified OAuth configuration for “bare URL” servers:
  - `oauth.redirectUrl` is now **optional** and defaults to a stable loopback redirect (`DEFAULT_OAUTH_REDIRECT_URL`)
  - `{ "url": ... }` server configs can require no extra OAuth setup to participate
- Updated the TUI `/mcp` experience:
  - Shows **needs auth** (plus an **Authenticate** action) when authorization is required
  - Shows **authenticating** state with **Cancel authentication**
  - Opens consent URLs in a browser when allowed, and **always prints** the URL for headless/manual use
  - Supports headless URL output via `MASTRA_MCP_OAUTH_NO_BROWSER=1`
- Docs + tests:
  - Expanded MCP client documentation for the interactive OAuth flow and auth-state behavior
  - Added/updated unit, integration, and TUI e2e tests covering authentication, cancellation, reconnect, token storage behavior, and concurrency; included end-to-end fixtures for OAuth-protected MCP servers
<!-- end of auto-generated comment: release notes by coderabbit.ai -->