### PR TITLE
fix(core): resolve object-form Standard Schema path segments in tool validation errors

### DIFF
--- a/.changeset/fix-standard-schema-object-path-segments.md
+++ b/.changeset/fix-standard-schema-object-path-segments.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool validation error messages showing `[object Object]` instead of the field name when using schema libraries whose issue paths use object-form segments (`{ key }`), such as Valibot and ArkType. Error messages now resolve the actual field path in all cases.

--- a/packages/core/src/tools/validation.test.ts
+++ b/packages/core/src/tools/validation.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { z } from 'zod/v4';
 
 import { createTool } from './tool';
-import { validateToolInput } from './validation';
+import { validateToolInput, validateToolOutput } from './validation';
 
 describe('Tool Input Validation Integration Tests', () => {
   describe('createTool validation', () => {
@@ -2281,5 +2281,28 @@ describe('prompt alias normalization (GitHub #14154)', () => {
     });
     expect(result.error).toBeUndefined();
     expect(result.data).toEqual({ prompt: 'from message' });
+  });
+});
+
+describe('Standard Schema object path segments (#19124)', () => {
+  // The Standard Schema spec allows an issue's path segments to be either a plain
+  // key (used by Zod) or a `{ key }` object (used by Valibot and ArkType). Error
+  // messages must resolve the field name in both cases, not print `[object Object]`.
+  const objectPathSchema = {
+    '~standard': {
+      version: 1,
+      vendor: 'test',
+      validate: () => ({
+        issues: [{ message: 'Invalid type', path: [{ key: 'user' }, { key: 'name' }] }],
+      }),
+    },
+  } as unknown as NonNullable<Parameters<typeof validateToolOutput>[0]>;
+
+  it('shows field names for object-form path segments instead of [object Object]', () => {
+    const result = validateToolOutput(objectPathSchema, { user: { name: 123 } }, 'my-tool');
+
+    expect(result.error).toBeDefined();
+    expect(result.error!.message).toContain('user.name');
+    expect(result.error!.message).not.toContain('[object Object]');
   });
 });

--- a/packages/core/src/tools/validation.ts
+++ b/packages/core/src/tools/validation.ts
@@ -159,7 +159,9 @@ export function validateToolSuspendData<T = unknown>(
   }
 
   // Validation failed, return error
-  const errorMessages = validation.issues.map(e => `- ${e.path?.join('.') || 'root'}: ${e.message}`).join('\n');
+  const errorMessages = validation.issues
+    .map(e => `- ${e.path?.map(getPathKey).join('.') || 'root'}: ${e.message}`)
+    .join('\n');
 
   const error: ValidationError<T> = {
     error: true,
@@ -557,7 +559,9 @@ export function validateToolInput<T = unknown>(
 
   // All attempts failed - return the original (non-stripped) error since it's
   // more informative about what the schema actually expects
-  const errorMessages = validation.issues.map(e => `- ${e.path?.join('.') || 'root'}: ${e.message}`).join('\n');
+  const errorMessages = validation.issues
+    .map(e => `- ${e.path?.map(getPathKey).join('.') || 'root'}: ${e.message}`)
+    .join('\n');
 
   const error: ValidationError<T> = {
     error: true,
@@ -595,7 +599,9 @@ export function validateToolOutput<T = unknown>(
   }
 
   // Validation failed, return error
-  const errorMessages = validation.issues.map(e => `- ${e.path?.join('.') || 'root'}: ${e.message}`).join('\n');
+  const errorMessages = validation.issues
+    .map(e => `- ${e.path?.map(getPathKey).join('.') || 'root'}: ${e.message}`)
+    .join('\n');
 
   const error: ValidationError<T> = {
     error: true,
@@ -675,7 +681,9 @@ export function validateRequestContext<T = any>(
   }
 
   // Validation failed, return error
-  const errorMessages = validation.issues.map(e => `- ${e.path?.join('.') || 'root'}: ${e.message}`).join('\n');
+  const errorMessages = validation.issues
+    .map(e => `- ${e.path?.map(getPathKey).join('.') || 'root'}: ${e.message}`)
+    .join('\n');
 
   // Redact sensitive keys before including in error message
   const redactedContext = redactSensitiveKeys(contextValues);


### PR DESCRIPTION
## Description

Standard Schema issue paths may contain either a plain key (used by Zod) or a `{ key }` object segment (used by **Valibot** and **ArkType**). The error-message builders in `validateToolInput`, `validateToolOutput`, `validateToolSuspendData`, and `validateRequestContext` joined the raw path array with `.join(".")`, which stringifies object segments to `[object Object]` — so the error message loses the actual field name.

Before (Valibot/ArkType schema):
```
- [object Object].[object Object]: Invalid type
```
After:
```
- user.name: Invalid type
```

The fix routes each segment through the existing `getPathKey` helper in the same file (already used by `buildFormattedErrors`), so field names resolve for both plain-key and object-form paths. Zod (plain keys) is unaffected.

## Related issue(s)

Fixes #19124

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have added tests that prove my fix is effective or that my feature works

## Notes on verification

Added a regression test in `validation.test.ts` (a Standard Schema returning `{ key }` path segments asserts the message contains `user.name`, not `[object Object]`). I verified the `getPathKey` + join logic standalone (object path -> `user.name`; the old bare join -> `[object Object]`; Zod string paths unchanged). I was not able to run the full workspace `vitest` suite locally, so CI is the source of truth for the added test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Validation errors now show the real field name instead of `[object Object]` for schemas like Valibot and ArkType, while keeping Zod paths working as before.

## Changes

- Normalize path segments with `getPathKey` across tool input, output, suspend-data, and request-context validation.
- Add regression coverage for nested paths such as `user.name`.
- Add a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->