### PR TITLE
MC Web: Factory audit trail (human + agent actions) and PR intake flow

### DIFF
--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -31,6 +31,7 @@ import { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { prepareAgentControllerMount } from '@mastra/code-sdk';
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
+import { observeAgentGitAction } from '../web/audit/agent-audit.js';
 import { buildAuthRoutes, createWebAuthGate, createWebAuthProvider, isWebAuthEnabled } from '../web/auth.js';
 import { buildLinearAgentTools } from '../web/linear/agent-tools.js';
 import { handleServerError } from '../web/server-error.js';
@@ -146,6 +147,11 @@ const prepared = await prepareAgentControllerMount({
         }) => {
           const pullRequestUrl = parseCreatedPullRequest(context);
           const requestContext = (context.context as { requestContext?: RequestContext } | undefined)?.requestContext;
+          // Audit externally-visible git side effects performed by the agent
+          // (commit / push / PR creation). Fire-and-forget; never throws.
+          if (requestContext) {
+            void observeAgentGitAction({ ...context, context: requestContext });
+          }
           if (pullRequestUrl && requestContext) {
             await subscribeCurrentSessionToPullRequest(requestContext, pullRequestUrl, 'auto-gh-pr-create');
           }

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -148,9 +148,10 @@ const prepared = await prepareAgentControllerMount({
           const pullRequestUrl = parseCreatedPullRequest(context);
           const requestContext = (context.context as { requestContext?: RequestContext } | undefined)?.requestContext;
           // Audit externally-visible git side effects performed by the agent
-          // (commit / push / PR creation). Fire-and-forget; never throws.
+          // (commit / push / PR creation). Awaited so the local audit write
+          // completes before teardown; never throws (failures are swallowed).
           if (requestContext) {
-            void observeAgentGitAction({ ...context, context: requestContext });
+            await observeAgentGitAction({ ...context, context: requestContext });
           }
           if (pullRequestUrl && requestContext) {
             await subscribeCurrentSessionToPullRequest(requestContext, pullRequestUrl, 'auto-gh-pr-create');

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -23,6 +23,9 @@ export const queryKeys = {
   workItems: (githubProjectId: string | undefined) => ['factory', 'work-items', githubProjectId ?? null] as const,
   factoryMetrics: (githubProjectId: string | undefined, days: number) =>
     ['factory', 'metrics', githubProjectId ?? null, days] as const,
+  factoryAudit: (githubProjectId: string | undefined, group: string) =>
+    ['factory', 'audit', githubProjectId ?? null, group] as const,
+  factoryAuditPortal: () => ['factory', 'audit-portal'] as const,
   workspaces: (projectId: string | undefined) => ['workspaces', projectId ?? null] as const,
   userSessions: (projectId: string | undefined) => ['user-sessions', projectId ?? null] as const,
   providers: () => ['providers'] as const,

--- a/mastracode/web/src/web/audit/agent-audit.test.ts
+++ b/mastracode/web/src/web/audit/agent-audit.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+const recorded: any[] = [];
+let recordFailure: Error | undefined;
+
+vi.mock('./store', () => ({
+  recordAuditEvent: vi.fn(async (input: any) => {
+    if (recordFailure) throw recordFailure;
+    recorded.push(input);
+    return {
+      id: `00000000-0000-4000-8000-${String(recorded.length).padStart(12, '0')}`,
+      occurredAt: new Date('2026-07-16T10:00:00Z'),
+      orgId: input.orgId,
+      actorId: input.actorId,
+      actorType: input.actorType ?? 'human',
+      action: input.action,
+      targets: input.targets,
+      metadata: input.metadata ?? {},
+      githubProjectId: input.githubProjectId ?? null,
+      context: input.context ?? {},
+    };
+  }),
+  listAuditEvents: vi.fn(async () => ({ events: [] })),
+}));
+
+const forwardToWorkOS = vi.fn(async (_row: unknown) => undefined);
+vi.mock('./workos-sink', () => ({
+  forwardToWorkOS: (row: unknown) => forwardToWorkOS(row),
+}));
+
+import { emitAgentAudit, observeAgentGitAction } from './agent-audit';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+const THREAD = 'thread-42';
+const PROJECT = '11111111-1111-4111-8111-111111111111';
+const SCOPE = '/sandbox/mastra-worktrees/feat-audit';
+const USER = { workosId: 'user_abc', id: 'user_abc', email: 'a@b.c', name: 'Abhi', organizationId: 'org_123' };
+
+function makeRequestContext(overrides: { controller?: unknown; user?: unknown } = {}) {
+  const controller =
+    'controller' in overrides
+      ? overrides.controller
+      : {
+          threadId: THREAD,
+          scope: SCOPE,
+          session: { id: 'session-1', ownerId: 'owner-1' },
+          resourceId: 'resource-1',
+          getState: () => ({ githubProjectId: PROJECT }),
+        };
+  const user = 'user' in overrides ? overrides.user : USER;
+  const entries: Record<string, unknown> = { controller, user };
+  return { get: (key: string) => entries[key] } as any;
+}
+
+function toolCall(command: string, extras: Record<string, unknown> = {}) {
+  return {
+    toolName: 'execute_command',
+    input: { command },
+    output: { stdout: '' },
+    context: makeRequestContext(),
+    ...extras,
+  };
+}
+
+beforeEach(() => {
+  recorded.length = 0;
+  recordFailure = undefined;
+  forwardToWorkOS.mockClear();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── emitAgentAudit ───────────────────────────────────────────────────────
+describe('emitAgentAudit', () => {
+  it('records an agent-attributed event chained back to the initiating human', async () => {
+    await emitAgentAudit(makeRequestContext(), {
+      action: 'factory.agent.commit',
+      targets: [{ type: 'worktree', id: SCOPE }],
+      metadata: { command: 'git commit -m "x"' },
+    });
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      orgId: 'org_123',
+      actorId: `agent:${THREAD}`,
+      actorType: 'agent',
+      action: 'factory.agent.commit',
+      githubProjectId: PROJECT,
+      context: {},
+      metadata: { command: 'git commit -m "x"', startedBy: 'user_abc' },
+    });
+    expect(forwardToWorkOS).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ['controller missing', { controller: undefined }],
+    ['user missing', { user: undefined }],
+    ['thread missing', { controller: { scope: SCOPE, getState: () => ({ githubProjectId: PROJECT }) } }],
+    ['github project missing', { controller: { threadId: THREAD, scope: SCOPE, getState: () => ({}) } }],
+    ['org missing', { user: { ...USER, organizationId: undefined } }],
+  ])('no-ops when the session context is incomplete (%s)', async (_label, overrides) => {
+    await emitAgentAudit(makeRequestContext(overrides as any), {
+      action: 'factory.agent.commit',
+      targets: [],
+    });
+    expect(recorded).toHaveLength(0);
+    expect(forwardToWorkOS).not.toHaveBeenCalled();
+  });
+
+  it('never throws when recording rejects', async () => {
+    recordFailure = new Error('insert exploded');
+    await expect(
+      emitAgentAudit(makeRequestContext(), { action: 'factory.agent.commit', targets: [] }),
+    ).resolves.toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Audit] Failed to emit agent audit event',
+      expect.objectContaining({ action: 'factory.agent.commit' }),
+    );
+  });
+});
+
+// ── observeAgentGitAction ────────────────────────────────────────────────
+describe('observeAgentGitAction', () => {
+  it('records a commit event with the worktree target and a bounded command excerpt', async () => {
+    await observeAgentGitAction(toolCall('git commit -m "feat: add audit trail"'));
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      action: 'factory.agent.commit',
+      actorId: `agent:${THREAD}`,
+      actorType: 'agent',
+      targets: [{ type: 'worktree', id: SCOPE }],
+      metadata: { command: 'git commit -m "feat: add audit trail"', startedBy: 'user_abc' },
+    });
+  });
+
+  it('truncates long command excerpts to 200 characters', async () => {
+    await observeAgentGitAction(toolCall(`git commit -m "${'x'.repeat(400)}"`));
+    expect((recorded[0].metadata.command as string).length).toBe(200);
+  });
+
+  it('records a push event with the branch parsed from the command', async () => {
+    await observeAgentGitAction(toolCall('git push origin feat/audit-logging'));
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      action: 'factory.agent.push',
+      metadata: { command: 'git push origin feat/audit-logging', branch: 'feat/audit-logging' },
+    });
+  });
+
+  it('omits the branch when it is not parseable from the push command', async () => {
+    await observeAgentGitAction(toolCall('git push'));
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0].action).toBe('factory.agent.push');
+    expect(recorded[0].metadata.branch).toBeUndefined();
+  });
+
+  it('records a pr_opened event with the PR URL target from the command output', async () => {
+    await observeAgentGitAction(
+      toolCall('gh pr create --title "Audit" --body "..."', {
+        output: { stdout: 'https://github.com/mastra-ai/mastra/pull/19500\n' },
+      }),
+    );
+
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]).toMatchObject({
+      action: 'factory.agent.pr_opened',
+      targets: [{ type: 'pull_request', id: 'https://github.com/mastra-ai/mastra/pull/19500' }],
+    });
+  });
+
+  it('emits one event per matching command in a chained invocation', async () => {
+    await observeAgentGitAction(toolCall('git commit -m "x" && git push origin main'));
+
+    expect(recorded.map(r => r.action)).toEqual(['factory.agent.commit', 'factory.agent.push']);
+  });
+
+  it('ignores git commands inside heredoc bodies', async () => {
+    await observeAgentGitAction(toolCall('cat > notes.md <<EOF\ngit push origin main\ngit commit -m "not real"\nEOF'));
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('ignores failed commands', async () => {
+    await observeAgentGitAction(toolCall('git push origin main', { error: new Error('exit 1') }));
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('ignores tools other than execute_command', async () => {
+    await observeAgentGitAction({
+      toolName: 'view',
+      input: { command: 'git push origin main' },
+      context: makeRequestContext(),
+    });
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('ignores unrelated commands', async () => {
+    await observeAgentGitAction(toolCall('git status && git log --oneline'));
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('no-ops when the session context is incomplete', async () => {
+    await observeAgentGitAction({
+      ...toolCall('git push origin main'),
+      context: makeRequestContext({ controller: undefined }),
+    });
+    expect(recorded).toHaveLength(0);
+  });
+
+  it('never throws even when recording rejects', async () => {
+    recordFailure = new Error('insert exploded');
+    await expect(observeAgentGitAction(toolCall('git commit -m "x"'))).resolves.toBeUndefined();
+    expect(recorded).toHaveLength(0);
+  });
+});

--- a/mastracode/web/src/web/audit/agent-audit.test.ts
+++ b/mastracode/web/src/web/audit/agent-audit.test.ts
@@ -80,7 +80,7 @@ describe('emitAgentAudit', () => {
     await emitAgentAudit(makeRequestContext(), {
       action: 'factory.agent.commit',
       targets: [{ type: 'worktree', id: SCOPE }],
-      metadata: { command: 'git commit -m "x"' },
+      metadata: { branch: 'main' },
     });
 
     expect(recorded).toHaveLength(1);
@@ -91,7 +91,7 @@ describe('emitAgentAudit', () => {
       action: 'factory.agent.commit',
       githubProjectId: PROJECT,
       context: {},
-      metadata: { command: 'git commit -m "x"', startedBy: 'user_abc' },
+      metadata: { branch: 'main', startedBy: 'user_abc' },
     });
     expect(forwardToWorkOS).toHaveBeenCalledTimes(1);
   });
@@ -125,7 +125,7 @@ describe('emitAgentAudit', () => {
 
 // ── observeAgentGitAction ────────────────────────────────────────────────
 describe('observeAgentGitAction', () => {
-  it('records a commit event with the worktree target and a bounded command excerpt', async () => {
+  it('records a commit event with the worktree target', async () => {
     await observeAgentGitAction(toolCall('git commit -m "feat: add audit trail"'));
 
     expect(recorded).toHaveLength(1);
@@ -134,13 +134,18 @@ describe('observeAgentGitAction', () => {
       actorId: `agent:${THREAD}`,
       actorType: 'agent',
       targets: [{ type: 'worktree', id: SCOPE }],
-      metadata: { command: 'git commit -m "feat: add audit trail"', startedBy: 'user_abc' },
+      metadata: { startedBy: 'user_abc' },
     });
   });
 
-  it('truncates long command excerpts to 200 characters', async () => {
-    await observeAgentGitAction(toolCall(`git commit -m "${'x'.repeat(400)}"`));
-    expect((recorded[0].metadata.command as string).length).toBe(200);
+  it('never persists the raw command in event metadata', async () => {
+    await observeAgentGitAction(
+      toolCall('git commit -m "x" && git push https://token@github.com/mastra-ai/mastra.git main'),
+    );
+    expect(recorded.length).toBeGreaterThan(0);
+    for (const row of recorded) {
+      expect(row.metadata.command).toBeUndefined();
+    }
   });
 
   it('records a push event with the branch parsed from the command', async () => {
@@ -149,7 +154,7 @@ describe('observeAgentGitAction', () => {
     expect(recorded).toHaveLength(1);
     expect(recorded[0]).toMatchObject({
       action: 'factory.agent.push',
-      metadata: { command: 'git push origin feat/audit-logging', branch: 'feat/audit-logging' },
+      metadata: { branch: 'feat/audit-logging' },
     });
   });
 

--- a/mastracode/web/src/web/audit/agent-audit.ts
+++ b/mastracode/web/src/web/audit/agent-audit.ts
@@ -26,9 +26,6 @@ import { forwardToWorkOS } from './workos-sink';
 
 type GithubSessionState = { githubProjectId?: string };
 
-/** Bounded excerpt of the matched command line stored in event metadata. */
-const MAX_COMMAND_EXCERPT_LENGTH = 200;
-
 export interface EmitAgentAuditInput {
   /** Dot-namespaced action, e.g. 'factory.agent.commit'. */
   action: string;
@@ -85,12 +82,6 @@ const GIT_COMMIT_RE = /(?:^|\n|;|&&|\|\|)\s*git\s+commit(?:\s|$)/;
 const GIT_PUSH_RE = /(?:^|\n|;|&&|\|\|)\s*git\s+push(?:\s|$)/;
 const GH_PR_CREATE_RE = /(?:^|\n|;|&&|\|\|)\s*gh\s+pr\s+create(?:\s|$)/;
 
-/** First line of the command that contains the given pattern, truncated. */
-function commandExcerpt(command: string, pattern: RegExp): string | undefined {
-  const line = command.split('\n').find(l => pattern.test(l));
-  return line?.trim().slice(0, MAX_COMMAND_EXCERPT_LENGTH);
-}
-
 /** Parse the branch from a plain `git push <remote> <branch>` invocation. */
 function parsePushedBranch(command: string): string | undefined {
   const match = command.match(
@@ -120,7 +111,6 @@ export async function observeAgentGitAction(toolContext: ToolObserverContext): P
       await emitAgentAudit(toolContext.context, {
         action: 'factory.agent.commit',
         targets: worktreePath ? [{ type: 'worktree', id: worktreePath }] : [],
-        metadata: { command: commandExcerpt(command, /\bgit\s+commit\b/) },
       });
     }
 
@@ -129,10 +119,7 @@ export async function observeAgentGitAction(toolContext: ToolObserverContext): P
       await emitAgentAudit(toolContext.context, {
         action: 'factory.agent.push',
         targets: worktreePath ? [{ type: 'worktree', id: worktreePath }] : [],
-        metadata: {
-          command: commandExcerpt(command, /\bgit\s+push\b/),
-          ...(branch ? { branch } : {}),
-        },
+        ...(branch ? { metadata: { branch } } : {}),
       });
     }
 
@@ -141,7 +128,6 @@ export async function observeAgentGitAction(toolContext: ToolObserverContext): P
       await emitAgentAudit(toolContext.context, {
         action: 'factory.agent.pr_opened',
         targets: url ? [{ type: 'pull_request', id: url }] : [],
-        metadata: { command: commandExcerpt(command, /\bgh\s+pr\s+create\b/) },
       });
     }
   } catch (err) {

--- a/mastracode/web/src/web/audit/agent-audit.ts
+++ b/mastracode/web/src/web/audit/agent-audit.ts
@@ -1,0 +1,152 @@
+/**
+ * Agent-level audit events (Audit v1.1).
+ *
+ * Git actions performed by agents inside runs never touch web routes, so the
+ * `factory.git.*` events only capture human-initiated route calls. This module
+ * closes that gap: `observeAgentGitAction` watches completed tool calls (via
+ * the agent controller's postToolObserver) for externally-visible git side
+ * effects — commits, pushes, and PR creation — and records them as
+ * `factory.agent.*` audit events.
+ *
+ * Agent events are attributed to the run itself (`actor_id = 'agent:<threadId>'`,
+ * `actor_type = 'agent'`) and chained back to the human who drove the run via
+ * `metadata.startedBy`. Like all auditing, this never throws — failures are
+ * logged with an `[Audit]` prefix and swallowed.
+ */
+
+import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
+import type { RequestContext } from '@mastra/core/request-context';
+
+import type { WebAuthUser } from '../auth';
+import { getWebAuthOrgId, getWebAuthUserId } from '../auth';
+import { parseCreatedPullRequest, stripHeredocBodies } from '../github/session-subscriptions';
+import type { AuditTarget } from './schema';
+import { recordAuditEvent } from './store';
+import { forwardToWorkOS } from './workos-sink';
+
+type GithubSessionState = { githubProjectId?: string };
+
+/** Bounded excerpt of the matched command line stored in event metadata. */
+const MAX_COMMAND_EXCERPT_LENGTH = 200;
+
+export interface EmitAgentAuditInput {
+  /** Dot-namespaced action, e.g. 'factory.agent.commit'. */
+  action: string;
+  targets: AuditTarget[];
+  /** Bounded event summary — never full payloads, never secrets. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Record an audit event for an action an agent performed inside a run. The
+ * non-Hono sibling of `emitAudit`: the actor is the run's thread and the
+ * initiating human is chained via `metadata.startedBy`. Silently no-ops when
+ * the session context is incomplete; never throws.
+ */
+export async function emitAgentAudit(requestContext: RequestContext, input: EmitAgentAuditInput): Promise<void> {
+  try {
+    const context = requestContext.get('controller') as AgentControllerRequestContext<GithubSessionState> | undefined;
+    const user = requestContext.get('user') as WebAuthUser | undefined;
+    const orgId = getWebAuthOrgId(user);
+    const userId = getWebAuthUserId(user);
+    const threadId = context?.threadId;
+    const githubProjectId = context?.getState().githubProjectId;
+    if (!orgId || !userId || !threadId || !githubProjectId) return;
+
+    const row = await recordAuditEvent({
+      orgId,
+      actorId: `agent:${threadId}`,
+      actorType: 'agent',
+      action: input.action,
+      targets: input.targets,
+      metadata: { ...input.metadata, startedBy: userId },
+      githubProjectId,
+      context: {},
+    });
+    if (row) void forwardToWorkOS(row);
+  } catch (err) {
+    console.warn('[Audit] Failed to emit agent audit event', {
+      action: input.action,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+interface ToolObserverContext {
+  toolName: string;
+  input: unknown;
+  output?: unknown;
+  error?: unknown;
+  context: RequestContext;
+}
+
+/** Match command-start positions, same style as `parseCreatedPullRequest`. */
+const GIT_COMMIT_RE = /(?:^|\n|;|&&|\|\|)\s*git\s+commit(?:\s|$)/;
+const GIT_PUSH_RE = /(?:^|\n|;|&&|\|\|)\s*git\s+push(?:\s|$)/;
+const GH_PR_CREATE_RE = /(?:^|\n|;|&&|\|\|)\s*gh\s+pr\s+create(?:\s|$)/;
+
+/** First line of the command that contains the given pattern, truncated. */
+function commandExcerpt(command: string, pattern: RegExp): string | undefined {
+  const line = command.split('\n').find(l => pattern.test(l));
+  return line?.trim().slice(0, MAX_COMMAND_EXCERPT_LENGTH);
+}
+
+/** Parse the branch from a plain `git push <remote> <branch>` invocation. */
+function parsePushedBranch(command: string): string | undefined {
+  const match = command.match(
+    /(?:^|\n|;|&&|\|\|)\s*git\s+push\s+(?:-[^\s]+\s+)*([^\s;&|-][^\s;&|]*)\s+([^\s;&|-][^\s;&|]*)/,
+  );
+  return match?.[2];
+}
+
+/**
+ * Detect externally-visible git side effects in a completed tool call and
+ * record `factory.agent.*` audit events for them. One command can emit
+ * multiple events (`git commit && git push` emits both). Never throws.
+ */
+export async function observeAgentGitAction(toolContext: ToolObserverContext): Promise<void> {
+  try {
+    if (toolContext.toolName !== 'execute_command' || toolContext.error) return;
+    const rawCommand = (toolContext.input as { command?: unknown } | undefined)?.command;
+    if (typeof rawCommand !== 'string') return;
+    const command = stripHeredocBodies(rawCommand);
+
+    const controller = toolContext.context.get('controller') as
+      | AgentControllerRequestContext<GithubSessionState>
+      | undefined;
+    const worktreePath = controller?.scope;
+
+    if (GIT_COMMIT_RE.test(command)) {
+      await emitAgentAudit(toolContext.context, {
+        action: 'factory.agent.commit',
+        targets: worktreePath ? [{ type: 'worktree', id: worktreePath }] : [],
+        metadata: { command: commandExcerpt(command, /\bgit\s+commit\b/) },
+      });
+    }
+
+    if (GIT_PUSH_RE.test(command)) {
+      const branch = parsePushedBranch(command);
+      await emitAgentAudit(toolContext.context, {
+        action: 'factory.agent.push',
+        targets: worktreePath ? [{ type: 'worktree', id: worktreePath }] : [],
+        metadata: {
+          command: commandExcerpt(command, /\bgit\s+push\b/),
+          ...(branch ? { branch } : {}),
+        },
+      });
+    }
+
+    if (GH_PR_CREATE_RE.test(command)) {
+      const url = parseCreatedPullRequest(toolContext);
+      await emitAgentAudit(toolContext.context, {
+        action: 'factory.agent.pr_opened',
+        targets: url ? [{ type: 'pull_request', id: url }] : [],
+        metadata: { command: commandExcerpt(command, /\bgh\s+pr\s+create\b/) },
+      });
+    }
+  } catch (err) {
+    console.warn('[Audit] Failed to observe agent git action', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/mastracode/web/src/web/audit/audit.test.ts
+++ b/mastracode/web/src/web/audit/audit.test.ts
@@ -1,0 +1,73 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const recordAuditEvent = vi.fn(async (input: any) => ({ id: 'evt-1', ...input, occurredAt: new Date() }));
+const forwardToWorkOS = vi.fn(async (_event: any) => undefined);
+
+vi.mock('./store', () => ({ recordAuditEvent: (input: any) => recordAuditEvent(input) }));
+vi.mock('./workos-sink', () => ({ forwardToWorkOS: (event: any) => forwardToWorkOS(event) }));
+
+import { emitAudit } from './audit';
+
+/** Run `emitAudit` inside a real Hono request with an optional stashed user. */
+async function emit(user: { workosId: string; organizationId?: string } | null, headers: Record<string, string> = {}) {
+  const app = new Hono();
+  app.post('/t', async c => {
+    if (user) c.set('webAuthUser' as never, user as never);
+    await emitAudit(c, {
+      action: 'factory.work_item.created',
+      projectId: '11111111-1111-4111-8111-111111111111',
+      targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix login' }],
+      metadata: { source: 'github-issue' },
+    });
+    return c.json({ ok: true });
+  });
+  const res = await app.request('/t', { method: 'POST', headers });
+  expect(res.status).toBe(200);
+}
+
+beforeEach(() => {
+  recordAuditEvent.mockClear();
+  forwardToWorkOS.mockClear();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('emitAudit', () => {
+  it('records the event with the tenant actor and request context, then forwards it', async () => {
+    await emit(
+      { workosId: 'user_abc', organizationId: 'org_123' },
+      { 'x-forwarded-for': '10.0.0.1, 172.16.0.1', 'user-agent': 'vitest' },
+    );
+
+    expect(recordAuditEvent).toHaveBeenCalledWith({
+      orgId: 'org_123',
+      actorId: 'user_abc',
+      action: 'factory.work_item.created',
+      targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix login' }],
+      metadata: { source: 'github-issue' },
+      githubProjectId: '11111111-1111-4111-8111-111111111111',
+      context: { location: '10.0.0.1', userAgent: 'vitest' },
+    });
+    // Forward fires with the recorded row (fire-and-forget).
+    await vi.waitFor(() => expect(forwardToWorkOS).toHaveBeenCalledTimes(1));
+    expect(forwardToWorkOS.mock.calls[0]![0]).toMatchObject({ id: 'evt-1', actorId: 'user_abc' });
+  });
+
+  it('is a silent no-op without an org-scoped tenant', async () => {
+    await emit(null);
+    await emit({ workosId: 'user_abc' }); // personal account, no org
+    expect(recordAuditEvent).not.toHaveBeenCalled();
+    expect(forwardToWorkOS).not.toHaveBeenCalled();
+  });
+
+  it('never throws when recording fails', async () => {
+    recordAuditEvent.mockRejectedValueOnce(new Error('db down'));
+    await emit({ workosId: 'user_abc', organizationId: 'org_123' });
+    expect(forwardToWorkOS).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/mastracode/web/src/web/audit/audit.ts
+++ b/mastracode/web/src/web/audit/audit.ts
@@ -1,0 +1,67 @@
+/**
+ * The one public entry point for emitting Factory audit events from routes.
+ *
+ * `emitAudit(c, input)` resolves the actor from the request context, captures
+ * request context (client IP / user-agent), appends the local `audit_events`
+ * row (awaited, swallow-on-failure) and kicks off the fire-and-forget WorkOS
+ * mirror. Call it AFTER the mutation succeeds; it never throws, so auditing
+ * can never break the factory.
+ */
+
+import type { Context } from 'hono';
+
+import { webAuthTenant } from '../auth';
+import type { AuditContext, AuditTarget } from './schema';
+import { recordAuditEvent } from './store';
+import { forwardToWorkOS } from './workos-sink';
+
+export interface EmitAuditInput {
+  /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
+  action: string;
+  /** Project the event is scoped to; omit for org-level events. */
+  projectId?: string;
+  targets: AuditTarget[];
+  /** Bounded event summary — never full payloads, never secrets. */
+  metadata?: Record<string, unknown>;
+}
+
+/** Extract the audit request context from the incoming request headers. */
+export function auditRequestContext(c: Context): AuditContext {
+  const forwarded = c.req.header('x-forwarded-for');
+  const location = forwarded?.split(',')[0]?.trim();
+  const userAgent = c.req.header('user-agent');
+  return {
+    ...(location ? { location } : {}),
+    ...(userAgent ? { userAgent } : {}),
+  };
+}
+
+/**
+ * Record an audit event for a successful mutation. Never throws. The local
+ * insert is awaited (so tests can observe it); the WorkOS forward is
+ * fire-and-forget.
+ */
+export async function emitAudit(c: Context, input: EmitAuditInput): Promise<void> {
+  try {
+    // Routes call emitAudit after resolveTenant/resolveOrgTenant succeeded, so
+    // the tenant is already on the context; bail quietly if it somehow isn't.
+    const tenant = webAuthTenant(c);
+    if (!tenant?.orgId) return;
+
+    const row = await recordAuditEvent({
+      orgId: tenant.orgId,
+      actorId: tenant.userId,
+      action: input.action,
+      targets: input.targets,
+      metadata: input.metadata,
+      githubProjectId: input.projectId,
+      context: auditRequestContext(c),
+    });
+    if (row) void forwardToWorkOS(row);
+  } catch (err) {
+    console.warn('[Audit] Failed to emit audit event', {
+      action: input.action,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/mastracode/web/src/web/audit/db.ts
+++ b/mastracode/web/src/web/audit/db.ts
@@ -1,0 +1,31 @@
+/**
+ * Database readiness for the audit-events table. Reuses the shared
+ * application Postgres (`../github/db`) and runs the idempotent DDL once per
+ * process, mirroring `ensureFactoryDbReady`.
+ */
+
+import { sql } from 'drizzle-orm';
+import { getAppDb } from '../github/db';
+import { AUDIT_MIGRATION_SQL } from './schema';
+
+let migrationPromise: Promise<void> | undefined;
+
+/** Run the idempotent audit-events migrations once. Safe to call repeatedly. */
+export async function ensureAuditDbReady(): Promise<void> {
+  if (migrationPromise) return migrationPromise;
+  migrationPromise = (async () => {
+    await getAppDb().execute(sql.raw(AUDIT_MIGRATION_SQL));
+  })();
+  try {
+    await migrationPromise;
+  } catch (err) {
+    // Reset so a later retry can attempt again.
+    migrationPromise = undefined;
+    throw err;
+  }
+}
+
+/** For tests: reset the once-per-process migration latch. */
+export function __resetAuditDbForTests(): void {
+  migrationPromise = undefined;
+}

--- a/mastracode/web/src/web/audit/routes.test.ts
+++ b/mastracode/web/src/web/audit/routes.test.ts
@@ -1,0 +1,240 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+vi.mock('drizzle-orm', async () => {
+  const actual = (await vi.importActual('drizzle-orm')) as Record<string, unknown>;
+  return {
+    ...actual,
+    eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+    and: (...conds: any[]) => ({ kind: 'and', conds: conds.filter(Boolean) }),
+  };
+});
+
+// In-memory github_projects rows for the `resolveProject` guard.
+let projects: Array<Record<string, any>> = [];
+
+function columnJsKey(table: any, columnName: string): string | undefined {
+  for (const [jsKey, col] of Object.entries(table)) {
+    if ((col as any)?.name === columnName) return jsKey;
+  }
+  return undefined;
+}
+
+function matches(table: any, row: any, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'and') return cond.conds.every((c: any) => matches(table, row, c));
+  if (cond.kind === 'eq') {
+    const jsKey = columnJsKey(table, cond.column);
+    return jsKey !== undefined && row[jsKey] === cond.value;
+  }
+  return true;
+}
+
+vi.mock('../github/db', () => ({
+  getAppDb: () => ({
+    select: () => ({
+      from: (table: any) => ({
+        where: async (cond: any) => projects.filter(row => matches(table, row, cond)),
+      }),
+    }),
+  }),
+}));
+
+// Capture list queries at the store boundary; routes are exercised end to end.
+let listCalls: Array<Record<string, any>> = [];
+let listResult: Record<string, any> = { events: [] };
+
+vi.mock('./store', () => ({
+  listAuditEvents: async (input: any) => {
+    listCalls.push(input);
+    return listResult;
+  },
+}));
+
+// Web auth stays real (disabled in tests → context-var user), but the WorkOS
+// availability gate and provider are controllable for the portal-link specs.
+let webAuthEnabled = false;
+
+vi.mock('../auth', async () => {
+  const actual = (await vi.importActual('../auth')) as Record<string, unknown>;
+  return {
+    ...actual,
+    isWebAuthEnabled: () => webAuthEnabled,
+    getWorkOSProvider: () => ({ getWorkOS: () => ({ tag: 'workos-client' }) }),
+  };
+});
+
+let portalCalls: Array<{ orgId: string; intent: string; returnUrl: string }> = [];
+let portalFailure: Error | undefined;
+
+vi.mock('@mastra/auth-workos', () => ({
+  MastraAuthWorkos: class {},
+  WorkOSAdminPortal: class {
+    private returnUrl: string;
+    constructor(_workos: unknown, options?: { returnUrl?: string }) {
+      this.returnUrl = options?.returnUrl ?? '/';
+    }
+    async getPortalLink(orgId: string, intent: string): Promise<string> {
+      if (portalFailure) throw portalFailure;
+      portalCalls.push({ orgId, intent, returnUrl: this.returnUrl });
+      return 'https://portal.workos.com/one-time-link';
+    }
+  },
+}));
+
+import { githubProjects } from '../github/schema';
+import { mountApiRoutes } from '../test-utils';
+import { buildAuditRoutes } from './routes';
+
+// ── Test harness ─────────────────────────────────────────────────────────
+function buildApp(user: { workosId: string; organizationId?: string } | null) {
+  const app = new Hono();
+  app.use('*', async (c, next) => {
+    if (user) c.set('webAuthUser' as never, user as never);
+    await next();
+  });
+  mountApiRoutes(app as any, buildAuditRoutes({ baseUrl: 'https://web.example.com' }));
+  return app;
+}
+
+const orgUser = { workosId: 'u1', organizationId: 'org1' };
+const PROJECT_ID = '11111111-1111-4111-8111-111111111111';
+
+function seedProject(overrides: Record<string, any> = {}) {
+  projects.push({
+    id: PROJECT_ID,
+    orgId: 'org1',
+    repoFullName: 'acme/repo',
+    // Only fields the guard reads matter; keep the mock row minimal.
+    ...overrides,
+  });
+}
+
+beforeEach(() => {
+  projects = [];
+  listCalls = [];
+  listResult = { events: [] };
+  webAuthEnabled = false;
+  portalCalls = [];
+  portalFailure = undefined;
+});
+
+// ── GET /web/factory/projects/:id/audit ─────────────────────────────────
+describe('GET /web/factory/projects/:id/audit', () => {
+  it('401s when unauthenticated', async () => {
+    const res = await buildApp(null).request(`/web/factory/projects/${PROJECT_ID}/audit`);
+    expect(res.status).toBe(401);
+    expect(listCalls).toHaveLength(0);
+  });
+
+  it('403s for personal (no-org) accounts', async () => {
+    const res = await buildApp({ workosId: 'u1' }).request(`/web/factory/projects/${PROJECT_ID}/audit`);
+    expect(res.status).toBe(403);
+  });
+
+  it("404s when the project isn't in the caller's org", async () => {
+    seedProject({ orgId: 'other-org' });
+    const res = await buildApp(orgUser).request(`/web/factory/projects/${PROJECT_ID}/audit`);
+    expect(res.status).toBe(404);
+    expect(listCalls).toHaveLength(0);
+  });
+
+  it('404s on a non-uuid project id', async () => {
+    const res = await buildApp(orgUser).request('/web/factory/projects/not-a-uuid/audit');
+    expect(res.status).toBe(404);
+  });
+
+  it('returns the event page scoped to the org and project', async () => {
+    seedProject();
+    listResult = {
+      events: [{ id: 'e1', action: 'factory.work_item.created' }],
+      nextCursor: '2026-07-15T00:00:00.000Z_e1',
+    };
+    const res = await buildApp(orgUser).request(`/web/factory/projects/${PROJECT_ID}/audit`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(listResult);
+    expect(listCalls).toEqual([
+      {
+        orgId: 'org1',
+        githubProjectId: PROJECT_ID,
+        actions: undefined,
+        actorId: undefined,
+        before: undefined,
+        limit: undefined,
+      },
+    ]);
+    // Sanity: the guard read the real table shape.
+    expect(columnJsKey(githubProjects, 'org_id')).toBe('orgId');
+  });
+
+  it('passes actions/actor/before/limit filters through to the store', async () => {
+    seedProject();
+    const query = new URLSearchParams({
+      actions: 'factory.work_item.created, factory.git.push,',
+      actor: 'u2',
+      before: '2026-07-15T00:00:00.000Z_e9',
+      limit: '25',
+    });
+    const res = await buildApp(orgUser).request(`/web/factory/projects/${PROJECT_ID}/audit?${query}`);
+    expect(res.status).toBe(200);
+    expect(listCalls).toEqual([
+      {
+        orgId: 'org1',
+        githubProjectId: PROJECT_ID,
+        actions: ['factory.work_item.created', 'factory.git.push'],
+        actorId: 'u2',
+        before: '2026-07-15T00:00:00.000Z_e9',
+        limit: 25,
+      },
+    ]);
+  });
+
+  it('ignores an unparseable limit', async () => {
+    seedProject();
+    await buildApp(orgUser).request(`/web/factory/projects/${PROJECT_ID}/audit?limit=lots`);
+    expect(listCalls[0]?.limit).toBeUndefined();
+  });
+});
+
+// ── GET /web/audit/portal-link ───────────────────────────────────────────
+describe('GET /web/audit/portal-link', () => {
+  it('401s when unauthenticated', async () => {
+    const res = await buildApp(null).request('/web/audit/portal-link');
+    expect(res.status).toBe(401);
+  });
+
+  it('403s for personal (no-org) accounts', async () => {
+    const res = await buildApp({ workosId: 'u1' }).request('/web/audit/portal-link');
+    expect(res.status).toBe(403);
+  });
+
+  it("404s when WorkOS auth isn't configured so the UI hides the button", async () => {
+    webAuthEnabled = false;
+    const res = await buildApp(orgUser).request('/web/audit/portal-link');
+    expect(res.status).toBe(404);
+    expect(portalCalls).toHaveLength(0);
+  });
+
+  it('returns a one-time audit_logs portal URL for the org', async () => {
+    webAuthEnabled = true;
+    const res = await buildApp(orgUser).request('/web/audit/portal-link');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ url: 'https://portal.workos.com/one-time-link' });
+    expect(portalCalls).toEqual([
+      { orgId: 'org1', intent: 'audit_logs', returnUrl: 'https://web.example.com/factory/audit' },
+    ]);
+  });
+
+  it('502s when the portal link cannot be generated', async () => {
+    webAuthEnabled = true;
+    portalFailure = new Error('workos down');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await buildApp(orgUser).request('/web/audit/portal-link');
+    expect(res.status).toBe(502);
+    expect(warnSpy).toHaveBeenCalledWith('[Audit] Failed to generate WorkOS Admin Portal link', {
+      error: 'workos down',
+    });
+    warnSpy.mockRestore();
+  });
+});

--- a/mastracode/web/src/web/audit/routes.ts
+++ b/mastracode/web/src/web/audit/routes.ts
@@ -1,0 +1,140 @@
+/**
+ * Mastra `apiRoutes` for reading the Factory audit trail.
+ *
+ * Registered alongside the other `/web/*` routes behind the WorkOS auth gate,
+ * and only when the Factory feature is ready (audit events hang off factory
+ * mutations). Two endpoints:
+ *
+ *   - `GET /web/factory/projects/:id/audit` — org+project-scoped event list
+ *     with keyset pagination (same tenant guards as the work-item routes).
+ *   - `GET /web/audit/portal-link` — one-time WorkOS Admin Portal URL opening
+ *     the `audit_logs` viewer; 404 when WorkOS auth isn't configured so the
+ *     UI can hide the button.
+ */
+
+import { WorkOSAdminPortal } from '@mastra/auth-workos';
+import type { ApiRoute } from '@mastra/core/server';
+import { registerApiRoute } from '@mastra/core/server';
+import { and, eq } from 'drizzle-orm';
+import type { Context } from 'hono';
+
+import { ensureWebAuthUser, getWorkOSProvider, isWebAuthEnabled, webAuthTenant } from '../auth';
+import { getAppDb } from '../github/db';
+import { githubProjects } from '../github/schema';
+import { listAuditEvents } from './store';
+
+function loose(c: unknown): Context {
+  return c as Context;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const MAX_ACTION_FILTERS = 16;
+
+/** Resolve the `(orgId, userId)` tenant or a ready-to-return error response. */
+async function resolveTenant(c: Context): Promise<{ orgId: string; userId: string } | { response: Response }> {
+  await ensureWebAuthUser(c);
+  const tenant = webAuthTenant(c);
+  if (!tenant) return { response: c.json({ error: 'unauthorized' }, 401) };
+  if (!tenant.orgId) {
+    return {
+      response: c.json(
+        { error: 'organization_required', message: 'The audit trail requires a WorkOS organization.' },
+        403,
+      ),
+    };
+  }
+  return { orgId: tenant.orgId, userId: tenant.userId };
+}
+
+/** Resolve the tenant AND the org-owned project from the `:id` param. */
+async function resolveProject(
+  c: Context,
+): Promise<{ orgId: string; userId: string; projectId: string } | { response: Response }> {
+  const tenant = await resolveTenant(c);
+  if ('response' in tenant) return tenant;
+
+  const projectId = c.req.param('id');
+  if (!projectId || !UUID_RE.test(projectId)) {
+    return { response: c.json({ error: 'Project not found' }, 404) };
+  }
+  const [project] = await getAppDb()
+    .select()
+    .from(githubProjects)
+    .where(and(eq(githubProjects.id, projectId), eq(githubProjects.orgId, tenant.orgId)));
+  if (!project) {
+    return { response: c.json({ error: 'Project not found' }, 404) };
+  }
+  return { ...tenant, projectId };
+}
+
+/** Parse the `actions` query param (comma-separated) into a bounded list. */
+function parseActionsParam(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const actions = raw
+    .split(',')
+    .map(action => action.trim())
+    .filter(Boolean)
+    .slice(0, MAX_ACTION_FILTERS);
+  return actions.length > 0 ? actions : undefined;
+}
+
+/** Parse the `limit` query param, leaving clamping to the store. */
+function parseLimitParam(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const limit = Number.parseInt(raw, 10);
+  return Number.isFinite(limit) ? limit : undefined;
+}
+
+export interface AuditRoutesDeps {
+  /** Public origin used as the Admin Portal return URL base. */
+  baseUrl: string;
+}
+
+export function buildAuditRoutes(deps: AuditRoutesDeps): ApiRoute[] {
+  return [
+    registerApiRoute('/web/factory/projects/:id/audit', {
+      method: 'GET',
+      handler: async cc => {
+        const c = loose(cc);
+        const scope = await resolveProject(c);
+        if ('response' in scope) return scope.response;
+
+        const page = await listAuditEvents({
+          orgId: scope.orgId,
+          githubProjectId: scope.projectId,
+          actions: parseActionsParam(c.req.query('actions')),
+          actorId: c.req.query('actor') || undefined,
+          before: c.req.query('before') || undefined,
+          limit: parseLimitParam(c.req.query('limit')),
+        });
+        return c.json(page);
+      },
+    }),
+
+    registerApiRoute('/web/audit/portal-link', {
+      method: 'GET',
+      handler: async cc => {
+        const c = loose(cc);
+        const tenant = await resolveTenant(c);
+        if ('response' in tenant) return tenant.response;
+
+        if (!isWebAuthEnabled()) {
+          return c.json({ error: 'not_available' }, 404);
+        }
+        try {
+          const portal = new WorkOSAdminPortal(getWorkOSProvider().getWorkOS(), {
+            returnUrl: `${deps.baseUrl}/factory/audit`,
+          });
+          const url = await portal.getPortalLink(tenant.orgId, 'audit_logs');
+          return c.json({ url });
+        } catch (err) {
+          console.warn('[Audit] Failed to generate WorkOS Admin Portal link', {
+            error: err instanceof Error ? err.message : String(err),
+          });
+          return c.json({ error: 'portal_link_failed' }, 502);
+        }
+      },
+    }),
+  ];
+}

--- a/mastracode/web/src/web/audit/schema.ts
+++ b/mastracode/web/src/web/audit/schema.ts
@@ -1,0 +1,103 @@
+/**
+ * Drizzle schema for Factory audit events — the append-only "who did what,
+ * when" trail behind the software factory.
+ *
+ * One `audit_events` row records a single audited mutation (work-item change,
+ * stage move, run start, worktree create/delete, git action, intake config
+ * change). Rows are append-only: there is no update/delete API, and the table
+ * is the local source of truth even when the WorkOS Audit Logs mirror is
+ * unavailable.
+ *
+ * Tenancy is **org-first**, like `work_items`: events are scoped by `org_id`
+ * and (usually) `github_project_id`; `actor_id` records who acted but never
+ * scopes reads.
+ *
+ * v1 action taxonomy (register these in the WorkOS dashboard under
+ * Audit Logs → Events for the export mirror to accept them):
+ *   - factory.work_item.created
+ *   - factory.work_item.updated
+ *   - factory.work_item.stage_moved
+ *   - factory.work_item.deleted
+ *   - factory.run.started
+ *   - factory.worktree.created
+ *   - factory.worktree.deleted
+ *   - factory.triage.started
+ *   - factory.git.commit
+ *   - factory.git.push
+ *   - factory.git.pr_opened
+ *   - factory.intake.config_updated
+ */
+
+import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
+
+/** What an audit event acted on (WorkOS Audit Logs target shape). */
+export interface AuditTarget {
+  /** Target kind, e.g. 'work_item', 'worktree', 'issue', 'pull_request'. */
+  type: string;
+  /** Stable identifier of the target (row id, branch name, issue number...). */
+  id: string;
+  /** Human-readable label (work-item title, branch name...). */
+  name?: string;
+}
+
+/** Request context captured alongside the event. */
+export interface AuditContext {
+  /** Client IP (first hop of `x-forwarded-for`) when available. */
+  location?: string;
+  /** Request `user-agent` header when available. */
+  userAgent?: string;
+}
+
+export const auditEvents = pgTable(
+  'audit_events',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    /** Owning WorkOS organization id — the trail is org-wide. */
+    orgId: text('org_id').notNull(),
+    /** WorkOS user id of whoever performed the action. */
+    actorId: text('actor_id').notNull(),
+    /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
+    action: text('action').notNull(),
+    /** What was acted on. */
+    targets: jsonb('targets').$type<AuditTarget[]>().notNull(),
+    /** Bounded event summary — never full payloads, never secrets. */
+    metadata: jsonb('metadata').$type<Record<string, unknown>>().notNull(),
+    /** Project the event is scoped to; null for org-level events. */
+    githubProjectId: uuid('github_project_id'),
+    /** Request context (`x-forwarded-for` / `user-agent`). */
+    context: jsonb('context').$type<AuditContext>().notNull(),
+    occurredAt: timestamp('occurred_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  table => [
+    index('audit_events_org_occurred_idx').on(table.orgId, table.occurredAt),
+    index('audit_events_org_project_occurred_idx').on(table.orgId, table.githubProjectId, table.occurredAt),
+  ],
+);
+
+export type AuditEventRow = typeof auditEvents.$inferSelect;
+export type NewAuditEventRow = typeof auditEvents.$inferInsert;
+
+/**
+ * Idempotent DDL run on boot, mirroring the inline-migration pattern of
+ * `../factory/schema` (`CREATE ... IF NOT EXISTS` keeps re-runs safe; the
+ * schema only grows additively).
+ */
+export const AUDIT_MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS audit_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  org_id text NOT NULL,
+  actor_id text NOT NULL,
+  action text NOT NULL,
+  targets jsonb NOT NULL,
+  metadata jsonb NOT NULL,
+  github_project_id uuid,
+  context jsonb NOT NULL,
+  occurred_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS audit_events_org_occurred_idx
+  ON audit_events (org_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS audit_events_org_project_occurred_idx
+  ON audit_events (org_id, github_project_id, occurred_at DESC);
+`;

--- a/mastracode/web/src/web/audit/schema.ts
+++ b/mastracode/web/src/web/audit/schema.ts
@@ -26,6 +26,15 @@
  *   - factory.git.push
  *   - factory.git.pr_opened
  *   - factory.intake.config_updated
+ *
+ * v1.1 adds agent-level actions (also register these in WorkOS):
+ *   - factory.agent.commit
+ *   - factory.agent.push
+ *   - factory.agent.pr_opened
+ *
+ * Agent events carry `actor_type = 'agent'` with `actor_id = 'agent:<threadId>'`
+ * and `metadata.startedBy = <userId>` chaining accountability back to the human
+ * whose message drove the run.
  */
 
 import { index, jsonb, pgTable, text, timestamp, uuid } from 'drizzle-orm/pg-core';
@@ -39,6 +48,9 @@ export interface AuditTarget {
   /** Human-readable label (work-item title, branch name...). */
   name?: string;
 }
+
+/** Who performed the audited action. */
+export type AuditActorType = 'human' | 'agent';
 
 /** Request context captured alongside the event. */
 export interface AuditContext {
@@ -54,8 +66,10 @@ export const auditEvents = pgTable(
     id: uuid('id').primaryKey().defaultRandom(),
     /** Owning WorkOS organization id — the trail is org-wide. */
     orgId: text('org_id').notNull(),
-    /** WorkOS user id of whoever performed the action. */
+    /** WorkOS user id of whoever performed the action, or `agent:<threadId>`. */
     actorId: text('actor_id').notNull(),
+    /** Whether a human or an agent (inside a run) performed the action. */
+    actorType: text('actor_type').$type<AuditActorType>().notNull().default('human'),
     /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
     action: text('action').notNull(),
     /** What was acted on. */
@@ -100,4 +114,6 @@ CREATE INDEX IF NOT EXISTS audit_events_org_occurred_idx
 
 CREATE INDEX IF NOT EXISTS audit_events_org_project_occurred_idx
   ON audit_events (org_id, github_project_id, occurred_at DESC);
+
+ALTER TABLE audit_events ADD COLUMN IF NOT EXISTS actor_type text NOT NULL DEFAULT 'human';
 `;

--- a/mastracode/web/src/web/audit/store.test.ts
+++ b/mastracode/web/src/web/audit/store.test.ts
@@ -130,6 +130,20 @@ describe('recordAuditEvent', () => {
     expect(rows).toHaveLength(1);
   });
 
+  it('defaults actorType to human', async () => {
+    const row = await recordAuditEvent(baseEvent());
+    expect(row!.actorType).toBe('human');
+  });
+
+  it('stores an agent actorType when provided', async () => {
+    const row = await recordAuditEvent(
+      baseEvent({ actorId: 'agent:thread-1', actorType: 'agent', metadata: { startedBy: 'user_abc' } }),
+    );
+    expect(row!.actorType).toBe('agent');
+    expect(row!.actorId).toBe('agent:thread-1');
+    expect(row!.metadata).toEqual({ startedBy: 'user_abc' });
+  });
+
   it('stores metadata and context when provided', async () => {
     const row = await recordAuditEvent(
       baseEvent({

--- a/mastracode/web/src/web/audit/store.test.ts
+++ b/mastracode/web/src/web/audit/store.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+vi.mock('drizzle-orm', async () => {
+  const actual = (await vi.importActual('drizzle-orm')) as Record<string, unknown>;
+  return {
+    ...actual,
+    eq: (column: any, value: any) => ({ kind: 'eq', column: column?.name, value }),
+    and: (...conds: any[]) => ({ kind: 'and', conds: conds.filter(Boolean) }),
+    or: (...conds: any[]) => ({ kind: 'or', conds: conds.filter(Boolean) }),
+    lt: (column: any, value: any) => ({ kind: 'lt', column: column?.name, value }),
+    inArray: (column: any, values: any[]) => ({ kind: 'in', column: column?.name, values }),
+    desc: (column: any) => ({ kind: 'desc', column: column?.name }),
+  };
+});
+
+// In-memory audit_events rows.
+let rows: Array<Record<string, any>> = [];
+let nextId = 1;
+let failNextInsert = false;
+
+const COLUMNS: Record<string, string> = {
+  id: 'id',
+  org_id: 'orgId',
+  actor_id: 'actorId',
+  action: 'action',
+  github_project_id: 'githubProjectId',
+  occurred_at: 'occurredAt',
+};
+
+function valueOf(row: any, column: string): any {
+  return row[COLUMNS[column] ?? column];
+}
+
+function compare(a: any, b: any): number {
+  if (a instanceof Date && b instanceof Date) return a.getTime() - b.getTime();
+  if (a === b) return 0;
+  return a < b ? -1 : 1;
+}
+
+function matches(row: any, cond: any): boolean {
+  if (!cond) return true;
+  if (cond.kind === 'and') return cond.conds.every((c: any) => matches(row, c));
+  if (cond.kind === 'or') return cond.conds.some((c: any) => matches(row, c));
+  if (cond.kind === 'eq') return compare(valueOf(row, cond.column), cond.value) === 0;
+  if (cond.kind === 'lt') return compare(valueOf(row, cond.column), cond.value) < 0;
+  if (cond.kind === 'in') return cond.values.includes(valueOf(row, cond.column));
+  return true;
+}
+
+vi.mock('../github/db', () => ({
+  getAppDb: () => ({
+    execute: async () => undefined,
+    insert: () => ({
+      values: (vals: any) => ({
+        returning: async () => {
+          if (failNextInsert) {
+            failNextInsert = false;
+            throw new Error('insert exploded');
+          }
+          const row = { id: `00000000-0000-4000-8000-${String(nextId++).padStart(12, '0')}`, ...vals };
+          rows.push(row);
+          return [row];
+        },
+      }),
+    }),
+    select: () => ({
+      from: () => ({
+        where: (cond: any) => ({
+          orderBy: (...orders: any[]) => ({
+            limit: async (n: number) => {
+              const filtered = rows.filter(row => matches(row, cond));
+              filtered.sort((a, b) => {
+                for (const order of orders) {
+                  const diff = compare(valueOf(a, order.column), valueOf(b, order.column));
+                  if (diff !== 0) return -diff; // all orders are desc
+                }
+                return 0;
+              });
+              return filtered.slice(0, n);
+            },
+          }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+import { __resetAuditDbForTests } from './db';
+import { listAuditEvents, recordAuditEvent } from './store';
+
+const ORG = 'org_123';
+const ACTOR = 'user_abc';
+const PROJECT = '11111111-1111-4111-8111-111111111111';
+
+function baseEvent(overrides: Record<string, any> = {}) {
+  return {
+    orgId: ORG,
+    actorId: ACTOR,
+    action: 'factory.work_item.created',
+    targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix login' }],
+    githubProjectId: PROJECT,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  rows = [];
+  nextId = 1;
+  failNextInsert = false;
+  __resetAuditDbForTests();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('recordAuditEvent', () => {
+  it('appends a row with defaults for optional fields', async () => {
+    const row = await recordAuditEvent(baseEvent());
+    expect(row).not.toBeNull();
+    expect(row!.orgId).toBe(ORG);
+    expect(row!.actorId).toBe(ACTOR);
+    expect(row!.action).toBe('factory.work_item.created');
+    expect(row!.targets).toEqual([{ type: 'work_item', id: 'wi-1', name: 'Fix login' }]);
+    expect(row!.metadata).toEqual({});
+    expect(row!.context).toEqual({});
+    expect(row!.occurredAt).toBeInstanceOf(Date);
+    expect(rows).toHaveLength(1);
+  });
+
+  it('stores metadata and context when provided', async () => {
+    const row = await recordAuditEvent(
+      baseEvent({
+        metadata: { fromStages: ['intake'], toStages: ['triage'] },
+        context: { location: '10.0.0.1', userAgent: 'vitest' },
+      }),
+    );
+    expect(row!.metadata).toEqual({ fromStages: ['intake'], toStages: ['triage'] });
+    expect(row!.context).toEqual({ location: '10.0.0.1', userAgent: 'vitest' });
+  });
+
+  it('replaces oversized metadata with a truncation marker instead of dropping the event', async () => {
+    const row = await recordAuditEvent(baseEvent({ metadata: { blob: 'x'.repeat(10_000) } }));
+    expect(row).not.toBeNull();
+    expect(row!.metadata).toEqual({ truncated: true });
+  });
+
+  it('swallows insert failures and returns null', async () => {
+    failNextInsert = true;
+    const row = await recordAuditEvent(baseEvent());
+    expect(row).toBeNull();
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Audit] Failed to record audit event',
+      expect.objectContaining({ action: 'factory.work_item.created' }),
+    );
+    // The failure never propagates — a later record works fine.
+    expect(await recordAuditEvent(baseEvent())).not.toBeNull();
+  });
+});
+
+describe('listAuditEvents', () => {
+  it('returns the org events newest-first and excludes other orgs', async () => {
+    await recordAuditEvent(baseEvent({ occurredAt: new Date('2026-07-01T10:00:00Z') }));
+    await recordAuditEvent(baseEvent({ occurredAt: new Date('2026-07-02T10:00:00Z'), action: 'factory.git.push' }));
+    await recordAuditEvent(baseEvent({ orgId: 'org_other' }));
+
+    const page = await listAuditEvents({ orgId: ORG });
+    expect(page.events.map(e => e.action)).toEqual(['factory.git.push', 'factory.work_item.created']);
+    expect(page.nextCursor).toBeUndefined();
+  });
+
+  it('filters by project, actions and actor', async () => {
+    await recordAuditEvent(baseEvent());
+    await recordAuditEvent(baseEvent({ githubProjectId: '22222222-2222-4222-8222-222222222222' }));
+    await recordAuditEvent(baseEvent({ action: 'factory.worktree.deleted' }));
+    await recordAuditEvent(baseEvent({ actorId: 'user_other' }));
+
+    const byProject = await listAuditEvents({ orgId: ORG, githubProjectId: PROJECT });
+    expect(byProject.events).toHaveLength(3);
+
+    const byAction = await listAuditEvents({ orgId: ORG, actions: ['factory.worktree.deleted'] });
+    expect(byAction.events).toHaveLength(1);
+    expect(byAction.events[0]!.action).toBe('factory.worktree.deleted');
+
+    const byActor = await listAuditEvents({ orgId: ORG, actorId: 'user_other' });
+    expect(byActor.events).toHaveLength(1);
+    expect(byActor.events[0]!.actorId).toBe('user_other');
+  });
+
+  it('paginates with a keyset cursor and ends without one', async () => {
+    for (let i = 1; i <= 5; i++) {
+      await recordAuditEvent(baseEvent({ occurredAt: new Date(`2026-07-0${i}T10:00:00Z`) }));
+    }
+
+    const first = await listAuditEvents({ orgId: ORG, limit: 2 });
+    expect(first.events).toHaveLength(2);
+    expect(first.nextCursor).toBeDefined();
+
+    const second = await listAuditEvents({ orgId: ORG, limit: 2, before: first.nextCursor });
+    expect(second.events).toHaveLength(2);
+    expect(second.nextCursor).toBeDefined();
+
+    const third = await listAuditEvents({ orgId: ORG, limit: 2, before: second.nextCursor });
+    expect(third.events).toHaveLength(1);
+    expect(third.nextCursor).toBeUndefined();
+
+    const seen = [...first.events, ...second.events, ...third.events].map(e => e.occurredAt.toISOString());
+    expect(seen).toEqual([...seen].sort().reverse());
+    expect(new Set(seen).size).toBe(5);
+  });
+
+  it('breaks occurredAt ties by id so pages never skip or repeat rows', async () => {
+    const at = new Date('2026-07-01T10:00:00Z');
+    for (let i = 0; i < 3; i++) await recordAuditEvent(baseEvent({ occurredAt: at }));
+
+    const first = await listAuditEvents({ orgId: ORG, limit: 2 });
+    const second = await listAuditEvents({ orgId: ORG, limit: 2, before: first.nextCursor });
+    const ids = [...first.events, ...second.events].map(e => e.id);
+    expect(new Set(ids).size).toBe(3);
+  });
+
+  it('ignores malformed cursors and clamps limits', async () => {
+    for (let i = 1; i <= 3; i++) {
+      await recordAuditEvent(baseEvent({ occurredAt: new Date(`2026-07-0${i}T10:00:00Z`) }));
+    }
+    const page = await listAuditEvents({ orgId: ORG, before: 'not-a-cursor', limit: 0 });
+    expect(page.events).toHaveLength(1); // limit clamped up to 1
+  });
+});

--- a/mastracode/web/src/web/audit/store.ts
+++ b/mastracode/web/src/web/audit/store.ts
@@ -1,0 +1,144 @@
+/**
+ * Persistence for Factory audit events.
+ *
+ * `recordAuditEvent` is deliberately swallow-on-failure: auditing must never
+ * break the mutation it observes, so insert errors are logged with an
+ * `[Audit]` prefix and dropped. Reads are cursor-paginated newest-first.
+ */
+
+import { and, desc, eq, inArray, lt, or } from 'drizzle-orm';
+import type { SQL } from 'drizzle-orm';
+
+import { getAppDb } from '../github/db';
+import { ensureAuditDbReady } from './db';
+import { auditEvents } from './schema';
+import type { AuditContext, AuditEventRow, AuditTarget } from './schema';
+
+/** Metadata is a bounded summary — never full payloads, never secrets. */
+const MAX_METADATA_JSON_LENGTH = 4096;
+
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
+
+export interface RecordAuditEventInput {
+  orgId: string;
+  actorId: string;
+  /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
+  action: string;
+  targets: AuditTarget[];
+  metadata?: Record<string, unknown>;
+  githubProjectId?: string;
+  context?: AuditContext;
+  occurredAt?: Date;
+}
+
+/** Truncate oversized metadata rather than dropping the whole event. */
+function boundMetadata(metadata: Record<string, unknown> | undefined): Record<string, unknown> {
+  if (!metadata) return {};
+  try {
+    if (JSON.stringify(metadata).length <= MAX_METADATA_JSON_LENGTH) return metadata;
+  } catch {
+    return { truncated: true };
+  }
+  return { truncated: true };
+}
+
+/**
+ * Append one audit event. Failures are logged and swallowed — auditing never
+ * breaks the factory. Returns the inserted row, or `null` on failure.
+ */
+export async function recordAuditEvent(input: RecordAuditEventInput): Promise<AuditEventRow | null> {
+  try {
+    await ensureAuditDbReady();
+    const [inserted] = await getAppDb()
+      .insert(auditEvents)
+      .values({
+        orgId: input.orgId,
+        actorId: input.actorId,
+        action: input.action,
+        targets: input.targets,
+        metadata: boundMetadata(input.metadata),
+        githubProjectId: input.githubProjectId ?? null,
+        context: input.context ?? {},
+        occurredAt: input.occurredAt ?? new Date(),
+      })
+      .returning();
+    return inserted ?? null;
+  } catch (err) {
+    console.warn('[Audit] Failed to record audit event', {
+      action: input.action,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
+}
+
+export interface ListAuditEventsInput {
+  orgId: string;
+  githubProjectId?: string;
+  /** Restrict to these actions (exact match). */
+  actions?: string[];
+  actorId?: string;
+  /** Opaque cursor from a previous page (`nextCursor`). */
+  before?: string;
+  limit?: number;
+}
+
+export interface AuditEventPage {
+  events: AuditEventRow[];
+  /** Pass back as `before` to fetch the next (older) page; absent at the end. */
+  nextCursor?: string;
+}
+
+/** Encode the `(occurredAt, id)` keyset cursor of a row. */
+function encodeCursor(row: AuditEventRow): string {
+  return `${row.occurredAt.toISOString()}_${row.id}`;
+}
+
+/** Decode a cursor back into its `(occurredAt, id)` parts, or `undefined`. */
+function decodeCursor(cursor: string): { occurredAt: Date; id: string } | undefined {
+  const sep = cursor.lastIndexOf('_');
+  if (sep <= 0) return undefined;
+  const occurredAt = new Date(cursor.slice(0, sep));
+  const id = cursor.slice(sep + 1);
+  if (Number.isNaN(occurredAt.getTime()) || !id) return undefined;
+  return { occurredAt, id };
+}
+
+/** List an org's audit events newest-first with keyset pagination. */
+export async function listAuditEvents(input: ListAuditEventsInput): Promise<AuditEventPage> {
+  await ensureAuditDbReady();
+  const limit = Math.min(Math.max(input.limit ?? DEFAULT_PAGE_SIZE, 1), MAX_PAGE_SIZE);
+
+  const conditions: (SQL | undefined)[] = [eq(auditEvents.orgId, input.orgId)];
+  if (input.githubProjectId) conditions.push(eq(auditEvents.githubProjectId, input.githubProjectId));
+  if (input.actions && input.actions.length > 0) conditions.push(inArray(auditEvents.action, input.actions));
+  if (input.actorId) conditions.push(eq(auditEvents.actorId, input.actorId));
+
+  if (input.before) {
+    const cursor = decodeCursor(input.before);
+    if (cursor) {
+      conditions.push(
+        or(
+          lt(auditEvents.occurredAt, cursor.occurredAt),
+          and(eq(auditEvents.occurredAt, cursor.occurredAt), lt(auditEvents.id, cursor.id)),
+        ),
+      );
+    }
+  }
+
+  const rows = await getAppDb()
+    .select()
+    .from(auditEvents)
+    .where(and(...conditions))
+    .orderBy(desc(auditEvents.occurredAt), desc(auditEvents.id))
+    .limit(limit + 1);
+
+  const events = rows.slice(0, limit);
+  const hasMore = rows.length > limit;
+  const last = events[events.length - 1];
+  return {
+    events,
+    ...(hasMore && last ? { nextCursor: encodeCursor(last) } : {}),
+  };
+}

--- a/mastracode/web/src/web/audit/store.ts
+++ b/mastracode/web/src/web/audit/store.ts
@@ -12,7 +12,7 @@ import type { SQL } from 'drizzle-orm';
 import { getAppDb } from '../github/db';
 import { ensureAuditDbReady } from './db';
 import { auditEvents } from './schema';
-import type { AuditContext, AuditEventRow, AuditTarget } from './schema';
+import type { AuditActorType, AuditContext, AuditEventRow, AuditTarget } from './schema';
 
 /** Metadata is a bounded summary — never full payloads, never secrets. */
 const MAX_METADATA_JSON_LENGTH = 4096;
@@ -23,6 +23,8 @@ const MAX_PAGE_SIZE = 200;
 export interface RecordAuditEventInput {
   orgId: string;
   actorId: string;
+  /** Who performed the action; defaults to 'human'. */
+  actorType?: AuditActorType;
   /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
   action: string;
   targets: AuditTarget[];
@@ -55,6 +57,7 @@ export async function recordAuditEvent(input: RecordAuditEventInput): Promise<Au
       .values({
         orgId: input.orgId,
         actorId: input.actorId,
+        actorType: input.actorType ?? 'human',
         action: input.action,
         targets: input.targets,
         metadata: boundMetadata(input.metadata),

--- a/mastracode/web/src/web/audit/workos-sink.test.ts
+++ b/mastracode/web/src/web/audit/workos-sink.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const createEvent = vi.fn(async () => undefined);
+
+vi.mock('../auth', async () => {
+  const actual = (await vi.importActual('../auth')) as Record<string, unknown>;
+  return {
+    ...actual,
+    getWorkOSProvider: () => ({ getWorkOS: () => ({ auditLogs: { createEvent } }) }),
+  };
+});
+
+import type { AuditEventRow } from './schema';
+import { forwardToWorkOS, toWorkOSEvent } from './workos-sink';
+
+function makeRow(overrides: Partial<AuditEventRow> = {}): AuditEventRow {
+  return {
+    id: '00000000-0000-4000-8000-000000000001',
+    orgId: 'org_123',
+    actorId: 'user_abc',
+    action: 'factory.work_item.stage_moved',
+    targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix login' }],
+    metadata: { fromStages: ['intake'], toStages: ['triage'], count: 2, ok: true },
+    githubProjectId: '11111111-1111-4111-8111-111111111111',
+    context: { location: '10.0.0.1', userAgent: 'vitest' },
+    occurredAt: new Date('2026-07-15T12:00:00Z'),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  createEvent.mockClear();
+  vi.spyOn(console, 'warn').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env.WORKOS_API_KEY;
+  delete process.env.WORKOS_CLIENT_ID;
+});
+
+describe('toWorkOSEvent', () => {
+  it('maps the local row to the WorkOS createEvent payload', () => {
+    const event = toWorkOSEvent(makeRow());
+    expect(event).toEqual({
+      action: 'factory.work_item.stage_moved',
+      occurredAt: new Date('2026-07-15T12:00:00Z'),
+      actor: { type: 'user', id: 'user_abc' },
+      targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix login' }],
+      context: { location: '10.0.0.1', userAgent: 'vitest' },
+      metadata: { fromStages: '["intake"]', toStages: '["triage"]', count: 2, ok: true },
+    });
+  });
+
+  it('falls back to an unknown location and drops null metadata values', () => {
+    const event = toWorkOSEvent(makeRow({ context: {}, metadata: { a: null, b: undefined, keep: 'yes' } }));
+    expect(event.context).toEqual({ location: 'unknown' });
+    expect(event.metadata).toEqual({ keep: 'yes' });
+  });
+});
+
+describe('forwardToWorkOS', () => {
+  it('is a no-op when WorkOS auth is not configured', async () => {
+    await forwardToWorkOS(makeRow());
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it('forwards the mapped event scoped to the org when configured', async () => {
+    process.env.WORKOS_API_KEY = 'sk_test';
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+
+    await forwardToWorkOS(makeRow());
+    expect(createEvent).toHaveBeenCalledTimes(1);
+    expect(createEvent).toHaveBeenCalledWith(
+      'org_123',
+      expect.objectContaining({ action: 'factory.work_item.stage_moved', actor: { type: 'user', id: 'user_abc' } }),
+    );
+  });
+
+  it('never throws when the WorkOS call rejects (e.g. unregistered action)', async () => {
+    process.env.WORKOS_API_KEY = 'sk_test';
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+    createEvent.mockRejectedValueOnce(new Error('Invalid Audit Log event'));
+
+    await expect(forwardToWorkOS(makeRow())).resolves.toBeUndefined();
+    expect(console.warn).toHaveBeenCalledWith(
+      '[Audit] Failed to forward audit event to WorkOS',
+      expect.objectContaining({ action: 'factory.work_item.stage_moved' }),
+    );
+  });
+});

--- a/mastracode/web/src/web/audit/workos-sink.test.ts
+++ b/mastracode/web/src/web/audit/workos-sink.test.ts
@@ -18,6 +18,7 @@ function makeRow(overrides: Partial<AuditEventRow> = {}): AuditEventRow {
     id: '00000000-0000-4000-8000-000000000001',
     orgId: 'org_123',
     actorId: 'user_abc',
+    actorType: 'human',
     action: 'factory.work_item.stage_moved',
     targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix login' }],
     metadata: { fromStages: ['intake'], toStages: ['triage'], count: 2, ok: true },
@@ -50,6 +51,11 @@ describe('toWorkOSEvent', () => {
       context: { location: '10.0.0.1', userAgent: 'vitest' },
       metadata: { fromStages: '["intake"]', toStages: '["triage"]', count: 2, ok: true },
     });
+  });
+
+  it('maps agent rows to an agent actor type', () => {
+    const event = toWorkOSEvent(makeRow({ actorId: 'agent:thread-1', actorType: 'agent' }));
+    expect(event.actor).toEqual({ type: 'agent', id: 'agent:thread-1' });
   });
 
   it('falls back to an unknown location and drops null metadata values', () => {

--- a/mastracode/web/src/web/audit/workos-sink.ts
+++ b/mastracode/web/src/web/audit/workos-sink.ts
@@ -46,7 +46,7 @@ export function toWorkOSEvent(event: AuditEventRow): {
   return {
     action: event.action,
     occurredAt: event.occurredAt,
-    actor: { type: 'user', id: event.actorId },
+    actor: { type: event.actorType === 'agent' ? 'agent' : 'user', id: event.actorId },
     targets: event.targets.map(target => ({
       type: target.type,
       id: target.id,

--- a/mastracode/web/src/web/audit/workos-sink.ts
+++ b/mastracode/web/src/web/audit/workos-sink.ts
@@ -1,0 +1,79 @@
+/**
+ * Best-effort mirror of local audit events into WorkOS Audit Logs.
+ *
+ * When WorkOS auth is configured, every locally-recorded audit event is also
+ * forwarded to `workos.auditLogs.createEvent()` so enterprises get the WorkOS
+ * Admin Portal viewer/export and SIEM log streams. Forwarding is
+ * fire-and-forget: failures (including actions not yet registered in the
+ * WorkOS dashboard under Audit Logs → Events) are logged with an `[Audit]`
+ * prefix and dropped — the local `audit_events` table remains the source of
+ * truth.
+ */
+
+import { getWorkOSProvider, isWebAuthEnabled } from '../auth';
+import type { AuditEventRow } from './schema';
+
+/** WorkOS requires a `context.location`; fall back when the request had none. */
+const UNKNOWN_LOCATION = 'unknown';
+
+/** Flatten metadata to the primitive record WorkOS accepts. */
+function flattenMetadata(metadata: Record<string, unknown>): Record<string, string | number | boolean> {
+  const flat: Record<string, string | number | boolean> = {};
+  for (const [key, value] of Object.entries(metadata)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      flat[key] = value;
+    } else {
+      try {
+        flat[key] = JSON.stringify(value);
+      } catch {
+        // Unserializable value — drop the key rather than the event.
+      }
+    }
+  }
+  return flat;
+}
+
+/** Map a local audit row to the WorkOS `createEvent` payload. */
+export function toWorkOSEvent(event: AuditEventRow): {
+  action: string;
+  occurredAt: Date;
+  actor: { type: string; id: string };
+  targets: Array<{ type: string; id: string; name?: string }>;
+  context: { location: string; userAgent?: string };
+  metadata: Record<string, string | number | boolean>;
+} {
+  return {
+    action: event.action,
+    occurredAt: event.occurredAt,
+    actor: { type: 'user', id: event.actorId },
+    targets: event.targets.map(target => ({
+      type: target.type,
+      id: target.id,
+      ...(target.name !== undefined ? { name: target.name } : {}),
+    })),
+    context: {
+      location: event.context.location ?? UNKNOWN_LOCATION,
+      ...(event.context.userAgent !== undefined ? { userAgent: event.context.userAgent } : {}),
+    },
+    metadata: flattenMetadata(event.metadata),
+  };
+}
+
+/**
+ * Forward one recorded audit event to WorkOS Audit Logs. Never throws; no-op
+ * when WorkOS auth isn't configured. Fire-and-forget — callers should not
+ * await this on the request path.
+ */
+export async function forwardToWorkOS(event: AuditEventRow): Promise<void> {
+  if (!isWebAuthEnabled()) return;
+  try {
+    const workos = getWorkOSProvider().getWorkOS();
+    await workos.auditLogs.createEvent(event.orgId, toWorkOSEvent(event));
+  } catch (err) {
+    console.warn('[Audit] Failed to forward audit event to WorkOS', {
+      action: event.action,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}

--- a/mastracode/web/src/web/auth.ts
+++ b/mastracode/web/src/web/auth.ts
@@ -109,6 +109,16 @@ function getSessionProvider(): MastraAuthWorkos {
   return sessionProvider;
 }
 
+/**
+ * Shared module-level WorkOS auth provider, exposed for features that need the
+ * raw WorkOS client (audit-log export, Admin Portal links). Callers must gate
+ * on {@link isWebAuthEnabled} first — constructing the provider without the
+ * WorkOS env vars throws.
+ */
+export function getWorkOSProvider(): MastraAuthWorkos {
+  return getSessionProvider();
+}
+
 /** Build a predictable personal-org name from the user's profile. */
 function personalOrgName(user: WebAuthUser, userId: string): string {
   const label = user.email ?? user.name ?? userId;

--- a/mastracode/web/src/web/factory/routes.test.ts
+++ b/mastracode/web/src/web/factory/routes.test.ts
@@ -117,12 +117,19 @@ vi.mock('../github/db', () => {
       }),
     }),
     delete: (table: any) => ({
-      where: async (cond: any) => {
-        const rows = rowsOf(table);
-        const remaining = rows.filter(row => !matches(table, row, cond));
-        rows.length = 0;
-        rows.push(...remaining);
-      },
+      where: (cond: any) => ({
+        returning: async () => {
+          // Yield like the select does so concurrent deletes interleave and
+          // only one caller wins the row (regression coverage for atomicity).
+          await new Promise(resolve => setTimeout(resolve, 0));
+          const rows = rowsOf(table);
+          const deleted = rows.filter(row => matches(table, row, cond));
+          const remaining = rows.filter(row => !matches(table, row, cond));
+          rows.length = 0;
+          rows.push(...remaining);
+          return deleted;
+        },
+      }),
     }),
     transaction: (fn: (tx: any) => Promise<unknown>) => {
       const run = txTail.then(() => fn(makeDbClient()));
@@ -478,6 +485,28 @@ describe('audit events', () => {
       targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
       metadata: { source: 'github-issue', sourceKey: 'github-issue:42', stages: ['intake'] },
     });
+  });
+
+  it('records updated (not created) when a POST reuses an existing sourceKey', async () => {
+    const item = await createItem();
+    auditRecorded = [];
+
+    const session = { projectPath: '/sb/wt/issue-42', branch: 'factory/issue-42', threadId: 't-1' };
+    await json(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/work-items`,
+      createBody({ stages: ['execute'], sessions: { work: session } }),
+    );
+    expect(auditRecorded.map(e => e.action)).toEqual([
+      'factory.work_item.updated',
+      'factory.work_item.stage_moved',
+      'factory.run.started',
+    ]);
+    expect(auditRecorded[1]).toMatchObject({
+      targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
+      metadata: { from: ['intake'], to: ['execute'] },
+    });
+    expect(auditRecorded[2].metadata).toMatchObject({ role: 'work', branch: 'factory/issue-42' });
   });
 
   it('records updated + stage_moved with the server-diffed from/to on a stage PATCH', async () => {

--- a/mastracode/web/src/web/factory/routes.test.ts
+++ b/mastracode/web/src/web/factory/routes.test.ts
@@ -45,6 +45,27 @@ function rowsOf(table: any): Array<Record<string, any>> {
 // for the previous one to finish, so a locked read always sees prior writes.
 let txTail: Promise<unknown> = Promise.resolve();
 
+// Capture audit events at the store boundary so the real `emitAudit` path
+// (actor resolution, request context, never-throws) is exercised end to end.
+let auditRecorded: Array<Record<string, any>> = [];
+let auditFailure: Error | undefined;
+
+vi.mock('../audit/store', () => ({
+  recordAuditEvent: async (input: any) => {
+    if (auditFailure) throw auditFailure;
+    auditRecorded.push(input);
+    return {
+      id: `00000000-0000-4000-9000-${String(auditRecorded.length).padStart(12, '0')}`,
+      occurredAt: new Date(),
+      ...input,
+      githubProjectId: input.githubProjectId ?? null,
+      metadata: input.metadata ?? {},
+      context: input.context ?? {},
+    };
+  },
+  listAuditEvents: async () => ({ events: [] }),
+}));
+
 vi.mock('../github/db', () => {
   const makeDbClient = (): any => ({
     select: () => ({
@@ -155,6 +176,8 @@ beforeEach(() => {
   tables = {};
   nextId = 1;
   txTail = Promise.resolve();
+  auditRecorded = [];
+  auditFailure = undefined;
   seedProject();
 });
 
@@ -434,6 +457,101 @@ describe('GET /web/factory/projects/:id/metrics', () => {
     expect(metrics.cycleTime).toEqual({ medianMs: null, p90Ms: null, samples: 0 });
     expect(metrics.wip).toEqual([]);
     expect(metrics.agingWip).toEqual([]);
+  });
+});
+
+// ── Audit events ─────────────────────────────────────────────────────────
+describe('audit events', () => {
+  async function createItem(overrides: Record<string, unknown> = {}) {
+    const res = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody(overrides));
+    return (await res.json()).workItem;
+  }
+
+  it('records work_item.created on POST with actor, project, and target', async () => {
+    const item = await createItem();
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      orgId: 'org1',
+      actorId: 'u1',
+      action: 'factory.work_item.created',
+      githubProjectId: PROJECT_ID,
+      targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
+      metadata: { source: 'github-issue', sourceKey: 'github-issue:42', stages: ['intake'] },
+    });
+  });
+
+  it('records updated + stage_moved with the server-diffed from/to on a stage PATCH', async () => {
+    const item = await createItem();
+    auditRecorded = [];
+
+    await json('PATCH', `/web/factory/work-items/${item.id}`, { stages: ['execute'] });
+    expect(auditRecorded.map(e => e.action)).toEqual(['factory.work_item.updated', 'factory.work_item.stage_moved']);
+    expect(auditRecorded[0].metadata).toEqual({ fields: ['stages'] });
+    expect(auditRecorded[1]).toMatchObject({
+      githubProjectId: PROJECT_ID,
+      targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
+      metadata: { from: ['intake'], to: ['execute'] },
+    });
+  });
+
+  it('records run.started when a PATCH introduces a new session role, but not on re-file', async () => {
+    const item = await createItem();
+    auditRecorded = [];
+
+    const session = { projectPath: '/sb/wt/issue-42', branch: 'factory/issue-42', threadId: 't-1' };
+    await json('PATCH', `/web/factory/work-items/${item.id}`, { sessions: { work: session } });
+    expect(auditRecorded.map(e => e.action)).toEqual(['factory.work_item.updated', 'factory.run.started']);
+    expect(auditRecorded[1].metadata).toEqual({
+      role: 'work',
+      branch: 'factory/issue-42',
+      threadId: 't-1',
+      projectPath: '/sb/wt/issue-42',
+    });
+
+    // Re-filing the same role is not a new run.
+    auditRecorded = [];
+    await json('PATCH', `/web/factory/work-items/${item.id}`, { sessions: { work: session } });
+    expect(auditRecorded.map(e => e.action)).toEqual(['factory.work_item.updated']);
+  });
+
+  it('records only updated when the patch does not move stages', async () => {
+    const item = await createItem();
+    auditRecorded = [];
+
+    await json('PATCH', `/web/factory/work-items/${item.id}`, { title: 'Renamed card' });
+    expect(auditRecorded.map(e => e.action)).toEqual(['factory.work_item.updated']);
+    expect(auditRecorded[0].metadata).toEqual({ fields: ['title'] });
+  });
+
+  it('records work_item.deleted on DELETE', async () => {
+    const item = await createItem();
+    auditRecorded = [];
+
+    await json('DELETE', `/web/factory/work-items/${item.id}`);
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      action: 'factory.work_item.deleted',
+      githubProjectId: PROJECT_ID,
+      targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
+    });
+  });
+
+  it('never blocks the mutation when the audit insert throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    auditFailure = new Error('audit db down');
+
+    const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
+    expect(created.status).toBe(200);
+    const { workItem } = await created.json();
+
+    const patched = await json('PATCH', `/web/factory/work-items/${workItem.id}`, { stages: ['done'] });
+    expect(patched.status).toBe(200);
+
+    const deleted = await json('DELETE', `/web/factory/work-items/${workItem.id}`);
+    expect(deleted.status).toBe(200);
+    expect(tables['work_items']).toHaveLength(0);
+
+    warn.mockRestore();
   });
 });
 

--- a/mastracode/web/src/web/factory/routes.ts
+++ b/mastracode/web/src/web/factory/routes.ts
@@ -12,10 +12,13 @@ import { registerApiRoute } from '@mastra/core/server';
 import { and, eq } from 'drizzle-orm';
 import type { Context } from 'hono';
 
+import { emitAudit } from '../audit/audit';
 import { ensureWebAuthUser, webAuthTenant } from '../auth';
 import { getAppDb } from '../github/db';
 import { githubProjects } from '../github/schema';
 import { clampMetricsWindow, computeFactoryMetrics } from './metrics';
+import type { WorkItemRow } from './schema';
+import type { WorkItemPriorState } from './store';
 import {
   deleteWorkItem,
   listWorkItems,
@@ -80,6 +83,59 @@ async function readJson(c: Context): Promise<unknown | undefined> {
   }
 }
 
+/** Fields a PATCH touched, for the bounded `updated` event summary. */
+function patchedFields(patch: Record<string, unknown>): string[] {
+  return Object.keys(patch).filter(key => patch[key] !== undefined);
+}
+
+/**
+ * Emit the audit events a successful work-item PATCH implies: always
+ * `updated`, plus `stage_moved` when the stages actually changed and one
+ * `run.started` per session role the patch introduced.
+ */
+async function auditWorkItemPatch(
+  c: Context,
+  item: WorkItemRow,
+  previous: WorkItemPriorState,
+  patch: Record<string, unknown>,
+): Promise<void> {
+  const target = { type: 'work_item', id: item.id, name: item.title };
+  await emitAudit(c, {
+    action: 'factory.work_item.updated',
+    projectId: item.githubProjectId,
+    targets: [target],
+    metadata: { fields: patchedFields(patch) },
+  });
+
+  const stagesChanged =
+    patch.stages !== undefined &&
+    (previous.stages.length !== item.stages.length || previous.stages.some((s, i) => s !== item.stages[i]));
+  if (stagesChanged) {
+    await emitAudit(c, {
+      action: 'factory.work_item.stage_moved',
+      projectId: item.githubProjectId,
+      targets: [target],
+      metadata: { from: previous.stages, to: item.stages },
+    });
+  }
+
+  const newRoles = Object.keys(item.sessions).filter(role => !previous.sessionRoles.includes(role));
+  for (const role of newRoles) {
+    const session = item.sessions[role];
+    await emitAudit(c, {
+      action: 'factory.run.started',
+      projectId: item.githubProjectId,
+      targets: [target],
+      metadata: {
+        role,
+        branch: session?.branch,
+        threadId: session?.threadId,
+        projectPath: session?.projectPath,
+      },
+    });
+  }
+}
+
 /** Build the Factory work-item routes as Mastra `apiRoutes`. */
 export function buildFactoryRoutes(): ApiRoute[] {
   return [
@@ -127,6 +183,12 @@ export function buildFactoryRoutes(): ApiRoute[] {
           githubProjectId: resolved.projectId,
           input,
         });
+        await emitAudit(loose(c), {
+          action: 'factory.work_item.created',
+          projectId: resolved.projectId,
+          targets: [{ type: 'work_item', id: item.id, name: item.title }],
+          metadata: { source: item.source, sourceKey: item.sourceKey, stages: item.stages },
+        });
         return c.json({ workItem: item });
       },
     }),
@@ -147,9 +209,10 @@ export function buildFactoryRoutes(): ApiRoute[] {
         const patch = parseUpdateWorkItem(body);
         if (!patch) return c.json({ error: 'invalid_work_item_patch' }, 400);
 
-        const item = await updateWorkItem(tenant.orgId, id, tenant.userId, patch);
-        if (!item) return c.json({ error: 'Work item not found' }, 404);
-        return c.json({ workItem: item });
+        const updated = await updateWorkItem(tenant.orgId, id, tenant.userId, patch);
+        if (!updated) return c.json({ error: 'Work item not found' }, 404);
+        await auditWorkItemPatch(loose(c), updated.item, updated.previous, patch as Record<string, unknown>);
+        return c.json({ workItem: updated.item });
       },
     }),
 
@@ -166,6 +229,11 @@ export function buildFactoryRoutes(): ApiRoute[] {
 
         const deleted = await deleteWorkItem(tenant.orgId, id);
         if (!deleted) return c.json({ error: 'Work item not found' }, 404);
+        await emitAudit(loose(c), {
+          action: 'factory.work_item.deleted',
+          projectId: deleted.githubProjectId,
+          targets: [{ type: 'work_item', id: deleted.id, name: deleted.title }],
+        });
         return c.json({ ok: true });
       },
     }),

--- a/mastracode/web/src/web/factory/routes.ts
+++ b/mastracode/web/src/web/factory/routes.ts
@@ -177,18 +177,25 @@ export function buildFactoryRoutes(): ApiRoute[] {
         const input = parseCreateWorkItem(body);
         if (!input) return c.json({ error: 'invalid_work_item' }, 400);
 
-        const item = await upsertWorkItem({
+        const result = await upsertWorkItem({
           orgId: resolved.orgId,
           userId: resolved.userId,
           githubProjectId: resolved.projectId,
           input,
         });
-        await emitAudit(loose(c), {
-          action: 'factory.work_item.created',
-          projectId: resolved.projectId,
-          targets: [{ type: 'work_item', id: item.id, name: item.title }],
-          metadata: { source: item.source, sourceKey: item.sourceKey, stages: item.stages },
-        });
+        const item = result.item;
+        if (result.created) {
+          await emitAudit(loose(c), {
+            action: 'factory.work_item.created',
+            projectId: resolved.projectId,
+            targets: [{ type: 'work_item', id: item.id, name: item.title }],
+            metadata: { source: item.source, sourceKey: item.sourceKey, stages: item.stages },
+          });
+        } else {
+          // Source-key reuse: the POST updated an existing card, so audit it
+          // as an update (plus stage/run events) instead of a false creation.
+          await auditWorkItemPatch(loose(c), item, result.previous, input as unknown as Record<string, unknown>);
+        }
         return c.json({ workItem: item });
       },
     }),

--- a/mastracode/web/src/web/factory/store.ts
+++ b/mastracode/web/src/web/factory/store.ts
@@ -237,9 +237,9 @@ export async function upsertWorkItem(params: {
   const { orgId, userId, githubProjectId, input } = params;
   const now = new Date();
 
-  const reuseExisting = (): Promise<WorkItemRow | null> => {
-    if (input.sourceKey === null) return Promise.resolve(null);
-    return getAppDb().transaction(tx =>
+  const reuseExisting = async (): Promise<WorkItemRow | null> => {
+    if (input.sourceKey === null) return null;
+    const updated = await getAppDb().transaction(tx =>
       applyUpdateLocked(
         tx,
         and(eq(workItems.githubProjectId, githubProjectId), eq(workItems.sourceKey, input.sourceKey!)),
@@ -248,6 +248,7 @@ export async function upsertWorkItem(params: {
         now,
       ),
     );
+    return updated?.item ?? null;
   };
 
   const reused = await reuseExisting();
@@ -284,12 +285,18 @@ export async function upsertWorkItem(params: {
 /** The transaction client drizzle hands to `db.transaction` callbacks. */
 type DbTx = Parameters<Parameters<AppDb['transaction']>[0]>[0];
 
+/** Pre-patch state returned alongside an update so callers can diff for auditing. */
+export interface WorkItemPriorState {
+  stages: string[];
+  sessionRoles: string[];
+}
+
 /**
  * Shared update path for upsert-reuse and PATCH: stage diff + merges. Must run
  * inside a transaction — the row is read with `FOR UPDATE` so concurrent
  * read-modify-writes of `stageHistory`/`sessions`/`metadata` serialize instead
  * of silently dropping each other's merges. Returns `null` when no row
- * matches `where`.
+ * matches `where`; otherwise the updated row plus the pre-patch state.
  */
 async function applyUpdateLocked(
   tx: DbTx,
@@ -297,9 +304,13 @@ async function applyUpdateLocked(
   patch: UpdateWorkItemInput,
   userId: string,
   now: Date,
-): Promise<WorkItemRow | null> {
+): Promise<{ item: WorkItemRow; previous: WorkItemPriorState } | null> {
   const [existing] = await tx.select().from(workItems).where(where).for('update');
   if (!existing) return null;
+  const previous: WorkItemPriorState = {
+    stages: [...existing.stages],
+    sessionRoles: Object.keys(existing.sessions),
+  };
   const set: Partial<WorkItemRow> = { updatedAt: now };
   if (patch.title !== undefined) set.title = patch.title;
   if (patch.url !== undefined) set.url = patch.url;
@@ -314,32 +325,33 @@ async function applyUpdateLocked(
     set.metadata = { ...existing.metadata, ...patch.metadata };
   }
   const [updated] = await tx.update(workItems).set(set).where(eq(workItems.id, existing.id)).returning();
-  return updated ?? { ...existing, ...set };
+  return { item: updated ?? { ...existing, ...set }, previous };
 }
 
 /**
  * Patch an org's work item: stage changes are diffed into history, sessions
- * and metadata are merged. Returns `null` when the item doesn't exist in the
- * caller's org.
+ * and metadata are merged. Returns the updated row plus the pre-patch stages
+ * and session roles (for audit diffing), or `null` when the item doesn't
+ * exist in the caller's org.
  */
 export async function updateWorkItem(
   orgId: string,
   id: string,
   userId: string,
   patch: UpdateWorkItemInput,
-): Promise<WorkItemRow | null> {
+): Promise<{ item: WorkItemRow; previous: WorkItemPriorState } | null> {
   return getAppDb().transaction(tx =>
     applyUpdateLocked(tx, and(eq(workItems.id, id), eq(workItems.orgId, orgId)), patch, userId, new Date()),
   );
 }
 
-/** Delete an org's work item. Returns `false` when it doesn't exist in the org. */
-export async function deleteWorkItem(orgId: string, id: string): Promise<boolean> {
+/** Delete an org's work item. Returns the deleted row, or `null` when it doesn't exist in the org. */
+export async function deleteWorkItem(orgId: string, id: string): Promise<WorkItemRow | null> {
   const [existing] = await getAppDb()
     .select()
     .from(workItems)
     .where(and(eq(workItems.id, id), eq(workItems.orgId, orgId)));
-  if (!existing) return false;
+  if (!existing) return null;
   await getAppDb().delete(workItems).where(eq(workItems.id, id));
-  return true;
+  return existing;
 }

--- a/mastracode/web/src/web/factory/store.ts
+++ b/mastracode/web/src/web/factory/store.ts
@@ -222,22 +222,29 @@ export async function listWorkItems(orgId: string, githubProjectId: string): Pro
   return rows.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
 }
 
+/** Discriminated result of `upsertWorkItem`: fresh insert vs source-key reuse. */
+export type UpsertWorkItemResult =
+  | { created: true; item: WorkItemRow }
+  | { created: false; item: WorkItemRow; previous: WorkItemPriorState };
+
 /**
  * Create a work item, reusing the existing record when `sourceKey` already has
  * one for the project (acting twice on the same issue must not duplicate the
  * card). On reuse the provided stages replace the current ones (with the
- * transition recorded in history) and sessions/metadata are merged in.
+ * transition recorded in history) and sessions/metadata are merged in. The
+ * result discriminates insert from reuse so callers can audit the actual
+ * outcome.
  */
 export async function upsertWorkItem(params: {
   orgId: string;
   userId: string;
   githubProjectId: string;
   input: CreateWorkItemInput;
-}): Promise<WorkItemRow> {
+}): Promise<UpsertWorkItemResult> {
   const { orgId, userId, githubProjectId, input } = params;
   const now = new Date();
 
-  const reuseExisting = async (): Promise<WorkItemRow | null> => {
+  const reuseExisting = async (): Promise<UpsertWorkItemResult | null> => {
     if (input.sourceKey === null) return null;
     const updated = await getAppDb().transaction(tx =>
       applyUpdateLocked(
@@ -248,7 +255,7 @@ export async function upsertWorkItem(params: {
         now,
       ),
     );
-    return updated?.item ?? null;
+    return updated ? { created: false, item: updated.item, previous: updated.previous } : null;
   };
 
   const reused = await reuseExisting();
@@ -272,7 +279,7 @@ export async function upsertWorkItem(params: {
 
   try {
     const [inserted] = await getAppDb().insert(workItems).values(row).returning();
-    return inserted!;
+    return { created: true, item: inserted! };
   } catch (err) {
     // Concurrent create for the same sourceKey: the partial unique index won
     // the race — fall back to updating the row it protected.
@@ -345,13 +352,11 @@ export async function updateWorkItem(
   );
 }
 
-/** Delete an org's work item. Returns the deleted row, or `null` when it doesn't exist in the org. */
+/** Delete an org's work item. Returns the row actually deleted, or `null` when it doesn't exist in the org. */
 export async function deleteWorkItem(orgId: string, id: string): Promise<WorkItemRow | null> {
-  const [existing] = await getAppDb()
-    .select()
-    .from(workItems)
-    .where(and(eq(workItems.id, id), eq(workItems.orgId, orgId)));
-  if (!existing) return null;
-  await getAppDb().delete(workItems).where(eq(workItems.id, id));
-  return existing;
+  const [deleted] = await getAppDb()
+    .delete(workItems)
+    .where(and(eq(workItems.id, id), eq(workItems.orgId, orgId)))
+    .returning();
+  return deleted ?? null;
 }

--- a/mastracode/web/src/web/github/routes.test.ts
+++ b/mastracode/web/src/web/github/routes.test.ts
@@ -29,6 +29,27 @@ interface Tables {
 }
 const tables: Tables = { installations: [], projects: [], sandboxes: [], worktrees: [], subscriptions: [] };
 
+// Capture audit events at the store boundary so the real `emitAudit` path
+// (actor resolution, request context, never-throws) is exercised end to end.
+let auditRecorded: Array<Record<string, any>> = [];
+let auditFailure: Error | undefined;
+
+vi.mock('../audit/store', () => ({
+  recordAuditEvent: async (input: any) => {
+    if (auditFailure) throw auditFailure;
+    auditRecorded.push(input);
+    return {
+      id: `00000000-0000-4000-9000-${String(auditRecorded.length).padStart(12, '0')}`,
+      occurredAt: new Date(),
+      ...input,
+      githubProjectId: input.githubProjectId ?? null,
+      metadata: input.metadata ?? {},
+      context: input.context ?? {},
+    };
+  },
+  listAuditEvents: async () => ({ events: [] }),
+}));
+
 vi.mock('./db', () => {
   // Minimal chainable drizzle-like stub keyed off the table object identity.
   const makeDb = () => ({
@@ -358,6 +379,8 @@ beforeEach(() => {
   featureEnabled = true;
   sandboxEnabled = true;
   cookieUser = null;
+  auditRecorded = [];
+  auditFailure = undefined;
   process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-webhook-secret';
   // No Postgres in these unit tests: keep the project lock purely in-process.
   process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
@@ -1617,5 +1640,124 @@ describe('pr route', () => {
     expect(createPullRequest).toHaveBeenCalledOnce();
     const opts = (createPullRequest.mock.calls[0] as unknown as any[])[2];
     expect(opts).toMatchObject({ token: 'install-token', base: 'main', head: 'feat/x', title: 'My PR' });
+  });
+});
+
+// ── Audit events ─────────────────────────────────────────────────────────
+describe('audit events', () => {
+  it('records worktree.created with actor, project, and branch metadata', async () => {
+    seedMaterializedProject();
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      orgId: 'org1',
+      actorId: 'u1',
+      action: 'factory.worktree.created',
+      githubProjectId: 'p1',
+      targets: [{ type: 'worktree', id: '/workspace/hello/../worktrees/feat/x', name: 'feat/x' }],
+      metadata: { branch: 'feat/x', baseBranch: 'main' },
+    });
+  });
+
+  it('does not record worktree.created when the worktree is reused', async () => {
+    seedMaterializedProject();
+    ensureWorktree.mockResolvedValueOnce({
+      worktreePath: '/workspace/hello/../worktrees/feat/x',
+      branch: 'feat/x',
+      baseBranch: 'main',
+      reused: true,
+    } as any);
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    expect(auditRecorded).toHaveLength(0);
+  });
+
+  it('records worktree.deleted when a worktree is removed', async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    await postJson(app, '/web/github/projects/p1/worktree', { branch: 'feat/x' });
+    auditRecorded = [];
+
+    await postJson(app, '/web/github/projects/p1/worktree/delete', { branch: 'feat/x' });
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      action: 'factory.worktree.deleted',
+      githubProjectId: 'p1',
+      targets: [{ type: 'worktree', id: '/workspace/hello/../worktrees/feat/x', name: 'feat/x' }],
+      metadata: { branch: 'feat/x' },
+    });
+  });
+
+  it('records triage.started with the issue number and title', async () => {
+    seedMaterializedProject();
+    const runIssueTriage = vi.fn(async () => ({ threadId: 'thread-triage' }));
+    await buildApp({ workosId: 'u1' }, { runIssueTriage }).request('/web/github/projects/p1/issues/12/triage', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ title: 'Fix flaky test', url: 'https://github.com/octo/hello/issues/12', labels: [] }),
+    });
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      actorId: 'u1',
+      action: 'factory.triage.started',
+      githubProjectId: 'p1',
+      targets: [{ type: 'issue', id: '12', name: 'Fix flaky test' }],
+      metadata: { issueNumber: 12, branch: 'factory/issue-12', threadId: 'thread-triage' },
+    });
+  });
+
+  it('records git.commit only when a commit was actually created', async () => {
+    seedMaterializedProject();
+    const app = buildApp({ workosId: 'u1' });
+    await postJson(app, '/web/github/projects/p1/commit', { message: 'wip' });
+    expect(auditRecorded.map(e => e.action)).toEqual(['factory.git.commit']);
+
+    auditRecorded = [];
+    commitAll.mockResolvedValueOnce({ committed: false } as any);
+    await postJson(app, '/web/github/projects/p1/commit', { message: 'nothing to do' });
+    expect(auditRecorded).toHaveLength(0);
+  });
+
+  it('records git.push with the branch target', async () => {
+    seedMaterializedProject();
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/push', { branch: 'feat/x' });
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      action: 'factory.git.push',
+      githubProjectId: 'p1',
+      targets: [{ type: 'branch', id: 'feat/x' }],
+      metadata: { branch: 'feat/x' },
+    });
+  });
+
+  it('records git.pr_opened with the PR url and title', async () => {
+    seedMaterializedProject();
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/pr', {
+      branch: 'feat/x',
+      title: 'My PR',
+    });
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      action: 'factory.git.pr_opened',
+      githubProjectId: 'p1',
+      targets: [{ type: 'pull_request', id: 'https://github.com/octo/hello/pull/1', name: 'My PR' }],
+      metadata: { branch: 'feat/x', base: 'main', url: 'https://github.com/octo/hello/pull/1' },
+    });
+  });
+
+  it('does not record audit events for rejected mutations', async () => {
+    seedMaterializedProject();
+    await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/push', { branch: 'bad branch' });
+    expect(auditRecorded).toHaveLength(0);
+  });
+
+  it('still succeeds the mutation when the audit insert throws', async () => {
+    seedMaterializedProject();
+    auditFailure = new Error('audit db down');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const res = await postJson(buildApp({ workosId: 'u1' }), '/web/github/projects/p1/push', { branch: 'feat/x' });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ pushed: true, branch: 'feat/x' });
+    expect(warnSpy).toHaveBeenCalledWith('[Audit] Failed to emit audit event', expect.anything());
+    warnSpy.mockRestore();
   });
 });

--- a/mastracode/web/src/web/github/routes.ts
+++ b/mastracode/web/src/web/github/routes.ts
@@ -31,6 +31,7 @@ function loose(c: unknown): RouteContext {
   return c as RouteContext;
 }
 import { streamSSE } from 'hono/streaming';
+import { emitAudit } from '../audit/audit';
 import { ensureWebAuthUser, getWebAuthUser, webAuthTenant } from '../auth';
 import type { WebAuthTenant } from '../auth';
 import {
@@ -721,6 +722,12 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions = {}): ApiRo
           projectPath,
           branch,
         });
+        await emitAudit(loose(c), {
+          action: 'factory.triage.started',
+          projectId: project.id,
+          targets: [{ type: 'issue', id: String(issueNumber), name: body.title }],
+          metadata: { issueNumber, branch, threadId: result.threadId },
+        });
         return c.json(
           {
             ok: true,
@@ -1063,6 +1070,19 @@ function buildProjectGitRoutes(): ApiRoute[] {
                 set: { baseBranch: result.baseBranch, worktreePath: result.worktreePath },
               });
 
+            if (!result.reused) {
+              await emitAudit(loose(c), {
+                action: 'factory.worktree.created',
+                projectId: project.id,
+                targets: [{ type: 'worktree', id: result.worktreePath, name: result.branch }],
+                metadata: {
+                  branch: result.branch,
+                  baseBranch: result.baseBranch,
+                  worktreePath: result.worktreePath,
+                },
+              });
+            }
+
             return c.json({
               worktreePath: result.worktreePath,
               branch: result.branch,
@@ -1117,6 +1137,12 @@ function buildProjectGitRoutes(): ApiRoute[] {
               worktreePath: worktreeRow.worktreePath,
             });
             await getAppDb().delete(githubWorktrees).where(rowFilter);
+            await emitAudit(loose(c), {
+              action: 'factory.worktree.deleted',
+              projectId: project.id,
+              targets: [{ type: 'worktree', id: worktreeRow.worktreePath, name: branch }],
+              metadata: { branch, worktreePath: worktreeRow.worktreePath },
+            });
             return c.json({ removed: true, branch, worktreePath: worktreeRow.worktreePath });
           });
         } catch (err) {
@@ -1157,6 +1183,14 @@ function buildProjectGitRoutes(): ApiRoute[] {
               body.message as string,
               identityFromUser(getWebAuthUser(loose(c))),
             );
+            if (result.committed) {
+              await emitAudit(loose(c), {
+                action: 'factory.git.commit',
+                projectId: project.id,
+                targets: [{ type: 'worktree', id: workdir }],
+                metadata: { worktreePath: workdir },
+              });
+            }
             return c.json({ committed: result.committed });
           });
         } catch (err) {
@@ -1194,6 +1228,12 @@ function buildProjectGitRoutes(): ApiRoute[] {
             const sandbox = await resolveProjectSandbox(sandboxRow);
             const token = await mintInstallationToken(project.installationId);
             await pushBranch(sandbox, workdir, branch, token, project.repoFullName);
+            await emitAudit(loose(c), {
+              action: 'factory.git.push',
+              projectId: project.id,
+              targets: [{ type: 'branch', id: branch }],
+              metadata: { branch, worktreePath: workdir },
+            });
             return c.json({ pushed: true, branch });
           });
         } catch (err) {
@@ -1251,6 +1291,12 @@ function buildProjectGitRoutes(): ApiRoute[] {
             const sandbox = await resolveProjectSandbox(sandboxRow);
             const token = await mintInstallationToken(project.installationId);
             const result = await createPullRequest(sandbox, workdir, { token, base, head, title, body: prBody });
+            await emitAudit(loose(c), {
+              action: 'factory.git.pr_opened',
+              projectId: project.id,
+              targets: [{ type: 'pull_request', id: result.url, name: title }],
+              metadata: { branch: head, base, url: result.url },
+            });
             if (
               typeof body.sessionId === 'string' &&
               body.sessionId &&

--- a/mastracode/web/src/web/github/session-subscriptions.ts
+++ b/mastracode/web/src/web/github/session-subscriptions.ts
@@ -128,7 +128,7 @@ export function createGithubSubscriptionTools(requestContext: RequestContext) {
   };
 }
 
-function stripHeredocBodies(command: string): string {
+export function stripHeredocBodies(command: string): string {
   const lines = command.split('\n');
   const executableLines: string[] = [];
   let delimiter: string | undefined;

--- a/mastracode/web/src/web/intake/routes.test.ts
+++ b/mastracode/web/src/web/intake/routes.test.ts
@@ -14,6 +14,27 @@ vi.mock('drizzle-orm', async () => {
 // In-memory intake_settings table.
 let settings: Array<Record<string, any>> = [];
 
+// Capture audit events at the store boundary so the real `emitAudit` path
+// (actor resolution, never-throws) is exercised end to end.
+let auditRecorded: Array<Record<string, any>> = [];
+let auditFailure: Error | undefined;
+
+vi.mock('../audit/store', () => ({
+  recordAuditEvent: async (input: any) => {
+    if (auditFailure) throw auditFailure;
+    auditRecorded.push(input);
+    return {
+      id: `00000000-0000-4000-9000-${String(auditRecorded.length).padStart(12, '0')}`,
+      occurredAt: new Date(),
+      ...input,
+      githubProjectId: input.githubProjectId ?? null,
+      metadata: input.metadata ?? {},
+      context: input.context ?? {},
+    };
+  },
+  listAuditEvents: async () => ({ events: [] }),
+}));
+
 function matches(table: any, row: any, cond: any): boolean {
   if (!cond) return true;
   if (cond.kind === 'and') return cond.conds.every((c: any) => matches(table, row, c));
@@ -65,6 +86,8 @@ const orgUser = { workosId: 'u1', organizationId: 'org1' };
 
 beforeEach(() => {
   settings = [];
+  auditRecorded = [];
+  auditFailure = undefined;
 });
 
 afterEach(() => {
@@ -149,6 +172,41 @@ describe('PUT /web/intake/config', () => {
       body: 'not-json',
     });
     expect(res.status).toBe(400);
+  });
+
+  it('records intake.config_updated with a bounded source summary', async () => {
+    await put({
+      github: { enabled: true, projectIds: ['gp-1', 'gp-2'] },
+      linear: { enabled: false, projectIds: null },
+    });
+    expect(auditRecorded).toHaveLength(1);
+    expect(auditRecorded[0]).toMatchObject({
+      orgId: 'org1',
+      actorId: 'u1',
+      action: 'factory.intake.config_updated',
+      targets: [{ type: 'intake_config', id: 'org1' }],
+      metadata: {
+        github: { enabled: true, projects: 2 },
+        linear: { enabled: false, projects: null },
+      },
+    });
+  });
+
+  it('does not record an audit event when the config is rejected', async () => {
+    await put({ github: { enabled: 'yes' }, linear: { enabled: true } });
+    expect(auditRecorded).toHaveLength(0);
+  });
+
+  it('still saves the config when the audit insert throws', async () => {
+    auditFailure = new Error('audit db down');
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const config = { github: { enabled: true, projectIds: null }, linear: { enabled: true, projectIds: null } };
+    const res = await put(config);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ config });
+    expect(settings).toHaveLength(1);
+    expect(warnSpy).toHaveBeenCalledWith('[Audit] Failed to emit audit event', expect.anything());
+    warnSpy.mockRestore();
   });
 });
 

--- a/mastracode/web/src/web/intake/routes.ts
+++ b/mastracode/web/src/web/intake/routes.ts
@@ -11,6 +11,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
+import { emitAudit } from '../audit/audit';
 import { ensureWebAuthUser, webAuthTenant } from '../auth';
 import { getIntakeConfig, parseIntakeConfig, saveIntakeConfig } from './store';
 
@@ -64,6 +65,14 @@ export function buildIntakeRoutes(): ApiRoute[] {
         if (!config) return c.json({ error: 'invalid_config' }, 400);
 
         await saveIntakeConfig(tenant.orgId, tenant.userId, config);
+        await emitAudit(loose(c), {
+          action: 'factory.intake.config_updated',
+          targets: [{ type: 'intake_config', id: tenant.orgId }],
+          metadata: {
+            github: { enabled: config.github.enabled, projects: config.github.projectIds?.length ?? null },
+            linear: { enabled: config.linear.enabled, projects: config.linear.projectIds?.length ?? null },
+          },
+        });
         return c.json({ config });
       },
     }),

--- a/mastracode/web/src/web/ui/domains/factory/AuditPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/AuditPage.tsx
@@ -1,0 +1,158 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { useState } from 'react';
+
+import { relativeTime } from '../../../../shared/lib/date';
+import { FactoryPageShell } from './components/FactoryPageShell';
+import { useAuditEvents, useAuditPortalLink } from './hooks/useAuditEvents';
+import type { AuditEvent } from './services/audit';
+
+/** Action-group filters mapped to the concrete v1 action taxonomy. */
+const ACTION_GROUPS = [
+  { key: 'all', label: 'All', actions: undefined },
+  {
+    key: 'work-items',
+    label: 'Work items',
+    actions: [
+      'factory.work_item.created',
+      'factory.work_item.updated',
+      'factory.work_item.stage_moved',
+      'factory.work_item.deleted',
+    ],
+  },
+  { key: 'runs', label: 'Runs', actions: ['factory.run.started', 'factory.triage.started'] },
+  { key: 'worktrees', label: 'Worktrees', actions: ['factory.worktree.created', 'factory.worktree.deleted'] },
+  { key: 'git', label: 'Git', actions: ['factory.git.commit', 'factory.git.push', 'factory.git.pr_opened'] },
+  { key: 'intake', label: 'Intake', actions: ['factory.intake.config_updated'] },
+] as const;
+
+type GroupKey = (typeof ACTION_GROUPS)[number]['key'];
+
+/** Short human label for a dot-namespaced action, e.g. 'Stage moved'. */
+function actionLabel(action: string): string {
+  const leaf = action.split('.').pop() ?? action;
+  const words = leaf.replace(/_/g, ' ');
+  return words.charAt(0).toUpperCase() + words.slice(1);
+}
+
+/**
+ * The Factory audit trail: an append-only, org-scoped record of who did what,
+ * when — every work-item mutation, stage move, run start, worktree change, and
+ * git action. Backed by the local `audit_events` table; the "Open in WorkOS"
+ * button (shown when WorkOS is configured) opens the enterprise viewer.
+ */
+export function AuditPage() {
+  return (
+    <FactoryPageShell
+      title="Audit"
+      description="Who did what, when — every board change, run start, worktree change, and git action."
+      maxWidthClassName="max-w-5xl"
+    >
+      {project => <AuditContent githubProjectId={project.githubProjectId} />}
+    </FactoryPageShell>
+  );
+}
+
+function AuditContent({ githubProjectId }: { githubProjectId: string }) {
+  const [group, setGroup] = useState<GroupKey>('all');
+  const actions = ACTION_GROUPS.find(entry => entry.key === group)?.actions;
+  const eventsQuery = useAuditEvents(githubProjectId, group, actions ? [...actions] : undefined);
+  const portalQuery = useAuditPortalLink(true);
+
+  if (eventsQuery.isError) {
+    return <Notice variant="destructive">{(eventsQuery.error as Error).message}</Notice>;
+  }
+  const events = eventsQuery.data?.pages.flatMap(page => page.events) ?? [];
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pb-6">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ButtonsGroup spacing="close" role="group" aria-label="Audit filter">
+          {ACTION_GROUPS.map(entry => (
+            <Button
+              key={entry.key}
+              variant={group === entry.key ? 'primary' : 'outline'}
+              size="sm"
+              aria-pressed={group === entry.key}
+              onClick={() => setGroup(entry.key)}
+            >
+              {entry.label}
+            </Button>
+          ))}
+        </ButtonsGroup>
+        {portalQuery.data ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              // Portal links are one-time use: open, then fetch a fresh one.
+              window.open(portalQuery.data!, '_blank', 'noopener,noreferrer');
+              void portalQuery.refetch();
+            }}
+          >
+            Open in WorkOS
+          </Button>
+        ) : null}
+      </div>
+
+      {!eventsQuery.data ? null : events.length === 0 ? (
+        <Notice variant="info">No audit events yet. Board changes, runs, and git actions will appear here.</Notice>
+      ) : (
+        <>
+          <ul className="m-0 flex list-none flex-col gap-1 p-0" aria-label="Audit events">
+            {events.map(event => (
+              <AuditEventRow key={event.id} event={event} />
+            ))}
+          </ul>
+          {eventsQuery.hasNextPage ? (
+            <Button
+              variant="outline"
+              size="sm"
+              className="self-center"
+              disabled={eventsQuery.isFetchingNextPage}
+              onClick={() => void eventsQuery.fetchNextPage()}
+            >
+              {eventsQuery.isFetchingNextPage ? 'Loading…' : 'Load more'}
+            </Button>
+          ) : null}
+        </>
+      )}
+    </div>
+  );
+}
+
+function AuditEventRow({ event }: { event: AuditEvent }) {
+  const target = event.targets[0];
+  const hasMetadata = Object.keys(event.metadata).length > 0;
+
+  return (
+    <li className="rounded-lg border border-border1 bg-surface2 px-3 py-2">
+      <div className="grid grid-cols-[4rem_10rem_1fr] items-baseline gap-3">
+        <Txt as="span" variant="ui-xs" className="text-icon3" title={event.occurredAt}>
+          {relativeTime(event.occurredAt)}
+        </Txt>
+        <span className="inline-flex w-fit rounded-md bg-surface4 px-1.5 py-0.5 text-ui-xs text-icon5">
+          {actionLabel(event.action)}
+        </span>
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <Txt as="span" variant="ui-sm" className="truncate text-icon6">
+            {target?.name ?? target?.id ?? '—'}
+          </Txt>
+          <Txt as="span" variant="ui-xs" className="text-icon3">
+            by {event.actorId}
+          </Txt>
+        </div>
+      </div>
+      {hasMetadata ? (
+        <details className="mt-1">
+          <summary className="cursor-pointer text-ui-xs text-icon3">Details</summary>
+          <pre className="m-0 mt-1 overflow-x-auto rounded-md bg-surface1 p-2 text-ui-xs text-icon4">
+            {JSON.stringify(event.metadata, null, 2)}
+          </pre>
+        </details>
+      ) : null}
+    </li>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/factory/AuditPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/AuditPage.tsx
@@ -25,6 +25,11 @@ const ACTION_GROUPS = [
   { key: 'runs', label: 'Runs', actions: ['factory.run.started', 'factory.triage.started'] },
   { key: 'worktrees', label: 'Worktrees', actions: ['factory.worktree.created', 'factory.worktree.deleted'] },
   { key: 'git', label: 'Git', actions: ['factory.git.commit', 'factory.git.push', 'factory.git.pr_opened'] },
+  {
+    key: 'agent',
+    label: 'Agent',
+    actions: ['factory.agent.commit', 'factory.agent.push', 'factory.agent.pr_opened'],
+  },
   { key: 'intake', label: 'Intake', actions: ['factory.intake.config_updated'] },
 ] as const;
 
@@ -141,7 +146,9 @@ function AuditEventRow({ event }: { event: AuditEvent }) {
             {target?.name ?? target?.id ?? '—'}
           </Txt>
           <Txt as="span" variant="ui-xs" className="text-icon3">
-            by {event.actorId}
+            {event.actorType === 'agent'
+              ? `by agent${typeof event.metadata.startedBy === 'string' ? ` · started by ${event.metadata.startedBy}` : ''}`
+              : `by ${event.actorId}`}
           </Txt>
         </div>
       </div>

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -53,11 +53,12 @@ function issueTriageThreadTags(issueNumber: number): Record<string, string> {
 
 /**
  * Candidate feeds the Intake swimlane can browse. Only one paginated list is
- * shown at a time; when both are configured a pill switcher inside the column
- * picks the active one.
+ * shown at a time; a pill switcher inside the column picks the active feed
+ * when more than one is available.
  */
 const INTAKE_SOURCES = [
-  { id: 'github', label: 'GitHub' },
+  { id: 'github', label: 'Issues' },
+  { id: 'github-prs', label: 'PRs' },
   { id: 'linear', label: 'Linear' },
 ] as const;
 
@@ -125,7 +126,7 @@ interface BoardCandidate {
   meta: string;
   icon: ComponentType<{ size?: number; className?: string }>;
   iconClassName: string;
-  /** Column the candidate is offered in: issues in Intake, PRs in Review. */
+  /** Column the candidate is offered in: everything starts in Intake (auto-triaged issues in Triage). */
   column: BoardStageId;
   /** Runs the candidate can start; the first is the one-click default. */
   runActions: RunAction[];
@@ -202,7 +203,7 @@ function pullRequestCandidate(pr: GithubPullRequest): BoardCandidate {
     meta: `#${pr.number}${pr.author ? ` · ${pr.author}` : ''} · ${pr.headBranch} → ${pr.baseBranch}`,
     icon: GitPullRequest,
     iconClassName: 'text-accent1',
-    column: 'review',
+    column: 'intake',
     runActions: [
       {
         label: 'Review',
@@ -334,9 +335,11 @@ function readDragPayload(event: DragEvent): DragPayload | null {
 /**
  * Factory › Board: an org-wide kanban over the project's work items. The
  * Intake column merges persisted `intake` cards with live GitHub/Linear
- * candidates (issues/PRs that have no record yet — records are materialized
- * only when someone acts on them). Cards move between columns by drag-and-drop
- * or the card menu; moves only file/move cards, never start agent runs.
+ * candidates (issues and PRs that have no record yet — records are
+ * materialized only when someone acts on them). Everything enters through
+ * Intake and moves through the system from there. Cards move between columns
+ * by drag-and-drop or the card menu; moves only file/move cards, never start
+ * agent runs.
  */
 export function BoardPage() {
   return (
@@ -356,8 +359,9 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   const configQuery = useIntakeConfigQuery();
   const linearStatusQuery = useLinearStatusQuery();
 
-  // Intake sources mirror the old Intake page gating: nothing is synced until
-  // it's picked in Settings › General. PRs always feed the board.
+  // Intake sources mirror the old Intake page gating: issues sync only once
+  // picked in Settings › General. Open PRs always feed the board; they start
+  // in Intake and only move once the Factory acts on them.
   const config = configQuery.data;
   const githubEnabled = config?.github.enabled ?? true;
   const githubSelected = config ? (config.github.projectIds?.includes(githubProjectId) ?? false) : true;
@@ -367,22 +371,23 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
     (config?.linear.enabled ?? false) && linearConnected && (config?.linear.projectIds?.length ?? 0) > 0;
 
   // The Intake swimlane browses one candidate feed at a time; a pill switcher
-  // inside the column picks between GitHub and Linear when both are set up.
+  // inside the column filters between Issues, PRs, and Linear as available.
   const githubIntakeActive = githubEnabled && githubSelected;
+  const availableIntakeSources: IntakeSource[] = [
+    ...(githubIntakeActive ? (['github'] as const) : []),
+    'github-prs' as const,
+    ...(linearReady ? (['linear'] as const) : []),
+  ];
   const [intakeSource, setIntakeSource] = useState<IntakeSource>('github');
-  const showIntakeSourceSwitch = githubIntakeActive && linearReady;
-  const activeIntakeSource: IntakeSource | null = showIntakeSourceSwitch
+  const showIntakeSourceSwitch = availableIntakeSources.length > 1;
+  const activeIntakeSource: IntakeSource | null = availableIntakeSources.includes(intakeSource)
     ? intakeSource
-    : githubIntakeActive
-      ? 'github'
-      : linearReady
-        ? 'linear'
-        : null;
+    : (availableIntakeSources[0] ?? null);
 
-  // Only the active intake feed fetches; the other feed loads on switch.
+  // Only the active intake feed fetches; the other feeds load on switch.
   const issues = useProjectIssuesQuery(activeIntakeSource === 'github' ? githubProjectId : undefined);
   const triageIssues = useProjectIssuesQuery(githubProjectId, AUTO_TRIAGED_LABEL);
-  const pulls = useProjectPullRequestsQuery(githubProjectId);
+  const pulls = useProjectPullRequestsQuery(activeIntakeSource === 'github-prs' ? githubProjectId : undefined);
   const linearIssues = useLinearIssuesQuery(activeIntakeSource === 'linear');
 
   const upsert = useUpsertWorkItemMutation(githubProjectId);
@@ -424,7 +429,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
     const all: BoardCandidate[] = [
       ...intakeIssues.map(issueCandidate),
       ...(triageIssues.data ?? []).map(issueCandidate),
-      ...(pulls.data ?? []).map(pullRequestCandidate),
+      ...(activeIntakeSource === 'github-prs' ? (pulls.data ?? []).map(pullRequestCandidate) : []),
       ...(activeIntakeSource === 'linear' ? (linearIssues.data ?? []).map(linearCandidate) : []),
     ];
     return all.filter(candidate => !known.has(candidate.sourceKey));
@@ -477,14 +482,14 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
             headerExtras={
               stage.id === 'intake' && showIntakeSourceSwitch ? (
                 <div role="group" aria-label="Intake source" className="flex items-center gap-1 pb-1">
-                  {INTAKE_SOURCES.map(source => (
+                  {INTAKE_SOURCES.filter(source => availableIntakeSources.includes(source.id)).map(source => (
                     <button
                       key={source.id}
                       type="button"
-                      aria-pressed={intakeSource === source.id}
+                      aria-pressed={activeIntakeSource === source.id}
                       onClick={() => setIntakeSource(source.id)}
                       className={`rounded-full border px-2.5 py-0.5 text-ui-xs transition ${
-                        intakeSource === source.id
+                        activeIntakeSource === source.id
                           ? 'border-accent1 bg-surface4 text-icon6'
                           : 'border-border1 bg-transparent text-icon3 hover:text-icon5'
                       }`}
@@ -561,9 +566,13 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                 />
               ))}
             {stage.id === 'intake' && (
-              <IntakeColumnExtras source={activeIntakeSource} issues={issues} linearIssues={linearIssues} />
+              <IntakeColumnExtras
+                source={activeIntakeSource}
+                issues={issues}
+                pulls={pulls}
+                linearIssues={linearIssues}
+              />
             )}
-            {stage.id === 'review' && <ReviewColumnExtras pulls={pulls} />}
           </BoardColumn>
         ))}
       </div>
@@ -831,15 +840,17 @@ function CandidateCard({
 function IntakeColumnExtras({
   source,
   issues,
+  pulls,
   linearIssues,
 }: {
   source: IntakeSource | null;
   issues: ReturnType<typeof useProjectIssuesQuery>;
+  pulls: ReturnType<typeof useProjectPullRequestsQuery>;
   linearIssues: ReturnType<typeof useLinearIssuesQuery>;
 }) {
   const { baseUrl } = useApiConfig();
   if (source === null) return null;
-  const feed = source === 'github' ? issues : linearIssues;
+  const feed = source === 'github' ? issues : source === 'github-prs' ? pulls : linearIssues;
 
   return (
     <>
@@ -861,23 +872,6 @@ function IntakeColumnExtras({
         isFetchingNextPage={Boolean(feed.isFetchingNextPage)}
         onLoadMore={() => void feed.fetchNextPage()}
         label="Load more candidates"
-      />
-    </>
-  );
-}
-
-/** Review column tail: loading state and pull-request pagination. */
-function ReviewColumnExtras({ pulls }: { pulls: ReturnType<typeof useProjectPullRequestsQuery> }) {
-  return (
-    <>
-      {pulls.isPending && pulls.fetchStatus !== 'idle' && (
-        <SkeletonRows label="Loading pull requests" rows={3} rowClassName="h-12 w-full" />
-      )}
-      <LoadMoreSentinel
-        hasNextPage={Boolean(pulls.hasNextPage)}
-        isFetchingNextPage={Boolean(pulls.isFetchingNextPage)}
-        onLoadMore={() => void pulls.fetchNextPage()}
-        label="Load more pull requests"
       />
     </>
   );

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/AuditPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/AuditPage.msw.test.tsx
@@ -237,7 +237,7 @@ describe('Factory Audit page', () => {
               actorType: 'agent',
               action: 'factory.agent.push',
               targets: [{ type: 'worktree', id: '/sandbox/mastra-worktrees/feat-audit' }],
-              metadata: { command: 'git push origin feat/audit', branch: 'feat/audit', startedBy: 'user_alice' },
+              metadata: { branch: 'feat/audit', startedBy: 'user_alice' },
             }),
           ],
         },

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/AuditPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/AuditPage.msw.test.tsx
@@ -57,6 +57,7 @@ function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
     id: 'evt-1',
     orgId: 'org-1',
     actorId: 'user_alice',
+    actorType: 'human',
     action: 'factory.work_item.stage_moved',
     targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix flaky test' }],
     metadata: { from: ['triage'], to: ['building'] },
@@ -208,6 +209,47 @@ describe('Factory Audit page', () => {
     await waitFor(() =>
       expect(state.requests.map(r => r.actions)).toContain('factory.git.commit,factory.git.push,factory.git.pr_opened'),
     );
+  });
+
+  it('given the All filter, when the user picks Agent, then events are refetched with the agent action list', async () => {
+    const state = useAuditHandlers();
+    renderAt('/factory/audit');
+
+    await screen.findByRole('list', { name: 'Audit events' });
+
+    await userEvent.click(screen.getByRole('button', { name: 'Agent' }));
+
+    await waitFor(() =>
+      expect(state.requests.map(r => r.actions)).toContain(
+        'factory.agent.commit,factory.agent.push,factory.agent.pr_opened',
+      ),
+    );
+  });
+
+  it('given an agent event, when the trail renders, then the row attributes it to the agent and the initiating human', async () => {
+    useAuditHandlers({
+      pages: [
+        {
+          events: [
+            makeEvent({
+              id: 'evt-agent',
+              actorId: 'agent:thread-42',
+              actorType: 'agent',
+              action: 'factory.agent.push',
+              targets: [{ type: 'worktree', id: '/sandbox/mastra-worktrees/feat-audit' }],
+              metadata: { command: 'git push origin feat/audit', branch: 'feat/audit', startedBy: 'user_alice' },
+            }),
+          ],
+        },
+      ],
+    });
+    renderAt('/factory/audit');
+
+    const list = await screen.findByRole('list', { name: 'Audit events' });
+    const row = within(list).getAllByRole('listitem')[0]!;
+    expect(within(row).getByText('Push')).toBeInTheDocument();
+    expect(within(row).getByText('by agent · started by user_alice')).toBeInTheDocument();
+    expect(within(row).queryByText(/agent:thread-42/)).not.toBeInTheDocument();
   });
 
   it('given more events than one page, when the user clicks Load more, then the next page is fetched with the cursor and appended', async () => {

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/AuditPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/AuditPage.msw.test.tsx
@@ -1,0 +1,260 @@
+/**
+ * BDD coverage for the Factory Audit page.
+ *
+ * Drives the real route table through a memory router with the full provider
+ * stack, so the specs exercise what a user sees at /factory/audit: the
+ * append-only audit trail fed by the server's org+project-scoped read API.
+ * Only the network is mocked (MSW).
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../../e2e/web-ui/render';
+import type { GithubStatus, Project } from '../../workspaces';
+import { createAppRoutes } from '../../../router';
+import type { AuditEvent } from '../services/audit';
+
+const API = `${TEST_BASE_URL}/api/agent-controller/code`;
+const RESOURCE_ID = 'resource-gh';
+const SESSION = `${API}/sessions/${RESOURCE_ID}`;
+const THREAD_ID = 'thread-test';
+const GITHUB_PROJECT_ID = 'github-project-1';
+
+const githubProject: Project = {
+  id: 'project-gh',
+  name: 'Mastra',
+  source: 'github',
+  githubProjectId: GITHUB_PROJECT_ID,
+  sandboxWorkdir: '/sandbox/mastra',
+  resourceId: RESOURCE_ID,
+  gitBranch: 'main',
+  worktrees: [{ branch: 'main', worktreePath: '/sandbox/mastra', baseBranch: 'main' }],
+  selectedWorktreePath: '/sandbox/mastra',
+  createdAt: 1,
+};
+
+const localProject: Project = {
+  id: 'project-local',
+  name: 'Local',
+  path: '/projects/local',
+  resourceId: RESOURCE_ID,
+  createdAt: 1,
+};
+
+const connectedStatus: GithubStatus = {
+  enabled: true,
+  connected: true,
+  installations: [{ installationId: 1, accountLogin: 'mastra-ai', accountType: 'Organization' }],
+};
+
+function makeEvent(overrides: Partial<AuditEvent> = {}): AuditEvent {
+  return {
+    id: 'evt-1',
+    orgId: 'org-1',
+    actorId: 'user_alice',
+    action: 'factory.work_item.stage_moved',
+    targets: [{ type: 'work_item', id: 'wi-1', name: 'Fix flaky test' }],
+    metadata: { from: ['triage'], to: ['building'] },
+    githubProjectId: GITHUB_PROJECT_ID,
+    context: {},
+    occurredAt: '2026-07-15T18:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function emptySse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start() {},
+      cancel() {},
+    }),
+    { headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function sessionState() {
+  return {
+    controllerId: 'code',
+    resourceId: RESOURCE_ID,
+    modeId: 'build',
+    modelId: 'openai/gpt-4o-mini',
+    threadId: THREAD_ID,
+    settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+  };
+}
+
+interface AuditHandlerState {
+  /** `(actions, before)` of every audit list request, in order. */
+  requests: { actions: string | null; before: string | null }[];
+}
+
+interface AuditHandlerOptions {
+  /** Pages served in order; the last page is repeated for extra requests. */
+  pages?: { events: AuditEvent[]; nextCursor?: string }[];
+  /** Portal-link response: a URL when WorkOS is configured, otherwise 404. */
+  portalUrl?: string;
+}
+
+function useAuditHandlers(options: AuditHandlerOptions = {}): AuditHandlerState {
+  const pages = options.pages ?? [{ events: [makeEvent()] }];
+  const state: AuditHandlerState = { requests: [] };
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () => new Response(null, { status: 404 })),
+    http.get(`${TEST_BASE_URL}/web/github/status`, () => HttpResponse.json(connectedStatus)),
+    http.get(`${TEST_BASE_URL}/web/intake/config`, () =>
+      HttpResponse.json({
+        config: { github: { enabled: true, projectIds: [] }, linear: { enabled: false, projectIds: [] } },
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
+      HttpResponse.json({ enabled: false, connected: false, workspace: null }),
+    ),
+    http.post(`${API}/sessions`, () =>
+      HttpResponse.json({ controllerId: 'code', resourceId: RESOURCE_ID, threadId: THREAD_ID }),
+    ),
+    http.get(`${API}/modes`, () => HttpResponse.json({ modes: [{ id: 'build', label: 'Build' }] })),
+    http.get(`${API}/models`, () => HttpResponse.json({ models: [] })),
+    http.get(SESSION, () => HttpResponse.json(sessionState())),
+    http.put(`${SESSION}/state`, () => HttpResponse.json(sessionState())),
+    http.get(`${SESSION}/permissions`, () => HttpResponse.json({ categories: {}, tools: {} })),
+    http.get(`${SESSION}/threads`, () => HttpResponse.json({ threads: [] })),
+    http.get(`${SESSION}/threads/${THREAD_ID}/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${SESSION}/stream`, () => emptySse()),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${GITHUB_PROJECT_ID}/audit`, ({ request }) => {
+      const url = new URL(request.url);
+      state.requests.push({ actions: url.searchParams.get('actions'), before: url.searchParams.get('before') });
+      const page = pages[Math.min(state.requests.length - 1, pages.length - 1)]!;
+      return HttpResponse.json(page);
+    }),
+    http.get(`${TEST_BASE_URL}/web/audit/portal-link`, () =>
+      options.portalUrl
+        ? HttpResponse.json({ url: options.portalUrl })
+        : HttpResponse.json({ error: 'not_available' }, { status: 404 }),
+    ),
+  );
+  return state;
+}
+
+function renderAt(initialEntry: string, project: Project = githubProject) {
+  localStorage.setItem('mastracode-projects', JSON.stringify([project]));
+  localStorage.setItem('mastracode-active-project', project.id);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [initialEntry] });
+  renderWithProviders(<RouterProvider router={router} />, client);
+  return { router, client };
+}
+
+afterEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe('Factory Audit page', () => {
+  it('given recorded events, when the page renders, then the trail shows action, target, actor, and metadata details', async () => {
+    useAuditHandlers({
+      pages: [
+        {
+          events: [
+            makeEvent(),
+            makeEvent({
+              id: 'evt-2',
+              actorId: 'user_bob',
+              action: 'factory.worktree.deleted',
+              targets: [{ type: 'worktree', id: '/sandbox/mastra-worktrees/feat-x', name: 'factory/issue-12' }],
+              metadata: {},
+              occurredAt: '2026-07-15T17:00:00.000Z',
+            }),
+          ],
+        },
+      ],
+    });
+    renderAt('/factory/audit');
+
+    expect(await screen.findByRole('heading', { name: 'Audit' })).toBeInTheDocument();
+    const list = await screen.findByRole('list', { name: 'Audit events' });
+    const rows = within(list).getAllByRole('listitem');
+    expect(rows).toHaveLength(2);
+
+    // Stage move: action badge, target name, actor, expandable metadata.
+    expect(within(rows[0]!).getByText('Stage moved')).toBeInTheDocument();
+    expect(within(rows[0]!).getByText('Fix flaky test')).toBeInTheDocument();
+    expect(within(rows[0]!).getByText('by user_alice')).toBeInTheDocument();
+    await userEvent.click(within(rows[0]!).getByText('Details'));
+    expect(within(rows[0]!).getByText(/"building"/)).toBeInTheDocument();
+
+    // Worktree delete: no metadata means no Details toggle.
+    expect(within(rows[1]!).getByText('Deleted')).toBeInTheDocument();
+    expect(within(rows[1]!).getByText('factory/issue-12')).toBeInTheDocument();
+    expect(within(rows[1]!).queryByText('Details')).not.toBeInTheDocument();
+
+    // WorkOS isn't configured (portal-link 404), so the button is hidden.
+    expect(screen.queryByRole('button', { name: 'Open in WorkOS' })).not.toBeInTheDocument();
+  });
+
+  it('given the All filter, when the user picks Git, then events are refetched with the git action list', async () => {
+    const state = useAuditHandlers();
+    renderAt('/factory/audit');
+
+    await screen.findByRole('list', { name: 'Audit events' });
+    expect(state.requests[0]!.actions).toBeNull();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Git' }));
+
+    await waitFor(() =>
+      expect(state.requests.map(r => r.actions)).toContain('factory.git.commit,factory.git.push,factory.git.pr_opened'),
+    );
+  });
+
+  it('given more events than one page, when the user clicks Load more, then the next page is fetched with the cursor and appended', async () => {
+    const state = useAuditHandlers({
+      pages: [
+        { events: [makeEvent()], nextCursor: '2026-07-15T18:00:00.000Z_evt-1' },
+        {
+          events: [
+            makeEvent({ id: 'evt-older', action: 'factory.work_item.created', occurredAt: '2026-07-14T00:00:00.000Z' }),
+          ],
+        },
+      ],
+    });
+    renderAt('/factory/audit');
+
+    await screen.findByRole('list', { name: 'Audit events' });
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() => expect(screen.getAllByRole('listitem')).toHaveLength(2));
+    expect(state.requests[1]!.before).toBe('2026-07-15T18:00:00.000Z_evt-1');
+    expect(screen.getByText('Created')).toBeInTheDocument();
+    // Both pages exhausted — nothing more to load.
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument();
+  });
+
+  it('given WorkOS is configured, when the user clicks Open in WorkOS, then the one-time portal link opens in a new tab', async () => {
+    useAuditHandlers({ portalUrl: 'https://portal.workos.com/audit-logs/one-time' });
+    const open = vi.spyOn(window, 'open').mockReturnValue(null);
+    renderAt('/factory/audit');
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Open in WorkOS' }));
+
+    expect(open).toHaveBeenCalledWith('https://portal.workos.com/audit-logs/one-time', '_blank', 'noopener,noreferrer');
+  });
+
+  it('given no events yet, when the page renders, then a friendly empty state appears', async () => {
+    useAuditHandlers({ pages: [{ events: [] }] });
+    renderAt('/factory/audit');
+
+    expect(await screen.findByText(/No audit events yet/)).toBeInTheDocument();
+  });
+
+  it('given a local project, when visiting Audit, then the GitHub-only notice renders instead of the trail', async () => {
+    useAuditHandlers();
+    renderAt('/factory/audit', localProject);
+
+    expect(await screen.findByText(/only available for GitHub projects/)).toBeInTheDocument();
+    expect(screen.queryByRole('list', { name: 'Audit events' })).not.toBeInTheDocument();
+  });
+});

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -364,6 +364,7 @@ describe('Factory sidebar section', () => {
     // The Board link appears once the GitHub status query resolves as connected.
     expect(await within(nav).findByRole('link', { name: /Board/ })).toHaveAttribute('href', '/factory/board');
     expect(within(nav).getByRole('link', { name: /Metrics/ })).toHaveAttribute('href', '/factory/metrics');
+    expect(within(nav).getByRole('link', { name: /Audit/ })).toHaveAttribute('href', '/factory/audit');
     // The factory Sessions list is nested under the same menu.
     expect(within(nav).getByRole('region', { name: 'Factory sessions' })).toBeInTheDocument();
   });
@@ -384,6 +385,7 @@ describe('Factory sidebar section', () => {
     expect(within(nav).getByRole('region', { name: 'Factory sessions' })).toBeInTheDocument();
     await waitFor(() => expect(within(nav).queryByRole('link', { name: /Board/ })).not.toBeInTheDocument());
     expect(within(nav).queryByRole('link', { name: /Metrics/ })).not.toBeInTheDocument();
+    expect(within(nav).queryByRole('link', { name: /Audit/ })).not.toBeInTheDocument();
   });
 });
 

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -422,7 +422,7 @@ describe('Factory Board routing', () => {
 });
 
 describe('Factory Board — Intake candidates', () => {
-  it('given open issues and PRs, when the Board renders, then issues appear as Intake candidates and PRs as Review candidates', async () => {
+  it('given open issues and PRs, when the Board renders, then both appear as Intake candidates behind the feed filter', async () => {
     const state = useBoardHandlers({ issues, pullRequests });
     renderAt('/factory/board');
 
@@ -440,11 +440,13 @@ describe('Factory Board — Intake candidates', () => {
     expect(
       within(within(intake).getByRole('article', { name: 'Fix flaky test' })).queryByText('bug'),
     ).not.toBeInTheDocument();
-    // Open PRs are review work: they land in the Review column, not Intake.
-    const review = column('review');
-    expect(await within(review).findByText('Add factory pages')).toBeInTheDocument();
-    expect(within(review).getAllByTestId('candidate-card')).toHaveLength(1);
-    expect(within(intake).queryByText('Add factory pages')).not.toBeInTheDocument();
+    // PRs start in Intake too — behind the PRs feed pill, never in Review.
+    expect(within(column('review')).queryByTestId('candidate-card')).not.toBeInTheDocument();
+    const sources = within(intake).getByRole('group', { name: 'Intake source' });
+    await userEvent.click(within(sources).getByRole('button', { name: 'PRs' }));
+    expect(await within(column('intake')).findByText('Add factory pages')).toBeInTheDocument();
+    expect(within(column('intake')).queryByText('Fix flaky test')).not.toBeInTheDocument();
+    expect(within(column('review')).queryByTestId('candidate-card')).not.toBeInTheDocument();
   });
 
   it('given an untriaged issue candidate, when Triage issue is chosen, then the server triage run starts and the Board stays open', async () => {
@@ -542,7 +544,7 @@ describe('Factory Board — Intake candidates', () => {
     });
     renderAt('/factory/board', githubProject, connectedStatus, { linearStatus: linearConnectedStatus });
 
-    // GitHub is the default feed: its issues show, Linear's don't.
+    // GitHub issues are the default feed: they show, Linear's don't.
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
     expect(within(intake).queryByText('Fix intake sync')).not.toBeInTheDocument();
@@ -553,11 +555,13 @@ describe('Factory Board — Intake candidates', () => {
     // Only the Linear feed's candidates remain in Intake.
     expect(await within(column('intake')).findByText('Fix intake sync')).toBeInTheDocument();
     expect(within(column('intake')).queryByText('Fix flaky test')).not.toBeInTheDocument();
-    // The switch only affects the Intake feed: PRs and persisted cards stay.
-    expect(within(column('review')).getByText('Add factory pages')).toBeInTheDocument();
+    // The switch only affects the Intake feed: persisted cards stay put, and
+    // PR candidates only render behind their own feed pill.
     expect(within(column('execute')).getByText('Linear card')).toBeInTheDocument();
+    expect(within(column('intake')).queryByText('Add factory pages')).not.toBeInTheDocument();
+    expect(within(column('review')).queryByTestId('candidate-card')).not.toBeInTheDocument();
 
-    await userEvent.click(within(sources).getByRole('button', { name: 'GitHub' }));
+    await userEvent.click(within(sources).getByRole('button', { name: 'Issues' }));
     expect(await within(column('intake')).findByText('Fix flaky test')).toBeInTheDocument();
     expect(within(column('intake')).queryByText('Fix intake sync')).not.toBeInTheDocument();
   });
@@ -573,15 +577,18 @@ describe('Factory Board — Intake candidates', () => {
     expect(within(intake).getByText(/ENG-42/)).toBeInTheDocument();
   });
 
-  it('given the Linear feature is disabled, when the Board renders, then no Linear candidates or source switch appear', async () => {
+  it('given the Linear feature is disabled, when the Board renders, then no Linear candidates or Linear feed pill appear', async () => {
     useBoardHandlers({ issues, linearIssues });
     renderAt('/factory/board');
 
     const intake = await screen.findByTestId('board-column-intake');
     expect(await within(intake).findByText('Fix flaky test')).toBeInTheDocument();
     expect(within(intake).queryByText('Fix intake sync')).not.toBeInTheDocument();
-    // A single active feed needs no switcher.
-    expect(within(intake).queryByRole('group', { name: 'Intake source' })).not.toBeInTheDocument();
+    // Issues + PRs still get a switcher, but Linear is not offered.
+    const sources = within(intake).getByRole('group', { name: 'Intake source' });
+    expect(within(sources).getByRole('button', { name: 'Issues' })).toBeInTheDocument();
+    expect(within(sources).getByRole('button', { name: 'PRs' })).toBeInTheDocument();
+    expect(within(sources).queryByRole('button', { name: 'Linear' })).not.toBeInTheDocument();
   });
 
   it('given a work item exists for an issue, when the Board renders, then candidates from both issue feeds are deduped by source key', async () => {
@@ -1141,15 +1148,16 @@ describe('Factory Board — investigate flow', () => {
     }
   });
 
-  it('given a PR candidate, when Review is clicked, then the review prompt runs and a work item materializes into Review with a review session', async () => {
+  it('given a PR candidate in Intake, when Review is clicked, then the review prompt runs and a work item materializes into Review with a review session', async () => {
     const state = useBoardHandlers({ pullRequests });
     const captured = useFactoryRunHandlers('factory-pr-34');
     const { router } = renderAt('/factory/board');
 
-    await screen.findByTestId('board-column-intake');
-    const review = column('review');
-    await within(review).findByText('Add factory pages');
-    await userEvent.click(within(review).getByRole('button', { name: 'Review Add factory pages' }));
+    const intake = await screen.findByTestId('board-column-intake');
+    const sources = within(intake).getByRole('group', { name: 'Intake source' });
+    await userEvent.click(within(sources).getByRole('button', { name: 'PRs' }));
+    await within(intake).findByText('Add factory pages');
+    await userEvent.click(within(intake).getByRole('button', { name: 'Review Add factory pages' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/pr-34' });

--- a/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
@@ -1,5 +1,5 @@
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ChartLine, SquareKanban } from 'lucide-react';
+import { ChartLine, ScrollText, SquareKanban } from 'lucide-react';
 import type { ComponentType, ReactNode } from 'react';
 import { NavLink } from 'react-router';
 
@@ -33,6 +33,7 @@ export function FactorySection({ children }: { children?: ReactNode }) {
         <div className="flex flex-col gap-1">
           <FactoryLink to="/factory/board" icon={SquareKanban} label="Board" />
           <FactoryLink to="/factory/metrics" icon={ChartLine} label="Metrics" />
+          <FactoryLink to="/factory/audit" icon={ScrollText} label="Audit" />
         </div>
       )}
       {children && <div className="flex flex-col gap-2 pl-2">{children}</div>}

--- a/mastracode/web/src/web/ui/domains/factory/hooks/useAuditEvents.ts
+++ b/mastracode/web/src/web/ui/domains/factory/hooks/useAuditEvents.ts
@@ -1,0 +1,39 @@
+import { useInfiniteQuery, useQuery } from '@tanstack/react-query';
+
+import { useApiConfig } from '../../../../../shared/api/config';
+import { queryKeys } from '../../../../../shared/api/keys';
+import { fetchAuditEvents, fetchAuditPortalLink } from '../services/audit';
+import type { AuditEventPage } from '../services/audit';
+
+/**
+ * Cursor-paginated audit trail for the project, newest-first. `group` is the
+ * UI's action-group filter key; `actions` the concrete action list it maps to
+ * (undefined = all actions).
+ */
+export function useAuditEvents(githubProjectId: string | undefined, group: string, actions: string[] | undefined) {
+  const { baseUrl } = useApiConfig();
+  return useInfiniteQuery({
+    queryKey: queryKeys.factoryAudit(githubProjectId, group),
+    queryFn: ({ pageParam }) => fetchAuditEvents(baseUrl, githubProjectId!, { actions, before: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage: AuditEventPage) => lastPage.nextCursor,
+    enabled: Boolean(githubProjectId),
+    staleTime: 15_000,
+  });
+}
+
+/**
+ * One-time WorkOS Admin Portal URL for the audit-log viewer, or `null` when
+ * WorkOS isn't configured (the button is hidden). Links are single-use, so
+ * consumers refetch after opening one.
+ */
+export function useAuditPortalLink(enabled: boolean) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.factoryAuditPortal(),
+    queryFn: () => fetchAuditPortalLink(baseUrl),
+    enabled,
+    staleTime: Infinity,
+    retry: false,
+  });
+}

--- a/mastracode/web/src/web/ui/domains/factory/index.ts
+++ b/mastracode/web/src/web/ui/domains/factory/index.ts
@@ -1,3 +1,4 @@
+export { AuditPage } from './AuditPage';
 export { BoardPage } from './BoardPage';
 export { MetricsPage } from './MetricsPage';
 export { FactorySection } from './components/FactorySection';

--- a/mastracode/web/src/web/ui/domains/factory/services/audit.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/audit.ts
@@ -1,0 +1,81 @@
+/**
+ * Browser-side helpers for the Factory audit-trail endpoints.
+ *
+ * Mirrors the server's audit read API (`src/web/audit/routes.ts`): an
+ * org+project-scoped event list with keyset pagination, plus an optional
+ * one-time WorkOS Admin Portal link for the enterprise audit-log viewer.
+ */
+
+export interface AuditTarget {
+  type: string;
+  id: string;
+  name?: string;
+}
+
+export interface AuditEvent {
+  id: string;
+  orgId: string;
+  /** WorkOS user id of whoever performed the action. */
+  actorId: string;
+  /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
+  action: string;
+  targets: AuditTarget[];
+  /** Bounded event summary — never full payloads. */
+  metadata: Record<string, unknown>;
+  githubProjectId: string | null;
+  context: { location?: string; userAgent?: string };
+  /** ISO timestamp. */
+  occurredAt: string;
+}
+
+export interface AuditEventPage {
+  events: AuditEvent[];
+  /** Pass back as `before` to fetch the next (older) page; absent at the end. */
+  nextCursor?: string;
+}
+
+async function throwRequestError(res: Response): Promise<never> {
+  let message = `Request failed (${res.status})`;
+  try {
+    const body = (await res.json()) as { error?: string; message?: string };
+    if (body.message) message = body.message;
+    else if (body.error) message = body.error;
+  } catch {
+    /* ignore non-JSON */
+  }
+  throw new Error(message);
+}
+
+/** Fetch one page of the project's audit trail, newest-first. */
+export async function fetchAuditEvents(
+  baseUrl: string,
+  githubProjectId: string,
+  options: { actions?: string[]; before?: string; limit?: number } = {},
+): Promise<AuditEventPage> {
+  const query = new URLSearchParams();
+  if (options.actions && options.actions.length > 0) query.set('actions', options.actions.join(','));
+  if (options.before) query.set('before', options.before);
+  if (options.limit) query.set('limit', String(options.limit));
+  const qs = query.size > 0 ? `?${query}` : '';
+  const res = await fetch(`${baseUrl}/web/factory/projects/${encodeURIComponent(githubProjectId)}/audit${qs}`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  });
+  if (!res.ok) return throwRequestError(res);
+  return (await res.json()) as AuditEventPage;
+}
+
+/**
+ * Fetch a one-time WorkOS Admin Portal URL for the audit-log viewer, or
+ * `null` when WorkOS isn't configured (the UI hides the button).
+ */
+export async function fetchAuditPortalLink(baseUrl: string): Promise<string | null> {
+  const res = await fetch(`${baseUrl}/web/audit/portal-link`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  });
+  if (res.status === 404) return null;
+  if (!res.ok) return throwRequestError(res);
+  const data = (await res.json()) as { url: string };
+  return data.url;
+}

--- a/mastracode/web/src/web/ui/domains/factory/services/audit.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/audit.ts
@@ -15,8 +15,10 @@ export interface AuditTarget {
 export interface AuditEvent {
   id: string;
   orgId: string;
-  /** WorkOS user id of whoever performed the action. */
+  /** WorkOS user id of whoever performed the action, or `agent:<threadId>`. */
   actorId: string;
+  /** Whether a human or an agent (inside a run) performed the action. */
+  actorType: 'human' | 'agent';
   /** Dot-namespaced action, e.g. 'factory.work_item.stage_moved'. */
   action: string;
   targets: AuditTarget[];

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -16,6 +16,7 @@ import { SignInPage, useWebAuth } from './domains/auth';
 import Chat from './domains/chat/Chat';
 import { NewPage } from './domains/chat/NewPage';
 import { ThreadPage } from './domains/chat/ThreadPage';
+import { AuditPage } from './domains/factory/AuditPage';
 import { BoardPage } from './domains/factory/BoardPage';
 import { MetricsPage } from './domains/factory/MetricsPage';
 
@@ -88,6 +89,7 @@ export function createAppRoutes(): RouteObject[] {
             { path: 'user/threads/:threadId', element: <ThreadPage /> },
             { path: 'factory/board', element: <BoardPage /> },
             { path: 'factory/metrics', element: <MetricsPage /> },
+            { path: 'factory/audit', element: <AuditPage /> },
             // Legacy Factory pages, folded into the Board.
             { path: 'factory/intake', element: <Navigate to="/factory/board" replace /> },
             { path: 'factory/review', element: <Navigate to="/factory/board" replace /> },

--- a/mastracode/web/src/web/web-surface.ts
+++ b/mastracode/web/src/web/web-surface.ts
@@ -13,6 +13,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import type { AuthStorage } from '@mastra/code-sdk/auth/storage';
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 
+import { buildAuditRoutes } from './audit/routes.js';
 import { buildConfigRoutes } from './config-routes.js';
 import { buildFsRoutes } from './fs-routes.js';
 import {
@@ -334,5 +335,6 @@ export function assembleWebApiRoutes(deps: WebApiRoutesDeps): ApiRoute[] {
     ...(deps.linearReady ? buildLinearRoutes({ baseUrl: deps.publicOrigin }) : []),
     ...(deps.intakeReady ? buildIntakeRoutes() : []),
     ...(deps.factoryReady ? buildFactoryRoutes() : []),
+    ...(deps.factoryReady ? buildAuditRoutes({ baseUrl: deps.publicOrigin }) : []),
   ];
 }


### PR DESCRIPTION
## Summary

Adds an append-only, org-scoped audit trail to the Factory so teams can answer "who did what, when" — for both humans and agents — plus a board flow change so open PRs enter through Intake like every other work source.

### Factory audit trail (v1)

- New `audit_events` Postgres table (append-only, org-first tenancy, idempotent migration) with a cursor-paginated query endpoint: `GET /web/factory/projects/:id/audit`.
- 12 dot-namespaced actions instrumented across factory, github, and intake routes: work-item created/updated/stage_moved/deleted, run started, worktree created/deleted, triage started, git commit/push/PR opened, intake config updated.
- Fire-and-forget mirror to **WorkOS Audit Logs** for enterprise export/SIEM streaming, plus a `GET /web/audit/portal-link` endpoint that opens the WorkOS Admin Portal audit viewer. Auditing never blocks or breaks factory mutations — local insert failures are logged and swallowed, the WorkOS forward is best-effort.
- New **Audit** page at `/factory/audit` (next to Board/Metrics): event table with time, actor, action badge, targets, expandable metadata; action-group filters; cursor "Load more"; "Open in WorkOS" button.

### Agent-level audit events (v1.1)

Git actions performed by agents *inside runs* never touch web routes, so they were invisible to the trail. Now the agent controller's post-tool observer detects successful `git commit`, `git push`, and `gh pr create` commands and records `factory.agent.commit/push/pr_opened` events:

- New `actor_type` column (`human` | `agent`); agent events use `actor_id = agent:<threadId>` with `metadata.startedBy = <userId>` chaining accountability back to the human who started the run.
- The Audit page gains an **Agent** filter group and renders agent events as "by agent · started by user".
- Detection handles chained commands (`git commit && git push`) and ignores heredoc bodies and failed commands. No SDK changes — everything lives in `mastracode/web`.

### PR intake flow

Open PRs previously bypassed the front of the board and appeared directly in the Review swimlane. They now enter through **Intake** like issues and Linear items, and the Intake feed switcher gains a **PRs** pill (Issues / PRs / Linear, shown as available). The Review run still moves the card into Review once the Factory acts on it.

## Test plan

- [x] Unit + route tests: audit store/sink/emit, agent-audit detector, instrumented factory/github/intake routes (mutations succeed even when audit insert throws)
- [x] MSW suites: AuditPage (filters, pagination, portal link, agent attribution), FactoryPages (PR intake placement, feed switcher, run flows) — 55 files / 436 tests green
- [x] `pnpm check` (tsc + UI typecheck) clean, prettier applied
- [ ] Manual: run a factory job, confirm `factory.agent.*` rows appear on `/factory/audit` under the Agent filter
- [ ] Ops: register the 15 audit actions in the WorkOS dashboard (Audit Logs → Events) for the export mirror — local table works regardless

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR keeps a permanent record of what people and automated agents do in Factory, making it easier to understand changes and track responsibility. It also improves how pull requests enter and move through the Factory workflow.

## What changed

- Added an append-only, organization-scoped Factory audit trail with:
  - Human and agent attribution
  - Metadata, targets, request context, and timestamps
  - Cursor-based pagination and filters
  - Best-effort WorkOS Audit Logs forwarding
- Instrumented Factory, GitHub, and Intake mutations.
- Added detection and auditing of agent commits, pushes, and pull request creation, including the initiating human.
- Added authenticated audit APIs and a Factory Audit page with filters, pagination, event details, and an optional WorkOS portal link.
- Added database initialization, metadata size protection, and extensive unit, route, MSW, and typecheck coverage.
- Changed open pull requests to enter Intake instead of Review.
- Added an Intake PR feed filter; PRs move to Review when Factory acts on them.
- Manual agent-event verification and WorkOS dashboard action registration remain pending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->