### PR TITLE
fix(playground): use tooltip for variable syntax help

### DIFF
--- a/.changeset/neat-pandas-hover.md
+++ b/.changeset/neat-pandas-hover.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed the variable syntax help so only the underlined text opens its tooltip.

--- a/packages/playground/src/domains/agents/components/__tests__/agent-playground-config.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-playground-config.test.tsx
@@ -66,5 +66,18 @@ describe('AgentPlaygroundConfig', () => {
       expect(screen.queryByRole('button', { name: 'Preview' })).toBeNull();
       expect(screen.queryByRole('button', { name: 'Edit' })).toBeNull();
     });
+
+    it('shows variable syntax help as a tooltip from the underlined text', async () => {
+      render(<AgentPlaygroundConfigHarness />);
+
+      fireEvent.click(screen.getByRole('tab', { name: 'System Prompt' }));
+
+      const variableHelpTrigger = screen.getByRole('button', { name: 'use variables' });
+      fireEvent.focus(variableHelpTrigger);
+
+      expect((await screen.findByRole('tooltip')).textContent).toBe(
+        'Use {{variableName}} syntax to insert dynamic values into your instruction blocks.',
+      );
+    });
   });
 });

--- a/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
+++ b/packages/playground/src/domains/agents/components/agent-playground/agent-playground-config.tsx
@@ -1,9 +1,9 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
-import { HoverPopover, PopoverTrigger, PopoverContent } from '@mastra/playground-ui/components/Popover';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Tab, TabContent, TabList, Tabs } from '@mastra/playground-ui/components/Tabs';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { cn } from '@mastra/playground-ui/utils/cn';
@@ -724,23 +724,18 @@ export function AgentPlaygroundConfig({ agentId, selectedVersionId, latestVersio
               <div className="flex flex-col gap-3 pt-4 pb-2">
                 <Txt variant="ui-sm" className="font-normal text-neutral3">
                   Add instruction blocks to your agent. Blocks are combined in order to form the system prompt. You can{' '}
-                  <HoverPopover>
-                    <PopoverTrigger asChild>
-                      <button
-                        type="button"
-                        className="text-neutral3 underline decoration-dotted hover:text-neutral5 cursor-pointer inline"
-                      >
-                        use variables
-                      </button>
-                    </PopoverTrigger>{' '}
-                    as part of your instruction blocks.
-                    <PopoverContent side="bottom" align="start">
-                      <p className="text-ui-sm text-neutral5">
+                  <Tooltip>
+                    <TooltipTrigger className="text-neutral3 underline decoration-dotted hover:text-neutral5 cursor-pointer inline">
+                      use variables
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom" align="start" className="max-w-72">
+                      <span>
                         Use <code className="text-accent1 font-medium">{'{{variableName}}'}</code> syntax to insert
                         dynamic values into your instruction blocks.
-                      </p>
-                    </PopoverContent>
-                  </HoverPopover>
+                      </span>
+                    </TooltipContent>
+                  </Tooltip>{' '}
+                  as part of your instruction blocks.
                 </Txt>
               </div>
 


### PR DESCRIPTION
The variable syntax hint now uses a tooltip triggered only by the underlined “use variables” text. The previous hover popover wrapped the rest of the sentence, so hovering outside the link could open it.

Validated with focused Vitest coverage, Playground typecheck and lint, a production build, React Doctor, and a local Studio browser check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The help popup now appears only when hovering or focusing the underlined “use variables” text, instead of opening when hovering nearby. A test was added to make sure the variable guidance remains accessible.

## Changes

- Replaced the broad hover popover with a focused tooltip trigger.
- Added Vitest coverage for the tooltip and `{{variableName}}` guidance.
- Added a patch changeset for `@internal/playground`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->