### PR TITLE
fix(core): guard scheduler interval unref for non-Node runtimes

### DIFF
--- a/.changeset/ten-actors-relax.md
+++ b/.changeset/ten-actors-relax.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed a crash on Cloudflare Workers where calling generate() on an Agent not registered to a Mastra instance threw `TypeError: this.#intervalHandle.unref is not a function`. The scheduler now only calls unref() on its polling interval when the runtime provides it (Node.js); on runtimes where setInterval returns a number (workerd) the call is skipped. Fixes [#19462](https://github.com/mastra-ai/mastra/issues/19462).

--- a/packages/core/src/workflows/scheduler/scheduler.test.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.test.ts
@@ -304,6 +304,25 @@ describe('Scheduler', () => {
     setIntervalSpy.mockRestore();
   });
 
+  it('starts on runtimes where setInterval returns a numeric handle (e.g. Cloudflare Workers)', async () => {
+    // workerd's setInterval returns a number, which has no .unref method
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval').mockImplementation((() => 123) as any);
+
+    const { store } = makeStore();
+    const pubsub = new EventEmitterPubSub();
+    const scheduler = new Scheduler({
+      schedulesStore: store,
+      pubsub,
+      config: { tickIntervalMs: 60_000 },
+    });
+
+    await expect(scheduler.start()).resolves.toBeUndefined();
+    expect(scheduler.isRunning).toBe(true);
+
+    await scheduler.stop();
+    setIntervalSpy.mockRestore();
+  });
+
   it('skips firing when the target workflow is not registered', async () => {
     const { store } = makeStore();
     const pubsub = new EventEmitterPubSub();

--- a/packages/core/src/workflows/scheduler/scheduler.test.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.test.ts
@@ -308,19 +308,22 @@ describe('Scheduler', () => {
     // workerd's setInterval returns a number, which has no .unref method
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval').mockImplementation((() => 123) as any);
 
-    const { store } = makeStore();
-    const pubsub = new EventEmitterPubSub();
-    const scheduler = new Scheduler({
-      schedulesStore: store,
-      pubsub,
-      config: { tickIntervalMs: 60_000 },
-    });
+    try {
+      const { store } = makeStore();
+      const pubsub = new EventEmitterPubSub();
+      const scheduler = new Scheduler({
+        schedulesStore: store,
+        pubsub,
+        config: { tickIntervalMs: 60_000 },
+      });
 
-    await expect(scheduler.start()).resolves.toBeUndefined();
-    expect(scheduler.isRunning).toBe(true);
+      await expect(scheduler.start()).resolves.toBeUndefined();
+      expect(scheduler.isRunning).toBe(true);
 
-    await scheduler.stop();
-    setIntervalSpy.mockRestore();
+      await scheduler.stop();
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
   });
 
   it('skips firing when the target workflow is not registered', async () => {

--- a/packages/core/src/workflows/scheduler/scheduler.ts
+++ b/packages/core/src/workflows/scheduler/scheduler.ts
@@ -96,7 +96,9 @@ export class Scheduler extends MastraBase {
       // scripts that create a Mastra instance (which auto-creates the
       // notification dispatch workflow with a cron schedule) and exit
       // after a single agent.generate() call.
-      this.#intervalHandle.unref();
+      // Optional call: on runtimes where setInterval returns a number
+      // (e.g. Cloudflare Workers) there is no unref and nothing to release.
+      this.#intervalHandle.unref?.();
     } catch (err) {
       // Reset state so a future start() can retry. Without this, a failed
       // warm-up tick would leave #started=true with no interval armed and


### PR DESCRIPTION
## Description

Fixes a crash on Cloudflare Workers (workerd) where calling `generate()` on an `Agent` not registered to a `Mastra` instance threw `TypeError: this.#intervalHandle.unref is not a function`. The standalone agent's ephemeral Mastra lazily starts workers, which starts the `Scheduler`, whose polling interval called `.unref()` unconditionally — but workerd's `setInterval` returns a number, not a Node.js `Timeout`, so `.unref` does not exist.

- Changed `this.#intervalHandle.unref()` to `this.#intervalHandle.unref?.()` in `packages/core/src/workflows/scheduler/scheduler.ts`, matching the guarded pattern already used at 8 other call sites in core (e.g. `tool-search-stores.ts`, `signal-provider.ts`)
- Fully preserves the Node.js process-exit fix from #18713 — `unref()` is still called whenever the runtime provides it, and the existing unref test still passes
- Added a regression test that mocks `setInterval` to return a numeric handle (workerd behavior) and asserts `scheduler.start()` succeeds; the test fails without the fix
- Added a patch changeset for `@mastra/core`

## Related Issue(s)

Fixes #19462

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some environments give timers back as plain numbers instead of timer objects with an `.unref()` method. This PR makes the scheduler only call `.unref()` when it exists, so Cloudflare Workers don’t crash—and `Agent.generate()` works again even when the agent isn’t registered with a `Mastra` instance.

## Changes

- Updated `Scheduler.start()` to call `unref` safely via optional chaining (`unref?.()`), preventing `TypeError` when `setInterval` returns a numeric handle (Worker runtimes).
- Added a regression test that mocks `globalThis.setInterval` to return a number and verifies the scheduler starts/stops without crashing.
- Added a patch changeset for `@mastra/core` documenting the Cloudflare Workers fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->