### PR TITLE
feat(convex): add observational memory support to @mastra/convex

### DIFF
--- a/.changeset/breezy-rocks-tan.md
+++ b/.changeset/breezy-rocks-tan.md
@@ -1,0 +1,28 @@
+---
+'@mastra/convex': minor
+---
+
+Added Observational Memory support to the Convex storage adapter. Agents using `ConvexStore` can now enable `observationalMemory` in `@mastra/memory`, including async observation buffering and reflections.
+
+To enable it, add the new `mastraObservationalMemoryTable` to your Convex schema and redeploy:
+
+```ts title="convex/schema.ts"
+import { defineSchema } from 'convex/server';
+import {
+  mastraThreadsTable,
+  mastraMessagesTable,
+  mastraResourcesTable,
+  mastraObservationalMemoryTable,
+  // ...other Mastra tables
+} from '@mastra/convex/schema';
+
+export default defineSchema({
+  mastra_threads: mastraThreadsTable,
+  mastra_messages: mastraMessagesTable,
+  mastra_resources: mastraResourcesTable,
+  mastra_observational_memory: mastraObservationalMemoryTable,
+  // ...other Mastra tables
+});
+```
+
+Then run `npx convex deploy` (or `npx convex dev`) so the new table and storage operations are live. All observational memory writes run inside the deployed Convex storage mutation, so buffered-observation swaps and reflection generations are atomic.

--- a/.changeset/curly-meals-lose.md
+++ b/.changeset/curly-meals-lose.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Updated the unsupported-adapter error for resource-scoped message listing to include convex in the list of storage adapters that support Observational Memory.

