### PR TITLE
docs: add PlatformSandbox and PlatformFilesystem reference docs

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/overview.mdx
+++ b/docs/src/content/en/docs/mastra-platform/overview.mdx
@@ -13,7 +13,7 @@ The [Mastra platform](https://projects.mastra.ai) provides three products for de
 
 Deploy with a single command, [`mastra deploy`](/docs/mastra-platform/deploy), or connect a GitHub repository for push-to-deploy. See the [GitHub integration](/docs/mastra-platform/github) for the repository-linked flow.
 
-Each project can run multiple [**Environments**](/docs/mastra-platform/environments) (for example `production` and `staging`) and provision [**Hosted databases**](/docs/mastra-platform/database) from the CLI or project settings to persist application data with no manual configuration.
+Each project can run multiple [**Environments**](/docs/mastra-platform/environments) (for example `production` and `staging`), provision [**Hosted databases**](/docs/mastra-platform/database) from the CLI or project settings to persist application data, and get a managed [**Workspace**](/docs/mastra-platform/workspace) per environment that gives agents a filesystem and a sandbox with no manual configuration.
 
 ## Get started
 

--- a/docs/src/content/en/docs/mastra-platform/workspace.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspace.mdx
@@ -1,0 +1,94 @@
+---
+title: "Workspace | Mastra platform"
+description: Provision a managed workspace for each Mastra platform environment. The platform supplies a bucket for filesystem storage and a Railway-backed sandbox for command execution, and injects the credentials your deploy needs.
+---
+
+# Workspace
+
+A workspace gives an environment two things your agents can use at runtime:
+
+- A **bucket** for filesystem storage, exposed to your code as [`PlatformFilesystem`](/reference/workspace/platform-filesystem).
+- A **sandbox** for executing commands, exposed as [`PlatformSandbox`](/reference/workspace/platform-sandbox).
+
+Workspaces are provisioned per [environment](/docs/mastra-platform/environments), so `production` and `staging` each get their own bucket and sandbox. The platform manages provisioning, credentials, and lifecycle; your deploy code only needs to construct the providers.
+
+## When workspaces are provisioned
+
+New projects have workspaces enabled by default. When you create an environment, the platform provisions a bucket for it automatically. The sandbox base image is warmed in the background so the first `PlatformSandbox` call starts quickly.
+
+Existing projects that haven't opted in show an **Enable workspaces** action in the Workspaces tab. Enabling provisions a bucket for every environment on the project.
+
+If provisioning fails for an environment — for example while Railway is under load — the Workspaces tab shows the failure and offers a retry. The environment itself is still created; only the workspace is unavailable until you retry.
+
+## Use the workspace from your code
+
+Install the provider package:
+
+```bash npm2yarn
+npm install @mastra/platform-workspace
+```
+
+Compose the providers into a workspace and register it with Mastra:
+
+```typescript title="src/mastra/workspace.ts"
+import { Workspace } from '@mastra/core/workspace'
+import { PlatformFilesystem, PlatformSandbox } from '@mastra/platform-workspace'
+
+export const workspace = new Workspace({
+  filesystem: new PlatformFilesystem(),
+  sandbox: new PlatformSandbox(),
+})
+```
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core'
+import { workspace } from './workspace'
+
+export const mastra = new Mastra({
+  workspace,
+})
+```
+
+`PlatformFilesystem` and `PlatformSandbox` read their credentials from environment variables the platform injects at deploy time, so you don't pass any options on the platform.
+
+## Injected environment variables
+
+Every deploy that runs on a platform environment with a workspace receives these variables:
+
+| Variable | Contents |
+| - | - |
+| `MASTRA_PLATFORM_ACCESS_TOKEN` | Access token scoped to the deploy. Used by the workspace providers to authenticate. |
+| `MASTRA_PROJECT_ID` | Project the deploy belongs to. |
+| `MASTRA_ENVIRONMENT_ID` | Environment the deploy belongs to. Selects which sandbox pool the platform uses. |
+| `MASTRA_PLATFORM_BUCKET_NAME` | Bucket name attached to the environment. Selects which bucket `PlatformFilesystem` reads and writes. |
+
+These names are reserved. If your project sets any of them explicitly, the platform-managed values take precedence.
+
+## Local development
+
+Reuse the same providers locally by exporting the four variables into your shell or `.env` file. Get the values from your project's Workspaces tab:
+
+```bash
+MASTRA_PLATFORM_ACCESS_TOKEN=your-access-token
+MASTRA_PROJECT_ID=your-project-id
+MASTRA_ENVIRONMENT_ID=your-environment-id
+MASTRA_PLATFORM_BUCKET_NAME=your-bucket-name
+```
+
+`PlatformFilesystem` and `PlatformSandbox` behave the same locally as on the platform — they connect to the same bucket and sandbox pool for that environment. Use a `staging` or `preview` environment's variables for local runs if you want to keep production data isolated.
+
+For a purely offline loop that never touches the platform, swap the providers for [`LocalFilesystem`](/reference/workspace/local-filesystem) and [`LocalSandbox`](/reference/workspace/local-sandbox) in a local build.
+
+## Inspect the workspace
+
+The Workspaces tab in your platform project shows, per environment:
+
+- Bucket status and its contents, with upload, download, and delete actions.
+- Recent sandbox sessions with their command, exit code, and duration.
+- Provisioning failures with a **Retry** action.
+
+## See also
+
+- [`PlatformFilesystem`](/reference/workspace/platform-filesystem) — reference for the filesystem provider.
+- [`PlatformSandbox`](/reference/workspace/platform-sandbox) — reference for the sandbox provider.
+- [Environments](/docs/mastra-platform/environments) — how environments scope workspaces, variables, and databases.

--- a/docs/src/content/en/docs/mastra-platform/workspace.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspace.mdx
@@ -66,9 +66,9 @@ These names are reserved. If your project sets any of them explicitly, the platf
 
 ## Local development
 
-Reuse the same providers locally by exporting the four variables into your shell or `.env` file. Get the values from your project's Workspaces tab:
+Reuse the same providers locally by putting the four variables in your `.env` file. Get the values from your project's Workspaces tab:
 
-```bash
+```bash title=".env"
 MASTRA_PLATFORM_ACCESS_TOKEN=your-access-token
 MASTRA_PROJECT_ID=your-project-id
 MASTRA_ENVIRONMENT_ID=your-environment-id

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -1048,6 +1048,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'mastra-platform/workspace',
+          label: 'Workspace',
+          customProps: {
+            tags: ['new'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'mastra-platform/configuration',
           label: 'Configuration',
         },

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -28,6 +28,7 @@ Available providers:
 - [`LocalFilesystem`](/reference/workspace/local-filesystem): Stores files in a directory on disk
 - [`S3Filesystem`](/reference/workspace/s3-filesystem): Stores files in Amazon S3 or S3-compatible storage (R2, MinIO, Tigris)
 - [`GCSFilesystem`](/reference/workspace/gcs-filesystem): Stores files in Google Cloud Storage
+- [`PlatformFilesystem`](/reference/workspace/platform-filesystem): Stores files in a Mastra Platform bucket via the workspace proxy
 - [`GoogleDriveFilesystem`](/reference/workspace/google-drive-filesystem): Stores files inside a Google Drive folder
 - [`AzureBlobFilesystem`](/reference/workspace/azure-blob-filesystem): Stores files in Azure Blob Storage
 - [`FilesSDKFilesystem`](/reference/workspace/files-sdk-filesystem): Stores files in any [FilesSDK](https://files-sdk.dev) adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) — useful when you want one provider that can target multiple backends

--- a/docs/src/content/en/docs/workspace/filesystem.mdx
+++ b/docs/src/content/en/docs/workspace/filesystem.mdx
@@ -28,7 +28,7 @@ Available providers:
 - [`LocalFilesystem`](/reference/workspace/local-filesystem): Stores files in a directory on disk
 - [`S3Filesystem`](/reference/workspace/s3-filesystem): Stores files in Amazon S3 or S3-compatible storage (R2, MinIO, Tigris)
 - [`GCSFilesystem`](/reference/workspace/gcs-filesystem): Stores files in Google Cloud Storage
-- [`PlatformFilesystem`](/reference/workspace/platform-filesystem): Stores files in a Mastra Platform bucket via the workspace proxy
+- [`PlatformFilesystem`](/reference/workspace/platform-filesystem): Stores files in a Mastra Platform workspace bucket
 - [`GoogleDriveFilesystem`](/reference/workspace/google-drive-filesystem): Stores files inside a Google Drive folder
 - [`AzureBlobFilesystem`](/reference/workspace/azure-blob-filesystem): Stores files in Azure Blob Storage
 - [`FilesSDKFilesystem`](/reference/workspace/files-sdk-filesystem): Stores files in any [FilesSDK](https://files-sdk.dev) adapter (S3, R2, GCS, Azure Blob, Vercel Blob, local filesystem, and more) — useful when you want one provider that can target multiple backends

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -35,6 +35,7 @@ Watch [Mastra remote sandboxes overview](https://www.youtube.com/watch?v=Ix2X-sj
 - [`DaytonaSandbox`](/reference/workspace/daytona-sandbox): Executes commands in isolated Daytona cloud sandboxes
 - [`E2BSandbox`](/reference/workspace/e2b-sandbox): Executes commands in isolated E2B cloud sandboxes
 - [`ModalSandbox`](/reference/workspace/modal-sandbox): Executes commands in isolated Modal cloud sandboxes
+- [`PlatformSandbox`](/reference/workspace/platform-sandbox): Executes commands in a Mastra Platform environment via the workspace proxy
 - [`RailwaySandbox`](/reference/workspace/railway-sandbox): Executes commands in ephemeral, isolated Railway cloud sandboxes
 
 ## Basic usage

--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -35,7 +35,7 @@ Watch [Mastra remote sandboxes overview](https://www.youtube.com/watch?v=Ix2X-sj
 - [`DaytonaSandbox`](/reference/workspace/daytona-sandbox): Executes commands in isolated Daytona cloud sandboxes
 - [`E2BSandbox`](/reference/workspace/e2b-sandbox): Executes commands in isolated E2B cloud sandboxes
 - [`ModalSandbox`](/reference/workspace/modal-sandbox): Executes commands in isolated Modal cloud sandboxes
-- [`PlatformSandbox`](/reference/workspace/platform-sandbox): Executes commands in a Mastra Platform environment via the workspace proxy
+- [`PlatformSandbox`](/reference/workspace/platform-sandbox): Executes commands in a sandbox tied to a Mastra Platform environment
 - [`RailwaySandbox`](/reference/workspace/railway-sandbox): Executes commands in ephemeral, isolated Railway cloud sandboxes
 
 ## Basic usage

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -853,6 +853,8 @@ const sidebars = {
         { type: 'doc', id: 'workspace/local-sandbox', label: 'LocalSandbox' },
         { type: 'doc', id: 'workspace/mesa-filesystem', label: 'MesaFilesystem' },
         { type: 'doc', id: 'workspace/modal-sandbox', label: 'ModalSandbox' },
+        { type: 'doc', id: 'workspace/platform-filesystem', label: 'PlatformFilesystem' },
+        { type: 'doc', id: 'workspace/platform-sandbox', label: 'PlatformSandbox' },
         { type: 'doc', id: 'workspace/railway-sandbox', label: 'RailwaySandbox' },
         { type: 'doc', id: 'workspace/s3-filesystem', label: 'S3Filesystem' },
         { type: 'doc', id: 'workspace/process-manager', label: 'SandboxProcessManager' },

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # PlatformFilesystem
 
-Stores files in a Mastra Platform workspace bucket through the [workspace proxy](https://workspaces.mastra.ai). Each Mastra Platform environment can have one bucket, and `PlatformFilesystem` gives agents `read`, `write`, `list`, `delete`, and `move` operations against it.
+Stores files in a Mastra Platform workspace bucket. Each Mastra Platform environment can have one bucket, and `PlatformFilesystem` gives agents `read`, `write`, `list`, `delete`, and `move` operations against it.
 
 Use `PlatformFilesystem` when your agent runs on a Mastra Platform deployment and you want the filesystem to be backed by the platform-provisioned bucket. For direct S3 access, see [`S3Filesystem`](/reference/workspace/s3-filesystem). For a local directory during development, see [`LocalFilesystem`](/reference/workspace/local-filesystem).
 
@@ -26,7 +26,7 @@ For interface details, see [WorkspaceFilesystem interface](/reference/workspace/
 npm install @mastra/platform-workspace
 ```
 
-Configure the platform credentials. All options fall back to environment variables, so a Mastra Platform deployment can pass zero constructor options.
+Configure the platform credentials. The access token, project ID, and bucket name fall back to environment variables, so a Mastra Platform deployment can pass zero constructor options.
 
 <Tabs>
   <TabItem value="env-file" label=".env file">
@@ -102,7 +102,7 @@ await fs.writeFile('/analyses/repo.md', 'x') // throws WorkspaceReadOnlyError
 
 `writeFile` supports `overwrite: false` and throws `FileExistsError` when the destination already exists.
 
-`copyFile` and `moveFile` always overwrite the destination. The workspace proxy has no conditional wire field to prevent overwrite, so passing `overwrite: false` to either method throws an error rather than silently overwriting.
+`copyFile` and `moveFile` always overwrite the destination. Passing `overwrite: false` to either method throws an error rather than silently overwriting.
 
 ### Appending files
 
@@ -179,8 +179,6 @@ await fs.writeFile('/analyses/repo.md', 'x') // throws WorkspaceReadOnlyError
 ]}
 />
 
