### PR TITLE
chore(docs): Document required id for LibSQLStore

### DIFF
--- a/docs/src/content/en/docs/agent-builder/deploying.mdx
+++ b/docs/src/content/en/docs/agent-builder/deploying.mdx
@@ -40,6 +40,7 @@ import { LibSQLStore } from '@mastra/libsql'
 
 new Mastra({
   storage: new LibSQLStore({
+    id: 'mastra-storage',
     url: process.env.DATABASE_URL!,
     authToken: process.env.DATABASE_AUTH_TOKEN,
   }),

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -60,7 +60,7 @@ import { createBuilderAgent } from '@mastra/editor/ee'
 import { LibSQLStore } from '@mastra/libsql'
 
 export const mastra = new Mastra({
-  storage: new LibSQLStore({ url: 'file:./mastra.db' }),
+  storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
   agents: { builderAgent: createBuilderAgent() },
   editor: new MastraEditor({
     builder: {

--- a/docs/src/content/en/docs/agent-controller/overview.mdx
+++ b/docs/src/content/en/docs/agent-controller/overview.mdx
@@ -74,7 +74,7 @@ const agent = new Agent({
 const agentController = new AgentController({
   id: 'my-agent',
   agent,
-  storage: new LibSQLStore({ url: 'file:./data.db' }),
+  storage: new LibSQLStore({ id: 'agent-storage', url: 'file:./data.db' }),
   modes: [
     {
       id: 'plan',

--- a/docs/src/content/en/docs/capabilities/channels/overview.mdx
+++ b/docs/src/content/en/docs/capabilities/channels/overview.mdx
@@ -67,6 +67,7 @@ import { yourAgent } from './agents/your-agent'
 export const mastra = new Mastra({
   agents: { yourAgent },
   storage: new LibSQLStore({
+    id: 'mastra-storage',
     url: process.env.DATABASE_URL,
   }),
 })

--- a/docs/src/content/en/docs/long-running-agents/schedules.mdx
+++ b/docs/src/content/en/docs/long-running-agents/schedules.mdx
@@ -44,7 +44,7 @@ const pinger = new Agent({
 
 const mastra = new Mastra({
   agents: { pinger },
-  storage: new LibSQLStore({ url: 'file:./mastra.db' }),
+  storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
 })
 
 await mastra.schedules.create({
@@ -178,7 +178,7 @@ Hooks let you run code at key points in an agent schedule's lifecycle, for examp
 ```typescript title="src/mastra/index.ts"
 const mastra = new Mastra({
   agents: { pinger },
-  storage: new LibSQLStore({ url: 'file:./mastra.db' }),
+  storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
   schedules: {
     prepare: async ({ agentId, schedule, trigger }) => {
       // Return overrides, null to skip this fire, or undefined for defaults

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -117,6 +117,7 @@ Turso exposes two environment variables: `TURSO_DATABASE_URL` and `TURSO_AUTH_TO
 import { LibSQLStore } from '@mastra/libsql'
 
 export const storage = new LibSQLStore({
+  id: 'mastra-storage',
   url: process.env.TURSO_DATABASE_URL!,
   authToken: process.env.TURSO_AUTH_TOKEN!,
 })

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -57,6 +57,7 @@ A local `.env` file is optional. Environment variables stored on the platform ar
 
     ```ts title="src/mastra/index.ts"
     new LibSQLStore({
+      id: 'mastra-storage',
       // Uses the hosted database when deployed, a local file during development
       url: process.env.TURSO_DATABASE_URL ?? 'file:./mastra.db',
       authToken: process.env.TURSO_AUTH_TOKEN,
@@ -111,6 +112,7 @@ Preflight validates the built output before anything ships, and only flags issue
   import { LibSQLStore } from '@mastra/libsql'
 
   export const storage = new LibSQLStore({
+    id: 'mastra-storage',
     // Uses the hosted database when deployed, a local file during development
     url: process.env.TURSO_DATABASE_URL ?? 'file:./mastra.db',
     authToken: process.env.TURSO_AUTH_TOKEN,

--- a/docs/src/content/en/docs/memory/multi-user-threads.mdx
+++ b/docs/src/content/en/docs/memory/multi-user-threads.mdx
@@ -65,7 +65,7 @@ import { Memory } from '@mastra/memory'
 import { LibSQLStore } from '@mastra/libsql'
 
 const memory = new Memory({
-  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  storage: new LibSQLStore({ id: 'collab-storage', url: 'file:./collab.db' }),
   options: {
     lastMessages: 20,
   },
@@ -135,7 +135,7 @@ import { Memory } from '@mastra/memory'
 import { LibSQLStore } from '@mastra/libsql'
 
 const memory = new Memory({
-  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  storage: new LibSQLStore({ id: 'collab-storage', url: 'file:./collab.db' }),
   options: {
     lastMessages: 20,
   },
@@ -155,7 +155,7 @@ import { Memory } from '@mastra/memory'
 import { LibSQLStore } from '@mastra/libsql'
 
 const memory = new Memory({
-  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  storage: new LibSQLStore({ id: 'collab-storage', url: 'file:./collab.db' }),
   options: {
     lastMessages: 20,
     observationalMemory: true,
@@ -182,7 +182,7 @@ import { Memory } from '@mastra/memory'
 import { LibSQLStore } from '@mastra/libsql'
 
 const memory = new Memory({
-  storage: new LibSQLStore({ url: 'file:./collab.db' }),
+  storage: new LibSQLStore({ id: 'collab-storage', url: 'file:./collab.db' }),
   options: {
     lastMessages: 20,
     workingMemory: {

--- a/docs/src/content/en/docs/memory/working-memory.mdx
+++ b/docs/src/content/en/docs/memory/working-memory.mdx
@@ -426,7 +426,7 @@ By default, working memory reaches the model as part of the system message. You 
 
 ```typescript
 const memory = new Memory({
-  storage: new LibSQLStore({ url: 'file:./mastra.db' }),
+  storage: new LibSQLStore({ id: 'mastra-storage', url: 'file:./mastra.db' }),
   options: {
     workingMemory: {
       enabled: true,

--- a/docs/src/content/en/docs/voice/livekit.mdx
+++ b/docs/src/content/en/docs/voice/livekit.mdx
@@ -344,7 +344,7 @@ import { LibSQLStore } from '@mastra/libsql'
 import { Observability, MastraStorageExporter } from '@mastra/observability'
 
 export const mastra = new Mastra({
-  storage: new LibSQLStore({ url: 'file:./voice-agent.db' }),
+  storage: new LibSQLStore({ id: 'voice-agent-storage', url: 'file:./voice-agent.db' }),
   observability: new Observability({
     configs: {
       default: {

--- a/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
+++ b/docs/src/content/en/guides/build-your-ui/ai-sdk-ui.mdx
@@ -1166,6 +1166,7 @@ The workflow uses:
     export const mastra = new Mastra({
       workflows: { approvalWorkflow },
       storage: new LibSQLStore({
+        id: 'mastra-storage',
         url: 'file:../mastra.db',
       }),
       server: {

--- a/docs/src/content/en/guides/guide/signal-provider.mdx
+++ b/docs/src/content/en/guides/guide/signal-provider.mdx
@@ -33,6 +33,7 @@ import { LibSQLStore } from '@mastra/libsql'
 
 export const mastra = new Mastra({
   storage: new LibSQLStore({
+    id: 'mastra-storage',
     url: 'file:./mastra.db',
   }),
 })
@@ -143,6 +144,7 @@ export const mastra = new Mastra({
   // highlight-next-line
   agents: { devAgent },
   storage: new LibSQLStore({
+    id: 'mastra-storage',
     url: 'file:./mastra.db',
   }),
 })

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -31,7 +31,7 @@ import { z } from 'zod'
 const agentController = new AgentController({
   id: 'my-coding-agent',
   agent: myAgent,
-  storage: new LibSQLStore({ url: 'file:./data.db' }),
+  storage: new LibSQLStore({ id: 'agent-storage', url: 'file:./data.db' }),
   stateSchema: z.object({
     currentModelId: z.string().optional(),
   }),


### PR DESCRIPTION
## Description

Some code examples were missing the required `id` key for `new LibSQLStore()`

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The documentation examples now include the required name (`id`) when setting up storage. This helps readers copy working examples without missing configuration.

## Summary

- Updated `LibSQLStore` examples across deployment, agent, memory, voice, UI, guide, and reference documentation.
- Added explicit storage IDs such as `mastra-storage`, `agent-storage`, `collab-storage`, and `voice-agent-storage`.
- Documentation-only change; no production code or public APIs were modified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->