### PR TITLE
refactor(core): use Web Crypto randomUUID instead of node:crypto

### DIFF
--- a/.changeset/floppy-spiders-make.md
+++ b/.changeset/floppy-spiders-make.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+UUID generation now uses the Web Crypto global (crypto.randomUUID) instead of importing randomUUID from node:crypto. No behavior change on Node.js; removes an unnecessary Node-only module dependency so @mastra/core bundles more cleanly for edge and V8-isolate runtimes such as the Convex default runtime and Cloudflare Workers.

--- a/packages/core/src/a2a/a2a-agent.ts
+++ b/packages/core/src/a2a/a2a-agent.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { AgentCard, Message, Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent } from '@a2a-js/sdk';
 import type { AgentExecutionOptionsBase } from '../agent/agent.types';
 import { MessageList } from '../agent/message-list';
@@ -473,7 +472,7 @@ export class A2AAgent implements SubAgent {
     this.#abortSignal = options.abortSignal;
     this.#timeoutMs = options.timeoutMs;
     this.#verifyAgentCard = options.verifyAgentCard;
-    this.id = options.id ?? `a2a-${randomUUID()}`;
+    this.id = options.id ?? `a2a-${crypto.randomUUID()}`;
     this.name = options.name ?? options.description ?? 'A2A Agent';
   }
 
