### PR TITLE
fix(client-js): add reconnect to AgentControllerSession.subscribe()

### DIFF
--- a/.changeset/thick-pillows-peel.md
+++ b/.changeset/thick-pillows-peel.md
@@ -1,0 +1,22 @@
+---
+'@mastra/client-js': minor
+---
+
+Added reconnect support to `AgentControllerSession.subscribe()` so SSE subscriptions recover after proxy timeouts or transport errors. Fixes #19202.
+
+**Before**
+
+```ts
+await session.subscribe({
+  onEvent: event => { /* ... */ },
+});
+```
+
+**After**
+
+```ts
+await session.subscribe({
+  onEvent: event => { /* ... */ },
+  reconnect: true, // or { maxRetries: 5, delayMs: 1000 }
+});
+```

--- a/.changeset/thick-pillows-peel.md
+++ b/.changeset/thick-pillows-peel.md
@@ -3,3 +3,10 @@
 ---
 
 Added reconnect support to `AgentControllerSession.subscribe()` so SSE subscriptions recover after proxy timeouts or transport errors. Fixes #19202.
+
+```ts
+await session.subscribe({
+  onEvent: event => { /* handle event */ },
+  reconnect: true,
+});
+```

--- a/.changeset/thick-pillows-peel.md
+++ b/.changeset/thick-pillows-peel.md
@@ -3,20 +3,3 @@
 ---
 
 Added reconnect support to `AgentControllerSession.subscribe()` so SSE subscriptions recover after proxy timeouts or transport errors. Fixes #19202.
-
-**Before**
-
-```ts
-await session.subscribe({
-  onEvent: event => { /* ... */ },
-});
-```
-
-**After**
-
-```ts
-await session.subscribe({
-  onEvent: event => { /* ... */ },
-  reconnect: true, // or { maxRetries: 5, delayMs: 1000 }
-});
-```

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -33,6 +33,17 @@ describe('AgentController Resource', () => {
     );
   };
 
+  const sseResponse = (frames: string[]) =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(new TextEncoder().encode(frame));
+          controller.close();
+        },
+      }),
+      { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
+    );
+
   const lastCall = () => (global.fetch as any).mock.calls.at(-1) as [string, RequestInit];
 
   beforeEach(() => {
@@ -265,6 +276,154 @@ describe('AgentController Resource', () => {
     sub.unsubscribe();
 
     expect(received).toEqual([event]);
+  });
+
+  it('calls onError when the stream ends without reconnect enabled', async () => {
+    mockSse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]);
+
+    const onError = vi.fn();
+    const sub = await client
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: () => {},
+        onError,
+      });
+
+    await new Promise(r => setTimeout(r, 10));
+    sub.unsubscribe();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect((onError.mock.calls[0]![0] as Error).message).toBe('Agent controller session stream ended unexpectedly');
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+  });
+
+  it('reconnects when the stream ends cleanly and reconnect is enabled', async () => {
+    const firstEvent = { type: 'agent_start' };
+    const secondEvent = { type: 'agent_end', reason: 'complete' };
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(firstEvent)}\n\n`]))
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(secondEvent)}\n\n`]));
+
+    const received: AgentControllerEvent[] = [];
+    const done = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), 2000);
+      void client
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: event => {
+            received.push(event);
+            if (received.length === 2) {
+              clearTimeout(timer);
+              resolve();
+            }
+          },
+          onError: error => {
+            clearTimeout(timer);
+            reject(error);
+          },
+          reconnect: { maxRetries: 1, delayMs: 0 },
+        })
+        .then(sub => {
+          void done.then(() => sub.unsubscribe());
+        });
+    });
+
+    await done;
+
+    expect((global.fetch as any).mock.calls).toHaveLength(2);
+    expect(received).toEqual([firstEvent, secondEvent]);
+  });
+
+  it('retries failed resubscribe requests within the reconnect limit', async () => {
+    const firstEvent = { type: 'agent_start' };
+    const secondEvent = { type: 'agent_end', reason: 'complete' };
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(firstEvent)}\n\n`]))
+      .mockRejectedValueOnce(new Error('temporary reconnect failure'))
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(secondEvent)}\n\n`]));
+
+    const received: AgentControllerEvent[] = [];
+    const done = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), 2000);
+      void client
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: event => {
+            received.push(event);
+            if (received.length === 2) {
+              clearTimeout(timer);
+              resolve();
+            }
+          },
+          onError: error => {
+            clearTimeout(timer);
+            reject(error);
+          },
+          reconnect: { maxRetries: 2, delayMs: 0 },
+        })
+        .then(sub => {
+          void done.then(() => sub.unsubscribe());
+        });
+    });
+
+    await done;
+
+    expect((global.fetch as any).mock.calls).toHaveLength(3);
+    expect(received).toEqual([firstEvent, secondEvent]);
+  });
+
+  it('does not reconnect after unsubscribe', async () => {
+    const firstEvent = { type: 'agent_start' };
+    (global.fetch as any).mockResolvedValueOnce(
+      new Response(
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(firstEvent)}\n\n`));
+          },
+        }),
+        { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
+      ),
+    );
+
+    const sub = await client
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: () => {},
+        reconnect: { maxRetries: 5, delayMs: 100 },
+      });
+
+    await new Promise(r => setTimeout(r, 10));
+    sub.unsubscribe();
+    await new Promise(r => setTimeout(r, 250));
+
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+  });
+
+  it('does not reconnect when the onEvent callback throws', async () => {
+    mockSse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]);
+
+    const callbackError = new Error('boom from onEvent');
+    const onError = vi.fn();
+    const sub = await client
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: () => {
+          throw callbackError;
+        },
+        onError,
+        reconnect: { maxRetries: 5, delayMs: 0 },
+      });
+
+    await new Promise(r => setTimeout(r, 10));
+    sub.unsubscribe();
+
+    expect(onError).toHaveBeenCalledWith(callbackError);
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
   });
 
   it('sends a notification signal', async () => {

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -278,6 +278,24 @@ describe('AgentController Resource', () => {
     expect(received).toEqual([event]);
   });
 
+  it('parses CRLF-delimited SSE frames', async () => {
+    const event = { type: 'agent_start' };
+    mockSse([`data: ${JSON.stringify(event)}\r\n\r\n`]);
+
+    const received: AgentControllerEvent[] = [];
+    const sub = await client
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: e => received.push(e),
+      });
+
+    await new Promise(r => setTimeout(r, 10));
+    sub.unsubscribe();
+
+    expect(received).toEqual([event]);
+  });
+
   it('calls onError when the stream ends without reconnect enabled', async () => {
     mockSse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]);
 
@@ -377,16 +395,7 @@ describe('AgentController Resource', () => {
 
   it('does not reconnect after unsubscribe', async () => {
     const firstEvent = { type: 'agent_start' };
-    (global.fetch as any).mockResolvedValueOnce(
-      new Response(
-        new ReadableStream({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode(`data: ${JSON.stringify(firstEvent)}\n\n`));
-          },
-        }),
-        { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
-      ),
-    );
+    (global.fetch as any).mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(firstEvent)}\n\n`]));
 
     const sub = await client
       .getAgentController('code')
