### PR TITLE
refactor(packages): use Web Crypto randomUUID instead of node:crypto (1/2)

### DIFF
--- a/.changeset/web-crypto-uuid-packages.md
+++ b/.changeset/web-crypto-uuid-packages.md
@@ -1,0 +1,13 @@
+---
+'@mastra/agent-builder': patch
+'@mastra/core': patch
+'@mastra/deployer': patch
+'@mastra/editor': patch
+'@mastra/mcp': patch
+'@mastra/memory': patch
+'@mastra/rag': patch
+'@mastra/server': patch
+'mastra': patch
+---
+
+Switched UUID generation to the Web Crypto global (crypto.randomUUID) instead of importing randomUUID from node:crypto. No behavior change on Node.js; removes an unnecessary Node-only module dependency so packages bundle more cleanly for edge and V8-isolate runtimes such as the Convex default runtime and Cloudflare Workers.

--- a/packages/agent-builder/integration-tests/src/template-integration.test.ts
+++ b/packages/agent-builder/integration-tests/src/template-integration.test.ts
@@ -1,6 +1,5 @@
 import type { ChildProcess } from 'node:child_process';
 import { spawn, execSync } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import { mkdtempSync, mkdirSync, rmSync, cpSync, existsSync, readFileSync } from 'node:fs';
 import { createServer } from 'node:net';
 import { join, resolve } from 'node:path';
@@ -256,7 +255,7 @@ describe('Template Workflow Integration Tests', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         messages: [{ role: 'user', content: 'What is the weather in San Francisco?' }],
-        threadId: randomUUID(),
+        threadId: crypto.randomUUID(),
         resourceId: 'test-resource',
       }),
     });
@@ -278,7 +277,7 @@ describe('Template Workflow Integration Tests', () => {
             content: 'I want to analyze a CSV file with sales data. Can you help me?',
           },
         ],
-        threadId: randomUUID(),
+        threadId: crypto.randomUUID(),
         resourceId: 'test-resource',
       }),
     });

