### PR TITLE
feat(mcp-registry-registry): live server-fetch for the mcpindex registry

### DIFF
--- a/.changeset/mcpindex-server-fetch.md
+++ b/.changeset/mcpindex-server-fetch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp-registry-registry': patch
+---
+
+Add a live server-fetch processor for the mcpindex registry so `registryServers` returns mcpindex's quality-ranked catalog instead of only metadata.

--- a/packages/mcp-registry-registry/src/registry/__tests__/processors/mcpindex.test.ts
+++ b/packages/mcp-registry-registry/src/registry/__tests__/processors/mcpindex.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { getServersFromRegistry } from '../../fetch-servers';
+import { processMcpindexServers } from '../../processors/mcpindex';
+import type { ServerEntry } from '../../types';
+
+describe('mcpindex processor', () => {
+  it('should process mcpindex server data correctly (live)', async () => {
+    try {
+      const result = await getServersFromRegistry('mcpindex');
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result.length).toBeGreaterThan(0);
+
+      result.forEach((server: ServerEntry) => {
+        expect(server).toHaveProperty('id');
+        expect(server).toHaveProperty('name');
+        expect(server).toHaveProperty('description');
+        expect(server).toHaveProperty('createdAt');
+        expect(server).toHaveProperty('updatedAt');
+      });
+    } catch (error) {
+      console.warn('Error during mcpindex live test (network/endpoint):', error);
+      // Skip if the endpoint is unreachable in CI.
+    }
+  });
+
+  it('should handle sample mcpindex data correctly', () => {
+    // Mirrors the /api/v1/servers browse-feed envelope.
+    const sampleData = {
+      total: 15953,
+      returned: 2,
+      generatedAt: '2026-07-15T00:00:00.000Z',
+      servers: [
+        {
+          slug: 'io-github-pipeworx-io-github',
+          name: 'io.github.pipeworx-io/github',
+          title: 'Github',
+          description: 'GitHub MCP — wraps the GitHub public REST API (no auth required for public endpoints).',
+          category: 'github',
+          version: '0.1.1',
+          qualityScore: 90,
+          installs: { remote: 'https://gateway.pipeworx.io/github/mcp' },
+          url: 'https://mcpindex.ai/server/io-github-pipeworx-io-github',
+          updatedAt: '2026-07-01T12:00:00.000Z',
+        },
+        {
+          slug: 'ac-inference-sh-mcp',
+          name: 'ac.inference.sh/mcp',
+          title: 'inference.sh',
+          description: 'Run 150+ AI apps — image, video, audio, LLMs, 3D and more.',
+          category: 'ai',
+          version: '1.0.1',
+          qualityScore: 65,
+          installs: { remote: 'https://sh.inference.ac' },
+          url: 'https://mcpindex.ai/server/ac-inference-sh-mcp',
+          updatedAt: '',
+        },
+        // No slug -> must be filtered out.
+        { name: 'orphan', title: 'Orphan', description: 'no slug' },
+      ],
+    };
+
+    const servers = processMcpindexServers(sampleData);
+
+    // The slug-less entry is dropped.
+    expect(servers.length).toBe(2);
+
+    // id <- slug, name <- title, description mapped, createdAt always '', updatedAt passed through.
+    expect(servers[0]).toEqual({
+      id: 'io-github-pipeworx-io-github',
+      name: 'Github',
+      description: 'GitHub MCP — wraps the GitHub public REST API (no auth required for public endpoints).',
+      createdAt: '',
+      updatedAt: '2026-07-01T12:00:00.000Z',
+    });
+    expect(servers[1].id).toBe('ac-inference-sh-mcp');
+    expect(servers[1].name).toBe('inference.sh');
+    expect(servers[1].updatedAt).toBe('');
+  });
+
+  it('returns an empty array for a malformed payload', () => {
+    expect(processMcpindexServers(null)).toEqual([]);
+    expect(processMcpindexServers({})).toEqual([]);
+    expect(processMcpindexServers({ servers: 'nope' })).toEqual([]);
+  });
+});

