### PR TITLE
fix(core): report real step durations on replay engines and per-branch parallel status

### DIFF
--- a/.changeset/olive-doors-repeat.md
+++ b/.changeset/olive-doors-repeat.md
@@ -1,0 +1,9 @@
+---
+'@mastra/core': patch
+---
+
+Fix two workflow reporting bugs that surface in Studio's workflow graph.
+
+Step timings are now captured inside the durable operation instead of around it. On replay-based engines (`@mastra/inngest`) the workflow function body re-runs from the top after every completed step and finished steps are served from the memo, so the surrounding `Date.now()` readings timed the replay rather than the execution — completed steps and sub-workflows collapsed to single-digit-millisecond durations in the persisted snapshot regardless of how long they really took.
+
+Parallel branches now persist each child as it settles. `executeParallel` pre-marks every child `running` and only the surrounding `executeEntry` persisted, after the join — so `getWorkflowRunById` reported already-finished children as `running` until the slowest sibling landed, and the graph showed completed steps still spinning.

--- a/.github/scripts/use-workspace-protocol.mjs
+++ b/.github/scripts/use-workspace-protocol.mjs
@@ -1,0 +1,60 @@
+/**
+ * Rewrites intra-repo dependencies to `workspace:*` ahead of a snapshot publish.
+ *
+ * Only packages that actually live in this workspace are rewritten. The `@mastra`
+ * scope on npm also carries packages that are NOT developed here (the Docusaurus
+ * plugins the docs site depends on, for example), and pointing those at
+ * `workspace:*` makes the follow-up install fail with ERR_PNPM_WORKSPACE_PKG_NOT_FOUND.
+ */
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies', 'optionalDependencies'];
+
+// `pnpm ls -r` is the authority on workspace membership — it resolves
+// pnpm-workspace.yaml's globs rather than re-implementing them here.
+const projects = JSON.parse(execFileSync('pnpm', ['ls', '-r', '--depth', '-1', '--json'], { encoding: 'utf8' }));
+
+const members = new Map(projects.filter(project => project.name && project.path).map(p => [p.name, p.path]));
+
+let changedCount = 0;
+
+for (const [name, path] of members) {
+  const manifestPath = join(path, 'package.json');
+  let manifest;
+  try {
+    manifest = readFileSync(manifestPath, 'utf8');
+  } catch {
+    continue;
+  }
+
+  const parsed = JSON.parse(manifest);
+  let touched = false;
+
+  for (const field of DEP_FIELDS) {
+    for (const [dep, range] of Object.entries(parsed[field] ?? {})) {
+      // Normalize ranges that already opted into the workspace protocol
+      // (`workspace:^` and friends) and pin true workspace members onto it.
+      // Anything else — including same-scope packages resolved from the
+      // registry — is left exactly as the manifest declares it.
+      const shouldPin = String(range).startsWith('workspace:') || members.has(dep);
+      if (!shouldPin || range === 'workspace:*') continue;
+
+      parsed[field][dep] = 'workspace:*';
+      touched = true;
+    }
+  }
+
+  if (touched) {
+    // Trailing newline keeps the diff clean against prettier-formatted manifests.
+    writeFileSync(manifestPath, `${JSON.stringify(parsed, null, 2)}\n`);
+    console.log(`Updating ${name} (${manifestPath})`);
+    changedCount += 1;
+  }
+}
+
+const skipped = projects.length - members.size;
+console.log(`Finished updating workspace dependencies. ${changedCount} files updated.`);
+if (skipped > 0) console.log(`Skipped ${skipped} project(s) without a resolvable name/path.`);

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -456,18 +456,7 @@ jobs:
           fi
 
       - name: Update workspace dependencies
