### PR TITLE
fix(ai-sdk): approval responses on earlier messages were never resumed

### DIFF
--- a/.changeset/fresh-donuts-divide.md
+++ b/.changeset/fresh-donuts-divide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed the AI SDK v6 native approval flow in handleChatStream so approval responses are collected across all assistant messages instead of only the final message. Approving a tool call now resumes its exact run and tool call, multiple approval responses in one request resume sequentially in a single framed response stream, and already-resolved responses from history are safely skipped instead of executing again.

--- a/client-sdks/ai-sdk/__recordings__/ai-sdk-src-__tests__-tool-call-approval.e2e.json
+++ b/client-sdks/ai-sdk/__recordings__/ai-sdk-src-__tests__-tool-call-approval.e2e.json
@@ -1,0 +1,404 @@
+{
+  "meta": {
+    "name": "ai-sdk-src-__tests__-tool-call-approval.e2e",
+    "testFile": "src/__tests__/tool-call-approval.e2e.test.ts",
+    "model": "gpt-5.4-mini",
+    "createdAt": "2026-07-15T16:37:08.295Z"
+  },
+  "recordings": [
+    {
+      "hash": "09525000dfe8185d",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.4-mini",
+          "input": [
+            {
+              "role": "developer",
+              "content": "When asked to record a value, call recordValue exactly once with that exact value. After the tool succeeds, confirm completion without calling another tool."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Record the value VALUE_A."
+                }
+              ]
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "recordValue",
+              "description": "Record the exact value provided by the user. Call this tool exactly once per request.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1784133420662
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a1ba307a5b56be62-SJC",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Wed, 15 Jul 2026 16:37:02 GMT",
+          "openai-organization": "work-kxidzh",
+          "openai-processing-ms": "821",
+          "openai-project": "proj_FCyHAyf1sRhVrYbrkAklMIPx",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "5000",
+          "x-ratelimit-limit-tokens": "2000000",
+          "x-ratelimit-remaining-requests": "4999",
+          "x-ratelimit-remaining-tokens": "1999453",
+          "x-ratelimit-reset-requests": "12ms",
+          "x-ratelimit-reset-tokens": "16ms",
+          "x-request-id": "req_ab6cce01b6484d4b961a8423dce18183"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0dbfc40853f09e61006a57b72de2d0819b929fa6046cbfce80\",\"object\":\"response\"",
+          ",\"created_at\":1784133421,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\nevent",
+          ": response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0dbfc40853f09e61006a57b72de2d0819b929fa6046cbfce80\",\"object\":\"response\",\"created_at\":1784133421,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalPr",
+          "operties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_an6zHEPprz52AIUlosAt4LKs\",\"name\":\"recordValue\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.function_cal",
+          "l_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"obfuscation\":\"TroHhYq76jDMGh\",\"output_index\":0,\"sequence_number\":3}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"value\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"obfuscation\":\"nyHpoPl6wkq\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"obfuscation\":\"ZqCWHcZLKNy4M\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"VALUE\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"obfuscation\":\"F1ycNObCCPd\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.function_cal",
+          "l_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"_A\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"obfuscation\":\"Cqe93HDh02M5jt\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"obfuscation\":\"k2efSFqLJndyiA\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.function_cal",
+          "l_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"value\\\":\\\"VALUE_A\\\"}\",\"item_id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"value\\\":\\\"VALUE_A\\\"}\",\"call_id\":\"call_an6zHEPprz52AIUlosAt4LKs\",\"name\":\"recordValue\"},\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0dbfc40853f09e61006a57b72de2d0819b929fa6046cbfce80\",\"object\":\"response\",\"created_at\":1784133421,\"status\":\"completed\",\"background\":false,\"completed_at\":1784133423,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[{\"id\":\"fc_0dbfc40853f09e61006a57b72ef378819b8e73dcff14e345e2\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"value\\\":\\\"VALUE_A\\\"}\",\"call_id\":\"call_an6zHEPprz52AIUlosAt4LKs\",\"name\":\"recordValue\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactl",
+          "y once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":92,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":19,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":111},\"user\":null,\"metadata\":{}},\"sequence_number\":11}\n\n"
+        ],
+        "chunkTimings": [0, 0, 1, 0, 249, 16, 0, 2, 1, 2, 8, 0, 0, 60, 0, 16, 172, 0],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "3769c81f3adae368",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.4-mini",
+          "input": [
+            {
+              "role": "developer",
+              "content": "When asked to record a value, call recordValue exactly once with that exact value. After the tool succeeds, confirm completion without calling another tool."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Record the value VALUE_B."
+                }
+              ]
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "recordValue",
+              "description": "Record the exact value provided by the user. Call this tool exactly once per request.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1784133423207
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a1ba30898e3fad44-SJC",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Wed, 15 Jul 2026 16:37:03 GMT",
+          "openai-organization": "work-kxidzh",
+          "openai-processing-ms": "213",
+          "openai-project": "proj_FCyHAyf1sRhVrYbrkAklMIPx",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "5000",
+          "x-ratelimit-limit-tokens": "2000000",
+          "x-ratelimit-remaining-requests": "4999",
+          "x-ratelimit-remaining-tokens": "1999453",
+          "x-ratelimit-reset-requests": "12ms",
+          "x-ratelimit-reset-tokens": "16ms",
+          "x-request-id": "req_90601bc397074835bac0d4e85601db58"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0f0c239b111fa127006a57b72fa9e48199a4d1d6c91766ecfe\",\"object\":\"respons",
+          "e\",\"created_at\":1784133423,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\neve",
+          "nt: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0f0c239b111fa127006a57b72fa9e48199a4d1d6c91766ecfe\",\"object\":\"response\",\"created_at\":1784133423,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additional",
+          "Properties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"type\":\"function_call\",\"status\":\"in_progress\",\"arguments\":\"\",\"call_id\":\"call_JIVNXji8F3OqrG13SY4E9ZW9\",\"name\":\"recordValue\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"{\\\"\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"obfuscation\":\"peOzEw6qAVYWfN\",\"output_index\":0,\"sequence_number\":3}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"value\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"obfuscation\":\"Kh7dF3LNHjm\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\":\\\"\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"obfuscation\":\"3BLPZLEyYEM1e\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.function_cal",
+          "l_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"VALUE\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"obfuscation\":\"35xHgxp4f0V\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"_B\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"obfuscation\":\"bwUAYvNjuQK40l\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.function_call_arguments.delta\ndata: {\"type\":\"response.function_call_arguments.delta\",\"delta\":\"\\\"}\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"obfuscation\":\"boaIIgkCkOVzVZ\",\"output_index\":0,\"sequence_number\":8}\n\n",
+          "event: response.function_call_arguments.done\ndata: {\"type\":\"response.function_call_arguments.done\",\"arguments\":\"{\\\"value\\\":\\\"VALUE_B\\\"}\",\"item_id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"output_index\":0,\"sequence_number\":9}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"value\\\":\\\"VALUE_B\\\"}\",\"call_id\":\"call_JIVNXji8F3OqrG13SY4E9ZW9\",\"name\":\"recordValue\"},\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.completed\nd",
+          "ata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0f0c239b111fa127006a57b72fa9e48199a4d1d6c91766ecfe\",\"object\":\"response\",\"created_at\":1784133423,\"status\":\"completed\",\"background\":false,\"completed_at\":1784133424,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[{\"id\":\"fc_0f0c239b111fa127006a57b7302a648199853f4aa97f7ffd68\",\"type\":\"function_call\",\"status\":\"completed\",\"arguments\":\"{\\\"value\\\":\\\"VALUE_B\\\"}\",\"call_id\":\"call_JIVNXji8F3OqrG13SY4E9ZW9\",\"name\":\"recordValue\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\"",
+          ":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":92,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":19,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":111},\"user\":null,\"metadata\":{}},\"sequence_number\":11}\n\n"
+        ],
+        "chunkTimings": [0, 0, 0, 0, 301, 24, 2, 2, 7, 0, 11, 0, 65, 1, 185, 0, 0],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "1b4813f1881487d0",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.4-mini",
+          "input": [
+            {
+              "role": "developer",
+              "content": "When asked to record a value, call recordValue exactly once with that exact value. After the tool succeeds, confirm completion without calling another tool."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Record the value VALUE_A."
+                }
+              ]
+            },
+            {
+              "type": "function_call",
+              "call_id": "call_an6zHEPprz52AIUlosAt4LKs",
+              "name": "recordValue",
+              "arguments": "{\"value\":\"VALUE_A\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_an6zHEPprz52AIUlosAt4LKs",
+              "output": "{\"recorded\":\"VALUE_A\"}"
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "recordValue",
+              "description": "Record the exact value provided by the user. Call this tool exactly once per request.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1784133424442
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a1ba308ffd78be62-SJC",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Wed, 15 Jul 2026 16:37:05 GMT",
+          "openai-organization": "work-kxidzh",
+          "openai-processing-ms": "405",
+          "openai-project": "proj_FCyHAyf1sRhVrYbrkAklMIPx",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "5000",
+          "x-ratelimit-limit-tokens": "2000000",
+          "x-ratelimit-remaining-requests": "4999",
+          "x-ratelimit-remaining-tokens": "1999416",
+          "x-ratelimit-reset-requests": "12ms",
+          "x-ratelimit-reset-tokens": "17ms",
+          "x-request-id": "req_8f27c7f7867a440eb34998cd02b8d512"
+        },
+        "chunks": [
+          "event: response.created\ndata: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0989de2d40338a3b006a57b730aa04819aba1ed5ec577165f0\",\"object\":\"respons",
+          "e\",\"created_at\":1784133424,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\neve",
+          "nt: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0989de2d40338a3b006a57b730aa04819aba1ed5ec577165f0\",\"object\":\"response\",\"created_at\":1784133424,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additional",
+          "Properties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Recorded\",\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"logprobs\":[],\"obfuscation\":\"J3E70Hvb\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"logprobs\":[],\"obfuscation\":\"NHyta9aoOmGauAt\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" VALUE\",\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"logprobs\":[],\"obfuscation\":\"FrF0QXaXr0\",\"output_index\":0,\"sequence_number\":6}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"_A\",\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"logprobs\":[],\"obfuscation\":\"nPlfwozZWvm1X8\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":8,\"text\":\"Recorded: VALUE_A\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Recorded: VALUE_A\"},\"sequence_number\":9}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Recorded: VALUE_A\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0989de2d40338a3b006a57b730aa04819aba1ed5ec577165f0\",\"object\":\"response\",\"created_at\":1784133424,\"status\":\"completed\",\"background\":false,\"completed_at\":1784133425,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[{\"id\":\"msg_0989de2d40338a3b006a57b73145b8819aadaecdec37a79370\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Recorded: VALUE_A\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by th",
+          "e user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":129,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":137},\"user\":null,\"metadata\":{}},\"sequence_number\":11}\n\n"
+        ],
+        "chunkTimings": [0, 4, 0, 0, 212, 0, 0, 18, 2, 0, 60, 5, 7, 116, 0],
+        "isStreaming": true
+      }
+    },
+    {
+      "hash": "c36200293d0c0596",
+      "request": {
+        "url": "https://api.openai.com/v1/responses",
+        "method": "POST",
+        "body": {
+          "model": "gpt-5.4-mini",
+          "input": [
+            {
+              "role": "developer",
+              "content": "When asked to record a value, call recordValue exactly once with that exact value. After the tool succeeds, confirm completion without calling another tool."
+            },
+            {
+              "role": "user",
+              "content": [
+                {
+                  "type": "input_text",
+                  "text": "Record the value VALUE_B."
+                }
+              ]
+            },
+            {
+              "type": "function_call",
+              "call_id": "call_JIVNXji8F3OqrG13SY4E9ZW9",
+              "name": "recordValue",
+              "arguments": "{\"value\":\"VALUE_B\"}"
+            },
+            {
+              "type": "function_call_output",
+              "call_id": "call_JIVNXji8F3OqrG13SY4E9ZW9",
+              "output": "{\"recorded\":\"VALUE_B\"}"
+            }
+          ],
+          "tools": [
+            {
+              "type": "function",
+              "name": "recordValue",
+              "description": "Record the exact value provided by the user. Call this tool exactly once per request.",
+              "parameters": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                "required": ["value"],
+                "additionalProperties": false
+              }
+            }
+          ],
+          "tool_choice": "auto",
+          "stream": true
+        },
+        "timestamp": 1784133427418
+      },
+      "response": {
+        "status": 200,
+        "statusText": "OK",
+        "headers": {
+          "access-control-expose-headers": "X-Request-ID, CF-Ray, CF-Ray",
+          "alt-svc": "h3=\":443\"; ma=86400",
+          "cf-cache-status": "DYNAMIC",
+          "cf-ray": "a1ba30a28802be62-SJC",
+          "connection": "keep-alive",
+          "content-type": "text/event-stream; charset=utf-8",
+          "date": "Wed, 15 Jul 2026 16:37:07 GMT",
+          "openai-organization": "work-kxidzh",
+          "openai-processing-ms": "169",
+          "openai-project": "proj_FCyHAyf1sRhVrYbrkAklMIPx",
+          "openai-version": "2020-10-01",
+          "server": "cloudflare",
+          "strict-transport-security": "max-age=31536000; includeSubDomains; preload",
+          "x-content-type-options": "nosniff",
+          "x-ratelimit-limit-requests": "5000",
+          "x-ratelimit-limit-tokens": "2000000",
+          "x-ratelimit-remaining-requests": "4999",
+          "x-ratelimit-remaining-tokens": "1999416",
+          "x-ratelimit-reset-requests": "12ms",
+          "x-ratelimit-reset-tokens": "17ms",
+          "x-request-id": "req_9cdf25f36bcf475cab6a1c2d94275994"
+        },
+        "chunks": [
+          "event: response.created\ndat",
+          "a: {\"type\":\"response.created\",\"response\":{\"id\":\"resp_0042fc1523932eae006a57b733a784819b9788007f611d15bf\",\"object\":\"response\",\"created_at\":1784133427,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\"",
+          ":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":0}\n\n",
+          "event: response.in_progress\ndata: {\"type\":\"response.in_progress\",\"response\":{\"id\":\"resp_0042fc1523932eae006a57b733a784819b9788007f611d15bf\",\"object\":\"response\",\"created_at\":1784133427,\"status\":\"in_progress\",\"background\":false,\"completed_at\":null,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"auto\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"ad",
+          "ditionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":null,\"user\":null,\"metadata\":{}},\"sequence_number\":1}\n\n",
+          "event: response.output_item.added\ndata: {\"type\":\"response.output_item.added\",\"item\":{\"id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"type\":\"message\",\"status\":\"in_progress\",\"content\":[],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":2}\n\n",
+          "event: response.content_part.added\ndata: {\"type\":\"response.content_part.added\",\"content_index\":0,\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"\"},\"sequence_number\":3}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"Recorded\",\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"logprobs\":[],\"obfuscation\":\"VixFoqDy\",\"output_index\":0,\"sequence_number\":4}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\":\",\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"logprobs\":[],\"obfuscation\":\"dT50hyf3PfDivlq\",\"output_index\":0,\"sequence_number\":5}\n\n",
+          "event: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\" VALUE\",\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"logprobs\":[],\"obfuscation\":\"Vq4NQC16SL\",\"output_index\":0,\"sequence_number\":6}\n\nevent: response.output_text.delta\ndata: {\"type\":\"response.output_text.delta\",\"content_index\":0,\"delta\":\"_B\",\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"logprobs\":[],\"obfuscation\":\"PpzkV2uOQ6lBPh\",\"output_index\":0,\"sequence_number\":7}\n\n",
+          "event: response.output_text.done\ndata: {\"type\":\"response.output_text.done\",\"content_index\":0,\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"logprobs\":[],\"output_index\":0,\"sequence_number\":8,\"text\":\"Recorded: VALUE_B\"}\n\n",
+          "event: response.content_part.done\ndata: {\"type\":\"response.content_part.done\",\"content_index\":0,\"item_id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"output_index\":0,\"part\":{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Recorded: VALUE_B\"},\"sequence_number\":9}\n\n",
+          "event: response.output_item.done\ndata: {\"type\":\"response.output_item.done\",\"item\":{\"id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Recorded: VALUE_B\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"},\"output_index\":0,\"sequence_number\":10}\n\n",
+          "event: response.completed\ndata: {\"type\":\"response.completed\",\"response\":{\"id\":\"resp_0042fc1523932eae006a57b733a784819b9788007f611d15bf\",\"object\":\"response\",\"created_at\":1784133427,\"status\":\"completed\",\"background\":false,\"completed_at\":1784133428,\"error\":null,\"frequency_penalty\":0.0,\"incomplete_details\":null,\"instructions\":null,\"max_output_tokens\":null,\"max_tool_calls\":null,\"model\":\"gpt-5.4-mini-2026-03-17\",\"moderation\":null,\"output\":[{\"id\":\"msg_0042fc1523932eae006a57b73411e0819bb2f1128ffc4dd9ef\",\"type\":\"message\",\"status\":\"completed\",\"content\":[{\"type\":\"output_text\",\"annotations\":[],\"logprobs\":[],\"text\":\"Recorded: VALUE_B\"}],\"phase\":\"final_answer\",\"role\":\"assistant\"}],\"parallel_tool_calls\":true,\"presence_penalty\":0.0,\"previous_response_id\":null,\"prompt_cache_key\":null,\"prompt_cache_retention\":\"24h\",\"reasoning\":{\"context\":\"current_turn\",\"effort\":\"none\",\"mode\":\"standard\",\"summary\":null},\"safety_identifier\":null,\"service_tier\":\"default\",\"store\":true,\"temperature\":1.0,\"text\":{\"format\":{\"type\":\"text\"},\"verbosity\":\"medium\"},\"tool_choice\":\"auto\",\"tool_usage\":{\"image_gen\":{\"input_tokens\":0,\"input_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"output_tokens\":0,\"output_tokens_details\":{\"image_tokens\":0,\"text_tokens\":0},\"total_tokens\":0},\"web_search\":{\"num_requests\":0}},\"tools\":[{\"type\":\"function\",\"description\":\"Record the exact value provided by the user. Call this tool exactly once per request.\",\"name\":\"recordValue\",\"output_schema\":null,\"parameters\":{\"$schema\":\"http://json-schema.org/draft-07/schema#\",\"type\":\"object\",\"properties\":{\"value\":{\"type\":\"string\"}},\"required\":[\"value\"],\"additionalProperties\":false},\"strict\":true}],\"top_logprobs\":0,\"top_p\":0.98,\"truncation\":\"disabled\",\"usage\":{\"input_tokens\":129,\"input_tokens_details\":{\"cache_write_tokens\":0,\"cached_tokens\":0},\"output_tokens\":8,\"output_tokens_details\":{\"reasoning_tokens\":0},\"total_tokens\":137},\"user\":null,\"metadata\":{}},\"sequence_number\":11}\n\n"
+        ],
+        "chunkTimings": [0, 1, 0, 9, 0, 243, 1, 0, 15, 3, 56, 1, 4, 187],
+        "isStreaming": true
+      }
+    }
+  ]
+}