-The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` environment variable (useful for staging).
-
 ## Properties
 
 <PropertiesTable
@@ -216,7 +214,7 @@ Filesystem-specific errors match the standard workspace error types:
 - `FileExistsError`: `writeFile` was called with `overwrite: false` and the destination already exists.
 - `WorkspaceReadOnlyError`: A mutating call was made on a read-only filesystem.
 
-Non-filesystem failures from the workspace proxy raise `PlatformApiError`. Structured `{ error: { message, type } }` responses are parsed into `.code` (machine-readable kind) and `.proxyMessage` (human string):
+Other Platform API failures raise `PlatformApiError`. Structured `{ error: { message, type } }` responses are parsed into `.code` (machine-readable kind) and `.proxyMessage` (human string):
 
 ```typescript
 import { FileNotFoundError, PlatformApiError } from '@mastra/platform-workspace'
@@ -235,7 +233,7 @@ try {
 }
 ```
 
-`code` and `proxyMessage` are `undefined` when the proxy returns a non-JSON body, for example an HTML 502 from a load balancer.
+`code` and `proxyMessage` are `undefined` when the response body is not JSON, for example an HTML 502 from a load balancer.
 
 ## Related
 

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -1,0 +1,244 @@
+---
+title: "Reference: PlatformFilesystem | Workspace"
+description: "Documentation for the PlatformFilesystem provider for bucket-backed storage on Mastra Platform."
+packages:
+  - "@mastra/platform-workspace"
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# PlatformFilesystem
+
+Stores files in a Mastra Platform workspace bucket through the [workspace proxy](https://workspaces.mastra.ai). Each Mastra Platform environment can have one bucket, and `PlatformFilesystem` gives agents `read`, `write`, `list`, `delete`, and `move` operations against it.
+
+Use `PlatformFilesystem` when your agent runs on a Mastra Platform deployment and you want the filesystem to be backed by the platform-provisioned bucket. For direct S3 access, see [`S3Filesystem`](/reference/workspace/s3-filesystem). For a local directory during development, see [`LocalFilesystem`](/reference/workspace/local-filesystem).
+
+:::info
+
+For interface details, see [WorkspaceFilesystem interface](/reference/workspace/filesystem).
+
+:::
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/platform-workspace
+```
+
+Configure the platform credentials. All options fall back to environment variables, so a Mastra Platform deployment can pass zero constructor options.
+
+<Tabs>
+  <TabItem value="env-file" label=".env file">
+    ```bash
+    MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
+    MASTRA_PROJECT_ID=your-project-id
+    MASTRA_PLATFORM_BUCKET_NAME=your-bucket-name
+    ```
+  </TabItem>
+
+  <TabItem value="constructor" label="Constructor">
+    ```typescript
+    new PlatformFilesystem({
+      accessToken: 'your-platform-access-token',
+      projectId: 'your-project-id',
+      bucketName: 'your-bucket-name',
+    })
+    ```
+  </TabItem>
+</Tabs>
+
+On a Mastra Platform deployment these variables are injected automatically, so the constructor can be called with no options.
+
+## Usage
+
+Add a `PlatformFilesystem` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { PlatformFilesystem } from '@mastra/platform-workspace'
+
+const workspace = new Workspace({
+  filesystem: new PlatformFilesystem({
+    // accessToken, projectId, bucketName all fall back to env vars
+  }),
+})
+
+const agent = new Agent({
+  id: 'file-agent',
+  name: 'File Agent',
+  instructions: 'You are a research assistant that reads and writes reports.',
+  model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  workspace,
+})
+```
+
+### Reading and writing files
+
+Object keys are percent-encoded per segment, so filenames with `?`, `#`, `%`, `&`, `+`, or spaces are preserved end-to-end:
+
+```typescript
+const fs = new PlatformFilesystem()
+
+await fs.writeFile('/analyses/repo.md', markdown)
+const content = await fs.readFile('/analyses/repo.md')
+const entries = await fs.readdir('/analyses')
+await fs.moveFile('/analyses/repo.md', '/analyses/repo-final.md')
+```
+
+### Read-only mode
+
+Pass `readOnly: true` to mount the bucket read-only. Any mutating call throws `WorkspaceReadOnlyError`:
+
+```typescript
+const fs = new PlatformFilesystem({ readOnly: true })
+
+await fs.readFile('/analyses/repo.md') // ok
+await fs.writeFile('/analyses/repo.md', 'x') // throws WorkspaceReadOnlyError
+```
+
+### Overwrite semantics
+
+`writeFile` supports `overwrite: false` and throws `FileExistsError` when the destination already exists.
+
+`copyFile` and `moveFile` always overwrite the destination. The workspace proxy has no conditional wire field to prevent overwrite, so passing `overwrite: false` to either method throws an error rather than silently overwriting.
+
+### Appending files
+
+`appendFile` is a read-modify-write and is not atomic. Concurrent appends to the same path can overwrite each other. For concurrent writers, use `writeFile` with distinct keys.
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'accessToken',
+    type: 'string',
+    description: 'Platform access token. Falls back to the MASTRA_PLATFORM_ACCESS_TOKEN environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'projectId',
+    type: 'string',
+    description: 'Platform project ID. Falls back to the MASTRA_PROJECT_ID environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'bucketName',
+    type: 'string',
+    description:
+      'Platform bucket name to store files in. Falls back to the MASTRA_PLATFORM_BUCKET_NAME environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'readOnly',
+    type: 'boolean',
+    description: 'When true, all mutating calls throw WorkspaceReadOnlyError.',
+    isOptional: true,
+    defaultValue: 'false',
+  },
+  {
+    name: 'displayName',
+    type: 'string',
+    description: 'Human-readable name shown in workspace UIs.',
+    isOptional: true,
+  },
+  {
+    name: 'description',
+    type: 'string',
+    description: 'Short description shown in workspace UIs.',
+    isOptional: true,
+  },
+  {
+    name: 'icon',
+    type: 'FilesystemIcon',
+    description: 'Icon shown in workspace UIs.',
+    isOptional: true,
+  },
+  {
+    name: 'instructions',
+    type: 'string | ((opts: { defaultInstructions: string; requestContext?: RequestContext }) => string)',
+    description:
+      'Custom instructions returned by getInstructions(). A string fully replaces the defaults; a function receives the defaults and can extend or customize them per-request.',
+    isOptional: true,
+  },
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this filesystem instance.',
+    isOptional: true,
+    defaultValue: 'Auto-generated',
+  },
+  {
+    name: 'fetch',
+    type: 'typeof fetch',
+    description: 'Custom fetch implementation, mainly for testing.',
+    isOptional: true,
+  },
+]}
+/>
+
+The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` environment variable (useful for staging).
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Filesystem instance identifier.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "Provider name ('PlatformFilesystem').",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "Provider identifier ('platform').",
+  },
+  {
+    name: 'readOnly',
+    type: 'boolean | undefined',
+    description: 'Whether the filesystem was mounted read-only.',
+  },
+]}
+/>
+
+## Errors
+
+Filesystem-specific errors match the standard workspace error types:
+
+- `FileNotFoundError`: The path does not exist. Thrown by `readFile`, `stat`, and `deleteFile` (unless `force: true` is set).
+- `FileExistsError`: `writeFile` was called with `overwrite: false` and the destination already exists.
+- `WorkspaceReadOnlyError`: A mutating call was made on a read-only filesystem.
+
+Non-filesystem failures from the workspace proxy raise `PlatformApiError`. Structured `{ error: { message, type } }` responses are parsed into `.code` (machine-readable kind) and `.proxyMessage` (human string):
+
+```typescript
+import { FileNotFoundError, PlatformApiError } from '@mastra/platform-workspace'
+
+try {
+  await fs.readFile('/missing.txt')
+} catch (err) {
+  if (err instanceof FileNotFoundError) {
+    // handle missing file
+  } else if (err instanceof PlatformApiError) {
+    if (err.code === 'authentication_error') {
+      // refresh token
+    }
+    console.error(err.status, err.code, err.proxyMessage)
+  }
+}
+```
+
+`code` and `proxyMessage` are `undefined` when the proxy returns a non-JSON body, for example an HTML 502 from a load balancer.
+
+## Related
+
+- [PlatformSandbox reference](/reference/workspace/platform-sandbox)
+- [S3Filesystem reference](/reference/workspace/s3-filesystem)
+- [WorkspaceFilesystem interface](/reference/workspace/filesystem)

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -1,0 +1,278 @@
+---
+title: "Reference: PlatformSandbox | Workspace"
+description: "Documentation for the PlatformSandbox provider for executing commands in a Mastra Platform environment."
+packages:
+  - "@mastra/platform-workspace"
+---
+
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+
+# PlatformSandbox
+
+Executes commands inside a Mastra Platform sandbox tied to a Platform environment. Sessions run on the [workspace proxy](https://workspaces.mastra.ai) and boot from a pre-built recipe checkpoint with Python 3, Node 22, TypeScript, tsx, and common build tooling already installed.
+
+Use `PlatformSandbox` when your agent runs on a Mastra Platform deployment and you want the sandbox to be provisioned and managed by the platform. For self-hosted Railway sandboxes, see [`RailwaySandbox`](/reference/workspace/railway-sandbox). For a local sandbox during development, see [`LocalSandbox`](/reference/workspace/local-sandbox).
+
+:::info
+
+For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
+
+:::
+
+## Installation
+
+```bash npm2yarn
+npm install @mastra/platform-workspace
+```
+
+Configure the platform credentials. All options fall back to environment variables, so a Mastra Platform deployment can pass zero constructor options.
+
+<Tabs>
+  <TabItem value="env-file" label=".env file">
+    ```bash
+    MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
+    MASTRA_PROJECT_ID=your-project-id
+    MASTRA_ENVIRONMENT_ID=your-environment-id
+    ```
+  </TabItem>
+
+  <TabItem value="constructor" label="Constructor">
+    ```typescript
+    new PlatformSandbox({
+      accessToken: 'your-platform-access-token',
+      projectId: 'your-project-id',
+      environmentId: 'your-environment-id',
+    })
+    ```
+  </TabItem>
+</Tabs>
+
+On a Mastra Platform deployment these variables are injected automatically, so the constructor can be called with no options.
+
+## Usage
+
+Add a `PlatformSandbox` to a workspace and assign it to an agent:
+
+```typescript
+import { Agent } from '@mastra/core/agent'
+import { Workspace } from '@mastra/core/workspace'
+import { PlatformSandbox } from '@mastra/platform-workspace'
+
+const workspace = new Workspace({
+  sandbox: new PlatformSandbox({
+    // accessToken, projectId, environmentId all fall back to env vars
+    idleTimeoutMinutes: 30,
+  }),
+})
+
+const agent = new Agent({
+  id: 'code-agent',
+  name: 'Code Agent',
+  instructions: 'You are a coding assistant working in this workspace.',
+  model: '__GATEWAY_ANTHROPIC_MODEL_SONNET__',
+  workspace,
+})
+
+const response = await agent.generate(
+  'Print "Hello, world!" and show the current working directory.',
+)
+
+console.log(response.text)
+```
+
+### Private networking
+
+Set `networkIsolation` to `PRIVATE` to join the environment's private network and reach other services running in the same Mastra Platform environment:
+
+```typescript
+const workspace = new Workspace({
+  sandbox: new PlatformSandbox({
+    networkIsolation: 'PRIVATE',
+  }),
+})
+```
+
+The default `ISOLATED` mode allows outbound internet access only, with no private network connectivity.
+
+### Reattaching to a running sandbox
+
+Pass an existing `sandboxId` to reattach to a live sandbox instead of creating a new one. This is useful for stateful agents that resume between requests:
+
+```typescript
+const sandbox = new PlatformSandbox({
+  sandboxId: 'sbx_abc123',
+})
+await sandbox.start()
+
+const result = await sandbox.executeCommand('cat', ['/workspace/state.json'])
+```
+
+When `sandboxId` is set, `environmentId` is not required because the sandbox already exists.
+
+### Executing commands
+
+`executeCommand` runs a command on the remote sandbox and returns its output. Pass `args` to have arguments safely shell-quoted:
+
+```typescript
+const result = await sandbox.executeCommand('python', ['analyze.py'], {
+  timeout: 30_000,
+  cwd: '/workspace',
+  env: { INPUT: 'repo' },
+})
+
+console.log(result.stdout)
+console.log(result.exitCode)
+```
+
+:::warning
+
+The `command` argument is a shell string and is concatenated verbatim into the remote shell. This lets you use pipes, redirects, and chaining (`ls -la | grep foo`) but means untrusted input must be passed through `args` (safely quoted) or shell-quoted by the caller. Untrusted `command` values allow arbitrary shell execution on the sandbox.
+
+:::
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'accessToken',
+    type: 'string',
+    description: 'Platform access token. Falls back to the MASTRA_PLATFORM_ACCESS_TOKEN environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'projectId',
+    type: 'string',
+    description: 'Platform project ID. Falls back to the MASTRA_PROJECT_ID environment variable.',
+    isOptional: true,
+  },
+  {
+    name: 'environmentId',
+    type: 'string',
+    description:
+      'Platform environment ID the sandbox belongs to. Falls back to the MASTRA_ENVIRONMENT_ID environment variable. Required unless sandboxId is passed.',
+    isOptional: true,
+  },
+  {
+    name: 'sandboxId',
+    type: 'string',
+    description:
+      'Existing sandbox ID to reattach to instead of creating a new sandbox. When set, environmentId is not required.',
+    isOptional: true,
+  },
+  {
+    name: 'idleTimeoutMinutes',
+    type: 'number',
+    description: 'How long the sandbox stays alive with no activity before the platform destroys it.',
+    isOptional: true,
+  },
+  {
+    name: 'networkIsolation',
+    type: "'ISOLATED' | 'PRIVATE'",
+    description:
+      "Network mode. 'ISOLATED' (default) allows outbound internet only. 'PRIVATE' joins the platform environment's private network.",
+    isOptional: true,
+  },
+  {
+    name: 'env',
+    type: 'Record<string, string>',
+    description:
+      'Environment variables baked into the sandbox at creation time. Per-command environment variables can also be passed to executeCommand.',
+    isOptional: true,
+  },
+  {
+    name: 'timeout',
+    type: 'number',
+    description:
+      'Default command execution timeout in milliseconds. Overridable per call via ExecuteCommandOptions.timeout.',
+    isOptional: true,
+  },
+  {
+    name: 'instructions',
+    type: 'string | ((opts: { defaultInstructions: string; requestContext?: RequestContext }) => string)',
+    description:
+      'Custom instructions returned by getInstructions(). A string fully replaces the defaults; a function receives the defaults and can extend or customize them per-request.',
+    isOptional: true,
+  },
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Unique identifier for this sandbox instance.',
+    isOptional: true,
+    defaultValue: 'Auto-generated',
+  },
+  {
+    name: 'fetch',
+    type: 'typeof fetch',
+    description: 'Custom fetch implementation, mainly for testing.',
+    isOptional: true,
+  },
+]}
+/>
+
+The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` environment variable (useful for staging).
+
+## Properties
+
+<PropertiesTable
+  content={[
+  {
+    name: 'id',
+    type: 'string',
+    description: 'Sandbox instance identifier.',
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: "Provider name ('PlatformSandbox').",
+  },
+  {
+    name: 'provider',
+    type: 'string',
+    description: "Provider identifier ('platform').",
+  },
+  {
+    name: 'status',
+    type: 'ProviderStatus',
+    description:
+      "'pending' | 'initializing' | 'ready' | 'starting' | 'running' | 'stopping' | 'stopped' | 'destroying' | 'destroyed' | 'error'.",
+  },
+  {
+    name: 'processes',
+    type: 'PlatformProcessManager',
+    description:
+      'Background process manager. See [SandboxProcessManager reference](/reference/workspace/process-manager).',
+  },
+]}
+/>
+
+## Errors
+
+Failures from the workspace proxy raise `PlatformApiError`. Structured `{ error: { message, type } }` responses are parsed into `.code` (machine-readable kind) and `.proxyMessage` (human string); the raw response body stays available on `.body`:
+
+```typescript
+import { PlatformApiError } from '@mastra/platform-workspace'
+
+try {
+  await sandbox.executeCommand('cat', ['/missing.txt'])
+} catch (err) {
+  if (err instanceof PlatformApiError) {
+    if (err.code === 'not_found') {
+      // handle missing resource
+    } else if (err.code === 'authentication_error') {
+      // refresh token
+    }
+    console.error(err.status, err.code, err.proxyMessage)
+  }
+}
+```
+
+`code` and `proxyMessage` are `undefined` when the proxy returns a non-JSON body, for example an HTML 502 from a load balancer.
+
+## Related
+
+- [PlatformFilesystem reference](/reference/workspace/platform-filesystem)
+- [RailwaySandbox reference](/reference/workspace/railway-sandbox)
+- [WorkspaceSandbox interface](/reference/workspace/sandbox)
+- [SandboxProcessManager reference](/reference/workspace/process-manager)

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # PlatformSandbox
 