--- a/packages/mcp-registry-registry/src/registry/processors/mcpindex.ts
+++ b/packages/mcp-registry-registry/src/registry/processors/mcpindex.ts
@@ -1,0 +1,26 @@
+import type { ServerEntry } from '../types';
+
+/**
+ * Post-processor for the mcpindex registry.
+ * Maps mcpindex's public browse feed (https://mcpindex.ai/api/v1/servers) into ServerEntry[].
+ * Feed shape: { servers: [{ slug, name, title, description, updatedAt, ... }], total, returned, generatedAt }.
+ * The feed is quality-ranked and bounded (default 100, max 250) — not the full corpus.
+ */
+export function processMcpindexServers(data: any): ServerEntry[] {
+  const serversData = data?.servers;
+
+  if (!Array.isArray(serversData)) {
+    return [];
+  }
+
+  return serversData
+    .filter((item: any) => item && item.slug && (item.title || item.name))
+    .map((item: any) => ({
+      id: String(item.slug),
+      name: String(item.title || item.name),
+      description: typeof item.description === 'string' ? item.description.slice(0, 300) : '',
+      createdAt: '', // mcpindex's browse feed doesn't carry a creation date
+      updatedAt: typeof item.updatedAt === 'string' ? item.updatedAt : '',
+    }))
+    .slice(0, 250);
+}

--- a/packages/mcp-registry-registry/src/registry/processors/mcpindex.ts
+++ b/packages/mcp-registry-registry/src/registry/processors/mcpindex.ts
@@ -1,21 +1,35 @@
 import type { ServerEntry } from '../types';
 
+// Shape of an item in mcpindex's browse feed (https://mcpindex.ai/api/v1/servers).
+// All fields optional — the payload is external, so every read is narrowed.
+interface McpindexServer {
+  slug?: string;
+  name?: string;
+  title?: string;
+  description?: string;
+  updatedAt?: string;
+}
+
 /**
  * Post-processor for the mcpindex registry.
- * Maps mcpindex's public browse feed (https://mcpindex.ai/api/v1/servers) into ServerEntry[].
+ * Maps mcpindex's public browse feed into ServerEntry[].
  * Feed shape: { servers: [{ slug, name, title, description, updatedAt, ... }], total, returned, generatedAt }.
  * The feed is quality-ranked and bounded (default 100, max 250) — not the full corpus.
  */
