### PR TITLE
fix(mastracode-web): scope Factory progress to exact actions

### DIFF
--- a/mastracode/web/src/shared/hooks/useFactoryData.ts
+++ b/mastracode/web/src/shared/hooks/useFactoryData.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useInfiniteQuery, useMutation, useMutationState, useQueryClient } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
@@ -28,7 +28,9 @@ export function useProjectIssuesQuery(githubProjectId: string | undefined, label
 export function useStartIssueTriageMutation(githubProjectId: string | undefined) {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
-  return useMutation({
+  const mutationKey = ['factory', 'triage-issue', githubProjectId] as const;
+  const mutation = useMutation({
+    mutationKey,
     mutationFn: (issue: GithubIssue) => startProjectIssueTriage(baseUrl, githubProjectId!, issue),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.githubIssues(githubProjectId) });
@@ -36,6 +38,19 @@ export function useStartIssueTriageMutation(githubProjectId: string | undefined)
       void queryClient.invalidateQueries({ queryKey: queryKeys.workItems(githubProjectId) });
     },
   });
+  const pendingIssueNumbers = useMutationState({
+    filters: { mutationKey, status: 'pending' },
+    select: pending => {
+      const variables = pending.state.variables;
+      return isGithubIssue(variables) ? variables.number : undefined;
+    },
+  }).filter(number => number !== undefined);
+  return { triage: mutation, pendingIssueNumbers };
+}
+
+function isGithubIssue(value: unknown): value is GithubIssue {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  return 'number' in value && typeof value.number === 'number';
 }
 
 /** Open (non-draft) pull requests for a GitHub project, one page at a time. */

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -50,7 +50,8 @@ export type FactoryRunInvocation =
   | { type: 'prompt'; prompt: string }
   | { type: 'skill'; skillName: string; arguments: string };
 
