### PR TITLE
fix(core): bump bundled OpenRouter provider to fix 400 on thinking + parallel tool calls

### DIFF
--- a/.changeset/beige-mails-post.md
+++ b/.changeset/beige-mails-post.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed model router requests through OpenRouter failing with a 400 "thinking blocks cannot be modified" error when an Anthropic model (e.g. openrouter/anthropic/claude-sonnet-4-6) used extended thinking together with parallel tool calls. The bundled OpenRouter provider was updated from 1.5.4 to 2.10.0, which no longer duplicates reasoning details on each tool call when sending conversation history back to the API. Fixes #19436

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -918,6 +918,7 @@
     "@internal/voice": "workspace:*",
     "@openrouter/ai-sdk-provider": "^0.7.5",
     "@openrouter/ai-sdk-provider-v5": "npm:@openrouter/ai-sdk-provider@1.5.4",
+    "@openrouter/ai-sdk-provider-v6": "npm:@openrouter/ai-sdk-provider@2.10.0",
     "@types/babel__core": "^7.20.5",
     "@types/json-schema": "^7.0.15",
     "@types/node": "22.20.1",

--- a/packages/core/src/llm/model/gateways/mastra.ts
+++ b/packages/core/src/llm/model/gateways/mastra.ts
@@ -1,5 +1,5 @@
 import { createAnthropic } from '@ai-sdk/anthropic-v6';
-import { createOpenRouter } from '@openrouter/ai-sdk-provider-v5';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider-v6';
 import { MastraError } from '../../../error/index.js';
 import { PROVIDER_REGISTRY } from '../provider-registry.js';
 import { MastraModelGateway } from './base.js';

