### PR TITLE
fix(core): run background tasks without startWorkers() in library mode

### DIFF
--- a/.changeset/tame-poems-serve.md
+++ b/.changeset/tame-poems-serve.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed background tasks never executing when Mastra is used as a library without a Mastra server. Previously, background-eligible tool calls (including background subagent delegations) were dispatched but stayed in the `running` state forever because the task workers only started with a Mastra server (`mastra dev` or a deployed server). Now the workers start automatically on the first background task dispatch or resume, so background tasks complete in apps that embed Mastra directly (for example Express or Next.js servers). Fixes [#19339](https://github.com/mastra-ai/mastra/issues/19339).

--- a/packages/core/src/background-tasks/library-mode.test.ts
+++ b/packages/core/src/background-tasks/library-mode.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import { EventEmitterPubSub } from '../events/event-emitter';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage';
 import { createTool } from '../tools';
@@ -188,6 +189,51 @@ describe('background tasks in library mode (no startWorkers)', () => {
 
     expect(completed.status).toBe('completed');
     expect(executeFn).toHaveBeenCalledTimes(1);
+
+    await mastra.stopWorkers();
+  });
+
+  it('tears down workers started by a lazy start still in flight when stopWorkers() is called', async () => {
+    const pubsub = new EventEmitterPubSub();
+    const mastra = makeLibraryModeMastra({ pubsub });
+    const manager = mastra.backgroundTaskManager!;
+
+    // Gate the orchestration worker's subscription so the lazy start is
+    // reliably still in flight when stopWorkers() runs.
+    const originalSubscribe = pubsub.subscribe.bind(pubsub);
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => (release = resolve));
+    const subscribeSpy = vi.spyOn(pubsub, 'subscribe').mockImplementation(async (topic, cb, options) => {
+      if (options?.group === 'mastra-orchestration') await gate;
+      return originalSubscribe(topic, cb, options);
+    });
+    const unsubscribeSpy = vi.spyOn(pubsub, 'unsubscribe');
+
+    const enqueued = manager.enqueue(
+      { toolName: 't', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'r1' },
+      ctx(vi.fn().mockResolvedValue('x')),
+    );
+    await vi.waitFor(() => {
+      expect(subscribeSpy.mock.calls.some(call => call[2]?.group === 'mastra-orchestration')).toBe(true);
+    });
+
+    // Stop while the lazy start is parked on the gated subscribe, then let
+    // the start finish. stopWorkers() must not leave the freshly started
+    // workers running behind its back.
+    const stopping = mastra.stopWorkers();
+    release();
+    await stopping;
+    await enqueued;
+    await tick();
+
+    const orchestrationCbs = subscribeSpy.mock.calls
+      .filter(call => call[2]?.group === 'mastra-orchestration')
+      .map(call => call[1]);
+    expect(orchestrationCbs.length).toBeGreaterThan(0);
+    const unsubscribed = unsubscribeSpy.mock.calls.map(call => call[1]);
+    for (const cb of orchestrationCbs) {
+      expect(unsubscribed).toContain(cb);
+    }
 
     await mastra.stopWorkers();
   });