-export function processMcpindexServers(data: any): ServerEntry[] {
-  const serversData = data?.servers;
+export function processMcpindexServers(data: unknown): ServerEntry[] {
+  const serversData = (data as { servers?: unknown })?.servers;
 
   if (!Array.isArray(serversData)) {
     return [];
   }
 
-  return serversData
-    .filter((item: any) => item && item.slug && (item.title || item.name))
-    .map((item: any) => ({
+  return (serversData as unknown[])
+    .filter((item): item is McpindexServer => {
+      if (!item || typeof item !== 'object') return false;
+      const s = item as McpindexServer;
+      return !!s.slug && !!(s.title || s.name);
+    })
+    .map((item) => ({
       id: String(item.slug),
       name: String(item.title || item.name),
       description: typeof item.description === 'string' ? item.description.slice(0, 300) : '',

--- a/packages/mcp-registry-registry/src/registry/registry.ts
+++ b/packages/mcp-registry-registry/src/registry/registry.ts
@@ -2,6 +2,7 @@ import { processApifyServers } from './processors/apify';
 import { processApiTrackerServers } from './processors/apitracker';
 import { processDockerServers } from './processors/docker';
 import { processFleurServers } from './processors/fleur';
+import { processMcpindexServers } from './processors/mcpindex';
 import { processMcpRunServers } from './processors/mcprun';
 import { processPulseMcpServers } from './processors/pulse';
 import type { RegistryFile } from './types';
@@ -131,7 +132,10 @@ export const registryData: RegistryFile = {
       description:
         'Find MCP servers by natural-language task, with quality scores and an advisory trust screen (REVIEW / UNVERIFIED) that flags a tool before an agent calls it.',
       url: 'https://mcpindex.ai',
+      servers_url: 'https://mcpindex.ai/api/v1/servers',
       tags: ['open-source'],
+      count: '15000+',
+      postProcessServers: processMcpindexServers,
     },
     {
       id: 'mcpmarket',


### PR DESCRIPTION
Closes #19532

## What

Follow-up to #19527 (which added `mcpindex` as a metadata-only entry). This wires it up for **live server fetch**, so the `registryServers` tool returns mcpindex's catalog instead of only a link.

- New `processMcpindexServers` (`src/registry/processors/mcpindex.ts`) maps mcpindex's browse feed → `ServerEntry[]`.
- Adds `servers_url`, `count`, and `postProcessServers` to the existing `mcpindex` entry.
- New processor test mirroring `pulse.test.ts` (live-fetch case that skips on network error + sample-data mapping + malformed-payload guard).

## Why it fits

`fetch-servers.ts` consumes a registry's `servers_url` with a bare `fetch()` (GET, no auth, single request) and hands the JSON to `postProcessServers`. mcpindex exposes exactly that:

`GET https://mcpindex.ai/api/v1/servers` (public, unauthenticated, CORS `*`)

```json
{
  "total": 15953,
  "returned": 100,
  "generatedAt": "2026-07-15T22:43:49.139Z",
  "servers": [
    { "slug": "ai-dinglebear-cortex-rmcp", "name": "ai.dinglebear/cortex-rmcp",
      "title": "Cortex RMCP", "description": "Rust MCP server for homelab logs...",
      "category": "docker", "qualityScore": 100,
      "url": "https://mcpindex.ai/server/ai-dinglebear-cortex-rmcp",
      "updatedAt": "2026-07-12T11:58:28Z" }
  ]
}
```

The feed is quality-ranked and bounded (default 100, max 250) — a sampler, not a 50k dump; `total` reports the active-corpus size (~16k). The processor maps `slug → id`, `title → name`, caps `description` at 300 chars, and passes `updatedAt` through (`createdAt` stays `''`, the feed has no creation date).

## Notes

- Endpoint is live and verified: default page returns 100, `?limit=99999` caps at 250, a garbage `limit` returns 200 (never 500, never a corpus dump), CORS `*` present.
- `count: '15000+'` follows the existing approximate-count convention (`'17000+'`, `'1800+'`); no fabricated exact number.
- Changeset included (`patch` for `@mastra/mcp-registry-registry`).
- Not affiliated with Mastra.

## ELI5

Before, Mastra's mcpindex entry was just a link. This connects it to a live feed, so asking Mastra for mcpindex's servers returns a ranked list of real MCP servers with quality scores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

MCPIndex now publishes a public list of MCP servers. This PR teaches the registry to download that list and convert it into the same `ServerEntry[]` format that `registryServers` already expects, so callers get real server catalogs instead of just links.

## Changes

- Added `processMcpindexServers` to fetch/map MCPIndex’s public browse feed (`servers_url: https://mcpindex.ai/api/v1/servers`) into `ServerEntry[]`.
- Wired the `mcpindex` registry entry with `servers_url`, `count: '15000+'`, and `postProcessServers: processMcpindexServers`.
- Field mapping/normalization:
  - `id` from `slug`, `name` from `title` (fallback to `name`)
  - `description` truncated to 300 characters (or `''` if not a string)
  - `createdAt` always `''`
  - `updatedAt` preserved when it’s a string (otherwise `''`)
  - filters out items missing `slug` and a `title`/`name`, and returns at most 250 servers
- Added tests for:
  - live fetching via `getServersFromRegistry('mcpindex')`
  - deterministic sample payload mapping
  - malformed payload handling (returns `[]`)
- Added a patch changeset for `@mastra/mcp-registry-registry`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->