--- a/packages/core/src/llm/model/gateways/models-dev.test.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.test.ts
@@ -49,7 +49,7 @@ vi.mock('@ai-sdk/perplexity-v5', () => ({ createPerplexity: createPerplexityMock
 vi.mock('@ai-sdk/togetherai-v5', () => ({ createTogetherAI: createTogetherAIMock }));
 vi.mock('@ai-sdk/xai-v6', () => ({ createXai: createXaiMock }));
 vi.mock('@internal/ai-v6', () => ({ createGateway: createGatewayMock }));
-vi.mock('@openrouter/ai-sdk-provider-v5', () => ({ createOpenRouter: createOpenRouterMock }));
+vi.mock('@openrouter/ai-sdk-provider-v6', () => ({ createOpenRouter: createOpenRouterMock }));
 
 // Mock fetch globally
 const mockFetch = vi.fn();

--- a/packages/core/src/llm/model/gateways/models-dev.ts
+++ b/packages/core/src/llm/model/gateways/models-dev.ts
@@ -12,7 +12,7 @@ import { createPerplexity } from '@ai-sdk/perplexity-v5';
 import { createTogetherAI } from '@ai-sdk/togetherai-v5';
 import { createXai } from '@ai-sdk/xai-v6';
 import { createGateway } from '@internal/ai-v6';
-import { createOpenRouter } from '@openrouter/ai-sdk-provider-v5';
+import { createOpenRouter } from '@openrouter/ai-sdk-provider-v6';
 import { parseModelRouterId } from '../gateway-resolver.js';
 import { MastraModelGateway } from './base.js';
 import type {

--- a/packages/core/src/llm/model/router-openrouter-headers.test.ts
+++ b/packages/core/src/llm/model/router-openrouter-headers.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Agent } from '../../agent/index.js';
 import { createMockModel } from '../../test-utils/llm-mock.js';
 
-// Mock the @openrouter/ai-sdk-provider-v5 module BEFORE importing it
-vi.mock('@openrouter/ai-sdk-provider-v5', async () => {
+// Mock the @openrouter/ai-sdk-provider-v6 module BEFORE importing it
+vi.mock('@openrouter/ai-sdk-provider-v6', async () => {
   return {
     createOpenRouter: vi.fn(),
   };
 });
 
 // Now import the mocked module
-const { createOpenRouter } = await import('@openrouter/ai-sdk-provider-v5');
+const { createOpenRouter } = await import('@openrouter/ai-sdk-provider-v6');
 
 describe('ModelRouter - OpenRouter Headers Support', () => {
   beforeEach(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4245,6 +4245,9 @@ importers:
       '@openrouter/ai-sdk-provider-v5':
         specifier: npm:@openrouter/ai-sdk-provider@1.5.4
         version: '@openrouter/ai-sdk-provider@1.5.4(zod@4.4.3)'
+      '@openrouter/ai-sdk-provider-v6':
+        specifier: npm:@openrouter/ai-sdk-provider@2.10.0
+        version: '@openrouter/ai-sdk-provider@2.10.0(zod@4.4.3)'
       '@types/babel__core':
         specifier: ^7.20.5
         version: 7.20.5
@@ -14894,6 +14897,13 @@ packages:
     peerDependencies:
       ai: ^5.0.0
       zod: ^3.24.1 || ^v4
+
+  '@openrouter/ai-sdk-provider@2.10.0':
+    resolution: {integrity: sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ai: ^6.0.0
+      zod: ^3.25.0 || ^4.0.0
 
   '@openrouter/sdk@0.1.27':
     resolution: {integrity: sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==}
@@ -37064,6 +37074,10 @@ snapshots:
   '@openrouter/ai-sdk-provider@1.5.4(zod@4.4.3)':
     dependencies:
       '@openrouter/sdk': 0.1.27
+      zod: 4.4.3
+
+  '@openrouter/ai-sdk-provider@2.10.0(zod@4.4.3)':
+    dependencies:
       zod: 4.4.3
 
   '@openrouter/sdk@0.1.27':


### PR DESCRIPTION
Using an Anthropic model through OpenRouter with extended thinking enabled would 400 on the second step whenever the model made parallel tool calls:

```ts
const agent = new Agent({
  model: 'openrouter/anthropic/claude-sonnet-4-6',
  tools: { weatherTool, timeTool }, // model calls both in one turn
});
await agent.generate('get the weather and the time', { maxSteps: 5 });
// AI_APICallError: 400 "thinking blocks cannot be modified"
```

The model router bundles `@openrouter/ai-sdk-provider` for `openrouter/...` model strings, and the bundled 1.5.4 duplicates `reasoning_details` onto every tool-call part and re-accumulates them when sending history back — so the same signed thinking block gets sent once per tool call and Anthropic rejects it as modified. OpenRouter fixed this upstream in 2.0.2 (OpenRouterTeam/ai-sdk-provider#344).

This adds a `@openrouter/ai-sdk-provider-v6` alias pinned to 2.10.0 and switches both gateways (`mastra.ts`, `models-dev.ts`) to it. That also brings OpenRouter in line with the `-v6` alias convention every other gateway provider already uses — the router handles the resulting V3-spec model through its existing `AISDKV6LanguageModel` path. The `-v5` alias stays for e2e tests that exercise user-supplied v5-spec models.

Fixes #19436

Test plan: `pnpm build:core` (verified the dist bundle now contains the 2.x provider code with the dedup fix), full `src/llm/model` vitest suite (35 files / 426 tests passing, including the updated gateway + header tests now mocking the v6 alias), and `tsc --noEmit` on packages/core.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some Anthropic requests were sending the same “thinking” information multiple times, causing OpenRouter to reject them. This updates the OpenRouter provider and switches the relevant gateways and tests to the fixed version.

## Changes

- Upgraded the bundled OpenRouter provider from `1.5.4` to `2.10.0`.
- Added and adopted the `@openrouter/ai-sdk-provider-v6` alias in the model gateways and related tests.
- Retained the v5 alias for tests using user-supplied v5-spec models.
- Added a patch changeset for `@mastra/core`.
- Validated with `pnpm build:core`, 426 model tests across 35 files, and `tsc --noEmit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->