-        run: |
-          for file in $(find . -type f -name package.json -not -path "./node_modules/*" -not -path "./package.json"); do
-            content="$(< "$file")"
-            updated="$(echo "$content" | sed -E 's/"workspace:\^"/"workspace:*"/g')"
-            updated="$(echo "$updated" | sed 's/"@mastra\/\([^"]*\)":[[:space:]]"[^"]*"/"@mastra\/\1": "workspace:*"/g')"
-            if [ "$content" != "$updated" ]; then
-              echo "Updating $file"
-              echo "$updated" > "$file"
-              changed_count=$((changed_count + 1))
-            fi
-          done
-          echo "Finished updating workspace dependencies. $changed_count files updated."
+        run: node .github/scripts/use-workspace-protocol.mjs
         shell: bash
 
       - name: Update lockfile

--- a/packages/core/src/workflows/handlers/control-flow.ts
+++ b/packages/core/src/workflows/handlers/control-flow.ts
@@ -186,6 +186,25 @@ export async function executeParallel(
       // Apply context changes from parallel step execution
       engine.applyMutableContext(executionContext, stepExecResult.mutableContext);
       Object.assign(stepResults, stepExecResult.stepResults);
+
+      // Publish this branch's outcome now rather than waiting on the join below.
+      // `executeEntry` only persists once every branch has settled, so without
+      // this a finished child stays `running` in the snapshot — and in the
+      // Studio graph — for as long as its slowest sibling takes. The `phase`
+      // keeps the durable operation id unique per branch so replay engines
+      // don't collapse these into a single memoized write.
+      await engine.persistStepUpdate({
+        workflowId,
+        runId,
+        resourceId,
+        serializedStepGraph,
+        stepResults,
+        executionContext,
+        workflowStatus: 'running',
+        requestContext,
+        phase: `parallel.${i}.end`,
+      });
+
       return stepExecResult.result;
     }),
   );

--- a/packages/core/src/workflows/handlers/parallel-step-persist.test.ts
+++ b/packages/core/src/workflows/handlers/parallel-step-persist.test.ts
@@ -1,0 +1,99 @@
+/**
+ * A parallel branch's finished children must reach the persisted snapshot as soon
+ * as they finish — not only once the whole block joins.
+ *
+ * `executeParallel` pre-marks every child `running`, fans out over `Promise.all`,
+ * and only the surrounding `executeEntry` persists afterwards. Until the slowest
+ * sibling lands, `getWorkflowRunById` therefore keeps reporting already-finished
+ * children as `running`, and the Studio graph shows a completed step still
+ * spinning while a long-running sibling holds the branch open.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { createWorkflow } from '../create';
+import { DefaultExecutionEngine } from '../default';
+import { createStep } from '../workflow';
+
+type StepResults = Record<string, { status?: string } | undefined>;
+
+/**
+ * Records every persisted snapshot's step map. The snapshot holds a live
+ * reference to the engine's `stepResults`, so each write is deep-copied at write
+ * time — otherwise later mutations would rewrite the history under assertion.
+ */
+function makeRecordingMastra() {
+  const snapshots: StepResults[] = [];
+  const store = {
+    persistWorkflowSnapshot: async ({ snapshot }: { snapshot: { context?: unknown } }) => {
+      snapshots.push(JSON.parse(JSON.stringify(snapshot.context ?? {})) as StepResults);
+    },
+  };
+  const mastra = {
+    getStorage: () => ({ getStore: async () => store }),
+  } as any;
+  return { mastra, snapshots };
+}
+
+const FAST_MS = 10;
+const SLOW_MS = 250;
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function makeParallelWorkflow(engine: DefaultExecutionEngine) {
+  const io = { inputSchema: z.object({}), outputSchema: z.object({ ok: z.boolean() }) };
+
+  const fastStep = createStep({
+    id: 'fast-step',
+    ...io,
+    execute: async () => {
+      await sleep(FAST_MS);
+      return { ok: true };
+    },
+  });
+
+  const slowStep = createStep({
+    id: 'slow-step',
+    ...io,
+    execute: async () => {
+      await sleep(SLOW_MS);
+      return { ok: true };
+    },
+  });
+
+  return createWorkflow({
+    id: 'parallel-persist-workflow',
+    inputSchema: z.object({}),
+    outputSchema: z.looseObject({}),
+    executionEngine: engine,
+  })
+    .parallel([fastStep, slowStep])
+    .commit();
+}
+
+describe('parallel step persistence', () => {
+  it('persists a fast child as success while a slow sibling is still running', async () => {
+    const { mastra, snapshots } = makeRecordingMastra();
+    const engine = new DefaultExecutionEngine({
+      mastra,
+      options: { validateInputs: false, shouldPersistSnapshot: () => true },
+    });
+
+    const workflow = makeParallelWorkflow(engine);
+    const run = await workflow.createRun();
+    const result = await run.start({ inputData: {} });
+
+    expect(result.status).toBe('success');
+
+    // The window under test: `fast-step` has landed but `slow-step` has not. This
+    // is the state `getWorkflowRunById` serves for ~240ms of the run, and it is
+    // what the Studio graph renders.
+    const sawFastDoneWhileSlowRunning = snapshots.some(
+      steps => steps['fast-step']?.status === 'success' && steps['slow-step']?.status === 'running',
+    );
+
+    expect(sawFastDoneWhileSlowRunning).toBe(true);
+  });
+});

