### PR TITLE
fix(core): align A2AAgent streams with the Agent chunk contract

### DIFF
--- a/.changeset/jolly-parts-tease.md
+++ b/.changeset/jolly-parts-tease.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Aligned A2AAgent streams with the regular Agent stream contract. A2A streams now emit a leading start chunk on fresh runs (skipped when resuming, matching Agent behavior) and the finish chunk now carries the Agent-shaped payload (stepResult.reason, output.usage) so downstream consumers like @mastra/ai-sdk can treat sub-agent streams uniformly. The previous flat finishReason and usage fields are still included for backward compatibility but are deprecated.
+Aligned A2AAgent streams with the regular Agent stream contract. A2A streams now emit a leading start chunk on fresh runs (skipped when resuming, matching Agent behavior) and the finish chunk now carries the Agent-shaped payload (stepResult.reason, output.usage) so downstream consumers can treat sub-agent streams uniformly. The previous flat finishReason and usage fields are still included for backward compatibility but are deprecated.

--- a/.changeset/jolly-parts-tease.md
+++ b/.changeset/jolly-parts-tease.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Aligned A2AAgent streams with the regular Agent stream contract. A2A streams now emit a leading start chunk on fresh runs (skipped when resuming, matching Agent behavior) and the finish chunk now carries the Agent-shaped payload (stepResult.reason, output.usage) so downstream consumers like @mastra/ai-sdk can treat sub-agent streams uniformly. The previous flat finishReason and usage fields are still included for backward compatibility but are deprecated.

--- a/client-sdks/ai-sdk/src/__tests__/transform-agent-a2a-stream.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/transform-agent-a2a-stream.test.ts
@@ -3,32 +3,30 @@ import { describe, expect, it } from 'vitest';
 import { transformAgent } from '../transformers';
 
 /**
- * Regression test for A2AAgent sub-agent delegation through handleChatStream.
+ * Regression coverage for start-less sub-agent streams and the legacy
+ * A2AAgent chunk contract through handleChatStream.
  *
- * A2AAgent remote streams differ from regular Agent streams in two ways:
+ * Resumed Agent and A2AAgent streams omit `start`, so the buffered run state
+ * may not exist when the first content chunk arrives. A2AAgent versions from
+ * before the chunk contracts were aligned also omitted `start` on fresh runs
+ * and emitted a flat `{ finishReason, usage }` payload.
  *
- * 1. They never emit a `start` chunk — the first chunks are
- *    `text-start` / `text-delta` — so the buffered run state for the runId
- *    does not exist when the first content chunk arrives.
- * 2. Their `finish` chunk carries a flat `{ finishReason, usage }` payload
- *    instead of the regular Agent shape `{ stepResult: { reason }, output: { usage } }`.
- *
- * Both previously crashed transformAgent ("Cannot read properties of
+ * Both cases previously crashed transformAgent ("Cannot read properties of
  * undefined (reading 'text')" and "... (reading 'reason')"), killing the UI
  * stream with an error chunk.
  */