--- a/packages/cli/src/analytics/index.ts
+++ b/packages/cli/src/analytics/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -86,7 +85,7 @@ export class PosthogAnalytics {
         if (distinctId && !this.isHostnameDerivedDistinctId(distinctId)) {
           const config = {
             distinctId,
-            sessionId: sessionId || randomUUID(),
+            sessionId: sessionId || crypto.randomUUID(),
           };
           if (config.sessionId !== sessionId) {
             this.writeCliConfig(config, configPath);
@@ -100,7 +99,7 @@ export class PosthogAnalytics {
 
     const config = {
       distinctId: this.createDistinctId(),
-      sessionId: randomUUID(),
+      sessionId: crypto.randomUUID(),
     };
     this.writeCliConfig(config, configPath);
     return config;
@@ -142,7 +141,7 @@ export class PosthogAnalytics {
   }
 
   private createDistinctId(): string {
-    return `mastra-${randomUUID()}`;
+    return `mastra-${crypto.randomUUID()}`;
   }
 
   private isHostnameDerivedDistinctId(distinctId: string): boolean {

--- a/packages/core/src/a2a/a2a-agent.ts
+++ b/packages/core/src/a2a/a2a-agent.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { AgentCard, Message, Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk';
 import type { AgentExecutionOptionsBase } from '../agent/agent.types';
 import { MessageList } from '../agent/message-list';
@@ -473,7 +472,7 @@ export class A2AAgent implements SubAgent {
     this.#abortSignal = options.abortSignal;
     this.#timeoutMs = options.timeoutMs;
     this.#verifyAgentCard = options.verifyAgentCard;
-    this.id = options.id ?? `a2a-${randomUUID()}`;
+    this.id = options.id ?? `a2a-${crypto.randomUUID()}`;
     this.name = options.name ?? options.description ?? 'A2A Agent';
   }
 
@@ -522,7 +521,7 @@ export class A2AAgent implements SubAgent {
     options?: AgentExecutionOptionsBase<unknown>,
   ): Promise<A2AAgentGenerateResult> {
     const bootstrap = await this.#getBootstrap();
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = messagesToPrompt(messages, options);
     const memoryInfo = resolveMemoryInfo(options);
 
@@ -589,7 +588,7 @@ export class A2AAgent implements SubAgent {
     options?: AgentExecutionOptionsBase<unknown>,
   ): Promise<A2AAgentStreamResult> {
     const bootstrap = await this.#getBootstrap();
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = messagesToPrompt(messages, options);
     const memoryInfo = resolveMemoryInfo(options);
 
@@ -711,13 +710,13 @@ export class A2AAgent implements SubAgent {
       signal,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'message/send',
         params: {
           message: {
             role: 'user',
             kind: 'message',
-            messageId: randomUUID(),
+            messageId: crypto.randomUUID(),
             parts: [{ kind: 'text', text: prompt }],
             ...(contextId ? { contextId } : {}),
             ...(referenceTaskIds?.length ? { referenceTaskIds } : {}),
@@ -792,7 +791,7 @@ export class A2AAgent implements SubAgent {
       signal,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'tasks/get',
         params: { id: taskId },
       } satisfies JSONRPCRequestBody,
@@ -945,13 +944,13 @@ export class A2AAgent implements SubAgent {
       stream: true,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'message/stream',
         params: {
           message: {
             role: 'user',
             kind: 'message',
-            messageId: randomUUID(),
+            messageId: crypto.randomUUID(),
             parts: [{ kind: 'text', text: prompt }],
             ...(contextId ? { contextId } : {}),
             ...(referenceTaskIds?.length ? { referenceTaskIds } : {}),
@@ -992,7 +991,7 @@ export class A2AAgent implements SubAgent {
       stream: true,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'tasks/resubscribe',
         params: { id: taskId },
       } satisfies JSONRPCRequestBody,

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { Agent } from '../agent';
 import { resolveFilePartMediaTypeAndData } from '../agent/message-list/prompt/image-utils';
 import type { MastraDBMessage } from '../agent/message-list/state/types';
@@ -1625,7 +1623,7 @@ export class AgentController<TState = {}> {
     if (!this.#resolveStorage()) return null;
     const memoryStorage = await this.getMemoryStorage();
     const dbMessage = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       role,
       threadId,
       resourceId,
@@ -2319,6 +2317,6 @@ export class AgentController<TState = {}> {
     if (this.config.idGenerator) {
       return this.config.idGenerator();
     }
-    return randomUUID();
+    return crypto.randomUUID();
   }
 }

--- a/packages/core/src/agent/__tests__/memory-readonly.test.ts
+++ b/packages/core/src/agent/__tests__/memory-readonly.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
@@ -54,7 +53,7 @@ describe('Memory readOnly option', () => {
    * no messages are saved to memory.
    */
   it('should NOT save messages when memory.options.readOnly is true in stream()', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-test';
 
     const mockMemory = new MockMemory();
@@ -99,7 +98,7 @@ describe('Memory readOnly option', () => {
    * Same test but for generate() method
    */
   it('should NOT save messages when memory.options.readOnly is true in generate()', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-test-generate';
 
     const mockMemory = new MockMemory();
@@ -142,7 +141,7 @@ describe('Memory readOnly option', () => {
    * Verify that without readOnly, messages ARE saved (control test)
    */
   it('should save messages when memory.options.readOnly is NOT set', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-save-test';
 
     const mockMemory = new MockMemory();
@@ -181,7 +180,7 @@ describe('Memory readOnly option', () => {
    * Verify that readOnly: true still allows reading from memory
    */
   it('should still read from memory when options.readOnly is true', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-read-test';
 
     const mockMemory = new MockMemory();
@@ -237,7 +236,7 @@ describe('Memory readOnly option', () => {
    * Verify that savePerStep also respects readOnly flag
    */
   it('should NOT save messages with savePerStep when memory.options.readOnly is true', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-savePerStep';
 
     const mockMemory = new MockMemory();

--- a/packages/core/src/agent/__tests__/memory-requestcontext-inheritance.test.ts
+++ b/packages/core/src/agent/__tests__/memory-requestcontext-inheritance.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { RequestContext } from '../../request-context';
@@ -51,7 +50,7 @@ describe('RequestContext memory isolation - Issue #11651', () => {
    * Expected: Child agent should be able to save messages (its readOnly: false should win)
    */
   it('should respect child agent readOnly:false when RequestContext has parent readOnly:true', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 
@@ -97,7 +96,7 @@ describe('RequestContext memory isolation - Issue #11651', () => {
    * Control test: Verify readOnly: true still works correctly
    */
   it('should NOT save messages when agent has readOnly:true regardless of parent context', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 
@@ -142,8 +141,8 @@ describe('RequestContext memory isolation - Issue #11651', () => {
    * Test that two agents can have different readOnly settings with the same RequestContext
    */
   it('should allow different readOnly settings for sequential agent calls with shared RequestContext', async () => {
-    const thread1Id = randomUUID();
-    const thread2Id = randomUUID();
+    const thread1Id = crypto.randomUUID();
+    const thread2Id = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 

--- a/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
+++ b/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
@@ -101,8 +100,8 @@ describe('PrefillErrorHandler Recovery', () => {
   describe('generate()', () => {
     it('should recover from prefill error by appending a system reminder continue message and retrying', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const now = new Date();
 
       // Create a thread and pre-populate it with a conversation ending in an assistant message
@@ -110,7 +109,7 @@ describe('PrefillErrorHandler Recovery', () => {
       await mockMemory.saveMessages({
         messages: [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'user' as const,
             content: {
               format: 2 as const,
@@ -122,7 +121,7 @@ describe('PrefillErrorHandler Recovery', () => {
             type: 'text' as const,
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'assistant' as const,
             content: {
               format: 2 as const,
@@ -343,8 +342,8 @@ describe('PrefillErrorHandler Recovery', () => {
 
     it('should NOT retry for non-prefill API errors', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       await mockMemory.createThread({ threadId, resourceId });
 
@@ -393,15 +392,15 @@ describe('PrefillErrorHandler Recovery', () => {
   describe('stream()', () => {
     it('should recover from prefill error by appending a system reminder continue message and retrying', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const now = new Date();
 
       await mockMemory.createThread({ threadId, resourceId });
       await mockMemory.saveMessages({
         messages: [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'user' as const,
             content: {
               format: 2 as const,
@@ -413,7 +412,7 @@ describe('PrefillErrorHandler Recovery', () => {
             type: 'text' as const,
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'assistant' as const,
             content: {
               format: 2 as const,
@@ -463,15 +462,15 @@ describe('PrefillErrorHandler Recovery', () => {
 
     it('should only retry once even if the error persists', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const now = new Date();
 
       await mockMemory.createThread({ threadId, resourceId });
       await mockMemory.saveMessages({
         messages: [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'user' as const,
             content: {
               format: 2 as const,
@@ -483,7 +482,7 @@ describe('PrefillErrorHandler Recovery', () => {
             type: 'text' as const,
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'assistant' as const,
             content: {
               format: 2 as const,

--- a/packages/core/src/agent/__tests__/reasoning-memory.test.ts
+++ b/packages/core/src/agent/__tests__/reasoning-memory.test.ts
@@ -14,7 +14,6 @@
  * @see https://github.com/mastra-ai/mastra/issues/11103
  */
 
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
@@ -273,7 +272,7 @@ describe('Reasoning + Memory Integration', () => {
    * part had an rs_ ID which OpenAI rejected (expecting msg_ for assistant messages).
    */
   it('should not leak reasoning providerMetadata into text parts', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
 
@@ -334,7 +333,7 @@ describe('Reasoning + Memory Integration', () => {
    * @see https://github.com/mastra-ai/mastra/issues/11481
    */
   it('should capture text-start providerMetadata for text parts (issue #11481)', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
     const textItemId = 'msg_test987654321'; // The itemId that OpenAI sends with text-start
@@ -391,7 +390,7 @@ describe('Reasoning + Memory Integration', () => {
    * @see https://github.com/mastra-ai/mastra/issues/11481
    */
   it('should handle follow-up messages with both reasoning and text itemIds (issue #11481)', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
     const textItemId = 'msg_test987654321';
@@ -468,7 +467,7 @@ describe('Reasoning + Memory Integration', () => {
    * The second call should not fail due to mismatched IDs.
    */
   it('should handle follow-up messages after reasoning response with memory', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
 
@@ -534,7 +533,7 @@ describe('Reasoning + Memory Integration', () => {
    * @see https://github.com/mastra-ai/mastra/issues/11481
    */
   it('should capture text providerMetadata when using generate() (issue #11481)', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
     const textItemId = 'msg_test987654321';
@@ -610,7 +609,7 @@ describe('Reasoning + Memory Integration', () => {
    * the text's providerMetadata doesn't leak into the subsequent part.
    */
   it('should clear text providerMetadata after text-end to prevent leaking', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const textItemId = 'msg_text123';
 
@@ -732,7 +731,7 @@ describe('Reasoning + Memory Integration', () => {
    * So neither reasoning nor text metadata leaks into subsequent parts.
    */
   it('should properly clean up providerMetadata through reasoning → text → tool call sequence', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_reasoning123';
     const textItemId = 'msg_text123';
@@ -909,7 +908,7 @@ describe('Reasoning Data Spy: Response vs Request Comparison (Issue #12980)', ()
    * and OpenAI resolves them server-side. Reasoning and itemIds must be preserved.
    */
   it('should preserve OpenAI reasoning and providerMetadata through round-trip', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-spy-openai';
     const reasoningItemId = 'rs_spy_reasoning_123';
     const textItemId = 'msg_spy_text_456';

--- a/packages/core/src/agent/__tests__/stream-id.test.ts
+++ b/packages/core/src/agent/__tests__/stream-id.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { simulateReadableStream } from '@internal/ai-sdk-v4';
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
@@ -54,7 +53,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const streamResult = await agent.streamLegacy('Hello!', {
@@ -126,7 +125,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastraWithCustomId);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const stream = await agent.streamLegacy('Hello!', { threadId, resourceId });
@@ -183,7 +182,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const streamResult = await agent.stream('Hello!', {
@@ -265,7 +264,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastraWithCustomId);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const stream = await agent.stream('Hello!', { memory: { thread: threadId, resource: resourceId } });
@@ -324,7 +323,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
     const stream = await agent.stream('Hello!', { memory: { thread: threadId, resource: resourceId } });
 
@@ -396,7 +395,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const result = await agent.generate('Hello!', {
@@ -499,7 +498,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const streamResult = await agent.stream('Use the test tool', {
@@ -566,7 +565,7 @@ describe('Stream ID Consistency', () => {
         memory,
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'structured-output-persisted-text';
       await memory.createThread({ threadId, resourceId });
 

--- a/packages/core/src/agent/__tests__/stream.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/stream.e2e.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai';
 import { openai as openai_v5 } from '@ai-sdk/openai-v5';
 import { openai as openai_v6 } from '@ai-sdk/openai-v6';
@@ -541,7 +540,7 @@ function runStreamE2ETest(version: 'v1' | 'v2' | 'v3') {
       });
 
       it(`should order tool calls/results and response text properly`, async () => {
-        const threadId = randomUUID();
+        const threadId = crypto.randomUUID();
         const resourceId = 'ordering';
 
         const mockMemory = new MockMemory();

--- a/packages/core/src/agent/__tests__/structured-output-memory.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.e2e.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { getLLMTestMode } from '@internal/llm-recorder';
 import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -22,8 +21,8 @@ const profileSchema = z.object({
 
 describe('Structured output memory inheritance (e2e)', { timeout: 180_000 }, () => {
   it('uses prior thread memory when structured output runs on a separate model after multiple turns', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-e2e-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-e2e-${crypto.randomUUID()}`;
     const memory = new MockMemory();
 
     await memory.createThread({ threadId, resourceId });

--- a/packages/core/src/agent/__tests__/structured-output-memory.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MockMemory } from '../../memory/mock';
@@ -23,7 +22,7 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model'
  */
 describe('Structured output with memory - assistant message in final position (#12800)', () => {
   it('should not send prompt ending with assistant message when input is assistant-role with structuredOutput and memory', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-12800';
 
     const mockMemory = new MockMemory();
@@ -106,7 +105,7 @@ describe('Structured output with memory - assistant message in final position (#
     await mockMemory.saveMessages({
       messages: [
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'user',
           content: { format: 2, parts: [{ type: 'text', text: 'Which agent should research dolphins?' }] },
           threadId,
@@ -114,7 +113,7 @@ describe('Structured output with memory - assistant message in final position (#
           createdAt: new Date(),
         },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'assistant',
           content: { format: 2, parts: [{ type: 'text', text: 'Let me route this request.' }] },
           threadId,
@@ -152,7 +151,7 @@ describe('Structured output with memory - assistant message in final position (#
   });
 
   it('should not send prompt ending with assistant message when using stream with assistant-role input, structuredOutput and memory', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-12800-stream';
 
     const mockMemory = new MockMemory();
@@ -236,7 +235,7 @@ describe('Structured output with memory - assistant message in final position (#
     await mockMemory.saveMessages({
       messages: [
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'user' as const,
           content: {
             format: 2 as const,
@@ -248,7 +247,7 @@ describe('Structured output with memory - assistant message in final position (#
           type: 'text' as const,
         },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'assistant' as const,
           content: {
             format: 2 as const,
@@ -300,8 +299,8 @@ describe('Structured output with memory - assistant message in final position (#
 
 describe('Structured output memory inheritance', () => {
   it('includes prior memory context when useAgent is true for a separate structuring model', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -475,8 +474,8 @@ describe('Structured output memory inheritance', () => {
   });
 
   it('does not leak the structuring agent readOnly memory config into the parent request context', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -580,8 +579,8 @@ describe('Structured output memory inheritance', () => {
   });
 
   it('does not include prior memory context when useAgent is omitted for a separate structuring model', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -726,8 +725,8 @@ describe('Structured output memory inheritance', () => {
   });
 
   it('keeps main-agent text chunks in the outer stream while suppressing structuring-agent text chunks', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-streaming-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-streaming-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -870,7 +869,7 @@ describe('Structured output memory inheritance', () => {
  */
 describe('Structured output stream memory persistence (#14659)', () => {
   it('should persist well-formed text when using stream with structuredOutput, not "[object Object]"', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-14659';
 
     const mockMemory = new MockMemory();

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -3299,8 +3298,8 @@ describe('Supervisor Pattern - Message history transfer to sub-agents', () => {
       memory: new MockMemory(),
     });
 
-    const resourceId = randomUUID();
-    const threadId = randomUUID();
+    const resourceId = crypto.randomUUID();
+    const threadId = crypto.randomUUID();
 
     // Supervisor conversation has multiple user messages
     await supervisorAgent.generate(
@@ -3407,8 +3406,8 @@ describe('Supervisor Pattern - Message history transfer to sub-agents', () => {
     });
 
     let supervisorCallCount = 0;
-    const resourceId = randomUUID();
-    const threadId = randomUUID();
+    const resourceId = crypto.randomUUID();
+    const threadId = crypto.randomUUID();
 
     const supervisorAgent = new Agent({
       id: 'supervisor-reserved-keys',

--- a/packages/core/src/agent/__tests__/tool-approval.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.e2e.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID, createHash } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { getLLMTestMode, defaultNameGenerator, getLLMRecordingsDir } from '@internal/llm-recorder';
 import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
@@ -747,8 +747,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
           suspendedToolName: '',
         };
         const memory = {
-          thread: randomUUID(),
-          resource: randomUUID(),
+          thread: crypto.randomUUID(),
+          resource: crypto.randomUUID(),
         };
         const stream = await agentOne.stream('Find the name, age and profession of the user - Dero Israel', {
           memory,
@@ -856,8 +856,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
           suspendedToolName: '',
         };
         const memory = {
-          thread: randomUUID(),
-          resource: randomUUID(),
+          thread: crypto.randomUUID(),
+          resource: crypto.randomUUID(),
         };
         const stream = await agentOne.stream('Find the name, email, age and profession of the user - Dero Israel', {
           memory,
@@ -954,8 +954,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const agentOne = mastra.getAgent('userAgent');
 
         const memory = {
-          thread: randomUUID(),
-          resource: randomUUID(),
+          thread: crypto.randomUUID(),
+          resource: crypto.randomUUID(),
         };
         const output = await agentOne.generate('Find the name, age and profession of the user - Dero Israel', {
           memory,

--- a/packages/core/src/agent/__tests__/tool-approval.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { EventEmitterPubSub } from '../../events';
@@ -135,8 +134,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         try {
           const agentOne = mastra.getAgent('userAgent');
           const memory = {
-            thread: randomUUID(),
-            resource: randomUUID(),
+            thread: crypto.randomUUID(),
+            resource: crypto.randomUUID(),
           };
 
           const stream = await agentOne.stream('Find the user with name - Dero Israel', { memory });
@@ -215,7 +214,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const approveAll = vi.fn().mockReturnValue(true);
         const suspendingAgent = makeAgent();
         const suspendStream = await suspendingAgent.stream('Find the user with name - Dero Israel', {
-          memory: { thread: randomUUID(), resource: randomUUID() },
+          memory: { thread: crypto.randomUUID(), resource: crypto.randomUUID() },
           requireToolApproval: approveAll,
         });
         let approvedToolName = '';
@@ -234,7 +233,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const denyApproval = vi.fn().mockReturnValue(false);
         const runningAgent = makeAgent();
         const runStream = await runningAgent.stream('Find the user with name - Dero Israel', {
-          memory: { thread: randomUUID(), resource: randomUUID() },
+          memory: { thread: crypto.randomUUID(), resource: crypto.randomUUID() },
           requireToolApproval: denyApproval,
         });
         let sawApproval = false;
@@ -319,7 +318,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
 
         const mastra = new Mastra({ agents: { resumeAgent }, logger: false, storage: mockStorage });
         const agent = mastra.getAgent('resumeAgent');
-        const memory = { thread: randomUUID(), resource: randomUUID() };
+        const memory = { thread: crypto.randomUUID(), resource: crypto.randomUUID() };
         const requireToolApproval = vi.fn().mockReturnValue(true);
 
         mockFindUser.mockClear();

--- a/packages/core/src/agent/__tests__/workflow-tool-memory-isolation.test.ts
+++ b/packages/core/src/agent/__tests__/workflow-tool-memory-isolation.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
@@ -72,8 +71,8 @@ function createSimpleTextModel() {
 
 describe('Workflow tool MastraMemory isolation', () => {
   it('should restore MastraMemory on requestContext after workflow tool execution', async () => {
-    const parentThreadId = randomUUID();
-    const subAgentThreadId = randomUUID();
+    const parentThreadId = crypto.randomUUID();
+    const subAgentThreadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 
@@ -142,7 +141,7 @@ describe('Workflow tool MastraMemory isolation', () => {
   });
 
   it('should restore MastraMemory even when workflow tool execution fails', async () => {
-    const parentThreadId = randomUUID();
+    const parentThreadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { WritableStream } from 'node:stream/web';
 import type { CoreMessage, UIMessage, Tool } from '@internal/ai-sdk-v4';
 import deepEqual from 'fast-deep-equal';
@@ -794,7 +793,7 @@ export class AgentLegacyHandler {
         threadId: threadFromArgs?.id,
         resourceId,
       }) ||
-      randomUUID();
+      crypto.randomUUID();
     const instructions = args.instructions || (await this.capabilities.getInstructions({ requestContext }));
     const llm = await this.capabilities.getLLM({
       requestContext,
@@ -990,7 +989,7 @@ export class AgentLegacyHandler {
         usage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
         finishReason: 'other',
         response: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           modelId: 'tripwire',
           messages: [],
@@ -1065,7 +1064,7 @@ export class AgentLegacyHandler {
           usage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
           finishReason: 'other',
           response: {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             timestamp: new Date(),
             modelId: 'tripwire',
             messages: [],
@@ -1195,7 +1194,7 @@ export class AgentLegacyHandler {
         usage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
         finishReason: 'other',
         response: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           modelId: 'tripwire',
           messages: [],
@@ -1341,7 +1340,7 @@ export class AgentLegacyHandler {
         finishReason: Promise.resolve('other'),
         tripwire: beforeResult.tripwire,
         response: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           modelId: 'tripwire',
           messages: [],

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { UIMessage } from '@internal/ai-sdk-v4';
 import type { ModelMessage } from '@internal/ai-sdk-v5';
 import { wrapSchemaWithNullTransform } from '@mastra/schema-compat';
@@ -912,7 +911,7 @@ export class Agent<
 
     const now = Date.now();
     const record: GoalObjectiveRecord = {
-      id: options.id ?? randomUUID(),
+      id: options.id ?? crypto.randomUUID(),
       objective,
       status: 'active',
       runsUsed: 0,
@@ -2797,7 +2796,7 @@ export class Agent<
    */
   private static toFallbackEntry(mdl: ModelWithRetries, defaultMaxRetries: number): ModelFallbacks[number] {
     return {
-      id: mdl.id ?? randomUUID(),
+      id: mdl.id ?? crypto.randomUUID(),
       model: mdl.model as DynamicArgument<MastraModelConfig>,
       maxRetries: mdl.maxRetries ?? defaultMaxRetries,
       enabled: mdl.enabled ?? true,
@@ -4540,7 +4539,7 @@ export class Agent<
           execute: async (inputData: SubAgentToolInput, context) => {
             const invocationActor = getInvocationActor(context);
             const startTime = Date.now();
-            const toolCallId = context?.agent?.toolCallId || randomUUID();
+            const toolCallId = context?.agent?.toolCallId || crypto.randomUUID();
 
             // Get messages from context - available at tool execution time
             const contextMessages = (context?.agent?.messages || []) as MastraDBMessage[];
@@ -4566,7 +4565,7 @@ export class Agent<
                 maxSteps: inputData.maxSteps || undefined,
               },
               iteration: derivedIteration,
-              runId: runId || randomUUID(),
+              runId: runId || crypto.randomUUID(),
               threadId,
               resourceId,
               parentAgentId: this.id,
@@ -4579,13 +4578,13 @@ export class Agent<
             // These are needed for both successful execution and rejection cases
             const slugify = await import(`@sindresorhus/slugify`);
             const subAgentThreadId = inputData.threadId
-              ? `${inputData.threadId}-${randomUUID()}`
+              ? `${inputData.threadId}-${crypto.randomUUID()}`
               : context?.mastra?.generateId({
                   idType: 'thread',
                   source: 'agent',
                   entityId: agentName,
                   resourceId,
-                }) || randomUUID();
+                }) || crypto.randomUUID();
 
             const subAgentResourceId = inputData.resourceId
               ? `${inputData.resourceId}-${agentName}`
@@ -4686,7 +4685,7 @@ export class Agent<
                       await context.writer?.write({
                         type: 'text-delta',
                         payload: {
-                          id: randomUUID(),
+                          id: crypto.randomUUID(),
                           text: `[Delegation Rejected] ${rejectionMessage}`,
                         },
                         runId,
@@ -4700,7 +4699,7 @@ export class Agent<
                       try {
                         // Create user message with the original prompt
                         const userMessage: MastraDBMessage = {
-                          id: this.#mastra?.generateId() || randomUUID(),
+                          id: this.#mastra?.generateId() || crypto.randomUUID(),
                           role: 'user',
                           type: 'text',
                           createdAt: new Date(),
@@ -4719,7 +4718,7 @@ export class Agent<
 
                         // Create assistant message with the rejection
                         const assistantMessage: MastraDBMessage = {
-                          id: this.#mastra?.generateId() || randomUUID(),
+                          id: this.#mastra?.generateId() || crypto.randomUUID(),
                           role: 'assistant',
                           type: 'text',
                           createdAt: new Date(new Date().getTime() + 1),
@@ -4827,7 +4826,7 @@ export class Agent<
                     primitiveType: 'agent',
                     prompt: effectivePrompt,
                     iteration: derivedIteration,
-                    runId: runId || randomUUID(),
+                    runId: runId || crypto.randomUUID(),
                     threadId,
                     resourceId,
                     parentAgentId: this.id,
@@ -4912,7 +4911,7 @@ export class Agent<
                 }));
                 // Create user message with the original prompt
                 const userMessage: MastraDBMessage = {
-                  id: this.#mastra?.generateId() || randomUUID(),
+                  id: this.#mastra?.generateId() || crypto.randomUUID(),
                   role: 'user',
                   type: 'text',
                   createdAt: subAgentPromptCreatedAt,
@@ -5090,7 +5089,7 @@ export class Agent<
                 const agentResponseMessages = streamResult.messageList.get.response.db();
                 // Create user message with the original prompt
                 const userMessage: MastraDBMessage = {
-                  id: this.#mastra?.generateId() || randomUUID(),
+                  id: this.#mastra?.generateId() || crypto.randomUUID(),
                   role: 'user',
                   type: 'text',
                   createdAt: subAgentPromptCreatedAt,
@@ -5202,7 +5201,7 @@ export class Agent<
                     duration: Date.now() - startTime,
                     success: true,
                     iteration: derivedIteration,
-                    runId: runId || randomUUID(),
+                    runId: runId || crypto.randomUUID(),
                     toolCallId,
                     parentAgentId: this.id,
                     parentAgentName: this.name,
@@ -5222,7 +5221,7 @@ export class Agent<
                   // Handle feedback if provided
                   if (completeResult?.feedback) {
                     const feedbackMessage: MastraDBMessage = {
-                      id: this.#mastra?.generateId() || randomUUID(),
+                      id: this.#mastra?.generateId() || crypto.randomUUID(),
                       role: 'assistant',
                       type: 'text',
                       createdAt: new Date(),
@@ -5283,7 +5282,7 @@ export class Agent<
                     success: false,
                     error: err instanceof Error ? err : new Error(String(err)),
                     iteration: derivedIteration,
-                    runId: runId || randomUUID(),
+                    runId: runId || crypto.randomUUID(),
                     toolCallId,
                     parentAgentId: this.id,
                     parentAgentName: this.name,
@@ -5301,7 +5300,7 @@ export class Agent<
 
                   if (completeResult?.feedback) {
                     const feedbackMessage: MastraDBMessage = {
-                      id: this.#mastra?.generateId() || randomUUID(),
+                      id: this.#mastra?.generateId() || crypto.randomUUID(),
                       role: 'assistant',
                       type: 'text',
                       createdAt: new Date(),
@@ -5501,7 +5500,7 @@ export class Agent<
               // For resume cases, suspendedToolRunId is injected into inputData by
               // tool-call-step (from metadata stored during suspension).
               // For fresh calls: generate a new unique runId.
-              const runIdToUse = suspendedToolRunId || randomUUID();
+              const runIdToUse = suspendedToolRunId || crypto.randomUUID();
               this.logger.debug('Executing workflow as tool', {
                 agent: this.name,
                 workflow: workflowName,
@@ -6721,7 +6720,7 @@ export class Agent<
         threadId: threadFromArgs?.id,
         resourceId,
       }) ||
-      randomUUID();
+      crypto.randomUUID();
     const instructions = options.instructions || (await this.getInstructions({ requestContext }));
     const mcpServerGuidance = await this.getMcpServerGuidance({
       requestContext,
@@ -6814,7 +6813,7 @@ export class Agent<
       logger: this.logger,
       getMemory: this.getMemory.bind(this),
       getModel: this.getModel.bind(this),
-      generateMessageId: this.#mastra?.generateId?.bind(this.#mastra) || (() => randomUUID()),
+      generateMessageId: this.#mastra?.generateId?.bind(this.#mastra) || (() => crypto.randomUUID()),
       mastra: this.#mastra,
       _agentNetworkAppend:
         '_agentNetworkAppend' in this
@@ -6914,7 +6913,7 @@ export class Agent<
     llm.__registerMastra(effectiveMastra);
 
     const useEventedExecution = process.env.MASTRA_EVENTED_EXECUTION === 'true';
-    const executionRunId = randomUUID();
+    const executionRunId = crypto.randomUUID();
 
     if (useEventedExecution) {
       // Evented engine path: needs pubsub workers and internal workflow registration.
@@ -7209,7 +7208,7 @@ export class Agent<
       completion: { ...defaultNetworkOptions?.completion, ...options?.completion },
     };
 
-    const runId = mergedOptions?.runId || this.#mastra?.generateId() || randomUUID();
+    const runId = mergedOptions?.runId || this.#mastra?.generateId() || crypto.randomUUID();
 
     // Reserved keys from requestContext take precedence for security.
     // This allows middleware to securely set resourceId/threadId based on authenticated user,
@@ -7233,7 +7232,7 @@ export class Agent<
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
       } as unknown as AgentExecutionOptions<OUTPUT>,
-      generateId: context => this.#mastra?.generateId(context) || randomUUID(),
+      generateId: context => this.#mastra?.generateId(context) || crypto.randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,
       messages,
       threadId,
@@ -7308,7 +7307,7 @@ export class Agent<
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
       },
-      generateId: context => this.#mastra?.generateId(context) || randomUUID(),
+      generateId: context => this.#mastra?.generateId(context) || crypto.randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,
       messages: [],
       threadId,
@@ -8043,7 +8042,7 @@ export class Agent<
         idType: 'run',
         source: 'agent',
         entityId: this.id,
-      }) ?? randomUUID();
+      }) ?? crypto.randomUUID();
     const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
       { ...loopOptions, runId: mergedOptions.runId, actor } as AgentExecutionOptions<OUTPUT>,
       threadStreamPubSub,

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { UIMessage, CoreMessage, Message } from '@internal/ai-sdk-v4';
 import { appendClientMessage, appendResponseMessages } from '@internal/ai-sdk-v4';
 import { describe, expect, it } from 'vitest';
@@ -775,7 +774,7 @@ describe('MessageList', () => {
       // msg2
       messages = appendResponseMessages({
         messages,
-        responseMessages: [{ ...msg2, id: randomUUID() }],
+        responseMessages: [{ ...msg2, id: crypto.randomUUID() }],
       });
       // Filter out tool invocations with state="call" from expected UI messages
       const expectedUIMessages = messages.map(m => {
@@ -794,7 +793,7 @@ describe('MessageList', () => {
       expect(list.get.all.ui()).toEqual(expectedUIMessages);
 
       // msg3
-      messages = appendResponseMessages({ messages, responseMessages: [{ id: randomUUID(), ...msg3 }] });
+      messages = appendResponseMessages({ messages, responseMessages: [{ id: crypto.randomUUID(), ...msg3 }] });
       expect(new MessageList().add(messages, 'response').get.all.ui()).toMatchObject([
         expect.objectContaining({
           role: 'user',
@@ -2188,7 +2187,7 @@ describe('MessageList', () => {
       ];
       expect(uiMessages).toEqual(expectedMessages);
 
-      let newId = randomUUID();
+      let newId = crypto.randomUUID();
       const responseMessages = [
         {
           id: newId,
@@ -2223,7 +2222,7 @@ describe('MessageList', () => {
       ]);
 
       const newClientMessage = {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         role: 'user',
         createdAt: new Date(),
         content: 'Do it anyway please',
@@ -2243,14 +2242,14 @@ describe('MessageList', () => {
       );
 
       const responseMessages2 = [
-        { id: randomUUID(), role: 'assistant', content: "Ok fine I'll call a tool then" },
+        { id: crypto.randomUUID(), role: 'assistant', content: "Ok fine I'll call a tool then" },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'assistant',
           content: [{ type: 'tool-call', args: { ok: 'fine' }, toolCallId: 'ok-fine-1', toolName: 'okFineTool' }],
         },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'tool',
           content: [{ type: 'tool-result', toolName: 'okFineTool', toolCallId: 'ok-fine-1', result: { lets: 'go' } }],
         },

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { getErrorFromUnknown } from '../error';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import { isLeaseProvider, NoopLeaseProvider } from '../events/pubsub';
@@ -209,7 +207,7 @@ export class AgentThreadStreamRuntime {
   }
 
   #getSourceId(): string {
-    this.#id ??= randomUUID();
+    this.#id ??= crypto.randomUUID();
     return this.#id;
   }
 
@@ -400,7 +398,7 @@ export class AgentThreadStreamRuntime {
   #nextStreamIdentity(state: AgentThreadRuntimeState, runId: string) {
     const streamSeq = (state.streamSeqByRunId.get(runId) ?? 0) + 1;
     state.streamSeqByRunId.set(runId, streamSeq);
-    return { streamId: randomUUID(), streamSeq };
+    return { streamId: crypto.randomUUID(), streamSeq };
   }
 
   #markRunSuspending(
@@ -957,7 +955,7 @@ export class AgentThreadStreamRuntime {
       // old owner already lost the lease (e.g. a pubsub blip let the TTL lapse
       // and another process took over), forward the signal to the new winner
       // instead of starting a competing run here.
-      const nextRunId = randomUUID();
+      const nextRunId = crypto.randomUUID();
       state.activeThreadRunIds.set(key, nextRunId);
       const owns = await this.#acquireOrTransferThreadLease(pubsub, key, nextRunId, previousRun.runId);
       if (!owns.acquired) {
@@ -1105,7 +1103,7 @@ export class AgentThreadStreamRuntime {
   ): { accepted: true; runId: string } {
     const state = this.#getState(pubsub);
     const key = this.#threadKey(target.resourceId, target.threadId);
-    const runId = target.runId ?? randomUUID();
+    const runId = target.runId ?? crypto.randomUUID();
     const pending: PendingContinuation<OUTPUT> = {
       agent,
       messages,
@@ -1642,7 +1640,7 @@ export class AgentThreadStreamRuntime {
     }
 
     key ??= this.#threadKey(resourceId, threadId);
-    const queuedRunId = randomUUID();
+    const queuedRunId = crypto.randomUUID();
     const queuedStreamOptions = target.ifIdle?.streamOptions ?? activeRecord?.streamOptions;
 
     if (activeRecord) {
@@ -1870,7 +1868,7 @@ export class AgentThreadStreamRuntime {
       throw new Error('No active agent run found for signal target');
     }
 
-    runId = randomUUID();
+    runId = crypto.randomUUID();
     key ??= this.#threadKey(resourceId, threadId);
     if (idleBehavior === 'persist') {
       const persisted = this.#persistAndBroadcastIdleSignal(

--- a/packages/core/src/agent/trip-wire.ts
+++ b/packages/core/src/agent/trip-wire.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { ObservabilityContext } from '../observability';
@@ -104,7 +103,7 @@ export const getModelOutputForTripwire = async <OUTPUT = undefined, TMetadata = 
       returnScorerData: options.returnScorerData,
       requestContext: options.requestContext,
     },
-    messageId: randomUUID(),
+    messageId: crypto.randomUUID(),
   });
 
   return modelOutput;

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Mastra } from '..';
 import type { PubSub } from '../events/pubsub';
 import type { Event, EventCallback } from '../events/types';
@@ -224,7 +223,7 @@ export class BackgroundTaskManager {
     if (this.initPromise) await this.initPromise;
 
     const task: BackgroundTask = {
-      id: this.#mastra?.generateId() ?? randomUUID(),
+      id: this.#mastra?.generateId() ?? crypto.randomUUID(),
       status: 'pending',
       toolName: payload.toolName,
       toolCallId: payload.toolCallId,

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -19,7 +19,6 @@
  * ```
  */
 
-import { randomUUID } from 'node:crypto';
 import type {
   ComputeStateSignalArgs,
   ComputeStateSignalResult,
@@ -27,7 +26,7 @@ import type {
   ProcessInputResult,
 } from '../processors/index';
 
-const BROWSER_PROCESS_ID = randomUUID();
+const BROWSER_PROCESS_ID = crypto.randomUUID();
 
 /**
  * Browser context stored in RequestContext.

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { z } from 'zod/v4';
 import { Agent, isSupportedLanguageModel } from '../agent';
 import type { MastraDBMessage, MastraMessagePart, MastraToolInvocationPart } from '../agent/message-list';
@@ -580,7 +579,7 @@ class MastraScorer<
 
     let runId = prepared.runId;
     if (!runId) {
-      runId = randomUUID();
+      runId = crypto.randomUUID();
     }
 
     const normalizedRequestContext = this.normalizeRunRequestContext(prepared.requestContext);

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdir, open, stat, unlink } from 'node:fs/promises';
 import type { FileHandle } from 'node:fs/promises';
 import net from 'node:net';
@@ -194,7 +193,7 @@ export class UnixSocketPubSub extends PubSub {
     if (options?.localOnly) {
       const localEvent: Event = {
         ...event,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         createdAt: new Date(),
         deliveryAttempt: 1,
       };
@@ -615,7 +614,7 @@ export class UnixSocketPubSub extends PubSub {
   ) {
     const brokerEvent: Event = {
       ...event,
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: new Date(),
       deliveryAttempt: 1,
     };

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 /**
  * Converts a doGenerate result to a ReadableStream format.
  * This is shared between V2 and V3 model wrappers since the content/result structure is compatible.
@@ -76,7 +74,7 @@ export function createStreamFromGenerateResult(result: {
             text: string;
             providerMetadata?: unknown;
           };
-          const id = `msg_${randomUUID()}`;
+          const id = `msg_${crypto.randomUUID()}`;
           controller.enqueue({
             type: 'text-start',
             id,
@@ -92,7 +90,7 @@ export function createStreamFromGenerateResult(result: {
             id,
           });
         } else if (message.type === 'reasoning') {
-          const id = `reasoning_${randomUUID()}`;
+          const id = `reasoning_${crypto.randomUUID()}`;
           const reasoning = message as {
             type: 'reasoning';
             text: string;

--- a/packages/core/src/loop/test-utils/aimock/scenarios/auto-resume-suspended-tools.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/auto-resume-suspended-tools.scenario.test.ts
@@ -3,7 +3,6 @@ import { z } from 'zod/v4';
 import { MockMemory } from '../../../../memory';
 import { createTool } from '../../../../tools';
 import { createSharedAgent, runLoopScenario, useLoopScenarioAimock, describeForAllEngines } from '../aimock-scenario';
-import { randomUUID } from 'node:crypto';
 
 /**
  * Automatic tool resumption with `autoResumeSuspendedTools`.
@@ -54,8 +53,8 @@ describeForAllEngines(
         engine,
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       // First call: model calls the tool, loop suspends for approval
       const { chunks } = await runLoopScenario({
@@ -165,8 +164,8 @@ describeForAllEngines(
         engine,
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       // First call: tool suspends
       const { chunks } = await runLoopScenario({

--- a/packages/core/src/loop/test-utils/aimock/scenarios/evented-unix-pubsub.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/evented-unix-pubsub.scenario.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { stepCountIs } from '@internal/ai-sdk-v5';
@@ -40,7 +39,7 @@ describe('AIMock loop scenario: evented + UnixSocketPubSub', () => {
     // UUID to make the test portable on every host.
     const socketDir = mkdtempSync('/tmp/aim-');
     socketDirs.push(socketDir);
-    const socketPath = join(socketDir, `${randomUUID().slice(0, 8)}.sock`);
+    const socketPath = join(socketDir, `${crypto.randomUUID().slice(0, 8)}.sock`);
     const pubsub = new UnixSocketPubSub(socketPath);
     pubsubs.push(pubsub);
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ToolSet } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../../auth/ee';
@@ -1136,7 +1135,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                           {
                             role: 'tool' as const,
                             type: 'tool-call',
-                            id: readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? randomUUID(),
+                            id: readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? crypto.randomUUID(),
                             createdAt: new Date(),
                             content: [
                               {

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { StepResult, ToolSet } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage } from '../../../memory';
 import { InternalSpans } from '../../../observability';
@@ -211,7 +210,7 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
             if (iterationResult.feedback && typedInputData.stepResult?.isContinued) {
               messageList.add(
                 {
-                  id: rest.mastra?.generateId() || randomUUID(),
+                  id: rest.mastra?.generateId() || crypto.randomUUID(),
                   createdAt: new Date(),
                   type: 'text',
                   role: 'assistant',

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Agent } from '../agent';
 import { agentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { DurableAgentLike } from '../agent/types';
@@ -1128,7 +1127,7 @@ export class Mastra<
       }
       return id;
     }
-    return randomUUID();
+    return crypto.randomUUID();
   }
 
   /**

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import slugify from '@sindresorhus/slugify';
 import type { ToolsInput } from '../agent';
 import { MastraBase } from '../base';
@@ -180,7 +179,7 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
       this._id = slugify(config.id) as TId;
       this.idWasSet = true;
     } else {
-      this._id = (this.mastra?.generateId() || randomUUID()) as TId;
+      this._id = (this.mastra?.generateId() || crypto.randomUUID()) as TId;
     }
 
     this.description = config.description;

--- a/packages/core/src/notifications/storage.ts
+++ b/packages/core/src/notifications/storage.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { StorageDomain } from '../storage/domains/base';
 import type {
   CreateNotificationInput,
@@ -94,7 +93,7 @@ export class InMemoryNotificationsStorage extends NotificationsStorage {
 
     const now = input.createdAt ?? new Date();
     const record: NotificationRecord = {
-      id: input.id ?? randomUUID(),
+      id: input.id ?? crypto.randomUUID(),
       threadId: input.threadId,
       source: input.source,
       kind: input.kind,

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from './index';
 
 const CLAUDE_46_PATTERN = /[^0-9]4[.-]6/;
@@ -67,7 +65,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
       messages: [
         ...messages,
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'user' as const,
           content: {
             format: 2 as const,

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import slugify from '@sindresorhus/slugify';
 import type { AgentSignalAttributes, AgentSignalType } from '../agent/signals';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
@@ -312,7 +311,7 @@ export class Schedules {
     const id =
       input.id !== undefined
         ? normalizeScheduleId(input.id, AGENT_SCHEDULE_PREFIX)
-        : `${AGENT_SCHEDULE_PREFIX}${randomUUID()}`;
+        : `${AGENT_SCHEDULE_PREFIX}${crypto.randomUUID()}`;
     await this.#assertIdAvailable(store, id, input.id !== undefined);
     const now = Date.now();
     const nextFireAt = computeNextFireAt(input.cron, { timezone: input.timezone, after: now });
@@ -361,7 +360,7 @@ export class Schedules {
     const id =
       input.id !== undefined
         ? normalizeScheduleId(input.id, WORKFLOW_SCHEDULE_PREFIX)
-        : `${WORKFLOW_SCHEDULE_PREFIX}${randomUUID()}`;
+        : `${WORKFLOW_SCHEDULE_PREFIX}${crypto.randomUUID()}`;
     await this.#assertIdAvailable(store, id, input.id !== undefined);
     const now = Date.now();
     const nextFireAt = computeNextFireAt(input.cron, { timezone: input.timezone, after: now });

--- a/packages/core/src/storage/domains/schedules/inmemory.ts
+++ b/packages/core/src/storage/domains/schedules/inmemory.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { InMemoryDB } from '../inmemory-db';
 import type { Schedule, ScheduleFilter, ScheduleTrigger, ScheduleTriggerListOptions, ScheduleUpdate } from './base';
 import { normalizeScheduleTarget, SchedulesStorage } from './base';
@@ -122,7 +121,7 @@ export class InMemorySchedulesStorage extends SchedulesStorage {
   async recordTrigger(trigger: ScheduleTrigger): Promise<void> {
     const stored: ScheduleTrigger = {
       ...trigger,
-      id: trigger.id ?? randomUUID(),
+      id: trigger.id ?? crypto.randomUUID(),
       triggerKind: trigger.triggerKind ?? 'schedule-fire',
     };
     this.db.scheduleTriggers.push(clone(stored));

--- a/packages/core/src/storage/domains/skills/inmemory.ts
+++ b/packages/core/src/storage/domains/skills/inmemory.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { normalizePerPage, calculatePagination } from '../../base';
 import type {
   StorageSkillType,
@@ -70,7 +68,7 @@ export class InMemorySkillsStorage extends SkillsStorage {
     const { id: _id, authorId: _authorId, visibility: _visibility, ...snapshotConfig } = skill;
 
     // Create version 1 from the config
-    const versionId = randomUUID();
+    const versionId = crypto.randomUUID();
     try {
       await this.createVersion({
         id: versionId,
@@ -181,7 +179,7 @@ export class InMemorySkillsStorage extends SkillsStorage {
 
       // Only create a new version if something actually changed
       if (changedFields.length > 0) {
-        const newVersionId = randomUUID();
+        const newVersionId = crypto.randomUUID();
         const newVersionNumber = latestVersion.versionNumber + 1;
 
         await this.createVersion({

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { MessageList } from '../agent';
 import type { MastraMessageV1, StorageThreadType } from '../memory/types';
@@ -378,7 +377,7 @@ describe('InMemoryStore - listMessagesById', () => {
     messageCounter += 1;
 
     const defaults = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       role: 'user' as const,
       resourceId,
       createdAt: new Date(Date.now() + messageCounter * 1000),

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -1,27 +1,13 @@
-import { randomUUID } from 'node:crypto';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage/mock';
 import { createWorkflow } from './create';
 import { createStep } from './workflow';
 
-vi.mock('crypto', () => {
-  return {
-    randomUUID: vi.fn(() => 'mock-uuid-1'),
-  };
-});
-
+// UUID determinism comes from @internal/test-utils/setup, which stubs the
+// global crypto.randomUUID with a per-test counter.
 describe('Branch with Map Bug - Issue #10407', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-
-    let counter = 0;
-    (randomUUID as vi.Mock).mockImplementation(() => {
-      return `mock-uuid-${++counter}`;
-    });
-  });
-
   it('should pass inputData to nested workflow with map inside branch', async () => {
     const commonInputSchema = z.object({
       value: z.number(),

--- a/packages/core/src/workflows/default.test.ts
+++ b/packages/core/src/workflows/default.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { RequestContext } from '../di';
@@ -210,7 +209,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
     const { result } = await runConditional({
       conditions,
       workflowId: 'test-workflow',
-      runId: randomUUID(),
+      runId: crypto.randomUUID(),
     });
 
     // Assert: Verify error handling, truthyIndexes, and workflow continuation
@@ -223,7 +222,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
     // Arrange: Set up conditions array with one throwing regular Error and one valid
     const regularError = new Error('Test regular error');
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     // Mock the logger to capture trackException calls
     const mockTrackException = vi.fn();
@@ -281,7 +280,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
   describe('conditional time-travel reconciliation', () => {
     it("rewrites a targeted-but-non-truthy arm from 'running' to 'skipped' during time travel", async () => {
       const workflowId = 'test-workflow';
-      const runId = randomUUID();
+      const runId = crypto.randomUUID();
 
       // arm step1 (index 0) is truthy, arm step2 (index 1) is NOT truthy.
       const conditions = [async () => true, async () => false];
@@ -321,7 +320,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
 
     it("leaves a 'running' arm untouched for normal start/resume (no time travel)", async () => {
       const workflowId = 'test-workflow';
-      const runId = randomUUID();
+      const runId = crypto.randomUUID();
 
       const conditions = [async () => true, async () => false];
 
@@ -361,7 +360,7 @@ describe('DefaultExecutionEngine.executeEntry resume payload handling', () => {
 
   it('should use the suspended step payload when resuming a step with stale previous output', async () => {
     const workflowId = 'resume-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const resumedStep = {
       id: 'needs-approval',
       inputSchema: z.object({ id: z.string() }),
@@ -429,7 +428,7 @@ describe('DefaultExecutionEngine.executeEntry resume payload handling', () => {
 
   it('should use a null suspended step payload when resuming a step with stale previous output', async () => {
     const workflowId = 'resume-null-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const resumedStep = {
       id: 'needs-approval',
       inputSchema: z.null(),
@@ -497,7 +496,7 @@ describe('DefaultExecutionEngine.executeEntry resume payload handling', () => {
 
   it('should use the suspended foreach payload when resuming with stale previous output', async () => {
     const workflowId = 'resume-foreach-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const foreachStep = {
       id: 'process-item',
       inputSchema: z.number(),
@@ -584,7 +583,7 @@ describe('DefaultExecutionEngine.executeLoop resume payload handling', () => {
 
   it('should use a null suspended loop payload when resuming with stale previous output', async () => {
     const workflowId = 'resume-loop-null-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const step = {
       id: 'loop-step',
       inputSchema: z.null(),
@@ -662,7 +661,7 @@ describe('DefaultExecutionEngine.executeLoop cancellation', () => {
   // cancelled, even when the user's step does not observe abortSignal.
   it('should stop iterating a dountil loop when abortController is aborted between iterations', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     let iterations = 0;
     const step = {
@@ -727,7 +726,7 @@ describe('DefaultExecutionEngine.executeLoop cancellation', () => {
   // must still surface 'canceled' rather than 'success'.
   it('should surface canceled when abortController is aborted during condition evaluation', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     let stepCalls = 0;
     const step = {
@@ -800,7 +799,7 @@ describe('DefaultExecutionEngine.executeForeach cancellation', () => {
   // would otherwise let the loop keep iterating.
   it('should return canceled before dispatching the next concurrency chunk', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     let callCount = 0;
     const step = {
@@ -859,7 +858,7 @@ describe('DefaultExecutionEngine.executeForeach cancellation', () => {
   // result and persist 'success' even though the run was cancelled.
   it('should return canceled when abortController is aborted during the final chunk', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     const step = {
       id: 'process-item',
@@ -939,7 +938,7 @@ describe('DefaultExecutionEngine.executeForeach concurrency', () => {
     prevOutput,
     concurrency,
     workflowId = 'test-workflow',
-    runId = randomUUID(),
+    runId = crypto.randomUUID(),
   }: {
     step: any;
     prevOutput: any[];
@@ -984,7 +983,7 @@ describe('DefaultExecutionEngine.executeForeach concurrency', () => {
   });
 
   it('keeps concurrency slots filled and preserves ordered results while progress follows completion order', async () => {
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const firstItemGate = deferred();
     const starts: number[] = [];
     const completed: number[] = [];

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { TripWire } from '../../agent/trip-wire';
 import { MastraBase } from '../../base';
 import type { RequestContext } from '../../di';
@@ -163,7 +162,7 @@ export class StepExecutor extends MastraBase {
         throw validationError;
       }
 
-      const callId = randomUUID();
+      const callId = crypto.randomUUID();
       const outputWriter = this.createOutputWriter(runId);
 
       const stepOutput = await executeWithContext({
@@ -428,7 +427,7 @@ export class StepExecutor extends MastraBase {
     retryCount?: number;
     iterationCount: number;
   }): Promise<boolean> {
-    const callId = randomUUID();
+    const callId = crypto.randomUUID();
     const outputWriter = this.createOutputWriter(runId);
 
     return condition(
@@ -502,7 +501,7 @@ export class StepExecutor extends MastraBase {
     }
 
     try {
-      const callId = randomUUID();
+      const callId = crypto.randomUUID();
       const outputWriter = this.createOutputWriter(runId);
 
       return await step.fn(
@@ -585,7 +584,7 @@ export class StepExecutor extends MastraBase {
     }
 
     try {
-      const callId = randomUUID();
+      const callId = crypto.randomUUID();
       const outputWriter = this.createOutputWriter(runId);
 
       const result = await step.fn(

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import EventEmitter from 'node:events';
 import { ErrorCategory, ErrorDomain, MastraError, getErrorFromUnknown } from '../../../error';
 import { EventProcessor } from '../../../events/processor';
@@ -1341,7 +1340,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else if (timeTravel && timeTravel.steps?.length > 1 && timeTravel.steps[0] === step.step.id) {
-        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? randomUUID();
+        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? crypto.randomUUID();
         const snapshot =
           (await workflowsStore?.loadWorkflowSnapshot({
             workflowName: step.step.id,
@@ -1395,7 +1394,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else if (restart && !!restart.activeStepsPath?.[step.step.id]) {
-        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? randomUUID();
+        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? crypto.randomUUID();
         const snapshot =
           (await workflowsStore?.loadWorkflowSnapshot({
             workflowName: step.step.id,
@@ -1440,7 +1439,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else {
-        const nestedRunId = randomUUID();
+        const nestedRunId = crypto.randomUUID();
         const shouldPersist =
           nestedWorkflow?.options?.shouldPersistSnapshot?.({
             stepResults: {},

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { z } from 'zod/v4';
@@ -1617,7 +1616,7 @@ export class EventedWorkflow<
       throw new Error('Uncommitted step flow changes detected. Call .commit() to register the steps.');
     }
 
-    const runIdToUse = options?.runId || randomUUID();
+    const runIdToUse = options?.runId || crypto.randomUUID();
 
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
 

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import fastq from 'fastq';
 import type { done as DoneCallback } from 'fastq';
 import type { ActorSignal } from '../../auth/ee';
@@ -354,7 +353,7 @@ export async function executeConditional(
             writer: new ToolStream(
               {
                 prefix: 'workflow-step',
-                callId: randomUUID(),
+                callId: crypto.randomUUID(),
                 name: 'conditional',
                 runId,
               },
@@ -774,7 +773,7 @@ export async function executeLoop(
           writer: new ToolStream(
             {
               prefix: 'workflow-step',
-              callId: randomUUID(),
+              callId: crypto.randomUUID(),
               name: 'loop',
               runId,
             },

--- a/packages/core/src/workflows/handlers/sleep.ts
+++ b/packages/core/src/workflows/handlers/sleep.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { RequestContext } from '../../di';
 import type { PubSub } from '../../events/pubsub';
 import { SpanType, createObservabilityContext, resolveObservabilityContext } from '../../observability';
@@ -77,7 +76,7 @@ export async function executeSleep(engine: DefaultExecutionEngine, params: Execu
   });
 
   if (fn) {
-    const stepCallId = randomUUID();
+    const stepCallId = crypto.randomUUID();
     duration = await engine.wrapDurableOperation(`workflow.${workflowId}.sleep.${entry.id}`, async () => {
       return fn({
         runId,
@@ -203,7 +202,7 @@ export async function executeSleepUntil(
   });
 
   if (fn) {
-    const stepCallId = randomUUID();
+    const stepCallId = crypto.randomUUID();
     const dateResult = await engine.wrapDurableOperation(`workflow.${workflowId}.sleepUntil.${entry.id}`, async () => {
       return fn({
         runId,

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ActorSignal } from '../../auth/ee';
 import type { RequestContext } from '../../di';
 import { MastraError, ErrorDomain, ErrorCategory, getErrorFromUnknown } from '../../error';
@@ -96,7 +95,7 @@ export async function executeStep(
   } = params;
   const observabilityContext = resolveObservabilityContext(rest);
 
-  const stepCallId = randomUUID();
+  const stepCallId = crypto.randomUUID();
 
   const { inputData, validationError: inputValidationError } = await validateStepInput({
     prevOutput,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { z } from 'zod/v4';
@@ -1733,7 +1732,7 @@ export class Workflow<
    * @returns The workflow instance for chaining
    */
   sleep(duration: number | ExecuteFunction<TState, TPrevSchema, number, any, any, TEngineType>) {
-    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || randomUUID()}`;
+    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || crypto.randomUUID()}`;
 
     const opts: StepFlowEntry<TEngineType> =
       typeof duration === 'function'
@@ -1772,7 +1771,7 @@ export class Workflow<
    * @returns The workflow instance for chaining
    */
   sleepUntil(date: Date | ExecuteFunction<TState, TPrevSchema, Date, any, any, TEngineType>) {
-    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || randomUUID()}`;
+    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || crypto.randomUUID()}`;
     const opts: StepFlowEntry<TEngineType> =
       typeof date === 'function'
         ? { type: 'sleepUntil', id, fn: date }
@@ -1851,7 +1850,7 @@ export class Workflow<
       const mappingStep: any = createStep({
         id:
           stepOptions?.id ||
-          `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || randomUUID()}`,
+          `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || crypto.randomUUID()}`,
         inputSchema: z.any(),
         outputSchema: z.any(),
         execute: mappingConfig as any,
@@ -1917,7 +1916,7 @@ export class Workflow<
     const mappingStep: any = createStep({
       id:
         stepOptions?.id ||
-        `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || randomUUID()}`,
+        `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || crypto.randomUUID()}`,
       inputSchema: z.any(),
       outputSchema: z.any(),
       execute: async ctx => {
@@ -2340,7 +2339,7 @@ export class Workflow<
         entityId: this.id,
         resourceId: options?.resourceId,
       }) ||
-      randomUUID();
+      crypto.randomUUID();
 
     // Return a new Run instance with object parameters
     const run =

--- a/packages/deployer/src/server/handlers/a2a.ts
+++ b/packages/deployer/src/server/handlers/a2a.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { MessageSendParams, TaskQueryParams, TaskIdParams } from '@mastra/core/a2a';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
@@ -48,7 +47,7 @@ export async function getAgentExecutionHandler(c: Context) {
     mastra,
     agentId,
     requestContext,
-    requestId: randomUUID(),
+    requestId: crypto.randomUUID(),
     method: body.method as 'message/send' | 'message/stream' | 'tasks/get' | 'tasks/cancel',
     params: body.params as MessageSendParams | TaskQueryParams | TaskIdParams,
     taskStore,

--- a/packages/editor/src/editor-integration-tools.test.ts
+++ b/packages/editor/src/editor-integration-tools.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { randomUUID } from 'crypto';
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import type {
@@ -81,7 +80,7 @@ function createMockToolProvider(
 
 const createTestStorage = () => {
   return new LibSQLStore({
-    id: `test-${randomUUID()}`,
+    id: `test-${crypto.randomUUID()}`,
     url: ':memory:',
   });
 };
@@ -818,7 +817,7 @@ describe.skipIf(!process.env.ARCADE_API_KEY)('ArcadeToolProvider e2e (real API)'
   }, 30_000);
 
   it('should hydrate a stored agent with Arcade integration tools', async () => {
-    const _storage = new LibSQLStore({ id: `arcade-e2e-${randomUUID()}`, url: ':memory:' });
+    const _storage = new LibSQLStore({ id: `arcade-e2e-${crypto.randomUUID()}`, url: ':memory:' });
     const _editor = new MastraEditor({ toolProviders: { arcade: provider } });
     const _mastra = new Mastra({ storage: _storage, editor: _editor });
     await _storage.init();

--- a/packages/editor/src/editor-libsql.integration.test.ts
+++ b/packages/editor/src/editor-libsql.integration.test.ts
@@ -7,7 +7,6 @@ import { createWorkflow, createStep } from '@mastra/core/workflows';
 import { createScorer } from '@mastra/core/evals';
 import { RequestContext } from '@mastra/core/request-context';
 import { MastraEditor } from './index';
-import { randomUUID } from 'crypto';
 import os from 'node:os';
 import { convertArrayToReadableStream, LanguageModelV2, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import {
@@ -26,8 +25,8 @@ import { MastraModelGateway, ProviderConfig } from '@mastra/core/llm';
 // Create in-memory LibSQL store for testing
 const createTestStorage = () => {
   return new LibSQLStore({
-    id: `test-${randomUUID()}`,
-    url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+    id: `test-${crypto.randomUUID()}`,
+    url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
   });
 };
 
@@ -35,7 +34,7 @@ const createTestStorage = () => {
 const createTestVector = (id: string) => {
   return new LibSQLVector({
     id,
-    url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+    url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
   });
 };
 
@@ -898,7 +897,7 @@ describe('MastraEditor with LibSQL Integration', () => {
 
       // Config changes require createVersion + update(activeVersionId)
       await agentsStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         agentId: 'versioned-agent',
         versionNumber: 2,
         name: 'Version 2',
@@ -949,7 +948,7 @@ describe('MastraEditor with LibSQL Integration', () => {
 
       // Config changes require createVersion + update(activeVersionId)
       await agentsStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         agentId: 'numbered-version-agent',
         versionNumber: 2,
         name: 'Version 2',
@@ -1099,7 +1098,7 @@ describe('MastraEditor with LibSQL Integration', () => {
 
       // Update the agent in storage — config changes require createVersion + update(activeVersionId)
       await agentsStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         agentId: 'cached-agent',
         versionNumber: 2,
         name: 'Updated Cached Agent',
@@ -1160,7 +1159,7 @@ describe('MastraEditor with LibSQL Integration', () => {
       // Verify cache is cleared by updating and retrieving
       // Config changes require createVersion + update(activeVersionId)
       await agentsStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         agentId: 'cache-test-1',
         versionNumber: 2,
         name: 'Updated 1',
@@ -1176,7 +1175,7 @@ describe('MastraEditor with LibSQL Integration', () => {
       });
 
       await agentsStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         agentId: 'cache-test-2',
         versionNumber: 2,
         name: 'Updated 2',
@@ -2060,7 +2059,7 @@ describe('MastraEditor with LibSQL Integration', () => {
       // Config changes require createVersion + update(activeVersionId)
       const promptStore = await storage.getStore('promptBlocks');
       await promptStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         blockId: 'versioned-block',
         versionNumber: 2,
         name: 'Versioned Block',
@@ -2132,7 +2131,7 @@ describe('MastraEditor with LibSQL Integration', () => {
       // Config changes require createVersion + update(activeVersionId)
       const promptStore = await storage.getStore('promptBlocks');
       await promptStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         blockId: 'updatable-block',
         versionNumber: 2,
         name: 'Updatable Block',
@@ -2228,7 +2227,7 @@ describe('MastraEditor with LibSQL Integration', () => {
       // Update — config changes require createVersion + update(activeVersionId)
       const promptStore = await storage.getStore('promptBlocks');
       await promptStore?.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         blockId: 'lifecycle-block',
         versionNumber: 2,
         name: 'Updated Block',

--- a/packages/editor/src/editor-mcp-server.test.ts
+++ b/packages/editor/src/editor-mcp-server.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { randomUUID } from 'crypto';
 import { Mastra } from '@mastra/core';
 import { MCPServerBase } from '@mastra/core/mcp';
 import { createTool } from '@mastra/core/tools';
@@ -10,7 +9,7 @@ import { MastraEditor } from './index';
 
 const createTestStorage = () => {
   return new LibSQLStore({
-    id: `test-${randomUUID()}`,
+    id: `test-${crypto.randomUUID()}`,
     url: ':memory:',
   });
 };
@@ -401,7 +400,7 @@ describe('EditorMCPServerNamespace', () => {
       // Create a new version with both tools
       const mcpServerStore = await storage.getStore('mcpServers');
       const newVersion = await mcpServerStore!.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         versionNumber: 2,
         mcpServerId: 'update-test',
         name: 'Updated Server',

--- a/packages/editor/src/editor-mcp.test.ts
+++ b/packages/editor/src/editor-mcp.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
-import { randomUUID } from 'crypto';
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { MCPServerBase } from '@mastra/core/mcp';
@@ -49,7 +48,7 @@ class TestMCPServer extends MCPServerBase {
 
 const createTestStorage = () => {
   return new LibSQLStore({
-    id: `test-${randomUUID()}`,
+    id: `test-${crypto.randomUUID()}`,
     url: ':memory:',
   });
 };
@@ -120,7 +119,7 @@ describe('EditorMCPNamespace', () => {
 
       // Config changes require createVersion + update(activeVersionId)
       await mcpStore!.createVersion({
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         mcpClientId: 'mcp-update',
         versionNumber: 2,
         name: 'Updated Name',
@@ -843,7 +842,7 @@ describe('Agent MCP tool resolution', () => {
     // Update the MCP client config via createVersion + update(activeVersionId)
     const mcpStore = await storage.getStore('mcpClients');
     await mcpStore!.createVersion({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       mcpClientId: 'updatable-mcp',
       versionNumber: 2,
       name: 'Updated MCP',
@@ -879,7 +878,7 @@ describe('Agent MCP tool resolution', () => {
 
     // Create v2 via createVersion + activate
     await mcpStore!.createVersion({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       mcpClientId: 'versioned-mcp',
       versionNumber: 2,
       name: 'Version 2',
@@ -894,7 +893,7 @@ describe('Agent MCP tool resolution', () => {
 
     // Create v3 via createVersion + activate
     await mcpStore!.createVersion({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       mcpClientId: 'versioned-mcp',
       versionNumber: 3,
       name: 'Version 3',

--- a/packages/editor/src/editor-scorers.test.ts
+++ b/packages/editor/src/editor-scorers.test.ts
@@ -5,7 +5,6 @@ import { createScorer } from '@mastra/core/evals';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '@mastra/core/evals';
 import { MastraEditor } from './index';
-import { randomUUID } from 'crypto';
 import { LibSQLStore } from '@mastra/libsql';
 import { convertArrayToReadableStream, LanguageModelV2, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { MastraModelGateway, ProviderConfig } from '@mastra/core/llm';
@@ -16,7 +15,7 @@ import { MastraModelGateway, ProviderConfig } from '@mastra/core/llm';
 
 const createTestStorage = () => {
   return new LibSQLStore({
-    id: `test-${randomUUID()}`,
+    id: `test-${crypto.randomUUID()}`,
     url: ':memory:',
   });
 };
@@ -32,7 +31,7 @@ const createTestStorage = () => {
  */
 const createScorerMockLLM = (score: number, reason: string) => {
   let callIndex = 0;
-  const modelId = `scorer-model-${randomUUID()}`;
+  const modelId = `scorer-model-${crypto.randomUUID()}`;
 
   const mockLLM = new MockLanguageModelV2({
     doGenerate: async () => {
@@ -165,7 +164,7 @@ function createAgentTestRun({
       taggedSystemMessages: {},
     },
     output,
-    runId: randomUUID(),
+    runId: crypto.randomUUID(),
   };
 }
 

--- a/packages/editor/src/editor-skills.test.ts
+++ b/packages/editor/src/editor-skills.test.ts
@@ -3,7 +3,6 @@ import { z } from 'zod';
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import os from 'node:os';
-import { randomUUID } from 'node:crypto';
 import { Mastra } from '@mastra/core';
 import { Agent } from '@mastra/core/agent';
 import { LibSQLStore } from '@mastra/libsql';
@@ -31,7 +30,7 @@ let testStorageCount = 0;
 const createSetup = async () => {
   const storage = new LibSQLStore({
     id: `skill-test-${testStorageCount++}`,
-    url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+    url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
   });
   const editor = new MastraEditor({ logger: mockLogger() as any });
   const mastra = new Mastra({ storage, editor });
@@ -673,7 +672,7 @@ describe('editor.skill — agent resolution strategies', () => {
   const createAgentSetup = async () => {
     const storage = new LibSQLStore({
       id: `skill-agent-${testStorageCount++}`,
-      url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+      url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
     });
     const editor = new MastraEditor({ logger: mockLogger() as any });
     const mastra = new Mastra({
@@ -870,7 +869,7 @@ describe('editor.skill — end-to-end: publish → agent → skill discovery', (
   const createE2ESetup = async () => {
     const storage = new LibSQLStore({
       id: `skill-e2e-${testStorageCount++}`,
-      url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+      url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
     });
     const editor = new MastraEditor({ logger: mockLogger() as any });
     const mastra = new Mastra({
@@ -1122,7 +1121,7 @@ describe('editor.skill — agent execution integration', () => {
   const createExecSetup = async (extraTools?: Record<string, any>) => {
     const storage = new LibSQLStore({
       id: `skill-exec-${testStorageCount++}`,
-      url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+      url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
     });
     const editor = new MastraEditor({ logger: mockLogger() as any });
     const mastra = new Mastra({
@@ -1681,7 +1680,7 @@ describe('editor.skill — live strategy execution', () => {
   const createLiveSetup = async () => {
     const storage = new LibSQLStore({
       id: `live-skill-${testStorageCount++}`,
-      url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+      url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
     });
     const editor = new MastraEditor({ logger: mockLogger() as any });
     const mastra = new Mastra({

--- a/packages/editor/src/editor-workspaces.test.ts
+++ b/packages/editor/src/editor-workspaces.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -31,7 +30,7 @@ let testStorageCount = 0;
 const createSetup = async (editorConfig?: ConstructorParameters<typeof MastraEditor>[0]) => {
   const storage = new LibSQLStore({
     id: `ws-test-${testStorageCount++}`,
-    url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+    url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
   });
   const editor = new MastraEditor({ logger: mockLogger() as any, ...editorConfig });
   const mastra = new Mastra({ storage, editor });
@@ -773,7 +772,7 @@ describe('editor.agent — workspace execution integration', () => {
   const createExecutionSetup = async (extraTools?: Record<string, any>) => {
     const storage = new LibSQLStore({
       id: `ws-exec-${testStorageCount++}`,
-      url: `file:${os.tmpdir()}/mastra-test-${randomUUID()}.db`,
+      url: `file:${os.tmpdir()}/mastra-test-${crypto.randomUUID()}.db`,
     });
     const editor = new MastraEditor({ logger: mockLogger() as any });
     const mastra = new Mastra({

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -1,5 +1,4 @@
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import { createServer } from 'node:http';
 import type { Server as HttpServer } from 'node:http';
@@ -201,7 +200,7 @@ async function setupTestServer(withSessionManagement: boolean) {
 
   if (withSessionManagement) {
     const serverTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
+      sessionIdGenerator: () => crypto.randomUUID(),
     });
 
     await mcpServer.connect(serverTransport);
@@ -2265,7 +2264,7 @@ describe('MastraMCPClient - Session Reconnection (Issue #7675)', () => {
     );
 
     let serverTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
+      sessionIdGenerator: () => crypto.randomUUID(),
     });
 
     await mcpServer.connect(serverTransport);
@@ -2321,7 +2320,7 @@ describe('MastraMCPClient - Session Reconnection (Issue #7675)', () => {
     );
 
     serverTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
+      sessionIdGenerator: () => crypto.randomUUID(),
     });
 
     await mcpServer.connect(serverTransport);
@@ -2361,7 +2360,7 @@ describe('MastraMCPClient - Session Reconnection (Issue #7675)', () => {
     });
 
     let serverTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
+      sessionIdGenerator: () => crypto.randomUUID(),
     });
 
     await mcpServer.connect(serverTransport);
@@ -2411,7 +2410,7 @@ describe('MastraMCPClient - Session Reconnection (Issue #7675)', () => {
     });
 
     serverTransport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
+      sessionIdGenerator: () => crypto.randomUUID(),
     });
 
     await mcpServer.connect(serverTransport);
@@ -3278,7 +3277,7 @@ describe('MastraMCPClient - custom fetch failure modes (auth-token loop)', () =>
         }
 
         if (body?.method === 'initialize') {
-          sessionId = randomUUID();
+          sessionId = crypto.randomUUID();
           res.writeHead(200, {
             'content-type': 'application/json',
             'mcp-session-id': sessionId,

--- a/packages/mcp/src/client/iserror-agent-integration.test.ts
+++ b/packages/mcp/src/client/iserror-agent-integration.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:http';
 import type { Server as HttpServer } from 'node:http';
 import type { AddressInfo } from 'node:net';
@@ -162,8 +161,8 @@ describe('MCP isError - agent integration (four surfaces)', () => {
 
     // --- Surface 2 wiring: persistence ---
     const memory = new MockMemory();
-    const thread = randomUUID();
-    const resource = randomUUID();
+    const thread = crypto.randomUUID();
+    const resource = crypto.randomUUID();
 
     const agent = new Agent({
       id: 'mcp-iserror-agent',

--- a/packages/mcp/src/client/oauth.test.ts
+++ b/packages/mcp/src/client/oauth.test.ts
@@ -12,7 +12,6 @@
  * 4. Token validation on protected endpoints
  */
 
-import { randomUUID } from 'node:crypto';
 import { createServer } from 'node:http';
 import type { Server as HttpServer, IncomingMessage, ServerResponse } from 'node:http';
 
@@ -527,7 +526,7 @@ describe('OAuth Middleware Integration', () => {
   const SERVER_URL = `http://localhost:${PORT}`;
   let httpServer: HttpServer;
 
-  const VALID_TOKEN = 'valid-test-token-' + randomUUID();
+  const VALID_TOKEN = 'valid-test-token-' + crypto.randomUUID();
 
   beforeAll(async () => {
     // Create an MCP server with a simple tool

--- a/packages/mcp/src/server/server.ts
+++ b/packages/mcp/src/server/server.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import type * as http from 'node:http';
 import type { ToolsInput, Agent } from '@mastra/core/agent';
@@ -1730,7 +1729,6 @@ export class MCPServer extends MCPServerBase {
    * @example
    * ```typescript
    * import http from 'node:http';
-   * import { randomUUID } from 'node:crypto';
    *
    * const httpServer = http.createServer(async (req, res) => {
    *   await server.startHTTP({
@@ -1739,7 +1737,7 @@ export class MCPServer extends MCPServerBase {
    *     req,
    *     res,
    *     options: {
-   *       sessionIdGenerator: () => randomUUID(),
+   *       sessionIdGenerator: () => crypto.randomUUID(),
    *       onsessioninitialized: (sessionId) => {
    *         console.log(`New MCP session: ${sessionId}`);
    *       },
@@ -1821,7 +1819,7 @@ export class MCPServer extends MCPServerBase {
     }
 
     const mergedOptions = {
-      sessionIdGenerator: () => randomUUID(), // default: enabled
+      sessionIdGenerator: () => crypto.randomUUID(), // default: enabled
       ...options, // user-provided overrides default
     };
 
@@ -2682,7 +2680,7 @@ export class MCPServer extends MCPServerBase {
     try {
       const finalExecutionContext = {
         messages: executionContext?.messages || [],
-        toolCallId: executionContext?.toolCallId || randomUUID(),
+        toolCallId: executionContext?.toolCallId || crypto.randomUUID(),
         requestContext: executionContext?.requestContext,
       };
       await this.enforceToolExecutionFGA(toolId, finalExecutionContext.requestContext);

--- a/packages/memory/integration-tests/src/observer-thread-title.test.ts
+++ b/packages/memory/integration-tests/src/observer-thread-title.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -53,10 +52,10 @@ describe('Observer thread title generation', () => {
   });
 
   it('should generate and persist a thread title through Memory observational memory', async () => {
-    const threadId = randomUUID();
-    const resourceId = randomUUID();
+    const threadId = crypto.randomUUID();
+    const resourceId = crypto.randomUUID();
     const storage = new LibSQLStore({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       url: `file:${join(dbDir, `${threadId}.db`)}`,
     });
     await storage.init();

--- a/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
+++ b/packages/memory/integration-tests/src/om-extracted-metadata.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -17,7 +16,7 @@ const createMessage = (
   text: string,
   createdAt: string,
 ): MastraDBMessage => ({
-  id: randomUUID(),
+  id: crypto.randomUUID(),
   threadId,
   resourceId,
   role,
@@ -35,7 +34,7 @@ describe('Observational Memory extracted metadata persistence', () => {
   beforeEach(async () => {
     dbDir = await mkdtemp(join(tmpdir(), 'memory-om-extracted-metadata-'));
     const storage = new LibSQLStore({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       url: `file:${join(dbDir, 'test.db')}`,
     });
     await storage.init();
@@ -47,8 +46,8 @@ describe('Observational Memory extracted metadata persistence', () => {
   });
 
   it('persists extracted values through LibSQL thread metadata helpers', async () => {
-    const threadId = randomUUID();
-    const resourceId = randomUUID();
+    const threadId = crypto.randomUUID();
+    const resourceId = crypto.randomUUID();
     const now = new Date();
 
     await memory.saveThread({
@@ -111,8 +110,8 @@ describe('Observational Memory extracted metadata persistence', () => {
   });
 
   it('updates markdown working memory from an end-to-end LibSQL observation run', async () => {
-    const threadId = randomUUID();
-    const resourceId = randomUUID();
+    const threadId = crypto.randomUUID();
+    const resourceId = crypto.randomUUID();
     const observerOutput = `<observations>
 - User shared durable profile details.
 </observations>
@@ -178,8 +177,8 @@ describe('Observational Memory extracted metadata persistence', () => {
   });
 
   it('replaces schema-backed working memory from an end-to-end LibSQL observation run', async () => {
-    const threadId = randomUUID();
-    const resourceId = randomUUID();
+    const threadId = crypto.randomUUID();
+    const resourceId = crypto.randomUUID();
     const observerOutput = `<observations>
 - User shared durable schema-backed profile details.
 </observations>`;
@@ -262,8 +261,8 @@ describe('Observational Memory extracted metadata persistence', () => {
   });
 
   it('persists extracted values from an end-to-end LibSQL observation run', async () => {
-    const threadId = randomUUID();
-    const resourceId = randomUUID();
+    const threadId = crypto.randomUUID();
+    const resourceId = crypto.randomUUID();
     const observerOutput = `<observations>
 - User is prioritizing the extractor API and needs documentation coverage.
 </observations>

--- a/packages/memory/integration-tests/src/performance-testing/performance-tests.ts
+++ b/packages/memory/integration-tests/src/performance-testing/performance-tests.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { faker } from '@faker-js/faker';
 import type { Memory } from '@mastra/memory';
 import type { TextPart, ImagePart, FilePart, ToolCallPart } from 'ai';
@@ -7,7 +6,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 const resourceId = 'resource';
 // Test helpers
 const createTestThread = (title: string, metadata = {}) => ({
-  id: randomUUID(),
+  id: crypto.randomUUID(),
   title,
   resourceId,
   metadata,
@@ -24,7 +23,7 @@ const createTestMessage = (
 ) => {
   messageCounter++;
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     threadId,
     content,
     role,

--- a/packages/memory/integration-tests/src/performance-testing/with-upstash-storage.test.ts
+++ b/packages/memory/integration-tests/src/performance-testing/with-upstash-storage.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { createServer } from 'node:net';
@@ -103,7 +102,7 @@ describe('Memory with UpstashStore Performance', () => {
       }),
       vector: new LibSQLVector({
         url: `file:${join(dbPath, 'perf-upstash-vector.db')}`,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
       }),
       embedder: fastembed.small,
       options: {

--- a/packages/memory/integration-tests/src/save-messages-vector-metadata.test.ts
+++ b/packages/memory/integration-tests/src/save-messages-vector-metadata.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { fastembed } from '@mastra/fastembed';
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
@@ -16,10 +15,10 @@ describe('saveMessages should persist role/content/created_at into vector metada
   let storage: LibSQLStore;
   let vector: LibSQLVector;
   let threadId: string;
-  const resourceId = `test-resource-${randomUUID()}`;
+  const resourceId = `test-resource-${crypto.randomUUID()}`;
 
   beforeEach(async () => {
-    const uniqueId = randomUUID();
+    const uniqueId = crypto.randomUUID();
     const dbFile = `file:/tmp/test-${uniqueId}.db`;
 
     storage = new LibSQLStore({ id: `save-msg-storage-${uniqueId}`, url: dbFile });
@@ -38,7 +37,7 @@ describe('saveMessages should persist role/content/created_at into vector metada
 
     const thread = await memory.saveThread({
       thread: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         title: 'Save Message Vector Metadata Test',
         resourceId,
         metadata: {},
@@ -64,7 +63,7 @@ describe('saveMessages should persist role/content/created_at into vector metada
     const text = 'I prefer morning meetings.';
     const createdAt = new Date('2026-01-01T12:00:00.000Z');
     const message = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       threadId,
       content: { format: 2 as const, parts: [{ type: 'text' as const, text }] },
       role: 'user' as const,
@@ -104,7 +103,7 @@ describe('saveMessages should persist role/content/created_at into vector metada
 
     const createdAt = new Date('2026-02-02T08:00:00.000Z');
     const message = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       threadId,
       content: { format: 2 as const, parts: [{ type: 'text' as const, text: longText }] },
       role: 'assistant' as const,

--- a/packages/memory/integration-tests/src/semantic-recall-metadata-filter.test.ts
+++ b/packages/memory/integration-tests/src/semantic-recall-metadata-filter.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -24,7 +23,7 @@ function createThread(id: string, metadata: Record<string, unknown>) {
 
 function createMessage(threadId: string, text: string, role: 'user' | 'assistant' = 'user'): MastraDBMessage {
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     threadId,
     resourceId,
     role,
@@ -50,11 +49,11 @@ describe('Semantic recall with metadata filtering', () => {
     const dbPath = join(await mkdtemp(join(tmpdir(), 'memory-metadata-filter-test-')), 'test.db');
 
     const storage = new LibSQLStore({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       url: `file:${dbPath}`,
     });
     const vector = new LibSQLVector({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       url: `file:${dbPath}`,
     });
 

--- a/packages/memory/integration-tests/src/shared/agent-memory.ts
+++ b/packages/memory/integration-tests/src/shared/agent-memory.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -214,7 +213,7 @@ export async function getAgentMemoryTests({
       const resourceId = 'test-resource-semantic';
 
       // First, create a thread and add some messages to establish history
-      const thread1Id = randomUUID();
+      const thread1Id = crypto.randomUUID();
 
       await agentGenerate(agent, 'Tell me about cats', { threadId: thread1Id, resourceId }, model);
 
@@ -224,7 +223,7 @@ export async function getAgentMemoryTests({
 
       // Now create a second thread - this should be able to access memory from thread1
       // due to resource scope, even on the first message
-      const thread2Id = randomUUID();
+      const thread2Id = crypto.randomUUID();
 
       const secondResponse = (await agentGenerate(
         agent,
@@ -270,7 +269,7 @@ export async function getAgentMemoryTests({
       tools,
     });
     it('should save all user messages (not just the most recent)', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'all-user-messages';
 
       // Send multiple user messages
@@ -299,7 +298,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should save assistant responses for both text and object output modes', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'assistant-responses';
       // 1. Text mode
       await agentGenerate(agent, [{ role: 'user', content: 'What is 2+2?' }], { threadId, resourceId }, model);
@@ -330,7 +329,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should not save messages provided in the context option', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'context-option-messages-not-saved';
 
       const userMessageContent = 'This is a user message.';
@@ -372,7 +371,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should persist UIMessageWithMetadata through agent generate and memory', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'ui-message-metadata';
 
       // Create messages with metadata
@@ -470,7 +469,7 @@ export async function getAgentMemoryTests({
           memory,
         });
 
-        const threadId = randomUUID();
+        const threadId = crypto.randomUUID();
         const resourceId = 'test-resource-reasoning';
 
         const result = (await agentGenerate(
@@ -575,7 +574,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should preserve metadata when generateTitle is true', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'gen-title-metadata';
       const metadata = { foo: 'bar', custom: 123 };
 
@@ -608,7 +607,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should use generateTitle with request context', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'gen-title-with-request-context';
       const metadata = { foo: 'bar', custom: 123 };
 
@@ -647,7 +646,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should preserve metadata when generateTitle is false', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'no-gen-title-metadata';
       const metadata = { foo: 'baz', custom: 456 };
 
@@ -705,7 +704,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should apply processors to filter tool messages from context', async () => {
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'processor-filter-tool-message';
 
       // First, ask a question that will trigger a tool call
@@ -822,7 +821,7 @@ export async function getAgentMemoryTests({
         memory: memoryWithWorkingMemory,
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'test-resource-wm';
 
       // First, set working memory
@@ -927,7 +926,7 @@ export async function getAgentMemoryTests({
         memory: inputProcessorMemory,
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'input-processor-resource';
 
       // First message
@@ -1008,7 +1007,7 @@ export async function getAgentMemoryTests({
         outputProcessors: [abortingGuardrail],
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'guardrail-memory-test';
 
       // Generate should complete but with tripwire
@@ -1055,7 +1054,7 @@ export async function getAgentMemoryTests({
         outputProcessors: [passingGuardrail],
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'passing-guardrail-memory-test';
 
       // Generate should complete normally
@@ -1114,7 +1113,7 @@ export async function getAgentMemoryTests({
         inputProcessors: [inputAbortingGuardrail],
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'input-guardrail-memory-test';
 
       // Generate should complete but with tripwire (no LLM call made)
@@ -1164,7 +1163,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should clone a thread with all messages', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-test-resource';
 
       // Create a conversation in the source thread
@@ -1199,7 +1198,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should clone a thread with custom title', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-custom-title-resource';
 
       // Create source thread with a message
@@ -1216,7 +1215,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should clone a thread with message limit', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-limit-resource';
 
       // Create multiple messages
@@ -1239,7 +1238,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should allow continuing conversation on cloned thread independently', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-continue-resource';
 
       // Create initial conversation
@@ -1272,8 +1271,8 @@ export async function getAgentMemoryTests({
     });
 
     it('should clone thread with custom thread ID', async () => {
-      const sourceThreadId = randomUUID();
-      const customCloneId = `custom-clone-${randomUUID()}`;
+      const sourceThreadId = crypto.randomUUID();
+      const customCloneId = `custom-clone-${crypto.randomUUID()}`;
       const resourceId = 'clone-custom-id-resource';
 
       // Create source thread
@@ -1289,7 +1288,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should use utility methods to check clone status', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-utility-resource';
 
       // Create source thread
@@ -1323,7 +1322,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should list all clones of a source thread', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-list-resource';
 
       // Create source thread
@@ -1342,7 +1341,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should track clone history chain', async () => {
-      const originalThreadId = randomUUID();
+      const originalThreadId = crypto.randomUUID();
       const resourceId = 'clone-history-resource';
 
       // Create original thread
@@ -1369,7 +1368,7 @@ export async function getAgentMemoryTests({
     });
 
     it('should create embeddings for cloned messages that are searchable via semantic recall', async () => {
-      const sourceThreadId = randomUUID();
+      const sourceThreadId = crypto.randomUUID();
       const resourceId = 'clone-embedding-resource';
 
       // Create a unique, memorable message in the source thread

--- a/packages/memory/integration-tests/src/shared/input-processors.ts
+++ b/packages/memory/integration-tests/src/shared/input-processors.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { Agent } from '@mastra/core/agent';
 import { MockStore } from '@mastra/core/storage';
 import { fastembed } from '@mastra/fastembed';
@@ -29,7 +28,7 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
 
   describe(`Input Processor Verification - MessageHistory (${version})`, () => {
     it('should run MessageHistory input processor and include previous messages in LLM request', async () => {
-      const testStorage = new MockStore({ id: `mock-store-${randomUUID()}` });
+      const testStorage = new MockStore({ id: `mock-store-${crypto.randomUUID()}` });
       const memory = new Memory({
         storage: testStorage,
         options: {
@@ -40,15 +39,15 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `message-history-test-${version}-${randomUUID()}`,
+        id: `message-history-test-${version}-${crypto.randomUUID()}`,
         name: 'Message History Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const threadId = `msg-history-${version}-${randomUUID()}`;
-      const resourceId = `message-history-resource-${version}-${randomUUID()}`;
+      const threadId = `msg-history-${version}-${crypto.randomUUID()}`;
+      const resourceId = `message-history-resource-${version}-${crypto.randomUUID()}`;
 
       // First message
       await agent.generate('My name is Alice', {
@@ -113,7 +112,7 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
     });
 
     it('should respect lastMessages limit in MessageHistory processor', async () => {
-      const testStorage = new MockStore({ id: `mock-store-${randomUUID()}` });
+      const testStorage = new MockStore({ id: `mock-store-${crypto.randomUUID()}` });
 
       const memory = new Memory({
         storage: testStorage,
@@ -125,15 +124,15 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `message-history-limit-test-${version}-${randomUUID()}`,
+        id: `message-history-limit-test-${version}-${crypto.randomUUID()}`,
         name: 'Message History Limit Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const threadId = `msg-limit-${version}-${randomUUID()}`;
-      const resourceId = `limit-test-resource-${version}-${randomUUID()}`;
+      const threadId = `msg-limit-${version}-${crypto.randomUUID()}`;
+      const resourceId = `limit-test-resource-${version}-${crypto.randomUUID()}`;
 
       // Create 3 exchanges (6 messages total)
       await agent.generate('Message 1', { memory: { thread: threadId, resource: resourceId }, maxSteps: 1 });
@@ -187,7 +186,7 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
   describe(`Input Processor Verification - WorkingMemory (${version})`, () => {
     it('should run WorkingMemory input processor and include working memory in LLM request', async () => {
       const memory = new Memory({
-        storage: new MockStore({ id: `mock-store-${randomUUID()}` }),
+        storage: new MockStore({ id: `mock-store-${crypto.randomUUID()}` }),
         options: {
           workingMemory: {
             enabled: true,
@@ -198,15 +197,15 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `working-memory-test-${version}-${randomUUID()}`,
+        id: `working-memory-test-${version}-${crypto.randomUUID()}`,
         name: 'Working Memory Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const threadId = `wm-${version}-${randomUUID()}`;
-      const resourceId = `working-memory-resource-${version}-${randomUUID()}`;
+      const threadId = `wm-${version}-${crypto.randomUUID()}`;
+      const resourceId = `working-memory-resource-${version}-${crypto.randomUUID()}`;
 
       // Set working memory
       await memory.updateWorkingMemory({
@@ -262,7 +261,7 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       };
 
       const memory = new Memory({
-        storage: new MockStore({ id: `mock-store-${randomUUID()}` }),
+        storage: new MockStore({ id: `mock-store-${crypto.randomUUID()}` }),
         options: {
           workingMemory: {
             enabled: true,
@@ -274,15 +273,15 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `custom-template-test-${version}-${randomUUID()}`,
+        id: `custom-template-test-${version}-${crypto.randomUUID()}`,
         name: 'Custom Template Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const threadId = `custom-template-${version}-${randomUUID()}`;
-      const resourceId = `custom-template-resource-${version}-${randomUUID()}`;
+      const threadId = `custom-template-${version}-${crypto.randomUUID()}`;
+      const resourceId = `custom-template-resource-${version}-${crypto.randomUUID()}`;
 
       await memory.updateWorkingMemory({
         threadId,
@@ -317,12 +316,12 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       // Use shared in-memory database so storage and vector use the same DB
       const dbFile = 'file::memory:?cache=shared';
       const storage = new LibSQLStore({
-        id: `semantic-recall-storage-${version}-${randomUUID()}`,
+        id: `semantic-recall-storage-${version}-${crypto.randomUUID()}`,
         url: dbFile,
       });
       const vector = new LibSQLVector({
         url: dbFile,
-        id: `semantic-recall-vector-${version}-${randomUUID()}`,
+        id: `semantic-recall-vector-${version}-${crypto.randomUUID()}`,
       });
 
       // Initialize storage to create tables
@@ -345,16 +344,16 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `semantic-recall-test-${version}-${randomUUID()}`,
+        id: `semantic-recall-test-${version}-${crypto.randomUUID()}`,
         name: 'Semantic Recall Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const resourceId = `semantic-recall-resource-${version}-${randomUUID()}`;
-      const thread1Id = `semantic-thread-1-${version}-${randomUUID()}`;
-      const thread2Id = `semantic-thread-2-${version}-${randomUUID()}`;
+      const resourceId = `semantic-recall-resource-${version}-${crypto.randomUUID()}`;
+      const thread1Id = `semantic-thread-1-${version}-${crypto.randomUUID()}`;
+      const thread2Id = `semantic-thread-2-${version}-${crypto.randomUUID()}`;
 
       // Thread 1: Discuss Python programming
       await agent.generate('I love programming in Python, especially for data science', {
@@ -395,12 +394,12 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       // Use shared in-memory database so storage and vector use the same DB
       const dbFile = 'file::memory:?cache=shared';
       const storage = new LibSQLStore({
-        id: `semantic-topk-storage-${version}-${randomUUID()}`,
+        id: `semantic-topk-storage-${version}-${crypto.randomUUID()}`,
         url: dbFile,
       });
       const vector = new LibSQLVector({
         url: dbFile,
-        id: `semantic-topk-vector-${version}-${randomUUID()}`,
+        id: `semantic-topk-vector-${version}-${crypto.randomUUID()}`,
       });
 
       // Initialize storage to create tables
@@ -423,16 +422,16 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `semantic-topk-test-${version}-${randomUUID()}`,
+        id: `semantic-topk-test-${version}-${crypto.randomUUID()}`,
         name: 'Semantic TopK Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const resourceId = `topk-resource-${version}-${randomUUID()}`;
-      const thread1Id = `topk-thread-1-${version}-${randomUUID()}`;
-      const thread2Id = `topk-thread-2-${version}-${randomUUID()}`;
+      const resourceId = `topk-resource-${version}-${crypto.randomUUID()}`;
+      const thread1Id = `topk-thread-1-${version}-${crypto.randomUUID()}`;
+      const thread2Id = `topk-thread-2-${version}-${crypto.randomUUID()}`;
 
       // Create multiple messages in thread 1
       await agent.generate('I like cats', { memory: { thread: thread1Id, resource: resourceId } });
@@ -458,12 +457,12 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
     it('should only fetch semantically matched messages, not all thread messages', async () => {
       const dbFile = 'file::memory:?cache=shared';
       const storage = new LibSQLStore({
-        id: `semantic-perpage-storage-${version}-${randomUUID()}`,
+        id: `semantic-perpage-storage-${version}-${crypto.randomUUID()}`,
         url: dbFile,
       });
       const vector = new LibSQLVector({
         url: dbFile,
-        id: `semantic-perpage-vector-${version}-${randomUUID()}`,
+        id: `semantic-perpage-vector-${version}-${crypto.randomUUID()}`,
       });
 
       await storage.init();
@@ -480,15 +479,15 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
 
       const mockModel = createMockModel(config);
       const agent = new Agent({
-        id: `semantic-perpage-test-${version}-${randomUUID()}`,
+        id: `semantic-perpage-test-${version}-${crypto.randomUUID()}`,
         name: 'Semantic PerPage Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const resourceId = `perpage-resource-${version}-${randomUUID()}`;
-      const threadId = `perpage-thread-${version}-${randomUUID()}`;
+      const resourceId = `perpage-resource-${version}-${crypto.randomUUID()}`;
+      const threadId = `perpage-thread-${version}-${crypto.randomUUID()}`;
 
       // Create 4 messages with distinct topics
       await agent.generate('I really love apples, they are my favorite fruit', {
@@ -536,12 +535,12 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       // Use shared in-memory database so storage and vector use the same DB
       const dbFile = 'file::memory:?cache=shared';
       const storage = new LibSQLStore({
-        id: `combined-storage-${version}-${randomUUID()}`,
+        id: `combined-storage-${version}-${crypto.randomUUID()}`,
         url: dbFile,
       });
       const vector = new LibSQLVector({
         url: dbFile,
-        id: `combined-vector-${version}-${randomUUID()}`,
+        id: `combined-vector-${version}-${crypto.randomUUID()}`,
       });
 
       // Initialize storage to create tables
@@ -567,16 +566,16 @@ export function getInputProcessorsTests(config: InputProcessorsTestConfig) {
       const mockModel = createMockModel(config);
 
       const agent = new Agent({
-        id: `combined-test-${version}-${randomUUID()}`,
+        id: `combined-test-${version}-${crypto.randomUUID()}`,
         name: 'Combined Test',
         instructions: 'You are a helpful assistant',
         model: mockModel,
         memory,
       });
 
-      const resourceId = `combined-resource-${version}-${randomUUID()}`;
-      const thread1Id = `combined-thread-1-${version}-${randomUUID()}`;
-      const thread2Id = `combined-thread-2-${version}-${randomUUID()}`;
+      const resourceId = `combined-resource-${version}-${crypto.randomUUID()}`;
+      const thread1Id = `combined-thread-1-${version}-${crypto.randomUUID()}`;
+      const thread2Id = `combined-thread-2-${version}-${crypto.randomUUID()}`;
 
       // Set working memory
       await memory.updateWorkingMemory({

--- a/packages/memory/integration-tests/src/shared/message-ordering.ts
+++ b/packages/memory/integration-tests/src/shared/message-ordering.ts
@@ -13,7 +13,6 @@
  *
  * Tests run with OpenAI models.
  */
-import { randomUUID } from 'node:crypto';
 import { Agent } from '@mastra/core/agent';
 import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
 import type { MastraModelConfig } from '@mastra/core/llm';
@@ -192,7 +191,7 @@ export function getMessageOrderingTests(config: MessageOrderingTestConfig) {
   for (const modelConfig of models) {
     describe(`Message Ordering with ${modelConfig.name} (${version}) (Issue #9909)`, () => {
       const createMemory = () => {
-        const testId = randomUUID();
+        const testId = crypto.randomUUID();
 
         return new Memory({
           options: { lastMessages: 20 },
@@ -216,8 +215,8 @@ export function getMessageOrderingTests(config: MessageOrderingTestConfig) {
           tools,
         });
 
-        const threadId = randomUUID();
-        const resourceId = `ordering-test-user-${randomUUID()}`;
+        const threadId = crypto.randomUUID();
+        const resourceId = `ordering-test-user-${crypto.randomUUID()}`;
 
         console.info('\n========================================');
         console.info(`TEST: Stream -> Raw Storage -> Recall (${modelConfig.name} ${version})`);
@@ -362,8 +361,8 @@ export function getMessageOrderingTests(config: MessageOrderingTestConfig) {
           tools,
         });
 
-        const threadId = randomUUID();
-        const resourceId = `multi-tool-test-${randomUUID()}`;
+        const threadId = crypto.randomUUID();
+        const resourceId = `multi-tool-test-${crypto.randomUUID()}`;
 
         console.info('\n========================================');
         console.info(`TEST: Multiple Tool Calls Ordering (${modelConfig.name} ${version})`);
@@ -459,8 +458,8 @@ export function getMessageOrderingTests(config: MessageOrderingTestConfig) {
           tools,
         });
 
-        const threadId = randomUUID();
-        const resourceId = `exact-match-test-${randomUUID()}`;
+        const threadId = crypto.randomUUID();
+        const resourceId = `exact-match-test-${crypto.randomUUID()}`;
 
         console.info('\n========================================');
         console.info(`TEST: Exact Stream-Storage Match (${modelConfig.name} ${version})`);

--- a/packages/memory/integration-tests/src/shared/reusable-tests.ts
+++ b/packages/memory/integration-tests/src/shared/reusable-tests.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import * as path from 'node:path';
 import { Worker } from 'node:worker_threads';
 import { MessageList } from '@mastra/core/agent';
@@ -31,7 +30,7 @@ interface WorkerTestConfig {
 const createTestThread = (title: string, metadata = {}, i = 0) => {
   const now = Date.now();
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     title,
     resourceId,
     metadata,
@@ -58,7 +57,7 @@ const createTestMessage = (
   }
 
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     threadId,
     content: {
       format: 2,
@@ -704,7 +703,7 @@ export function getResuableTests(optionsFactory: () => { memory: Memory; workerT
       });
 
       it('should handle deleting non-existent message gracefully', async () => {
-        const nonExistentId = randomUUID();
+        const nonExistentId = crypto.randomUUID();
 
         // Should not throw when deleting non-existent message
         await expect(memory.deleteMessages([nonExistentId])).resolves.not.toThrow();
@@ -1131,7 +1130,7 @@ export function getResuableTests(optionsFactory: () => { memory: Memory; workerT
     ): ObservationalMemoryRecord => {
       const now = new Date();
       return {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         scope: overrides.scope,
         threadId: overrides.threadId,
         resourceId: overrides.resourceId,
@@ -1273,7 +1272,7 @@ export function getResuableTests(optionsFactory: () => { memory: Memory; workerT
 
         const chunkDate = new Date();
         const chunk1: BufferedObservationChunk = {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           cycleId: 'cycle-1',
           observations: 'Chunk 1 observations',
           tokenCount: 20,
@@ -1283,7 +1282,7 @@ export function getResuableTests(optionsFactory: () => { memory: Memory; workerT
           createdAt: chunkDate,
         };
         const chunk2: BufferedObservationChunk = {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           cycleId: 'cycle-2',
           observations: 'Chunk 2 observations',
           tokenCount: 15,
@@ -1470,7 +1469,7 @@ export function getResuableTests(optionsFactory: () => { memory: Memory; workerT
         const store = await memory.storage.getStore('memory');
         if (!store?.supportsObservationalMemory) return;
 
-        const newResourceId = `om-clone-new-${randomUUID()}`;
+        const newResourceId = `om-clone-new-${crypto.randomUUID()}`;
 
         const sourceThread = createTestThread('Resource OM Clone Source');
         sourceThread.resourceId = omResourceId;

--- a/packages/memory/integration-tests/src/shared/streaming-memory.ts
+++ b/packages/memory/integration-tests/src/shared/streaming-memory.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { UUID } from 'node:crypto';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -42,8 +41,8 @@ export async function setupStreamingMemoryTest({
         tools,
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const isV5Plus = isV5PlusModel(model);
 
       const stream1 = (await agentStream(agent, 'what is the weather in LA?', { threadId, resourceId }, model)) as any;
@@ -129,13 +128,13 @@ export async function setupStreamingMemoryTest({
           memory: isolatedMemory,
         });
 
-        const threadId = randomUUID();
+        const threadId = crypto.randomUUID();
         const resourceId = 'test-resource-msg-id';
         const customIds: UUID[] = [];
 
         new Mastra({
           idGenerator: () => {
-            const id = randomUUID();
+            const id = crypto.randomUUID();
             customIds.push(id);
             return id;
           },
@@ -164,7 +163,7 @@ export async function setupStreamingMemoryTest({
       it('should preserve data-* parts through save → recall → UI conversion round-trip', async () => {
         const dbPath = join(await mkdtemp(join(tmpdir(), `streaming-memory-data-parts-${Date.now()}-`)), 'mastra.db');
         const isolatedMemory = (createIsolatedMemory ?? createMemory)(dbPath);
-        const threadId = randomUUID();
+        const threadId = crypto.randomUUID();
         const resourceId = 'test-data-parts-resource';
 
         await isolatedMemory.createThread({
@@ -175,7 +174,7 @@ export async function setupStreamingMemoryTest({
 
         const messagesWithDataParts = [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'user' as const,
@@ -186,7 +185,7 @@ export async function setupStreamingMemoryTest({
             createdAt: new Date(),
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'assistant' as const,
@@ -207,7 +206,7 @@ export async function setupStreamingMemoryTest({
             createdAt: new Date(Date.now() + 1000),
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'assistant' as const,

--- a/packages/memory/integration-tests/src/shared/useChat.ts
+++ b/packages/memory/integration-tests/src/shared/useChat.ts
@@ -1,5 +1,4 @@
 import { spawn } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import { mkdtemp } from 'node:fs/promises';
 import { createServer } from 'node:net';
 import { tmpdir } from 'node:os';
@@ -57,7 +56,7 @@ export function setupUseChatV4() {
     let port: number;
     let agent: ReturnType<typeof createWeatherAgent>;
     let dbPath: string;
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     beforeAll(async () => {
@@ -171,7 +170,7 @@ export function setupUseChatV4() {
 
     it('should stream useChat with client side tool calling', async () => {
       let error: Error | null = null;
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
 
       await agent.generateLegacy(`hi`, {
         threadId,
@@ -287,7 +286,7 @@ export function setupUseChatV5Plus({ useChatFunc, version }: { useChatFunc: any;
     let port: number;
     let agent: ReturnType<typeof createWeatherAgentV5>;
     let dbPath: string;
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     beforeAll(async () => {
@@ -404,7 +403,7 @@ export function setupUseChatV5Plus({ useChatFunc, version }: { useChatFunc: any;
 
     it('should stream useChat with client side tool calling', async () => {
       let error: Error | null = null;
-      const localThreadId = randomUUID();
+      const localThreadId = crypto.randomUUID();
 
       await agent.generate(`hi`, {
         memory: { thread: localThreadId, resource: resourceId },
@@ -532,7 +531,7 @@ export function setupUseChatV5Plus({ useChatFunc, version }: { useChatFunc: any;
     });
 
     it('should not create duplicate assistant messages', async () => {
-      const testThreadId = randomUUID();
+      const testThreadId = crypto.randomUUID();
       const testResourceId = 'test-user-exact-flow-11091';
       const mastraClient = new MastraClient({ baseUrl: `http://localhost:${port}` });
 

--- a/packages/memory/integration-tests/src/shared/with-pg-storage.ts
+++ b/packages/memory/integration-tests/src/shared/with-pg-storage.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { anthropic as anthropicV6 } from '@ai-sdk/anthropic-v6';
 import { createGatewayMock } from '@internal/test-utils';
 import { toAISdkV5Messages } from '@mastra/ai-sdk/ui';
@@ -192,7 +191,7 @@ export function getPgStorageTests(connectionString: string) {
 
   getResuableTests(() => {
     const storage = new PostgresStore({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       ...config,
       ...poolLimits,
     });
@@ -219,7 +218,7 @@ export function getPgStorageTests(connectionString: string) {
 
   describe('Memory with PostgresStore Integration', () => {
     const integrationStorage = new PostgresStore({
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       ...config,
       ...poolLimits,
     });
@@ -291,7 +290,7 @@ export function getPgStorageTests(connectionString: string) {
         }
       });
       it('should create and retrieve a thread', async () => {
-        const threadId = randomUUID();
+        const threadId = crypto.randomUUID();
         const thread = await memory.createThread({
           threadId,
           resourceId,
@@ -310,12 +309,12 @@ export function getPgStorageTests(connectionString: string) {
       it('should list threads by resource id', async () => {
         // Create multiple threads
         await memory.createThread({
-          threadId: randomUUID(),
+          threadId: crypto.randomUUID(),
           resourceId,
           title: 'Thread 1',
         });
         await memory.createThread({
-          threadId: randomUUID(),
+          threadId: crypto.randomUUID(),
           resourceId,
           title: 'Thread 2',
         });
@@ -335,7 +334,7 @@ export function getPgStorageTests(connectionString: string) {
       let threadId: string;
 
       beforeEach(async () => {
-        threadId = randomUUID();
+        threadId = crypto.randomUUID();
         await memory.createThread({
           threadId,
           resourceId,
@@ -346,7 +345,7 @@ export function getPgStorageTests(connectionString: string) {
       it('should save and recall messages', async () => {
         const messages = [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'user' as const,
@@ -357,7 +356,7 @@ export function getPgStorageTests(connectionString: string) {
             createdAt: new Date(),
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'assistant' as const,
@@ -385,7 +384,7 @@ export function getPgStorageTests(connectionString: string) {
       it('should respect lastMessages limit', async () => {
         // Create 15 messages
         const messages = Array.from({ length: 15 }, (_, i) => ({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           threadId,
           resourceId,
           role: 'user' as const,
@@ -413,7 +412,7 @@ export function getPgStorageTests(connectionString: string) {
       let threadId: string;
 
       beforeEach(async () => {
-        threadId = randomUUID();
+        threadId = crypto.randomUUID();
         await memory.createThread({
           threadId,
           resourceId,
@@ -424,7 +423,7 @@ export function getPgStorageTests(connectionString: string) {
       it('should find semantically similar messages', async () => {
         const messages = [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'user' as const,
@@ -435,7 +434,7 @@ export function getPgStorageTests(connectionString: string) {
             createdAt: new Date(),
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'assistant' as const,
@@ -446,7 +445,7 @@ export function getPgStorageTests(connectionString: string) {
             createdAt: new Date(Date.now() + 1000),
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             role: 'user' as const,
@@ -494,7 +493,7 @@ export function getPgStorageTests(connectionString: string) {
         // Create a fresh thread for testing
         const thread = await memory.saveThread({
           thread: {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             title: 'Pagination Test Thread',
             resourceId,
             metadata: {},
@@ -510,7 +509,7 @@ export function getPgStorageTests(connectionString: string) {
         const messages = [];
         for (let i = 0; i < 10; i++) {
           messages.push({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             content: {
@@ -617,7 +616,7 @@ export function getPgStorageTests(connectionString: string) {
         const messages = [];
         for (let i = 0; i < 3; i++) {
           messages.push({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId,
             content: `Message ${i + 1}`,
@@ -655,7 +654,7 @@ export function getPgStorageTests(connectionString: string) {
     describe('PostgreSQL Vector Index Configuration', () => {
       it('should support HNSW index configuration', async () => {
         const hnswMemory = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -675,8 +674,8 @@ export function getPgStorageTests(connectionString: string) {
           },
         });
 
-        const threadId = randomUUID();
-        const testResourceId = randomUUID();
+        const threadId = crypto.randomUUID();
+        const testResourceId = crypto.randomUUID();
 
         // Create thread first
         await hnswMemory.createThread({
@@ -688,7 +687,7 @@ export function getPgStorageTests(connectionString: string) {
         await hnswMemory.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'Test message for HNSW index' as any,
               role: 'user',
               createdAt: new Date(),
@@ -711,7 +710,7 @@ export function getPgStorageTests(connectionString: string) {
 
       it('should support IVFFlat index configuration with custom lists', async () => {
         const ivfflatMemory = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -730,8 +729,8 @@ export function getPgStorageTests(connectionString: string) {
           },
         });
 
-        const threadId = randomUUID();
-        const testResourceId = randomUUID();
+        const threadId = crypto.randomUUID();
+        const testResourceId = crypto.randomUUID();
 
         // Create thread first
         await ivfflatMemory.createThread({
@@ -743,7 +742,7 @@ export function getPgStorageTests(connectionString: string) {
         await ivfflatMemory.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'Test message for IVFFlat index' as any,
               role: 'user',
               createdAt: new Date(),
@@ -766,7 +765,7 @@ export function getPgStorageTests(connectionString: string) {
 
       it('should support flat (no index) configuration', async () => {
         const flatMemory = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -782,8 +781,8 @@ export function getPgStorageTests(connectionString: string) {
           },
         });
 
-        const threadId = randomUUID();
-        const testResourceId = randomUUID();
+        const threadId = crypto.randomUUID();
+        const testResourceId = crypto.randomUUID();
 
         // Create thread first
         await flatMemory.createThread({
@@ -795,7 +794,7 @@ export function getPgStorageTests(connectionString: string) {
         await flatMemory.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'Test message for flat scan' as any,
               role: 'user',
               createdAt: new Date(),
@@ -819,7 +818,7 @@ export function getPgStorageTests(connectionString: string) {
       it('should handle index configuration changes', async () => {
         // Start with IVFFlat
         const memory1 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -834,14 +833,14 @@ export function getPgStorageTests(connectionString: string) {
           },
         });
 
-        const threadId = randomUUID();
-        const testResourceId = randomUUID();
+        const threadId = crypto.randomUUID();
+        const testResourceId = crypto.randomUUID();
 
         await memory1.createThread({ threadId, resourceId: testResourceId });
         await memory1.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'First configuration' as any,
               role: 'user',
               createdAt: new Date(),
@@ -854,7 +853,7 @@ export function getPgStorageTests(connectionString: string) {
 
         // Now switch to HNSW - should trigger index recreation
         const memory2 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -873,7 +872,7 @@ export function getPgStorageTests(connectionString: string) {
         await memory2.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'Second configuration with HNSW' as any,
               role: 'user',
               createdAt: new Date(),
@@ -895,7 +894,7 @@ export function getPgStorageTests(connectionString: string) {
       it('should preserve existing index when no config provided', async () => {
         // First, create with HNSW
         const memory1 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -911,14 +910,14 @@ export function getPgStorageTests(connectionString: string) {
           },
         });
 
-        const threadId = randomUUID();
-        const testResourceId = randomUUID();
+        const threadId = crypto.randomUUID();
+        const testResourceId = crypto.randomUUID();
 
         await memory1.createThread({ threadId, resourceId: testResourceId });
         await memory1.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'HNSW index created' as any,
               role: 'user',
               createdAt: new Date(),
@@ -931,7 +930,7 @@ export function getPgStorageTests(connectionString: string) {
 
         // Create another memory instance without index config - should preserve HNSW
         const memory2 = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           vector: new PgVector({ connectionString, id: 'test-vector', ...poolLimits }),
           embedder: fastembed,
           options: {
@@ -946,7 +945,7 @@ export function getPgStorageTests(connectionString: string) {
         await memory2.saveMessages({
           messages: [
             {
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               content: 'Should still use HNSW index' as any,
               role: 'user',
               createdAt: new Date(),
@@ -970,7 +969,7 @@ export function getPgStorageTests(connectionString: string) {
       // PR-added regression repro. Kept skipped by default because CI currently falls back to
       // fuzzy llm-recorder matches for this path, which makes the recorded tool-heavy run unstable.
       it.skip('splits buffered output into multiple assistant messages instead of one mega-message', async () => {
-        const storage = new PostgresStore({ id: randomUUID(), ...config, ...poolLimits });
+        const storage = new PostgresStore({ id: crypto.randomUUID(), ...config, ...poolLimits });
         const memory = createMemoryWithCleanup({
           storage,
           options: {
@@ -1222,14 +1221,14 @@ CRITICAL RULES:
         // This breaks conversation history for any thread that exceeds lastMessages.
 
         const memoryWithLimit = createMemoryWithCleanup({
-          storage: new PostgresStore({ ...config, id: randomUUID(), ...poolLimits }),
+          storage: new PostgresStore({ ...config, id: crypto.randomUUID(), ...poolLimits }),
           options: {
             lastMessages: 3, // Limit to 3 messages
           },
         });
 
-        const threadId = randomUUID();
-        const testResourceId = randomUUID();
+        const threadId = crypto.randomUUID();
+        const testResourceId = crypto.randomUUID();
 
         // Create thread
         await memoryWithLimit.createThread({
@@ -1243,7 +1242,7 @@ CRITICAL RULES:
         const baseTime = Date.now();
         for (let i = 1; i <= 10; i++) {
           messages.push({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             resourceId: testResourceId,
             content: {

--- a/packages/memory/integration-tests/src/shared/working-memory-additive.ts
+++ b/packages/memory/integration-tests/src/shared/working-memory-additive.ts
@@ -5,7 +5,6 @@
  * These tests verify that schema-based working memory uses MERGE semantics (PATCH),
  * preserving existing data when new data is added across multiple conversation turns.
  */
-import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -47,7 +46,7 @@ async function agentGenerate(
 }
 
 const createTestThread = (title: string, metadata = {}) => ({
-  id: randomUUID(),
+  id: crypto.randomUUID(),
   title,
   resourceId,
   metadata,

--- a/packages/memory/integration-tests/src/shared/working-memory.ts
+++ b/packages/memory/integration-tests/src/shared/working-memory.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
@@ -70,7 +69,7 @@ const createTestThread = (title: string, metadata = {}) => ({
 const createTestMessage = (threadId: string, content: string, role: 'user' | 'assistant' = 'user'): MastraDBMessage => {
   messageCounter++;
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     threadId,
     content: {
       format: 2,
@@ -431,7 +430,7 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
           createTestMessage(threadId, 'User says something'),
           // Pure tool-call message (should be removed)
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             role: 'assistant',
             content: {
@@ -440,7 +439,7 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
                 {
                   type: 'tool-invocation',
                   toolInvocation: {
-                    toolCallId: randomUUID(),
+                    toolCallId: crypto.randomUUID(),
                     toolName: 'updateWorkingMemory',
                     args: {},
                     state: 'result',
@@ -454,7 +453,7 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
           } as MastraDBMessage,
           // Mixed content: tool-call + text (tool-call part should be filtered, text kept)
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             role: 'assistant',
             content: {
@@ -463,7 +462,7 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
                 {
                   type: 'tool-invocation',
                   toolInvocation: {
-                    toolCallId: randomUUID(),
+                    toolCallId: crypto.randomUUID(),
                     toolName: 'updateWorkingMemory',
                     args: { memory: 'should not persist' },
                     state: 'result',
@@ -481,7 +480,7 @@ export function getWorkingMemoryTests(model: MastraModelConfig) {
           } as MastraDBMessage,
           // Pure text message (should be kept)
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             threadId,
             role: 'assistant',
             content: {
@@ -1711,7 +1710,7 @@ function runWorkingMemoryNetworkTests(getMemory: () => Memory, model: MastraMode
         memory,
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
 
       const result = await networkAgent.network('My email is test@example.com', {
         memory: { thread: threadId, resource: resourceId },

--- a/packages/memory/integration-tests/src/storage-init.test.ts
+++ b/packages/memory/integration-tests/src/storage-init.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import { Agent } from '@mastra/core/agent';
 import { Mastra } from '@mastra/core/mastra';
@@ -202,7 +201,7 @@ describe('Storage domain init during agent.stream with LibSQL', () => {
       agents: { 'test-agent': agent },
     });
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-user';
 
     // Stream multiple times with memory enabled
@@ -267,13 +266,13 @@ describe('Storage domain init during agent.stream with LibSQL', () => {
     // Fire multiple concurrent stream calls (different threads but same storage)
     const streams = await Promise.all([
       agent.stream('Message 1', {
-        memory: { thread: randomUUID(), resource: resourceId },
+        memory: { thread: crypto.randomUUID(), resource: resourceId },
       }),
       agent.stream('Message 2', {
-        memory: { thread: randomUUID(), resource: resourceId },
+        memory: { thread: crypto.randomUUID(), resource: resourceId },
       }),
       agent.stream('Message 3', {
-        memory: { thread: randomUUID(), resource: resourceId },
+        memory: { thread: crypto.randomUUID(), resource: resourceId },
       }),
     ]);
 

--- a/packages/memory/integration-tests/src/update-messages-vector-sync.test.ts
+++ b/packages/memory/integration-tests/src/update-messages-vector-sync.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { fastembed } from '@mastra/fastembed';
 import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
 import { Memory } from '@mastra/memory';
@@ -19,11 +18,11 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
   let storage: LibSQLStore;
   let vector: LibSQLVector;
   let threadId: string;
-  const resourceId = `test-resource-${randomUUID()}`;
+  const resourceId = `test-resource-${crypto.randomUUID()}`;
 
   beforeEach(async () => {
     // Use a unique file-based database for each test to avoid state pollution
-    const uniqueId = randomUUID();
+    const uniqueId = crypto.randomUUID();
     const dbFile = `file:/tmp/test-${uniqueId}.db`;
 
     storage = new LibSQLStore({
@@ -55,7 +54,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
     // Create a thread for testing
     const thread = await memory.saveThread({
       thread: {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         title: 'Update Message Vector Test',
         resourceId,
         metadata: {},
@@ -81,7 +80,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
     // Step 1: Save a message with original content about "quantum physics"
     const originalContent = 'Quantum physics explores subatomic particles and wave functions in the universe.';
     const originalMessage = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       threadId,
       content: {
         format: 2 as const,
@@ -170,7 +169,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
   it('should delete vectors when message content is cleared', async () => {
     // Save a message with content
     const message = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       threadId,
       content: {
         format: 2 as const,
@@ -217,7 +216,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
   it('should handle updating multiple messages at once', async () => {
     // Create two messages about very different topics
     const message1 = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       threadId,
       content: {
         format: 2 as const,
@@ -229,7 +228,7 @@ describe('updateMessages should sync vector database (Issue #6195)', () => {
     };
 
     const message2 = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       threadId,
       content: {
         format: 2 as const,

--- a/packages/memory/integration-tests/src/with-libsql-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-libsql-storage.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -44,11 +43,11 @@ describe('Memory with LibSQL Integration', () => {
     memory = new Memory({
       storage: new LibSQLStore({
         url: `file:${join(dbStoragePath, 'test.db')}`,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
       }),
       vector: new LibSQLVector({
         url: 'file:libsql-test.db',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
       }),
       embedder: fastembed,
       options: memoryOptions,
@@ -64,11 +63,11 @@ describe('Memory with LibSQL Integration', () => {
       memory,
       workerTestConfig: {
         storageTypeForWorker: StorageType.LibSQL,
-        storageConfigForWorker: { url: `file:${join(dbStoragePath, 'libsql-test.db')}`, id: randomUUID() },
+        storageConfigForWorker: { url: `file:${join(dbStoragePath, 'libsql-test.db')}`, id: crypto.randomUUID() },
         memoryOptionsForWorker: memoryOptions,
         vectorConfigForWorker: {
           url: 'file:libsql-test.db',
-          id: randomUUID(),
+          id: crypto.randomUUID(),
         },
       },
     };
@@ -79,7 +78,7 @@ describe('Memory with LibSQL Integration', () => {
       const memoryWithLimit = new Memory({
         storage: new LibSQLStore({
           url: 'file:libsql-test.db',
-          id: randomUUID(),
+          id: crypto.randomUUID(),
         }),
         embedder: fastembed.small,
         options: {
@@ -87,8 +86,8 @@ describe('Memory with LibSQL Integration', () => {
         },
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       await memoryWithLimit.createThread({
         threadId,
@@ -99,7 +98,7 @@ describe('Memory with LibSQL Integration', () => {
       const baseTime = Date.now();
       for (let i = 1; i <= 10; i++) {
         messages.push({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           threadId,
           resourceId,
           content: {
@@ -152,7 +151,7 @@ describe('Memory with LibSQL Integration', () => {
       omDbPath = await mkdtemp(join(tmpdir(), 'memory-om-ordering-'));
       omStorage = new LibSQLStore({
         url: `file:${join(omDbPath, 'om-ordering.db')}`,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
       });
       await omStorage.init();
     });
@@ -202,7 +201,7 @@ describe('Memory with LibSQL Integration', () => {
 
     it('persists user then assistant with final text; monotonic createdAt; unique ids (no bufferTokens)', async () => {
       const agent = createOmAgent(false);
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
 
       await agent.generate('Please help me with something important.', {
         memory: { thread: threadId, resource: 'test-resource' },
@@ -225,7 +224,7 @@ describe('Memory with LibSQL Integration', () => {
 
     it('with bufferTokens, tool-invocation parts precede final text in storage order', async () => {
       const agent = createOmAgent(15);
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
 
       await agent.generate('Please help me with something important.', {
         memory: { thread: threadId, resource: 'test-resource' },
@@ -241,7 +240,7 @@ describe('Memory with LibSQL Integration', () => {
 
     it('second generate keeps both user messages ordered with unique ids (bufferTokens)', async () => {
       const agent = createOmAgent(15);
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
 
       await agent.generate('First message about flights.', {
         memory: { thread: threadId, resource: 'test-resource' },
@@ -264,7 +263,7 @@ describe('Memory with LibSQL Integration', () => {
 
     it('no duplicate user rows by content after two turns (bufferTokens)', async () => {
       const agent = createOmAgent(15);
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
 
       await agent.generate('Turn 1: search for restaurants.', {
         memory: { thread: threadId, resource: 'test-resource' },
@@ -287,7 +286,7 @@ describe('Memory with LibSQL Integration', () => {
      */
     it('persists post-seal assistant text under the rotated response message id (buffer beforeBuffer + LibSQL)', async () => {
       const memoryStore = (await omStorage.getStore('memory'))!;
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'om-14745-libsql-resource';
 
       await runOm14745RotationScenario({

--- a/packages/memory/integration-tests/src/with-upstash-storage.test.ts
+++ b/packages/memory/integration-tests/src/with-upstash-storage.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -50,7 +49,7 @@ describe('Memory with UpstashStore Integration', () => {
   const storageConfig = {
     url: 'http://localhost:8079',
     token: 'test_token',
-    id: randomUUID(),
+    id: crypto.randomUUID(),
   };
 
   getResuableTests(() => {
@@ -63,7 +62,7 @@ describe('Memory with UpstashStore Integration', () => {
       vector: new LibSQLVector({
         // TODO: use upstash vector in tests
         url: `file:${join(dbPath, 'upstash-test-vector.db')}`,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
       }),
       embedder: fastembed,
       options: memoryOptions,
@@ -91,8 +90,8 @@ describe('Memory with UpstashStore Integration', () => {
         },
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       await memoryWithLimit.createThread({
         threadId,
@@ -103,7 +102,7 @@ describe('Memory with UpstashStore Integration', () => {
       const baseTime = Date.now();
       for (let i = 1; i <= 10; i++) {
         messages.push({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           threadId,
           resourceId,
           content: {

--- a/packages/memory/src/processors/observational-memory/repro-capture.ts
+++ b/packages/memory/src/processors/observational-memory/repro-capture.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { inspect } from 'node:util';
@@ -244,7 +243,7 @@ function createOmReproCaptureDir(threadId: string, label: string): string {
     process.cwd(),
     getOmReproCaptureDir(),
     sanitizedThreadId,
-    `${Date.now()}-${label}-${randomUUID()}`,
+    `${Date.now()}-${label}-${crypto.randomUUID()}`,
   );
   mkdirSync(captureDir, { recursive: true });
   return captureDir;

--- a/packages/memory/src/processors/observational-memory/temporary-memory.ts
+++ b/packages/memory/src/processors/observational-memory/temporary-memory.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import type { AgentMemoryOption } from '@mastra/core/agent';
 import type { MastraMemory } from '@mastra/core/memory';
 import { InMemoryStore } from '@mastra/core/storage';
@@ -11,7 +9,7 @@ export interface TemporaryOmMemoryContext {
 }
 
 export function createTemporaryOmMemoryContext(prefix: string): TemporaryOmMemoryContext {
-  const threadId = `${prefix}-${randomUUID()}`;
+  const threadId = `${prefix}-${crypto.randomUUID()}`;
   const resourceId = prefix;
   const options: AgentMemoryOption = {
     thread: threadId,

--- a/packages/rag/src/document/schema/node.ts
+++ b/packages/rag/src/document/schema/node.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { NodeRelationship, ObjectType } from './types';
 import type { Metadata, RelatedNodeInfo, RelatedNodeType, BaseNodeParams, TextNodeParams } from './types';
 
@@ -15,7 +15,7 @@ export abstract class BaseNode<T extends Metadata = Metadata> {
 
   protected constructor(init?: BaseNodeParams<T>) {
     const { id_, metadata, relationships } = init || {};
-    this.id_ = id_ ?? randomUUID();
+    this.id_ = id_ ?? crypto.randomUUID();
     this.metadata = metadata ?? ({} as T);
     this.relationships = relationships ?? {};
   }

--- a/packages/server/src/server/handlers/conversations.ts
+++ b/packages/server/src/server/handlers/conversations.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { MastraFGAPermissions } from '../fga-permissions';
 import { HTTPException } from '../http-exception';
 import {
@@ -68,7 +67,7 @@ export const CREATE_CONVERSATION_ROUTE = createRoute({
         throw new HTTPException(400, { message: `Memory storage is not configured for agent "${agent.id}"` });
       }
 
-      const threadId = conversation_id ?? randomUUID();
+      const threadId = conversation_id ?? crypto.randomUUID();
       const resourceId = getEffectiveResourceId(requestContext, resource_id) ?? threadId;
       const thread = await memory.createThread({
         threadId,

--- a/packages/server/src/server/handlers/responses.adapter.ts
+++ b/packages/server/src/server/handlers/responses.adapter.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { MastraDBMessage } from '@mastra/core/agent';
 import { isProviderDefinedTool } from '@mastra/core/tools';
 import { zodToJsonSchema } from '@mastra/core/utils/zod-to-json';
@@ -488,7 +487,7 @@ export function mapMastraMessagesToResponseOutputItems({
  * Creates a stable assistant-message-backed response identifier.
  */
 export function createMessageId() {
-  return `msg_${randomUUID()}`;
+  return `msg_${crypto.randomUUID()}`;
 }
 
 /**

--- a/packages/server/src/server/handlers/responses.ts
+++ b/packages/server/src/server/handlers/responses.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Agent, MastraDBMessage } from '@mastra/core/agent';
 import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
@@ -230,7 +229,7 @@ async function resolveThreadExecutionContext({
       return null;
     }
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const createdThread = await memory.createThread({
       threadId,
       resourceId: effectiveResourceId ?? threadId,


### PR DESCRIPTION
## Description

Part 1 of 2 of the repo-wide UUID unification (split from #19502, which exceeded the 150-file review limit). This part covers `packages/*`: core, memory, server, mcp, editor, rag, deployer, cli, agent-builder — 84 files. Part 2 covers stores/, agent-sdks/, pubsub/, mastracode/ and the remaining workspaces.

Before this change the codebase used two UUID forms side by side: files importing `randomUUID` from `node:crypto` next to files (35 in `@mastra/core` alone) already calling the Web Crypto global `crypto.randomUUID()`. The forms are identical on every supported platform — the global has existed since Node 19 and the engines floor is Node 22 — but the import form marks the importing module, and through bundler chunking entire dist chunks, as Node-only. For V8-isolate runtimes that provide Web Crypto but no Node builtin modules (Convex default runtime, Cloudflare Workers without `nodejs_compat`), each such import is a bundling failure. Same convention as the `@mastra/convex` fix in #19498.

**The change is mechanical:**

- Remove `randomUUID` from `node:crypto`/`crypto` import specifiers (dropping the import entirely where it was the only specifier; other specifiers like `createHash` are kept).
- Rewrite bare `randomUUID(...)` call sites to `crypto.randomUUID(...)`.
- `packages/core/src/workflows/branch-map-bug.test.ts` mocked the `crypto` module for UUID determinism; that mock is dead once the source uses the global, and determinism is already provided by `@internal/test-utils/setup` (which stubs the global `crypto.randomUUID` with a per-test counter), so the local mock is removed.
- One stale JSDoc example import removed in `packages/mcp/src/server/server.ts`.

Out of scope: other `node:crypto` APIs (`createHash`, HMAC/cipher usage) — different portability trade-offs.

## Related issue(s)

Fixes #19501

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Testing

- Zero leftover runtime `randomUUID`-from-crypto imports in `packages/*` (repo-wide grep; one type-only `import type { UUID }` remains, erased at build).
- `pnpm turbo build` for `@mastra/core`, `@mastra/memory`, `@mastra/server`, `@mastra/mcp` and their dependency graphs: clean.
- `packages/memory` `tsc --noEmit`: clean.
- Targeted tests: rewritten `branch-map-bug.test.ts` (2 passed) and a `@mastra/memory` slice exercising UUID-generating paths (19 passed).
- Changeset patch-bumps the 9 published packages touched here.

## AI disclosure

Implemented with Claude Code (Fable 5) as a reviewed codemod; human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes every UUID generator use the built-in Web Crypto API instead of Node-only crypto imports. That keeps the code working in edge environments like Cloudflare Workers and Convex without changing UUID behavior.

## Summary

- Replaced `randomUUID` imports and calls across 84 package files with `crypto.randomUUID()`.
- Preserved other Node crypto APIs, such as `createHash`.
- Updated runtime code, integrations, tests, examples, and test setup.
- Removed an obsolete crypto mock and stale JSDoc import example.
- Added patch changesets for nine published packages.
- No public APIs or signatures changed.
- Builds, type-checking, and targeted tests were updated accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->