### PR TITLE
refactor(convex): restore strict table-name typing in ConvexDB

### DIFF
--- a/.changeset/loud-flowers-cut.md
+++ b/.changeset/loud-flowers-cut.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Improved type safety of the Convex storage layer. Table names accepted by the internal ConvexDB are now a closed union (core storage tables plus the observational memory table) instead of any string, so table-name typos are caught at compile time instead of silently routing records to the mastra_documents fallback table. The internal observational memory operations no longer take a table-name argument.

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -9,11 +9,18 @@ import {
   TABLE_THREADS,
   TABLE_WORKFLOW_SNAPSHOT,
 } from '@mastra/core/storage';
-import type { StorageColumn, StorageResourceType, TABLE_NAMES, UpdateWorkflowStateOptions } from '@mastra/core/storage';
+import type { StorageColumn, StorageResourceType, UpdateWorkflowStateOptions } from '@mastra/core/storage';
 import type { StepResult, WorkflowRunState } from '@mastra/core/workflows';
 
 import { ConvexAdminClient } from '../client';
-import type { EqualityFilter, IndexHint, SerializedOMChunk, SerializedOMCurrentRecord } from '../types';
+import { TABLE_OBSERVATIONAL_MEMORY } from '../types';
+import type {
+  ConvexStorageTable,
+  EqualityFilter,
+  IndexHint,
+  SerializedOMChunk,
+  SerializedOMCurrentRecord,
+} from '../types';
 
 // Must not exceed the server-side loadMany id cap in server/storage.ts.
 const LOAD_MANY_REQUEST_BATCH_SIZE = 10;