--- a/packages/core/src/workflows/handlers/step-timing-replay.test.ts
+++ b/packages/core/src/workflows/handlers/step-timing-replay.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Step timings must survive a durable replay.
+ *
+ * Durable engines (`@mastra/inngest`) re-run the workflow function body from the
+ * top after each completed step, serving already-finished steps from a memo
+ * rather than executing them again — see the `wrapDurableOperation` override in
+ * `@mastra/inngest`'s `InngestExecutionEngine`. Any wall-clock reading taken
+ * *outside* that memoized region therefore measures replay overhead instead of
+ * the step's real execution, and the last replay is what lands in the persisted
+ * snapshot that the Studio renders.
+ *
+ * These tests pin the invariant: a step's reported `startedAt`/`endedAt` must be
+ * captured inside the durable operation, so a replay reports the original span.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { createWorkflow } from '../create';
+import { DefaultExecutionEngine } from '../default';
+import type { StepResult } from '../types';
+import { createStep } from '../workflow';
+
+/**
+ * Stands in for Inngest: every durable operation is memoized by operation id and
+ * is never re-executed. A second run over the same engine therefore replays the
+ * first run's steps exactly as Inngest replays a function invocation.
+ */
+class ReplayExecutionEngine extends DefaultExecutionEngine {
+  private memo = new Map<string, unknown>();
+  public replayedOperations = 0;
+
+  async wrapDurableOperation<T>(operationId: string, operationFn: () => Promise<T>): Promise<T> {
+    if (this.memo.has(operationId)) {
+      this.replayedOperations++;
+      return this.memo.get(operationId) as T;
+    }
+    const result = await operationFn();
+    this.memo.set(operationId, result);
+    return result;
+  }
+}
+
+const STEP_WORK_MS = 150;
+// Timer slack: setTimeout may fire a hair early, and the assertions only need to
+// separate "real span" (~150ms) from "replay overhead" (~0ms).
+const SLACK_MS = 25;
+
+function durationOf(step: StepResult<any, any, any, any> | undefined) {
+  const started = (step as any)?.startedAt;
+  const ended = (step as any)?.endedAt;
+  if (typeof started !== 'number' || typeof ended !== 'number') {
+    throw new Error(`step is missing timestamps: ${JSON.stringify(step)}`);
+  }
+  return ended - started;
+}
+
+function makeSlowWorkflow(engine: DefaultExecutionEngine) {
+  const slowStep = createStep({
+    id: 'slow-step',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ ok: z.boolean() }),
+    execute: async () => {
+      await new Promise(resolve => setTimeout(resolve, STEP_WORK_MS));
+      return { ok: true };
+    },
+  });
+
+  return createWorkflow({
+    id: 'replay-timing-workflow',
+    inputSchema: z.object({}),
+    outputSchema: z.object({ ok: z.boolean() }),
+    executionEngine: engine,
+  })
+    .then(slowStep)
+    .commit();
+}
+
+describe('step timings across a durable replay', () => {
+  it('reports the real execution span on the first (non-replayed) run', async () => {
+    const engine = new ReplayExecutionEngine({ mastra: undefined, options: { validateInputs: false } });
+    const workflow = makeSlowWorkflow(engine);
+
+    const run = await workflow.createRun();
+    const result = await run.start({ inputData: {} });
+
+    expect(result.status).toBe('success');
+    expect(durationOf(result.steps['slow-step'])).toBeGreaterThanOrEqual(STEP_WORK_MS - SLACK_MS);
+  });
+
+  it('reports the original span again when the step is served from the durable memo', async () => {
+    const engine = new ReplayExecutionEngine({ mastra: undefined, options: { validateInputs: false } });
+    const workflow = makeSlowWorkflow(engine);
+
+    const firstRun = await workflow.createRun();
+    const first = await firstRun.start({ inputData: {} });
+    expect(first.status).toBe('success');
+
+    // Same engine ⇒ the step's durable operation is already memoized, so this run
+    // replays it without executing the 150ms body — exactly what Inngest does on
+    // every re-invocation of the workflow function.
+    const replayRun = await workflow.createRun();
+    const replayed = await replayRun.start({ inputData: {} });
+
+    expect(replayed.status).toBe('success');
+    // Guard the simulation itself: if nothing was served from the memo this test
+    // would trivially pass by re-executing the step for real.
+    expect(engine.replayedOperations).toBeGreaterThan(0);
+
+    // The step really took ~150ms. A replay must not report ~0ms just because the
+    // memoized body returned instantly.
+    expect(durationOf(replayed.steps['slow-step'])).toBeGreaterThanOrEqual(STEP_WORK_MS - SLACK_MS);
+  });
+});

