### PR TITLE
feat(mastracode): add /adversarial-review slash command

### DIFF
--- a/.changeset/hot-turtles-design.md
+++ b/.changeset/hot-turtles-design.md
@@ -1,0 +1,5 @@
+---
+'mastracode': minor
+---
+
+Added a new /adversarial-review slash command that reviews a pull request in a fresh headless Mastra Code instance, optionally with a different model than your current session. Run `/adversarial-review [pr-number] [model-id]` — the PR number defaults to the current branch's PR and the model defaults to your configured model. The review runs on a fresh thread with no context from your current session and the result is rendered in the chat when it completes.

--- a/mastracode/tui/src/tui/command-dispatch.ts
+++ b/mastracode/tui/src/tui/command-dispatch.ts
@@ -33,6 +33,7 @@ import {
   handleSettingsCommand,
   handleLoginCommand,
   handleReviewCommand as handleReviewCmd,
+  handleAdversarialReviewCommand as handleAdversarialReviewCmd,
   handleReportIssueCommand as handleReportIssueCmd,
   handleSetupCommand,
   handleBrowserCommand,
@@ -237,6 +238,9 @@ export async function dispatchSlashCommand(
       return true;
     case 'review':
       await handleReviewCmd(ctx, args);
+      return true;
+    case 'adversarial-review':
+      await handleAdversarialReviewCmd(ctx, args);
       return true;
     case 'report-issue':
       await handleReportIssueCmd(ctx, args);

--- a/mastracode/tui/src/tui/commands/__tests__/adversarial-review.test.ts
+++ b/mastracode/tui/src/tui/commands/__tests__/adversarial-review.test.ts
@@ -1,0 +1,167 @@
+import { EventEmitter } from 'node:events';
+
+import { Container } from '@earendil-works/pi-tui';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  buildAdversarialReviewPrompt,
+  handleAdversarialReviewCommand,
+  parseAdversarialReviewArgs,
+  parseHeadlessJsonOutput,
+} from '../adversarial-review.js';
+import type { SlashCommandContext } from '../types.js';
+
+const spawnMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+class FakeChild extends EventEmitter {
+  stdout = new EventEmitter();
+  stderr = new EventEmitter();
+  kill = vi.fn();
+}
+
+function createContext(models: Array<{ id: string; hasApiKey: boolean }> = []) {
+  const chatContainer = new Container();
+  const ctx = {
+    state: {
+      chatContainer,
+      ui: { requestRender: vi.fn() },
+    },
+    controller: {
+      listAvailableModels: vi.fn(async () => models),
+    },
+    showInfo: vi.fn(),
+    showError: vi.fn(),
+  } as unknown as SlashCommandContext;
+  return { ctx, chatContainer };
+}
+
+describe('parseAdversarialReviewArgs', () => {
+  it('treats a numeric token as the PR number and a non-numeric token as the model', () => {
+    expect(parseAdversarialReviewArgs(['1234', 'openai/gpt-5.2'])).toEqual({
+      prNumber: '1234',
+      model: 'openai/gpt-5.2',
+    });
+  });
+
+  it('is order-independent and strips a leading #', () => {
+    expect(parseAdversarialReviewArgs(['openai/gpt-5.2', '#1234'])).toEqual({
+      prNumber: '1234',
+      model: 'openai/gpt-5.2',
+    });
+  });
+
+  it('supports omitting either argument', () => {
+    expect(parseAdversarialReviewArgs([])).toEqual({});
+    expect(parseAdversarialReviewArgs(['1234'])).toEqual({ prNumber: '1234' });
+    expect(parseAdversarialReviewArgs(['openai/gpt-5.2'])).toEqual({ model: 'openai/gpt-5.2' });
+  });
+});
+
+describe('buildAdversarialReviewPrompt', () => {
+  it('targets the given PR number', () => {
+    const prompt = buildAdversarialReviewPrompt('1234');
+    expect(prompt).toContain('Review PR #1234.');
+    expect(prompt).toContain('READ-ONLY');
+  });
+
+  it('falls back to detecting the current branch PR', () => {
+    const prompt = buildAdversarialReviewPrompt();
+    expect(prompt).toContain('gh pr view --json number,title,url');
+  });
+});
+
+describe('parseHeadlessJsonOutput', () => {
+  it('parses the final JSON object and skips non-JSON noise', () => {
+    const stdout = 'some warning\n{"status":"completed","text":"LGTM","threadId":"t-1"}\n';
+    expect(parseHeadlessJsonOutput(stdout)).toEqual({ status: 'completed', text: 'LGTM', threadId: 't-1' });
+  });
+
+  it('returns undefined when no JSON is present', () => {
+    expect(parseHeadlessJsonOutput('garbage output')).toBeUndefined();
+  });
+});
+
+describe('handleAdversarialReviewCommand', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('rejects an unknown model without spawning', async () => {
+    const { ctx } = createContext([{ id: 'openai/gpt-5.2', hasApiKey: true }]);
+
+    await handleAdversarialReviewCommand(ctx, ['no-such/model']);
+
+    expect(ctx.showError).toHaveBeenCalledWith(
+      'Unknown model: "no-such/model". Use /models to see available model IDs.',
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns a headless instance with the model and PR-targeted prompt', async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+    const { ctx } = createContext([{ id: 'openai/gpt-5.2', hasApiKey: true }]);
+
+    await handleAdversarialReviewCommand(ctx, ['1234', 'openai/gpt-5.2']);
+    child.emit('close', 0);
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    const [execPath, spawnArgs, options] = spawnMock.mock.calls[0]!;
+    expect(execPath).toBe(process.execPath);
+    expect(spawnArgs).toContain(process.argv[1]);
+    const promptIndex = spawnArgs.indexOf('--prompt');
+    expect(spawnArgs[promptIndex + 1]).toContain('Review PR #1234.');
+    const modelIndex = spawnArgs.indexOf('--model');
+    expect(spawnArgs[modelIndex + 1]).toBe('openai/gpt-5.2');
+    const outputIndex = spawnArgs.indexOf('--output');
+    expect(spawnArgs[outputIndex + 1]).toBe('json');
+    expect(spawnArgs).not.toContain('--continue');
+    expect(spawnArgs).not.toContain('--thread');
+    expect(options.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+  });
+
+  it('omits --model when no model is given', async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+    const { ctx } = createContext();
+
+    await handleAdversarialReviewCommand(ctx, ['1234']);
+    child.emit('close', 0);
+
+    const [, spawnArgs] = spawnMock.mock.calls[0]!;
+    expect(spawnArgs).not.toContain('--model');
+  });
+
+  it('renders the review text in chat when the run completes', async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+    const { ctx, chatContainer } = createContext();
+
+    await handleAdversarialReviewCommand(ctx, ['1234']);
+    const childrenBefore = chatContainer.children.length;
+
+    child.stdout.emit('data', Buffer.from('{"status":"completed","text":"## Review\\nLooks good","threadId":"t-1"}\n'));
+    child.emit('close', 0);
+
+    expect(chatContainer.children.length).toBeGreaterThan(childrenBefore);
+    expect(ctx.showError).not.toHaveBeenCalled();
+  });
+
+  it('does not render a review component when the run fails', async () => {
+    const child = new FakeChild();
+    spawnMock.mockReturnValue(child);
+    const { ctx, chatContainer } = createContext();
+
+    await handleAdversarialReviewCommand(ctx, ['1234']);
+    const childrenBefore = chatContainer.children.length;
+
+    child.stderr.emit('data', Buffer.from('Error: something exploded\n'));
+    child.emit('close', 1);
+
+    expect(chatContainer.children.length).toBe(childrenBefore);
+  });
+});

