### PR TITLE
fix(playground): remove duplicate instruction editor padding

### DIFF
--- a/packages/playground/src/domains/agents/components/agent-cms-pages/instruction-blocks-page.tsx
+++ b/packages/playground/src/domains/agents/components/agent-cms-pages/instruction-blocks-page.tsx
@@ -11,22 +11,20 @@ export function InstructionBlocksPage() {
 
   return (
     <ScrollArea className="h-full">
-      <div className="py-6 px-2">
-        <Controller
-          name="instructionBlocks"
-          control={form.control}
-          defaultValue={[]}
-          render={({ field }) => (
-            <AgentCMSBlocks
-              items={field.value ?? []}
-              onChange={field.onChange}
-              placeholder="Enter content..."
-              schema={schema}
-              readOnly={readOnly}
-            />
-          )}
-        />
-      </div>
+      <Controller
+        name="instructionBlocks"
+        control={form.control}
+        defaultValue={[]}
+        render={({ field }) => (
+          <AgentCMSBlocks
+            items={field.value ?? []}
+            onChange={field.onChange}
+            placeholder="Enter content..."
+            schema={schema}
+            readOnly={readOnly}
+          />
+        )}
+      />
     </ScrollArea>
   );
 }


### PR DESCRIPTION
Removes the extra padding wrapper around instruction blocks in the System Prompt tab. The tab content already provides the layout spacing, so the nested wrapper made the editor and drag controls unnecessarily inset.

Checked with focused ESLint, Prettier, and the pre-commit checks. The package typecheck was attempted but is blocked by unbuilt workspace package outputs in this worktree.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The System Prompt editor had an unnecessary padded box around it. This removes that extra box so the editor and drag controls line up with the rest of the page.

## Changes

- Rendered the instruction-block form controller directly inside the scroll area.
- Preserved the existing editor behavior and configuration.
- Focused ESLint, Prettier, and pre-commit checks passed.
- Package typecheck remains blocked by unbuilt workspace package outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->