### PR TITLE
fix(mastracode): stop repeated upgrade prompts

### DIFF
--- a/.changeset/afraid-humans-hide.md
+++ b/.changeset/afraid-humans-hide.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed Mastra Code repeatedly prompting users to install the version they already have.

--- a/e2e-tests/pkg-outputs/mastracode-version.test.ts
+++ b/e2e-tests/pkg-outputs/mastracode-version.test.ts
@@ -1,0 +1,15 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+import { expect, it } from 'vitest';
+
+it('embeds the Mastra Code package version in the installed CLI', async () => {
+  const packageDir = resolve(__dirname, '..', '..', 'mastracode', 'tui');
+  const pkg = JSON.parse(await readFile(resolve(packageDir, 'package.json'), 'utf8')) as { version: string };
+  const cli = await readFile(resolve(packageDir, 'dist', 'cli.js'), 'utf8');
+
+  expect(cli).toContain(JSON.stringify(pkg.version));
+  expect(cli).not.toMatch(
+    /import\s*\{[^}]*\bgetCurrentVersion\b[^}]*\}\s*from\s*['"]@mastra\/code-sdk\/utils\/update-check['"]/,
+  );
+});

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -13,10 +13,10 @@ import { formatScaffoldSuccess, scaffoldPlugin } from '@mastra/code-sdk/plugins/
 import { setupDebugLogging } from '@mastra/code-sdk/utils/debug-log';
 import { drainPipedStdin, reopenStdinFromTTY } from '@mastra/code-sdk/utils/stdin-pipe';
 import { releaseAllThreadLocks } from '@mastra/code-sdk/utils/thread-lock';
-import { getCurrentVersion } from '@mastra/code-sdk/utils/update-check';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
+import { getCurrentVersion } from './version.js';
 
 let controller: Awaited<ReturnType<typeof createMastraCode>>['controller'];
 let mcpManager: Awaited<ReturnType<typeof createMastraCode>>['mcpManager'];

--- a/mastracode/tui/src/version.test.ts
+++ b/mastracode/tui/src/version.test.ts
@@ -1,0 +1,10 @@
+import { readFile } from 'node:fs/promises';
+import { expect, it } from 'vitest';
+
+import { getCurrentVersion } from './version.js';
+
+it('reads the Mastra Code package version when running from source', async () => {
+  const pkg = JSON.parse(await readFile(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+
+  expect(getCurrentVersion()).toBe(pkg.version);
+});

--- a/mastracode/tui/src/version.ts
+++ b/mastracode/tui/src/version.ts
@@ -1,0 +1,12 @@
+import { readFileSync } from 'node:fs';
+
+declare const MASTRACODE_VERSION: string | undefined;
+
+export function getCurrentVersion(): string {
+  if (typeof MASTRACODE_VERSION !== 'undefined') {
+    return MASTRACODE_VERSION;
+  }
+
+  const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8')) as { version: string };
+  return pkg.version;
+}


### PR DESCRIPTION
Mastra Code 0.31.0 resolves its current version through `@mastra/code-sdk`, causing the installed CLI to report the SDK version (`0.1.0`) and repeatedly offer to install the version it already has. This moves application-version resolution into the TUI package and adds source and built-artifact regression coverage for the package boundary.

Before: an installed `mastracode@0.31.0` reports `current: v0.1.0`. After: the CLI embeds and reports the version from the `mastracode` package.

Tested with `pnpm build:mastracode`, the focused version unit and package-output tests, TUI typecheck and lint, Prettier, and the `update-startup-prompt` E2E scenario. The full `pnpm test:mastracode` run completed 993 tests successfully but remains non-green because of three failures in the unchanged `shell-output.test.ts` suite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra Code was forgetting its own version and repeatedly asking users to install it. This change makes it use the version of the app that is actually installed.

## What changed

- Added local TUI version resolution using the package version or embedded build-time version.
- Updated the CLI to use the TUI-owned version instead of `@mastra/code-sdk`.
- Added source and built-bundle regression tests to verify correct version embedding and package boundaries.
- Added a patch changeset for `mastracode`.

## Validation

- Mastra Code build and focused version/package-output tests passed.
- TUI typecheck, lint, Prettier, and `update-startup-prompt` E2E passed.
- Full test run: 993 tests passed; 3 existing `shell-output.test.ts` failures remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->