### PR TITLE
feat(braintrust)!: Bump bundled braintrust SDK to version `3.22.0`

### DIFF
--- a/.changeset/itchy-nails-chew.md
+++ b/.changeset/itchy-nails-chew.md
@@ -1,5 +1,5 @@
 ---
-'@mastra/braintrust': major
+'@mastra/braintrust': minor
 ---
 
 **Breaking change**
@@ -10,6 +10,6 @@ Braintrust v3 uses a separate W3C trace ID for `root_span_id`. Mastra's returned
 
 **Migration**
 
-No `BraintrustExporter` configuration changes are required.
+The `BraintrustExporterConfig` interface changed, so if you were using the `braintrustLogger` field or the `getCurrentSpan()` method, those now hold narrower types that are no longer tied to the Braintrust SDK. It is unlikely that this is affecting you but technically a breaking change, which is why it is outlined.
 
 Applications that independently upgrade Braintrust and use Nunjucks prompt templates should follow the Braintrust v2 to v3 migration guide: https://www.braintrust.dev/docs/sdks/typescript/migrations/v2-to-v3

--- a/.changeset/itchy-nails-chew.md
+++ b/.changeset/itchy-nails-chew.md
@@ -1,0 +1,15 @@
+---
+'@mastra/braintrust': major
+---
+
+**Breaking change**
+
+Updated the bundled Braintrust SDK from v2 to v3 and replaced the SDK-specific logger and span types with stable Mastra interfaces/shims. Compatible Braintrust v2 and v3 logger and span objects remain supported.
+
+Braintrust v3 uses a separate W3C trace ID for `root_span_id`. Mastra's returned `spanId` remains the Braintrust row ID and span ID for feedback and lookup.
+
+**Migration**
+
+No `BraintrustExporter` configuration changes are required.
+
+Applications that independently upgrade Braintrust and use Nunjucks prompt templates should follow the Braintrust v2 to v3 migration guide: https://www.braintrust.dev/docs/sdks/typescript/migrations/v2-to-v3

