### PR TITLE
fix(playground): expand prompt block editor width

### DIFF
--- a/.changeset/warm-badgers-smile.md
+++ b/.changeset/warm-badgers-smile.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed instruction block actions so the prompt editor uses the full available width.

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -194,12 +194,7 @@ const InlineBlockContent = ({
 
   return (
     <>
-      <div
-        className={cn(
-          'relative group rounded-md transition-colors duration-150 hover:bg-surface2/50',
-          !readOnly && 'pr-20',
-        )}
-      >
+      <div className="relative group rounded-md transition-colors duration-150 hover:bg-surface2/50">
         {/* Left gutter — drag handle (visible on hover/focus-within) */}
         {!readOnly && (
           <div className="absolute -left-8 top-1 flex flex-col items-center transition-opacity duration-150 opacity-0 group-hover:opacity-100 group-focus-within:opacity-100">
@@ -227,18 +222,13 @@ const InlineBlockContent = ({
             />
 
             {onConvertToRef && block.content.trim().length > 0 && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setSaveDialogOpen(true)}
-                tooltip="Save as prompt block"
-              >
+              <Button variant="ghost" size="sm" onClick={() => setSaveDialogOpen(true)} tooltip="Save as prompt block">
                 <BookmarkPlus />
               </Button>
             )}
 
             {onDelete && (
-              <Button variant="ghost" size="icon-sm" onClick={onDelete} tooltip="Delete block">
+              <Button variant="ghost" size="sm" onClick={onDelete} tooltip="Delete block">
                 <X />
               </Button>
             )}

--- a/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-blocks/agent-cms-block.tsx
@@ -222,13 +222,18 @@ const InlineBlockContent = ({
             />
 
             {onConvertToRef && block.content.trim().length > 0 && (
-              <Button variant="ghost" size="sm" onClick={() => setSaveDialogOpen(true)} tooltip="Save as prompt block">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => setSaveDialogOpen(true)}
+                tooltip="Save as prompt block"
+              >
                 <BookmarkPlus />
               </Button>
             )}
 
             {onDelete && (
-              <Button variant="ghost" size="sm" onClick={onDelete} tooltip="Delete block">
+              <Button variant="ghost" size="icon-sm" onClick={onDelete} tooltip="Delete block">
                 <X />
               </Button>
             )}


### PR DESCRIPTION
Before:

<img width="407" height="450" alt="image" src="https://github.com/user-attachments/assets/60ab6940-9474-494e-b26c-6e4bb0494753" />


After:
<img width="439" height="316" alt="CleanShot 2026-07-15 at 11 49 22" src="https://github.com/user-attachments/assets/e96efb5f-2e73-4c48-8275-ca6dbb27996d" />


Keeps the existing icon-sm ghost buttons for prompt block actions, overlays the action row in the top-right corner, and removes the reserved right padding so prompt content can use the full editor width.

Validated with Playground typecheck, ESLint, Prettier, React Doctor, a production build, and a live browser check against the local chef-agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The prompt editor now uses all the available space, while its action buttons sit neatly in the top-right corner instead of taking up room beside the text.

## Changes

- Removed reserved right padding from the prompt block editor.
- Kept prompt actions as small icon ghost buttons and overlaid them in the top-right.
- Added a patch changeset for `@internal/playground`.
- Validated with typecheck, ESLint, Prettier, React Doctor, production build, and a live browser check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->