--- a/packages/core/src/workflows/handlers/step.ts
+++ b/packages/core/src/workflows/handlers/step.ts
@@ -298,6 +298,11 @@ export async function executeStep(
         throw validationError;
       }
 
+      // Read inside the durable operation so the timestamp is memoized with the
+      // rest of the result. A reading taken outside would be re-taken on every
+      // replay, collapsing the reported span to the replay's own overhead.
+      const durableStartedAt = Date.now();
+
       const retryCount = engine.getOrGenerateRetryCount(step.id);
 
       let timeTravelSteps: string[] = [];
@@ -447,7 +452,14 @@ export async function executeStep(
 
       const nestedWflowStepPaused = isNestedWorkflowStep && perStep;
 
-      return { output, suspended, bailed, contextMutations, nestedWflowStepPaused };
+      return {
+        output,
+        suspended,
+        bailed,
+        contextMutations,
+        nestedWflowStepPaused,
+        timings: { startedAt: durableStartedAt, endedAt: Date.now() },
+      };
     },
     { retries, delay, stepSpan, workflowId, runId },
   );
@@ -487,19 +499,34 @@ export async function executeStep(
       });
     }
 
+    // Timestamps come from inside the durable operation. On replay engines the
+    // operation above is served from the memo, so reading the clock out here
+    // would time the replay rather than the execution. `startedAt` is only
+    // restored for a fresh attempt: on resume the original `startedAt` is
+    // carried over from the pre-suspend attempt via `stepInfo` and must stay.
+    const { timings } = durableResult;
+    const startedAtOverride = startTime && timings ? { startedAt: timings.startedAt } : {};
+    const resolvedEndedAt = timings?.endedAt ?? Date.now();
+
     if (durableResult.suspended) {
       execResults = {
         status: 'suspended',
         suspendPayload: durableResult.suspended.payload,
         ...(durableResult.output ? { suspendOutput: durableResult.output } : {}),
-        suspendedAt: Date.now(),
+        ...startedAtOverride,
+        suspendedAt: resolvedEndedAt,
       };
     } else if (durableResult.bailed) {
-      execResults = { status: 'bailed', output: durableResult.bailed.payload, endedAt: Date.now() };
+      execResults = {
+        status: 'bailed',
+        output: durableResult.bailed.payload,
+        ...startedAtOverride,
+        endedAt: resolvedEndedAt,
+      };
     } else if (durableResult.nestedWflowStepPaused) {
       execResults = { status: 'paused' };
     } else {
-      execResults = { status: 'success', output: durableResult.output, endedAt: Date.now() };
+      execResults = { status: 'success', output: durableResult.output, ...startedAtOverride, endedAt: resolvedEndedAt };
     }
   }
 