--- a/packages/core/src/background-tasks/library-mode.test.ts
+++ b/packages/core/src/background-tasks/library-mode.test.ts
@@ -1,0 +1,228 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Mastra } from '../mastra';
+import { MockStore } from '../storage';
+import { createTool } from '../tools';
+import { createBackgroundTask } from './create';
+import type { BackgroundTask, TaskContext } from './types';
+
+/**
+ * "Library mode" coverage: the app constructs a Mastra and dispatches
+ * background tasks without ever calling `mastra.startWorkers()` (no server,
+ * no `mastra dev`). Dispatch/resume must lazily start the execution workers
+ * or the task's evented workflow has no consumer and the task sits at
+ * `running` forever.
+ */
+
+function ctx(executeFn: (args: any, opts?: any) => Promise<any>): TaskContext {
+  return { executor: { execute: executeFn } };
+}
+
+const tick = (ms = 200) => new Promise(resolve => setTimeout(resolve, ms));
+
+function makeLibraryModeMastra(overrides: ConstructorParameters<typeof Mastra>[0] = {}) {
+  // NOTE: deliberately no `startWorkers()` call anywhere in this file's
+  // happy paths — that is the scenario under test.
+  return new Mastra({
+    logger: false,
+    storage: new MockStore(),
+    backgroundTasks: { enabled: true },
+    ...overrides,
+  });
+}
+
+describe('background tasks in library mode (no startWorkers)', () => {
+  it('completes a dispatched task', async () => {
+    const mastra = makeLibraryModeMastra();
+    const manager = mastra.backgroundTaskManager!;
+
+    const executeFn = vi.fn().mockResolvedValue({ ok: true });
+    const handle = createBackgroundTask(manager, {
+      toolName: 'lib-tool',
+      toolCallId: 'call-1',
+      args: { q: 'x' },
+      agentId: 'agent-1',
+      runId: 'run-1',
+      context: ctx(executeFn),
+    });
+
+    const { task } = await handle.dispatch();
+    const completed = await manager.waitForNextTask([task.id], { timeoutMs: 5000 });
+
+    expect(completed.status).toBe('completed');
+    expect(completed.result).toEqual({ ok: true });
+    expect(executeFn).toHaveBeenCalledTimes(1);
+
+    await mastra.stopWorkers();
+  });
+
+  it('completes concurrent first dispatches on a cold instance, each executor exactly once', async () => {
+    const mastra = makeLibraryModeMastra();
+    const manager = mastra.backgroundTaskManager!;
+
+    const executeA = vi.fn().mockResolvedValue('a');
+    const executeB = vi.fn().mockResolvedValue('b');
+
+    const [{ task: taskA }, { task: taskB }] = await Promise.all([
+      manager.enqueue({ toolName: 't-a', toolCallId: 'ca', args: {}, agentId: 'a1', runId: 'r1' }, ctx(executeA)),
+      manager.enqueue({ toolName: 't-b', toolCallId: 'cb', args: {}, agentId: 'a1', runId: 'r1' }, ctx(executeB)),
+    ]);
+
+    const [doneA, doneB] = await Promise.all([
+      manager.waitForNextTask([taskA.id], { timeoutMs: 5000 }),
+      manager.waitForNextTask([taskB.id], { timeoutMs: 5000 }),
+    ]);
+
+    expect(doneA.status).toBe('completed');
+    expect(doneB.status).toBe('completed');
+    expect(executeA).toHaveBeenCalledTimes(1);
+    expect(executeB).toHaveBeenCalledTimes(1);
+
+    await mastra.stopWorkers();
+  });
+
+  it('suspends and resumes a task', async () => {
+    const mastra = makeLibraryModeMastra();
+    const manager = mastra.backgroundTaskManager!;
+
+    const executeFn = vi.fn(async (_args, opts: any) => {
+      if (!opts.resumeData) {
+        await opts.suspend({ awaiting: 'approval' });
+        return undefined;
+      }
+      return { approvedBy: (opts.resumeData as { user: string }).user };
+    });
+
+    const { task } = await manager.enqueue(
+      { toolName: 't', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'r1' },
+      ctx(executeFn),
+    );
+    await tick();
+    expect((await manager.getTask(task.id))?.status).toBe('suspended');
+
+    await manager.resume(task.id, { user: 'alice' });
+    const completed = await manager.waitForNextTask([task.id], { timeoutMs: 5000 });
+
+    expect(completed.status).toBe('completed');
+    expect(completed.result).toEqual({ approvedBy: 'alice' });
+
+    await mastra.stopWorkers();
+  });
+
+  it('completes a task dispatched after stopWorkers()', async () => {
+    const mastra = makeLibraryModeMastra();
+    const manager = mastra.backgroundTaskManager!;
+
+    await mastra.startWorkers();
+    await mastra.stopWorkers();
+
+    const executeFn = vi.fn().mockResolvedValue('after-stop');
+    const { task } = await manager.enqueue(
+      { toolName: 't', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'r1' },
+      ctx(executeFn),
+    );
+
+    const completed = await manager.waitForNextTask([task.id], { timeoutMs: 5000 });
+    expect(completed.status).toBe('completed');
+    expect(executeFn).toHaveBeenCalledTimes(1);
+
+    await mastra.stopWorkers();
+  });
+
+  it('completes a task when only the backgroundTasks worker was started by name', async () => {
+    const mastra = makeLibraryModeMastra();
+    const manager = mastra.backgroundTaskManager!;
+
+    // A named partial start marks the boot path as run but never starts the
+    // orchestration worker or push wiring — the lazy path must still supply
+    // the missing workflow consumer.
+    await mastra.startWorkers('backgroundTasks');
+
+    const executeFn = vi.fn().mockResolvedValue('ok');
+    const { task } = await manager.enqueue(
+      { toolName: 't', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'r1' },
+      ctx(executeFn),
+    );
+
+    const completed = await manager.waitForNextTask([task.id], { timeoutMs: 5000 });
+    expect(completed.status).toBe('completed');
+    expect(executeFn).toHaveBeenCalledTimes(1);
+
+    await mastra.stopWorkers();
+  });
+
+  it('recovers and completes a pending task from a previous process via the static tool registry', async () => {
+    // Seed a pending task (as if a previous process enqueued it and died
+    // before dispatch) BEFORE constructing Mastra, so the manager's
+    // constructor-time recovery is what picks it up.
+    const storage = new MockStore();
+    const bgStore = await storage.getStore('backgroundTasks');
+    const staleTask: BackgroundTask = {
+      id: 'stale-1',
+      status: 'pending',
+      toolName: 'recoverable-tool',
+      toolCallId: 'call-stale',
+      args: {},
+      agentId: 'agent-1',
+      runId: 'run-stale',
+      retryCount: 0,
+      maxRetries: 0,
+      timeoutMs: 5000,
+      createdAt: new Date(),
+    };
+    await bgStore!.createTask(staleTask);
+
+    const executeFn = vi.fn().mockResolvedValue({ recovered: true });
+    const mastra = makeLibraryModeMastra({
+      storage,
+      tools: {
+        'recoverable-tool': createTool({
+          id: 'recoverable-tool',
+          description: 'recoverable',
+          execute: executeFn,
+        }),
+      },
+    });
+
+    const manager = mastra.backgroundTaskManager!;
+    const completed = await manager.waitForNextTask([staleTask.id], { timeoutMs: 5000 });
+
+    expect(completed.status).toBe('completed');
+    expect(executeFn).toHaveBeenCalledTimes(1);
+
+    await mastra.stopWorkers();
+  });
+
+  it('creates no background-task manager when the instance opted out via workers: false', () => {
+    // `workers: false` means the consumer of the background-tasks topic lives
+    // in a separate worker process — this instance never creates a manager,
+    // so there is no lazy-start surface to trigger.
+    const mastra = makeLibraryModeMastra({ workers: false });
+    expect(mastra.backgroundTaskManager).toBeUndefined();
+  });
+
+  it('does not lazily start execution workers excluded by the MASTRA_WORKERS filter', async () => {
+    process.env.MASTRA_WORKERS = 'scheduler';
+    let mastra: Mastra;
+    try {
+      mastra = makeLibraryModeMastra();
+    } finally {
+      delete process.env.MASTRA_WORKERS;
+    }
+    const manager = mastra.backgroundTaskManager!;
+
+    const executeFn = vi.fn().mockResolvedValue('never');
+    const { task } = await manager.enqueue(
+      { toolName: 't', toolCallId: 'c1', args: {}, agentId: 'a1', runId: 'r1' },
+      ctx(executeFn),
+    );
+    await tick(500);
+
+    // With orchestration/backgroundTasks filtered out, the task's evented
+    // workflow has no local consumer — a separate worker process is expected
+    // to pick it up, so this instance must not execute it.
+    expect(executeFn).not.toHaveBeenCalled();
+    expect((await manager.getTask(task.id))?.status).not.toBe('completed');
+
+    await mastra.stopWorkers();
+  });
+});

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -390,6 +390,10 @@ export class BackgroundTaskManager {
       throw new Error(`Concurrency limit reached, cannot resume task "${taskId}" — retry once a slot is available`);
     }
 
