### PR TITLE
fix(stagehand): forward local mode options

### DIFF
--- a/.changeset/thin-zoos-divide.md
+++ b/.changeset/thin-zoos-divide.md
@@ -2,4 +2,12 @@
 '@mastra/stagehand': patch
 ---
 
-Fixed StagehandBrowser support for local model execution options.
+Fixed local model execution in `StagehandBrowser` by forwarding the `experimental` and `disableAPI` options.
+
+```ts
+new StagehandBrowser({
+  scope: 'shared',
+  experimental: true,
+  disableAPI: true,
+});
+```

--- a/.changeset/thin-zoos-divide.md
+++ b/.changeset/thin-zoos-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/stagehand': patch
+---
+
+Fixed StagehandBrowser support for local model execution options.

--- a/browser/stagehand/src/__tests__/stagehand-browser.test.ts
+++ b/browser/stagehand/src/__tests__/stagehand-browser.test.ts
@@ -223,6 +223,23 @@ describe('StagehandBrowser', () => {
       );
     });
 
+    it('forwards local model execution options to Stagehand', async () => {
+      const customBrowser = new StagehandBrowser({
+        scope: 'shared',
+        experimental: true,
+        disableAPI: true,
+      } as StagehandBrowserConfig);
+      await customBrowser.launch();
+      await customBrowser.close();
+
+      expect(mockStagehandConstructor).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          experimental: true,
+          disableAPI: true,
+        }),
+      );
+    });
+
     it('passes model configuration objects through to Stagehand', async () => {
       const model = {
         modelName: '__GATEWAY_OPENAI_MODEL__',

--- a/browser/stagehand/src/__tests__/stagehand-browser.test.ts
+++ b/browser/stagehand/src/__tests__/stagehand-browser.test.ts
@@ -228,7 +228,7 @@ describe('StagehandBrowser', () => {
         scope: 'shared',
         experimental: true,
         disableAPI: true,
-      } as StagehandBrowserConfig);
+      });
       await customBrowser.launch();
       await customBrowser.close();
 

--- a/browser/stagehand/src/stagehand-browser.ts
+++ b/browser/stagehand/src/stagehand-browser.ts
@@ -120,6 +120,8 @@ export class StagehandBrowser extends MastraBrowser {
     const stagehandOptions: ConstructorParameters<typeof Stagehand>[0] = {
       env: config.env ?? 'LOCAL',
       model: config.model,
+      experimental: config.experimental,
+      disableAPI: config.disableAPI,
       selfHeal: config.selfHeal ?? true,
       domSettleTimeout: config.domSettleTimeout,
       verbose: (config.verbose ?? 0) as 0 | 1 | 2,

--- a/browser/stagehand/src/types.ts
+++ b/browser/stagehand/src/types.ts
@@ -48,6 +48,16 @@ interface StagehandConfigExtensions {
   model?: ModelConfiguration;
 
   /**
+   * Enable Stagehand experimental features.
+   */
+  experimental?: boolean;
+
+  /**
+   * Disable the Stagehand API so model execution runs locally.
+   */
+  disableAPI?: boolean;
+
+  /**
    * Enable self-healing selectors.
    * When enabled, Stagehand uses AI to find elements even when selectors fail.
    * @default true


### PR DESCRIPTION
StagehandBrowser currently drops Stagehand's `experimental` and `disableAPI` constructor options, so local model execution cannot be enabled through the Mastra adapter. In the affected production path, Stagehand reports `Feature "Vertex provider" is an experimental feature, and cannot be configured when disableAPI: false`.

This exposes both options on `StagehandBrowserConfig`, forwards them unchanged to Stagehand, and adds a credential-free mocked regression test plus a patch changeset. The reported configuration is:

```ts
new StagehandBrowser({
  scope: 'shared',
  experimental: true,
  disableAPI: true,
});
```

The adapter-boundary test reproduces the dropped options without Vertex, Browserbase, or Stagehand API credentials. Validation passed with the focused and full package test suites (103 tests), package lint, TypeScript checking, and the package build.

Fixes #19477. Downstream context: https://linear.app/nomerra/issue/DEV-806/fix-vertex-stagehand-configuration-in-mastra-portal-fetch-runtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR teaches `StagehandBrowser` to pass through two new settings—`experimental` and `disableAPI`—so it can run models locally instead of going through Stagehand’s API. It also adds a test that checks those options are forwarded correctly without needing any real credentials.

## What changed

- Added optional `experimental` and `disableAPI` to `StagehandBrowserConfig`.
- Updated `StagehandBrowser` to forward both options when constructing the underlying `@browserbasehq/stagehand` instance, preserving Stagehand defaults when omitted.
- Added a credential-free mocked regression test to verify option forwarding.
- Added a patch changeset for `@mastra/stagehand`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->