### PR TITLE
fix(convex): use Web Crypto instead of node:crypto

### DIFF
--- a/.changeset/lovely-aliens-matter.md
+++ b/.changeset/lovely-aliens-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/convex': patch
+---
+
+Removed the Convex adapters' only Node builtin dependency. ConvexStore, the vector adapters, and the storage domains now use the Web Crypto API (crypto.randomUUID) instead of importing node:crypto, so @mastra/convex itself no longer requires the Node.js runtime ("use node") to bundle inside a Convex project.

--- a/stores/convex/src/isolate-safety.test.ts
+++ b/stores/convex/src/isolate-safety.test.ts
@@ -1,0 +1,58 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { builtinModules } from 'node:module';
+import { join, relative } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Drift guard: keep the package bundleable for Convex's default (V8 isolate)
+ * runtime, which provides Web APIs but no Node builtin modules.
+ *
+ * The schema and server entrypoints are deployed as Convex functions, and the
+ * client adapters (ConvexStore, vectors, cache) only need HTTP + JSON + Web
+ * Crypto — so no source file may import a Node builtin module. Web-standard
+ * globals (crypto.randomUUID, fetch, ReadableStream) are fine.
+ *
+ * See https://docs.convex.dev/functions/runtimes#supported-apis
+ */
+const SRC_DIR = join(__dirname);
+
+// Builtins Convex's default runtime explicitly provides as importable modules.
+const CONVEX_ALLOWED_BUILTINS = new Set(['async_hooks', 'node:async_hooks']);
+
+function listSourceFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap(entry => {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) return listSourceFiles(path);
+    if (!entry.name.endsWith('.ts') || entry.name.endsWith('.test.ts')) return [];
+    return [path];
+  });
+}
+
+function findBuiltinImports(source: string): string[] {
+  const specifiers = [...source.matchAll(/(?:from\s+|import\s*\(\s*|require\s*\(\s*)['"]([^'"]+)['"]/g)].map(
+    match => match[1]!,
+  );
+  return specifiers.filter(specifier => {
+    if (CONVEX_ALLOWED_BUILTINS.has(specifier)) return false;
+    const bare = specifier.startsWith('node:') ? specifier.slice(5) : specifier;
+    return specifier.startsWith('node:') || builtinModules.includes(bare);
+  });
+}
+
+describe('Convex isolate-runtime safety', () => {
+  it('no source file imports Node builtin modules', () => {
+    const offenders: string[] = [];
+    for (const file of listSourceFiles(SRC_DIR)) {
+      const builtins = findBuiltinImports(readFileSync(file, 'utf8'));
+      if (builtins.length > 0) {
+        offenders.push(`${relative(SRC_DIR, file)}: ${builtins.join(', ')}`);
+      }
+    }
+    expect(
+      offenders,
+      'Node builtin imports break bundling for the Convex default runtime. ' +
+        'Use Web APIs (e.g. globalThis crypto.randomUUID) or move the code behind an optional Node-only entrypoint.',
+    ).toEqual([]);
+  });
+});

--- a/stores/convex/src/storage/db/index.ts
+++ b/stores/convex/src/storage/db/index.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import { MastraBase } from '@mastra/core/base';
 import type { StorageThreadType } from '@mastra/core/memory';
 import {

--- a/stores/convex/src/storage/domains/memory/index.ts
+++ b/stores/convex/src/storage/domains/memory/index.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';

--- a/stores/convex/src/storage/domains/schedules/index.ts
+++ b/stores/convex/src/storage/domains/schedules/index.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import type {
   Schedule,
   ScheduleFilter,

--- a/stores/convex/src/storage/domains/scores/index.ts
+++ b/stores/convex/src/storage/domains/scores/index.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type {
   ListScoresResponse,

--- a/stores/convex/src/vector/index.ts
+++ b/stores/convex/src/vector/index.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';

--- a/stores/convex/src/vector/native.ts
+++ b/stores/convex/src/vector/native.ts
@@ -1,5 +1,3 @@
-import crypto from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';


### PR DESCRIPTION
## Description

`@mastra/convex`'s client adapters (ConvexDB, the memory/scores/schedules storage domains, and both vector adapters) imported `node:crypto` in six files, solely for `crypto.randomUUID()`. That import was the package's only Node builtin dependency, and it made any Convex function importing `@mastra/convex` fail to bundle for Convex's default (V8 isolate) runtime with `Could not resolve "crypto"`, forcing users into `"use node"` actions.

This PR:

- Drops the `node:crypto` imports and relies on the Web Crypto global instead — provided by Convex's default runtime ([supported APIs](https://docs.convex.dev/functions/runtimes#supported-apis)) and by Node >= 19, which is well within the package's `node >= 22` engines range. Half the adapter already used the global form; this makes it consistent.
- Adds an isolate-safety test that fails if any source file reintroduces a Node builtin import, allowlisting only modules Convex's default runtime explicitly provides (`node:async_hooks`).

**Scope note:** with this change `@mastra/convex` contributes zero unresolved Node imports when bundled for the Convex default runtime — verified by deploying to a live self-hosted Convex backend and attributing every remaining bundler error: all now come from `@mastra/core` dist chunks (pulled in via `@mastra/core/base`/`storage`/`vector`), which is a separate workstream.

## Related issue(s)

Fixes #19497

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Testing

- New `src/isolate-safety.test.ts` drift guard: scans all source files for Node builtin imports (static, dynamic, and require forms) and fails on any not explicitly provided by Convex's default runtime.
- `pnpm --filter @mastra/convex test` — 259 passed.
- `pnpm --filter @mastra/convex build:lib` and lint clean.
- Empirical bundling check against a live self-hosted Convex deployment (docker `ghcr.io/get-convex/convex-backend`): before the change, `import { ConvexStore } from '@mastra/convex'` in a non-`"use node"` file failed with `Could not resolve "crypto"` pointing into `@mastra/convex/dist`; after the change, zero bundler errors originate from `@mastra/convex`.

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable — none needed; behavior is unchanged on Node)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## AI disclosure

Implemented with Claude Code (Fable 5), human-reviewed; bundling verified against a real Convex deployment as described above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Convex can’t use Node-only tools in its default environment, so this change switches ID generation to the browser-style Web Crypto API. This lets `@mastra/convex` work without requiring `"use node"`.

## Changes

- Removed `node:crypto` imports from ConvexDB, memory, scores, schedules, and vector adapters.
- Continued using `crypto.randomUUID()` through the runtime’s global Web Crypto API.
- Added an isolate-safety test that detects unsupported Node builtin imports while allowing `async_hooks`.
- Added a Changesets patch for `@mastra/convex`.

## Validation

- 259 package tests pass.
- Build and lint pass.
- Convex bundling verification confirms no remaining bundler errors from `@mastra/convex`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->