+    // Resume publishes directly (not via dispatch()), so it needs its own
+    // lazy worker start for the library-mode process-restart case.
+    await this.#ensureExecutionWorkersStarted();
+
     // Hand off to the worker subscriber. `task.resume` rides the same
     // `TOPIC_DISPATCH` + `WORKER_GROUP` exactly-once channel as
     // `task.dispatch`, so any worker (including a different process from
@@ -731,7 +735,31 @@ export class BackgroundTaskManager {
 
   // --- Internal ---
 
+  /**
+   * Lazily start Mastra's execution workers before publishing. In "library
+   * mode" nothing ever calls `mastra.startWorkers()`, so the evented
+   * `__background-task` workflow started by `handleDispatch` would publish
+   * to the `workflows` topic with no consumer and the task would sit at
+   * `running` forever (#19339). A no-op once workers are running; honors the
+   * `workers: false` / `MASTRA_WORKERS` opt-outs.
+   *
+   * Startup failures are logged but don't abort the publish — in distributed
+   * topologies a remote worker on the shared broker can still pick the task
+   * up, and throwing here would also abort `drainPending()` /
+   * `recoverStaleTasks()` loops.
+   */
+  async #ensureExecutionWorkersStarted(): Promise<void> {
+    if (!this.#mastra) return;
+    try {
+      await this.#mastra.__ensureExecutionWorkersStarted();
+    } catch (err) {
+      this.#mastra.getLogger?.()?.error('Failed to start execution workers for background task', err as any);
+    }
+  }
+
   private async dispatch(task: BackgroundTask, isRestart?: boolean): Promise<void> {
+    await this.#ensureExecutionWorkersStarted();
+
     // Publish `task.dispatch` on `TOPIC_DISPATCH` with `WORKER_GROUP`, so
     // exactly one worker handles the task. `handleDispatch` flips the
     // task to running and starts the per-task workflow run.

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -756,6 +756,20 @@ export class Mastra<
    * worker-existence checks and double-subscribe to the scheduling topics.
    */
   #schedulingWorkersStartPromise?: Promise<void>;
+  /**
+   * In-flight promise for `__ensureExecutionWorkersStarted()`. Serializes
+   * concurrent lazy startups triggered by background-task dispatches so two
+   * first dispatches on a cold instance can't both init/start the same
+   * workers.
+   */
+  #executionWorkersStartPromise?: Promise<void>;
+  /**
+   * Fast path for `__ensureExecutionWorkersStarted()`. Set once the execution
+   * workers + push wiring are confirmed running; reset by `stopWorkers()`.
+   * Kept separate from `#workersStarted`, which partial `startWorkers(name)`
+   * calls also set without starting the workflow consumer.
+   */
+  #executionWorkersStarted = false;
   // Lazily-constructed processor used by handleWorkflowEvent(). Shared between
   // pull-mode workers (OrchestrationWorker) and push-mode entry points
   // (in-process EventEmitter listener, the /api/workers/events HTTP route).
@@ -5277,71 +5291,7 @@ export class Mastra<
     // OrchestrationWorker pulling events — wire handleWorkflowEvent directly
     // to the pubsub so workflow events still get processed in-process.
     if (!name) {
-      const modes = this.#pubsub.supportedModes ?? ['pull'];
-      const pushOnly = modes.includes('push') && !modes.includes('pull');
-      if (pushOnly && !this.#pushSubscription) {
-        const cb: EventCallback = (event, ack, nack) => {
-          // In cross-process push environments (e.g. UnixSocketPubSub),
-          // every subscriber receives every event — including events for
-          // internal workflows registered on a different process. Skip
-          // events whose workflow exists in neither the internal nor the
-          // public registry so only the owning process handles them.
-          // Without this guard the WEP would publish workflow.fail,
-          // propagating through workflows-finish and erroneously
-          // terminating the correct process's run.
-          const data = event.data as Record<string, unknown> | undefined;
-          const wfId = data?.workflowId as string | undefined;
-          const rId = data?.runId as string | undefined;
-          if (wfId && rId && !this.#ownsWorkflow(wfId, rId, data?.parentWorkflow)) {
-            if (ack) {
-              void ack().catch(err => this.#logger?.error?.('Error acking skipped workflow event', err));
-            }
-            return;
-          }
-
-          void this.handleWorkflowEvent(event)
-            .then(result => {
-              if (result.ok) {
-                if (ack) {
-                  return ack().catch(err =>
-                    this.#logger?.error?.('Error acking workflow event in push subscription', err),
-                  );
-                }
-                return;
-              }
-              // Non-ok result: ask the transport to redeliver (nack) when the
-              // handle layer says retry. The WEP tracks per-event delivery
-              // attempts and eventually returns `retry: false` to break the
-              // loop and surface a terminal workflow.fail. For terminal
-              // failures we ack so the event is dropped from the transport.
-              if (result.retry) {
-                if (nack) {
-                  return nack().catch(err =>
-                    this.#logger?.error?.('Error nacking workflow event in push subscription', err),
-                  );
-                }
-                // Transport does not support nack. Do NOT ack — acking a
-                // retryable failure would drop the event and silently lose
-                // the workflow run. Log and let the transport's own delivery
-                // semantics decide (most non-ack transports redeliver until
-                // explicitly acked).
-                this.#logger?.error?.('Retryable workflow event cannot be requeued because nack is unavailable', {
-                  type: event.type,
-                  runId: event.runId,
-                });
-                return;
-              }
-              if (ack) {
-                return ack().catch(err =>
-                  this.#logger?.error?.('Error acking terminal workflow event in push subscription', err),
-                );
-              }
-            })
-            .catch(err => this.#logger?.error?.('Unhandled error in workflow event push subscription', err));
-        };
-        await this.#pubsub.subscribe('workflows', cb);
-        this.#pushSubscription = { topic: 'workflows', cb };
-      }
+      await this.#wirePushWorkflowSubscription();
     }
 
     // Subscribe user-defined event listeners (non-workflow topics, or legacy inline WEP)
@@ -5372,6 +5322,147 @@ export class Mastra<
   }
 
   /**
+   * Wire `handleWorkflowEvent` directly to the pubsub when it is push-only
+   * (no pull mode for an OrchestrationWorker to drive). Idempotent — no-op
+   * when the pubsub supports pull or the subscription already exists.
+   * Shared by `startWorkers()` and `__ensureExecutionWorkersStarted()`.
+   */
+  async #wirePushWorkflowSubscription(): Promise<void> {
+    const modes = this.#pubsub.supportedModes ?? ['pull'];
+    const pushOnly = modes.includes('push') && !modes.includes('pull');
+    if (pushOnly && !this.#pushSubscription) {
+      const cb: EventCallback = (event, ack, nack) => {
+        // In cross-process push environments (e.g. UnixSocketPubSub),
+        // every subscriber receives every event — including events for
+        // internal workflows registered on a different process. Skip
+        // events whose workflow exists in neither the internal nor the
+        // public registry so only the owning process handles them.
+        // Without this guard the WEP would publish workflow.fail,
+        // propagating through workflows-finish and erroneously
+        // terminating the correct process's run.
+        const data = event.data as Record<string, unknown> | undefined;
+        const wfId = data?.workflowId as string | undefined;
+        const rId = data?.runId as string | undefined;
+        if (wfId && rId && !this.#ownsWorkflow(wfId, rId, data?.parentWorkflow)) {
+          if (ack) {
+            void ack().catch(err => this.#logger?.error?.('Error acking skipped workflow event', err));
+          }
+          return;
+        }
+
+        void this.handleWorkflowEvent(event)
+          .then(result => {
+            if (result.ok) {
+              if (ack) {
+                return ack().catch(err =>
+                  this.#logger?.error?.('Error acking workflow event in push subscription', err),
+                );
+              }
+              return;
+            }
+            // Non-ok result: ask the transport to redeliver (nack) when the
+            // handle layer says retry. The WEP tracks per-event delivery
+            // attempts and eventually returns `retry: false` to break the
+            // loop and surface a terminal workflow.fail. For terminal
+            // failures we ack so the event is dropped from the transport.
+            if (result.retry) {
+              if (nack) {
+                return nack().catch(err =>
+                  this.#logger?.error?.('Error nacking workflow event in push subscription', err),
+                );
+              }
+              // Transport does not support nack. Do NOT ack — acking a
+              // retryable failure would drop the event and silently lose
+              // the workflow run. Log and let the transport's own delivery
+              // semantics decide (most non-ack transports redeliver until
+              // explicitly acked).
+              this.#logger?.error?.('Retryable workflow event cannot be requeued because nack is unavailable', {
+                type: event.type,
+                runId: event.runId,
+              });
+              return;
+            }
+            if (ack) {
+              return ack().catch(err =>
+                this.#logger?.error?.('Error acking terminal workflow event in push subscription', err),
+              );
+            }
+          })
+          .catch(err => this.#logger?.error?.('Unhandled error in workflow event push subscription', err));
+      };
+      await this.#pubsub.subscribe('workflows', cb);
+      this.#pushSubscription = { topic: 'workflows', cb };
+    }
+  }
+
+  /**
+   * Ensure the execution-side machinery — the `orchestration` and
+   * `backgroundTasks` workers, plus the push-mode workflow subscription —
+   * is running. Called lazily by {@link BackgroundTaskManager} when a task
+   * is dispatched or resumed, so background tasks execute in "library mode"
+   * where nothing ever calls `startWorkers()` (no server, no `mastra dev`;
+   * see #19339).
+   *
+   * Deliberately narrower than `startWorkers()`: it never injects or starts
+   * the scheduler/agent-schedule workers and never subscribes user event
+   * listeners — dispatching a background task must not boot cron machinery
+   * as a side effect.
+   *
+   * Honors the same opt-outs as the rest of the worker lifecycle:
+   * `workers: false` / `MASTRA_WORKERS=false` (standalone-worker topologies
+   * run their own worker processes, so this instance must not start local
+   * ones) and the `MASTRA_WORKERS` name filter.
+   *
+   * The fast path is its own `#executionWorkersStarted` flag, NOT
+   * `#workersStarted` — the latter is set by any `startWorkers(name)` call,
+   * including partial named starts (e.g. `startWorkers('backgroundTasks')`)
+   * that never start the orchestration worker or push wiring, which would
+   * leave dispatched tasks stuck again. The pass itself is idempotent
+   * (per-worker `isRunning` checks, idempotent push wiring), so running it
+   * once after a full `startWorkers()` boot is a cheap no-op.
+   *
+   * @internal
+   */
+  async __ensureExecutionWorkersStarted(): Promise<void> {
+    if (this.#executionWorkersStarted) return;
+    if (this.#workersDisabled) return;
+    // Memoize the in-flight startup so concurrent first dispatches on a cold
+    // instance share one start instead of racing worker.init()/start().
+    // Cleared on settle so a dispatch after stopWorkers() can start again.
+    if (!this.#executionWorkersStartPromise) {
+      this.#executionWorkersStartPromise = this.#startExecutionWorkers().finally(() => {
+        this.#executionWorkersStartPromise = undefined;
+      });
+    }
+    await this.#executionWorkersStartPromise;
+  }
+
+  async #startExecutionWorkers(): Promise<void> {
+    // Storage init is memoized (see augmentWithInit) — cheap when already run.
+    if (this.#storage) {
+      await this.#storage.init();
+    }
+
+    const deps: WorkerDeps = {
+      pubsub: this.#pubsub,
+      storage: this.#storage!,
+      logger: this.#logger as unknown as IMastraLogger,
+      mastra: this,
+    };
+
+    for (const worker of this.#workers) {
+      if (worker.name !== 'orchestration' && worker.name !== 'backgroundTasks') continue;
+      if (this.#workerFilter && !this.#workerFilter.has(worker.name)) continue;
+      if (worker.isRunning) continue;
+      await worker.init(deps);
+      await worker.start();
+    }
+
+    await this.#wirePushWorkflowSubscription();
+    this.#executionWorkersStarted = true;
+  }
+
+  /**
    * Stop all running workers and unsubscribe event listeners.
    */
   public async stopWorkers(): Promise<void> {
@@ -5398,6 +5489,7 @@ export class Mastra<
 
     await this.#pubsub.flush();
     this.#workersStarted = false;
+    this.#executionWorkersStarted = false;
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -5466,6 +5466,16 @@ export class Mastra<
    * Stop all running workers and unsubscribe event listeners.
    */
   public async stopWorkers(): Promise<void> {
+    // A background-task dispatch may have kicked off a lazy execution-worker
+    // start (`__ensureExecutionWorkersStarted`) that is still in flight. Wait
+    // for it so the teardown below covers what it started — otherwise the
+    // start finishes after this method returns, leaving workers running and
+    // subscriptions wired behind a "stopped" instance. Failures are already
+    // logged by the start path; here they just mean there is less to stop.
+    while (this.#executionWorkersStartPromise) {
+      await this.#executionWorkersStartPromise.catch(() => {});
+    }
+
     // Stop registered workers in reverse order
     for (const worker of [...this.#workers].reverse()) {
       if (worker.isRunning) {


### PR DESCRIPTION
## Description

Background tasks (including backgrounded subagent delegations) never executed when Mastra runs as a library — e.g. inside an Express or Next.js server that constructs `new Mastra()` directly — because nothing calls `startWorkers()`, so the evented `__background-task` workflow published to the `workflows` topic with no consumer and tasks sat at `running` forever. This PR lazily starts the execution workers at the manager's dispatch/resume choke points, so background tasks complete without any manual worker startup.

- Add internal `Mastra.__ensureExecutionWorkersStarted()`: single-flight (memoized in-flight promise, mirroring the existing scheduling-workers pattern), starts only the `orchestration` and `backgroundTasks` workers plus the push-mode workflow subscription — never the scheduler/agent-schedule workers or user event listeners
- Gate the fast path on a dedicated `#executionWorkersStarted` flag (set when the workflow consumer is confirmed running, reset by `stopWorkers()`) rather than `#workersStarted`, which partial named `startWorkers(name)` calls also set without starting the workflow consumer
- Honor existing opt-outs: `workers: false` / `MASTRA_WORKERS=false` (standalone-worker topologies must not execute tasks locally) and the `MASTRA_WORKERS` name filter
- Extract the push-mode workflow wiring from `startWorkers()` into a shared, idempotent `#wirePushWorkflowSubscription()`
- Call the lazy start from `BackgroundTaskManager.dispatch()` (covers enqueue, restarts, drain-pending, stale-task recovery) and `resume()` (publishes directly); startup failures log instead of throwing so recovery loops survive and remote workers on a shared broker can still consume
- Add `library-mode.test.ts` with 8 regression tests: dispatch completion, concurrent cold-instance dispatches (executor exactly once), suspend/resume, dispatch after `stopWorkers()`, partial `startWorkers('backgroundTasks')` start, cross-process pending-task recovery via the static tool registry, `workers: false` design guard, and `MASTRA_WORKERS` filter opt-out

## Related Issue(s)

Fixes #19339

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When Mastra runs inside another app (like Express/Next.js), background jobs used to never “wake up” unless you manually started Mastra workers. This PR makes background workers start automatically the first time a background task is dispatched or resumed, so background agents/subagents can finish instead of getting stuck.

## What changed

- Added lazy, single-flight startup for **execution** workers (orchestration + background-tasks) at background-task **dispatch** and **resume** points.
- Separated “execution-worker startup” from general `startWorkers()` so library mode can work without explicit worker startup.
- Reused idempotent **push-mode workflow subscription** wiring for both normal and lazy startup paths.
- Ensured worker behavior respects `workers: false` / `MASTRA_WORKERS=false` and any configured worker-name filters.
- Updated `stopWorkers()` to wait for any in-flight lazy execution-worker startup, and reset execution-worker state so later dispatches can restart workers.
- Made lazy startup failures log errors without throwing, so dispatch/resume still proceeds.
- Added eight library-mode regression tests covering: dispatch, concurrency (each first dispatch triggers once), suspend/resume recovery, worker restarts, partial startup, recovery, and opt-outs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->