@@ -400,6 +409,36 @@ describe('AgentController Resource', () => {
     sub.unsubscribe();
     await new Promise(r => setTimeout(r, 250));
 
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+  });
+
+  it('calls onError with the stream read failure when reconnect is exhausted', async () => {
+    const readError = new Error('stream read failed');
+    (global.fetch as any).mockResolvedValueOnce(
+      new Response(
+        new ReadableStream({
+          pull() {
+            throw readError;
+          },
+        }),
+        { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
+      ),
+    );
+
+    const onError = vi.fn();
+    const sub = await client
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: () => {},
+        onError,
+        reconnect: { maxRetries: 0, delayMs: 0 },
+      });
+
+    await new Promise(r => setTimeout(r, 50));
+    sub.unsubscribe();
+
+    expect(onError).toHaveBeenCalledWith(readError);
     expect((global.fetch as any).mock.calls).toHaveLength(1);
   });
 

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -351,6 +351,14 @@ export interface SubscribeAgentControllerSessionOptions {
   onEvent: (event: AgentControllerEvent) => void;
   /** Called when the stream errors or ends unexpectedly. */
   onError?: (error: unknown) => void;
+  reconnect?:
+    | boolean
+    | {
+        /** Maximum reconnect attempts after the initial stream ends or errors. Defaults to Infinity. */
+        maxRetries?: number;
+        /** Delay between reconnect attempts in milliseconds. Defaults to 1000. */
+        delayMs?: number;
+      };
 }
 
 export interface AgentControllerSubscription {
@@ -409,21 +417,43 @@ export class AgentControllerSession extends BaseResource {
    * message arrives here as `message_*` events, not on the sendMessage call.
    */
   async subscribe(options: SubscribeAgentControllerSessionOptions): Promise<AgentControllerSubscription> {
-    const response = (await this.request(this.url(`${this.base()}/stream`), { stream: true })) as Response;
-    if (!response.body) {
-      throw new Error('No response body for agent controller session stream');
-    }
+    const reconnectOptions =
+      options.reconnect === true
+        ? { maxRetries: Infinity, delayMs: 1000 }
+        : options.reconnect
+          ? { maxRetries: options.reconnect.maxRetries ?? Infinity, delayMs: options.reconnect.delayMs ?? 1000 }
+          : null;
 
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
     let cancelled = false;
-    let buffer = '';
+    let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+    let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
 
-    const pump = async () => {
+    const delay = (ms: number) =>
+      new Promise<void>(resolve => {
+        reconnectTimer = setTimeout(() => {
+          reconnectTimer = undefined;
+          resolve();
+        }, ms);
+      });
+
+    const requestStream = () => this.request(this.url(`${this.base()}/stream`), { stream: true }) as Promise<Response>;
+
+    const streamEndedError = () => new Error('Agent controller session stream ended unexpectedly');
+
+    const pump = async (response: Response): Promise<'done' | 'transport_error' | 'consumer_error' | 'cancelled'> => {
+      if (!response.body) {
+        throw new Error('No response body for agent controller session stream');
+      }
+
+      const reader = response.body.getReader();
+      currentReader = reader;
+      const decoder = new TextDecoder();
+      let buffer = '';
+
       try {
         while (!cancelled) {
           const { done, value } = await reader.read();
-          if (done) break;
+          if (done) return cancelled ? 'cancelled' : 'done';
           buffer += decoder.decode(value, { stream: true });
 
           // SSE frames are separated by a blank line.
@@ -435,25 +465,94 @@ export class AgentControllerSession extends BaseResource {
               if (!line.startsWith('data:')) continue; // skip ": heartbeat" comments
               const data = line.slice(5).trim();
               if (!data) continue;
+              let event: AgentControllerEvent;
               try {
-                options.onEvent(JSON.parse(data) as AgentControllerEvent);
+                event = JSON.parse(data) as AgentControllerEvent;
               } catch {
-                // ignore malformed frame
+                continue; // ignore malformed frame
+              }
+              try {
+                options.onEvent(event);
+              } catch (cause) {
+                if (!cancelled) options.onError?.(cause);
+                return 'consumer_error';
               }
             }
           }
         }
-      } catch (error) {
-        if (!cancelled) options.onError?.(error);
+        return 'cancelled';
+      } catch {
+        return cancelled ? 'cancelled' : 'transport_error';
+      } finally {
+        if (currentReader === reader) currentReader = null;
+        void reader.cancel().catch(() => {});
       }
     };
 
-    void pump();
+    const run = async () => {
+      let attempts = 0;
+
+      while (!cancelled) {
+        let response: Response;
+        try {
+          response = await requestStream();
+        } catch (error) {
+          if (cancelled) return;
+          if (!reconnectOptions || attempts >= reconnectOptions.maxRetries) {
+            options.onError?.(error);
+            return;
+          }
+          attempts++;
+          await delay(reconnectOptions.delayMs);
+          if (cancelled) return;
+          continue;
+        }
+
+        let result: 'done' | 'transport_error' | 'consumer_error' | 'cancelled';
+        try {
+          result = await pump(response);
+        } catch (error) {
+          if (cancelled) return;
+          if (!reconnectOptions) {
+            options.onError?.(error);
+            return;
+          }
+          result = 'transport_error';
+        }
+
+        if (cancelled || result === 'cancelled') return;
+        if (result === 'consumer_error') return;
+
+        if (!reconnectOptions) {
+          if (result === 'done' || result === 'transport_error') {
+            options.onError?.(streamEndedError());
+          }
+          return;
+        }
+
+        if (result === 'done' || result === 'transport_error') {
+          if (attempts >= reconnectOptions.maxRetries) {
+            options.onError?.(streamEndedError());
+            return;
+          }
+          attempts++;
+          await delay(reconnectOptions.delayMs);
+          if (cancelled) return;
+          continue;
+        }
+      }
+    };
+
+    void run();
 
     return {
       unsubscribe: () => {
         cancelled = true;
-        void reader.cancel().catch(() => {});
+        if (reconnectTimer) {
+          clearTimeout(reconnectTimer);
+          reconnectTimer = undefined;
+        }
+        void currentReader?.cancel().catch(() => {});
       },
     };
   }

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -354,9 +354,7 @@ export interface SubscribeAgentControllerSessionOptions {
   reconnect?:
     | boolean
     | {
-        /** Maximum reconnect attempts after the initial stream ends or errors. Defaults to Infinity. */
         maxRetries?: number;
-        /** Delay between reconnect attempts in milliseconds. Defaults to 1000. */
         delayMs?: number;
       };
 }
@@ -456,20 +454,19 @@ export class AgentControllerSession extends BaseResource {
           if (done) return cancelled ? 'cancelled' : 'done';
           buffer += decoder.decode(value, { stream: true });
 
-          // SSE frames are separated by a blank line.
           let sep: number;
           while ((sep = buffer.indexOf('\n\n')) !== -1) {
             const frame = buffer.slice(0, sep);
             buffer = buffer.slice(sep + 2);
             for (const line of frame.split('\n')) {
-              if (!line.startsWith('data:')) continue; // skip ": heartbeat" comments
+              if (!line.startsWith('data:')) continue;
               const data = line.slice(5).trim();
               if (!data) continue;
               let event: AgentControllerEvent;
               try {
                 event = JSON.parse(data) as AgentControllerEvent;
               } catch {
-                continue; // ignore malformed frame
+                continue;
               }
               try {
                 options.onEvent(event);

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -425,20 +425,45 @@ export class AgentControllerSession extends BaseResource {
     let cancelled = false;
     let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
     let reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+    let delayResolve: (() => void) | undefined;
+
+    const settleDelay = () => {
+      if (reconnectTimer) {
+        clearTimeout(reconnectTimer);
+        reconnectTimer = undefined;
+      }
+      const resolve = delayResolve;
+      delayResolve = undefined;
+      resolve?.();
+    };
 
     const delay = (ms: number) =>
       new Promise<void>(resolve => {
-        reconnectTimer = setTimeout(() => {
-          reconnectTimer = undefined;
-          resolve();
-        }, ms);
+        delayResolve = resolve;
+        reconnectTimer = setTimeout(settleDelay, ms);
       });
 
     const requestStream = () => this.request(this.url(`${this.base()}/stream`), { stream: true }) as Promise<Response>;
 
     const streamEndedError = () => new Error('Agent controller session stream ended unexpectedly');
 
-    const pump = async (response: Response): Promise<'done' | 'transport_error' | 'consumer_error' | 'cancelled'> => {
+    const findFrameSeparator = (text: string): { index: number; length: number } | null => {
+      const candidates = [
+        { index: text.indexOf('\r\n\r\n'), length: 4 },
+        { index: text.indexOf('\n\n'), length: 2 },
+        { index: text.indexOf('\r\r'), length: 2 },
+      ].filter(candidate => candidate.index !== -1);
+      if (candidates.length === 0) return null;
+      return candidates.reduce((earliest, candidate) => (candidate.index < earliest.index ? candidate : earliest));
+    };
+
+    type PumpResult =
+      | { kind: 'done' }
+      | { kind: 'cancelled' }
+      | { kind: 'consumer_error' }
+      | { kind: 'transport_error'; error: unknown };
+
+    const pump = async (response: Response): Promise<PumpResult> => {
       if (!response.body) {
         throw new Error('No response body for agent controller session stream');
       }
@@ -451,14 +476,14 @@ export class AgentControllerSession extends BaseResource {
       try {
         while (!cancelled) {
           const { done, value } = await reader.read();
-          if (done) return cancelled ? 'cancelled' : 'done';
+          if (done) return cancelled ? { kind: 'cancelled' } : { kind: 'done' };
           buffer += decoder.decode(value, { stream: true });
 
-          let sep: number;
-          while ((sep = buffer.indexOf('\n\n')) !== -1) {
-            const frame = buffer.slice(0, sep);
-            buffer = buffer.slice(sep + 2);
-            for (const line of frame.split('\n')) {
+          let separator: { index: number; length: number } | null;
+          while ((separator = findFrameSeparator(buffer)) !== null) {
+            const frame = buffer.slice(0, separator.index);
+            buffer = buffer.slice(separator.index + separator.length);
+            for (const line of frame.split(/\r\n|\n|\r/)) {
               if (!line.startsWith('data:')) continue;
               const data = line.slice(5).trim();
               if (!data) continue;
@@ -472,18 +497,26 @@ export class AgentControllerSession extends BaseResource {
                 options.onEvent(event);
               } catch (cause) {
                 if (!cancelled) options.onError?.(cause);
-                return 'consumer_error';
+                return { kind: 'consumer_error' };
               }
             }
           }
         }
-        return 'cancelled';
-      } catch {
-        return cancelled ? 'cancelled' : 'transport_error';
+        return { kind: 'cancelled' };
+      } catch (error) {
+        return cancelled ? { kind: 'cancelled' } : { kind: 'transport_error', error };
       } finally {
         if (currentReader === reader) currentReader = null;
         void reader.cancel().catch(() => {});
       }
+    };
+
+    const reportTerminalError = (result: Extract<PumpResult, { kind: 'done' } | { kind: 'transport_error' }>) => {
+      if (result.kind === 'transport_error') {
+        options.onError?.(result.error);
+        return;
+      }
+      options.onError?.(streamEndedError());
     };
 
     const run = async () => {
@@ -505,7 +538,7 @@ export class AgentControllerSession extends BaseResource {
           continue;
         }
 
-        let result: 'done' | 'transport_error' | 'consumer_error' | 'cancelled';
+        let result: PumpResult;
         try {
           result = await pump(response);
         } catch (error) {
@@ -514,22 +547,22 @@ export class AgentControllerSession extends BaseResource {
             options.onError?.(error);
             return;
           }
-          result = 'transport_error';
+          result = { kind: 'transport_error', error };
         }
 
-        if (cancelled || result === 'cancelled') return;
-        if (result === 'consumer_error') return;
+        if (cancelled || result.kind === 'cancelled') return;
+        if (result.kind === 'consumer_error') return;
 
         if (!reconnectOptions) {
-          if (result === 'done' || result === 'transport_error') {
-            options.onError?.(streamEndedError());
+          if (result.kind === 'done' || result.kind === 'transport_error') {
+            reportTerminalError(result);
           }
           return;
         }
 
-        if (result === 'done' || result === 'transport_error') {
+        if (result.kind === 'done' || result.kind === 'transport_error') {
           if (attempts >= reconnectOptions.maxRetries) {
-            options.onError?.(streamEndedError());
+            reportTerminalError(result);
             return;
           }
           attempts++;
@@ -545,10 +578,7 @@ export class AgentControllerSession extends BaseResource {
     return {
       unsubscribe: () => {
         cancelled = true;
-        if (reconnectTimer) {
-          clearTimeout(reconnectTimer);
-          reconnectTimer = undefined;
-        }
+        settleDelay();
         void currentReader?.cancel().catch(() => {});
       },
     };

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
@@ -47,6 +47,7 @@ export function useAgentControllerEvents({
 
     void session
       .subscribe({
+        reconnect: true,
         onEvent: event => onEventRef.current(event),
         onError: () => {
           if (!disposed) disconnect();


### PR DESCRIPTION
## Description

Adds optional `reconnect` support to `AgentControllerSession.subscribe()` in `@mastra/client-js`, matching the reconnect behavior already available on agent thread streams.

When `reconnect: true` (or `{ maxRetries, delayMs }`) is passed, the client automatically retries the SSE subscription after a clean close or transport error instead of ending the subscription. `unsubscribe()` cancels in-flight reads and pending reconnect timers. If `onEvent` throws, `onError` is called and reconnect stops.

When reconnect is not enabled, a clean stream close now invokes `onError` with `"Agent controller session stream ended unexpectedly"` (previously silent).

Mastra Code web is wired to use `reconnect: true` in `useAgentControllerEvents` so the UI benefits from transport-level reconnect instead of relying only on the hook-level re-subscribe loop.

## Related issue(s)

Fixes #19202

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

## Out of scope (follow-up)

Issue #19202 also mentions per-request auth header refresh (`ClientOptions.headers` as a provider callback). This PR only adds transport-level `reconnect` for `AgentControllerSession.subscribe()`. Auth refresh would be a separate change to `BaseResource.request` and is not required for the reconnect loop itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the app’s “live updates” connection drops, the client now automatically reconnects and asks for the updates again, so you don’t lose events. If you unsubscribe, it stops trying. If your event handler crashes, it reports the error and stops reconnecting.

## What changed

- Extended `AgentControllerSession.subscribe()` in `@mastra/client-js` with optional SSE reconnection:
  - `reconnect: true` now retries automatically.
  - `reconnect: { maxRetries?, delayMs? }` lets you control retry count and delay.
- Reconnection triggers include both:
  - Transport/read failures.
  - Unexpected clean SSE termination (treated as an error when reconnect is off).
- On each retry, the client re-requests the session stream and resumes SSE reading.
- `unsubscribe()` now cancels the active stream reader and clears any pending reconnect/delay timer to prevent late retries.
- Error semantics:
  - With reconnect disabled, unexpected clean closure now calls `onError`.
  - If `onEvent` throws, `onError` is called and reconnecting stops (non-retriable “consumer_error”).
  - When retries are exhausted, `onError` is called (including the underlying read failure).
- Updated Mastra Code to enable this behavior by passing `reconnect: true` in `useAgentControllerEvents`.
- Added/expanded tests for SSE frame parsing and the full subscribe/reconnect/unsubscribe/error lifecycle, plus a client changeset documenting the enhancement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->