### PR DESCRIPTION
Two independent bugs make the workflow graph in Studio misreport what a run actually did. Both originate in `@mastra/core`'s step execution, not in the UI. A third, unrelated fix to the snapshot publish job is included because it currently blocks publishing a snapshot of this branch.

## 1. Completed steps and sub-workflows report near-zero durations

**Symptom:** on durable engines, a step that really took seconds renders as single-digit milliseconds once it completes. Sub-workflow cards are hit hardest, since they aggregate a whole nested run.

**Cause:** `executeStep` read both timestamps *outside* the durable operation:

```ts
const startTime = resumeDataToUse ? undefined : Date.now();   // before
// ... await engine.executeStepWithRetry(id, async () => { /* memoized */ })
execResults = { status: 'success', output, endedAt: Date.now() };  // after
```

`@mastra/inngest`'s `InngestExecutionEngine` implements `wrapDurableOperation` with `step.run(...)`, so after every completed step the workflow function body re-runs from the top and finished steps are served from the memo without executing. Both readings above are re-taken on each replay, moments apart, and the last replay is what lands in the persisted snapshot the graph renders. `endedAt - startedAt` therefore measures replay overhead, not execution.

Note this is the same replay hazard the surrounding code already handles for `contextMutations`:

> `// For Inngest: on replay, the wrapped function didn't re-execute, so we restore from the memoized result`

The timestamps were simply never included in the memoized result.

**Fix:** capture `startedAt`/`endedAt` inside the durable operation, return them with the result, and restore them from the memo. `startedAt` is only restored for a fresh attempt — on resume the original start is still carried over from the pre-suspend attempt via `stepInfo`, so suspend/resume duration semantics are unchanged.

## 2. Parallel branches don't report a child as finished until every sibling is

**Symptom:** in `.parallel([a, b, c])`, a fast child stays `running` in the graph until the slowest sibling lands. A step that has demonstrably finished keeps spinning because a long-running sibling holds the branch open.

**Cause:** `executeParallel` pre-marks every child `running`, fans out over `Promise.all`, and contains no `persistStepUpdate` calls at all. The first write is the surrounding `executeEntry`'s, *after* the join. So `getWorkflowRunById` keeps serving `running` for children that already succeeded. Sequential steps aren't affected because `executeEntry` runs once per step.

The live watch stream is correct here — per-child `workflow-step-result` events are emitted as each child settles. It's the snapshot that lags, which is what the graph falls back to on reload, when observing a run it didn't start, or via any `runById` poll.

**Fix:** persist each child as it settles. The `phase` keeps the durable operation id unique per branch so replay engines don't collapse the writes into a single memoized operation.

## 3. Snapshot publishes fail on any non-workspace `@mastra/*` dependency

Unrelated to the two fixes above, but folded in here because it blocks publishing a snapshot of this branch. The snapshot job rewrote **every** `@mastra/*` dependency to `workspace:*` with a blanket sed, whether or not the package is developed in this repo:

```bash
sed 's/"@mastra\/\([^"]*\)":[[:space:]]"[^"]*"/"@mastra\/\1": "workspace:*"/g'
```

The `@mastra` scope on npm also carries packages that aren't workspace members. `docs` depends on two — `@mastra/docusaurus-plugin-algolia` and `@mastra/docusaurus-plugin-kapa` — so the rewrite pointed two registry deps at packages that don't exist here:

```
[ERR_PNPM_WORKSPACE_PKG_NOT_FOUND] In docs: "@mastra/docusaurus-plugin-algolia@workspace:*"
is in the dependencies but no package named "@mastra/docusaurus-plugin-algolia" is present
in the workspace
```

This has broken every snapshot publish since docs took those plugins on (#19117). It's also why the job's first `pnpm install` succeeds and only the post-rewrite `--lockfile-only` install fails — the rewrite happens in between.

Replaced the sed with a script that asks `pnpm ls -r` which packages are actually in the workspace and pins only those. Ranges already on the workspace protocol are still normalized to `workspace:*`, matching previous behaviour.

Verified against the real workspace: the old sed reproduces the error above exactly (exit 1); the new script pins 110 manifests, leaves both docs plugins on their registry ranges, and lets `pnpm install --no-frozen-lockfile --lockfile-only` complete (exit 0). The job never commits these manifests back, so the script's reformatting is contained to the runner.

## Tests

Both bugs are covered by tests that fail on the previous behaviour:

- `step-timing-replay.test.ts` — drives a `DefaultExecutionEngine` subclass whose `wrapDurableOperation` memoizes and never re-executes, mirroring Inngest. A 150ms step reports **0ms** on replay before the fix. The test asserts a replayed operation actually occurred, so it can't pass by silently re-executing.
- `parallel-step-persist.test.ts` — records every persisted snapshot and asserts one exists where a fast child is `success` while a slow sibling is still `running`. Never true before the fix.

`packages/core` workflows suite: **814 passed, 9 skipped, 31 files**. `tsc --noEmit` clean.

## Trade-off worth a reviewer's eye

The per-branch persist adds one `persistStepUpdate` per parallel child. On Inngest each of those is a `step.run`, so parallel blocks gain one durable step per branch. That felt like the right call given the snapshot is otherwise wrong for the entire duration of the block, and `executeStep` already persists once per step at `phase: 'start'` — but if the step-count cost is a concern, the alternative is to leave the snapshot coarse and have consumers prefer the live stream.

## Not included

While tracing this I found some adjacent issues in `packages/playground` that I've left out to keep this reviewable:

- `workflow-clock.tsx` renders `toSigFigs(diff, 3)}ms`, so any duration ≥1s is rounded (`1234ms` → `1230ms`) and there's no s/m rollover — a 2-minute step renders `123000ms`.
- That same clock's 100ms interval is never cleared when `endedAt` arrives, so every completed step card re-renders 10×/sec for the life of the page. `use-time-diff.ts` is an already-corrected twin of this logic.
- `getRunDuration` in `workflow-trigger.tsx` takes `max(endedAt)` over steps before falling back to `Date.now()` for active runs, so once *any* step finishes the header duration freezes while a long step is still in flight.

Happy to send those as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workflows should show real progress: this PR makes step timers stay correct even when the engine “replays” work, and it makes parallel branches show `success` as soon as they finish instead of waiting for their slowest sibling.

## Summary

- Capture `startedAt`/`endedAt` inside durable operations and return memoized `timings`, so replay-based engines report the original execution duration accurately.
- Persist parallel branches independently when each branch settles (with per-branch phase markers), so completed children appear as `success` while sibling branches can remain `running`.
- Add tests for (1) replayed step timing correctness and (2) incremental persistence across parallel branches.
- Add a patch changeset for `@mastra/core`.
- Fix snapshot publishing dependency rewriting by updating workspace dependencies using a new workspace-aware script (switching the CI job from an inline `sed` loop to Node).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->