@@ -69,7 +76,7 @@ export class ConvexDB extends MastraBase {
     tableName,
     schema: _schema,
   }: {
-    tableName: TABLE_NAMES | string;
+    tableName: ConvexStorageTable;
     schema: Record<string, StorageColumn>;
   }): Promise<void> {
     // No-op for Convex; schema is managed server-side via schema.ts
@@ -81,7 +88,7 @@ export class ConvexDB extends MastraBase {
     schema: _schema,
     ifNotExists: _ifNotExists,
   }: {
-    tableName: TABLE_NAMES | string;
+    tableName: ConvexStorageTable;
     schema: Record<string, StorageColumn>;
     ifNotExists: string[];
   }): Promise<void> {
@@ -89,7 +96,7 @@ export class ConvexDB extends MastraBase {
     this.logger.debug(`ConvexDB: alterTable called for ${tableName} (schema managed server-side)`);
   }
 
-  async clearTable({ tableName }: { tableName: TABLE_NAMES | string }): Promise<void> {
+  async clearTable({ tableName }: { tableName: ConvexStorageTable }): Promise<void> {
     // Delete in batches since each mutation can only delete a small number of docs
     // to stay within Convex's 1-second mutation timeout.
     let hasMore = true;
@@ -102,7 +109,7 @@ export class ConvexDB extends MastraBase {
     }
   }
 
-  async dropTable({ tableName }: { tableName: TABLE_NAMES | string }): Promise<void> {
+  async dropTable({ tableName }: { tableName: ConvexStorageTable }): Promise<void> {
     // Delete in batches since each mutation can only delete a small number of docs
     // to stay within Convex's 1-second mutation timeout.
     let hasMore = true;
@@ -115,7 +122,7 @@ export class ConvexDB extends MastraBase {
     }
   }
 
-  async insert({ tableName, record }: { tableName: TABLE_NAMES | string; record: Record<string, any> }): Promise<void> {
+  async insert({ tableName, record }: { tableName: ConvexStorageTable; record: Record<string, any> }): Promise<void> {
     await this.client.callStorage({
       op: 'insert',
       tableName,
@@ -127,7 +134,7 @@ export class ConvexDB extends MastraBase {
     tableName,
     records,
   }: {
-    tableName: TABLE_NAMES | string;
+    tableName: ConvexStorageTable;
     records: Record<string, any>[];
   }): Promise<void> {
     if (records.length === 0) return;
@@ -144,7 +151,7 @@ export class ConvexDB extends MastraBase {
     id,
     record,
   }: {
-    tableName: TABLE_NAMES | string;
+    tableName: ConvexStorageTable;
     id: string;
     record: Record<string, any>;
   }): Promise<boolean> {
@@ -201,13 +208,7 @@ export class ConvexDB extends MastraBase {
     });
   }
 
-  async load<R>({
-    tableName,
-    keys,
-  }: {
-    tableName: TABLE_NAMES | string;
-    keys: Record<string, any>;
-  }): Promise<R | null> {
+  async load<R>({ tableName, keys }: { tableName: ConvexStorageTable; keys: Record<string, any> }): Promise<R | null> {
     const result = await this.client.callStorage<R | null>({
       op: 'load',
       tableName,
@@ -217,7 +218,7 @@ export class ConvexDB extends MastraBase {
     return result;
   }
 
-  async loadMany<R>(tableName: TABLE_NAMES | string, ids: string[]): Promise<R[]> {
+  async loadMany<R>(tableName: ConvexStorageTable, ids: string[]): Promise<R[]> {
     const uniqueIds = [...new Set(ids)];
     if (uniqueIds.length === 0) return [];
 
@@ -235,7 +236,7 @@ export class ConvexDB extends MastraBase {
   }
 
   public async queryTable<R>(
-    tableName: TABLE_NAMES | string,
+    tableName: ConvexStorageTable,
     filters?: EqualityFilter[],
     indexHint?: IndexHint,
     limit?: number,
@@ -249,7 +250,7 @@ export class ConvexDB extends MastraBase {
     });
   }
 
-  public async deleteMany(tableName: TABLE_NAMES | string, ids: string[]): Promise<void> {
+  public async deleteMany(tableName: ConvexStorageTable, ids: string[]): Promise<void> {
     if (ids.length === 0) return;
     await this.client.callStorage({
       op: 'deleteMany',
@@ -409,117 +410,114 @@ export class ConvexDB extends MastraBase {
 
   // ============================================
   // Observational Memory Operations
+  // These always target TABLE_OBSERVATIONAL_MEMORY — the server rejects
+  // om* operations against any other table.
   // ============================================
 
-  public async omGetLatest<R>(tableName: string, lookupKey: string): Promise<R | null> {
+  public async omGetLatest<R>(lookupKey: string): Promise<R | null> {
     return this.client.callStorage<R | null>({
       op: 'omGetLatest',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       lookupKey,
     });
   }
 
-  public async omGetHistory<R>(
-    tableName: string,
-    args: { lookupKey: string; limit: number; from?: string; to?: string; offset?: number },
-  ): Promise<R[]> {
+  public async omGetHistory<R>(args: {
+    lookupKey: string;
+    limit: number;
+    from?: string;
+    to?: string;
+    offset?: number;
+  }): Promise<R[]> {
     return this.client.callStorage<R[]>({
       op: 'omGetHistory',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  public async omUpdateActive(
-    tableName: string,
-    args: {
-      id: string;
-      observations: string;
-      tokenCount: number;
-      lastObservedAt: string;
-      observedMessageIds: string[] | null;
-      updatedAt: string;
-    },
-  ): Promise<void> {
+  public async omUpdateActive(args: {
+    id: string;
+    observations: string;
+    tokenCount: number;
+    lastObservedAt: string;
+    observedMessageIds: string[] | null;
+    updatedAt: string;
+  }): Promise<void> {
     await this.client.callStorage({
       op: 'omUpdateActive',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  public async omAppendBufferedChunk(
-    tableName: string,
-    args: { id: string; chunk: SerializedOMChunk; lastBufferedAtTime?: string; updatedAt: string },
-  ): Promise<void> {
+  public async omAppendBufferedChunk(args: {
+    id: string;
+    chunk: SerializedOMChunk;
+    lastBufferedAtTime?: string;
+    updatedAt: string;
+  }): Promise<void> {
     await this.client.callStorage({
       op: 'omAppendBufferedChunk',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  public async omSwapBuffered<R>(
-    tableName: string,
-    args: {
-      id: string;
-      activationRatio: number;
-      messageTokensThreshold: number;
-      currentPendingTokens: number;
-      forceMaxActivation?: boolean;
-      lastObservedAt?: string;
-      bufferedChunks?: SerializedOMChunk[];
-      now: string;
-    },
-  ): Promise<R> {
+  public async omSwapBuffered<R>(args: {
+    id: string;
+    activationRatio: number;
+    messageTokensThreshold: number;
+    currentPendingTokens: number;
+    forceMaxActivation?: boolean;
+    lastObservedAt?: string;
+    bufferedChunks?: SerializedOMChunk[];
+    now: string;
+  }): Promise<R> {
     return this.client.callStorage<R>({
       op: 'omSwapBuffered',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  public async omUpdateBufferedReflection(
-    tableName: string,
-    args: {
-      id: string;
-      reflection: string;
-      tokenCount: number;
-      inputTokenCount: number;
-      reflectedObservationLineCount: number;
-      updatedAt: string;
-    },
-  ): Promise<void> {
+  public async omUpdateBufferedReflection(args: {
+    id: string;
+    reflection: string;
+    tokenCount: number;
+    inputTokenCount: number;
+    reflectedObservationLineCount: number;
+    updatedAt: string;
+  }): Promise<void> {
     await this.client.callStorage({
       op: 'omUpdateBufferedReflection',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  public async omSwapBufferedReflection<R>(
-    tableName: string,
-    args: { currentRecord: SerializedOMCurrentRecord; newId: string; tokenCount: number; now: string },
-  ): Promise<R> {
+  public async omSwapBufferedReflection<R>(args: {
+    currentRecord: SerializedOMCurrentRecord;
+    newId: string;
+    tokenCount: number;
+    now: string;
+  }): Promise<R> {
     return this.client.callStorage<R>({
       op: 'omSwapBufferedReflection',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  public async omUpdateConfig(
-    tableName: string,
-    args: { id: string; config: string; updatedAt: string },
-  ): Promise<void> {
+  public async omUpdateConfig(args: { id: string; config: string; updatedAt: string }): Promise<void> {
     await this.client.callStorage({
       op: 'omUpdateConfig',
-      tableName,
+      tableName: TABLE_OBSERVATIONAL_MEMORY,
       ...args,
     });
   }
 
-  private normalizeRecord(tableName: TABLE_NAMES | string, record: Record<string, any>): Record<string, any> {
+  private normalizeRecord(tableName: ConvexStorageTable, record: Record<string, any>): Record<string, any> {
     const normalized: Record<string, any> = { ...record };
 
     if (tableName === TABLE_WORKFLOW_SNAPSHOT && !normalized.id) {

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -38,14 +38,8 @@ import type {
 
 import { ConvexDB, resolveConvexConfig } from '../../db';
 import type { ConvexDomainConfig } from '../../db';
+import { TABLE_OBSERVATIONAL_MEMORY } from '../../types';
 import type { SerializedOMChunk, SerializedOMCurrentRecord } from '../../types';
-
-/**
- * Local constant for the observational memory table name.
- * Defined locally to avoid a static import that crashes on older @mastra/core
- * versions that don't export TABLE_OBSERVATIONAL_MEMORY.
- */
-const TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';
 
 type StoredMessage = {
   id: string;
@@ -896,7 +890,7 @@ export class MemoryConvex extends MemoryStorage {
 
   async getObservationalMemory(threadId: string | null, resourceId: string): Promise<ObservationalMemoryRecord | null> {
     const lookupKey = this.getOMKey(threadId, resourceId);
-    const doc = await this.#db.omGetLatest<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, lookupKey);
+    const doc = await this.#db.omGetLatest<StoredOMRecord>(lookupKey);
     return doc ? parseStoredOMRecord(doc) : null;
   }
 
@@ -907,7 +901,7 @@ export class MemoryConvex extends MemoryStorage {
     options?: ObservationalMemoryHistoryOptions,
   ): Promise<ObservationalMemoryRecord[]> {
     const lookupKey = this.getOMKey(threadId, resourceId);
-    const docs = await this.#db.omGetHistory<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, {
+    const docs = await this.#db.omGetHistory<StoredOMRecord>({
       lookupKey,
       limit,
       from: options?.from ? options.from.toISOString() : undefined,
@@ -1025,7 +1019,7 @@ export class MemoryConvex extends MemoryStorage {
   }
 
   async updateActiveObservations(input: UpdateActiveObservationsInput): Promise<void> {
-    await this.#db.omUpdateActive(TABLE_OBSERVATIONAL_MEMORY, {
+    await this.#db.omUpdateActive({
       id: input.id,
       observations: input.observations,
       tokenCount: input.tokenCount,
@@ -1052,7 +1046,7 @@ export class MemoryConvex extends MemoryStorage {
       extractionFailures: input.chunk.extractionFailures,
     };
 
-    await this.#db.omAppendBufferedChunk(TABLE_OBSERVATIONAL_MEMORY, {
+    await this.#db.omAppendBufferedChunk({
       id: input.id,
       chunk,
       lastBufferedAtTime: input.lastBufferedAtTime ? toISO(input.lastBufferedAtTime) : undefined,
@@ -1061,7 +1055,7 @@ export class MemoryConvex extends MemoryStorage {
   }
 
   async swapBufferedToActive(input: SwapBufferedToActiveInput): Promise<SwapBufferedToActiveResult> {
-    return this.#db.omSwapBuffered<SwapBufferedToActiveResult>(TABLE_OBSERVATIONAL_MEMORY, {
+    return this.#db.omSwapBuffered<SwapBufferedToActiveResult>({
       id: input.id,
       activationRatio: input.activationRatio,
       messageTokensThreshold: input.messageTokensThreshold,
@@ -1140,7 +1134,7 @@ export class MemoryConvex extends MemoryStorage {
   }
 
   async updateBufferedReflection(input: UpdateBufferedReflectionInput): Promise<void> {
-    await this.#db.omUpdateBufferedReflection(TABLE_OBSERVATIONAL_MEMORY, {
+    await this.#db.omUpdateBufferedReflection({
       id: input.id,
       reflection: input.reflection,
       tokenCount: input.tokenCount,
@@ -1166,7 +1160,7 @@ export class MemoryConvex extends MemoryStorage {
       generationCount: currentRecord.generationCount,
     };
 
-    const doc = await this.#db.omSwapBufferedReflection<StoredOMRecord>(TABLE_OBSERVATIONAL_MEMORY, {
+    const doc = await this.#db.omSwapBufferedReflection<StoredOMRecord>({
       currentRecord: serializedCurrentRecord,
       newId: crypto.randomUUID(),
       tokenCount: input.tokenCount,
@@ -1257,7 +1251,7 @@ export class MemoryConvex extends MemoryStorage {
   }
 
   async updateObservationalMemoryConfig(input: UpdateObservationalMemoryConfigInput): Promise<void> {
-    await this.#db.omUpdateConfig(TABLE_OBSERVATIONAL_MEMORY, {
+    await this.#db.omUpdateConfig({
       id: input.id,
       config: JSON.stringify(input.config ?? {}),
       updatedAt: new Date().toISOString(),

--- a/stores/convex/src/storage/types.ts
+++ b/stores/convex/src/storage/types.ts
@@ -1,5 +1,21 @@
 import type { TABLE_NAMES } from '@mastra/core/storage';
 
+/**
+ * Observational memory table name. Defined locally (not value-imported from
+ * core) following the mongodb/pg convention: core exports the constant, but
+ * OM is optional and the constant is absent from older cores in the peer range.
+ */
+export const TABLE_OBSERVATIONAL_MEMORY = 'mastra_observational_memory';
+
+/**
+ * Table names accepted by ConvexDB: core storage tables plus the Convex OM
+ * table, which is intentionally excluded from core's TABLE_NAMES union
+ * because observational memory is an optional, per-adapter capability.
+ * Kept as a closed union (never `| string`) so table-name typos stay
+ * compile-time errors instead of routing to the mastra_documents fallback.
+ */
+export type ConvexStorageTable = TABLE_NAMES | typeof TABLE_OBSERVATIONAL_MEMORY;
+
 export type EqualityFilter = {
   field: string;
   value: string | number | boolean | null;


### PR DESCRIPTION
## Description

Follow-up to #19474. That PR widened every internal `ConvexDB` signature from `tableName: TABLE_NAMES` to `TABLE_NAMES | string` because the observational memory table is intentionally excluded from core's `TABLE_NAMES` union. TypeScript union absorption collapses `TABLE_NAMES | string` to bare `string`, which silently disabled literal-type checking for every `ConvexDB` caller — a table-name typo would compile and route records to the `mastra_documents` fallback table at runtime instead of failing the build.

This PR restores strict typing:

- New closed union in `storage/types.ts`: `ConvexStorageTable = TABLE_NAMES | typeof TABLE_OBSERVATIONAL_MEMORY`, with the OM table name declared once client-side (the deployment-bundled `schema.ts` and `server/storage.ts` keep their own local constants for old-core isolation, unchanged).
- All `ConvexDB` signatures use `ConvexStorageTable` instead of `TABLE_NAMES | string`. `ConvexDB` is only consumed by the six storage domains, so no caller needs a bare string; the vector and cache adapters talk to `ConvexAdminClient` directly and are unaffected (the wire-level `StorageRequest.tableName: TABLE_NAMES | string` is pre-existing and unchanged).
- The `om*` methods on `ConvexDB` no longer take a `tableName` parameter — they are only valid for the observational memory table (the server rejects other tables), so the table name is set internally. Wire requests are byte-identical.

No runtime behavior change; none of the touched APIs have shipped in a release yet (added in #19474, unreleased).

## Related issue(s)

Fixes #19484. Follow-up to #19474.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Testing

- `pnpm --filter @mastra/convex build:lib` — typecheck proves no `ConvexDB` caller needed a bare string
- `pnpm --filter @mastra/convex test` — 258 passed (unit; wire-request expectations unchanged since `om*` requests still carry the same `tableName`)
- `pnpm --filter @mastra/convex lint` — clean

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable — none needed, internal types only)
- [x] I have added tests that prove my fix is effective or that my feature works (existing tests cover the unchanged wire behavior; the change itself is compile-time)
- [ ] I have addressed all Coderabbit comments on this PR

## AI disclosure

Implemented with Claude Code (Fable 5), human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

ConvexDB now only accepts valid table names, so typos are caught during build instead of sending data to the wrong table. Observational memory operations automatically use their dedicated table.

## What changed

- Added the closed `ConvexStorageTable` union, including core tables and observational memory.
- Updated ConvexDB table-related APIs to enforce valid table names at compile time.
- Removed redundant table-name arguments from `om*` methods and centralized the observational memory table selection.
- Updated memory domain callers and added a patch changeset.
- Runtime requests and behavior remain unchanged.
- Build, test, and lint validation included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->