### PR TITLE
fix(mastracode-web): polish Factory board entry

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
@@ -39,16 +39,16 @@ afterEach(() => {
   vi.mocked(redirectToLogin).mockClear();
 });
 
-function seedProject() {
-  const project: Project = {
+function seedProject(project?: Project) {
+  const selectedProject: Project = project ?? {
     id: 'project-test',
     name: 'MastraCode Test',
     path: '/tmp/mastracode-test',
     resourceId: RESOURCE_ID,
     createdAt: 1,
   };
-  localStorage.setItem('mastracode-projects', JSON.stringify([project]));
-  localStorage.setItem('mastracode-active-project', project.id);
+  localStorage.setItem('mastracode-projects', JSON.stringify([selectedProject]));
+  localStorage.setItem('mastracode-active-project', selectedProject.id);
 }
 
 function sessionState(): AgentControllerSessionState {
@@ -95,10 +95,26 @@ const UNAUTHENTICATED = () => HttpResponse.json({ authenticated: false, user: nu
 const AUTHENTICATED = () =>
   HttpResponse.json({ authenticated: true, user: { name: 'Ada Lovelace', email: 'ada@example.com' } });
 
-function renderRoutes(initialEntry: string, authMe: () => Response | Promise<Response>) {
-  seedProject();
+function renderRoutes(
+  initialEntry: string,
+  authMe: () => Response | Promise<Response>,
+  options?: { project?: Project; workItemCount?: number; workItemsReady?: Promise<void> },
+) {
+  seedProject(options?.project);
   useAgentControllerHandlers();
   server.use(http.get(`${TEST_BASE_URL}/auth/me`, authMe));
+  if (options?.project?.githubProjectId) {
+    const workItems = Array.from({ length: options.workItemCount ?? 0 }, (_, index) => ({ id: `work-${index}` }));
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/factory/projects/${options.project.githubProjectId}/work-items`, async () => {
+        await options.workItemsReady;
+        return HttpResponse.json({ workItems });
+      }),
+      http.get(`${TEST_BASE_URL}/web/github/status`, () =>
+        HttpResponse.json({ enabled: true, connected: false, installations: [] }),
+      ),
+    );
+  }
 
   const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
   const router = createMemoryRouter(createAppRoutes(), { initialEntries: [initialEntry] });
@@ -140,6 +156,57 @@ describe('MastraCode web routing', () => {
     expect(await screen.findByText('What do you want to work on?')).toBeInTheDocument();
   });
 
+  it('given a GitHub project has persisted Factory work, when visiting /, then the user lands on the board', async () => {
+    const project: Project = {
+      id: 'github-project',
+      name: 'mastra-ai/mastra',
+      source: 'github',
+      githubProjectId: 'github-project-id',
+      resourceId: RESOURCE_ID,
+      createdAt: 1,
+    };
+    const { router } = renderRoutes('/', AUTHENTICATED, { project, workItemCount: 1 });
+
+    await expectPathname(router, '/factory/board');
+    expect(await screen.findByText(/Factory requires a GitHub connection/)).toBeInTheDocument();
+  });
+
+  it('given Factory work is still loading, when visiting /, then the app waits before choosing a destination', async () => {
+    const project: Project = {
+      id: 'github-project',
+      name: 'mastra-ai/mastra',
+      source: 'github',
+      githubProjectId: 'github-project-id',
+      resourceId: RESOURCE_ID,
+      createdAt: 1,
+    };
+    let resolveWorkItems!: () => void;
+    const workItemsReady = new Promise<void>(resolve => {
+      resolveWorkItems = resolve;
+    });
+    const { router } = renderRoutes('/', AUTHENTICATED, { project, workItemCount: 1, workItemsReady });
+
+    await screen.findByRole('status', { name: 'Loading Factory board' });
+    expect(router.state.location.pathname).toBe('/');
+    resolveWorkItems();
+    await expectPathname(router, '/factory/board');
+  });
+
+  it('given a GitHub project has no persisted Factory work, when visiting /, then the user lands on /new', async () => {
+    const project: Project = {
+      id: 'github-project',
+      name: 'mastra-ai/mastra',
+      source: 'github',
+      githubProjectId: 'github-project-id',
+      resourceId: RESOURCE_ID,
+      createdAt: 1,
+    };
+    const { router } = renderRoutes('/', AUTHENTICATED, { project });
+
+    await expectPathname(router, '/new');
+    expect(await screen.findByText('What do you want to work on?')).toBeInTheDocument();
+  });
+
   it('given auth is disabled, when visiting an unknown path, then the user is redirected to /new', async () => {
     const { router } = renderRoutes('/does-not-exist', AUTH_DISABLED);
 
@@ -150,6 +217,7 @@ describe('MastraCode web routing', () => {
     const { router } = renderRoutes('/new', UNAUTHENTICATED);
 
     await expectPathname(router, '/signin');
+    expect(router.state.location.search).toBe('?returnTo=%2Fnew');
     expect(await screen.findByRole('button', { name: /sign in/i })).toBeInTheDocument();
     expect(screen.queryByText('What do you want to work on?')).not.toBeInTheDocument();
   });
@@ -181,8 +249,20 @@ describe('MastraCode web routing', () => {
     expect(screen.queryByRole('button', { name: /sign in/i })).not.toBeInTheDocument();
   });
 
-  it('given an authenticated session, when visiting /signin, then the user is redirected to /new', async () => {
+  it('given an authenticated session, when visiting /signin, then the user is redirected through the root landing', async () => {
     const { router } = renderRoutes('/signin', AUTHENTICATED);
+
+    await expectPathname(router, '/new');
+  });
+
+  it('given an authenticated session and a safe returnTo, when visiting /signin, then the explicit destination wins', async () => {
+    const { router } = renderRoutes('/signin?returnTo=%2Ffactory%2Fmetrics', AUTHENTICATED);
+
+    await expectPathname(router, '/factory/metrics');
+  });
+
+  it('given an authenticated session and an unsafe returnTo, when visiting /signin, then it falls back through root landing', async () => {
+    const { router } = renderRoutes('/signin?returnTo=https%3A%2F%2Fevil.example', AUTHENTICATED);
 
     await expectPathname(router, '/new');
   });

--- a/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
@@ -98,7 +98,7 @@ const AUTHENTICATED = () =>
 function renderRoutes(
   initialEntry: string,
   authMe: () => Response | Promise<Response>,
-  options?: { project?: Project; workItemCount?: number; workItemsReady?: Promise<void> },
+  options?: { project?: Project; workItemCount?: number; workItemsReady?: Promise<void>; workItemsError?: boolean },
 ) {
   seedProject(options?.project);
   useAgentControllerHandlers();
@@ -108,6 +108,7 @@ function renderRoutes(
     server.use(
       http.get(`${TEST_BASE_URL}/web/factory/projects/${options.project.githubProjectId}/work-items`, async () => {
         await options.workItemsReady;
+        if (options.workItemsError) return HttpResponse.json({ error: 'Factory unavailable' }, { status: 500 });
         return HttpResponse.json({ workItems });
       }),
       http.get(`${TEST_BASE_URL}/web/github/status`, () =>
@@ -190,6 +191,21 @@ describe('MastraCode web routing', () => {
     expect(router.state.location.pathname).toBe('/');
     resolveWorkItems();
     await expectPathname(router, '/factory/board');
+  });
+
+  it('given persisted Factory work cannot be loaded, when visiting /, then the app does not redirect', async () => {
+    const project: Project = {
+      id: 'github-project',
+      name: 'mastra-ai/mastra',
+      source: 'github',
+      githubProjectId: 'github-project-id',
+      resourceId: RESOURCE_ID,
+      createdAt: 1,
+    };
+    const { router } = renderRoutes('/', AUTHENTICATED, { project, workItemsError: true });
+
+    expect(await screen.findByText('Factory unavailable')).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/');
   });
 
   it('given a GitHub project has no persisted Factory work, when visiting /, then the user lands on /new', async () => {

--- a/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
@@ -6,8 +6,8 @@ import type { FormEvent } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
+import { useWebAuth } from '../../../../../shared/hooks/useWebAuth';
 import { Wordmark } from '../../../ui';
-import { useWebAuth } from '../hooks/useWebAuth';
 import { navigateAfterSignIn, redirectToLogin, signInWithPassword, signUpWithPassword } from '../services/auth';
 
 /**

--- a/mastracode/web/src/web/ui/domains/auth/index.ts
+++ b/mastracode/web/src/web/ui/domains/auth/index.ts
@@ -1,4 +1,4 @@
-export { SignInPage } from './components/SignInPage';
+export { safeReturnTo, SignInPage } from './components/SignInPage';
 export { useWebAuth } from '../../../../shared/hooks/useWebAuth';
 export {
   fetchAuthState,

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -1,10 +1,10 @@
-import { Button } from '@mastra/playground-ui/components/Button';
+import { Button, buttonVariants } from '@mastra/playground-ui/components/Button';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { CircleDot, EllipsisVertical, GitPullRequest, MessageSquare } from 'lucide-react';
+import { CircleDot, EllipsisVertical, GitPullRequest, MessageSquare, Plus } from 'lucide-react';
 import type { ComponentType, DragEvent } from 'react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 
 import { useApiConfig } from '../../../../shared/api/config';
@@ -42,6 +42,11 @@ const NEEDS_APPROVAL_LABEL = 'needs-approval';
 
 function hasLabel(labels: readonly string[], label: string): boolean {
   return labels.some(item => item.toLowerCase() === label);
+}
+
+function githubNewIssueUrl(repoFullName: string): string | undefined {
+  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repoFullName)) return undefined;
+  return `https://github.com/${repoFullName}/issues/new`;
 }
 
 function metadataLabels(metadata: Record<string, unknown>): string[] {
@@ -381,6 +386,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
     'github-prs' as const,
     ...(linearReady ? (['linear'] as const) : []),
   ];
+  const newIssueUrl = config && githubIntakeActive ? githubNewIssueUrl(project.name) : undefined;
   const [intakeSource, setIntakeSource] = useState<IntakeSource>('github');
   const showIntakeSourceSwitch = availableIntakeSources.length > 1;
   const activeIntakeSource: IntakeSource | null = availableIntakeSources.includes(intakeSource)
@@ -399,6 +405,10 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   const { start, enabled: runEnabled } = useStartFactoryRun();
   const triage = useStartIssueTriageMutation(githubProjectId);
   const navigate = useNavigate();
+  const boardContainerRef = useRef<HTMLDivElement>(null);
+  const laneRefs = useRef(new Map<BoardStageId, HTMLElement>());
+  const positionedProjectRef = useRef<string | undefined>(undefined);
+  const userPositionedProjectRef = useRef<string | undefined>(undefined);
 
   // Worktrees that still exist. A card's session ref whose worktree was
   // deleted is stale: its thread is gone (worktree deletion cascades onto its
@@ -438,6 +448,31 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
     return all.filter(candidate => !known.has(candidate.sourceKey));
   }, [workItems, issues.data, triageIssues.data, pulls.data, linearIssues.data, activeIntakeSource]);
 
+  const boardDataPending =
+    items.isPending ||
+    configQuery.isPending ||
+    linearStatusQuery.isPending ||
+    triageIssues.isPending ||
+    (activeIntakeSource === 'github' && issues.isPending) ||
+    (activeIntakeSource === 'github-prs' && pulls.isPending) ||
+    (activeIntakeSource === 'linear' && linearIssues.isPending);
+
+  useEffect(() => {
+    if (boardDataPending || positionedProjectRef.current === project.id) return;
+    positionedProjectRef.current = project.id;
+    if (userPositionedProjectRef.current === project.id) return;
+
+    const firstPopulatedStage = BOARD_STAGES.find(
+      stage =>
+        workItems.some(item => item.stages.includes(stage.id)) ||
+        candidates.some(candidate => candidate.column === stage.id),
+    );
+    const container = boardContainerRef.current;
+    const lane = firstPopulatedStage ? laneRefs.current.get(firstPopulatedStage.id) : undefined;
+    if (!container || !lane) return;
+    container.scrollTo?.({ left: Math.max(0, lane.offsetLeft - container.offsetLeft), behavior: 'auto' });
+  }, [boardDataPending, candidates, project.id, workItems]);
+
   const moveItem = (id: string, fromStage: string | null, toStage: string) => {
     const item = workItems.find(i => i.id === id);
     if (!item) return;
@@ -475,13 +510,44 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
           {mutationError instanceof Error ? mutationError.message : 'Board action failed'}
         </Notice>
       )}
-      <div className="flex min-h-0 flex-1 gap-3 overflow-x-auto pb-2" aria-label="Board columns">
+      <div
+        ref={boardContainerRef}
+        className="flex min-h-0 flex-1 gap-3 overflow-x-auto pb-2"
+        aria-label="Board columns"
+        onPointerDown={() => {
+          userPositionedProjectRef.current = project.id;
+        }}
+        onWheel={() => {
+          userPositionedProjectRef.current = project.id;
+        }}
+        onScroll={() => {
+          if (positionedProjectRef.current !== project.id) userPositionedProjectRef.current = project.id;
+        }}
+      >
         {BOARD_STAGES.map(stage => (
           <BoardColumn
             key={stage.id}
             stage={stage.id}
             label={stage.label}
+            laneRef={element => {
+              if (element) laneRefs.current.set(stage.id, element);
+              else laneRefs.current.delete(stage.id);
+            }}
             onDrop={handleDrop}
+            headerAction={
+              stage.id === 'intake' && newIssueUrl ? (
+                <a
+                  href={newIssueUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="Create GitHub issue"
+                  title="Create GitHub issue"
+                  className={buttonVariants({ variant: 'ghost', size: 'icon-sm' })}
+                >
+                  <Plus size={13} aria-hidden />
+                </a>
+              ) : undefined
+            }
             headerExtras={
               stage.id === 'intake' && showIntakeSourceSwitch ? (
                 <div role="group" aria-label="Intake source" className="flex items-center gap-1 pb-1">
@@ -588,13 +654,17 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
 function BoardColumn({
   stage,
   label,
+  laneRef,
   onDrop,
+  headerAction,
   headerExtras,
   children,
 }: {
   stage: BoardStageId;
   label: string;
+  laneRef: (element: HTMLElement | null) => void;
   onDrop: (payload: DragPayload, toStage: BoardStageId) => void;
+  headerAction?: React.ReactNode;
   /** Pinned below the column title, outside the scrolling card list. */
   headerExtras?: React.ReactNode;
   children: React.ReactNode;
@@ -603,6 +673,7 @@ function BoardColumn({
 
   return (
     <section
+      ref={laneRef}
       aria-label={label}
       data-testid={`board-column-${stage}`}
       className={`flex min-h-0 w-72 shrink-0 flex-col gap-2 rounded-lg border p-2 transition ${
@@ -622,9 +693,12 @@ function BoardColumn({
         if (payload) onDrop(payload, stage);
       }}
     >
-      <Txt as="h2" variant="ui-xs" className="m-0 px-1 uppercase tracking-wide text-icon3">
-        {label}
-      </Txt>
+      <div className="flex items-center justify-between gap-2 px-1">
+        <Txt as="h2" variant="ui-xs" className="m-0 uppercase tracking-wide text-icon3">
+          {label}
+        </Txt>
+        {headerAction}
+      </div>
       {headerExtras}
       {/* Cards scroll inside the swimlane; the page stays fixed. */}
       <div className="flex min-h-16 flex-1 flex-col gap-1.5 overflow-y-auto">{children}</div>

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -411,7 +411,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   const navigate = useNavigate();
   const boardContainerRef = useRef<HTMLDivElement>(null);
   const laneRefs = useRef(new Map<BoardStageId, HTMLElement>());
-  const positionedProjectRef = useRef<string | undefined>(undefined);
+  const autoPositionedProjectRef = useRef<string | undefined>(undefined);
   const userPositionedProjectRef = useRef<string | undefined>(undefined);
 
   // Worktrees that still exist. A card's session ref whose worktree was
@@ -462,8 +462,8 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
     (activeIntakeSource === 'linear' && linearIssues.isPending);
 
   useEffect(() => {
-    if (boardDataPending || positionedProjectRef.current === project.id) return;
-    positionedProjectRef.current = project.id;
+    if (boardDataPending || autoPositionedProjectRef.current === project.id) return;
+    autoPositionedProjectRef.current = project.id;
     if (userPositionedProjectRef.current === project.id) return;
 
     const firstPopulatedStage = BOARD_STAGES.find(
@@ -525,7 +525,8 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
           userPositionedProjectRef.current = project.id;
         }}
         onScroll={() => {
-          if (positionedProjectRef.current !== project.id) userPositionedProjectRef.current = project.id;
+          // Ignore the scroll event emitted by our own initial scrollTo call.
+          if (autoPositionedProjectRef.current !== project.id) userPositionedProjectRef.current = project.id;
         }}
       >
         {BOARD_STAGES.map(stage => (

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -45,8 +45,12 @@ function hasLabel(labels: readonly string[], label: string): boolean {
 }
 
 function githubNewIssueUrl(repoFullName: string): string | undefined {
-  if (!/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(repoFullName)) return undefined;
-  return `https://github.com/${repoFullName}/issues/new`;
+  const [owner, repo, extra] = repoFullName.split('/');
+  if (extra || !owner || !repo || repo === '.' || repo === '..') return undefined;
+  if (!/^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$/.test(owner) || !/^[A-Za-z0-9_.-]+$/.test(repo)) {
+    return undefined;
+  }
+  return `https://github.com/${owner}/${repo}/issues/new`;
 }
 
 function metadataLabels(metadata: Record<string, unknown>): string[] {

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -474,6 +474,14 @@ describe('Factory Board — Intake candidates', () => {
     expect(within(intake).queryByRole('link', { name: 'Create GitHub issue' })).not.toBeInTheDocument();
   });
 
+  it('given the project name is not a canonical GitHub repository, when the Board renders, then no issue URL is invented', async () => {
+    useBoardHandlers();
+    renderAt('/factory/board', { ...githubProject, name: '../not-a-repository' });
+
+    const intake = await screen.findByTestId('board-column-intake');
+    expect(within(intake).queryByRole('link', { name: 'Create GitHub issue' })).not.toBeInTheDocument();
+  });
+
   it('given the first board content is in Review, when all feeds settle, then the Board positions Review in view', async () => {
     useBoardHandlers({
       workItems: [
@@ -546,12 +554,13 @@ describe('Factory Board — Intake candidates', () => {
     HTMLElement.prototype.scrollTo = scrollTo;
 
     try {
-      renderAt('/factory/board');
+      const { client } = renderAt('/factory/board');
       fireEvent.wheel(await screen.findByLabelText('Board columns'));
       resolveIssues();
 
       expect(await within(column('review')).findByText('Add factory pages')).toBeInTheDocument();
-      await waitFor(() => expect(scrollTo).not.toHaveBeenCalled());
+      await client.invalidateQueries();
+      expect(scrollTo).not.toHaveBeenCalled();
     } finally {
       HTMLElement.prototype.scrollTo = originalScrollTo;
     }

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -31,7 +31,7 @@ const GITHUB_PROJECT_ID = 'github-project-1';
 
 const githubProject: Project = {
   id: 'project-gh',
-  name: 'Mastra',
+  name: 'mastra-ai/mastra',
   source: 'github',
   githubProjectId: GITHUB_PROJECT_ID,
   sandboxWorkdir: '/sandbox/mastra',
@@ -447,6 +447,114 @@ describe('Factory Board — Intake candidates', () => {
     expect(await within(column('intake')).findByText('Add factory pages')).toBeInTheDocument();
     expect(within(column('intake')).queryByText('Fix flaky test')).not.toBeInTheDocument();
     expect(within(column('review')).queryByTestId('candidate-card')).not.toBeInTheDocument();
+  });
+
+  it('given GitHub Intake is configured, when the Board renders, then Intake offers repository issue creation in a new tab', async () => {
+    useBoardHandlers();
+    renderAt('/factory/board');
+
+    const intake = await screen.findByTestId('board-column-intake');
+    expect(within(intake).getByRole('link', { name: 'Create GitHub issue' })).toMatchObject({
+      href: 'https://github.com/mastra-ai/mastra/issues/new',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+  });
+
+  it('given GitHub Intake is unavailable, when the Board renders, then issue creation is hidden', async () => {
+    useBoardHandlers();
+    renderAt('/factory/board', githubProject, connectedStatus, {
+      intakeConfig: {
+        github: { enabled: false, projectIds: [] },
+        linear: { enabled: false, projectIds: [] },
+      },
+    });
+
+    const intake = await screen.findByTestId('board-column-intake');
+    expect(within(intake).queryByRole('link', { name: 'Create GitHub issue' })).not.toBeInTheDocument();
+  });
+
+  it('given the first board content is in Review, when all feeds settle, then the Board positions Review in view', async () => {
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: '00000000-0000-4000-8000-000000000042',
+          title: 'Add factory pages',
+          source: 'github-pr',
+          sourceKey: 'github-pr:42',
+          stages: ['review'],
+        }),
+      ],
+    });
+    let resolveIssues!: () => void;
+    const issuesReady = new Promise<void>(resolve => {
+      resolveIssues = resolve;
+    });
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${GITHUB_PROJECT_ID}/issues`, async ({ request }) => {
+        if (new URL(request.url).searchParams.has('label')) return HttpResponse.json({ issues: [], nextPage: null });
+        await issuesReady;
+        return HttpResponse.json({ issues: [], nextPage: null });
+      }),
+    );
+    const scrollTo = vi.fn();
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    HTMLElement.prototype.scrollTo = scrollTo;
+
+    try {
+      const { client } = renderAt('/factory/board');
+      const review = await screen.findByTestId('board-column-review');
+      Object.defineProperty(review, 'offsetLeft', { configurable: true, value: 864 });
+      resolveIssues();
+
+      expect(await within(review).findByText('Add factory pages')).toBeInTheDocument();
+      await waitFor(() => expect(scrollTo).toHaveBeenCalledWith({ left: 864, behavior: 'auto' }));
+
+      scrollTo.mockClear();
+      await client.invalidateQueries();
+      expect(scrollTo).not.toHaveBeenCalled();
+    } finally {
+      HTMLElement.prototype.scrollTo = originalScrollTo;
+    }
+  });
+
+  it('given the user moves the Board before feeds settle, when content loads, then automatic positioning does not override them', async () => {
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: '00000000-0000-4000-8000-000000000042',
+          title: 'Add factory pages',
+          source: 'github-pr',
+          sourceKey: 'github-pr:42',
+          stages: ['review'],
+        }),
+      ],
+    });
+    let resolveIssues!: () => void;
+    const issuesReady = new Promise<void>(resolve => {
+      resolveIssues = resolve;
+    });
+    server.use(
+      http.get(`${TEST_BASE_URL}/web/github/projects/${GITHUB_PROJECT_ID}/issues`, async ({ request }) => {
+        if (new URL(request.url).searchParams.has('label')) return HttpResponse.json({ issues: [], nextPage: null });
+        await issuesReady;
+        return HttpResponse.json({ issues: [], nextPage: null });
+      }),
+    );
+    const scrollTo = vi.fn();
+    const originalScrollTo = HTMLElement.prototype.scrollTo;
+    HTMLElement.prototype.scrollTo = scrollTo;
+
+    try {
+      renderAt('/factory/board');
+      fireEvent.wheel(await screen.findByLabelText('Board columns'));
+      resolveIssues();
+
+      expect(await within(column('review')).findByText('Add factory pages')).toBeInTheDocument();
+      await waitFor(() => expect(scrollTo).not.toHaveBeenCalled());
+    } finally {
+      HTMLElement.prototype.scrollTo = originalScrollTo;
+    }
   });
 
   it('given an untriaged issue candidate, when Triage issue is chosen, then the server triage run starts and the Board stays open', async () => {

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -8,6 +8,7 @@
  * mirrors the guard: signed-in (or auth-disabled) visitors are sent back to
  * `/` so the app can choose the active project's board or draft composer.
  */
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { createBrowserRouter, Navigate, Outlet, useLocation, useSearchParams } from 'react-router';
 import type { RouteObject } from 'react-router';
@@ -73,6 +74,15 @@ function RootLanding() {
   const workItems = useWorkItemsQuery(githubProjectId);
 
   if (githubProjectId && workItems.isPending) return <AuthPendingSkeleton label="Loading Factory board" />;
+  if (githubProjectId && workItems.isError) {
+    return (
+      <div className="flex h-dvh w-full items-center justify-center bg-surface1 p-4">
+        <Notice variant="destructive">
+          {workItems.error instanceof Error ? workItems.error.message : 'Failed to load Factory work'}
+        </Notice>
+      </div>
+    );
+  }
   return <Navigate to={githubProjectId && (workItems.data?.length ?? 0) > 0 ? '/factory/board' : '/new'} replace />;
 }
 

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -6,16 +6,18 @@
  * React Query hook (shared cache key with the rest of the UI), redirecting
  * unauthenticated sessions to `/signin` when web auth is enabled. `SignInGate`
  * mirrors the guard: signed-in (or auth-disabled) visitors are sent back to
- * `/` so the app can render the draft composer.
+ * `/` so the app can choose the active project's board or draft composer.
  */
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
-import { createBrowserRouter, Navigate, Outlet } from 'react-router';
+import { createBrowserRouter, Navigate, Outlet, useLocation, useSearchParams } from 'react-router';
 import type { RouteObject } from 'react-router';
 
-import { SignInPage, useWebAuth } from './domains/auth';
+import { safeReturnTo, SignInPage, useWebAuth } from './domains/auth';
 import Chat from './domains/chat/Chat';
 import { NewPage } from './domains/chat/NewPage';
 import { ThreadPage } from './domains/chat/ThreadPage';
+import { useActiveProject } from '../../shared/hooks/useActiveProject';
+import { useWorkItemsQuery } from '../../shared/hooks/useWorkItems';
 import { AuditPage } from './domains/factory/AuditPage';
 import { BoardPage } from './domains/factory/BoardPage';
 import { MetricsPage } from './domains/factory/MetricsPage';
@@ -24,13 +26,9 @@ import { MetricsPage } from './domains/factory/MetricsPage';
  * Full-page placeholder while `/auth/me` resolves — a shimmer block instead
  * of a blank screen on deep links / refreshes.
  */
-function AuthPendingSkeleton() {
+function AuthPendingSkeleton({ label = 'Checking sign-in' }: { label?: string }) {
   return (
-    <div
-      role="status"
-      aria-label="Checking sign-in"
-      className="flex h-dvh w-full items-center justify-center bg-surface1"
-    >
+    <div role="status" aria-label={label} className="flex h-dvh w-full items-center justify-center bg-surface1">
       <div className="flex w-64 flex-col gap-3">
         <Skeleton className="h-8 w-full" />
         <Skeleton className="h-4 w-3/4" />
@@ -47,19 +45,35 @@ function AuthPendingSkeleton() {
  */
 function RequireAuth() {
   const auth = useWebAuth();
+  const location = useLocation();
   if (auth.isPending) return <AuthPendingSkeleton />;
   const state = auth.data;
-  if (state?.authEnabled && !state.authenticated) return <Navigate to="/signin" replace />;
+  if (state?.authEnabled && !state.authenticated) {
+    const returnTo = `${location.pathname}${location.search}${location.hash}`;
+    return <Navigate to={`/signin?returnTo=${encodeURIComponent(returnTo)}`} replace />;
+  }
   return <Outlet />;
 }
 
 /** Inverse guard for /signin: only unauthenticated (auth-enabled) users stay. */
 function SignInGate() {
   const auth = useWebAuth();
+  const [searchParams] = useSearchParams();
   if (auth.isPending) return <AuthPendingSkeleton />;
   const state = auth.data;
-  if (!state?.authEnabled || state.authenticated) return <Navigate to="/" replace />;
+  if (!state?.authEnabled || state.authenticated) {
+    return <Navigate to={safeReturnTo(searchParams.get('returnTo') ?? undefined)} replace />;
+  }
   return <SignInPage />;
+}
+
+function RootLanding() {
+  const { activeProject } = useActiveProject();
+  const githubProjectId = activeProject?.source === 'github' ? activeProject.githubProjectId : undefined;
+  const workItems = useWorkItemsQuery(githubProjectId);
+
+  if (githubProjectId && workItems.isPending) return <AuthPendingSkeleton label="Loading Factory board" />;
+  return <Navigate to={githubProjectId && (workItems.data?.length ?? 0) > 0 ? '/factory/board' : '/new'} replace />;
 }
 
 function RedirectToDraftThread() {
@@ -75,7 +89,7 @@ export function createAppRoutes(): RouteObject[] {
       path: '/',
       element: <RequireAuth />,
       children: [
-        { index: true, element: <RedirectToDraftThread /> },
+        { index: true, element: <RootLanding /> },
         {
           // Pathless layout: <Chat /> (providers, session, SSE stream) stays
           // mounted while navigating between thread URLs, so thread navigation


### PR DESCRIPTION
## Summary

- send signed-in users with persisted Factory work to the board while preserving explicit safe return paths and keeping empty projects on the new-chat screen
- add an accessible Intake action that opens the canonical GitHub repository's new-issue page in a safe new tab
- position the board at its first populated lane once without overriding manual scrolling or later query refetches

## Test plan

- `cd mastracode/web && pnpm exec vitest run --config e2e/web-ui/vitest.config.ts src/web/ui/domains/auth/hooks/__tests__/useWebAuth.msw.test.tsx src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx src/web/ui/__tests__/routing.msw.test.tsx --reporter=dot --bail 1`
- `cd mastracode/web && pnpm check`
- `bash .mastracode/plans/factory-feedback-series.proof/demo.sh board-entry --app-root "$(git rev-parse --show-toplevel)" --expect green`
- live browser check against `TylerBarnes/mastracode-web-signals-proof-20260713`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
If you’re signed in and you already have Factory work saved, the app takes you back to your Factory board (instead of starting a fresh chat). It also adds a safe “Create GitHub issue” link in the Intake lane and makes the board auto-scroll to the first real content only once—without fighting your own scrolling.

## Changes
- Updated root (`/`) landing: for authenticated GitHub projects with persisted Factory work, route to `/factory/board`; for empty projects, route to `/new`.
- If persisted Factory work fails to load, keep the existing root landing decision (don’t treat it like “empty” and redirect to `/new`).
- Improved auth redirects:
  - When sending users to `/signin`, preserve a safe `returnTo`.
  - On `/signin`, route authenticated users back via `returnTo` (or fall back to `/new` if the destination is unsafe).
  - Added an auth-loading skeleton to avoid flashes/bounce behavior during `/auth/me` resolution.
- Added Intake “Create GitHub issue” action on the Factory board:
  - Generates the canonical `https://github.com/<owner>/<repo>/issues/new` URL only for valid canonical `owner/repo` inputs.
  - Hides the link when GitHub/Intake isn’t configured or when the repo name is invalid.
  - Opens the link in a safe new tab.
- Board auto-positioning:
  - Scrolls the board to its first populated lane after initial load.
  - Tracks user manual horizontal scrolling so later automatic positioning won’t override it.
  - Prevents the initial programmatic scroll from triggering subsequent scroll handling/refetch-driven jumps.
- Expanded routing and Factory board regression tests to cover the above behaviors, including delayed work-items readiness and persisted-work failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->