### PR TITLE
draft emitter changes - cancel to cleanup only this stream's listeners

### DIFF
--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1759,6 +1759,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
   #createEventedStream() {
     const self = this;
+    let chunkHandler: ((chunk: ChunkType<OUTPUT>) => void) | undefined;
+    let finishHandler: (() => void) | undefined;
 
     return new ReadableStream<ChunkType<OUTPUT>>({
       start(controller) {
@@ -1774,13 +1776,13 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
         }
 
         // Listen for new chunks and stream finish
-        const chunkHandler = (chunk: ChunkType<OUTPUT>) => {
+        chunkHandler = (chunk: ChunkType<OUTPUT>) => {
           safeEnqueue(controller, chunk);
         };
 
-        const finishHandler = () => {
-          self.#emitter.off('chunk', chunkHandler);
-          self.#emitter.off('finish', finishHandler);
+        finishHandler = () => {
+          self.#emitter.off('chunk', chunkHandler!);
+          self.#emitter.off('finish', finishHandler!);
           safeClose(controller);
         };
 
@@ -1796,8 +1798,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       },
 
       cancel() {
-        // Stream was cancelled, clean up
-        self.#emitter.removeAllListeners();
+        if (chunkHandler) {
+          self.#emitter.off('chunk', chunkHandler);
+        }
+        if (finishHandler) {
+          self.#emitter.off('finish', finishHandler);
+        }
       },
     });
   }


### PR DESCRIPTION
## Description

`MastraModelOutput.#createEventedStream` is supposed to allow multiple consumers for the same stream, but its `cancel()` method calls `removeAllListeners()` that, if called, in turn removes internal listeners responsible for the cleanup in `thread-stream-runtime.ts` (`_waitUntilFinished`). As a result, runtime state for streams canceled by client code (`fullStream.cancel()`) is never cleaned up.

This draft change is incomplete and I'm submitting it to discuss direction - can convert to a concrete PR if/when agreed with maintainers.

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