--- a/client-sdks/ai-sdk/package.json
+++ b/client-sdks/ai-sdk/package.json
@@ -42,6 +42,8 @@
     "@internal/ai-sdk-v5": "workspace:*",
     "@internal/ai-v6": "workspace:*",
     "@internal/lint": "workspace:*",
+    "@internal/llm-recorder": "workspace:*",
+    "@internal/test-utils": "workspace:*",
     "@internal/types-builder": "workspace:*",
     "@mastra/core": "workspace:*",
     "@mastra/libsql": "workspace:*",

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.e2e.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.e2e.test.ts
@@ -1,0 +1,142 @@
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { createGatewayMock, setupDummyApiKeys } from '@internal/test-utils';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { InMemoryStore } from '@mastra/core/storage';
+import { createTool } from '@mastra/core/tools';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { handleChatStream } from '../chat-route';
+import { toAISdkStream } from '../convert-streams';
+import type { V6UIMessage } from '../public-types';
+
+const MODE = getLLMTestMode();
+setupDummyApiKeys(MODE, ['openai']);
+
+const mock = createGatewayMock();
+beforeAll(() => mock.start());
+afterAll(() => mock.saveAndStop());
+
+async function collectChunks(stream: ReadableStream) {
+  const chunks: any[] = [];
+  for await (const chunk of stream as any) chunks.push(chunk);
+  return chunks;
+}
+
+type ApprovalRequest = {
+  approvalId: string;
+  toolCallId: string;
+  input: { value: string };
+};
+
+function approvalMessage(request: ApprovalRequest, approved?: boolean): V6UIMessage {
+  const part =
+    approved === undefined
+      ? {
+          type: 'tool-recordValue' as const,
+          toolCallId: request.toolCallId,
+          state: 'approval-requested' as const,
+          input: request.input,
+          approval: { id: request.approvalId },
+        }
+      : {
+          type: 'tool-recordValue' as const,
+          toolCallId: request.toolCallId,
+          state: 'approval-responded' as const,
+          input: request.input,
+          output: undefined,
+          approval: { id: request.approvalId, approved },
+        };
+
+  return {
+    id: `message-${request.toolCallId}`,
+    role: 'assistant',
+    parts: [part],
+  };
+}
+
+describe('v6 whole-request tool approval extraction (e2e)', { timeout: 180_000 }, () => {
+  it('resumes a new exact target while safely skipping a resolved response from history', async () => {
+    const executedValues: string[] = [];
+    const recordValue = createTool({
+      id: 'recordValue',
+      description: 'Record the exact value provided by the user. Call this tool exactly once per request.',
+      inputSchema: z.object({ value: z.string() }),
+      requireApproval: true,
+      execute: async ({ value }) => {
+        executedValues.push(value);
+        return { recorded: value };
+      },
+    });
+    const agent = new Agent({
+      id: 'approval-extraction-e2e',
+      name: 'Approval Extraction E2E',
+      instructions:
+        'When asked to record a value, call recordValue exactly once with that exact value. After the tool succeeds, confirm completion without calling another tool.',
+      model: 'openai/gpt-5.4-mini',
+      tools: { recordValue },
+    });
+    const mastra = new Mastra({
+      agents: { approvalExtractionE2e: agent },
+      storage: new InMemoryStore(),
+      logger: false,
+    });
+    const registeredAgent = mastra.getAgent('approvalExtractionE2e');
+
+    const requestApproval = async (value: string): Promise<ApprovalRequest> => {
+      const result = await registeredAgent.stream(`Record the value ${value}.`, {
+        maxSteps: 3,
+        modelSettings: { maxRetries: 0 },
+      });
+      const chunks = await collectChunks(
+        toAISdkStream(result, {
+          from: 'agent',
+          version: 'v6',
+        }),
+      );
+      const approval = chunks.find(chunk => chunk.type === 'tool-approval-request');
+      const input = chunks.find(
+        chunk => chunk.type === 'tool-input-available' && chunk.toolCallId === approval?.toolCallId,
+      )?.input;
+
+      expect(approval).toBeDefined();
+      expect(input).toEqual({ value });
+      return { approvalId: approval.approvalId, toolCallId: approval.toolCallId, input };
+    };
+
+    const approvalA = await requestApproval('VALUE_A');
+    const approvalB = await requestApproval('VALUE_B');
+
+    const firstResponse = await handleChatStream({
+      mastra,
+      agentId: agent.id,
+      version: 'v6',
+      params: {
+        messages: [approvalMessage(approvalA, true), approvalMessage(approvalB)],
+      },
+    });
+    const firstChunks = await collectChunks(firstResponse);
+
+    expect(executedValues).toEqual(['VALUE_A']);
+    expect(firstChunks[0]?.type).toBe('start');
+    expect(firstChunks.filter(chunk => chunk.type === 'start')).toHaveLength(1);
+    expect(firstChunks.filter(chunk => chunk.type === 'finish')).toHaveLength(1);
+    expect(firstChunks.find(chunk => chunk.type === 'error')).toBeUndefined();
+
+    const secondResponse = await handleChatStream({
+      mastra,
+      agentId: agent.id,
+      version: 'v6',
+      params: {
+        messages: [approvalMessage(approvalA, true), approvalMessage(approvalB, true)],
+      },
+    });
+    const secondChunks = await collectChunks(secondResponse);
+
+    expect(executedValues).toEqual(['VALUE_A', 'VALUE_B']);
+    expect(secondChunks[0]?.type).toBe('start');
+    expect(secondChunks.filter(chunk => chunk.type === 'start')).toHaveLength(1);
+    expect(secondChunks.filter(chunk => chunk.type === 'finish')).toHaveLength(1);
+    expect(secondChunks.find(chunk => chunk.type === 'error')).toBeUndefined();
+  });
+});

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -247,6 +247,27 @@ describe('extractV6NativeApproval', () => {
     expect(extractV6NativeApprovals(messages as any)).toEqual([]);
   });
 
