### PR TITLE
feat(acp): add createClient hook for custom ACP clients (extMethod/extNotification)

### DIFF
--- a/.changeset/sweet-suits-itch.md
+++ b/.changeset/sweet-suits-itch.md
@@ -1,0 +1,32 @@
+---
+'@mastra/acp': minor
+---
+
+Added a `createClient` option to `createACPTool()` and `AcpAgent` for customizing the ACP client, and fixed a crash when the ACP agent command fails to start.
+
+**Custom ACP client (`createClient`)**
+
+Some ACP agents call custom extension methods (`extMethod` / `extNotification`) on the client. The built-in client rejected these with a "Method not found" error and could not be replaced, so those agents were unusable without reimplementing the whole connection. The new `createClient` option receives the default client and returns the client used for the connection:
+
+```ts
+import { createACPTool } from '@mastra/acp';
+
+const tool = createACPTool({
+  id: 'grok',
+  description: 'Dispatch tasks to Grok',
+  command: 'grok',
+  createClient: defaultClient =>
+    Object.assign(defaultClient, {
+      extMethod: async (method, params) => ({}),
+      extNotification: async (method, params) => {},
+    }),
+});
+```
+
+The `Client` type is now re-exported from `@mastra/acp` for fully custom implementations.
+
+**Spawn failure handling**
+
+If the configured `command` could not be started (for example the executable does not exist), the child process 'error' event was unhandled and crashed the host process. Tool execution now rejects with the spawn error instead.
+
+Fixes #19109

--- a/agent-sdks/acp/src/__tests__/tool.test.ts
+++ b/agent-sdks/acp/src/__tests__/tool.test.ts
@@ -396,6 +396,23 @@ describe('ACPConnection', () => {
     ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow_once' } });
   });
 
