### PR TITLE
fix(pg): attach 'error' listeners to library-created pools so dropped idle connections don't crash the process

### DIFF
--- a/.changeset/pg-pool-error-listener.md
+++ b/.changeset/pg-pool-error-listener.md
@@ -1,0 +1,9 @@
+---
+'@mastra/pg': patch
+---
+
+Attach `'error'` listeners to the `pg.Pool` instances `@mastra/pg` creates (PgVector, PostgresStore primary and vNext observability pools, and standalone domain pools from `resolvePgConfig`).
+
+When Postgres drops an **idle** pooled connection (backend restart, failover, network partition, cloud proxies reaping idle sockets), `pg` emits `'error'` on the pool. With no listener attached, Node escalates that event to an `uncaughtException` and crashes the process (`Error: read ECONNRESET` at `TCP.onStreamRead`). The pool already discards the dead client, so the listener logs a warning and the next checkout reconnects.
+
+Pools supplied by the caller (`{ pool }` configs) are not touched — their error handling stays with their owner, mirroring `close()` semantics.

--- a/.changeset/pg-pool-error-listener.md
+++ b/.changeset/pg-pool-error-listener.md
@@ -2,8 +2,8 @@
 '@mastra/pg': patch
 ---
 
-Attach `'error'` listeners to the `pg.Pool` instances `@mastra/pg` creates (PgVector, PostgresStore primary and vNext observability pools, and standalone domain pools from `resolvePgConfig`).
+Fixed an issue where the process could crash when Postgres drops an idle database connection (e.g., due to a backend restart, failover, or network failure).
 
-When Postgres drops an **idle** pooled connection (backend restart, failover, network partition, cloud proxies reaping idle sockets), `pg` emits `'error'` on the pool. With no listener attached, Node escalates that event to an `uncaughtException` and crashes the process (`Error: read ECONNRESET` at `TCP.onStreamRead`). The pool already discards the dead client, so the listener logs a warning and the next checkout reconnects.
+Previously, a dropped idle connection caused an uncaught exception that terminated the process. Now the connection drop is caught and logged as a warning, and the store automatically reconnects on the next database operation.
 
-Pools supplied by the caller (`{ pool }` configs) are not touched — their error handling stays with their owner, mirroring `close()` semantics.
+User-provided connection pools are unaffected and keep their existing error handling.

--- a/stores/pg/src/pool-error-listener.test.ts
+++ b/stores/pg/src/pool-error-listener.test.ts
@@ -2,7 +2,7 @@ import pg from 'pg';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
 import type { PoolAdapter } from './storage';
-import { PostgresStore } from './storage';
+import { PostgresStore, PostgresStoreVNext } from './storage';
 import { resolvePgConfig } from './storage/db';
 import { PgVector } from './vector';
 
