### PR TITLE
feat(playground): center tool execution page and add read-more for tool descriptions

### DIFF
--- a/.changeset/clean-apes-build.md
+++ b/.changeset/clean-apes-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added ClampedText, a design-system component that clamps text to a number of lines and shows a "Read more" toggle only when the clamp actually cuts content. Detection is based on the rendered layout (element measurement, re-checked on resize and after fonts load), not on character count.

--- a/.changeset/yummy-llamas-fry.md
+++ b/.changeset/yummy-llamas-fry.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Simplified the tool execution page: form and result now stack in a single centered column, the result appears only after running the tool, and the result view is read-only with a copy button.

--- a/packages/playground-ui/src/ds/components/ClampedText/clamped-text.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ClampedText/clamped-text.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { ClampedText } from './clamped-text';
+
+const meta: Meta<typeof ClampedText> = {
+  title: 'Elements/ClampedText',
+  component: ClampedText,
+  decorators: [
+    Story => (
+      <div className="w-80">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: {
+    layout: 'centered',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ClampedText>;
+
+const longText =
+  'Create and manage a structured task list for your current coding session. This helps you track progress, organize complex tasks, and demonstrate thoroughness. Pass the full task list each time this tool is called.';
+
+export const Default: Story = {
+  args: {
+    children: longText,
+    variant: 'ui-sm',
+    className: 'text-neutral3',
+  },
+};
+
+export const ShortTextNoToggle: Story = {
+  args: {
+    children: 'Short text that fits within the clamp — no toggle shown.',
+    variant: 'ui-sm',
+    className: 'text-neutral3',
+  },
+};
+
+export const ThreeLines: Story = {
+  args: {
+    children: longText,
+    lines: 3,
+    variant: 'ui-sm',
+    className: 'text-neutral3',
+  },
+};

--- a/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
+++ b/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
@@ -26,12 +26,7 @@ export interface ClampedTextProps extends Omit<TxtProps, 'children' | 'ref'> {
   showLessLabel?: string;
 }
 
-/**
- * Text clamped to a number of lines with a "read more" toggle. The toggle only
- * appears when the clamp actually cuts content: the rendered element is measured
- * (`scrollHeight > clientHeight`), so the detection follows layout — element
- * width, font loading — rather than any character count.
- */
+/** Text clamped to a number of lines, with a "read more" toggle shown only when the clamp actually cuts content. */
 export function ClampedText({
   children,
   lines = 2,

--- a/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
+++ b/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react';
+import { Button } from '@/ds/components/Button';
+import type { TxtProps } from '@/ds/components/Txt';
+import { Txt } from '@/ds/components/Txt';
+import { ChevronIcon } from '@/ds/icons/ChevronIcon';
+import { cn } from '@/lib/utils';
+
+// Tailwind needs static class names — map instead of interpolating.
+const clampClasses = {
+  1: 'line-clamp-1',
+  2: 'line-clamp-2',
+  3: 'line-clamp-3',
+  4: 'line-clamp-4',
+  5: 'line-clamp-5',
+  6: 'line-clamp-6',
+} as const;
+
+export type ClampedTextLines = keyof typeof clampClasses;
+
+export interface ClampedTextProps extends Omit<TxtProps, 'children' | 'ref'> {
+  children: string;
+  /** Number of lines to clamp to (default: 2) */
+  lines?: ClampedTextLines;
+  readMoreLabel?: string;
+  showLessLabel?: string;
+}
+
+/**
+ * Text clamped to a number of lines with a "read more" toggle. The toggle only
+ * appears when the clamp actually cuts content: the rendered element is measured
+ * (`scrollHeight > clientHeight`), so the detection follows layout — element
+ * width, font loading — rather than any character count.
+ */
+export function ClampedText({
+  children,
+  lines = 2,
+  readMoreLabel = 'Read more',
+  showLessLabel = 'Show less',
+  className,
+  ...txtProps
+}: ClampedTextProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isClamped, setIsClamped] = useState(false);
+
+  return (
+    <>
+      <Txt
+        {...txtProps}
+        className={cn(!isExpanded && clampClasses[lines], className)}
+        ref={el => {
+          if (!el || isExpanded) return;
+          const measure = () => setIsClamped(el.scrollHeight > el.clientHeight);
+          if (typeof ResizeObserver === 'undefined') {
+            measure();
+            return;
+          }
+          // Clamping depends on rendered layout — re-measure when the element
+          // resizes (fires once on observe) and once fonts finish loading.
+          const observer = new ResizeObserver(measure);
+          observer.observe(el);
+          document.fonts?.ready.then(measure).catch(() => {});
+          return () => observer.disconnect();
+        }}
+      >
+        {children}
+      </Txt>
+      {(isClamped || isExpanded) && (
+        <Button
+          variant="ghost"
+          size="xs"
+          className="mt-1 -ml-[.8em] self-start justify-self-start"
+          onClick={() => setIsExpanded(v => !v)}
+        >
+          {isExpanded ? showLessLabel : readMoreLabel}
+          <ChevronIcon className={cn('transition-transform', isExpanded && 'rotate-180')} />
+        </Button>
+      )}
+    </>
+  );
+}

--- a/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
+++ b/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
@@ -3,6 +3,7 @@ import { Button } from '@/ds/components/Button';
 import type { TxtProps } from '@/ds/components/Txt';
 import { Txt } from '@/ds/components/Txt';
 import { ChevronIcon } from '@/ds/icons/ChevronIcon';
+import { useIsClamped } from '@/hooks/use-is-clamped';
 import { cn } from '@/lib/utils';
 
 // Tailwind needs static class names — map instead of interpolating.
@@ -40,28 +41,11 @@ export function ClampedText({
   ...txtProps
 }: ClampedTextProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isClamped, setIsClamped] = useState(false);
+  const { ref, isClamped } = useIsClamped({ enabled: !isExpanded });
 
   return (
     <>
-      <Txt
-        {...txtProps}
-        className={cn(!isExpanded && clampClasses[lines], className)}
-        ref={el => {
-          if (!el || isExpanded) return;
-          const measure = () => setIsClamped(el.scrollHeight > el.clientHeight);
-          if (typeof ResizeObserver === 'undefined') {
-            measure();
-            return;
-          }
-          // Clamping depends on rendered layout — re-measure when the element
-          // resizes (fires once on observe) and once fonts finish loading.
-          const observer = new ResizeObserver(measure);
-          observer.observe(el);
-          document.fonts?.ready.then(measure).catch(() => {});
-          return () => observer.disconnect();
-        }}
-      >
+      <Txt {...txtProps} className={cn(!isExpanded && clampClasses[lines], className)} ref={ref}>
         {children}
       </Txt>
       {(isClamped || isExpanded) && (

--- a/packages/playground-ui/src/ds/components/ClampedText/index.ts
+++ b/packages/playground-ui/src/ds/components/ClampedText/index.ts
@@ -1,0 +1,1 @@
+export * from './clamped-text';

--- a/packages/playground-ui/src/ds/components/Txt/Txt.tsx
+++ b/packages/playground-ui/src/ds/components/Txt/Txt.tsx
@@ -1,10 +1,11 @@
-import type { HTMLAttributes, ReactNode } from 'react';
+import type { HTMLAttributes, ReactNode, Ref } from 'react';
 
 import type { FontSizes } from '../../tokens';
 import { cn } from '@/lib/utils';
 
 export interface TxtProps extends HTMLAttributes<HTMLDivElement | HTMLLabelElement> {
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'p' | 'span' | 'label' | 'div';
+  ref?: Ref<HTMLElement>;
   variant?: keyof typeof FontSizes;
   font?: 'mono';
   htmlFor?: string;
@@ -32,6 +33,7 @@ const fonts = {
   mono: 'font-mono',
 };
 
-export const Txt = ({ as: Root = 'p', className, variant = 'ui-md', font, ...props }: TxtProps) => {
-  return <Root className={cn(variants[variant], font && fonts[font], className)} {...props} />;
+export const Txt = ({ as: Root = 'p', className, variant = 'ui-md', font, ref, ...props }: TxtProps) => {
+  // Cast needed: `Root` is polymorphic, so TS narrows the expected ref to a single element type.
+  return <Root ref={ref as never} className={cn(variants[variant], font && fonts[font], className)} {...props} />;
 };

--- a/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
+++ b/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
@@ -89,7 +89,6 @@ describe('useIsClamped', () => {
     act(() => result.current.ref(element));
     expect(result.current.isClamped).toBe(true);
 
-    // The element grew tall enough to fit its content.
     setElementSize(element, { scrollHeight: 60, clientHeight: 60 });
     act(() => lastObserver().resize());
 
@@ -105,8 +104,6 @@ describe('useIsClamped', () => {
     act(() => result.current.ref(element));
     expect(result.current.isClamped).toBe(true);
 
-    // Disabling (clamp lifted, e.g. text expanded) stops observing and keeps
-    // the last value even though the element no longer overflows.
     setElementSize(element, { scrollHeight: 60, clientHeight: 60 });
     rerender({ enabled: false });
 

--- a/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
+++ b/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
@@ -1,123 +1,116 @@
 // @vitest-environment jsdom
-import { act, renderHook, waitFor } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import assert from 'node:assert';
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useIsClamped } from './use-is-clamped';
 
-const createElement = ({ scrollHeight, clientHeight }: { scrollHeight: number; clientHeight: number }) => {
+interface ElementSize {
+  scrollHeight: number;
+  clientHeight: number;
+}
+
+// jsdom performs no layout, so overflow is stubbed per element.
+const setElementSize = (element: HTMLElement, { scrollHeight, clientHeight }: ElementSize) => {
+  Object.defineProperties(element, {
+    scrollHeight: { configurable: true, value: scrollHeight },
+    clientHeight: { configurable: true, value: clientHeight },
+  });
+};
+
+const createClampableElement = (size: ElementSize) => {
   const element = document.createElement('p');
-  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: scrollHeight });
-  Object.defineProperty(element, 'clientHeight', { configurable: true, value: clientHeight });
+  setElementSize(element, size);
   return element;
 };
 
-class MockResizeObserver implements ResizeObserver {
-  static instances: MockResizeObserver[] = [];
+const observers: MockResizeObserver[] = [];
 
+class MockResizeObserver implements ResizeObserver {
   constructor(private readonly callback: ResizeObserverCallback) {
-    MockResizeObserver.instances.push(this);
+    observers.push(this);
   }
 
   observe = vi.fn();
   unobserve = vi.fn();
   disconnect = vi.fn();
-  takeRecords = () => [];
+  takeRecords = (): ResizeObserverEntry[] => [];
 
-  trigger() {
+  resize() {
     this.callback([], this);
   }
 }
 
+const lastObserver = () => {
+  const observer = observers.at(-1);
+  assert(observer, 'expected the hook to create a ResizeObserver');
+  return observer;
+};
+
+beforeEach(() => {
+  observers.length = 0;
+  vi.stubGlobal('ResizeObserver', MockResizeObserver);
+});
+
 afterEach(() => {
-  MockResizeObserver.instances = [];
-  vi.restoreAllMocks();
   vi.unstubAllGlobals();
 });
 
 describe('useIsClamped', () => {
-  it('reports clamped when content overflows the element', async () => {
+  it('reports clamped when content overflows the element', () => {
+    const { result } = renderHook(() => useIsClamped());
+
+    act(() => result.current.ref(createClampableElement({ scrollHeight: 60, clientHeight: 40 })));
+
+    expect(result.current.isClamped).toBe(true);
+  });
+
+  it('reports not clamped when content fits', () => {
+    const { result } = renderHook(() => useIsClamped());
+
+    act(() => result.current.ref(createClampableElement({ scrollHeight: 40, clientHeight: 40 })));
+
+    expect(result.current.isClamped).toBe(false);
+  });
+
+  it('still measures once when ResizeObserver is unsupported', () => {
     vi.stubGlobal('ResizeObserver', undefined);
-
-    const element = createElement({ scrollHeight: 60, clientHeight: 40 });
     const { result } = renderHook(() => useIsClamped());
 
-    act(() => {
-      result.current.ref(element);
-    });
+    act(() => result.current.ref(createClampableElement({ scrollHeight: 60, clientHeight: 40 })));
 
-    await waitFor(() => {
-      expect(result.current.isClamped).toBe(true);
-    });
+    expect(result.current.isClamped).toBe(true);
   });
 
-  it('reports not clamped when content fits', async () => {
-    vi.stubGlobal('ResizeObserver', undefined);
-
-    const element = createElement({ scrollHeight: 40, clientHeight: 40 });
+  it('re-measures when the element resizes', () => {
+    const element = createClampableElement({ scrollHeight: 60, clientHeight: 40 });
     const { result } = renderHook(() => useIsClamped());
 
-    act(() => {
-      result.current.ref(element);
-    });
+    act(() => result.current.ref(element));
+    expect(result.current.isClamped).toBe(true);
 
-    await waitFor(() => {
-      expect(result.current.isClamped).toBe(false);
-    });
+    // The element grew tall enough to fit its content.
+    setElementSize(element, { scrollHeight: 60, clientHeight: 60 });
+    act(() => lastObserver().resize());
+
+    expect(result.current.isClamped).toBe(false);
   });
 
-  it('re-measures when the element resizes', async () => {
-    vi.stubGlobal('ResizeObserver', MockResizeObserver);
-
-    const element = createElement({ scrollHeight: 60, clientHeight: 40 });
-    const { result } = renderHook(() => useIsClamped());
-
-    act(() => {
-      result.current.ref(element);
-    });
-
-    await waitFor(() => {
-      expect(result.current.isClamped).toBe(true);
-    });
-
-    // Element grew tall enough to fit its content.
-    Object.defineProperty(element, 'clientHeight', { configurable: true, value: 60 });
-
-    const observer = MockResizeObserver.instances[0];
-    if (!observer) throw new Error('ResizeObserver was not created.');
-
-    act(() => {
-      observer.trigger();
-    });
-
-    await waitFor(() => {
-      expect(result.current.isClamped).toBe(false);
-    });
-  });
-
-  it('keeps the last measurement while disabled', async () => {
-    vi.stubGlobal('ResizeObserver', MockResizeObserver);
-
-    const element = createElement({ scrollHeight: 60, clientHeight: 40 });
-    const { result, rerender } = renderHook(({ enabled }) => useIsClamped({ enabled }), {
+  it('keeps the last measurement while disabled', () => {
+    const element = createClampableElement({ scrollHeight: 60, clientHeight: 40 });
+    const { result, rerender } = renderHook(({ enabled }: { enabled: boolean }) => useIsClamped({ enabled }), {
       initialProps: { enabled: true },
     });
 
-    act(() => {
-      result.current.ref(element);
-    });
+    act(() => result.current.ref(element));
+    expect(result.current.isClamped).toBe(true);
 
-    await waitFor(() => {
-      expect(result.current.isClamped).toBe(true);
-    });
-
-    // Disabling (e.g. text expanded, clamp lifted) tears down the observer
-    // and keeps the last value even though the element no longer overflows.
-    Object.defineProperty(element, 'clientHeight', { configurable: true, value: 60 });
+    // Disabling (clamp lifted, e.g. text expanded) stops observing and keeps
+    // the last value even though the element no longer overflows.
+    setElementSize(element, { scrollHeight: 60, clientHeight: 60 });
     rerender({ enabled: false });
 
-    const observer = MockResizeObserver.instances[0];
-    if (!observer) throw new Error('ResizeObserver was not created.');
-    expect(observer.disconnect).toHaveBeenCalled();
+    expect(lastObserver().disconnect).toHaveBeenCalled();
     expect(result.current.isClamped).toBe(true);
   });
 });

--- a/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
+++ b/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useIsClamped } from './use-is-clamped';
+
+const createElement = ({ scrollHeight, clientHeight }: { scrollHeight: number; clientHeight: number }) => {
+  const element = document.createElement('p');
+  Object.defineProperty(element, 'scrollHeight', { configurable: true, value: scrollHeight });
+  Object.defineProperty(element, 'clientHeight', { configurable: true, value: clientHeight });
+  return element;
+};
+
+class MockResizeObserver implements ResizeObserver {
+  static instances: MockResizeObserver[] = [];
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe = vi.fn();
+  unobserve = vi.fn();
+  disconnect = vi.fn();
+  takeRecords = () => [];
+
+  trigger() {
+    this.callback([], this);
+  }
+}
+
+afterEach(() => {
+  MockResizeObserver.instances = [];
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('useIsClamped', () => {
+  it('reports clamped when content overflows the element', async () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+
+    const element = createElement({ scrollHeight: 60, clientHeight: 40 });
+    const { result } = renderHook(() => useIsClamped());
+
+    act(() => {
+      result.current.ref(element);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isClamped).toBe(true);
+    });
+  });
+
+  it('reports not clamped when content fits', async () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+
+    const element = createElement({ scrollHeight: 40, clientHeight: 40 });
+    const { result } = renderHook(() => useIsClamped());
+
+    act(() => {
+      result.current.ref(element);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isClamped).toBe(false);
+    });
+  });
+
+  it('re-measures when the element resizes', async () => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+    const element = createElement({ scrollHeight: 60, clientHeight: 40 });
+    const { result } = renderHook(() => useIsClamped());
+
+    act(() => {
+      result.current.ref(element);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isClamped).toBe(true);
+    });
+
+    // Element grew tall enough to fit its content.
+    Object.defineProperty(element, 'clientHeight', { configurable: true, value: 60 });
+
+    const observer = MockResizeObserver.instances[0];
+    if (!observer) throw new Error('ResizeObserver was not created.');
+
+    act(() => {
+      observer.trigger();
+    });
+
+    await waitFor(() => {
+      expect(result.current.isClamped).toBe(false);
+    });
+  });
+
+  it('keeps the last measurement while disabled', async () => {
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+    const element = createElement({ scrollHeight: 60, clientHeight: 40 });
+    const { result, rerender } = renderHook(({ enabled }) => useIsClamped({ enabled }), {
+      initialProps: { enabled: true },
+    });
+
+    act(() => {
+      result.current.ref(element);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isClamped).toBe(true);
+    });
+
+    // Disabling (e.g. text expanded, clamp lifted) tears down the observer
+    // and keeps the last value even though the element no longer overflows.
+    Object.defineProperty(element, 'clientHeight', { configurable: true, value: 60 });
+    rerender({ enabled: false });
+
+    const observer = MockResizeObserver.instances[0];
+    if (!observer) throw new Error('ResizeObserver was not created.');
+    expect(observer.disconnect).toHaveBeenCalled();
+    expect(result.current.isClamped).toBe(true);
+  });
+});

--- a/packages/playground-ui/src/hooks/use-is-clamped.ts
+++ b/packages/playground-ui/src/hooks/use-is-clamped.ts
@@ -1,41 +1,56 @@
-import * as React from 'react';
+import { useState } from 'react';
+import type { RefCallback } from 'react';
 
 import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect';
 
+export interface UseIsClampedOptions {
+  /**
+   * Keep measuring while true. Pass false when the clamp is lifted (e.g. the
+   * text is expanded) to freeze the last measurement instead of reporting the
+   * unclamped element as not cut off.
+   */
+  enabled?: boolean;
+}
+
 export interface UseIsClampedResult<TElement extends HTMLElement> {
-  ref: React.RefCallback<TElement>;
+  ref: RefCallback<TElement>;
   isClamped: boolean;
 }
 
 /**
- * Reports whether a line-clamped (or otherwise overflow-hidden) element
- * actually has content cut off, by measuring the rendered layout
- * (`scrollHeight > clientHeight`) — never by counting characters.
- *
+ * Whether a line-clamped (or otherwise overflow-hidden) element actually has
+ * content cut off, measured from the rendered layout
+ * (`scrollHeight > clientHeight`) — never from a character count.
  * Re-measures when the element resizes and once fonts finish loading, since
- * both change line wrapping. Pass `enabled: false` while the clamp is lifted
- * (e.g. text expanded) to keep the last measured value instead of reporting
- * the unclamped element as not cut off.
+ * both change line wrapping.
  */
 export function useIsClamped<TElement extends HTMLElement = HTMLElement>({
   enabled = true,
-}: { enabled?: boolean } = {}): UseIsClampedResult<TElement> {
-  const [element, setElement] = React.useState<TElement | null>(null);
-  const [isClamped, setIsClamped] = React.useState(false);
+}: UseIsClampedOptions = {}): UseIsClampedResult<TElement> {
+  const [element, setElement] = useState<TElement | null>(null);
+  const [isClamped, setIsClamped] = useState(false);
 
   useIsomorphicLayoutEffect(() => {
-    if (!element || !enabled) return undefined;
+    if (!element || !enabled) return;
 
-    const measure = () => setIsClamped(element.scrollHeight > element.clientHeight);
+    let stopped = false;
+    const measure = () => {
+      if (!stopped) setIsClamped(element.scrollHeight > element.clientHeight);
+    };
+
     measure();
 
-    if (typeof ResizeObserver === 'undefined') return undefined;
+    if (typeof ResizeObserver === 'undefined') return;
 
     const observer = new ResizeObserver(measure);
     observer.observe(element);
+    // Font swaps change line wrapping without resizing the observed box.
     document.fonts?.ready.then(measure).catch(() => {});
 
-    return () => observer.disconnect();
+    return () => {
+      stopped = true;
+      observer.disconnect();
+    };
   }, [element, enabled]);
 
   return { ref: setElement, isClamped };

--- a/packages/playground-ui/src/hooks/use-is-clamped.ts
+++ b/packages/playground-ui/src/hooks/use-is-clamped.ts
@@ -4,11 +4,7 @@ import type { RefCallback } from 'react';
 import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect';
 
 export interface UseIsClampedOptions {
-  /**
-   * Keep measuring while true. Pass false when the clamp is lifted (e.g. the
-   * text is expanded) to freeze the last measurement instead of reporting the
-   * unclamped element as not cut off.
-   */
+  /** Set false while the clamp is lifted (e.g. text expanded) to freeze the last measurement. */
   enabled?: boolean;
 }
 
@@ -17,13 +13,7 @@ export interface UseIsClampedResult<TElement extends HTMLElement> {
   isClamped: boolean;
 }
 
-/**
- * Whether a line-clamped (or otherwise overflow-hidden) element actually has
- * content cut off, measured from the rendered layout
- * (`scrollHeight > clientHeight`) — never from a character count.
- * Re-measures when the element resizes and once fonts finish loading, since
- * both change line wrapping.
- */
+/** Measures whether a clamped element has content cut off (`scrollHeight > clientHeight`), re-measuring on resize and font load. */
 export function useIsClamped<TElement extends HTMLElement = HTMLElement>({
   enabled = true,
 }: UseIsClampedOptions = {}): UseIsClampedResult<TElement> {

--- a/packages/playground-ui/src/hooks/use-is-clamped.ts
+++ b/packages/playground-ui/src/hooks/use-is-clamped.ts
@@ -1,0 +1,42 @@
+import * as React from 'react';
+
+import { useIsomorphicLayoutEffect } from './use-isomorphic-layout-effect';
+
+export interface UseIsClampedResult<TElement extends HTMLElement> {
+  ref: React.RefCallback<TElement>;
+  isClamped: boolean;
+}
+
+/**
+ * Reports whether a line-clamped (or otherwise overflow-hidden) element
+ * actually has content cut off, by measuring the rendered layout
+ * (`scrollHeight > clientHeight`) — never by counting characters.
+ *
+ * Re-measures when the element resizes and once fonts finish loading, since
+ * both change line wrapping. Pass `enabled: false` while the clamp is lifted
+ * (e.g. text expanded) to keep the last measured value instead of reporting
+ * the unclamped element as not cut off.
+ */
+export function useIsClamped<TElement extends HTMLElement = HTMLElement>({
+  enabled = true,
+}: { enabled?: boolean } = {}): UseIsClampedResult<TElement> {
+  const [element, setElement] = React.useState<TElement | null>(null);
+  const [isClamped, setIsClamped] = React.useState(false);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!element || !enabled) return undefined;
+
+    const measure = () => setIsClamped(element.scrollHeight > element.clientHeight);
+    measure();
+
+    if (typeof ResizeObserver === 'undefined') return undefined;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    document.fonts?.ready.then(measure).catch(() => {});
+
+    return () => observer.disconnect();
+  }, [element, enabled]);
+
+  return { ref: setElement, isClamped };
+}

--- a/packages/playground/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.tsx
@@ -1,11 +1,8 @@
-import { jsonLanguage } from '@codemirror/lang-json';
 import type { MCPToolType } from '@mastra/core/mcp';
-import { useCodemirrorTheme } from '@mastra/playground-ui/components/CodeEditor';
-import { CopyButton } from '@mastra/playground-ui/components/CopyButton';
+import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { MainContentContent } from '@mastra/playground-ui/components/MainContent';
 import { Tabs, Tab, TabList } from '@mastra/playground-ui/components/Tabs';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import CodeMirror from '@uiw/react-codemirror';
 import { useState } from 'react';
 import type { ZodType } from 'zod';
 import {
@@ -40,44 +37,48 @@ const ToolExecutorContent = ({
   toolType,
   requestContextSchema,
 }: Omit<ToolExecutorProps, 'executionResult'> & { result: any }) => {
-  const theme = useCodemirrorTheme();
+  const hasResult = errorString !== undefined || result !== undefined;
   const code = JSON.stringify(result ?? {}, null, 2);
   const [selectedTab, setSelectedTab] = useState('input-data');
   const { schemaValues } = useSchemaRequestContext();
 
   return (
-    <MainContentContent hasLeftServiceColumn={true} className="relative">
-      <div className="bg-surface2 border-r border-border1 w-80 flex flex-col">
-        <ToolInformation toolDescription={toolDescription} toolId={toolId} toolType={toolType} />
-        <div className="flex-1 overflow-hidden border-t border-border1 flex flex-col">
+    <MainContentContent>
+      <div className="flex w-full flex-col items-center p-5 lg:flex-row lg:items-start lg:justify-center">
+        <div className="grid w-full min-w-0 max-w-3xl content-start gap-5">
+          <ToolInformation toolDescription={toolDescription} toolId={toolId} toolType={toolType} />
           <Tabs defaultTab="input-data" value={selectedTab} onValueChange={setSelectedTab}>
-            <TabList>
+            <TabList variant="pill">
               <Tab value="input-data">Input Data</Tab>
               {requestContextSchema && <Tab value="request-context">Request Context</Tab>}
             </TabList>
           </Tabs>
-          <div className={cn('p-5 overflow-y-auto', selectedTab !== 'input-data' && 'hidden')}>
+          <div className={cn(selectedTab !== 'input-data' && 'hidden')}>
             <DynamicForm
               isSubmitLoading={isExecutingTool}
               schema={zodInputSchema}
               onSubmit={data => {
                 handleExecuteTool(data, schemaValues);
               }}
-              className="h-auto pb-7"
+              className="h-auto"
             />
           </div>
           {requestContextSchema && (
-            <div className={cn('p-5 overflow-y-auto', selectedTab !== 'request-context' && 'hidden')}>
+            <div className={cn(selectedTab !== 'request-context' && 'hidden')}>
               <RequestContextSchemaForm requestContextSchema={requestContextSchema} />
             </div>
           )}
         </div>
-      </div>
-      <div className="absolute top-4 right-4 z-10">
-        <CopyButton content={code} tooltip="Copy JSON result to clipboard" />
-      </div>
-      <div className="p-5 h-full relative overflow-x-auto overflow-y-auto">
-        <CodeMirror value={errorString || code} editable={true} theme={theme} extensions={[jsonLanguage]} />
+        <div
+          className={cn(
+            'w-full min-w-0 overflow-hidden lg:transition-[max-width,opacity,margin-left] lg:duration-300 lg:ease-in-out',
+            hasResult
+              ? 'mt-5 max-w-3xl opacity-100 lg:ml-5 lg:mt-0'
+              : 'hidden lg:block lg:ml-0 lg:max-w-0 lg:opacity-0',
+          )}
+        >
+          <CodeEditor value={errorString || code} language="json" editable={false} />
+        </div>
       </div>
     </MainContentContent>
   );

--- a/packages/playground/src/domains/tools/components/ToolInformation.tsx
+++ b/packages/playground/src/domains/tools/components/ToolInformation.tsx
@@ -1,4 +1,5 @@
 import type { MCPToolType } from '@mastra/core/mcp';
+import { ClampedText } from '@mastra/playground-ui/components/ClampedText';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { Icon } from '@mastra/playground-ui/icons/Icon';
 import { ToolIconMap } from '@/domains/tools/components/ToolIcon';
@@ -13,24 +14,18 @@ export const ToolInformation = ({ toolDescription, toolId, toolType }: ToolInfor
   const ToolIconComponent = ToolIconMap[toolType || 'tool'];
 
   return (
-    <div className="p-5 border-b border-border1">
-      <div className="text-neutral6 flex gap-2">
-        <div>
-          <Icon size="lg" className="bg-surface4 rounded-md p-1">
-            <ToolIconComponent />
-          </Icon>
-        </div>
+    <div className="text-neutral6 flex gap-2">
+      <Icon size="lg" className="bg-surface4 rounded-md p-1 self-start shrink-0">
+        <ToolIconComponent />
+      </Icon>
 
-        <div className="flex gap-4 justify-between w-full min-w-0">
-          <div>
-            <Txt variant="header-md" as="h2" className="font-medium truncate">
-              {toolId}
-            </Txt>
-            <Txt variant="ui-sm" className="text-neutral3">
-              {toolDescription}
-            </Txt>
-          </div>
-        </div>
+      <div className="flex min-w-0 flex-col">
+        <Txt variant="header-md" as="h2" className="font-medium truncate">
+          {toolId}
+        </Txt>
+        <ClampedText variant="ui-sm" className="text-neutral3">
+          {toolDescription}
+        </ClampedText>
       </div>
     </div>
   );


### PR DESCRIPTION
https://github.com/user-attachments/assets/3996faa1-0cac-43e5-b387-394999480973

Reworks the tool execution page (Studio > Tools / agent tools / MCP tools) which previously used a two-column layout with a narrow sidebar form and a full-bleed editable CodeMirror result.

The page is now a single centered column (max-w-3xl): tool info, pill tabs, then the input form. The result only renders after running the tool, read-only via the design-system `CodeEditor` (copy button included), and slides in as a right column on desktop — the form gets pushed left with a smooth max-width transition. On mobile the result stacks below the form.

Tool descriptions are now clamped to 2 lines with a "Read more" toggle. That comes from a new `@mastra/playground-ui` component, `ClampedText`: the toggle only appears when the clamp actually cuts content, detected by measuring the rendered element (re-checked on resize and after fonts load) rather than counting characters.

```tsx
<ClampedText variant="ui-sm" className="text-neutral3" lines={2}>
  {toolDescription}
</ClampedText>
```

`Txt` also accepts a `ref` now (React 19 ref-as-prop), which `ClampedText` uses for the measurement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This makes the tool playground cleaner and easier to use on phones and computers. Long descriptions can be expanded, and tool results are shown in a read-only box with a copy button.

## What changed

- Reworked the tool execution page into a centered, responsive layout.
- Displayed results only after execution, beside the form on desktop and below it on mobile.
- Replaced the editable result pane with the design-system `CodeEditor`.
- Added `ClampedText` with measured “Read more”/“Show less” behavior.
- Added `useIsClamped`, including resize and font-loading checks.
- Updated `Txt` to support React 19 refs.
- Added Storybook stories and tests for clamping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->