--- a/docs/src/content/en/docs/observability/integrations/exporters/braintrust.mdx
+++ b/docs/src/content/en/docs/observability/integrations/exporters/braintrust.mdx
@@ -95,9 +95,17 @@ new BraintrustExporter({
 
 ## Attach traces to Braintrust evals
 
+Install the Braintrust SDK directly when your application uses `Eval()`, `logger.traced()`, or `currentSpan`:
+
+```bash npm2yarn
+npm install braintrust@latest
+```
+
 When you run Mastra inside Braintrust `Eval()` or `logger.traced()`, pass the Braintrust logger and `currentSpan` resolver to the exporter. Import `currentSpan` from the same `braintrust` package instance that creates the eval or traced span.
 
 This helps Mastra attach its spans under the active Braintrust span when your app and `@mastra/braintrust` resolve different installed copies of the Braintrust SDK.
+
+The exporter accepts compatible logger and span objects from Braintrust SDK v2 and v3. Your application's Braintrust SDK version doesn't need to match the version installed by `@mastra/braintrust`.
 
 ```typescript title="src/mastra/index.ts"
 import { currentSpan, initLogger } from 'braintrust'
@@ -130,15 +138,19 @@ await Eval('my-project', {
 })
 ```
 
+If your application upgrades its direct Braintrust dependency from v2 to v3 and uses Nunjucks prompt templates, follow the [Braintrust v2 to v3 migration guide](https://www.braintrust.dev/docs/sdks/typescript/migrations/v2-to-v3).
+
 ## Querying Braintrust with returned `spanId`
 
-For Braintrust, use `spanId` as the root span identifier when searching for traces because Braintrust root-span queries are typically faster than trace-id queries.
+Mastra uses its returned `spanId` as both the Braintrust row ID and span ID. Use it to find the corresponding Braintrust span by `id` or `span_id`.
+
+Braintrust v3 stores a separate W3C trace ID in `root_span_id`, so the returned Mastra `spanId` isn't the Braintrust `root_span_id`.
 
 ```typescript title="src/mastra/usage.ts"
 const result = await agent.stream('Summarize this ticket')
 
 console.log('Mastra trace ID:', result.traceId)
-console.log('Braintrust root span ID:', result.spanId)
+console.log('Braintrust row and span ID:', result.spanId)
 
 // Use result.spanId in your Braintrust lookup/query path
 ```

--- a/observability/braintrust/README.md
+++ b/observability/braintrust/README.md
@@ -66,14 +66,14 @@ const mastra = new Mastra({
 
 ### Configuration Options
 
-| Option             | Type                      | Description                                                    |
-| ------------------ | ------------------------- | -------------------------------------------------------------- |
-| `apiKey`           | `string`                  | Braintrust API key. Defaults to `BRAINTRUST_API_KEY` env var   |
-| `endpoint`         | `string`                  | Custom endpoint URL. Defaults to `BRAINTRUST_ENDPOINT` env var |
-| `projectName`      | `string`                  | Project name. Defaults to `'mastra-tracing'`                   |
-| `braintrustLogger` | `Logger<true>`            | Optional Braintrust logger instance for context integration    |
-| `currentSpan`      | `() => Span \| undefined` | Optional resolver from the app's Braintrust package instance   |
-| `tuningParameters` | `Record<string,any>`      | Support tuning parameters                                      |
+| Option             | Type                                | Description                                                    |
+| ------------------ | ----------------------------------- | -------------------------------------------------------------- |
+| `apiKey`           | `string`                            | Braintrust API key. Defaults to `BRAINTRUST_API_KEY` env var   |
+| `endpoint`         | `string`                            | Custom endpoint URL. Defaults to `BRAINTRUST_ENDPOINT` env var |
+| `projectName`      | `string`                            | Project name. Defaults to `'mastra-tracing'`                   |
+| `braintrustLogger` | `BraintrustLogger`                  | Optional compatible Braintrust logger for context integration  |
+| `currentSpan`      | `() => BraintrustSpan \| undefined` | Optional resolver from the app's Braintrust package instance   |
+| `tuningParameters` | `Record<string,any>`                | Support tuning parameters                                      |
 
 ## Features
 

--- a/observability/braintrust/package.json
+++ b/observability/braintrust/package.json
@@ -35,7 +35,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@mastra/observability": "workspace:*",
-    "braintrust": "^2.2.2"
+    "braintrust": "^3.22.0"
   },
   "devDependencies": {
     "@internal/lint": "workspace:*",

--- a/observability/braintrust/src/braintrust-nesting.test.ts
+++ b/observability/braintrust/src/braintrust-nesting.test.ts
@@ -11,8 +11,8 @@
  * startSpan() chain to establish proper parent-child relationships.
  *
  * Key behaviors tested:
- * 1. Root spans get _rootSpanId = own _spanId (no parentSpanIds passed)
- * 2. Child spans get correct _rootSpanId and _spanParents via startSpan() chain
+ * 1. Root spans get a W3C trace ID as _rootSpanId (no parentSpanIds passed)
+ * 2. Child spans inherit _rootSpanId and get _spanParents via startSpan() chain
  * 3. External context spans properly nest under external parent
  */
 
@@ -90,11 +90,12 @@ describe('Braintrust SDK - Direct startSpan() behavior', () => {
     });
   });
 
-  it('logger.startSpan() without parentSpanIds auto-sets rootSpanId to itself', () => {
+  it('logger.startSpan() without parentSpanIds creates a W3C rootSpanId', () => {
     const rootSpan = logger.startSpan({ name: 'root', type: 'task' });
     const root = getSpanInternals(rootSpan);
 
-    expect(root.rootSpanId).toBe(root.spanId);
+    expect(root.rootSpanId).toMatch(/^[0-9a-f]{32}$/);
+    expect(root.rootSpanId).not.toBe(root.spanId);
     expect(root.spanParents).toBeUndefined();
 
     rootSpan.end();
@@ -109,10 +110,10 @@ describe('Braintrust SDK - Direct startSpan() behavior', () => {
     const child = getSpanInternals(childSpan);
     const grandchild = getSpanInternals(grandchildSpan);
 
-    // All share the same rootSpanId
-    expect(root.rootSpanId).toBe(root.spanId);
-    expect(child.rootSpanId).toBe(root.spanId);
-    expect(grandchild.rootSpanId).toBe(root.spanId);
+    // All share the same W3C trace ID as rootSpanId
+    expect(root.rootSpanId).toMatch(/^[0-9a-f]{32}$/);
+    expect(child.rootSpanId).toBe(root.rootSpanId);
+    expect(grandchild.rootSpanId).toBe(root.rootSpanId);
 
     // Each has correct immediate parent
     expect(root.spanParents).toBeUndefined();
@@ -150,7 +151,7 @@ describe('BraintrustExporter - Non-External Case', () => {
     await exporter.shutdown();
   });
 
-  it('root span processed by exporter has correct rootSpanId = spanId', async () => {
+  it('root span processed by exporter has a W3C rootSpanId', async () => {
     const mastraRoot = createMastraSpan({
       id: 'mastra-root-1',
       name: 'agent-run',
@@ -173,8 +174,8 @@ describe('BraintrustExporter - Non-External Case', () => {
 
     const internals = getSpanInternals(spanData!.span);
 
-    // Root span should have rootSpanId = its own spanId
-    expect(internals.rootSpanId).toBe(internals.spanId);
+    expect(internals.rootSpanId).toMatch(/^[0-9a-f]{32}$/);
+    expect(internals.rootSpanId).not.toBe(internals.spanId);
     expect(internals.spanParents).toBeUndefined();
   });
 
@@ -232,10 +233,10 @@ describe('BraintrustExporter - Non-External Case', () => {
     const llm = getSpanInternals(llmBt);
     const tool = getSpanInternals(toolBt);
 
-    // All should share the same rootSpanId (the root's spanId)
-    expect(root.rootSpanId).toBe(root.spanId);
-    expect(llm.rootSpanId).toBe(root.spanId);
-    expect(tool.rootSpanId).toBe(root.spanId);
+    // All should share the same W3C trace ID as rootSpanId
+    expect(root.rootSpanId).toMatch(/^[0-9a-f]{32}$/);
+    expect(llm.rootSpanId).toBe(root.rootSpanId);
+    expect(tool.rootSpanId).toBe(root.rootSpanId);
 
     // Each should have correct immediate parent
     expect(root.spanParents).toBeUndefined();
@@ -288,11 +289,11 @@ describe('BraintrustExporter - Non-External Case', () => {
     const l3 = getSpanInternals(traceData.getSpan({ spanId: 'l3' })!.span);
     const l4 = getSpanInternals(traceData.getSpan({ spanId: 'l4' })!.span);
 
-    // All share rootSpanId
-    expect(l1.rootSpanId).toBe(l1.spanId);
-    expect(l2.rootSpanId).toBe(l1.spanId);
-    expect(l3.rootSpanId).toBe(l1.spanId);
-    expect(l4.rootSpanId).toBe(l1.spanId);
+    // All share the same W3C trace ID as rootSpanId
+    expect(l1.rootSpanId).toMatch(/^[0-9a-f]{32}$/);
+    expect(l2.rootSpanId).toBe(l1.rootSpanId);
+    expect(l3.rootSpanId).toBe(l1.rootSpanId);
+    expect(l4.rootSpanId).toBe(l1.rootSpanId);
 
     // Correct parent chain
     expect(l1.spanParents).toBeUndefined();
@@ -364,9 +365,9 @@ describe('BraintrustExporter - External Case', () => {
     const root = getSpanInternals(rootBtData!.span);
     const child = getSpanInternals(childBtData!.span);
 
-    // Both should have external span as their root
-    expect(root.rootSpanId).toBe(externalInternals.spanId);
-    expect(child.rootSpanId).toBe(externalInternals.spanId);
+    // Both should inherit the external span's W3C trace ID
+    expect(root.rootSpanId).toBe(externalInternals.rootSpanId);
+    expect(child.rootSpanId).toBe(externalInternals.rootSpanId);
 
     // Mastra root's parent should be external span
     expect(root.spanParents).toEqual([externalInternals.spanId]);

--- a/observability/braintrust/src/tracing.test.ts
+++ b/observability/braintrust/src/tracing.test.ts
@@ -17,10 +17,9 @@ import type {
 } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { initLogger, _exportsForTestingOnly } from 'braintrust';
-import type { Logger } from 'braintrust';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { BraintrustExporter } from './tracing';
-import type { BraintrustExporterConfig } from './tracing';
+import type { BraintrustExporterConfig, BraintrustLogger, BraintrustSpan } from './tracing';
 
 // Mock Braintrust initLogger function (must be at the top level)
 vi.mock('braintrust');
@@ -2390,7 +2389,7 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
 
     // Create exporter with braintrustLogger parameter
     const config: BraintrustExporterConfig = {
-      braintrustLogger: mockLogger as Logger<true>,
+      braintrustLogger: mockLogger,
     };
     const exporter = new TestBraintrustExporter(config);
 
@@ -2436,6 +2435,53 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
     expect(traceData.getRoot()).toBe(mockLogger);
   });
 
+  it('accepts a structurally compatible logger and span', async () => {
+    const spanStart = vi.fn(() => span);
+    const spanLog = vi.fn();
+    const spanEnd = vi.fn(() => 0);
+    const span: BraintrustSpan = {
+      id: 'structural-span-id',
+      startSpan: spanStart,
+      log: spanLog,
+      end: spanEnd,
+    };
+    const loggerStart = vi.fn(() => span);
+    const loggerFeedback = vi.fn();
+    const logger: BraintrustLogger = {
+      startSpan: loggerStart,
+      logFeedback: loggerFeedback,
+    };
+    const exporter = new TestBraintrustExporter({ braintrustLogger: logger });
+    const rootSpan = createMockSpan({
+      id: 'structural-root-id',
+      name: 'structural-root',
+      type: SpanType.AGENT_RUN,
+      isRoot: true,
+      attributes: {},
+    });
+
+    await exporter.exportTracingEvent({
+      type: TracingEventType.SPAN_STARTED,
+      exportedSpan: rootSpan,
+    });
+    await exporter.onScoreEvent({
+      type: 'score',
+      score: {
+        scoreId: 'structural-score-id',
+        timestamp: new Date(),
+        traceId: rootSpan.traceId,
+        spanId: rootSpan.id,
+        scorerId: 'structural-scorer',
+        score: 1,
+      },
+    });
+
+    expect(loggerStart).toHaveBeenCalledOnce();
+    expect(loggerFeedback).toHaveBeenCalledWith(
+      expect.objectContaining({ id: rootSpan.id, scores: { 'structural-scorer': 1 } }),
+    );
+  });
+
   it('should attach to external span when detected via currentSpan()', async () => {
     // Mock currentSpan to return an external span (simulating logger.traced() or Eval context)
     const { currentSpan: realCurrentSpan } = await import('braintrust');
@@ -2447,7 +2493,7 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
 
     // Create exporter with braintrustLogger parameter
     const config: BraintrustExporterConfig = {
-      braintrustLogger: mockLogger as Logger<true>,
+      braintrustLogger: mockLogger,
     };
     const exporter = new TestBraintrustExporter(config);
     const traceId = 'trace-id';
@@ -2504,8 +2550,8 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
     mockedCurrentSpan.mockReturnValue(undefined as any);
 
     const config: BraintrustExporterConfig = {
-      braintrustLogger: mockLogger as Logger<true>,
-      currentSpan: vi.fn(() => mockExternalSpan as any),
+      braintrustLogger: mockLogger,
+      currentSpan: vi.fn(() => mockExternalSpan),
     };
     const exporter = new TestBraintrustExporter(config);
     const rootSpan = createMockSpan({
@@ -2551,7 +2597,7 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
 
     // Create exporter with braintrustLogger parameter
     const config: BraintrustExporterConfig = {
-      braintrustLogger: mockLogger as Logger<true>,
+      braintrustLogger: mockLogger,
     };
     const exporter = new TestBraintrustExporter(config);
     const traceId = 'trace-id';
@@ -2664,7 +2710,7 @@ describe('BraintrustExporter with braintrustLogger parameter', () => {
     mockedCurrentSpan.mockReturnValue(mockExternalSpan as any);
 
     const config: BraintrustExporterConfig = {
-      braintrustLogger: mockLogger as Logger<true>,
+      braintrustLogger: mockLogger,
       logLevel: 'debug',
     };
     const exporter = new TestBraintrustExporter(config);

--- a/observability/braintrust/src/tracing.ts
+++ b/observability/braintrust/src/tracing.ts
@@ -12,18 +12,62 @@ import { omitKeys } from '@mastra/core/utils';
 import { TrackingExporter } from '@mastra/observability';
 import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import { initLogger, currentSpan } from 'braintrust';
-import type { Span, Logger } from 'braintrust';
 import { removeNullish, convertAISDKMessage, serializeToolResult } from './formatter';
 import type { OpenAIMessage } from './formatter';
 import { formatUsageMetrics } from './metrics';
 import { reconstructThreadOutput } from './thread-reconstruction';
 import type { ThreadData, ThreadStepData, PendingToolResult } from './thread-reconstruction';
 
+type BraintrustSpanType = 'llm' | 'score' | 'function' | 'eval' | 'task' | 'tool';
+
+/**
+ * The subset of a Braintrust span used by the exporter.
+ *
+ * This structural interface lets applications provide spans from a different
+ * compatible Braintrust SDK instance without coupling Mastra's public types to
+ * a specific SDK version.
+ */
+export interface BraintrustSpan {
+  id: string;
+  startSpan(args: {
+    spanId: string;
+    name: string;
+    type: BraintrustSpanType;
+    startTime: number;
+    event: Record<string, any>;
+  }): BraintrustSpan;
+  log(event: Record<string, any>): void;
+  end(args?: { endTime?: number }): number;
+}
+
+/**
+ * The subset of a Braintrust logger used by the exporter.
+ *
+ * Logger instances from compatible Braintrust SDK versions satisfy this
+ * interface without sharing the same nominal SDK types as the exporter.
+ */
+export interface BraintrustLogger {
+  startSpan(args: {
+    spanId: string;
+    name: string;
+    type: BraintrustSpanType;
+    startTime: number;
+    event: Record<string, any>;
+  }): BraintrustSpan;
+  logFeedback(event: {
+    id: string;
+    scores: Record<string, number>;
+    comment?: string;
+    metadata?: Record<string, any>;
+    source: 'external';
+  }): void;
+}
+
 /**
  * Extended Braintrust span data that includes span type and thread reconstruction data
  */
 interface BraintrustSpanData {
-  span: Span;
+  span: BraintrustSpan;
   spanType: SpanType;
   threadData?: ThreadData; // only populated for MODEL_GENERATION spans
   // Tool results stored when TOOL_CALL ends (may arrive before MODEL_STEP ends)
@@ -38,7 +82,7 @@ export interface BraintrustExporterConfig extends TrackingExporterConfig {
    * - logger.traced(): Agent traces nest inside traced spans
    * - Parent spans: Auto-detects and attaches to external Braintrust spans
    */
-  braintrustLogger?: Logger<true>;
+  braintrustLogger?: BraintrustLogger;
 
   /**
    * Optional resolver for the active Braintrust span.
@@ -47,7 +91,7 @@ export interface BraintrustExporterConfig extends TrackingExporterConfig {
    * `Eval()` or `logger.traced()` spans when your app and Mastra may resolve
    * different copies of the `braintrust` package.
    */
-  currentSpan?: () => Span | undefined;
+  currentSpan?: () => BraintrustSpan | undefined;
 
   /** Braintrust API key. Required if logger is not provided. */
   apiKey?: string;
@@ -59,11 +103,11 @@ export interface BraintrustExporterConfig extends TrackingExporterConfig {
   tuningParameters?: Record<string, any>;
 }
 
-type BraintrustRoot = Logger<true> | Span;
-type BraintrustSpan = BraintrustSpanData;
-type BraintrustEvent = Span;
+type BraintrustRoot = BraintrustLogger | BraintrustSpan;
+type BraintrustTrackedSpan = BraintrustSpanData;
+type BraintrustEvent = BraintrustSpan;
 type BraintrustMetadata = unknown;
-type BraintrustTraceData = TraceData<BraintrustRoot, BraintrustSpan, BraintrustEvent, BraintrustMetadata>;
+type BraintrustTraceData = TraceData<BraintrustRoot, BraintrustTrackedSpan, BraintrustEvent, BraintrustMetadata>;
 
 // Default span type for all spans
 const DEFAULT_SPAN_TYPE = 'task';
@@ -85,7 +129,7 @@ function mapSpanType(spanType: SpanType): 'llm' | 'score' | 'function' | 'eval' 
 
 export class BraintrustExporter extends TrackingExporter<
   BraintrustRoot,
-  BraintrustSpan,
+  BraintrustTrackedSpan,
   BraintrustEvent,
   BraintrustMetadata,
   BraintrustExporterConfig
@@ -94,8 +138,8 @@ export class BraintrustExporter extends TrackingExporter<
 
   // Flags and logger for context-aware mode
   #useProvidedLogger: boolean;
-  #providedLogger?: Logger<true>;
-  #localLogger?: Logger<true>;
+  #providedLogger?: BraintrustLogger;
+  #localLogger?: BraintrustLogger;
 
   constructor(config: BraintrustExporterConfig = {}) {
     // Resolve env vars BEFORE calling super (config is readonly in base class)
@@ -126,7 +170,7 @@ export class BraintrustExporter extends TrackingExporter<
     }
   }
 
-  private async getLocalLogger(): Promise<Logger<true> | undefined> {
+  private async getLocalLogger(): Promise<BraintrustLogger | undefined> {
     if (this.#localLogger) {
       return this.#localLogger;
     }
@@ -184,7 +228,7 @@ export class BraintrustExporter extends TrackingExporter<
     }
   }
 
-  private startSpan(args: { parent: Span | Logger<true>; span: AnyExportedSpan }): BraintrustSpanData {
+  private startSpan(args: { parent: BraintrustSpan | BraintrustLogger; span: AnyExportedSpan }): BraintrustSpanData {
     const { parent, span } = args;
     const payload = this.buildSpanPayload(span);
 
@@ -221,7 +265,7 @@ export class BraintrustExporter extends TrackingExporter<
       // Try to find a Braintrust span to attach to:
       // 1. Auto-detect from Braintrust's current span (logger.traced(), Eval(), etc.)
       // 2. Fall back to the configured logger
-      let externalSpan: Span | undefined;
+      let externalSpan: BraintrustSpan | undefined;
       try {
         externalSpan = this.config.currentSpan?.();
       } catch (err) {
@@ -267,7 +311,7 @@ export class BraintrustExporter extends TrackingExporter<
   protected override async _buildEvent(args: {
     span: AnyExportedSpan;
     traceData: BraintrustTraceData;
-  }): Promise<Span | undefined> {
+  }): Promise<BraintrustEvent | undefined> {
     const spanData = await this._buildSpan(args);
 
     if (!spanData) {
@@ -319,7 +363,7 @@ export class BraintrustExporter extends TrackingExporter<
     }
   }
 
-  protected override async _abortSpan(args: { span: BraintrustSpan; reason: SpanErrorInfo }): Promise<void> {
+  protected override async _abortSpan(args: { span: BraintrustTrackedSpan; reason: SpanErrorInfo }): Promise<void> {
     const { span: spanData, reason } = args;
     spanData.span.log({
       error: reason.message,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2553,8 +2553,8 @@ importers:
         specifier: workspace:*
         version: link:../mastra
       braintrust:
-        specifier: ^2.2.2
-        version: 2.2.2(@aws-sdk/credential-provider-web-identity@3.972.61)(chokidar@3.6.0)(zod@3.25.76)
+        specifier: ^3.22.0
+        version: 3.22.0(@aws-sdk/credential-provider-web-identity@3.972.61)(zod@3.25.76)
       zod:
         specifier: ^3.25.34 || ^4.0.0
         version: 3.25.76
@@ -11103,6 +11103,44 @@ packages:
   '@braintree/sanitize-url@7.1.2':
     resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
 
+  '@braintrust/bt-darwin-arm64@0.12.0':
+    resolution: {integrity: sha512-mY6VW/3VwcOQOGN8sYHS6F0xzHTFwgZcNlj7zlQttI6OXOCGt/bhonGIqd03QBhxmj0M31ymSS7TqSeCK/RYIQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@braintrust/bt-darwin-x64@0.12.0':
+    resolution: {integrity: sha512-woyRyDv2DfCF8+von+3X9f1cddAbFnKLSfCbEkrBQVc0ZsAM60as8nehYv7DkafJF/67yKFx/sUraV65sukesQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@braintrust/bt-linux-arm64@0.12.0':
+    resolution: {integrity: sha512-J9/7f3EIMKmFmSSQHQnAQLpUgB8YJENrOlkABjlTprBgsIYVgz7tSH7yg2P3ur+2Jem7PpGnrDxHGh/UjRfjsg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@braintrust/bt-linux-x64-musl@0.12.0':
+    resolution: {integrity: sha512-KnLgENOoztBXcH+mLFJe4bYzi67kSOuELOQrm4Hler35GjgaBMI1fFLIUjKRPAmyT9VIhBMhy1ICfGEFLueMEQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@braintrust/bt-linux-x64@0.12.0':
+    resolution: {integrity: sha512-HJFbUl3HYYY1Ivw8OYBeIMcIsU9r7+fC9BzLWB5FdH7881ToKee2wbbLZssMCxFbMVeUxzEo+SzGD/1Z9Gk9CA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@braintrust/bt-win32-arm64@0.12.0':
+    resolution: {integrity: sha512-+7PkdBAmiqEJsWteGHP/Zs62F75PkHPA8m/ej4TOz/mHGKulUU0bZibw91KRqIB7J7jGi5ItvCiqkiGaLKLnyw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@braintrust/bt-win32-x64@0.12.0':
+    resolution: {integrity: sha512-Q0c+pVUGm82n/7N8QJ5s6j/G/Q0GFzqOaTipHjkmElLbAOOEcfRH/uljdtIPNBiEQcrzqirS0GmOgiFkeQ3Txg==}
+    cpu: [x64]
+    os: [win32]
+
   '@browserbasehq/sdk@2.10.0':
     resolution: {integrity: sha512-pOL4yW8P8AI2+N5y6zEP6XXKqIXtYyKunr1JXppqQDOyKLxxvZEDqQCHJXWUzqgx3R1tGWpn7m9AjXN7MeYInA==}
 
@@ -12266,6 +12304,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -12292,6 +12336,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -12326,6 +12376,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.28.1':
     resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
@@ -12352,6 +12408,12 @@ packages:
 
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -12386,6 +12448,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
@@ -12412,6 +12480,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -12446,6 +12520,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
@@ -12472,6 +12552,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -12506,6 +12592,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
@@ -12532,6 +12624,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -12566,6 +12664,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
@@ -12592,6 +12696,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -12626,6 +12736,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
@@ -12652,6 +12768,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -12686,6 +12808,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
@@ -12712,6 +12840,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -12746,6 +12880,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
@@ -12766,6 +12906,12 @@ packages:
 
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -12800,6 +12946,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -12820,6 +12972,12 @@ packages:
 
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -12854,6 +13012,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openbsd-x64@0.28.1':
     resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
@@ -12874,6 +13038,12 @@ packages:
 
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -12908,6 +13078,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
@@ -12934,6 +13110,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -12968,6 +13150,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
@@ -12994,6 +13182,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -18939,9 +19133,6 @@ packages:
   '@types/node@22.19.15':
     resolution: {integrity: sha512-F0R/h2+dsy5wJAUe3tAU6oqa2qbWY5TpNfL/RGmo1y38hiyO1w3x2jPtt76wmuaJI4DQnOBu21cNXQ2STIUUWg==}
 
-  '@types/nunjucks@3.2.6':
-    resolution: {integrity: sha512-pHiGtf83na1nCzliuAdq8GowYiXvH5l931xZ0YEHaLMNFgynpEqx+IPStlu7UaDkehfvl01e4x/9Tpwhy7Ue3w==}
-
   '@types/oracledb@6.5.2':
     resolution: {integrity: sha512-kK1eBS/Adeyis+3OlBDMeQQuasIDLUYXsi2T15ccNJ0iyUpQ4xDF7svFu3+bGVrI0CMBUclPciz+lsQR3JX3TQ==}
 
@@ -19778,9 +19969,6 @@ packages:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
 
-  a-sync-waterfall@1.0.1:
-    resolution: {integrity: sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==}
-
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -20438,10 +20626,6 @@ packages:
     resolution: {integrity: sha512-2hCgjEmP8YLWQ130n2FerGv7rYpfBmnmp9Uy2Le1vge6X3gZIfSmEzP5QTDElFxcvVcXlEn8Aq6MU/PZygIOog==}
     engines: {node: '>=14.16'}
 
-  boxen@8.0.1:
-    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
-    engines: {node: '>=18'}
-
   brace-expansion@1.1.13:
     resolution: {integrity: sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==}
 
@@ -20456,8 +20640,8 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  braintrust@2.2.2:
-    resolution: {integrity: sha512-g8TPnfZb7X8ziJG3w2iYRBMiIbSTV6YW79rjhDyDAeVCwa4hq52ns4JzQeQTPRWusm7vE3gXAEgIxuBc9q18uQ==}
+  braintrust@3.22.0:
+    resolution: {integrity: sha512-r3RmoLmZ/UsR3uReYWCV/B5CFA4kZjt+iXI41b8Hl6B7CDn8OLbeBxAX8ryMVGRJERNlGmbXLn0+n0IUqMFTqQ==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.34 || ^4.0
@@ -21565,6 +21749,9 @@ packages:
   dayjs@1.11.21:
     resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
+  dc-browser@1.0.4:
+    resolution: {integrity: sha512-7oEtnzNlcE+hr4OvO3GR6Gndgw8BhW+wKOEwMqSleyY7N29jbAxzyW5BaJl7qBCw+6OIxfMWtY0T+6dxq8RWLw==}
+
   dc-polyfill@0.1.11:
     resolution: {integrity: sha512-TyyeGcjx0YeThAI9fTFtgsvj5qd4R+aGfVmXiUhevbgzWFDr7IK4tv4YjE6jaGzLHQTchk4h7DHdr5q4WGgaZw==}
     engines: {node: '>=12.17'}
@@ -22187,6 +22374,11 @@ packages:
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -24791,6 +24983,10 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
+  meriyah@6.1.4:
+    resolution: {integrity: sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==}
+    engines: {node: '>=18.0.0'}
+
   mermaid@11.16.0:
     resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
@@ -25513,16 +25709,6 @@ packages:
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       webpack: ^4.0.0 || ^5.0.0
-
-  nunjucks@3.2.4:
-    resolution: {integrity: sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==}
-    engines: {node: '>= 6.9.0'}
-    hasBin: true
-    peerDependencies:
-      chokidar: ^3.3.0
-    peerDependenciesMeta:
-      chokidar:
-        optional: true
 
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
@@ -27670,6 +27856,9 @@ packages:
     resolution: {integrity: sha512-ftnu3TW4+3eBfLRFnDEkzGxSF/10BJBkaLJuBHZX0kiPS7bRdlpZGu6YGt4KngMkdTwJE6MbjavFpqHvqVt+Ew==}
     engines: {node: '>=18'}
 
+  semifies@1.0.0:
+    resolution: {integrity: sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==}
+
   semver-compare@1.0.0:
     resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
 
@@ -29545,10 +29734,6 @@ packages:
   widest-line@4.0.1:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
-
-  widest-line@5.0.0:
-    resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
-    engines: {node: '>=18'}
 
   wildcard@2.0.1:
     resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
@@ -32302,6 +32487,27 @@ snapshots:
 
   '@braintree/sanitize-url@7.1.2': {}
 
+  '@braintrust/bt-darwin-arm64@0.12.0':
+    optional: true
+
+  '@braintrust/bt-darwin-x64@0.12.0':
+    optional: true
+
+  '@braintrust/bt-linux-arm64@0.12.0':
+    optional: true
+
+  '@braintrust/bt-linux-x64-musl@0.12.0':
+    optional: true
+
+  '@braintrust/bt-linux-x64@0.12.0':
+    optional: true
+
+  '@braintrust/bt-win32-arm64@0.12.0':
+    optional: true
+
+  '@braintrust/bt-win32-x64@0.12.0':
+    optional: true
+
   '@browserbasehq/sdk@2.10.0(encoding@0.1.13)':
     dependencies:
       '@types/node': 22.19.15
@@ -34496,6 +34702,9 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -34509,6 +34718,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
@@ -34526,6 +34738,9 @@ snapshots:
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
     optional: true
 
@@ -34539,6 +34754,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
@@ -34556,6 +34774,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
@@ -34569,6 +34790,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
@@ -34586,6 +34810,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
@@ -34599,6 +34826,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -34616,6 +34846,9 @@ snapshots:
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
@@ -34629,6 +34862,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
@@ -34646,6 +34882,9 @@ snapshots:
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
@@ -34659,6 +34898,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
@@ -34676,6 +34918,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
@@ -34689,6 +34934,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -34706,6 +34954,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
@@ -34719,6 +34970,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
@@ -34736,6 +34990,9 @@ snapshots:
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
@@ -34746,6 +35003,9 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
@@ -34763,6 +35023,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
@@ -34773,6 +35036,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
@@ -34790,6 +35056,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
@@ -34800,6 +35069,9 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
@@ -34817,6 +35089,9 @@ snapshots:
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
@@ -34830,6 +35105,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
@@ -34847,6 +35125,9 @@ snapshots:
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
@@ -34860,6 +35141,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -41247,8 +41531,6 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
-  '@types/nunjucks@3.2.6': {}
-
   '@types/oracledb@6.5.2':
     dependencies:
       '@types/node': 22.19.15
@@ -42334,8 +42616,6 @@ snapshots:
       jsonparse: 1.3.1
       through: 2.3.8
 
-  a-sync-waterfall@1.0.1: {}
-
   abbrev@1.1.1:
     optional: true
 
@@ -43032,17 +43312,6 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  boxen@8.0.1:
-    dependencies:
-      ansi-align: 3.0.1
-      camelcase: 8.0.0
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      string-width: 7.2.0
-      type-fest: 4.41.0
-      widest-line: 5.0.0
-      wrap-ansi: 9.0.2
-
   brace-expansion@1.1.13:
     dependencies:
       balanced-match: 1.0.2
@@ -43060,38 +43329,49 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  braintrust@2.2.2(@aws-sdk/credential-provider-web-identity@3.972.61)(chokidar@3.6.0)(zod@3.25.76):
+  braintrust@3.22.0(@aws-sdk/credential-provider-web-identity@3.972.61)(zod@3.25.76):
     dependencies:
-      '@ai-sdk/provider': 1.1.3
       '@next/env': 14.2.33
-      '@types/nunjucks': 3.2.6
       '@vercel/functions': 1.6.0(@aws-sdk/credential-provider-web-identity@3.972.61)
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
       ajv: 8.20.0
       argparse: 2.0.1
-      boxen: 8.0.1
-      chalk: 4.1.2
+      astring: 1.9.0
+      cjs-module-lexer: 2.2.0
       cli-progress: 3.12.0
       cli-table3: 0.6.5
       cors: 2.8.6
+      dc-browser: 1.0.4
       dotenv: 16.6.1
-      esbuild: 0.27.7
+      esbuild: 0.28.0
+      esquery: 1.7.0
       eventsource-parser: 1.1.2
-      express: 4.22.2
-      graceful-fs: 4.2.11
+      express: 5.2.1
       http-errors: 2.0.1
-      minimatch: 9.0.7
+      meriyah: 6.1.4
+      minimatch: 10.2.5
+      module-details-from-path: 1.0.4
       mustache: 4.2.0
-      nunjucks: 3.2.4(chokidar@3.6.0)
       pluralize: 8.0.0
+      semifies: 1.0.0
       simple-git: 3.36.0
       source-map: 0.7.6
       termi-link: 1.1.0
+      unplugin: 2.3.11
       uuid: 11.1.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@braintrust/bt-darwin-arm64': 0.12.0
+      '@braintrust/bt-darwin-x64': 0.12.0
+      '@braintrust/bt-linux-arm64': 0.12.0
+      '@braintrust/bt-linux-x64': 0.12.0
+      '@braintrust/bt-linux-x64-musl': 0.12.0
+      '@braintrust/bt-win32-arm64': 0.12.0
+      '@braintrust/bt-win32-x64': 0.12.0
     transitivePeerDependencies:
       - '@aws-sdk/credential-provider-web-identity'
-      - chokidar
       - supports-color
 
   browserify-zlib@0.1.4:
@@ -44295,6 +44575,8 @@ snapshots:
 
   dayjs@1.11.21: {}
 
+  dc-browser@1.0.4: {}
+
   dc-polyfill@0.1.11: {}
 
   dd-trace@5.108.0(@openfeature/server-sdk@1.18.0(@openfeature/core@1.9.1)):
@@ -44957,6 +45239,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.27.7
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -48151,6 +48462,8 @@ snapshots:
 
   merge2@1.4.1: {}
 
+  meriyah@6.1.4: {}
+
   mermaid@11.16.0:
     dependencies:
       '@braintree/sanitize-url': 7.1.2
@@ -49076,14 +49389,6 @@ snapshots:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
       webpack: 5.108.4(@swc/core@1.15.7(@swc/helpers@0.5.17))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(lightningcss@1.32.0)(postcss@8.5.16)
-
-  nunjucks@3.2.4(chokidar@3.6.0):
-    dependencies:
-      a-sync-waterfall: 1.0.1
-      asap: 2.0.6
-      commander: 5.1.0
-    optionalDependencies:
-      chokidar: 3.6.0
 
   nwsapi@2.2.23: {}
 
@@ -51807,6 +52112,8 @@ snapshots:
       '@peculiar/x509': 1.14.3
       pkijs: 3.3.3
 
+  semifies@1.0.0: {}
+
   semver-compare@1.0.0: {}
 
   semver-diff@4.0.0:
@@ -54164,10 +54471,6 @@ snapshots:
   widest-line@4.0.1:
     dependencies:
       string-width: 5.1.2
-
-  widest-line@5.0.0:
-    dependencies:
-      string-width: 7.2.0
 
   wildcard@2.0.1: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -322,3 +322,4 @@ allowBuilds:
   '@mongodb-js/zstd': false
   node-liblzma: false
   workerd: false
+  braintrust: false


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

(Note: I am a Braintrust employee and the maintainer of the Braintrust JS SDK)

This PR bumps the `braintrust` dependency in the `@mastra/braintrust` package from `2.2.2` to `3.22.0`.

This is not a crazy major update. The only thing that will require migration is outlined in the changeset (nunjucks being a separate dependency now).

Additionally, I wanted to narrow the blast radius of future braintrust majors so I shimmed the braintrust types instead of using them directly. This means, as long as we don't break compatibility with the shims in future braintrust majors, v4+ may be compatible with `@mastra/braintrust` going forward.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

Sorry, no direct issue but housekeeping and a big mastra/braintrust user asked for it.

Maybe https://github.com/mastra-ai/mastra/issues/9505

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates Mastra’s Braintrust integration to work with Braintrust’s newer v3 SDK. It keeps things working for Braintrust v2 too, by using Mastra-side “shim” types and updating docs/tests to reflect the new tracing IDs.

## What changed
- Updated the bundled `braintrust` dependency from `2.2.2` to `3.22.0`.
- Introduced version-agnostic structural `BraintrustLogger` and `BraintrustSpan` interfaces/shims in the exporter to reduce coupling to Braintrust SDK-specific types.
- Updated `BraintrustExporterConfig` typing so `braintrustLogger` and `currentSpan` use the new shim types (narrower types vs the old SDK-tied ones).
- Updated tests to reflect Braintrust v3 tracing behavior:
  - `rootSpanId` is now a W3C trace ID (different from the span’s `spanId`/row id), while parent relationships still use the immediate parent span IDs.
  - Added coverage that structurally compatible logger/span objects are accepted.
- Updated Braintrust exporter documentation:
  - Added/clarified setup guidance for using Braintrust `Eval()`, `logger.traced()`, and `currentSpan`.
  - Rewrote guidance on `spanId` vs Braintrust v3 `root_span_id`, and included notes for users upgrading from Braintrust v2→v3 when using Nunjucks templates.
- Added a changeset documenting the breaking type-migration details for `BraintrustExporterConfig`.
- Disallowed `braintrust` builds in `pnpm-workspace.yaml` (`braintrust: false`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->