### PR TITLE
fix(dynamodb): listMessages hasMore accounts for messages returned via include

### DIFF
--- a/.changeset/puny-oranges-hug.md
+++ b/.changeset/puny-oranges-hug.md
@@ -1,0 +1,5 @@
+---
+'@mastra/dynamodb': patch
+---
+
+Fixed listMessages reporting hasMore: true when the remaining thread messages were already returned through include context. DynamoDB now matches other storage adapters: hasMore is false once every thread message has been returned via pagination or include.

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -542,8 +542,15 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
       // Sort all messages (paginated + included) for final output
       finalMessages = this._sortMessages(finalMessages, field, direction);
 
-      // hasMore reflects filtered pagination only; included context must not suppress it.
-      const hasMore = perPageInput !== false && offset + perPage < total;
+      // Calculate hasMore based on pagination window
+      // If all thread messages have been returned (through pagination or include), hasMore = false
+      // Otherwise, check if there are more pages in the pagination window
+      const threadIdSet = new Set(threadIds);
+      const returnedThreadMessageIds = new Set(
+        finalMessages.filter(m => m.threadId && threadIdSet.has(m.threadId)).map(m => m.id),
+      );
+      const allThreadMessagesReturned = returnedThreadMessageIds.size >= total;
+      const hasMore = perPageInput !== false && !allThreadMessagesReturned && offset + perPage < total;
 
       return {
         messages: finalMessages,

--- a/stores/dynamodb/src/storage/domains/memory/index.ts
+++ b/stores/dynamodb/src/storage/domains/memory/index.ts
@@ -466,6 +466,9 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
 
       let paginatedMessages: MastraDBMessage[] = [];
       let total = 0;
+      // Ids of thread messages matching the active filters (resourceId/dateRange). Used for hasMore:
+      // included context can pull in messages outside the filters, which must not count toward total.
+      const filteredMessageIds = new Set<string>();
 
       if (threadIds.length > 1) {
         // DynamoDB can't query multiple partitions in one request. For multi-thread calls,
@@ -477,11 +480,14 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
             );
             const countResult = await q.go({ pages: 'all', attributes: ['id'] });
             const results = await q.go({ pages: 'all', order });
-            return { total: countResult.data.length, messages: parseQueryMessages(results.data) };
+            return { ids: countResult.data.map((item: any) => item.id), messages: parseQueryMessages(results.data) };
           }),
         );
 
-        total = threadResults.reduce((sum, r) => sum + r.total, 0);
+        for (const r of threadResults) {
+          for (const id of r.ids) filteredMessageIds.add(id);
+        }
+        total = threadResults.reduce((sum, r) => sum + r.ids.length, 0);
         const merged = threadResults.flatMap(r => r.messages);
         const sorted = this._sortMessages(merged, field, direction);
         paginatedMessages = perPageInput === false ? sorted : sorted.slice(offset, offset + perPage);
@@ -493,6 +499,7 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
         // Lightweight total: id-only reads across all pages (no full message bodies).
         const countResult = await query.go({ pages: 'all', attributes: ['id'] });
         total = countResult.data.length;