--- a/.changeset/vast-clowns-rescue.md
+++ b/.changeset/vast-clowns-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Updated the async-buffering compatibility error to include `@mastra/convex` in the list of storage adapters that support Observational Memory.

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -58,7 +58,7 @@ For an AI SDK example, see [Using Mastra Memory](/guides/build-your-ui/ai-sdk-ui
 
 :::note
 
-OM currently only supports `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb` storage adapters.
+OM currently only supports `@mastra/pg`, `@mastra/libsql`, `@mastra/mongodb`, and `@mastra/convex` storage adapters.
 It uses background agents for managing memory. When no model is set, the default model is `google/gemini-2.5-flash`.
 
 :::

--- a/docs/src/content/en/reference/storage/convex.mdx
+++ b/docs/src/content/en/reference/storage/convex.mdx
@@ -42,6 +42,7 @@ import {
   mastraResourcesTable,
   mastraWorkflowSnapshotsTable,
   mastraScoresTable,
+  mastraObservationalMemoryTable,
   mastraVectorIndexesTable,
   mastraVectorsTable,
   mastraCacheTable,
@@ -55,6 +56,7 @@ export default defineSchema({
   mastra_resources: mastraResourcesTable,
   mastra_workflow_snapshots: mastraWorkflowSnapshotsTable,
   mastra_scorers: mastraScoresTable,
+  mastra_observational_memory: mastraObservationalMemoryTable,
   mastra_vector_indexes: mastraVectorIndexesTable,
   mastra_vectors: mastraVectorsTable,
   mastra_cache: mastraCacheTable,
@@ -242,11 +244,16 @@ The storage implementation uses typed Convex tables for each Mastra domain:
 | Threads | `mastra_threads` | Conversation threads |
 | Messages | `mastra_messages` | Chat messages |
 | Resources | `mastra_resources` | User working memory |
+| Observational Memory | `mastra_observational_memory` | Observational memory generations |
 | Workflows | `mastra_workflow_snapshots` | Workflow state |
 | Scorers | `mastra_scorers` | Evaluation data |
 | Cache | `mastra_cache` | Cache values, counters, and list metadata |
 | Cache Items | `mastra_cache_list_items` | Cache list entries |
 | Fallback | `mastra_documents` | Unknown tables |
+
+### Observational memory
+
+`ConvexStore` supports [observational memory](/docs/memory/observational-memory). Add `mastraObservationalMemoryTable` to your Convex schema and redeploy with `npx convex deploy` to enable it. Existing deployments created before this table was added need the same schema update.
 
 ### Architecture
 

--- a/packages/core/src/storage/domains/memory/base.ts
+++ b/packages/core/src/storage/domains/memory/base.ts
@@ -84,7 +84,7 @@ export abstract class MemoryStorage extends StorageDomain {
   async listMessagesByResourceId(_args: StorageListMessagesByResourceIdInput): Promise<StorageListMessagesOutput> {
     throw new Error(
       `Resource-scoped message listing is not implemented by this storage adapter (${this.constructor.name}). ` +
-        `Use an adapter that supports Observational Memory (pg, libsql, mongodb) or disable observational memory.`,
+        `Use an adapter that supports Observational Memory (pg, libsql, mongodb, convex) or disable observational memory.`,
     );
   }
 

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -1686,7 +1686,7 @@ ${workingMemory}`;
     if (omConfig.observation?.bufferTokens !== false && !coreFeatures.has('asyncBuffering')) {
       throw new Error(
         'Observational memory async buffering is enabled by default but the installed version of @mastra/core does not support it. ' +
-          'Either upgrade @mastra/core, @mastra/memory, and your storage adapter (@mastra/libsql, @mastra/pg, or @mastra/mongodb) to the latest version, ' +
+          'Either upgrade @mastra/core, @mastra/memory, and your storage adapter (@mastra/libsql, @mastra/pg, @mastra/mongodb, or @mastra/convex) to the latest version, ' +
           'or explicitly disable async buffering by setting `observation: { bufferTokens: false }` in your observationalMemory config.',
       );
     }

--- a/stores/convex/README.md
+++ b/stores/convex/README.md
@@ -2,7 +2,7 @@
 
 Convex adapters for Mastra:
 
-- `ConvexStore` implements the Mastra storage contract (threads, messages, workflows, scores, resources, schedules, channels, background tasks).
+- `ConvexStore` implements the Mastra storage contract (threads, messages, workflows, scores, resources, schedules, channels, background tasks, observational memory).
 - `ConvexVector` stores embeddings inside Convex and performs development-scale cosine similarity search.
 - `ConvexNativeVector` uses Convex native vector search for production workloads.
 - `ConvexServerCache` stores Mastra server cache entries in Convex for durable stream replay and response caching.
@@ -33,6 +33,7 @@ import {
   mastraChannelInstallationsTable,
   mastraChannelConfigTable,
   mastraBackgroundTasksTable,
+  mastraObservationalMemoryTable,
   mastraVectorIndexesTable,
   mastraVectorsTable,
   mastraCacheTable,
@@ -51,6 +52,7 @@ export default defineSchema({
   mastra_channel_installations: mastraChannelInstallationsTable,
   mastra_channel_config: mastraChannelConfigTable,
   mastra_background_tasks: mastraBackgroundTasksTable,
+  mastra_observational_memory: mastraObservationalMemoryTable,
   mastra_vector_indexes: mastraVectorIndexesTable,
   mastra_vectors: mastraVectorsTable,
   mastra_cache: mastraCacheTable,
@@ -170,22 +172,23 @@ Native vector search uses Convex's schema-defined vector indexes and action-only
 
 This adapter uses **typed Convex tables** for each Mastra domain:
 
-| Domain           | Convex Table                                            | Purpose                          |
-| ---------------- | ------------------------------------------------------- | -------------------------------- |
-| Threads          | `mastra_threads`                                        | Conversation threads             |
-| Messages         | `mastra_messages`                                       | Chat messages                    |
-| Resources        | `mastra_resources`                                      | User working memory              |
-| Workflows        | `mastra_workflow_snapshots`                             | Workflow state                   |
-| Scorers          | `mastra_scorers`                                        | Evaluation data                  |
-| Schedules        | `mastra_schedules`                                      | Workflow schedules               |
-| Triggers         | `mastra_schedule_triggers`                              | Schedule history                 |
-| Channels         | `mastra_channel_installations`, `mastra_channel_config` | Channel installations and config |
-| Background Tasks | `mastra_background_tasks`                               | Background task state            |
-| Vector Indexes   | `mastra_vector_indexes`                                 | Index metadata                   |
-| Vectors          | `mastra_vectors`                                        | Embeddings                       |
-| Cache            | `mastra_cache`                                          | Cache metadata                   |
-| Cache Items      | `mastra_cache_list_items`                               | Cache list entries               |
-| Fallback         | `mastra_documents`                                      | Unknown tables                   |
+| Domain               | Convex Table                                            | Purpose                          |
+| -------------------- | ------------------------------------------------------- | -------------------------------- |
+| Threads              | `mastra_threads`                                        | Conversation threads             |
+| Messages             | `mastra_messages`                                       | Chat messages                    |
+| Resources            | `mastra_resources`                                      | User working memory              |
+| Workflows            | `mastra_workflow_snapshots`                             | Workflow state                   |
+| Scorers              | `mastra_scorers`                                        | Evaluation data                  |
+| Schedules            | `mastra_schedules`                                      | Workflow schedules               |
+| Triggers             | `mastra_schedule_triggers`                              | Schedule history                 |
+| Channels             | `mastra_channel_installations`, `mastra_channel_config` | Channel installations and config |
+| Background Tasks     | `mastra_background_tasks`                               | Background task state            |
+| Observational Memory | `mastra_observational_memory`                           | Observational memory generations |
+| Vector Indexes       | `mastra_vector_indexes`                                 | Index metadata                   |
+| Vectors              | `mastra_vectors`                                        | Embeddings                       |
+| Cache                | `mastra_cache`                                          | Cache metadata                   |
+| Cache Items          | `mastra_cache_list_items`                               | Cache list entries               |
+| Fallback             | `mastra_documents`                                      | Unknown tables                   |
 
 All typed tables include:
 
@@ -195,6 +198,14 @@ All typed tables include:
 Schedule due reads and trigger-history reads use bounded Convex queries to avoid deployment read limits. When no explicit trigger-history limit is provided, the adapter returns the newest 100 rows. Schedule listing is capped at 8,000 rows per call. Schedule rows also store a normalized `workflow_id` alongside the serialized target so workflow filters can run inside Convex before the listing cap is applied.
 
 Background task reads and updates also tolerate older rows that were written to the fallback `mastra_documents` table.
+
+### Observational memory
+
+`ConvexStore` supports Mastra's observational memory. Records are keyed by a `lookupKey` (`thread:{id}` or `resource:{id}`) and the latest generation is served through the `by_lookup_key` index. All observational memory read-modify-write operations run inside the deployed storage mutation, so swaps and counter updates are atomic.
+
+Upgrading from a version without observational memory: add `mastraObservationalMemoryTable` to your `convex/schema.ts` (as shown in the quick start) and run `npx convex deploy` again.
+
+Active observations and buffered chunks share one Convex document, which is subject to Convex's 1 MiB document size limit. Default observational memory thresholds stay well below this limit; extremely large custom thresholds can exceed it.
 
 ## Testing
 

--- a/stores/convex/src/schema.test.ts
+++ b/stores/convex/src/schema.test.ts
@@ -1,0 +1,44 @@
+import { OBSERVATIONAL_MEMORY_SCHEMA } from '@mastra/core/storage';
+import { describe, expect, it } from 'vitest';
+
+import { mastraObservationalMemoryTable } from './schema';
+import { TABLE_INDEX_MAP } from './server/index-map';
+
+/**
+ * Drift guard for the hand-defined observational memory table.
+ *
+ * The table cannot be built from core's schema constants (they are excluded
+ * from TABLE_SCHEMAS and this file is bundled into user deployments), so this
+ * test fails when a column is added to core's OBSERVATIONAL_MEMORY_SCHEMA
+ * without a matching field in mastraObservationalMemoryTable — the Convex
+ * equivalent of pg's om-migration-columns guard.
+ */
+describe('mastraObservationalMemoryTable schema drift guard', () => {
+  const exported = JSON.parse(JSON.stringify(mastraObservationalMemoryTable.export())) as {
+    indexes: Array<{ indexDescriptor: string; fields: string[] }>;
+    documentType: { type: string; value: Record<string, { fieldType: unknown; optional: boolean }> };
+  };
+
+  it('mirrors every column of core OBSERVATIONAL_MEMORY_SCHEMA', () => {
+    const tableFields = Object.keys(exported.documentType.value).sort();
+    const coreColumns = Object.keys(OBSERVATIONAL_MEMORY_SCHEMA).sort();
+    expect(tableFields).toEqual(coreColumns);
+  });
+
+  it('marks exactly the nullable core columns as optional', () => {
+    const optionalFields = Object.entries(exported.documentType.value)
+      .filter(([, field]) => field.optional)
+      .map(([name]) => name)
+      .sort();
+    const nullableColumns = Object.keys(OBSERVATIONAL_MEMORY_SCHEMA)
+      .filter(column => OBSERVATIONAL_MEMORY_SCHEMA[column]!.nullable)
+      .sort();
+    expect(optionalFields).toEqual(nullableColumns);
+  });
+
+  it('defines the indexes registered in the server index map', () => {
+    const tableIndexes = exported.indexes.map(index => ({ name: index.indexDescriptor, fields: index.fields }));
+    expect(tableIndexes).toEqual(expect.arrayContaining(TABLE_INDEX_MAP.mastra_observational_memory!));
+    expect(tableIndexes.map(index => index.name).sort()).toEqual(['by_lookup_key', 'by_record_id']);
+  });
+});

--- a/stores/convex/src/schema.ts
+++ b/stores/convex/src/schema.ts
@@ -274,6 +274,65 @@ export const mastraBackgroundTasksTable = defineTable({
   .index('by_tool', ['tool_name'])
   .index('by_created', ['createdAt']);
 
+/**
+ * Observational memory table - stores observational memory generations.
+ *
+ * Fields mirror @mastra/core's OBSERVATIONAL_MEMORY_SCHEMA (storage/constants.ts).
+ * The schema is defined explicitly (not via buildTableFromSchema) because the
+ * core export is intentionally excluded from TABLE_SCHEMAS (OM is optional) and
+ * older cores in the peer range may not export it at all.
+ *
+ * Serialization conventions:
+ * - Timestamps are ISO strings.
+ * - `config`, `metadata`, and `bufferedObservationChunks` are JSON strings
+ *   because user-influenced payloads can contain Convex-reserved field names
+ *   such as `$schema` (same reasoning as mastraSchedulesTable).
+ * - Nullable fields accept explicit null so cleared state can travel over JSON.
+ *
+ * Records are keyed by `lookupKey` ('thread:{id}' or 'resource:{id}'); the
+ * latest generation is the highest `generationCount` per lookupKey, served by
+ * the by_lookup_key index in descending order.
+ */
+export const mastraObservationalMemoryTable = defineTable({
+  id: v.string(),
+  lookupKey: v.string(),
+  scope: v.string(),
+  // Nullable in core's OBSERVATIONAL_MEMORY_SCHEMA; the adapter always writes it.
+  resourceId: v.optional(v.union(v.string(), v.null())),
+  threadId: v.optional(v.union(v.string(), v.null())),
+  activeObservations: v.string(),
+  activeObservationsPendingUpdate: v.optional(v.union(v.string(), v.null())),
+  originType: v.string(),
+  config: v.string(),
+  generationCount: v.number(),
+  lastObservedAt: v.optional(v.union(v.string(), v.null())),
+  lastReflectionAt: v.optional(v.union(v.string(), v.null())),
+  pendingMessageTokens: v.number(),
+  totalTokensObserved: v.number(),
+  observationTokenCount: v.number(),
+  isObserving: v.boolean(),
+  isReflecting: v.boolean(),
+  observedMessageIds: v.optional(v.union(v.array(v.string()), v.null())),
+  observedTimezone: v.optional(v.union(v.string(), v.null())),
+  bufferedObservations: v.optional(v.union(v.string(), v.null())),
+  bufferedObservationTokens: v.optional(v.union(v.number(), v.null())),
+  bufferedMessageIds: v.optional(v.union(v.array(v.string()), v.null())),
+  bufferedReflection: v.optional(v.union(v.string(), v.null())),
+  bufferedReflectionTokens: v.optional(v.union(v.number(), v.null())),
+  bufferedReflectionInputTokens: v.optional(v.union(v.number(), v.null())),
+  reflectedObservationLineCount: v.optional(v.union(v.number(), v.null())),
+  bufferedObservationChunks: v.optional(v.union(v.string(), v.null())),
+  isBufferingObservation: v.boolean(),
+  isBufferingReflection: v.boolean(),
+  lastBufferedAtTokens: v.number(),
+  lastBufferedAtTime: v.optional(v.union(v.string(), v.null())),
+  metadata: v.optional(v.union(v.string(), v.null())),
+  createdAt: v.string(),
+  updatedAt: v.string(),
+})
+  .index('by_record_id', ['id'])
+  .index('by_lookup_key', ['lookupKey', 'generationCount']);
+
 // ============================================================================
 // Vector Tables - Not in core schemas (vector-specific)
 // ============================================================================
@@ -427,3 +486,8 @@ export {
 export const TABLE_VECTOR_INDEXES = 'mastra_vector_indexes';
 export const TABLE_VECTORS = 'mastra_vectors';
 export const TABLE_DOCUMENTS = 'mastra_documents';
+
+// Observational memory table name. Defined locally (not imported from core)
+// because this file is bundled into the user's Convex deployment and must not
+// rely on value exports that older @mastra/core versions in the peer range lack.
+export const TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';

--- a/stores/convex/src/server/index-map.ts
+++ b/stores/convex/src/server/index-map.ts
@@ -79,6 +79,10 @@ export const TABLE_INDEX_MAP: Record<string, Array<{ name: string; fields: strin
     { name: 'by_name', fields: ['indexName'] },
     { name: 'by_record_id', fields: ['id'] },
   ],
+  mastra_observational_memory: [
+    { name: 'by_lookup_key', fields: ['lookupKey', 'generationCount'] },
+    { name: 'by_record_id', fields: ['id'] },
+  ],
 };
 
 /**

--- a/stores/convex/src/server/index.ts
+++ b/stores/convex/src/server/index.ts
@@ -16,6 +16,7 @@ export {
   mastraChannelInstallationsTable,
   mastraChannelConfigTable,
   mastraBackgroundTasksTable,
+  mastraObservationalMemoryTable,
   mastraVectorIndexesTable,
   mastraVectorsTable,
   defineMastraNativeVectorTable,
@@ -34,4 +35,5 @@ export {
   TABLE_CHANNEL_INSTALLATIONS,
   TABLE_CHANNEL_CONFIG,
   TABLE_BACKGROUND_TASKS,
+  TABLE_OBSERVATIONAL_MEMORY,
 } from '../schema';

--- a/stores/convex/src/server/observational-memory.test.ts
+++ b/stores/convex/src/server/observational-memory.test.ts
@@ -1,0 +1,576 @@
+import type { GenericId } from 'convex/values';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { SerializedOMChunk, StorageRequest, StorageResponse } from '../storage/types';
+import {
+  deepMergeOMConfig,
+  handleObservationalMemoryOperation,
+  mergeReflectionWithUnreflected,
+  parseStoredChunks,
+  selectActivationBoundary,
+} from './observational-memory';
+import { mastraStorage } from './storage';
+
+type OMOperationCtx = Parameters<typeof handleObservationalMemoryOperation>[0];
+type StorageHandlerForTest = typeof mastraStorage & {
+  _handler: (ctx: OMOperationCtx, request: StorageRequest) => Promise<StorageResponse>;
+};
+
+const OM_TABLE = 'mastra_observational_memory';
+
+function storedOMDoc(overrides: Record<string, any> = {}) {
+  return {
+    id: 'om-1',
+    lookupKey: 'resource:res-1',
+    scope: 'resource',
+    resourceId: 'res-1',
+    threadId: null,
+    activeObservations: '',
+    activeObservationsPendingUpdate: null,
+    originType: 'initial',
+    config: '{}',
+    generationCount: 0,
+    lastObservedAt: null,
+    lastReflectionAt: null,
+    pendingMessageTokens: 0,
+    totalTokensObserved: 0,
+    observationTokenCount: 0,
+    isObserving: false,
+    isReflecting: false,
+    isBufferingObservation: false,
+    isBufferingReflection: false,
+    lastBufferedAtTokens: 0,
+    lastBufferedAtTime: null,
+    createdAt: '2026-06-01T00:00:00.000Z',
+    updatedAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function serializedChunk(overrides: Partial<SerializedOMChunk> = {}): SerializedOMChunk {
+  return {
+    id: 'ombuf-1',
+    cycleId: 'cycle-1',
+    observations: 'observed something',
+    tokenCount: 100,
+    messageIds: ['msg-1'],
+    messageTokens: 1000,
+    lastObservedAt: '2026-06-01T01:00:00.000Z',
+    createdAt: '2026-06-01T01:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/**
+ * In-memory fake of the Convex db surface used by the OM operations.
+ * Emulates by_record_id (eq id) and by_lookup_key (eq lookupKey, sorted by
+ * generationCount with .order() control) index semantics.
+ */
+function createFakeOMDb(initialDocs: Array<Record<string, any>>) {
+  const docs = initialDocs.map((doc, index) => ({ _id: `doc-${index}` as GenericId<string>, ...doc }));
+  const usedIndexes: string[] = [];
+  const inserted: Array<{ table: string; doc: Record<string, any> }> = [];
+
+  const db = {
+    query: vi.fn((_table: string) => {
+      let filtered: Array<Record<string, any>> = [...docs];
+      let direction: 'asc' | 'desc' = 'asc';
+      const ordered = () => (direction === 'desc' ? [...filtered].reverse() : filtered);
+      const chain = {
+        withIndex: (indexName: string, queryBuilder?: (q: any) => any) => {
+          usedIndexes.push(indexName);
+          const eqPairs: Array<[string, unknown]> = [];
+          const builder = {
+            eq: (field: string, value: unknown) => {
+              eqPairs.push([field, value]);
+              return builder;
+            },
+          };
+          queryBuilder?.(builder);
+          filtered = filtered.filter(doc => eqPairs.every(([field, value]) => doc[field] === value));
+          if (indexName === 'by_lookup_key') {
+            filtered.sort((a, b) => a.generationCount - b.generationCount);
+          }
+          return chain;
+        },
+        order: (dir: 'asc' | 'desc') => {
+          direction = dir;
+          return chain;
+        },
+        first: async () => ordered()[0] ?? null,
+        take: async (n: number) => ordered().slice(0, n),
+        unique: async () => {
+          if (filtered.length > 1) throw new Error('unique() matched more than one document');
+          return filtered[0] ?? null;
+        },
+      };
+      return chain;
+    }),
+    patch: vi.fn(async (_id: GenericId<string>, patch: Record<string, any>) => {
+      const doc = docs.find(d => d._id === _id);
+      if (!doc) throw new Error(`doc not found: ${String(_id)}`);
+      Object.assign(doc, patch);
+    }),
+    insert: vi.fn(async (table: string, doc: Record<string, any>) => {
+      const stored = { _id: `doc-inserted-${inserted.length}` as GenericId<string>, ...doc };
+      docs.push(stored);
+      inserted.push({ table, doc });
+      return stored._id;
+    }),
+  };
+
+  return { ctx: { db } as unknown as OMOperationCtx, db, docs, inserted, usedIndexes };
+}
+
+describe('parseStoredChunks', () => {
+  it('parses a JSON array of chunks', () => {
+    const chunk = serializedChunk();
+    expect(parseStoredChunks(JSON.stringify([chunk]))).toEqual([chunk]);
+  });
+
+  it.each([[null], [undefined], [''], ['not-json'], ['{"a":1}']])('returns an empty array for %j', value => {
+    expect(parseStoredChunks(value)).toEqual([]);
+  });
+});
+
+describe('selectActivationBoundary', () => {
+  it('activates everything when the target covers all chunks (ratio 1)', () => {
+    const chunks = [{ messageTokens: 1000 }, { messageTokens: 1000 }, { messageTokens: 1000 }];
+    expect(
+      selectActivationBoundary(chunks, {
+        activationRatio: 1,
+        messageTokensThreshold: 3000,
+        currentPendingTokens: 3000,
+      }),
+    ).toBe(3);
+  });
+
+  it('picks the boundary that lands the remaining context at the retention floor', () => {
+    // floor = 5000 * (1 - 0.8) = 1000; target = 6000 - 1000 = 5000
+    const chunks = [{ messageTokens: 3000 }, { messageTokens: 2000 }, { messageTokens: 2000 }];
+    expect(
+      selectActivationBoundary(chunks, {
+        activationRatio: 0.8,
+        messageTokensThreshold: 5000,
+        currentPendingTokens: 6000,
+      }),
+    ).toBe(2);
+  });
+
+  it('falls back to the under boundary when the over boundary overshoots the floor', () => {
+    // floor = 1000; target = 5000. Boundary 2 activates 6000 (overshoot 1000 > 950).
+    const chunks = [{ messageTokens: 2000 }, { messageTokens: 4000 }];
+    expect(
+      selectActivationBoundary(chunks, {
+        activationRatio: 0.8,
+        messageTokensThreshold: 5000,
+        currentPendingTokens: 6000,
+      }),
+    ).toBe(1);
+  });
+
+  it('prefers the over boundary under forceMaxActivation while respecting the minimum remaining tokens', () => {
+    // floor = 25000; target = 5000. Boundary 2 activates 28900 (overshoot 23900 > 23750)
+    // but leaves 1100 >= min(1000, floor) remaining, so force takes it.
+    const chunks = [{ messageTokens: 4000 }, { messageTokens: 24900 }];
+    const opts = {
+      activationRatio: 0.5,
+      messageTokensThreshold: 50000,
+      currentPendingTokens: 30000,
+    };
+    expect(selectActivationBoundary(chunks, { ...opts, forceMaxActivation: true })).toBe(2);
+    expect(selectActivationBoundary(chunks, opts)).toBe(1);
+  });
+
+  it('activates at least one chunk when every boundary violates the safeguards', () => {
+    const chunks = [{ messageTokens: 0 }];
+    expect(
+      selectActivationBoundary(chunks, {
+        activationRatio: 0.5,
+        messageTokensThreshold: 1000,
+        currentPendingTokens: 100,
+      }),
+    ).toBe(1);
+  });
+});
+
+describe('mergeReflectionWithUnreflected', () => {
+  it('returns only the reflection when all observation lines were reflected on', () => {
+    expect(mergeReflectionWithUnreflected('line 1\nline 2', 'the reflection', 2)).toBe('the reflection');
+  });
+
+  it('appends observation lines added after the reflection started', () => {
+    expect(mergeReflectionWithUnreflected('line 1\nline 2\nline 3\nline 4', 'the reflection', 2)).toBe(
+      'the reflection\n\nline 3\nline 4',
+    );
+  });
+});
+
+describe('deepMergeOMConfig', () => {
+  it('deep-merges nested objects and skips undefined source values', () => {
+    expect(
+      deepMergeOMConfig(
+        { observation: { messageTokens: 1000, model: 'a' }, keep: true },
+        { observation: { messageTokens: 2000, extra: 1 }, gone: undefined },
+      ),
+    ).toEqual({ observation: { messageTokens: 2000, model: 'a', extra: 1 }, keep: true });
+  });
+});
+
+describe('handleObservationalMemoryOperation', () => {
+  it('omGetLatest serves the highest generation through by_lookup_key descending', async () => {
+    const { ctx, usedIndexes } = createFakeOMDb([
+      storedOMDoc({ id: 'om-gen0', generationCount: 0 }),
+      storedOMDoc({ id: 'om-gen2', generationCount: 2 }),
+      storedOMDoc({ id: 'om-gen1', generationCount: 1 }),
+      storedOMDoc({ id: 'om-other', lookupKey: 'resource:res-2', generationCount: 9 }),
+    ]);
+
+    const result = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omGetLatest',
+      tableName: OM_TABLE,
+      lookupKey: 'resource:res-1',
+    });
+
+    expect(result.ok).toBe(true);
+    expect((result as any).result).toMatchObject({ id: 'om-gen2', generationCount: 2 });
+    expect(usedIndexes).toEqual(['by_lookup_key']);
+  });
+
+  it('omGetLatest returns null when no record exists', async () => {
+    const { ctx } = createFakeOMDb([]);
+    const result = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omGetLatest',
+      tableName: OM_TABLE,
+      lookupKey: 'resource:missing',
+    });
+    expect(result).toEqual({ ok: true, result: null });
+  });
+
+  it('omGetHistory filters by createdAt range and applies offset and limit in descending order', async () => {
+    const { ctx } = createFakeOMDb([
+      storedOMDoc({ id: 'om-gen0', generationCount: 0, createdAt: '2026-06-01T00:00:00.000Z' }),
+      storedOMDoc({ id: 'om-gen1', generationCount: 1, createdAt: '2026-06-02T00:00:00.000Z' }),
+      storedOMDoc({ id: 'om-gen2', generationCount: 2, createdAt: '2026-06-03T00:00:00.000Z' }),
+      storedOMDoc({ id: 'om-gen3', generationCount: 3, createdAt: '2026-06-04T00:00:00.000Z' }),
+    ]);
+
+    const all = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omGetHistory',
+      tableName: OM_TABLE,
+      lookupKey: 'resource:res-1',
+      limit: 10,
+    });
+    expect((all as any).result.map((doc: any) => doc.id)).toEqual(['om-gen3', 'om-gen2', 'om-gen1', 'om-gen0']);
+
+    const filtered = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omGetHistory',
+      tableName: OM_TABLE,
+      lookupKey: 'resource:res-1',
+      limit: 1,
+      from: '2026-06-02T00:00:00.000Z',
+      to: '2026-06-03T23:59:59.000Z',
+      offset: 1,
+    });
+    expect((filtered as any).result.map((doc: any) => doc.id)).toEqual(['om-gen1']);
+  });
+
+  it('omUpdateActive increments totalTokensObserved and resets pendingMessageTokens', async () => {
+    const { ctx, db, docs } = createFakeOMDb([storedOMDoc({ totalTokensObserved: 500, pendingMessageTokens: 1200 })]);
+
+    const result = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omUpdateActive',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      observations: 'new observations',
+      tokenCount: 300,
+      lastObservedAt: '2026-06-05T00:00:00.000Z',
+      observedMessageIds: ['msg-1', 'msg-2'],
+      updatedAt: '2026-06-05T00:00:00.000Z',
+    });
+
+    expect(result).toEqual({ ok: true });
+    expect(db.patch).toHaveBeenCalledTimes(1);
+    expect(docs[0]).toMatchObject({
+      activeObservations: 'new observations',
+      observationTokenCount: 300,
+      totalTokensObserved: 800,
+      pendingMessageTokens: 0,
+      observedMessageIds: ['msg-1', 'msg-2'],
+      lastObservedAt: '2026-06-05T00:00:00.000Z',
+      updatedAt: '2026-06-05T00:00:00.000Z',
+    });
+  });
+
+  it('throws a not-found error for updates against missing records', async () => {
+    const { ctx } = createFakeOMDb([]);
+    await expect(
+      handleObservationalMemoryOperation(ctx, OM_TABLE, {
+        op: 'omUpdateActive',
+        tableName: OM_TABLE,
+        id: 'missing',
+        observations: '',
+        tokenCount: 0,
+        lastObservedAt: '2026-06-05T00:00:00.000Z',
+        observedMessageIds: null,
+        updatedAt: '2026-06-05T00:00:00.000Z',
+      }),
+    ).rejects.toThrow('Observational memory record not found: missing');
+  });
+
+  it('omAppendBufferedChunk appends to the stored chunk array and updates the buffer cursor', async () => {
+    const existingChunk = serializedChunk({ id: 'ombuf-0', cycleId: 'cycle-0' });
+    const { ctx, docs } = createFakeOMDb([storedOMDoc({ bufferedObservationChunks: JSON.stringify([existingChunk]) })]);
+
+    const newChunk = serializedChunk({ id: 'ombuf-2', cycleId: 'cycle-2' });
+    await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omAppendBufferedChunk',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      chunk: newChunk,
+      lastBufferedAtTime: '2026-06-05T02:00:00.000Z',
+      updatedAt: '2026-06-05T02:00:00.000Z',
+    });
+
+    expect(JSON.parse(docs[0]!.bufferedObservationChunks)).toEqual([existingChunk, newChunk]);
+    expect(docs[0]).toMatchObject({ lastBufferedAtTime: '2026-06-05T02:00:00.000Z' });
+  });
+
+  it('omSwapBuffered activates chunks, appends with a message boundary, and clears the buffer', async () => {
+    const chunkA = serializedChunk({
+      id: 'ombuf-a',
+      cycleId: 'cycle-a',
+      observations: 'obs A',
+      tokenCount: 50,
+      messageIds: ['msg-1', 'msg-2'],
+      messageTokens: 1000,
+      suggestedContinuation: 'stale hint',
+    });
+    const chunkB = serializedChunk({
+      id: 'ombuf-b',
+      cycleId: 'cycle-b',
+      observations: 'obs B',
+      tokenCount: 70,
+      messageIds: ['msg-3'],
+      messageTokens: 1000,
+      lastObservedAt: '2026-06-01T02:00:00.000Z',
+      suggestedContinuation: 'fresh hint',
+      currentTask: 'the task',
+    });
+    const { ctx, docs } = createFakeOMDb([
+      storedOMDoc({
+        activeObservations: 'existing observations',
+        observationTokenCount: 10,
+        pendingMessageTokens: 2500,
+        bufferedObservationChunks: JSON.stringify([chunkA, chunkB]),
+      }),
+    ]);
+
+    const result = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omSwapBuffered',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      activationRatio: 1,
+      messageTokensThreshold: 2000,
+      currentPendingTokens: 2000,
+      now: '2026-06-05T03:00:00.000Z',
+    });
+
+    expect((result as any).result).toMatchObject({
+      chunksActivated: 2,
+      messageTokensActivated: 2000,
+      observationTokensActivated: 120,
+      messagesActivated: 3,
+      activatedCycleIds: ['cycle-a', 'cycle-b'],
+      activatedMessageIds: ['msg-1', 'msg-2', 'msg-3'],
+      observations: 'obs A\n\nobs B',
+      suggestedContinuation: 'fresh hint',
+      currentTask: 'the task',
+    });
+    expect(docs[0]).toMatchObject({
+      activeObservations: `existing observations\n\n--- message boundary (2026-06-01T02:00:00.000Z) ---\n\nobs A\n\nobs B`,
+      observationTokenCount: 130,
+      pendingMessageTokens: 500,
+      bufferedObservationChunks: null,
+      lastObservedAt: '2026-06-01T02:00:00.000Z',
+      updatedAt: '2026-06-05T03:00:00.000Z',
+    });
+  });
+
+  it('omSwapBuffered reports zero activation when nothing is buffered', async () => {
+    const { ctx, db } = createFakeOMDb([storedOMDoc({ bufferedObservationChunks: null })]);
+
+    const result = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omSwapBuffered',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      activationRatio: 1,
+      messageTokensThreshold: 2000,
+      currentPendingTokens: 2000,
+      // Refreshed chunks from a stale read must not resurrect an already-swapped buffer.
+      bufferedChunks: [serializedChunk()],
+      now: '2026-06-05T03:00:00.000Z',
+    });
+
+    expect((result as any).result).toMatchObject({ chunksActivated: 0, activatedMessageIds: [] });
+    expect(db.patch).not.toHaveBeenCalled();
+  });
+
+  it('omUpdateBufferedReflection appends content and accumulates token counters', async () => {
+    const { ctx, docs } = createFakeOMDb([
+      storedOMDoc({
+        bufferedReflection: 'first part',
+        bufferedReflectionTokens: 100,
+        bufferedReflectionInputTokens: 1000,
+      }),
+    ]);
+
+    await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omUpdateBufferedReflection',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      reflection: 'second part',
+      tokenCount: 50,
+      inputTokenCount: 500,
+      reflectedObservationLineCount: 12,
+      updatedAt: '2026-06-05T04:00:00.000Z',
+    });
+
+    expect(docs[0]).toMatchObject({
+      bufferedReflection: 'first part\n\nsecond part',
+      bufferedReflectionTokens: 150,
+      bufferedReflectionInputTokens: 1500,
+      reflectedObservationLineCount: 12,
+    });
+  });
+
+  it('omSwapBufferedReflection creates the next generation and clears the buffered state', async () => {
+    const { ctx, docs, inserted } = createFakeOMDb([
+      storedOMDoc({
+        activeObservations: 'line 1\nline 2\nline 3',
+        bufferedReflection: 'the reflection',
+        bufferedReflectionTokens: 80,
+        bufferedReflectionInputTokens: 800,
+        reflectedObservationLineCount: 2,
+        generationCount: 1,
+      }),
+    ]);
+
+    const result = await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omSwapBufferedReflection',
+      tableName: OM_TABLE,
+      currentRecord: {
+        id: 'om-1',
+        lookupKey: 'resource:res-1',
+        scope: 'resource',
+        threadId: null,
+        resourceId: 'res-1',
+        config: '{"observation":{"messageTokens":1000}}',
+        metadata: null,
+        observedTimezone: 'Europe/Berlin',
+        lastObservedAt: '2026-06-04T00:00:00.000Z',
+        totalTokensObserved: 900,
+        generationCount: 1,
+      },
+      newId: 'om-2',
+      tokenCount: 95,
+      now: '2026-06-05T05:00:00.000Z',
+    });
+
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0]!.table).toBe(OM_TABLE);
+    expect((result as any).result).toMatchObject({
+      id: 'om-2',
+      lookupKey: 'resource:res-1',
+      originType: 'reflection',
+      generationCount: 2,
+      activeObservations: 'the reflection\n\nline 3',
+      observationTokenCount: 95,
+      totalTokensObserved: 900,
+      lastReflectionAt: '2026-06-05T05:00:00.000Z',
+      observedTimezone: 'Europe/Berlin',
+      isBufferingReflection: false,
+    });
+    // Old record's buffered state is cleared
+    expect(docs[0]).toMatchObject({
+      bufferedReflection: null,
+      bufferedReflectionTokens: null,
+      bufferedReflectionInputTokens: null,
+      reflectedObservationLineCount: null,
+      updatedAt: '2026-06-05T05:00:00.000Z',
+    });
+  });
+
+  it('omSwapBufferedReflection throws when no reflection is buffered', async () => {
+    const { ctx } = createFakeOMDb([storedOMDoc({ bufferedReflection: null })]);
+    await expect(
+      handleObservationalMemoryOperation(ctx, OM_TABLE, {
+        op: 'omSwapBufferedReflection',
+        tableName: OM_TABLE,
+        currentRecord: {
+          id: 'om-1',
+          lookupKey: 'resource:res-1',
+          scope: 'resource',
+          threadId: null,
+          resourceId: 'res-1',
+          config: '{}',
+          metadata: null,
+          observedTimezone: null,
+          lastObservedAt: null,
+          totalTokensObserved: 0,
+          generationCount: 0,
+        },
+        newId: 'om-2',
+        tokenCount: 0,
+        now: '2026-06-05T05:00:00.000Z',
+      }),
+    ).rejects.toThrow('No buffered reflection to swap');
+  });
+
+  it('omUpdateConfig deep-merges the incoming config into the stored config', async () => {
+    const { ctx, docs } = createFakeOMDb([
+      storedOMDoc({ config: JSON.stringify({ observation: { messageTokens: 1000, model: 'a' }, keep: true }) }),
+    ]);
+
+    await handleObservationalMemoryOperation(ctx, OM_TABLE, {
+      op: 'omUpdateConfig',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      config: JSON.stringify({ observation: { messageTokens: 2000 } }),
+      updatedAt: '2026-06-05T06:00:00.000Z',
+    });
+
+    expect(JSON.parse(docs[0]!.config)).toEqual({
+      observation: { messageTokens: 2000, model: 'a' },
+      keep: true,
+    });
+  });
+});
+
+describe('mastraStorage routing for observational memory', () => {
+  it('routes the observational memory table to the typed table instead of mastra_documents', async () => {
+    const { ctx, db } = createFakeOMDb([storedOMDoc()]);
+
+    const result = await (mastraStorage as StorageHandlerForTest)._handler(ctx, {
+      op: 'omGetLatest',
+      tableName: OM_TABLE,
+      lookupKey: 'resource:res-1',
+    });
+
+    expect(result.ok).toBe(true);
+    expect((result as any).result).toMatchObject({ id: 'om-1' });
+    expect(db.query).toHaveBeenCalledWith(OM_TABLE);
+    expect(db.query).not.toHaveBeenCalledWith('mastra_documents');
+  });
+
+  it('rejects om operations against other tables', async () => {
+    const { ctx } = createFakeOMDb([]);
+    await expect(
+      (mastraStorage as StorageHandlerForTest)._handler(ctx, {
+        op: 'omGetLatest',
+        tableName: 'mastra_threads',
+        lookupKey: 'resource:res-1',
+      }),
+    ).rejects.toThrow('omGetLatest is only supported for mastra_observational_memory');
+  });
+});

--- a/stores/convex/src/server/observational-memory.ts
+++ b/stores/convex/src/server/observational-memory.ts
@@ -1,0 +1,440 @@
+/**
+ * Server-side observational memory operations for the generic Convex storage
+ * mutation. All read-modify-write logic lives here so each operation is atomic
+ * (Convex mutations are serializable transactions).
+ *
+ * Logic mirrors @mastra/core's in-memory reference implementation
+ * (packages/core/src/storage/domains/memory/inmemory.ts) and the MongoDB
+ * adapter. Pure helpers are exported for unit testing.
+ *
+ * This module is bundled into the user's Convex deployment: no Node.js APIs
+ * and no value imports from @mastra/core.
+ */
+import type { GenericMutationCtx as MutationCtx } from 'convex/server';
+
+import type { SerializedOMChunk, StorageRequest, StorageResponse } from '../storage/types';
+
+type OMRequest = Extract<
+  StorageRequest,
+  {
+    op:
+      | 'omGetLatest'
+      | 'omGetHistory'
+      | 'omUpdateActive'
+      | 'omAppendBufferedChunk'
+      | 'omSwapBuffered'
+      | 'omUpdateBufferedReflection'
+      | 'omSwapBufferedReflection'
+      | 'omUpdateConfig';
+  }
+>;
+
+const OM_QUERY_MAX_DOCS = 10000;
+
+/**
+ * Parse the stored bufferedObservationChunks JSON string. Tolerates null,
+ * missing, and malformed values by returning an empty array.
+ */
+export function parseStoredChunks(value: unknown): SerializedOMChunk[] {
+  if (typeof value !== 'string' || !value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Select how many buffered chunks to activate.
+ *
+ * Finds the chunk boundary closest to the activation target, biased over
+ * (prefer removing slightly more than the target so remaining context lands at
+ * or below the retention floor), with an overshoot safeguard that falls back
+ * to the best under boundary. Ported from the core in-memory reference.
+ */
+export function selectActivationBoundary(
+  chunks: Array<{ messageTokens?: number }>,
+  opts: {
+    activationRatio: number;
+    messageTokensThreshold: number;
+    currentPendingTokens: number;
+    forceMaxActivation?: boolean;
+  },
+): number {
+  // Calculate target: how many message tokens to remove so that
+  // (1 - activationRatio) * threshold worth of raw messages remain.
+  // e.g., ratio=0.8, threshold=5000, pending=6000 → remove 6000 - 1000 = 5000
+  const retentionFloor = opts.messageTokensThreshold * (1 - opts.activationRatio);
+  const targetMessageTokens = Math.max(0, opts.currentPendingTokens - retentionFloor);
+
+  // Track both best-over and best-under boundaries so we can fall back to
+  // under if the over boundary would overshoot by too much.
+  let cumulativeMessageTokens = 0;
+  let bestOverBoundary = 0;
+  let bestOverTokens = 0;
+  let bestUnderBoundary = 0;
+  let bestUnderTokens = 0;
+
+  for (let i = 0; i < chunks.length; i++) {
+    cumulativeMessageTokens += chunks[i]!.messageTokens ?? 0;
+    const boundary = i + 1;
+
+    if (cumulativeMessageTokens >= targetMessageTokens) {
+      // Over or equal — track the closest (lowest) over boundary
+      if (bestOverBoundary === 0 || cumulativeMessageTokens < bestOverTokens) {
+        bestOverBoundary = boundary;
+        bestOverTokens = cumulativeMessageTokens;
+      }
+    } else {
+      // Under — track the closest (highest) under boundary
+      if (cumulativeMessageTokens > bestUnderTokens) {
+        bestUnderBoundary = boundary;
+        bestUnderTokens = cumulativeMessageTokens;
+      }
+    }
+  }
+
+  // Safeguard: if the over boundary would eat into more than 95% of the
+  // retention floor, fall back to the best under boundary instead.
+  // When forceMaxActivation is set (above blockAfter), still prefer the over
+  // boundary, but never if it would leave fewer than the smaller of 1000
+  // tokens or the retention floor remaining.
+  const maxOvershoot = retentionFloor * 0.95;
+  const overshoot = bestOverTokens - targetMessageTokens;
+  const remainingAfterOver = opts.currentPendingTokens - bestOverTokens;
+  const remainingAfterUnder = opts.currentPendingTokens - bestUnderTokens;
+  // When activationRatio ≈ 1.0, retentionFloor is 0 and minRemaining becomes 0 — intentional for "activate everything" configs.
+  const minRemaining = Math.min(1000, retentionFloor);
+
+  if (opts.forceMaxActivation && bestOverBoundary > 0 && remainingAfterOver >= minRemaining) {
+    return bestOverBoundary;
+  }
+  if (bestOverBoundary > 0 && overshoot <= maxOvershoot && remainingAfterOver >= minRemaining) {
+    return bestOverBoundary;
+  }
+  if (bestUnderBoundary > 0 && remainingAfterUnder >= minRemaining) {
+    return bestUnderBoundary;
+  }
+  if (bestOverBoundary > 0) {
+    // All boundaries are over and exceed the safeguard — still activate
+    // the closest over boundary (better than nothing)
+    return bestOverBoundary;
+  }
+  return 1;
+}
+
+/**
+ * Merge a buffered reflection with the observations added after the reflection
+ * started. Lines 0..reflectedLineCount of activeObservations were reflected on
+ * and are replaced by the reflection; later lines are appended as-is.
+ */
+export function mergeReflectionWithUnreflected(
+  activeObservations: string,
+  bufferedReflection: string,
+  reflectedLineCount: number,
+): string {
+  const allLines = (activeObservations || '').split('\n');
+  const unreflectedLines = allLines.slice(reflectedLineCount);
+  const unreflectedContent = unreflectedLines.join('\n').trim();
+  return unreflectedContent ? `${bufferedReflection}\n\n${unreflectedContent}` : bufferedReflection;
+}
+
+function isPlainObj(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Deep-merge two plain config objects (source wins; undefined source values
+ * are skipped). Mirrors MemoryStorage.deepMergeConfig in @mastra/core.
+ */
+export function deepMergeOMConfig(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>,
+): Record<string, unknown> {
+  const output: Record<string, unknown> = { ...target };
+  for (const key of Object.keys(source)) {
+    const tVal = target[key];
+    const sVal = source[key];
+    if (isPlainObj(tVal) && isPlainObj(sVal)) {
+      output[key] = deepMergeOMConfig(tVal, sVal);
+    } else if (sVal !== undefined) {
+      output[key] = sVal;
+    }
+  }
+  return output;
+}
+
+function parseJsonObject(value: unknown): Record<string, unknown> {
+  if (typeof value !== 'string' || !value) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return isPlainObj(parsed) ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function findRecordById(ctx: MutationCtx<any>, convexTable: string, id: string) {
+  return await ctx.db
+    .query(convexTable)
+    .withIndex('by_record_id', (q: any) => q.eq('id', id))
+    .unique();
+}
+
+function requireRecord(doc: unknown, id: string) {
+  if (!doc) {
+    throw new Error(`Observational memory record not found: ${id}`);
+  }
+  return doc as Record<string, any> & { _id: any };
+}
+
+const EMPTY_SWAP_RESULT = {
+  chunksActivated: 0,
+  messageTokensActivated: 0,
+  observationTokensActivated: 0,
+  messagesActivated: 0,
+  activatedCycleIds: [] as string[],
+  activatedMessageIds: [] as string[],
+};
+
+export async function handleObservationalMemoryOperation(
+  ctx: MutationCtx<any>,
+  convexTable: string,
+  request: OMRequest,
+): Promise<StorageResponse> {
+  switch (request.op) {
+    case 'omGetLatest': {
+      // by_lookup_key is [lookupKey, generationCount]; after eq(lookupKey) the
+      // descending order sorts by generationCount, so first() is the latest generation.
+      const doc = await ctx.db
+        .query(convexTable)
+        .withIndex('by_lookup_key', (q: any) => q.eq('lookupKey', request.lookupKey))
+        .order('desc')
+        .first();
+      return { ok: true, result: doc ?? null };
+    }
+
+    case 'omGetHistory': {
+      let docs = await ctx.db
+        .query(convexTable)
+        .withIndex('by_lookup_key', (q: any) => q.eq('lookupKey', request.lookupKey))
+        .order('desc')
+        .take(OM_QUERY_MAX_DOCS);
+
+      // createdAt is a UTC ISO string, so lexicographic comparison is chronological.
+      if (request.from) {
+        docs = docs.filter((doc: any) => typeof doc.createdAt === 'string' && doc.createdAt >= request.from!);
+      }
+      if (request.to) {
+        docs = docs.filter((doc: any) => typeof doc.createdAt === 'string' && doc.createdAt <= request.to!);
+      }
+      if (request.offset != null) {
+        docs = docs.slice(request.offset);
+      }
+      return { ok: true, result: docs.slice(0, request.limit) };
+    }
+
+    case 'omUpdateActive': {
+      const doc = requireRecord(await findRecordById(ctx, convexTable, request.id), request.id);
+      const safeTokenCount = Number.isFinite(request.tokenCount) && request.tokenCount >= 0 ? request.tokenCount : 0;
+
+      await ctx.db.patch(doc._id, {
+        activeObservations: request.observations,
+        lastObservedAt: request.lastObservedAt,
+        // Reset pending tokens since we've now observed them
+        pendingMessageTokens: 0,
+        observationTokenCount: safeTokenCount,
+        totalTokensObserved: Number(doc.totalTokensObserved || 0) + safeTokenCount,
+        observedMessageIds: request.observedMessageIds,
+        updatedAt: request.updatedAt,
+      });
+      return { ok: true };
+    }
+
+    case 'omAppendBufferedChunk': {
+      const doc = requireRecord(await findRecordById(ctx, convexTable, request.id), request.id);
+      const chunks = parseStoredChunks(doc.bufferedObservationChunks);
+      chunks.push(request.chunk);
+
+      const patch: Record<string, unknown> = {
+        bufferedObservationChunks: JSON.stringify(chunks),
+        updatedAt: request.updatedAt,
+      };
+      if (request.lastBufferedAtTime) {
+        patch.lastBufferedAtTime = request.lastBufferedAtTime;
+      }
+      await ctx.db.patch(doc._id, patch);
+      return { ok: true };
+    }
+
+    case 'omSwapBuffered': {
+      const doc = requireRecord(await findRecordById(ctx, convexTable, request.id), request.id);
+
+      const persistedChunks = parseStoredChunks(doc.bufferedObservationChunks);
+      // Nothing buffered (or already swapped) — report zero activation.
+      if (persistedChunks.length === 0) {
+        return { ok: true, result: EMPTY_SWAP_RESULT };
+      }
+
+      // Use caller-provided refreshed chunks (with up-to-date token weights)
+      // for activation math when present, falling back to persisted chunks.
+      const chunks = Array.isArray(request.bufferedChunks) ? request.bufferedChunks : persistedChunks;
+      if (chunks.length === 0) {
+        return { ok: true, result: EMPTY_SWAP_RESULT };
+      }
+
+      const chunksToActivate = selectActivationBoundary(chunks, {
+        activationRatio: request.activationRatio,
+        messageTokensThreshold: request.messageTokensThreshold,
+        currentPendingTokens: request.currentPendingTokens,
+        forceMaxActivation: request.forceMaxActivation,
+      });
+      const activatedChunks = chunks.slice(0, chunksToActivate);
+      const remainingChunks = chunks.slice(chunksToActivate);
+
+      // Combine activated chunks into content
+      const activatedContent = activatedChunks.map(c => c.observations).join('\n\n');
+      const activatedTokens = activatedChunks.reduce((sum, c) => sum + c.tokenCount, 0);
+      const activatedMessageTokens = activatedChunks.reduce((sum, c) => sum + (c.messageTokens ?? 0), 0);
+      const activatedMessageCount = activatedChunks.reduce((sum, c) => sum + (c.messageIds?.length ?? 0), 0);
+      const activatedCycleIds = activatedChunks.map(c => c.cycleId).filter((id): id is string => !!id);
+      const activatedMessageIds = activatedChunks.flatMap(c => c.messageIds ?? []);
+
+      // Derive lastObservedAt from the latest activated chunk, or use provided value
+      const latestChunk = activatedChunks[activatedChunks.length - 1];
+      const lastObservedAt = request.lastObservedAt ?? latestChunk?.lastObservedAt ?? request.now;
+
+      // Append activated content to active observations with message boundary for cache stability
+      const existingActive = (doc.activeObservations as string) || '';
+      const boundary = `\n\n--- message boundary (${lastObservedAt}) ---\n\n`;
+      const newActive = existingActive ? `${existingActive}${boundary}${activatedContent}` : activatedContent;
+
+      // NOTE: We intentionally do NOT add activatedMessageIds to observedMessageIds.
+      // observedMessageIds is used by getUnobservedMessages to filter future messages.
+      // Since AI SDK may reuse message IDs for new content, adding them here would
+      // permanently block new content from being observed. Instead, we return
+      // activatedMessageIds so the caller can remove them from messageList directly.
+
+      await ctx.db.patch(doc._id, {
+        activeObservations: newActive,
+        observationTokenCount: Number(doc.observationTokenCount || 0) + activatedTokens,
+        // Decrement pending message tokens (clamped to zero)
+        pendingMessageTokens: Math.max(0, Number(doc.pendingMessageTokens || 0) - activatedMessageTokens),
+        bufferedObservationChunks: remainingChunks.length > 0 ? JSON.stringify(remainingChunks) : null,
+        lastObservedAt,
+        updatedAt: request.now,
+      });
+
+      // Use hints from the most recent activated chunk only — stale hints from older chunks are discarded
+      const latestChunkHints = activatedChunks[activatedChunks.length - 1];
+
+      return {
+        ok: true,
+        result: {
+          chunksActivated: activatedChunks.length,
+          messageTokensActivated: activatedMessageTokens,
+          observationTokensActivated: activatedTokens,
+          messagesActivated: activatedMessageCount,
+          activatedCycleIds,
+          activatedMessageIds,
+          observations: activatedContent,
+          perChunk: activatedChunks.map(c => ({
+            cycleId: c.cycleId ?? '',
+            messageTokens: c.messageTokens ?? 0,
+            observationTokens: c.tokenCount,
+            messageCount: c.messageIds?.length ?? 0,
+            observations: c.observations,
+          })),
+          suggestedContinuation: latestChunkHints?.suggestedContinuation ?? undefined,
+          currentTask: latestChunkHints?.currentTask ?? undefined,
+        },
+      };
+    }
+
+    case 'omUpdateBufferedReflection': {
+      const doc = requireRecord(await findRecordById(ctx, convexTable, request.id), request.id);
+
+      const existingContent = (doc.bufferedReflection as string) || '';
+      await ctx.db.patch(doc._id, {
+        bufferedReflection: existingContent ? `${existingContent}\n\n${request.reflection}` : request.reflection,
+        bufferedReflectionTokens: Number(doc.bufferedReflectionTokens || 0) + request.tokenCount,
+        bufferedReflectionInputTokens: Number(doc.bufferedReflectionInputTokens || 0) + request.inputTokenCount,
+        reflectedObservationLineCount: request.reflectedObservationLineCount,
+        updatedAt: request.updatedAt,
+      });
+      return { ok: true };
+    }
+
+    case 'omSwapBufferedReflection': {
+      const { currentRecord, newId, tokenCount, now } = request;
+      const doc = requireRecord(await findRecordById(ctx, convexTable, currentRecord.id), currentRecord.id);
+
+      const bufferedReflection = (doc.bufferedReflection as string) || '';
+      if (!bufferedReflection) {
+        throw new Error('No buffered reflection to swap');
+      }
+
+      const newObservations = mergeReflectionWithUnreflected(
+        (doc.activeObservations as string) || '',
+        bufferedReflection,
+        Number(doc.reflectedObservationLineCount || 0),
+      );
+
+      // Create the new generation record
+      const newRecord = {
+        id: newId,
+        lookupKey: currentRecord.lookupKey,
+        scope: currentRecord.scope,
+        resourceId: currentRecord.resourceId,
+        threadId: currentRecord.threadId,
+        activeObservations: newObservations,
+        activeObservationsPendingUpdate: null,
+        originType: 'reflection',
+        config: currentRecord.config,
+        generationCount: currentRecord.generationCount + 1,
+        lastObservedAt: currentRecord.lastObservedAt,
+        lastReflectionAt: now,
+        pendingMessageTokens: 0,
+        totalTokensObserved: currentRecord.totalTokensObserved,
+        observationTokenCount: tokenCount,
+        isObserving: false,
+        isReflecting: false,
+        isBufferingObservation: false,
+        isBufferingReflection: false,
+        lastBufferedAtTokens: 0,
+        lastBufferedAtTime: null,
+        observedTimezone: currentRecord.observedTimezone,
+        metadata: currentRecord.metadata,
+        createdAt: now,
+        updatedAt: now,
+      };
+      await ctx.db.insert(convexTable, newRecord);
+
+      // Clear buffered state on the old record
+      await ctx.db.patch(doc._id, {
+        bufferedReflection: null,
+        bufferedReflectionTokens: null,
+        bufferedReflectionInputTokens: null,
+        reflectedObservationLineCount: null,
+        updatedAt: now,
+      });
+
+      return { ok: true, result: newRecord };
+    }
+
+    case 'omUpdateConfig': {
+      const doc = requireRecord(await findRecordById(ctx, convexTable, request.id), request.id);
+
+      const existing = parseJsonObject(doc.config);
+      const incoming = parseJsonObject(request.config);
+      const merged = deepMergeOMConfig(existing, incoming);
+
+      await ctx.db.patch(doc._id, {
+        config: JSON.stringify(merged),
+        updatedAt: request.updatedAt,
+      });
+      return { ok: true };
+    }
+  }
+}

--- a/stores/convex/src/server/storage.ts
+++ b/stores/convex/src/server/storage.ts
@@ -16,6 +16,7 @@ import type { GenericId } from 'convex/values';
 
 import type { EqualityFilter, StorageRequest, StorageResponse } from '../storage/types';
 import { findBestIndex } from './index-map';
+import { handleObservationalMemoryOperation } from './observational-memory';
 import { createEmptyWorkflowSnapshot, mergeWorkflowStepResult } from './workflow-snapshot';
 
 // Vector-specific table names (not in @mastra/core)
@@ -24,6 +25,10 @@ const VECTOR_TABLE_PREFIX = 'mastra_vector_';
 const CONVEX_TABLE_WORKFLOW_SNAPSHOTS = 'mastra_workflow_snapshots';
 const CONVEX_TABLE_BACKGROUND_TASKS = 'mastra_background_tasks';
 const CONVEX_TABLE_DOCUMENTS = 'mastra_documents';
+// Defined locally (not imported from core) because this file is bundled into
+// the user's Convex deployment and older cores in the peer range may not
+// export the observational memory constants.
+const CONVEX_TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';
 const STORAGE_MUTATION_BATCH_SIZE = 25;
 // Keep this in sync with ConvexDB's loadMany client chunk size. The low cap
 // bounds full-doc responses per request; individual document size still matters.
@@ -247,6 +252,8 @@ function resolveTable(tableName: string): { convexTable: string; isTyped: boolea
       return { convexTable: CONVEX_TABLE_BACKGROUND_TASKS, isTyped: true };
     case TABLE_VECTOR_INDEXES:
       return { convexTable: 'mastra_vector_indexes', isTyped: true };
+    case CONVEX_TABLE_OBSERVATIONAL_MEMORY:
+      return { convexTable: CONVEX_TABLE_OBSERVATIONAL_MEMORY, isTyped: true };
     default:
       // Check if it's a vector data table
       if (tableName.startsWith(VECTOR_TABLE_PREFIX)) {
@@ -333,6 +340,20 @@ export async function handleTypedOperation(
   request: StorageRequest,
 ): Promise<StorageResponse> {
   switch (request.op) {
+    case 'omGetLatest':
+    case 'omGetHistory':
+    case 'omUpdateActive':
+    case 'omAppendBufferedChunk':
+    case 'omSwapBuffered':
+    case 'omUpdateBufferedReflection':
+    case 'omSwapBufferedReflection':
+    case 'omUpdateConfig': {
+      if (convexTable !== CONVEX_TABLE_OBSERVATIONAL_MEMORY) {
+        throw new Error(`${request.op} is only supported for ${CONVEX_TABLE_OBSERVATIONAL_MEMORY}`);
+      }
+      return handleObservationalMemoryOperation(ctx, convexTable, request);
+    }
+
     case 'createSchedule': {
       if (convexTable !== 'mastra_schedules') {
         throw new Error(`createSchedule is only supported for mastra_schedules`);

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -13,7 +13,7 @@ import type { StorageColumn, StorageResourceType, TABLE_NAMES, UpdateWorkflowSta
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 
 import { ConvexAdminClient } from '../client';
-import type { EqualityFilter, IndexHint } from '../types';
+import type { EqualityFilter, IndexHint, SerializedOMChunk, SerializedOMCurrentRecord } from '../types';
 
 // Must not exceed the server-side loadMany id cap in server/storage.ts.
 const LOAD_MANY_REQUEST_BATCH_SIZE = 10;
@@ -69,7 +69,7 @@ export class ConvexDB extends MastraBase {
     tableName,
     schema: _schema,
   }: {
-    tableName: TABLE_NAMES;
+    tableName: TABLE_NAMES | string;
     schema: Record<string, StorageColumn>;
   }): Promise<void> {
     // No-op for Convex; schema is managed server-side via schema.ts
@@ -81,7 +81,7 @@ export class ConvexDB extends MastraBase {
     schema: _schema,
     ifNotExists: _ifNotExists,
   }: {
-    tableName: TABLE_NAMES;
+    tableName: TABLE_NAMES | string;
     schema: Record<string, StorageColumn>;
     ifNotExists: string[];
   }): Promise<void> {
@@ -89,7 +89,7 @@ export class ConvexDB extends MastraBase {
     this.logger.debug(`ConvexDB: alterTable called for ${tableName} (schema managed server-side)`);
   }
 
-  async clearTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+  async clearTable({ tableName }: { tableName: TABLE_NAMES | string }): Promise<void> {
     // Delete in batches since each mutation can only delete a small number of docs
     // to stay within Convex's 1-second mutation timeout.
     let hasMore = true;
@@ -102,7 +102,7 @@ export class ConvexDB extends MastraBase {
     }
   }
 
-  async dropTable({ tableName }: { tableName: TABLE_NAMES }): Promise<void> {
+  async dropTable({ tableName }: { tableName: TABLE_NAMES | string }): Promise<void> {
     // Delete in batches since each mutation can only delete a small number of docs
     // to stay within Convex's 1-second mutation timeout.
     let hasMore = true;
@@ -115,7 +115,7 @@ export class ConvexDB extends MastraBase {
     }
   }
 
-  async insert({ tableName, record }: { tableName: TABLE_NAMES; record: Record<string, any> }): Promise<void> {
+  async insert({ tableName, record }: { tableName: TABLE_NAMES | string; record: Record<string, any> }): Promise<void> {
     await this.client.callStorage({
       op: 'insert',
       tableName,
@@ -123,7 +123,13 @@ export class ConvexDB extends MastraBase {
     });
   }
 
-  async batchInsert({ tableName, records }: { tableName: TABLE_NAMES; records: Record<string, any>[] }): Promise<void> {
+  async batchInsert({
+    tableName,
+    records,
+  }: {
+    tableName: TABLE_NAMES | string;
+    records: Record<string, any>[];
+  }): Promise<void> {
     if (records.length === 0) return;
 
     await this.client.callStorage({
@@ -138,7 +144,7 @@ export class ConvexDB extends MastraBase {
     id,
     record,
   }: {
-    tableName: TABLE_NAMES;
+    tableName: TABLE_NAMES | string;
     id: string;
     record: Record<string, any>;
   }): Promise<boolean> {
@@ -195,7 +201,13 @@ export class ConvexDB extends MastraBase {
     });
   }
 
-  async load<R>({ tableName, keys }: { tableName: TABLE_NAMES; keys: Record<string, any> }): Promise<R | null> {
+  async load<R>({
+    tableName,
+    keys,
+  }: {
+    tableName: TABLE_NAMES | string;
+    keys: Record<string, any>;
+  }): Promise<R | null> {
     const result = await this.client.callStorage<R | null>({
       op: 'load',
       tableName,
@@ -205,7 +217,7 @@ export class ConvexDB extends MastraBase {
     return result;
   }
 
-  async loadMany<R>(tableName: TABLE_NAMES, ids: string[]): Promise<R[]> {
+  async loadMany<R>(tableName: TABLE_NAMES | string, ids: string[]): Promise<R[]> {
     const uniqueIds = [...new Set(ids)];
     if (uniqueIds.length === 0) return [];
 
@@ -223,7 +235,7 @@ export class ConvexDB extends MastraBase {
   }
 
   public async queryTable<R>(
-    tableName: TABLE_NAMES,
+    tableName: TABLE_NAMES | string,
     filters?: EqualityFilter[],
     indexHint?: IndexHint,
     limit?: number,
@@ -237,7 +249,7 @@ export class ConvexDB extends MastraBase {
     });
   }
 
-  public async deleteMany(tableName: TABLE_NAMES, ids: string[]): Promise<void> {
+  public async deleteMany(tableName: TABLE_NAMES | string, ids: string[]): Promise<void> {
     if (ids.length === 0) return;
     await this.client.callStorage({
       op: 'deleteMany',
@@ -395,7 +407,119 @@ export class ConvexDB extends MastraBase {
     }
   }
 
-  private normalizeRecord(tableName: TABLE_NAMES, record: Record<string, any>): Record<string, any> {
+  // ============================================
+  // Observational Memory Operations
+  // ============================================
+
+  public async omGetLatest<R>(tableName: string, lookupKey: string): Promise<R | null> {
+    return this.client.callStorage<R | null>({
+      op: 'omGetLatest',
+      tableName,
+      lookupKey,
+    });
+  }
+
+  public async omGetHistory<R>(
+    tableName: string,
+    args: { lookupKey: string; limit: number; from?: string; to?: string; offset?: number },
+  ): Promise<R[]> {
+    return this.client.callStorage<R[]>({
+      op: 'omGetHistory',
+      tableName,
+      ...args,
+    });
+  }
+
+  public async omUpdateActive(
+    tableName: string,
+    args: {
+      id: string;
+      observations: string;
+      tokenCount: number;
+      lastObservedAt: string;
+      observedMessageIds: string[] | null;
+      updatedAt: string;
+    },
+  ): Promise<void> {
+    await this.client.callStorage({
+      op: 'omUpdateActive',
+      tableName,
+      ...args,
+    });
+  }
+
+  public async omAppendBufferedChunk(
+    tableName: string,
+    args: { id: string; chunk: SerializedOMChunk; lastBufferedAtTime?: string; updatedAt: string },
+  ): Promise<void> {
+    await this.client.callStorage({
+      op: 'omAppendBufferedChunk',
+      tableName,
+      ...args,
+    });
+  }
+
+  public async omSwapBuffered<R>(
+    tableName: string,
+    args: {
+      id: string;
+      activationRatio: number;
+      messageTokensThreshold: number;
+      currentPendingTokens: number;
+      forceMaxActivation?: boolean;
+      lastObservedAt?: string;
+      bufferedChunks?: SerializedOMChunk[];
+      now: string;
+    },
+  ): Promise<R> {
+    return this.client.callStorage<R>({
+      op: 'omSwapBuffered',
+      tableName,
+      ...args,
+    });
+  }
+
+  public async omUpdateBufferedReflection(
+    tableName: string,
+    args: {
+      id: string;
+      reflection: string;
+      tokenCount: number;
+      inputTokenCount: number;
+      reflectedObservationLineCount: number;
+      updatedAt: string;
+    },
+  ): Promise<void> {
+    await this.client.callStorage({
+      op: 'omUpdateBufferedReflection',
+      tableName,
+      ...args,
+    });
+  }
+
+  public async omSwapBufferedReflection<R>(
+    tableName: string,
+    args: { currentRecord: SerializedOMCurrentRecord; newId: string; tokenCount: number; now: string },
+  ): Promise<R> {
+    return this.client.callStorage<R>({
+      op: 'omSwapBufferedReflection',
+      tableName,
+      ...args,
+    });
+  }
+
+  public async omUpdateConfig(
+    tableName: string,
+    args: { id: string; config: string; updatedAt: string },
+  ): Promise<void> {
+    await this.client.callStorage({
+      op: 'omUpdateConfig',
+      tableName,
+      ...args,
+    });
+  }
+
+  private normalizeRecord(tableName: TABLE_NAMES | string, record: Record<string, any>): Record<string, any> {
     const normalized: Record<string, any> = { ...record };
 
     if (tableName === TABLE_WORKFLOW_SNAPSHOT && !normalized.id) {

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -1,3 +1,5 @@
+import crypto from 'node:crypto';
+
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -14,15 +16,36 @@ import {
   safelyParseJSON,
 } from '@mastra/core/storage';
 import type {
+  BufferedObservationChunk,
+  CreateObservationalMemoryInput,
+  CreateReflectionGenerationInput,
+  ObservationalMemoryHistoryOptions,
+  ObservationalMemoryRecord,
+  StorageListMessagesByResourceIdInput,
   StorageListMessagesInput,
   StorageListMessagesOutput,
   StorageListThreadsInput,
   StorageListThreadsOutput,
   StorageResourceType,
+  SwapBufferedReflectionToActiveInput,
+  SwapBufferedToActiveInput,
+  SwapBufferedToActiveResult,
+  UpdateActiveObservationsInput,
+  UpdateBufferedObservationsInput,
+  UpdateBufferedReflectionInput,
+  UpdateObservationalMemoryConfigInput,
 } from '@mastra/core/storage';
 
 import { ConvexDB, resolveConvexConfig } from '../../db';
 import type { ConvexDomainConfig } from '../../db';
+import type { SerializedOMChunk, SerializedOMCurrentRecord } from '../../types';
+
+/**
+ * Local constant for the observational memory table name.
+ * Defined locally to avoid a static import that crashes on older @mastra/core
+ * versions that don't export TABLE_OBSERVATIONAL_MEMORY.
+ */
+const TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';
 
 type StoredMessage = {
   id: string;
@@ -65,7 +88,121 @@ function parseStoredResource(record: StoredResource): StorageResourceType {
   };
 }
 
+/**
+ * Stored (Convex document) shape of an observational memory record.
+ * Timestamps are ISO strings; config/metadata/bufferedObservationChunks are
+ * JSON strings. Mirrors mastraObservationalMemoryTable in schema.ts.
+ */
+type StoredOMRecord = {
+  id: string;
+  lookupKey: string;
+  scope: string;
+  resourceId: string;
+  threadId?: string | null;
+  activeObservations: string;
+  activeObservationsPendingUpdate?: string | null;
+  originType: string;
+  config: string;
+  generationCount: number;
+  lastObservedAt?: string | null;
+  lastReflectionAt?: string | null;
+  pendingMessageTokens: number;
+  totalTokensObserved: number;
+  observationTokenCount: number;
+  isObserving: boolean;
+  isReflecting: boolean;
+  observedMessageIds?: string[] | null;
+  observedTimezone?: string | null;
+  bufferedObservations?: string | null;
+  bufferedObservationTokens?: number | null;
+  bufferedMessageIds?: string[] | null;
+  bufferedReflection?: string | null;
+  bufferedReflectionTokens?: number | null;
+  bufferedReflectionInputTokens?: number | null;
+  reflectedObservationLineCount?: number | null;
+  bufferedObservationChunks?: string | null;
+  isBufferingObservation: boolean;
+  isBufferingReflection: boolean;
+  lastBufferedAtTokens: number;
+  lastBufferedAtTime?: string | null;
+  metadata?: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+function toISO(value: Date | string): string {
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function serializeOMChunk(chunk: BufferedObservationChunk): SerializedOMChunk {
+  return {
+    ...chunk,
+    lastObservedAt: toISO(chunk.lastObservedAt),
+    createdAt: toISO(chunk.createdAt),
+  };
+}
+
+function parseOMChunk(chunk: SerializedOMChunk): BufferedObservationChunk {
+  return {
+    ...chunk,
+    lastObservedAt: new Date(chunk.lastObservedAt),
+    createdAt: new Date(chunk.createdAt),
+  };
+}
+
+function parseStoredOMChunks(value: string | null | undefined): BufferedObservationChunk[] | undefined {
+  if (!value) return undefined;
+  const parsed = safelyParseJSON(value);
+  if (!Array.isArray(parsed)) return undefined;
+  return parsed.map(chunk => parseOMChunk(chunk));
+}
+
+function parseStoredOMRecord(doc: StoredOMRecord): ObservationalMemoryRecord {
+  const config = safelyParseJSON(doc.config);
+  const metadata = doc.metadata ? safelyParseJSON(doc.metadata) : undefined;
+  return {
+    id: doc.id,
+    scope: doc.scope as ObservationalMemoryRecord['scope'],
+    threadId: doc.threadId || null,
+    resourceId: doc.resourceId,
+    createdAt: new Date(doc.createdAt),
+    updatedAt: new Date(doc.updatedAt),
+    lastObservedAt: doc.lastObservedAt ? new Date(doc.lastObservedAt) : undefined,
+    originType: (doc.originType || 'initial') as ObservationalMemoryRecord['originType'],
+    generationCount: Number(doc.generationCount || 0),
+    activeObservations: doc.activeObservations || '',
+    bufferedObservationChunks: parseStoredOMChunks(doc.bufferedObservationChunks),
+    // Deprecated fields (for backward compatibility)
+    bufferedObservations: doc.activeObservationsPendingUpdate || undefined,
+    bufferedObservationTokens: doc.bufferedObservationTokens ? Number(doc.bufferedObservationTokens) : undefined,
+    bufferedMessageIds: undefined, // Use bufferedObservationChunks instead
+    bufferedReflection: doc.bufferedReflection || undefined,
+    bufferedReflectionTokens: doc.bufferedReflectionTokens ? Number(doc.bufferedReflectionTokens) : undefined,
+    bufferedReflectionInputTokens: doc.bufferedReflectionInputTokens
+      ? Number(doc.bufferedReflectionInputTokens)
+      : undefined,
+    reflectedObservationLineCount: doc.reflectedObservationLineCount
+      ? Number(doc.reflectedObservationLineCount)
+      : undefined,
+    totalTokensObserved: Number(doc.totalTokensObserved || 0),
+    observationTokenCount: Number(doc.observationTokenCount || 0),
+    pendingMessageTokens: Number(doc.pendingMessageTokens || 0),
+    isReflecting: Boolean(doc.isReflecting),
+    isObserving: Boolean(doc.isObserving),
+    isBufferingObservation: Boolean(doc.isBufferingObservation),
+    isBufferingReflection: Boolean(doc.isBufferingReflection),
+    lastBufferedAtTokens: Number(doc.lastBufferedAtTokens || 0),
+    lastBufferedAtTime: doc.lastBufferedAtTime ? new Date(doc.lastBufferedAtTime) : null,
+    config: (config as Record<string, unknown>) ?? {},
+    metadata: (metadata as Record<string, unknown>) ?? undefined,
+    observedMessageIds: doc.observedMessageIds || undefined,
+    observedTimezone: doc.observedTimezone || undefined,
+  };
+}
+
 export class MemoryConvex extends MemoryStorage {
+  readonly supportsObservationalMemory = true;
+
   #db: ConvexDB;
   constructor(config: ConvexDomainConfig) {
     super();
@@ -81,6 +218,7 @@ export class MemoryConvex extends MemoryStorage {
     await this.#db.clearTable({ tableName: TABLE_THREADS });
     await this.#db.clearTable({ tableName: TABLE_MESSAGES });
     await this.#db.clearTable({ tableName: TABLE_RESOURCES });
+    await this.#db.clearTable({ tableName: TABLE_OBSERVATIONAL_MEMORY });
   }
 
   async getThreadById({
@@ -345,6 +483,66 @@ export class MemoryConvex extends MemoryStorage {
     };
   }
 
+  async listMessagesByResourceId(args: StorageListMessagesByResourceIdInput): Promise<StorageListMessagesOutput> {
+    const { resourceId, filter, perPage: perPageInput, page = 0, orderBy } = args;
+    const { field, direction } = this.parseOrderBy(orderBy, 'ASC');
+
+    // Normalize perPage for query (false → MAX_SAFE_INTEGER, 0 → 0, undefined → 40)
+    const perPage = normalizePerPage(perPageInput, 40);
+
+    if (page < 0) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('CONVEX', 'LIST_MESSAGES_BY_RESOURCE_ID', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page },
+        },
+        new Error('page must be >= 0'),
+      );
+    }
+
+    // Prevent unreasonably large page values that could cause performance issues
+    const maxOffset = Number.MAX_SAFE_INTEGER / 2;
+    if (page * perPage > maxOffset) {
+      throw new MastraError(
+        {
+          id: createStorageErrorId('CONVEX', 'LIST_MESSAGES_BY_RESOURCE_ID', 'INVALID_PAGE'),
+          domain: ErrorDomain.STORAGE,
+          category: ErrorCategory.USER,
+          details: { page, perPage },
+        },
+        new Error('page value too large'),
+      );
+    }
+
+    const { offset, perPage: perPageForResponse } = calculatePagination(page, perPageInput, perPage);
+
+    // Get all messages for the resource across all threads (hits the by_resource index)
+    let rows = await this.#db.queryTable<StoredMessage>(TABLE_MESSAGES, [{ field: 'resourceId', value: resourceId }]);
+
+    // Apply date range filter
+    rows = filterByDateRange(rows, row => new Date(row.createdAt), filter?.dateRange);
+
+    rows = this._sortStoredMessages(rows, field, direction);
+
+    const total = rows.length;
+    const paginatedRows = rows.slice(offset, offset + perPage);
+
+    const list = new MessageList().add(
+      paginatedRows.map(row => this.parseStoredMessage(row)),
+      'memory',
+    );
+
+    return {
+      messages: list.get.all.db(),
+      total,
+      page,
+      perPage: perPageForResponse,
+      hasMore: offset + paginatedRows.length < total,
+    };
+  }
+
   async listMessagesById({ messageIds }: { messageIds: string[] }): Promise<{ messages: MastraDBMessage[] }> {
     if (messageIds.length === 0) {
       return { messages: [] };
@@ -520,6 +718,25 @@ export class MemoryConvex extends MemoryStorage {
     return parseStoredResource(updated);
   }
 
+  private _sortStoredMessages(rows: StoredMessage[], field: string, direction: string): StoredMessage[] {
+    return rows.sort((a, b) => {
+      const aValue =
+        field === 'createdAt' || field === 'updatedAt'
+          ? new Date((a as Record<string, any>)[field]).getTime()
+          : (a as Record<string, any>)[field];
+      const bValue =
+        field === 'createdAt' || field === 'updatedAt'
+          ? new Date((b as Record<string, any>)[field]).getTime()
+          : (b as Record<string, any>)[field];
+      if (typeof aValue === 'number' && typeof bValue === 'number') {
+        return direction === 'ASC' ? aValue - bValue : bValue - aValue;
+      }
+      return direction === 'ASC'
+        ? String(aValue).localeCompare(String(bValue))
+        : String(bValue).localeCompare(String(aValue));
+    });
+  }
+
   private _sortMessages(messages: MastraDBMessage[], field: string, direction: string): MastraDBMessage[] {
     return messages.sort((a, b) => {
       const aValue =
@@ -657,5 +874,393 @@ export class MemoryConvex extends MemoryStorage {
         }
       }
     }
+  }
+
+  // ============================================
+  // Observational Memory Methods
+  // ============================================
+
+  private getOMKey(threadId: string | null, resourceId: string): string {
+    return threadId ? `thread:${threadId}` : `resource:${resourceId}`;
+  }
+
+  private omRecordNotFound(operation: string, id: string): MastraError {
+    return new MastraError({
+      id: createStorageErrorId('CONVEX', operation, 'NOT_FOUND'),
+      text: `Observational memory record not found: ${id}`,
+      domain: ErrorDomain.STORAGE,
+      category: ErrorCategory.THIRD_PARTY,
+      details: { id },
+    });
+  }
+
+  async getObservationalMemory(threadId: string | null, resourceId: string): Promise<ObservationalMemoryRecord | null> {
+    const lookupKey = this.getOMKey(threadId, resourceId);
+    const doc = await this.#db.omGetLatest<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, lookupKey);
+    return doc ? parseStoredOMRecord(doc) : null;
+  }
+
+  async getObservationalMemoryHistory(
+    threadId: string | null,
+    resourceId: string,
+    limit: number = 10,
+    options?: ObservationalMemoryHistoryOptions,
+  ): Promise<ObservationalMemoryRecord[]> {
+    const lookupKey = this.getOMKey(threadId, resourceId);
+    const docs = await this.#db.omGetHistory<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, {
+      lookupKey,
+      limit,
+      from: options?.from ? options.from.toISOString() : undefined,
+      to: options?.to ? options.to.toISOString() : undefined,
+      offset: options?.offset ?? undefined,
+    });
+    return docs.map(doc => parseStoredOMRecord(doc));
+  }
+
+  async initializeObservationalMemory(input: CreateObservationalMemoryInput): Promise<ObservationalMemoryRecord> {
+    const id = crypto.randomUUID();
+    const now = new Date();
+    const lookupKey = this.getOMKey(input.threadId, input.resourceId);
+
+    const record: ObservationalMemoryRecord = {
+      id,
+      scope: input.scope,
+      threadId: input.threadId,
+      resourceId: input.resourceId,
+      createdAt: now,
+      updatedAt: now,
+      // lastObservedAt starts undefined - all messages are "unobserved" initially
+      lastObservedAt: undefined,
+      originType: 'initial',
+      generationCount: 0,
+      activeObservations: '',
+      totalTokensObserved: 0,
+      observationTokenCount: 0,
+      pendingMessageTokens: 0,
+      isReflecting: false,
+      isObserving: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      config: input.config,
+      observedTimezone: input.observedTimezone,
+    };
+
+    await this.#db.insert({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      record: {
+        id,
+        lookupKey,
+        scope: input.scope,
+        resourceId: input.resourceId,
+        threadId: input.threadId || null,
+        activeObservations: '',
+        activeObservationsPendingUpdate: null,
+        originType: 'initial',
+        config: JSON.stringify(input.config ?? {}),
+        generationCount: 0,
+        lastObservedAt: null,
+        lastReflectionAt: null,
+        pendingMessageTokens: 0,
+        totalTokensObserved: 0,
+        observationTokenCount: 0,
+        isObserving: false,
+        isReflecting: false,
+        isBufferingObservation: false,
+        isBufferingReflection: false,
+        lastBufferedAtTokens: 0,
+        lastBufferedAtTime: null,
+        observedTimezone: input.observedTimezone || null,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+    });
+
+    return record;
+  }
+
+  async insertObservationalMemoryRecord(record: ObservationalMemoryRecord): Promise<void> {
+    const lookupKey = this.getOMKey(record.threadId, record.resourceId);
+    await this.#db.insert({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      record: {
+        id: record.id,
+        lookupKey,
+        scope: record.scope,
+        resourceId: record.resourceId,
+        threadId: record.threadId || null,
+        activeObservations: record.activeObservations || '',
+        activeObservationsPendingUpdate: null,
+        originType: record.originType || 'initial',
+        config: JSON.stringify(record.config ?? {}),
+        generationCount: record.generationCount || 0,
+        lastObservedAt: record.lastObservedAt ? toISO(record.lastObservedAt) : null,
+        lastReflectionAt: null,
+        pendingMessageTokens: record.pendingMessageTokens || 0,
+        totalTokensObserved: record.totalTokensObserved || 0,
+        observationTokenCount: record.observationTokenCount || 0,
+        observedMessageIds: record.observedMessageIds || null,
+        bufferedObservationChunks: JSON.stringify(
+          (Array.isArray(record.bufferedObservationChunks) ? record.bufferedObservationChunks : []).map(chunk =>
+            serializeOMChunk(chunk),
+          ),
+        ),
+        bufferedReflection: record.bufferedReflection || null,
+        bufferedReflectionTokens: record.bufferedReflectionTokens ?? null,
+        bufferedReflectionInputTokens: record.bufferedReflectionInputTokens ?? null,
+        reflectedObservationLineCount: record.reflectedObservationLineCount ?? null,
+        isObserving: record.isObserving || false,
+        isReflecting: record.isReflecting || false,
+        isBufferingObservation: record.isBufferingObservation || false,
+        isBufferingReflection: record.isBufferingReflection || false,
+        lastBufferedAtTokens: record.lastBufferedAtTokens || 0,
+        lastBufferedAtTime: record.lastBufferedAtTime ? toISO(record.lastBufferedAtTime) : null,
+        observedTimezone: record.observedTimezone || null,
+        metadata: record.metadata ? JSON.stringify(record.metadata) : null,
+        createdAt: toISO(record.createdAt),
+        updatedAt: toISO(record.updatedAt),
+      },
+    });
+  }
+
+  async updateActiveObservations(input: UpdateActiveObservationsInput): Promise<void> {
+    await this.#db.omUpdateActive(TABLE_OBSERVATIONAL_MEMORY, {
+      id: input.id,
+      observations: input.observations,
+      tokenCount: input.tokenCount,
+      lastObservedAt: toISO(input.lastObservedAt),
+      observedMessageIds: input.observedMessageIds ?? null,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async updateBufferedObservations(input: UpdateBufferedObservationsInput): Promise<void> {
+    const chunk: SerializedOMChunk = {
+      id: `ombuf-${crypto.randomUUID()}`,
+      cycleId: input.chunk.cycleId,
+      observations: input.chunk.observations,
+      tokenCount: input.chunk.tokenCount,
+      messageIds: input.chunk.messageIds,
+      messageTokens: input.chunk.messageTokens,
+      lastObservedAt: toISO(input.chunk.lastObservedAt),
+      createdAt: new Date().toISOString(),
+      suggestedContinuation: input.chunk.suggestedContinuation,
+      currentTask: input.chunk.currentTask,
+      threadTitle: input.chunk.threadTitle,
+      extractedValues: input.chunk.extractedValues,
+      extractionFailures: input.chunk.extractionFailures,
+    };
+
+    await this.#db.omAppendBufferedChunk(TABLE_OBSERVATIONAL_MEMORY, {
+      id: input.id,
+      chunk,
+      lastBufferedAtTime: input.lastBufferedAtTime ? toISO(input.lastBufferedAtTime) : undefined,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async swapBufferedToActive(input: SwapBufferedToActiveInput): Promise<SwapBufferedToActiveResult> {
+    return this.#db.omSwapBuffered<SwapBufferedToActiveResult>(TABLE_OBSERVATIONAL_MEMORY, {
+      id: input.id,
+      activationRatio: input.activationRatio,
+      messageTokensThreshold: input.messageTokensThreshold,
+      currentPendingTokens: input.currentPendingTokens,
+      forceMaxActivation: input.forceMaxActivation,
+      lastObservedAt: input.lastObservedAt ? toISO(input.lastObservedAt) : undefined,
+      bufferedChunks: Array.isArray(input.bufferedChunks)
+        ? input.bufferedChunks.map(chunk => serializeOMChunk(chunk))
+        : undefined,
+      now: new Date().toISOString(),
+    });
+  }
+
+  async createReflectionGeneration(input: CreateReflectionGenerationInput): Promise<ObservationalMemoryRecord> {
+    const id = crypto.randomUUID();
+    const now = new Date();
+    const lookupKey = this.getOMKey(input.currentRecord.threadId, input.currentRecord.resourceId);
+
+    const record: ObservationalMemoryRecord = {
+      id,
+      scope: input.currentRecord.scope,
+      threadId: input.currentRecord.threadId,
+      resourceId: input.currentRecord.resourceId,
+      createdAt: now,
+      updatedAt: now,
+      lastObservedAt: input.currentRecord.lastObservedAt,
+      originType: 'reflection',
+      generationCount: input.currentRecord.generationCount + 1,
+      activeObservations: input.reflection,
+      totalTokensObserved: input.currentRecord.totalTokensObserved,
+      observationTokenCount: input.tokenCount,
+      pendingMessageTokens: 0,
+      isReflecting: false,
+      isObserving: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      config: input.currentRecord.config,
+      metadata: input.currentRecord.metadata,
+      observedTimezone: input.currentRecord.observedTimezone,
+    };
+
+    await this.#db.insert({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      record: {
+        id,
+        lookupKey,
+        scope: record.scope,
+        resourceId: record.resourceId,
+        threadId: record.threadId || null,
+        activeObservations: input.reflection,
+        activeObservationsPendingUpdate: null,
+        originType: 'reflection',
+        config: JSON.stringify(record.config ?? {}),
+        generationCount: record.generationCount,
+        lastObservedAt: record.lastObservedAt ? toISO(record.lastObservedAt) : null,
+        lastReflectionAt: now.toISOString(),
+        pendingMessageTokens: 0,
+        totalTokensObserved: record.totalTokensObserved,
+        observationTokenCount: record.observationTokenCount,
+        isObserving: false,
+        isReflecting: false,
+        isBufferingObservation: false,
+        isBufferingReflection: false,
+        lastBufferedAtTokens: 0,
+        lastBufferedAtTime: null,
+        observedTimezone: record.observedTimezone || null,
+        metadata: record.metadata ? JSON.stringify(record.metadata) : null,
+        createdAt: now.toISOString(),
+        updatedAt: now.toISOString(),
+      },
+    });
+
+    return record;
+  }
+
+  async updateBufferedReflection(input: UpdateBufferedReflectionInput): Promise<void> {
+    await this.#db.omUpdateBufferedReflection(TABLE_OBSERVATIONAL_MEMORY, {
+      id: input.id,
+      reflection: input.reflection,
+      tokenCount: input.tokenCount,
+      inputTokenCount: input.inputTokenCount,
+      reflectedObservationLineCount: input.reflectedObservationLineCount,
+      updatedAt: new Date().toISOString(),
+    });
+  }
+
+  async swapBufferedReflectionToActive(input: SwapBufferedReflectionToActiveInput): Promise<ObservationalMemoryRecord> {
+    const { currentRecord } = input;
+    const serializedCurrentRecord: SerializedOMCurrentRecord = {
+      id: currentRecord.id,
+      lookupKey: this.getOMKey(currentRecord.threadId, currentRecord.resourceId),
+      scope: currentRecord.scope,
+      threadId: currentRecord.threadId || null,
+      resourceId: currentRecord.resourceId,
+      config: JSON.stringify(currentRecord.config ?? {}),
+      metadata: currentRecord.metadata ? JSON.stringify(currentRecord.metadata) : null,
+      observedTimezone: currentRecord.observedTimezone || null,
+      lastObservedAt: currentRecord.lastObservedAt ? toISO(currentRecord.lastObservedAt) : null,
+      totalTokensObserved: currentRecord.totalTokensObserved,
+      generationCount: currentRecord.generationCount,
+    };
+
+    const doc = await this.#db.omSwapBufferedReflection<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, {
+      currentRecord: serializedCurrentRecord,
+      newId: crypto.randomUUID(),
+      tokenCount: input.tokenCount,
+      now: new Date().toISOString(),
+    });
+
+    return parseStoredOMRecord(doc);
+  }
+
+  async setReflectingFlag(id: string, isReflecting: boolean): Promise<void> {
+    const found = await this.#db.patch({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      id,
+      record: { isReflecting, updatedAt: new Date() },
+    });
+    if (!found) {
+      throw this.omRecordNotFound('SET_REFLECTING_FLAG', id);
+    }
+  }
+
+  async setObservingFlag(id: string, isObserving: boolean): Promise<void> {
+    const found = await this.#db.patch({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      id,
+      record: { isObserving, updatedAt: new Date() },
+    });
+    if (!found) {
+      throw this.omRecordNotFound('SET_OBSERVING_FLAG', id);
+    }
+  }
+
+  async setBufferingObservationFlag(id: string, isBuffering: boolean, lastBufferedAtTokens?: number): Promise<void> {
+    const found = await this.#db.patch({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      id,
+      record: {
+        isBufferingObservation: isBuffering,
+        ...(lastBufferedAtTokens !== undefined ? { lastBufferedAtTokens } : {}),
+        updatedAt: new Date(),
+      },
+    });
+    if (!found) {
+      throw this.omRecordNotFound('SET_BUFFERING_OBSERVATION_FLAG', id);
+    }
+  }
+
+  async setBufferingReflectionFlag(id: string, isBuffering: boolean): Promise<void> {
+    const found = await this.#db.patch({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      id,
+      record: { isBufferingReflection: isBuffering, updatedAt: new Date() },
+    });
+    if (!found) {
+      throw this.omRecordNotFound('SET_BUFFERING_REFLECTION_FLAG', id);
+    }
+  }
+
+  async setPendingMessageTokens(id: string, tokenCount: number): Promise<void> {
+    if (typeof tokenCount !== 'number' || !Number.isFinite(tokenCount) || tokenCount < 0) {
+      throw new MastraError({
+        id: createStorageErrorId('CONVEX', 'SET_PENDING_MESSAGE_TOKENS', 'INVALID_INPUT'),
+        text: `Invalid tokenCount: must be a finite non-negative number, got ${tokenCount}`,
+        domain: ErrorDomain.STORAGE,
+        category: ErrorCategory.USER,
+        details: { id, tokenCount },
+      });
+    }
+
+    const found = await this.#db.patch({
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
+      id,
+      record: { pendingMessageTokens: tokenCount, updatedAt: new Date() },
+    });
+    if (!found) {
+      throw this.omRecordNotFound('SET_PENDING_MESSAGE_TOKENS', id);
+    }
+  }
+
+  async clearObservationalMemory(threadId: string | null, resourceId: string): Promise<void> {
+    const lookupKey = this.getOMKey(threadId, resourceId);
+    const docs = await this.#db.queryTable<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, [
+      { field: 'lookupKey', value: lookupKey },
+    ]);
+    await this.#db.deleteMany(
+      TABLE_OBSERVATIONAL_MEMORY,
+      docs.map(doc => doc.id),
+    );
+  }
+
+  async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
+    await this.#db.omUpdateConfig(TABLE_OBSERVATIONAL_MEMORY, {
+      id: input.id,
+      config: JSON.stringify(input.config ?? {}),
+      updatedAt: new Date().toISOString(),
+    });
   }
 }

--- a/stores/convex/src/storage/domains/memory/memory.test.ts
+++ b/stores/convex/src/storage/domains/memory/memory.test.ts
@@ -372,3 +372,510 @@ describe('MemoryConvex atomic memory writes', () => {
     expect(created.updatedAt).toBeInstanceOf(Date);
   });
 });
+
+describe('MemoryConvex observational memory', () => {
+  const OM_TABLE = 'mastra_observational_memory';
+
+  function storedOMDoc(overrides: Record<string, any> = {}) {
+    return {
+      _id: 'convex-doc-1',
+      _creationTime: 1234,
+      id: 'om-1',
+      lookupKey: 'resource:resource-1',
+      scope: 'resource',
+      resourceId: 'resource-1',
+      threadId: null,
+      activeObservations: 'some observations',
+      activeObservationsPendingUpdate: null,
+      originType: 'initial',
+      config: JSON.stringify({ observation: { messageTokens: 1000 } }),
+      generationCount: 0,
+      lastObservedAt: '2026-06-02T00:00:00.000Z',
+      lastReflectionAt: null,
+      pendingMessageTokens: 5,
+      totalTokensObserved: 100,
+      observationTokenCount: 40,
+      isObserving: false,
+      isReflecting: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      metadata: JSON.stringify({ custom: true }),
+      createdAt: '2026-06-01T00:00:00.000Z',
+      updatedAt: '2026-06-02T00:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('advertises observational memory support', () => {
+    const { memory } = createMemoryDomain(() => null);
+    expect(memory.supportsObservationalMemory).toBe(true);
+  });
+
+  it('getObservationalMemory queries the resource lookup key and parses the stored document', async () => {
+    const { calls, memory } = createMemoryDomain(() => storedOMDoc());
+
+    const record = await memory.getObservationalMemory(null, 'resource-1');
+
+    expect(calls).toEqual([{ op: 'omGetLatest', tableName: OM_TABLE, lookupKey: 'resource:resource-1' }]);
+    expect(record).toMatchObject({
+      id: 'om-1',
+      scope: 'resource',
+      threadId: null,
+      resourceId: 'resource-1',
+      activeObservations: 'some observations',
+      config: { observation: { messageTokens: 1000 } },
+      metadata: { custom: true },
+      pendingMessageTokens: 5,
+      lastBufferedAtTime: null,
+    });
+    expect(record?.createdAt).toEqual(new Date('2026-06-01T00:00:00.000Z'));
+    expect(record?.lastObservedAt).toEqual(new Date('2026-06-02T00:00:00.000Z'));
+    // Convex-internal fields must not leak into the parsed record
+    expect(record).not.toHaveProperty('_id');
+    expect(record).not.toHaveProperty('lookupKey');
+  });
+
+  it('getObservationalMemory uses the thread lookup key when a threadId is provided', async () => {
+    const { calls, memory } = createMemoryDomain(() => null);
+
+    const record = await memory.getObservationalMemory('thread-9', 'resource-1');
+
+    expect(calls[0]).toMatchObject({ op: 'omGetLatest', lookupKey: 'thread:thread-9' });
+    expect(record).toBeNull();
+  });
+
+  it('getObservationalMemoryHistory forwards range options as ISO strings with a default limit', async () => {
+    const { calls, memory } = createMemoryDomain(() => [storedOMDoc()]);
+
+    const records = await memory.getObservationalMemoryHistory(null, 'resource-1', undefined, {
+      from: new Date('2026-06-01T00:00:00.000Z'),
+      to: new Date('2026-06-03T00:00:00.000Z'),
+      offset: 2,
+    });
+
+    expect(calls).toEqual([
+      {
+        op: 'omGetHistory',
+        tableName: OM_TABLE,
+        lookupKey: 'resource:resource-1',
+        limit: 10,
+        from: '2026-06-01T00:00:00.000Z',
+        to: '2026-06-03T00:00:00.000Z',
+        offset: 2,
+      },
+    ]);
+    expect(records).toHaveLength(1);
+    expect(records[0]?.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('initializeObservationalMemory inserts a serialized record and returns generation zero', async () => {
+    const { calls, memory } = createMemoryDomain(() => undefined);
+
+    const record = await memory.initializeObservationalMemory({
+      threadId: null,
+      resourceId: 'resource-1',
+      scope: 'resource',
+      config: { observation: { messageTokens: 1000 } },
+      observedTimezone: 'Europe/Berlin',
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      op: 'insert',
+      tableName: OM_TABLE,
+      record: {
+        id: record.id,
+        lookupKey: 'resource:resource-1',
+        scope: 'resource',
+        threadId: null,
+        activeObservations: '',
+        originType: 'initial',
+        config: JSON.stringify({ observation: { messageTokens: 1000 } }),
+        generationCount: 0,
+        lastObservedAt: null,
+        observedTimezone: 'Europe/Berlin',
+        createdAt: expect.any(String),
+        updatedAt: expect.any(String),
+      },
+    });
+    expect(record).toMatchObject({
+      scope: 'resource',
+      threadId: null,
+      resourceId: 'resource-1',
+      generationCount: 0,
+      activeObservations: '',
+      lastObservedAt: undefined,
+      config: { observation: { messageTokens: 1000 } },
+    });
+    expect(record.createdAt).toBeInstanceOf(Date);
+  });
+
+  it('setObservingFlag patches the record and throws when it does not exist', async () => {
+    const { calls, memory } = createMemoryDomain(request => request.op === 'patch');
+
+    await memory.setObservingFlag('om-1', true);
+    expect(calls[0]).toMatchObject({
+      op: 'patch',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      record: { isObserving: true, updatedAt: expect.any(String) },
+    });
+
+    const { memory: missingMemory } = createMemoryDomain(() => false);
+    await expect(missingMemory.setObservingFlag('missing', true)).rejects.toThrow(
+      'Observational memory record not found: missing',
+    );
+  });
+
+  it('setBufferingObservationFlag only includes lastBufferedAtTokens when provided', async () => {
+    const { calls, memory } = createMemoryDomain(() => true);
+
+    await memory.setBufferingObservationFlag('om-1', true, 1234);
+    await memory.setBufferingObservationFlag('om-1', false);
+
+    expect(calls[0]).toMatchObject({
+      op: 'patch',
+      record: { isBufferingObservation: true, lastBufferedAtTokens: 1234 },
+    });
+    expect((calls[1] as { record: Record<string, unknown> }).record).not.toHaveProperty('lastBufferedAtTokens');
+  });
+
+  it('setPendingMessageTokens rejects invalid token counts before calling storage', async () => {
+    const { calls, memory } = createMemoryDomain(() => true);
+
+    await expect(memory.setPendingMessageTokens('om-1', -1)).rejects.toThrow('Invalid tokenCount');
+    expect(calls).toHaveLength(0);
+
+    await memory.setPendingMessageTokens('om-1', 42);
+    expect(calls[0]).toMatchObject({ op: 'patch', record: { pendingMessageTokens: 42 } });
+  });
+
+  it('updateActiveObservations emits an atomic omUpdateActive request', async () => {
+    const { calls, memory } = createMemoryDomain(() => undefined);
+
+    await memory.updateActiveObservations({
+      id: 'om-1',
+      observations: 'new observations',
+      tokenCount: 50,
+      lastObservedAt: new Date('2026-06-03T00:00:00.000Z'),
+      observedMessageIds: ['msg-1'],
+    });
+
+    expect(calls).toEqual([
+      {
+        op: 'omUpdateActive',
+        tableName: OM_TABLE,
+        id: 'om-1',
+        observations: 'new observations',
+        tokenCount: 50,
+        lastObservedAt: '2026-06-03T00:00:00.000Z',
+        observedMessageIds: ['msg-1'],
+        updatedAt: expect.any(String),
+      },
+    ]);
+  });
+
+  it('updateBufferedObservations serializes the chunk with a generated ombuf id', async () => {
+    const { calls, memory } = createMemoryDomain(() => undefined);
+
+    await memory.updateBufferedObservations({
+      id: 'om-1',
+      chunk: {
+        cycleId: 'cycle-1',
+        observations: 'buffered obs',
+        tokenCount: 10,
+        messageIds: ['msg-1'],
+        messageTokens: 500,
+        lastObservedAt: new Date('2026-06-03T01:00:00.000Z'),
+      },
+      lastBufferedAtTime: new Date('2026-06-03T01:00:01.000Z'),
+    });
+
+    expect(calls[0]).toMatchObject({
+      op: 'omAppendBufferedChunk',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      chunk: {
+        id: expect.stringMatching(/^ombuf-/),
+        cycleId: 'cycle-1',
+        observations: 'buffered obs',
+        lastObservedAt: '2026-06-03T01:00:00.000Z',
+        createdAt: expect.any(String),
+      },
+      lastBufferedAtTime: '2026-06-03T01:00:01.000Z',
+    });
+  });
+
+  it('swapBufferedToActive serializes refreshed chunks and returns the server result untouched', async () => {
+    const serverResult = {
+      chunksActivated: 1,
+      messageTokensActivated: 500,
+      observationTokensActivated: 10,
+      messagesActivated: 1,
+      activatedCycleIds: ['cycle-1'],
+      activatedMessageIds: ['msg-1'],
+      observations: 'buffered obs',
+    };
+    const { calls, memory } = createMemoryDomain(() => serverResult);
+
+    const result = await memory.swapBufferedToActive({
+      id: 'om-1',
+      activationRatio: 0.8,
+      messageTokensThreshold: 5000,
+      currentPendingTokens: 6000,
+      bufferedChunks: [
+        {
+          id: 'ombuf-1',
+          cycleId: 'cycle-1',
+          observations: 'buffered obs',
+          tokenCount: 10,
+          messageIds: ['msg-1'],
+          messageTokens: 500,
+          lastObservedAt: new Date('2026-06-03T01:00:00.000Z'),
+          createdAt: new Date('2026-06-03T01:00:00.000Z'),
+        },
+      ],
+    });
+
+    expect(calls[0]).toMatchObject({
+      op: 'omSwapBuffered',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      activationRatio: 0.8,
+      messageTokensThreshold: 5000,
+      currentPendingTokens: 6000,
+      bufferedChunks: [
+        {
+          id: 'ombuf-1',
+          lastObservedAt: '2026-06-03T01:00:00.000Z',
+          createdAt: '2026-06-03T01:00:00.000Z',
+        },
+      ],
+      now: expect.any(String),
+    });
+    expect(result).toEqual(serverResult);
+  });
+
+  it('createReflectionGeneration inserts the next generation built from the current record', async () => {
+    const { calls, memory } = createMemoryDomain(() => undefined);
+
+    const currentRecord = {
+      id: 'om-1',
+      scope: 'resource' as const,
+      threadId: null,
+      resourceId: 'resource-1',
+      createdAt: new Date('2026-06-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-06-02T00:00:00.000Z'),
+      lastObservedAt: new Date('2026-06-02T00:00:00.000Z'),
+      originType: 'initial' as const,
+      generationCount: 3,
+      activeObservations: 'old observations',
+      totalTokensObserved: 900,
+      observationTokenCount: 100,
+      pendingMessageTokens: 0,
+      isReflecting: false,
+      isObserving: false,
+      isBufferingObservation: false,
+      isBufferingReflection: false,
+      lastBufferedAtTokens: 0,
+      lastBufferedAtTime: null,
+      config: { observation: { messageTokens: 1000 } },
+      metadata: { custom: true },
+      observedTimezone: 'Europe/Berlin',
+    };
+
+    const record = await memory.createReflectionGeneration({
+      currentRecord,
+      reflection: 'the reflection',
+      tokenCount: 42,
+    });
+
+    expect(calls[0]).toMatchObject({
+      op: 'insert',
+      tableName: OM_TABLE,
+      record: {
+        id: record.id,
+        lookupKey: 'resource:resource-1',
+        originType: 'reflection',
+        generationCount: 4,
+        activeObservations: 'the reflection',
+        observationTokenCount: 42,
+        totalTokensObserved: 900,
+        lastReflectionAt: expect.any(String),
+        metadata: JSON.stringify({ custom: true }),
+      },
+    });
+    expect(record).toMatchObject({
+      originType: 'reflection',
+      generationCount: 4,
+      activeObservations: 'the reflection',
+      observationTokenCount: 42,
+      config: { observation: { messageTokens: 1000 } },
+      metadata: { custom: true },
+    });
+    expect(record.id).not.toBe(currentRecord.id);
+  });
+
+  it('swapBufferedReflectionToActive sends the serialized current record and parses the new generation', async () => {
+    const { calls, memory } = createMemoryDomain(() =>
+      storedOMDoc({
+        id: 'om-2',
+        originType: 'reflection',
+        generationCount: 1,
+        activeObservations: 'the reflection',
+        lastReflectionAt: '2026-06-05T00:00:00.000Z',
+      }),
+    );
+
+    const record = await memory.swapBufferedReflectionToActive({
+      currentRecord: {
+        id: 'om-1',
+        scope: 'resource',
+        threadId: null,
+        resourceId: 'resource-1',
+        createdAt: new Date('2026-06-01T00:00:00.000Z'),
+        updatedAt: new Date('2026-06-02T00:00:00.000Z'),
+        lastObservedAt: new Date('2026-06-02T00:00:00.000Z'),
+        originType: 'initial',
+        generationCount: 0,
+        activeObservations: 'line 1\nline 2',
+        totalTokensObserved: 900,
+        observationTokenCount: 100,
+        pendingMessageTokens: 0,
+        isReflecting: false,
+        isObserving: false,
+        isBufferingObservation: false,
+        isBufferingReflection: true,
+        lastBufferedAtTokens: 0,
+        lastBufferedAtTime: null,
+        config: { observation: { messageTokens: 1000 } },
+      },
+      tokenCount: 42,
+    });
+
+    expect(calls[0]).toMatchObject({
+      op: 'omSwapBufferedReflection',
+      tableName: OM_TABLE,
+      currentRecord: {
+        id: 'om-1',
+        lookupKey: 'resource:resource-1',
+        config: JSON.stringify({ observation: { messageTokens: 1000 } }),
+        metadata: null,
+        lastObservedAt: '2026-06-02T00:00:00.000Z',
+        totalTokensObserved: 900,
+        generationCount: 0,
+      },
+      newId: expect.any(String),
+      tokenCount: 42,
+      now: expect.any(String),
+    });
+    expect(record).toMatchObject({
+      id: 'om-2',
+      originType: 'reflection',
+      generationCount: 1,
+      activeObservations: 'the reflection',
+    });
+  });
+
+  it('clearObservationalMemory deletes every generation for the lookup key', async () => {
+    const { calls, memory } = createMemoryDomain(request =>
+      request.op === 'queryTable' ? [storedOMDoc({ id: 'om-1' }), storedOMDoc({ id: 'om-2' })] : undefined,
+    );
+
+    await memory.clearObservationalMemory(null, 'resource-1');
+
+    expect(calls[0]).toMatchObject({
+      op: 'queryTable',
+      tableName: OM_TABLE,
+      filters: [{ field: 'lookupKey', value: 'resource:resource-1' }],
+    });
+    expect(calls[1]).toMatchObject({
+      op: 'deleteMany',
+      tableName: OM_TABLE,
+      ids: ['om-1', 'om-2'],
+    });
+  });
+
+  it('updateObservationalMemoryConfig sends the config as a JSON string', async () => {
+    const { calls, memory } = createMemoryDomain(() => undefined);
+
+    await memory.updateObservationalMemoryConfig({
+      id: 'om-1',
+      config: { observation: { messageTokens: 2000 } },
+    });
+
+    expect(calls[0]).toMatchObject({
+      op: 'omUpdateConfig',
+      tableName: OM_TABLE,
+      id: 'om-1',
+      config: JSON.stringify({ observation: { messageTokens: 2000 } }),
+      updatedAt: expect.any(String),
+    });
+  });
+});
+
+describe('MemoryConvex listMessagesByResourceId', () => {
+  function storedMessage(id: string, threadId: string, createdAt: string, resourceId = 'resource-1') {
+    return {
+      id,
+      thread_id: threadId,
+      content: JSON.stringify({ format: 2, parts: [{ type: 'text', text: id }], content: id }),
+      role: 'user',
+      type: 'v2',
+      createdAt,
+      resourceId,
+    };
+  }
+
+  it('queries messages across threads by resourceId and sorts ascending by default', async () => {
+    const rows = [
+      storedMessage('msg-2', 'thread-b', '2026-06-02T00:00:00.000Z'),
+      storedMessage('msg-1', 'thread-a', '2026-06-01T00:00:00.000Z'),
+      storedMessage('msg-3', 'thread-a', '2026-06-03T00:00:00.000Z'),
+    ];
+    const { calls, memory } = createMemoryDomain(() => rows);
+
+    const result = await memory.listMessagesByResourceId({ resourceId: 'resource-1' });
+
+    expect(calls).toEqual([
+      {
+        op: 'queryTable',
+        tableName: TABLE_MESSAGES,
+        filters: [{ field: 'resourceId', value: 'resource-1' }],
+        indexHint: undefined,
+        limit: undefined,
+      },
+    ]);
+    expect(result.messages.map(message => message.id)).toEqual(['msg-1', 'msg-2', 'msg-3']);
+    expect(result.total).toBe(3);
+    expect(result.hasMore).toBe(false);
+  });
+
+  it('applies date range filtering and pagination', async () => {
+    const rows = [
+      storedMessage('msg-1', 'thread-a', '2026-06-01T00:00:00.000Z'),
+      storedMessage('msg-2', 'thread-a', '2026-06-02T00:00:00.000Z'),
+      storedMessage('msg-3', 'thread-b', '2026-06-03T00:00:00.000Z'),
+      storedMessage('msg-4', 'thread-b', '2026-06-04T00:00:00.000Z'),
+    ];
+    const { memory } = createMemoryDomain(() => rows);
+
+    const result = await memory.listMessagesByResourceId({
+      resourceId: 'resource-1',
+      filter: { dateRange: { start: new Date('2026-06-02T00:00:00.000Z') } },
+      page: 0,
+      perPage: 2,
+    });
+
+    expect(result.messages.map(message => message.id)).toEqual(['msg-2', 'msg-3']);
+    expect(result.total).toBe(3);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('rejects negative page values', async () => {
+    const { memory } = createMemoryDomain(() => []);
+    await expect(memory.listMessagesByResourceId({ resourceId: 'resource-1', page: -1 })).rejects.toThrow();
+  });
+});

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -9,6 +9,48 @@ export type IndexHint =
   | { index: 'by_workflow'; workflowName: string }
   | { index: 'by_workflow_run'; workflowName: string; runId: string };
 
+/**
+ * A buffered observation chunk in wire/storage format: Date fields are ISO
+ * strings so chunks survive the JSON HTTP boundary and Convex storage
+ * (persisted as a JSON string inside the record's bufferedObservationChunks).
+ */
+export type SerializedOMChunk = {
+  id: string;
+  cycleId: string;
+  observations: string;
+  tokenCount: number;
+  messageIds: string[];
+  messageTokens: number;
+  /** ISO timestamp */
+  lastObservedAt: string;
+  /** ISO timestamp */
+  createdAt: string;
+  suggestedContinuation?: string;
+  currentTask?: string;
+  threadTitle?: string;
+  extractedValues?: Record<string, unknown>;
+  extractionFailures?: Array<{ slug: string; error: string }>;
+};
+
+/**
+ * Serialized observational memory generation fields the server needs to create
+ * a new generation record (used by omSwapBufferedReflection). Timestamps are
+ * ISO strings; config/metadata are JSON strings.
+ */
+export type SerializedOMCurrentRecord = {
+  id: string;
+  lookupKey: string;
+  scope: string;
+  threadId: string | null;
+  resourceId: string;
+  config: string;
+  metadata: string | null;
+  observedTimezone: string | null;
+  lastObservedAt: string | null;
+  totalTokensObserved: number;
+  generationCount: number;
+};
+
 export type StorageRequest =
   | {
       op: 'insert';
@@ -132,6 +174,90 @@ export type StorageRequest =
       op: 'deleteScheduleTriggers';
       tableName: TABLE_NAMES | string;
       scheduleId: string;
+    }
+  | {
+      op: 'omGetLatest';
+      tableName: TABLE_NAMES | string;
+      lookupKey: string;
+    }
+  | {
+      op: 'omGetHistory';
+      tableName: TABLE_NAMES | string;
+      lookupKey: string;
+      limit: number;
+      /** ISO timestamp; records with createdAt >= from */
+      from?: string;
+      /** ISO timestamp; records with createdAt <= to */
+      to?: string;
+      offset?: number;
+    }
+  | {
+      op: 'omUpdateActive';
+      tableName: TABLE_NAMES | string;
+      id: string;
+      observations: string;
+      tokenCount: number;
+      /** ISO timestamp */
+      lastObservedAt: string;
+      observedMessageIds: string[] | null;
+      /** ISO timestamp */
+      updatedAt: string;
+    }
+  | {
+      op: 'omAppendBufferedChunk';
+      tableName: TABLE_NAMES | string;
+      id: string;
+      chunk: SerializedOMChunk;
+      /** ISO timestamp */
+      lastBufferedAtTime?: string;
+      /** ISO timestamp */
+      updatedAt: string;
+    }
+  | {
+      op: 'omSwapBuffered';
+      tableName: TABLE_NAMES | string;
+      id: string;
+      activationRatio: number;
+      messageTokensThreshold: number;
+      currentPendingTokens: number;
+      forceMaxActivation?: boolean;
+      /** ISO timestamp override for lastObservedAt after swap */
+      lastObservedAt?: string;
+      /** Refreshed chunks with up-to-date messageTokens (see SwapBufferedToActiveInput) */
+      bufferedChunks?: SerializedOMChunk[];
+      /** ISO timestamp used for updatedAt and lastObservedAt fallback */
+      now: string;
+    }
+  | {
+      op: 'omUpdateBufferedReflection';
+      tableName: TABLE_NAMES | string;
+      id: string;
+      reflection: string;
+      tokenCount: number;
+      inputTokenCount: number;
+      reflectedObservationLineCount: number;
+      /** ISO timestamp */
+      updatedAt: string;
+    }
+  | {
+      op: 'omSwapBufferedReflection';
+      tableName: TABLE_NAMES | string;
+      currentRecord: SerializedOMCurrentRecord;
+      /** ID for the new generation record */
+      newId: string;
+      /** Token count of the combined new activeObservations */
+      tokenCount: number;
+      /** ISO timestamp */
+      now: string;
+    }
+  | {
+      op: 'omUpdateConfig';
+      tableName: TABLE_NAMES | string;
+      id: string;
+      /** JSON string; deep-merged into the stored config server-side */
+      config: string;
+      /** ISO timestamp */
+      updatedAt: string;
     };
 
 export type StorageResponse =


### PR DESCRIPTION
## Description

Adds Observational Memory (OM) support to the Convex storage adapter. `ConvexStore` users can now enable `observationalMemory` in `@mastra/memory` — previously OM only supported `@mastra/pg`, `@mastra/libsql`, and `@mastra/mongodb`.

**What's included:**

- **Schema**: new `mastraObservationalMemoryTable` exported from `@mastra/convex/schema`, keyed by `lookupKey` (`thread:{id}` / `resource:{id}`) with a `by_lookup_key` index that serves latest-generation reads in descending `generationCount` order. Hand-defined (core intentionally excludes `OBSERVATIONAL_MEMORY_SCHEMA` from `TABLE_SCHEMAS`, and schema/server files bundle into user deployments where older cores in the peer range may lack the export).
- **Server**: new `om*` operations dispatched by the deployed `mastraStorage` mutation. All read-modify-write flows (buffered-observation swaps, reflection generations, config deep-merges, token counters) run inside the mutation, so they are atomic — Convex mutations are serializable transactions, which also removes the need for MongoDB-style optimistic-concurrency guards. Activation-boundary and reflection-merge logic is ported from core's in-memory reference implementation.
- **Client**: `MemoryConvex` sets `supportsObservationalMemory = true`, implements all 18 OM methods plus `listMessagesByResourceId` (served by the existing `by_resource` index), and handles serialization (ISO timestamps; `config`/`metadata`/`bufferedObservationChunks` as JSON strings so user payloads containing Convex-reserved keys like `$schema` don't fail validation — same convention as `mastraSchedulesTable`).
- **Error strings**: the adapter lists in `MemoryStorage.listMessagesByResourceId` (core) and the async-buffering compatibility error (memory) now mention convex.
- **Docs**: OM supported-adapters note, Convex storage reference (schema example, table listing, migration step), and the package README.

**Migration for existing `@mastra/convex` users:** add `mastraObservationalMemoryTable` to `convex/schema.ts` and run `npx convex deploy`. No other changes; the new table and ops are unused unless `observationalMemory` is enabled.

## Related issue(s)

Fixes #19473 — [FEATURE] Add Observational Memory support to @mastra/convex

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Testing

- **Shared kit**: the existing integration suite (`createTestSuite`) now auto-runs `createObservationalMemoryTest` — the same 76-test OM kit pg/libsql/mongodb run — because it gates on `supportsObservationalMemory`. Verified live against a self-hosted Convex backend (docker `ghcr.io/get-convex/convex-backend`) with the schema and handlers deployed from packed tarballs: **76/76 pass**, plus the resource-scoped message listing kit.
- **New unit tests** (run without a deployment):
  - `src/server/observational-memory.test.ts` (28 tests): mutation ops against a fake `ctx.db` with index semantics, ported activation-boundary scenarios (exact boundary, overshoot fallback, `forceMaxActivation`, minimum-remaining safeguard), reflection line-split merge, and routing (OM table must not fall through to the `mastra_documents` fallback).
  - `src/storage/domains/memory/memory.test.ts` (+15 tests): emitted wire shapes and record serde via the existing mock-client pattern.
  - `src/schema.test.ts` (3 tests): drift guard asserting the hand-defined table mirrors core's `OBSERVATIONAL_MEMORY_SCHEMA` columns/nullability and the server index map — the Convex analog of pg's `om-migration-columns` test.
- Full-suite comparison against an `origin/main` build on a second fresh backend showed the only integration failures (2 scores/workflow-state, ~54 vector filter tests) reproduce identically on main — pre-existing, unrelated to this change.
- `pnpm --filter @mastra/convex test` (offline): 258 passed. Lint and `build:lib` clean; `@mastra/core` and `@mastra/memory` rebuild clean.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## AI disclosure

Implemented with Claude Code (Fable 5). Design, implementation, and tests were model-written; a human reviewed the approach, drove the requirements, and validated the results. Live verification ran against a real self-hosted Convex deployment as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Convex can now remember and organize conversations using Observational Memory, including safely updating notes and reflections. It also supports finding messages across all threads for a resource, while documenting the schema update required for existing users.

## What changed

- Added the `mastra_observational_memory` Convex table with lookup and generation indexes.
- Implemented atomic read-modify-write operations for observations, buffering, reflections, generations, and configuration.
- Added full Observational Memory support to `MemoryConvex`, including serialization, resource-scoped message listing, cleanup, and capability reporting.
- Added Convex-specific OM types, storage operations, schema exports, and compatibility error updates.
- Updated Convex and Observational Memory documentation with schema migration instructions.
- Added schema drift, unit, helper, and integration coverage, including all shared OM tests against a live Convex deployment.

Existing users must add `mastraObservationalMemoryTable` to `convex/schema.ts` and run `npx convex deploy`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->