### PR TITLE
feat: announce GitHub releases on Discord

### DIFF
--- a/.github/scripts/discord-release.mjs
+++ b/.github/scripts/discord-release.mjs
@@ -1,0 +1,145 @@
+import { appendFile } from 'node:fs/promises';
+import { pathToFileURL } from 'node:url';
+
+const DISCORD_LIMITS = {
+  description: 4096,
+  title: 256,
+};
+const MASTRA_GREEN = 0x72ff70;
+
+function truncate(value, limit, suffix = '…') {
+  const characters = Array.from(value);
+  if (characters.length <= limit) return value;
+
+  return `${characters.slice(0, limit - Array.from(suffix).length).join('')}${suffix}`;
+}
+
+function releaseUrl(value, repository, tag) {
+  try {
+    const url = new URL(value);
+    if ((url.protocol === 'https:' || url.protocol === 'http:') && url.href.length <= 2048) {
+      return url.href;
+    }
+  } catch {
+    // Use the GitHub release URL fallback below.
+  }
+
+  return `https://github.com/${repository}/releases/tag/${encodeURIComponent(tag)}`;
+}
+
+export function createPayload({ name, tag, url, notes, repository, timestamp, isTest }) {
+  const releaseName = name.trim();
+  const displayName = releaseName && releaseName !== tag ? `${tag} — ${releaseName}` : tag;
+  const normalizedUrl = releaseUrl(url, repository, tag);
+  const fullNotesLink = `\n\n[Read the full release notes](${normalizedUrl})`;
+  const defaultNotes = `Release notes are available on [GitHub](${normalizedUrl}).`;
+  const description = notes.trim() ? truncate(notes.trim(), DISCORD_LIMITS.description, fullNotesLink) : defaultNotes;
+
+  return {
+    username: 'Mastra Releases',
+    allowed_mentions: { parse: [] },
+    embeds: [
+      {
+        title: truncate(
+          `${isTest ? 'Test release announcement: ' : 'New release: '}${displayName}`,
+          DISCORD_LIMITS.title,
+        ),
+        url: normalizedUrl,
+        description,
+        color: MASTRA_GREEN,
+        timestamp,
+        footer: {
+          text: `${repository}${isTest ? ' • Test notification' : ''}`,
+        },
+      },
+    ],
+  };
+}
+
+export async function sendPayload(
+  webhookUrl,
+  payload,
+  { fetchImpl = fetch, sleep = delay => new Promise(resolve => setTimeout(resolve, delay)), maxAttempts = 3 } = {},
+) {
+  if (!webhookUrl) {
+    throw new Error('DISCORD_RELEASE_WEBHOOK_URL is required when delivering a notification.');
+  }
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    let response;
+    try {
+      response = await fetchImpl(webhookUrl, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+    } catch (error) {
+      if (attempt === maxAttempts) throw error;
+
+      const delay = 500 * 2 ** (attempt - 1);
+      console.warn(`Discord request failed; retrying in ${delay}ms (${attempt}/${maxAttempts}).`);
+      await sleep(delay);
+      continue;
+    }
+
+    if (response.ok) return;
+
+    const responseBody = await response.text();
+    const retryable = response.status === 429 || response.status >= 500;
+    if (!retryable || attempt === maxAttempts) {
+      throw new Error(`Discord webhook returned ${response.status}: ${responseBody}`);
+    }
+
+    let delay = 500 * 2 ** (attempt - 1);
+    if (response.status === 429) {
+      const retryAfterHeader = Number(response.headers.get('retry-after'));
+      try {
+        const retryAfterBody = Number(JSON.parse(responseBody).retry_after);
+        delay = Math.ceil((retryAfterBody || retryAfterHeader || delay / 1000) * 1000);
+      } catch {
+        delay = Math.ceil((retryAfterHeader || delay / 1000) * 1000);
+      }
+    }
+
+    console.warn(`Discord returned ${response.status}; retrying in ${delay}ms (${attempt}/${maxAttempts}).`);
+    await sleep(delay);
+  }
+}
+
+async function main() {
+  const repository = process.env.RELEASE_REPOSITORY || 'mastra-ai/mastra';
+  const tag = process.env.RELEASE_TAG || 'v0.0.0-test';
+  const isTest = process.env.RELEASE_IS_TEST === 'true';
+  const payload = createPayload({
+    name: process.env.RELEASE_NAME || '',
+    tag,
+    url: process.env.RELEASE_URL || '',
+    notes: process.env.RELEASE_NOTES || '',
+    repository,
+    timestamp: process.env.RELEASE_TIMESTAMP || new Date().toISOString(),
+    isTest,
+  });
+
+  if (process.env.RELEASE_PREVIEW === 'true') {
+    const preview = JSON.stringify(payload, null, 2);
+    console.log(preview);
+
+    if (process.env.GITHUB_STEP_SUMMARY) {
+      await appendFile(
+        process.env.GITHUB_STEP_SUMMARY,
+        `## Discord payload preview\n\n\`\`\`json\n${preview}\n\`\`\`\n`,
+      );
+    }
+    return;
+  }
+
+  await sendPayload(process.env.DISCORD_RELEASE_WEBHOOK_URL, payload);
+  console.log(`Sent ${isTest ? 'test ' : ''}release announcement for ${tag}.`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(error => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}

--- a/.github/scripts/discord-release.test.mjs
+++ b/.github/scripts/discord-release.test.mjs
@@ -1,0 +1,115 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import test from 'node:test';
+
+import { createPayload, sendPayload } from './discord-release.mjs';
+
+const release = {
+  name: 'Mastra 1.0',
+  tag: 'v1.0.0',
+  url: 'https://github.com/mastra-ai/mastra/releases/tag/v1.0.0',
+  notes: '## What changed\n\n- Added a feature',
+  repository: 'mastra-ai/mastra',
+  timestamp: '2026-07-15T12:00:00Z',
+  isTest: false,
+};
+
+test('creates a linked release embed and disables mentions', () => {
+  const payload = createPayload(release);
+
+  assert.equal(payload.username, 'Mastra Releases');
+  assert.deepEqual(payload.allowed_mentions, { parse: [] });
+  assert.deepEqual(payload.embeds, [
+    {
+      title: 'New release: v1.0.0 — Mastra 1.0',
+      url: release.url,
+      description: release.notes,
+      color: 7536496,
+      timestamp: release.timestamp,
+      footer: { text: release.repository },
+    },
+  ]);
+});
+
+test('clearly labels manual test notifications', () => {
+  const payload = createPayload({ ...release, isTest: true });
+
+  assert.equal(payload.embeds[0].title, 'Test release announcement: v1.0.0 — Mastra 1.0');
+  assert.equal(payload.embeds[0].color, 7536496);
+  assert.equal(payload.embeds[0].footer.text, 'mastra-ai/mastra • Test notification');
+});
+
+test('uses safe fallbacks and truncates long release notes', () => {
+  const payload = createPayload({
+    ...release,
+    name: '',
+    url: 'not-a-url',
+    notes: 'a'.repeat(5000),
+  });
+  const embed = payload.embeds[0];
+
+  assert.equal(embed.title, 'New release: v1.0.0');
+  assert.equal(embed.url, release.url);
+  assert.equal(Array.from(embed.description).length, 4096);
+  assert.match(embed.description, /\[Read the full release notes\]\(.+\)$/);
+});
+
+test('posts the JSON payload to a webhook', async t => {
+  let receivedPayload;
+  const server = createServer((request, response) => {
+    let body = '';
+    request.setEncoding('utf8');
+    request.on('data', chunk => {
+      body += chunk;
+    });
+    request.on('end', () => {
+      receivedPayload = JSON.parse(body);
+      response.writeHead(204).end();
+    });
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+  t.after(() => server.close());
+
+  const payload = createPayload(release);
+  const address = server.address();
+  await sendPayload(`http://127.0.0.1:${address.port}`, payload);
+
+  assert.deepEqual(receivedPayload, payload);
+});
+
+test('retries server errors before succeeding', async () => {
+  let attempts = 0;
+  const delays = [];
+  const fetchImpl = async () => {
+    attempts++;
+    return attempts === 1 ? new Response('temporary failure', { status: 503 }) : new Response(null, { status: 204 });
+  };
+
+  await sendPayload('https://discord.test/webhook', createPayload(release), {
+    fetchImpl,
+    sleep: async delay => delays.push(delay),
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(delays, [500]);
+});
+
+test('honors Discord rate-limit retry timing', async () => {
+  let attempts = 0;
+  const delays = [];
+  const fetchImpl = async () => {
+    attempts++;
+    return attempts === 1
+      ? new Response(JSON.stringify({ retry_after: 0.25 }), { status: 429 })
+      : new Response(null, { status: 204 });
+  };
+
+  await sendPayload('https://discord.test/webhook', createPayload(release), {
+    fetchImpl,
+    sleep: async delay => delays.push(delay),
+  });
+
+  assert.equal(attempts, 2);
+  assert.deepEqual(delays, [250]);
+});

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -1,0 +1,75 @@
+name: Announce GitHub Release on Discord
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      release_name:
+        description: 'Release name shown in the test notification'
+        required: true
+        type: string
+        default: 'Mastra test release'
+      release_tag:
+        description: 'Release tag shown in the test notification'
+        required: true
+        type: string
+        default: 'v0.0.0-test'
+      release_url:
+        description: 'Optional URL opened from the notification title'
+        required: false
+        type: string
+      release_notes:
+        description: 'Release notes shown in the test notification'
+        required: true
+        type: string
+        default: |-
+          ## Test release
+
+          This is a preview of a Mastra release announcement.
+      deliver:
+        description: 'Send this test notification to Discord instead of only previewing its payload'
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout notification script
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/discord-release.mjs
+          sparse-checkout-cone-mode: false
+
+      - name: Preview test notification
+        if: ${{ github.event_name == 'workflow_dispatch' && !inputs.deliver }}
+        env:
+          RELEASE_NAME: ${{ inputs.release_name }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          RELEASE_URL: ${{ inputs.release_url }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_IS_TEST: 'true'
+          RELEASE_PREVIEW: 'true'
+        run: node .github/scripts/discord-release.mjs
+
+      - name: Send release notification
+        if: ${{ github.event_name == 'release' || inputs.deliver }}
+        env:
+          DISCORD_RELEASE_WEBHOOK_URL: ${{ secrets.DISCORD_RELEASE_WEBHOOK_URL }}
+          RELEASE_NAME: ${{ github.event.release.name || inputs.release_name }}
+          RELEASE_TAG: ${{ github.event.release.tag_name || inputs.release_tag }}
+          RELEASE_URL: ${{ github.event.release.html_url || inputs.release_url }}
+          RELEASE_NOTES: ${{ github.event.release.body || inputs.release_notes }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TIMESTAMP: ${{ github.event.release.published_at }}
+          RELEASE_IS_TEST: ${{ github.event_name == 'workflow_dispatch' }}
+        run: node .github/scripts/discord-release.mjs

--- a/.github/workflows/discord-release.yml
+++ b/.github/workflows/discord-release.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   announce:
-    if: ${{ github.repository == 'mastra-ai/mastra' }}
+    if: ${{ github.repository == 'mastra-ai/mastra' && (github.event_name == 'workflow_dispatch' || !github.event.release.prerelease) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout notification script


### PR DESCRIPTION
This adds an in-house workflow that posts published GitHub releases to Discord using Mastra-branded embeds. It includes manual preview and test delivery options, release-note truncation with a link to the full release, disabled mentions, and retries for rate limits and temporary failures.

A notification title looks like `New release: @mastra/core@1.51.0 — July 15, 2026`. The webhook URL is read from the `DISCORD_RELEASE_WEBHOOK_URL` Actions secret.

<img width="714" height="645" alt="image" src="https://github.com/user-attachments/assets/9ffdc8c7-1175-4658-a3ee-7739b92d0d64" />

The payload builder and webhook delivery are covered by Node tests, including server-error and rate-limit retries.

`DISCORD_RELEASE_WEBHOOK_URL` has already been setup in the secrets ;)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a new stable Mastra release is published, this workflow automatically posts a branded announcement to Discord. It also supports previews, retries temporary failures, and keeps long release notes manageable.

## What changed

- Added a GitHub Actions workflow for:
  - Automatic notifications on stable `release.published` events
  - Manual preview and delivery runs
  - Prerelease filtering
  - Secure webhook access via `DISCORD_RELEASE_WEBHOOK_URL`
- Added Discord payload generation with:
  - Mastra-branded embeds
  - Release name, version, date, URL, and notes
  - Test-release labeling
  - Mention suppression
  - Safe URL fallbacks and release-note truncation
- Added webhook delivery with retries for network errors, rate limits, and server failures.
- Added Node.js tests covering payload construction, truncation, successful delivery, retries, and `retry_after` handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->