### PR TITLE
docs: fix RedisServerCache constructor usage — takes { client }, not { url }

### DIFF
--- a/.changeset/spicy-donkeys-search.md
+++ b/.changeset/spicy-donkeys-search.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fix `RedisServerCache` examples in the durable-agents docs, the durable-agents example README, and the `createDurableAgent` JSDoc. The examples constructed the cache with `new RedisServerCache({ url: '...' })`, but the actual constructor signature is `new RedisServerCache({ client })` — it takes a connected Redis client (e.g. ioredis), not a URL. Anyone following the production-hardening docs hit a runtime failure on the first cache call. The `{ url }` shape belongs to `UpstashServerCache`, which the snippets were likely copied from.
+Fix the `createDurableAgent` JSDoc examples to construct `RedisServerCache` with a connected Redis client (`{ client }`) instead of a `{ url }` config the class does not accept.

--- a/.changeset/spicy-donkeys-search.md
+++ b/.changeset/spicy-donkeys-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fix `RedisServerCache` examples in the durable-agents docs, the durable-agents example README, and the `createDurableAgent` JSDoc. The examples constructed the cache with `new RedisServerCache({ url: '...' })`, but the actual constructor signature is `new RedisServerCache({ client })` — it takes a connected Redis client (e.g. ioredis), not a URL. Anyone following the production-hardening docs hit a runtime failure on the first cache call. The `{ url }` shape belongs to `UpstashServerCache`, which the snippets were likely copied from.

--- a/docs/src/content/en/docs/long-running-agents/durable-agents.mdx
+++ b/docs/src/content/en/docs/long-running-agents/durable-agents.mdx
@@ -166,11 +166,12 @@ cleanup()
 
 `createDurableAgent()` and `createEventedAgent()` use an in-memory cache by default, which means resumable streams work within a single process. For production, provide a persistent cache backend (e.g., Redis) so cached events survive process restarts:
 
-```typescript title="src/mastra/agents/durable-with-cache.ts" {2,7}
+```typescript title="src/mastra/agents/durable-with-cache.ts" {2,3,5,9}
 import { createDurableAgent } from '@mastra/core/agent/durable'
 import { RedisServerCache } from '@mastra/redis'
+import Redis from 'ioredis'
 
-const cache = new RedisServerCache({ url: 'redis://localhost:6379' })
+const cache = new RedisServerCache({ client: new Redis('redis://localhost:6379') })
 
 export const durableAgent = createDurableAgent({
   agent,

--- a/examples/durable-agents/README.md
+++ b/examples/durable-agents/README.md
@@ -63,9 +63,10 @@ All three agent types inherit `cache` and `pubsub` from the Mastra instance:
 ```typescript
 import { EventEmitterPubSub } from '@mastra/core/events';
 import { RedisServerCache } from '@mastra/redis';
+import Redis from 'ioredis';
 
 // Redis cache for resumable streams - events persist across reconnections
-const cache = new RedisServerCache({ url: 'redis://localhost:6379' });
+const cache = new RedisServerCache({ client: new Redis('redis://localhost:6379') });
 
 // EventEmitter pubsub for real-time delivery (process-local)
 const pubsub = new EventEmitterPubSub();

--- a/packages/core/src/agent/durable/index.ts
+++ b/packages/core/src/agent/durable/index.ts
@@ -45,18 +45,19 @@
  *
  * @example Custom cache backend (e.g., Redis)
  * ```typescript
- * import { RedisServerCache } from '@mastra/redis'; // hypothetical
+ * import { RedisServerCache } from '@mastra/redis';
+ * import Redis from 'ioredis';
  *
  * const durableAgent = createDurableAgent({
  *   agent,
- *   cache: new RedisServerCache({ url: 'redis://...' }),
+ *   cache: new RedisServerCache({ client: new Redis('redis://...') }),
  * });
  * ```
  *
  * @example Cache inheritance from Mastra
  * ```typescript
  * const mastra = new Mastra({
- *   cache: new RedisServerCache({ url: 'redis://...' }),
+ *   cache: new RedisServerCache({ client: new Redis('redis://...') }),
  *   agents: {
  *     myAgent: createDurableAgent({ agent }), // Inherits Redis cache from Mastra
  *   },


### PR DESCRIPTION
## Description

The durable-agents docs, the durable-agents example README, and the `createDurableAgent` JSDoc construct the cache with `new RedisServerCache({ url: '...' })`, but the actual constructor (`stores/redis/src/cache.ts`, unchanged since #12557 introduced the class) is:

```ts
constructor(config: { client: RedisClient }, options: RedisServerCacheOptions = {})
```

There is no `url` handling. TypeScript users get a compile error on a snippet copied verbatim from the docs. For JavaScript users the constructor accepts the object, leaves `this.client` undefined, and the crash comes on the first real cache operation with `TypeError: Cannot read properties of undefined (reading 'get')`, which fires when a durable stream first writes cache events.

The `{ url }` shape belongs to `UpstashServerCache` (`{ client } | { url; token }`); the JSDoc still carried a `// hypothetical` marker from before `RedisServerCache` existed. The example's own source (`examples/durable-agents/src/mastra/index.ts`) has used the correct `{ client: new Redis(...) }` form since the same birth commit. This PR aligns the three living text locations with it (ioredis shown as the client):

- `docs/src/content/en/docs/long-running-agents/durable-agents.mdx` (the "persistent cache backend for production" snippet)
- `examples/durable-agents/README.md`
- `packages/core/src/agent/durable/index.ts` JSDoc (both `@example` blocks; `// hypothetical` marker dropped)

We leave the historical CHANGELOG entries that inherited the snippet untouched. The changeset exists because the PR touches a `packages/core` source file (a JSDoc comment). Drop it if a comment-only change shouldn't cut a release.

## Related issue(s)

Fixes #19568

## Type of change

- [x] Documentation update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (docs-only change)
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates the docs and code examples so they connect to Redis the right way. That way, when you copy-paste the example, the Redis cache will actually have a working Redis client instead of crashing or failing TypeScript.

## What changed
- Updated durable-agents documentation, example README, and `createDurableAgent` JSDoc to construct `RedisServerCache` with `{ client: new Redis(...) }` instead of `{ url: '...' }`.
- Removed the outdated `// hypothetical` markers from the JSDoc examples.
- Added a `@mastra/core` patch changeset for the JSDoc update.
- Left historical CHANGELOG entries unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