--- a/mastracode/tui/src/tui/commands/adversarial-review.ts
+++ b/mastracode/tui/src/tui/commands/adversarial-review.ts
@@ -1,0 +1,218 @@
+/**
+ * /adversarial-review — run a PR review in a spawned headless MastraCode
+ * instance on a fresh thread, optionally with a different model than the
+ * current session. The idea: after opening a PR, get a second opinion from
+ * another model that has no context from (and no bias toward) the work done
+ * in this session.
+ */
+import { spawn } from 'node:child_process';
+
+import { Container, Markdown, Text } from '@earendil-works/pi-tui';
+import { insertChatComponentWithBoundarySpacing } from '../chat-boundary-reconciliation.js';
+import type { ChatSpacingKind } from '../components/chat-spacing.js';
+import { SimpleProgressComponent } from '../components/simple-progress.js';
+import { SlashCommandComponent } from '../components/slash-command.js';
+import { sanitizeAnsiForRendering } from '../sanitize-ansi.js';
+import { CHAT_INDENT, getMarkdownTheme, theme } from '../theme.js';
+import type { SlashCommandContext } from './types.js';
+
+/** Hard cap for the headless child run (seconds). */
+const REVIEW_TIMEOUT_SECONDS = 900;
+
+class AdversarialReviewOutputComponent extends Container {
+  constructor(header: string, markdownText: string) {
+    super();
+    this.addChild(new Text(theme.fg('muted', header), 1, 0));
+    this.addChild(
+      new Markdown(sanitizeAnsiForRendering(markdownText.trim()), CHAT_INDENT, 0, getMarkdownTheme(), {
+        color: (text: string) => theme.fg('text', text),
+      }),
+    );
+  }
+
+  getChatSpacingKind(): ChatSpacingKind {
+    return 'assistant-message';
+  }
+}
+
+export interface AdversarialReviewArgs {
+  prNumber?: string;
+  model?: string;
+}
+
+/**
+ * Parse positional args: a numeric token (optionally `#`-prefixed) is the PR
+ * number; the first non-numeric token is the model id. Order-independent.
+ */
+export function parseAdversarialReviewArgs(args: string[]): AdversarialReviewArgs {
+  const parsed: AdversarialReviewArgs = {};
+  for (const arg of args) {
+    const normalized = arg.replace(/^#/, '');
+    if (/^\d+$/.test(normalized) && parsed.prNumber === undefined) {
+      parsed.prNumber = normalized;
+    } else if (parsed.model === undefined) {
+      parsed.model = arg;
+    }
+  }
+  return parsed;
+}
+
+export function buildAdversarialReviewPrompt(prNumber?: string): string {
+  const target = prNumber
+    ? `Review PR #${prNumber}.`
+    : `Find the open pull request for the current branch by running \`gh pr view --json number,title,url\`. ` +
+      `If there is no PR for the current branch, state that clearly and stop. Then review that PR.`;
+
+  return (
+    `You are performing an ADVERSARIAL code review. You did not write this code; ` +
+    `your job is to find real problems the author missed. Be skeptical and rigorous, ` +
+    `but honest — do not invent issues that don't exist.\n\n` +
+    `${target}\n\n` +
+    `This is a READ-ONLY review: do not modify any files, do not commit, do not push, ` +
+    `and do not comment on the PR.\n\n` +
+    `Steps:\n` +
+    `1. Run \`gh pr view <number>\` for the PR description and metadata.\n` +
+    `2. Run \`gh pr diff <number>\` for the full diff.\n` +
+    `3. Run \`gh pr checks <number>\` for CI status.\n` +
+    `4. Read the surrounding source files to understand the context of every change — ` +
+    `do not review the diff in isolation.\n` +
+    `5. Verify the claims in the PR description against what the diff actually does.\n\n` +
+    `Report:\n` +
+    `- Brief summary of what the PR does\n` +
+    `- Bugs and correctness issues (with file/line references)\n` +
+    `- Edge cases and failure modes not handled\n` +
+    `- Security concerns\n` +
+    `- Missing or inadequate tests\n` +
+    `- Discrepancies between the PR description and the actual changes\n` +
+    `- Final verdict: approve / request changes / comment, with reasoning\n\n` +
+    `If the PR is solid, say so — a short review of a good PR is a valid outcome.`
+  );
+}
+
+interface HeadlessReviewResult {
+  status?: string;
+  text?: string;
+  threadId?: string;
+  error?: { name?: string; message?: string };
+}
+
+/** Extract the final JSON result object from headless `--output json` stdout. */
+export function parseHeadlessJsonOutput(stdout: string): HeadlessReviewResult | undefined {
+  const lines = stdout.split('\n').filter(line => line.trim().startsWith('{'));
+  for (let i = lines.length - 1; i >= 0; i--) {
+    try {
+      return JSON.parse(lines[i]!) as HeadlessReviewResult;
+    } catch {
+      // Not JSON — keep scanning backwards.
+    }
+  }
+  return undefined;
+}
+
+export async function handleAdversarialReviewCommand(ctx: SlashCommandContext, args: string[]): Promise<void> {
+  const { prNumber, model } = parseAdversarialReviewArgs(args);
+
+  // Fail fast on an unknown model before spawning a whole headless instance.
+  if (model) {
+    try {
+      const available = await ctx.controller.listAvailableModels();
+      const match = available.find((m: { id: string }) => m.id === model);
+      if (!match) {
+        ctx.showError(`Unknown model: "${model}". Use /models to see available model IDs.`);
+        return;
+      }
+    } catch {
+      // Model listing failed — let the headless child validate instead.
+    }
+  }
+
+  const entry = process.argv[1];
+  if (!entry) {
+    ctx.showError('Could not determine the mastracode entry point to spawn a headless instance.');
+    return;
+  }
+
+  const prompt = buildAdversarialReviewPrompt(prNumber);
+  const prLabel = prNumber ? `PR #${prNumber}` : 'the current branch PR';
+  const modelLabel = model ?? 'the default model';
+  const title = `Adversarial review: ${prNumber ? `PR #${prNumber}` : 'current branch'}`;
+
+  const echo = new SlashCommandComponent(
+    'adversarial-review',
+    `Reviewing ${prLabel} with ${modelLabel} in a fresh headless instance`,
+  );
+  insertChatComponentWithBoundarySpacing(ctx.state.chatContainer, echo);
+
+  const progress = new SimpleProgressComponent({ showPercentage: false });
+  progress.start(`Adversarial review of ${prLabel} running (${modelLabel})…`);
+  insertChatComponentWithBoundarySpacing(ctx.state.chatContainer, progress);
+  ctx.state.ui.requestRender();
+
+  const spawnArgs = [
+    ...process.execArgv,
+    entry,
+    '--prompt',
+    prompt,
+    '--output',
+    'json',
+    '--title',
+    title,
+    '--timeout',
+    String(REVIEW_TIMEOUT_SECONDS),
+  ];
+  if (model) {
+    spawnArgs.push('--model', model);
+  }
+
+  const child = spawn(process.execPath, spawnArgs, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  // Keep the spinner animating while the child runs.
+  const renderInterval = setInterval(() => ctx.state.ui.requestRender(), 250);
+  // Don't orphan a long-running review if the TUI exits.
+  const killChild = () => child.kill('SIGTERM');
+  process.once('exit', killChild);
+
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', chunk => {
+    stdout += chunk.toString();
+  });
+  child.stderr.on('data', chunk => {
+    stderr += chunk.toString();
+  });
+
+  const cleanup = () => {
+    clearInterval(renderInterval);
+    process.removeListener('exit', killChild);
+  };
+
+  child.on('error', error => {
+    cleanup();
+    progress.fail(`Adversarial review failed to start: ${error.message}`);
+    ctx.state.ui.requestRender();
+  });
+
+  child.on('close', code => {
+    cleanup();
+
+    const result = parseHeadlessJsonOutput(stdout);
+    const stderrTail = stderr.trim().split('\n').slice(-5).join('\n');
+
+    if (code === 0 && result?.text) {
+      progress.complete(`Adversarial review of ${prLabel} complete (${modelLabel})`);
+      const header = result.threadId ? `Review thread: ${result.threadId}` : '';
+      insertChatComponentWithBoundarySpacing(
+        ctx.state.chatContainer,
+        new AdversarialReviewOutputComponent(header, result.text),
+      );
+    } else {
+      const detail = result?.error?.message ?? (stderrTail || `exit code ${code}`);
+      progress.fail(`Adversarial review failed: ${detail}`);
+    }
+    ctx.state.ui.requestRender();
+  });
+}

