### PR TITLE
refactor(adapters): use Web Crypto randomUUID instead of node:crypto (2/2)

### DIFF
--- a/.changeset/web-crypto-uuid-adapters.md
+++ b/.changeset/web-crypto-uuid-adapters.md
@@ -1,0 +1,29 @@
+---
+'@mastra/acp': patch
+'@mastra/claude': patch
+'@mastra/cloudflare': patch
+'@mastra/cloudflare-d1': patch
+'@mastra/code-sdk': patch
+'@mastra/couchbase': patch
+'@mastra/cursor': patch
+'@mastra/github-signals': patch
+'@mastra/inngest': patch
+'@mastra/libsql': patch
+'@mastra/mongodb': patch
+'@mastra/mssql': patch
+'@mastra/mysql': patch
+'@mastra/nestjs': patch
+'@mastra/observability': patch
+'@mastra/openai': patch
+'@mastra/pg': patch
+'@mastra/google-cloud-pubsub': patch
+'@mastra/redis-streams': patch
+'@mastra/spanner': patch
+'@mastra/upstash': patch
+'@mastra/vectorize': patch
+'@mastra/voice-aws-nova-sonic': patch
+'@mastra/voice-google-gemini-live': patch
+'mastracode': patch
+---
+
+Switched UUID generation to the Web Crypto global (crypto.randomUUID) instead of importing randomUUID from node:crypto. No behavior change on Node.js; removes an unnecessary Node-only module dependency so packages bundle more cleanly for edge and V8-isolate runtimes such as the Convex default runtime and Cloudflare Workers.

--- a/agent-sdks/acp/src/agent.ts
+++ b/agent-sdks/acp/src/agent.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 
 import type { ModelInfo, SessionUpdate } from '@agentclientprotocol/sdk';
@@ -111,7 +110,7 @@ export class AcpAgent<
       },
       toolResults: [],
       finishReason: 'stop',
-      runId: options?.runId ?? randomUUID(),
+      runId: options?.runId ?? crypto.randomUUID(),
     };
   }
 