+  it('skips a part whose composite approval id embeds a different toolCallId', () => {
+    const approvalId = `run-123${APPROVAL_ID_SEPARATOR}tooluse_other`;
+    const messages = [
+      {
+        role: 'assistant' as const,
+        id: 'msg-1',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'tooluse_abc123',
+            state: 'approval-responded' as const,
+            input: {},
+            approval: { id: approvalId, approved: true },
+          },
+        ],
+      },
+    ];
+
+    expect(extractV6NativeApprovals(messages as any)).toEqual([]);
+  });
+
   it('returns null when the approval id has no separator', () => {
     const messages = [
       {

--- a/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/tool-call-approval.test.ts
@@ -3,7 +3,7 @@ import { readUIMessageStream } from '@internal/ai-v6';
 import { ChunkFrom } from '@mastra/core/stream';
 import type { MastraModelOutput } from '@mastra/core/stream';
 import { describe, expect, it, vi } from 'vitest';
-import { handleChatStream, extractV6NativeApproval } from '../chat-route';
+import { handleChatStream, extractV6NativeApprovals } from '../chat-route';
 import { toAISdkStream, toAISdkV5Stream } from '../convert-streams';
 import { convertMastraChunkToAISDKv5, convertMastraChunkToAISDKv6, APPROVAL_ID_SEPARATOR } from '../helpers';
 
@@ -163,13 +163,15 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    const result = extractV6NativeApproval(messages as any);
+    const result = extractV6NativeApprovals(messages as any);
 
-    expect(result).toEqual({
-      resumeData: { approved: true },
-      runId: 'run-123',
-      toolCallId: 'tooluse_abc123',
-    });
+    expect(result).toEqual([
+      {
+        resumeData: { approved: true },
+        runId: 'run-123',
+        toolCallId: 'tooluse_abc123',
+      },
+    ]);
   });
 
   it('includes reason when the user denied with a reason', () => {
@@ -190,13 +192,15 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    const result = extractV6NativeApproval(messages as any);
+    const result = extractV6NativeApprovals(messages as any);
 
-    expect(result).toEqual({
-      resumeData: { approved: false, reason: 'Not safe' },
-      runId: 'run-456',
-      toolCallId: 'tooluse_xyz',
-    });
+    expect(result).toEqual([
+      {
+        resumeData: { approved: false, reason: 'Not safe' },
+        runId: 'run-456',
+        toolCallId: 'tooluse_xyz',
+      },
+    ]);
   });
 
   it('omits reason when not provided', () => {
@@ -217,9 +221,9 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    const result = extractV6NativeApproval(messages as any);
+    const result = extractV6NativeApprovals(messages as any);
 
-    expect(result?.resumeData).not.toHaveProperty('reason');
+    expect(result[0]?.resumeData).not.toHaveProperty('reason');
   });
 
   it('returns null when no approval-responded part exists', () => {
@@ -240,7 +244,7 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    expect(extractV6NativeApproval(messages as any)).toBeNull();
+    expect(extractV6NativeApprovals(messages as any)).toEqual([]);
   });
 
   it('returns null when the approval id has no separator', () => {
@@ -260,10 +264,10 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    expect(extractV6NativeApproval(messages as any)).toBeNull();
+    expect(extractV6NativeApprovals(messages as any)).toEqual([]);
   });
 
-  it('picks the most recent approval-responded part when one assistant message has several (issue #17899)', () => {
+  it('collects every approval response when one assistant message has several (issue #17899)', () => {
     const messages = [
       {
         role: 'assistant' as const,
@@ -287,14 +291,15 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    const result = extractV6NativeApproval(messages as any);
+    const result = extractV6NativeApprovals(messages as any);
 
-    expect(result?.runId).toBe('new-run');
-    expect(result?.resumeData.approved).toBe(false);
-    expect(result?.resumeData.reason).toBe('changed mind');
+    expect(result).toEqual([
+      { resumeData: { approved: true }, runId: 'old-run', toolCallId: 'old-call' },
+      { resumeData: { approved: false, reason: 'changed mind' }, runId: 'new-run', toolCallId: 'new-call' },
+    ]);
   });
 
-  it('scans from the end and picks the most recent approval-responded part', () => {
+  it('collects approval responses across assistant messages', () => {
     const messages = [
       {
         role: 'assistant' as const,
@@ -324,13 +329,15 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    const result = extractV6NativeApproval(messages as any);
+    const result = extractV6NativeApprovals(messages as any);
 
-    expect(result?.runId).toBe('new-run');
-    expect(result?.resumeData.approved).toBe(false);
+    expect(result).toEqual([
+      { resumeData: { approved: true }, runId: 'old-run', toolCallId: 'old-call' },
+      { resumeData: { approved: false }, runId: 'new-run', toolCallId: 'new-call' },
+    ]);
   });
 
-  it('ignores earlier approval responses once a later user follow-up exists', () => {
+  it('extracts history independently of the trailing message role', () => {
     const messages = [
       {
         role: 'assistant' as const,
@@ -352,7 +359,28 @@ describe('extractV6NativeApproval', () => {
       },
     ];
 
-    expect(extractV6NativeApproval(messages as any)).toBeNull();
+    expect(extractV6NativeApprovals(messages as any)).toEqual([
+      { resumeData: { approved: true }, runId: 'old-run', toolCallId: 'old-call' },
+    ]);
+  });
+
+  it('keeps responses with the same toolCallId when they target different runs', () => {
+    const part = (runId: string, approved: boolean) => ({
+      type: 'tool-myTool',
+      toolCallId: 'shared-call',
+      state: 'approval-responded' as const,
+      input: {},
+      approval: { id: `${runId}${APPROVAL_ID_SEPARATOR}shared-call`, approved },
+    });
+    const messages = [
+      { role: 'assistant', id: 'msg-1', parts: [part('run-1', true)] },
+      { role: 'assistant', id: 'msg-2', parts: [part('run-2', false)] },
+    ];
+
+    expect(extractV6NativeApprovals(messages as any)).toEqual([
+      { resumeData: { approved: true }, runId: 'run-1', toolCallId: 'shared-call' },
+      { resumeData: { approved: false }, runId: 'run-2', toolCallId: 'shared-call' },
+    ]);
   });
 });
 
@@ -454,6 +482,210 @@ describe('handleChatStream v6 native approve() resume flow', () => {
       { approved: true },
       expect.objectContaining({ runId: 'explicit-run' }),
     );
+  });
+
+  it('finds an approval response on an earlier assistant message', async () => {
+    vi.clearAllMocks();
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded',
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+        ],
+      },
+      {
+        id: 'msg-2',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'new-call',
+            state: 'approval-requested',
+            input: {},
+            approval: { id: `new-run${APPROVAL_ID_SEPARATOR}new-call` },
+          },
+        ],
+      },
+    ];
+
+    const stream = await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages } as any,
+    });
+    await collectChunks(stream);
+
+    expect(mockAgent.resumeStream).toHaveBeenCalledWith(
+      { approved: true },
+      expect.objectContaining({ runId: 'old-run', toolCallId: 'old-call' }),
+    );
+    expect(mockAgent.stream).not.toHaveBeenCalled();
+  });
+
+  it('does not consume a later user message as an approval resume', async () => {
+    vi.clearAllMocks();
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'old-call',
+            state: 'approval-responded',
+            input: {},
+            approval: { id: `old-run${APPROVAL_ID_SEPARATOR}old-call`, approved: true },
+          },
+        ],
+      },
+      { id: 'msg-2', role: 'user', parts: [{ type: 'text', text: 'What happened?' }] },
+    ];
+
+    const stream = await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages } as any,
+    });
+    await collectChunks(stream);
+
+    expect(mockAgent.stream).toHaveBeenCalledTimes(1);
+    expect(mockAgent.resumeStream).not.toHaveBeenCalled();
+  });
+
+  it('skips a re-sent resolved response when a later exact target resumes', async () => {
+    vi.clearAllMocks();
+    mockAgent.resumeStream
+      .mockRejectedValueOnce(Object.assign(new Error('already resolved'), { id: 'AGENT_RESUME_NO_SNAPSHOT_FOUND' }))
+      .mockResolvedValueOnce(emptyStream);
+    const response = (runId: string, toolCallId: string) => ({
+      id: `msg-${runId}`,
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-myTool',
+          toolCallId,
+          state: 'approval-responded',
+          input: {},
+          approval: { id: `${runId}${APPROVAL_ID_SEPARATOR}${toolCallId}`, approved: true },
+        },
+      ],
+    });
+
+    const stream = await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages: [response('old-run', 'old-call'), response('new-run', 'new-call')] } as any,
+    });
+    await collectChunks(stream);
+
+    expect(mockAgent.resumeStream).toHaveBeenCalledTimes(2);
+    expect(mockAgent.resumeStream).toHaveBeenLastCalledWith(
+      { approved: true },
+      expect.objectContaining({ runId: 'new-run', toolCallId: 'new-call' }),
+    );
+  });
+
+  it('surfaces the core error when no approval target can be resumed', async () => {
+    vi.clearAllMocks();
+    mockAgent.resumeStream.mockRejectedValueOnce(
+      Object.assign(new Error('target is not suspended'), { id: 'AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED' }),
+    );
+    const messages = [
+      {
+        id: 'msg-1',
+        role: 'assistant',
+        parts: [
+          {
+            type: 'tool-myTool',
+            toolCallId: 'call-B',
+            state: 'approval-responded',
+            input: {},
+            approval: { id: `run-1${APPROVAL_ID_SEPARATOR}call-B`, approved: true },
+          },
+        ],
+      },
+    ];
+
+    const stream = await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages } as any,
+    });
+    const chunks = await collectChunks(stream);
+
+    expect(chunks).toContainEqual(expect.objectContaining({ type: 'error' }));
+    expect(mockAgent.stream).not.toHaveBeenCalled();
+  });
+
+  it('resumes multiple exact targets sequentially and keeps one framed response', async () => {
+    vi.clearAllMocks();
+    const resumeStream = (runId: string) => ({
+      fullStream: new ReadableStream({
+        start(controller) {
+          controller.enqueue({ type: 'start', runId, from: ChunkFrom.AGENT, payload: {} });
+          controller.enqueue({
+            type: 'finish',
+            runId,
+            from: ChunkFrom.AGENT,
+            payload: { stepResult: { reason: runId === 'run-1' ? 'length' : 'stop' }, output: { usage: {} } },
+          });
+          controller.close();
+        },
+      }),
+    });
+    // An empty first leg must not suppress framing from the final leg.
+    mockAgent.resumeStream.mockResolvedValueOnce(emptyStream).mockResolvedValueOnce(resumeStream('run-2'));
+    const response = (runId: string, toolCallId: string) => ({
+      id: `msg-${runId}`,
+      role: 'assistant',
+      parts: [
+        {
+          type: 'tool-myTool',
+          toolCallId,
+          state: 'approval-responded',
+          input: {},
+          approval: { id: `${runId}${APPROVAL_ID_SEPARATOR}${toolCallId}`, approved: true },
+        },
+      ],
+    });
+
+    const stream = await handleChatStream({
+      mastra: mockMastra as any,
+      agentId: 'test-agent',
+      version: 'v6',
+      params: { messages: [response('run-1', 'call-A'), response('run-2', 'call-B')] } as any,
+      messageMetadata: ({ part }: any) =>
+        part?.type === 'finish' ? { finishReason: part.rawFinishReason } : undefined,
+    });
+    const chunks = await collectChunks(stream);
+
+    expect(mockAgent.resumeStream).toHaveBeenCalledTimes(2);
+    expect(mockAgent.resumeStream).toHaveBeenNthCalledWith(
+      1,
+      { approved: true },
+      expect.objectContaining({ runId: 'run-1', toolCallId: 'call-A' }),
+    );
+    expect(mockAgent.resumeStream).toHaveBeenNthCalledWith(
+      2,
+      { approved: true },
+      expect.objectContaining({ runId: 'run-2', toolCallId: 'call-B' }),
+    );
+    expect(chunks[0]?.type).toBe('start');
+    expect(chunks.filter(chunk => chunk.type === 'start')).toHaveLength(1);
+    expect(chunks.filter(chunk => chunk.type === 'finish')).toEqual([
+      expect.objectContaining({ messageMetadata: { finishReason: 'stop' } }),
+    ]);
   });
 });
 

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -23,51 +23,139 @@ import type {
   V6UIMessageStream,
 } from './public-types';
 