+        for (const item of countResult.data) filteredMessageIds.add(item.id);
 
         if (perPageInput === false) {
           const results = await query.go({ pages: 'all', order });
@@ -543,14 +550,14 @@ export class MemoryStorageDynamoDB extends MemoryStorage {
       finalMessages = this._sortMessages(finalMessages, field, direction);
 
       // Calculate hasMore based on pagination window
-      // If all thread messages have been returned (through pagination or include), hasMore = false
-      // Otherwise, check if there are more pages in the pagination window
-      const threadIdSet = new Set(threadIds);
-      const returnedThreadMessageIds = new Set(
-        finalMessages.filter(m => m.threadId && threadIdSet.has(m.threadId)).map(m => m.id),
+      // If all filter-matching thread messages have been returned (through pagination or include),
+      // hasMore = false. Otherwise, check if there are more pages in the pagination window.
+      // Only count messages matching the active filters: include can add messages outside them.
+      const returnedFilteredMessageIds = new Set(
+        finalMessages.filter(m => filteredMessageIds.has(m.id)).map(m => m.id),
       );
-      const allThreadMessagesReturned = returnedThreadMessageIds.size >= total;
-      const hasMore = perPageInput !== false && !allThreadMessagesReturned && offset + perPage < total;
+      const allFilteredMessagesReturned = returnedFilteredMessageIds.size >= total;
+      const hasMore = perPageInput !== false && !allFilteredMessagesReturned && offset + perPage < total;
 
       return {
         messages: finalMessages,

--- a/stores/dynamodb/src/storage/domains/memory/list-messages.test.ts
+++ b/stores/dynamodb/src/storage/domains/memory/list-messages.test.ts
@@ -317,6 +317,66 @@ describe('DynamoDB listMessages pagination', () => {
     expect(result.hasMore).toBe(true);
   });
 
+  it('does not suppress hasMore when include adds messages outside the date range filter', async () => {
+    const thread = createSampleThread();
+    await memory.saveThread({ thread });
+
+    const base = Date.now();
+    const messages: MastraDBMessage[] = Array.from({ length: 10 }, (_, i) =>
+      createSampleMessageV2({
+        threadId: thread.id,
+        createdAt: new Date(base + i * 1000),
+        content: { content: `msg-${i}` },
+      }),
+    );
+    await memory.saveMessages({ messages });
+
+    // Filter matches msg-4..msg-9 (total 6). Page 0 returns msg-4, msg-5, msg-6.
+    // Include targets msg-0 with context msg-0..msg-2 — all outside the date range.
+    // The 3 filtered + 3 included = 6 returned messages must NOT satisfy total=6:
+    // msg-7..msg-9 still match the filter and remain unfetched.
+    const result = await memory.listMessages({
+      threadId: thread.id,
+      perPage: 3,
+      page: 0,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+      filter: { dateRange: { start: new Date(base + 4000) } },
+      include: [{ id: messages[0]!.id, withNextMessages: 2 }],
+    });
+
+    expect(result.total).toBe(6);
+    expect(result.messages.map(getMessageText)).toEqual(['msg-0', 'msg-1', 'msg-2', 'msg-4', 'msg-5', 'msg-6']);
+    expect(result.hasMore).toBe(true);
+  });
+
+  it('reports hasMore false when pagination plus include return all filtered messages', async () => {
+    const thread = createSampleThread();
+    await memory.saveThread({ thread });
+
+    const base = Date.now();
+    const messages: MastraDBMessage[] = Array.from({ length: 5 }, (_, i) =>
+      createSampleMessageV2({
+        threadId: thread.id,
+        createdAt: new Date(base + i * 1000),
+        content: { content: `msg-${i}` },
+      }),
+    );
+    await memory.saveMessages({ messages });
+
+    // Page 0 returns msg-0..msg-2; include pulls msg-3 and msg-4 → all 5 returned.
+    const result = await memory.listMessages({
+      threadId: thread.id,
+      perPage: 3,
+      page: 0,
+      orderBy: { field: 'createdAt', direction: 'ASC' },
+      include: [{ id: messages[3]!.id, withNextMessages: 1 }],
+    });
+
+    expect(result.total).toBe(5);
+    expect(result.messages).toHaveLength(5);
+    expect(result.hasMore).toBe(false);
+  });
+
   it('supports exclusive date range boundaries via between() plus where()', async () => {
     const thread = createSampleThread();
     await memory.saveThread({ thread });


### PR DESCRIPTION
## Summary

The `Combined Store Tests / test (dynamodb)` CI job is failing on `main` (and blocking the changesets release PR #19522). The shared store test `should respect pagination when using include` expects `hasMore: false` when a page plus its `include` context together return every message in the thread — the behavior implemented by the libsql and pg adapters.

#19562 fixed DynamoDB `listMessages` truncation (#19550) but computed `hasMore` from the pagination window alone, so a call returning all 5 thread messages (3 paginated + 2 via include) still reported `hasMore: true`.

This change aligns DynamoDB with the other storage adapters: `hasMore` is `false` once every thread message has been returned via pagination or include; otherwise it still reflects the pagination window.

The truncation protections from #19550/#19562 are preserved — `total` is still counted with an id-only read across **all** DynamoDB pages, so a truncated large thread can never satisfy the "all messages returned" condition and incorrectly report `hasMore: false`.

## Test plan

- [x] `stores/dynamodb` full test suite against DynamoDB Local: 255 passed (incl. the previously failing `should respect pagination when using include` and the #19550 regression tests `returns include context for a target beyond the first DynamoDB page` / `returns full requested page when offset+perPage crosses a DynamoDB page boundary`)
- [x] `tsc --noEmit` in `stores/dynamodb`

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

DynamoDB now correctly says whether more messages exist after combining paginated messages with included messages. When everything has been returned, it reports `hasMore: false`, like the other database adapters.

## Changes

- Updated DynamoDB `listMessages` to determine `hasMore` using all returned thread message IDs, including messages from `include`.
- Preserved truncation protections by counting totals across all pages with an ID-only read.
- Added a patch changeset for `@mastra/dynamodb`.
- TypeScript checks and DynamoDB regression tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->