@@ -124,7 +123,7 @@ export class AcpAgent<
   }
 
   async stream(messages: MessageListInput, options?: AgentStreamOptions): Promise<SubAgentStreamResult> {
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = this.getPrompt(messages, options?.instructions);
     const signal = (options as { abortSignal?: AbortSignal } | undefined)?.abortSignal;
     const messageList = new MessageList();
@@ -139,7 +138,7 @@ export class AcpAgent<
 
     const fullStream = new ReadableStream<ChunkType>({
       start: async controller => {
-        const textId = randomUUID();
+        const textId = crypto.randomUUID();
         const chunks: string[] = [];
         const toolNames = new Map<string, string>();
         const toolResults: AcpToolResult[] = [];
@@ -359,7 +358,7 @@ function createFinishChunk(type: 'step-finish' | 'finish', runId: string): Chunk
     runId,
     from: CHUNK_FROM_AGENT,
     payload: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       output: {
         steps: [],
         usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },

--- a/agent-sdks/claude/src/index.ts
+++ b/agent-sdks/claude/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 
 import { query } from '@anthropic-ai/claude-agent-sdk';
@@ -138,7 +137,7 @@ export class ClaudeSDKAgent extends Agent {
     options?: ClaudeSDKAgentRunOptions<OUTPUT>,
   ): Promise<FullOutput<OUTPUT>> {
     const prompt = promptToText(messages);
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const requestContext = options?.requestContext ?? new RequestContext();
     const instructions = options?.instructions ? promptToText(options.instructions) : undefined;
     const telemetry = createSDKAgentTelemetry({
@@ -182,7 +181,7 @@ export class ClaudeSDKAgent extends Agent {
     messages: MessageListInput,
     options?: ClaudeSDKAgentRunOptions<OUTPUT>,
   ): Promise<MastraModelOutput<OUTPUT>> {
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = promptToText(messages);
     const modelId = getModelId(this.options);
     const requestContext = options?.requestContext ?? new RequestContext();
@@ -323,7 +322,7 @@ async function runClaudeGenerate<OUTPUT>(
     finishReason: { unified: 'stop', raw: 'stop' },
     usage: usage.toV3Usage(),
     response: {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       modelId: getModelId(options),
       timestamp: new Date(),
     },
@@ -342,8 +341,8 @@ function runClaudeAsMastraStream<OUTPUT>(
 ): ReadableStream<ChunkType> {
   return new ReadableStream<ChunkType>({
     start: async controller => {
-      const textId = randomUUID();
-      const responseId = randomUUID();
+      const textId = crypto.randomUUID();
+      const responseId = crypto.randomUUID();
       const modelId = getModelId(options);
       const usage = createClaudeUsageCollector();
       let text = '';

--- a/agent-sdks/claude/src/utils.ts
+++ b/agent-sdks/claude/src/utils.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { ReadableStreamDefaultController } from 'node:stream/web';
 
@@ -97,7 +96,7 @@ export function createCompletedMastraStream({
 }): ReadableStream<ChunkType> {
   return new ReadableStream<ChunkType>({
     start(controller) {
-      const textId = randomUUID();
+      const textId = crypto.randomUUID();
       enqueueStartChunks(controller, {
         runId,
         prompt,
@@ -155,7 +154,7 @@ export function createMastraOutput<OUTPUT>({
     },
     stream: stream as ReadableStream<ChunkType<OUTPUT>>,
     messageList,
-    messageId: randomUUID(),
+    messageId: crypto.randomUUID(),
     options: {
       ...options,
       runId,

--- a/agent-sdks/cursor/src/index.ts
+++ b/agent-sdks/cursor/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 
 import { Agent as CursorAgent } from '@cursor/sdk';
@@ -155,7 +154,7 @@ export class CursorSDKAgent extends Agent {
     options?: SDKAgentRunOptions<OUTPUT>,
   ): Promise<FullOutput<OUTPUT>> {
     const prompt = promptToText(messages);
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const modelId = getCursorModelId(this.options, sdkAgent);
     const requestContext = options?.requestContext ?? new RequestContext();
     const instructions = options?.instructions ? promptToText(options.instructions) : undefined;
@@ -210,7 +209,7 @@ export class CursorSDKAgent extends Agent {
     sdkAgent: SDKAgent,
     options?: SDKAgentRunOptions<OUTPUT>,
   ): Promise<MastraModelOutput<OUTPUT>> {
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = promptToText(messages);
     const modelId = getCursorModelId(this.options, sdkAgent);
     const requestContext = options?.requestContext ?? new RequestContext();
@@ -353,7 +352,7 @@ function runCursorAsMastraStream(
 ): ReadableStream<ChunkType> {
   return new ReadableStream<ChunkType>({
     start: async controller => {
-      const textId = randomUUID();
+      const textId = crypto.randomUUID();
       const usage = createCursorUsageCollector();
       let text = '';
 

--- a/agent-sdks/cursor/src/utils.ts
+++ b/agent-sdks/cursor/src/utils.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { ReadableStreamDefaultController } from 'node:stream/web';
 
@@ -95,7 +94,7 @@ export function createCompletedMastraStream({
 }): ReadableStream<ChunkType> {
   return new ReadableStream<ChunkType>({
     start(controller) {
-      const textId = randomUUID();
+      const textId = crypto.randomUUID();
       enqueueStartChunks(controller, {
         runId,
         prompt,
@@ -151,7 +150,7 @@ export function createMastraOutput<OUTPUT>({
     },
     stream: stream as ReadableStream<ChunkType<OUTPUT>>,
     messageList,
-    messageId: randomUUID(),
+    messageId: crypto.randomUUID(),
     options: {
       ...options,
       runId,

--- a/agent-sdks/openai/src/index.ts
+++ b/agent-sdks/openai/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 
 import { Agent } from '@mastra/core/agent';
@@ -129,7 +128,7 @@ export class OpenAISDKAgent extends Agent {
     options?: SDKAgentRunOptions<OUTPUT>,
   ): Promise<FullOutput<OUTPUT>> {
     const prompt = promptToText(messages);
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const sdkAgent = getRunOpenAIAgent(this.resolveOpenAIAgent(), options);
     const modelId = getModelId(this.options, sdkAgent);
     const requestContext = options?.requestContext ?? new RequestContext();
@@ -177,7 +176,7 @@ export class OpenAISDKAgent extends Agent {
     options?: SDKAgentRunOptions<OUTPUT>,
   ): Promise<MastraModelOutput<OUTPUT>> {
     const prompt = promptToText(messages);
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const sdkAgent = getRunOpenAIAgent(this.resolveOpenAIAgent(), options);
     const modelId = getModelId(this.options, sdkAgent);
     const requestContext = options?.requestContext ?? new RequestContext();
@@ -316,7 +315,7 @@ function runOpenAIAsMastraStream<OUTPUT>(
 ): ReadableStream<ChunkType> {
   return new ReadableStream<ChunkType>({
     start: async controller => {
-      const textId = randomUUID();
+      const textId = crypto.randomUUID();
       let text = '';
       let responseId: string | undefined;
       let modelId = requestedModelId;

--- a/agent-sdks/openai/src/utils.ts
+++ b/agent-sdks/openai/src/utils.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { ReadableStreamDefaultController } from 'node:stream/web';
 
@@ -99,7 +98,7 @@ export function createCompletedMastraStream({
 }): ReadableStream<ChunkType> {
   return new ReadableStream<ChunkType>({
     start(controller) {
-      const textId = randomUUID();
+      const textId = crypto.randomUUID();
       enqueueStartChunks(controller, {
         runId,
         prompt,
@@ -155,7 +154,7 @@ export function createMastraOutput<OUTPUT>({
     },
     stream: stream as ReadableStream<ChunkType<OUTPUT>>,
     messageList,
-    messageId: randomUUID(),
+    messageId: crypto.randomUUID(),
     options: {
       ...options,
       runId,

--- a/mastracode/sdk/src/acp/server.ts
+++ b/mastracode/sdk/src/acp/server.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { Readable, Writable } from 'node:stream';
 import { AgentSideConnection, ndJsonStream } from '@agentclientprotocol/sdk';
 import type { AgentController, AgentControllerMode, Session } from '@mastra/core/agent-controller';
@@ -23,8 +22,8 @@ export async function runAcpServer(
   // Handle cleanup on disconnect (success or error)
   try {
     session = await controller.createSession({
-      id: `acp-${randomUUID()}`,
-      ownerId: `acp-owner-${randomUUID()}`,
+      id: `acp-${crypto.randomUUID()}`,
+      ownerId: `acp-owner-${crypto.randomUUID()}`,
     });
     const activeSession = session;
 

--- a/mastracode/sdk/src/analytics.ts
+++ b/mastracode/sdk/src/analytics.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -16,7 +15,7 @@ interface AnalyticsConfig {
 }
 
 function createMastraAnalyticsDistinctId(): string {
-  return `mastra-${randomUUID()}`;
+  return `mastra-${crypto.randomUUID()}`;
 }
 
 function isHostnameDerivedDistinctId(distinctId: string, hostname = os.hostname()): boolean {
@@ -113,7 +112,7 @@ class NoopMastraCodeAnalytics implements MastraCodeAnalytics {
 class PostHogMastraCodeAnalytics implements MastraCodeAnalytics {
   private readonly client: PostHog;
   private readonly distinctId: string;
-  private readonly sessionId = randomUUID();
+  private readonly sessionId = crypto.randomUUID();
   private readonly version: string;
 
   constructor({ version, apiKey = POSTHOG_API_KEY, host = POSTHOG_HOST }: MastraCodeAnalyticsOptions) {

--- a/mastracode/tui/src/tui/goal-manager.ts
+++ b/mastracode/tui/src/tui/goal-manager.ts
@@ -11,7 +11,6 @@
  * the core goal step drives continuation and surfaces progress via `goal` stream
  * chunks.
  */
-import { randomUUID } from 'node:crypto';
 import { loadSettings } from '@mastra/code-sdk/onboarding/settings';
 import type { Agent } from '@mastra/core/agent';
 import type { GoalObjectiveRecord } from '@mastra/core/storage';
@@ -133,7 +132,7 @@ export class GoalManager {
     const threadId = state.session.thread.getId();
     const agent = this.getAgent(state);
     const now = Date.now();
-    const id = randomUUID();
+    const id = crypto.randomUUID();
 
     if (agent && threadId) {
       const persisted = await agent.setObjective(objective, {
@@ -293,7 +292,7 @@ export class GoalManager {
       try {
         const record = await agent.getObjective({ threadId });
         if (record) {
-          this.record = { ...record, id: record.id ?? randomUUID() };
+          this.record = { ...record, id: record.id ?? crypto.randomUUID() };
           return;
         }
       } catch {
@@ -321,7 +320,7 @@ export class GoalManager {
         judgeModelId: saved.judgeModelId ?? '',
         startedAt: saved.startedAt ? Date.parse(saved.startedAt) || Date.now() : Date.now(),
         updatedAt: Date.now(),
-        id: saved.id ?? randomUUID(),
+        id: saved.id ?? crypto.randomUUID(),
       };
       this.activeDurationMs = saved.activeDurationMs ?? 0;
     } else {

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -4,7 +4,6 @@
  */
 import { spawn } from 'node:child_process';
 import type { ChildProcess } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 import type { Component } from '@earendil-works/pi-tui';
 import { getOAuthProviders } from '@mastra/code-sdk/auth/storage';
 import {
@@ -996,7 +995,7 @@ export class MastraTUI {
   private beginLifecycleRun(): void {
     const hookMgr = this.state.hookManager;
     if (!hookMgr) return;
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     hookMgr.setRunId(runId);
     hookMgr.runAgentStart().catch(() => {});
   }

--- a/observability/mastra/src/processor-tracing.test.ts
+++ b/observability/mastra/src/processor-tracing.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { Agent } from '@mastra/core/agent';
 import type { MastraDBMessage, MessageList } from '@mastra/core/agent/message-list';
@@ -1630,7 +1629,7 @@ describe('Processor Tracing Tests', () => {
     it('should trace MessageHistory processor when memory is enabled', async () => {
       const model = createMockModel();
       const mockMemory = new MockMemory({ enableMessageHistory: true });
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'test-resource';
 
       // Create thread first
@@ -1707,7 +1706,7 @@ describe('Processor Tracing Tests', () => {
         enableMessageHistory: true,
         enableWorkingMemory: true,
       });
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'test-resource';
 
       // Create thread first
@@ -1775,7 +1774,7 @@ describe('Processor Tracing Tests', () => {
     it('should trace memory processors alongside custom processors', async () => {
       const model = createMockModel();
       const mockMemory = new MockMemory({ enableMessageHistory: true });
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'test-resource';
 
       // Create thread first
@@ -1849,7 +1848,7 @@ describe('Processor Tracing Tests', () => {
     it('should respect processor execution order for memory processors', async () => {
       const model = createMockModel();
       const mockMemory = new MockMemory({ enableMessageHistory: true });
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'test-resource';
 
       // Create thread first

--- a/pubsub/google-cloud-pubsub/src/agentic-loop-pubsub.test.ts
+++ b/pubsub/google-cloud-pubsub/src/agentic-loop-pubsub.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { createOpenAI } from '@ai-sdk/openai-v5';
 import { LLMock } from '@copilotkit/aimock';
 import { stepCountIs } from '@internal/ai-sdk-v5';
@@ -52,7 +51,7 @@ describe('AIMock loop scenario: evented + GoogleCloudPubSub', () => {
     if (!mock) throw new Error('AIMock server is not running');
 
     const pubsub = new GoogleCloudPubSub({
-      projectId: `aimock-${randomUUID().slice(0, 8)}`,
+      projectId: `aimock-${crypto.randomUUID().slice(0, 8)}`,
       apiEndpoint: EMULATOR_HOST,
     });
     pubsubs.push(pubsub);
@@ -97,7 +96,7 @@ describe('AIMock loop scenario: evented + GoogleCloudPubSub', () => {
       baseURL: `${mock.url.replace(/\/+$/, '')}/v1`,
     });
 
-    const agentId = `aimock-gcp-scenario-${randomUUID()}`;
+    const agentId = `aimock-gcp-scenario-${crypto.randomUUID()}`;
     const agent = new Agent({
       id: agentId,
       name: 'AIMock GCP Scenario Agent',

--- a/pubsub/redis-streams/src/agentic-loop-pubsub.test.ts
+++ b/pubsub/redis-streams/src/agentic-loop-pubsub.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { createOpenAI } from '@ai-sdk/openai-v5';
 import { LLMock } from '@copilotkit/aimock';
 import { stepCountIs } from '@internal/ai-sdk-v5';
@@ -53,7 +52,7 @@ describe('AIMock loop scenario: evented + RedisStreamsPubSub', () => {
     // Per-test keyPrefix so concurrent or repeated runs don't cross talk.
     const pubsub = new RedisStreamsPubSub({
       url: REDIS_URL,
-      keyPrefix: `aimock-${randomUUID()}`,
+      keyPrefix: `aimock-${crypto.randomUUID()}`,
       blockMs: 200,
     });
     pubsubs.push(pubsub);
@@ -98,7 +97,7 @@ describe('AIMock loop scenario: evented + RedisStreamsPubSub', () => {
       baseURL: `${mock.url.replace(/\/+$/, '')}/v1`,
     });
 
-    const agentId = `aimock-redis-scenario-${randomUUID()}`;
+    const agentId = `aimock-redis-scenario-${crypto.randomUUID()}`;
     const agent = new Agent({
       id: agentId,
       name: 'AIMock Redis Scenario Agent',

--- a/pubsub/redis-streams/src/connection-and-cleanup.test.ts
+++ b/pubsub/redis-streams/src/connection-and-cleanup.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import net from 'node:net';
 import type { Event, EventCallback } from '@mastra/core/events';
 import { createClient } from 'redis';
@@ -94,7 +93,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
       try {
         const port = await proxy.listening;
         ps = new RedisStreamsPubSub({ url: `redis://127.0.0.1:${port}`, blockMs: 200 });
-        const topic = `sever-${randomUUID()}`;
+        const topic = `sever-${crypto.randomUUID()}`;
         const received: Event[] = [];
         const cb: EventCallback = (event, ack) => {
           received.push(event);
@@ -132,7 +131,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
   describe('clearTopic', () => {
     it('deletes the topic stream so finished runs release their memory', async () => {
       const ps = createPubSub();
-      const topic = `clear-${randomUUID()}`;
+      const topic = `clear-${crypto.randomUUID()}`;
       await ps.publish(topic, makeEvent());
       await ps.publish(topic, makeEvent());
 
@@ -146,12 +145,12 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
 
     it('is a no-op for a topic that was never published to', async () => {
       const ps = createPubSub();
-      await expect(ps.clearTopic(`never-${randomUUID()}`)).resolves.toBeUndefined();
+      await expect(ps.clearTopic(`never-${crypto.randomUUID()}`)).resolves.toBeUndefined();
     }, 15_000);
 
     it('lets a still-attached subscriber recover after the stream is deleted', async () => {
       const ps = createPubSub();
-      const topic = `clear-live-${randomUUID()}`;
+      const topic = `clear-live-${crypto.randomUUID()}`;
       const received: string[] = [];
       await ps.subscribe(topic, (event, ack) => {
         received.push((event.data as { n: number }).n.toString());
@@ -173,7 +172,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
   describe('streamIdleTtlMs', () => {
     it('stamps a rolling TTL on the stream key when configured (atomically with the write)', async () => {
       const ps = createPubSub({ streamIdleTtlMs: 60_000 });
-      const topic = `ttl-${randomUUID()}`;
+      const topic = `ttl-${crypto.randomUUID()}`;
       await ps.publish(topic, makeEvent());
 
       const inspector = await createInspector();
@@ -189,7 +188,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
 
     it('leaves streams persistent by default', async () => {
       const ps = createPubSub();
-      const topic = `nottl-${randomUUID()}`;
+      const topic = `nottl-${crypto.randomUUID()}`;
       await ps.publish(topic, makeEvent());
 
       const inspector = await createInspector();
@@ -207,7 +206,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
 
     it('refreshes the TTL on a nack retry republish', async () => {
       const ps = createPubSub({ streamIdleTtlMs: 60_000, maxDeliveryAttempts: 3 });
-      const topic = `ttl-nack-${randomUUID()}`;
+      const topic = `ttl-nack-${crypto.randomUUID()}`;
       const inspector = await createInspector();
       const streamKey = `mastra:topic:${topic}`;
 
@@ -232,7 +231,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
 
     it('reapplies the TTL when the read loop recreates a deleted stream (no publish)', async () => {
       const ps = createPubSub({ streamIdleTtlMs: 60_000 });
-      const topic = `ttl-recreate-${randomUUID()}`;
+      const topic = `ttl-recreate-${crypto.randomUUID()}`;
       const inspector = await createInspector();
       const streamKey = `mastra:topic:${topic}`;
 
@@ -261,7 +260,7 @@ describe('RedisStreamsPubSub connection resilience and topic cleanup', () => {
       };
       const ps1 = createPubSub({ streamIdleTtlMs: 60_000, logger });
       const ps2 = createPubSub({ streamIdleTtlMs: 60_000, logger });
-      const topic = `busygroup-${randomUUID()}`;
+      const topic = `busygroup-${crypto.randomUUID()}`;
       const group = 'workers';
       const received: number[] = [];
       const cb: EventCallback = (event, ack) => {

--- a/pubsub/redis-streams/src/index.ts
+++ b/pubsub/redis-streams/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { PubSub } from '@mastra/core/events';
 import type { Event, EventCallback, LeaseProvider, PubSubDeliveryMode, SubscribeOptions } from '@mastra/core/events';
 import { createClient } from 'redis';
@@ -181,7 +180,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
   #subKey(topic: string, cb: EventCallback): string {
     let cbId = this.#cbIds.get(cb);
     if (!cbId) {
-      cbId = randomUUID();
+      cbId = crypto.randomUUID();
       this.#cbIds.set(cb, cbId);
     }
     return `${topic}::${cbId}`;
@@ -211,7 +210,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     if (options?.localOnly) {
       const localEvent: Event = {
         ...event,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         createdAt: new Date(),
         deliveryAttempt: event.deliveryAttempt ?? 1,
       };
@@ -221,7 +220,7 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
 
     await this.#ensureWriterConnected();
 
-    const id = randomUUID();
+    const id = crypto.randomUUID();
     const createdAt = new Date();
     const payload: Event = {
       ...event,
@@ -287,8 +286,8 @@ export class RedisStreamsPubSub extends PubSub implements LeaseProvider {
     await this.#ensureWriterConnected();
 
     const isGrouped = !!options?.group;
-    const group = options?.group ?? `__fanout-${randomUUID()}`;
-    const consumer = `${group}-${randomUUID()}`;
+    const group = options?.group ?? `__fanout-${crypto.randomUUID()}`;
+    const consumer = `${group}-${crypto.randomUUID()}`;
     const streamKey = this.#streamKey(topic);
 
     // Create the consumer group if it doesn't exist. MKSTREAM creates the

--- a/pubsub/redis-streams/src/pubsub.test.ts
+++ b/pubsub/redis-streams/src/pubsub.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Event, EventCallback } from '@mastra/core/events';
 import { createClient } from 'redis';
 import type { RedisClientType } from 'redis';
@@ -70,7 +69,7 @@ describe('RedisStreamsPubSub', () => {
   describe('fan-out (no group)', () => {
     it('delivers each published message to all subscribers', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
       const b = captureCalls();
 
@@ -86,7 +85,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('does not deliver to unsubscribed callbacks', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
       const b = captureCalls();
 
@@ -105,8 +104,8 @@ describe('RedisStreamsPubSub', () => {
 
     it('does not deliver across different topics', async () => {
       const ps = createPubSub();
-      const topicA = `t-${randomUUID()}`;
-      const topicB = `t-${randomUUID()}`;
+      const topicA = `t-${crypto.randomUUID()}`;
+      const topicB = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
       const b = captureCalls();
 
@@ -124,7 +123,7 @@ describe('RedisStreamsPubSub', () => {
   describe('group (competing consumers)', () => {
     it('delivers each message to exactly one subscriber in the group', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
       const b = captureCalls();
 
@@ -152,7 +151,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('different groups on the same topic each receive every message', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
       const b = captureCalls();
 
@@ -170,7 +169,7 @@ describe('RedisStreamsPubSub', () => {
   describe('ack/nack/redelivery', () => {
     it('nack increments deliveryAttempt and redelivers', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const seenAttempts: number[] = [];
 
       const cb: EventCallback = (event, ack, nack) => {
@@ -192,7 +191,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('async handler that rejects is treated as nack and redelivered', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const seenAttempts: number[] = [];
 
       const cb: EventCallback = async (event, ack) => {
@@ -214,7 +213,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('flush waits for in-flight publishes', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
 
       // Fire several publishes without awaiting, then flush.
       const promises = [
@@ -234,7 +233,7 @@ describe('RedisStreamsPubSub', () => {
     it('a separate pubsub instance can consume messages published by another', async () => {
       const producer = createPubSub();
       const consumer = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const cap = captureCalls();
 
       await consumer.subscribe(topic, cap.cbAutoAck, { group: 'shared' });
@@ -248,7 +247,7 @@ describe('RedisStreamsPubSub', () => {
   describe('lifecycle', () => {
     it('publish() on a closed instance throws', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       // Trigger lazy connect first so close has something to tear down.
       await ps.publish(topic, makeEvent());
       await ps.close();
@@ -257,7 +256,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('subscribe() on a closed instance throws', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       await ps.publish(topic, makeEvent());
       await ps.close();
       const cap = captureCalls();
@@ -266,7 +265,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('close() is idempotent', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       await ps.publish(topic, makeEvent());
       await ps.close();
       await expect(ps.close()).resolves.toBeUndefined();
@@ -274,7 +273,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('unsubscribe() for an unknown callback is a no-op', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const cap = captureCalls();
       // never subscribed — should not throw
       await expect(ps.unsubscribe(topic, cap.cbAutoAck)).resolves.toBeUndefined();
@@ -285,8 +284,8 @@ describe('RedisStreamsPubSub', () => {
     it('subscribe after publish in a fresh group still receives the published message', async () => {
       const producer = createPubSub();
       const consumer = createPubSub();
-      const topic = `t-${randomUUID()}`;
-      const groupName = `late-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
+      const groupName = `late-${crypto.randomUUID()}`;
 
       // Publish first, with no consumer group anywhere.
       await producer.publish(topic, makeEvent({ type: 'before-subscribe' }));
@@ -302,9 +301,9 @@ describe('RedisStreamsPubSub', () => {
     it('an existing group keeps its own checkpoint and does not replay history', async () => {
       const ps = createPubSub();
       const keyPrefix = 'mastra:topic';
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const streamKey = `${keyPrefix}:${topic}`;
-      const groupName = `existing-${randomUUID()}`;
+      const groupName = `existing-${crypto.randomUUID()}`;
 
       // Publish event-1 first so the stream exists with at least one entry.
       await ps.publish(topic, makeEvent({ type: 'event-1' }));
@@ -346,8 +345,8 @@ describe('RedisStreamsPubSub', () => {
       });
       pubsubs.push(ps);
 
-      const topic = `t-${randomUUID()}`;
-      const groupName = `claim-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
+      const groupName = `claim-${crypto.randomUUID()}`;
 
       // First subscriber never acks/nacks — its pending entry will go idle.
       const seenA: Event[] = [];
@@ -390,8 +389,8 @@ describe('RedisStreamsPubSub', () => {
       });
       pubsubs.push(ps);
 
-      const topic = `t-cap-${randomUUID()}`;
-      const groupName = `g-cap-${randomUUID()}`;
+      const topic = `t-cap-${crypto.randomUUID()}`;
+      const groupName = `g-cap-${crypto.randomUUID()}`;
       let attempts = 0;
       const cb: EventCallback = (_event, _ack, nack) => {
         attempts++;
@@ -416,8 +415,8 @@ describe('RedisStreamsPubSub', () => {
       });
       pubsubs.push(ps);
 
-      const topic = `t-cap-inf-${randomUUID()}`;
-      const groupName = `g-cap-inf-${randomUUID()}`;
+      const topic = `t-cap-inf-${crypto.randomUUID()}`;
+      const groupName = `g-cap-inf-${crypto.randomUUID()}`;
       let attempts = 0;
       const cb: EventCallback = (_event, _ack, nack) => {
         attempts++;
@@ -457,8 +456,8 @@ describe('RedisStreamsPubSub', () => {
         seen.push({ topic: event.type.startsWith('a-') ? 'A' : 'B', type: event.type });
         void ack?.();
       };
-      const topicA = `t-A-${randomUUID()}`;
-      const topicB = `t-B-${randomUUID()}`;
+      const topicA = `t-A-${crypto.randomUUID()}`;
+      const topicB = `t-B-${crypto.randomUUID()}`;
       await ps.subscribe(topicA, cb);
       await ps.subscribe(topicB, cb);
 
@@ -482,7 +481,7 @@ describe('RedisStreamsPubSub', () => {
   describe('lease', () => {
     it('grants a lease when the key is free', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       const result = await ps.acquireLease(key, 'owner-a', 5000);
       expect(result).toEqual({ acquired: true, owner: 'owner-a' });
       expect(await ps.getLeaseOwner(key)).toBe('owner-a');
@@ -491,7 +490,7 @@ describe('RedisStreamsPubSub', () => {
     it('denies a lease while another owner holds it, across instances', async () => {
       const psA = createPubSub();
       const psB = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
 
       const a = await psA.acquireLease(key, 'owner-a', 5000);
       const b = await psB.acquireLease(key, 'owner-b', 5000);
@@ -504,7 +503,7 @@ describe('RedisStreamsPubSub', () => {
     it('lets exactly one of two racing instances win', async () => {
       const psA = createPubSub();
       const psB = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
 
       const [a, b] = await Promise.all([
         psA.acquireLease(key, 'owner-a', 5000),
@@ -521,7 +520,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('lets the same owner re-acquire (idempotent, refreshes TTL)', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 5000);
       const again = await ps.acquireLease(key, 'owner-a', 5000);
       expect(again).toEqual({ acquired: true, owner: 'owner-a' });
@@ -530,7 +529,7 @@ describe('RedisStreamsPubSub', () => {
     it('expires the lease after TTL and lets a new owner acquire it', async () => {
       const psA = createPubSub();
       const psB = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
 
       const a = await psA.acquireLease(key, 'owner-a', 100);
       expect(a.acquired).toBe(true);
@@ -546,7 +545,7 @@ describe('RedisStreamsPubSub', () => {
     it('does not release a lease held by a different owner', async () => {
       const psA = createPubSub();
       const psB = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
 
       await psA.acquireLease(key, 'owner-a', 5000);
       await psB.releaseLease(key, 'owner-b'); // non-owner — should no-op
@@ -555,7 +554,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('releases a lease the caller owns', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 5000);
       await ps.releaseLease(key, 'owner-a');
       expect(await ps.getLeaseOwner(key)).toBeUndefined();
@@ -563,7 +562,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('renews a lease the caller owns', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 200);
       // Renew before expiry.
       await new Promise(r => setTimeout(r, 100));
@@ -578,7 +577,7 @@ describe('RedisStreamsPubSub', () => {
     it('fails to renew a lease held by a different owner', async () => {
       const psA = createPubSub();
       const psB = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await psA.acquireLease(key, 'owner-a', 5000);
       const renewed = await psB.renewLease(key, 'owner-b', 5000);
       expect(renewed).toBe(false);
@@ -587,7 +586,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('fails to renew a lease that has expired', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 100);
       await new Promise(r => setTimeout(r, 200));
       const renewed = await ps.renewLease(key, 'owner-a', 1000);
@@ -596,7 +595,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('transfers a lease from the current owner to a new owner', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 5000);
       const transferred = await ps.transferLease!(key, 'owner-a', 'owner-b', 5000);
       expect(transferred).toBe(true);
@@ -605,7 +604,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('does not transfer a lease the caller does not own', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 5000);
       const transferred = await ps.transferLease!(key, 'someone-else', 'owner-b', 5000);
       expect(transferred).toBe(false);
@@ -614,7 +613,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('does not transfer a lease that has expired', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 100);
       await new Promise(r => setTimeout(r, 200));
       const transferred = await ps.transferLease!(key, 'owner-a', 'owner-b', 5000);
@@ -624,7 +623,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('resets the TTL to the full window on transfer', async () => {
       const ps = createPubSub();
-      const key = `lease-${randomUUID()}`;
+      const key = `lease-${crypto.randomUUID()}`;
       await ps.acquireLease(key, 'owner-a', 200);
       // Transfer just before the original TTL would expire, with a fresh window.
       await new Promise(r => setTimeout(r, 100));
@@ -637,14 +636,14 @@ describe('RedisStreamsPubSub', () => {
 
     it('returns undefined owner for a non-existent key', async () => {
       const ps = createPubSub();
-      expect(await ps.getLeaseOwner(`lease-${randomUUID()}`)).toBeUndefined();
+      expect(await ps.getLeaseOwner(`lease-${crypto.randomUUID()}`)).toBeUndefined();
     });
   });
 
   describe('localOnly publish', () => {
     it('delivers to subscribers in the same process without round-tripping through Redis', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
 
       await ps.subscribe(topic, a.cbAutoAck);
@@ -669,7 +668,7 @@ describe('RedisStreamsPubSub', () => {
     it('does not leak local-only events to other processes', async () => {
       const psA = createPubSub();
       const psB = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const remote = captureCalls();
 
       await psB.subscribe(topic, remote.cbAutoAck);
@@ -683,7 +682,7 @@ describe('RedisStreamsPubSub', () => {
 
     it('unsubscribe stops local delivery too', async () => {
       const ps = createPubSub();
-      const topic = `t-${randomUUID()}`;
+      const topic = `t-${crypto.randomUUID()}`;
       const a = captureCalls();
 
       await ps.subscribe(topic, a.cbAutoAck);

--- a/pubsub/redis-streams/test-fixtures/agent-thread-worker.entry.ts
+++ b/pubsub/redis-streams/test-fixtures/agent-thread-worker.entry.ts
@@ -17,7 +17,6 @@
  * The "runMs" field controls how long the stubbed agent.stream() takes to
  * resolve _waitUntilFinished, simulating an in-flight model call.
  */
-import { randomUUID } from 'node:crypto';
 import { createInterface } from 'node:readline';
 
 import type { Agent } from '@mastra/core/agent';
@@ -50,7 +49,7 @@ function makeStubAgent(runMs: number, runtime: AgentThreadStreamRuntime, pubsub:
     stream: async (input: any, options: any) => {
       // The signal carrying the user message exposes its sigId as contents.
       const sigId: string = typeof input === 'string' ? input : (input?.contents ?? input?.text ?? '');
-      const runId = options?.runId ?? randomUUID();
+      const runId = options?.runId ?? crypto.randomUUID();
       const finished = new Promise<void>(resolve => {
         const timer = setTimeout(() => {
           runEnds.delete(sigId);

--- a/server-adapters/nestjs/src/services/shutdown.service.ts
+++ b/server-adapters/nestjs/src/services/shutdown.service.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { OnApplicationShutdown, OnModuleDestroy } from '@nestjs/common';
 import type { Response } from 'express';
@@ -40,7 +39,7 @@ export class ShutdownService implements OnModuleDestroy, OnApplicationShutdown {
    * Returns a unique request ID for tracking.
    */
   registerRequest(path: string): string {
-    const requestId = randomUUID();
+    const requestId = crypto.randomUUID();
     this.activeRequests.set(requestId, {
       startTime: Date.now(),
       path,

--- a/signals/github/src/index.ts
+++ b/signals/github/src/index.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
@@ -1176,7 +1176,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
   async subscribeThreadToPR(input: GithubPollingThread & { pr: GithubPRSignalInput }): Promise<GithubOperationResult> {
     const pr = typeof input.pr === 'number' ? { number: input.pr } : input.pr;
     return this.#subscribe({
-      id: `github-command-subscribe-${randomUUID()}`,
+      id: `github-command-subscribe-${crypto.randomUUID()}`,
       ...pr,
       threadId: input.threadId,
       resourceId: input.resourceId,
@@ -1188,7 +1188,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
   ): Promise<GithubOperationResult> {
     const pr = typeof input.pr === 'number' ? { number: input.pr } : input.pr;
     return this.#unsubscribe({
-      id: `github-command-unsubscribe-${randomUUID()}`,
+      id: `github-command-unsubscribe-${crypto.randomUUID()}`,
       ...pr,
       threadId: input.threadId,
       resourceId: input.resourceId,
@@ -1378,7 +1378,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         execute: async (input, context) => {
           const executionThreadContext = getExecutionThreadContext(context);
           const result = await this.#subscribe({
-            id: `github-tool-subscribe-${randomUUID()}`,
+            id: `github-tool-subscribe-${crypto.randomUUID()}`,
             owner: input.owner,
             repo: input.repo,
             number: input.number,
@@ -1409,7 +1409,7 @@ export class GithubSignals extends SignalProvider<'github-signals'> {
         execute: async (input, context) => {
           const executionThreadContext = getExecutionThreadContext(context);
           const result = await this.#unsubscribe({
-            id: `github-tool-unsubscribe-${randomUUID()}`,
+            id: `github-tool-unsubscribe-${crypto.randomUUID()}`,
             owner: input.owner,
             repo: input.repo,
             number: input.number,

--- a/stores/_test-utils/src/domains/agents/data.ts
+++ b/stores/_test-utils/src/domains/agents/data.ts
@@ -1,12 +1,11 @@
 import type { StorageCreateAgentInput } from '@mastra/core/storage';
-import { randomUUID } from 'node:crypto';
 
 /**
  * Creates a sample agent input for testing storage operations.
  * @param overrides - Optional fields to override the default values
  */
 export const createSampleAgent = ({
-  id = `agent-${randomUUID()}`,
+  id = `agent-${crypto.randomUUID()}`,
   authorId,
   visibility,
   metadata,
@@ -47,7 +46,7 @@ export const createSampleAgent = ({
  * Creates a sample agent with all fields populated for comprehensive testing.
  */
 export const createFullSampleAgent = ({
-  id = `agent-${randomUUID()}`,
+  id = `agent-${crypto.randomUUID()}`,
 }: {
   id?: string;
 } = {}): StorageCreateAgentInput => ({
@@ -119,7 +118,7 @@ export const createFullSampleAgent = ({
  */
 export const createSampleAgents = (count: number): StorageCreateAgentInput[] => {
   return Array.from({ length: count }, (_, i) => ({
-    id: `agent-${randomUUID()}`,
+    id: `agent-${crypto.randomUUID()}`,
     name: `Test Agent ${i + 1}`,
     description: `Description for agent ${i + 1}`,
     instructions: `Instructions for agent ${i + 1}`,

--- a/stores/_test-utils/src/domains/agents/index.ts
+++ b/stores/_test-utils/src/domains/agents/index.ts
@@ -1,7 +1,6 @@
 import type { MastraStorage, AgentsStorage } from '@mastra/core/storage';
 import { createSampleAgent, createFullSampleAgent, createSampleAgents } from './data';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { randomUUID } from 'node:crypto';
 
 export function createAgentsTests({ storage }: { storage: MastraStorage }) {
   // Skip tests if storage doesn't have agents domain
@@ -156,7 +155,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
         const created = await agentsStorage.create({ agent });
 
         // Set an active version
-        const versionId = randomUUID();
+        const versionId = crypto.randomUUID();
         await agentsStorage.createVersion({
           id: versionId,
           agentId: agent.id,
@@ -190,7 +189,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
 
         // Create version 2
         await agentsStorage.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           agentId: agent.id,
           versionNumber: 2,
           name: 'Version 2',
@@ -202,7 +201,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
 
         // Create version 3 (latest)
         await agentsStorage.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           agentId: agent.id,
           versionNumber: 3,
           name: 'Latest Version',
@@ -283,7 +282,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
         const originalVersionId = created.activeVersionId;
 
         // Create a second version
-        const versionId = randomUUID();
+        const versionId = crypto.randomUUID();
         await agentsStorage.createVersion({
           id: versionId,
           agentId: agent.id,
@@ -338,7 +337,7 @@ export function createAgentsTests({ storage }: { storage: MastraStorage }) {
 
         // Create additional versions
         await agentsStorage.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           agentId: agent.id,
           versionNumber: 2,
           name: 'Version 2',

--- a/stores/_test-utils/src/domains/background-tasks/data.ts
+++ b/stores/_test-utils/src/domains/background-tasks/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { BackgroundTask } from '@mastra/core/background-tasks';
 
 /**
@@ -6,13 +5,13 @@ import type { BackgroundTask } from '@mastra/core/background-tasks';
  */
 export function createSampleTask(overrides?: Partial<BackgroundTask>): BackgroundTask {
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     status: 'pending',
     toolName: 'test-tool',
-    toolCallId: `call-${randomUUID()}`,
+    toolCallId: `call-${crypto.randomUUID()}`,
     args: { query: 'test' },
     agentId: 'agent-1',
-    runId: `run-${randomUUID()}`,
+    runId: `run-${crypto.randomUUID()}`,
     retryCount: 0,
     maxRetries: 0,
     timeoutMs: 300_000,

--- a/stores/_test-utils/src/domains/channels/data.ts
+++ b/stores/_test-utils/src/domains/channels/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ChannelConfig, ChannelInstallation } from '@mastra/core/storage';
 
 /**
@@ -7,13 +6,13 @@ import type { ChannelConfig, ChannelInstallation } from '@mastra/core/storage';
 export function createSampleInstallation(overrides?: Partial<ChannelInstallation>): ChannelInstallation {
   const now = new Date();
   return {
-    id: `install_${randomUUID()}`,
+    id: `install_${crypto.randomUUID()}`,
     platform: 'slack',
-    agentId: `agent_${randomUUID()}`,
+    agentId: `agent_${crypto.randomUUID()}`,
     status: 'active',
-    webhookId: `webhook_${randomUUID()}`,
+    webhookId: `webhook_${crypto.randomUUID()}`,
     data: { botToken: 'xoxb-test-token', teamId: 'T123456' },
-    configHash: `hash_${randomUUID()}`,
+    configHash: `hash_${crypto.randomUUID()}`,
     createdAt: now,
     updatedAt: now,
     ...overrides,

--- a/stores/_test-utils/src/domains/datasets/data.ts
+++ b/stores/_test-utils/src/domains/datasets/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { CreateDatasetInput, AddDatasetItemInput } from '@mastra/core/storage';
 
 /**
@@ -7,7 +6,7 @@ import type { CreateDatasetInput, AddDatasetItemInput } from '@mastra/core/stora
  */
 export function createSampleDataset(overrides?: Partial<CreateDatasetInput>): CreateDatasetInput {
   return {
-    name: `dataset-${randomUUID().slice(0, 8)}`,
+    name: `dataset-${crypto.randomUUID().slice(0, 8)}`,
     ...overrides,
   };
 }
@@ -20,7 +19,7 @@ export function createSampleDatasetItem(
   overrides?: Partial<Omit<AddDatasetItemInput, 'datasetId'>>,
 ): Omit<AddDatasetItemInput, 'datasetId'> {
   return {
-    input: { q: `question-${randomUUID().slice(0, 8)}` },
+    input: { q: `question-${crypto.randomUUID().slice(0, 8)}` },
     ...overrides,
   };
 }

--- a/stores/_test-utils/src/domains/experiments/data.ts
+++ b/stores/_test-utils/src/domains/experiments/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { CreateExperimentInput, AddExperimentResultInput } from '@mastra/core/storage';
 
 /**
@@ -7,11 +6,11 @@ import type { CreateExperimentInput, AddExperimentResultInput } from '@mastra/co
  */
 export function createSampleExperiment(overrides?: Partial<CreateExperimentInput>): CreateExperimentInput {
   return {
-    name: `experiment-${randomUUID().slice(0, 8)}`,
+    name: `experiment-${crypto.randomUUID().slice(0, 8)}`,
     datasetId: null,
     datasetVersion: null,
     targetType: 'agent',
-    targetId: `agent-${randomUUID().slice(0, 8)}`,
+    targetId: `agent-${crypto.randomUUID().slice(0, 8)}`,
     totalItems: 5,
     ...overrides,
   };
@@ -26,10 +25,10 @@ export function createSampleExperimentResult(
 ): Omit<AddExperimentResultInput, 'experimentId'> {
   const now = new Date();
   return {
-    itemId: `item-${randomUUID().slice(0, 8)}`,
+    itemId: `item-${crypto.randomUUID().slice(0, 8)}`,
     itemDatasetVersion: null,
-    input: { q: `question-${randomUUID().slice(0, 8)}` },
-    output: { a: `answer-${randomUUID().slice(0, 8)}` },
+    input: { q: `question-${crypto.randomUUID().slice(0, 8)}` },
+    output: { a: `answer-${crypto.randomUUID().slice(0, 8)}` },
     groundTruth: null,
     error: null,
     startedAt: now,

--- a/stores/_test-utils/src/domains/favorites/data.ts
+++ b/stores/_test-utils/src/domains/favorites/data.ts
@@ -1,8 +1,7 @@
 import type { StorageCreateAgentInput, StorageCreateSkillInput } from '@mastra/core/storage';
-import { randomUUID } from 'node:crypto';
 
 export const createSampleAgent = ({
-  id = `agent-${randomUUID()}`,
+  id = `agent-${crypto.randomUUID()}`,
   authorId = 'owner',
   visibility = 'public',
   name = 'Test Agent',
@@ -18,7 +17,7 @@ export const createSampleAgent = ({
 });
 
 export const createSampleSkill = ({
-  id = `skill-${randomUUID()}`,
+  id = `skill-${crypto.randomUUID()}`,
   authorId = 'owner',
   visibility = 'public',
   name = 'Test Skill',

--- a/stores/_test-utils/src/domains/memory/data.ts
+++ b/stores/_test-utils/src/domains/memory/data.ts
@@ -1,7 +1,6 @@
 import type { MastraMessageV1, MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import type { StorageResourceType } from '@mastra/core/storage';
-import { randomUUID } from 'node:crypto';
 
 let role: 'assistant' | 'user' = 'assistant';
 export const getRole = () => {
@@ -15,8 +14,8 @@ export const resetRole = () => {
 };
 
 export const createSampleThread = ({
-  id = `thread-${randomUUID()}`,
-  resourceId = `resource-${randomUUID()}`,
+  id = `thread-${crypto.randomUUID()}`,
+  resourceId = `resource-${crypto.randomUUID()}`,
   date = new Date(),
 }: {
   id?: string;
@@ -48,7 +47,7 @@ export const createSampleThreadWithParams = (
 export const createSampleMessageV1 = ({
   threadId,
   content = 'Hello',
-  resourceId = `resource-${randomUUID()}`,
+  resourceId = `resource-${crypto.randomUUID()}`,
   createdAt = new Date(),
 }: {
   threadId: string;
@@ -57,7 +56,7 @@ export const createSampleMessageV1 = ({
   createdAt?: Date;
 }) =>
   ({
-    id: `msg-${randomUUID()}`,
+    id: `msg-${crypto.randomUUID()}`,
     role: getRole(),
     type: 'text',
     threadId,
@@ -82,7 +81,7 @@ export const createSampleMessageV2 = ({
   thread?: StorageThreadType;
 }): MastraDBMessage => {
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     threadId,
     resourceId: resourceId || thread?.resourceId || 'test-resource',
     role,
@@ -90,14 +89,14 @@ export const createSampleMessageV2 = ({
     content: {
       format: 2,
       parts: content?.parts || [{ type: 'text', text: content?.content ?? '' }],
-      content: content?.content || `Sample content ${randomUUID()}`,
+      content: content?.content || `Sample content ${crypto.randomUUID()}`,
       ...content,
     },
   };
 };
 
 export const createSampleResource = ({
-  id = `resource-${randomUUID()}`,
+  id = `resource-${crypto.randomUUID()}`,
   workingMemory = 'Sample working memory content',
   metadata = { key: 'value', test: true },
   date = new Date(),

--- a/stores/_test-utils/src/domains/memory/messages-update.ts
+++ b/stores/_test-utils/src/domains/memory/messages-update.ts
@@ -2,7 +2,6 @@ import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { createSampleMessageV2, createSampleThread } from './data';
 import type { MastraStorage, MemoryStorage } from '@mastra/core/storage';
-import { randomUUID } from 'node:crypto';
 
 export function createMessagesUpdateTest({ storage }: { storage: MastraStorage }) {
   let memoryStorage: MemoryStorage;
@@ -164,7 +163,7 @@ export function createMessagesUpdateTest({ storage }: { storage: MastraStorage }
       const originalMessage = createSampleMessageV2({ threadId: thread.id });
       await memoryStorage.saveMessages({ messages: [originalMessage] });
 
-      const messages = [{ id: randomUUID(), role: 'assistant' }] as MastraDBMessage[];
+      const messages = [{ id: crypto.randomUUID(), role: 'assistant' }] as MastraDBMessage[];
 
       await expect(
         memoryStorage.updateMessages({

--- a/stores/_test-utils/src/domains/memory/observational-memory.ts
+++ b/stores/_test-utils/src/domains/memory/observational-memory.ts
@@ -1,13 +1,12 @@
 import type { MastraStorage, MemoryStorage } from '@mastra/core/storage';
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
-import { randomUUID } from 'node:crypto';
 
 /**
  * Helper to create sample OM initialization input
  */
 function createSampleOMInput({
   threadId = null,
-  resourceId = `resource-${randomUUID()}`,
+  resourceId = `resource-${crypto.randomUUID()}`,
   scope = 'resource' as const,
 }: {
   threadId?: string | null;
@@ -45,10 +44,10 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
     });
 
     const createChunk = ({ observations, messageTokens }: { observations: string; messageTokens: number }) => ({
-      cycleId: `cycle-${randomUUID()}`,
+      cycleId: `cycle-${crypto.randomUUID()}`,
       observations,
       tokenCount: Math.round(messageTokens / 2),
-      messageIds: [`msg-${randomUUID()}`],
+      messageIds: [`msg-${crypto.randomUUID()}`],
       messageTokens,
       lastObservedAt: new Date(),
     });
@@ -87,7 +86,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should create a thread-scoped observational memory record', async () => {
-        const threadId = `thread-${randomUUID()}`;
+        const threadId = `thread-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ threadId, scope: 'thread' });
 
         const record = await memoryStorage.initializeObservationalMemory(input);
@@ -124,7 +123,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should retrieve thread-scoped record with threadId', async () => {
-        const threadId = `thread-${randomUUID()}`;
+        const threadId = `thread-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ threadId, scope: 'thread' });
         const created = await memoryStorage.initializeObservationalMemory(input);
 
@@ -143,7 +142,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return history in reverse chronological order', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record
@@ -164,7 +163,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should respect limit parameter', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record
@@ -186,7 +185,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should filter by from date', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record
@@ -213,7 +212,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should filter by to date', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record
@@ -240,7 +239,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should filter by from and to date combined', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record
@@ -278,7 +277,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should support offset', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record + 3 reflections = 4 records total
@@ -302,7 +301,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should support offset with limit', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record + 3 reflections = 4 records total
@@ -325,7 +324,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return all records when empty options object is passed', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -344,7 +343,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return empty array when from is in the future', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -363,7 +362,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return empty array when to is far in the past', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -382,7 +381,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return empty array when offset exceeds total records', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -399,7 +398,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should treat offset 0 the same as no offset', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -422,7 +421,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should preserve reverse chronological order when filtering by from', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -454,7 +453,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should preserve reverse chronological order when using offset', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create 5 records total
@@ -477,7 +476,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should combine from + to + limit correctly', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Record before range
@@ -521,7 +520,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should combine from + to + offset correctly', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Record before range
@@ -566,7 +565,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should combine from + to + offset + limit for full pagination', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Record before range
@@ -610,8 +609,8 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should work with thread-scoped records (non-null threadId)', async () => {
-        const scopedThreadId = `thread-${randomUUID()}`;
-        const resourceId = `resource-${randomUUID()}`;
+        const scopedThreadId = `thread-${crypto.randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ threadId: scopedThreadId, resourceId, scope: 'thread' });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -649,8 +648,8 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should not return records from a different resource when filtering', async () => {
-        const resourceIdA = `resource-a-${randomUUID()}`;
-        const resourceIdB = `resource-b-${randomUUID()}`;
+        const resourceIdA = `resource-a-${crypto.randomUUID()}`;
+        const resourceIdB = `resource-b-${crypto.randomUUID()}`;
 
         // Create records for resource A
         const firstA = await memoryStorage.initializeObservationalMemory(
@@ -687,7 +686,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return empty array when from equals to and no record has that exact timestamp', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         await memoryStorage.initializeObservationalMemory(input);
@@ -703,7 +702,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should handle offset on a single record', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Only 1 record
@@ -723,7 +722,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should paginate correctly using offset + limit across multiple pages', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create 6 records total (gen 0..5)
@@ -767,7 +766,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return correct results when limit exceeds available records after offset', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // 3 records total
@@ -788,7 +787,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should return correct results when limit exceeds available records after date filtering', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         const first = await memoryStorage.initializeObservationalMemory(input);
@@ -1106,7 +1105,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should clear all history for a resource', async () => {
-        const resourceId = `resource-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
         const input = createSampleOMInput({ resourceId });
 
         // Create initial record
@@ -1232,8 +1231,8 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should maintain separate records for different resources', async () => {
-        const resource1 = `resource-${randomUUID()}`;
-        const resource2 = `resource-${randomUUID()}`;
+        const resource1 = `resource-${crypto.randomUUID()}`;
+        const resource2 = `resource-${crypto.randomUUID()}`;
 
         await memoryStorage.initializeObservationalMemory(createSampleOMInput({ resourceId: resource1 }));
         await memoryStorage.initializeObservationalMemory(createSampleOMInput({ resourceId: resource2 }));
@@ -1247,8 +1246,8 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       });
 
       it('should maintain separate records for thread-scoped vs resource-scoped', async () => {
-        const resourceId = `resource-${randomUUID()}`;
-        const threadId = `thread-${randomUUID()}`;
+        const resourceId = `resource-${crypto.randomUUID()}`;
+        const threadId = `thread-${crypto.randomUUID()}`;
 
         // Create resource-scoped record
         await memoryStorage.initializeObservationalMemory(
@@ -1392,7 +1391,7 @@ export function createObservationalMemoryTest({ storage }: { storage: MastraStor
       it('should retain observed message IDs across buffered activation', async () => {
         const input = createSampleOMInput();
         const record = await memoryStorage.initializeObservationalMemory(input);
-        const observedMessageIds = [`msg-${randomUUID()}`, `msg-${randomUUID()}`];
+        const observedMessageIds = [`msg-${crypto.randomUUID()}`, `msg-${crypto.randomUUID()}`];
 
         await memoryStorage.updateActiveObservations({
           id: record.id,

--- a/stores/_test-utils/src/domains/memory/resources.ts
+++ b/stores/_test-utils/src/domains/memory/resources.ts
@@ -1,7 +1,6 @@
 import type { MastraStorage, MemoryStorage } from '@mastra/core/storage';
 import { beforeAll, describe, expect, it } from 'vitest';
 import { createSampleResource } from './data';
-import { randomUUID } from 'node:crypto';
 
 export function createResourcesTest({ storage }: { storage: MastraStorage }) {
   let memoryStorage: MemoryStorage;
@@ -147,7 +146,7 @@ export function createResourcesTest({ storage }: { storage: MastraStorage }) {
     });
 
     it('should create new resource when updating non-existent resource', async () => {
-      const nonExistentId = `resource-${randomUUID()}`;
+      const nonExistentId = `resource-${crypto.randomUUID()}`;
       const newWorkingMemory = 'New working memory';
       const newMetadata = { created: true, source: 'update' };
 
@@ -182,7 +181,7 @@ export function createResourcesTest({ storage }: { storage: MastraStorage }) {
 
     it('should handle null/undefined workingMemory', async () => {
       const resource = {
-        id: `resource-${randomUUID()}`,
+        id: `resource-${crypto.randomUUID()}`,
         workingMemory: undefined,
         metadata: { key: 'value', test: true },
         createdAt: new Date(),
@@ -210,7 +209,7 @@ export function createResourcesTest({ storage }: { storage: MastraStorage }) {
 
     it('should handle null/undefined metadata', async () => {
       const resource = {
-        id: `resource-${randomUUID()}`,
+        id: `resource-${crypto.randomUUID()}`,
         workingMemory: 'Sample working memory content',
         metadata: undefined,
         createdAt: new Date(),

--- a/stores/_test-utils/src/domains/memory/threads.ts
+++ b/stores/_test-utils/src/domains/memory/threads.ts
@@ -2,7 +2,6 @@ import type { MastraStorage, MemoryStorage } from '@mastra/core/storage';
 import { createSampleMessageV2, createSampleThread, createSampleThreadWithParams } from './data';
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import type { MastraDBMessage, StorageThreadType } from '@mastra/core/memory';
-import { randomUUID } from 'node:crypto';
 
 export function createThreadsTest({ storage }: { storage: MastraStorage }) {
   let memoryStorage: MemoryStorage;
@@ -80,8 +79,8 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
 
     describe('resourceId isolation in getThreadById', () => {
       it('should return thread when resourceId matches (tenant match)', async () => {
-        const id = `thread-match-${randomUUID()}`;
-        const resourceId = `tenant-${randomUUID()}`;
+        const id = `thread-match-${crypto.randomUUID()}`;
+        const resourceId = `tenant-${crypto.randomUUID()}`;
         const thread = createSampleThreadWithParams(id, resourceId, new Date(), new Date());
         await memoryStorage.saveThread({ thread });
 
@@ -91,9 +90,9 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       });
 
       it('should return null when resourceId does not match (tenant mismatch)', async () => {
-        const id = `thread-mismatch-${randomUUID()}`;
-        const resourceId = `tenant-${randomUUID()}`;
-        const otherResourceId = `tenant-other-${randomUUID()}`;
+        const id = `thread-mismatch-${crypto.randomUUID()}`;
+        const resourceId = `tenant-${crypto.randomUUID()}`;
+        const otherResourceId = `tenant-other-${crypto.randomUUID()}`;
         const thread = createSampleThreadWithParams(id, resourceId, new Date(), new Date());
         await memoryStorage.saveThread({ thread });
 
@@ -102,8 +101,8 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       });
 
       it('should treat an empty string resourceId as an explicit scope', async () => {
-        const id = `thread-empty-resourceId-${randomUUID()}`;
-        const resourceId = `tenant-${randomUUID()}`;
+        const id = `thread-empty-resourceId-${crypto.randomUUID()}`;
+        const resourceId = `tenant-${crypto.randomUUID()}`;
         const thread = createSampleThreadWithParams(id, resourceId, new Date(), new Date());
         await memoryStorage.saveThread({ thread });
 
@@ -112,8 +111,8 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       });
 
       it('should return thread when resourceId is not provided (backwards compatibility)', async () => {
-        const id = `thread-no-resourceId-${randomUUID()}`;
-        const resourceId = `tenant-${randomUUID()}`;
+        const id = `thread-no-resourceId-${crypto.randomUUID()}`;
+        const resourceId = `tenant-${crypto.randomUUID()}`;
         const thread = createSampleThreadWithParams(id, resourceId, new Date(), new Date());
         await memoryStorage.saveThread({ thread });
 
@@ -279,7 +278,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       // Simulate user passing stringified JSON as message content (like the original bug report)
       const stringifiedContent = JSON.stringify({ userInput: 'test data', metadata: { key: 'value' } });
       const message: MastraDBMessage = {
-        id: `msg-${randomUUID()}`,
+        id: `msg-${crypto.randomUUID()}`,
         role: 'user',
         threadId: thread.id,
         resourceId: thread.resourceId,
@@ -318,7 +317,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
     });
 
     it('should return paginated threads with total count', async () => {
-      const resourceId = `pg-paginated-resource-${randomUUID()}`;
+      const resourceId = `pg-paginated-resource-${crypto.randomUUID()}`;
       const threadPromises = Array.from({ length: 17 }, () =>
         memoryStorage.saveThread({ thread: { ...createSampleThread(), resourceId } }),
       );
@@ -338,7 +337,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
     });
 
     it('should return paginated results when no pagination params for listThreads', async () => {
-      const resourceId = `pg-non-paginated-resource-${randomUUID()}`;
+      const resourceId = `pg-non-paginated-resource-${crypto.randomUUID()}`;
       await memoryStorage.saveThread({ thread: { ...createSampleThread(), resourceId } });
 
       const results = await memoryStorage.listThreads({ filter: { resourceId }, page: 0, perPage: 100 });
@@ -499,13 +498,13 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
 
     beforeEach(async () => {
       // Create unique resourceId for each test
-      resourceId = `sort-test-resource-${randomUUID()}`;
+      resourceId = `sort-test-resource-${crypto.randomUUID()}`;
 
       // Create test threads with specific dates for predictable sorting
       const baseTime = new Date('2024-01-01T00:00:00Z');
       const threadData = [
         {
-          id: `thread-${randomUUID()}`,
+          id: `thread-${crypto.randomUUID()}`,
           resourceId,
           title: 'Thread 1',
           createdAt: new Date(baseTime.getTime()), // oldest createdAt
@@ -513,7 +512,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
           metadata: { index: 1 },
         },
         {
-          id: `thread-${randomUUID()}`,
+          id: `thread-${crypto.randomUUID()}`,
           resourceId,
           title: 'Thread 2',
           createdAt: new Date(baseTime.getTime() + 1000),
@@ -521,7 +520,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
           metadata: { index: 2 },
         },
         {
-          id: `thread-${randomUUID()}`,
+          id: `thread-${crypto.randomUUID()}`,
           resourceId,
           title: 'Thread 3',
           createdAt: new Date(baseTime.getTime() + 2000),
@@ -529,7 +528,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
           metadata: { index: 3 },
         },
         {
-          id: `thread-${randomUUID()}`,
+          id: `thread-${crypto.randomUUID()}`,
           resourceId,
           title: 'Thread 4',
           createdAt: new Date(baseTime.getTime() + 3000),
@@ -537,7 +536,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
           metadata: { index: 4 },
         },
         {
-          id: `thread-${randomUUID()}`,
+          id: `thread-${crypto.randomUUID()}`,
           resourceId,
           title: 'Thread 5',
           createdAt: new Date(baseTime.getTime() + 4000), // newest createdAt
@@ -711,7 +710,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       });
 
       it('should handle empty results with sorting parameters', async () => {
-        const emptyResourceId = `empty-resource-${randomUUID()}`;
+        const emptyResourceId = `empty-resource-${crypto.randomUUID()}`;
 
         const result = await memoryStorage.listThreads({
           filter: { resourceId: emptyResourceId },
@@ -728,7 +727,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       });
 
       it('should handle single thread with sorting parameters', async () => {
-        const singleResourceId = `single-resource-${randomUUID()}`;
+        const singleResourceId = `single-resource-${crypto.randomUUID()}`;
         const singleThread = await memoryStorage.saveThread({
           thread: { ...createSampleThread(), resourceId: singleResourceId },
         });
@@ -749,13 +748,13 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
 
     describe('Thread sorting edge cases', () => {
       it('should handle threads with identical timestamps', async () => {
-        const identicalResourceId = `identical-resource-${randomUUID()}`;
+        const identicalResourceId = `identical-resource-${crypto.randomUUID()}`;
         const sameDate = new Date('2024-01-01T12:00:00Z');
 
         const identicalThreads = await Promise.all([
           memoryStorage.saveThread({
             thread: {
-              id: `identical-1-${randomUUID()}`,
+              id: `identical-1-${crypto.randomUUID()}`,
               resourceId: identicalResourceId,
               title: 'Identical Thread 1',
               createdAt: sameDate,
@@ -765,7 +764,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
           }),
           memoryStorage.saveThread({
             thread: {
-              id: `identical-2-${randomUUID()}`,
+              id: `identical-2-${crypto.randomUUID()}`,
               resourceId: identicalResourceId,
               title: 'Identical Thread 2',
               createdAt: sameDate,
@@ -775,7 +774,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
           }),
           memoryStorage.saveThread({
             thread: {
-              id: `identical-3-${randomUUID()}`,
+              id: `identical-3-${crypto.randomUUID()}`,
               resourceId: identicalResourceId,
               title: 'Identical Thread 3',
               createdAt: sameDate,
@@ -820,11 +819,11 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       });
 
       beforeEach(async () => {
-        filterResourceId1 = randomUUID();
+        filterResourceId1 = crypto.randomUUID();
 
         // Create threads with different timestamps for sorting tests
         filterThread1 = createSampleThreadWithParams(
-          randomUUID(),
+          crypto.randomUUID(),
           filterResourceId1,
           new Date(Date.now() - 4000),
           new Date(Date.now() - 4000),
@@ -832,7 +831,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
         filterThread1.metadata = { category: 'support', priority: 'high' };
 
         filterThread2 = createSampleThreadWithParams(
-          randomUUID(),
+          crypto.randomUUID(),
           filterResourceId1,
           new Date(Date.now() - 2000),
           new Date(Date.now() - 2000),
@@ -906,13 +905,13 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
     });
 
     beforeEach(async () => {
-      resourceId1 = randomUUID();
-      resourceId2 = randomUUID();
+      resourceId1 = crypto.randomUUID();
+      resourceId2 = crypto.randomUUID();
 
       // Use unique metadata values to avoid conflicts with other test blocks
       // Create threads with different metadata
       thread1 = createSampleThreadWithParams(
-        randomUUID(),
+        crypto.randomUUID(),
         resourceId1,
         new Date(Date.now() - 4000),
         new Date(Date.now() - 4000),
@@ -921,7 +920,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       thread1.title = 'Thread 1';
 
       thread2 = createSampleThreadWithParams(
-        randomUUID(),
+        crypto.randomUUID(),
         resourceId1,
         new Date(Date.now() - 3000),
         new Date(Date.now() - 3000),
@@ -930,7 +929,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       thread2.title = 'Thread 2';
 
       thread3 = createSampleThreadWithParams(
-        randomUUID(),
+        crypto.randomUUID(),
         resourceId2,
         new Date(Date.now() - 2000),
         new Date(Date.now() - 2000),
@@ -939,7 +938,7 @@ export function createThreadsTest({ storage }: { storage: MastraStorage }) {
       thread3.title = 'Thread 3';
 
       thread4 = createSampleThreadWithParams(
-        randomUUID(),
+        crypto.randomUUID(),
         resourceId2,
         new Date(Date.now() - 1000),
         new Date(Date.now() - 1000),

--- a/stores/_test-utils/src/domains/observability/data.ts
+++ b/stores/_test-utils/src/domains/observability/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { SpanType, EntityType } from '@mastra/core/observability';
 import type { CreateFeedbackRecord, CreateSpanRecord, SpanRecord } from '@mastra/core/storage';
 
@@ -13,8 +12,8 @@ export const DEFAULT_BASE_DATE = new Date('2024-01-01T00:00:00Z');
  */
 export function createSpan(overrides: Partial<CreateSpanRecord> = {}): CreateSpanRecord {
   const baseDate = overrides.startedAt || DEFAULT_BASE_DATE;
-  const traceId = overrides.traceId || `trace-${randomUUID()}`;
-  const spanId = overrides.spanId || `span-${randomUUID()}`;
+  const traceId = overrides.traceId || `trace-${crypto.randomUUID()}`;
+  const spanId = overrides.spanId || `span-${crypto.randomUUID()}`;
 
   return {
     traceId,
@@ -93,8 +92,8 @@ export function createChildSpan(parentSpanId: string, overrides: Partial<CreateS
  */
 export function createOldSchemaSpan(overrides: Partial<CreateSpanRecord> = {}): CreateSpanRecord {
   const baseDate = overrides.startedAt || DEFAULT_BASE_DATE;
-  const traceId = overrides.traceId || `trace-${randomUUID()}`;
-  const spanId = overrides.spanId || `span-${randomUUID()}`;
+  const traceId = overrides.traceId || `trace-${crypto.randomUUID()}`;
+  const spanId = overrides.spanId || `span-${crypto.randomUUID()}`;
 
   return {
     traceId,
@@ -139,7 +138,7 @@ export function createOldSchemaSpan(overrides: Partial<CreateSpanRecord> = {}): 
  */
 export function createFeedbackRecord(overrides: Partial<CreateFeedbackRecord> = {}): CreateFeedbackRecord {
   return {
-    feedbackId: overrides.feedbackId ?? `feedback-${randomUUID()}`,
+    feedbackId: overrides.feedbackId ?? `feedback-${crypto.randomUUID()}`,
     timestamp: overrides.timestamp ?? DEFAULT_BASE_DATE,
     feedbackType: 'thumbs',
     feedbackSource: 'human',

--- a/stores/_test-utils/src/domains/schedules/data.ts
+++ b/stores/_test-utils/src/domains/schedules/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Schedule, ScheduleTrigger } from '@mastra/core/storage';
 
 /**
@@ -7,7 +6,7 @@ import type { Schedule, ScheduleTrigger } from '@mastra/core/storage';
 export function createSampleSchedule(overrides?: Partial<Schedule>): Schedule {
   const now = Date.now();
   return {
-    id: `sched_${randomUUID()}`,
+    id: `sched_${crypto.randomUUID()}`,
     target: {
       type: 'workflow',
       workflowId: 'test-workflow',
@@ -28,9 +27,9 @@ export function createSampleSchedule(overrides?: Partial<Schedule>): Schedule {
 export function createSampleTrigger(overrides?: Partial<ScheduleTrigger>): ScheduleTrigger {
   const now = Date.now();
   return {
-    id: `tr_${randomUUID()}`,
+    id: `tr_${crypto.randomUUID()}`,
     scheduleId: 'sched_1',
-    runId: `run_${randomUUID()}`,
+    runId: `run_${crypto.randomUUID()}`,
     scheduledFireAt: now,
     actualFireAt: now,
     outcome: 'published',

--- a/stores/_test-utils/src/domains/scores/data.ts
+++ b/stores/_test-utils/src/domains/scores/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ScoreRowData, ScoringEntityType, ScoringSource } from '@mastra/core/evals';
 
 export function createSampleScore({
@@ -29,7 +28,7 @@ export function createSampleScore({
   runId?: string;
 }): ScoreRowData {
   return {
-    id: randomUUID(),
+    id: crypto.randomUUID(),
     entityId: entityId ?? 'eval-agent',
     entityType: entityType ?? 'AGENT',
     scorerId,
@@ -42,7 +41,7 @@ export function createSampleScore({
     datasetItemId,
     createdAt: new Date(),
     updatedAt: new Date(),
-    runId: runId ?? randomUUID(),
+    runId: runId ?? crypto.randomUUID(),
     reason: 'Sample reason',
     preprocessStepResult: {
       text: 'Sample preprocess step result',
@@ -61,7 +60,7 @@ export function createSampleScore({
     },
     input: [
       {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         name: 'input-1',
         value: 'Sample input',
       },

--- a/stores/_test-utils/src/domains/scores/index.ts
+++ b/stores/_test-utils/src/domains/scores/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { beforeAll, describe, it, expect, beforeEach } from 'vitest';
 import { createSampleScore } from './data';
 import type { ScoreRowData } from '@mastra/core/evals';
@@ -54,7 +53,7 @@ export function createScoresTest({
     });
 
     it('should retrieve scores by scorer id', async () => {
-      const scorerId = `scorer-${randomUUID()}`;
+      const scorerId = `scorer-${crypto.randomUUID()}`;
 
       // Create sample scores
       const score1 = createSampleScore({ scorerId });
@@ -90,20 +89,20 @@ export function createScoresTest({
 
     if (capabilities.deterministicScorePagination === true) {
       it('should paginate scores by scorer id in descending creation order', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
+        const scorerId = `scorer-${crypto.randomUUID()}`;
 
         const { score: oldest } = await scoresStorage.saveScore(
-          createSampleScore({ scorerId, traceId: randomUUID(), spanId: randomUUID() }),
+          createSampleScore({ scorerId, traceId: crypto.randomUUID(), spanId: crypto.randomUUID() }),
         );
         await new Promise(resolve => setTimeout(resolve, 20));
 
         const { score: middle } = await scoresStorage.saveScore(
-          createSampleScore({ scorerId, traceId: randomUUID(), spanId: randomUUID() }),
+          createSampleScore({ scorerId, traceId: crypto.randomUUID(), spanId: crypto.randomUUID() }),
         );
         await new Promise(resolve => setTimeout(resolve, 20));
 
         const { score: newest } = await scoresStorage.saveScore(
-          createSampleScore({ scorerId, traceId: randomUUID(), spanId: randomUUID() }),
+          createSampleScore({ scorerId, traceId: crypto.randomUUID(), spanId: crypto.randomUUID() }),
         );
 
         const firstPage = await scoresStorage.listScoresByScorerId({
@@ -129,7 +128,7 @@ export function createScoresTest({
     }
 
     it('should return score payload matching the saved score', async () => {
-      const scorerId = `scorer-${randomUUID()}`;
+      const scorerId = `scorer-${crypto.randomUUID()}`;
       const score = createSampleScore({ scorerId });
 
       await scoresStorage.saveScore(score);
@@ -180,7 +179,7 @@ export function createScoresTest({
     });
 
     it('should retrieve scores by source', async () => {
-      const scorerId = `scorer-${randomUUID()}`;
+      const scorerId = `scorer-${crypto.randomUUID()}`;
       const score1 = createSampleScore({ scorerId, source: 'TEST' });
       const score2 = createSampleScore({ scorerId, source: 'LIVE' });
       await scoresStorage.saveScore(score1);
@@ -195,7 +194,7 @@ export function createScoresTest({
     });
 
     it('should save scorer', async () => {
-      const scorerId = `scorer-${randomUUID()}`;
+      const scorerId = `scorer-${crypto.randomUUID()}`;
       const scorer = createSampleScore({ scorerId });
       await scoresStorage.saveScore(scorer);
       const result = await scoresStorage.listScoresByRunId({
@@ -210,7 +209,7 @@ export function createScoresTest({
     });
 
     it('should retrieve saved score by its returned id', async () => {
-      const scorerId = `scorer-${randomUUID()}`;
+      const scorerId = `scorer-${crypto.randomUUID()}`;
       const score = createSampleScore({ scorerId });
 
       // Save the score and get the returned score with its id
@@ -227,7 +226,7 @@ export function createScoresTest({
     });
 
     it('listScoresByEntityId should return paginated scores with total count when returnPaginationResults is true', async () => {
-      const scorer = createSampleScore({ scorerId: `scorer-${randomUUID()}` });
+      const scorer = createSampleScore({ scorerId: `scorer-${crypto.randomUUID()}` });
       await scoresStorage.saveScore(scorer);
 
       const result = await scoresStorage.listScoresByEntityId({
@@ -245,9 +244,9 @@ export function createScoresTest({
     // listScoresBySpan defaults to true since most stores support it
     if (capabilities.listScoresBySpan !== false) {
       it('should retrieve scores by trace and span id', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const traceId = randomUUID();
-        const spanId = randomUUID();
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const traceId = crypto.randomUUID();
+        const spanId = crypto.randomUUID();
 
         const score = createSampleScore({ scorerId, traceId, spanId });
         await scoresStorage.saveScore(score);
@@ -266,9 +265,9 @@ export function createScoresTest({
       });
 
       it('should retrieve multiple scores by trace and span id', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const traceId = randomUUID();
-        const spanId = randomUUID();
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const traceId = crypto.randomUUID();
+        const spanId = crypto.randomUUID();
 
         // Create multiple scores for the same trace/span
         const score1 = createSampleScore({ scorerId, traceId, spanId });
@@ -293,15 +292,15 @@ export function createScoresTest({
       });
 
       it('should handle first page pagination correctly', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const traceId = randomUUID();
-        const spanId = randomUUID();
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const traceId = crypto.randomUUID();
+        const spanId = crypto.randomUUID();
 
         await createScores([
           { count: 5, scorerId, traceId, spanId }, // target scores
-          { count: 1, scorerId, traceId: randomUUID(), spanId }, // different trace
-          { count: 1, scorerId, traceId, spanId: randomUUID() }, // different span
-          { count: 1, scorerId, traceId: randomUUID(), spanId: randomUUID() }, // both different
+          { count: 1, scorerId, traceId: crypto.randomUUID(), spanId }, // different trace
+          { count: 1, scorerId, traceId, spanId: crypto.randomUUID() }, // different span
+          { count: 1, scorerId, traceId: crypto.randomUUID(), spanId: crypto.randomUUID() }, // both different
         ]);
 
         const firstPage = await scoresStorage.listScoresBySpan({
@@ -320,15 +319,15 @@ export function createScoresTest({
       });
 
       it('should handle middle page pagination correctly', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const traceId = randomUUID();
-        const spanId = randomUUID();
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const traceId = crypto.randomUUID();
+        const spanId = crypto.randomUUID();
 
         const allScores = await createScores([
           { count: 5, scorerId, traceId, spanId }, // target scores
-          { count: 1, scorerId, traceId: randomUUID(), spanId }, // different trace
-          { count: 1, scorerId, traceId, spanId: randomUUID() }, // different span
-          { count: 1, scorerId, traceId: randomUUID(), spanId: randomUUID() }, // both different
+          { count: 1, scorerId, traceId: crypto.randomUUID(), spanId }, // different trace
+          { count: 1, scorerId, traceId, spanId: crypto.randomUUID() }, // different span
+          { count: 1, scorerId, traceId: crypto.randomUUID(), spanId: crypto.randomUUID() }, // both different
         ]);
 
         const secondPage = await scoresStorage.listScoresBySpan({
@@ -347,14 +346,14 @@ export function createScoresTest({
       });
 
       it('should handle last page pagination', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const traceId = randomUUID();
-        const spanId = randomUUID();
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const traceId = crypto.randomUUID();
+        const spanId = crypto.randomUUID();
 
-        const otherTraceId1 = randomUUID();
-        const otherTraceId2 = randomUUID();
-        const otherSpanId1 = randomUUID();
-        const otherSpanId2 = randomUUID();
+        const otherTraceId1 = crypto.randomUUID();
+        const otherTraceId2 = crypto.randomUUID();
+        const otherSpanId1 = crypto.randomUUID();
+        const otherSpanId2 = crypto.randomUUID();
 
         await createScores([
           { count: 5, scorerId, traceId, spanId }, // target scores
@@ -398,7 +397,7 @@ export function createScoresTest({
 
     describe('multi-tenant filters', () => {
       it('persists organizationId and projectId on saved scores', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
+        const scorerId = `scorer-${crypto.randomUUID()}`;
         const score = createSampleScore({ scorerId, organizationId: 'org-a', projectId: 'proj-1' });
 
         const { score: saved } = await scoresStorage.saveScore(score);
@@ -408,7 +407,7 @@ export function createScoresTest({
       });
 
       it('round-trips batch and dataset provenance fields', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
+        const scorerId = `scorer-${crypto.randomUUID()}`;
         const { score: saved } = await scoresStorage.saveScore(
           createSampleScore({
             scorerId,
@@ -426,7 +425,7 @@ export function createScoresTest({
       });
 
       it('filters listScoresByScorerId by organizationId and projectId', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
+        const scorerId = `scorer-${crypto.randomUUID()}`;
         await scoresStorage.saveScore(createSampleScore({ scorerId, organizationId: 'org-a', projectId: 'proj-1' }));
         await scoresStorage.saveScore(createSampleScore({ scorerId, organizationId: 'org-a', projectId: 'proj-2' }));
         await scoresStorage.saveScore(createSampleScore({ scorerId, organizationId: 'org-b', projectId: 'proj-1' }));
@@ -449,8 +448,8 @@ export function createScoresTest({
       });
 
       it('filters listScoresByEntityId by tenancy', async () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const entityId = `agent-${randomUUID()}`;
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const entityId = `agent-${crypto.randomUUID()}`;
         await scoresStorage.saveScore(createSampleScore({ scorerId, entityId, organizationId: 'org-a' }));
         await scoresStorage.saveScore(createSampleScore({ scorerId, entityId, organizationId: 'org-b' }));
 

--- a/stores/_test-utils/src/domains/tool-provider-connections/data.ts
+++ b/stores/_test-utils/src/domains/tool-provider-connections/data.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { StorageUpsertToolProviderConnectionInput } from '@mastra/core/storage';
 
 /**
@@ -8,10 +7,10 @@ export function createSampleConnection(
   overrides?: Partial<StorageUpsertToolProviderConnectionInput>,
 ): StorageUpsertToolProviderConnectionInput {
   return {
-    authorId: `author_${randomUUID()}`,
+    authorId: `author_${crypto.randomUUID()}`,
     providerId: 'composio',
     toolkit: 'gmail',
-    connectionId: `conn_${randomUUID()}`,
+    connectionId: `conn_${crypto.randomUUID()}`,
     label: 'Work Gmail',
     scope: 'per-author',
     ...overrides,

--- a/stores/_test-utils/src/domains/workflows/data.ts
+++ b/stores/_test-utils/src/domains/workflows/data.ts
@@ -1,5 +1,4 @@
 import type { WorkflowRunState } from '@mastra/core/workflows';
-import { randomUUID } from 'node:crypto';
 import { expect } from 'vitest';
 
 export const checkWorkflowSnapshot = (snapshot: WorkflowRunState | string, stepId: string, status: string) => {
@@ -10,8 +9,8 @@ export const checkWorkflowSnapshot = (snapshot: WorkflowRunState | string, stepI
 };
 
 export const createSampleWorkflowSnapshot = (status: string, createdAt?: Date) => {
-  const runId = `run-${randomUUID()}`;
-  const stepId = `step-${randomUUID()}`;
+  const runId = `run-${crypto.randomUUID()}`;
+  const stepId = `step-${crypto.randomUUID()}`;
   const timestamp = createdAt || new Date();
   const snapshot = {
     result: { success: true },

--- a/stores/_test-utils/src/domains/workflows/index.ts
+++ b/stores/_test-utils/src/domains/workflows/index.ts
@@ -1,6 +1,5 @@
 import type { MastraStorage, WorkflowsStorage } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
-import { randomUUID } from 'node:crypto';
 import { beforeAll, describe, it, expect, beforeEach } from 'vitest';
 import { checkWorkflowSnapshot, createSampleWorkflowSnapshot } from './data';
 
@@ -420,7 +419,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
   describe('Workflow Snapshots', () => {
     it('should persist and load workflow snapshots', async () => {
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const snapshot = {
         status: 'running',
         context: {
@@ -455,7 +454,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
 
     it('should update existing workflow snapshot', async () => {
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const initialSnapshot = {
         status: 'running',
         context: {
@@ -498,7 +497,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
 
     it('should handle complex workflow state', async () => {
       const workflowName = 'complex-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const complexSnapshot = {
         value: { currentState: 'running' },
         context: {
@@ -559,8 +558,8 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
 
     it('should persist resourceId when creating workflow runs', async () => {
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
-      const resourceId = `resource-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
+      const resourceId = `resource-${crypto.randomUUID()}`;
       const snapshot = {
         status: 'running',
         context: {},
@@ -591,7 +590,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
         return;
       }
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const snapshot = {
         status: 'running',
         context: {},
@@ -686,7 +685,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
         return;
       }
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const snapshot = {
         status: 'running',
         context: { initialStep: { status: 'success' } },
@@ -756,7 +755,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
       }
       const result = await workflowsStorage.updateWorkflowState({
         workflowName: 'non-existent-workflow',
-        runId: `run-${randomUUID()}`,
+        runId: `run-${crypto.randomUUID()}`,
         opts: {
           status: 'success',
         },
@@ -774,7 +773,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
         return;
       }
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const snapshot = {
         status: 'running',
         context: {},
@@ -880,7 +879,7 @@ export function createWorkflowsTests({ storage }: WorkflowsTestOptions) {
         return;
       }
       const workflowName = 'test-workflow';
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const snapshot = {
         status: 'running',
         context: {},

--- a/stores/cloudflare-d1/src/storage/rest-api.test.ts
+++ b/stores/cloudflare-d1/src/storage/rest-api.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import {
   createSampleMessageV1,
   createSampleMessageV2,
@@ -676,7 +675,7 @@ describe.skip('D1Store REST API', () => {
     });
 
     it('should handle complex workflow state', async () => {
-      const runId = `run-${randomUUID()}`;
+      const runId = `run-${crypto.randomUUID()}`;
       const workflowName = 'complex-workflow';
 
       const complexSnapshot = {

--- a/stores/cloudflare-d1/src/storage/test-utils.ts
+++ b/stores/cloudflare-d1/src/storage/test-utils.ts
@@ -1,9 +1,7 @@
-import { randomUUID } from 'node:crypto';
-
 export const createSampleTrace = (name: string, scope?: string, attributes?: Record<string, string>) => ({
-  id: `trace-${randomUUID()}`,
-  parentSpanId: `span-${randomUUID()}`,
-  traceId: `trace-${randomUUID()}`,
+  id: `trace-${crypto.randomUUID()}`,
+  parentSpanId: `span-${crypto.randomUUID()}`,
+  traceId: `trace-${crypto.randomUUID()}`,
   name,
   scope,
   kind: 'internal',

--- a/stores/cloudflare/src/kv/storage/test-utils.ts
+++ b/stores/cloudflare/src/kv/storage/test-utils.ts
@@ -1,10 +1,9 @@
-import { randomUUID } from 'node:crypto';
 import type { WorkflowRunState } from '@mastra/core/workflows';
 
 export const createSampleTrace = (name: string, scope?: string, attributes?: Record<string, string>) => ({
-  id: `trace-${randomUUID()}`,
-  parentSpanId: `span-${randomUUID()}`,
-  traceId: `trace-${randomUUID()}`,
+  id: `trace-${crypto.randomUUID()}`,
+  parentSpanId: `span-${crypto.randomUUID()}`,
+  traceId: `trace-${crypto.randomUUID()}`,
   name,
   scope,
   kind: 'internal',
@@ -19,8 +18,8 @@ export const createSampleTrace = (name: string, scope?: string, attributes?: Rec
 });
 
 export const createSampleWorkflowSnapshot = (threadId: string, status: string, createdAt?: Date) => {
-  const runId = `run-${randomUUID()}`;
-  const stepId = `step-${randomUUID()}`;
+  const runId = `run-${crypto.randomUUID()}`;
+  const stepId = `step-${crypto.randomUUID()}`;
   const timestamp = createdAt || new Date();
   const snapshot: WorkflowRunState = {
     status: status as WorkflowRunState['status'],

--- a/stores/couchbase/src/vector/index.integration.test.ts
+++ b/stores/couchbase/src/vector/index.integration.test.ts
@@ -3,7 +3,6 @@
 // The tests will automatically start and configure the required Couchbase container.
 
 import { execSync } from 'node:child_process';
-import { randomUUID } from 'node:crypto';
 
 import type { Cluster, Bucket, Scope, Collection } from 'couchbase';
 import { connect, QueryScanConsistency, ServiceType, PingState } from 'couchbase';
@@ -589,7 +588,7 @@ describe('Integration Testing CouchbaseVector', async () => {
     }, 50000);
 
     it('should handle duplicate index creation gracefully', async () => {
-      const duplicateIndexName = `duplicate-test-${randomUUID()}`;
+      const duplicateIndexName = `duplicate-test-${crypto.randomUUID()}`;
       const dimension = 768;
       const infoSpy = vi.spyOn(couchbase_client['logger'], 'info');
       const warnSpy = vi.spyOn(couchbase_client['logger'], 'warn');

--- a/stores/libsql/src/storage/domains/memory/index.ts
+++ b/stores/libsql/src/storage/domains/memory/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Client, InValue } from '@libsql/client';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { MessageList } from '@mastra/core/agent';
@@ -2186,7 +2185,7 @@ export class MemoryLibSQL extends MemoryStorage {
 
       // Create new chunk with ID and timestamp
       const newChunk: BufferedObservationChunk = {
-        id: `ombuf-${randomUUID()}`,
+        id: `ombuf-${crypto.randomUUID()}`,
         cycleId: input.chunk.cycleId,
         observations: input.chunk.observations,
         tokenCount: input.chunk.tokenCount,

--- a/stores/libsql/src/storage/domains/notifications/index.ts
+++ b/stores/libsql/src/storage/domains/notifications/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import type { Client, InValue } from '@libsql/client';
 import { NotificationsStorage, TABLE_NOTIFICATIONS, TABLE_SCHEMAS } from '@mastra/core/storage';
 import type {
@@ -181,7 +179,7 @@ export class NotificationsLibSQL extends NotificationsStorage {
 
     const now = input.createdAt ?? new Date();
     const record: NotificationRecord = {
-      id: input.id ?? randomUUID(),
+      id: input.id ?? crypto.randomUUID(),
       threadId: input.threadId,
       source: input.source,
       kind: input.kind,

--- a/stores/mongodb/src/storage/domains/agents/index.ts
+++ b/stores/mongodb/src/storage/domains/agents/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   AgentsStorage,
@@ -243,7 +241,7 @@ export class MongoDBAgentsStorage extends AgentsStorage {
       // Extract config fields from the flat input
       const { id: _id, authorId: _authorId, visibility: _visibility, metadata: _metadata, ...snapshotConfig } = agent;
 
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         agentId: agent.id,

--- a/stores/mongodb/src/storage/domains/datasets/index.ts
+++ b/stores/mongodb/src/storage/domains/datasets/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   DatasetsStorage,
@@ -227,7 +225,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
   async createDataset(input: CreateDatasetInput): Promise<DatasetRecord> {
     try {
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       if (input.id !== undefined) this.validateCallerDefinedDatasetId(input.id);
       const now = new Date();
       const collection = await this.getCollection(TABLE_DATASETS);
@@ -470,8 +468,8 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
   protected async _doAddItem(args: AddDatasetItemInput): Promise<DatasetItem> {
     try {
-      const id = randomUUID();
-      const versionId = randomUUID();
+      const id = crypto.randomUUID();
+      const versionId = crypto.randomUUID();
       const now = new Date();
 
       const datasetsCollection = await this.getCollection(TABLE_DATASETS);
@@ -597,7 +595,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       }
 
       const now = new Date();
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
 
       const mergedInput = args.input !== undefined ? args.input : existing.input;
       const mergedGroundTruth = args.groundTruth !== undefined ? args.groundTruth : existing.groundTruth;
@@ -717,7 +715,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       }
 
       const now = new Date();
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
 
       const datasetsCollection = await this.getCollection(TABLE_DATASETS);
       const itemsCollection = await this.getCollection(TABLE_DATASET_ITEMS);
@@ -844,7 +842,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
         const plan = this.planDatasetItemBatch(
           input.items,
           historyRows.map(row => this.transformItemRowFull(row)),
-          randomUUID,
+          () => crypto.randomUUID(),
         );
         const resolved = new Map<string, DatasetItem>(
           [...plan.existingCurrentItems].map(([id, row]) => [id, this.datasetItemFromRow(row)]),
@@ -880,7 +878,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
             resolved.set(item.id, item);
           }
           await versionsCollection.insertOne(
-            { id: randomUUID(), datasetId: input.datasetId, version: newVersion, createdAt: now },
+            { id: crypto.randomUUID(), datasetId: input.datasetId, version: newVersion, createdAt: now },
             { session },
           );
         }
@@ -929,7 +927,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
       if (currentItems.length === 0) return;
 
       const now = new Date();
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
 
       const datasetsCollection = await this.getCollection(TABLE_DATASETS);
       const versionsCollection = await this.getCollection(TABLE_DATASET_VERSIONS);
@@ -1179,7 +1177,7 @@ export class MongoDBDatasetsStorage extends DatasetsStorage {
 
   async createDatasetVersion(datasetId: string, version: number): Promise<DatasetVersion> {
     try {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const now = new Date();
       const collection = await this.getCollection(TABLE_DATASET_VERSIONS);
 

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   ExperimentsStorage,
@@ -255,7 +253,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
   // -------------------------------------------------------------------------
 
   async createExperiment(input: CreateExperimentInput): Promise<Experiment> {
-    const id = input.id ?? randomUUID();
+    const id = input.id ?? crypto.randomUUID();
     const now = new Date();
 
     const doc = {
@@ -503,7 +501,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
   // -------------------------------------------------------------------------
 
   async addExperimentResult(input: AddExperimentResultInput): Promise<ExperimentResult> {
-    const id = input.id ?? randomUUID();
+    const id = input.id ?? crypto.randomUUID();
     const now = new Date();
 
     const doc = {

--- a/stores/mongodb/src/storage/domains/mcp-clients/index.ts
+++ b/stores/mongodb/src/storage/domains/mcp-clients/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   MCPClientsStorage,
@@ -171,7 +169,7 @@ export class MongoDBMCPClientsStorage extends MCPClientsStorage {
       for (const field of SNAPSHOT_FIELDS) {
         if ((mcpClient as any)[field] !== undefined) snapshotConfig[field] = (mcpClient as any)[field];
       }
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         mcpClientId: mcpClient.id,

--- a/stores/mongodb/src/storage/domains/mcp-servers/index.ts
+++ b/stores/mongodb/src/storage/domains/mcp-servers/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   MCPServersStorage,
@@ -188,7 +186,7 @@ export class MongoDBMCPServersStorage extends MCPServersStorage {
       }
 
       // Create version 1
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         mcpServerId: mcpServer.id,

--- a/stores/mongodb/src/storage/domains/memory/index.ts
+++ b/stores/mongodb/src/storage/domains/memory/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -1239,7 +1237,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       });
     }
 
-    const newThreadId = providedThreadId || randomUUID();
+    const newThreadId = providedThreadId || crypto.randomUUID();
 
     const existingThread = await this.getThreadById({ threadId: newThreadId });
     if (existingThread) {
@@ -1326,7 +1324,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
       if (sourceMessages.length > 0) {
         const messageDocs: any[] = [];
         for (const sourceMsg of sourceMessages) {
-          const newMessageId = randomUUID();
+          const newMessageId = crypto.randomUUID();
           messageIdMap[sourceMsg.id] = newMessageId;
 
           let parsedContent = sourceMsg.content;
@@ -1516,7 +1514,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
 
   async initializeObservationalMemory(input: CreateObservationalMemoryInput): Promise<ObservationalMemoryRecord> {
     try {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const now = new Date();
       const lookupKey = this.getOMKey(input.threadId, input.resourceId);
 
@@ -1688,7 +1686,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
 
   async createReflectionGeneration(input: CreateReflectionGenerationInput): Promise<ObservationalMemoryRecord> {
     try {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const now = new Date();
       const lookupKey = this.getOMKey(input.currentRecord.threadId, input.currentRecord.resourceId);
 
@@ -2003,7 +2001,7 @@ export class MemoryStorageMongoDB extends MemoryStorage {
 
       // Create new chunk with ID and timestamp
       const newChunk: BufferedObservationChunk = {
-        id: `ombuf-${randomUUID()}`,
+        id: `ombuf-${crypto.randomUUID()}`,
         cycleId: input.chunk.cycleId,
         observations: input.chunk.observations,
         tokenCount: input.chunk.tokenCount,

--- a/stores/mongodb/src/storage/domains/notifications/index.ts
+++ b/stores/mongodb/src/storage/domains/notifications/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { NotificationsStorage, TABLE_NOTIFICATIONS } from '@mastra/core/storage';
 import type {
   CreateNotificationInput,
@@ -251,7 +249,7 @@ export class NotificationsMongoDB extends NotificationsStorage {
 
     const now = input.createdAt ?? new Date();
     const record: NotificationRecord = {
-      id: input.id ?? randomUUID(),
+      id: input.id ?? crypto.randomUUID(),
       threadId: input.threadId,
       source: input.source,
       kind: input.kind,

--- a/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
+++ b/stores/mongodb/src/storage/domains/prompt-blocks/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   PromptBlocksStorage,
@@ -175,7 +173,7 @@ export class MongoDBPromptBlocksStorage extends PromptBlocksStorage {
       }
 
       // Create version 1
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         blockId: promptBlock.id,

--- a/stores/mongodb/src/storage/domains/scorer-definitions/index.ts
+++ b/stores/mongodb/src/storage/domains/scorer-definitions/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   ScorerDefinitionsStorage,
@@ -184,7 +182,7 @@ export class MongoDBScorerDefinitionsStorage extends ScorerDefinitionsStorage {
       }
 
       // Create version 1
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         scorerDefinitionId: scorerDefinition.id,

--- a/stores/mongodb/src/storage/domains/scores/index.ts
+++ b/stores/mongodb/src/storage/domains/scores/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
@@ -187,7 +185,7 @@ export class ScoresStorageMongoDB extends ScoresStorage {
     }
     try {
       const now = new Date();
-      const scoreId = randomUUID();
+      const scoreId = crypto.randomUUID();
 
       const scorer =
         typeof validatedScore.scorer === 'string' ? safelyParseJSON(validatedScore.scorer) : validatedScore.scorer;

--- a/stores/mongodb/src/storage/domains/skills/index.ts
+++ b/stores/mongodb/src/storage/domains/skills/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   SkillsStorage,
@@ -189,7 +187,7 @@ export class MongoDBSkillsStorage extends SkillsStorage {
       for (const field of SNAPSHOT_FIELDS) {
         if ((skill as any)[field] !== undefined) snapshotConfig[field] = (skill as any)[field];
       }
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         skillId: id,
@@ -302,7 +300,7 @@ export class MongoDBSkillsStorage extends SkillsStorage {
         if (changedFields.length > 0) {
           const mergedSnapshot = { ...existingSnapshot, ...configFields };
           newVersionDoc = {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             skillId: id,
             versionNumber: latestVersion.versionNumber + 1,
             changedFields,

--- a/stores/mongodb/src/storage/domains/workspaces/index.ts
+++ b/stores/mongodb/src/storage/domains/workspaces/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   WorkspacesStorage,
@@ -198,7 +196,7 @@ export class MongoDBWorkspacesStorage extends WorkspacesStorage {
       for (const field of SNAPSHOT_FIELDS) {
         if ((workspace as any)[field] !== undefined) snapshotConfig[field] = (workspace as any)[field];
       }
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const versionDoc: Record<string, any> = {
         id: versionId,
         workspaceId: id,
@@ -288,7 +286,7 @@ export class MongoDBWorkspacesStorage extends WorkspacesStorage {
         const existingSnapshot = this.extractSnapshotFields(latestVersion);
         const mergedSnapshot = { ...existingSnapshot, ...configFields };
         newVersionDoc = {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           workspaceId: id,
           versionNumber: latestVersion.versionNumber + 1,
           changedFields: Object.keys(configFields),

--- a/stores/mssql/src/storage/domains/agents/index.ts
+++ b/stores/mssql/src/storage/domains/agents/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   AgentsStorage,
@@ -233,7 +231,7 @@ export class AgentsMSSQL extends AgentsStorage {
         },
       });
       const { id: _id, authorId: _authorId, metadata: _metadata, ...snapshotConfig } = agent;
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       await this.createVersion({
         id: versionId,
         agentId: agent.id,

--- a/stores/mssql/src/storage/domains/scores/index.ts
+++ b/stores/mssql/src/storage/domains/scores/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
 import { saveScorePayloadSchema } from '@mastra/core/evals';
@@ -186,7 +185,7 @@ export class ScoresMSSQL extends ScoresStorage {
 
     try {
       // Generate ID like other storage implementations
-      const scoreId = randomUUID();
+      const scoreId = crypto.randomUUID();
       const now = new Date();
 
       const {

--- a/stores/mysql/src/storage/domains/datasets/index.ts
+++ b/stores/mysql/src/storage/domains/datasets/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   TABLE_DATASETS,
@@ -305,7 +304,7 @@ export class DatasetsMySQL extends DatasetsStorage {
 
   async createDataset(input: CreateDatasetInput): Promise<DatasetRecord> {
     try {
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       if (input.id !== undefined) this.validateCallerDefinedDatasetId(input.id);
       const now = new Date();
 
@@ -635,8 +634,8 @@ export class DatasetsMySQL extends DatasetsStorage {
     try {
       await connection.beginTransaction();
 
-      const id = randomUUID();
-      const versionId = randomUUID();
+      const id = crypto.randomUUID();
+      const versionId = crypto.randomUUID();
       const now = new Date();
       const tableDatasetsName = formatTableName(TABLE_DATASETS);
       const tableItemsName = formatTableName(TABLE_DATASET_ITEMS);
@@ -734,7 +733,7 @@ export class DatasetsMySQL extends DatasetsStorage {
     try {
       await connection.beginTransaction();
 
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const now = new Date();
       const tableDatasetsName = formatTableName(TABLE_DATASETS);
       const tableItemsName = formatTableName(TABLE_DATASET_ITEMS);
@@ -844,7 +843,7 @@ export class DatasetsMySQL extends DatasetsStorage {
     try {
       await connection.beginTransaction();
 
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const now = new Date();
       const tableDatasetsName = formatTableName(TABLE_DATASETS);
       const tableItemsName = formatTableName(TABLE_DATASET_ITEMS);
@@ -1073,7 +1072,7 @@ export class DatasetsMySQL extends DatasetsStorage {
 
   async createDatasetVersion(datasetId: string, version: number): Promise<DatasetVersion> {
     try {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const now = new Date();
 
       await this.operations.insert({
@@ -1188,7 +1187,7 @@ export class DatasetsMySQL extends DatasetsStorage {
         historyRows = rows.map(row => this.mapItemFull(row));
       }
 
-      const plan = this.planDatasetItemBatch(input.items, historyRows, randomUUID);
+      const plan = this.planDatasetItemBatch(input.items, historyRows, () => crypto.randomUUID());
       const existingItems = new Map<string, DatasetItem>(
         [...plan.existingCurrentItems].map(([id, row]) => [id, this.datasetItemFromRow(row)]),
       );
@@ -1241,7 +1240,7 @@ export class DatasetsMySQL extends DatasetsStorage {
 
       await connection.execute(
         `INSERT INTO ${tableVersionsName} (\`id\`, \`datasetId\`, \`version\`, \`createdAt\`) VALUES (?, ?, ?, ?)`,
-        [randomUUID(), input.datasetId, newVersion, transformToSqlValue(now)],
+        [crypto.randomUUID(), input.datasetId, newVersion, transformToSqlValue(now)],
       );
       await connection.commit();
 
@@ -1289,7 +1288,7 @@ export class DatasetsMySQL extends DatasetsStorage {
       await connection.beginTransaction();
 
       const now = new Date();
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const tableDatasetsName = formatTableName(TABLE_DATASETS);
       const tableItemsName = formatTableName(TABLE_DATASET_ITEMS);
       const tableVersionsName = formatTableName(TABLE_DATASET_VERSIONS);

--- a/stores/mysql/src/storage/domains/experiments/index.ts
+++ b/stores/mysql/src/storage/domains/experiments/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
   TABLE_EXPERIMENTS,
@@ -245,7 +244,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
 
   async createExperiment(input: CreateExperimentInput): Promise<Experiment> {
     try {
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       const now = new Date();
 
       await this.operations.insert({
@@ -543,7 +542,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       });
     }
     try {
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       const now = new Date();
 
       await this.operations.insert({

--- a/stores/mysql/src/storage/domains/memory/index.ts
+++ b/stores/mysql/src/storage/domains/memory/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -817,7 +816,7 @@ export class MemoryMySQL extends MemoryStorage {
           });
         }
         const createdAt = message.createdAt ? new Date(message.createdAt) : new Date();
-        const id = message.id ?? randomUUID();
+        const id = message.id ?? crypto.randomUUID();
         const record = {
           id,
           thread_id: message.threadId,
@@ -1035,7 +1034,7 @@ export class MemoryMySQL extends MemoryStorage {
     }
 
     // Use provided ID or generate a new one
-    const newThreadId = providedThreadId || randomUUID();
+    const newThreadId = providedThreadId || crypto.randomUUID();
 
     // Check if the new thread ID already exists
     const existingThread = await this.getThreadById({ threadId: newThreadId });
@@ -1133,7 +1132,7 @@ export class MemoryMySQL extends MemoryStorage {
 
       for (const sourceRow of sourceMessageRows) {
         const row = sourceRow as MessageRow;
-        const newMessageId = randomUUID();
+        const newMessageId = crypto.randomUUID();
         messageIdMap[row.id] = newMessageId;
 
         let content = row.content;
@@ -1743,7 +1742,7 @@ export class MemoryMySQL extends MemoryStorage {
 
   async initializeObservationalMemory(input: CreateObservationalMemoryInput): Promise<ObservationalMemoryRecord> {
     try {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const now = new Date();
       const lookupKey = this.getOMKey(input.threadId, input.resourceId);
 
@@ -1874,7 +1873,7 @@ export class MemoryMySQL extends MemoryStorage {
 
   async createReflectionGeneration(input: CreateReflectionGenerationInput): Promise<ObservationalMemoryRecord> {
     try {
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       const now = new Date();
       const lookupKey = this.getOMKey(input.currentRecord.threadId, input.currentRecord.resourceId);
 
@@ -2051,7 +2050,7 @@ export class MemoryMySQL extends MemoryStorage {
         const existingChunks = parseBufferedChunks(currentRows[0]!.bufferedObservationChunks);
 
         const newChunk: BufferedObservationChunk = {
-          id: `ombuf-${randomUUID()}`,
+          id: `ombuf-${crypto.randomUUID()}`,
           cycleId: input.chunk.cycleId,
           observations: input.chunk.observations,
           tokenCount: input.chunk.tokenCount,

--- a/stores/mysql/src/storage/domains/schedules/index.ts
+++ b/stores/mysql/src/storage/domains/schedules/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import {
   normalizeScheduleTarget,
   SchedulesStorage,
@@ -342,7 +341,7 @@ export class SchedulesMySQL extends SchedulesStorage {
   }
 
   async recordTrigger(trigger: ScheduleTrigger): Promise<void> {
-    const id = trigger.id ?? randomUUID();
+    const id = trigger.id ?? crypto.randomUUID();
     await this.pool.execute(
       `INSERT INTO ${formatTableName(TABLE_SCHEDULE_TRIGGERS)} (${quoteIdentifier('id', 'column name')}, ${quoteIdentifier('schedule_id', 'column name')}, ${quoteIdentifier('run_id', 'column name')}, ${quoteIdentifier('scheduled_fire_at', 'column name')}, ${quoteIdentifier('actual_fire_at', 'column name')}, ${quoteIdentifier('outcome', 'column name')}, ${quoteIdentifier('error', 'column name')}, ${quoteIdentifier('trigger_kind', 'column name')}, ${quoteIdentifier('parent_trigger_id', 'column name')}, ${quoteIdentifier('metadata', 'column name')}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       [

--- a/stores/pg/src/storage/domains/memory/index.ts
+++ b/stores/pg/src/storage/domains/memory/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { MessageList } from '@mastra/core/agent';
 import type { MastraMessageContentV2 } from '@mastra/core/agent';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
@@ -2630,7 +2629,7 @@ export class MemoryPG extends MemoryStorage {
 
       // Create new chunk with ID and timestamp
       const newChunk: BufferedObservationChunk = {
-        id: `ombuf-${randomUUID()}`,
+        id: `ombuf-${crypto.randomUUID()}`,
         cycleId: input.chunk.cycleId,
         observations: input.chunk.observations,
         tokenCount: Math.round(input.chunk.tokenCount),

--- a/stores/pg/src/storage/domains/notifications/index.ts
+++ b/stores/pg/src/storage/domains/notifications/index.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { NotificationsStorage, TABLE_NOTIFICATIONS, TABLE_SCHEMAS } from '@mastra/core/storage';
 import type {
   CreateIndexOptions,
@@ -301,7 +299,7 @@ export class NotificationsPG extends NotificationsStorage {
 
     const now = input.createdAt ?? new Date();
     const record: NotificationRecord = {
-      id: input.id ?? randomUUID(),
+      id: input.id ?? crypto.randomUUID(),
       threadId: input.threadId,
       source: input.source,
       kind: input.kind,

--- a/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/integration.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { coreFeatures } from '@mastra/core/features';
 import { SpanType } from '@mastra/core/observability';
 import { Pool } from 'pg';
@@ -60,7 +59,7 @@ function schemaName(prefix: string): string {
     .replace(/[^a-z0-9_]/g, '_')
     .slice(0, 52)
     .replace(/_+$/g, '');
-  const suffix = randomUUID().replace(/-/g, '').slice(0, 8);
+  const suffix = crypto.randomUUID().replace(/-/g, '').slice(0, 8);
   return `${normalized || 'obs'}_${suffix}`;
 }
 
@@ -170,8 +169,8 @@ function makeSpan(overrides: Partial<Record<string, unknown>> = {}) {
   const endedAt = (overrides.endedAt as Date | undefined) ?? new Date(startedAt.getTime() + 1_000);
 
   return {
-    traceId: `trace-${randomUUID()}`,
-    spanId: `span-${randomUUID()}`,
+    traceId: `trace-${crypto.randomUUID()}`,
+    spanId: `span-${crypto.randomUUID()}`,
     name: 'root-span',
     spanType: SpanType.AGENT_RUN,
     isEvent: false,
@@ -186,7 +185,7 @@ function makeSpan(overrides: Partial<Record<string, unknown>> = {}) {
 
 function makeMetric(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    metricId: `metric-${randomUUID()}`,
+    metricId: `metric-${crypto.randomUUID()}`,
     timestamp: dayAt(0, 11),
     name: 'mastra_latency_ms',
     value: 1,
@@ -200,7 +199,7 @@ function makeMetric(overrides: Partial<Record<string, unknown>> = {}) {
 
 function makeLog(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    logId: `log-${randomUUID()}`,
+    logId: `log-${crypto.randomUUID()}`,
     timestamp: dayAt(0, 11),
     level: 'info' as const,
     message: 'test-log',
@@ -212,9 +211,9 @@ function makeLog(overrides: Partial<Record<string, unknown>> = {}) {
 
 function makeScore(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    scoreId: `score-${randomUUID()}`,
+    scoreId: `score-${crypto.randomUUID()}`,
     timestamp: dayAt(0, 11),
-    traceId: `score-trace-${randomUUID()}`,
+    traceId: `score-trace-${crypto.randomUUID()}`,
     spanId: null,
     scorerId: 'quality',
     score: 0.5,
@@ -226,9 +225,9 @@ function makeScore(overrides: Partial<Record<string, unknown>> = {}) {
 
 function makeFeedback(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    feedbackId: `feedback-${randomUUID()}`,
+    feedbackId: `feedback-${crypto.randomUUID()}`,
     timestamp: dayAt(0, 11),
-    traceId: `feedback-trace-${randomUUID()}`,
+    traceId: `feedback-trace-${crypto.randomUUID()}`,
     spanId: null,
     feedbackType: 'rating',
     feedbackSource: 'user',

--- a/stores/pg/src/storage/domains/observability/v-next/retention.test.ts
+++ b/stores/pg/src/storage/domains/observability/v-next/retention.test.ts
@@ -8,7 +8,6 @@
  * partitions that are wholly older than the cutoff.
  */
 
-import { randomUUID } from 'node:crypto';
 import { SpanType } from '@mastra/core/observability';
 import { Pool } from 'pg';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -76,8 +75,8 @@ function makeSpan(overrides: Partial<Record<string, unknown>> = {}) {
   const startedAt = (overrides.startedAt as Date | undefined) ?? dayAt(0, 10);
   const endedAt = (overrides.endedAt as Date | undefined) ?? new Date(startedAt.getTime() + 1_000);
   return {
-    traceId: `trace-${randomUUID()}`,
-    spanId: `span-${randomUUID()}`,
+    traceId: `trace-${crypto.randomUUID()}`,
+    spanId: `span-${crypto.randomUUID()}`,
     name: 'retention-span',
     spanType: SpanType.AGENT_RUN,
     isEvent: false,
@@ -92,7 +91,7 @@ function makeSpan(overrides: Partial<Record<string, unknown>> = {}) {
 
 function makeMetric(timestamp: Date) {
   return {
-    metricId: `metric-${randomUUID()}`,
+    metricId: `metric-${crypto.randomUUID()}`,
     timestamp,
     name: 'mastra_latency_ms',
     value: 1,
@@ -105,7 +104,7 @@ function makeMetric(timestamp: Date) {
 
 function makeLog(timestamp: Date) {
   return {
-    logId: `log-${randomUUID()}`,
+    logId: `log-${crypto.randomUUID()}`,
     timestamp,
     level: 'info' as const,
     message: 'retention-log',
@@ -116,9 +115,9 @@ function makeLog(timestamp: Date) {
 
 function makeScore(timestamp: Date) {
   return {
-    scoreId: `score-${randomUUID()}`,
+    scoreId: `score-${crypto.randomUUID()}`,
     timestamp,
-    traceId: `score-trace-${randomUUID()}`,
+    traceId: `score-trace-${crypto.randomUUID()}`,
     spanId: null,
     scorerId: 'quality',
     score: 0.5,
@@ -128,7 +127,7 @@ function makeScore(timestamp: Date) {
 }
 
 describe('ObservabilityStoragePostgresVNext — retention (native partitions)', () => {
-  const schema = `obs_retention_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+  const schema = `obs_retention_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
   let pool: Pool;
   let client: DbClient;
   let domain: ObservabilityStoragePostgresVNext;

--- a/stores/pg/src/storage/index.vnext.test.ts
+++ b/stores/pg/src/storage/index.vnext.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { createObservabilityVNextTests } from '@internal/storage-test-utils';
 import { Pool } from 'pg';
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -160,7 +159,7 @@ describe.skipIf(!integrationEnabled)('PostgresStoreVNext / shared observability 
 
   beforeAll(async () => {
     const connection = parseConnectionString(TIMESCALE_URL);
-    sharedSchema = `pgvnext_shared_${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+    sharedSchema = `pgvnext_shared_${crypto.randomUUID().replace(/-/g, '').slice(0, 8)}`;
     sharedPool = new Pool({ connectionString: connection.connectionString, max: 2 });
     sharedClient = new PoolAdapter(sharedPool);
     await sharedClient.none('CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE');

--- a/stores/redis/src/storage/index.test.ts
+++ b/stores/redis/src/storage/index.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import {
   createTestSuite,
   createConfigValidationTests,
@@ -33,8 +32,8 @@ const createTestClient = async (): Promise<RedisClient> => {
 };
 
 const createThread = (overrides: Partial<StorageThreadType> = {}): StorageThreadType => ({
-  id: `thread-${randomUUID()}`,
-  resourceId: `resource-${randomUUID()}`,
+  id: `thread-${crypto.randomUUID()}`,
+  resourceId: `resource-${crypto.randomUUID()}`,
   title: 'Test Thread',
   metadata: {},
   createdAt: new Date(),
@@ -48,7 +47,7 @@ const createMessage = (params: {
   createdAt: Date;
   content: string;
 }): MastraDBMessage => ({
-  id: randomUUID(),
+  id: crypto.randomUUID(),
   threadId: params.threadId,
   resourceId: params.resourceId,
   role: 'user',

--- a/stores/spanner/src/storage/domains/datasets/index.ts
+++ b/stores/spanner/src/storage/domains/datasets/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Database, Transaction } from '@google-cloud/spanner';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
@@ -234,7 +233,7 @@ export class DatasetsSpanner extends DatasetsStorage {
   async createDataset(input: CreateDatasetInput): Promise<DatasetRecord> {
     try {
       const now = new Date();
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       if (input.id !== undefined) this.validateCallerDefinedDatasetId(input.id);
       const record: DatasetRecord = {
         id,
@@ -603,7 +602,7 @@ export class DatasetsSpanner extends DatasetsStorage {
   private async insertVersionRow(tx: Transaction, datasetId: string, version: number, now: Date): Promise<void> {
     await this.db.insert({
       tableName: TABLE_DATASET_VERSIONS,
-      record: { id: randomUUID(), datasetId, version, createdAt: now },
+      record: { id: crypto.randomUUID(), datasetId, version, createdAt: now },
       transaction: tx,
     });
   }
@@ -641,7 +640,7 @@ export class DatasetsSpanner extends DatasetsStorage {
   protected async _doAddItem(args: AddDatasetItemInput): Promise<DatasetItem> {
     try {
       const now = new Date();
-      const itemId = randomUUID();
+      const itemId = crypto.randomUUID();
       let created: DatasetItem | null = null;
       await this.db.runWithAbortRetry(() =>
         this.database.runTransactionAsync(async tx => {
@@ -1048,7 +1047,7 @@ export class DatasetsSpanner extends DatasetsStorage {
   async createDatasetVersion(datasetId: string, version: number): Promise<DatasetVersion> {
     try {
       const now = new Date();
-      const id = randomUUID();
+      const id = crypto.randomUUID();
       await this.db.insert({
         tableName: TABLE_DATASET_VERSIONS,
         record: { id, datasetId, version, createdAt: now },
@@ -1151,7 +1150,7 @@ export class DatasetsSpanner extends DatasetsStorage {
               });
               historyRows = (rows as Array<Record<string, any>>).map(rowToItemRow);
             }
-            const plan = this.planDatasetItemBatch(input.items, historyRows, randomUUID);
+            const plan = this.planDatasetItemBatch(input.items, historyRows, () => crypto.randomUUID());
             const resolved = new Map<string, DatasetItem>(
               [...plan.existingCurrentItems].map(([id, row]) => [id, this.datasetItemFromRow(row)]),
             );

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Database } from '@google-cloud/spanner';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
@@ -176,7 +175,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
   async createExperiment(input: CreateExperimentInput): Promise<Experiment> {
     try {
       const now = new Date();
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       const experiment: Experiment = {
         id,
         name: input.name ?? undefined,
@@ -476,7 +475,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
   async addExperimentResult(input: AddExperimentResultInput): Promise<ExperimentResult> {
     try {
       const now = new Date();
-      const id = input.id ?? randomUUID();
+      const id = input.id ?? crypto.randomUUID();
       const result: ExperimentResult = {
         id,
         experimentId: input.experimentId,

--- a/stores/spanner/src/storage/domains/observability/metrics.ts
+++ b/stores/spanner/src/storage/domains/observability/metrics.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { Spanner } from '@google-cloud/spanner';
 import type { Database, Transaction } from '@google-cloud/spanner';
 import type { ExecuteSqlRequest, TimestampBounds } from '@google-cloud/spanner/build/src/transaction';
@@ -761,7 +760,7 @@ export async function batchCreateMetrics(database: Database, args: BatchCreateMe
   // the JSON.stringify up-front sidesteps that fork.
   const encodeJson = (v: unknown): string | null => (v == null ? null : JSON.stringify(v));
   const rows = args.metrics.map(m => ({
-    metricId: m.metricId ?? randomUUID(),
+    metricId: m.metricId ?? crypto.randomUUID(),
     timestamp: m.timestamp instanceof Date ? m.timestamp : new Date(m.timestamp as unknown as string | number),
     name: m.name,
     value: Spanner.float(Number(m.value)),

--- a/stores/spanner/src/storage/domains/schedules/index.ts
+++ b/stores/spanner/src/storage/domains/schedules/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Database } from '@google-cloud/spanner';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import {
@@ -513,7 +512,7 @@ export class SchedulesSpanner extends SchedulesStorage {
       await this.db.insert({
         tableName: TABLE_SCHEDULE_TRIGGERS,
         record: {
-          id: trigger.id ?? randomUUID(),
+          id: trigger.id ?? crypto.randomUUID(),
           schedule_id: trigger.scheduleId,
           run_id: trigger.runId ?? null,
           scheduled_fire_at: trigger.scheduledFireAt,

--- a/stores/spanner/src/storage/domains/scores/index.ts
+++ b/stores/spanner/src/storage/domains/scores/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Database } from '@google-cloud/spanner';
 import { ErrorCategory, ErrorDomain, MastraError } from '@mastra/core/error';
 import type { ListScoresResponse, SaveScorePayload, ScoreRowData, ScoringSource } from '@mastra/core/evals';
@@ -151,7 +150,7 @@ export class ScoresSpanner extends ScoresStorage {
     }
 
     try {
-      const scoreId = randomUUID();
+      const scoreId = crypto.randomUUID();
       const now = new Date();
       const {
         scorer,

--- a/stores/spanner/src/storage/index.test.ts
+++ b/stores/spanner/src/storage/index.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { Spanner } from '@google-cloud/spanner';
 import {
   createSampleMessageV2,
@@ -192,7 +191,7 @@ if (ENABLE_TESTS) {
     });
 
     it('creates a draft workspace with a seed version', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       const created = await workspaces.create({
         workspace: { id, name: 'My Workspace', description: 'first', autoSync: true } as any,
       });
@@ -211,7 +210,7 @@ if (ENABLE_TESTS) {
     });
 
     it('creates a new version when config fields change but not for metadata-only updates', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'W', description: 'a' } as any });
 
       // metadata-only update: no new version
@@ -233,7 +232,7 @@ if (ENABLE_TESTS) {
     });
 
     it('auto-publishes when activeVersionId is set', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'W' } as any });
       const v1 = await workspaces.getLatestVersion(id);
       const updated = await workspaces.update({ id, activeVersionId: v1!.id } as any);
@@ -242,7 +241,7 @@ if (ENABLE_TESTS) {
     });
 
     it('resolves the active version by default and a specific version by id', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'orig' } as any });
       const v1 = await workspaces.getLatestVersion(id);
       await workspaces.update({ id, name: 'orig', description: 'v2desc' } as any);
@@ -257,8 +256,8 @@ if (ENABLE_TESTS) {
     });
 
     it('lists workspaces and paginates versions', async () => {
-      const id = `ws-${randomUUID()}`;
-      const authorId = `author-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
+      const authorId = `author-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'L', authorId } as any });
       await workspaces.update({ id, description: 'v2' } as any);
       await workspaces.update({ id, description: 'v3' } as any);
@@ -274,7 +273,7 @@ if (ENABLE_TESTS) {
     });
 
     it('deletes a workspace and all its versions', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'D' } as any });
       await workspaces.update({ id, description: 'v2' } as any);
       expect(await workspaces.countVersions(id)).toBe(2);
@@ -285,16 +284,16 @@ if (ENABLE_TESTS) {
     });
 
     it('getById / getVersion return null for unknown ids', async () => {
-      expect(await workspaces.getById(`missing-${randomUUID()}`)).toBeNull();
-      expect(await workspaces.getVersion(`missing-${randomUUID()}`)).toBeNull();
-      expect(await workspaces.getVersionByNumber(`missing-${randomUUID()}`, 1)).toBeNull();
-      expect(await workspaces.getLatestVersion(`missing-${randomUUID()}`)).toBeNull();
+      expect(await workspaces.getById(`missing-${crypto.randomUUID()}`)).toBeNull();
+      expect(await workspaces.getVersion(`missing-${crypto.randomUUID()}`)).toBeNull();
+      expect(await workspaces.getVersionByNumber(`missing-${crypto.randomUUID()}`, 1)).toBeNull();
+      expect(await workspaces.getLatestVersion(`missing-${crypto.randomUUID()}`)).toBeNull();
     });
 
     it('createVersion appends a version and getVersion fetches it by id', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'CV' } as any });
-      const versionId = randomUUID();
+      const versionId = crypto.randomUUID();
       const created = await workspaces.createVersion({
         id: versionId,
         workspaceId: id,
@@ -316,7 +315,7 @@ if (ENABLE_TESTS) {
     });
 
     it('deleteVersion removes a single version; deleteVersionsByParentId clears all', async () => {
-      const id = `ws-${randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'DV' } as any });
       await workspaces.update({ id, description: 'v2' } as any);
       const v2 = await workspaces.getVersionByNumber(id, 2);
@@ -330,10 +329,10 @@ if (ENABLE_TESTS) {
     });
 
     it('list paginates and filters by metadata', async () => {
-      const tag = `grp-${randomUUID()}`;
+      const tag = `grp-${crypto.randomUUID()}`;
       for (let i = 0; i < 3; i++) {
         await workspaces.create({
-          workspace: { id: `ws-${randomUUID()}`, name: `M${i}`, metadata: { grp: tag } } as any,
+          workspace: { id: `ws-${crypto.randomUUID()}`, name: `M${i}`, metadata: { grp: tag } } as any,
         });
       }
       const page0 = await workspaces.list({ metadata: { grp: tag }, page: 0, perPage: 2 });
@@ -347,8 +346,8 @@ if (ENABLE_TESTS) {
     });
 
     it('listResolved merges the active version config into each record', async () => {
-      const authorId = `author-${randomUUID()}`;
-      const id = `ws-${randomUUID()}`;
+      const authorId = `author-${crypto.randomUUID()}`;
+      const id = `ws-${crypto.randomUUID()}`;
       await workspaces.create({ workspace: { id, name: 'R', description: 'd1', authorId } as any });
       const resolved = await workspaces.listResolved({ authorId } as any);
       const row = resolved.workspaces.find(w => w.id === id);
@@ -388,7 +387,7 @@ if (ENABLE_TESTS) {
     });
 
     it('favorite increments the counter and is idempotent', async () => {
-      const id = `a-${randomUUID()}`;
+      const id = `a-${crypto.randomUUID()}`;
       await makeAgent(id);
       expect(await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id })).toEqual({
         favorited: true,
@@ -407,12 +406,12 @@ if (ENABLE_TESTS) {
 
     it('favorite throws when the entity does not exist', async () => {
       await expect(
-        favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: `missing-${randomUUID()}` }),
+        favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: `missing-${crypto.randomUUID()}` }),
       ).rejects.toThrow();
     });
 
     it('unfavorite decrements, clamps at 0, and is idempotent', async () => {
-      const id = `s-${randomUUID()}`;
+      const id = `s-${crypto.randomUUID()}`;
       await makeSkill(id);
       await favorites.favorite({ userId: 'u1', entityType: 'skill', entityId: id });
       expect(await favorites.unfavorite({ userId: 'u1', entityType: 'skill', entityId: id })).toEqual({
@@ -428,8 +427,8 @@ if (ENABLE_TESTS) {
     });
 
     it('isFavorited / isFavoritedBatch report state per user', async () => {
-      const a1 = `a-${randomUUID()}`;
-      const a2 = `a-${randomUUID()}`;
+      const a1 = `a-${crypto.randomUUID()}`;
+      const a2 = `a-${crypto.randomUUID()}`;
       await makeAgent(a1);
       await makeAgent(a2);
       await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: a1 });
@@ -443,8 +442,8 @@ if (ENABLE_TESTS) {
     });
 
     it('listFavoritedIds is scoped by user and entity type', async () => {
-      const a1 = `a-${randomUUID()}`;
-      const s1 = `s-${randomUUID()}`;
+      const a1 = `a-${crypto.randomUUID()}`;
+      const s1 = `s-${crypto.randomUUID()}`;
       await makeAgent(a1);
       await makeSkill(s1);
       await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: a1 });
@@ -456,7 +455,7 @@ if (ENABLE_TESTS) {
     });
 
     it('deleteFavoritesForEntity removes rows, resets the counter, and returns the count', async () => {
-      const id = `a-${randomUUID()}`;
+      const id = `a-${crypto.randomUUID()}`;
       await makeAgent(id);
       await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id });
       await favorites.favorite({ userId: 'u2', entityType: 'agent', entityId: id });
@@ -468,7 +467,7 @@ if (ENABLE_TESTS) {
     });
 
     it('agent and skill counters with colliding ids stay independent', async () => {
-      const id = `shared-${randomUUID()}`;
+      const id = `shared-${crypto.randomUUID()}`;
       await makeAgent(id);
       await makeSkill(id);
       await favorites.favorite({ userId: 'u1', entityType: 'agent', entityId: id });
@@ -478,7 +477,7 @@ if (ENABLE_TESTS) {
     });
 
     it('concurrent same-user favorite calls are idempotent (counter never exceeds 1)', async () => {
-      const id = `a-${randomUUID()}`;
+      const id = `a-${crypto.randomUUID()}`;
       await makeAgent(id);
       // Fire several concurrent favorite() calls for the same key. Spanner's
       // serializable isolation + ABORTED retry must collapse them into one row.
@@ -496,9 +495,9 @@ if (ENABLE_TESTS) {
       // this matches the cross-adapter conformance contract (and the Postgres
       // reference, which applies no default status). A normal list() with no
       // favorites params still defaults to published-only.
-      const u = `u-${randomUUID()}`;
-      const draft = `a-${randomUUID()}`;
-      const published = `a-${randomUUID()}`;
+      const u = `u-${crypto.randomUUID()}`;
+      const draft = `a-${crypto.randomUUID()}`;
+      const published = `a-${crypto.randomUUID()}`;
       await makeAgent(draft); // create() => draft
       await makeAgent(published);
       const pubV = await agents.getLatestVersion(published);
@@ -545,13 +544,13 @@ if (ENABLE_TESTS) {
     let channels: ChannelsSpanner;
 
     const sampleInstallation = (over: Partial<any> = {}) => ({
-      id: `inst-${randomUUID()}`,
+      id: `inst-${crypto.randomUUID()}`,
       platform: 'slack',
-      agentId: `ag-${randomUUID()}`,
+      agentId: `ag-${crypto.randomUUID()}`,
       status: 'active' as const,
-      webhookId: `wh-${randomUUID()}`,
+      webhookId: `wh-${crypto.randomUUID()}`,
       data: { botToken: 'xoxb', teamId: 'T1' },
-      configHash: `hash-${randomUUID()}`,
+      configHash: `hash-${crypto.randomUUID()}`,
       createdAt: new Date(),
       updatedAt: new Date(),
       ...over,
@@ -586,7 +585,7 @@ if (ENABLE_TESTS) {
     });
 
     it('getInstallationByAgent prefers active, then pending; scoped per platform', async () => {
-      const agentId = `ag-${randomUUID()}`;
+      const agentId = `ag-${crypto.randomUUID()}`;
       await channels.saveInstallation(sampleInstallation({ id: 'p', platform: 'slack', agentId, status: 'pending' }));
       await channels.saveInstallation(sampleInstallation({ id: 'a', platform: 'slack', agentId, status: 'active' }));
       expect((await channels.getInstallationByAgent('slack', agentId))?.id).toBe('a');
@@ -653,7 +652,7 @@ if (ENABLE_TESTS) {
     });
     const baseResult = (experimentId: string, over: Partial<any> = {}) => ({
       experimentId,
-      itemId: `item-${randomUUID()}`,
+      itemId: `item-${crypto.randomUUID()}`,
       itemDatasetVersion: null,
       input: { q: 'x' },
       output: null,
@@ -704,7 +703,7 @@ if (ENABLE_TESTS) {
     });
 
     it('listExperiments filters and paginates', async () => {
-      const targetId = `t-${randomUUID()}`;
+      const targetId = `t-${crypto.randomUUID()}`;
       for (let i = 0; i < 3; i++) await experiments.createExperiment(baseExp({ targetId }));
       await experiments.createExperiment(baseExp({ targetId: 'other' }));
 
@@ -1606,7 +1605,7 @@ if (ENABLE_TESTS) {
 
         it('throws when thread does not exist', async () => {
           await expect(
-            memory.updateThread({ id: `missing-${randomUUID()}`, title: 'x', metadata: {} }),
+            memory.updateThread({ id: `missing-${crypto.randomUUID()}`, title: 'x', metadata: {} }),
           ).rejects.toThrow(/not found/i);
         });
       });
@@ -1627,12 +1626,12 @@ if (ENABLE_TESTS) {
         });
 
         it('is a no-op for a missing thread', async () => {
-          await expect(memory.deleteThread({ threadId: `missing-${randomUUID()}` })).resolves.toBeUndefined();
+          await expect(memory.deleteThread({ threadId: `missing-${crypto.randomUUID()}` })).resolves.toBeUndefined();
         });
       });
 
       describe('listThreads', () => {
-        const sharedResourceId = `list-resource-${randomUUID()}`;
+        const sharedResourceId = `list-resource-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           for (let i = 0; i < 5; i++) {
@@ -1860,7 +1859,7 @@ if (ENABLE_TESTS) {
 
       describe('updateResource', () => {
         it('creates a new resource if the id does not exist', async () => {
-          const id = `new-resource-${randomUUID()}`;
+          const id = `new-resource-${crypto.randomUUID()}`;
           const updated = await memory.updateResource({
             resourceId: id,
             workingMemory: 'fresh',
@@ -1873,7 +1872,7 @@ if (ENABLE_TESTS) {
 
         it('merges metadata and updates workingMemory on existing resources', async () => {
           const resource = {
-            id: `update-resource-${randomUUID()}`,
+            id: `update-resource-${crypto.randomUUID()}`,
             workingMemory: 'old',
             metadata: { a: 1, b: 2 },
             createdAt: new Date(),
@@ -1891,7 +1890,7 @@ if (ENABLE_TESTS) {
 
         it('updates workingMemory only when metadata is omitted', async () => {
           const resource = {
-            id: `wm-only-${randomUUID()}`,
+            id: `wm-only-${crypto.randomUUID()}`,
             workingMemory: 'first',
             metadata: { keep: true },
             createdAt: new Date(),
@@ -1906,8 +1905,8 @@ if (ENABLE_TESTS) {
 
       describe('hasMore correctness with include', () => {
         it('keeps hasMore=true when include adds same-thread messages on a paginated window', async () => {
-          const threadId = `wf-hm-${randomUUID()}`;
-          const resourceId = `res-hm-${randomUUID()}`;
+          const threadId = `wf-hm-${crypto.randomUUID()}`;
+          const resourceId = `res-hm-${crypto.randomUUID()}`;
           await memory.saveThread({
             thread: {
               id: threadId,
@@ -1921,7 +1920,7 @@ if (ENABLE_TESTS) {
           // Insert 5 messages with strictly-ordered createdAt so pagination
           // is deterministic.
           const baseTs = Date.now();
-          const ids = Array.from({ length: 5 }, (_, i) => `m${i}-${randomUUID()}`);
+          const ids = Array.from({ length: 5 }, (_, i) => `m${i}-${crypto.randomUUID()}`);
           await memory.saveMessages({
             messages: ids.map((id, i) => ({
               id,
@@ -1972,8 +1971,8 @@ if (ENABLE_TESTS) {
           // Use a real thread so the upstream validation passes; the spy
           // intercepts the first .run() call, which is the COUNT(*) for the
           // listMessages path.
-          const threadId = `wf-err-${randomUUID()}`;
-          const resourceId = `res-err-${randomUUID()}`;
+          const threadId = `wf-err-${crypto.randomUUID()}`;
+          const resourceId = `res-err-${crypto.randomUUID()}`;
           await memory.saveThread({
             thread: {
               id: threadId,
@@ -2003,8 +2002,8 @@ if (ENABLE_TESTS) {
         // update across many messages must still produce the right per-row
         // updates. Previously this used messages.find() per row (O(n²)).
         it('correctly updates a large batch of messages by id', async () => {
-          const threadId = `wf-upd-${randomUUID()}`;
-          const resourceId = `res-upd-${randomUUID()}`;
+          const threadId = `wf-upd-${crypto.randomUUID()}`;
+          const resourceId = `res-upd-${crypto.randomUUID()}`;
           await memory.saveThread({
             thread: {
               id: threadId,
@@ -2015,7 +2014,7 @@ if (ENABLE_TESTS) {
               updatedAt: new Date(),
             },
           });
-          const ids = Array.from({ length: 8 }, () => randomUUID());
+          const ids = Array.from({ length: 8 }, () => crypto.randomUUID());
           await memory.saveMessages({
             messages: ids.map((id, i) => ({
               id,
@@ -2049,8 +2048,8 @@ if (ENABLE_TESTS) {
         // Functional regression for the IN-batched target query: results must
         // still include every requested target plus the requested neighbours.
         it('returns every requested include target in a single batched lookup', async () => {
-          const threadId = `wf-inc-${randomUUID()}`;
-          const resourceId = `res-inc-${randomUUID()}`;
+          const threadId = `wf-inc-${crypto.randomUUID()}`;
+          const resourceId = `res-inc-${crypto.randomUUID()}`;
           await memory.saveThread({
             thread: {
               id: threadId,
@@ -2062,7 +2061,7 @@ if (ENABLE_TESTS) {
             },
           });
           const baseTs = Date.now();
-          const ids = Array.from({ length: 6 }, () => randomUUID());
+          const ids = Array.from({ length: 6 }, () => crypto.randomUUID());
           await memory.saveMessages({
             messages: ids.map((id, i) => ({
               id,
@@ -2089,8 +2088,8 @@ if (ENABLE_TESTS) {
         });
 
         it('still returns prev/next neighbours alongside the targets', async () => {
-          const threadId = `wf-inc-nb-${randomUUID()}`;
-          const resourceId = `res-inc-nb-${randomUUID()}`;
+          const threadId = `wf-inc-nb-${crypto.randomUUID()}`;
+          const resourceId = `res-inc-nb-${crypto.randomUUID()}`;
           await memory.saveThread({
             thread: {
               id: threadId,
@@ -2102,7 +2101,7 @@ if (ENABLE_TESTS) {
             },
           });
           const baseTs = Date.now();
-          const ids = Array.from({ length: 5 }, () => randomUUID());
+          const ids = Array.from({ length: 5 }, () => crypto.randomUUID());
           await memory.saveMessages({
             messages: ids.map((id, i) => ({
               id,
@@ -2137,7 +2136,7 @@ if (ENABLE_TESTS) {
       describe('persistWorkflowSnapshot and loadWorkflowSnapshot', () => {
         it('inserts a snapshot and reads it back', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           const loaded = await workflows.loadWorkflowSnapshot({ workflowName, runId });
           expect(loaded?.runId).toBe(runId);
@@ -2146,7 +2145,7 @@ if (ENABLE_TESTS) {
 
         it('upserts on conflict', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           await workflows.persistWorkflowSnapshot({
             workflowName,
@@ -2167,7 +2166,7 @@ if (ENABLE_TESTS) {
 
         it('preserves createdAt across subsequent upserts when caller omits it', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           const originalCreatedAt = new Date('2024-01-15T10:00:00.000Z');
           await workflows.persistWorkflowSnapshot({
             workflowName,
@@ -2196,7 +2195,7 @@ if (ENABLE_TESTS) {
       describe('updateWorkflowResults', () => {
         it('merges step result and request context', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           const merged = await workflows.updateWorkflowResults({
             workflowName,
@@ -2211,8 +2210,8 @@ if (ENABLE_TESTS) {
         });
 
         it('creates the snapshot when none exists', async () => {
-          const workflowName = `wf-${randomUUID()}`;
-          const runId = `run-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
+          const runId = `run-${crypto.randomUUID()}`;
           await workflows.updateWorkflowResults({
             workflowName,
             runId,
@@ -2226,7 +2225,7 @@ if (ENABLE_TESTS) {
 
         it('preserves createdAt on the existing row when stepping the snapshot', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           const originalCreatedAt = new Date('2024-02-20T08:30:00.000Z');
           await workflows.persistWorkflowSnapshot({
             workflowName,
@@ -2255,7 +2254,7 @@ if (ENABLE_TESTS) {
       describe('updateWorkflowState', () => {
         it('merges options into the existing snapshot', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           const updated = await workflows.updateWorkflowState({
             workflowName,
@@ -2278,7 +2277,7 @@ if (ENABLE_TESTS) {
       describe('getWorkflowRunById', () => {
         it('returns the run for a known runId', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           const fetched = await workflows.getWorkflowRunById({ runId, workflowName });
           expect(fetched?.runId).toBe(runId);
@@ -2292,7 +2291,7 @@ if (ENABLE_TESTS) {
 
         it('finds runs by runId only', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           const fetched = await workflows.getWorkflowRunById({ runId });
           expect(fetched?.runId).toBe(runId);
@@ -2312,7 +2311,7 @@ if (ENABLE_TESTS) {
       describe('deleteWorkflowRunById', () => {
         it('removes a snapshot row', async () => {
           const { snapshot, runId } = createSampleWorkflowSnapshot('running');
-          const workflowName = `wf-${randomUUID()}`;
+          const workflowName = `wf-${crypto.randomUUID()}`;
           await workflows.persistWorkflowSnapshot({ workflowName, runId, snapshot });
           await workflows.deleteWorkflowRunById({ runId, workflowName });
           expect(await workflows.loadWorkflowSnapshot({ workflowName, runId })).toBeNull();
@@ -2326,9 +2325,9 @@ if (ENABLE_TESTS) {
       });
 
       describe('listWorkflowRuns', () => {
-        const workflowA = `wf-a-${randomUUID()}`;
-        const workflowB = `wf-b-${randomUUID()}`;
-        const resourceX = `resource-${randomUUID()}`;
+        const workflowA = `wf-a-${crypto.randomUUID()}`;
+        const workflowB = `wf-b-${crypto.randomUUID()}`;
+        const resourceX = `resource-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           // Three runs of A (one with resourceId), two of B.
@@ -2460,8 +2459,8 @@ if (ENABLE_TESTS) {
       });
 
       describe('listTasks', () => {
-        const agentId = `agent-list-${randomUUID()}`;
-        const otherAgent = `agent-other-${randomUUID()}`;
+        const agentId = `agent-list-${crypto.randomUUID()}`;
+        const otherAgent = `agent-other-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           for (let i = 0; i < 3; i++) {
@@ -2529,7 +2528,7 @@ if (ENABLE_TESTS) {
 
       describe('deleteTasks', () => {
         it('deletes by status filter', async () => {
-          const agentId = `delete-${randomUUID()}`;
+          const agentId = `delete-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'pending' }));
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'completed' }));
 
@@ -2546,7 +2545,7 @@ if (ENABLE_TESTS) {
         it('is a no-op for an empty status array (does not emit `IN ()`)', async () => {
           // Bug guard: prior to the fix this would build invalid SQL like
           // `WHERE status IN ()` and throw at the Spanner layer.
-          const agentId = `delete-empty-${randomUUID()}`;
+          const agentId = `delete-empty-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'pending' }));
           await expect(backgroundTasks.deleteTasks({ status: [] })).resolves.toBeUndefined();
           // The pending task survives the no-op delete.
@@ -2561,7 +2560,7 @@ if (ENABLE_TESTS) {
           // Insert something so the table is non-empty; the empty status
           // filter must still return zero rows without hitting Spanner with
           // an invalid `IN ()` clause.
-          const agentId = `list-empty-status-${randomUUID()}`;
+          const agentId = `list-empty-status-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'pending' }));
           const result = await backgroundTasks.listTasks({ status: [] });
           expect(result).toEqual({ tasks: [], total: 0 });
@@ -2585,7 +2584,7 @@ if (ENABLE_TESTS) {
           // the dedicated COUNT(*) round-trip and reads `total` off the
           // returned array. This regression-checks both the count value and
           // that the count query was avoided.
-          const agentId = `list-no-pagination-${randomUUID()}`;
+          const agentId = `list-no-pagination-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'pending' }));
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'pending' }));
           await backgroundTasks.createTask(createSampleTask({ agentId, status: 'pending' }));
@@ -2645,8 +2644,8 @@ if (ENABLE_TESTS) {
         });
 
         it('counts running tasks scoped to the given agent', async () => {
-          const a1 = `agent-${randomUUID()}`;
-          const a2 = `agent-${randomUUID()}`;
+          const a1 = `agent-${crypto.randomUUID()}`;
+          const a2 = `agent-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId: a1, status: 'running' }));
           await backgroundTasks.createTask(createSampleTask({ agentId: a1, status: 'running' }));
           await backgroundTasks.createTask(createSampleTask({ agentId: a2, status: 'running' }));
@@ -2655,7 +2654,7 @@ if (ENABLE_TESTS) {
         });
 
         it('ignores non-running tasks for the same agent', async () => {
-          const a = `agent-${randomUUID()}`;
+          const a = `agent-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId: a, status: 'running' }));
           await backgroundTasks.createTask(createSampleTask({ agentId: a, status: 'pending' }));
           await backgroundTasks.createTask(createSampleTask({ agentId: a, status: 'completed' }));
@@ -2664,8 +2663,8 @@ if (ENABLE_TESTS) {
         });
 
         it('ignores running tasks belonging to other agents', async () => {
-          const a1 = `agent-${randomUUID()}`;
-          const a2 = `agent-${randomUUID()}`;
+          const a1 = `agent-${crypto.randomUUID()}`;
+          const a2 = `agent-${crypto.randomUUID()}`;
           await backgroundTasks.createTask(createSampleTask({ agentId: a1, status: 'running' }));
           await backgroundTasks.createTask(createSampleTask({ agentId: a2, status: 'running' }));
           await backgroundTasks.createTask(createSampleTask({ agentId: a2, status: 'running' }));
@@ -2687,10 +2686,10 @@ if (ENABLE_TESTS) {
 
       describe('update', () => {
         it('updates status, activeVersionId, authorId, metadata', async () => {
-          const id = `update-${randomUUID()}`;
+          const id = `update-${crypto.randomUUID()}`;
           await agents.create({ agent: { id, ...baseSnapshot } });
 
-          const versionId = randomUUID();
+          const versionId = crypto.randomUUID();
           await agents.createVersion({
             id: versionId,
             agentId: id,
@@ -2722,10 +2721,10 @@ if (ENABLE_TESTS) {
 
       describe('delete', () => {
         it('removes the thin record and all versions', async () => {
-          const id = `delete-${randomUUID()}`;
+          const id = `delete-${crypto.randomUUID()}`;
           await agents.create({ agent: { id, ...baseSnapshot } });
           await agents.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             agentId: id,
             versionNumber: 2,
             name: 'V2',
@@ -2750,7 +2749,7 @@ if (ENABLE_TESTS) {
           // Spy on the underlying SpannerDB.insert and reject when the call
           // targets the versions table; capture the original BEFORE the spy
           // so the thin-row insert can pass through without recursing.
-          const id = `orphan-create-${randomUUID()}`;
+          const id = `orphan-create-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (agents as any).db;
           const originalInsert = internalDb.insert.bind(internalDb);
           const insertSpy = vi.spyOn(internalDb, 'insert').mockImplementation(async (args: any) => {
@@ -2771,7 +2770,7 @@ if (ENABLE_TESTS) {
         });
 
         it('init() sweeps orphaned draft=null,activeVersionId=null rows when cleanupStaleDraftsOnStartup is enabled', async () => {
-          const id = `orphan-init-${randomUUID()}`;
+          const id = `orphan-init-${crypto.randomUUID()}`;
 
           // Simulate a prior crash: thin row exists but no version was ever
           // inserted. Use the underlying SpannerDB directly to plant the orphan.
@@ -2812,11 +2811,11 @@ if (ENABLE_TESTS) {
         });
 
         it('init() with cleanupStaleDraftsOnStartup leaves published agents and drafts with active versions untouched', async () => {
-          const publishedId = `keep-published-${randomUUID()}`;
-          const draftWithVersionId = `keep-draft-${randomUUID()}`;
+          const publishedId = `keep-published-${crypto.randomUUID()}`;
+          const draftWithVersionId = `keep-draft-${crypto.randomUUID()}`;
 
           await agents.create({ agent: { id: publishedId, ...baseSnapshot } });
-          const versionId = randomUUID();
+          const versionId = crypto.randomUUID();
           await agents.createVersion({
             id: versionId,
             agentId: publishedId,
@@ -2829,7 +2828,7 @@ if (ENABLE_TESTS) {
 
           // A draft that DOES have an active version (e.g. mid-edit) must survive.
           await agents.create({ agent: { id: draftWithVersionId, ...baseSnapshot } });
-          const v1Id = randomUUID();
+          const v1Id = crypto.randomUUID();
           await agents.createVersion({
             id: v1Id,
             agentId: draftWithVersionId,
@@ -2860,15 +2859,15 @@ if (ENABLE_TESTS) {
       });
 
       describe('list', () => {
-        const authorA = `author-a-${randomUUID()}`;
-        const authorB = `author-b-${randomUUID()}`;
+        const authorA = `author-a-${crypto.randomUUID()}`;
+        const authorB = `author-b-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           await agents.dangerouslyClearAll();
           for (let i = 0; i < 4; i++) {
             await agents.create({
               agent: {
-                id: `list-${randomUUID()}`,
+                id: `list-${crypto.randomUUID()}`,
                 ...baseSnapshot,
                 authorId: i < 3 ? authorA : authorB,
                 metadata: { tier: i % 2 === 0 ? 'gold' : 'silver' },
@@ -2915,11 +2914,11 @@ if (ENABLE_TESTS) {
         const versionIds: string[] = [];
 
         beforeAll(async () => {
-          agentId = `versions-${randomUUID()}`;
+          agentId = `versions-${crypto.randomUUID()}`;
           await agents.create({ agent: { id: agentId, ...baseSnapshot } });
           // create() already added v1; add v2 and v3.
           for (let n = 2; n <= 3; n++) {
-            const vid = randomUUID();
+            const vid = crypto.randomUUID();
             versionIds.push(vid);
             await agents.createVersion({
               id: vid,
@@ -2975,10 +2974,10 @@ if (ENABLE_TESTS) {
         });
 
         it('deleteVersionsByParentId removes all versions for the agent', async () => {
-          const tempAgentId = `bulk-${randomUUID()}`;
+          const tempAgentId = `bulk-${crypto.randomUUID()}`;
           await agents.create({ agent: { id: tempAgentId, ...baseSnapshot } });
           await agents.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             agentId: tempAgentId,
             versionNumber: 2,
             name: 'V2',
@@ -2998,7 +2997,7 @@ if (ENABLE_TESTS) {
       });
 
       it('getVersion returns the row by id', async () => {
-        const id = `mcp-c-${randomUUID()}`;
+        const id = `mcp-c-${crypto.randomUUID()}`;
         await mcpClients.create({
           mcpClient: { id, name: 'Client', servers: { fs: { url: 'http://localhost' } as any } },
         });
@@ -3013,10 +3012,10 @@ if (ENABLE_TESTS) {
       });
 
       it('getVersionByNumber returns the matching version', async () => {
-        const id = `mcp-c-${randomUUID()}`;
+        const id = `mcp-c-${crypto.randomUUID()}`;
         await mcpClients.create({ mcpClient: { id, name: 'C', servers: {} } });
         await mcpClients.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           mcpClientId: id,
           versionNumber: 2,
           name: 'C v2',
@@ -3029,9 +3028,9 @@ if (ENABLE_TESTS) {
       });
 
       it('deleteVersion removes a single version', async () => {
-        const id = `mcp-c-${randomUUID()}`;
+        const id = `mcp-c-${crypto.randomUUID()}`;
         await mcpClients.create({ mcpClient: { id, name: 'C', servers: {} } });
-        const v2Id = randomUUID();
+        const v2Id = crypto.randomUUID();
         await mcpClients.createVersion({
           id: v2Id,
           mcpClientId: id,
@@ -3047,7 +3046,7 @@ if (ENABLE_TESTS) {
 
       describe('orphan-draft handling', () => {
         it('rolls back the draft thin row when the version insert fails inside the create() transaction', async () => {
-          const id = `mcp-c-orphan-${randomUUID()}`;
+          const id = `mcp-c-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (mcpClients as any).db;
           const originalInsert = internalDb.insert.bind(internalDb);
           const insertSpy = vi.spyOn(internalDb, 'insert').mockImplementation(async (args: any) => {
@@ -3067,7 +3066,7 @@ if (ENABLE_TESTS) {
         });
 
         it('init() sweeps orphaned draft+activeVersionId=NULL rows when cleanupStaleDraftsOnStartup is enabled', async () => {
-          const id = `mcp-c-init-orphan-${randomUUID()}`;
+          const id = `mcp-c-init-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (mcpClients as any).db;
           const now = new Date();
           await internalDb.insert({
@@ -3096,8 +3095,8 @@ if (ENABLE_TESTS) {
         });
 
         it('init() with cleanupStaleDraftsOnStartup leaves published clients and drafts with active versions untouched', async () => {
-          const publishedId = `mcp-c-keep-pub-${randomUUID()}`;
-          const draftWithVersionId = `mcp-c-keep-draft-${randomUUID()}`;
+          const publishedId = `mcp-c-keep-pub-${crypto.randomUUID()}`;
+          const draftWithVersionId = `mcp-c-keep-draft-${crypto.randomUUID()}`;
 
           await mcpClients.create({ mcpClient: { id: publishedId, name: 'P', servers: {} } });
           const v1Pub = await mcpClients.getLatestVersion(publishedId);
@@ -3127,7 +3126,7 @@ if (ENABLE_TESTS) {
       });
 
       describe('list defaulting to status=published', () => {
-        const tag = `pub-default-${randomUUID()}`;
+        const tag = `pub-default-${crypto.randomUUID()}`;
         beforeAll(async () => {
           await mcpClients.dangerouslyClearAll();
           // 2 drafts (left in initial draft state by create())
@@ -3168,13 +3167,13 @@ if (ENABLE_TESTS) {
           // number. Verifying the invariant is in force also means the
           // "unique index failure must not be swallowed at init()"
           // hardening is doing its job.
-          const id = `mcp-c-unique-${randomUUID()}`;
+          const id = `mcp-c-unique-${crypto.randomUUID()}`;
           await mcpClients.create({ mcpClient: { id, name: 'C', servers: {} } });
           // The seed createVersion already wrote versionNumber=1; a second
           // write with the same number must throw.
           await expect(
             mcpClients.createVersion({
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               mcpClientId: id,
               versionNumber: 1,
               name: 'duplicate v1',
@@ -3191,10 +3190,10 @@ if (ENABLE_TESTS) {
       });
 
       it('delete removes the thin record and all versions', async () => {
-        const id = `mcp-s-${randomUUID()}`;
+        const id = `mcp-s-${crypto.randomUUID()}`;
         await mcpServers.create({ mcpServer: { id, name: 'S', version: '0.1.0' } });
         await mcpServers.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           mcpServerId: id,
           versionNumber: 2,
           name: 'S v2',
@@ -3207,10 +3206,10 @@ if (ENABLE_TESTS) {
       });
 
       it('getVersionByNumber returns the matching version', async () => {
-        const id = `mcp-s-${randomUUID()}`;
+        const id = `mcp-s-${crypto.randomUUID()}`;
         await mcpServers.create({ mcpServer: { id, name: 'S', version: '1.0.0' } });
         await mcpServers.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           mcpServerId: id,
           versionNumber: 2,
           name: 'S v2',
@@ -3222,11 +3221,11 @@ if (ENABLE_TESTS) {
       });
 
       it('getLatestVersion returns the highest version', async () => {
-        const id = `mcp-s-${randomUUID()}`;
+        const id = `mcp-s-${crypto.randomUUID()}`;
         await mcpServers.create({ mcpServer: { id, name: 'S', version: '1.0.0' } });
         for (let n = 2; n <= 3; n++) {
           await mcpServers.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             mcpServerId: id,
             versionNumber: n,
             name: `S v${n}`,
@@ -3239,11 +3238,11 @@ if (ENABLE_TESTS) {
       });
 
       it('listVersions paginates and orders', async () => {
-        const id = `mcp-s-${randomUUID()}`;
+        const id = `mcp-s-${crypto.randomUUID()}`;
         await mcpServers.create({ mcpServer: { id, name: 'List Server', version: '1.0.0' } });
         for (let n = 2; n <= 5; n++) {
           await mcpServers.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             mcpServerId: id,
             versionNumber: n,
             name: `v${n}`,
@@ -3266,9 +3265,9 @@ if (ENABLE_TESTS) {
       });
 
       it('deleteVersion removes a single version row', async () => {
-        const id = `mcp-s-${randomUUID()}`;
+        const id = `mcp-s-${crypto.randomUUID()}`;
         await mcpServers.create({ mcpServer: { id, name: 'S', version: '0.1.0' } });
-        const v2Id = randomUUID();
+        const v2Id = crypto.randomUUID();
         await mcpServers.createVersion({
           id: v2Id,
           mcpServerId: id,
@@ -3282,11 +3281,11 @@ if (ENABLE_TESTS) {
       });
 
       it('countVersions reports the version total', async () => {
-        const id = `mcp-s-${randomUUID()}`;
+        const id = `mcp-s-${crypto.randomUUID()}`;
         await mcpServers.create({ mcpServer: { id, name: 'S', version: '0.1.0' } });
         expect(await mcpServers.countVersions(id)).toBe(1);
         await mcpServers.createVersion({
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           mcpServerId: id,
           versionNumber: 2,
           name: 'S v2',
@@ -3298,7 +3297,7 @@ if (ENABLE_TESTS) {
 
       describe('orphan-draft handling', () => {
         it('rolls back the draft thin row when the version insert fails inside the create() transaction', async () => {
-          const id = `mcp-s-orphan-${randomUUID()}`;
+          const id = `mcp-s-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (mcpServers as any).db;
           const originalInsert = internalDb.insert.bind(internalDb);
           const insertSpy = vi.spyOn(internalDb, 'insert').mockImplementation(async (args: any) => {
@@ -3318,7 +3317,7 @@ if (ENABLE_TESTS) {
         });
 
         it('init() sweeps orphaned draft+activeVersionId=NULL rows when cleanupStaleDraftsOnStartup is enabled', async () => {
-          const id = `mcp-s-init-orphan-${randomUUID()}`;
+          const id = `mcp-s-init-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (mcpServers as any).db;
           const now = new Date();
           await internalDb.insert({
@@ -3347,8 +3346,8 @@ if (ENABLE_TESTS) {
         });
 
         it('init() with cleanupStaleDraftsOnStartup leaves published servers and drafts with active versions untouched', async () => {
-          const publishedId = `mcp-s-keep-pub-${randomUUID()}`;
-          const draftWithVersionId = `mcp-s-keep-draft-${randomUUID()}`;
+          const publishedId = `mcp-s-keep-pub-${crypto.randomUUID()}`;
+          const draftWithVersionId = `mcp-s-keep-draft-${crypto.randomUUID()}`;
 
           await mcpServers.create({ mcpServer: { id: publishedId, name: 'P', version: '1.0.0' } });
           const v1Pub = await mcpServers.getLatestVersion(publishedId);
@@ -3380,7 +3379,7 @@ if (ENABLE_TESTS) {
       });
 
       describe('list defaulting to status=published', () => {
-        const tag = `mcp-s-pub-${randomUUID()}`;
+        const tag = `mcp-s-pub-${crypto.randomUUID()}`;
         beforeAll(async () => {
           await mcpServers.dangerouslyClearAll();
           // 2 drafts (left in initial draft state by create())
@@ -3420,11 +3419,11 @@ if (ENABLE_TESTS) {
           // number. Verifying the invariant is in force also confirms
           // SpannerDB.createIndexes propagates unique-index failures
           // instead of silently swallowing them.
-          const id = `mcp-s-unique-${randomUUID()}`;
+          const id = `mcp-s-unique-${crypto.randomUUID()}`;
           await mcpServers.create({ mcpServer: { id, name: 'S', version: '0.1.0' } });
           await expect(
             mcpServers.createVersion({
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               mcpServerId: id,
               versionNumber: 1, // duplicate
               name: 'duplicate v1',
@@ -3449,7 +3448,7 @@ if (ENABLE_TESTS) {
 
       describe('create', () => {
         it('creates the thin record as draft and seeds version 1', async () => {
-          const id = `skill-${randomUUID()}`;
+          const id = `skill-${crypto.randomUUID()}`;
           const created = await skills.create({ skill: { id, ...baseSnapshot } });
           expect(created.id).toBe(id);
           expect(created.status).toBe('draft');
@@ -3462,7 +3461,7 @@ if (ENABLE_TESTS) {
         });
 
         it('persists optional snapshot fields', async () => {
-          const id = `skill-full-${randomUUID()}`;
+          const id = `skill-full-${crypto.randomUUID()}`;
           await skills.create({
             skill: {
               id,
@@ -3489,11 +3488,11 @@ if (ENABLE_TESTS) {
         });
 
         it('defaults visibility to private for authored skills and persists explicit values', async () => {
-          const authored = `skill-vis-${randomUUID()}`;
+          const authored = `skill-vis-${crypto.randomUUID()}`;
           await skills.create({ skill: { id: authored, ...baseSnapshot, authorId: 'author-1' } as any });
           expect(((await skills.getById(authored)) as any)?.visibility).toBe('private');
 
-          const pub = `skill-vis-${randomUUID()}`;
+          const pub = `skill-vis-${crypto.randomUUID()}`;
           await skills.create({
             skill: { id: pub, ...baseSnapshot, authorId: 'author-1', visibility: 'public' } as any,
           });
@@ -3507,9 +3506,9 @@ if (ENABLE_TESTS) {
 
       describe('list filters', () => {
         it('filters by status and visibility', async () => {
-          const authorId = `author-${randomUUID()}`;
-          const draftPrivate = `skill-${randomUUID()}`;
-          const publishedPublic = `skill-${randomUUID()}`;
+          const authorId = `author-${crypto.randomUUID()}`;
+          const draftPrivate = `skill-${crypto.randomUUID()}`;
+          const publishedPublic = `skill-${crypto.randomUUID()}`;
           await skills.create({ skill: { id: draftPrivate, ...baseSnapshot, authorId, visibility: 'private' } as any });
           await skills.create({
             skill: { id: publishedPublic, ...baseSnapshot, authorId, visibility: 'public' } as any,
@@ -3534,11 +3533,11 @@ if (ENABLE_TESTS) {
 
       describe('getById', () => {
         it('returns null for unknown ids', async () => {
-          expect(await skills.getById(`missing-${randomUUID()}`)).toBeNull();
+          expect(await skills.getById(`missing-${crypto.randomUUID()}`)).toBeNull();
         });
 
         it('returns the thin record (no snapshot fields)', async () => {
-          const id = `skill-thin-${randomUUID()}`;
+          const id = `skill-thin-${crypto.randomUUID()}`;
           await skills.create({ skill: { id, ...baseSnapshot } });
           const fetched = (await skills.getById(id)) as any;
           expect(fetched?.id).toBe(id);
@@ -3549,9 +3548,9 @@ if (ENABLE_TESTS) {
 
       describe('update', () => {
         it('updates activeVersionId, status and authorId', async () => {
-          const id = `skill-update-${randomUUID()}`;
+          const id = `skill-update-${crypto.randomUUID()}`;
           await skills.create({ skill: { id, ...baseSnapshot } });
-          const versionId = randomUUID();
+          const versionId = crypto.randomUUID();
           await skills.createVersion({
             id: versionId,
             skillId: id,
@@ -3579,16 +3578,16 @@ if (ENABLE_TESTS) {
         });
 
         it('throws for missing skills', async () => {
-          await expect(skills.update({ id: `missing-${randomUUID()}` })).rejects.toThrow(/not found/i);
+          await expect(skills.update({ id: `missing-${crypto.randomUUID()}` })).rejects.toThrow(/not found/i);
         });
       });
 
       describe('delete', () => {
         it('removes the thin record and all versions', async () => {
-          const id = `skill-delete-${randomUUID()}`;
+          const id = `skill-delete-${crypto.randomUUID()}`;
           await skills.create({ skill: { id, ...baseSnapshot } });
           await skills.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             skillId: id,
             versionNumber: 2,
             name: 'method-skill',
@@ -3607,15 +3606,15 @@ if (ENABLE_TESTS) {
       });
 
       describe('list', () => {
-        const authorA = `author-a-${randomUUID()}`;
-        const authorB = `author-b-${randomUUID()}`;
+        const authorA = `author-a-${crypto.randomUUID()}`;
+        const authorB = `author-b-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           await skills.dangerouslyClearAll();
           for (let i = 0; i < 4; i++) {
             await skills.create({
               skill: {
-                id: `list-skill-${randomUUID()}`,
+                id: `list-skill-${crypto.randomUUID()}`,
                 ...baseSnapshot,
                 authorId: i < 3 ? authorA : authorB,
               },
@@ -3687,10 +3686,10 @@ if (ENABLE_TESTS) {
         const versionIds: string[] = [];
 
         beforeAll(async () => {
-          skillId = `skill-versions-${randomUUID()}`;
+          skillId = `skill-versions-${crypto.randomUUID()}`;
           await skills.create({ skill: { id: skillId, ...baseSnapshot } });
           for (let n = 2; n <= 3; n++) {
-            const vid = randomUUID();
+            const vid = crypto.randomUUID();
             versionIds.push(vid);
             await skills.createVersion({
               id: vid,
@@ -3782,10 +3781,10 @@ if (ENABLE_TESTS) {
         });
 
         it('deleteVersionsByParentId removes all versions for the skill', async () => {
-          const tempId = `bulk-skill-${randomUUID()}`;
+          const tempId = `bulk-skill-${crypto.randomUUID()}`;
           await skills.create({ skill: { id: tempId, ...baseSnapshot } });
           await skills.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             skillId: tempId,
             versionNumber: 2,
             name: 'method-skill',
@@ -3800,7 +3799,7 @@ if (ENABLE_TESTS) {
 
       describe('orphan-draft handling', () => {
         it('rolls back the draft thin row when the version insert fails inside the create() transaction', async () => {
-          const id = `skill-orphan-${randomUUID()}`;
+          const id = `skill-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (skills as any).db;
           const originalInsert = internalDb.insert.bind(internalDb);
           const insertSpy = vi.spyOn(internalDb, 'insert').mockImplementation(async (args: any) => {
@@ -3820,7 +3819,7 @@ if (ENABLE_TESTS) {
         });
 
         it('init() sweeps orphaned draft+activeVersionId=NULL rows when cleanupStaleDraftsOnStartup is enabled', async () => {
-          const id = `skill-init-orphan-${randomUUID()}`;
+          const id = `skill-init-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (skills as any).db;
           const now = new Date();
           await internalDb.insert({
@@ -3848,8 +3847,8 @@ if (ENABLE_TESTS) {
         });
 
         it('init() with cleanupStaleDraftsOnStartup leaves published skills and drafts with active versions untouched', async () => {
-          const publishedId = `skill-keep-pub-${randomUUID()}`;
-          const draftWithVersionId = `skill-keep-draft-${randomUUID()}`;
+          const publishedId = `skill-keep-pub-${crypto.randomUUID()}`;
+          const draftWithVersionId = `skill-keep-draft-${crypto.randomUUID()}`;
 
           await skills.create({ skill: { id: publishedId, ...baseSnapshot } });
           const v1Pub = await skills.getLatestVersion(publishedId);
@@ -3885,11 +3884,11 @@ if (ENABLE_TESTS) {
           // Verifying the invariant is in force also confirms that
           // SpannerDB.createIndexes propagates unique-index failures
           // instead of silently swallowing them.
-          const id = `skill-unique-${randomUUID()}`;
+          const id = `skill-unique-${crypto.randomUUID()}`;
           await skills.create({ skill: { id, ...baseSnapshot } });
           await expect(
             skills.createVersion({
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               skillId: id,
               versionNumber: 1, // duplicate of the seed version
               name: 'duplicate v1',
@@ -3905,7 +3904,7 @@ if (ENABLE_TESTS) {
     describe('BlobsSpanner methods', () => {
       // Build a deterministic synthetic hash so tests don't depend on a real
       // SHA-256 implementation.
-      const makeHash = (label: string) => `sha256-${label}-${randomUUID()}`;
+      const makeHash = (label: string) => `sha256-${label}-${crypto.randomUUID()}`;
       const makeEntry = (label = 'blob', overrides: Partial<Parameters<BlobsSpanner['put']>[0]> = {}) => ({
         hash: makeHash(label),
         content: `content for ${label}`,
@@ -3968,7 +3967,7 @@ if (ENABLE_TESTS) {
 
       describe('get', () => {
         it('returns null for unknown hashes', async () => {
-          expect(await blobs.get(`missing-${randomUUID()}`)).toBeNull();
+          expect(await blobs.get(`missing-${crypto.randomUUID()}`)).toBeNull();
         });
       });
 
@@ -3980,7 +3979,7 @@ if (ENABLE_TESTS) {
         });
 
         it('returns false for unknown hashes', async () => {
-          expect(await blobs.has(`missing-${randomUUID()}`)).toBe(false);
+          expect(await blobs.has(`missing-${crypto.randomUUID()}`)).toBe(false);
         });
       });
 
@@ -3993,7 +3992,7 @@ if (ENABLE_TESTS) {
         });
 
         it('returns false for unknown hashes', async () => {
-          expect(await blobs.delete(`missing-${randomUUID()}`)).toBe(false);
+          expect(await blobs.delete(`missing-${crypto.randomUUID()}`)).toBe(false);
         });
 
         it('is safe to call twice on the same hash', async () => {
@@ -4036,7 +4035,7 @@ if (ENABLE_TESTS) {
         it('returns only the hashes that exist, omitting unknown ones', async () => {
           const a = makeEntry('many-get-a');
           const b = makeEntry('many-get-b');
-          const missing = `missing-${randomUUID()}`;
+          const missing = `missing-${crypto.randomUUID()}`;
           await blobs.putMany([a, b]);
           const result = await blobs.getMany([a.hash, b.hash, missing]);
           expect(result.size).toBe(2);
@@ -4102,7 +4101,7 @@ if (ENABLE_TESTS) {
 
       describe('create', () => {
         it('creates the thin record as draft and seeds version 1', async () => {
-          const id = `pb-${randomUUID()}`;
+          const id = `pb-${crypto.randomUUID()}`;
           const created = await promptBlocks.create({ promptBlock: { id, ...baseSnapshot } });
           expect(created.id).toBe(id);
           expect(created.status).toBe('draft');
@@ -4115,7 +4114,7 @@ if (ENABLE_TESTS) {
         });
 
         it('persists optional snapshot fields (rules and requestContextSchema)', async () => {
-          const id = `pb-full-${randomUUID()}`;
+          const id = `pb-full-${crypto.randomUUID()}`;
           const rules = {
             type: 'all',
             children: [{ field: 'env', operator: 'equals', value: 'prod' }],
@@ -4146,11 +4145,11 @@ if (ENABLE_TESTS) {
 
       describe('getById', () => {
         it('returns null for unknown ids', async () => {
-          expect(await promptBlocks.getById(`missing-${randomUUID()}`)).toBeNull();
+          expect(await promptBlocks.getById(`missing-${crypto.randomUUID()}`)).toBeNull();
         });
 
         it('returns the thin record (no snapshot fields)', async () => {
-          const id = `pb-thin-${randomUUID()}`;
+          const id = `pb-thin-${crypto.randomUUID()}`;
           await promptBlocks.create({ promptBlock: { id, ...baseSnapshot } });
           const fetched = (await promptBlocks.getById(id)) as any;
           expect(fetched?.id).toBe(id);
@@ -4161,9 +4160,9 @@ if (ENABLE_TESTS) {
 
       describe('update', () => {
         it('updates activeVersionId, status, authorId, and metadata', async () => {
-          const id = `pb-update-${randomUUID()}`;
+          const id = `pb-update-${crypto.randomUUID()}`;
           await promptBlocks.create({ promptBlock: { id, ...baseSnapshot } });
-          const versionId = randomUUID();
+          const versionId = crypto.randomUUID();
           await promptBlocks.createVersion({
             id: versionId,
             blockId: id,
@@ -4192,11 +4191,11 @@ if (ENABLE_TESTS) {
         });
 
         it('throws for missing prompt blocks', async () => {
-          await expect(promptBlocks.update({ id: `missing-${randomUUID()}` })).rejects.toThrow(/not found/i);
+          await expect(promptBlocks.update({ id: `missing-${crypto.randomUUID()}` })).rejects.toThrow(/not found/i);
         });
 
         it('replaces metadata wholesale (DB adapter semantics)', async () => {
-          const id = `pb-meta-${randomUUID()}`;
+          const id = `pb-meta-${crypto.randomUUID()}`;
           await promptBlocks.create({
             promptBlock: { id, ...baseSnapshot, metadata: { keep: true, drop: 'me' } },
           });
@@ -4208,10 +4207,10 @@ if (ENABLE_TESTS) {
 
       describe('delete', () => {
         it('removes the thin record and all versions', async () => {
-          const id = `pb-delete-${randomUUID()}`;
+          const id = `pb-delete-${crypto.randomUUID()}`;
           await promptBlocks.create({ promptBlock: { id, ...baseSnapshot } });
           await promptBlocks.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             blockId: id,
             versionNumber: 2,
             name: 'method-block',
@@ -4229,15 +4228,15 @@ if (ENABLE_TESTS) {
       });
 
       describe('list', () => {
-        const authorA = `pb-author-a-${randomUUID()}`;
-        const authorB = `pb-author-b-${randomUUID()}`;
+        const authorA = `pb-author-a-${crypto.randomUUID()}`;
+        const authorB = `pb-author-b-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           await promptBlocks.dangerouslyClearAll();
           for (let i = 0; i < 4; i++) {
             await promptBlocks.create({
               promptBlock: {
-                id: `pb-list-${randomUUID()}`,
+                id: `pb-list-${crypto.randomUUID()}`,
                 ...baseSnapshot,
                 authorId: i < 3 ? authorA : authorB,
                 metadata: { tier: i % 2 === 0 ? 'gold' : 'silver' },
@@ -4324,10 +4323,10 @@ if (ENABLE_TESTS) {
         const versionIds: string[] = [];
 
         beforeAll(async () => {
-          blockId = `pb-versions-${randomUUID()}`;
+          blockId = `pb-versions-${crypto.randomUUID()}`;
           await promptBlocks.create({ promptBlock: { id: blockId, ...baseSnapshot } });
           for (let n = 2; n <= 3; n++) {
-            const vid = randomUUID();
+            const vid = crypto.randomUUID();
             versionIds.push(vid);
             await promptBlocks.createVersion({
               id: vid,
@@ -4425,10 +4424,10 @@ if (ENABLE_TESTS) {
         });
 
         it('deleteVersionsByParentId removes all versions for the block', async () => {
-          const tempId = `pb-bulk-${randomUUID()}`;
+          const tempId = `pb-bulk-${crypto.randomUUID()}`;
           await promptBlocks.create({ promptBlock: { id: tempId, ...baseSnapshot } });
           await promptBlocks.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             blockId: tempId,
             versionNumber: 2,
             name: 'method-block',
@@ -4465,7 +4464,7 @@ if (ENABLE_TESTS) {
 
       describe('create', () => {
         it('creates the thin record as draft and seeds version 1 (llm-judge)', async () => {
-          const id = `sd-${randomUUID()}`;
+          const id = `sd-${crypto.randomUUID()}`;
           const created = await scorerDefinitions.create({
             scorerDefinition: { id, ...llmJudgeSnapshot },
           });
@@ -4482,7 +4481,7 @@ if (ENABLE_TESTS) {
         });
 
         it('persists preset-style snapshot fields', async () => {
-          const id = `sd-preset-${randomUUID()}`;
+          const id = `sd-preset-${crypto.randomUUID()}`;
           await scorerDefinitions.create({
             scorerDefinition: {
               id,
@@ -4503,11 +4502,11 @@ if (ENABLE_TESTS) {
 
       describe('getById', () => {
         it('returns null for unknown ids', async () => {
-          expect(await scorerDefinitions.getById(`missing-${randomUUID()}`)).toBeNull();
+          expect(await scorerDefinitions.getById(`missing-${crypto.randomUUID()}`)).toBeNull();
         });
 
         it('returns the thin record (no snapshot fields)', async () => {
-          const id = `sd-thin-${randomUUID()}`;
+          const id = `sd-thin-${crypto.randomUUID()}`;
           await scorerDefinitions.create({ scorerDefinition: { id, ...llmJudgeSnapshot } });
           const fetched = (await scorerDefinitions.getById(id)) as any;
           expect(fetched?.id).toBe(id);
@@ -4519,9 +4518,9 @@ if (ENABLE_TESTS) {
 
       describe('update', () => {
         it('updates activeVersionId, status, authorId, and metadata', async () => {
-          const id = `sd-update-${randomUUID()}`;
+          const id = `sd-update-${crypto.randomUUID()}`;
           await scorerDefinitions.create({ scorerDefinition: { id, ...llmJudgeSnapshot } });
-          const versionId = randomUUID();
+          const versionId = crypto.randomUUID();
           await scorerDefinitions.createVersion({
             id: versionId,
             scorerDefinitionId: id,
@@ -4553,11 +4552,13 @@ if (ENABLE_TESTS) {
         });
 
         it('throws for missing scorer definitions', async () => {
-          await expect(scorerDefinitions.update({ id: `missing-${randomUUID()}` })).rejects.toThrow(/not found/i);
+          await expect(scorerDefinitions.update({ id: `missing-${crypto.randomUUID()}` })).rejects.toThrow(
+            /not found/i,
+          );
         });
 
         it('replaces metadata wholesale (DB adapter semantics)', async () => {
-          const id = `sd-meta-${randomUUID()}`;
+          const id = `sd-meta-${crypto.randomUUID()}`;
           await scorerDefinitions.create({
             scorerDefinition: { id, ...llmJudgeSnapshot, metadata: { keep: true, drop: 'me' } },
           });
@@ -4569,10 +4570,10 @@ if (ENABLE_TESTS) {
 
       describe('delete', () => {
         it('removes the thin record and all versions', async () => {
-          const id = `sd-delete-${randomUUID()}`;
+          const id = `sd-delete-${crypto.randomUUID()}`;
           await scorerDefinitions.create({ scorerDefinition: { id, ...llmJudgeSnapshot } });
           await scorerDefinitions.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             scorerDefinitionId: id,
             versionNumber: 2,
             name: 'method-judge',
@@ -4590,15 +4591,15 @@ if (ENABLE_TESTS) {
       });
 
       describe('list', () => {
-        const authorA = `sd-author-a-${randomUUID()}`;
-        const authorB = `sd-author-b-${randomUUID()}`;
+        const authorA = `sd-author-a-${crypto.randomUUID()}`;
+        const authorB = `sd-author-b-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           await scorerDefinitions.dangerouslyClearAll();
           for (let i = 0; i < 4; i++) {
             await scorerDefinitions.create({
               scorerDefinition: {
-                id: `sd-list-${randomUUID()}`,
+                id: `sd-list-${crypto.randomUUID()}`,
                 ...llmJudgeSnapshot,
                 authorId: i < 3 ? authorA : authorB,
                 metadata: { tier: i % 2 === 0 ? 'gold' : 'silver' },
@@ -4685,10 +4686,10 @@ if (ENABLE_TESTS) {
         const versionIds: string[] = [];
 
         beforeAll(async () => {
-          scorerId = `sd-versions-${randomUUID()}`;
+          scorerId = `sd-versions-${crypto.randomUUID()}`;
           await scorerDefinitions.create({ scorerDefinition: { id: scorerId, ...llmJudgeSnapshot } });
           for (let n = 2; n <= 3; n++) {
-            const vid = randomUUID();
+            const vid = crypto.randomUUID();
             versionIds.push(vid);
             await scorerDefinitions.createVersion({
               id: vid,
@@ -4794,10 +4795,10 @@ if (ENABLE_TESTS) {
         });
 
         it('deleteVersionsByParentId removes all versions for the scorer', async () => {
-          const tempId = `sd-bulk-${randomUUID()}`;
+          const tempId = `sd-bulk-${crypto.randomUUID()}`;
           await scorerDefinitions.create({ scorerDefinition: { id: tempId, ...llmJudgeSnapshot } });
           await scorerDefinitions.createVersion({
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             scorerDefinitionId: tempId,
             versionNumber: 2,
             name: 'method-judge',
@@ -4819,7 +4820,7 @@ if (ENABLE_TESTS) {
           // of the transactional path. We capture a reference to the original
           // BEFORE installing the spy so the thin-row insert can pass through
           // without recursing back into the spied wrapper.
-          const id = `sd-orphan-${randomUUID()}`;
+          const id = `sd-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (scorerDefinitions as any).db;
           const originalInsert = internalDb.insert.bind(internalDb);
           const insertSpy = vi.spyOn(internalDb, 'insert').mockImplementation(async (args: any) => {
@@ -4840,7 +4841,7 @@ if (ENABLE_TESTS) {
         });
 
         it('init() sweeps orphaned draft+activeVersionId=NULL rows when cleanupStaleDraftsOnStartup is enabled', async () => {
-          const id = `sd-init-orphan-${randomUUID()}`;
+          const id = `sd-init-orphan-${crypto.randomUUID()}`;
           const internalDb: SpannerDB = (scorerDefinitions as any).db;
           const now = new Date();
           await internalDb.insert({
@@ -4869,8 +4870,8 @@ if (ENABLE_TESTS) {
         });
 
         it('init() with cleanupStaleDraftsOnStartup leaves published definitions and drafts with active versions untouched', async () => {
-          const publishedId = `sd-keep-pub-${randomUUID()}`;
-          const draftWithVersionId = `sd-keep-draft-${randomUUID()}`;
+          const publishedId = `sd-keep-pub-${crypto.randomUUID()}`;
+          const draftWithVersionId = `sd-keep-draft-${crypto.randomUUID()}`;
 
           await scorerDefinitions.create({
             scorerDefinition: { id: publishedId, ...llmJudgeSnapshot },
@@ -4913,13 +4914,13 @@ if (ENABLE_TESTS) {
           // number. Verifying the invariant is in force also confirms that
           // SpannerDB.createIndexes propagates unique-index failures instead
           // of silently swallowing them.
-          const id = `sd-unique-${randomUUID()}`;
+          const id = `sd-unique-${crypto.randomUUID()}`;
           await scorerDefinitions.create({
             scorerDefinition: { id, ...llmJudgeSnapshot },
           });
           await expect(
             scorerDefinitions.createVersion({
-              id: randomUUID(),
+              id: crypto.randomUUID(),
               scorerDefinitionId: id,
               versionNumber: 1, // duplicate of the seed version
               name: 'duplicate v1',
@@ -4937,13 +4938,13 @@ if (ENABLE_TESTS) {
       // Inlining keeps the dependency narrow and avoids reaching into the
       // test-utils package for an internal factory.
       function makeSamplePayload(overrides: Partial<Record<string, any>> = {}): any {
-        const scorerId = overrides.scorerId ?? `scorer-${randomUUID()}`;
+        const scorerId = overrides.scorerId ?? `scorer-${crypto.randomUUID()}`;
         return {
           scorerId,
-          entityId: overrides.entityId ?? `agent-${randomUUID()}`,
+          entityId: overrides.entityId ?? `agent-${crypto.randomUUID()}`,
           entityType: overrides.entityType ?? 'AGENT',
-          runId: overrides.runId ?? `run-${randomUUID()}`,
-          input: overrides.input ?? [{ id: randomUUID(), name: 'in', value: 'sample input' }],
+          runId: overrides.runId ?? `run-${crypto.randomUUID()}`,
+          input: overrides.input ?? [{ id: crypto.randomUUID(), name: 'in', value: 'sample input' }],
           output: overrides.output ?? { text: 'sample output' },
           score: overrides.score ?? 0.75,
           source: overrides.source ?? 'LIVE',
@@ -4998,15 +4999,15 @@ if (ENABLE_TESTS) {
         });
 
         it('returns null from getScoreById for an unknown id', async () => {
-          const result = await scores.getScoreById({ id: `missing-${randomUUID()}` });
+          const result = await scores.getScoreById({ id: `missing-${crypto.randomUUID()}` });
           expect(result).toBeNull();
         });
       });
 
       describe('listScoresByScorerId', () => {
-        const scorerId = `scorer-${randomUUID()}`;
-        const otherScorerId = `scorer-${randomUUID()}`;
-        const entityId = `agent-${randomUUID()}`;
+        const scorerId = `scorer-${crypto.randomUUID()}`;
+        const otherScorerId = `scorer-${crypto.randomUUID()}`;
+        const entityId = `agent-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           // Three scores for `scorerId` (two LIVE + one TEST), one for another scorer.
@@ -5065,7 +5066,7 @@ if (ENABLE_TESTS) {
 
         it('returns an empty page (total: 0) for an unknown scorerId', async () => {
           const result = await scores.listScoresByScorerId({
-            scorerId: `missing-${randomUUID()}`,
+            scorerId: `missing-${crypto.randomUUID()}`,
             pagination: { page: 0, perPage: 10 },
           });
           expect(result.pagination.total).toBe(0);
@@ -5075,13 +5076,13 @@ if (ENABLE_TESTS) {
       });
 
       describe('listScoresByRunId', () => {
-        const runId = `run-${randomUUID()}`;
+        const runId = `run-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           await scores.saveScore(makeSamplePayload({ runId }));
           await scores.saveScore(makeSamplePayload({ runId }));
           // Different runId  must NOT be returned.
-          await scores.saveScore(makeSamplePayload({ runId: `run-${randomUUID()}` }));
+          await scores.saveScore(makeSamplePayload({ runId: `run-${crypto.randomUUID()}` }));
         });
 
         it('returns only scores for the requested runId', async () => {
@@ -5095,7 +5096,7 @@ if (ENABLE_TESTS) {
 
         it('returns an empty page for an unknown runId', async () => {
           const result = await scores.listScoresByRunId({
-            runId: `missing-${randomUUID()}`,
+            runId: `missing-${crypto.randomUUID()}`,
             pagination: { page: 0, perPage: 10 },
           });
           expect(result.pagination.total).toBe(0);
@@ -5104,16 +5105,16 @@ if (ENABLE_TESTS) {
       });
 
       describe('listScoresBySpan', () => {
-        const traceId = `trace-${randomUUID()}`;
-        const spanId = `span-${randomUUID()}`;
+        const traceId = `trace-${crypto.randomUUID()}`;
+        const spanId = `span-${crypto.randomUUID()}`;
 
         beforeAll(async () => {
           await scores.saveScore(makeSamplePayload({ traceId, spanId }));
           await scores.saveScore(makeSamplePayload({ traceId, spanId }));
           // Same trace, different span  excluded.
-          await scores.saveScore(makeSamplePayload({ traceId, spanId: `span-${randomUUID()}` }));
+          await scores.saveScore(makeSamplePayload({ traceId, spanId: `span-${crypto.randomUUID()}` }));
           // Different trace, same span string  excluded.
-          await scores.saveScore(makeSamplePayload({ traceId: `trace-${randomUUID()}`, spanId }));
+          await scores.saveScore(makeSamplePayload({ traceId: `trace-${crypto.randomUUID()}`, spanId }));
         });
 
         it('matches on the (traceId, spanId) pair, not either column alone', async () => {
@@ -5128,8 +5129,8 @@ if (ENABLE_TESTS) {
 
         it('returns an empty page when no rows match the pair', async () => {
           const result = await scores.listScoresBySpan({
-            traceId: `missing-${randomUUID()}`,
-            spanId: `missing-${randomUUID()}`,
+            traceId: `missing-${crypto.randomUUID()}`,
+            spanId: `missing-${crypto.randomUUID()}`,
             pagination: { page: 0, perPage: 10 },
           });
           expect(result.pagination.total).toBe(0);
@@ -5147,8 +5148,8 @@ if (ENABLE_TESTS) {
       const now = () => new Date();
 
       function makeSpan(overrides: Record<string, any> = {}): any {
-        const traceId = overrides.traceId ?? `trace-${randomUUID()}`;
-        const spanId = overrides.spanId ?? `span-${randomUUID()}`;
+        const traceId = overrides.traceId ?? `trace-${crypto.randomUUID()}`;
+        const spanId = overrides.spanId ?? `span-${crypto.randomUUID()}`;
         const start = overrides.startedAt ?? now();
         return {
           traceId,
@@ -5654,7 +5655,7 @@ if (ENABLE_TESTS) {
 
         function makeMetric(overrides: Record<string, any> = {}): any {
           return {
-            metricId: overrides.metricId ?? randomUUID(),
+            metricId: overrides.metricId ?? crypto.randomUUID(),
             timestamp: overrides.timestamp ?? baseDate,
             name: overrides.name ?? 'agent.duration_ms',
             value: overrides.value ?? 100,
@@ -5741,7 +5742,7 @@ if (ENABLE_TESTS) {
         });
 
         it('round-trips JSON columns (labels, tags, costMetadata, metadata, scope)', async () => {
-          const id = randomUUID();
+          const id = crypto.randomUUID();
           await observability.batchCreateMetrics({
             metrics: [
               makeMetric({

--- a/stores/upstash/src/storage/index.test.ts
+++ b/stores/upstash/src/storage/index.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import {
   createTestSuite,
   createConfigValidationTests,
@@ -29,8 +28,8 @@ const createTestClient = () =>
     token: TEST_CONFIG.token,
   });
 
-const createThread = (resourceId = `resource-${randomUUID()}`): StorageThreadType => ({
-  id: `thread-${randomUUID()}`,
+const createThread = (resourceId = `resource-${crypto.randomUUID()}`): StorageThreadType => ({
+  id: `thread-${crypto.randomUUID()}`,
   resourceId,
   title: 'Test Thread',
   metadata: {},
@@ -39,7 +38,7 @@ const createThread = (resourceId = `resource-${randomUUID()}`): StorageThreadTyp
 });
 
 const createMessage = (thread: StorageThreadType, overrides: Partial<MastraDBMessage> = {}): MastraDBMessage => ({
-  id: overrides.id ?? randomUUID(),
+  id: overrides.id ?? crypto.randomUUID(),
   threadId: overrides.threadId ?? thread.id,
   resourceId: overrides.resourceId ?? thread.resourceId,
   role: overrides.role ?? 'user',
@@ -329,9 +328,9 @@ describe('WorkflowsUpstash.persistWorkflowSnapshot', () => {
     const workflowsDomain = new WorkflowsUpstash({ client: createTestClient() });
     await workflowsDomain.init();
 
-    const workflowName = `workflow-${randomUUID()}`;
-    const runId = `run-${randomUUID()}`;
-    const resourceId = `resource-${randomUUID()}`;
+    const workflowName = `workflow-${crypto.randomUUID()}`;
+    const runId = `run-${crypto.randomUUID()}`;
+    const resourceId = `resource-${crypto.randomUUID()}`;
     const createdAt = new Date('2024-01-15T10:00:00.000Z');
     const updatedAt = new Date('2024-06-01T12:00:00.000Z');
 

--- a/stores/upstash/src/vector/index.ts
+++ b/stores/upstash/src/vector/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { MastraError, ErrorDomain, ErrorCategory } from '@mastra/core/error';
 import { createVectorErrorId } from '@mastra/core/storage';
 import { MastraVector } from '@mastra/core/vector';
@@ -48,7 +47,7 @@ export class UpstashVector extends MastraVector<UpstashVectorFilter> {
     ids,
     sparseVectors,
   }: UpstashUpsertVectorParams): Promise<string[]> {
-    const generatedIds = ids || vectors.map(() => randomUUID());
+    const generatedIds = ids || vectors.map(() => crypto.randomUUID());
 
     const points = vectors.map((vector, index) => ({
       id: generatedIds[index]!,

--- a/stores/vectorize/src/vector/index.test.ts
+++ b/stores/vectorize/src/vector/index.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { QueryResult } from '@mastra/core/vector';
 import dotenv from 'dotenv';
 import { describe, it, expect, beforeAll, afterAll, beforeEach, vi, afterEach } from 'vitest';
@@ -226,8 +225,8 @@ async function waitForQueryResults({
 describe('CloudflareVector', () => {
   let vectorDB: CloudflareVector;
   const VECTOR_DIMENSION = 1536;
-  const testIndexName = `default-${randomUUID()}`;
-  const testIndexName2 = `default-${randomUUID()}`;
+  const testIndexName = `default-${crypto.randomUUID()}`;
+  const testIndexName2 = `default-${crypto.randomUUID()}`;
 
   // Helper function to create a normalized vector
   const createVector = (primaryDimension: number, value: number = 1.0): number[] => {
@@ -262,7 +261,7 @@ describe('CloudflareVector', () => {
 
   describe('Index Operations', () => {
     const tempIndexName = 'test_temp_index';
-    const tempIndexNameCreateDescribeDelete = `create-describe-delete-${randomUUID().slice(0, 8)}`;
+    const tempIndexNameCreateDescribeDelete = `create-describe-delete-${crypto.randomUUID().slice(0, 8)}`;
 
     beforeEach(async () => {
       // Cleanup any existing index before each test
@@ -532,7 +531,7 @@ describe('CloudflareVector', () => {
 
   describe('Error Handling', () => {
     it('should handle duplicate index creation gracefully', async () => {
-      const duplicateIndexName = `duplicate-test-${randomUUID()}`;
+      const duplicateIndexName = `duplicate-test-${crypto.randomUUID()}`;
       const dimension = 768;
       const infoSpy = vi.spyOn(vectorDB['logger'], 'info');
       const warnSpy = vi.spyOn(vectorDB['logger'], 'warn');

--- a/voice/aws-nova-sonic/src/index.ts
+++ b/voice/aws-nova-sonic/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { PassThrough } from 'node:stream';
 import { BedrockRuntimeClient, InvokeModelWithBidirectionalStreamCommand } from '@aws-sdk/client-bedrock-runtime';
 import { MastraVoice } from '@internal/voice';
@@ -570,7 +569,7 @@ export class NovaSonicVoice extends MastraVoice<
     this.log('Pre-populating queue with sessionStart and promptStart events...');
 
     // Generate promptName for this session
-    const promptName = randomUUID();
+    const promptName = crypto.randomUUID();
     this._promptName = promptName;
 
     // 1. Session start event
@@ -728,7 +727,7 @@ export class NovaSonicVoice extends MastraVoice<
     // 3. System prompt events
     // AWS requires that the FIRST content after promptStart must have SYSTEM role
     // We always send a SYSTEM content, even if instructions are empty
-    const systemContentName = randomUUID();
+    const systemContentName = crypto.randomUUID();
     // Content start
     eventQueue.push({
       event: {
@@ -1726,7 +1725,7 @@ export class NovaSonicVoice extends MastraVoice<
       );
     }
 
-    const contentName = randomUUID();
+    const contentName = crypto.randomUUID();
     // Content start
     await this.sendClientEvent({
       contentStart: {
@@ -1838,7 +1837,7 @@ export class NovaSonicVoice extends MastraVoice<
     }
     if (!this.audioContentStarted) {
       // First time sending audio - need to send contentStart first
-      const audioContentId = randomUUID();
+      const audioContentId = crypto.randomUUID();
       this.audioContentName = audioContentId;
 
       this.log(`[send] First audio send - sending AUDIO contentStart with contentName: ${audioContentId}`);

--- a/voice/google-gemini-live-api/src/index.ts
+++ b/voice/google-gemini-live-api/src/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { MastraVoice } from '@internal/voice';
 import type { ToolsInput, VoiceEventType, VoiceConfig } from '@internal/voice';
 import { GoogleSchemaCompatLayer } from '@mastra/schema-compat';
@@ -491,7 +490,7 @@ export class GeminiLiveVoice extends MastraVoice<
       // Send initial configuration (session_resumption handle is embedded in setup frame)
       this.sendInitialConfig();
       this.sessionStartTime = Date.now();
-      this.sessionId = randomUUID();
+      this.sessionId = crypto.randomUUID();
 
       // Wait for session to be created after sending config
       await this.waitForSessionCreated();
@@ -1473,7 +1472,7 @@ export class GeminiLiveVoice extends MastraVoice<
             toolCall: {
               name: part.functionCall.name,
               args: part.functionCall.args || {},
-              id: part.functionCall.id || randomUUID(),
+              id: part.functionCall.id || crypto.randomUUID(),
             },
           };
 
@@ -1491,7 +1490,7 @@ export class GeminiLiveVoice extends MastraVoice<
             const int16Array = this.audioStreamManager.base64ToInt16Array(audioData);
 
             // Use the tracked response ID or generate one if not available
-            const responseId = this.getCurrentResponseId() || randomUUID();
+            const responseId = this.getCurrentResponseId() || crypto.randomUUID();
 
             // Get or create the speaker stream for this response
             let speakerStream = this.audioStreamManager.getSpeakerStream(responseId);
@@ -1609,7 +1608,7 @@ export class GeminiLiveVoice extends MastraVoice<
     for (const toolCall of toolCalls) {
       const toolName = toolCall.name || '';
       const toolArgs = toolCall.args || {};
-      const toolId = toolCall.id || randomUUID();
+      const toolId = toolCall.id || crypto.randomUUID();
 
       await this.processSingleToolCall(toolName, toolArgs, toolId);
     }

--- a/workflows/_test-utils/src/domains/streaming.ts
+++ b/workflows/_test-utils/src/domains/streaming.ts
@@ -8,7 +8,6 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { z } from 'zod';
-import { randomUUID } from 'crypto';
 import { simulateReadableStream } from '@internal/ai-sdk-v4';
 // @ts-ignore - module resolution for test utilities
 import { MockLanguageModelV1, MockLanguageModelV2 } from '@internal/ai-sdk-v4/test';
@@ -1118,7 +1117,7 @@ export function createStreamingTests(ctx: WorkflowTestContext, registry?: Workfl
         new Mastra({
           workflows: { 'agent-detailed-streaming-test': workflow },
           agents: { 'test-agent-1': agent, 'test-agent-2': agent2 },
-          idGenerator: () => randomUUID(),
+          idGenerator: () => crypto.randomUUID(),
         });
 
         const agentStep1 = createStep(agent);
@@ -1499,7 +1498,7 @@ export function createStreamingTests(ctx: WorkflowTestContext, registry?: Workfl
         new Mastra({
           workflows: { 'test-workflow-agent-options-callbacks': workflow },
           agents: { 'test-agent-with-options': agent },
-          idGenerator: () => randomUUID(),
+          idGenerator: () => crypto.randomUUID(),
         });
 
         const agentStep = createStep(agent, {
@@ -1604,7 +1603,7 @@ export function createStreamingTests(ctx: WorkflowTestContext, registry?: Workfl
         new Mastra({
           workflows: { 'agent-vnext-streaming-test': workflow },
           agents: { 'test-agent-1': agent, 'test-agent-2': agent2 },
-          idGenerator: () => randomUUID(),
+          idGenerator: () => crypto.randomUUID(),
         });
 
         const agentStep1 = createStep(agent);
@@ -1734,7 +1733,7 @@ export function createStreamingTests(ctx: WorkflowTestContext, registry?: Workfl
         new Mastra({
           workflows: { 'agent-nonstreaming-test': workflow },
           agents: { 'test-agent-1': agent, 'test-agent-2': agent2 },
-          idGenerator: () => randomUUID(),
+          idGenerator: () => crypto.randomUUID(),
         });
 
         const agentStep1 = createStep(agent);
@@ -2224,7 +2223,7 @@ export function createStreamingTests(ctx: WorkflowTestContext, registry?: Workfl
           new Mastra({
             workflows: { 'article-workflow': workflow },
             agents: { 'article-generator': agent },
-            idGenerator: () => randomUUID(),
+            idGenerator: () => crypto.randomUUID(),
           });
 
           workflow

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ActorSignal } from '@mastra/core/auth/ee';
 import type { RequestContext } from '@mastra/core/di';
 import { getErrorFromUnknown, MastraNonRetryableError } from '@mastra/core/error';
@@ -516,7 +515,7 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
 
     try {
       if (isResume) {
-        runId = stepResults[resume?.steps?.[0] ?? '']?.suspendPayload?.__workflow_meta?.runId ?? randomUUID();
+        runId = stepResults[resume?.steps?.[0] ?? '']?.suspendPayload?.__workflow_meta?.runId ?? crypto.randomUUID();
         const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
         const snapshot: any = await workflowsStore?.loadWorkflowSnapshot({
           workflowName: step.id,
@@ -603,10 +602,10 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
       if (errorCause && typeof errorCause === 'object') {
         result = errorCause as WorkflowResult<any, any, any, any>;
         // The runId might be in the result's steps metadata
-        runId = errorCause.runId || randomUUID();
+        runId = errorCause.runId || crypto.randomUUID();
       } else {
         // Fallback: if we can't get the result from error, construct a basic failed result
-        runId = randomUUID();
+        runId = crypto.randomUUID();
         result = {
           status: 'failed',
           error: e instanceof Error ? e : new Error(String(e)),

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { emitErrorEvent } from '@mastra/core/agent/durable';
 import { RequestContext } from '@mastra/core/di';
 import type { PubSub } from '@mastra/core/events';
@@ -186,7 +185,7 @@ export class InngestWorkflow<
     runId?: string;
     resourceId?: string;
   }): Promise<Run<TEngineType, TSteps, TState, TInput, TOutput>> {
-    const runIdToUse = options?.runId || randomUUID();
+    const runIdToUse = options?.runId || crypto.randomUUID();
 
     // Return a new Run instance with object parameters
     const existingInMemoryRun = this.runs.get(runIdToUse);
@@ -311,7 +310,7 @@ export class InngestWorkflow<
 
         if (!runId) {
           runId = await step.run(`workflow.${this.id}.runIdGen`, async () => {
-            return randomUUID();
+            return crypto.randomUUID();
           });
         }
 


### PR DESCRIPTION
## Description

Part 2 of 2 of the repo-wide UUID unification (split from #19502, which exceeded the 150-file review limit; part 1 covers `packages/*`). This part covers `stores/*`, `agent-sdks/*`, `pubsub/*`, `mastracode/`, `workflows/inngest`, `voice/*`, `signals/github`, `server-adapters/nestjs`, and `observability/` — 83 files.

Same mechanical change and rationale as part 1: drop `randomUUID` from `node:crypto`/`crypto` imports and call the identical Web Crypto global, removing an unnecessary Node-only module dependency that breaks bundling for V8-isolate runtimes (Convex default runtime, Cloudflare Workers without `nodejs_compat`). Follows the `@mastra/convex` fix in #19498.

One non-trivial spot: the datasets storage domains in `stores/mongodb`, `stores/mysql`, and `stores/spanner` passed `randomUUID` as a function reference to `planDatasetItemBatch`; those now pass `() => crypto.randomUUID()`.

## Related issue(s)

Fixes #19501

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Testing

- Zero leftover runtime `randomUUID`-from-crypto imports in the covered directories (repo-wide grep).
- `pnpm turbo build` for `@mastra/mongodb`, `@mastra/mysql`, `@mastra/spanner`, `@mastra/openai` and their dependency graphs: clean (this caught and verified the function-reference fix above).
- Deterministic test UUIDs unaffected: `@internal/test-utils/setup` stubs the global `crypto.randomUUID`.
- Changeset patch-bumps the 25 published packages touched here.

## AI disclosure

Implemented with Claude Code (Fable 5) as a reviewed codemod; human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

We replaced Node-specific UUID generation with the browser-compatible Web Crypto version across the codebase. This helps the same code run in edge environments like Cloudflare Workers and Convex without extra Node compatibility settings.

## Summary

- Updated UUID generation across storage, SDKs, workflows, voice, pubsub, signals, adapters, Mastra Code, and observability to use `crypto.randomUUID()`.
- Updated MongoDB, MySQL, and Spanner dataset batching to receive UUID generators.
- Preserved deterministic UUID stubs in tests and other `node:crypto` APIs.
- Added validation to prevent covered directories from reintroducing `randomUUID` imports.
- Added patch changesets for 25 published packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->