--- a/mastracode/tui/src/tui/commands/index.ts
+++ b/mastracode/tui/src/tui/commands/index.ts
@@ -28,6 +28,7 @@ export { handleSettingsCommand } from './settings.js';
 export { handleBrowserCommand } from './browser.js';
 export { handleLoginCommand } from './login.js';
 export { handleReviewCommand } from './review.js';
+export { handleAdversarialReviewCommand } from './adversarial-review.js';
 export { handleReportIssueCommand } from './report-issue.js';
 export { handleSetupCommand } from './setup.js';
 export { handleThemeCommand } from './theme.js';

--- a/mastracode/tui/src/tui/setup.ts
+++ b/mastracode/tui/src/tui/setup.ts
@@ -366,6 +366,10 @@ export function setupAutocomplete(state: TUIState): void {
       description: 'Manage push-to-talk voice input (engine, provider, model)',
     },
     { name: 'review', description: 'Review a GitHub pull request' },
+    {
+      name: 'adversarial-review',
+      description: 'Review a PR in a fresh headless instance (optionally another model)',
+    },
     { name: 'report-issue', description: 'Open or browse mastracode issues' },
     { name: 'setup', description: 'Re-run the setup wizard' },
     { name: 'browser', description: 'Configure browser automation' },


### PR DESCRIPTION
Adds a `/adversarial-review` slash command to the Mastra Code TUI. It spawns a headless Mastra Code instance on a fresh thread to review a PR, optionally with a different model than your current session — so you get a second opinion from a reviewer with no context from (and no bias toward) the work you just did.

