### PR TITLE
fix(observability): correct Vercel Gateway and Vertex cost estimates

### DIFF
--- a/.changeset/tangy-garlics-sniff.md
+++ b/.changeset/tangy-garlics-sniff.md
@@ -1,0 +1,5 @@
+---
+'@mastra/observability': patch
+---
+
+Fixed cost estimates for supported models routed through Vercel AI Gateway.

--- a/.changeset/tangy-garlics-sniff.md
+++ b/.changeset/tangy-garlics-sniff.md
@@ -2,4 +2,4 @@
 '@mastra/observability': patch
 ---
 
-Fixed cost estimates for supported models routed through Vercel AI Gateway.
+Fixed cost estimates when AI SDK provider names differ from embedded pricing data, including Vercel AI Gateway and Google Vertex.

--- a/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
+++ b/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
@@ -1,5 +1,9 @@
 {"i":"openai-gpt-4o-mini","p":"openai","m":"gpt-4o-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":7.5e-8},"it":{"c":1.5e-7},"ot":{"c":6e-7}}}]}}}
+{"i":"google-gemini-2-0-flash","p":"google","m":"gemini-2-0-flash","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2.5e-8},"it":{"c":1e-7},"ot":{"c":4e-7}}}]}}}
 {"i":"google-gemini-2-5-pro","p":"google","m":"gemini-2-5-pro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1.25e-7},"it":{"c":0.00000125},"ot":{"c":0.00001}}},{"w":[{"f":"tit","op":"gt","value":200000}],"r":{"icrt":{"c":2.5e-7},"it":{"c":0.0000025},"ot":{"c":0.000015}}}]}}}
+{"i":"google-vertex-gemini-2-0-flash","p":"google-vertex","m":"gemini-2-0-flash","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2.5e-8},"it":{"c":1.5e-7},"ot":{"c":6e-7}}}]}}}
+{"i":"google-vertex-deepseek-v3-1-maas","p":"google-vertex","m":"deepseek-ai-deepseek-v3-1-maas","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":6e-7},"ot":{"c":0.0000017}}}]}}}
+{"i":"google-vertex-anthropic-claude-sonnet-4-5","p":"google-vertex-anthropic","m":"claude-sonnet-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3e-7},"icwt":{"c":0.00000375},"it":{"c":0.000003},"ot":{"c":0.000015}}}]}}}
 {"i":"anthropic-claude-sonnet-4-5","p":"anthropic","m":"claude-sonnet-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3e-7},"icwt":{"c":0.00000375},"it":{"c":0.000003},"ot":{"c":0.000015}}}]}}}
 {"i":"anthropic-claude-haiku-4-5","p":"anthropic","m":"claude-haiku-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1e-7},"icwt":{"c":0.00000125},"it":{"c":0.000001},"ot":{"c":0.000005}}}]}}}
 {"i":"vercel-claude-haiku-4-5","p":"vercel","m":"claude-haiku-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1e-7},"icwt":{"c":0.00000125},"it":{"c":0.000001},"ot":{"c":0.000005}}}]}}}

--- a/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
+++ b/observability/mastra/src/metrics/__fixtures__/pricing-data-test.jsonl
@@ -1,6 +1,9 @@
 {"i":"openai-gpt-4o-mini","p":"openai","m":"gpt-4o-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":7.5e-8},"it":{"c":1.5e-7},"ot":{"c":6e-7}}}]}}}
 {"i":"google-gemini-2-5-pro","p":"google","m":"gemini-2-5-pro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1.25e-7},"it":{"c":0.00000125},"ot":{"c":0.00001}}},{"w":[{"f":"tit","op":"gt","value":200000}],"r":{"icrt":{"c":2.5e-7},"it":{"c":0.0000025},"ot":{"c":0.000015}}}]}}}
 {"i":"anthropic-claude-sonnet-4-5","p":"anthropic","m":"claude-sonnet-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3e-7},"icwt":{"c":0.00000375},"it":{"c":0.000003},"ot":{"c":0.000015}}}]}}}
+{"i":"anthropic-claude-haiku-4-5","p":"anthropic","m":"claude-haiku-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1e-7},"icwt":{"c":0.00000125},"it":{"c":0.000001},"ot":{"c":0.000005}}}]}}}
+{"i":"vercel-claude-haiku-4-5","p":"vercel","m":"claude-haiku-4-5","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":1e-7},"icwt":{"c":0.00000125},"it":{"c":0.000001},"ot":{"c":0.000005}}}]}}}
+{"i":"vercel-amazon-nova-micro","p":"vercel","m":"amazon-nova-micro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":8.75e-9},"it":{"c":3.5e-8},"ot":{"c":1.4e-7}}}]}}}
 {"i":"openrouter-xiaomi-mimo-v2-pro","p":"openrouter","m":"xiaomi-mimo-v2-pro","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2e-7},"it":{"c":1e-6},"ot":{"c":3e-6}}}]}}}
 {"i":"openrouter-gpt-5-mini","p":"openrouter","m":"gpt-5-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":2.5e-8},"it":{"c":2.5e-7},"ot":{"c":2e-6}}}]}}}
 {"i":"openrouter-anthropic-claude-sonnet-4-6","p":"openrouter","m":"claude-sonnet-4-6","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"icrt":{"c":3e-7},"icwt":{"c":0.00000375},"it":{"c":0.000003},"ot":{"c":0.000015}}}]}}}

--- a/observability/mastra/src/metrics/auto-extract.test.ts
+++ b/observability/mastra/src/metrics/auto-extract.test.ts
@@ -645,6 +645,31 @@ describe('AutoExtractedMetrics', () => {
     );
   });
 
