### PR TITLE
fix(core): cap delegation maxSteps at the sub-agent's configured default

### DIFF
--- a/.changeset/deep-impalas-float.md
+++ b/.changeset/deep-impalas-float.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Cap the LLM-provided delegation `maxSteps` at the sub-agent's own `defaultOptions.maxSteps`. Previously a supervisor's model could silently raise a sub-agent's step budget past its configured default via the delegation tool's optional `maxSteps` argument. The supervisor's model can still reduce the budget, and `onDelegationStart`'s `modifiedMaxSteps` (developer code) still overrides the cap. A warning is logged when a value is capped.

--- a/packages/core/src/agent/__tests__/supervisor-integration.test.ts
+++ b/packages/core/src/agent/__tests__/supervisor-integration.test.ts
@@ -4309,3 +4309,143 @@ describe('Supervisor Pattern - AbortSignal forwarding', () => {
     expect(capturedSignal!.aborted).toBe(true);
   });
 });
+
+describe('Delegation maxSteps cap', () => {
+  // Supervisor model that delegates once and includes maxSteps in the tool-call input,
+  // simulating the LLM filling the optional maxSteps delegation arg.
+  function makeSupervisorModelWithMaxSteps(agentKey: string, prompt: string, maxSteps: number) {
+    let callCount = 0;
+    return new MockLanguageModelV2({
+      doGenerate: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            finishReason: 'tool-calls' as const,
+            usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+            text: '',
+            content: [
+              {
+                type: 'tool-call' as const,
+                toolCallId: 'call-1',
+                toolName: `agent-${agentKey}`,
+                input: JSON.stringify({ prompt, maxSteps }),
+              },
+            ],
+            warnings: [],
+          };
+        }
+        return {
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+          text: 'Done',
+          content: [{ type: 'text' as const, text: 'Done' }],
+          warnings: [],
+        };
+      },
+    });
+  }
+
+  // Sub-agent with a fixed text response and its own configured step budget
+  function makeCappedSubAgent(id: string, maxSteps: number) {
+    return new Agent({
+      id,
+      name: id,
+      description: `Sub-agent: ${id}`,
+      instructions: 'You are a helpful sub-agent.',
+      model: new MockLanguageModelV2({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { inputTokens: 5, outputTokens: 10, totalTokens: 15 },
+          text: 'child response',
+          content: [{ type: 'text', text: 'child response' }],
+          warnings: [],
+        }),
+      }),
+      defaultOptions: { maxSteps },
+    });
+  }
+
+  it('caps the LLM-provided maxSteps at the sub-agent defaultOptions.maxSteps', async () => {
+    const cappedSubAgent = makeCappedSubAgent('capped-child', 4);
+    const generateSpy = vi.spyOn(cappedSubAgent, 'generate');
+
+    const supervisor = new Agent({
+      id: 'cap-supervisor',
+      name: 'cap-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModelWithMaxSteps('cappedChild', 'do work', 10),
+      agents: { cappedChild: cappedSubAgent },
+      memory: new MockMemory(),
+    });
+
+    await supervisor.generate('go', { maxSteps: 5 });
+
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(generateSpy.mock.calls[0]?.[1]?.maxSteps).toBe(4);
+  });
+
+  it('keeps the LLM-provided maxSteps when it is below the sub-agent default', async () => {
+    const cappedSubAgent = makeCappedSubAgent('reduce-child', 10);
+    const generateSpy = vi.spyOn(cappedSubAgent, 'generate');
+
+    const supervisor = new Agent({
+      id: 'reduce-supervisor',
+      name: 'reduce-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModelWithMaxSteps('reduceChild', 'do work', 3),
+      agents: { reduceChild: cappedSubAgent },
+      memory: new MockMemory(),
+    });
+
+    await supervisor.generate('go', { maxSteps: 5 });
+
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(generateSpy.mock.calls[0]?.[1]?.maxSteps).toBe(3);
+  });
+
+  it('passes the LLM-provided maxSteps through when the sub-agent has no default', async () => {
+    const subAgent = makeSubAgent('uncapped-child', 'child response');
+    const generateSpy = vi.spyOn(subAgent, 'generate');
+
+    const supervisor = new Agent({
+      id: 'uncapped-supervisor',
+      name: 'uncapped-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModelWithMaxSteps('uncappedChild', 'do work', 10),
+      agents: { uncappedChild: subAgent },
+      memory: new MockMemory(),
+    });
+
+    await supervisor.generate('go', { maxSteps: 5 });
+
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(generateSpy.mock.calls[0]?.[1]?.maxSteps).toBe(10);
+  });
+
+  it('lets onDelegationStart modifiedMaxSteps bypass the cap', async () => {
+    const cappedSubAgent = makeCappedSubAgent('hook-child', 4);
+    const generateSpy = vi.spyOn(cappedSubAgent, 'generate');
+
+    const supervisor = new Agent({
+      id: 'hook-supervisor',
+      name: 'hook-supervisor',
+      instructions: 'You orchestrate sub-agents.',
+      model: makeSupervisorModelWithMaxSteps('hookChild', 'do work', 10),
+      agents: { hookChild: cappedSubAgent },
+      memory: new MockMemory(),
+    });
+
+    await supervisor.generate('go', {
+      maxSteps: 5,
+      delegation: {
+        onDelegationStart: () => ({ proceed: true, modifiedMaxSteps: 12 }),
+      },
+    });
+
+    expect(generateSpy).toHaveBeenCalledTimes(1);
+    expect(generateSpy.mock.calls[0]?.[1]?.maxSteps).toBe(12);
+  });
+});

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -4665,6 +4665,24 @@ export class Agent<
             let effectivePrompt = inputData.prompt;
             let effectiveInstructions = inputData.instructions;
             let effectiveMaxSteps = inputData.maxSteps;
