### PR TITLE
fix(github-signals): resolve gitcrawl db path across platforms

### DIFF
--- a/.changeset/blue-memes-share.md
+++ b/.changeset/blue-memes-share.md
@@ -1,0 +1,6 @@
+---
+'mastracode': patch
+'@mastra/github-signals': patch
+---
+
+Fixed GitHub PR subscription notifications never firing on macOS. The gitcrawl database location is now resolved by asking gitcrawl itself (with the macOS ~/Library/Application Support location as a fallback) instead of assuming the Linux ~/.config path. Snapshot read failures are no longer silently swallowed - they are recorded on the subscription so polling problems are visible.

--- a/.changeset/blue-memes-share.md
+++ b/.changeset/blue-memes-share.md
@@ -1,5 +1,4 @@
 ---
-'mastracode': patch
 '@mastra/github-signals': patch
 ---
 

--- a/.changeset/long-insects-wait.md
+++ b/.changeset/long-insects-wait.md
@@ -1,0 +1,6 @@
+---
+'mastracode': patch
+'@mastra/github-signals': patch
+---
+
+The /github debug command now shows snapshot read errors (snapshotError=...) for subscribed PRs, making silent gitcrawl database problems visible.

--- a/.changeset/long-insects-wait.md
+++ b/.changeset/long-insects-wait.md
@@ -1,6 +1,5 @@
 ---
 'mastracode': patch
-'@mastra/github-signals': patch
 ---
 
 The /github debug command now shows snapshot read errors (snapshotError=...) for subscribed PRs, making silent gitcrawl database problems visible.

--- a/mastracode/tui/src/tui/commands/github.ts
+++ b/mastracode/tui/src/tui/commands/github.ts
@@ -123,7 +123,7 @@ async function describeGithubSubscriptions(ctx: SlashCommandContext): Promise<st
     const notification = subscription.lastNotificationKind
       ? `lastNotification=${subscription.lastNotificationKind}/${subscription.lastNotificationPriority ?? 'unknown'} at ${notificationTime}: ${subscription.lastNotificationSummary ?? ''}`
       : 'lastNotification=none';
-    return `- ${pr} ${sync} ${poll}${subscription.lastSyncError ? ` error=${subscription.lastSyncError}` : ''}${observed.length ? ` (${observed.join(', ')})` : ''}\n  ${notification}`;
+    return `- ${pr} ${sync} ${poll}${subscription.lastSyncError ? ` error=${subscription.lastSyncError}` : ''}${subscription.lastSnapshotError ? ` snapshotError=${subscription.lastSnapshotError}` : ''}${observed.length ? ` (${observed.join(', ')})` : ''}\n  ${notification}`;
   });
   return [header, ...lines].join('\n');
 }

--- a/signals/github/src/index.test.ts
+++ b/signals/github/src/index.test.ts
@@ -999,6 +999,78 @@ describe('GithubSignals', () => {
     });
   });
 