+  it('should estimate costs for Vercel AI Gateway model ids', () => {
+    setup();
+    const span = createMockSpan({
+      type: SpanType.MODEL_GENERATION,
+      endTime: new Date('2026-01-01T00:00:01Z'),
+      attributes: {
+        provider: 'gateway',
+        model: 'anthropic/claude-haiku-4.5',
+        usage: { inputTokens: 100, outputTokens: 50 },
+      },
+    });
+
+    vi.spyOn(PricingRegistry, 'getGlobal').mockReturnValue(pricingRegistry);
+
+    emitAutoExtractedMetrics(span, createMetricsContext(span));
+
+    const inputTokens = emittedMetrics.find(m => m.metric.name === 'mastra_model_total_input_tokens');
+    expect(inputTokens!.metric.costContext).toMatchObject({
+      provider: 'vercel',
+      model: 'claude-haiku-4-5',
+      costMetadata: { pricing_id: 'vercel-claude-haiku-4-5' },
+    });
+    expect(inputTokens!.metric.costContext?.estimatedCost).toBeCloseTo(0.0001);
+  });
+
   it('should estimate costs for Bedrock inference-profile model ids', () => {
     setup();
     const span = createMockSpan({

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -491,6 +491,91 @@ describe('estimateCosts', () => {
     },
   );
 
+  it('prefers exact Gateway pricing before the Vercel fallback', () => {
+    const registry = PricingRegistry.fromText(`
+{"i":"gateway-openai-gpt-4o-mini","p":"gateway","m":"openai/gpt-4o-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":2e-7}}}]}}}
+{"i":"vercel-gpt-4o-mini","p":"vercel","m":"gpt-4o-mini","s":{"v":"model_pricing/v1","d":{"u":"USD","t":[{"r":{"it":{"c":1.5e-7}}}]}}}
+`);
+    const costs = estimateCosts(
+      {
+        provider: 'gateway',
+        model: 'openai/gpt-4o-mini',
+        usage: { inputTokens: 1_000 },
+      },
+      registry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toMatchObject({
+      provider: 'gateway',
+      model: 'openai/gpt-4o-mini',
+      costMetadata: { pricing_id: 'gateway-openai-gpt-4o-mini' },
+    });
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.estimatedCost).toBeCloseTo(0.0002);
+  });
+
+  it.each([
+    ['openai.chat', 'gpt-4o-mini', 'openai', 'openai-gpt-4o-mini'],
+    ['google.generative-ai', 'gemini-2.0-flash', 'google', 'google-gemini-2-0-flash'],
+  ])('falls back from AI SDK provider %s to %s pricing', (provider, model, pricingProvider, pricingId) => {
+    const costs = estimateCosts(
+      {
+        provider,
+        model,
+        usage: { inputTokens: 1_000 },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toMatchObject({
+      provider: pricingProvider,
+      costMetadata: { pricing_id: pricingId },
+    });
+  });
+
+  it.each([
+    ['google.vertex.chat', 'gemini-2.0-flash', 'google-vertex', 'google-vertex-gemini-2-0-flash', 0.00015],
+    ['vertex.maas.chat', 'deepseek-ai/deepseek-v3.1-maas', 'google-vertex', 'google-vertex-deepseek-v3-1-maas', 0.0006],
+    [
+      'vertex.anthropic.messages',
+      'claude-sonnet-4-5@20250929',
+      'google-vertex-anthropic',
+      'google-vertex-anthropic-claude-sonnet-4-5',
+      0.003,
+    ],
+  ])('resolves AI SDK provider %s against %s pricing', (provider, model, pricingProvider, pricingId, estimatedCost) => {
+    const costs = estimateCosts(
+      {
+        provider,
+        model,
+        usage: { inputTokens: 1_000 },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toMatchObject({
+      provider: pricingProvider,
+      costMetadata: { pricing_id: pricingId },
+    });
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.estimatedCost).toBeCloseTo(estimatedCost);
+  });
+
+  it('does not fall back from Google Vertex to direct Google pricing', () => {
+    const costs = estimateCosts(
+      {
+        provider: 'google.vertex.chat',
+        model: 'gemini-2.5-pro',
+        usage: { inputTokens: 1_000 },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+      provider: 'google.vertex.chat',
+      model: 'gemini-2.5-pro',
+      costMetadata: { error: 'no_matching_model' },
+    });
+  });
+
   it('resolves Bedrock inference-profile ids and prices all Anthropic token meters', () => {
     const costs = estimateCosts(
       {

--- a/observability/mastra/src/metrics/estimator.test.ts
+++ b/observability/mastra/src/metrics/estimator.test.ts
@@ -451,6 +451,46 @@ describe('estimateCosts', () => {
     });
   });
 
+  it.each([
+    ['anthropic/claude-haiku-4.5', 'vercel-claude-haiku-4-5', 0.001],
+    ['amazon/nova-micro', 'vercel-amazon-nova-micro', 0.000035],
+  ])('resolves Vercel AI Gateway model id %s against Vercel pricing', (model, pricingId, estimatedCost) => {
+    const costs = estimateCosts(
+      {
+        provider: 'gateway',
+        model,
+        usage: { inputTokens: 1_000 },
+      },
+      pricingRegistry,
+    );
+
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)).toMatchObject({
+      provider: 'vercel',
+      costMetadata: { pricing_id: pricingId },
+    });
+    expect(costs.get(TokenMetrics.TOTAL_INPUT)?.estimatedCost).toBeCloseTo(estimatedCost);
+  });
+
+  it.each(['claude-haiku-4.5', ' /claude-haiku-4.5', 'anthropic/claude/haiku-4.5'])(
+    'does not treat invalid Gateway model id %s as Vercel pricing',
+    model => {
+      const costs = estimateCosts(
+        {
+          provider: 'gateway',
+          model,
+          usage: { inputTokens: 1_000 },
+        },
+        pricingRegistry,
+      );
+
+      expect(costs.get(TokenMetrics.TOTAL_INPUT)).toEqual({
+        provider: 'gateway',
+        model,
+        costMetadata: { error: 'no_matching_model' },
+      });
+    },
+  );
+
   it('resolves Bedrock inference-profile ids and prices all Anthropic token meters', () => {
     const costs = estimateCosts(
       {

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -6,6 +6,10 @@ import type { PricingMeter, PricingConditionOperator, PricingConditionField } fr
 
 const DATA_FILE_NAME = 'pricing-data.jsonl';
 const BEDROCK_GEOGRAPHY_PREFIXES = new Set(['global', 'us', 'eu', 'apac', 'jp', 'au']);
+// Provider ID emitted by @ai-sdk/gateway for Vercel AI Gateway models.
+const AI_SDK_VERCEL_GATEWAY_PROVIDER_ID = 'gateway';
+// Canonical provider ID used by the embedded pricing snapshot for those models.
+const VERCEL_PRICING_PROVIDER_ID = 'vercel';
 
 type MinifiedMeterKey = 'it' | 'ot' | 'icrt' | 'icwt' | 'iat' | 'oat' | 'ort';
 type MinifiedConditionFieldKey = 'tit';
@@ -193,12 +197,21 @@ function normalizeProvider(provider: string): string {
 
 function resolvePricingProvider(provider: string, model: string): string {
   const normalizedProvider = normalizeProvider(provider);
-  const modelSegments = model.split('/');
-  const hasCreatorModelShape = modelSegments.length === 2 && modelSegments.every(segment => segment.trim().length > 0);
 
-  // AI SDK calls the Vercel AI Gateway provider "gateway", while the pricing
-  // snapshot stores its model-level prices under "vercel".
-  return normalizedProvider === 'gateway' && hasCreatorModelShape ? 'vercel' : normalizedProvider;
+  if (normalizedProvider !== AI_SDK_VERCEL_GATEWAY_PROVIDER_ID) {
+    return normalizedProvider;
+  }
+
+  if (!hasCreatorModelIdShape(model)) {
+    return normalizedProvider;
+  }
+
+  return VERCEL_PRICING_PROVIDER_ID;
+}
+
+function hasCreatorModelIdShape(model: string): boolean {
+  const segments = model.split('/');
+  return segments.length === 2 && segments.every(segment => segment.trim().length > 0);
 }
 
 /**

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -74,10 +74,11 @@ export class PricingRegistry {
   }
 
   get(args: { provider: string; model: string }): PricingModel | null {
+    const provider = resolvePricingProvider(args.provider, args.model);
     // Try all model name variants in order of preference
-    const variants = getModelVariants(args.model, normalizeProvider(args.provider));
+    const variants = getModelVariants(args.model, provider);
     for (const variant of variants) {
-      const key = makePricingKey({ provider: args.provider, model: variant });
+      const key = makePricingKey({ provider, model: variant });
       const match = this.pricingModels.get(key);
       if (match) return match;
     }
@@ -188,6 +189,16 @@ function normalizeProvider(provider: string): string {
   const normalized = provider.trim().toLowerCase();
   const dotIndex = normalized.indexOf('.');
   return dotIndex !== -1 ? normalized.substring(0, dotIndex) : normalized;
+}
+
+function resolvePricingProvider(provider: string, model: string): string {
+  const normalizedProvider = normalizeProvider(provider);
+  const modelSegments = model.split('/');
+  const hasCreatorModelShape = modelSegments.length === 2 && modelSegments.every(segment => segment.trim().length > 0);
+
+  // AI SDK calls the Vercel AI Gateway provider "gateway", while the pricing
+  // snapshot stores its model-level prices under "vercel".
+  return normalizedProvider === 'gateway' && hasCreatorModelShape ? 'vercel' : normalizedProvider;
 }
 
 /**

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -10,6 +10,11 @@ const BEDROCK_GEOGRAPHY_PREFIXES = new Set(['global', 'us', 'eu', 'apac', 'jp', 
 const AI_SDK_VERCEL_GATEWAY_PROVIDER_ID = 'gateway';
 // Canonical provider ID used by the embedded pricing snapshot for those models.
 const VERCEL_PRICING_PROVIDER_ID = 'vercel';
+const AI_SDK_PROVIDER_NAMESPACE_ALIASES = new Map([
+  ['google.vertex', 'google-vertex'],
+  ['vertex.anthropic', 'google-vertex-anthropic'],
+  ['vertex.maas', 'google-vertex'],
+]);
 
 type MinifiedMeterKey = 'it' | 'ot' | 'icrt' | 'icwt' | 'iat' | 'oat' | 'ort';
 type MinifiedConditionFieldKey = 'tit';
@@ -78,13 +83,14 @@ export class PricingRegistry {
   }
 
   get(args: { provider: string; model: string }): PricingModel | null {
-    const provider = resolvePricingProvider(args.provider, args.model);
-    // Try all model name variants in order of preference
-    const variants = getModelVariants(args.model, provider);
-    for (const variant of variants) {
-      const key = makePricingKey({ provider, model: variant });
-      const match = this.pricingModels.get(key);
-      if (match) return match;
+    for (const provider of getPricingProviderCandidates(args.provider, args.model)) {
+      // Try all model name variants in order of preference
+      const variants = getModelVariants(args.model, provider);
+      for (const variant of variants) {
+        const key = makePricingKey({ provider, model: variant });
+        const match = this.pricingModels.get(key);
+        if (match) return match;
+      }
     }
     return null;
   }
@@ -177,7 +183,7 @@ function getPackageRoot(): string {
 }
 
 function makePricingKey(args: { provider: string; model: string }): string {
-  return `${normalizeProvider(args.provider)}::${normalizeKeyPart(args.model)}`;
+  return `${normalizeKeyPart(args.provider)}::${normalizeKeyPart(args.model)}`;
 }
 
 function normalizeKeyPart(value: string): string {
@@ -185,28 +191,37 @@ function normalizeKeyPart(value: string): string {
 }
 
 /**
- * Normalize a provider string by stripping AI SDK capability suffixes
- * (e.g. "openai.chat" → "openai", "anthropic.messages" → "anthropic").
- * The pricing data uses bare provider names without these suffixes.
+ * Return provider keys in lookup order: the exact runtime value, a known
+ * namespace alias, or the ordinary AI SDK base-provider fallback.
  */
-function normalizeProvider(provider: string): string {
-  const normalized = provider.trim().toLowerCase();
-  const dotIndex = normalized.indexOf('.');
-  return dotIndex !== -1 ? normalized.substring(0, dotIndex) : normalized;
-}
+function getPricingProviderCandidates(provider: string, model: string): string[] {
+  const normalizedProvider = normalizeKeyPart(provider);
+  const candidates = new Set([normalizedProvider]);
 
-function resolvePricingProvider(provider: string, model: string): string {
-  const normalizedProvider = normalizeProvider(provider);
-
-  if (normalizedProvider !== AI_SDK_VERCEL_GATEWAY_PROVIDER_ID) {
-    return normalizedProvider;
+  for (const [providerNamespace, pricingProvider] of AI_SDK_PROVIDER_NAMESPACE_ALIASES) {
+    if (normalizedProvider === providerNamespace || normalizedProvider.startsWith(`${providerNamespace}.`)) {
+      candidates.add(providerNamespace);
+      candidates.add(pricingProvider);
+      // Known multi-segment namespaces must not fall through to their first
+      // segment (for example, Vertex pricing must not fall back to Google).
+      return [...candidates];
+    }
   }
 
-  if (!hasCreatorModelIdShape(model)) {
-    return normalizedProvider;
+  // Most AI SDK providers append a capability suffix, such as "openai.chat" or
+  // "anthropic.messages", while the pricing data uses the base provider name.
+  const capabilitySeparator = normalizedProvider.indexOf('.');
+  const baseProvider =
+    capabilitySeparator === -1 ? normalizedProvider : normalizedProvider.substring(0, capabilitySeparator);
+  candidates.add(baseProvider);
+
+  // @ai-sdk/gateway uses "gateway" for Vercel AI Gateway. Preserve exact
+  // gateway pricing entries, then fall back to the snapshot's "vercel" rows.
+  if (baseProvider === AI_SDK_VERCEL_GATEWAY_PROVIDER_ID && hasCreatorModelIdShape(model)) {
+    candidates.add(VERCEL_PRICING_PROVIDER_ID);
   }
 
-  return VERCEL_PRICING_PROVIDER_ID;
+  return [...candidates];
 }
 
 function hasCreatorModelIdShape(model: string): boolean {
@@ -279,11 +294,16 @@ function getModelVariants(model: string, provider: string): string[] {
  * Handles multiple date formats used by different providers:
  * - OpenAI: YYYY-MM-DD at end (e.g., "gpt-5-4-mini-2026-03-17" → "gpt-5-4-mini")
  * - Anthropic: YYYYMMDD with optional suffix (e.g., "claude-sonnet-4-5-20250929-thinking" → "claude-sonnet-4-5-thinking")
+ * - Vertex Anthropic: @YYYYMMDD at end (e.g., "claude-sonnet-4-5@20250929" → "claude-sonnet-4-5")
  * - Cohere/Gemini: MM-YYYY at end (e.g., "command-r-08-2024" → "command-r")
  */
 function stripDateSuffix(model: string): string {
+  // Vertex Anthropic format: @YYYYMMDD at end
+  let stripped = model.replace(/@20\d{6}$/, '');
+  if (stripped !== model) return stripped;
+
   // OpenAI format: -YYYY-MM-DD at end
-  let stripped = model.replace(/-20\d{2}-\d{2}-\d{2}$/, '');
+  stripped = model.replace(/-20\d{2}-\d{2}-\d{2}$/, '');
   if (stripped !== model) return stripped;
 
   // Anthropic format: -YYYYMMDD, possibly followed by suffix like -thinking

--- a/observability/mastra/src/metrics/pricing-registry.ts
+++ b/observability/mastra/src/metrics/pricing-registry.ts
@@ -6,9 +6,7 @@ import type { PricingMeter, PricingConditionOperator, PricingConditionField } fr
 
 const DATA_FILE_NAME = 'pricing-data.jsonl';
 const BEDROCK_GEOGRAPHY_PREFIXES = new Set(['global', 'us', 'eu', 'apac', 'jp', 'au']);
-// Provider ID emitted by @ai-sdk/gateway for Vercel AI Gateway models.
 const AI_SDK_VERCEL_GATEWAY_PROVIDER_ID = 'gateway';
-// Canonical provider ID used by the embedded pricing snapshot for those models.
 const VERCEL_PRICING_PROVIDER_ID = 'vercel';
 const AI_SDK_PROVIDER_NAMESPACE_ALIASES = new Map([
   ['google.vertex', 'google-vertex'],
@@ -84,7 +82,6 @@ export class PricingRegistry {
 
   get(args: { provider: string; model: string }): PricingModel | null {
     for (const provider of getPricingProviderCandidates(args.provider, args.model)) {
-      // Try all model name variants in order of preference
       const variants = getModelVariants(args.model, provider);
       for (const variant of variants) {
         const key = makePricingKey({ provider, model: variant });
@@ -190,38 +187,40 @@ function normalizeKeyPart(value: string): string {
   return value.trim().toLowerCase();
 }
 
-/**
- * Return provider keys in lookup order: the exact runtime value, a known
- * namespace alias, or the ordinary AI SDK base-provider fallback.
- */
 function getPricingProviderCandidates(provider: string, model: string): string[] {
   const normalizedProvider = normalizeKeyPart(provider);
-  const candidates = new Set([normalizedProvider]);
+  const providerCandidates =
+    getNamespacedProviderCandidates(normalizedProvider) ?? getBaseProviderCandidates(normalizedProvider, model);
 
+  return [...new Set([normalizedProvider, ...providerCandidates])];
+}
+
+function getNamespacedProviderCandidates(provider: string): string[] | null {
   for (const [providerNamespace, pricingProvider] of AI_SDK_PROVIDER_NAMESPACE_ALIASES) {
-    if (normalizedProvider === providerNamespace || normalizedProvider.startsWith(`${providerNamespace}.`)) {
-      candidates.add(providerNamespace);
-      candidates.add(pricingProvider);
-      // Known multi-segment namespaces must not fall through to their first
-      // segment (for example, Vertex pricing must not fall back to Google).
-      return [...candidates];
+    if (matchesProviderNamespace(provider, providerNamespace)) {
+      return [providerNamespace, pricingProvider];
     }
   }
 
-  // Most AI SDK providers append a capability suffix, such as "openai.chat" or
-  // "anthropic.messages", while the pricing data uses the base provider name.
-  const capabilitySeparator = normalizedProvider.indexOf('.');
-  const baseProvider =
-    capabilitySeparator === -1 ? normalizedProvider : normalizedProvider.substring(0, capabilitySeparator);
-  candidates.add(baseProvider);
+  return null;
+}
 
-  // @ai-sdk/gateway uses "gateway" for Vercel AI Gateway. Preserve exact
-  // gateway pricing entries, then fall back to the snapshot's "vercel" rows.
-  if (baseProvider === AI_SDK_VERCEL_GATEWAY_PROVIDER_ID && hasCreatorModelIdShape(model)) {
-    candidates.add(VERCEL_PRICING_PROVIDER_ID);
-  }
+function matchesProviderNamespace(provider: string, providerNamespace: string): boolean {
+  return provider === providerNamespace || provider.startsWith(`${providerNamespace}.`);
+}
 
-  return [...candidates];
+function getBaseProviderCandidates(provider: string, model: string): string[] {
+  const baseProvider = getBaseProvider(provider);
+  return isVercelGatewayModel(baseProvider, model) ? [baseProvider, VERCEL_PRICING_PROVIDER_ID] : [baseProvider];
+}
+
+function getBaseProvider(provider: string): string {
+  const capabilitySeparator = provider.indexOf('.');
+  return capabilitySeparator === -1 ? provider : provider.substring(0, capabilitySeparator);
+}
+
+function isVercelGatewayModel(provider: string, model: string): boolean {
+  return provider === AI_SDK_VERCEL_GATEWAY_PROVIDER_ID && hasCreatorModelIdShape(model);
 }
 
 function hasCreatorModelIdShape(model: string): boolean {


### PR DESCRIPTION
Fixes #19461.

AI SDK provider IDs do not always match the provider keys in the embedded pricing snapshot. Vercel AI Gateway reports `gateway` while the snapshot uses `vercel`. Google Vertex reports `google.vertex.*`, `vertex.anthropic.*`, and `vertex.maas.*`, while the snapshot uses Google Vertex provider names.

The pricing registry now tries exact provider entries first, then verified namespace aliases, then ordinary capability-suffix fallbacks. This preserves exact Gateway pricing and prevents Vertex requests from falling through to direct Google prices.

### Reproduction

Constructing `gateway("anthropic/claude-haiku-4.5")` with the installed AI SDK returns `provider: "gateway"` and `modelId: "anthropic/claude-haiku-4.5"`.

Before this change, that input produced `costMetadata.error: "no_matching_model"` and no estimated cost:

```text
provider: gateway
model: anthropic/claude-haiku-4.5
usage: 1,000 input tokens
```

The lookup stayed under `gateway`, but the embedded snapshot has zero `gateway` rows and stores the supported catalog under `vercel`.

With this change, the same input resolves to:

```text
provider: vercel
model: claude-haiku-4-5
pricing_id: vercel-claude-haiku-4-5
estimatedCost: 0.001 USD
```

A second regression case covers `gateway` + `amazon/nova-micro`, which now resolves to `vercel-amazon-nova-micro` and estimates `0.000035 USD` for 1,000 input tokens. The auto-extracted metrics test verifies that the corrected cost context reaches the emitted metric, not only the registry lookup.

The same audit reproduced a pre-existing Vertex error: `google.vertex.chat` was reduced to direct `google`, pricing 1,000 Gemini 2.0 Flash input tokens at `0.0001 USD`. It now selects `google-vertex` pricing at `0.00015 USD`.

Regression coverage also verifies malformed Gateway IDs remain unmatched and an exact `gateway` pricing row wins before the Vercel fallback. Costs remain snapshot-based estimates.

Validated with:

- `pnpm --filter @mastra/observability test` — 961 passed, 2 skipped
- `pnpm --filter @mastra/observability lint`
- `pnpm --filter @mastra/observability build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some models use different names depending on where they run, so their usage costs were sometimes missing or incorrect. This update teaches observability how to match those names safely, especially for Vercel AI Gateway and Google Vertex models.

## What changed

- Added provider alias and namespace resolution for:
  - Vercel AI Gateway (`gateway` → `vercel`)
  - Google Vertex models
  - Other supported AI SDK provider variants
- Prioritized exact provider pricing before aliases and capability-suffix fallbacks.
- Prevented malformed Gateway IDs and Vertex models from matching incorrect pricing entries.
- Added Vertex Anthropic date-suffix normalization.
- Expanded pricing fixtures and regression coverage for pricing lookups and emitted cost metrics.
- Added a patch changeset for `@mastra/observability`.

## Validation

- Observability tests: 961 passed, 2 skipped
- Lint passed
- Build passed

<!-- end of auto-generated comment: release notes by coderabbit.ai -->