### PR TITLE
feat(client-js): pass context to agent controller sessions

### DIFF
--- a/.changeset/curly-deer-rest.md
+++ b/.changeset/curly-deer-rest.md
@@ -1,0 +1,10 @@
+---
+'@mastra/client-js': minor
+---
+
+Added a `requestContext` option to agent controller session methods in @mastra/client-js. You can now pass custom request context to `sendMessage`, `steer`, `followUp`, `approveTool`, and `respondToToolSuspension`, matching what `agent.generate()` already supports. The context is merged into the run's request context on the server, so it reaches dynamic instructions and tools.
+
+```ts
+const session = client.getAgentController('code').session('user-1');
+await session.sendMessage('hello', { requestContext: { userId: 'user-1', tier: 'pro' } });
+```

--- a/.changeset/olive-camels-repeat.md
+++ b/.changeset/olive-camels-repeat.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Documented the optional `requestContext` body field on agent controller run routes (send message, steer, follow-up, tool approval, tool suspension) so it appears in the generated OpenAPI spec. The server already merged this field into the request context; only the route schemas were missing it.

--- a/client-sdks/client-js/src/index.ts
+++ b/client-sdks/client-js/src/index.ts
@@ -24,6 +24,7 @@ export type {
   KnownAgentControllerEvent,
   OtherAgentControllerEvent,
   CreateAgentControllerSessionResponse,
+  AgentControllerRequestOptions,
   SubscribeAgentControllerSessionOptions,
   AgentControllerSubscription,
   AgentControllerSessionState,

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -1,3 +1,4 @@
+import { RequestContext } from '@mastra/core/request-context';
 import { describe, expect, beforeEach, it, vi } from 'vitest';
 
 import { MastraClient } from '../client';
@@ -73,6 +74,43 @@ describe('AgentController Resource', () => {
     const [url, init] = lastCall();
     expect(url).toBe('http://localhost:4111/api/agent-controller/code/sessions/user-1/messages');
     expect(JSON.parse(init.body as string)).toEqual({ message: 'see attached', files });
+  });
+
+  it('sends requestContext in the body for run-triggering methods', async () => {
+    const session = client.getAgentController('code').session('user-1');
+    const requestContext = { userId: 'u-42', tier: 'pro' };
+
+    mockJson({ ok: true });
+    await session.sendMessage('hello', { requestContext });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'hello', requestContext });
+
+    mockJson({ ok: true });
+    await session.steer('focus', { requestContext });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'focus', requestContext });
+
+    mockJson({ ok: true });
+    await session.followUp('later', { requestContext });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'later', requestContext });
+
+    mockJson({ ok: true });
+    await session.approveTool('call-7', true, { requestContext });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ toolCallId: 'call-7', approved: true, requestContext });
+
+    mockJson({ ok: true });
+    await session.respondToToolSuspension('call-9', 'answer', { requestContext });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({
+      toolCallId: 'call-9',
+      resumeData: 'answer',
+      requestContext,
+    });
+  });
+
+  it('serializes a RequestContext instance passed to sendMessage', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('userId', 'u-42');
+    mockJson({ ok: true });
+    await client.getAgentController('code').session('user-1').sendMessage('hello', { requestContext });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'hello', requestContext: { userId: 'u-42' } });
   });
 
   it('aborts the in-flight run', async () => {

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -1,5 +1,7 @@
-import type { ClientOptions } from '../types';
+import type { RequestContext } from '@mastra/core/request-context';
 
+import type { ClientOptions } from '../types';
+import { parseClientRequestContext } from '../utils';
 import { BaseResource } from './base';
 
 /**
@@ -333,6 +335,16 @@ export interface PlanResume {
   feedback?: string;
 }
 
+/**
+ * Options accepted by session methods that trigger or resume agent execution.
+ * The `requestContext` is merged into the server-derived request context for
+ * that run (server-controlled keys win), so it reaches dynamic instructions,
+ * tools, and workspace resolution — mirroring `agent.generate()`.
+ */
+export interface AgentControllerRequestOptions {
+  requestContext?: RequestContext | Record<string, any>;
+}
+
 /** Options for subscribing to an agent controller session's event stream. */
 export interface SubscribeAgentControllerSessionOptions {
   /** Called for each event received over the stream. */
@@ -450,14 +462,21 @@ export class AgentControllerSession extends BaseResource {
    * Send a user message. The reply streams over `subscribe()`.
    * Pass a structured message to attach files (e.g. pasted images) as base64-encoded data:
    * `sendMessage({ content: 'What is in this image?', files })`.
+   * Pass `options.requestContext` to merge custom context into the run's request context.
    */
   async sendMessage(
     message: string | { content: string; files?: Array<{ data: string; mediaType: string; filename?: string }> },
+    options?: AgentControllerRequestOptions,
   ): Promise<void> {
     const { content, files } = typeof message === 'string' ? { content: message, files: undefined } : message;
+    const requestContext = parseClientRequestContext(options?.requestContext);
     await this.request(this.url(`${this.base()}/messages`), {
       method: 'POST',
-      body: { message: content, ...(files?.length ? { files } : {}) },
+      body: {
+        message: content,
+        ...(files?.length ? { files } : {}),
+        ...(requestContext ? { requestContext } : {}),
+      },
     });
   }
 
@@ -467,10 +486,11 @@ export class AgentControllerSession extends BaseResource {
   }
 
   /** Approve or decline a pending tool call (`tool_approval_required`). */
-  async approveTool(toolCallId: string, approved: boolean): Promise<void> {
+  async approveTool(toolCallId: string, approved: boolean, options?: AgentControllerRequestOptions): Promise<void> {
+    const requestContext = parseClientRequestContext(options?.requestContext);
     await this.request(this.url(`${this.base()}/tool-approval`), {
       method: 'POST',
-      body: { toolCallId, approved },
+      body: { toolCallId, approved, ...(requestContext ? { requestContext } : {}) },
     });
   }
 
@@ -479,16 +499,25 @@ export class AgentControllerSession extends BaseResource {
    * depends on the tool: a string (or string[]) for `ask_user`, "Yes"/"No" for
    * `request_access`, and a {@link PlanResume} for `submit_plan`.
    */
-  async respondToToolSuspension(toolCallId: string, resumeData: string | string[] | PlanResume): Promise<void> {
+  async respondToToolSuspension(
+    toolCallId: string,
+    resumeData: string | string[] | PlanResume,
+    options?: AgentControllerRequestOptions,
+  ): Promise<void> {
+    const requestContext = parseClientRequestContext(options?.requestContext);
     await this.request(this.url(`${this.base()}/tool-suspension`), {
       method: 'POST',
-      body: { toolCallId, resumeData },
+      body: { toolCallId, resumeData, ...(requestContext ? { requestContext } : {}) },
     });
   }
 
   /** Inject a message into the in-flight run without starting a new turn. */
-  async steer(message: string): Promise<void> {
-    await this.request(this.url(`${this.base()}/steer`), { method: 'POST', body: { message } });
+  async steer(message: string, options?: AgentControllerRequestOptions): Promise<void> {
+    const requestContext = parseClientRequestContext(options?.requestContext);
+    await this.request(this.url(`${this.base()}/steer`), {
+      method: 'POST',
+      body: { message, ...(requestContext ? { requestContext } : {}) },
+    });
   }
 
   /** Get the current mode, model, and thread (for initial UI hydration). */
@@ -584,8 +613,12 @@ export class AgentControllerSession extends BaseResource {
    * Queue a follow-up message. If the session is idle it sends immediately;
    * if a run is active it queues for after completion.
    */
-  async followUp(message: string): Promise<void> {
-    await this.request(this.url(`${this.base()}/follow-up`), { method: 'POST', body: { message } });
+  async followUp(message: string, options?: AgentControllerRequestOptions): Promise<void> {
+    const requestContext = parseClientRequestContext(options?.requestContext);
+    await this.request(this.url(`${this.base()}/follow-up`), {
+      method: 'POST',
+      body: { message, ...(requestContext ? { requestContext } : {}) },
+    });
   }
 
   /** Get the observational memory record for this session's thread. */

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -91851,6 +91851,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParam
 
 export type PostAgentControllerControllerIdSessionsResourceIdMessages_Body = {
   message: string;
+  requestContext?:
+    | {
+        [key: string]: any;
+      }
+    | undefined;
   files?:
     | {
         data: string;
@@ -91903,6 +91908,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams =
 
 export type PostAgentControllerControllerIdSessionsResourceIdSteer_Body = {
   message: string;
+  requestContext?:
+    | {
+        [key: string]: any;
+      }
+    | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdSteer_Response = {
@@ -91948,6 +91958,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_QueryParam
 
 export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_Body = {
   message: string;
+  requestContext?:
+    | {
+        [key: string]: any;
+      }
+    | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdFollowUp_Response = {
@@ -92031,6 +92046,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_QueryP
 export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_Body = {
   toolCallId: string;
   approved: boolean;
+  requestContext?:
+    | {
+        [key: string]: any;
+      }
+    | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdToolApproval_Response = {
@@ -92077,6 +92097,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Quer
 export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Body = {
   toolCallId: string;
   resumeData: any;
+  requestContext?:
+    | {
+        [key: string]: any;
+      }
+    | undefined;
 };
 
 export type PostAgentControllerControllerIdSessionsResourceIdToolSuspension_Response = {

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -6006,7 +6006,8 @@ export const API_ROUTE_METADATA = {
     ],
     "bodyParams": [
       "files",
-      "message"
+      "message",
+      "requestContext"
     ],
     "hasQuery": true,
     "hasBody": true,
@@ -6025,7 +6026,8 @@ export const API_ROUTE_METADATA = {
       "sessionScope"
     ],
     "bodyParams": [
-      "message"
+      "message",
+      "requestContext"
     ],
     "hasQuery": true,
     "hasBody": true,
@@ -6044,7 +6046,8 @@ export const API_ROUTE_METADATA = {
       "sessionScope"
     ],
     "bodyParams": [
-      "message"
+      "message",
+      "requestContext"
     ],
     "hasQuery": true,
     "hasBody": true,
@@ -6081,6 +6084,7 @@ export const API_ROUTE_METADATA = {
     ],
     "bodyParams": [
       "approved",
+      "requestContext",
       "toolCallId"
     ],
     "hasQuery": true,
@@ -6100,6 +6104,7 @@ export const API_ROUTE_METADATA = {
       "sessionScope"
     ],
     "bodyParams": [
+      "requestContext",
       "resumeData",
       "toolCallId"
     ],

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -98,8 +98,17 @@ const createSessionBodySchema = z.object({
 // file, 20MB total), adjusted for base64 overhead (~4/3x).
 const MAX_FILE_DATA_LENGTH = 14 * 1024 * 1024;
 const MAX_TOTAL_FILE_DATA_LENGTH = 28 * 1024 * 1024;
+/**
+ * Optional client-supplied request context, merged into the server-derived
+ * request context by the adapter context middleware (reserved keys are
+ * server-controlled). Declared on run-triggering body schemas so the OpenAPI
+ * spec documents it.
+ */
+const bodyRequestContextSchema = z.record(z.string(), z.any()).optional();
+
 const sendMessageBodySchema = z.object({
   message: z.string(),
+  requestContext: bodyRequestContextSchema,
   // Optional attachments (e.g. pasted images). `data` is base64-encoded.
   files: z
     .array(
@@ -115,10 +124,11 @@ const sendMessageBodySchema = z.object({
     })
     .optional(),
 });
-const steerBodySchema = z.object({ message: z.string() });
+const steerBodySchema = z.object({ message: z.string(), requestContext: bodyRequestContextSchema });
 const toolApprovalBodySchema = z.object({
   toolCallId: z.string(),
   approved: z.boolean(),
+  requestContext: bodyRequestContextSchema,
 });
 const toolSuspensionBodySchema = z.object({
   toolCallId: z.string(),
@@ -126,6 +136,7 @@ const toolSuspensionBodySchema = z.object({
   // multi-select); for submit_plan it's `{ action, feedback? }`; for
   // request_access it's "Yes"/"No".
   resumeData: z.any(),
+  requestContext: bodyRequestContextSchema,
 });
 const switchModeBodySchema = z.object({ modeId: z.string() });
 const switchModelBodySchema = z.object({
@@ -162,7 +173,7 @@ const listThreadsQuerySchema = z.object({
     }, z.record(z.string(), z.string()).optional())
     .optional(),
 });
-const followUpBodySchema = z.object({ message: z.string() });
+const followUpBodySchema = z.object({ message: z.string(), requestContext: bodyRequestContextSchema });
 
 const sendNotificationBodySchema = z.object({
   source: z.string(),


### PR DESCRIPTION
AgentControllerSession methods couldn't send client request context even though the server already forwarded request context into controller runs. This adds an optional trailing option to sendMessage, steer, followUp, approveTool, and respondToToolSuspension. Plain objects and RequestContext instances are both supported.

```ts
const session = client.getAgentController('code').session('user-1');
await session.sendMessage('hello', {
  requestContext: { userId: 'user-1', tier: 'pro' },
});
```

The server route schemas now document the existing requestContext body field so generated API types match runtime behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Agent controller calls can now carry extra information about the person or request making them. The server also documents this information correctly so generated API types match actual behavior.

## Changes

- Added optional `requestContext` support to `sendMessage`, `steer`, `followUp`, `approveTool`, and `respondToToolSuspension`.
- Supports both plain objects and `RequestContext` instances.
- Exported `AgentControllerRequestOptions` from the client package.
- Updated server route schemas and OpenAPI documentation for `requestContext`.
- Added tests covering context serialization and all supported session methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->