+  it('surfaces snapshot read failures on the subscription and clears them after recovery', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-snapshot-error',
+      resourceId: 'resource-snapshot-error',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {
+        mastra: {
+          [GITHUB_SIGNALS_METADATA_KEY]: {
+            subscriptions: [
+              {
+                owner: 'mastra-ai',
+                repo: 'mastra',
+                number: 123,
+                subscribedAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+                lastSubscribeSignalId: 'signal-1',
+              },
+            ],
+          },
+        },
+      },
+    };
+    const threadStore = createThreadStore(thread);
+    let snapshotCalls = 0;
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true })),
+      getPullRequestSnapshot: vi.fn(async () => {
+        snapshotCalls += 1;
+        if (snapshotCalls === 1) {
+          throw new Error('gitcrawl database query failed (db: /missing/gitcrawl.db): unable to open database file');
+        }
+        return {
+          title: 'Add GitHub signals',
+          state: 'open',
+          githubUpdatedAt: '2026-01-01T00:05:00.000Z',
+          contentHash: 'recovered-hash',
+          latestCommentAuthor: 'contributor',
+        };
+      }),
+    };
+    const sendNotificationSignal = vi.fn(async () => ({ accepted: true }));
+    const permissionResolver = { getPermission: vi.fn(async () => 'write' as const) };
+    const processor = new GithubSignals({ threadStore, syncClient, permissionResolver });
+    processor.addAgent({ sendSignal: vi.fn(), sendNotificationSignal });
+
+    // First sync: the snapshot read fails, so the failure must be recorded on
+    // the subscription instead of silently reporting a healthy poll.
+    await expect(processor.syncThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+    expect(sendNotificationSignal).not.toHaveBeenCalled();
+    const failedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [failedSubscription] = (failedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(failedSubscription).toMatchObject({
+      lastSyncStatus: 'success',
+      lastSnapshotError: 'gitcrawl database query failed (db: /missing/gitcrawl.db): unable to open database file',
+    });
+    expect(failedSubscription.lastObservedContentHash).toBeUndefined();
+
+    // Second sync: the snapshot read recovers, the error clears, and the
+    // baseline observation notifies as usual.
+    await expect(processor.syncThreadNow({ threadId: thread.id, resourceId: thread.resourceId })).resolves.toBe(1);
+    expect(sendNotificationSignal).toHaveBeenCalledTimes(1);
+    const recoveredThread = vi.mocked(threadStore.saveThread).mock.calls[1]![0].thread;
+    const [recoveredSubscription] = (recoveredThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY]
+      .subscriptions;
+    expect(recoveredSubscription.lastSnapshotError).toBeUndefined();
+    expect(recoveredSubscription).toMatchObject({
+      lastSyncStatus: 'success',
+      lastObservedContentHash: 'recovered-hash',
+    });
+  });
+
   it('expires cached author permissions and reloads them after the TTL', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'));

--- a/signals/github/src/index.test.ts
+++ b/signals/github/src/index.test.ts
@@ -627,6 +627,60 @@ describe('GithubSignals', () => {
     );
   });
 
