### PR TITLE
fix(mcp): isolate HOME in loadMcpConfig test suite to prevent global config leaking

### DIFF
--- a/mastracode/sdk/src/mcp/__tests__/config.test.ts
+++ b/mastracode/sdk/src/mcp/__tests__/config.test.ts
@@ -374,13 +374,21 @@ describe('expandEnvVars', () => {
 
 describe('loadMcpConfig', () => {
   let projectDir: string;
+  let homeDir: string;
+  let previousHome: string | undefined;
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-config-'));
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
+    previousHome = process.env.HOME;
+    process.env.HOME = homeDir;
   });
 
   afterEach(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
     fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
   function writeJson(filePath: string, data: unknown): void {
@@ -427,25 +435,16 @@ describe('loadMcpConfig', () => {
   });
 
   it('lets a root .mcp.json override the global ~/.mastracode/mcp.json by server name', () => {
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
-    try {
-      writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
-        mcpServers: { shared: { command: 'global-cmd' } },
-      });
-      writeJson(path.join(projectDir, '.mcp.json'), {
-        mcpServers: { shared: { command: 'root-cmd' } },
-      });
+    writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
+      mcpServers: { shared: { command: 'global-cmd' } },
+    });
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { shared: { command: 'root-cmd' } },
+    });
 
-      const config = loadMcpConfig(projectDir);
+    const config = loadMcpConfig(projectDir);
 
-      expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
-    } finally {
-      if (previousHome === undefined) delete process.env.HOME;
-      else process.env.HOME = previousHome;
-      fs.rmSync(homeDir, { recursive: true, force: true });
-    }
+    expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
   });
 
   it('lets a root .mcp.json override .claude/settings.local.json by server name', () => {


### PR DESCRIPTION
## Problem
Two tests in `config.test.ts` were non-hermetic. `loadMcpConfig` reads 
`~/.mastracode/mcp.json` for global config, so any developer with a 
personal MCP server configured locally saw these tests fail with an 
extra server in the received object:

- `reads MCP servers from a root .mcp.json (Claude Code compatible)`
- `merges distinct servers from root .mcp.json and .mastracode/mcp.json`

## Fix
Moved HOME isolation to `beforeEach`/`afterEach` at the describe block 
level — creates a fresh empty temp directory as HOME before each test, 
restores it after. This pattern already existed in the same file for 
one individual test; this PR applies it consistently at the suite level.

The now-redundant per-test HOME setup in the override test has been removed.

## Verification
Run with isolated HOME to confirm all tests pass:
HOME="$(mktemp -d)" pnpm test -- --run src/mcp/__tests__/config.test.ts

All 3 affected tests pass with no global config leakage.

Fixes #19545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The tests now use a temporary home folder instead of your real settings, so personal MCP configuration cannot change test results.

## Summary

- Isolated `loadMcpConfig` tests with a temporary `HOME` directory.
- Added consistent setup and cleanup via `beforeEach` and `afterEach`.
- Removed redundant per-test `HOME` override and teardown logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->