### PR TITLE
fix(server): make memory.resource optional in agent execution body schemas

### DIFF
--- a/.changeset/cool-cameras-fall.md
+++ b/.changeset/cool-cameras-fall.md
@@ -1,0 +1,16 @@
+---
+'@mastra/server': patch
+---
+
+Fixed agent generate and stream requests being rejected with a 400 error when `memory.resource` was omitted but server auth was configured with `mapUserToResourceId`. The request body schema required `memory.resource` even though the server derives the resource ID from the authenticated user and overrides any client-provided value.
+
+Clients no longer need to send a placeholder resource ID:
+
+```json
+{
+  "messages": ["what was my last message?"],
+  "memory": { "thread": "test-thread" }
+}
+```
+
+If a request uses memory and neither the body nor the authenticated request context provides a resource ID, the server now returns a clear 400 error. Fixes [#19518](https://github.com/mastra-ai/mastra/issues/19518).

--- a/.changeset/modern-crabs-pump.md
+++ b/.changeset/modern-crabs-pump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Updated generated route types so `memory.resource` is optional in agent generate and stream request bodies. The server can derive the resource ID from the authenticated user via `mapUserToResourceId`, so clients no longer need to provide it. Fixes [#19518](https://github.com/mastra-ai/mastra/issues/19518).

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -4873,7 +4873,7 @@ export type PostAgentsAgentIdGenerate_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -5048,7 +5048,7 @@ export type PostAgentsAgentIdGenerateVnext_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -5225,7 +5225,7 @@ export type PostAgentsAgentIdStream_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -5400,7 +5400,7 @@ export type PostAgentsAgentIdStreamUntilIdle_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -5580,7 +5580,7 @@ export type PostAgentsAgentIdStreamVnext_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -5915,7 +5915,7 @@ export type PostAgentsAgentIdSendMessage_Body =
                               id: string;
                               [x: string]: unknown;
                             };
-                        resource: string;
+                        resource?: string | undefined;
                         options?:
                           | {
                               [key: string]: any;
@@ -6301,7 +6301,7 @@ export type PostAgentsAgentIdQueueMessage_Body =
                               id: string;
                               [x: string]: unknown;
                             };
-                        resource: string;
+                        resource?: string | undefined;
                         options?:
                           | {
                               [key: string]: any;
@@ -6661,7 +6661,7 @@ export type PostAgentsAgentIdSignals_Body =
                               id: string;
                               [x: string]: unknown;
                             };
-                        resource: string;
+                        resource?: string | undefined;
                         options?:
                           | {
                               [key: string]: any;
@@ -7206,7 +7206,7 @@ export type PostAgentsAgentIdResumeStream_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -7602,7 +7602,7 @@ export type PostAgentsAgentIdResumeStreamUntilIdle_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -7782,7 +7782,7 @@ export type PostAgentsAgentIdNetwork_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -8433,7 +8433,7 @@ export type PostAgentsAgentIdStreamVNext_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -8613,7 +8613,7 @@ export type PostAgentsAgentIdStreamVnextUi_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -8795,7 +8795,7 @@ export type PostAgentsAgentIdStreamUi_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -21097,7 +21097,7 @@ export type PostAgentsAgentIdGenerateLegacy_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;
@@ -21277,7 +21277,7 @@ export type PostAgentsAgentIdStreamLegacy_Body = {
               id: string;
               [x: string]: unknown;
             };
-        resource: string;
+        resource?: string | undefined;
         options?:
           | {
               [key: string]: any;

--- a/docs/src/content/en/docs/server/request-context.mdx
+++ b/docs/src/content/en/docs/server/request-context.mdx
@@ -256,6 +256,8 @@ auth: {
 }
 ```
 
+When the resource ID is derived this way, clients can omit `memory.resource` from agent generate and stream request bodies — the server-derived value is used instead (and always takes precedence over any client-provided value). If a request uses memory and neither the body nor the request context provides a resource ID, the server responds with a 400 error.
+
 You can also set these keys manually in middleware:
 
 ```typescript

--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { HTTPException } from '../http-exception';
 import {
   abortAgentThreadBodySchema,
+  agentExecutionBodySchema,
   approveToolCallBodySchema,
   declineToolCallBodySchema,
   queueAgentMessageBodySchema,
@@ -754,6 +755,49 @@ describe('Agent Routes Authorization', () => {
         } as any),
       ).resolves.toBeDefined();
     });
+
+    it('should accept memory without resource when context provides one (mapUserToResourceId)', async () => {
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+
+      let capturedMemoryOption: any;
+      vi.spyOn(mockAgent, 'generate').mockImplementation(async (_messages, options) => {
+        capturedMemoryOption = options?.memory;
+        return { text: 'mocked response' } as any;
+      });
+
+      await GENERATE_AGENT_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        messages: [{ role: 'user', content: 'test' }],
+        memory: {
+          thread: 'new-thread',
+          // no resource — server derives it from the request context
+        },
+      } as any);
+
+      expect(capturedMemoryOption.resource).toBe('user-a');
+    });
+
+    it('should return 400 when memory is provided but no resource can be resolved', async () => {
+      await expect(
+        GENERATE_AGENT_ROUTE.handler({
+          mastra,
+          agentId: 'test-agent',
+          requestContext: new RequestContext(),
+          abortSignal: new AbortController().signal,
+          messages: [{ role: 'user', content: 'test' }],
+          memory: {
+            thread: 'new-thread',
+          },
+        } as any),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          status: 400,
+        }),
+      );
+    });
   });
 
   describe('STREAM_GENERATE_ROUTE', () => {
@@ -814,6 +858,78 @@ describe('Agent Routes Authorization', () => {
 
       // The resource should be overridden to user-a (from context)
       expect(capturedMemoryOption.resource).toBe('user-a');
+    });
+
+    it('should accept memory without resource when context provides one (mapUserToResourceId)', async () => {
+      const requestContext = createContextWithReservedKeys({ resourceId: 'user-a' });
+
+      let capturedMemoryOption: any;
+      vi.spyOn(mockAgent, 'stream').mockImplementation(async (_messages, options) => {
+        capturedMemoryOption = options?.memory;
+        return { fullStream: new ReadableStream() } as any;
+      });
+
+      await STREAM_GENERATE_ROUTE.handler({
+        mastra,
+        agentId: 'test-agent',
+        requestContext,
+        abortSignal: new AbortController().signal,
+        messages: [{ role: 'user', content: 'test' }],
+        memory: {
+          thread: 'new-stream-thread',
+          // no resource — server derives it from the request context
+        },
+      } as any);
+
+      expect(capturedMemoryOption.resource).toBe('user-a');
+    });
+
+    it('should return 400 when memory is provided but no resource can be resolved', async () => {
+      await expect(
+        STREAM_GENERATE_ROUTE.handler({
+          mastra,
+          agentId: 'test-agent',
+          requestContext: new RequestContext(),
+          abortSignal: new AbortController().signal,
+          messages: [{ role: 'user', content: 'test' }],
+          memory: {
+            thread: 'new-stream-thread',
+          },
+        } as any),
+      ).rejects.toThrow(
+        expect.objectContaining({
+          status: 400,
+        }),
+      );
+    });
+  });
+
+  describe('agentExecutionBodySchema memory option', () => {
+    it('accepts a memory option without resource', () => {
+      const result = agentExecutionBodySchema.safeParse({
+        messages: ['what was my last message?'],
+        memory: { thread: 'test-thread' },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('still accepts a memory option with resource', () => {
+      const result = agentExecutionBodySchema.safeParse({
+        messages: ['hi'],
+        memory: { thread: 'test-thread', resource: 'user-1' },
+      });
+
+      expect(result.success).toBe(true);
+    });
+
+    it('still requires thread when memory is provided', () => {
+      const result = agentExecutionBodySchema.safeParse({
+        messages: ['hi'],
+        memory: { resource: 'user-1' },
+      });
+
+      expect(result.success).toBe(false);
     });
   });
 

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -84,6 +84,7 @@ import {
   sanitizeBody,
   validateBody,
   getEffectiveResourceId,
+  requireEffectiveResourceId,
   getEffectiveThreadId,
   enforceThreadAccess,
   validateThreadOwnership,
@@ -1270,6 +1271,7 @@ export const GENERATE_AGENT_ROUTE = createRoute({
         const clientThreadId = typeof memoryOption.thread === 'string' ? memoryOption.thread : memoryOption.thread?.id;
 
         const effectiveResourceId = getEffectiveResourceId(serverRequestContext, memoryOption.resource);
+        requireEffectiveResourceId(effectiveResourceId);
         const effectiveThreadId = getEffectiveThreadId(serverRequestContext, clientThreadId);
 
         // Validate thread ownership if accessing an existing thread
@@ -1643,6 +1645,7 @@ export const STREAM_GENERATE_ROUTE = createRoute({
         const clientThreadId = typeof memoryOption.thread === 'string' ? memoryOption.thread : memoryOption.thread?.id;
 
         const effectiveResourceId = getEffectiveResourceId(serverRequestContext, memoryOption.resource);
+        requireEffectiveResourceId(effectiveResourceId);
         const effectiveThreadId = getEffectiveThreadId(serverRequestContext, clientThreadId);
 
         // Validate thread ownership if accessing an existing thread
@@ -2172,6 +2175,7 @@ export const STREAM_UNTIL_IDLE_GENERATE_ROUTE = createRoute({
         const clientThreadId = typeof memoryOption.thread === 'string' ? memoryOption.thread : memoryOption.thread?.id;
 
         const effectiveResourceId = getEffectiveResourceId(serverRequestContext, memoryOption.resource);
+        requireEffectiveResourceId(effectiveResourceId);
         const effectiveThreadId = getEffectiveThreadId(serverRequestContext, clientThreadId);
 
         // Validate thread ownership if accessing an existing thread
@@ -2623,6 +2627,9 @@ export const RESUME_STREAM_ROUTE = createRoute({
       let authorizedMemoryOption = memoryOption;
       const clientThreadId = typeof memoryOption?.thread === 'string' ? memoryOption.thread : memoryOption?.thread?.id;
       const effectiveResourceId = getEffectiveResourceId(serverRequestContext, memoryOption?.resource);
+      if (memoryOption) {
+        requireEffectiveResourceId(effectiveResourceId);
+      }
       const effectiveThreadId = getEffectiveThreadId(serverRequestContext, clientThreadId);
 
       if (effectiveThreadId) {
@@ -2816,6 +2823,9 @@ export const RESUME_STREAM_UNTIL_IDLE_ROUTE = createRoute({
       let authorizedMemoryOption = memoryOption;
       const clientThreadId = typeof memoryOption?.thread === 'string' ? memoryOption.thread : memoryOption?.thread?.id;
       const effectiveResourceId = getEffectiveResourceId(serverRequestContext, memoryOption?.resource);
+      if (memoryOption) {
+        requireEffectiveResourceId(effectiveResourceId);
+      }
       const effectiveThreadId = getEffectiveThreadId(serverRequestContext, clientThreadId);
 
       // Use the same FGA-aware ownership gate as RESUME_STREAM_ROUTE — the
@@ -2986,8 +2996,17 @@ export const STREAM_NETWORK_ROUTE = createRoute({
 
       validateBody({ messages });
 
+      // Authorization: context values take precedence over client-provided values
+      let authorizedMemoryOption = params.memory;
+      if (params.memory) {
+        const effectiveResourceId = getEffectiveResourceId(requestContext, params.memory.resource);
+        requireEffectiveResourceId(effectiveResourceId);
+        authorizedMemoryOption = { ...params.memory, resource: effectiveResourceId };
+      }
+
       const streamResult = await agent.network(messages, {
         ...params,
+        memory: authorizedMemoryOption,
       });
 
       return streamResult;

--- a/packages/server/src/server/handlers/utils.ts
+++ b/packages/server/src/server/handlers/utils.ts
@@ -79,6 +79,24 @@ export function getEffectiveResourceId(
 }
 
 /**
+ * Ensures a memory request has a resolvable resource ID. The body's
+ * `memory.resource` is optional so authenticated setups can rely on the
+ * server-derived resource ID (MASTRA_RESOURCE_ID_KEY set via mapUserToResourceId).
+ * When neither the body nor the request context provides one, reject with a
+ * clear 400 instead of failing deep inside agent execution.
+ */
+export function requireEffectiveResourceId(
+  effectiveResourceId: string | undefined,
+): asserts effectiveResourceId is string {
+  if (!effectiveResourceId) {
+    throw new HTTPException(400, {
+      message:
+        'A resource ID is required when using memory. Provide memory.resource in the request body, or configure server auth with mapUserToResourceId to derive it from the authenticated user.',
+    });
+  }
+}
+
+/**
  * Gets the effective threadId, preferring the reserved key from requestContext
  * over client-provided values for security.
  */

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -270,7 +270,13 @@ export const listToolsResponseSchema = z.record(z.string(), serializedToolSchema
  */
 const agentMemoryOptionSchema = z.object({
   thread: z.union([z.string(), z.object({ id: z.string() }).passthrough()]),
-  resource: z.string(),
+  /**
+   * Optional so authenticated setups can rely on the server-derived resource ID
+   * (`mapUserToResourceId` sets MASTRA_RESOURCE_ID_KEY in the request context, which
+   * takes precedence over this value). Handlers return a 400 when neither the body
+   * nor the request context provides a resource ID.
+   */
+  resource: z.string().optional(),
   options: z.record(z.string(), z.any()).optional(),
   readOnly: z.boolean().optional(),
 });


### PR DESCRIPTION
When server auth is configured with `mapUserToResourceId`, the server derives the memory resource ID from the authenticated user and overrides anything the client sends. But the body schemas for the agent generate/stream routes still required `memory.resource`, so requests relying on the auth-derived ID got a 400 before ever reaching the handler. The workaround was sending a placeholder value.

Before:

```json
{ "messages": ["hi"], "memory": { "thread": "my-thread", "resource": "ignored" } }
```

After:

```json
{ "messages": ["hi"], "memory": { "thread": "my-thread" } }
```

`memory.resource` is now optional in the schema, and handlers return a clear 400 if memory is used but no resource ID can be resolved from either the body or the request context. The network route also now applies the same context-wins resource resolution as the other routes. Client-js route types were regenerated and the request-context docs updated. There's no security impact since the server-derived resource ID already took precedence over client values.

Fixes #19518


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You no longer need to send a memory resource ID when the server can figure it out from your login. If neither the request nor the server provides one, the API now returns a clear 400 error.

## Changes

- Made `memory.resource` optional for agent execution requests.
- Preserved authenticated server context as the source of truth over client-provided values.
- Added validation across generate, stream, resume, and network routes.
- Regenerated client route types and updated request-context documentation.
- Added tests covering inferred resources, missing resources, and schema validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->