### PR TITLE
fix(code-sdk): isolate HOME in loadMcpConfig tests so a global mcp.json cannot leak in

### DIFF
--- a/mastracode/sdk/src/mcp/__tests__/config.test.ts
+++ b/mastracode/sdk/src/mcp/__tests__/config.test.ts
@@ -374,13 +374,28 @@ describe('expandEnvVars', () => {
 
 describe('loadMcpConfig', () => {
   let projectDir: string;
+  let homeDir: string;
+  let previousHome: string | undefined;
+  let previousUserProfile: string | undefined;
 
   beforeEach(() => {
     projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-config-'));
+    // Isolate the global ~/.mastracode/mcp.json so a developer's real config
+    // cannot leak into assertions (os.homedir() reads HOME / USERPROFILE).
+    homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
+    previousHome = process.env.HOME;
+    previousUserProfile = process.env.USERPROFILE;
+    process.env.HOME = homeDir;
+    process.env.USERPROFILE = homeDir;
   });
 
   afterEach(() => {
+    if (previousHome === undefined) delete process.env.HOME;
+    else process.env.HOME = previousHome;
+    if (previousUserProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = previousUserProfile;
     fs.rmSync(projectDir, { recursive: true, force: true });
+    fs.rmSync(homeDir, { recursive: true, force: true });
   });
 
   function writeJson(filePath: string, data: unknown): void {
@@ -427,25 +442,16 @@ describe('loadMcpConfig', () => {
   });
 
   it('lets a root .mcp.json override the global ~/.mastracode/mcp.json by server name', () => {
-    const homeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-home-'));
-    const previousHome = process.env.HOME;
-    process.env.HOME = homeDir;
-    try {
-      writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
-        mcpServers: { shared: { command: 'global-cmd' } },
-      });
-      writeJson(path.join(projectDir, '.mcp.json'), {
-        mcpServers: { shared: { command: 'root-cmd' } },
-      });
+    writeJson(path.join(homeDir, '.mastracode', 'mcp.json'), {
+      mcpServers: { shared: { command: 'global-cmd' } },
+    });
+    writeJson(path.join(projectDir, '.mcp.json'), {
+      mcpServers: { shared: { command: 'root-cmd' } },
+    });
 
-      const config = loadMcpConfig(projectDir);
+    const config = loadMcpConfig(projectDir);
 
-      expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
-    } finally {
-      if (previousHome === undefined) delete process.env.HOME;
-      else process.env.HOME = previousHome;
-      fs.rmSync(homeDir, { recursive: true, force: true });
-    }
+    expect(config.mcpServers!['shared']).toEqual({ command: 'root-cmd', args: undefined, env: undefined });
   });
 
   it('lets a root .mcp.json override .claude/settings.local.json by server name', () => {


### PR DESCRIPTION
Fixes #19545

Two tests in `mastracode/sdk/src/mcp/__tests__/config.test.ts` asserted on the entire merged `mcpServers` object without isolating `$HOME`, so anyone with a personal `~/.mastracode/mcp.json` saw them fail locally with an extra server leaking into the assertion.

This moves HOME (and USERPROFILE, for Windows) isolation into the `loadMcpConfig` describe block's `beforeEach`/`afterEach` using a temp dir, so no test in the suite can read a real global config. The one test that already did per-test HOME isolation now relies on the shared setup instead.

Verified by running the suite with a fake contaminated `$HOME` containing a global `mcp.json`: fails before this change, all 39 tests pass after. Test-only change, no changeset needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Tests now use a temporary pretend home folder instead of accidentally reading your personal MCP settings. This makes them reliable on every developer machine.

## Summary

- Isolated `HOME` and `USERPROFILE` with temporary directories for the entire `loadMcpConfig` test block.
- Restored environment variables and cleaned up temporary files after each test.
- Removed redundant per-test setup and cleanup.
- Verified all 39 tests pass with a contaminated fake `HOME`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->