```
/adversarial-review                        # review the current branch's PR with your default model
/adversarial-review 1234                   # review PR #1234
/adversarial-review 1234 openai/gpt-5.2    # review PR #1234 with a specific model
```

The child runs with a read-only adversarial review prompt (verify PR description claims against the diff, hunt bugs/edge cases/security issues/missing tests, give a verdict), is capped at 15 minutes, and gets killed if the TUI exits. While it runs, a spinner with elapsed time shows in chat; on completion the review renders as markdown along with the child thread ID so you can jump into that thread for follow-ups. A model id passed explicitly is validated against available models before spawning.

Test plan: 12 new unit tests cover arg parsing, prompt building, headless JSON output parsing, spawn arguments, and success/failure rendering. Full TUI command + dispatch suites pass (26 files, 200 tests), plus typecheck and lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Adds a command that asks a fresh Mastra Code helper to review a pull request without changing any code. It shows progress while the review runs and displays the results in the TUI.

## What changed

- Added `/adversarial-review` slash command with optional PR number and model.
- Runs reviews in a fresh, read-only headless instance with a 15-minute timeout.
- Validates explicitly selected models and cleans up the child process when the TUI exits.
- Supports reviewing the current branch’s PR when no number is provided.
- Renders completed reviews as markdown and includes the child thread ID for follow-ups.
- Added command dispatch, autocomplete, release changeset, and 12 unit tests covering parsing, spawning, output handling, and success/failure states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->