-Executes commands inside a Mastra Platform sandbox tied to a Platform environment. Sessions run on the [workspace proxy](https://workspaces.mastra.ai) and boot from a pre-built recipe checkpoint with Python 3, Node 22, TypeScript, tsx, and common build tooling already installed.
+Executes commands inside a Mastra Platform sandbox tied to a Platform environment. Sandboxes boot from a pre-built recipe checkpoint with Python 3, Node 22, TypeScript, tsx, and common build tooling already installed.
 
 Use `PlatformSandbox` when your agent runs on a Mastra Platform deployment and you want the sandbox to be provisioned and managed by the platform. For self-hosted Railway sandboxes, see [`RailwaySandbox`](/reference/workspace/railway-sandbox). For a local sandbox during development, see [`LocalSandbox`](/reference/workspace/local-sandbox).
 
@@ -26,7 +26,7 @@ For interface details, see [WorkspaceSandbox interface](/reference/workspace/san
 npm install @mastra/platform-workspace
 ```
 
-Configure the platform credentials. All options fall back to environment variables, so a Mastra Platform deployment can pass zero constructor options.
+Configure the platform credentials. The access token, project ID, and environment ID fall back to environment variables, so a Mastra Platform deployment can pass zero constructor options.
 
 <Tabs>
   <TabItem value="env-file" label=".env file">
@@ -211,8 +211,6 @@ The `command` argument is a shell string and is concatenated verbatim into the r
 ]}
 />
 
-The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` environment variable (useful for staging).
-
 ## Properties
 
 <PropertiesTable
@@ -249,7 +247,7 @@ The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden w
 
 ## Errors
 
-Failures from the workspace proxy raise `PlatformApiError`. Structured `{ error: { message, type } }` responses are parsed into `.code` (machine-readable kind) and `.proxyMessage` (human string); the raw response body stays available on `.body`:
+Platform API failures raise `PlatformApiError`. Structured `{ error: { message, type } }` responses are parsed into `.code` (machine-readable kind) and `.proxyMessage` (human string); the raw response body stays available on `.body`:
 
 ```typescript
 import { PlatformApiError } from '@mastra/platform-workspace'
@@ -268,7 +266,7 @@ try {
 }
 ```
 
-`code` and `proxyMessage` are `undefined` when the proxy returns a non-JSON body, for example an HTML 502 from a load balancer.
+`code` and `proxyMessage` are `undefined` when the response body is not JSON, for example an HTML 502 from a load balancer.
 
 ## Related
 


### PR DESCRIPTION
Adds reference documentation for the two workspace providers shipped by the [`@mastra/platform-workspace`](https://www.npmjs.com/package/@mastra/platform-workspace) package.

## What's included

- **New:** `reference/workspace/platform-sandbox.mdx` — full reference for `PlatformSandbox` (constructor params, properties, pre-built tooling, reattaching, background processes, network isolation, error handling).
- **New:** `reference/workspace/platform-filesystem.mdx` — full reference for `PlatformFilesystem` (constructor params, properties, file operations, URL-safe key encoding, read-only mode, error handling).
- **Updated:** `docs/workspace/sandbox.mdx` — added `PlatformSandbox` to the supported providers list.
- **Updated:** `docs/workspace/filesystem.mdx` — added `PlatformFilesystem` to the supported providers list.
- **Updated:** `reference/sidebars.js` — registered both new reference pages in the workspace reference section.

## Test plan

- Frontmatter validated (title, description, package).
- Internal links point at valid reference IDs.
- Sidebar entries render alphabetically alongside existing workspace providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds new documentation pages that teach you how to use two Mastra Platform “workspace” tools: one for persistent files and one for running commands. It also updates the website navigation so these new pages show up in the right places.

## What changed

- Added new reference documentation pages:
  - `PlatformFilesystem` (setup, configuration/env vars vs constructor options, workspace/agent usage, path/overwrite semantics, read-only behavior, and error mapping).
  - `PlatformSandbox` (setup, injected credential/env vars, sandbox wiring in `Workspace`/`Agent`, private network option, reattaching via `sandboxId`, command execution semantics, and error mapping).
- Updated workspace overview docs to include `PlatformFilesystem` and `PlatformSandbox` in the “Supported providers” lists.
- Added a Mastra Platform “Workspace” setup guide explaining:
  - per-environment workspace provisioning (bucket + sandbox),
  - injected environment variables for platform deploys,
  - how to compose the providers into a `Workspace`,
  - how to switch to local providers for offline development.
- Linked the new workspace guide from the Mastra Platform overview and included it in the docs sidebar.
- Registered both new provider reference pages in the workspace reference sidebar and ensured the sidebar ordering/validation expectations (frontmatter correctness, internal links, alphabetical ordering).
- Updated wording based on review feedback by clarifying credential fallback behavior and removing user-facing references to internal proxy URL details / `MASTRA_WORKSPACE_PROXY_URL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->