@@ -61,6 +61,37 @@ describe('pool error listeners', () => {
 
     try {
       // Error handling on a user-owned pool stays the user's, mirroring close().
+      expect(userPool.listenerCount('error')).toBe(0);
+    } finally {
+      await store.close();
+      await userPool.end();
+    }
+  });
+
+  it('PostgresStoreVNext attaches an error listener to the observability pool it creates', async () => {
+    const userPool = new pg.Pool({ connectionString: DEAD_CONNECTION_STRING });
+    // The observability pool lives in a native private field, so track
+    // listener registration through the shared Pool prototype instead.
+    const onSpy = vi.spyOn(pg.Pool.prototype, 'on');
+
+    const store = new PostgresStoreVNext({
+      id: 'pool-error-test',
+      pool: userPool,
+      observability: { connectionString: 'postgresql://user:pass@127.0.0.1:2/db' },
+    });
+
+    try {
+      const errorRegistrations = onSpy.mock.calls
+        .map((call, i) => ({ event: call[0], instance: onSpy.mock.instances[i] as pg.Pool }))
+        .filter(({ event }) => event === 'error');
+
+      // Exactly one 'error' listener was attached during construction — on the
+      // store-created observability pool, not the caller-supplied primary pool.
+      expect(errorRegistrations).toHaveLength(1);
+      const obsPool = errorRegistrations[0]!.instance;
+      expect(obsPool).not.toBe(userPool);
+      expect(obsPool.listenerCount('error')).toBe(1);
+      expect(() => obsPool.emit('error', new Error('idle client dropped'))).not.toThrow();
       expect(userPool.listenerCount('error')).toBe(0);
     } finally {
       await store.close();

--- a/stores/pg/src/pool-error-listener.test.ts
+++ b/stores/pg/src/pool-error-listener.test.ts
@@ -1,0 +1,84 @@
+import pg from 'pg';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { PoolAdapter } from './storage';
+import { PostgresStore } from './storage';
+import { resolvePgConfig } from './storage/db';
+import { PgVector } from './vector';
+
+// Points at a dead port — none of these tests need a live database. The pool
+// only opens sockets on first checkout, and PgVector's cache warmup failure
+// is swallowed internally.
+const DEAD_CONNECTION_STRING = 'postgresql://user:pass@127.0.0.1:1/db';
+
+// Regression coverage for the missing pool 'error' listeners: pg emits
+// 'error' on the pool when an idle client's connection drops; with no
+// listener attached Node escalates it to an uncaughtException and crashes
+// the process ("Error: read ECONNRESET" at TCP.onStreamRead).
+describe('pool error listeners', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('PgVector attaches an error listener to the pool it creates', async () => {
+    const vector = new PgVector({
+      id: 'pool-error-test',
+      connectionString: DEAD_CONNECTION_STRING,
+    });
+
+    try {
+      expect(vector.pool.listenerCount('error')).toBe(1);
+      // With no listener this emit would throw (EventEmitter 'error' contract).
+      expect(() => vector.pool.emit('error', new Error('idle client dropped'))).not.toThrow();
+    } finally {
+      await vector.disconnect();
+    }
+  });
+
+  it('PostgresStore attaches an error listener to pools it creates', async () => {
+    const store = new PostgresStore({
+      id: 'pool-error-test',
+      connectionString: DEAD_CONNECTION_STRING,
+    });
+
+    // createPool is the single construction path for store-owned pools.
+    const pool = (store as unknown as { createPool(config: unknown): pg.Pool }).createPool({
+      connectionString: DEAD_CONNECTION_STRING,
+    });
+
+    try {
+      expect(pool.listenerCount('error')).toBe(1);
+      expect(() => pool.emit('error', new Error('idle client dropped'))).not.toThrow();
+    } finally {
+      await pool.end();
+      await store.close();
+    }
+  });
+
+  it('PostgresStore leaves user-provided pools untouched', async () => {
+    const userPool = new pg.Pool({ connectionString: DEAD_CONNECTION_STRING });
+    const store = new PostgresStore({ id: 'pool-error-test', pool: userPool });
+
+    try {
+      // Error handling on a user-owned pool stays the user's, mirroring close().
+      expect(userPool.listenerCount('error')).toBe(0);
+    } finally {
+      await store.close();
+      await userPool.end();
+    }
+  });
+
+  it('resolvePgConfig attaches an error listener to pools it creates', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { client } = resolvePgConfig({ connectionString: DEAD_CONNECTION_STRING });
+    const pool = (client as PoolAdapter).$pool;
+
+    try {
+      expect(pool.listenerCount('error')).toBe(1);
+      expect(() => pool.emit('error', new Error('idle client dropped'))).not.toThrow();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      await pool.end();
+    }
+  });
+});

--- a/stores/pg/src/storage/db/index.ts
+++ b/stores/pg/src/storage/db/index.ts
@@ -134,6 +134,16 @@ export function resolvePgConfig(config: PgDomainConfig): {
     });
   }
 
