### PR TITLE
fix(core): infer requestContext type from requestContextSchema in dynamic skills option

### DIFF
--- a/.changeset/shaggy-hornets-jam.md
+++ b/.changeset/shaggy-hornets-jam.md
@@ -1,0 +1,19 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `requestContext` typing in the dynamic `skills` agent option. When an agent defines `requestContextSchema`, the `skills` callback now receives a typed `RequestContext` (with key autocomplete and typo checking), matching `instructions`, `tools`, `memory`, and the other dynamic options. Previously it was always `RequestContext<unknown>`.
+
+```typescript
+const agent = new Agent({
+  requestContextSchema: z.object({ documentId: z.string(), userId: z.string() }),
+  // Before: requestContext was RequestContext<unknown> — any key compiled
+  // After: requestContext is RequestContext<{ documentId: string; userId: string }>
+  skills: ({ requestContext }) => {
+    requestContext.get('documentId'); // typed as string
+    return ['./skills/basic'];
+  },
+});
+```
+
+Fixes [#19553](https://github.com/mastra-ai/mastra/issues/19553)

--- a/packages/core/src/agent/agent-types.test-d.ts
+++ b/packages/core/src/agent/agent-types.test-d.ts
@@ -151,6 +151,40 @@ describe('Agent Type Tests', () => {
 
       expectTypeOf(config.id).toEqualTypeOf<'test-agent'>();
     });
+
+    it('should type requestContext in skills function based on requestContextSchema', () => {
+      const config: AgentConfig<
+        'test-agent',
+        Record<string, never>,
+        undefined,
+        { documentId: string; userId: string }
+      > = {
+        id: 'test-agent',
+        name: 'Test Agent',
+        model: {} as any,
+        requestContextSchema: z.object({
+          documentId: z.string(),
+          userId: z.string(),
+        }),
+        instructions: 'You are a helpful assistant',
+        skills: ({ requestContext }) => {
+          // Verify requestContext is typed
+          expectTypeOf(requestContext).toEqualTypeOf<RequestContext<{ documentId: string; userId: string }>>();
+
+          // Verify get() returns the correct type
+          const documentId = requestContext.get('documentId');
+          expectTypeOf(documentId).toEqualTypeOf<string>();
+
+          // Verify unknown keys are rejected
+          // @ts-expect-error - key does not exist in the request context schema
+          requestContext.get('nonexistentKey');
+
+          return [];
+        },
+      };
+
+      expectTypeOf(config.id).toEqualTypeOf<'test-agent'>();
+    });
   });
 
   describe('Issue #16732: AgentExecutionOptions<undefined> should not require structuredOutput', () => {

--- a/packages/core/src/agent/agent-types.test-d.ts
+++ b/packages/core/src/agent/agent-types.test-d.ts
@@ -153,12 +153,9 @@ describe('Agent Type Tests', () => {
     });
 
     it('should type requestContext in skills function based on requestContextSchema', () => {
-      const config: AgentConfig<
-        'test-agent',
-        Record<string, never>,
-        undefined,
-        { documentId: string; userId: string }
-      > = {
+      // No explicit TRequestContext generic — the type must be inferred from
+      // requestContextSchema so a regression to RequestContext<unknown> fails.
+      new Agent({
         id: 'test-agent',
         name: 'Test Agent',
         model: {} as any,
@@ -181,9 +178,7 @@ describe('Agent Type Tests', () => {
 
           return [];
         },
-      };
-
-      expectTypeOf(config.id).toEqualTypeOf<'test-agent'>();
+      });
     });
   });
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -487,7 +487,7 @@ export class Agent<
   #pubsub?: PubSub;
   #inheritedPubSub?: PubSub;
   #memory?: DynamicArgument<MastraMemory, TRequestContext>;
-  #skills?: AgentSkillsInput;
+  #skills?: AgentSkillsInput<TRequestContext>;
   #skillsFormat?: SkillFormat;
   #workflows?: DynamicArgument<Record<string, AnyWorkflow>, TRequestContext>;
   #defaultGenerateOptionsLegacy: DynamicArgument<AgentGenerateOptions, TRequestContext>;
@@ -1140,7 +1140,7 @@ export class Agent<
     if (this.#skills) {
       let resolvedInputs: SkillInput[];
       if (typeof this.#skills === 'function') {
-        resolvedInputs = await this.#skills({ requestContext: rc });
+        resolvedInputs = await this.#skills({ requestContext: rc as RequestContext<TRequestContext> });
       } else {
         resolvedInputs = this.#skills;
       }

--- a/packages/core/src/agent/types.ts
+++ b/packages/core/src/agent/types.ts
@@ -732,7 +732,7 @@ interface AgentConfigBase<
    * }
    * ```
    */
-  skills?: AgentSkillsInput;
+  skills?: AgentSkillsInput<TRequestContext>;
   /**
    * Format for skill information injection when workspace has skills.
    * @default 'xml'

--- a/packages/core/src/skills/types.ts
+++ b/packages/core/src/skills/types.ts
@@ -68,8 +68,8 @@ export type SkillInput = string | InlineSkill;
 /**
  * Context passed to a dynamic skills resolver.
  */
-export interface AgentSkillsContext {
-  requestContext: RequestContext;
+export interface AgentSkillsContext<TRequestContext extends Record<string, any> | unknown = unknown> {
+  requestContext: RequestContext<TRequestContext>;
 }
 
 /**
@@ -93,6 +93,8 @@ export interface AgentSkillsContext {
  * }
  * ```
  */
-export type AgentSkillsInput = SkillInput[] | ((context: AgentSkillsContext) => SkillInput[] | Promise<SkillInput[]>);
+export type AgentSkillsInput<TRequestContext extends Record<string, any> | unknown = unknown> =
+  | SkillInput[]
+  | ((context: AgentSkillsContext<TRequestContext>) => SkillInput[] | Promise<SkillInput[]>);
 
 export type { Skill, SkillMetadata, SkillFormat, WorkspaceSkills };


### PR DESCRIPTION
## Description

When an agent defines `requestContextSchema`, every dynamic config callback (`instructions`, `tools`, `memory`, `model`, ...) receives a typed `RequestContext<TRequestContext>` — except `skills`, which was always `RequestContext<unknown>` (no key autocomplete, typos compile silently).

```ts
new Agent({
  requestContextSchema: z.object({ documentId: z.string(), userId: z.string() }),
  instructions: ({ requestContext }) => {
    requestContext.get('typo'); // ❌ compile error (correct)
    return 'x';
  },
  skills: ({ requestContext }) => {
    requestContext.get('typo'); // ✅ compiled silently (the bug)
    return [];
  },
});
```

**Root cause:** `skills` uses a bespoke `AgentSkillsContext` instead of `DynamicArgument`, and never received the `TRequestContext` generic. Same class of bug as #14581 (fixed in #14582 for 12 other fields); reintroduced for the new `skills` field in #18360.

This is a type-only fix — runtime already passes the real `RequestContext` to the callback.

## Changes

- `skills/types.ts`: `AgentSkillsContext` / `AgentSkillsInput` now take `TRequestContext` (constraint and `= unknown` default copied from `DynamicArgument`, so existing usage compiles unchanged)
- `agent/types.ts`: `skills?: AgentSkillsInput<TRequestContext>`
- `agent.ts`: generic on the `#skills` field + `rc as RequestContext<TRequestContext>` cast at the internal call site (same pattern as `#agents`, `#errorProcessors`, etc. from #14582)
- `agent-types.test-d.ts`: new type test mirroring the existing instructions/tools cases, including a `@ts-expect-error` on an unknown key (fails without this fix)

## Test plan

- [x] `pnpm typecheck` + `pnpm check` in `packages/core` pass
- [x] `vitest run --typecheck src/agent/agent-types.test-d.ts` — 18 passed (incl. new skills test)
- [x] Skills unit tests (`agent-skills-wiring`, `skills-activation-persistence`, `src/skills`) — 44 passed
- [x] Repro from the issue verified: unknown key in `skills` callback now errors like `instructions`

Fixes #19553

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If an agent says what “request context” fields it expects (via `requestContextSchema`), TypeScript now teaches the `skills` callback about those exact fields—so you get autocomplete and errors for typos. This is a type-only improvement; the code runs the same at runtime.

## Changes

- Updated the dynamic `skills` callback typing to infer `RequestContext<TRequestContext>` from the agent’s `requestContextSchema` (instead of always using `RequestContext<unknown>`).
- Added a `TRequestContext` generic (defaulting to `unknown`) to `AgentSkillsContext` and `AgentSkillsInput`, and threaded it through `Agent`/internal `#skills` typing.
- Added an internal type cast when invoking the function-based `#skills` resolver, ensuring the callback receives the correctly typed `RequestContext<TRequestContext>`.
- Added TypeScript type tests that confirm:
  - known context keys are correctly typed (e.g., `documentId`, `userId` as `string`)
  - unknown keys are rejected via `@ts-expect-error`.
- Added a patch changeset documenting the fix and referencing issue `#19553`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->