@@ -522,7 +521,7 @@ export class A2AAgent implements SubAgent {
     options?: AgentExecutionOptionsBase<unknown>,
   ): Promise<A2AAgentGenerateResult> {
     const bootstrap = await this.#getBootstrap();
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = messagesToPrompt(messages, options);
     const memoryInfo = resolveMemoryInfo(options);
 
@@ -589,7 +588,7 @@ export class A2AAgent implements SubAgent {
     options?: AgentExecutionOptionsBase<unknown>,
   ): Promise<A2AAgentStreamResult> {
     const bootstrap = await this.#getBootstrap();
-    const runId = options?.runId ?? randomUUID();
+    const runId = options?.runId ?? crypto.randomUUID();
     const prompt = messagesToPrompt(messages, options);
     const memoryInfo = resolveMemoryInfo(options);
 
@@ -711,13 +710,13 @@ export class A2AAgent implements SubAgent {
       signal,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'message/send',
         params: {
           message: {
             role: 'user',
             kind: 'message',
-            messageId: randomUUID(),
+            messageId: crypto.randomUUID(),
             parts: [{ kind: 'text', text: prompt }],
             ...(contextId ? { contextId } : {}),
             ...(referenceTaskIds?.length ? { referenceTaskIds } : {}),
@@ -792,7 +791,7 @@ export class A2AAgent implements SubAgent {
       signal,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'tasks/get',
         params: { id: taskId },
       } satisfies JSONRPCRequestBody,
@@ -945,13 +944,13 @@ export class A2AAgent implements SubAgent {
       stream: true,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'message/stream',
         params: {
           message: {
             role: 'user',
             kind: 'message',
-            messageId: randomUUID(),
+            messageId: crypto.randomUUID(),
             parts: [{ kind: 'text', text: prompt }],
             ...(contextId ? { contextId } : {}),
             ...(referenceTaskIds?.length ? { referenceTaskIds } : {}),
@@ -992,7 +991,7 @@ export class A2AAgent implements SubAgent {
       stream: true,
       body: {
         jsonrpc: '2.0',
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         method: 'tasks/resubscribe',
         params: { id: taskId },
       } satisfies JSONRPCRequestBody,

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { Agent } from '../agent';
 import { resolveFilePartMediaTypeAndData } from '../agent/message-list/prompt/image-utils';
 import type { MastraDBMessage } from '../agent/message-list/state/types';
@@ -1625,7 +1623,7 @@ export class AgentController<TState = {}> {
     if (!this.#resolveStorage()) return null;
     const memoryStorage = await this.getMemoryStorage();
     const dbMessage = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       role,
       threadId,
       resourceId,
@@ -2319,6 +2317,6 @@ export class AgentController<TState = {}> {
     if (this.config.idGenerator) {
       return this.config.idGenerator();
     }
-    return randomUUID();
+    return crypto.randomUUID();
   }
 }

--- a/packages/core/src/agent/__tests__/memory-readonly.test.ts
+++ b/packages/core/src/agent/__tests__/memory-readonly.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
@@ -54,7 +53,7 @@ describe('Memory readOnly option', () => {
    * no messages are saved to memory.
    */
   it('should NOT save messages when memory.options.readOnly is true in stream()', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-test';
 
     const mockMemory = new MockMemory();
@@ -99,7 +98,7 @@ describe('Memory readOnly option', () => {
    * Same test but for generate() method
    */
   it('should NOT save messages when memory.options.readOnly is true in generate()', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-test-generate';
 
     const mockMemory = new MockMemory();
@@ -142,7 +141,7 @@ describe('Memory readOnly option', () => {
    * Verify that without readOnly, messages ARE saved (control test)
    */
   it('should save messages when memory.options.readOnly is NOT set', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-save-test';
 
     const mockMemory = new MockMemory();
@@ -181,7 +180,7 @@ describe('Memory readOnly option', () => {
    * Verify that readOnly: true still allows reading from memory
    */
   it('should still read from memory when options.readOnly is true', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-read-test';
 
     const mockMemory = new MockMemory();
@@ -237,7 +236,7 @@ describe('Memory readOnly option', () => {
    * Verify that savePerStep also respects readOnly flag
    */
   it('should NOT save messages with savePerStep when memory.options.readOnly is true', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-readonly-savePerStep';
 
     const mockMemory = new MockMemory();

--- a/packages/core/src/agent/__tests__/memory-requestcontext-inheritance.test.ts
+++ b/packages/core/src/agent/__tests__/memory-requestcontext-inheritance.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { RequestContext } from '../../request-context';
@@ -51,7 +50,7 @@ describe('RequestContext memory isolation - Issue #11651', () => {
    * Expected: Child agent should be able to save messages (its readOnly: false should win)
    */
   it('should respect child agent readOnly:false when RequestContext has parent readOnly:true', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 
@@ -97,7 +96,7 @@ describe('RequestContext memory isolation - Issue #11651', () => {
    * Control test: Verify readOnly: true still works correctly
    */
   it('should NOT save messages when agent has readOnly:true regardless of parent context', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 
@@ -142,8 +141,8 @@ describe('RequestContext memory isolation - Issue #11651', () => {
    * Test that two agents can have different readOnly settings with the same RequestContext
    */
   it('should allow different readOnly settings for sequential agent calls with shared RequestContext', async () => {
-    const thread1Id = randomUUID();
-    const thread2Id = randomUUID();
+    const thread1Id = crypto.randomUUID();
+    const thread2Id = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 

--- a/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
+++ b/packages/core/src/agent/__tests__/prefill-error-recovery.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { APICallError } from '@internal/ai-sdk-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it, vi } from 'vitest';
@@ -101,8 +100,8 @@ describe('PrefillErrorHandler Recovery', () => {
   describe('generate()', () => {
     it('should recover from prefill error by appending a system reminder continue message and retrying', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const now = new Date();
 
       // Create a thread and pre-populate it with a conversation ending in an assistant message
@@ -110,7 +109,7 @@ describe('PrefillErrorHandler Recovery', () => {
       await mockMemory.saveMessages({
         messages: [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'user' as const,
             content: {
               format: 2 as const,
@@ -122,7 +121,7 @@ describe('PrefillErrorHandler Recovery', () => {
             type: 'text' as const,
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'assistant' as const,
             content: {
               format: 2 as const,
@@ -343,8 +342,8 @@ describe('PrefillErrorHandler Recovery', () => {
 
     it('should NOT retry for non-prefill API errors', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       await mockMemory.createThread({ threadId, resourceId });
 
@@ -393,15 +392,15 @@ describe('PrefillErrorHandler Recovery', () => {
   describe('stream()', () => {
     it('should recover from prefill error by appending a system reminder continue message and retrying', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const now = new Date();
 
       await mockMemory.createThread({ threadId, resourceId });
       await mockMemory.saveMessages({
         messages: [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'user' as const,
             content: {
               format: 2 as const,
@@ -413,7 +412,7 @@ describe('PrefillErrorHandler Recovery', () => {
             type: 'text' as const,
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'assistant' as const,
             content: {
               format: 2 as const,
@@ -463,15 +462,15 @@ describe('PrefillErrorHandler Recovery', () => {
 
     it('should only retry once even if the error persists', async () => {
       const mockMemory = new MockMemory();
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
       const now = new Date();
 
       await mockMemory.createThread({ threadId, resourceId });
       await mockMemory.saveMessages({
         messages: [
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'user' as const,
             content: {
               format: 2 as const,
@@ -483,7 +482,7 @@ describe('PrefillErrorHandler Recovery', () => {
             type: 'text' as const,
           },
           {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             role: 'assistant' as const,
             content: {
               format: 2 as const,

--- a/packages/core/src/agent/__tests__/reasoning-memory.test.ts
+++ b/packages/core/src/agent/__tests__/reasoning-memory.test.ts
@@ -14,7 +14,6 @@
  * @see https://github.com/mastra-ai/mastra/issues/11103
  */
 
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
 import { MockMemory } from '../../memory/mock';
 import { Agent } from '../agent';
@@ -273,7 +272,7 @@ describe('Reasoning + Memory Integration', () => {
    * part had an rs_ ID which OpenAI rejected (expecting msg_ for assistant messages).
    */
   it('should not leak reasoning providerMetadata into text parts', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
 
@@ -334,7 +333,7 @@ describe('Reasoning + Memory Integration', () => {
    * @see https://github.com/mastra-ai/mastra/issues/11481
    */
   it('should capture text-start providerMetadata for text parts (issue #11481)', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
     const textItemId = 'msg_test987654321'; // The itemId that OpenAI sends with text-start
@@ -391,7 +390,7 @@ describe('Reasoning + Memory Integration', () => {
    * @see https://github.com/mastra-ai/mastra/issues/11481
    */
   it('should handle follow-up messages with both reasoning and text itemIds (issue #11481)', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
     const textItemId = 'msg_test987654321';
@@ -468,7 +467,7 @@ describe('Reasoning + Memory Integration', () => {
    * The second call should not fail due to mismatched IDs.
    */
   it('should handle follow-up messages after reasoning response with memory', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
 
@@ -534,7 +533,7 @@ describe('Reasoning + Memory Integration', () => {
    * @see https://github.com/mastra-ai/mastra/issues/11481
    */
   it('should capture text providerMetadata when using generate() (issue #11481)', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_test123456789';
     const textItemId = 'msg_test987654321';
@@ -610,7 +609,7 @@ describe('Reasoning + Memory Integration', () => {
    * the text's providerMetadata doesn't leak into the subsequent part.
    */
   it('should clear text providerMetadata after text-end to prevent leaking', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const textItemId = 'msg_text123';
 
@@ -732,7 +731,7 @@ describe('Reasoning + Memory Integration', () => {
    * So neither reasoning nor text metadata leaks into subsequent parts.
    */
   it('should properly clean up providerMetadata through reasoning → text → tool call sequence', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-1234';
     const reasoningItemId = 'rs_reasoning123';
     const textItemId = 'msg_text123';
@@ -909,7 +908,7 @@ describe('Reasoning Data Spy: Response vs Request Comparison (Issue #12980)', ()
    * and OpenAI resolves them server-side. Reasoning and itemIds must be preserved.
    */
   it('should preserve OpenAI reasoning and providerMetadata through round-trip', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-spy-openai';
     const reasoningItemId = 'rs_spy_reasoning_123';
     const textItemId = 'msg_spy_text_456';

--- a/packages/core/src/agent/__tests__/stream-id.test.ts
+++ b/packages/core/src/agent/__tests__/stream-id.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { simulateReadableStream } from '@internal/ai-sdk-v4';
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
@@ -54,7 +53,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const streamResult = await agent.streamLegacy('Hello!', {
@@ -126,7 +125,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastraWithCustomId);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const stream = await agent.streamLegacy('Hello!', { threadId, resourceId });
@@ -183,7 +182,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const streamResult = await agent.stream('Hello!', {
@@ -265,7 +264,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastraWithCustomId);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const stream = await agent.stream('Hello!', { memory: { thread: threadId, resource: resourceId } });
@@ -324,7 +323,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
     const stream = await agent.stream('Hello!', { memory: { thread: threadId, resource: resourceId } });
 
@@ -396,7 +395,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const result = await agent.generate('Hello!', {
@@ -499,7 +498,7 @@ describe('Stream ID Consistency', () => {
 
     agent.__registerMastra(mastra);
 
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'test-resource';
 
     const streamResult = await agent.stream('Use the test tool', {
@@ -566,7 +565,7 @@ describe('Stream ID Consistency', () => {
         memory,
       });
 
-      const threadId = randomUUID();
+      const threadId = crypto.randomUUID();
       const resourceId = 'structured-output-persisted-text';
       await memory.createThread({ threadId, resourceId });
 

--- a/packages/core/src/agent/__tests__/stream.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/stream.e2e.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai';
 import { openai as openai_v5 } from '@ai-sdk/openai-v5';
 import { openai as openai_v6 } from '@ai-sdk/openai-v6';
@@ -541,7 +540,7 @@ function runStreamE2ETest(version: 'v1' | 'v2' | 'v3') {
       });
 
       it(`should order tool calls/results and response text properly`, async () => {
-        const threadId = randomUUID();
+        const threadId = crypto.randomUUID();
         const resourceId = 'ordering';
 
         const mockMemory = new MockMemory();

--- a/packages/core/src/agent/__tests__/structured-output-memory.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.e2e.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { getLLMTestMode } from '@internal/llm-recorder';
 import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
@@ -22,8 +21,8 @@ const profileSchema = z.object({
 
 describe('Structured output memory inheritance (e2e)', { timeout: 180_000 }, () => {
   it('uses prior thread memory when structured output runs on a separate model after multiple turns', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-e2e-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-e2e-${crypto.randomUUID()}`;
     const memory = new MockMemory();
 
     await memory.createThread({ threadId, resourceId });

--- a/packages/core/src/agent/__tests__/structured-output-memory.test.ts
+++ b/packages/core/src/agent/__tests__/structured-output-memory.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { MockMemory } from '../../memory/mock';
@@ -23,7 +22,7 @@ import { MockLanguageModelV2, convertArrayToReadableStream } from './mock-model'
  */
 describe('Structured output with memory - assistant message in final position (#12800)', () => {
   it('should not send prompt ending with assistant message when input is assistant-role with structuredOutput and memory', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-12800';
 
     const mockMemory = new MockMemory();
@@ -106,7 +105,7 @@ describe('Structured output with memory - assistant message in final position (#
     await mockMemory.saveMessages({
       messages: [
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'user',
           content: { format: 2, parts: [{ type: 'text', text: 'Which agent should research dolphins?' }] },
           threadId,
@@ -114,7 +113,7 @@ describe('Structured output with memory - assistant message in final position (#
           createdAt: new Date(),
         },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'assistant',
           content: { format: 2, parts: [{ type: 'text', text: 'Let me route this request.' }] },
           threadId,
@@ -152,7 +151,7 @@ describe('Structured output with memory - assistant message in final position (#
   });
 
   it('should not send prompt ending with assistant message when using stream with assistant-role input, structuredOutput and memory', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-12800-stream';
 
     const mockMemory = new MockMemory();
@@ -236,7 +235,7 @@ describe('Structured output with memory - assistant message in final position (#
     await mockMemory.saveMessages({
       messages: [
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'user' as const,
           content: {
             format: 2 as const,
@@ -248,7 +247,7 @@ describe('Structured output with memory - assistant message in final position (#
           type: 'text' as const,
         },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'assistant' as const,
           content: {
             format: 2 as const,
@@ -300,8 +299,8 @@ describe('Structured output with memory - assistant message in final position (#
 
 describe('Structured output memory inheritance', () => {
   it('includes prior memory context when useAgent is true for a separate structuring model', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -475,8 +474,8 @@ describe('Structured output memory inheritance', () => {
   });
 
   it('does not leak the structuring agent readOnly memory config into the parent request context', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -580,8 +579,8 @@ describe('Structured output memory inheritance', () => {
   });
 
   it('does not include prior memory context when useAgent is omitted for a separate structuring model', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-memory-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-memory-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -726,8 +725,8 @@ describe('Structured output memory inheritance', () => {
   });
 
   it('keeps main-agent text chunks in the outer stream while suppressing structuring-agent text chunks', async () => {
-    const threadId = randomUUID();
-    const resourceId = `structured-output-streaming-${randomUUID()}`;
+    const threadId = crypto.randomUUID();
+    const resourceId = `structured-output-streaming-${crypto.randomUUID()}`;
     const mockMemory = new MockMemory();
 
     const mainModel = new MockLanguageModelV2({
@@ -870,7 +869,7 @@ describe('Structured output memory inheritance', () => {
  */
 describe('Structured output stream memory persistence (#14659)', () => {
   it('should persist well-formed text when using stream with structuredOutput, not "[object Object]"', async () => {
-    const threadId = randomUUID();
+    const threadId = crypto.randomUUID();
     const resourceId = 'user-14659';
 
     const mockMemory = new MockMemory();

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { openai } from '@ai-sdk/openai-v5';
 import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -3299,8 +3298,8 @@ describe('Supervisor Pattern - Message history transfer to sub-agents', () => {
       memory: new MockMemory(),
     });
 
-    const resourceId = randomUUID();
-    const threadId = randomUUID();
+    const resourceId = crypto.randomUUID();
+    const threadId = crypto.randomUUID();
 
     // Supervisor conversation has multiple user messages
     await supervisorAgent.generate(
@@ -3407,8 +3406,8 @@ describe('Supervisor Pattern - Message history transfer to sub-agents', () => {
     });
 
     let supervisorCallCount = 0;
-    const resourceId = randomUUID();
-    const threadId = randomUUID();
+    const resourceId = crypto.randomUUID();
+    const threadId = crypto.randomUUID();
 
     const supervisorAgent = new Agent({
       id: 'supervisor-reserved-keys',

--- a/packages/core/src/agent/__tests__/tool-approval.e2e.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.e2e.test.ts
@@ -1,4 +1,4 @@
-import { randomUUID, createHash } from 'node:crypto';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
 import { getLLMTestMode, defaultNameGenerator, getLLMRecordingsDir } from '@internal/llm-recorder';
 import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
@@ -747,8 +747,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
           suspendedToolName: '',
         };
         const memory = {
-          thread: randomUUID(),
-          resource: randomUUID(),
+          thread: crypto.randomUUID(),
+          resource: crypto.randomUUID(),
         };
         const stream = await agentOne.stream('Find the name, age and profession of the user - Dero Israel', {
           memory,
@@ -856,8 +856,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
           suspendedToolName: '',
         };
         const memory = {
-          thread: randomUUID(),
-          resource: randomUUID(),
+          thread: crypto.randomUUID(),
+          resource: crypto.randomUUID(),
         };
         const stream = await agentOne.stream('Find the name, email, age and profession of the user - Dero Israel', {
           memory,
@@ -954,8 +954,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const agentOne = mastra.getAgent('userAgent');
 
         const memory = {
-          thread: randomUUID(),
-          resource: randomUUID(),
+          thread: crypto.randomUUID(),
+          resource: crypto.randomUUID(),
         };
         const output = await agentOne.generate('Find the name, age and profession of the user - Dero Israel', {
           memory,

--- a/packages/core/src/agent/__tests__/tool-approval.test.ts
+++ b/packages/core/src/agent/__tests__/tool-approval.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { EventEmitterPubSub } from '../../events';
@@ -135,8 +134,8 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         try {
           const agentOne = mastra.getAgent('userAgent');
           const memory = {
-            thread: randomUUID(),
-            resource: randomUUID(),
+            thread: crypto.randomUUID(),
+            resource: crypto.randomUUID(),
           };
 
           const stream = await agentOne.stream('Find the user with name - Dero Israel', { memory });
@@ -215,7 +214,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const approveAll = vi.fn().mockReturnValue(true);
         const suspendingAgent = makeAgent();
         const suspendStream = await suspendingAgent.stream('Find the user with name - Dero Israel', {
-          memory: { thread: randomUUID(), resource: randomUUID() },
+          memory: { thread: crypto.randomUUID(), resource: crypto.randomUUID() },
           requireToolApproval: approveAll,
         });
         let approvedToolName = '';
@@ -234,7 +233,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
         const denyApproval = vi.fn().mockReturnValue(false);
         const runningAgent = makeAgent();
         const runStream = await runningAgent.stream('Find the user with name - Dero Israel', {
-          memory: { thread: randomUUID(), resource: randomUUID() },
+          memory: { thread: crypto.randomUUID(), resource: crypto.randomUUID() },
           requireToolApproval: denyApproval,
         });
         let sawApproval = false;
@@ -319,7 +318,7 @@ export function toolApprovalAndSuspensionTests(version: 'v1' | 'v2') {
 
         const mastra = new Mastra({ agents: { resumeAgent }, logger: false, storage: mockStorage });
         const agent = mastra.getAgent('resumeAgent');
-        const memory = { thread: randomUUID(), resource: randomUUID() };
+        const memory = { thread: crypto.randomUUID(), resource: crypto.randomUUID() };
         const requireToolApproval = vi.fn().mockReturnValue(true);
 
         mockFindUser.mockClear();

--- a/packages/core/src/agent/__tests__/workflow-tool-memory-isolation.test.ts
+++ b/packages/core/src/agent/__tests__/workflow-tool-memory-isolation.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
@@ -72,8 +71,8 @@ function createSimpleTextModel() {
 
 describe('Workflow tool MastraMemory isolation', () => {
   it('should restore MastraMemory on requestContext after workflow tool execution', async () => {
-    const parentThreadId = randomUUID();
-    const subAgentThreadId = randomUUID();
+    const parentThreadId = crypto.randomUUID();
+    const subAgentThreadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 
@@ -142,7 +141,7 @@ describe('Workflow tool MastraMemory isolation', () => {
   });
 
   it('should restore MastraMemory even when workflow tool execution fails', async () => {
-    const parentThreadId = randomUUID();
+    const parentThreadId = crypto.randomUUID();
     const resourceId = 'test-user';
     const mockMemory = new MockMemory();
 

--- a/packages/core/src/agent/agent-legacy.ts
+++ b/packages/core/src/agent/agent-legacy.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { WritableStream } from 'node:stream/web';
 import type { CoreMessage, UIMessage, Tool } from '@internal/ai-sdk-v4';
 import deepEqual from 'fast-deep-equal';
@@ -794,7 +793,7 @@ export class AgentLegacyHandler {
         threadId: threadFromArgs?.id,
         resourceId,
       }) ||
-      randomUUID();
+      crypto.randomUUID();
     const instructions = args.instructions || (await this.capabilities.getInstructions({ requestContext }));
     const llm = await this.capabilities.getLLM({
       requestContext,
@@ -990,7 +989,7 @@ export class AgentLegacyHandler {
         usage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
         finishReason: 'other',
         response: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           modelId: 'tripwire',
           messages: [],
@@ -1065,7 +1064,7 @@ export class AgentLegacyHandler {
           usage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
           finishReason: 'other',
           response: {
-            id: randomUUID(),
+            id: crypto.randomUUID(),
             timestamp: new Date(),
             modelId: 'tripwire',
             messages: [],
@@ -1195,7 +1194,7 @@ export class AgentLegacyHandler {
         usage: { totalTokens: 0, promptTokens: 0, completionTokens: 0 },
         finishReason: 'other',
         response: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           modelId: 'tripwire',
           messages: [],
@@ -1341,7 +1340,7 @@ export class AgentLegacyHandler {
         finishReason: Promise.resolve('other'),
         tripwire: beforeResult.tripwire,
         response: {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           timestamp: new Date(),
           modelId: 'tripwire',
           messages: [],

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { UIMessage } from '@internal/ai-sdk-v4';
 import type { ModelMessage } from '@internal/ai-sdk-v5';
 import { wrapSchemaWithNullTransform } from '@mastra/schema-compat';
@@ -912,7 +911,7 @@ export class Agent<
 
     const now = Date.now();
     const record: GoalObjectiveRecord = {
-      id: options.id ?? randomUUID(),
+      id: options.id ?? crypto.randomUUID(),
       objective,
       status: 'active',
       runsUsed: 0,
@@ -2797,7 +2796,7 @@ export class Agent<
    */
   private static toFallbackEntry(mdl: ModelWithRetries, defaultMaxRetries: number): ModelFallbacks[number] {
     return {
-      id: mdl.id ?? randomUUID(),
+      id: mdl.id ?? crypto.randomUUID(),
       model: mdl.model as DynamicArgument<MastraModelConfig>,
       maxRetries: mdl.maxRetries ?? defaultMaxRetries,
       enabled: mdl.enabled ?? true,
@@ -4540,7 +4539,7 @@ export class Agent<
           execute: async (inputData: SubAgentToolInput, context) => {
             const invocationActor = getInvocationActor(context);
             const startTime = Date.now();
-            const toolCallId = context?.agent?.toolCallId || randomUUID();
+            const toolCallId = context?.agent?.toolCallId || crypto.randomUUID();
 
             // Get messages from context - available at tool execution time
             const contextMessages = (context?.agent?.messages || []) as MastraDBMessage[];
@@ -4566,7 +4565,7 @@ export class Agent<
                 maxSteps: inputData.maxSteps || undefined,
               },
               iteration: derivedIteration,
-              runId: runId || randomUUID(),
+              runId: runId || crypto.randomUUID(),
               threadId,
               resourceId,
               parentAgentId: this.id,
@@ -4579,13 +4578,13 @@ export class Agent<
             // These are needed for both successful execution and rejection cases
             const slugify = await import(`@sindresorhus/slugify`);
             const subAgentThreadId = inputData.threadId
-              ? `${inputData.threadId}-${randomUUID()}`
+              ? `${inputData.threadId}-${crypto.randomUUID()}`
               : context?.mastra?.generateId({
                   idType: 'thread',
                   source: 'agent',
                   entityId: agentName,
                   resourceId,
-                }) || randomUUID();
+                }) || crypto.randomUUID();
 
             const subAgentResourceId = inputData.resourceId
               ? `${inputData.resourceId}-${agentName}`
@@ -4686,7 +4685,7 @@ export class Agent<
                       await context.writer?.write({
                         type: 'text-delta',
                         payload: {
-                          id: randomUUID(),
+                          id: crypto.randomUUID(),
                           text: `[Delegation Rejected] ${rejectionMessage}`,
                         },
                         runId,
@@ -4700,7 +4699,7 @@ export class Agent<
                       try {
                         // Create user message with the original prompt
                         const userMessage: MastraDBMessage = {
-                          id: this.#mastra?.generateId() || randomUUID(),
+                          id: this.#mastra?.generateId() || crypto.randomUUID(),
                           role: 'user',
                           type: 'text',
                           createdAt: new Date(),
@@ -4719,7 +4718,7 @@ export class Agent<
 
                         // Create assistant message with the rejection
                         const assistantMessage: MastraDBMessage = {
-                          id: this.#mastra?.generateId() || randomUUID(),
+                          id: this.#mastra?.generateId() || crypto.randomUUID(),
                           role: 'assistant',
                           type: 'text',
                           createdAt: new Date(new Date().getTime() + 1),
@@ -4827,7 +4826,7 @@ export class Agent<
                     primitiveType: 'agent',
                     prompt: effectivePrompt,
                     iteration: derivedIteration,
-                    runId: runId || randomUUID(),
+                    runId: runId || crypto.randomUUID(),
                     threadId,
                     resourceId,
                     parentAgentId: this.id,
@@ -4912,7 +4911,7 @@ export class Agent<
                 }));
                 // Create user message with the original prompt
                 const userMessage: MastraDBMessage = {
-                  id: this.#mastra?.generateId() || randomUUID(),
+                  id: this.#mastra?.generateId() || crypto.randomUUID(),
                   role: 'user',
                   type: 'text',
                   createdAt: subAgentPromptCreatedAt,
@@ -5090,7 +5089,7 @@ export class Agent<
                 const agentResponseMessages = streamResult.messageList.get.response.db();
                 // Create user message with the original prompt
                 const userMessage: MastraDBMessage = {
-                  id: this.#mastra?.generateId() || randomUUID(),
+                  id: this.#mastra?.generateId() || crypto.randomUUID(),
                   role: 'user',
                   type: 'text',
                   createdAt: subAgentPromptCreatedAt,
@@ -5202,7 +5201,7 @@ export class Agent<
                     duration: Date.now() - startTime,
                     success: true,
                     iteration: derivedIteration,
-                    runId: runId || randomUUID(),
+                    runId: runId || crypto.randomUUID(),
                     toolCallId,
                     parentAgentId: this.id,
                     parentAgentName: this.name,
@@ -5222,7 +5221,7 @@ export class Agent<
                   // Handle feedback if provided
                   if (completeResult?.feedback) {
                     const feedbackMessage: MastraDBMessage = {
-                      id: this.#mastra?.generateId() || randomUUID(),
+                      id: this.#mastra?.generateId() || crypto.randomUUID(),
                       role: 'assistant',
                       type: 'text',
                       createdAt: new Date(),
@@ -5283,7 +5282,7 @@ export class Agent<
                     success: false,
                     error: err instanceof Error ? err : new Error(String(err)),
                     iteration: derivedIteration,
-                    runId: runId || randomUUID(),
+                    runId: runId || crypto.randomUUID(),
                     toolCallId,
                     parentAgentId: this.id,
                     parentAgentName: this.name,
@@ -5301,7 +5300,7 @@ export class Agent<
 
                   if (completeResult?.feedback) {
                     const feedbackMessage: MastraDBMessage = {
-                      id: this.#mastra?.generateId() || randomUUID(),
+                      id: this.#mastra?.generateId() || crypto.randomUUID(),
                       role: 'assistant',
                       type: 'text',
                       createdAt: new Date(),
@@ -5501,7 +5500,7 @@ export class Agent<
               // For resume cases, suspendedToolRunId is injected into inputData by
               // tool-call-step (from metadata stored during suspension).
               // For fresh calls: generate a new unique runId.
-              const runIdToUse = suspendedToolRunId || randomUUID();
+              const runIdToUse = suspendedToolRunId || crypto.randomUUID();
               this.logger.debug('Executing workflow as tool', {
                 agent: this.name,
                 workflow: workflowName,
@@ -6721,7 +6720,7 @@ export class Agent<
         threadId: threadFromArgs?.id,
         resourceId,
       }) ||
-      randomUUID();
+      crypto.randomUUID();
     const instructions = options.instructions || (await this.getInstructions({ requestContext }));
     const mcpServerGuidance = await this.getMcpServerGuidance({
       requestContext,
@@ -6814,7 +6813,7 @@ export class Agent<
       logger: this.logger,
       getMemory: this.getMemory.bind(this),
       getModel: this.getModel.bind(this),
-      generateMessageId: this.#mastra?.generateId?.bind(this.#mastra) || (() => randomUUID()),
+      generateMessageId: this.#mastra?.generateId?.bind(this.#mastra) || (() => crypto.randomUUID()),
       mastra: this.#mastra,
       _agentNetworkAppend:
         '_agentNetworkAppend' in this
@@ -6914,7 +6913,7 @@ export class Agent<
     llm.__registerMastra(effectiveMastra);
 
     const useEventedExecution = process.env.MASTRA_EVENTED_EXECUTION === 'true';
-    const executionRunId = randomUUID();
+    const executionRunId = crypto.randomUUID();
 
     if (useEventedExecution) {
       // Evented engine path: needs pubsub workers and internal workflow registration.
@@ -7209,7 +7208,7 @@ export class Agent<
       completion: { ...defaultNetworkOptions?.completion, ...options?.completion },
     };
 
-    const runId = mergedOptions?.runId || this.#mastra?.generateId() || randomUUID();
+    const runId = mergedOptions?.runId || this.#mastra?.generateId() || crypto.randomUUID();
 
     // Reserved keys from requestContext take precedence for security.
     // This allows middleware to securely set resourceId/threadId based on authenticated user,
@@ -7233,7 +7232,7 @@ export class Agent<
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
       } as unknown as AgentExecutionOptions<OUTPUT>,
-      generateId: context => this.#mastra?.generateId(context) || randomUUID(),
+      generateId: context => this.#mastra?.generateId(context) || crypto.randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,
       messages,
       threadId,
@@ -7308,7 +7307,7 @@ export class Agent<
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
       },
-      generateId: context => this.#mastra?.generateId(context) || randomUUID(),
+      generateId: context => this.#mastra?.generateId(context) || crypto.randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,
       messages: [],
       threadId,
@@ -8043,7 +8042,7 @@ export class Agent<
         idType: 'run',
         source: 'agent',
         entityId: this.id,
-      }) ?? randomUUID();
+      }) ?? crypto.randomUUID();
     const preparedOptions = agentThreadStreamRuntime.prepareRunOptions(
       { ...loopOptions, runId: mergedOptions.runId, actor } as AgentExecutionOptions<OUTPUT>,
       threadStreamPubSub,

--- a/packages/core/src/agent/message-list/tests/message-list.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { UIMessage, CoreMessage, Message } from '@internal/ai-sdk-v4';
 import { appendClientMessage, appendResponseMessages } from '@internal/ai-sdk-v4';
 import { describe, expect, it } from 'vitest';
@@ -775,7 +774,7 @@ describe('MessageList', () => {
       // msg2
       messages = appendResponseMessages({
         messages,
-        responseMessages: [{ ...msg2, id: randomUUID() }],
+        responseMessages: [{ ...msg2, id: crypto.randomUUID() }],
       });
       // Filter out tool invocations with state="call" from expected UI messages
       const expectedUIMessages = messages.map(m => {
@@ -794,7 +793,7 @@ describe('MessageList', () => {
       expect(list.get.all.ui()).toEqual(expectedUIMessages);
 
       // msg3
-      messages = appendResponseMessages({ messages, responseMessages: [{ id: randomUUID(), ...msg3 }] });
+      messages = appendResponseMessages({ messages, responseMessages: [{ id: crypto.randomUUID(), ...msg3 }] });
       expect(new MessageList().add(messages, 'response').get.all.ui()).toMatchObject([
         expect.objectContaining({
           role: 'user',
@@ -2188,7 +2187,7 @@ describe('MessageList', () => {
       ];
       expect(uiMessages).toEqual(expectedMessages);
 
-      let newId = randomUUID();
+      let newId = crypto.randomUUID();
       const responseMessages = [
         {
           id: newId,
@@ -2223,7 +2222,7 @@ describe('MessageList', () => {
       ]);
 
       const newClientMessage = {
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         role: 'user',
         createdAt: new Date(),
         content: 'Do it anyway please',
@@ -2243,14 +2242,14 @@ describe('MessageList', () => {
       );
 
       const responseMessages2 = [
-        { id: randomUUID(), role: 'assistant', content: "Ok fine I'll call a tool then" },
+        { id: crypto.randomUUID(), role: 'assistant', content: "Ok fine I'll call a tool then" },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'assistant',
           content: [{ type: 'tool-call', args: { ok: 'fine' }, toolCallId: 'ok-fine-1', toolName: 'okFineTool' }],
         },
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'tool',
           content: [{ type: 'tool-result', toolName: 'okFineTool', toolCallId: 'ok-fine-1', result: { lets: 'go' } }],
         },

--- a/packages/core/src/agent/thread-stream-runtime.ts
+++ b/packages/core/src/agent/thread-stream-runtime.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { getErrorFromUnknown } from '../error';
 import { EventEmitterPubSub } from '../events/event-emitter';
 import { isLeaseProvider, NoopLeaseProvider } from '../events/pubsub';
@@ -209,7 +207,7 @@ export class AgentThreadStreamRuntime {
   }
 
   #getSourceId(): string {
-    this.#id ??= randomUUID();
+    this.#id ??= crypto.randomUUID();
     return this.#id;
   }
 
@@ -400,7 +398,7 @@ export class AgentThreadStreamRuntime {
   #nextStreamIdentity(state: AgentThreadRuntimeState, runId: string) {
     const streamSeq = (state.streamSeqByRunId.get(runId) ?? 0) + 1;
     state.streamSeqByRunId.set(runId, streamSeq);
-    return { streamId: randomUUID(), streamSeq };
+    return { streamId: crypto.randomUUID(), streamSeq };
   }
 
   #markRunSuspending(
@@ -957,7 +955,7 @@ export class AgentThreadStreamRuntime {
       // old owner already lost the lease (e.g. a pubsub blip let the TTL lapse
       // and another process took over), forward the signal to the new winner
       // instead of starting a competing run here.
-      const nextRunId = randomUUID();
+      const nextRunId = crypto.randomUUID();
       state.activeThreadRunIds.set(key, nextRunId);
       const owns = await this.#acquireOrTransferThreadLease(pubsub, key, nextRunId, previousRun.runId);
       if (!owns.acquired) {
@@ -1105,7 +1103,7 @@ export class AgentThreadStreamRuntime {
   ): { accepted: true; runId: string } {
     const state = this.#getState(pubsub);
     const key = this.#threadKey(target.resourceId, target.threadId);
-    const runId = target.runId ?? randomUUID();
+    const runId = target.runId ?? crypto.randomUUID();
     const pending: PendingContinuation<OUTPUT> = {
       agent,
       messages,
@@ -1642,7 +1640,7 @@ export class AgentThreadStreamRuntime {
     }
 
     key ??= this.#threadKey(resourceId, threadId);
-    const queuedRunId = randomUUID();
+    const queuedRunId = crypto.randomUUID();
     const queuedStreamOptions = target.ifIdle?.streamOptions ?? activeRecord?.streamOptions;
 
     if (activeRecord) {
@@ -1870,7 +1868,7 @@ export class AgentThreadStreamRuntime {
       throw new Error('No active agent run found for signal target');
     }
 
-    runId = randomUUID();
+    runId = crypto.randomUUID();
     key ??= this.#threadKey(resourceId, threadId);
     if (idleBehavior === 'persist') {
       const persisted = this.#persistAndBroadcastIdleSignal(

--- a/packages/core/src/agent/trip-wire.ts
+++ b/packages/core/src/agent/trip-wire.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 import type { MastraLanguageModel } from '../llm/model/shared.types';
 import type { ObservabilityContext } from '../observability';
@@ -104,7 +103,7 @@ export const getModelOutputForTripwire = async <OUTPUT = undefined, TMetadata = 
       returnScorerData: options.returnScorerData,
       requestContext: options.requestContext,
     },
-    messageId: randomUUID(),
+    messageId: crypto.randomUUID(),
   });
 
   return modelOutput;

--- a/packages/core/src/background-tasks/manager.ts
+++ b/packages/core/src/background-tasks/manager.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Mastra } from '..';
 import type { PubSub } from '../events/pubsub';
 import type { Event, EventCallback } from '../events/types';
@@ -224,7 +223,7 @@ export class BackgroundTaskManager {
     if (this.initPromise) await this.initPromise;
 
     const task: BackgroundTask = {
-      id: this.#mastra?.generateId() ?? randomUUID(),
+      id: this.#mastra?.generateId() ?? crypto.randomUUID(),
       status: 'pending',
       toolName: payload.toolName,
       toolCallId: payload.toolCallId,

--- a/packages/core/src/browser/processor.ts
+++ b/packages/core/src/browser/processor.ts
@@ -19,7 +19,6 @@
  * ```
  */
 
-import { randomUUID } from 'node:crypto';
 import type {
   ComputeStateSignalArgs,
   ComputeStateSignalResult,
@@ -27,7 +26,7 @@ import type {
   ProcessInputResult,
 } from '../processors/index';
 
-const BROWSER_PROCESS_ID = randomUUID();
+const BROWSER_PROCESS_ID = crypto.randomUUID();
 
 /**
  * Browser context stored in RequestContext.

--- a/packages/core/src/evals/base.ts
+++ b/packages/core/src/evals/base.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { z } from 'zod/v4';
 import { Agent, isSupportedLanguageModel } from '../agent';
 import type { MastraDBMessage, MastraMessagePart, MastraToolInvocationPart } from '../agent/message-list';
@@ -580,7 +579,7 @@ class MastraScorer<
 
     let runId = prepared.runId;
     if (!runId) {
-      runId = randomUUID();
+      runId = crypto.randomUUID();
     }
 
     const normalizedRequestContext = this.normalizeRunRequestContext(prepared.requestContext);

--- a/packages/core/src/events/unix-socket-pubsub.ts
+++ b/packages/core/src/events/unix-socket-pubsub.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdir, open, stat, unlink } from 'node:fs/promises';
 import type { FileHandle } from 'node:fs/promises';
 import net from 'node:net';
@@ -194,7 +193,7 @@ export class UnixSocketPubSub extends PubSub {
     if (options?.localOnly) {
       const localEvent: Event = {
         ...event,
-        id: randomUUID(),
+        id: crypto.randomUUID(),
         createdAt: new Date(),
         deliveryAttempt: 1,
       };
@@ -615,7 +614,7 @@ export class UnixSocketPubSub extends PubSub {
   ) {
     const brokerEvent: Event = {
       ...event,
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       createdAt: new Date(),
       deliveryAttempt: 1,
     };

--- a/packages/core/src/llm/model/aisdk/generate-to-stream.ts
+++ b/packages/core/src/llm/model/aisdk/generate-to-stream.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 /**
  * Converts a doGenerate result to a ReadableStream format.
  * This is shared between V2 and V3 model wrappers since the content/result structure is compatible.
@@ -76,7 +74,7 @@ export function createStreamFromGenerateResult(result: {
             text: string;
             providerMetadata?: unknown;
           };
-          const id = `msg_${randomUUID()}`;
+          const id = `msg_${crypto.randomUUID()}`;
           controller.enqueue({
             type: 'text-start',
             id,
@@ -92,7 +90,7 @@ export function createStreamFromGenerateResult(result: {
             id,
           });
         } else if (message.type === 'reasoning') {
-          const id = `reasoning_${randomUUID()}`;
+          const id = `reasoning_${crypto.randomUUID()}`;
           const reasoning = message as {
             type: 'reasoning';
             text: string;

--- a/packages/core/src/loop/test-utils/aimock/scenarios/auto-resume-suspended-tools.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/auto-resume-suspended-tools.scenario.test.ts
@@ -3,7 +3,6 @@ import { z } from 'zod/v4';
 import { MockMemory } from '../../../../memory';
 import { createTool } from '../../../../tools';
 import { createSharedAgent, runLoopScenario, useLoopScenarioAimock, describeForAllEngines } from '../aimock-scenario';
-import { randomUUID } from 'node:crypto';
 
 /**
  * Automatic tool resumption with `autoResumeSuspendedTools`.
@@ -54,8 +53,8 @@ describeForAllEngines(
         engine,
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       // First call: model calls the tool, loop suspends for approval
       const { chunks } = await runLoopScenario({
@@ -165,8 +164,8 @@ describeForAllEngines(
         engine,
       });
 
-      const threadId = randomUUID();
-      const resourceId = randomUUID();
+      const threadId = crypto.randomUUID();
+      const resourceId = crypto.randomUUID();
 
       // First call: tool suspends
       const { chunks } = await runLoopScenario({

--- a/packages/core/src/loop/test-utils/aimock/scenarios/evented-unix-pubsub.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/evented-unix-pubsub.scenario.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { stepCountIs } from '@internal/ai-sdk-v5';
@@ -40,7 +39,7 @@ describe('AIMock loop scenario: evented + UnixSocketPubSub', () => {
     // UUID to make the test portable on every host.
     const socketDir = mkdtempSync('/tmp/aim-');
     socketDirs.push(socketDir);
-    const socketPath = join(socketDir, `${randomUUID().slice(0, 8)}.sock`);
+    const socketPath = join(socketDir, `${crypto.randomUUID().slice(0, 8)}.sock`);
     const pubsub = new UnixSocketPubSub(socketPath);
     pubsubs.push(pubsub);
 

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ToolSet } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
 import { MastraFGAPermissions } from '../../../auth/ee';
@@ -1136,7 +1135,7 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
                           {
                             role: 'tool' as const,
                             type: 'tool-call',
-                            id: readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? randomUUID(),
+                            id: readScoped(scopeCtx, GENERATE_ID_KEY, 'generateId')?.() ?? crypto.randomUUID(),
                             createdAt: new Date(),
                             content: [
                               {

--- a/packages/core/src/loop/workflows/agentic-loop/index.ts
+++ b/packages/core/src/loop/workflows/agentic-loop/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { StepResult, ToolSet } from '@internal/ai-sdk-v5';
 import type { MastraDBMessage } from '../../../memory';
 import { InternalSpans } from '../../../observability';
@@ -211,7 +210,7 @@ export function createAgenticLoopWorkflow<Tools extends ToolSet = ToolSet, OUTPU
             if (iterationResult.feedback && typedInputData.stepResult?.isContinued) {
               messageList.add(
                 {
-                  id: rest.mastra?.generateId() || randomUUID(),
+                  id: rest.mastra?.generateId() || crypto.randomUUID(),
                   createdAt: new Date(),
                   type: 'text',
                   role: 'assistant',

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { Agent } from '../agent';
 import { agentThreadStreamRuntime } from '../agent/thread-stream-runtime';
 import type { DurableAgentLike } from '../agent/types';
@@ -1128,7 +1127,7 @@ export class Mastra<
       }
       return id;
     }
-    return randomUUID();
+    return crypto.randomUUID();
   }
 
   /**

--- a/packages/core/src/mcp/index.ts
+++ b/packages/core/src/mcp/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import slugify from '@sindresorhus/slugify';
 import type { ToolsInput } from '../agent';
 import { MastraBase } from '../base';
@@ -180,7 +179,7 @@ export abstract class MCPServerBase<TId extends string = string> extends MastraB
       this._id = slugify(config.id) as TId;
       this.idWasSet = true;
     } else {
-      this._id = (this.mastra?.generateId() || randomUUID()) as TId;
+      this._id = (this.mastra?.generateId() || crypto.randomUUID()) as TId;
     }
 
     this.description = config.description;

--- a/packages/core/src/notifications/storage.ts
+++ b/packages/core/src/notifications/storage.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { StorageDomain } from '../storage/domains/base';
 import type {
   CreateNotificationInput,
@@ -94,7 +93,7 @@ export class InMemoryNotificationsStorage extends NotificationsStorage {
 
     const now = input.createdAt ?? new Date();
     const record: NotificationRecord = {
-      id: input.id ?? randomUUID(),
+      id: input.id ?? crypto.randomUUID(),
       threadId: input.threadId,
       source: input.source,
       kind: input.kind,

--- a/packages/core/src/processors/trailing-assistant-guard.ts
+++ b/packages/core/src/processors/trailing-assistant-guard.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import type { Processor, ProcessInputStepArgs, ProcessInputStepResult } from './index';
 
 const CLAUDE_46_PATTERN = /[^0-9]4[.-]6/;
@@ -67,7 +65,7 @@ export class TrailingAssistantGuard implements Processor<'trailing-assistant-gua
       messages: [
         ...messages,
         {
-          id: randomUUID(),
+          id: crypto.randomUUID(),
           role: 'user' as const,
           content: {
             format: 2 as const,

--- a/packages/core/src/schedules/schedules.ts
+++ b/packages/core/src/schedules/schedules.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import slugify from '@sindresorhus/slugify';
 import type { AgentSignalAttributes, AgentSignalType } from '../agent/signals';
 import { ErrorCategory, ErrorDomain, MastraError } from '../error';
@@ -312,7 +311,7 @@ export class Schedules {
     const id =
       input.id !== undefined
         ? normalizeScheduleId(input.id, AGENT_SCHEDULE_PREFIX)
-        : `${AGENT_SCHEDULE_PREFIX}${randomUUID()}`;
+        : `${AGENT_SCHEDULE_PREFIX}${crypto.randomUUID()}`;
     await this.#assertIdAvailable(store, id, input.id !== undefined);
     const now = Date.now();
     const nextFireAt = computeNextFireAt(input.cron, { timezone: input.timezone, after: now });
@@ -361,7 +360,7 @@ export class Schedules {
     const id =
       input.id !== undefined
         ? normalizeScheduleId(input.id, WORKFLOW_SCHEDULE_PREFIX)
-        : `${WORKFLOW_SCHEDULE_PREFIX}${randomUUID()}`;
+        : `${WORKFLOW_SCHEDULE_PREFIX}${crypto.randomUUID()}`;
     await this.#assertIdAvailable(store, id, input.id !== undefined);
     const now = Date.now();
     const nextFireAt = computeNextFireAt(input.cron, { timezone: input.timezone, after: now });

--- a/packages/core/src/storage/domains/schedules/inmemory.ts
+++ b/packages/core/src/storage/domains/schedules/inmemory.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { InMemoryDB } from '../inmemory-db';
 import type { Schedule, ScheduleFilter, ScheduleTrigger, ScheduleTriggerListOptions, ScheduleUpdate } from './base';
 import { normalizeScheduleTarget, SchedulesStorage } from './base';
@@ -122,7 +121,7 @@ export class InMemorySchedulesStorage extends SchedulesStorage {
   async recordTrigger(trigger: ScheduleTrigger): Promise<void> {
     const stored: ScheduleTrigger = {
       ...trigger,
-      id: trigger.id ?? randomUUID(),
+      id: trigger.id ?? crypto.randomUUID(),
       triggerKind: trigger.triggerKind ?? 'schedule-fire',
     };
     this.db.scheduleTriggers.push(clone(stored));

--- a/packages/core/src/storage/domains/skills/inmemory.ts
+++ b/packages/core/src/storage/domains/skills/inmemory.ts
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import { normalizePerPage, calculatePagination } from '../../base';
 import type {
   StorageSkillType,
@@ -70,7 +68,7 @@ export class InMemorySkillsStorage extends SkillsStorage {
     const { id: _id, authorId: _authorId, visibility: _visibility, ...snapshotConfig } = skill;
 
     // Create version 1 from the config
-    const versionId = randomUUID();
+    const versionId = crypto.randomUUID();
     try {
       await this.createVersion({
         id: versionId,
@@ -181,7 +179,7 @@ export class InMemorySkillsStorage extends SkillsStorage {
 
       // Only create a new version if something actually changed
       if (changedFields.length > 0) {
-        const newVersionId = randomUUID();
+        const newVersionId = crypto.randomUUID();
         const newVersionNumber = latestVersion.versionNumber + 1;
 
         await this.createVersion({

--- a/packages/core/src/storage/mock.test.ts
+++ b/packages/core/src/storage/mock.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { describe, expect, it, beforeEach } from 'vitest';
 import { MessageList } from '../agent';
 import type { MastraMessageV1, StorageThreadType } from '../memory/types';
@@ -378,7 +377,7 @@ describe('InMemoryStore - listMessagesById', () => {
     messageCounter += 1;
 
     const defaults = {
-      id: randomUUID(),
+      id: crypto.randomUUID(),
       role: 'user' as const,
       resourceId,
       createdAt: new Date(Date.now() + messageCounter * 1000),

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -1,27 +1,13 @@
-import { randomUUID } from 'node:crypto';
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage/mock';
 import { createWorkflow } from './create';
 import { createStep } from './workflow';
 
-vi.mock('crypto', () => {
-  return {
-    randomUUID: vi.fn(() => 'mock-uuid-1'),
-  };
-});
-
+// UUID determinism comes from @internal/test-utils/setup, which stubs the
+// global crypto.randomUUID with a per-test counter.
 describe('Branch with Map Bug - Issue #10407', () => {
-  beforeEach(() => {
-    vi.resetAllMocks();
-
-    let counter = 0;
-    (randomUUID as vi.Mock).mockImplementation(() => {
-      return `mock-uuid-${++counter}`;
-    });
-  });
-
   it('should pass inputData to nested workflow with map inside branch', async () => {
     const commonInputSchema = z.object({
       value: z.number(),

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -1,27 +1,13 @@
-import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage/mock';
 import { createWorkflow } from './create';
 import { createStep } from './workflow';
 
-vi.mock('crypto', () => {
-  return {
-    randomUUID: vi.fn(() => 'mock-uuid-1'),
-  };
-});
-
+// UUID determinism comes from @internal/test-utils/setup, which stubs the
+// global crypto.randomUUID with a per-test counter.
 describe('Branch with Map Bug - Issue #10407', () => {
-  beforeEach(async () => {
-    vi.resetAllMocks();
-
-    let counter = 0;
-    const { randomUUID } = await import('node:crypto');
-    (randomUUID as vi.Mock).mockImplementation(() => {
-      return `mock-uuid-${++counter}`;
-    });
-  });
-
   it('should pass inputData to nested workflow with map inside branch', async () => {
     const commonInputSchema = z.object({
       value: z.number(),

--- a/packages/core/src/workflows/branch-map-bug.test.ts
+++ b/packages/core/src/workflows/branch-map-bug.test.ts
@@ -1,13 +1,27 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { z } from 'zod/v4';
 import { Mastra } from '../mastra';
 import { MockStore } from '../storage/mock';
 import { createWorkflow } from './create';
 import { createStep } from './workflow';
 
-// UUID determinism comes from @internal/test-utils/setup, which stubs the
-// global crypto.randomUUID with a per-test counter.
+vi.mock('crypto', () => {
+  return {
+    randomUUID: vi.fn(() => 'mock-uuid-1'),
+  };
+});
+
 describe('Branch with Map Bug - Issue #10407', () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+
+    let counter = 0;
+    const { randomUUID } = await import('node:crypto');
+    (randomUUID as vi.Mock).mockImplementation(() => {
+      return `mock-uuid-${++counter}`;
+    });
+  });
+
   it('should pass inputData to nested workflow with map inside branch', async () => {
     const commonInputSchema = z.object({
       value: z.number(),

--- a/packages/core/src/workflows/default.test.ts
+++ b/packages/core/src/workflows/default.test.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod/v4';
 import { RequestContext } from '../di';
@@ -210,7 +209,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
     const { result } = await runConditional({
       conditions,
       workflowId: 'test-workflow',
-      runId: randomUUID(),
+      runId: crypto.randomUUID(),
     });
 
     // Assert: Verify error handling, truthyIndexes, and workflow continuation
@@ -223,7 +222,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
     // Arrange: Set up conditions array with one throwing regular Error and one valid
     const regularError = new Error('Test regular error');
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     // Mock the logger to capture trackException calls
     const mockTrackException = vi.fn();
@@ -281,7 +280,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
   describe('conditional time-travel reconciliation', () => {
     it("rewrites a targeted-but-non-truthy arm from 'running' to 'skipped' during time travel", async () => {
       const workflowId = 'test-workflow';
-      const runId = randomUUID();
+      const runId = crypto.randomUUID();
 
       // arm step1 (index 0) is truthy, arm step2 (index 1) is NOT truthy.
       const conditions = [async () => true, async () => false];
@@ -321,7 +320,7 @@ describe('DefaultExecutionEngine.executeConditional error handling', () => {
 
     it("leaves a 'running' arm untouched for normal start/resume (no time travel)", async () => {
       const workflowId = 'test-workflow';
-      const runId = randomUUID();
+      const runId = crypto.randomUUID();
 
       const conditions = [async () => true, async () => false];
 
@@ -361,7 +360,7 @@ describe('DefaultExecutionEngine.executeEntry resume payload handling', () => {
 
   it('should use the suspended step payload when resuming a step with stale previous output', async () => {
     const workflowId = 'resume-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const resumedStep = {
       id: 'needs-approval',
       inputSchema: z.object({ id: z.string() }),
@@ -429,7 +428,7 @@ describe('DefaultExecutionEngine.executeEntry resume payload handling', () => {
 
   it('should use a null suspended step payload when resuming a step with stale previous output', async () => {
     const workflowId = 'resume-null-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const resumedStep = {
       id: 'needs-approval',
       inputSchema: z.null(),
@@ -497,7 +496,7 @@ describe('DefaultExecutionEngine.executeEntry resume payload handling', () => {
 
   it('should use the suspended foreach payload when resuming with stale previous output', async () => {
     const workflowId = 'resume-foreach-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const foreachStep = {
       id: 'process-item',
       inputSchema: z.number(),
@@ -584,7 +583,7 @@ describe('DefaultExecutionEngine.executeLoop resume payload handling', () => {
 
   it('should use a null suspended loop payload when resuming with stale previous output', async () => {
     const workflowId = 'resume-loop-null-payload-repro';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const step = {
       id: 'loop-step',
       inputSchema: z.null(),
@@ -662,7 +661,7 @@ describe('DefaultExecutionEngine.executeLoop cancellation', () => {
   // cancelled, even when the user's step does not observe abortSignal.
   it('should stop iterating a dountil loop when abortController is aborted between iterations', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     let iterations = 0;
     const step = {
@@ -727,7 +726,7 @@ describe('DefaultExecutionEngine.executeLoop cancellation', () => {
   // must still surface 'canceled' rather than 'success'.
   it('should surface canceled when abortController is aborted during condition evaluation', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     let stepCalls = 0;
     const step = {
@@ -800,7 +799,7 @@ describe('DefaultExecutionEngine.executeForeach cancellation', () => {
   // would otherwise let the loop keep iterating.
   it('should return canceled before dispatching the next concurrency chunk', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     let callCount = 0;
     const step = {
@@ -859,7 +858,7 @@ describe('DefaultExecutionEngine.executeForeach cancellation', () => {
   // result and persist 'success' even though the run was cancelled.
   it('should return canceled when abortController is aborted during the final chunk', async () => {
     const workflowId = 'test-workflow';
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
 
     const step = {
       id: 'process-item',
@@ -939,7 +938,7 @@ describe('DefaultExecutionEngine.executeForeach concurrency', () => {
     prevOutput,
     concurrency,
     workflowId = 'test-workflow',
-    runId = randomUUID(),
+    runId = crypto.randomUUID(),
   }: {
     step: any;
     prevOutput: any[];
@@ -984,7 +983,7 @@ describe('DefaultExecutionEngine.executeForeach concurrency', () => {
   });
 
   it('keeps concurrency slots filled and preserves ordered results while progress follows completion order', async () => {
-    const runId = randomUUID();
+    const runId = crypto.randomUUID();
     const firstItemGate = deferred();
     const starts: number[] = [];
     const completed: number[] = [];

--- a/packages/core/src/workflows/evented/step-executor.ts
+++ b/packages/core/src/workflows/evented/step-executor.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { TripWire } from '../../agent/trip-wire';
 import { MastraBase } from '../../base';
 import type { RequestContext } from '../../di';
@@ -163,7 +162,7 @@ export class StepExecutor extends MastraBase {
         throw validationError;
       }
 
-      const callId = randomUUID();
+      const callId = crypto.randomUUID();
       const outputWriter = this.createOutputWriter(runId);
 
       const stepOutput = await executeWithContext({
@@ -428,7 +427,7 @@ export class StepExecutor extends MastraBase {
     retryCount?: number;
     iterationCount: number;
   }): Promise<boolean> {
-    const callId = randomUUID();
+    const callId = crypto.randomUUID();
     const outputWriter = this.createOutputWriter(runId);
 
     return condition(
@@ -502,7 +501,7 @@ export class StepExecutor extends MastraBase {
     }
 
     try {
-      const callId = randomUUID();
+      const callId = crypto.randomUUID();
       const outputWriter = this.createOutputWriter(runId);
 
       return await step.fn(
@@ -585,7 +584,7 @@ export class StepExecutor extends MastraBase {
     }
 
     try {
-      const callId = randomUUID();
+      const callId = crypto.randomUUID();
       const outputWriter = this.createOutputWriter(runId);
 
       const result = await step.fn(

--- a/packages/core/src/workflows/evented/workflow-event-processor/index.ts
+++ b/packages/core/src/workflows/evented/workflow-event-processor/index.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import EventEmitter from 'node:events';
 import { ErrorCategory, ErrorDomain, MastraError, getErrorFromUnknown } from '../../../error';
 import { EventProcessor } from '../../../events/processor';
@@ -1341,7 +1340,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else if (timeTravel && timeTravel.steps?.length > 1 && timeTravel.steps[0] === step.step.id) {
-        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? randomUUID();
+        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? crypto.randomUUID();
         const snapshot =
           (await workflowsStore?.loadWorkflowSnapshot({
             workflowName: step.step.id,
@@ -1395,7 +1394,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else if (restart && !!restart.activeStepsPath?.[step.step.id]) {
-        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? randomUUID();
+        const nestedRunId = stepResults[step.step.id]?.metadata?.nestedRunId ?? crypto.randomUUID();
         const snapshot =
           (await workflowsStore?.loadWorkflowSnapshot({
             workflowName: step.step.id,
@@ -1440,7 +1439,7 @@ export class WorkflowEventProcessor extends EventProcessor {
           },
         });
       } else {
-        const nestedRunId = randomUUID();
+        const nestedRunId = crypto.randomUUID();
         const shouldPersist =
           nestedWorkflow?.options?.shouldPersistSnapshot?.({
             stepResults: {},

--- a/packages/core/src/workflows/evented/workflow.ts
+++ b/packages/core/src/workflows/evented/workflow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream } from 'node:stream/web';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { z } from 'zod/v4';
@@ -1617,7 +1616,7 @@ export class EventedWorkflow<
       throw new Error('Uncommitted step flow changes detected. Call .commit() to register the steps.');
     }
 
-    const runIdToUse = options?.runId || randomUUID();
+    const runIdToUse = options?.runId || crypto.randomUUID();
 
     const workflowsStore = await this.mastra?.getStorage()?.getStore('workflows');
 

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import fastq from 'fastq';
 import type { done as DoneCallback } from 'fastq';
 import type { ActorSignal } from '../../auth/ee';
@@ -354,7 +353,7 @@ export async function executeConditional(
             writer: new ToolStream(
               {
                 prefix: 'workflow-step',
-                callId: randomUUID(),
+                callId: crypto.randomUUID(),
                 name: 'conditional',
                 runId,
               },
@@ -774,7 +773,7 @@ export async function executeLoop(
           writer: new ToolStream(
             {
               prefix: 'workflow-step',
-              callId: randomUUID(),
+              callId: crypto.randomUUID(),
               name: 'loop',
               runId,
             },

--- a/packages/core/src/workflows/handlers/sleep.ts
+++ b/packages/core/src/workflows/handlers/sleep.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { RequestContext } from '../../di';
 import type { PubSub } from '../../events/pubsub';
 import { SpanType, createObservabilityContext, resolveObservabilityContext } from '../../observability';
@@ -77,7 +76,7 @@ export async function executeSleep(engine: DefaultExecutionEngine, params: Execu
   });
 
   if (fn) {
-    const stepCallId = randomUUID();
+    const stepCallId = crypto.randomUUID();
     duration = await engine.wrapDurableOperation(`workflow.${workflowId}.sleep.${entry.id}`, async () => {
       return fn({
         runId,
@@ -203,7 +202,7 @@ export async function executeSleepUntil(
   });
 
   if (fn) {
-    const stepCallId = randomUUID();
+    const stepCallId = crypto.randomUUID();
     const dateResult = await engine.wrapDurableOperation(`workflow.${workflowId}.sleepUntil.${entry.id}`, async () => {
       return fn({
         runId,

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import type { ActorSignal } from '../../auth/ee';
 import type { RequestContext } from '../../di';
 import { MastraError, ErrorDomain, ErrorCategory, getErrorFromUnknown } from '../../error';
@@ -96,7 +95,7 @@ export async function executeStep(
   } = params;
   const observabilityContext = resolveObservabilityContext(rest);
 
-  const stepCallId = randomUUID();
+  const stepCallId = crypto.randomUUID();
 
   const { inputData, validationError: inputValidationError } = await validateStepInput({
     prevOutput,

--- a/packages/core/src/workflows/workflow.ts
+++ b/packages/core/src/workflows/workflow.ts
@@ -1,4 +1,3 @@
-import { randomUUID } from 'node:crypto';
 import { ReadableStream, TransformStream } from 'node:stream/web';
 import type { CoreMessage } from '@internal/ai-sdk-v4';
 import { z } from 'zod/v4';
@@ -1733,7 +1732,7 @@ export class Workflow<
    * @returns The workflow instance for chaining
    */
   sleep(duration: number | ExecuteFunction<TState, TPrevSchema, number, any, any, TEngineType>) {
-    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || randomUUID()}`;
+    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep' }) || crypto.randomUUID()}`;
 
     const opts: StepFlowEntry<TEngineType> =
       typeof duration === 'function'
@@ -1772,7 +1771,7 @@ export class Workflow<
    * @returns The workflow instance for chaining
    */
   sleepUntil(date: Date | ExecuteFunction<TState, TPrevSchema, Date, any, any, TEngineType>) {
-    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || randomUUID()}`;
+    const id = `sleep_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'sleep-until' }) || crypto.randomUUID()}`;
     const opts: StepFlowEntry<TEngineType> =
       typeof date === 'function'
         ? { type: 'sleepUntil', id, fn: date }
@@ -1851,7 +1850,7 @@ export class Workflow<
       const mappingStep: any = createStep({
         id:
           stepOptions?.id ||
-          `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || randomUUID()}`,
+          `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || crypto.randomUUID()}`,
         inputSchema: z.any(),
         outputSchema: z.any(),
         execute: mappingConfig as any,
@@ -1917,7 +1916,7 @@ export class Workflow<
     const mappingStep: any = createStep({
       id:
         stepOptions?.id ||
-        `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || randomUUID()}`,
+        `mapping_${this.#mastra?.generateId({ idType: 'step', source: 'workflow', entityId: this.id, stepType: 'mapping' }) || crypto.randomUUID()}`,
       inputSchema: z.any(),
       outputSchema: z.any(),
       execute: async ctx => {
@@ -2340,7 +2339,7 @@ export class Workflow<
         entityId: this.id,
         resourceId: options?.resourceId,
       }) ||
-      randomUUID();
+      crypto.randomUUID();
 
     // Return a new Run instance with object parameters
     const run =


### PR DESCRIPTION
## Description

Unifies UUID generation in `@mastra/core` on the Web Crypto global — single package, single mechanical change (re-scoped from the closed repo-wide attempts #19503/#19504 per review feedback).

Before this change the package used two forms side by side: 27 source files imported `randomUUID` from `node:crypto` while 35 files already called the global `crypto.randomUUID()`. The forms are identical on every supported platform — the global has existed since Node 19 and the engines floor is Node 22 — but the import form marks the importing module, and through bundler chunking entire dist chunks, as Node-only. For V8-isolate runtimes that provide Web Crypto but no Node builtin modules (Convex default runtime, Cloudflare Workers without `nodejs_compat`), each such import is a bundling failure. Ten of the importing files sit on the agent inference path. Same convention as the merged `@mastra/convex` fix (#19498).

**The change is mechanical:**

- Remove `randomUUID` from `node:crypto` import specifiers (dropping the import entirely where it was the only specifier; other specifiers like `createHash` are kept).
- Rewrite `randomUUID(...)` call sites to `crypto.randomUUID(...)`.
- `src/workflows/branch-map-bug.test.ts` mocked the `crypto` module for UUID determinism; that mock is dead once the source uses the global, and determinism is already provided by `@internal/test-utils/setup` (which stubs the global `crypto.randomUUID` with a per-test counter), so the local mock is removed.

No API or behavior change on Node.js.

## Related issue(s)

Fixes #19501 (applied package-by-package; this PR covers `@mastra/core` — remaining packages tracked separately).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Testing

- Zero leftover `randomUUID`-from-`node:crypto` imports in `packages/core` (grep; the only bare `randomUUID()` calls left are `@lukeed/uuid` aliases in `message-list.ts`).
- `pnpm turbo build --filter ./packages/core` (full dependency graph): clean.
- Targeted tests: `branch-map-bug.test.ts` and `mastra/idgenerator.test.ts` — 41 passed / 1 skipped. Deterministic-UUID behavior in tests is unchanged since the shared setup already stubs the global.
- Changeset: patch bump for `@mastra/core` only.

## AI disclosure

Implemented with Claude Code (Fable 5) as a reviewed codemod; human-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of using a Node.js-only way to create unique IDs, `@mastra/core` now uses the standard Web Crypto API. This makes the package work better in environments like Cloudflare Workers and Convex without changing its behavior or public APIs.

## What changed

- Replaced `node:crypto` `randomUUID` imports across core source and tests with `crypto.randomUUID()`.
- Removed the obsolete crypto mock from `branch-map-bug.test.ts`; deterministic UUIDs now come from shared test setup.
- Added a patch changeset for `@mastra/core`.

## Validation

- Build and targeted tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->