+  // pg emits 'error' on the pool when an idle client's connection drops;
+  // without a listener Node escalates the event to an uncaughtException and
+  // crashes the process. No logger is threaded into this helper, so warn on
+  // the console like COLLISION_WARNING does.
+  pool.on('error', err => {
+    console.warn(
+      `resolvePgConfig: idle pool client error (pool discards the client and reconnects on next checkout): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  });
+
   return {
     client: new PoolAdapter(pool),
     schemaName: config.schemaName,

--- a/stores/pg/src/storage/db/pool-error-listener.test.ts
+++ b/stores/pg/src/storage/db/pool-error-listener.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { PoolAdapter } from '..';
+import { resolvePgConfig } from '.';
+
+// Points at a dead port — this test needs no live database. The pool only
+// opens sockets on first checkout.
+const DEAD_CONNECTION_STRING = 'postgresql://user:pass@127.0.0.1:1/db';
+
+// Regression coverage for the missing pool 'error' listener: pg emits
+// 'error' on the pool when an idle client's connection drops; with no
+// listener attached Node escalates it to an uncaughtException and crashes
+// the process ("Error: read ECONNRESET" at TCP.onStreamRead).
+describe('resolvePgConfig pool error listener', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('attaches an error listener to pools it creates', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { client } = resolvePgConfig({ connectionString: DEAD_CONNECTION_STRING });
+    const pool = (client as PoolAdapter).$pool;
+
+    try {
+      expect(pool.listenerCount('error')).toBe(1);
+      expect(() => pool.emit('error', new Error('idle client dropped'))).not.toThrow();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      await pool.end();
+    }
+  });
+});

--- a/stores/pg/src/storage/index.ts
+++ b/stores/pg/src/storage/index.ts
@@ -260,6 +260,27 @@ export class PostgresStore extends MastraCompositeStore {
   }
 
   private createPool(config: PostgresStoreConfig): Pool {
+    const pool = this.#buildPool(config);
+
+    // pg emits 'error' on the pool when an idle client's connection drops
+    // (backend restart, network partition, cloud proxies reaping idle
+    // sockets). Without a listener Node escalates the event to an
+    // uncaughtException and crashes the process. Only pools this store
+    // creates get the listener — a user-provided pool keeps the user's own
+    // listeners, mirroring close().
+    pool.on('error', err => {
+      this.logger?.warn?.(
+        'PostgresStore: idle pool client error (pool discards the client and reconnects on next checkout)',
+        {
+          err: err instanceof Error ? err.message : err,
+        },
+      );
+    });
+
+    return pool;
+  }
+
+  #buildPool(config: PostgresStoreConfig): Pool {
     if (isConnectionStringConfig(config)) {
       return createConnectionStringPool(config);
     }
@@ -509,6 +530,20 @@ export class PostgresStoreVNext extends PostgresStore {
     const observabilityClient = built.client;
     this.#observabilityPool = built.pool;
     this.#ownsObservabilityPool = built.owned;
+
+    // Same crash-prevention as the primary pool in createPool(): without an
+    // 'error' listener, an idle client dropped by the backend escalates to an
+    // uncaughtException. Only for pools this store created.
+    if (built.owned) {
+      built.pool.on('error', err => {
+        this.logger?.warn?.(
+          'PostgresStoreVNext: idle observability pool client error (pool discards the client and reconnects on next checkout)',
+          {
+            err: err instanceof Error ? err.message : err,
+          },
+        );
+      });
+    }
 
     // NOTE: `skipDefaultIndexes` / `indexes` from the primary config are
     // intentionally NOT forwarded. The vNext observability domain manages

--- a/stores/pg/src/storage/pool-error-listener.test.ts
+++ b/stores/pg/src/storage/pool-error-listener.test.ts
@@ -1,41 +1,22 @@
 import pg from 'pg';
 import { describe, it, expect, vi, afterEach } from 'vitest';
 
-import type { PoolAdapter } from './storage';
-import { PostgresStore, PostgresStoreVNext } from './storage';
-import { resolvePgConfig } from './storage/db';
-import { PgVector } from './vector';
+import { PostgresStore, PostgresStoreVNext } from '.';
 
-// Points at a dead port — none of these tests need a live database. The pool
-// only opens sockets on first checkout, and PgVector's cache warmup failure
-// is swallowed internally.
+// Points at a dead port — these tests need no live database. The pool only
+// opens sockets on first checkout.
 const DEAD_CONNECTION_STRING = 'postgresql://user:pass@127.0.0.1:1/db';
 
 // Regression coverage for the missing pool 'error' listeners: pg emits
 // 'error' on the pool when an idle client's connection drops; with no
 // listener attached Node escalates it to an uncaughtException and crashes
 // the process ("Error: read ECONNRESET" at TCP.onStreamRead).
-describe('pool error listeners', () => {
+describe('PostgresStore pool error listeners', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it('PgVector attaches an error listener to the pool it creates', async () => {
-    const vector = new PgVector({
-      id: 'pool-error-test',
-      connectionString: DEAD_CONNECTION_STRING,
-    });
-
-    try {
-      expect(vector.pool.listenerCount('error')).toBe(1);
-      // With no listener this emit would throw (EventEmitter 'error' contract).
-      expect(() => vector.pool.emit('error', new Error('idle client dropped'))).not.toThrow();
-    } finally {
-      await vector.disconnect();
-    }
-  });
-
-  it('PostgresStore attaches an error listener to pools it creates', async () => {
+  it('attaches an error listener to pools it creates', async () => {
     const store = new PostgresStore({
       id: 'pool-error-test',
       connectionString: DEAD_CONNECTION_STRING,
@@ -55,7 +36,7 @@ describe('pool error listeners', () => {
     }
   });
 
-  it('PostgresStore leaves user-provided pools untouched', async () => {
+  it('leaves user-provided pools untouched', async () => {
     const userPool = new pg.Pool({ connectionString: DEAD_CONNECTION_STRING });
     const store = new PostgresStore({ id: 'pool-error-test', pool: userPool });
 
@@ -96,20 +77,6 @@ describe('pool error listeners', () => {
     } finally {
       await store.close();
       await userPool.end();
-    }
-  });
-
-  it('resolvePgConfig attaches an error listener to pools it creates', async () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const { client } = resolvePgConfig({ connectionString: DEAD_CONNECTION_STRING });
-    const pool = (client as PoolAdapter).$pool;
-
-    try {
-      expect(pool.listenerCount('error')).toBe(1);
-      expect(() => pool.emit('error', new Error('idle client dropped'))).not.toThrow();
-      expect(warn).toHaveBeenCalledTimes(1);
-    } finally {
-      await pool.end();
     }
   });
 });

--- a/stores/pg/src/vector/index.disable-init.test.ts
+++ b/stores/pg/src/vector/index.disable-init.test.ts
@@ -64,6 +64,7 @@ vi.mock('pg', () => {
     public options: any;
     public connect = vi.fn(async () => mockClient);
     public end = vi.fn(async () => {});
+    public on = vi.fn().mockReturnThis();
 
     constructor(options: any) {
       this.options = options;

--- a/stores/pg/src/vector/index.schema-name.test.ts
+++ b/stores/pg/src/vector/index.schema-name.test.ts
@@ -58,6 +58,7 @@ vi.mock('pg', () => {
     public options: any;
     public connect = vi.fn(async () => mockClient);
     public end = vi.fn(async () => {});
+    public on = vi.fn().mockReturnThis();
 
     constructor(options: any) {
       this.options = options;

--- a/stores/pg/src/vector/index.ts
+++ b/stores/pg/src/vector/index.ts
@@ -162,6 +162,20 @@ export class PgVector extends MastraVector<PGVectorFilter> {
 
       this.pool = new pg.Pool(poolConfig);
 
+      // pg emits 'error' on the pool when an idle client's connection drops
+      // (backend restart, network partition, cloud proxies reaping idle
+      // sockets). Without a listener Node escalates the event to an
+      // uncaughtException and crashes the process. The pool already discards
+      // the dead client, so warn and let the next checkout reconnect.
+      this.pool.on('error', err => {
+        this.logger?.warn?.(
+          'PgVector: idle pool client error (pool discards the client and reconnects on next checkout)',
+          {
+            err: err instanceof Error ? err.message : err,
+          },
+        );
+      });
+
       // Warm the created indexes cache in background so we don't need to check if indexes exist every time
       // Store the promise so we can wait for it during disconnect to avoid "pool already closed" errors
       this.cacheWarmupPromise = (async () => {

--- a/stores/pg/src/vector/pool-error-listener.test.ts
+++ b/stores/pg/src/vector/pool-error-listener.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+import { PgVector } from '.';
+
+// Points at a dead port — this test needs no live database. The pool only
+// opens sockets on first checkout, and PgVector's cache warmup failure is
+// swallowed internally.
+const DEAD_CONNECTION_STRING = 'postgresql://user:pass@127.0.0.1:1/db';
+
+// Regression coverage for the missing pool 'error' listener: pg emits
+// 'error' on the pool when an idle client's connection drops; with no
+// listener attached Node escalates it to an uncaughtException and crashes
+// the process ("Error: read ECONNRESET" at TCP.onStreamRead).
+describe('PgVector pool error listener', () => {
+  it('attaches an error listener to the pool it creates', async () => {
+    const vector = new PgVector({
+      id: 'pool-error-test',
+      connectionString: DEAD_CONNECTION_STRING,
+    });
+
+    try {
+      expect(vector.pool.listenerCount('error')).toBe(1);
+      // With no listener this emit would throw (EventEmitter 'error' contract).
+      expect(() => vector.pool.emit('error', new Error('idle client dropped'))).not.toThrow();
+    } finally {
+      await vector.disconnect();
+    }
+  });
+});


### PR DESCRIPTION
## Description

`@mastra/pg` never attaches a `pool.on('error')` listener to any `pg.Pool` it creates. node-postgres emits `'error'` **on the pool** when an *idle* pooled client's connection drops (backend restart, failover, network partition, cloud proxies reaping idle sockets) — and per the [pg.Pool docs](https://node-postgres.com/apis/pool#error), with no listener attached Node escalates that event to an `uncaughtException`, crashing the process:

```
Error: read ECONNRESET
    at TCP.onStreamRead (node:internal/stream_base_commons:216:20)
```

We hit this in production (Cloud SQL + GKE, `@mastra/pg` 1.15.1). It's the same bug class as the node-redis clients in `pubsub/redis-streams` (#19122): the library owns the client, so the library owns the `'error'` listener.

### Fix

Attach a warn-and-continue `'error'` listener at every site where the library **creates** a pool — the pool already discards the dead client, so the next checkout reconnects:

| Site | Handler |
|---|---|
| `PgVector` constructor | `this.logger?.warn?.(...)` |
| `PostgresStore.createPool()` (single construction path for store-owned pools; pool building extracted to `#buildPool`) | `this.logger?.warn?.(...)` |
| `PostgresStoreVNext` observability pool (only when `built.owned`) | `this.logger?.warn?.(...)` |
| `resolvePgConfig()` (standalone domain pools; no logger threaded into the helper) | `console.warn(...)`, matching `COLLISION_WARNING` |

Pools **supplied by the caller** (`{ pool }` configs) are not touched — their error handling stays with their owner, mirroring `close()` semantics. The handler idiom mirrors the node-redis one in `pubsub/redis-streams/src/index.ts` (no rate-limiting needed: pg-pool emits once per dead idle client, not repeatedly).

### Reproduction / verification

Self-contained repro (TCP proxy + `socket.resetAndDestroy()` sends a real RST to the idle pooled connection) is in the linked issue. Before this change: `pool 'error' listener count: 0`, unhandled `'error'` on `BoundPool`, process exits 1. After this change (validated against the built dist of this branch): warn log, next checkout reconnects, process survives.

## Related issue(s)

Fixes #19468

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sometimes Postgres quietly drops an old “idle” connection. This PR makes sure those dropped connections don’t crash your Node app: it catches the error, logs a warning, and then reconnects the next time you try the database—without changing any pools you supply yourself.

## What changed

- Added warning-based `error` listeners to every `pg.Pool` created by `@mastra/pg`, including:
  - `PgVector`
  - `PostgresStore`
  - `PostgresStoreVNext` (observability pool when store-owned)
  - `resolvePgConfig()`
- When an idle pooled connection drops, the listener prevents the unhandled `error` behavior and lets the pool recover automatically on the next checkout.
- Caller-supplied pools are left untouched (no new listeners added).
- Added/updated regression tests to verify listener attachment, “warn-and-continue” behavior, and correct pool ownership semantics.
- Added a patch changeset for `@mastra/pg`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->