+  it('kills the agent process and rejects when createClient throws', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'grok',
+      description: 'Grok via ACP',
+      command: 'grok',
+      persistSession: true,
+      createClient: () => {
+        throw new Error('bad client factory');
+      },
+    });
+
+    await expect(connection.prompt('never runs')).rejects.toThrow('bad client factory');
+    expect((mocks.spawn.mock.results[0]?.value as ReturnType<typeof createProcess>).kill).toHaveBeenCalledTimes(1);
+  });
+
   it('uses the default client when createClient is omitted', async () => {
     const { ACPConnection } = await import('../connection');
 

--- a/agent-sdks/acp/src/__tests__/tool.test.ts
+++ b/agent-sdks/acp/src/__tests__/tool.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { PassThrough } from 'node:stream';
 
 import { MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
@@ -9,11 +10,12 @@ const mocks = vi.hoisted(() => {
   const ndJsonStream = vi.fn(() => ({ readable: {}, writable: {} }));
   const connectionInstances: MockClientSideConnection[] = [];
   let onPrompt: ((connection: MockClientSideConnection) => Promise<void> | void) | undefined;
+  let onInitialize: (() => Promise<unknown>) | undefined;
   let sessionResponse: Record<string, unknown> = { sessionId: 'session-1' };
 
   class MockClientSideConnection {
     client: any;
-    initialize = vi.fn().mockResolvedValue({});
+    initialize = vi.fn().mockImplementation(() => (onInitialize ? onInitialize() : Promise.resolve({})));
     authenticate = vi.fn().mockResolvedValue({});
     newSession = vi.fn().mockImplementation(() => Promise.resolve(sessionResponse));
     cancel = vi.fn().mockResolvedValue({});
@@ -39,6 +41,12 @@ const mocks = vi.hoisted(() => {
     },
     set onPrompt(value: ((connection: MockClientSideConnection) => Promise<void> | void) | undefined) {
       onPrompt = value;
+    },
+    get onInitialize() {
+      return onInitialize;
+    },
+    set onInitialize(value: (() => Promise<unknown>) | undefined) {
+      onInitialize = value;
     },
     get sessionResponse() {
       return sessionResponse;
@@ -68,16 +76,22 @@ vi.mock('@agentclientprotocol/sdk', async importOriginal => {
 });
 
 function createProcess() {
-  return {
-    stdin: new PassThrough(),
-    stdout: new PassThrough(),
-    stderr: new PassThrough(),
-    killed: false,
-    kill: vi.fn(function (this: { killed: boolean }) {
-      this.killed = true;
-      return true;
-    }),
+  const process = new EventEmitter() as EventEmitter & {
+    stdin: PassThrough;
+    stdout: PassThrough;
+    stderr: PassThrough;
+    killed: boolean;
+    kill: ReturnType<typeof vi.fn>;
   };
+  process.stdin = new PassThrough();
+  process.stdout = new PassThrough();
+  process.stderr = new PassThrough();
+  process.killed = false;
+  process.kill = vi.fn(() => {
+    process.killed = true;
+    return true;
+  });
+  return process;
 }
 
 describe('createACPTool', () => {
@@ -85,6 +99,7 @@ describe('createACPTool', () => {
     vi.clearAllMocks();
     mocks.connectionInstances.length = 0;
     mocks.onPrompt = undefined;
+    mocks.onInitialize = undefined;
     mocks.sessionResponse = { sessionId: 'session-1' };
     mocks.spawn.mockImplementation(() => createProcess());
   });
@@ -215,6 +230,7 @@ describe('ACPConnection', () => {
     vi.clearAllMocks();
     mocks.connectionInstances.length = 0;
     mocks.onPrompt = undefined;
+    mocks.onInitialize = undefined;
     mocks.sessionResponse = { sessionId: 'session-1' };
     mocks.spawn.mockImplementation(() => createProcess());
   });
@@ -347,6 +363,94 @@ describe('ACPConnection', () => {
         options: [{ optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' }],
       }),
     ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow_once' } });
+  });
+
+  it('uses the client returned by createClient and passes it the default client', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const extMethod = vi.fn().mockResolvedValue({ ok: true });
+    const createClient = vi.fn((defaultClient: any) => Object.assign(defaultClient, { extMethod }));
+
+    const connection = new ACPConnection({
+      id: 'grok',
+      description: 'Grok via ACP',
+      command: 'grok',
+      persistSession: true,
+      createClient,
+    });
+
+    await connection.prompt('needs extension methods');
+    const client = mocks.connectionInstances[0]?.client;
+
+    expect(createClient).toHaveBeenCalledTimes(1);
+    await expect(client.extMethod('_grok/ping', {})).resolves.toEqual({ ok: true });
+    expect(extMethod).toHaveBeenCalledWith('_grok/ping', {});
+
+    // default client behavior is preserved
+    await expect(
+      client.requestPermission({
+        sessionId: 'session-1',
+        toolCallId: 'tool-1',
+        options: [{ optionId: 'allow_once', name: 'Allow once', kind: 'allow_once' }],
+      }),
+    ).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow_once' } });
+  });
+
+  it('uses the default client when createClient is omitted', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    await connection.prompt('no custom client');
+    const client = mocks.connectionInstances[0]?.client;
+
+    expect(client.extMethod).toBeUndefined();
+    expect(typeof client.sessionUpdate).toBe('function');
+  });
+
+  it('rejects the prompt when the agent process fails to spawn', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    mocks.onInitialize = () => new Promise(() => {});
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'definitely-not-a-real-command',
+      persistSession: true,
+    });
+
+    const promptPromise = connection.prompt('never starts');
+    const agentProcess = mocks.spawn.mock.results[0]?.value as ReturnType<typeof createProcess>;
+    agentProcess.emit('error', new Error('spawn definitely-not-a-real-command ENOENT'));
+
+    await expect(promptPromise).rejects.toThrow('spawn definitely-not-a-real-command ENOENT');
+  });
+
+  it('rejects the prompt when the agent process exits during initialization', async () => {
+    const { ACPConnection } = await import('../connection');
+
+    mocks.onInitialize = () => new Promise(() => {});
+
+    const connection = new ACPConnection({
+      id: 'claude-code',
+      description: 'Build anything with Claude Code',
+      command: 'claude',
+      persistSession: true,
+    });
+
+    const promptPromise = connection.prompt('exits early');
+    const agentProcess = mocks.spawn.mock.results[0]?.value as ReturnType<typeof createProcess>;
+    agentProcess.emit('exit', 1, null);
+
+    await expect(promptPromise).rejects.toThrow(
+      'ACP agent process exited during initialization (code: 1, signal: null)',
+    );
   });
 
   it('delegates permission requests to onPermissionRequest callback', async () => {
@@ -565,6 +669,7 @@ describe('AcpAgent', () => {
     vi.clearAllMocks();
     mocks.connectionInstances.length = 0;
     mocks.onPrompt = undefined;
+    mocks.onInitialize = undefined;
     mocks.sessionResponse = { sessionId: 'session-1' };
     mocks.spawn.mockImplementation(() => createProcess());
   });

--- a/agent-sdks/acp/src/connection.ts
+++ b/agent-sdks/acp/src/connection.ts
@@ -250,6 +250,19 @@ export class ACPConnection {
       stdio: ['pipe', 'pipe', 'pipe'],
     });
 
+    // Keep an 'error' listener attached for the lifetime of the process so a
+    // failed spawn (e.g. ENOENT) rejects initialization instead of crashing
+    // the host process with an unhandled 'error' event.
+    const processFailure = new Promise<never>((_, reject) => {
+      this.agentProcess!.on('error', error => {
+        reject(error instanceof Error ? error : new Error(String(error)));
+      });
+      this.agentProcess!.on('exit', (code, signal) => {
+        reject(new Error(`ACP agent process exited during initialization (code: ${code}, signal: ${signal})`));
+      });
+    });
+    processFailure.catch(() => undefined);
+
     this.agentProcess.stderr.on('data', chunk => {
       this.stderr += String(chunk);
     });
@@ -265,36 +278,40 @@ export class ACPConnection {
         filesystem: new LocalFilesystem({ basePath: this.options.cwd ?? process.cwd() }),
       });
 
-    this.connection = new ClientSideConnection(
-      () => new ACPClient(() => this.currentPrompt, workspace, this.options.onPermissionRequest),
-      stream,
-    );
+    this.connection = new ClientSideConnection(() => {
+      const defaultClient = new ACPClient(() => this.currentPrompt, workspace, this.options.onPermissionRequest);
+      return this.options.createClient?.(defaultClient) ?? defaultClient;
+    }, stream);
 
     try {
-      await this.connection.initialize(this.getInitializeRequest());
-
-      if (this.options.authMethodId) {
-        await this.connection.authenticate({ methodId: this.options.authMethodId });
-      }
-
-      this.session = await this.connection.newSession(this.getNewSessionRequest());
-
-      if (this.options.model) {
-        const available = this.session.models?.availableModels;
-
-        if (available && !available.some(m => m.modelId === this.options.model)) {
-          const ids = available.map(m => m.modelId).join(', ') || '(none)';
-          throw new Error(`Model "${this.options.model}" is not available. Available models: ${ids}`);
-        }
-
-        await this.connection.unstable_setSessionModel({
-          sessionId: this.session.sessionId,
-          modelId: this.options.model,
-        });
-      }
+      await Promise.race([processFailure, this.initializeSession()]);
     } catch (error) {
       this.disconnect();
       throw this.withStderr(error);
+    }
+  }
+
+  private async initializeSession(): Promise<void> {
+    await this.connection!.initialize(this.getInitializeRequest());
+
+    if (this.options.authMethodId) {
+      await this.connection!.authenticate({ methodId: this.options.authMethodId });
+    }
+
+    this.session = await this.connection!.newSession(this.getNewSessionRequest());
+
+    if (this.options.model) {
+      const available = this.session.models?.availableModels;
+
+      if (available && !available.some(m => m.modelId === this.options.model)) {
+        const ids = available.map(m => m.modelId).join(', ') || '(none)';
+        throw new Error(`Model "${this.options.model}" is not available. Available models: ${ids}`);
+      }
+
+      await this.connection!.unstable_setSessionModel({
+        sessionId: this.session.sessionId,
+        modelId: this.options.model,
+      });
     }
   }
 

--- a/agent-sdks/acp/src/connection.ts
+++ b/agent-sdks/acp/src/connection.ts
@@ -278,12 +278,12 @@ export class ACPConnection {
         filesystem: new LocalFilesystem({ basePath: this.options.cwd ?? process.cwd() }),
       });
 
-    this.connection = new ClientSideConnection(() => {
-      const defaultClient = new ACPClient(() => this.currentPrompt, workspace, this.options.onPermissionRequest);
-      return this.options.createClient?.(defaultClient) ?? defaultClient;
-    }, stream);
-
     try {
+      this.connection = new ClientSideConnection(() => {
+        const defaultClient = new ACPClient(() => this.currentPrompt, workspace, this.options.onPermissionRequest);
+        return this.options.createClient?.(defaultClient) ?? defaultClient;
+      }, stream);
+
       await Promise.race([processFailure, this.initializeSession()]);
     } catch (error) {
       this.disconnect();

--- a/agent-sdks/acp/src/index.ts
+++ b/agent-sdks/acp/src/index.ts
@@ -1,4 +1,4 @@
-export type { ModelInfo } from '@agentclientprotocol/sdk';
+export type { Client, ModelInfo } from '@agentclientprotocol/sdk';
 export { AcpAgent } from './agent';
 export { createACPTool } from './tool';
 export type { AcpAgentOptions } from './agent';

--- a/agent-sdks/acp/src/types.ts
+++ b/agent-sdks/acp/src/types.ts
@@ -1,4 +1,5 @@
 import type {
+  Client,
   InitializeRequest,
   ModelId,
   NewSessionRequest,
@@ -33,6 +34,12 @@ export type CreateACPToolOptions = {
    * Defaults to auto-selecting the first permission option.
    */
   onPermissionRequest?: (request: RequestPermissionRequest) => Promise<RequestPermissionResponse>;
+  /**
+   * Customize the ACP client used to answer agent requests. Receives the default
+   * client so it can be wrapped or extended, for example with `extMethod` and
+   * `extNotification` handlers for agents that use extension methods.
+   */
+  createClient?: (defaultClient: Client) => Client;
   /** Workspace for the ACP agent process and ACP session. */
   workspace?: Workspace;
   /** Model ID to select after session creation via the ACP `session/set_model` method. */

--- a/docs/src/content/en/reference/acp/acp-agent.mdx
+++ b/docs/src/content/en/reference/acp/acp-agent.mdx
@@ -137,6 +137,13 @@ export const claudeCodeAgent = new AcpAgent({
     isOptional: true,
   },
   {
+    name: 'createClient',
+    type: '(defaultClient: Client) => Client',
+    description:
+      'Customize the ACP client used to answer agent requests. Receives the default client so it can be wrapped or extended, for example with `extMethod` and `extNotification` handlers. See [Extension methods](/reference/acp/create-acp-tool#extension-methods).',
+    isOptional: true,
+  },
+  {
     name: 'workspace',
     type: 'Workspace',
     description:

--- a/docs/src/content/en/reference/acp/create-acp-tool.mdx
+++ b/docs/src/content/en/reference/acp/create-acp-tool.mdx
@@ -114,6 +114,13 @@ export const codeSupervisor = new Agent({
     isOptional: true,
   },
   {
+    name: 'createClient',
+    type: '(defaultClient: Client) => Client',
+    description:
+      'Customize the ACP client used to answer agent requests. Receives the default client so it can be wrapped or extended, for example with `extMethod` and `extNotification` handlers.',
+    isOptional: true,
+  },
+  {
     name: 'workspace',
     type: 'Workspace',
     description:
@@ -228,6 +235,32 @@ export const codeAgentTool = createACPTool({
 ```
 
 Use this callback to enforce local policy, inspect the permission title, or route the decision to your own approval flow.
+
+## Extension methods
+
+Some ACP agents call custom extension methods on the client, outside the standard ACP request set. The default client rejects unknown methods with a "Method not found" error, which can abort the agent's turn.
+
+Pass `createClient` to extend or replace the default client. The callback receives the default client and returns the client used for the connection:
+
+```typescript title="src/mastra/agents/code-agent.ts"
+import { createACPTool } from '@mastra/acp'
+
+export const codeAgentTool = createACPTool({
+  id: 'code-agent',
+  description: 'Use an ACP-compatible coding agent',
+  command: 'acp-agent',
+  args: ['--stdio'],
+  createClient: defaultClient =>
+    Object.assign(defaultClient, {
+      async extMethod(method: string, params: Record<string, unknown>) {
+        return {}
+      },
+      async extNotification(method: string, params: Record<string, unknown>) {},
+    }),
+})
+```
+
+Return a fully custom `Client` implementation when you need to change the standard handlers as well. The `Client` type is re-exported from `@mastra/acp`.
 
 ## Related
 


### PR DESCRIPTION
## Description

`createACPTool()` and `AcpAgent` hardcoded the ACP client inside `ACPConnection`, so there was no way to answer agent-initiated extension methods (`extMethod` / `extNotification`). Agents that use them (e.g. Grok CLI) fail — the default client rejects any custom method with JSON-RPC `-32601 "Method not found"` and the agent aborts its turn — and the only workaround was forking ~300 lines of connection/spawn/stream plumbing just to swap one class. This PR exposes the injection point the underlying `@agentclientprotocol/sdk` already has.

- Add `createClient?: (defaultClient: Client) => Client` to `CreateACPToolOptions` (inherited by `AcpAgentOptions`); the callback receives the default client so it can be wrapped/extended or fully replaced, and the returned client is passed to `ClientSideConnection`
- Re-export the SDK `Client` type from `@mastra/acp` for fully custom implementations
- Handle child-process spawn failures: previously a bad `command` (ENOENT) emitted an unhandled `'error'` event and crashed the host process; initialization is now raced against process `error`/`exit` so the tool call rejects with the spawn error (stderr attached) instead
- Extract the init sequence into `initializeSession()` so it can be raced; default-path behavior is unchanged
- Tests: mock child process is now an `EventEmitter`; 4 new tests cover custom client wiring (ext methods handled, default handlers preserved), omitted option, spawn ENOENT rejection, and early process exit
- Docs: `createClient` parameter on both reference pages plus a new "Extension methods" section with a usage example

Verified end-to-end: a protocol-exact fake agent calling `_grok/ping` fails on main and succeeds with `createClient`; a real ACP agent (`@zed-industries/claude-code-acp`, live Anthropic API) works on both the default and wrapped-client paths; full customer-shaped run (real model → Mastra agent loop → tool-call → ACP process → ext method answered → output returned) passes.

## Related Issue(s)

Fixes #19109

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This update lets you plug in your own “ACP client” so the SDK can handle agent requests your way (including custom extension actions), without you having to copy the SDK’s complex connection code. It also prevents agent startup failures from crashing your app by turning spawn/early-exit problems into normal rejected tool calls.

## What changed

- Added an optional `createClient` hook to `createACPTool()` / `CreateACPToolOptions`, and it’s inherited by `AcpAgentOptions`.
- The factory receives the SDK’s default ACP `Client` and can wrap/extend/replace it (enabling custom extension handlers like `extMethod` and `extNotification`).
- Re-exported the ACP `Client` type from `@mastra/acp` to support fully custom client implementations.
- Fixed child-process failure handling during initialization:
  - Initialization failures now reject tool calls with spawn/initialization errors instead of causing unhandled host-process crashes.
  - Agent startup failure detection was implemented using `initializeSession()` and failure/early-exit handling; cleanup is added when the client factory throws.
- Added tests for:
  - custom client wiring + extension availability
  - omitted options (default behavior)
  - client-factory errors (including cleanup)
  - spawn failures (`error` event)
  - early process exits (`exit` during initialization)
- Updated documentation for `createClient` and added an “Extension methods” section with an example.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->