-describe('transformAgent A2A sub-agent streams', () => {
+describe('transformAgent start-less and legacy A2A sub-agent streams', () => {
   function makePayload(type: string, runId: string, payload: any) {
     return { type, runId, payload } as any;
   }
 
   const EMPTY_USAGE = { inputTokens: undefined, outputTokens: undefined, totalTokens: undefined };
 
-  it('handles a full A2A-shaped stream without a start chunk', () => {
+  it('handles a legacy A2A-shaped stream without a start chunk', () => {
     const bufferedSteps = new Map<string, any>();
     const runId = 'a2a-run';
 
-    // No `start` chunk — A2A streams begin with text-start/text-delta.
+    // Older A2AAgent streams began with text-start/text-delta.
     const firstDelta = transformAgent(
       makePayload('text-delta', runId, { id: 'text-1', text: 'Shipment ord_1003 ' }),
       bufferedSteps,
@@ -42,7 +40,7 @@ describe('transformAgent A2A sub-agent streams', () => {
 
     transformAgent(makePayload('text-delta', runId, { id: 'text-1', text: 'is in transit.' }), bufferedSteps);
 
-    // Flat A2A finish payload: no stepResult / output wrappers.
+    // Legacy flat A2A finish payload: no stepResult / output wrappers.
     const finish = transformAgent(
       makePayload('finish', runId, { finishReason: 'stop', usage: EMPTY_USAGE }),
       bufferedSteps,

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -677,13 +677,12 @@ export function transformAgent<OUTPUT>(payload: ChunkType<OUTPUT>, bufferedSteps
     }
     case 'finish': {
       // Not all sub-agent streams emit a `start` chunk before their first
-      // content chunk, so the run state may not exist yet. A2AAgent remote
-      // streams never emit one (see A2AAgentFullStreamChunkBase in
-      // @mastra/core), and resumed Agent streams skip it (`if (!resumeContext)`
-      // in core's loop/workflows/stream.ts).
+      // content chunk, so the run state may not exist yet. Resumed Agent and
+      // A2AAgent streams skip it, as did A2AAgent streams before the chunk
+      // contract was aligned with regular Agent streams.
       const finishRun = ensureAgentRunState(bufferedSteps, payload.runId!);
-      // Regular Agent streams emit `{ stepResult, output }`; A2AAgent remote
-      // streams emit a flat `{ finishReason, usage }` payload.
+      // Current Agent and A2AAgent streams emit `{ stepResult, output }`;
+      // older A2AAgent streams used a flat `{ finishReason, usage }` payload.
       const finishPayload = payload.payload as {
         stepResult?: { reason?: string; warnings?: unknown };
         output?: { usage?: unknown };

--- a/packages/core/src/a2a/a2a-agent.test.ts
+++ b/packages/core/src/a2a/a2a-agent.test.ts
@@ -499,6 +499,7 @@ describe('A2AAgent', () => {
       metadata: {},
       messages: { all: [], user: [], nonUser: [] },
       finishReason: 'stop',
+      usage: {},
     });
     expect(await stream.text).toBe('Buffered remote response');
     const result = await stream.getResult();
@@ -560,6 +561,7 @@ describe('A2AAgent', () => {
       metadata: {},
       messages: { all: [], user: [], nonUser: [] },
       finishReason: 'stop',
+      usage: {},
     });
     expect(await stream.text).toBe('Hello from stream');
     expect((await stream.task)?.status.state).toBe('completed');

--- a/packages/core/src/a2a/a2a-agent.test.ts
+++ b/packages/core/src/a2a/a2a-agent.test.ts
@@ -480,14 +480,14 @@ describe('A2AAgent', () => {
       fetch: fetchMock as typeof fetch,
     });
 
-    const stream = await agent.stream('Buffered request', { runId: 'stream-run-1' });
+    const stream = await agent.stream('Buffered request');
     const events: StreamEventWithOptionalId[] = [];
     for await (const event of stream.fullStream) {
       events.push(event as StreamEventWithOptionalId);
     }
 
     expect(events.map(event => event.type)).toEqual(['start', 'text-start', 'text-delta', 'text-end', 'finish']);
-    expect(events.every(event => event.runId === 'stream-run-1')).toBe(true);
+    expect(events.every(event => event.runId === stream.runId)).toBe(true);
     expect(events.every(event => event.from === 'AGENT')).toBe(true);
     expect(events[0]?.payload?.id).toBe(agent.id);
     expect(events[1]?.payload?.id).toBe('message-1');
@@ -501,7 +501,9 @@ describe('A2AAgent', () => {
       finishReason: 'stop',
     });
     expect(await stream.text).toBe('Buffered remote response');
-    expect((await stream.getResult()).text).toBe('Buffered remote response');
+    const result = await stream.getResult();
+    expect(result.text).toBe('Buffered remote response');
+    expect(result.runId).toBe(stream.runId);
   });
 
   it('consumes remote message/stream events when streaming is supported', async () => {

--- a/packages/core/src/a2a/a2a-agent.test.ts
+++ b/packages/core/src/a2a/a2a-agent.test.ts
@@ -486,12 +486,20 @@ describe('A2AAgent', () => {
       events.push(event as StreamEventWithOptionalId);
     }
 
-    expect(events.map(event => event.type)).toEqual(['text-start', 'text-delta', 'text-end', 'finish']);
+    expect(events.map(event => event.type)).toEqual(['start', 'text-start', 'text-delta', 'text-end', 'finish']);
     expect(events.every(event => event.runId === 'stream-run-1')).toBe(true);
     expect(events.every(event => event.from === 'AGENT')).toBe(true);
-    expect(events[0]?.payload?.id).toBe('message-1');
+    expect(events[0]?.payload?.id).toBe(agent.id);
     expect(events[1]?.payload?.id).toBe('message-1');
     expect(events[2]?.payload?.id).toBe('message-1');
+    expect(events[3]?.payload?.id).toBe('message-1');
+    expect(events[4]?.payload).toMatchObject({
+      stepResult: { reason: 'stop' },
+      output: { usage: {} },
+      metadata: {},
+      messages: { all: [], user: [], nonUser: [] },
+      finishReason: 'stop',
+    });
     expect(await stream.text).toBe('Buffered remote response');
     expect((await stream.getResult()).text).toBe('Buffered remote response');
   });
@@ -537,12 +545,20 @@ describe('A2AAgent', () => {
       events.push(event as StreamEventWithOptionalId);
     }
 
-    expect(events.map(event => event.type)).toEqual(['text-start', 'text-delta', 'text-end', 'finish']);
+    expect(events.map(event => event.type)).toEqual(['start', 'text-start', 'text-delta', 'text-end', 'finish']);
     expect(events.every(event => event.runId === 'stream-run-2')).toBe(true);
     expect(events.every(event => event.from === 'AGENT')).toBe(true);
-    expect(events[0]?.payload?.id).toBe('response:text');
+    expect(events[0]?.payload?.id).toBe(agent.id);
     expect(events[1]?.payload?.id).toBe('response:text');
     expect(events[2]?.payload?.id).toBe('response:text');
+    expect(events[3]?.payload?.id).toBe('response:text');
+    expect(events[4]?.payload).toMatchObject({
+      stepResult: { reason: 'stop' },
+      output: { usage: {} },
+      metadata: {},
+      messages: { all: [], user: [], nonUser: [] },
+      finishReason: 'stop',
+    });
     expect(await stream.text).toBe('Hello from stream');
     expect((await stream.task)?.status.state).toBe('completed');
   });
@@ -612,7 +628,7 @@ describe('A2AAgent', () => {
       events.push(event.type);
     }
 
-    expect(events).toEqual(['text-start', 'text-delta', 'text-end', 'tool-call-suspended']);
+    expect(events).toEqual(['start', 'text-start', 'text-delta', 'text-end', 'tool-call-suspended']);
     expect(await stream.text).toBe('Hello later');
     expect(await stream.suspendPayload).toMatchObject({
       taskId: 'task-1',
@@ -817,6 +833,14 @@ describe('A2AAgent', () => {
     });
 
     const resumed = await agent.resumeStream(undefined, { runId: 'stream-run-3' });
+    const resumedEvents: string[] = [];
+    for await (const event of resumed.fullStream) {
+      resumedEvents.push(event.type);
+    }
+
+    // Resumed runs continue an existing stream, so no `start` chunk is emitted
+    // (mirrors the regular Agent loop, which skips `start` when resuming).
+    expect(resumedEvents).toEqual(['text-start', 'text-delta', 'text-end', 'finish']);
     expect(await resumed.text).toBe('Resubscribed text');
     expect((await resumed.task)?.status.state).toBe('completed');
   });

--- a/packages/core/src/a2a/a2a-agent.ts
+++ b/packages/core/src/a2a/a2a-agent.ts
@@ -621,7 +621,7 @@ export class A2AAgent implements SubAgent {
     const memoryInfo = resolveMemoryInfo(options);
 
     if (!bootstrap.streamingSupported) {
-      const result = await this.generate(messages, options);
+      const result = await this.generate(messages, { ...options, runId });
       return this.#createBufferedStreamResult({ runId, result, emitStart: true, ...memoryInfo });
     }
 

--- a/packages/core/src/a2a/a2a-agent.ts
+++ b/packages/core/src/a2a/a2a-agent.ts
@@ -8,6 +8,7 @@ import type { SubAgent } from '../agent/subagent';
 import type { Mastra } from '../mastra';
 import type { MastraMemory } from '../memory/memory';
 import { RequestContext } from '../request-context';
+import type { ChunkType } from '../stream/types';
 import type { DynamicArgument } from '../types';
 import { MastraA2AError } from './error';
 import type {
@@ -72,6 +73,7 @@ type StreamConsumptionResult = {
 
 type A2AStreamEventData = Message | Task | TaskStatusUpdateEvent | TaskArtifactUpdateEvent;
 type A2AAgentFullStreamChunkBase =
+  | { type: 'start'; payload: { id: string } }
   | { type: 'text-start'; payload: { id: string } }
   | { type: 'text-delta'; payload: { id: string; text: string } }
   | { type: 'text-end'; payload: { id: string } }
@@ -87,11 +89,17 @@ type A2AAgentFullStreamChunkBase =
     }
   | {
       type: 'finish';
-      payload: {
-        finishReason: 'stop';
-        usage: typeof EMPTY_USAGE;
-      };
+      payload: A2AAgentFinishPayload;
     };
+
+type AgentFinishPayload = Extract<ChunkType, { type: 'finish' }>['payload'];
+
+type A2AAgentFinishPayload = AgentFinishPayload & {
+  /** @deprecated Use `stepResult.reason`. Kept for consumers of the previous flat payload shape. */
+  finishReason: 'stop';
+  /** @deprecated Use `output.usage`. Kept for consumers of the previous flat payload shape. */
+  usage: typeof EMPTY_USAGE;
+};
 type A2AAgentFullStreamChunk = A2AAgentFullStreamChunkBase & {
   runId: string;
   from: 'AGENT';
@@ -114,6 +122,25 @@ function toAgentStreamChunk(runId: string, chunk: A2AAgentFullStreamChunkBase): 
     ...chunk,
     runId,
     from: 'AGENT',
+  };
+}
+
+function createFinishPayload(): A2AAgentFinishPayload {
+  return {
+    stepResult: {
+      reason: 'stop',
+    },
+    output: {
+      usage: EMPTY_USAGE,
+    },
+    metadata: {},
+    messages: {
+      all: [],
+      user: [],
+      nonUser: [],
+    },
+    finishReason: 'stop',
+    usage: EMPTY_USAGE,
   };
 }
 
@@ -595,7 +622,7 @@ export class A2AAgent implements SubAgent {
 
     if (!bootstrap.streamingSupported) {
       const result = await this.generate(messages, options);
-      return this.#createBufferedStreamResult({ runId, result, ...memoryInfo });
+      return this.#createBufferedStreamResult({ runId, result, emitStart: true, ...memoryInfo });
     }
 
     return this.#runRemoteStream({
@@ -603,6 +630,7 @@ export class A2AAgent implements SubAgent {
       runId,
       prompt,
       signal: options?.abortSignal,
+      emitStart: true,
       ...memoryInfo,
     });
   }
@@ -626,7 +654,7 @@ export class A2AAgent implements SubAgent {
 
       if (!bootstrap.streamingSupported) {
         const result = await this.resumeGenerate(resumeData, options);
-        return this.#createBufferedStreamResult({ runId, result, ...memoryInfo });
+        return this.#createBufferedStreamResult({ runId, result, emitStart: false, ...memoryInfo });
       }
 
       return this.#runRemoteStream({
@@ -636,6 +664,8 @@ export class A2AAgent implements SubAgent {
         signal: options?.abortSignal,
         contextId: state.contextId,
         referenceTaskIds: state.taskId ? [state.taskId] : undefined,
+        // Resumed runs skip the `start` chunk, mirroring the regular Agent loop.
+        emitStart: false,
         ...memoryInfo,
       });
     }
@@ -646,7 +676,7 @@ export class A2AAgent implements SubAgent {
 
     if (!bootstrap.streamingSupported) {
       const result = await this.resumeGenerate(resumeData, options);
-      return this.#createBufferedStreamResult({ runId, result, ...memoryInfo });
+      return this.#createBufferedStreamResult({ runId, result, emitStart: false, ...memoryInfo });
     }
 
     return this.#resubscribeToRemoteStream({
@@ -929,6 +959,7 @@ export class A2AAgent implements SubAgent {
     referenceTaskIds,
     threadId,
     resourceId,
+    emitStart,
   }: {
     bootstrap: AgentBootstrap;
     runId: string;
@@ -938,6 +969,7 @@ export class A2AAgent implements SubAgent {
     referenceTaskIds?: string[];
     threadId?: string;
     resourceId?: string;
+    emitStart: boolean;
   }): Promise<A2AAgentStreamResult> {
     const response = await this.#request(bootstrap.executionUrl, {
       method: 'POST',
@@ -966,6 +998,7 @@ export class A2AAgent implements SubAgent {
       stream: await requireResponseBody(response, 'message/stream'),
       threadId,
       resourceId,
+      emitStart,
     });
   }
 
@@ -1005,6 +1038,9 @@ export class A2AAgent implements SubAgent {
       stream: await requireResponseBody(response, 'tasks/resubscribe'),
       threadId,
       resourceId,
+      // Resubscribing continues an existing run; `start` is only emitted for fresh runs,
+      // mirroring the regular Agent loop which skips `start` when resuming.
+      emitStart: false,
     });
   }
 
@@ -1015,6 +1051,7 @@ export class A2AAgent implements SubAgent {
     stream,
     threadId,
     resourceId,
+    emitStart,
   }: {
     bootstrap: AgentBootstrap;
     runId: string;
@@ -1022,6 +1059,7 @@ export class A2AAgent implements SubAgent {
     stream: ReadableStream<Uint8Array>;
     threadId?: string;
     resourceId?: string;
+    emitStart: boolean;
   }): Promise<A2AAgentStreamResult> {
     const [consumerStream, accumulatorStream] = stream.tee();
     const resultDeferred = createDeferred<A2AAgentGenerateResult>();
@@ -1091,7 +1129,7 @@ export class A2AAgent implements SubAgent {
 
     const streamResult = {
       runId,
-      fullStream: this.#streamEvents({ bootstrap, runId, stream: consumerStream }),
+      fullStream: this.#streamEvents({ bootstrap, runId, stream: consumerStream, emitStart }),
       text: textDeferred.promise,
       toolResults: Promise.resolve([]),
       messageList,
@@ -1108,11 +1146,17 @@ export class A2AAgent implements SubAgent {
     bootstrap,
     runId,
     stream,
+    emitStart,
   }: {
     bootstrap: AgentBootstrap;
     runId: string;
     stream: ReadableStream<Uint8Array>;
+    emitStart: boolean;
   }): AsyncIterable<A2AAgentFullStreamChunk> {
+    if (emitStart) {
+      yield toAgentStreamChunk(runId, { type: 'start', payload: { id: this.id } });
+    }
+
     const reader = stream.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
@@ -1237,10 +1281,7 @@ export class A2AAgent implements SubAgent {
         } else {
           yield toAgentStreamChunk(runId, {
             type: 'finish',
-            payload: {
-              finishReason: 'stop',
-              usage: EMPTY_USAGE,
-            },
+            payload: createFinishPayload(),
           });
         }
         return;
@@ -1382,14 +1423,17 @@ export class A2AAgent implements SubAgent {
     result,
     threadId,
     resourceId,
+    emitStart,
   }: {
     runId: string;
     result: A2AAgentGenerateResult;
     threadId?: string;
     resourceId?: string;
+    emitStart: boolean;
   }): A2AAgentStreamResult {
     const messageList = new MessageList({ threadId, resourceId });
     const toolName = this.id;
+    const agentId = this.id;
     const textId = resolveStreamTextId([result.message?.messageId, result.task?.id]);
     if (result.text) {
       messageList.add(
@@ -1402,6 +1446,10 @@ export class A2AAgent implements SubAgent {
     }
 
     const fullStream = (async function* (): AsyncIterable<A2AAgentFullStreamChunk> {
+      if (emitStart) {
+        yield toAgentStreamChunk(runId, { type: 'start', payload: { id: agentId } });
+      }
+
       if (result.text) {
         yield toAgentStreamChunk(runId, { type: 'text-start', payload: { id: textId } });
         yield toAgentStreamChunk(runId, { type: 'text-delta', payload: { id: textId, text: result.text } });
@@ -1424,10 +1472,7 @@ export class A2AAgent implements SubAgent {
 
       yield toAgentStreamChunk(runId, {
         type: 'finish',
-        payload: {
-          finishReason: 'stop',
-          usage: EMPTY_USAGE,
-        },
+        payload: createFinishPayload(),
       });
     })();
 

--- a/packages/memory/__recordings__/memory-integration-tests-src-agent-memory-v5.json
+++ b/packages/memory/__recordings__/memory-integration-tests-src-agent-memory-v5.json
@@ -1332,7 +1332,7 @@
       }
     },
     {
-      "hash": "c609edb5cbc03e8d",
+      "hash": "a68b5b627bb6ec86",
       "request": {
         "url": "https://openrouter.ai/api/v1/chat/completions",
         "method": "POST",
@@ -1341,7 +1341,12 @@
           "messages": [
             {
               "role": "system",
-              "content": "You are a helpful assistant that thinks through problems."
+              "content": [
+                {
+                  "text": "You are a helpful assistant that thinks through problems.",
+                  "type": "text"
+                }
+              ]
             },
             {
               "role": "user",


### PR DESCRIPTION
Follow-up to #19443. `A2AAgent` exposes a Mastra `fullStream`, but fresh runs omitted the regular `start` chunk and used a different `finish` payload. That forced downstream stream consumers to special-case remote agents.

Before:

```text
text-start → text-delta → text-end → finish { finishReason, usage }
```

After:

```text
start → text-start → text-delta → text-end → finish { stepResult, output, metadata, messages }
```

This translation happens in Mastra's adapter and does not change the A2A wire protocol. Resume paths remain start-less, matching regular Agent behavior. The old flat `finishReason` and `usage` fields are retained for compatibility, and the AI SDK transformer remains defensive for resumed and older A2A streams.

Verified with the focused core A2A tests (18 passing), AI SDK transformer tests (5 passing), TypeScript checks for both packages, and lint on the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Fresh A2A agent streams now begin by sending a small “start” signal and end by sending a “finish” message in a consistent shape, so downstream code can reliably parse results. If the stream is being resumed, it keeps the older “start-less” behavior, and older-style finish data is still accepted.

## Changes

- Updated `A2AAgent` streaming contract:
  - Fresh A2A streams now emit an initial `start` chunk.
  - Resumed/resubscribed streams remain start-less (`emitStart: false` paths).
  - Standardized `finish` payload creation via a helper so it matches the regular Agent stream payload shape (including `stepResult`, `output`, `metadata`, `messages`, and `stepResult.reason` / `output.usage`).
  - Kept legacy `finishReason` and flat `usage` fields for backward compatibility.
  - Ensured buffered fallback streaming preserves/generates correlated run IDs so emitted chunks and `getResult()` remain aligned.
- Updated AI SDK transformer resilience:
  - Adjusted `transformAgent` handling and tests to safely support resumed/start-less A2A sub-agent streams.
  - Prevented crashes when encountering legacy A2A `finish` payload shape.
- Expanded/updated tests and documentation:
  - Strengthened `A2AAgent` core streaming tests for the new event ordering and payload IDs.
  - Updated AI SDK transformer regression tests for start-less and legacy A2A finish cases.
  - Added a `@mastra/core` changeset (patch) documenting the contract update.
  - Updated a stored memory integration test recording to match the latest structured system-message format for deterministic replay.
- Verification:
  - Ran focused core A2A tests, AI SDK transformer tests, TypeScript checks for both packages, and linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->