### PR TITLE
docs: document build-time entry configuration

### DIFF
--- a/docs/src/content/en/docs/deployment/mastra-server.mdx
+++ b/docs/src/content/en/docs/deployment/mastra-server.mdx
@@ -70,6 +70,41 @@ Read the [`mastra start`](/reference/cli/mastra#mastra-start) reference for all 
 
 ## Build configuration
 
+### Build-time configuration
+
+Mastra reads the `bundler`, `deployer`, and `server` options while it builds your application. Keep those options as direct properties of the object passed to `new Mastra()` so the build can extract them.
+
+The following entry-file shape works:
+
+```typescript title="src/mastra/index.ts"
+import { Mastra } from '@mastra/core/mastra'
+
+export const mastra = new Mastra({
+  bundler: {
+    externals: ['sharp'],
+  },
+  server: {
+    port: 4111,
+  },
+})
+```
+
+The value of each option can come from a variable, import, or function call. The option itself must remain a direct property. Do not hide build-time options behind a factory call or an object spread:
+
+```typescript title="src/mastra/index.ts"
+const options = {
+  bundler: {
+    externals: ['sharp'],
+  },
+}
+
+// These patterns prevent Mastra from extracting `bundler` during the build.
+export const mastra = new Mastra(createMastraOptions())
+export const otherMastra = new Mastra({ ...options })
+```
+
+When Mastra can't extract an option, it uses the default build behavior for that option. See the [configuration reference](/reference/configuration) for the available `bundler`, `deployer`, and `server` settings.
+
 ### Public folder
 
 If a `public` folder exists in your Mastra directory (`src/mastra/public`), its contents are copied to the output directory during build. These files are served as static assets by the server.

--- a/docs/src/content/en/docs/deployment/monorepo.mdx
+++ b/docs/src/content/en/docs/deployment/monorepo.mdx
@@ -107,6 +107,8 @@ export const mastra = new Mastra({
 })
 ```
 
+Keep `bundler` as a direct property in the object passed to `new Mastra()`. See [build-time configuration](/docs/deployment/mastra-server#build-time-configuration) for the supported entry-file shape.
+
 ## Environment variables
 
 Store `.env` files in the Mastra application directory (e.g., `apps/api/.env`), not the monorepo root.


### PR DESCRIPTION
Closes #19382

Documents the entry-file contract for `bundler`, `deployer`, and `server`, including supported and unsupported shapes. Adds a link from the monorepo deployment guide so the constraint is visible where workspace bundling is configured.

Validated with `pnpm --dir docs build`, Prettier, and focused MDX lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra now explains which configuration settings it can read while building your app and shows the correct way to write them. The deployment guide also links to these rules so users can avoid configurations that silently fall back to defaults.

## Changes

- Documented build-time extraction for `bundler`, `deployer`, and `server`.
- Explained the required direct object-literal shape in `new Mastra({ ... })`.
- Documented unsupported patterns, including factory calls, object spreads, and reassigned `let` values.
- Added guidance about fallback build behavior and linked the configuration reference.
- Cross-linked the monorepo deployment guide, with emphasis on keeping `bundler` as a direct property.
- Validated with the docs build, Prettier, and focused MDX lint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->