### PR TITLE
feat(mcp-registry-registry): add mcpindex to the registry list

### DIFF
--- a/packages/mcp-registry-registry/src/registry/registry.ts
+++ b/packages/mcp-registry-registry/src/registry/registry.ts
@@ -126,6 +126,14 @@ export const registryData: RegistryFile = {
       count: 69,
     },
     {
+      id: 'mcpindex',
+      name: 'mcpindex',
+      description:
+        'Find MCP servers by natural-language task, with quality scores and an advisory trust screen (REVIEW / UNVERIFIED) that flags a tool before an agent calls it.',
+      url: 'https://mcpindex.ai',
+      tags: ['open-source'],
+    },
+    {
       id: 'mcpmarket',
       name: 'MCP Market',
       description: 'Explore our curated collection of MCP servers to connect AI to your favorite tools.',


### PR DESCRIPTION
Closes #19526

## What

Adds **mcpindex** (https://mcpindex.ai) to the MCP registry-registry list in `packages/mcp-registry-registry/src/registry/registry.ts`.

## Why it fits

This package is a list of MCP registries/indexes, and mcpindex is one: it indexes MCP servers from the official registry and adds a discovery + trust layer on top. You describe a task in plain language and get ranked server picks with quality scores, plus an advisory trust screen (`check_tool_trust` / `assess_server`) that flags a tool's integrity issues before an agent calls it (REVIEW / UNVERIFIED at v1; advisory, not a safety verdict). That trust/quality angle is distinct from the count-and-browse registries already listed.

## Notes

- Metadata-only entry (no `servers_url` / `postProcessServers`), matching several existing entries (Glama, MCP Market, MCP-Get, etc.). Happy to add a server-fetch processor in a follow-up if useful.
- Placed alphabetically by `id` in the `mcp*` cluster (between `mcpget` and `mcpmarket`).
- No fabricated server count included.

Not affiliated with Mastra. Supersedes #19525 (auto-closed by triage for missing a linked issue).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds mcpindex to the list of MCP registries so users can discover and evaluate MCP servers through its recommendations and advisory trust checks.

## Summary

- Added the `mcpindex` registry entry to `registry.ts`.
- Included its URL, open-source tag, quality scores, and advisory trust-screen description.
- Positioned it alphabetically between `mcpget` and `mcpmarket`.
- Kept the entry metadata-only without server counts or additional processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->