+            // Cap the LLM-provided maxSteps at the sub-agent's own configured
+            // default so the supervisor's model can reduce, but never expand,
+            // the developer-defined step budget. `onDelegationStart`'s
+            // `modifiedMaxSteps` (developer code) below bypasses this cap.
+            const subAgentMaxStepsCap = resolvedDefaultOptions?.maxSteps;
+            if (
+              typeof effectiveMaxSteps === 'number' &&
+              typeof subAgentMaxStepsCap === 'number' &&
+              effectiveMaxSteps > subAgentMaxStepsCap
+            ) {
+              this.logger.warn('Delegation maxSteps exceeds sub-agent default, capping', {
+                agent: this.name,
+                targetAgent: agentName,
+                requestedMaxSteps: effectiveMaxSteps,
+                cappedMaxSteps: subAgentMaxStepsCap,
+              });
+              effectiveMaxSteps = subAgentMaxStepsCap;
+            }
             if (delegation?.onDelegationStart) {
               try {
                 const startResult = await delegation.onDelegationStart(delegationStartContext);


### PR DESCRIPTION
When a supervisor delegates to a sub-agent, the delegation tool exposes an optional `maxSteps` argument to the supervisor's LLM. That value was passed straight through to the sub-agent, silently overriding the sub-agent's own `defaultOptions.maxSteps` with no upper bound — so a model (or a prompt injection) could expand a developer-defined step budget at will.

```ts
const researcher = new Agent({
  // ...
  defaultOptions: { maxSteps: 5 }, // developer's budget
});

// before: supervisor's LLM calls the delegation tool with maxSteps: 50 → researcher runs 50 steps
// after: capped at 5, with a warning log
```

The LLM can still *reduce* the budget below the sub-agent's default, and sub-agents without a configured default behave exactly as before. Developers keep full control: `onDelegationStart`'s `modifiedMaxSteps` bypasses the cap since it's application code, not model output.

Verified with four new regression tests in `supervisor-integration.test.ts` covering cap, reduction, no-default passthrough, and hook bypass — the cap test fails against `main`. Core typecheck and lint are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A supervisor can no longer accidentally give a helper agent more work than the developer allowed. Smaller limits still work, and explicit developer overrides remain honored.

## What changed

- Caps delegated `maxSteps` at the sub-agent’s configured default.
- Preserves lower model-provided limits.
- Logs a warning when a value is capped.
- Preserves existing behavior when no default is configured.
- Allows `onDelegationStart`’s `modifiedMaxSteps` to bypass the cap.
- Adds four regression tests covering these cases.
- Adds a patch changeset for `@mastra/core`.

Core typecheck and lint pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->