### PR TITLE
fix(dynamodb): resolve TypeScript strict null-check errors in listMessages date filtering

### DIFF
--- a/.changeset/early-eyes-rule.md
+++ b/.changeset/early-eyes-rule.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dynamodb': patch
+---
+
+Fixed a TypeScript build error in the DynamoDB store where date range filtering in listMessages failed strict null checks

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -433,17 +433,19 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
         const dateRange = filter?.dateRange;
         const startIso = dateRange?.start ? toIso(dateRange.start) : undefined;
         const endIso = dateRange?.end ? toIso(dateRange.end) : undefined;
-        const startOp = dateRange?.startExclusive ? 'gt' : 'gte';
-        const endOp = dateRange?.endExclusive ? 'lt' : 'lte';
+        const startExclusive = dateRange?.startExclusive ?? false;
+        const endExclusive = dateRange?.endExclusive ?? false;
+        const startOp = startExclusive ? 'gt' : 'gte';
+        const endOp = endExclusive ? 'lt' : 'lte';
 
         if (startIso && endIso) {
           query = query.between({ createdAt: startIso }, { createdAt: endIso });
-          if (dateRange.startExclusive || dateRange.endExclusive) {
+          if (startExclusive || endExclusive) {
             query = query.where(({ createdAt }: any, { gt, lt }: any) => {
-              if (dateRange.startExclusive && dateRange.endExclusive) {
+              if (startExclusive && endExclusive) {
                 return `${gt(createdAt, startIso)} AND ${lt(createdAt, endIso)}`;
               }
-              if (dateRange.startExclusive) {
+              if (startExclusive) {
                 return gt(createdAt, startIso);
               }
               return lt(createdAt, endIso);


### PR DESCRIPTION
## Summary

The release PR #19522 (`chore: version packages (alpha)`) failed CI in the Build and Validate build outputs jobs. `@mastra/dynamodb#build:lib` errored with five TS18048 (`'dateRange' is possibly 'undefined'`) errors in `stores/dynamodb/src/storage/domains/memory/index.ts`.

In `applyQueryFilters`, `dateRange` comes from `filter?.dateRange` and may be undefined. The code guarded on derived `startIso && endIso` values, which doesn't narrow `dateRange` itself, so subsequent `dateRange.startExclusive` / `dateRange.endExclusive` accesses failed strict null checks. Main stayed green only because the turbo cache had a hit for this package; the version bump in the release PR invalidated the cache and surfaced the error.

This change captures `startExclusive` and `endExclusive` as local booleans (defaulting to `false`) and uses them throughout, removing the unsafe accesses. No behavior change.

## Test plan

- `pnpm turbo build:lib --filter @mastra/dynamodb --force` passes locally (was failing with the same TS18048 errors before the fix)