-const factoryRunMutationKey = (resourceId: string) => ['factory', 'start-run', resourceId] as const;
+const factoryRunMutationKey = (resourceId: string, projectId: string | undefined) =>
+  ['factory', 'start-run', resourceId, projectId] as const;
 
 export interface PendingFactoryRun {
   id?: string;
@@ -108,7 +109,7 @@ export function useStartFactoryRun() {
   });
 
   const mutation = useMutation({
-    mutationKey: factoryRunMutationKey(resourceId),
+    mutationKey: factoryRunMutationKey(resourceId, activeProject?.id),
     mutationFn: async ({ branch, threadTitle, threadTags, invocation, workItem }: StartFactoryRunInput) => {
       const updatedProject = await createWorkspace.mutateAsync(branch);
       queryClient.setQueryData(queryKeys.projects(), (projects: Project[] | undefined) =>
@@ -215,7 +216,7 @@ export function useStartFactoryRun() {
   });
 
   const pendingRuns = useMutationState({
-    filters: { mutationKey: factoryRunMutationKey(resourceId), status: 'pending' },
+    filters: { mutationKey: factoryRunMutationKey(resourceId, activeProject?.id), status: 'pending' },
     select: pending => toPendingFactoryRun(pending.state.variables),
   }).filter(run => run !== undefined);
 

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useMutationState, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 
 import { useApiConfig } from '../api/config';
@@ -50,6 +50,27 @@ export type FactoryRunInvocation =
   | { type: 'prompt'; prompt: string }
   | { type: 'skill'; skillName: string; arguments: string };
 
+const factoryRunMutationKey = (resourceId: string) => ['factory', 'start-run', resourceId] as const;
+
+export interface PendingFactoryRun {
+  id?: string;
+  sourceKey: string | null;
+  role: string;
+}
+
+function toPendingFactoryRun(value: unknown): PendingFactoryRun | undefined {
+  if (!isRecord(value) || !isRecord(value.workItem)) return undefined;
+  const { id, sourceKey, role } = value.workItem;
+  if (id !== undefined && typeof id !== 'string') return undefined;
+  if (sourceKey !== null && typeof sourceKey !== 'string') return undefined;
+  if (typeof role !== 'string') return undefined;
+  return { id, sourceKey, role };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export interface StartFactoryRunInput {
   /** Feature branch for the new worktree (e.g. `factory/issue-12`). */
   branch: string;
@@ -87,6 +108,7 @@ export function useStartFactoryRun() {
   });
 
   const mutation = useMutation({
+    mutationKey: factoryRunMutationKey(resourceId),
     mutationFn: async ({ branch, threadTitle, threadTags, invocation, workItem }: StartFactoryRunInput) => {
       const updatedProject = await createWorkspace.mutateAsync(branch);
       queryClient.setQueryData(queryKeys.projects(), (projects: Project[] | undefined) =>
@@ -192,7 +214,12 @@ export function useStartFactoryRun() {
     },
   });
 
-  return { start: mutation, enabled: sessionEnabled };
+  const pendingRuns = useMutationState({
+    filters: { mutationKey: factoryRunMutationKey(resourceId), status: 'pending' },
+    select: pending => toPendingFactoryRun(pending.state.variables),
+  }).filter(run => run !== undefined);
+
+  return { start: mutation, pendingRuns, enabled: sessionEnabled };
 }
 
 /**

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -627,7 +627,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                   // for a perfectly live thread. Hold run/create actions until
                   // liveness is known.
                   runDisabled={!runEnabled || start.isPending || !workspaces.isSuccess}
-                  pendingRunRole={pendingRuns.find(run => run.id === item.id)?.role}
+                  pendingRunRoles={new Set(pendingRuns.filter(run => run.id === item.id).map(run => run.role))}
                   onOpenThread={session => void openThread(session)}
                   onCreateSession={spec =>
                     start.mutate({
@@ -675,7 +675,9 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                 <CandidateCard
                   key={candidate.sourceKey}
                   candidate={candidate}
-                  pendingRunRole={pendingRuns.find(run => run.sourceKey === candidate.sourceKey)?.role}
+                  pendingRunRoles={
+                    new Set(pendingRuns.filter(run => run.sourceKey === candidate.sourceKey).map(run => run.role))
+                  }
                   triageStarting={candidate.issue !== undefined && pendingIssueNumbers.includes(candidate.issue.number)}
                   disabled={!runEnabled}
                   onRun={(action, prompt) =>
@@ -818,7 +820,7 @@ function WorkItemCard({
   columnStage,
   liveWorktreePaths,
   runDisabled,
-  pendingRunRole,
+  pendingRunRoles,
   onOpenThread,
   onCreateSession,
   onStartRun,
@@ -830,7 +832,7 @@ function WorkItemCard({
   /** Worktrees that still exist; session refs outside this set are stale. */
   liveWorktreePaths: ReadonlySet<string>;
   runDisabled: boolean;
-  pendingRunRole?: string;
+  pendingRunRoles: ReadonlySet<string>;
   onOpenThread: (session: WorkItemSessionRef) => void;
   /** Title click when the card has no live session: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
@@ -875,7 +877,7 @@ function WorkItemCard({
           <button
             type="button"
             disabled={runDisabled}
-            aria-busy={pendingRunRole !== undefined || undefined}
+            aria-busy={pendingRunRoles.size > 0 || undefined}
             onClick={() => onCreateSession(itemSessionSpec(item))}
             className="min-w-0 flex-1 truncate text-left text-ui-sm text-icon6 hover:underline disabled:opacity-60"
           >
@@ -904,7 +906,7 @@ function WorkItemCard({
           <DropdownMenu.Content align="end" className="min-w-44">
             {runSpec !== null &&
               runActions.map(action => {
-                const starting = pendingRunRole === action.role;
+                const starting = pendingRunRoles.has(action.role);
                 return (
                   <DropdownMenu.Item
                     key={action.label}
@@ -939,7 +941,7 @@ function WorkItemCard({
 
 function CandidateCard({
   candidate,
-  pendingRunRole,
+  pendingRunRoles,
   triageStarting,
   disabled,
   onRun,
@@ -948,7 +950,7 @@ function CandidateCard({
   onTriage,
 }: {
   candidate: BoardCandidate;
-  pendingRunRole?: string;
+  pendingRunRoles: ReadonlySet<string>;
   triageStarting: boolean;
   disabled: boolean;
   /** Start a run; `prompt` undefined = the action's default prompt. */
@@ -989,7 +991,7 @@ function CandidateCard({
           <button
             type="button"
             disabled={disabled}
-            aria-busy={pendingRunRole === defaultAction.role || undefined}
+            aria-busy={pendingRunRoles.has(defaultAction.role) || undefined}
             onClick={onOpenSession}
             className="truncate text-left text-ui-sm text-icon6 hover:underline disabled:opacity-60"
           >
@@ -1010,12 +1012,12 @@ function CandidateCard({
       <FactoryItemActions
         actionLabel={defaultAction.label}
         itemLabel={candidate.title}
-        starting={pendingRunRole === defaultAction.role}
+        starting={pendingRunRoles.has(defaultAction.role)}
         disabled={disabled}
         onAction={() => onRun(defaultAction)}
         extraActions={otherActions.map(action => ({
           label: action.label,
-          starting: pendingRunRole === action.role,
+          starting: pendingRunRoles.has(action.role),
           onAction: () => onRun(action),
         }))}
         onRunPrompt={prompt => onRun(defaultAction, prompt)}

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -626,7 +626,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                   // create button and a click would mint a replacement session
                   // for a perfectly live thread. Hold run/create actions until
                   // liveness is known.
-                  runDisabled={!runEnabled || start.isPending || !workspaces.isSuccess}
+                  runDisabled={!runEnabled || !workspaces.isSuccess}
                   pendingRunRoles={new Set(pendingRuns.filter(run => run.id === item.id).map(run => run.role))}
                   onOpenThread={session => void openThread(session)}
                   onCreateSession={spec =>

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -544,6 +544,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   }
 
   const mutationError = [start, triage, upsert, update, remove, selectWorkspace].find(m => m.isError)?.error;
+  const pendingRunWorkItem = start.isPending ? start.variables?.workItem : undefined;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
@@ -627,7 +628,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                   // for a perfectly live thread. Hold run/create actions until
                   // liveness is known.
                   runDisabled={!runEnabled || start.isPending || !workspaces.isSuccess}
-                  runStarting={start.isPending}
+                  pendingRunRole={pendingRunWorkItem?.id === item.id ? pendingRunWorkItem.role : undefined}
                   onOpenThread={session => void openThread(session)}
                   onCreateSession={spec =>
                     start.mutate({
@@ -675,11 +676,11 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                 <CandidateCard
                   key={candidate.sourceKey}
                   candidate={candidate}
-                  starting={
-                    (start.isPending && start.variables?.branch === candidate.branch) ||
-                    (triage.isPending && triage.variables?.number === candidate.issue?.number)
+                  pendingRunRole={
+                    pendingRunWorkItem?.sourceKey === candidate.sourceKey ? pendingRunWorkItem.role : undefined
                   }
-                  disabled={!runEnabled || start.isPending || triage.isPending}
+                  triageStarting={triage.isPending && triage.variables?.number === candidate.issue?.number}
+                  disabled={!runEnabled}
                   onRun={(action, prompt) =>
                     start.mutate({
                       branch: candidate.branch,
@@ -820,7 +821,7 @@ function WorkItemCard({
   columnStage,
   liveWorktreePaths,
   runDisabled,
-  runStarting,
+  pendingRunRole,
   onOpenThread,
   onCreateSession,
   onStartRun,
@@ -832,7 +833,7 @@ function WorkItemCard({
   /** Worktrees that still exist; session refs outside this set are stale. */
   liveWorktreePaths: ReadonlySet<string>;
   runDisabled: boolean;
-  runStarting: boolean;
+  pendingRunRole?: string;
   onOpenThread: (session: WorkItemSessionRef) => void;
   /** Title click when the card has no live session: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
@@ -877,7 +878,7 @@ function WorkItemCard({
           <button
             type="button"
             disabled={runDisabled}
-            aria-busy={runStarting || undefined}
+            aria-busy={pendingRunRole !== undefined || undefined}
             onClick={() => onCreateSession(itemSessionSpec(item))}
             className="min-w-0 flex-1 truncate text-left text-ui-sm text-icon6 hover:underline disabled:opacity-60"
           >
@@ -905,15 +906,18 @@ function WorkItemCard({
           />
           <DropdownMenu.Content align="end" className="min-w-44">
             {runSpec !== null &&
-              runActions.map(action => (
-                <DropdownMenu.Item
-                  key={action.label}
-                  disabled={runDisabled}
-                  onClick={() => onStartRun(runSpec, action)}
-                >
-                  {runStarting ? 'Starting…' : action.label}
-                </DropdownMenu.Item>
-              ))}
+              runActions.map(action => {
+                const starting = pendingRunRole === action.role;
+                return (
+                  <DropdownMenu.Item
+                    key={action.label}
+                    disabled={runDisabled || starting}
+                    onClick={() => onStartRun(runSpec, action)}
+                  >
+                    {starting ? 'Starting…' : action.label}
+                  </DropdownMenu.Item>
+                );
+              })}
             {BOARD_STAGES.filter(stage => stage.id !== columnStage).map(stage => (
               <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
                 {stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}
@@ -938,7 +942,8 @@ function WorkItemCard({
 
 function CandidateCard({
   candidate,
-  starting,
+  pendingRunRole,
+  triageStarting,
   disabled,
   onRun,
   onOpenSession,
@@ -946,7 +951,8 @@ function CandidateCard({
   onTriage,
 }: {
   candidate: BoardCandidate;
-  starting: boolean;
+  pendingRunRole?: string;
+  triageStarting: boolean;
   disabled: boolean;
   /** Start a run; `prompt` undefined = the action's default prompt. */
   onRun: (action: RunAction, prompt?: string) => void;
@@ -986,7 +992,7 @@ function CandidateCard({
           <button
             type="button"
             disabled={disabled}
-            aria-busy={starting || undefined}
+            aria-busy={pendingRunRole === defaultAction.role || undefined}
             onClick={onOpenSession}
             className="truncate text-left text-ui-sm text-icon6 hover:underline disabled:opacity-60"
           >
@@ -1007,14 +1013,22 @@ function CandidateCard({
       <FactoryItemActions
         actionLabel={defaultAction.label}
         itemLabel={candidate.title}
-        starting={starting}
+        starting={pendingRunRole === defaultAction.role}
         disabled={disabled}
         onAction={() => onRun(defaultAction)}
-        extraActions={otherActions.map(action => ({ label: action.label, onAction: () => onRun(action) }))}
+        extraActions={otherActions.map(action => ({
+          label: action.label,
+          starting: pendingRunRole === action.role,
+          onAction: () => onRun(action),
+        }))}
         onRunPrompt={prompt => onRun(defaultAction, prompt)}
         menuExtras={
           <>
-            {showTriage && <DropdownMenu.Item onClick={onTriage}>Triage issue</DropdownMenu.Item>}
+            {showTriage && (
+              <DropdownMenu.Item disabled={triageStarting} onClick={onTriage}>
+                {triageStarting ? 'Starting…' : 'Triage issue'}
+              </DropdownMenu.Item>
+            )}
             <DropdownMenu.Item onClick={onFile}>Add to board</DropdownMenu.Item>
           </>
         }

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -444,8 +444,8 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   const upsert = useUpsertWorkItemMutation(githubProjectId);
   const update = useUpdateWorkItemMutation(githubProjectId);
   const remove = useDeleteWorkItemMutation(githubProjectId);
-  const { start, enabled: runEnabled } = useStartFactoryRun();
-  const triage = useStartIssueTriageMutation(githubProjectId);
+  const { start, pendingRuns, enabled: runEnabled } = useStartFactoryRun();
+  const { triage, pendingIssueNumbers } = useStartIssueTriageMutation(githubProjectId);
   const navigate = useNavigate();
   const boardContainerRef = useRef<HTMLDivElement>(null);
   const laneRefs = useRef(new Map<BoardStageId, HTMLElement>());
@@ -544,7 +544,6 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   }
 
   const mutationError = [start, triage, upsert, update, remove, selectWorkspace].find(m => m.isError)?.error;
-  const pendingRunWorkItem = start.isPending ? start.variables?.workItem : undefined;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
@@ -628,7 +627,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                   // for a perfectly live thread. Hold run/create actions until
                   // liveness is known.
                   runDisabled={!runEnabled || start.isPending || !workspaces.isSuccess}
-                  pendingRunRole={pendingRunWorkItem?.id === item.id ? pendingRunWorkItem.role : undefined}
+                  pendingRunRole={pendingRuns.find(run => run.id === item.id)?.role}
                   onOpenThread={session => void openThread(session)}
                   onCreateSession={spec =>
                     start.mutate({
@@ -676,10 +675,8 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                 <CandidateCard
                   key={candidate.sourceKey}
                   candidate={candidate}
-                  pendingRunRole={
-                    pendingRunWorkItem?.sourceKey === candidate.sourceKey ? pendingRunWorkItem.role : undefined
-                  }
-                  triageStarting={triage.isPending && triage.variables?.number === candidate.issue?.number}
+                  pendingRunRole={pendingRuns.find(run => run.sourceKey === candidate.sourceKey)?.role}
+                  triageStarting={candidate.issue !== undefined && pendingIssueNumbers.includes(candidate.issue.number)}
                   disabled={!runEnabled}
                   onRun={(action, prompt) =>
                     start.mutate({

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -18,6 +18,7 @@ import { server } from '../../../../../../e2e/web-ui/msw-server';
 import { renderWithProviders, TEST_BASE_URL } from '../../../../../../e2e/web-ui/render';
 import type { GithubStatus, Project } from '../../workspaces';
 import { createAppRoutes } from '../../../router';
+import { FactoryItemActions } from '../components/FactoryItemActions';
 import type { GithubIssue, GithubPullRequest } from '../services/factory';
 import type { IntakeConfig } from '../services/intake';
 import type { LinearIssue, LinearStatus } from '../services/linear';
@@ -746,6 +747,29 @@ describe('Factory Board — Intake candidates', () => {
     expect(within(intake).queryByText('Fix flaky test')).not.toBeInTheDocument();
     expect(within(column('triage')).queryByText('Fix flaky test')).not.toBeInTheDocument();
     expect(within(column('execute')).getByText('Fix flaky test')).toBeInTheDocument();
+  });
+});
+
+describe('Factory item actions', () => {
+  it('given a custom prompt opened before the action starts, then the stale form cannot duplicate the pending action', async () => {
+    const onRunPrompt = vi.fn();
+    const props = {
+      actionLabel: 'Investigate',
+      itemLabel: 'Fix flaky test',
+      disabled: false,
+      onAction: vi.fn(),
+      onRunPrompt,
+    };
+    const view = renderWithProviders(<FactoryItemActions {...props} starting={false} />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'More actions for Fix flaky test' }));
+    await userEvent.click(await screen.findByRole('menuitem', { name: 'Custom prompt…' }));
+    await userEvent.type(screen.getByRole('textbox', { name: 'Prompt for Fix flaky test' }), 'Check the race');
+    view.rerender(<FactoryItemActions {...props} starting />);
+
+    expect(screen.getByRole('button', { name: 'Run' })).toBeDisabled();
+    fireEvent.submit(screen.getByRole('form', { name: 'Custom prompt for Fix flaky test' }));
+    expect(onRunPrompt).not.toHaveBeenCalled();
   });
 });
 

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -1094,6 +1094,95 @@ describe('Factory Board — persisted cards', () => {
     }
   });
 
+  it('given two runs start concurrently, when one fails, then each action keeps its own pending lifecycle', async () => {
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: 'wi-1',
+          title: 'Fix flaky test',
+          source: 'github-issue',
+          sourceKey: 'github-issue:12',
+          stages: ['triage'],
+          metadata: { number: 12 },
+        }),
+        makeWorkItem({
+          id: 'wi-2',
+          title: 'Improve docs',
+          source: 'github-issue',
+          sourceKey: 'github-issue:15',
+          stages: ['triage'],
+          metadata: { number: 15 },
+        }),
+      ],
+    });
+    const captured = useFactoryRunHandlers('factory-issue-12');
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>(resolve => {
+      releaseFirst = resolve;
+    });
+    let releaseSecond!: () => void;
+    const secondBlocked = new Promise<void>(resolve => {
+      releaseSecond = resolve;
+    });
+    let markFirstRequested!: () => void;
+    const firstRequested = new Promise<void>(resolve => {
+      markFirstRequested = resolve;
+    });
+    let markSecondRequested!: () => void;
+    const secondRequested = new Promise<void>(resolve => {
+      markSecondRequested = resolve;
+    });
+    let requestCount = 0;
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/github/projects/${GITHUB_PROJECT_ID}/worktree`, async () => {
+        requestCount += 1;
+        if (requestCount === 1) {
+          markFirstRequested();
+          await firstBlocked;
+          return HttpResponse.json({
+            worktreePath: '/sandbox/mastra/worktrees/factory-issue-12',
+            branch: 'factory/issue-12',
+            baseBranch: 'main',
+            resourceId: RESOURCE_ID,
+          });
+        }
+        markSecondRequested();
+        await secondBlocked;
+        return HttpResponse.json({ error: 'git_error', message: 'second worktree failed' }, { status: 502 });
+      }),
+    );
+    renderAt('/factory/board');
+
+    try {
+      const triageColumn = await screen.findByTestId('board-column-triage');
+      const firstActions = within(triageColumn).getByRole('button', { name: 'Actions for Fix flaky test' });
+      const secondActions = within(triageColumn).getByRole('button', { name: 'Actions for Improve docs' });
+
+      await userEvent.click(firstActions);
+      await userEvent.click(await screen.findByRole('menuitem', { name: 'Investigate' }));
+      await firstRequested;
+      await userEvent.click(secondActions);
+      await userEvent.click(await screen.findByRole('menuitem', { name: 'Investigate' }));
+      await secondRequested;
+
+      await userEvent.click(firstActions);
+      expect(await screen.findByRole('menuitem', { name: 'Starting…' })).toHaveAttribute('aria-disabled', 'true');
+      await userEvent.click(secondActions);
+      expect(await screen.findByRole('menuitem', { name: 'Starting…' })).toHaveAttribute('aria-disabled', 'true');
+
+      releaseSecond();
+      expect(await screen.findByText('second worktree failed')).toBeInTheDocument();
+      await userEvent.click(secondActions);
+      expect(await screen.findByRole('menuitem', { name: 'Investigate' })).not.toHaveAttribute('aria-disabled', 'true');
+      await userEvent.click(firstActions);
+      expect(await screen.findByRole('menuitem', { name: 'Starting…' })).toHaveAttribute('aria-disabled', 'true');
+    } finally {
+      releaseSecond();
+      releaseFirst();
+      await waitFor(() => expect(captured.messages).toHaveLength(1));
+    }
+  });
+
   it('given a card in Planning, when Build is chosen, then planning exits and the card moves to Building', async () => {
     const state = useBoardHandlers({
       workItems: [
@@ -1326,6 +1415,8 @@ describe('Factory Board — investigate flow', () => {
 
       expect(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' })).toBeDisabled();
       expect(within(intake).getByRole('button', { name: 'Investigate Improve docs' })).toBeEnabled();
+      await userEvent.click(within(intake).getByRole('button', { name: 'More actions for Fix flaky test' }));
+      expect(await screen.findByRole('menuitem', { name: 'Custom prompt…' })).toHaveAttribute('aria-disabled', 'true');
     } finally {
       releaseWorktree();
       await waitFor(() => expect(captured.messages).toHaveLength(1));

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -604,9 +604,10 @@ describe('Factory Board — Intake candidates', () => {
     await userEvent.click(within(card).getByRole('button', { name: 'More actions for Fix flaky test' }));
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Triage issue' }));
 
-    const pendingButton = await within(card).findByRole('button', { name: 'Investigate Fix flaky test' });
-    expect(pendingButton).toBeDisabled();
-    expect(pendingButton).toHaveTextContent('Starting…');
+    await waitFor(() => expect(state.triageRequests).toHaveLength(1));
+    expect(within(card).getByRole('button', { name: 'Investigate Fix flaky test' })).toBeEnabled();
+    await userEvent.click(within(card).getByRole('button', { name: 'More actions for Fix flaky test' }));
+    expect(await screen.findByRole('menuitem', { name: 'Starting…' })).toHaveAttribute('aria-disabled', 'true');
     expect(state.triageRequests).toEqual([
       {
         number: 12,
@@ -1030,6 +1031,69 @@ describe('Factory Board — persisted cards', () => {
     expect(within(column('triage')).queryByTestId('work-item-card')).not.toBeInTheDocument();
   });
 
+  it('given two same-role cards, when one run starts, then only its action shows progress', async () => {
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: 'wi-1',
+          title: 'Fix flaky test',
+          source: 'github-issue',
+          sourceKey: 'github-issue:12',
+          stages: ['triage'],
+          metadata: { number: 12 },
+        }),
+        makeWorkItem({
+          id: 'wi-2',
+          title: 'Improve docs',
+          source: 'github-issue',
+          sourceKey: 'github-issue:15',
+          stages: ['triage'],
+          metadata: { number: 15 },
+        }),
+      ],
+    });
+    const captured = useFactoryRunHandlers('factory-issue-12');
+    let releaseWorktree!: () => void;
+    const worktreeBlocked = new Promise<void>(resolve => {
+      releaseWorktree = resolve;
+    });
+    let markWorktreeRequested!: () => void;
+    const worktreeRequested = new Promise<void>(resolve => {
+      markWorktreeRequested = resolve;
+    });
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/github/projects/${GITHUB_PROJECT_ID}/worktree`, async () => {
+        markWorktreeRequested();
+        await worktreeBlocked;
+        return HttpResponse.json({
+          worktreePath: '/sandbox/mastra/worktrees/factory-issue-12',
+          branch: 'factory/issue-12',
+          baseBranch: 'main',
+          resourceId: RESOURCE_ID,
+        });
+      }),
+    );
+    renderAt('/factory/board');
+
+    try {
+      const triageColumn = await screen.findByTestId('board-column-triage');
+      const firstActions = within(triageColumn).getByRole('button', { name: 'Actions for Fix flaky test' });
+      await userEvent.click(firstActions);
+      await userEvent.click(await screen.findByRole('menuitem', { name: 'Investigate' }));
+      await worktreeRequested;
+      await waitFor(() => expect(screen.queryByRole('menuitem')).not.toBeInTheDocument());
+      await userEvent.click(firstActions);
+      expect(await screen.findByRole('menuitem', { name: 'Starting…' })).toHaveAttribute('aria-disabled', 'true');
+      expect(screen.getByRole('menuitem', { name: 'Build' })).not.toHaveAttribute('aria-disabled', 'true');
+
+      await userEvent.click(within(triageColumn).getByRole('button', { name: 'Actions for Improve docs' }));
+      expect(await screen.findByRole('menuitem', { name: 'Investigate' })).not.toHaveAttribute('aria-disabled', 'true');
+    } finally {
+      releaseWorktree();
+      await waitFor(() => expect(captured.messages).toHaveLength(1));
+    }
+  });
+
   it('given a card in Planning, when Build is chosen, then planning exits and the card moves to Building', async () => {
     const state = useBoardHandlers({
       workItems: [
@@ -1230,6 +1294,44 @@ function useFactoryRunHandlers(branchDir: string): CapturedRun {
 }
 
 describe('Factory Board — investigate flow', () => {
+  it('given two candidates, when one run starts, then the unrelated candidate stays operable', async () => {
+    useBoardHandlers({ issues });
+    const captured = useFactoryRunHandlers('factory-issue-12');
+    let releaseWorktree!: () => void;
+    const worktreeBlocked = new Promise<void>(resolve => {
+      releaseWorktree = resolve;
+    });
+    let markWorktreeRequested!: () => void;
+    const worktreeRequested = new Promise<void>(resolve => {
+      markWorktreeRequested = resolve;
+    });
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/github/projects/${GITHUB_PROJECT_ID}/worktree`, async () => {
+        markWorktreeRequested();
+        await worktreeBlocked;
+        return HttpResponse.json({
+          worktreePath: '/sandbox/mastra/worktrees/factory-issue-12',
+          branch: 'factory/issue-12',
+          baseBranch: 'main',
+          resourceId: RESOURCE_ID,
+        });
+      }),
+    );
+    renderAt('/factory/board');
+
+    try {
+      const intake = await screen.findByTestId('board-column-intake');
+      await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
+      await worktreeRequested;
+
+      expect(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' })).toBeDisabled();
+      expect(within(intake).getByRole('button', { name: 'Investigate Improve docs' })).toBeEnabled();
+    } finally {
+      releaseWorktree();
+      await waitFor(() => expect(captured.messages).toHaveLength(1));
+    }
+  });
+
   it('given an issue candidate, when Investigate is clicked, then a worktree, thread, and direct skill activation are created, a work item materializes into Planning, and the app navigates to the thread', async () => {
     const state = useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
@@ -1693,6 +1795,7 @@ describe('Factory Board — investigate flow', () => {
     await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
 
     expect(await screen.findByText('worktree failed')).toBeInTheDocument();
+    expect(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' })).toBeEnabled();
     expect(state.posts).toEqual([]);
     expect(router.state.location.pathname).toBe('/factory/board');
   });

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -1183,6 +1183,62 @@ describe('Factory Board — persisted cards', () => {
     }
   });
 
+  it('given two actions on one card start concurrently, then both exact actions remain pending', async () => {
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: 'wi-1',
+          title: 'Fix flaky test',
+          source: 'github-issue',
+          sourceKey: 'github-issue:12',
+          stages: ['triage'],
+          metadata: { number: 12 },
+        }),
+      ],
+    });
+    const captured = useFactoryRunHandlers('factory-issue-12');
+    let releaseWorktrees!: () => void;
+    const worktreesBlocked = new Promise<void>(resolve => {
+      releaseWorktrees = resolve;
+    });
+    let requestCount = 0;
+    let markBothRequested!: () => void;
+    const bothRequested = new Promise<void>(resolve => {
+      markBothRequested = resolve;
+    });
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/github/projects/${GITHUB_PROJECT_ID}/worktree`, async () => {
+        requestCount += 1;
+        if (requestCount === 2) markBothRequested();
+        await worktreesBlocked;
+        return HttpResponse.json({
+          worktreePath: '/sandbox/mastra/worktrees/factory-issue-12',
+          branch: 'factory/issue-12',
+          baseBranch: 'main',
+          resourceId: RESOURCE_ID,
+        });
+      }),
+    );
+    renderAt('/factory/board');
+
+    try {
+      const triageColumn = await screen.findByTestId('board-column-triage');
+      const actions = within(triageColumn).getByRole('button', { name: 'Actions for Fix flaky test' });
+      await userEvent.click(actions);
+      await userEvent.click(await screen.findByRole('menuitem', { name: 'Investigate' }));
+      await waitFor(() => expect(requestCount).toBe(1));
+      await userEvent.click(actions);
+      await userEvent.click(await screen.findByRole('menuitem', { name: 'Build' }));
+      await bothRequested;
+
+      await userEvent.click(actions);
+      expect(await screen.findAllByRole('menuitem', { name: 'Starting…' })).toHaveLength(2);
+    } finally {
+      releaseWorktrees();
+      await waitFor(() => expect(captured.messages).toHaveLength(2));
+    }
+  });
+
   it('given a card in Planning, when Build is chosen, then planning exits and the card moves to Building', async () => {
     const state = useBoardHandlers({
       workItems: [

--- a/mastracode/web/src/web/ui/domains/factory/components/FactoryItemActions.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactoryItemActions.tsx
@@ -52,7 +52,7 @@ export function FactoryItemActions({
 
   const runPrompt = () => {
     const trimmed = prompt.trim();
-    if (!trimmed) return;
+    if (!trimmed || starting) return;
     closePrompt();
     onRunPrompt(trimmed);
   };
@@ -127,7 +127,7 @@ export function FactoryItemActions({
               <Button type="button" variant="ghost" size="xs" onClick={closePrompt}>
                 Cancel
               </Button>
-              <Button type="submit" size="xs" disabled={!prompt.trim()}>
+              <Button type="submit" size="xs" disabled={starting || !prompt.trim()}>
                 Run
               </Button>
             </div>

--- a/mastracode/web/src/web/ui/domains/factory/components/FactoryItemActions.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactoryItemActions.tsx
@@ -92,7 +92,9 @@ export function FactoryItemActions({
               {action.starting ? 'Starting…' : action.label}
             </DropdownMenu.Item>
           ))}
-          <DropdownMenu.Item onClick={() => setPromptOpen(true)}>Custom prompt…</DropdownMenu.Item>
+          <DropdownMenu.Item disabled={starting} onClick={() => setPromptOpen(true)}>
+            Custom prompt…
+          </DropdownMenu.Item>
           {menuExtras}
         </DropdownMenu.Content>
       </DropdownMenu>

--- a/mastracode/web/src/web/ui/domains/factory/components/FactoryItemActions.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactoryItemActions.tsx
@@ -18,7 +18,7 @@ export interface FactoryItemActionsProps {
   /** Run the default skill action (Investigate / Review). */
   onAction: () => void;
   /** Additional menu-only actions for the item. */
-  extraActions?: Array<{ label: string; onAction: () => void }>;
+  extraActions?: Array<{ label: string; starting: boolean; onAction: () => void }>;
   /** Run a custom prompt typed by the user (already trimmed, non-empty). */
   onRunPrompt: (prompt: string) => void;
   /** Extra menu items appended after the built-in ones (e.g. "Add to board"). */
@@ -63,7 +63,7 @@ export function FactoryItemActions({
         variant="ghost"
         size="sm"
         aria-label={`${actionLabel} ${itemLabel}`}
-        disabled={disabled}
+        disabled={disabled || starting}
         onClick={onAction}
       >
         <Play size={13} aria-hidden />
@@ -84,10 +84,12 @@ export function FactoryItemActions({
           }
         />
         <DropdownMenu.Content align="end" className="min-w-40">
-          <DropdownMenu.Item onClick={onAction}>{actionLabel}</DropdownMenu.Item>
+          <DropdownMenu.Item disabled={starting} onClick={onAction}>
+            {starting ? 'Starting…' : actionLabel}
+          </DropdownMenu.Item>
           {extraActions?.map(action => (
-            <DropdownMenu.Item key={action.label} onClick={action.onAction}>
-              {action.label}
+            <DropdownMenu.Item key={action.label} disabled={action.starting} onClick={action.onAction}>
+              {action.starting ? 'Starting…' : action.label}
             </DropdownMenu.Item>
           ))}
           <DropdownMenu.Item onClick={() => setPromptOpen(true)}>Custom prompt…</DropdownMenu.Item>


### PR DESCRIPTION
## Summary
- key Factory run and triage progress to the exact item/source and action role
- preserve independent pending and failure cleanup across concurrent actions
- prevent duplicate custom-prompt dispatch while the default action is pending

## Test plan
- `cd mastracode/web && pnpm check`
- `cd mastracode/web && pnpm exec vitest run --config e2e/web-ui/vitest.config.ts src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx --reporter=dot --bail 1`
- `cd mastracode/web && bash -o pipefail -c 'CI=false pnpm web:build 2>&1 | tail -80'`\n- `bash .mastracode/plans/factory-feedback-series.proof/demo.sh item-progress --expect green`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory now keeps track of exactly which card, issue, and action is starting, so unrelated actions stay usable and concurrent actions don’t interfere with each other. It also prevents a custom prompt from being submitted twice.

## Summary

- Scoped pending and disabled states to the initiating Factory item, issue, source, and action role.
- Preserved independent pending and failure cleanup for concurrent runs.
- Added React Query mutation tracking for Factory runs and issue triage.
- Prevented duplicate custom-prompt dispatch while an action is pending.
- Added comprehensive MSW tests covering concurrency, failures, triage, and investigate flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->