### PR TITLE
fix(deployer): avoid ENOTDIR during dependency optimization

### DIFF
--- a/.changeset/petite-memes-rescue.md
+++ b/.changeset/petite-memes-rescue.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed "Error: ENOTDIR: not a directory, open '...chunk-XYZ.js/package.json'" errors being printed during `mastra build` when using custom bundler options without `externals: true`. Package resolution no longer treats module files as directories when looking up dependency metadata, so builds run without these confusing (but harmless) errors in the output.

--- a/packages/cli/src/commands/build/BuildBundler.test.ts
+++ b/packages/cli/src/commands/build/BuildBundler.test.ts
@@ -73,6 +73,58 @@ describe('BuildBundler', () => {
     });
   });
 
+  describe('bundler options', () => {
+    it('defaults to externals true when no bundler config is provided', async () => {
+      const { Bundler, IS_DEFAULT } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals: [],
+        sourcemap: false,
+        transpilePackages: [],
+        [IS_DEFAULT]: true,
+      });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+
+      const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(options).toMatchObject({
+        externals: true,
+        sourcemap: false,
+      });
+    });
+
+    it('optimizes dependencies when a bundler config omits externals', async () => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({ sourcemap: true });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+
+      const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(options).toEqual({
+        sourcemap: true,
+      });
+      expect(options.externals).toBeUndefined();
+    });
+
+    it('preserves explicit externals true in a custom bundler config', async () => {
+      const { Bundler } = await import('@mastra/deployer/bundler');
+      vi.spyOn(Bundler.prototype as any, 'getUserBundlerOptions').mockResolvedValueOnce({
+        externals: true,
+        sourcemap: true,
+      });
+      const { BuildBundler } = await import('./BuildBundler');
+      const bundler = new BuildBundler();
+
+      const options = await (bundler as any).getUserBundlerOptions('/entry.ts', '/output');
+
+      expect(options).toEqual({
+        externals: true,
+        sourcemap: true,
+      });
+    });
+  });
+
   describe('getEntry', () => {
     it('should include studio: true when studio is enabled', async () => {
       const { BuildBundler } = await import('./BuildBundler');

--- a/packages/deployer/src/build/package-info.test.ts
+++ b/packages/deployer/src/build/package-info.test.ts
@@ -1,12 +1,47 @@
 import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { getPackageMetadata } from './package-info';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { getPackageMetadata, getPackageRootPath } from './package-info';
 
 const tempDirs: string[] = [];
 
 afterEach(async () => {
   await Promise.all(tempDirs.splice(0).map(dir => rm(dir, { recursive: true, force: true })));
+  vi.restoreAllMocks();
+});
+
+async function createTempPackage() {
+  const tempRoot = join(process.cwd(), '.tmp');
+  await mkdir(tempRoot, { recursive: true });
+  const tempDir = await mkdtemp(join(tempRoot, 'package-root-'));
+  tempDirs.push(tempDir);
+
+  const packageDir = join(tempDir, 'node_modules', '@mastra', 'core');
+  await mkdir(join(packageDir, 'dist'), { recursive: true });
+  await writeFile(join(packageDir, 'package.json'), JSON.stringify({ name: '@mastra/core', version: '1.0.0' }));
+  const chunkFile = join(packageDir, 'dist', 'chunk-ABC.js');
+  await writeFile(chunkFile, 'export {};');
+
+  return { tempDir, packageDir, chunkFile };
+}
+
+describe('getPackageRootPath', () => {
+  it('resolves a package when parentPath points to a file instead of a directory', async () => {
+    const { packageDir, chunkFile } = await createTempPackage();
+
+    await expect(getPackageRootPath('@mastra/core', chunkFile)).resolves.toBe(packageDir);
+  });
+
+  it('does not log ENOTDIR errors for unresolvable packages when parentPath is a file', async () => {
+    const { chunkFile } = await createTempPackage();
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // local-pkg logs non-MODULE_NOT_FOUND resolution errors (like ENOTDIR) to the console.
+    // Passing a module file path as the resolution base must not trigger that.
+    await expect(getPackageRootPath('mastra-nonexistent-package', chunkFile)).resolves.toBeNull();
+
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
 });
 
 describe('getPackageMetadata', () => {

--- a/packages/deployer/src/build/package-info.ts
+++ b/packages/deployer/src/build/package-info.ts
@@ -3,10 +3,36 @@
  * It is in a separate file to avoid including local-pkg in runtime code.
  */
 
-import { pathToFileURL } from 'node:url';
+import { statSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { readJSON } from 'fs-extra/esm';
 import { getPackageInfo } from 'local-pkg';
 import { getPackageName } from './utils';
+
+/**
+ * Normalize a resolution base path to a directory file URL.
+ *
+ * Callers often pass a module file path (e.g. a rollup module id like
+ * `node_modules/@mastra/core/dist/chunk-XYZ.js`) as the parent path. mlly (used by local-pkg)
+ * also treats each resolution base as a directory candidate (`<base>/_index.js`), which makes it
+ * try to read `<file>/package.json`. That fails with ENOTDIR, which mlly does not tolerate
+ * (only ENOENT) and local-pkg then logs the raw error to the console. Using the file's directory
+ * as the base avoids this while resolving identically.
+ */
+function toParentDirectoryUrl(parentPath: string): string {
+  let fsPath = parentPath.startsWith('file://') ? fileURLToPath(parentPath) : parentPath;
+
+  try {
+    if (statSync(fsPath).isFile()) {
+      fsPath = dirname(fsPath);
+    }
+  } catch {
+    // non-existent paths are used as-is
+  }
+
+  return pathToFileURL(fsPath).href;
+}
 
 /**
  * Get package root path
@@ -17,12 +43,8 @@ export async function getPackageRootPath(packageName: string, parentPath?: strin
   try {
     let options: { paths?: string[] } | undefined = undefined;
     if (parentPath) {
-      if (!parentPath.startsWith('file://')) {
-        parentPath = pathToFileURL(parentPath).href;
-      }
-
       options = {
-        paths: [parentPath],
+        paths: [toParentDirectoryUrl(parentPath)],
       };
     }
 


### PR DESCRIPTION
`mastra build` could print harmless ENOTDIR errors while optimizing dependencies when custom bundler options were provided without `externals: true`.

Before:

```ts
bundler: {
  sourcemap: true,
}
// Error: ENOTDIR ... chunk-XYZ.js/package.json
```

After, package metadata resolution uses the importing module's parent directory, so the same configuration builds without the error output. Explicit `externals: true` behavior is unchanged.

Covered by deployer regression tests and CLI tests for default, omitted, and explicit `externals` configurations. Deployer build tests and both package typechecks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`mastra build` no longer gets confused when looking for package information from a bundled file instead of a folder. Custom bundler settings now work without harmless `ENOTDIR` errors, while explicit `externals: true` behavior stays the same.

## Changes

- Normalize module file paths to their parent directories before resolving package metadata.
- Preserve default, omitted, and explicit `externals` configurations.
- Add deployer and CLI regression tests.
- Update the `@mastra/deployer` changeset for a patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->