+  it('still subscribes when the baseline snapshot read fails and records the error', async () => {
+    const thread: StorageThreadType = {
+      id: 'thread-subscribe-snapshot-error',
+      resourceId: 'resource-subscribe-snapshot-error',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+      metadata: {},
+    };
+    const threadStore = createThreadStore(thread);
+    const syncClient: GithubSignalsSyncClient = {
+      syncPullRequest: vi.fn(async () => ({ ok: true, stdout: '{"ok":true}' })),
+      getPullRequestSnapshot: vi.fn(async () => {
+        throw new Error('gitcrawl database query failed (db: /missing/gitcrawl.db): unable to open database file');
+      }),
+    };
+    const signal = createSignal({
+      ...GithubSignals.signals.subscribeToPR({ owner: 'mastra-ai', repo: 'mastra', number: 123 }),
+      type: 'reactive',
+    });
+    const messageList = new MessageList({ threadId: thread.id, resourceId: thread.resourceId });
+    messageList.add([signal.toDBMessage({ threadId: thread.id, resourceId: thread.resourceId })], 'input');
+    const chunks: unknown[] = [];
+
+    // The subscribe itself must not fail when only the snapshot read fails.
+    await runGithubSignalsProcessor({
+      processor: new GithubSignals({ threadStore, syncClient }),
+      messageList,
+      requestContext: createRequestContext(thread),
+      chunks,
+    });
+
+    expect(threadStore.saveThread).toHaveBeenCalledTimes(1);
+    const savedThread = vi.mocked(threadStore.saveThread).mock.calls[0]![0].thread;
+    const [subscription] = (savedThread.metadata?.mastra as any)[GITHUB_SIGNALS_METADATA_KEY].subscriptions;
+    expect(subscription).toMatchObject({
+      owner: 'mastra-ai',
+      repo: 'mastra',
+      number: 123,
+      lastSyncStatus: 'success',
+      lastSnapshotError: 'gitcrawl database query failed (db: /missing/gitcrawl.db): unable to open database file',
+    });
+    // No baseline cursor and no baseline notification without a snapshot.
+    expect(subscription.lastObservedContentHash).toBeUndefined();
+    expect(chunks).toContainEqual(
+      expect.objectContaining({
+        type: 'data-signal',
+        data: expect.objectContaining({
+          tagName: GITHUB_SYNC_STATUS_TAG,
+          attributes: expect.objectContaining({ status: 'subscribed', number: 123 }),
+        }),
+      }),
+    );
+  });
+
   it('preserves one-time hint state and granular cursors when resubscribing', async () => {
     const thread: StorageThreadType = {
       id: 'thread-resubscribe',

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -2034,7 +2034,18 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
       subscription.lastSyncStatus = syncResult.ok ? 'success' : 'error';
       if (syncResult.error) subscription.lastSyncError = syncResult.error;
       else delete subscription.lastSyncError;
-      const snapshot = syncResult.ok ? await this.#syncClient.getPullRequestSnapshot?.(syncInput) : undefined;
+      let snapshot: GithubPullRequestSnapshot | undefined;
+      if (syncResult.ok) {
+        try {
+          snapshot = await this.#syncClient.getPullRequestSnapshot?.(syncInput);
+        } catch (error) {
+          // Snapshot read failures must not fail the subscribe itself: keep
+          // the subscription and record the error so polling (and /github
+          // debug) can surface and later clear it.
+          subscription.lastSnapshotError = error instanceof Error ? error.message : String(error);
+        }
+      }
+      if (snapshot) delete subscription.lastSnapshotError;
       baselineSnapshot = snapshot;
       if (snapshot) applySnapshotCursor(subscription, snapshot);
     } else {

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -1,5 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto';
-import { readFile } from 'node:fs/promises';
+import { readFile, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
@@ -57,6 +57,8 @@ export type GithubPRSubscription = {
   lastSyncAt?: string;
   lastSyncStatus?: 'success' | 'error' | 'skipped';
   lastSyncError?: string;
+  /** Error from reading the PR snapshot out of the gitcrawl database after a successful sync. */
+  lastSnapshotError?: string;
   lastObservedGithubUpdatedAt?: string;
   lastObservedContentHash?: string;
   lastObservedThreadContentHash?: string;
@@ -310,23 +312,36 @@ function resolveHomePath(path: string): string {
   return path.startsWith('~/') ? join(homedir(), path.slice(2)) : path;
 }
 
-async function getGitcrawlDbPath(): Promise<string> {
-  if (process.env.GITCRAWL_DB_PATH) return resolveHomePath(process.env.GITCRAWL_DB_PATH);
-  const configPath = process.env.GITCRAWL_CONFIG_PATH ?? join(homedir(), '.config', 'gitcrawl', 'config.toml');
+async function readDbPathFromGitcrawlConfig(configPath: string): Promise<string | undefined> {
   try {
     const config = await readFile(resolveHomePath(configPath), 'utf8');
     const match = /^\s*db_path\s*=\s*['\"]([^'\"]+)['\"]/m.exec(config);
     if (match?.[1]) return resolveHomePath(match[1]);
   } catch {
-    // fall back to gitcrawl's default config location
+    // no readable config at this location
   }
-  return join(homedir(), '.config', 'gitcrawl', 'gitcrawl.db');
+  return undefined;
 }
 
-async function queryGitcrawlDb<T>(sql: string): Promise<T[]> {
-  const dbPath = await getGitcrawlDbPath();
-  const { stdout } = await execFileAsync('sqlite3', ['-json', dbPath, sql], { maxBuffer: 10 * 1024 * 1024 });
-  return JSON.parse(stdout || '[]') as T[];
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Directories gitcrawl uses for its config and database by default. Linux
+ * uses the XDG path, but macOS uses ~/Library/Application Support, so probing
+ * only ~/.config silently misses the database on macOS.
+ */
+function gitcrawlDefaultDirs(): string[] {
+  return [
+    join(homedir(), '.config', 'gitcrawl'),
+    ...(process.platform === 'darwin' ? [join(homedir(), 'Library', 'Application Support', 'gitcrawl')] : []),
+  ];
 }
 
 function sqlString(value: string): string {
@@ -369,6 +384,9 @@ function getGithubMetadata(threadMetadata: Record<string, unknown> | undefined):
         : {}),
       ...(readString(rawSubscription.lastSyncError)
         ? { lastSyncError: readString(rawSubscription.lastSyncError)! }
+        : {}),
+      ...(readString(rawSubscription.lastSnapshotError)
+        ? { lastSnapshotError: readString(rawSubscription.lastSnapshotError)! }
         : {}),
       ...(readString(rawSubscription.lastObservedGithubUpdatedAt)
         ? { lastObservedGithubUpdatedAt: readString(rawSubscription.lastObservedGithubUpdatedAt)! }
@@ -854,9 +872,55 @@ export class GitRemoteRepositoryResolver implements GithubRepositoryResolver {
 
 export class GitcrawlSyncClient implements GithubSignalsSyncClient {
   readonly #command: string;
+  #dbPathPromise?: Promise<string>;
 
   constructor(options: { command?: string } = {}) {
     this.#command = options.command ?? 'gitcrawl';
+  }
+
+  /**
+   * Resolve the gitcrawl SQLite database path. Explicit env overrides win,
+   * then gitcrawl itself is asked (authoritative across platforms and
+   * versions), then known default locations are probed.
+   */
+  async #resolveDbPath(): Promise<string> {
+    if (process.env.GITCRAWL_DB_PATH) return resolveHomePath(process.env.GITCRAWL_DB_PATH);
+    if (process.env.GITCRAWL_CONFIG_PATH) {
+      const fromEnvConfig = await readDbPathFromGitcrawlConfig(process.env.GITCRAWL_CONFIG_PATH);
+      if (fromEnvConfig) return fromEnvConfig;
+    }
+    try {
+      const { stdout } = await execFileAsync(this.#command, ['status', '--json'], { maxBuffer: 10 * 1024 * 1024 });
+      const status = JSON.parse(stdout) as { database_path?: unknown; db_path?: unknown };
+      const reported = readString(status.database_path) ?? readString(status.db_path);
+      if (reported) return resolveHomePath(reported);
+    } catch {
+      // gitcrawl unavailable or output unparsable; probe default locations
+    }
+    const defaultDirs = gitcrawlDefaultDirs();
+    for (const dir of defaultDirs) {
+      const fromConfig = await readDbPathFromGitcrawlConfig(join(dir, 'config.toml'));
+      if (fromConfig) return fromConfig;
+    }
+    for (const dir of defaultDirs) {
+      const candidate = join(dir, 'gitcrawl.db');
+      if (await fileExists(candidate)) return candidate;
+    }
+    return join(defaultDirs[0]!, 'gitcrawl.db');
+  }
+
+  async #queryDb<T>(sql: string): Promise<T[]> {
+    this.#dbPathPromise ??= this.#resolveDbPath();
+    const dbPath = await this.#dbPathPromise;
+    try {
+      const { stdout } = await execFileAsync('sqlite3', ['-json', dbPath, sql], { maxBuffer: 10 * 1024 * 1024 });
+      return JSON.parse(stdout || '[]') as T[];
+    } catch (error) {
+      // Drop the cached path so a fixed or moved database is picked up on the next poll.
+      this.#dbPathPromise = undefined;
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`gitcrawl database query failed (db: ${dbPath}): ${message}`);
+    }
   }
 
   async syncPullRequest(input: GithubSignalsSyncInput): Promise<GithubSignalsSyncResult> {
@@ -883,38 +947,37 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
   }
 
   async getPullRequestSnapshot(input: GithubSignalsSyncInput): Promise<GithubPullRequestSnapshot | undefined> {
-    try {
-      const { stdout } = await execFileAsync(
-        this.#command,
-        ['threads', `${input.owner}/${input.repo}`, '--numbers', String(input.number), '--json'],
-        {
-          cwd: input.cwd,
-          signal: input.abortSignal,
-          maxBuffer: 10 * 1024 * 1024,
-        },
-      );
-      const parsed = JSON.parse(stdout) as { threads?: Array<Record<string, unknown>> };
-      const thread = parsed.threads?.find(item => readNumber(item.number) === input.number);
-      if (!thread) return undefined;
+    const { stdout } = await execFileAsync(
+      this.#command,
+      ['threads', `${input.owner}/${input.repo}`, '--numbers', String(input.number), '--json'],
+      {
+        cwd: input.cwd,
+        signal: input.abortSignal,
+        maxBuffer: 10 * 1024 * 1024,
+      },
+    );
+    const parsed = JSON.parse(stdout) as { threads?: Array<Record<string, unknown>> };
+    const thread = parsed.threads?.find(item => readNumber(item.number) === input.number);
+    if (!thread) return undefined;
 
-      const owner = sqlString(input.owner);
-      const repo = sqlString(input.repo);
-      const number = input.number;
-      const [threadDetails] = await queryGitcrawlDb<{
-        state?: string;
-        closed_at_gh?: string;
-        merged_at_gh?: string;
-      }>(`select t.state, t.closed_at_gh, t.merged_at_gh
+    const owner = sqlString(input.owner);
+    const repo = sqlString(input.repo);
+    const number = input.number;
+    const [threadDetails] = await this.#queryDb<{
+      state?: string;
+      closed_at_gh?: string;
+      merged_at_gh?: string;
+    }>(`select t.state, t.closed_at_gh, t.merged_at_gh
           from threads t
           join repositories r on r.id=t.repo_id
          where r.owner=${owner} and r.name=${repo} and t.number=${number}
          limit 1`);
-      const [details] = await queryGitcrawlDb<{
-        head_sha?: string;
-        head_ref?: string;
-        mergeable_state?: string;
-        merged_at?: string;
-      }>(`select d.head_sha, d.head_ref, d.mergeable_state,
+    const [details] = await this.#queryDb<{
+      head_sha?: string;
+      head_ref?: string;
+      mergeable_state?: string;
+      merged_at?: string;
+    }>(`select d.head_sha, d.head_ref, d.mergeable_state,
                  json_extract(d.raw_json, '$.merged_at') as merged_at
           from pull_request_details d
           join threads t on t.id=d.thread_id
@@ -922,50 +985,50 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
          where r.owner=${owner} and r.name=${repo} and t.number=${number}
          limit 1`);
 
-      const headSha = readString(details?.head_sha);
-      const checkRows = await queryGitcrawlDb<{
-        name?: string;
-        status?: string;
-        conclusion?: string;
-        workflow_name?: string;
-        details_url?: string;
-        updated_at?: string;
-      }>(`select c.name, c.status, c.conclusion, c.workflow_name, c.details_url,
+    const headSha = readString(details?.head_sha);
+    const checkRows = await this.#queryDb<{
+      name?: string;
+      status?: string;
+      conclusion?: string;
+      workflow_name?: string;
+      details_url?: string;
+      updated_at?: string;
+    }>(`select c.name, c.status, c.conclusion, c.workflow_name, c.details_url,
                  coalesce(c.completed_at, c.started_at, c.fetched_at) as updated_at
             from pull_request_checks c
             join threads t on t.id=c.thread_id
             join repositories r on r.id=t.repo_id
            where r.owner=${owner} and r.name=${repo} and t.number=${number}${headSha ? ` and json_extract(c.raw_json, '$.head_sha')=${sqlString(headSha)}` : ''}`);
 
-      const workflowRows = details?.head_sha
-        ? await queryGitcrawlDb<{
-            workflow_name?: string;
-            status?: string;
-            conclusion?: string;
-            html_url?: string;
-            updated_at_gh?: string;
-          }>(`select workflow_name, status, conclusion, html_url, updated_at_gh
+    const workflowRows = details?.head_sha
+      ? await this.#queryDb<{
+          workflow_name?: string;
+          status?: string;
+          conclusion?: string;
+          html_url?: string;
+          updated_at_gh?: string;
+        }>(`select workflow_name, status, conclusion, html_url, updated_at_gh
                 from github_workflow_runs w
                 join repositories r on r.id=w.repo_id
                where r.owner=${owner} and r.name=${repo} and w.head_sha=${sqlString(details.head_sha)}`)
-        : [];
-      const [reviewState] = await queryGitcrawlDb<{
-        unresolved_count?: number;
-        latest_review_thread_at?: string;
-      }>(`select count(*) as unresolved_count,
+      : [];
+    const [reviewState] = await this.#queryDb<{
+      unresolved_count?: number;
+      latest_review_thread_at?: string;
+    }>(`select count(*) as unresolved_count,
                  max(coalesce(first_comment_updated_at, first_comment_created_at, fetched_at)) as latest_review_thread_at
             from pull_request_review_threads rt
             join threads t on t.id=rt.thread_id
             join repositories r on r.id=t.repo_id
            where r.owner=${owner} and r.name=${repo} and t.number=${number} and rt.is_resolved=0`);
-      const latestComments = await queryGitcrawlDb<{
-        author_login?: string;
-        author_type?: string;
-        is_bot?: number;
-        body?: string;
-        html_url?: string;
-        updated_at?: string;
-      }>(`select c.author_login, c.author_type, c.is_bot, c.body, json_extract(c.raw_json, '$.html_url') as html_url,
+    const latestComments = await this.#queryDb<{
+      author_login?: string;
+      author_type?: string;
+      is_bot?: number;
+      body?: string;
+      html_url?: string;
+      updated_at?: string;
+    }>(`select c.author_login, c.author_type, c.is_bot, c.body, json_extract(c.raw_json, '$.html_url') as html_url,
                  coalesce(c.updated_at_gh, c.created_at_gh) as updated_at
             from comments c
             join threads t on t.id=c.thread_id
@@ -973,94 +1036,91 @@ export class GitcrawlSyncClient implements GithubSignalsSyncClient {
            where r.owner=${owner} and r.name=${repo} and t.number=${number}
            order by coalesce(c.updated_at_gh, c.created_at_gh) desc
            limit 20`);
-      const latestComment = latestComments[0];
+    const latestComment = latestComments[0];
 
-      const checks = normalizeGithubChecksForSnapshot({
-        checkRows: checkRows.map(row => ({
-          source: 'check',
-          name: readString(row.name) ?? 'check',
-          status: readString(row.status),
-          conclusion: readString(row.conclusion),
-          workflowName: readString(row.workflow_name),
-          detailsUrl: readString(row.details_url),
-          updatedAt: readString(row.updated_at),
-        })),
-        workflowRows: workflowRows.map(row => ({
-          source: 'workflow',
-          name: readString(row.workflow_name) ?? 'workflow',
-          status: readString(row.status),
-          conclusion: readString(row.conclusion),
-          workflowName: readString(row.workflow_name),
-          detailsUrl: readString(row.html_url),
-          updatedAt: readString(row.updated_at_gh),
-        })),
-      });
-      const ciState = checks.some(check => check.conclusion === 'failure' || check.conclusion === 'timed_out')
-        ? 'failure'
-        : checks.some(check => check.status && check.status !== 'completed')
-          ? 'pending'
-          : checks.length > 0
-            ? 'success'
-            : 'unknown';
-      const threadContentHash = readString(thread.content_hash);
-      const unresolvedReviewThreads = Number(reviewState?.unresolved_count ?? 0);
-      const reviewStateHash = snapshotHash({
-        unresolvedReviewThreads,
-        latestReviewThreadAt: reviewState?.latest_review_thread_at,
-      });
-      const contentHash = snapshotHash({
-        threadContentHash,
-        state: thread.state,
-        headSha: details?.head_sha,
-        mergeableState: details?.mergeable_state,
-        ciState,
-        reviewStateHash,
-        checks: checks.map(check => ({
-          name: check.name,
-          status: check.status,
-          conclusion: check.conclusion,
-          detailsUrl: check.detailsUrl,
-          updatedAt: check.updatedAt,
-        })),
-      });
-      return {
-        title: readString(thread.title),
-        state:
-          readString(details?.merged_at) || readString(threadDetails?.merged_at_gh)
-            ? 'merged'
-            : (readString(threadDetails?.state) ?? readString(thread.state)),
-        htmlUrl: readString(thread.html_url),
-        githubUpdatedAt: readString(thread.updated_at_gh),
-        closedAt: readString(threadDetails?.closed_at_gh),
-        mergedAt: readString(details?.merged_at) ?? readString(threadDetails?.merged_at_gh),
-        threadContentHash,
-        contentHash,
-        headSha: readString(details?.head_sha),
-        headRef: readString(details?.head_ref),
-        mergeableState: readString(details?.mergeable_state),
-        checks,
-        ciState,
-        unresolvedReviewThreads,
-        reviewStateHash,
-        latestReviewThreadAt: readString(reviewState?.latest_review_thread_at),
-        latestCommentAuthor: readString(latestComment?.author_login),
-        latestCommentAuthorType: readString(latestComment?.author_type),
-        latestCommentIsBot: latestComment?.is_bot === 1,
-        latestCommentBody: sanitizeCommentBody(readString(latestComment?.body)),
-        latestCommentUrl: readString(latestComment?.html_url),
-        latestCommentUpdatedAt: readString(latestComment?.updated_at),
-        latestComments: latestComments.map(comment => ({
-          author: readString(comment.author_login),
-          authorType: readString(comment.author_type),
-          isBot: comment.is_bot === 1,
-          body: sanitizeCommentBody(readString(comment.body)),
-          url: readString(comment.html_url),
-          updatedAt: readString(comment.updated_at),
-        })),
-      };
-    } catch {
-      return undefined;
-    }
+    const checks = normalizeGithubChecksForSnapshot({
+      checkRows: checkRows.map(row => ({
+        source: 'check',
+        name: readString(row.name) ?? 'check',
+        status: readString(row.status),
+        conclusion: readString(row.conclusion),
+        workflowName: readString(row.workflow_name),
+        detailsUrl: readString(row.details_url),
+        updatedAt: readString(row.updated_at),
+      })),
+      workflowRows: workflowRows.map(row => ({
+        source: 'workflow',
+        name: readString(row.workflow_name) ?? 'workflow',
+        status: readString(row.status),
+        conclusion: readString(row.conclusion),
+        workflowName: readString(row.workflow_name),
+        detailsUrl: readString(row.html_url),
+        updatedAt: readString(row.updated_at_gh),
+      })),
+    });
+    const ciState = checks.some(check => check.conclusion === 'failure' || check.conclusion === 'timed_out')
+      ? 'failure'
+      : checks.some(check => check.status && check.status !== 'completed')
+        ? 'pending'
+        : checks.length > 0
+          ? 'success'
+          : 'unknown';
+    const threadContentHash = readString(thread.content_hash);
+    const unresolvedReviewThreads = Number(reviewState?.unresolved_count ?? 0);
+    const reviewStateHash = snapshotHash({
+      unresolvedReviewThreads,
+      latestReviewThreadAt: reviewState?.latest_review_thread_at,
+    });
+    const contentHash = snapshotHash({
+      threadContentHash,
+      state: thread.state,
+      headSha: details?.head_sha,
+      mergeableState: details?.mergeable_state,
+      ciState,
+      reviewStateHash,
+      checks: checks.map(check => ({
+        name: check.name,
+        status: check.status,
+        conclusion: check.conclusion,
+        detailsUrl: check.detailsUrl,
+        updatedAt: check.updatedAt,
+      })),
+    });
+    return {
+      title: readString(thread.title),
+      state:
+        readString(details?.merged_at) || readString(threadDetails?.merged_at_gh)
+          ? 'merged'
+          : (readString(threadDetails?.state) ?? readString(thread.state)),
+      htmlUrl: readString(thread.html_url),
+      githubUpdatedAt: readString(thread.updated_at_gh),
+      closedAt: readString(threadDetails?.closed_at_gh),
+      mergedAt: readString(details?.merged_at) ?? readString(threadDetails?.merged_at_gh),
+      threadContentHash,
+      contentHash,
+      headSha: readString(details?.head_sha),
+      headRef: readString(details?.head_ref),
+      mergeableState: readString(details?.mergeable_state),
+      checks,
+      ciState,
+      unresolvedReviewThreads,
+      reviewStateHash,
+      latestReviewThreadAt: readString(reviewState?.latest_review_thread_at),
+      latestCommentAuthor: readString(latestComment?.author_login),
+      latestCommentAuthorType: readString(latestComment?.author_type),
+      latestCommentIsBot: latestComment?.is_bot === 1,
+      latestCommentBody: sanitizeCommentBody(readString(latestComment?.body)),
+      latestCommentUrl: readString(latestComment?.html_url),
+      latestCommentUpdatedAt: readString(latestComment?.updated_at),
+      latestComments: latestComments.map(comment => ({
+        author: readString(comment.author_login),
+        authorType: readString(comment.author_type),
+        isBot: comment.is_bot === 1,
+        body: sanitizeCommentBody(readString(comment.body)),
+        url: readString(comment.html_url),
+        updatedAt: readString(comment.updated_at),
+      })),
+    };
   }
 }
 
@@ -1513,7 +1573,18 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
           includeComments: options.includeComments,
         };
         const syncResult = await this.#syncClient.syncPullRequest(syncInput);
-        let snapshot = syncResult.ok ? await this.#syncClient.getPullRequestSnapshot?.(syncInput) : undefined;
+        let snapshot: GithubPullRequestSnapshot | undefined;
+        let snapshotError: string | undefined;
+        if (syncResult.ok) {
+          try {
+            snapshot = await this.#syncClient.getPullRequestSnapshot?.(syncInput);
+          } catch (error) {
+            // A sync can succeed while the snapshot read fails (e.g. the
+            // gitcrawl database is missing or unreadable). Surface the error
+            // instead of silently reporting a healthy poll with no data.
+            snapshotError = error instanceof Error ? error.message : String(error);
+          }
+        }
         if (snapshot)
           snapshot = await this.#filterUnauthorizedLatestComment(subscription.owner, subscription.repo, snapshot);
         const nextSubscription: GithubPRSubscription = {
@@ -1524,6 +1595,8 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         };
         if (syncResult.error) nextSubscription.lastSyncError = syncResult.error;
         else delete nextSubscription.lastSyncError;
+        if (snapshotError) nextSubscription.lastSnapshotError = snapshotError;
+        else delete nextSubscription.lastSnapshotError;
 
         const previousGithubUpdatedAt = subscription.lastObservedGithubUpdatedAt;
         const previousContentHash = subscription.lastObservedContentHash;


### PR DESCRIPTION
## Summary

GitHub PR subscription notifications (the experimental GitHub Signals feature) never fired on macOS. Polling looked healthy — `/github debug` showed `sync=success` — but no notification was ever generated, even when a subscribed PR had CI failures or new review comments.

**Root cause:** after each successful `gitcrawl sync`, the signals package reads the PR snapshot directly out of gitcrawl's SQLite database, but it hardcoded the Linux XDG location (`~/.config/gitcrawl/gitcrawl.db`). On macOS, gitcrawl stores its config and database under `~/Library/Application Support/gitcrawl/`. Every snapshot query failed with "unable to open database file", the error was silently swallowed (`catch { return undefined }`), and with no snapshot there was never a detected change — so no notifications, and no visible error anywhere.

## Changes

**`@mastra/github-signals`**
- `GitcrawlSyncClient` now resolves the database path in this order:
  1. `GITCRAWL_DB_PATH` env var (explicit override, also used by e2e fixtures)
  2. `GITCRAWL_CONFIG_PATH` env var → `db_path` from that config
  3. Asking gitcrawl itself: `gitcrawl status --json` → `database_path` (authoritative across platforms and gitcrawl versions)
  4. Probing default config/db locations: `~/.config/gitcrawl` and, on macOS, `~/Library/Application Support/gitcrawl`
- The resolved path is cached per client and invalidated when a query fails, so a fixed or moved database is picked up on the next poll.
- `getPullRequestSnapshot` no longer swallows errors. Database failures throw with the offending db path in the message.
- The poll loop records snapshot read failures on the subscription as a new `lastSnapshotError` field (cleared once a snapshot succeeds), instead of silently reporting a healthy poll.

**`mastracode`**
- `/github debug` now prints `snapshotError=...` for a subscription when the last snapshot read failed, so this failure mode is diagnosable instead of invisible.

## Test plan

- [x] New regression test: a failing snapshot read records `lastSnapshotError` and sends no notification; the next successful poll clears the error and emits the baseline notification (all 59 `@mastra/github-signals` tests pass)
- [x] Verified on a macOS machine with gitcrawl 0.7.0 and no env overrides: the client resolves the Application Support database via `gitcrawl status --json` and returns a full PR snapshot (previously returned `undefined` on every poll)
- [x] Verified a bad `GITCRAWL_DB_PATH` now surfaces a descriptive error instead of silence
- [x] Typecheck, eslint, and builds pass for both packages; TUI e2e fixtures unaffected (they set `GITCRAWL_DB_PATH`, which remains the top-priority override)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

On macOS, GitHub Signals stopped notifying you because it looked for Gitcrawl’s database in the wrong place. This update teaches it to find the right database location everywhere and to clearly report (and later recover from) snapshot/database read failures instead of silently pretending there’s “no snapshot.”

## Changes

- Fixed macOS PR subscription notifications by making Gitcrawl database discovery cross-platform:
  - Supports environment overrides (`GITCRAWL_DB_PATH`, `GITCRAWL_CONFIG_PATH`)
  - Uses `gitcrawl status --json` to read the reported `database_path`/`db_path`
  - Falls back to platform-specific default directories (including `~/Library/Application Support/...` on macOS)
- Refactored Gitcrawl database querying in `GitcrawlSyncClient`:
  - Resolves and caches the DB path
  - Invalidates the cached DB path after query failures
  - Improves error messaging by adding DB query context
- Improved snapshot read failure handling for GitHub PR subscriptions:
  - Added `lastSnapshotError?: string` to `GithubPRSubscription` and persisted it in thread/subscription metadata
  - When snapshot reads fail:
    - The subscription continues polling (does not drop)
    - Baseline notification behavior is suppressed for the failing run
  - When snapshot reads succeed again:
    - `lastSnapshotError` is cleared
    - Baseline state (`lastObservedContentHash`) is updated and baseline notification is emitted
- Surfaced snapshot errors in the TUI debug output:
  - `/github debug` now renders `snapshotError=...` alongside existing sync errors
- Added regression tests covering:
  - Subscription baseline behavior when snapshot reads fail
  - Sync behavior when snapshot reads fail
  - Recovery when snapshot reads later succeed
- Updated changesets for the affected packages (patch releases).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->