+export interface V6NativeApprovalResponse {
+  resumeData: Record<string, unknown>;
+  runId: string;
+  toolCallId: string;
+}
+
 /**
- * Scans a v6 UIMessage array for the most recent 'approval-responded' tool
- * part in the last trailing assistant message only. When found, splits the
- * composite approvalId ("${runId}::${toolCallId}") to recover the runId and
- * toolCallId needed for a targeted resumeStream.
- *
- * Only the last trailing assistant message is inspected so that approval
- * responses from earlier turns are never re-processed. Within that message,
- * parts are scanned in reverse so the decision the user just acted on wins
- * over any earlier 'approval-responded' parts that have not yet transitioned
- * to 'output-available'.
- *
- * Returns null when no approval response is present (normal chat turn).
+ * Collects every approval response across all assistant messages in a v6
+ * request. Responses are deduplicated by their composite run/tool-call target,
+ * with the most recent part winning when history contains repeated copies.
  */
-export function extractV6NativeApproval(
-  messages: V6UIMessage[],
-): { resumeData: Record<string, unknown>; runId: string; toolCallId: string } | null {
-  // Only inspect the actual trailing message. If a user has already sent a
-  // follow-up turn after an approval response, we must treat that as a normal
-  // chat submission rather than replaying the stale approval response.
-  const lastAssistantMsg = messages.at(-1);
-  if (!lastAssistantMsg || lastAssistantMsg.role !== 'assistant') return null;
+export function extractV6NativeApprovals(messages: V6UIMessage[]): V6NativeApprovalResponse[] {
+  const byTarget = new Map<string, V6NativeApprovalResponse>();
+  const separator = APPROVAL_ID_SEPARATOR;
 
-  const parts = lastAssistantMsg.parts ?? [];
-  for (let i = parts.length - 1; i >= 0; i--) {
-    const part = parts[i]!;
-    if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
+  for (const message of messages) {
+    if (message.role !== 'assistant') continue;
 
-    const lastSep = part.approval.id.lastIndexOf(APPROVAL_ID_SEPARATOR);
-    if (lastSep === -1) continue;
-    const runId = part.approval.id.slice(0, lastSep);
-    const toolCallId = part.approval.id.slice(lastSep + APPROVAL_ID_SEPARATOR.length);
-    if (!runId || !toolCallId) continue;
+    for (const part of message.parts ?? []) {
+      if (!isToolUIPart(part) || part.state !== 'approval-responded') continue;
 
-    return {
-      resumeData: {
-        approved: part.approval.approved,
-        ...(part.approval.reason != null ? { reason: part.approval.reason } : {}),
-      },
-      runId,
-      toolCallId,
-    };
+      const lastSep = part.approval.id.lastIndexOf(separator);
+      if (lastSep === -1) continue;
+      const runId = part.approval.id.slice(0, lastSep);
+      const toolCallId = part.approval.id.slice(lastSep + separator.length);
+      if (!runId || !toolCallId) continue;
+
+      byTarget.set(`${runId}${separator}${toolCallId}`, {
+        resumeData: {
+          approved: part.approval.approved,
+          ...(part.approval.reason != null ? { reason: part.approval.reason } : {}),
+        },
+        runId,
+        toolCallId,
+      });
+    }
   }
 
-  return null;
+  return [...byTarget.values()];
+}
+
+/** Streams exact approval targets sequentially as one v6 UI-message response. */
+function streamV6ApprovalResumes(args: {
+  agent: { resumeStream: (resumeData: unknown, options: unknown) => Promise<unknown> };
+  approvals: V6NativeApprovalResponse[];
+  baseOptions: Record<string, unknown>;
+  structuredOutput?: unknown;
+  messages: V6UIMessage[];
+  lastMessageId?: string;
+  sendStart: boolean;
+  sendFinish: boolean;
+  sendReasoning: boolean;
+  sendSources: boolean;
+  onError?: (error: unknown) => string;
+  messageMetadata?: UIMessageStreamOptionsV6<V6UIMessage>['messageMetadata'];
+}): ReadableStream<any> {
+  const { agent, approvals, baseOptions, structuredOutput, messages, lastMessageId } = args;
+  const { sendStart, sendFinish, sendReasoning, sendSources, onError, messageMetadata } = args;
+
+  return createUIMessageStreamV6<any>({
+    originalMessages: messages,
+    onError,
+    execute: async ({ writer }) => {
+      let startWritten = false;
+      let successfulLegs = 0;
+      let firstResolvedTargetError: unknown;
+      let finalFinish: any;
+
+      for (const approval of approvals) {
+        try {
+          const result = await agent.resumeStream(approval.resumeData, {
+            ...baseOptions,
+            runId: approval.runId,
+            toolCallId: approval.toolCallId,
+            ...(structuredOutput ? { structuredOutput } : {}),
+          });
+
+          for await (const part of toAISdkStream(result as Parameters<typeof toAISdkStream>[0], {
+            from: 'agent',
+            version: 'v6',
+            lastMessageId,
+            sendStart,
+            sendFinish,
+            sendReasoning,
+            sendSources,
+            onError,
+            messageMetadata,
+          })) {
+            if (part.type === 'start') {
+              if (startWritten) continue;
+              startWritten = true;
+              writer.write(part);
+              continue;
+            }
+            // Resume streams can emit tool continuation chunks before their
+            // start chunk. Frame the combined response before forwarding any
+            // such content, then suppress the late duplicate start.
+            if (!startWritten && sendStart) {
+              writer.write({ type: 'start', ...(lastMessageId ? { messageId: lastMessageId } : {}) } as any);
+              startWritten = true;
+            }
+            // Hold each leg's finish until all candidates have been attempted,
+            // then emit only the final successful leg's metadata.
+            if (part.type === 'finish') {
+              finalFinish = part;
+              continue;
+            }
+            writer.write(part);
+          }
+          successfulLegs++;
+        } catch (error) {
+          const id = (error as { id?: string } | undefined)?.id;
+          if (id !== 'AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED' && id !== 'AGENT_RESUME_NO_SNAPSHOT_FOUND') {
+            throw error;
+          }
+          firstResolvedTargetError ??= error;
+        }
+      }
+
+      // Re-sent history may contain already-resolved responses alongside a new
+      // one. Skip only core's exact "not suspended" errors; if none of the
+      // targets resumed, surface the typed error instead of silently dropping
+      // a potentially valid approval.
+      if (successfulLegs === 0 && firstResolvedTargetError) throw firstResolvedTargetError;
+
+      if (!startWritten && sendStart) {
+        writer.write({ type: 'start', ...(lastMessageId ? { messageId: lastMessageId } : {}) } as any);
+      }
+      if (sendFinish) {
+        writer.write(finalFinish ?? ({ type: 'finish' } as any));
+      }
+    },
+  }) as ReadableStream<any>;
 }
 
 export type ChatStreamHandlerParams<
@@ -198,14 +286,6 @@ export async function handleChatStream<OUTPUT = undefined>({
     throw new Error('Messages must be an array of UIMessage objects');
   }
 
-  // For v6: if the user called approve() on the client, AI SDK v6 re-submits the
-  // conversation with the tool part transitioned to 'approval-responded'. Detect
-  // this and route to resumeStream instead of stream.
-  const nativeApproval = version === 'v6' && !resumeData ? extractV6NativeApproval(messages as V6UIMessage[]) : null;
-
-  const effectiveResumeData = nativeApproval?.resumeData ?? resumeData;
-  const effectiveRunId = nativeApproval?.runId ?? runId;
-
   // Capture the last assistant message ID for the stream response.
   // This helps the frontend identify which message the response corresponds to.
   let lastMessageId: string | undefined;
@@ -235,16 +315,40 @@ export async function handleChatStream<OUTPUT = undefined>({
   const baseOptions = {
     ...defaultOptionsRest,
     ...restOptions,
-    ...(effectiveRunId && { runId: effectiveRunId }),
-    ...(nativeApproval?.toolCallId && { toolCallId: nativeApproval.toolCallId }),
+    ...(runId && { runId }),
     requestContext: requestContext || defaultOptions?.requestContext,
     ...(Object.keys(mergedProviderOptions).length > 0 && { providerOptions: mergedProviderOptions }),
   };
 
-  const result = effectiveResumeData
+  // AI SDK v6 re-submits approval responses on assistant tool parts. Scan the
+  // whole request because the answered card may be on an earlier assistant
+  // message, then resume every exact run/tool-call target in request order.
+  // A trailing user message remains a normal chat turn; consuming it as an
+  // approval resume would silently drop the user's new request.
+  if (version === 'v6' && !resumeData && trigger !== 'regenerate-message' && messages.at(-1)?.role === 'assistant') {
+    const approvals = extractV6NativeApprovals(messages as V6UIMessage[]);
+    if (approvals.length > 0) {
+      return streamV6ApprovalResumes({
+        agent: agentObj as unknown as Parameters<typeof streamV6ApprovalResumes>[0]['agent'],
+        approvals,
+        baseOptions,
+        structuredOutput,
+        messages: messages as V6UIMessage[],
+        lastMessageId,
+        sendStart,
+        sendFinish,
+        sendReasoning,
+        sendSources,
+        onError,
+        messageMetadata: messageMetadata as UIMessageStreamOptionsV6<V6UIMessage>['messageMetadata'],
+      });
+    }
+  }
+
+  const result = resumeData
     ? structuredOutput
-      ? await agentObj.resumeStream(effectiveResumeData, { ...baseOptions, structuredOutput })
-      : await agentObj.resumeStream(effectiveResumeData, baseOptions as AgentExecutionOptionsBase<unknown>)
+      ? await agentObj.resumeStream(resumeData, { ...baseOptions, structuredOutput })
+      : await agentObj.resumeStream(resumeData, baseOptions as AgentExecutionOptionsBase<unknown>)
     : structuredOutput
       ? await agentObj.stream(messagesToSend, { ...baseOptions, structuredOutput })
       : await agentObj.stream(messagesToSend, baseOptions as AgentExecutionOptionsBase<unknown>);

--- a/client-sdks/ai-sdk/src/chat-route.ts
+++ b/client-sdks/ai-sdk/src/chat-route.ts
@@ -49,6 +49,10 @@ export function extractV6NativeApprovals(messages: V6UIMessage[]): V6NativeAppro
       const runId = part.approval.id.slice(0, lastSep);
       const toolCallId = part.approval.id.slice(lastSep + separator.length);
       if (!runId || !toolCallId) continue;
+      // The composite approval id embeds the same toolCallId the part carries.
+      // A mismatch means the part is malformed or stale, so skip it rather
+      // than resume a tool call the user never answered.
+      if (toolCallId !== part.toolCallId) continue;
 
       byTarget.set(`${runId}${separator}${toolCallId}`, {
         resumeData: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1099,6 +1099,12 @@ importers:
       '@internal/lint':
         specifier: workspace:*
         version: link:../../packages/_config
+      '@internal/llm-recorder':
+        specifier: workspace:*
+        version: link:../../packages/_llm-recorder
+      '@internal/test-utils':
+        specifier: workspace:*
+        version: link:../../packages/_test-utils
       '@internal/types-builder':
         specifier: workspace:*
         version: link:../../packages/_types-builder


### PR DESCRIPTION
## When does this happen?

You hit this in any AI SDK v6 chat app (`useChat` + `chatRoute`/`handleChatStream`) where an agent uses approval-gated tools and more than one approval card can be on screen:

1. The agent asks to run two gated tools — say `send_email` and `delete_records` — so the chat shows two approval cards, each on its own assistant message.
2. The user approves `send_email` (the older card). `useChat` re-submits the full history: the answer is recorded on an **earlier** assistant message, because the newer `delete_records` request is the last message.
3. `handleChatStream` only inspected the last `approval-responded` part of the **final** assistant message. It found nothing there, so the answer was silently ignored — no resume, no error.
4. To the user, the Approve button does nothing: the card stays pending forever, and clicking again just re-sends the same ignored history. The run stays suspended.

The same single-part assumption also meant a request carrying **two** answers (user approves both cards before the response lands) would resume at most one of them, and re-sent history containing an already-applied answer couldn't be told apart from a fresh one.

Note: this affects the AI SDK default transport (full history on every request), but also clients that follow the memory guidance and send only the last message — approval answers live as mutated parts on assistant messages, so a single trailing message can still carry multiple answered cards, and the old code read at most one of them.

## What changed

Approval responses are now collected across **all** assistant messages in the request, deduplicated, and resumed against their exact `(runId, toolCallId)` targets sequentially in one framed response stream (single `start`/`finish`). Answers for tool calls that are no longer suspended are skipped safely via core's fail-closed target validation, so re-submitted history never executes an already-approved tool again. As an extra guard, a part whose composite approval id disagrees with its own `toolCallId` is rejected rather than resumed.

```ts
// history where A was answered earlier and B is answered now
await handleChatStream({
  mastra,
  agentId,
  version: 'v6',
  params: { messages: [assistantWithResolvedA, assistantWithApprovedB] },
});
// before: B's answer was picked up only if it was the last part of the last message
// after: both answers resolve — A is skipped (already applied), B resumes its exact run
```

## Test plan

Covered by deterministic unit tests plus a recorded E2E (gpt-5.4-mini) that exercises real provider tool-call IDs, actual suspension snapshots, and re-submitted resolved history end to end.

`pnpm --filter @mastra/ai-sdk test` (27 approval tests incl. recorded E2E in replay mode), `tsc --noEmit`, ESLint, and package build all pass.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a chat needs permission to use tools, it now remembers every pending permission request, approves each one only once, and continues them in order without repeating completed work.

## What changed

- Reworked AI SDK v6 approval handling in `handleChatStream` to:
  - Collect approvals across all assistant messages.
  - Deduplicate approvals by exact `(runId, toolCallId)` targets.
  - Resume multiple approvals sequentially within one framed stream.
  - Safely skip approvals for tools that are no longer suspended.
- Replaced `extractV6NativeApproval` with the plural `extractV6NativeApprovals` API.
- Added coverage for earlier approvals, multiple responses, real tool-call IDs, suspension snapshots, and resolved-history replay.
- Added an end-to-end recording and test dependencies for the new approval-flow tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
