### PR TITLE
fix(playground): default theme to system

### DIFF
--- a/packages/playground/e2e/tests/settings/page.spec.ts
+++ b/packages/playground/e2e/tests/settings/page.spec.ts
@@ -26,13 +26,13 @@ test.describe('Settings page', () => {
       await expect(form).toBeVisible();
     });
 
-    test('shows the theme selector defaulting to dark', async ({ page }) => {
+    test('shows the theme selector defaulting to the system theme', async ({ page }) => {
       await page.goto('/settings');
 
       const selector = page.getByLabel('Theme mode');
 
       await expect(selector).toBeVisible();
-      await expect(selector).toContainText('Dark');
+      await expect(selector).toContainText('System');
     });
   });
 

--- a/packages/playground/index.html
+++ b/packages/playground/index.html
@@ -31,7 +31,7 @@
         const parsedStorage = storageValue ? JSON.parse(storageValue) : null;
         const persistedTheme = parsedStorage?.state?.theme;
 
-        const selectedTheme = persistedTheme === 'light' || persistedTheme === 'system' ? persistedTheme : 'dark';
+        const selectedTheme = persistedTheme === 'light' || persistedTheme === 'dark' ? persistedTheme : 'system';
 
         const resolvedTheme =
           selectedTheme === 'system'

--- a/packages/playground/src/components/layout.tsx
+++ b/packages/playground/src/components/layout.tsx
@@ -105,7 +105,7 @@ export const Layout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="bg-surface1 font-sans h-screen">
       <Toaster position="bottom-right" />
-      <ThemeProvider defaultTheme="dark">
+      <ThemeProvider defaultTheme="system">
         <TooltipProvider delayDuration={0}>
           <ExperimentalUIProvider experiments={experimentalUIEnabled ? UI_EXPERIMENTS : []}>
             <MainSidebarProvider>

--- a/packages/playground/src/components/minimal-layout.tsx
+++ b/packages/playground/src/components/minimal-layout.tsx
@@ -7,7 +7,7 @@ export const MinimalLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <div className="bg-surface1 font-sans h-screen">
       <Toaster position="bottom-right" />
-      <ThemeProvider defaultTheme="dark">
+      <ThemeProvider defaultTheme="system">
         <TooltipProvider delayDuration={0}>
           <div className="h-full overflow-y-auto">
             <AuthRequired>{children}</AuthRequired>


### PR DESCRIPTION
Studio now follows the operating system theme when there is no saved theme preference, instead of forcing dark mode. The bootstrap script and both layout providers use the same fallback so the first paint and settings state stay aligned.

Validated with the Playground dependency-graph build, package lint, React Doctor, and the focused Playwright settings test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Studio now follows your computer’s light or dark mode by default, instead of always choosing dark mode. This keeps the page and settings consistent from the first render.

## Changes

- Updated theme fallback logic to use `system` when no saved light/dark preference exists.
- Set both layout providers to default to the system theme.
- Updated the settings test to expect **System**.
- Validation included dependency-graph build, lint, React Doctor, and a focused Playwright test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->