### PR TITLE
MC Web: configurable factory entry point with pluggable auth and sandbox providers

### DIFF
--- a/.changeset/long-signs-retire.md
+++ b/.changeset/long-signs-retire.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': patch
+---
+
+Fixed AgentControllerSession.subscribe() so it resolves only after the stream is established (rejecting when it cannot connect), retries with exponential backoff, and notifies consumers of re-established streams via a new onReconnect callback so they can re-sync missed events.

--- a/.changeset/long-signs-retire.md
+++ b/.changeset/long-signs-retire.md
@@ -2,4 +2,16 @@
 '@mastra/client-js': patch
 ---
 
-Fixed AgentControllerSession.subscribe() so it resolves only after the stream is established and rejects when it cannot connect (leaving no background retry loop). Reconnect now applies only after an established stream drops, backs off exponentially, and fires a new onReconnect callback on each re-established stream so consumers can re-sync missed events.
+Fixed AgentControllerSession.subscribe() so it resolves only after the stream is established and rejects when it cannot connect (leaving no background retry loop). Reconnect now applies only after an established stream drops, backs off exponentially, and fires a new onReconnect callback on each re-established stream so consumers can re-sync missed events:
+
+```ts
+const subscription = await session.subscribe({
+  onEvent: event => applyEvent(event),
+  onError: error => showDisconnected(error),
+  reconnect: { maxRetries: 5, delayMs: 1000, maxDelayMs: 30_000 },
+  onReconnect: async () => {
+    // Events emitted while disconnected are not replayed — re-sync state.
+    applyState(await session.state());
+  },
+});
+```

--- a/.changeset/long-signs-retire.md
+++ b/.changeset/long-signs-retire.md
@@ -2,4 +2,4 @@
 '@mastra/client-js': patch
 ---
 
-Fixed AgentControllerSession.subscribe() so it resolves only after the stream is established (rejecting when it cannot connect), retries with exponential backoff, and notifies consumers of re-established streams via a new onReconnect callback so they can re-sync missed events.
+Fixed AgentControllerSession.subscribe() so it resolves only after the stream is established and rejects when it cannot connect (leaving no background retry loop). Reconnect now applies only after an established stream drops, backs off exponentially, and fires a new onReconnect callback on each re-established stream so consumers can re-sync missed events.

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -494,29 +494,7 @@ describe('AgentController Resource', () => {
     expect((global.fetch as any).mock.calls).toHaveLength(1);
   });
 
-  it('retries the initial connection under the reconnect policy before resolving', async () => {
-    const event = { type: 'agent_start' };
-    (global.fetch as any)
-      .mockRejectedValueOnce(new Error('connect refused'))
-      .mockResolvedValueOnce(openSseResponse([`data: ${JSON.stringify(event)}\n\n`]));
-
-    const received: AgentControllerEvent[] = [];
-    const sub = await noRetryClient()
-      .getAgentController('code')
-      .session('user-1')
-      .subscribe({
-        onEvent: e => received.push(e),
-        reconnect: { maxRetries: 1, delayMs: 0 },
-      });
-
-    await new Promise(r => setTimeout(r, 10));
-    sub.unsubscribe();
-
-    expect((global.fetch as any).mock.calls).toHaveLength(2);
-    expect(received).toEqual([event]);
-  });
-
-  it('rejects subscribe when initial connection retries are exhausted', async () => {
+  it('rejects subscribe on initial connection failure even with reconnect enabled', async () => {
     (global.fetch as any).mockRejectedValue(new Error('still down'));
 
     await expect(
@@ -525,12 +503,15 @@ describe('AgentController Resource', () => {
         .session('user-1')
         .subscribe({
           onEvent: () => {},
-          reconnect: { maxRetries: 2, delayMs: 0 },
+          reconnect: true,
         }),
     ).rejects.toThrow('still down');
 
-    // Initial attempt + 2 retries.
-    expect((global.fetch as any).mock.calls).toHaveLength(3);
+    // Reconnect governs only re-establishment after an established stream
+    // drops — a rejected subscribe leaves no retry loop running.
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+    await new Promise(r => setTimeout(r, 30));
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
   });
 
   it('calls onReconnect when the stream is re-established, but not on first connect', async () => {

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -582,6 +582,59 @@ describe('AgentController Resource', () => {
     sub.unsubscribe();
   });
 
+  it('normalizes invalid reconnect options instead of hot-looping', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]))
+      .mockRejectedValue(new Error('still down'));
+
+    const onError = vi.fn();
+    const sub = await noRetryClient()
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: () => {},
+        onError,
+        // NaN delays would fire zero-delay timers; NaN maxRetries would never
+        // exhaust (`n >= NaN` is false). Both must fall back to defaults.
+        reconnect: { maxRetries: NaN, delayMs: NaN, maxDelayMs: -1 },
+      });
+
+    // Default delayMs is 1000 — nothing should have retried this fast.
+    await new Promise(r => setTimeout(r, 50));
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+    expect(onError).not.toHaveBeenCalled();
+
+    sub.unsubscribe();
+  });
+
+  it('does not treat a throwing onError callback as an unhandled rejection or transport error', async () => {
+    mockSse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]);
+
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      const sub = await client
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: () => {},
+          onError: () => {
+            throw new Error('consumer onError blew up');
+          },
+        });
+
+      await new Promise(r => setTimeout(r, 20));
+      sub.unsubscribe();
+
+      // Terminal onError threw inside the detached loop — must be swallowed,
+      // not surfaced as an unhandled rejection, and must not trigger a retry.
+      expect(unhandled).not.toHaveBeenCalled();
+      expect((global.fetch as any).mock.calls).toHaveLength(1);
+    } finally {
+      process.removeListener('unhandledRejection', unhandled);
+    }
+  });
+
   it('sends a notification signal', async () => {
     mockJson({ accepted: true, notificationId: 'n-1', decision: 'deliver', runId: 'run-1' });
     const result = await client

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -465,6 +465,142 @@ describe('AgentController Resource', () => {
     expect((global.fetch as any).mock.calls).toHaveLength(1);
   });
 
+  // A stream that emits frames but never closes, so tests can control when the
+  // subscription ends via unsubscribe instead of racing a clean close.
+  const openSseResponse = (frames: string[]) =>
+    new Response(
+      new ReadableStream({
+        start(controller) {
+          for (const frame of frames) controller.enqueue(new TextEncoder().encode(frame));
+        },
+      }),
+      { status: 200, headers: new Headers({ 'Content-Type': 'text/event-stream' }) },
+    );
+
+  // request() has its own internal retry loop; disable it so these specs
+  // observe subscribe()'s connection policy directly.
+  const noRetryClient = () => new MastraClient({ baseUrl: 'http://localhost:4111', retries: 0 });
+
+  it('rejects subscribe when the initial connection fails without reconnect', async () => {
+    (global.fetch as any).mockRejectedValue(new Error('connect refused'));
+
+    await expect(
+      noRetryClient()
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({ onEvent: () => {} }),
+    ).rejects.toThrow('connect refused');
+
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+  });
+
+  it('retries the initial connection under the reconnect policy before resolving', async () => {
+    const event = { type: 'agent_start' };
+    (global.fetch as any)
+      .mockRejectedValueOnce(new Error('connect refused'))
+      .mockResolvedValueOnce(openSseResponse([`data: ${JSON.stringify(event)}\n\n`]));
+
+    const received: AgentControllerEvent[] = [];
+    const sub = await noRetryClient()
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: e => received.push(e),
+        reconnect: { maxRetries: 1, delayMs: 0 },
+      });
+
+    await new Promise(r => setTimeout(r, 10));
+    sub.unsubscribe();
+
+    expect((global.fetch as any).mock.calls).toHaveLength(2);
+    expect(received).toEqual([event]);
+  });
+
+  it('rejects subscribe when initial connection retries are exhausted', async () => {
+    (global.fetch as any).mockRejectedValue(new Error('still down'));
+
+    await expect(
+      noRetryClient()
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: () => {},
+          reconnect: { maxRetries: 2, delayMs: 0 },
+        }),
+    ).rejects.toThrow('still down');
+
+    // Initial attempt + 2 retries.
+    expect((global.fetch as any).mock.calls).toHaveLength(3);
+  });
+
+  it('calls onReconnect when the stream is re-established, but not on first connect', async () => {
+    const firstEvent = { type: 'agent_start' };
+    const secondEvent = { type: 'agent_end', reason: 'complete' };
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify(firstEvent)}\n\n`]))
+      .mockResolvedValueOnce(openSseResponse([`data: ${JSON.stringify(secondEvent)}\n\n`]));
+
+    const order: string[] = [];
+    const done = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => reject(new Error('timeout')), 2000);
+      void noRetryClient()
+        .getAgentController('code')
+        .session('user-1')
+        .subscribe({
+          onEvent: event => {
+            order.push(`event:${event.type}`);
+            if (event.type === 'agent_end') {
+              clearTimeout(timer);
+              resolve();
+            }
+          },
+          onReconnect: () => order.push('reconnect'),
+          onError: error => {
+            clearTimeout(timer);
+            reject(error);
+          },
+          reconnect: { maxRetries: 1, delayMs: 0 },
+        })
+        .then(sub => {
+          void done.then(() => sub.unsubscribe());
+        });
+    });
+
+    await done;
+
+    expect(order).toEqual(['event:agent_start', 'reconnect', 'event:agent_end']);
+  });
+
+  it('backs off exponentially between reconnect attempts', async () => {
+    (global.fetch as any)
+      .mockResolvedValueOnce(sseResponse([`data: ${JSON.stringify({ type: 'agent_start' })}\n\n`]))
+      .mockRejectedValue(new Error('still down'));
+
+    const onError = vi.fn();
+    const sub = await noRetryClient()
+      .getAgentController('code')
+      .session('user-1')
+      .subscribe({
+        onEvent: () => {},
+        onError,
+        reconnect: { maxRetries: 2, delayMs: 100 },
+      });
+
+    // First retry waits ~100ms, second ~200ms (100 * 2^1).
+    await new Promise(r => setTimeout(r, 50));
+    expect((global.fetch as any).mock.calls).toHaveLength(1);
+
+    await new Promise(r => setTimeout(r, 150));
+    expect((global.fetch as any).mock.calls).toHaveLength(2);
+    expect(onError).not.toHaveBeenCalled();
+
+    await new Promise(r => setTimeout(r, 300));
+    expect((global.fetch as any).mock.calls).toHaveLength(3);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    sub.unsubscribe();
+  });
+
   it('sends a notification signal', async () => {
     mockJson({ accepted: true, notificationId: 'n-1', decision: 'deliver', runId: 'run-1' });
     const result = await client

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -362,11 +362,13 @@ export interface SubscribeAgentControllerSessionOptions {
    */
   onReconnect?: () => void;
   /**
-   * Automatically re-establish the stream after a clean close or transport
-   * error. Retries back off exponentially from `delayMs` (default 1s) up to
-   * `maxDelayMs` (default 30s); `maxRetries` (default Infinity) bounds the
-   * attempts per outage — the counter resets once a connection is
-   * re-established. When retries are exhausted, `onError` fires.
+   * Automatically re-establish the stream after an established stream drops
+   * (clean close or transport error). Does not apply to the initial
+   * connection — `subscribe()` rejects if it can't connect. Retries back off
+   * exponentially from `delayMs` (default 1s) up to `maxDelayMs` (default
+   * 30s); `maxRetries` (default Infinity) bounds the attempts per outage —
+   * the counter resets once a connection is re-established. When retries are
+   * exhausted, `onError` fires.
    */
   reconnect?:
     | boolean
@@ -433,8 +435,10 @@ export class AgentControllerSession extends BaseResource {
    * message arrives here as `message_*` events, not on the sendMessage call.
    *
    * The returned promise resolves once the stream is actually established and
-   * rejects when it cannot be — with `reconnect` enabled, initial connection
-   * failures are retried under the same policy before rejecting.
+   * rejects when it cannot be. A rejected subscribe leaves nothing running —
+   * `reconnect` governs only re-establishment after an established stream
+   * drops, so callers that want connect-time retry can loop around
+   * `subscribe()` themselves and keep cancellation control.
    */
   async subscribe(options: SubscribeAgentControllerSessionOptions): Promise<AgentControllerSubscription> {
     const reconnectOptions =
@@ -561,22 +565,12 @@ export class AgentControllerSession extends BaseResource {
     };
 
     // Establish the FIRST stream before resolving so callers can trust that a
-    // resolved subscribe() means events are flowing. Unsubscribe isn't
-    // available yet, so no cancellation checks are needed here. Initial
-    // failures retry under the reconnect policy; when retries are exhausted
-    // (or reconnect is off) the promise rejects.
-    const firstResponse = await (async (): Promise<Response> => {
-      let attempts = 0;
-      while (true) {
-        try {
-          return await requestStream();
-        } catch (error) {
-          if (!reconnectOptions || attempts >= reconnectOptions.maxRetries) throw error;
-          attempts++;
-          await delay(backoffDelay(attempts));
-        }
-      }
-    })();
+    // resolved subscribe() means events are flowing, and a rejected one means
+    // nothing is running in the background. Reconnect deliberately does not
+    // apply here: retrying before a subscription handle exists would leave the
+    // caller with no way to cancel the loop (e.g. reconnect: true would hang
+    // forever against a down server).
+    const firstResponse = await requestStream();
 
     // Background loop: pump the current stream; on drop, re-establish it under
     // the reconnect policy (exponential backoff, per-outage retry budget) and

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -441,14 +441,21 @@ export class AgentControllerSession extends BaseResource {
    * `subscribe()` themselves and keep cancellation control.
    */
   async subscribe(options: SubscribeAgentControllerSessionOptions): Promise<AgentControllerSubscription> {
+    // Normalize reconnect knobs defensively: NaN/negative delays would produce
+    // zero-delay timers and a NaN retry cap would never exhaust (`n >= NaN` is
+    // always false), turning an outage into a hot retry loop.
+    const finiteOr = (value: number | undefined, fallback: number) =>
+      typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : fallback;
+    const retriesOr = (value: number | undefined, fallback: number) =>
+      value === Infinity || (typeof value === 'number' && Number.isFinite(value) && value >= 0) ? value : fallback;
     const reconnectOptions =
       options.reconnect === true
         ? { maxRetries: Infinity, delayMs: 1000, maxDelayMs: 30_000 }
         : options.reconnect
           ? {
-              maxRetries: options.reconnect.maxRetries ?? Infinity,
-              delayMs: options.reconnect.delayMs ?? 1000,
-              maxDelayMs: options.reconnect.maxDelayMs ?? 30_000,
+              maxRetries: retriesOr(options.reconnect.maxRetries, Infinity),
+              delayMs: finiteOr(options.reconnect.delayMs, 1000),
+              maxDelayMs: finiteOr(options.reconnect.maxDelayMs, 30_000),
             }
           : null;
 
@@ -532,7 +539,7 @@ export class AgentControllerSession extends BaseResource {
               try {
                 options.onEvent(event);
               } catch (cause) {
-                if (!cancelled) options.onError?.(cause);
+                if (!cancelled) safeOnError(cause);
                 return { kind: 'consumer_error' };
               }
             }
@@ -547,12 +554,19 @@ export class AgentControllerSession extends BaseResource {
       }
     };
 
-    const reportTerminalError = (result: Extract<PumpResult, { kind: 'done' } | { kind: 'transport_error' }>) => {
-      if (result.kind === 'transport_error') {
-        options.onError?.(result.error);
-        return;
+    // Consumer callbacks run inside the detached stream loop (`void run(...)`),
+    // so a throwing onError would surface as an unhandled promise rejection —
+    // and, thrown from inside pump(), would be misread as a transport error.
+    const safeOnError = (error: unknown) => {
+      try {
+        options.onError?.(error);
+      } catch {
+        // Consumer callback failures must not kill (or reroute) the stream loop.
       }
-      options.onError?.(streamEndedError());
+    };
+
+    const reportTerminalError = (result: Extract<PumpResult, { kind: 'done' } | { kind: 'transport_error' }>) => {
+      safeOnError(result.kind === 'transport_error' ? result.error : streamEndedError());
     };
 
     /** Pump one established stream, mapping unexpected throws to transport errors. */

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -349,13 +349,31 @@ export interface AgentControllerRequestOptions {
 export interface SubscribeAgentControllerSessionOptions {
   /** Called for each event received over the stream. */
   onEvent: (event: AgentControllerEvent) => void;
-  /** Called when the stream errors or ends unexpectedly. */
+  /**
+   * Called when the stream errors or ends and no (further) reconnect will be
+   * attempted — the subscription is dead after this fires.
+   */
   onError?: (error: unknown) => void;
+  /**
+   * Called each time the stream is re-established after a drop (reconnect
+   * only). The server does NOT replay events missed while disconnected, so
+   * stateful consumers MUST re-sync from here (e.g. `session.state()`) or
+   * they will silently lose the gap.
+   */
+  onReconnect?: () => void;
+  /**
+   * Automatically re-establish the stream after a clean close or transport
+   * error. Retries back off exponentially from `delayMs` (default 1s) up to
+   * `maxDelayMs` (default 30s); `maxRetries` (default Infinity) bounds the
+   * attempts per outage — the counter resets once a connection is
+   * re-established. When retries are exhausted, `onError` fires.
+   */
   reconnect?:
     | boolean
     | {
         maxRetries?: number;
         delayMs?: number;
+        maxDelayMs?: number;
       };
 }
 
@@ -413,14 +431,26 @@ export class AgentControllerSession extends BaseResource {
   /**
    * Subscribe to this session's event stream (SSE). The assistant's reply to a
    * message arrives here as `message_*` events, not on the sendMessage call.
+   *
+   * The returned promise resolves once the stream is actually established and
+   * rejects when it cannot be — with `reconnect` enabled, initial connection
+   * failures are retried under the same policy before rejecting.
    */
   async subscribe(options: SubscribeAgentControllerSessionOptions): Promise<AgentControllerSubscription> {
     const reconnectOptions =
       options.reconnect === true
-        ? { maxRetries: Infinity, delayMs: 1000 }
+        ? { maxRetries: Infinity, delayMs: 1000, maxDelayMs: 30_000 }
         : options.reconnect
-          ? { maxRetries: options.reconnect.maxRetries ?? Infinity, delayMs: options.reconnect.delayMs ?? 1000 }
+          ? {
+              maxRetries: options.reconnect.maxRetries ?? Infinity,
+              delayMs: options.reconnect.delayMs ?? 1000,
+              maxDelayMs: options.reconnect.maxDelayMs ?? 30_000,
+            }
           : null;
+
+    /** Exponential backoff for the Nth (1-based) retry of an outage streak. */
+    const backoffDelay = (attempt: number) =>
+      reconnectOptions ? Math.min(reconnectOptions.delayMs * 2 ** (attempt - 1), reconnectOptions.maxDelayMs) : 0;
 
     let cancelled = false;
     let currentReader: ReadableStreamDefaultReader<Uint8Array> | null = null;
@@ -443,7 +473,13 @@ export class AgentControllerSession extends BaseResource {
         reconnectTimer = setTimeout(settleDelay, ms);
       });
 
-    const requestStream = () => this.request(this.url(`${this.base()}/stream`), { stream: true }) as Promise<Response>;
+    const requestStream = async (): Promise<Response> => {
+      const response = (await this.request(this.url(`${this.base()}/stream`), { stream: true })) as Response;
+      if (!response.body) {
+        throw new Error('No response body for agent controller session stream');
+      }
+      return response;
+    };
 
     const streamEndedError = () => new Error('Agent controller session stream ended unexpectedly');
 
@@ -464,11 +500,7 @@ export class AgentControllerSession extends BaseResource {
       | { kind: 'transport_error'; error: unknown };
 
     const pump = async (response: Response): Promise<PumpResult> => {
-      if (!response.body) {
-        throw new Error('No response body for agent controller session stream');
-      }
-
-      const reader = response.body.getReader();
+      const reader = response.body!.getReader();
       currentReader = reader;
       const decoder = new TextDecoder();
       let buffer = '';
@@ -519,61 +551,83 @@ export class AgentControllerSession extends BaseResource {
       options.onError?.(streamEndedError());
     };
 
-    const run = async () => {
+    /** Pump one established stream, mapping unexpected throws to transport errors. */
+    const pumpSafe = async (response: Response): Promise<PumpResult> => {
+      try {
+        return await pump(response);
+      } catch (error) {
+        return cancelled ? { kind: 'cancelled' } : { kind: 'transport_error', error };
+      }
+    };
+
+    // Establish the FIRST stream before resolving so callers can trust that a
+    // resolved subscribe() means events are flowing. Unsubscribe isn't
+    // available yet, so no cancellation checks are needed here. Initial
+    // failures retry under the reconnect policy; when retries are exhausted
+    // (or reconnect is off) the promise rejects.
+    const firstResponse = await (async (): Promise<Response> => {
       let attempts = 0;
+      while (true) {
+        try {
+          return await requestStream();
+        } catch (error) {
+          if (!reconnectOptions || attempts >= reconnectOptions.maxRetries) throw error;
+          attempts++;
+          await delay(backoffDelay(attempts));
+        }
+      }
+    })();
+
+    // Background loop: pump the current stream; on drop, re-establish it under
+    // the reconnect policy (exponential backoff, per-outage retry budget) and
+    // notify the consumer via onReconnect so it can re-sync missed state.
+    const run = async (initial: Response) => {
+      let response = initial;
 
       while (!cancelled) {
-        let response: Response;
-        try {
-          response = await requestStream();
-        } catch (error) {
-          if (cancelled) return;
-          if (!reconnectOptions || attempts >= reconnectOptions.maxRetries) {
-            options.onError?.(error);
-            return;
-          }
-          attempts++;
-          await delay(reconnectOptions.delayMs);
-          if (cancelled) return;
-          continue;
-        }
+        let result = await pumpSafe(response);
 
-        let result: PumpResult;
-        try {
-          result = await pump(response);
-        } catch (error) {
-          if (cancelled) return;
-          if (!reconnectOptions) {
-            options.onError?.(error);
-            return;
-          }
-          result = { kind: 'transport_error', error };
-        }
+        if (cancelled || result.kind === 'cancelled' || result.kind === 'consumer_error') return;
 
-        if (cancelled || result.kind === 'cancelled') return;
-        if (result.kind === 'consumer_error') return;
-
+        // result is 'done' or 'transport_error' — the stream dropped.
         if (!reconnectOptions) {
-          if (result.kind === 'done' || result.kind === 'transport_error') {
-            reportTerminalError(result);
-          }
+          reportTerminalError(result);
           return;
         }
 
-        if (result.kind === 'done' || result.kind === 'transport_error') {
+        // Retry until a new stream is established or the budget is exhausted.
+        let attempts = 0;
+        let reconnectedResponse: Response | undefined;
+        while (!reconnectedResponse) {
           if (attempts >= reconnectOptions.maxRetries) {
             reportTerminalError(result);
             return;
           }
           attempts++;
-          await delay(reconnectOptions.delayMs);
+          await delay(backoffDelay(attempts));
           if (cancelled) return;
-          continue;
+          try {
+            reconnectedResponse = await requestStream();
+          } catch (error) {
+            result = { kind: 'transport_error', error };
+          }
+        }
+
+        if (cancelled) {
+          void reconnectedResponse.body?.cancel().catch(() => {});
+          return;
+        }
+
+        response = reconnectedResponse;
+        try {
+          options.onReconnect?.();
+        } catch {
+          // Consumer callback failures must not kill the stream loop.
         }
       }
     };
 
-    void run();
+    void run(firstResponse);
 
     return {
       unsubscribe: () => {

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -113,7 +113,8 @@ RAILWAY_API_TOKEN=
 # @public
 RAILWAY_ENVIRONMENT_ID=
 # Force a specific provider. Leave unset to auto-select: railway when
-# RAILWAY_API_TOKEN is set, else local.
+# RAILWAY_API_TOKEN is set, else sandboxes disabled. The non-isolated local
+# provider is never auto-selected — opt in explicitly with "local".
 # @public @type=enum("", "railway", "local")
 MASTRACODE_SANDBOX_PROVIDER=
 # Path inside a cloud sandbox; ignored by the local provider.

--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -39,6 +39,7 @@
     "@octokit/auth-app": "^8.0.0",
     "@octokit/rest": "^22.0.1",
     "@tanstack/react-query": "^5.90.21",
+    "better-auth": "^1.6.23",
     "date-fns": "^4.4.0",
     "drizzle-orm": "^0.45.0",
     "hono": "^4.12.8",

--- a/mastracode/web/pnpm-lock.yaml
+++ b/mastracode/web/pnpm-lock.yaml
@@ -47,12 +47,15 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.101.2(react@19.2.7)
+      better-auth:
+        specifier: ^1.6.23
+        version: 1.6.23(drizzle-orm@0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@22.20.1)(jsdom@26.1.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)))
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
       drizzle-orm:
         specifier: ^0.45.0
-        version: 0.45.2(@types/pg@8.20.0)(pg@8.22.0)
+        version: 0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0)
       hono:
         specifier: ^4.12.8
         version: 4.12.29
@@ -264,6 +267,85 @@ packages:
   '@babel/types@7.29.7':
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
+
+  '@better-auth/core@1.6.23':
+    resolution: {integrity: sha512-beEhOs0uVeOxYOZKUfIEBd/nQV2Bd4/6wyLxZ0OFkn6CMTK2Vi+hXuZLnyPBeB6RdHpebEoJWiHqwHxBIxgPDQ==}
+    peerDependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@cloudflare/workers-types': '>=4'
+      '@opentelemetry/api': ^1.9.0
+      better-call: 1.3.7
+      jose: ^6.1.0
+      kysely: ^0.28.5 || ^0.29.0
+      nanostores: ^1.0.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+
+  '@better-auth/drizzle-adapter@1.6.23':
+    resolution: {integrity: sha512-2+/PTVfIP9E7iz6af8TB3lhnowHUj9ljC66kECmHaFEdUqPgzHoWux9epotKwO7XDg2ui4ttWQ8CMeNFLvQeKQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      drizzle-orm: ^0.45.2
+    peerDependenciesMeta:
+      drizzle-orm:
+        optional: true
+
+  '@better-auth/kysely-adapter@1.6.23':
+    resolution: {integrity: sha512-zbNJsMbG09exfkGyvFqBLLqWoMPAUWjxCuUnEK5AsjbYoZeIjj/QGZgdf4CapVWryKxjA9Q6Jlr6fbiPpC3VAg==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      kysely: ^0.28.17 || ^0.29.0
+    peerDependenciesMeta:
+      kysely:
+        optional: true
+
+  '@better-auth/memory-adapter@1.6.23':
+    resolution: {integrity: sha512-krIiR0pIVkaKlAzm690n5bcMW4NGbqeMg0HQSD9fz/KcQF/eWLqcq9gG/BhHTj2i/y96qH+W5JWPmaSOS5iTgQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23':
+    resolution: {integrity: sha512-7+QdevitGlKBbP6JbiSk5SBnzPsKV/mDrQBGBn8hwByQLeJwqpqbuBPw7ZI8vzUlFfAAnyFiqwP3Eb8mxnp7pA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      mongodb: ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      mongodb:
+        optional: true
+
+  '@better-auth/prisma-adapter@1.6.23':
+    resolution: {integrity: sha512-2qSdzidq4tkb1eS5TTqb4Nzg0mdZWm3Qky9SYeXeb8PpVQbC2sxqJhEM5mK7y12uU6I8hc64wO9f7AFVNL+6UQ==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+    peerDependenciesMeta:
+      '@prisma/client':
+        optional: true
+      prisma:
+        optional: true
+
+  '@better-auth/telemetry@1.6.23':
+    resolution: {integrity: sha512-/R2Kb+z2BpDOOWwVHqOk+c0VNpuwfCv4Hp5Yr9003WIZPax/zyNraGLB9CFE8qF2gZW8Dsz419k4I8CPrGzpDA==}
+    peerDependencies:
+      '@better-auth/core': ^1.6.23
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
+
+  '@better-fetch/fetch@1.3.1':
+    resolution: {integrity: sha512-ABkD1WhyfPZprKRQI3bhATjeiFuNWC9PXhfGWqL+sg/gKrM977oFrYkdb4msM3hgUGonr7KlOsOFT5TU2rht9g==}
 
   '@copilotkit/aimock@1.35.1':
     resolution: {integrity: sha512-d+bJFOGjydly9ayh6kK3bhj6m8xskz5Z/G/kSAvcK1WJ2OwRgMjnSG+9nv7INyBmx+5P1DIBg85+ua1Hd5tlNw==}
@@ -673,6 +755,14 @@ packages:
     resolution: {integrity: sha512-VVPPgHyQ6ShqnrmDWuxjmUIsO9gWyOZFmuOfLd9LfBGQJwZfy0gvv9pbHSJuoFNIYC7ZDX9aoFwowjcdSC4E8w==}
     engines: {node: '>=18'}
 
+  '@noble/ciphers@2.2.0':
+    resolution: {integrity: sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA==}
+    engines: {node: '>= 20.19.0'}
+
+  '@noble/hashes@2.2.0':
+    resolution: {integrity: sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==}
+    engines: {node: '>= 20.19.0'}
+
   '@octokit/auth-app@8.2.0':
     resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
     engines: {node: '>= 20'}
@@ -760,6 +850,10 @@ packages:
 
   '@open-draft/until@2.1.0':
     resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
+
+  '@opentelemetry/semantic-conventions@1.43.0':
+    resolution: {integrity: sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==}
+    engines: {node: '>=14'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1183,6 +1277,76 @@ packages:
   before-after-hook@4.0.0:
     resolution: {integrity: sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==}
 
+  better-auth@1.6.23:
+    resolution: {integrity: sha512-4vOaRd9UiKGKm9R+ej0jjU1es3MiJIiNc9Qq3VCnYqOZ4/nb5272QqTxWYoDxyUXl5x6A2x2we5KZKQO9teTQQ==}
+    peerDependencies:
+      '@lynx-js/react': '*'
+      '@prisma/client': ^5.0.0 || ^6.0.0 || ^7.0.0
+      '@sveltejs/kit': ^2.0.0
+      '@tanstack/react-start': ^1.0.0
+      '@tanstack/solid-start': ^1.0.0
+      better-sqlite3: ^12.0.0
+      drizzle-kit: '>=0.31.4'
+      drizzle-orm: ^0.45.2
+      mongodb: ^6.0.0 || ^7.0.0
+      mysql2: ^3.0.0
+      next: ^14.0.0 || ^15.0.0 || ^16.0.0
+      pg: ^8.0.0
+      prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+      solid-js: ^1.0.0
+      svelte: ^4.0.0 || ^5.0.0
+      vitest: ^2.0.0 || ^3.0.0 || ^4.0.0
+      vue: ^3.0.0
+    peerDependenciesMeta:
+      '@lynx-js/react':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@sveltejs/kit':
+        optional: true
+      '@tanstack/react-start':
+        optional: true
+      '@tanstack/solid-start':
+        optional: true
+      better-sqlite3:
+        optional: true
+      drizzle-kit:
+        optional: true
+      drizzle-orm:
+        optional: true
+      mongodb:
+        optional: true
+      mysql2:
+        optional: true
+      next:
+        optional: true
+      pg:
+        optional: true
+      prisma:
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+      solid-js:
+        optional: true
+      svelte:
+        optional: true
+      vitest:
+        optional: true
+      vue:
+        optional: true
+
+  better-call@1.3.7:
+    resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
+    peerDependencies:
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
+
   browserslist@4.28.6:
     resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
@@ -1277,6 +1441,9 @@ packages:
 
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1524,6 +1691,9 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -1551,6 +1721,10 @@ packages:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kysely@0.29.3:
+    resolution: {integrity: sha512-VHtBdW6XB/pgoTSqraM3UAa2rYoYdNXqnNPpX+8XXP+cwYbVEFuAp3HyPt1vpNfU9l7Y2kpUrA9QDPsy8uUqOQ==}
+    engines: {node: '>=22.0.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1692,6 +1866,10 @@ packages:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  nanostores@1.4.0:
+    resolution: {integrity: sha512-i0tloweeudshAEuddpDxcg9Ik6pkPfVsHIgKyf143JrgG7/MOh0+q7BypdLXZPoOP7fOYt1eTcwGkyiVmhJFkA==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   node-releases@2.0.51:
     resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
@@ -1841,6 +2019,9 @@ packages:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rou3@0.7.12:
+    resolution: {integrity: sha512-iFE4hLDuloSWcD7mjdCDhx2bKcIsYbtOTpfH5MHHLSKMOUyjqQXTeZVa289uuwEGEKFoE/BAPbhaU4B774nceg==}
 
   rrweb-cssom@0.8.0:
     resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
@@ -2361,6 +2542,59 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
+  '@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)':
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@opentelemetry/semantic-conventions': 1.43.0
+      '@standard-schema/spec': 1.1.0
+      better-call: 1.3.7(zod@4.4.3)
+      jose: 6.2.3
+      kysely: 0.29.3
+      nanostores: 1.4.0
+      zod: 4.4.3
+
+  '@better-auth/drizzle-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0))':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0)
+
+  '@better-auth/kysely-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+    optionalDependencies:
+      kysely: 0.29.3
+
+  '@better-auth/memory-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/mongo-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/prisma-adapter@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+
+  '@better-auth/telemetry@1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+
+  '@better-auth/utils@0.4.2':
+    dependencies:
+      '@noble/hashes': 2.2.0
+
+  '@better-fetch/fetch@1.3.1': {}
+
   '@copilotkit/aimock@1.35.1(vitest@4.1.10(@types/node@22.20.1)(jsdom@26.1.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)))':
     optionalDependencies:
       vitest: 4.1.10(@types/node@22.20.1)(jsdom@26.1.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0))
@@ -2596,6 +2830,10 @@ snapshots:
       outvariant: 1.4.3
       strict-event-emitter: 0.5.1
 
+  '@noble/ciphers@2.2.0': {}
+
+  '@noble/hashes@2.2.0': {}
+
   '@octokit/auth-app@8.2.0':
     dependencies:
       '@octokit/auth-oauth-app': 9.0.3
@@ -2712,6 +2950,8 @@ snapshots:
       outvariant: 1.4.3
 
   '@open-draft/until@2.1.0': {}
+
+  '@opentelemetry/semantic-conventions@1.43.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3080,6 +3320,44 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
+  better-auth@1.6.23(drizzle-orm@0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0))(pg@8.22.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.10(@types/node@22.20.1)(jsdom@26.1.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0))):
+    dependencies:
+      '@better-auth/core': 1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0)
+      '@better-auth/drizzle-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0))
+      '@better-auth/kysely-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(kysely@0.29.3)
+      '@better-auth/memory-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/prisma-adapter': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.23(@better-auth/core@1.6.23(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.3)(kysely@0.29.3)(nanostores@1.4.0))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      '@noble/ciphers': 2.2.0
+      '@noble/hashes': 2.2.0
+      better-call: 1.3.7(zod@4.4.3)
+      defu: 6.1.7
+      jose: 6.2.3
+      kysely: 0.29.3
+      nanostores: 1.4.0
+      zod: 4.4.3
+    optionalDependencies:
+      drizzle-orm: 0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0)
+      pg: 8.22.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      vitest: 4.1.10(@types/node@22.20.1)(jsdom@26.1.0)(msw@2.15.0(@types/node@22.20.1)(typescript@6.0.3))(vite@6.4.3(@types/node@22.20.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0))
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - '@opentelemetry/api'
+
+  better-call@1.3.7(zod@4.4.3):
+    dependencies:
+      '@better-auth/utils': 0.4.2
+      '@better-fetch/fetch': 1.3.1
+      rou3: 0.7.12
+      set-cookie-parser: 3.1.2
+    optionalDependencies:
+      zod: 4.4.3
+
   browserslist@4.28.6:
     dependencies:
       baseline-browser-mapping: 2.10.43
@@ -3162,6 +3440,8 @@ snapshots:
 
   decimal.js@10.6.0: {}
 
+  defu@6.1.7: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -3174,9 +3454,10 @@ snapshots:
 
   dom-accessibility-api@0.6.3: {}
 
-  drizzle-orm@0.45.2(@types/pg@8.20.0)(pg@8.22.0):
+  drizzle-orm@0.45.2(@types/pg@8.20.0)(kysely@0.29.3)(pg@8.22.0):
     optionalDependencies:
       '@types/pg': 8.20.0
+      kysely: 0.29.3
       pg: 8.22.0
 
   electron-to-chromium@1.5.389: {}
@@ -3348,6 +3629,8 @@ snapshots:
 
   jiti@2.7.0: {}
 
+  jose@6.2.3: {}
+
   js-tokens@4.0.0: {}
 
   jsdom@26.1.0:
@@ -3384,6 +3667,8 @@ snapshots:
   json-with-bigint@3.5.10: {}
 
   json5@2.2.3: {}
+
+  kysely@0.29.3: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3513,6 +3798,8 @@ snapshots:
   mute-stream@3.0.0: {}
 
   nanoid@3.3.16: {}
+
+  nanostores@1.4.0: {}
 
   node-releases@2.0.51: {}
 
@@ -3670,6 +3957,8 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.62.2
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
+
+  rou3@0.7.12: {}
 
   rrweb-cssom@0.8.0: {}
 

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -19,6 +19,8 @@
 
 import { Mastra } from '@mastra/core/mastra';
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
+import { BetterAuthWebAuth } from '../web/auth-better-adapter.js';
+import type { WebAuthAdapter } from '../web/auth-adapter.js';
 import { WorkOSWebAuth } from '../web/auth-workos-adapter.js';
 import { MastraFactory } from '../web/factory-entry.js';
 
@@ -42,14 +44,25 @@ if (redisUrl) {
   console.log(`[PubSub] REDIS_URL set — event bus on Redis Streams (${redisTarget}), cross-process leases enabled.`);
 }
 
-// Web auth: when the WorkOS credentials are present, the whole server sits
-// behind WorkOS AuthKit (hosted login). The WorkOS SDK reads WORKOS_API_KEY /
-// WORKOS_CLIENT_ID itself; the redirect URI falls back to
-// `<publicUrl>/auth/callback` inside the adapter's init(). Swap in
-// `new BetterAuthWebAuth({ secret })` (or any custom `WebAuthAdapter`) to run
-// without an external identity vendor. Unset → auth disabled (open server).
+// Web auth, by env precedence (any custom `WebAuthAdapter` works here too):
+//   1. WORKOS_API_KEY + WORKOS_CLIENT_ID → WorkOS AuthKit (hosted login). The
+//      WorkOS SDK reads its own credentials; the redirect URI falls back to
+//      `<publicUrl>/auth/callback` inside the adapter's init().
+//   2. BETTER_AUTH_SECRET → self-hosted better-auth (email/password on the app
+//      Postgres — no external identity vendor in the availability path).
+//      MASTRACODE_AUTH_SIGNUP_DISABLED=1 turns off public sign-up.
+//   3. Neither → auth disabled (open server, bare local dev).
 const workosConfigured = Boolean(process.env.WORKOS_API_KEY && process.env.WORKOS_CLIENT_ID);
-const auth = workosConfigured ? new WorkOSWebAuth({ redirectUri: process.env.WORKOS_REDIRECT_URI }) : undefined;
+const betterAuthSecret = process.env.BETTER_AUTH_SECRET;
+let auth: WebAuthAdapter | undefined;
+if (workosConfigured) {
+  auth = new WorkOSWebAuth({ redirectUri: process.env.WORKOS_REDIRECT_URI });
+} else if (betterAuthSecret) {
+  auth = new BetterAuthWebAuth({
+    secret: betterAuthSecret,
+    signUpDisabled: process.env.MASTRACODE_AUTH_SIGNUP_DISABLED === '1',
+  });
+}
 
 export const factory = new MastraFactory({
   auth,

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -1,95 +1,32 @@
 /**
  * Platform-deployable Mastra entry for MastraCode.
  *
+ * This module is the ONE place deployment env is read. It maps today's env
+ * vars onto explicit `MastraFactory` config — instances for behaviors (pubsub),
+ * plain values for config (database connection string, publicUrl, origins) —
+ * so anyone reading the entry sees exactly which env var feeds which slot.
+ * Everything else (feature readiness, route/middleware assembly, controller
+ * construction) lives in `MastraFactory` (`../web/factory-entry.ts`).
+ *
  * `mastra build` requires the entry to export a `Mastra` instance named
- * `mastra` (validated by the `checkConfigExport` Babel plugin). Everything
- * outside that instance is discarded — the deployer generates its own Hono
- * server via `createHonoServer(mastra, ...)`. So this entry folds the ENTIRE
- * web surface onto the instance the deployer builds from:
- *
- *   - `server.apiRoutes`   — the custom `/web/*` routes (fs / config / github),
- *                            already migrated off `/api`, `requiresAuth: false`.
- *   - `server.middleware`  — the WorkOS auth gate (bare handler, runs first) and
- *                            the same-origin SPA static middleware.
- *   - `server.cors`        — the SPA is hosted separately (static host / CDN),
- *                            so cross-origin credentialed requests are allowed
- *                            for the configured origin(s).
- *
- * This entry is the single web surface. The Mastra CLI consumes it everywhere:
- * `mastra dev` (local), `mastra build`, and `mastra deploy` all bundle this
- * module and let the deployer generate the server — there is no separate
- * hand-wired dev bootstrap.
- *
- * NOTE: the deployer's own static serving is Studio-only. The SPA (vite build
- * output) is served same-origin at `/` by the SPA middleware below when a
- * build is found (`web:build` produces one); `server.cors` remains only for
- * the optional separately-hosted-SPA setup. In dev, Vite serves the SPA and
- * proxies API paths here instead.
+ * `mastra` constructed by a literal `new Mastra(...)` in THIS file (validated
+ * by the deployer's `checkConfigExport` Babel plugin) — which is why the
+ * factory returns constructor args from `prepare()` instead of the instance.
+ * The Mastra CLI consumes this entry everywhere: `mastra dev`, `mastra build`,
+ * and `mastra deploy` all bundle this module and let the deployer generate
+ * the server.
  */
 
 import { Mastra } from '@mastra/core/mastra';
-import type { RequestContext } from '@mastra/core/request-context';
-import { prepareAgentControllerMount } from '@mastra/code-sdk';
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
-import { observeAgentGitAction } from '../web/audit/agent-audit.js';
-import { buildAuthRoutes, createWebAuthGate, createWebAuthProvider, isWebAuthEnabled } from '../web/auth.js';
-import { buildLinearAgentTools } from '../web/linear/agent-tools.js';
-import { handleServerError } from '../web/server-error.js';
-import {
-  createGithubSubscriptionTools,
-  parseCreatedPullRequest,
-  subscribeCurrentSessionToPullRequest,
-} from '../web/github/session-subscriptions.js';
-import { createSpaStaticMiddleware, resolveUiDistDir } from '../web/spa-static.js';
-import {
-  assembleWebApiRoutes,
-  resolveFactoryReady,
-  resolveGithubReady,
-  resolveIntakeReady,
-  resolveLinearReady,
-} from '../web/web-surface.js';
-import type { WebApiRoutesDeps } from '../web/web-surface.js';
-
-type BuildApiRoutesDeps = Pick<WebApiRoutesDeps, 'controller' | 'authStorage'>;
-
-const CONTROLLER_ID = 'code';
-
-/**
- * Browser-facing origin used to build GitHub OAuth/install callback URLs and to
- * derive the WorkOS redirect URI. On the platform the SPA is hosted separately,
- * so this MUST be set to the public API origin via `MASTRACODE_PUBLIC_URL`.
- */
-const publicOrigin = (process.env.MASTRACODE_PUBLIC_URL ?? 'http://localhost:4111').replace(/\/+$/, '');
-
-/**
- * Allowed cross-origin SPA origins (comma-separated). The SPA is served from a
- * separate static host, so credentialed requests must be explicitly allowed.
- */
-const allowedOrigins = (process.env.MASTRACODE_ALLOWED_ORIGINS ?? '')
-  .split(',')
-  .map(o => o.trim().replace(/\/+$/, ''))
-  .filter(Boolean);
-
-// GitHub App + cloud-sandbox readiness, resolved BEFORE constructing Mastra so
-// the github routes are simply omitted from `apiRoutes` when unavailable. Fails
-// soft (see resolveGithubReady).
-const githubReady = await resolveGithubReady();
-
-// Linear intake readiness, same fail-soft pattern as GitHub.
-const linearReady = await resolveLinearReady();
-
-// Intake source configuration (Settings › Intake) — needs at least one source.
-const intakeReady = await resolveIntakeReady(githubReady || linearReady);
-
-// Factory work-item board — hangs off GitHub projects, same fail-soft pattern.
-const factoryReady = await resolveFactoryReady(githubReady);
+import { MastraFactory } from '../web/factory-entry.js';
 
 // Distributed pub/sub: when `REDIS_URL` is set, events (streams, workflows,
 // signals) ride Redis Streams so multiple web server processes can share one
-// event bus. RedisStreamsPubSub also implements LeaseProvider, so passing
-// `crossProcessPubSub` lets the controller drop its file-based thread locks in
-// favor of pubsub-coordinated leases. Without `REDIS_URL` (bare local dev) the
-// in-process default applies.
+// event bus. RedisStreamsPubSub also implements LeaseProvider, so the factory
+// marks it cross-process and the controller drops its file-based thread locks
+// in favor of pubsub-coordinated leases. Without `REDIS_URL` (bare local dev)
+// the in-process default applies.
 const redisUrl = process.env.REDIS_URL;
 const pubsub = redisUrl ? new RedisStreamsPubSub({ url: redisUrl }) : undefined;
 if (redisUrl) {
@@ -104,116 +41,31 @@ if (redisUrl) {
   console.log(`[PubSub] REDIS_URL set — event bus on Redis Streams (${redisTarget}), cross-process leases enabled.`);
 }
 
-const webAuthEnabled = isWebAuthEnabled();
-
-const redirectUri = process.env.WORKOS_REDIRECT_URI ?? `${publicOrigin}/auth/callback`;
-
-// One WorkOS provider for the process, shared by the gate middleware and the
-// public `/auth/*` routes so session encryption/validation stays consistent.
-const authProvider = webAuthEnabled ? createWebAuthProvider(redirectUri) : undefined;
-
-// Build the real production controller (agents, modes, tools, memory, OM, MCP,
-// providers) — identical to the terminal app — and register it on a Mastra whose
-// `server` config owns the whole web surface. The deployer generates its Hono
-// server from THIS instance, so the gate, custom routes, and CORS all ride along.
-//
-// Agent state (threads, messages, memory, OM, recall vectors) lives in the
-// single app Postgres (`APP_DATABASE_URL`) alongside the github/app tables —
-// one shared DB for all users, separated by `resourceId` scoping. Without
-// `APP_DATABASE_URL` (bare local dev) the default storage resolution applies
-// (local libSQL file).
-const prepared = await prepareAgentControllerMount({
-  controllerId: CONTROLLER_ID,
-  disableGithubSignals: true,
-  ...(process.env.APP_DATABASE_URL
-    ? { storage: { backend: 'pg', connectionString: process.env.APP_DATABASE_URL } }
-    : {}),
-  ...(githubReady || linearReady
-    ? {
-        extraTools: async ({ requestContext }: { requestContext: RequestContext }) => ({
-          ...(linearReady ? await buildLinearAgentTools({ requestContext }) : {}),
-          ...(githubReady ? createGithubSubscriptionTools(requestContext) : {}),
-        }),
-      }
-    : {}),
-  ...(githubReady
-    ? {
-        postToolObserver: async (context: {
-          toolName: string;
-          input: unknown;
-          output?: unknown;
-          error?: unknown;
-          context: unknown;
-        }) => {
-          const pullRequestUrl = parseCreatedPullRequest(context);
-          const requestContext = (context.context as { requestContext?: RequestContext } | undefined)?.requestContext;
-          // Audit externally-visible git side effects performed by the agent
-          // (commit / push / PR creation). Awaited so the local audit write
-          // completes before teardown; never throws (failures are swallowed).
-          if (requestContext) {
-            await observeAgentGitAction({ ...context, context: requestContext });
-          }
-          if (pullRequestUrl && requestContext) {
-            await subscribeCurrentSessionToPullRequest(requestContext, pullRequestUrl, 'auto-gh-pr-create');
-          }
-        },
-      }
-    : {}),
-  ...(pubsub ? { pubsub, crossProcessPubSub: true } : {}),
-  buildApiRoutes: ({ controller, authStorage }: BuildApiRoutesDeps) => [
-    // Public WorkOS `/auth/*` routes (login/callback/logout/me). Folded in as
-    // `apiRoutes` (not plain Hono routes) because the entry can't touch the Hono
-    // app the deployer generates. `requiresAuth: false`; the gate skips `/auth/*`.
-    ...(authProvider ? buildAuthRoutes(authProvider, redirectUri) : []),
-    // Custom `/web/*` routes (fs / config / github).
-    ...assembleWebApiRoutes({
-      controller,
-      authStorage,
-      publicOrigin,
-      githubReady,
-      linearReady,
-      intakeReady,
-      factoryReady,
-    }),
-  ],
-  buildServerConfig: () => {
-    const cors = allowedOrigins.length ? { cors: { origin: allowedOrigins, credentials: true } } : {};
-    // Log route errors with method/path/stack and answer with structured JSON
-    // instead of an opaque `Internal Server Error`. Applied by the deployer to
-    // both the top-level app and the custom-route sub-app.
-    const onError = { onError: handleServerError };
-    // Same-origin SPA: when a vite build is present (see resolveUiDistDir),
-    // serve it at `/` from this server. Mounted last so the auth gate (when
-    // enabled) covers it; it always passes `/api`, `/web`, `/auth` through.
-    const uiDist = resolveUiDistDir();
-    const spa = uiDist ? [createSpaStaticMiddleware(uiDist)] : [];
-    if (!webAuthEnabled || !authProvider) {
-      // Auth disabled: no gate. SPA + CORS only.
-      return { ...(spa.length ? { middleware: spa } : {}), ...cors, ...onError };
-    }
-
-    // Ordered middleware. The deployer applies these AFTER its context
-    // middleware sets `c.set('mastra', mastra)` and BEFORE routes, so:
-    //   1. gate  — validates the WorkOS session, stashes the user, and 401s /
-    //              redirects unauthenticated requests. Skips public `/auth/*`.
-    //   2. spa   — serves the built UI for everything the server doesn't own.
-    return {
-      middleware: [createWebAuthGate(authProvider), ...spa],
-      ...cors,
-      ...onError,
-    };
-  },
+export const factory = new MastraFactory({
+  // Agent state (threads, messages, memory, OM, recall vectors) lives in the
+  // single app Postgres alongside the github/app tables — one shared DB for
+  // all users, separated by `resourceId` scoping. Unset (bare local dev) →
+  // default storage resolution applies (local libSQL file).
+  database: process.env.APP_DATABASE_URL,
+  pubsub,
+  // Browser-facing origin. On the platform the SPA is hosted separately, so
+  // this MUST be set to the public API origin.
+  publicUrl: process.env.MASTRACODE_PUBLIC_URL,
+  // Allowed cross-origin SPA origins (comma-separated). The SPA is served from
+  // a separate static host, so credentialed requests must be explicitly allowed.
+  allowedOrigins: (process.env.MASTRACODE_ALLOWED_ORIGINS ?? '')
+    .split(',')
+    .map(o => o.trim())
+    .filter(Boolean),
 });
 
 // Construct the server-owned Mastra HERE so the `new Mastra(...)` literal lives
-// in the entry file. The deployer's `checkConfigExport` Babel plugin only marks
-// the config valid when it finds `export const mastra = new Mastra(...)` (or an
-// `export { x as mastra }` where `x = new Mastra(...)`) in the entry source AST.
-// `prepared.mastraArgs` already carries the controller (via `agentControllers`),
-// storage, and the assembled `server` config (middleware + apiRoutes + cors).
-export const mastra = new Mastra(prepared.mastraArgs);
+// in the entry file (see module docs). `prepare()` returns the constructor args
+// carrying the controller (via `agentControllers`), storage, and the assembled
+// `server` config (middleware + apiRoutes + cors).
+export const mastra = new Mastra(await factory.prepare());
 
 // Post-construct boot: initialize the controller (which now inherits this
 // instance's storage) and start its workers. Runs at module load via top-level
 // await, so the deployer imports a fully-booted instance.
-await prepared.finalize();
+await factory.finalize();

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -27,12 +27,17 @@ import type { WebSandboxProvider } from '../web/sandbox-provider.js';
 import { LocalSandboxProvider } from '../web/sandbox-local-provider.js';
 import { RailwaySandboxProvider } from '../web/sandbox-railway-provider.js';
 
-/** Parse a positive-integer env knob; anything else means "use the default". */
+/**
+ * Parse a positive-integer env knob; anything else means "use the default".
+ * Fractional values are rejected rather than floored — flooring `0.5` to `0`
+ * would silently disable a capacity knob or turn an idle window into
+ * immediate expiry.
+ */
 function positiveInt(raw: string | undefined): number | undefined {
   if (!raw) return undefined;
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
-  return Math.floor(parsed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return undefined;
+  return parsed;
 }
 
 // Distributed pub/sub: when `REDIS_URL` is set, events (streams, workflows,
@@ -80,15 +85,18 @@ if (workosConfigured) {
 //      selected without a token boots with sandboxes (and GitHub projects)
 //      disabled, surfaced in the feature diagnostics.
 //   2. RAILWAY_API_TOKEN set → Railway (isolated cloud VMs, multi-tenant safe).
-//   3. Neither → local host-process checkouts (single-user dev; no isolation).
+//   3. Neither → sandboxes disabled. The local host-process provider is NEVER
+//      an implicit default: it runs repo checkouts and agent commands as the
+//      server process with no tenant isolation, so it must be opted into with
+//      MASTRACODE_SANDBOX_PROVIDER=local (single-user local dev only).
 // Budget/GC knobs: MASTRACODE_SANDBOX_IDLE_MINUTES (default 30),
 // MASTRACODE_MAX_SANDBOXES (default unlimited), MASTRACODE_SANDBOX_WORKDIR
 // (cloud checkout base, default /workspace), MASTRACODE_LOCAL_SANDBOX_ROOT
 // (local checkout root, default ~/.mastracode/web/sandboxes).
-const sandboxKind = process.env.MASTRACODE_SANDBOX_PROVIDER ?? (process.env.RAILWAY_API_TOKEN ? 'railway' : 'local');
+const sandboxKind = process.env.MASTRACODE_SANDBOX_PROVIDER ?? (process.env.RAILWAY_API_TOKEN ? 'railway' : undefined);
 const idleMinutes = positiveInt(process.env.MASTRACODE_SANDBOX_IDLE_MINUTES);
 const maxSandboxes = positiveInt(process.env.MASTRACODE_MAX_SANDBOXES);
-let sandbox: WebSandboxProvider;
+let sandbox: WebSandboxProvider | undefined;
 if (sandboxKind === 'railway') {
   sandbox = new RailwaySandboxProvider({
     token: process.env.RAILWAY_API_TOKEN,
@@ -102,7 +110,7 @@ if (sandboxKind === 'railway') {
     idleMinutes,
     maxSandboxes,
   });
-} else {
+} else if (sandboxKind !== undefined) {
   throw new Error(
     `Unknown MASTRACODE_SANDBOX_PROVIDER "${sandboxKind}" — expected "railway" or "local" ` +
       '(or pass a custom WebSandboxProvider to MastraFactory).',

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -19,6 +19,7 @@
 
 import { Mastra } from '@mastra/core/mastra';
 import { RedisStreamsPubSub } from '@mastra/redis-streams';
+import { WorkOSWebAuth } from '../web/auth-workos-adapter.js';
 import { MastraFactory } from '../web/factory-entry.js';
 
 // Distributed pub/sub: when `REDIS_URL` is set, events (streams, workflows,
@@ -41,7 +42,17 @@ if (redisUrl) {
   console.log(`[PubSub] REDIS_URL set — event bus on Redis Streams (${redisTarget}), cross-process leases enabled.`);
 }
 
+// Web auth: when the WorkOS credentials are present, the whole server sits
+// behind WorkOS AuthKit (hosted login). The WorkOS SDK reads WORKOS_API_KEY /
+// WORKOS_CLIENT_ID itself; the redirect URI falls back to
+// `<publicUrl>/auth/callback` inside the adapter's init(). Swap in
+// `new BetterAuthWebAuth({ secret })` (or any custom `WebAuthAdapter`) to run
+// without an external identity vendor. Unset → auth disabled (open server).
+const workosConfigured = Boolean(process.env.WORKOS_API_KEY && process.env.WORKOS_CLIENT_ID);
+const auth = workosConfigured ? new WorkOSWebAuth({ redirectUri: process.env.WORKOS_REDIRECT_URI }) : undefined;
+
 export const factory = new MastraFactory({
+  auth,
   // Agent state (threads, messages, memory, OM, recall vectors) lives in the
   // single app Postgres alongside the github/app tables — one shared DB for
   // all users, separated by `resourceId` scoping. Unset (bare local dev) →

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -23,6 +23,17 @@ import { BetterAuthWebAuth } from '../web/auth-better-adapter.js';
 import type { WebAuthAdapter } from '../web/auth-adapter.js';
 import { WorkOSWebAuth } from '../web/auth-workos-adapter.js';
 import { MastraFactory } from '../web/factory-entry.js';
+import type { WebSandboxProvider } from '../web/sandbox-provider.js';
+import { LocalSandboxProvider } from '../web/sandbox-local-provider.js';
+import { RailwaySandboxProvider } from '../web/sandbox-railway-provider.js';
+
+/** Parse a positive-integer env knob; anything else means "use the default". */
+function positiveInt(raw: string | undefined): number | undefined {
+  if (!raw) return undefined;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return undefined;
+  return Math.floor(parsed);
+}
 
 // Distributed pub/sub: when `REDIS_URL` is set, events (streams, workflows,
 // signals) ride Redis Streams so multiple web server processes can share one
@@ -64,8 +75,43 @@ if (workosConfigured) {
   });
 }
 
+// Sandbox provider, by env precedence:
+//   1. MASTRACODE_SANDBOX_PROVIDER=railway|local — explicit selection. Railway
+//      selected without a token boots with sandboxes (and GitHub projects)
+//      disabled, surfaced in the feature diagnostics.
+//   2. RAILWAY_API_TOKEN set → Railway (isolated cloud VMs, multi-tenant safe).
+//   3. Neither → local host-process checkouts (single-user dev; no isolation).
+// Budget/GC knobs: MASTRACODE_SANDBOX_IDLE_MINUTES (default 30),
+// MASTRACODE_MAX_SANDBOXES (default unlimited), MASTRACODE_SANDBOX_WORKDIR
+// (cloud checkout base, default /workspace), MASTRACODE_LOCAL_SANDBOX_ROOT
+// (local checkout root, default ~/.mastracode/web/sandboxes).
+const sandboxKind = process.env.MASTRACODE_SANDBOX_PROVIDER ?? (process.env.RAILWAY_API_TOKEN ? 'railway' : 'local');
+const idleMinutes = positiveInt(process.env.MASTRACODE_SANDBOX_IDLE_MINUTES);
+const maxSandboxes = positiveInt(process.env.MASTRACODE_MAX_SANDBOXES);
+let sandbox: WebSandboxProvider;
+if (sandboxKind === 'railway') {
+  sandbox = new RailwaySandboxProvider({
+    token: process.env.RAILWAY_API_TOKEN,
+    workdirBase: process.env.MASTRACODE_SANDBOX_WORKDIR,
+    idleMinutes,
+    maxSandboxes,
+  });
+} else if (sandboxKind === 'local') {
+  sandbox = new LocalSandboxProvider({
+    root: process.env.MASTRACODE_LOCAL_SANDBOX_ROOT,
+    idleMinutes,
+    maxSandboxes,
+  });
+} else {
+  throw new Error(
+    `Unknown MASTRACODE_SANDBOX_PROVIDER "${sandboxKind}" — expected "railway" or "local" ` +
+      '(or pass a custom WebSandboxProvider to MastraFactory).',
+  );
+}
+
 export const factory = new MastraFactory({
   auth,
+  sandbox,
   // Agent state (threads, messages, memory, OM, recall vectors) lives in the
   // single app Postgres alongside the github/app tables — one shared DB for
   // all users, separated by `resourceId` scoping. Unset (bare local dev) →

--- a/mastracode/web/src/web/audit/routes.test.ts
+++ b/mastracode/web/src/web/audit/routes.test.ts
@@ -53,14 +53,18 @@ vi.mock('./store', () => ({
 }));
 
 // Web auth stays real (disabled in tests → context-var user), but the WorkOS
-// availability gate and provider are controllable for the portal-link specs.
-let webAuthEnabled = false;
+// capability gate and provider are controllable for the portal-link specs.
+// `isWebAuthEnabled` is pinned true so the specs prove the portal link gates
+// on the adapter *kind* (WorkOS), not on auth being enabled — under
+// better-auth, auth is enabled but the portal link must still 404.
+let workosAuthActive = false;
 
 vi.mock('../auth', async () => {
   const actual = (await vi.importActual('../auth')) as Record<string, unknown>;
   return {
     ...actual,
-    isWebAuthEnabled: () => webAuthEnabled,
+    isWebAuthEnabled: () => true,
+    isWorkOSAuth: () => workosAuthActive,
     getWorkOSProvider: () => ({ getWorkOS: () => ({ tag: 'workos-client' }) }),
   };
 });
@@ -115,7 +119,7 @@ beforeEach(() => {
   projects = [];
   listCalls = [];
   listResult = { events: [] };
-  webAuthEnabled = false;
+  workosAuthActive = false;
   portalCalls = [];
   portalFailure = undefined;
 });
@@ -209,15 +213,15 @@ describe('GET /web/audit/portal-link', () => {
     expect(res.status).toBe(403);
   });
 
-  it("404s when WorkOS auth isn't configured so the UI hides the button", async () => {
-    webAuthEnabled = false;
+  it('404s when the active auth adapter is not WorkOS (e.g. better-auth) so the UI hides the button', async () => {
+    workosAuthActive = false;
     const res = await buildApp(orgUser).request('/web/audit/portal-link');
     expect(res.status).toBe(404);
     expect(portalCalls).toHaveLength(0);
   });
 
   it('returns a one-time audit_logs portal URL for the org', async () => {
-    webAuthEnabled = true;
+    workosAuthActive = true;
     const res = await buildApp(orgUser).request('/web/audit/portal-link');
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ url: 'https://portal.workos.com/one-time-link' });
@@ -227,7 +231,7 @@ describe('GET /web/audit/portal-link', () => {
   });
 
   it('502s when the portal link cannot be generated', async () => {
-    webAuthEnabled = true;
+    workosAuthActive = true;
     portalFailure = new Error('workos down');
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const res = await buildApp(orgUser).request('/web/audit/portal-link');

--- a/mastracode/web/src/web/audit/routes.ts
+++ b/mastracode/web/src/web/audit/routes.ts
@@ -18,7 +18,7 @@ import { registerApiRoute } from '@mastra/core/server';
 import { and, eq } from 'drizzle-orm';
 import type { Context } from 'hono';
 
-import { ensureWebAuthUser, getWorkOSProvider, isWebAuthEnabled, webAuthTenant } from '../auth';
+import { ensureWebAuthUser, getWorkOSProvider, isWorkOSAuth, webAuthTenant } from '../auth';
 import { getAppDb } from '../github/db';
 import { githubProjects } from '../github/schema';
 import { listAuditEvents } from './store';
@@ -119,7 +119,7 @@ export function buildAuditRoutes(deps: AuditRoutesDeps): ApiRoute[] {
         const tenant = await resolveTenant(c);
         if ('response' in tenant) return tenant.response;
 
-        if (!isWebAuthEnabled()) {
+        if (!isWorkOSAuth()) {
           return c.json({ error: 'not_available' }, 404);
         }
         try {

--- a/mastracode/web/src/web/audit/workos-sink.test.ts
+++ b/mastracode/web/src/web/audit/workos-sink.test.ts
@@ -10,6 +10,8 @@ vi.mock('../auth', async () => {
   };
 });
 
+import type { WebAuthAdapter } from '../auth-adapter';
+import { __resetRuntimeConfigForTests, seedRuntimeConfig } from '../runtime-config';
 import type { AuditEventRow } from './schema';
 import { forwardToWorkOS, toWorkOSEvent } from './workos-sink';
 
@@ -36,6 +38,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  __resetRuntimeConfigForTests();
   delete process.env.WORKOS_API_KEY;
   delete process.env.WORKOS_CLIENT_ID;
 });
@@ -69,6 +72,18 @@ describe('forwardToWorkOS', () => {
   it('is a no-op when WorkOS auth is not configured', async () => {
     await forwardToWorkOS(makeRow());
     expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when auth is enabled but the active adapter is not WorkOS (better-auth)', async () => {
+    seedRuntimeConfig({ authAdapter: { kind: 'better-auth' } as WebAuthAdapter });
+    await forwardToWorkOS(makeRow());
+    expect(createEvent).not.toHaveBeenCalled();
+  });
+
+  it('forwards when the factory seeded a WorkOS adapter', async () => {
+    seedRuntimeConfig({ authAdapter: { kind: 'workos' } as WebAuthAdapter });
+    await forwardToWorkOS(makeRow());
+    expect(createEvent).toHaveBeenCalledTimes(1);
   });
 
   it('forwards the mapped event scoped to the org when configured', async () => {

--- a/mastracode/web/src/web/audit/workos-sink.ts
+++ b/mastracode/web/src/web/audit/workos-sink.ts
@@ -10,7 +10,7 @@
  * truth.
  */
 
-import { getWorkOSProvider, isWebAuthEnabled } from '../auth';
+import { getWorkOSProvider, isWorkOSAuth } from '../auth';
 import type { AuditEventRow } from './schema';
 
 /** WorkOS requires a `context.location`; fall back when the request had none. */
@@ -62,11 +62,12 @@ export function toWorkOSEvent(event: AuditEventRow): {
 
 /**
  * Forward one recorded audit event to WorkOS Audit Logs. Never throws; no-op
- * when WorkOS auth isn't configured. Fire-and-forget — callers should not
- * await this on the request path.
+ * unless the active auth adapter is WorkOS (other providers have no WorkOS
+ * client — the local `audit_events` table stays the source of truth).
+ * Fire-and-forget — callers should not await this on the request path.
  */
 export async function forwardToWorkOS(event: AuditEventRow): Promise<void> {
-  if (!isWebAuthEnabled()) return;
+  if (!isWorkOSAuth()) return;
   try {
     const workos = getWorkOSProvider().getWorkOS();
     await workos.auditLogs.createEvent(event.orgId, toWorkOSEvent(event));

--- a/mastracode/web/src/web/auth-adapter.ts
+++ b/mastracode/web/src/web/auth-adapter.ts
@@ -1,0 +1,139 @@
+import type { Context } from 'hono';
+
+/**
+ * Provider-pluggable web auth seam.
+ *
+ * A `WebAuthAdapter` is the class a deploy entry passes to `MastraFactory`'s
+ * `auth` slot. It captures exactly what the auth module (`./auth.ts`) needs
+ * from an identity provider: session authentication, personal-org bootstrap,
+ * the provider's public `/auth/*` routes, and how to clear its session cookie.
+ * Shipped implementations: `WorkOSWebAuth` (`./auth-workos-adapter.ts`) and
+ * `BetterAuthWebAuth` (`./auth-better-adapter.ts`); anything implementing this
+ * interface works.
+ *
+ * Everything provider-NEUTRAL — the gate middleware, `/auth/me`, the tenant
+ * helpers (`webAuthTenant`, `getWebAuthUser*`) — stays in `./auth.ts` and is
+ * implemented against the active adapter.
+ */
+
+/** Minimal shape of the signed-in user surfaced to the SPA (no tokens). */
+export interface WebAuthUser {
+  /** Stable WorkOS user id used to scope per-user data (GitHub installs etc.). */
+  workosId?: string;
+  /** Provider user id; WorkOS shapes may use `workosId` instead (see {@link workosId}). */
+  id?: string;
+  email?: string;
+  name?: string;
+  /**
+   * Organization id. The org is the top-level tenant: it owns the GitHub
+   * App installation and connected projects, while each user inside the org gets
+   * isolated building instances. Absent for personal (no-org) accounts.
+   */
+  organizationId?: string;
+}
+
+/**
+ * Tenant identity: the org is the top-level tenant, and each user inside it is
+ * an isolated builder. Agent state, worktrees and sandboxes are scoped per
+ * `(orgId, userId)`. Personal (no-org) users have `orgId === undefined`.
+ */
+export interface WebAuthTenant {
+  /** Organization id, or `undefined` for personal (no-org) accounts. */
+  orgId?: string;
+  /** Stable provider user id. */
+  userId: string;
+}
+
+/** HTTP methods supported for adapter-provided public auth routes. */
+export type AuthRouteMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'ALL';
+
+/**
+ * A public `/auth/*` route contributed by an adapter (login, OAuth callback,
+ * logout, provider API endpoints). Mounted unauthenticated: the gate skips
+ * `/auth/*`. The auth module mounts these both as plain Hono routes (local
+ * server) and as Mastra `server.apiRoutes` (platform entry).
+ */
+export interface AuthRouteSpec {
+  /** Route path, must start with `/auth/`. */
+  path: string;
+  method: AuthRouteMethod;
+  handler: (c: Context) => Response | Promise<Response>;
+}
+
+/** Factory-level context handed to `WebAuthAdapter.init()` once during `prepare()`. */
+export interface WebAuthAdapterInitContext {
+  /** Postgres connection string of the app database, when configured. */
+  databaseUrl?: string;
+  /** Browser-facing origin (no trailing slash), e.g. `https://factory.acme.com`. */
+  publicUrl?: string;
+}
+
+/**
+ * Identity-provider adapter behind the web auth gate.
+ *
+ * Implementations must validate their own constructor options (fail fast);
+ * requirements only satisfiable at prepare time (e.g. a database) are checked
+ * in `init()`.
+ */
+export interface WebAuthAdapter {
+  /** Provider discriminator: `'workos'`, `'better-auth'`, or a custom value. */
+  readonly kind: string;
+
+  /**
+   * Optional one-time initialization, called by `MastraFactory.prepare()` with
+   * factory-level context (database, public origin) so adapters can use it
+   * without the deploy entry passing it twice.
+   */
+  init?(ctx: WebAuthAdapterInitContext): Promise<void>;
+
+  /**
+   * Resolve the authenticated user for a request from a bearer token and/or
+   * the raw request's session cookie. Returns `null` when unauthenticated.
+   * Must not throw for ordinary invalid/expired sessions.
+   */
+  authenticate(token: string, raw: Request): Promise<WebAuthUser | null>;
+
+  /**
+   * Ensure the user belongs to an organization, bootstrapping a personal org
+   * on first use when they have none. Returns the org id, or `undefined` when
+   * the user genuinely stays no-org (bootstrap is best-effort). Must be
+   * idempotent under concurrent/retried first logins.
+   */
+  ensureOrg(user: WebAuthUser): Promise<string | undefined>;
+
+  /** Provider-specific public `/auth/*` routes (login, callback, logout, APIs). */
+  publicRoutes(): AuthRouteSpec[];
+
+  /** `Set-Cookie` string that clears this provider's session cookie. */
+  sessionClearCookie(): string;
+}
+
+/**
+ * Validate that a `returnTo` value is a safe same-site path, to prevent
+ * open-redirect attacks. Only absolute local paths (`/foo`) are allowed;
+ * protocol-relative (`//evil.com`) and absolute URLs are rejected.
+ */
+export function sanitizeReturnTo(raw: string | undefined): string {
+  if (!raw) return '/';
+  if (!raw.startsWith('/')) return '/';
+  // Reject protocol-relative URLs like "//evil.com" and "/\evil.com".
+  if (raw.startsWith('//') || raw.startsWith('/\\')) return '/';
+  return raw;
+}
+
+/** Extract a bearer token from the Authorization header, if present. */
+export function getBearerToken(authorization: string | undefined): string {
+  if (!authorization) return '';
+  const match = /^Bearer\s+(.+)$/i.exec(authorization);
+  return match?.[1] ?? '';
+}
+
+/**
+ * Whether the SPA is served cross-origin from this API (platform deploy). When
+ * `MASTRACODE_ALLOWED_ORIGINS` is set the browser talks to us cross-site, so
+ * session cookies must be `SameSite=None; Secure` for the browser to send them.
+ * Same-origin local dev leaves this unset and keeps the stricter `SameSite=Lax`.
+ */
+export function isCrossSiteAuth(): boolean {
+  return Boolean(process.env.MASTRACODE_ALLOWED_ORIGINS?.trim());
+}

--- a/mastracode/web/src/web/auth-adapter.ts
+++ b/mastracode/web/src/web/auth-adapter.ts
@@ -80,6 +80,14 @@ export interface WebAuthAdapter {
   readonly kind: string;
 
   /**
+   * Whether self-serve sign-up is disabled for providers that host their own
+   * credential forms (e.g. better-auth email/password). Surfaced through
+   * `/auth/me` so the SPA hides the sign-up affordance. Hosted-login providers
+   * (WorkOS) leave this undefined.
+   */
+  readonly signUpDisabled?: boolean;
+
+  /**
    * Optional one-time initialization, called by `MastraFactory.prepare()` with
    * factory-level context (database, public origin) so adapters can use it
    * without the deploy entry passing it twice.

--- a/mastracode/web/src/web/auth-adapter.ts
+++ b/mastracode/web/src/web/auth-adapter.ts
@@ -66,6 +66,12 @@ export interface WebAuthAdapterInitContext {
   databaseUrl?: string;
   /** Browser-facing origin (no trailing slash), e.g. `https://factory.acme.com`. */
   publicUrl?: string;
+  /**
+   * Extra browser origins allowed to talk to this API (cross-origin SPA
+   * deploys). Providers that enforce their own origin allow-list (e.g.
+   * better-auth `trustedOrigins`) must honor these.
+   */
+  allowedOrigins?: string[];
 }
 
 /**

--- a/mastracode/web/src/web/auth-better-adapter.test.ts
+++ b/mastracode/web/src/web/auth-better-adapter.test.ts
@@ -85,6 +85,21 @@ describe('construction and init', () => {
     const adapter = new BetterAuthWebAuth({ secret: 's3cret' });
     expect(() => adapter.instance).toThrow(/not initialized/);
   });
+
+  it('trusts the factory allowedOrigins on the default instance', async () => {
+    // SameSite=None only lets the browser send the cookie — better-auth still
+    // rejects requests from origins outside trustedOrigins, so cross-origin
+    // SPA deploys must have their origins forwarded.
+    const adapter = new BetterAuthWebAuth({ secret: 's3cret' });
+    await adapter.init?.({
+      databaseUrl: 'postgres://user:pw@localhost:5432/app',
+      publicUrl: 'https://api.acme.com',
+      allowedOrigins: ['https://app.acme.com'],
+    });
+    expect((adapter.instance as { options: { trustedOrigins?: unknown } }).options.trustedOrigins).toEqual([
+      'https://app.acme.com',
+    ]);
+  });
 });
 
 describe('authenticate', () => {
@@ -206,6 +221,41 @@ describe('ensureOrg (personal-org bootstrap)', () => {
     );
   });
 
+  it('does not adopt a slug-squatted org owned by another user', async () => {
+    // An attacker pre-created `personal-user_1` through the public org API and
+    // is its owner. Recovery must NOT attach the victim there — it creates a
+    // fresh personal org with an unguessable slug instead.
+    const createdOrgs: Array<{ slug: string }> = [];
+    const dbAdapter = mockDbAdapter({
+      create: vi.fn(async (input: { model: string; data?: { slug?: string } }) => {
+        if (input.model === 'organization') {
+          if (input.data?.slug === 'personal-user_1') throw new Error('duplicate key value violates unique constraint');
+          createdOrgs.push({ slug: input.data!.slug! });
+          return { id: 'org_fallback' };
+        }
+        return { id: 'member_new' };
+      }),
+      findOne: vi.fn(async (input: { model: string }) =>
+        input.model === 'organization' ? { id: 'org_squatted' } : null,
+      ),
+      findMany: vi.fn(async (input: { model: string; where?: Array<{ field: string }> }) => {
+        // First call: the victim's memberships (none). Second: the squatted org's members.
+        if (input.model === 'member' && input.where?.[0]?.field === 'organizationId') {
+          return [{ organizationId: 'org_squatted', userId: 'attacker_1' }];
+        }
+        return [];
+      }),
+    });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    expect(await adapter.ensureOrg(user)).toBe('org_fallback');
+    expect(createdOrgs[0]!.slug).toMatch(/^personal-user_1-[0-9a-f-]{36}$/);
+    // The victim's owner membership lands on the fallback org, never the squatted one.
+    const memberCall = dbAdapter.create.mock.calls.find(([input]) => input.model === 'member')![0];
+    expect(memberCall.data).toMatchObject({ organizationId: 'org_fallback', userId: 'user_1', role: 'owner' });
+  });
+
   it('tolerates a membership a concurrent bootstrap already created', async () => {
     const dbAdapter = mockDbAdapter({
       create: vi.fn(async (input: { model: string }) => {
@@ -260,6 +310,14 @@ describe('session cookie', () => {
     const { instance } = mockInstance({ options: { baseURL: 'https://factory.acme.com' } });
     const adapter = new BetterAuthWebAuth({ instance });
     expect(adapter.sessionClearCookie()).toMatch(/^__Secure-better-auth\.session_token=/);
+  });
+
+  it('honors a renamed session cookie via advanced.cookies.session_token.name', () => {
+    const { instance } = mockInstance({
+      options: { advanced: { cookies: { session_token: { name: 'acme_session' } } } },
+    });
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(adapter.sessionClearCookie()).toMatch(/^acme_session=/);
   });
 });
 

--- a/mastracode/web/src/web/auth-better-adapter.test.ts
+++ b/mastracode/web/src/web/auth-better-adapter.test.ts
@@ -317,3 +317,31 @@ describe('public routes', () => {
     expect(res.headers.getSetCookie().some(c => c.startsWith('better-auth.session_token=;'))).toBe(true);
   });
 });
+
+describe('/auth/me under better-auth', () => {
+  it('reports the better-auth provider so the SPA renders the credential form', async () => {
+    const { registerAuthRoutes } = await import('./auth.js');
+    const { instance } = mockInstance();
+    const app = new Hono();
+    registerAuthRoutes(app, new BetterAuthWebAuth({ instance }));
+
+    const res = await app.request('/auth/me');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ authenticated: false, user: null, provider: 'better-auth' });
+  });
+
+  it('surfaces signUpDisabled so the SPA hides the sign-up affordance', async () => {
+    const { registerAuthRoutes } = await import('./auth.js');
+    const { instance } = mockInstance();
+    const app = new Hono();
+    registerAuthRoutes(app, new BetterAuthWebAuth({ instance, signUpDisabled: true }));
+
+    const res = await app.request('/auth/me');
+    expect(await res.json()).toEqual({
+      authenticated: false,
+      user: null,
+      provider: 'better-auth',
+      signUpDisabled: true,
+    });
+  });
+});

--- a/mastracode/web/src/web/auth-better-adapter.test.ts
+++ b/mastracode/web/src/web/auth-better-adapter.test.ts
@@ -1,0 +1,319 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BetterAuthInstance } from './auth-better-adapter.js';
+import { BetterAuthWebAuth } from './auth-better-adapter.js';
+
+/**
+ * BetterAuthWebAuth against a mocked better-auth instance: session resolution
+ * (cookie + bearer synthesis), the WorkOS-mirroring personal-org bootstrap on
+ * the organization tables, sign-up gating plumbing, and the public routes
+ * (API passthrough, /auth/login → /signin, /auth/logout). Real better-auth
+ * behavior (handlers, migrations) is exercised in manual smoke.
+ */
+
+const ORIGINAL_ENV = { ...process.env };
+
+interface MockDbAdapter {
+  findMany: ReturnType<typeof vi.fn>;
+  findOne: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+}
+
+function mockDbAdapter(overrides: Partial<MockDbAdapter> = {}): MockDbAdapter {
+  return {
+    findMany: vi.fn(async () => []),
+    findOne: vi.fn(async () => null),
+    create: vi.fn(async (input: { model: string }) => ({ id: `${input.model}_created` })),
+    ...overrides,
+  };
+}
+
+function mockInstance({
+  session = null as unknown,
+  dbAdapter = mockDbAdapter(),
+  options = {} as Record<string, unknown>,
+} = {}) {
+  const instance = {
+    api: {
+      getSession: vi.fn(async (_input: { headers: Headers }) => session),
+      signOut: vi.fn(async () => new Response(null, { status: 200 })),
+    },
+    handler: vi.fn(async () => new Response('better-auth handled', { status: 200 })),
+    $context: Promise.resolve({ adapter: dbAdapter }),
+    options,
+  };
+  return { instance: instance as unknown as BetterAuthInstance, mocks: instance, dbAdapter };
+}
+
+function buildRouteApp(adapter: BetterAuthWebAuth) {
+  const app = new Hono();
+  for (const route of adapter.publicRoutes()) {
+    const methods = route.method === 'ALL' ? ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] : [route.method];
+    app.on(methods, route.path, c => route.handler(c));
+  }
+  return app;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.MASTRACODE_ALLOWED_ORIGINS;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('construction and init', () => {
+  it('requires secret or instance', () => {
+    expect(() => new BetterAuthWebAuth()).toThrow(/secret|instance/);
+  });
+
+  it('accepts a bring-your-own instance and skips construction in init()', async () => {
+    const { instance } = mockInstance();
+    const adapter = new BetterAuthWebAuth({ instance });
+    await adapter.init?.({});
+    expect(adapter.instance).toBe(instance);
+  });
+
+  it('the default path fails fast in init() without a database', async () => {
+    const adapter = new BetterAuthWebAuth({ secret: 's3cret' });
+    await expect(adapter.init?.({ publicUrl: 'https://factory.acme.com' })).rejects.toThrow(/database/);
+  });
+
+  it('accessing the instance before init() throws', () => {
+    const adapter = new BetterAuthWebAuth({ secret: 's3cret' });
+    expect(() => adapter.instance).toThrow(/not initialized/);
+  });
+});
+
+describe('authenticate', () => {
+  const sessionResult = {
+    session: { id: 'sess_1' },
+    user: { id: 'user_1', email: 'u@example.com', name: 'U Ser' },
+  };
+
+  it('resolves the user from the request session cookie', async () => {
+    const { instance, mocks } = mockInstance({ session: sessionResult });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    const raw = new Request('http://localhost/web/x', {
+      headers: { Cookie: 'better-auth.session_token=tok_abc' },
+    });
+    const user = await adapter.authenticate('', raw);
+
+    expect(user).toEqual({ id: 'user_1', email: 'u@example.com', name: 'U Ser' });
+    const headers = mocks.api.getSession.mock.calls[0]![0]!.headers;
+    expect(headers.get('Cookie')).toBe('better-auth.session_token=tok_abc');
+  });
+
+  it('synthesizes a session cookie from a bearer token when none is present', async () => {
+    const { instance, mocks } = mockInstance({ session: sessionResult });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    await adapter.authenticate('tok_bearer', new Request('http://localhost/web/x'));
+
+    const headers = mocks.api.getSession.mock.calls[0]![0]!.headers;
+    expect(headers.get('Cookie')).toBe('better-auth.session_token=tok_bearer');
+  });
+
+  it('leaves an existing session cookie alone even with a bearer token', async () => {
+    const { instance, mocks } = mockInstance({ session: sessionResult });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    const raw = new Request('http://localhost/web/x', {
+      headers: { Cookie: 'better-auth.session_token=tok_cookie' },
+    });
+    await adapter.authenticate('tok_bearer', raw);
+
+    const headers = mocks.api.getSession.mock.calls[0]![0]!.headers;
+    expect(headers.get('Cookie')).toBe('better-auth.session_token=tok_cookie');
+  });
+
+  it('returns null when there is no session', async () => {
+    const { instance } = mockInstance({ session: null });
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(await adapter.authenticate('', new Request('http://localhost/web/x'))).toBeNull();
+  });
+
+  it('returns null instead of throwing when getSession fails', async () => {
+    const { instance, mocks } = mockInstance();
+    mocks.api.getSession.mockRejectedValue(new Error('db down'));
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(await adapter.authenticate('', new Request('http://localhost/web/x'))).toBeNull();
+  });
+
+  it('maps the active organization from the session when present', async () => {
+    const { instance } = mockInstance({
+      session: { session: { id: 'sess_1', activeOrganizationId: 'org_active' }, user: sessionResult.user },
+    });
+    const adapter = new BetterAuthWebAuth({ instance });
+    const user = await adapter.authenticate('', new Request('http://localhost/web/x'));
+    expect(user?.organizationId).toBe('org_active');
+  });
+});
+
+describe('ensureOrg (personal-org bootstrap)', () => {
+  const user = { id: 'user_1', email: 'u@example.com' };
+
+  it('no-ops when the user already has an organization', async () => {
+    const { instance, dbAdapter } = mockInstance();
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(await adapter.ensureOrg({ ...user, organizationId: 'org_x' })).toBe('org_x');
+    expect(dbAdapter.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns the first existing membership org without creating', async () => {
+    const dbAdapter = mockDbAdapter({ findMany: vi.fn(async () => [{ organizationId: 'org_existing' }]) });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    expect(await adapter.ensureOrg(user)).toBe('org_existing');
+    expect(dbAdapter.create).not.toHaveBeenCalled();
+  });
+
+  it('creates a personal org + owner membership for a no-org user', async () => {
+    const dbAdapter = mockDbAdapter({
+      create: vi.fn(async (input: { model: string }) =>
+        input.model === 'organization' ? { id: 'org_new' } : { id: 'member_new' },
+      ),
+    });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    expect(await adapter.ensureOrg(user)).toBe('org_new');
+
+    const orgCall = dbAdapter.create.mock.calls.find(([input]) => input.model === 'organization')![0];
+    expect(orgCall.data).toMatchObject({ name: "u@example.com's org", slug: 'personal-user_1' });
+    const memberCall = dbAdapter.create.mock.calls.find(([input]) => input.model === 'member')![0];
+    expect(memberCall.data).toMatchObject({ organizationId: 'org_new', userId: 'user_1', role: 'owner' });
+  });
+
+  it('recovers the existing org by slug when the create hits the unique constraint', async () => {
+    const dbAdapter = mockDbAdapter({
+      create: vi.fn(async (input: { model: string }) => {
+        if (input.model === 'organization') throw new Error('duplicate key value violates unique constraint');
+        return { id: 'member_new' };
+      }),
+      findOne: vi.fn(async (input: { model: string }) => (input.model === 'organization' ? { id: 'org_prior' } : null)),
+    });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    expect(await adapter.ensureOrg(user)).toBe('org_prior');
+    expect(dbAdapter.findOne).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'organization', where: [{ field: 'slug', value: 'personal-user_1' }] }),
+    );
+  });
+
+  it('tolerates a membership a concurrent bootstrap already created', async () => {
+    const dbAdapter = mockDbAdapter({
+      create: vi.fn(async (input: { model: string }) => {
+        if (input.model === 'organization') return { id: 'org_new' };
+        throw new Error('duplicate member');
+      }),
+      findOne: vi.fn(async (input: { model: string }) => (input.model === 'member' ? { id: 'member_prior' } : null)),
+    });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    expect(await adapter.ensureOrg(user)).toBe('org_new');
+  });
+
+  it('is best-effort: swallows failures and returns undefined', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const dbAdapter = mockDbAdapter({ findMany: vi.fn(async () => Promise.reject(new Error('db down'))) });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    expect(await adapter.ensureOrg(user)).toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('caches the resolved org so subsequent calls skip the DB', async () => {
+    const dbAdapter = mockDbAdapter({ findMany: vi.fn(async () => [{ organizationId: 'org_cached' }]) });
+    const { instance } = mockInstance({ dbAdapter });
+    const adapter = new BetterAuthWebAuth({ instance });
+
+    await adapter.ensureOrg(user);
+    await adapter.ensureOrg(user);
+    expect(dbAdapter.findMany).toHaveBeenCalledOnce();
+  });
+});
+
+describe('session cookie', () => {
+  it('clears the default cookie with SameSite=Lax same-origin', () => {
+    const { instance } = mockInstance();
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(adapter.sessionClearCookie()).toBe('better-auth.session_token=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0');
+  });
+
+  it('uses SameSite=None; Secure for cross-site deploys', () => {
+    process.env.MASTRACODE_ALLOWED_ORIGINS = 'https://app.acme.com';
+    const { instance } = mockInstance();
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(adapter.sessionClearCookie()).toContain('SameSite=None; Secure');
+  });
+
+  it('honors the __Secure- prefix better-auth applies on https deploys', () => {
+    const { instance } = mockInstance({ options: { baseURL: 'https://factory.acme.com' } });
+    const adapter = new BetterAuthWebAuth({ instance });
+    expect(adapter.sessionClearCookie()).toMatch(/^__Secure-better-auth\.session_token=/);
+  });
+});
+
+describe('public routes', () => {
+  it('forwards /auth/api/* requests to the better-auth handler', async () => {
+    const { instance, mocks } = mockInstance();
+    const adapter = new BetterAuthWebAuth({ instance });
+    const app = buildRouteApp(adapter);
+
+    const res = await app.request('/auth/api/sign-in/email', { method: 'POST' });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('better-auth handled');
+    expect(mocks.handler).toHaveBeenCalledOnce();
+  });
+
+  it('/auth/login redirects to the SPA sign-in form, preserving returnTo', async () => {
+    const { instance } = mockInstance();
+    const app = buildRouteApp(new BetterAuthWebAuth({ instance }));
+
+    const res = await app.request('/auth/login?returnTo=%2Ffactory%2Fboard');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/signin?returnTo=%2Ffactory%2Fboard');
+  });
+
+  it('/auth/login sanitizes external returnTo values', async () => {
+    const { instance } = mockInstance();
+    const app = buildRouteApp(new BetterAuthWebAuth({ instance }));
+
+    const res = await app.request('/auth/login?returnTo=https%3A%2F%2Fevil.com');
+    expect(res.headers.get('location')).toBe('/signin?returnTo=%2F');
+  });
+
+  it('/auth/logout revokes the session, forwards its cookies, clears ours, and redirects', async () => {
+    const { instance, mocks } = mockInstance();
+    mocks.api.signOut.mockResolvedValue(
+      new Response(null, { status: 200, headers: { 'Set-Cookie': 'better-auth.session_token=; Max-Age=0' } }),
+    );
+    const app = buildRouteApp(new BetterAuthWebAuth({ instance }));
+
+    const res = await app.request('/auth/logout');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('/');
+    const cookies = res.headers.getSetCookie();
+    expect(cookies.some(c => c.includes('Max-Age=0'))).toBe(true);
+    expect(mocks.api.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('/auth/logout still clears the cookie when sign-out fails', async () => {
+    const { instance, mocks } = mockInstance();
+    mocks.api.signOut.mockRejectedValue(new Error('no session'));
+    const app = buildRouteApp(new BetterAuthWebAuth({ instance }));
+
+    const res = await app.request('/auth/logout');
+    expect(res.status).toBe(302);
+    expect(res.headers.getSetCookie().some(c => c.startsWith('better-auth.session_token=;'))).toBe(true);
+  });
+});

--- a/mastracode/web/src/web/auth-better-adapter.ts
+++ b/mastracode/web/src/web/auth-better-adapter.ts
@@ -75,6 +75,11 @@ export class BetterAuthWebAuth implements WebAuthAdapter {
     this.#instance = options.instance;
   }
 
+  /** Surfaced through `/auth/me` so the SPA hides the sign-up form when disabled. */
+  get signUpDisabled(): boolean {
+    return this.#signUpDisabled;
+  }
+
   /** The active better-auth instance. Throws before `init()` on the default path. */
   get instance(): BetterAuthInstance {
     if (!this.#instance) {

--- a/mastracode/web/src/web/auth-better-adapter.ts
+++ b/mastracode/web/src/web/auth-better-adapter.ts
@@ -1,0 +1,324 @@
+import { betterAuth } from 'better-auth';
+import type { BetterAuthOptions } from 'better-auth';
+import { getMigrations } from 'better-auth/db/migration';
+import { organization } from 'better-auth/plugins';
+import { Pool } from 'pg';
+
+import type { AuthRouteSpec, WebAuthAdapter, WebAuthAdapterInitContext, WebAuthUser } from './auth-adapter.js';
+import { isCrossSiteAuth, sanitizeReturnTo } from './auth-adapter.js';
+
+/**
+ * Self-hosted better-auth implementation of {@link WebAuthAdapter}.
+ *
+ * Email/password auth on the app's own Postgres — no external identity vendor
+ * in the availability path. Org tenancy comes from better-auth's organization
+ * plugin: `ensureOrg` mirrors the WorkOS personal-org bootstrap, so the tenant
+ * identity `(orgId, userId)` resolves exactly like it does under WorkOS and
+ * all org-scoped routes work unchanged.
+ *
+ * Two construction modes:
+ * - Default: pass `secret` and the adapter builds its own `betterAuth()`
+ *   instance in `init()` on the factory's database (`ctx.databaseUrl`),
+ *   running better-auth's programmatic migrations behind a once-per-process
+ *   latch (mirrors `ensureFactoryDbReady`).
+ * - Bring-your-own: pass a fully-configured `instance`; the adapter mounts it
+ *   as-is and leaves database/migrations to the caller.
+ */
+
+/** A configured better-auth instance (the result of `betterAuth({ ... })`). */
+export type BetterAuthInstance = ReturnType<typeof betterAuth>;
+
+export interface BetterAuthWebAuthOptions {
+  /** Secret used by the default `betterAuth()` instance for session signing. */
+  secret?: string;
+  /** Fully-configured `betterAuth()` instance; skips the default construction in `init()`. */
+  instance?: BetterAuthInstance;
+  /** Disable public email/password sign-up (default instance only). */
+  signUpDisabled?: boolean;
+}
+
+/** Build a predictable personal-org name from the user's profile. */
+function personalOrgName(user: WebAuthUser, userId: string): string {
+  const label = user.email ?? user.name ?? userId;
+  return `${label}'s org`;
+}
+
+/** Loose row shapes read back from better-auth's internal DB adapter. */
+interface MemberRow {
+  organizationId?: string;
+}
+interface OrganizationRow {
+  id: string;
+}
+
+export class BetterAuthWebAuth implements WebAuthAdapter {
+  readonly kind = 'better-auth';
+
+  #secret: string | undefined;
+  #signUpDisabled: boolean;
+  #instance: BetterAuthInstance | undefined;
+  /** True when `init()` built the instance — then we also own its migrations. */
+  #ownsInstance = false;
+  /** Once-per-process migration latch; reset on failure so a later call retries. */
+  #migrated: Promise<void> | undefined;
+  /** In-process `userId → orgId` cache so the gate doesn't hit the DB per request. */
+  #orgCache = new Map<string, string>();
+
+  constructor(options: BetterAuthWebAuthOptions = {}) {
+    if (!options.secret && !options.instance) {
+      throw new Error(
+        'BetterAuthWebAuth requires either `secret` (the adapter builds its own better-auth instance on the factory database) or a fully-configured `instance`.',
+      );
+    }
+    this.#secret = options.secret;
+    this.#signUpDisabled = options.signUpDisabled ?? false;
+    this.#instance = options.instance;
+  }
+
+  /** The active better-auth instance. Throws before `init()` on the default path. */
+  get instance(): BetterAuthInstance {
+    if (!this.#instance) {
+      throw new Error(
+        'BetterAuthWebAuth is not initialized — MastraFactory.prepare() must run first (or pass a configured `instance`).',
+      );
+    }
+    return this.#instance;
+  }
+
+  async init(ctx: WebAuthAdapterInitContext): Promise<void> {
+    if (this.#instance) return; // bring-your-own instance: nothing to build
+    if (!ctx.databaseUrl) {
+      throw new Error(
+        'BetterAuthWebAuth needs a database: configure the MastraFactory `database` slot (or pass your own better-auth `instance`).',
+      );
+    }
+    const crossSite = isCrossSiteAuth();
+    // Widen to BetterAuthOptions before calling betterAuth(): its return type
+    // is generic over the exact options object, which would make the instance
+    // incompatible with the plain `Auth<BetterAuthOptions>` alias we expose.
+    const options: BetterAuthOptions = {
+      database: new Pool({ connectionString: ctx.databaseUrl }),
+      secret: this.#secret,
+      // All provider endpoints (sign-in/up/out/session) live under /auth/api/*,
+      // which the gate treats as public like every /auth/* path.
+      basePath: '/auth/api',
+      ...(ctx.publicUrl ? { baseURL: ctx.publicUrl } : {}),
+      emailAndPassword: { enabled: true, disableSignUp: this.#signUpDisabled },
+      plugins: [organization()],
+      // Cross-origin SPA deploys need SameSite=None; Secure for the browser to
+      // send the session cookie (see isCrossSiteAuth).
+      ...(crossSite ? { advanced: { defaultCookieAttributes: { sameSite: 'none', secure: true } } } : {}),
+    };
+    this.#instance = betterAuth(options);
+    this.#ownsInstance = true;
+  }
+
+  /**
+   * Session cookie name, honoring better-auth's `cookiePrefix` and the
+   * `__Secure-` prefix it applies when secure cookies are active.
+   */
+  #sessionCookieName(): string {
+    const options = (this.#instance as { options?: { baseURL?: string; advanced?: Record<string, unknown> } })?.options;
+    const advanced = options?.advanced as { cookiePrefix?: string; useSecureCookies?: boolean } | undefined;
+    const prefix = advanced?.cookiePrefix ?? 'better-auth';
+    const secure = advanced?.useSecureCookies ?? options?.baseURL?.startsWith('https://') ?? false;
+    return `${secure ? '__Secure-' : ''}${prefix}.session_token`;
+  }
+
+  /**
+   * Ensure better-auth's tables exist in the app database. Only for instances
+   * this adapter built — bring-your-own instances manage their own migrations.
+   */
+  async #ensureDbReady(): Promise<void> {
+    if (!this.#ownsInstance) return;
+    this.#migrated ??= (async () => {
+      const { runMigrations } = await getMigrations(this.instance.options);
+      await runMigrations();
+    })();
+    try {
+      await this.#migrated;
+    } catch (error) {
+      this.#migrated = undefined; // allow a later call to retry
+      console.warn('[BetterAuth] Failed to run auth schema migrations; auth stays unavailable until this succeeds.');
+      throw error;
+    }
+  }
+
+  async authenticate(token: string, raw: Request): Promise<WebAuthUser | null> {
+    try {
+      await this.#ensureDbReady();
+
+      // better-auth only reads the session from the Cookie header, so synthesize
+      // a session cookie from a bearer token when no session cookie is present
+      // (same approach as @mastra/auth-better-auth).
+      const headers = new Headers();
+      const cookieHeader = raw.headers.get('Cookie');
+      if (cookieHeader) headers.set('Cookie', cookieHeader);
+      const cookieName = this.#sessionCookieName();
+      const hasSessionCookie = Boolean(
+        cookieHeader?.split(';').some(pair => pair.trim().split('=')[0]?.trim() === cookieName),
+      );
+      if (token && !hasSessionCookie) {
+        headers.set('Cookie', `${cookieHeader ? `${cookieHeader}; ` : ''}${cookieName}=${token}`);
+      }
+
+      const result = await this.instance.api.getSession({ headers });
+      if (!result?.user) return null;
+
+      const session = result.session as { activeOrganizationId?: string | null } | undefined;
+      const organizationId = session?.activeOrganizationId ?? this.#orgCache.get(result.user.id);
+      return {
+        id: result.user.id,
+        email: result.user.email,
+        name: result.user.name ?? undefined,
+        ...(organizationId ? { organizationId } : {}),
+      };
+    } catch {
+      // Ordinary invalid/expired sessions (and transient DB failures) read as
+      // unauthenticated rather than failing the request.
+      return null;
+    }
+  }
+
+  /**
+   * Mirror the WorkOS personal-org bootstrap on better-auth's organization
+   * tables: ≥1 membership → first org id; 0 → create a personal org with an
+   * idempotent slug derived from the user id. Concurrent/retried first logins
+   * recover via the unique slug instead of creating duplicates. Best-effort:
+   * any failure is swallowed and leaves the user no-org (same as WorkOS).
+   */
+  async ensureOrg(user: WebAuthUser): Promise<string | undefined> {
+    if (user.organizationId) return user.organizationId;
+    const userId = user.id ?? user.workosId;
+    if (!userId) return undefined;
+
+    const cached = this.#orgCache.get(userId);
+    if (cached) return cached;
+
+    try {
+      await this.#ensureDbReady();
+      const ctx = await this.instance.$context;
+
+      const memberships = (await ctx.adapter.findMany({
+        model: 'member',
+        where: [{ field: 'userId', value: userId }],
+      })) as MemberRow[];
+      const firstExisting = memberships.find(m => m.organizationId)?.organizationId;
+      if (firstExisting) {
+        this.#orgCache.set(userId, firstExisting);
+        return firstExisting;
+      }
+
+      // Create the personal org. The slug is derived from the user id, so a
+      // concurrent/prior bootstrap that already created it makes the insert
+      // reject on the unique slug — recover by looking the org up instead.
+      const slug = `personal-${userId}`;
+      let organizationId: string;
+      try {
+        const created = (await ctx.adapter.create({
+          model: 'organization',
+          data: {
+            name: personalOrgName(user, userId),
+            slug,
+            createdAt: new Date(),
+            metadata: JSON.stringify({ mastracodePersonalOrg: 'true' }),
+          },
+        })) as OrganizationRow;
+        organizationId = created.id;
+      } catch (error) {
+        const existing = (await ctx.adapter.findOne({
+          model: 'organization',
+          where: [{ field: 'slug', value: slug }],
+        })) as OrganizationRow | null;
+        if (!existing) throw error;
+        organizationId = existing.id;
+      }
+
+      // Idempotently attach the user: tolerate a membership a concurrent
+      // bootstrap already created.
+      try {
+        await ctx.adapter.create({
+          model: 'member',
+          data: { organizationId, userId, role: 'owner', createdAt: new Date() },
+        });
+      } catch (error) {
+        const member = await ctx.adapter.findOne({
+          model: 'member',
+          where: [
+            { field: 'organizationId', value: organizationId },
+            { field: 'userId', value: userId },
+          ],
+        });
+        if (!member) throw error;
+      }
+
+      this.#orgCache.set(userId, organizationId);
+      return organizationId;
+    } catch (error) {
+      console.warn(
+        `[BetterAuth] Failed to bootstrap personal organization for user ${userId}. ` +
+          'The user will see organization_required until this succeeds.',
+        error,
+      );
+      return undefined;
+    }
+  }
+
+  sessionClearCookie(): string {
+    const sameSite = isCrossSiteAuth() ? 'None; Secure' : 'Lax';
+    return `${this.#sessionCookieName()}=; Path=/; HttpOnly; SameSite=${sameSite}; Max-Age=0`;
+  }
+
+  /**
+   * Public routes: the better-auth API surface under `/auth/api/*`
+   * (sign-in/up/out/session — what the SPA's email/password form posts to),
+   * plus `/auth/login` (redirects to the SPA form) and `/auth/logout`.
+   */
+  publicRoutes(): AuthRouteSpec[] {
+    return [
+      {
+        path: '/auth/api/*',
+        method: 'ALL',
+        handler: async c => {
+          try {
+            await this.#ensureDbReady();
+          } catch {
+            return c.json({ error: 'auth_unavailable' }, 503);
+          }
+          return this.instance.handler(c.req.raw);
+        },
+      },
+      {
+        // Hosted-login equivalent: better-auth has no hosted page, so send the
+        // browser to the SPA's /signin form, preserving returnTo.
+        path: '/auth/login',
+        method: 'GET',
+        handler: c => {
+          const returnTo = sanitizeReturnTo(c.req.query('returnTo'));
+          return c.redirect(`/signin?returnTo=${encodeURIComponent(returnTo)}`);
+        },
+      },
+      {
+        path: '/auth/logout',
+        method: 'GET',
+        handler: async c => {
+          // Revoke the session server-side and forward better-auth's own
+          // clearing cookies; fall back to our clear cookie regardless.
+          try {
+            const response = (await this.instance.api.signOut({
+              headers: c.req.raw.headers,
+              asResponse: true,
+            })) as Response;
+            for (const cookie of response.headers.getSetCookie()) {
+              c.header('Set-Cookie', cookie, { append: true });
+            }
+          } catch {
+            // No/invalid session: nothing to revoke.
+          }
+          c.header('Set-Cookie', this.sessionClearCookie(), { append: true });
+          return c.redirect('/');
+        },
+      },
+    ];
+  }
+}

--- a/mastracode/web/src/web/auth-better-adapter.ts
+++ b/mastracode/web/src/web/auth-better-adapter.ts
@@ -98,6 +98,7 @@ export class BetterAuthWebAuth implements WebAuthAdapter {
       );
     }
     const crossSite = isCrossSiteAuth();
+    const allowedOrigins = ctx.allowedOrigins ?? [];
     // Widen to BetterAuthOptions before calling betterAuth(): its return type
     // is generic over the exact options object, which would make the instance
     // incompatible with the plain `Auth<BetterAuthOptions>` alias we expose.
@@ -108,6 +109,10 @@ export class BetterAuthWebAuth implements WebAuthAdapter {
       // which the gate treats as public like every /auth/* path.
       basePath: '/auth/api',
       ...(ctx.publicUrl ? { baseURL: ctx.publicUrl } : {}),
+      // Cross-origin SPA deploys: SameSite=None only lets the browser SEND the
+      // cookie — better-auth still rejects requests from origins outside its
+      // own allow-list, so the SPA origins must be trusted too.
+      ...(allowedOrigins.length ? { trustedOrigins: allowedOrigins } : {}),
       emailAndPassword: { enabled: true, disableSignUp: this.#signUpDisabled },
       plugins: [organization()],
       // Cross-origin SPA deploys need SameSite=None; Secure for the browser to
@@ -119,15 +124,24 @@ export class BetterAuthWebAuth implements WebAuthAdapter {
   }
 
   /**
-   * Session cookie name, honoring better-auth's `cookiePrefix` and the
-   * `__Secure-` prefix it applies when secure cookies are active.
+   * Session cookie name, honoring better-auth's `cookiePrefix`, a caller
+   * override via `advanced.cookies.session_token.name` (bring-your-own
+   * instances), and the `__Secure-` prefix it applies when secure cookies are
+   * active.
    */
   #sessionCookieName(): string {
     const options = (this.#instance as { options?: { baseURL?: string; advanced?: Record<string, unknown> } })?.options;
-    const advanced = options?.advanced as { cookiePrefix?: string; useSecureCookies?: boolean } | undefined;
+    const advanced = options?.advanced as
+      | {
+          cookiePrefix?: string;
+          useSecureCookies?: boolean;
+          cookies?: { session_token?: { name?: string } };
+        }
+      | undefined;
     const prefix = advanced?.cookiePrefix ?? 'better-auth';
     const secure = advanced?.useSecureCookies ?? options?.baseURL?.startsWith('https://') ?? false;
-    return `${secure ? '__Secure-' : ''}${prefix}.session_token`;
+    const baseName = advanced?.cookies?.session_token?.name ?? `${prefix}.session_token`;
+    return `${secure ? '__Secure-' : ''}${baseName}`;
   }
 
   /**
@@ -236,7 +250,32 @@ export class BetterAuthWebAuth implements WebAuthAdapter {
           where: [{ field: 'slug', value: slug }],
         })) as OrganizationRow | null;
         if (!existing) throw error;
-        organizationId = existing.id;
+        // Slug alone is NOT proof of ownership: the organization API is
+        // reachable by any authenticated user, so an attacker could squat
+        // `personal-<victimId>` and be granted the victim's tenant if we
+        // blindly adopted it. Only adopt the slug-matched org when nobody
+        // else is a member (zero members = a concurrent bootstrap of this
+        // same user that hasn't attached yet). Otherwise fall back to a
+        // fresh org with an unguessable slug.
+        const existingMembers = (await ctx.adapter.findMany({
+          model: 'member',
+          where: [{ field: 'organizationId', value: existing.id }],
+        })) as Array<MemberRow & { userId?: string }>;
+        const foreignMember = existingMembers.some(m => m.userId !== userId);
+        if (foreignMember) {
+          const fallback = (await ctx.adapter.create({
+            model: 'organization',
+            data: {
+              name: personalOrgName(user, userId),
+              slug: `personal-${userId}-${crypto.randomUUID()}`,
+              createdAt: new Date(),
+              metadata: JSON.stringify({ mastracodePersonalOrg: 'true' }),
+            },
+          })) as OrganizationRow;
+          organizationId = fallback.id;
+        } else {
+          organizationId = existing.id;
+        }
       }
 
       // Idempotently attach the user: tolerate a membership a concurrent

--- a/mastracode/web/src/web/auth-seam.test.ts
+++ b/mastracode/web/src/web/auth-seam.test.ts
@@ -1,0 +1,176 @@
+import { Hono } from 'hono';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WebAuthAdapter } from './auth-adapter.js';
+import { WorkOSWebAuth } from './auth-workos-adapter.js';
+import {
+  buildAuthRoutes,
+  getWorkOSProvider,
+  isWebAuthEnabled,
+  isWorkOSAuth,
+  mountWebAuth,
+  webAuthTenant,
+} from './auth.js';
+import { __resetRuntimeConfigForTests, seedRuntimeConfig } from './runtime-config.js';
+
+/**
+ * Adapter-seam behavior: the auth module resolves the ACTIVE adapter from the
+ * factory-seeded registry (seeded config authoritative, including "seeded with
+ * no adapter" = auth explicitly disabled) and falls back to a WorkOS adapter
+ * implied by the `WORKOS_*` env vars only when the factory never ran.
+ * Provider-specific WorkOS behavior itself is covered by `auth.test.ts`.
+ */
+
+// Mock @mastra/auth-workos so WorkOSWebAuth never constructs a real client.
+const mockAuthenticate = vi.fn();
+const mockGetLoginUrl = vi.fn(() => 'https://workos.example/login');
+vi.mock('@mastra/auth-workos', () => ({
+  MastraAuthWorkos: class {
+    getLoginUrl = mockGetLoginUrl;
+    authenticateToken = mockAuthenticate;
+  },
+}));
+
+const ORIGINAL_ENV = { ...process.env };
+
+/** Minimal custom adapter standing in for a non-WorkOS provider. */
+function fakeAdapter(overrides: Partial<WebAuthAdapter> = {}): WebAuthAdapter {
+  return {
+    kind: 'fake',
+    authenticate: vi.fn(async () => ({ id: 'user_fake', email: 'fake@example.com', organizationId: 'org_fake' })),
+    ensureOrg: vi.fn(async () => 'org_fake'),
+    publicRoutes: () => [
+      { path: '/auth/fake-login', method: 'GET', handler: c => c.redirect('https://fake.example/login') },
+    ],
+    sessionClearCookie: () => 'fake_session=; Path=/; Max-Age=0',
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetRuntimeConfigForTests();
+  delete process.env.WORKOS_API_KEY;
+  delete process.env.WORKOS_CLIENT_ID;
+  delete process.env.WORKOS_REDIRECT_URI;
+});
+
+afterEach(() => {
+  __resetRuntimeConfigForTests();
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('active adapter resolution', () => {
+  it('a seeded adapter enables auth regardless of env', () => {
+    seedRuntimeConfig({ authAdapter: fakeAdapter() });
+    expect(isWebAuthEnabled()).toBe(true);
+    expect(isWorkOSAuth()).toBe(false);
+  });
+
+  it('seeding without an adapter disables auth even when WORKOS env vars are set', () => {
+    process.env.WORKOS_API_KEY = 'sk_test';
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+    seedRuntimeConfig({});
+    expect(isWebAuthEnabled()).toBe(false);
+    expect(isWorkOSAuth()).toBe(false);
+  });
+
+  it('falls back to env-implied WorkOS when the factory never seeded (back-compat)', () => {
+    process.env.WORKOS_API_KEY = 'sk_test';
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+    expect(isWebAuthEnabled()).toBe(true);
+    expect(isWorkOSAuth()).toBe(true);
+  });
+
+  it('a seeded WorkOS adapter reports isWorkOSAuth and exposes its provider', () => {
+    const adapter = new WorkOSWebAuth({ redirectUri: 'http://localhost:4111/auth/callback' });
+    seedRuntimeConfig({ authAdapter: adapter });
+    expect(isWorkOSAuth()).toBe(true);
+    expect(getWorkOSProvider()).toBe(adapter.provider);
+  });
+
+  it('getWorkOSProvider throws when the active adapter is not WorkOS', () => {
+    seedRuntimeConfig({ authAdapter: fakeAdapter() });
+    expect(() => getWorkOSProvider()).toThrow(/not WorkOS/);
+  });
+});
+
+describe('mountWebAuth with a seeded custom adapter', () => {
+  function buildApp(adapter: WebAuthAdapter) {
+    seedRuntimeConfig({ authAdapter: adapter });
+    const app = new Hono();
+    const enabled = mountWebAuth(app);
+    app.get('*', c => c.text('ok'));
+    return { app, enabled };
+  }
+
+  it('returns false when the registry is seeded without an adapter', () => {
+    process.env.WORKOS_API_KEY = 'sk_test';
+    process.env.WORKOS_CLIENT_ID = 'client_test';
+    seedRuntimeConfig({});
+    const enabled = mountWebAuth(new Hono());
+    expect(enabled).toBe(false);
+  });
+
+  it('mounts the adapter-provided public routes', async () => {
+    const { app, enabled } = buildApp(fakeAdapter());
+    expect(enabled).toBe(true);
+
+    const res = await app.request('/auth/fake-login');
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toBe('https://fake.example/login');
+  });
+
+  it('gates protected routes through adapter.authenticate and stashes the tenant', async () => {
+    const adapter = fakeAdapter();
+    seedRuntimeConfig({ authAdapter: adapter });
+    const app = new Hono();
+    mountWebAuth(app);
+    app.get('/web/whoami', c => c.json(webAuthTenant(c) ?? { tenant: null }));
+
+    const res = await app.request('/web/whoami', { headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ orgId: 'org_fake', userId: 'user_fake' });
+    expect(adapter.authenticate).toHaveBeenCalledOnce();
+  });
+
+  it('bootstraps a no-org user through adapter.ensureOrg', async () => {
+    const adapter = fakeAdapter({
+      authenticate: vi.fn(async () => ({ id: 'user_solo', email: 'solo@example.com' })),
+      ensureOrg: vi.fn(async () => 'org_boot'),
+    });
+    seedRuntimeConfig({ authAdapter: adapter });
+    const app = new Hono();
+    mountWebAuth(app);
+    app.get('/web/whoami', c => c.json(webAuthTenant(c) ?? { tenant: null }));
+
+    const res = await app.request('/web/whoami', { headers: { Accept: 'application/json' } });
+    expect(await res.json()).toEqual({ orgId: 'org_boot', userId: 'user_solo' });
+    expect(adapter.ensureOrg).toHaveBeenCalledOnce();
+  });
+
+  it('returns 401 for unauthenticated API calls (adapter returns null)', async () => {
+    const { app } = buildApp(fakeAdapter({ authenticate: vi.fn(async () => null) }));
+    const res = await app.request('/web/projects', { headers: { Accept: 'application/json' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('serves the provider-neutral /auth/me from the adapter session', async () => {
+    const { app } = buildApp(fakeAdapter());
+    const res = await app.request('/auth/me');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      authenticated: true,
+      user: { userId: 'user_fake', email: 'fake@example.com', organizationId: 'org_fake' },
+    });
+  });
+});
+
+describe('buildAuthRoutes', () => {
+  it('folds the adapter routes plus /auth/me into unauthenticated apiRoutes', () => {
+    const routes = buildAuthRoutes(fakeAdapter());
+    const paths = routes.map(r => r.path);
+    expect(paths).toEqual(['/auth/fake-login', '/auth/me']);
+    expect(routes.every(r => r.requiresAuth === false)).toBe(true);
+  });
+});

--- a/mastracode/web/src/web/auth-seam.test.ts
+++ b/mastracode/web/src/web/auth-seam.test.ts
@@ -95,6 +95,23 @@ describe('active adapter resolution', () => {
   });
 });
 
+describe('WorkOSWebAuth.init callback-URL resolution', () => {
+  it('derives the callback URL from the factory publicUrl', async () => {
+    const adapter = new WorkOSWebAuth();
+    await expect(adapter.init?.({ publicUrl: 'https://factory.acme.com' })).resolves.toBeUndefined();
+  });
+
+  it('keeps an explicit redirectUri without needing a publicUrl', async () => {
+    const adapter = new WorkOSWebAuth({ redirectUri: 'http://localhost:4111/auth/callback' });
+    await expect(adapter.init?.({})).resolves.toBeUndefined();
+  });
+
+  it('fails init when no callback URL can be resolved', async () => {
+    const adapter = new WorkOSWebAuth();
+    await expect(adapter.init?.({})).rejects.toThrow(/could not resolve a callback URL/);
+  });
+});
+
 describe('mountWebAuth with a seeded custom adapter', () => {
   function buildApp(adapter: WebAuthAdapter) {
     seedRuntimeConfig({ authAdapter: adapter });

--- a/mastracode/web/src/web/auth-seam.test.ts
+++ b/mastracode/web/src/web/auth-seam.test.ts
@@ -162,6 +162,7 @@ describe('mountWebAuth with a seeded custom adapter', () => {
     expect(await res.json()).toEqual({
       authenticated: true,
       user: { userId: 'user_fake', email: 'fake@example.com', organizationId: 'org_fake' },
+      provider: 'fake',
     });
   });
 });

--- a/mastracode/web/src/web/auth-workos-adapter.ts
+++ b/mastracode/web/src/web/auth-workos-adapter.ts
@@ -1,0 +1,261 @@
+import { MastraAuthWorkos } from '@mastra/auth-workos';
+
+import type { AuthRouteSpec, WebAuthAdapter, WebAuthAdapterInitContext, WebAuthUser } from './auth-adapter.js';
+import { isCrossSiteAuth, sanitizeReturnTo } from './auth-adapter.js';
+
+/**
+ * WorkOS AuthKit implementation of {@link WebAuthAdapter}.
+ *
+ * The actual AuthKit session encryption, code exchange and token validation
+ * are delegated to the existing `@mastra/auth-workos` provider
+ * (`MastraAuthWorkos`), which reads its own `WORKOS_API_KEY` /
+ * `WORKOS_CLIENT_ID` credentials. The deploy entry constructs this adapter
+ * only when those env vars are set.
+ */
+
+export interface WorkOSWebAuthOptions {
+  /**
+   * Absolute URL WorkOS redirects back to after login. Must match an allowed
+   * redirect URI configured in the WorkOS dashboard. When omitted, `init()`
+   * derives `<publicUrl>/auth/callback` from the factory context.
+   */
+  redirectUri?: string;
+}
+
+/** Build a predictable personal-org name from the user's profile. */
+function personalOrgName(user: WebAuthUser, userId: string): string {
+  const label = user.email ?? user.name ?? userId;
+  return `${label}'s org`;
+}
+
+/** Pull a stable error code out of a WorkOS SDK error, if present. */
+function workosErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined;
+  const e = error as { code?: unknown; rawData?: { code?: unknown } };
+  if (typeof e.code === 'string') return e.code;
+  if (e.rawData && typeof e.rawData.code === 'string') return e.rawData.code;
+  return undefined;
+}
+
+/**
+ * True when `createOrganization` rejected because an org is already bound to
+ * this `externalId` — i.e. a prior bootstrap created the org but never attached
+ * the membership. The org can be recovered via `getOrganizationByExternalId`.
+ */
+function isExternalIdAlreadyUsed(error: unknown): boolean {
+  return workosErrorCode(error) === 'external_id_already_used';
+}
+
+/**
+ * True when `createOrganizationMembership` rejected because the user is already
+ * a member of the org. Safe to ignore: the desired end state already holds.
+ */
+function isMembershipAlreadyExists(error: unknown): boolean {
+  const code = workosErrorCode(error);
+  return code === 'organization_membership_already_exists' || code === 'entity_already_exists';
+}
+
+/**
+ * Ensure the authenticated user belongs to a WorkOS organization, creating a
+ * personal org on first use when they have none.
+ *
+ * The `organizationId` we need for org-scoped GitHub features lives in the
+ * WorkOS session, not our app DB, so personal (no-org) accounts otherwise dead
+ * end at `organization_required`. This puts the user into a real WorkOS org:
+ *
+ * - If the user already has an `organizationId` → no-op, return it.
+ * - Else list their memberships:
+ *   - ≥1 membership → return the first org id (they already belong somewhere;
+ *     we never auto-create when a membership exists).
+ *   - 0 memberships → create a personal org + membership and return its id.
+ *
+ * Idempotency: the create call carries `externalId = workosId` and a stable
+ * `idempotencyKey`, so concurrent/retried first logins never create duplicate
+ * personal orgs. If a prior run created the org but never attached the
+ * membership, the create rejects with `external_id_already_used`; we recover the
+ * existing org by `externalId` and (re)attach the membership instead of failing.
+ *
+ * Best-effort: any WorkOS error (e.g. API key lacking org-create permission) is
+ * swallowed and returns `undefined`, leaving the user in their no-org state
+ * rather than failing the request. Callers keep the existing
+ * `organization_required` behavior in that case.
+ */
+export async function ensureUserHasOrganization(
+  provider: MastraAuthWorkos,
+  user: WebAuthUser,
+): Promise<string | undefined> {
+  const existingOrg = user.organizationId;
+  if (existingOrg) return existingOrg;
+
+  const userId = user.workosId ?? user.id;
+  if (!userId) return undefined;
+
+  try {
+    const workos = provider.getWorkOS();
+
+    const memberships = await workos.userManagement
+      .listOrganizationMemberships({ userId })
+      .then(page => page.autoPagination());
+
+    const firstExisting = memberships.find(m => m.organizationId)?.organizationId;
+    if (firstExisting) return firstExisting;
+
+    // Create the personal org. A prior partial bootstrap (org created, but the
+    // membership step never landed) leaves an org already bound to this
+    // externalId, so the create 400s with `external_id_already_used`. Recover by
+    // looking the existing org up by externalId instead of dead-ending forever.
+    let organizationId: string;
+    try {
+      const organization = await workos.organizations.createOrganization(
+        {
+          name: personalOrgName(user, userId),
+          externalId: userId,
+          metadata: { mastracodePersonalOrg: 'true', workosUserId: userId },
+        },
+        { idempotencyKey: `mastracode-personal-org:${userId}` },
+      );
+      organizationId = organization.id;
+    } catch (error) {
+      if (!isExternalIdAlreadyUsed(error)) throw error;
+      const existing = await workos.organizations.getOrganizationByExternalId(userId);
+      organizationId = existing.id;
+    }
+
+    // Idempotently attach the user. If they are already a member (e.g. the org
+    // existed from a prior run), tolerate the conflict and keep the org id.
+    try {
+      await workos.userManagement.createOrganizationMembership({ organizationId, userId });
+    } catch (error) {
+      if (!isMembershipAlreadyExists(error)) throw error;
+    }
+
+    return organizationId;
+  } catch (error) {
+    console.warn(
+      `[WorkOS] Failed to bootstrap personal organization for user ${userId}. ` +
+        'The user will see organization_required until this succeeds. ' +
+        'Ensure the WorkOS API key can create organizations/memberships.',
+      error,
+    );
+    return undefined;
+  }
+}
+
+/** Encode a validated returnTo path into the OAuth `state` parameter. */
+function encodeState(returnTo: string): string {
+  return Buffer.from(JSON.stringify({ returnTo }), 'utf8').toString('base64url');
+}
+
+/** Decode the OAuth `state` parameter back into a sanitized returnTo path. */
+function decodeState(state: string | undefined): string {
+  if (!state) return '/';
+  try {
+    const parsed = JSON.parse(Buffer.from(state, 'base64url').toString('utf8')) as { returnTo?: string };
+    return sanitizeReturnTo(parsed.returnTo);
+  } catch {
+    return '/';
+  }
+}
+
+export class WorkOSWebAuth implements WebAuthAdapter {
+  readonly kind = 'workos';
+
+  #redirectUri: string | undefined;
+  #provider: MastraAuthWorkos | undefined;
+
+  constructor(options: WorkOSWebAuthOptions = {}) {
+    this.#redirectUri = options.redirectUri;
+  }
+
+  /**
+   * Shared WorkOS auth provider, exposed for features that need the raw WorkOS
+   * client (audit-log export, Admin Portal links). Constructed lazily so the
+   * adapter can be created before `init()` finalizes the redirect URI.
+   * `fetchMemberships: true` lets `authenticateToken` resolve `organizationId`
+   * from a single membership when the JWT has no org claim — required so a
+   * bootstrapped personal org resolves without re-auth.
+   */
+  get provider(): MastraAuthWorkos {
+    if (!this.#provider) {
+      this.#provider = new MastraAuthWorkos({ redirectUri: this.#redirectUri, fetchMemberships: true });
+    }
+    return this.#provider;
+  }
+
+  async init(ctx: WebAuthAdapterInitContext): Promise<void> {
+    if (!this.#redirectUri && ctx.publicUrl) {
+      this.#redirectUri = `${ctx.publicUrl}/auth/callback`;
+    }
+  }
+
+  async authenticate(token: string, raw: Request): Promise<WebAuthUser | null> {
+    return (await this.provider.authenticateToken(token, raw)) as WebAuthUser | null;
+  }
+
+  async ensureOrg(user: WebAuthUser): Promise<string | undefined> {
+    return ensureUserHasOrganization(this.provider, user);
+  }
+
+  /**
+   * Cookie string that clears the WorkOS session. Matches the `SameSite`/`Secure`
+   * attributes of the session cookie so the browser actually overwrites it: a
+   * `SameSite=None; Secure` session cookie can only be cleared by a clear cookie
+   * with the same attributes. See {@link isCrossSiteAuth}.
+   */
+  sessionClearCookie(): string {
+    const sameSite = isCrossSiteAuth() ? 'None; Secure' : 'Lax';
+    return `wos_session=; Path=/; HttpOnly; SameSite=${sameSite}; Max-Age=0`;
+  }
+
+  /** The public hosted-login routes: `/auth/login`, `/auth/callback`, `/auth/logout`. */
+  publicRoutes(): AuthRouteSpec[] {
+    return [
+      {
+        path: '/auth/login',
+        method: 'GET',
+        handler: c => {
+          const returnTo = sanitizeReturnTo(c.req.query('returnTo'));
+          const loginUrl = this.provider.getLoginUrl(this.#redirectUri ?? '', encodeState(returnTo));
+          return c.redirect(loginUrl);
+        },
+      },
+      {
+        path: '/auth/callback',
+        method: 'GET',
+        handler: async c => {
+          const code = c.req.query('code');
+          const returnTo = decodeState(c.req.query('state'));
+          if (!code) {
+            return c.redirect('/auth/login');
+          }
+          try {
+            const result = await this.provider.handleCallback(code, c.req.query('state') ?? '');
+            for (const cookie of result.cookies ?? []) {
+              c.header('Set-Cookie', cookie, { append: true });
+            }
+            return c.redirect(returnTo);
+          } catch {
+            // Code exchange failed (expired/replayed code, misconfig). Send the
+            // user back to login rather than surfacing a raw error.
+            return c.redirect('/auth/login');
+          }
+        },
+      },
+      {
+        path: '/auth/logout',
+        method: 'GET',
+        handler: async c => {
+          let logoutUrl: string | null = null;
+          try {
+            logoutUrl = await this.provider.getLogoutUrl('/', c.req.raw);
+          } catch {
+            logoutUrl = null;
+          }
+          // Clear the session cookie regardless of whether WorkOS returned a logout URL.
+          c.header('Set-Cookie', this.sessionClearCookie(), { append: true });
+          return c.redirect(logoutUrl ?? '/');
+        },
+      },
+    ];
+  }
+}

--- a/mastracode/web/src/web/auth-workos-adapter.ts
+++ b/mastracode/web/src/web/auth-workos-adapter.ts
@@ -186,6 +186,14 @@ export class WorkOSWebAuth implements WebAuthAdapter {
     if (!this.#redirectUri && ctx.publicUrl) {
       this.#redirectUri = `${ctx.publicUrl}/auth/callback`;
     }
+    // Fail the deploy at prepare() rather than handing WorkOS an empty
+    // redirect URI on the first /auth/login (which breaks hosted login for
+    // every user with an opaque provider error).
+    if (!this.#redirectUri) {
+      throw new Error(
+        'WorkOSWebAuth could not resolve a callback URL: pass `redirectUri` (WORKOS_REDIRECT_URI) or configure the MastraFactory `publicUrl` slot.',
+      );
+    }
   }
 
   async authenticate(token: string, raw: Request): Promise<WebAuthUser | null> {

--- a/mastracode/web/src/web/auth.test.ts
+++ b/mastracode/web/src/web/auth.test.ts
@@ -284,7 +284,7 @@ describe('mountWebAuth /auth routes (enabled)', () => {
     const { app } = buildApp();
     const res = await app.request('/auth/me');
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ authenticated: false, user: null });
+    expect(await res.json()).toEqual({ authenticated: false, user: null, provider: 'workos' });
   });
 
   it('/auth/me reports the user when authenticated', async () => {
@@ -292,7 +292,11 @@ describe('mountWebAuth /auth routes (enabled)', () => {
     const { app } = buildApp();
     const res = await app.request('/auth/me');
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ authenticated: true, user: { email: 'user@example.com', name: 'User' } });
+    expect(await res.json()).toEqual({
+      authenticated: true,
+      user: { email: 'user@example.com', name: 'User' },
+      provider: 'workos',
+    });
   });
 
   it('/auth/me surfaces the organization id and stable user id to the SPA', async () => {
@@ -308,6 +312,7 @@ describe('mountWebAuth /auth routes (enabled)', () => {
     expect(await res.json()).toEqual({
       authenticated: true,
       user: { email: 'user@example.com', name: 'User', organizationId: 'org_a', userId: 'user_1' },
+      provider: 'workos',
     });
   });
 });

--- a/mastracode/web/src/web/auth.ts
+++ b/mastracode/web/src/web/auth.ts
@@ -1,51 +1,33 @@
-import { MastraAuthWorkos } from '@mastra/auth-workos';
+import type { MastraAuthWorkos } from '@mastra/auth-workos';
 import { registerApiRoute } from '@mastra/core/server';
 import type { ApiRoute } from '@mastra/core/server';
 import type { Context, Hono } from 'hono';
 
-/**
- * WorkOS AuthKit gating for the MastraCode web server.
- *
- * When `WORKOS_API_KEY` and `WORKOS_CLIENT_ID` are both set, every route on the
- * web server is placed behind WorkOS AuthKit authentication: unauthenticated
- * browser navigations are redirected to the SPA's `/signin` page (whose button
- * starts the `/auth/login` hosted-login flow), API/XHR calls receive a 401, and
- * a small set of public routes stay reachable while signed out — the `/auth/*`
- * login/callback/logout/me routes plus the `/signin` page and its `/assets/*`
- * bundle. When the env vars are absent, `mountWebAuth` is a no-op and the
- * server behaves exactly as it does without auth.
- *
- * The actual AuthKit session encryption, code exchange and token validation are
- * delegated to the existing `@mastra/auth-workos` provider (`MastraAuthWorkos`).
- */
-
-/** Minimal shape of the signed-in user surfaced to the SPA (no tokens). */
-export interface WebAuthUser {
-  /** Stable WorkOS user id used to scope per-user data (GitHub installs etc.). */
-  workosId?: string;
-  /** WorkOS user id alias on some shapes; falls back to `workosId`. */
-  id?: string;
-  email?: string;
-  name?: string;
-  /**
-   * WorkOS organization id. The org is the top-level tenant: it owns the GitHub
-   * App installation and connected projects, while each user inside the org gets
-   * isolated building instances. Absent for personal (no-org) accounts.
-   */
-  organizationId?: string;
-}
+import type { WebAuthAdapter, WebAuthTenant, WebAuthUser } from './auth-adapter.js';
+import { getBearerToken, sanitizeReturnTo } from './auth-adapter.js';
+import { WorkOSWebAuth } from './auth-workos-adapter.js';
+import { getSeededAuthAdapter, isRuntimeConfigSeeded } from './runtime-config.js';
 
 /**
- * Tenant identity: the org is the top-level tenant, and each user inside it is
- * an isolated builder. Agent state, worktrees and sandboxes are scoped per
- * `(orgId, userId)`. Personal (no-org) users have `orgId === undefined`.
+ * Provider-neutral web auth gating for the MastraCode web server.
+ *
+ * When a `WebAuthAdapter` is active (passed to `MastraFactory`'s `auth` slot,
+ * or — back-compat for suites/paths that never boot the factory — implied by
+ * the WorkOS env vars), every route on the web server is placed behind it:
+ * unauthenticated browser navigations are redirected to the SPA's `/signin`
+ * page, API/XHR calls receive a 401, and a small set of public routes stay
+ * reachable while signed out — the adapter's `/auth/*` routes plus `/auth/me`,
+ * the `/signin` page and its `/assets/*` bundle. When no adapter is active,
+ * `mountWebAuth` is a no-op and the server behaves exactly as it does without
+ * auth.
+ *
+ * Provider specifics (session validation, hosted-login routes, org bootstrap,
+ * session cookie) live behind the {@link WebAuthAdapter} interface — see
+ * `./auth-adapter.ts` and the shipped `WorkOSWebAuth` adapter.
  */
-export interface WebAuthTenant {
-  /** WorkOS organization id, or `undefined` for personal (no-org) accounts. */
-  orgId?: string;
-  /** Stable WorkOS user id. */
-  userId: string;
-}
+
+export type { WebAuthAdapter, WebAuthTenant, WebAuthUser } from './auth-adapter.js';
+export { ensureUserHasOrganization, WorkOSWebAuth } from './auth-workos-adapter.js';
 
 /** Hono context variables set by the auth gate. */
 export interface WebAuthVariables {
@@ -56,7 +38,7 @@ export interface WebAuthVariables {
 const WEB_AUTH_USER_KEY = 'webAuthUser';
 
 /**
- * Read the authenticated WorkOS user the gate stashed on the context, or
+ * Read the authenticated user the gate stashed on the context, or
  * `undefined` when unauthenticated / auth disabled. Used by downstream routes
  * (e.g. GitHub) to scope rows per user.
  */
@@ -64,12 +46,12 @@ export function getWebAuthUser(c: Context): WebAuthUser | undefined {
   return c.get(WEB_AUTH_USER_KEY) as WebAuthUser | undefined;
 }
 
-/** Resolve the stable user id from a WorkOS user shape. */
+/** Resolve the stable user id from an authenticated user shape. */
 export function getWebAuthUserId(user: WebAuthUser | undefined): string | undefined {
   return user?.workosId ?? user?.id;
 }
 
-/** Resolve the WorkOS organization id from a user shape, if present. */
+/** Resolve the organization id from a user shape, if present. */
 export function getWebAuthOrgId(user: WebAuthUser | undefined): string | undefined {
   return user?.organizationId;
 }
@@ -88,154 +70,53 @@ export function webAuthTenant(c: Context): WebAuthTenant | undefined {
   return { orgId: getWebAuthOrgId(user), userId };
 }
 
-/**
- * Lazily-created provider used to authenticate session cookies on public
- * `/auth/*` routes that the gate skips (e.g. the GitHub connect/callback
- * navigations). Kept module-level so callers outside `mountWebAuth` — such as
- * the GitHub routes, which are mounted on a separate sub-app — can reuse it.
- */
-let sessionProvider: MastraAuthWorkos | undefined;
-
-function getSessionProvider(): MastraAuthWorkos {
-  if (!sessionProvider) {
-    sessionProvider = new MastraAuthWorkos({
-      redirectUri: process.env.WORKOS_REDIRECT_URI,
-      // Resolve `organizationId` from a single membership when the JWT lacks the
-      // claim. This is what lets a freshly bootstrapped personal org take effect
-      // on the next request without forcing a re-login.
-      fetchMemberships: true,
-    });
-  }
-  return sessionProvider;
+/** True when both WorkOS credential env vars are present (legacy env gate). */
+function envWorkosConfigured(): boolean {
+  return Boolean(process.env.WORKOS_API_KEY && process.env.WORKOS_CLIENT_ID);
 }
 
 /**
- * Shared module-level WorkOS auth provider, exposed for features that need the
- * raw WorkOS client (audit-log export, Admin Portal links). Callers must gate
- * on {@link isWebAuthEnabled} first — constructing the provider without the
- * WorkOS env vars throws.
+ * Module-level adapter used when the factory never seeded the registry but the
+ * WorkOS env vars are set — back-compat for modules and test suites exercised
+ * without booting the factory (route suites set `WORKOS_*` directly). Kept
+ * module-level so callers outside `mountWebAuth` — such as the GitHub routes,
+ * which are mounted on a separate sub-app — reuse one provider.
+ */
+let envFallbackAdapter: WorkOSWebAuth | undefined;
+
+/**
+ * Resolve the active web auth adapter: the factory-seeded adapter when the
+ * registry is seeded (including `undefined` = auth explicitly disabled),
+ * otherwise a WorkOS adapter implied by the `WORKOS_*` env vars (back-compat;
+ * slated for removal once all consumers seed the registry).
+ */
+export function getActiveWebAuthAdapter(): WebAuthAdapter | undefined {
+  if (isRuntimeConfigSeeded()) return getSeededAuthAdapter();
+  if (!envWorkosConfigured()) return undefined;
+  envFallbackAdapter ??= new WorkOSWebAuth({ redirectUri: process.env.WORKOS_REDIRECT_URI });
+  return envFallbackAdapter;
+}
+
+/** Web auth is enabled when an adapter is active. */
+export function isWebAuthEnabled(): boolean {
+  return getActiveWebAuthAdapter() !== undefined;
+}
+
+/** True when the active adapter is WorkOS. Gates WorkOS-only capabilities. */
+export function isWorkOSAuth(): boolean {
+  return getActiveWebAuthAdapter()?.kind === 'workos';
+}
+
+/**
+ * Shared WorkOS auth provider, exposed for features that need the raw WorkOS
+ * client (audit-log export, Admin Portal links). Callers must gate on
+ * {@link isWorkOSAuth} (or {@link isWebAuthEnabled} on WorkOS-only deploys)
+ * first — throws when the active adapter is not WorkOS.
  */
 export function getWorkOSProvider(): MastraAuthWorkos {
-  return getSessionProvider();
-}
-
-/** Build a predictable personal-org name from the user's profile. */
-function personalOrgName(user: WebAuthUser, userId: string): string {
-  const label = user.email ?? user.name ?? userId;
-  return `${label}'s org`;
-}
-
-/** Pull a stable error code out of a WorkOS SDK error, if present. */
-function workosErrorCode(error: unknown): string | undefined {
-  if (!error || typeof error !== 'object') return undefined;
-  const e = error as { code?: unknown; rawData?: { code?: unknown } };
-  if (typeof e.code === 'string') return e.code;
-  if (e.rawData && typeof e.rawData.code === 'string') return e.rawData.code;
-  return undefined;
-}
-
-/**
- * True when `createOrganization` rejected because an org is already bound to
- * this `externalId` — i.e. a prior bootstrap created the org but never attached
- * the membership. The org can be recovered via `getOrganizationByExternalId`.
- */
-function isExternalIdAlreadyUsed(error: unknown): boolean {
-  return workosErrorCode(error) === 'external_id_already_used';
-}
-
-/**
- * True when `createOrganizationMembership` rejected because the user is already
- * a member of the org. Safe to ignore: the desired end state already holds.
- */
-function isMembershipAlreadyExists(error: unknown): boolean {
-  const code = workosErrorCode(error);
-  return code === 'organization_membership_already_exists' || code === 'entity_already_exists';
-}
-
-/**
- * Ensure the authenticated user belongs to a WorkOS organization, creating a
- * personal org on first use when they have none.
- *
- * The `organizationId` we need for org-scoped GitHub features lives in the
- * WorkOS session, not our app DB, so personal (no-org) accounts otherwise dead
- * end at `organization_required`. This puts the user into a real WorkOS org:
- *
- * - If the user already has an `organizationId` → no-op, return it.
- * - Else list their memberships:
- *   - ≥1 membership → return the first org id (they already belong somewhere;
- *     we never auto-create when a membership exists).
- *   - 0 memberships → create a personal org + membership and return its id.
- *
- * Idempotency: the create call carries `externalId = workosId` and a stable
- * `idempotencyKey`, so concurrent/retried first logins never create duplicate
- * personal orgs. If a prior run created the org but never attached the
- * membership, the create rejects with `external_id_already_used`; we recover the
- * existing org by `externalId` and (re)attach the membership instead of failing.
- *
- * Best-effort: any WorkOS error (e.g. API key lacking org-create permission) is
- * swallowed and returns `undefined`, leaving the user in their no-org state
- * rather than failing the request. Callers keep the existing
- * `organization_required` behavior in that case.
- */
-export async function ensureUserHasOrganization(
-  provider: MastraAuthWorkos,
-  user: WebAuthUser,
-): Promise<string | undefined> {
-  const existingOrg = getWebAuthOrgId(user);
-  if (existingOrg) return existingOrg;
-
-  const userId = getWebAuthUserId(user);
-  if (!userId) return undefined;
-
-  try {
-    const workos = provider.getWorkOS();
-
-    const memberships = await workos.userManagement
-      .listOrganizationMemberships({ userId })
-      .then(page => page.autoPagination());
-
-    const firstExisting = memberships.find(m => m.organizationId)?.organizationId;
-    if (firstExisting) return firstExisting;
-
-    // Create the personal org. A prior partial bootstrap (org created, but the
-    // membership step never landed) leaves an org already bound to this
-    // externalId, so the create 400s with `external_id_already_used`. Recover by
-    // looking the existing org up by externalId instead of dead-ending forever.
-    let organizationId: string;
-    try {
-      const organization = await workos.organizations.createOrganization(
-        {
-          name: personalOrgName(user, userId),
-          externalId: userId,
-          metadata: { mastracodePersonalOrg: 'true', workosUserId: userId },
-        },
-        { idempotencyKey: `mastracode-personal-org:${userId}` },
-      );
-      organizationId = organization.id;
-    } catch (error) {
-      if (!isExternalIdAlreadyUsed(error)) throw error;
-      const existing = await workos.organizations.getOrganizationByExternalId(userId);
-      organizationId = existing.id;
-    }
-
-    // Idempotently attach the user. If they are already a member (e.g. the org
-    // existed from a prior run), tolerate the conflict and keep the org id.
-    try {
-      await workos.userManagement.createOrganizationMembership({ organizationId, userId });
-    } catch (error) {
-      if (!isMembershipAlreadyExists(error)) throw error;
-    }
-
-    return organizationId;
-  } catch (error) {
-    console.warn(
-      `[WorkOS] Failed to bootstrap personal organization for user ${userId}. ` +
-        'The user will see organization_required until this succeeds. ' +
-        'Ensure the WorkOS API key can create organizations/memberships.',
-      error,
-    );
-    return undefined;
-  }
+  const adapter = getActiveWebAuthAdapter();
+  if (adapter instanceof WorkOSWebAuth) return adapter.provider;
+  throw new Error('WorkOS provider requested but the active web auth adapter is not WorkOS');
 }
 
 /**
@@ -244,7 +125,7 @@ export async function ensureUserHasOrganization(
  * The gate only authenticates non-`/auth/*` requests via the `Authorization`
  * header, so cookie-based browser navigations to public `/auth/*` routes (the
  * GitHub connect/callback flow) arrive without a gate-stashed user. This reads
- * the WorkOS session cookie from the raw request the same way `/auth/me` does,
+ * the session cookie from the raw request the same way `/auth/me` does,
  * caches the result on the context, and returns it so downstream helpers like
  * {@link webAuthTenant} work uniformly on both gated and public routes.
  *
@@ -253,12 +134,13 @@ export async function ensureUserHasOrganization(
 export async function ensureWebAuthUser(c: Context): Promise<WebAuthUser | undefined> {
   const existing = getWebAuthUser(c);
   if (existing) return existing;
-  if (!isWebAuthEnabled()) return undefined;
+  const adapter = getActiveWebAuthAdapter();
+  if (!adapter) return undefined;
 
   const token = getBearerToken(c.req.header('Authorization'));
   let user: WebAuthUser | null = null;
   try {
-    user = (await getSessionProvider().authenticateToken(token, c.req.raw)) as WebAuthUser | null;
+    user = await adapter.authenticate(token, c.req.raw);
   } catch {
     user = null;
   }
@@ -267,9 +149,9 @@ export async function ensureWebAuthUser(c: Context): Promise<WebAuthUser | undef
   // Bootstrap a personal org for no-org accounts so org-scoped features (GitHub
   // connect) work without leaving the app. Mutating the resolved user lets the
   // current request see the org immediately; subsequent requests resolve it via
-  // the provider's single-membership fallback (`fetchMemberships: true`).
+  // the provider's own session/membership lookup.
   if (!getWebAuthOrgId(user)) {
-    const orgId = await ensureUserHasOrganization(getSessionProvider(), user);
+    const orgId = await adapter.ensureOrg(user);
     if (orgId) user.organizationId = orgId;
   }
 
@@ -277,79 +159,12 @@ export async function ensureWebAuthUser(c: Context): Promise<WebAuthUser | undef
   return user;
 }
 
-/**
- * Web auth is enabled only when both WorkOS credentials are present. These are
- * the same env vars `@mastra/auth-workos` reads, so configuration stays
- * consistent with the rest of the repo.
- */
-export function isWebAuthEnabled(): boolean {
-  return Boolean(process.env.WORKOS_API_KEY && process.env.WORKOS_CLIENT_ID);
-}
-
-/**
- * Whether the SPA is served cross-origin from this API (platform deploy). When
- * `MASTRACODE_ALLOWED_ORIGINS` is set the browser talks to us cross-site, so
- * session cookies must be `SameSite=None; Secure` for the browser to send them.
- * Same-origin local dev leaves this unset and keeps the stricter `SameSite=Lax`.
- */
-function isCrossSiteAuth(): boolean {
-  return Boolean(process.env.MASTRACODE_ALLOWED_ORIGINS?.trim());
-}
-
-/**
- * Cookie string that clears the WorkOS session. Matches the `SameSite`/`Secure`
- * attributes of the session cookie so the browser actually overwrites it: a
- * `SameSite=None; Secure` session cookie can only be cleared by a clear cookie
- * with the same attributes. See {@link isCrossSiteAuth}.
- */
-function sessionClearCookie(): string {
-  const sameSite = isCrossSiteAuth() ? 'None; Secure' : 'Lax';
-  return `wos_session=; Path=/; HttpOnly; SameSite=${sameSite}; Max-Age=0`;
-}
-
 export interface MountWebAuthOptions {
   /**
-   * Absolute URL WorkOS redirects back to after login. Must match an allowed
-   * redirect URI configured in the WorkOS dashboard. Defaults to the
-   * `WORKOS_REDIRECT_URI` env var.
+   * Absolute URL the identity provider redirects back to after login (WorkOS
+   * env-fallback path only). Defaults to the `WORKOS_REDIRECT_URI` env var.
    */
   redirectUri?: string;
-}
-
-/**
- * Validate that a `returnTo` value is a safe same-site path, to prevent
- * open-redirect attacks. Only absolute local paths (`/foo`) are allowed;
- * protocol-relative (`//evil.com`) and absolute URLs are rejected.
- */
-function sanitizeReturnTo(raw: string | undefined): string {
-  if (!raw) return '/';
-  if (!raw.startsWith('/')) return '/';
-  // Reject protocol-relative URLs like "//evil.com" and "/\evil.com".
-  if (raw.startsWith('//') || raw.startsWith('/\\')) return '/';
-  return raw;
-}
-
-/** Encode a validated returnTo path into the OAuth `state` parameter. */
-function encodeState(returnTo: string): string {
-  return Buffer.from(JSON.stringify({ returnTo }), 'utf8').toString('base64url');
-}
-
-/** Decode the OAuth `state` parameter back into a sanitized returnTo path. */
-function decodeState(state: string | undefined): string {
-  if (!state) return '/';
-  try {
-    const parsed = JSON.parse(Buffer.from(state, 'base64url').toString('utf8')) as { returnTo?: string };
-    return sanitizeReturnTo(parsed.returnTo);
-  } catch {
-    return '/';
-  }
-}
-
-/** Extract a bearer token from the Authorization header, if present. */
-function getBearerToken(authorization: string | undefined): string {
-  if (!authorization) return '';
-  const match = /^Bearer\s+(.+)$/i.exec(authorization);
-  return match?.[1] ?? '';
 }
 
 /**
@@ -363,161 +178,82 @@ function isNavigationRequest(path: string, accept: string | undefined): boolean 
 }
 
 /**
- * Register the public WorkOS `/auth/*` routes (login, callback, logout, me) on a
- * Hono app. Split out from `mountWebAuth` so both the local Hono server and the
- * platform Mastra entry can reuse the exact same handlers.
+ * Handle the provider-neutral `/auth/me` route: validate the session with the
+ * active adapter and report the signed-in user (no tokens) to the SPA.
+ * `/auth/me` is public (the gate skips `/auth/*`), so it validates the session
+ * itself rather than reading a value the gate would have stashed.
  */
-export function registerAuthRoutes(app: Hono<any>, provider: MastraAuthWorkos, redirectUri: string | undefined): void {
-  app.get('/auth/login', c => {
-    const returnTo = sanitizeReturnTo(c.req.query('returnTo'));
-    const loginUrl = provider.getLoginUrl(redirectUri ?? '', encodeState(returnTo));
-    return c.redirect(loginUrl);
-  });
-
-  app.get('/auth/callback', async c => {
-    const code = c.req.query('code');
-    const returnTo = decodeState(c.req.query('state'));
-    if (!code) {
-      return c.redirect('/auth/login');
-    }
-
-    try {
-      const result = await provider.handleCallback(code, c.req.query('state') ?? '');
-      for (const cookie of result.cookies ?? []) {
-        c.header('Set-Cookie', cookie, { append: true });
-      }
-      return c.redirect(returnTo);
-    } catch {
-      // Code exchange failed (expired/replayed code, misconfig). Send the user
-      // back to login rather than surfacing a raw error.
-      return c.redirect('/auth/login');
-    }
-  });
-
-  app.get('/auth/logout', async c => {
-    let logoutUrl: string | null = null;
-    try {
-      logoutUrl = await provider.getLogoutUrl('/', c.req.raw);
-    } catch {
-      logoutUrl = null;
-    }
-    // Clear the session cookie regardless of whether WorkOS returned a logout URL.
-    c.header('Set-Cookie', sessionClearCookie(), { append: true });
-    return c.redirect(logoutUrl ?? '/');
-  });
-
-  app.get('/auth/me', async c => {
-    // `/auth/me` is public (the gate skips `/auth/*`), so it validates the
-    // session itself rather than reading a value the gate would have stashed.
-    const token = getBearerToken(c.req.header('Authorization'));
-    let user: WebAuthUser | null = null;
-    try {
-      user = (await provider.authenticateToken(token, c.req.raw)) as WebAuthUser | null;
-    } catch {
-      user = null;
-    }
-    if (!user) {
-      return c.json({ authenticated: false, user: null });
-    }
-    return c.json({
-      authenticated: true,
-      user: { userId: getWebAuthUserId(user), email: user.email, name: user.name, organizationId: user.organizationId },
-    });
+async function handleAuthMe(adapter: WebAuthAdapter, c: Context): Promise<Response> {
+  const token = getBearerToken(c.req.header('Authorization'));
+  let user: WebAuthUser | null = null;
+  try {
+    user = await adapter.authenticate(token, c.req.raw);
+  } catch {
+    user = null;
+  }
+  if (!user) {
+    return c.json({ authenticated: false, user: null });
+  }
+  return c.json({
+    authenticated: true,
+    user: { userId: getWebAuthUserId(user), email: user.email, name: user.name, organizationId: user.organizationId },
   });
 }
 
 /**
- * Build the public WorkOS `/auth/*` routes (login, callback, logout, me) as
- * Mastra `server.apiRoutes`. Used by the platform Mastra entry
- * (`src/mastra/index.ts`), which can't register plain Hono routes on the
- * deployer-generated app the way the local server does via {@link registerAuthRoutes}.
+ * Register the public `/auth/*` routes on a Hono app: the adapter's own
+ * routes (login/callback/logout/provider APIs) plus the provider-neutral
+ * `/auth/me`. Split out from `mountWebAuth` so both the local Hono server and
+ * the platform Mastra entry can reuse the exact same handlers.
+ */
+export function registerAuthRoutes(app: Hono<any>, adapter: WebAuthAdapter): void {
+  for (const route of adapter.publicRoutes()) {
+    const methods = route.method === 'ALL' ? ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'] : [route.method];
+    app.on(methods, route.path, c => route.handler(c));
+  }
+  app.get('/auth/me', c => handleAuthMe(adapter, c));
+}
+
+/**
+ * Build the public `/auth/*` routes (adapter routes + `/auth/me`) as Mastra
+ * `server.apiRoutes`. Used by the platform Mastra entry (`src/mastra/index.ts`),
+ * which can't register plain Hono routes on the deployer-generated app the way
+ * the local server does via {@link registerAuthRoutes}.
  *
  * Handlers are identical to {@link registerAuthRoutes}. All are `requiresAuth: false`
  * (they must be reachable while unauthenticated), and the gate middleware skips
  * `/auth/*` so it never blocks them. `/auth/*` is not under `/api`, so it is a
  * valid custom-route path.
  */
-export function buildAuthRoutes(provider: MastraAuthWorkos, redirectUri: string | undefined): ApiRoute[] {
+export function buildAuthRoutes(adapter: WebAuthAdapter): ApiRoute[] {
   return [
-    registerApiRoute('/auth/login', {
-      method: 'GET',
-      requiresAuth: false,
-      handler: c => {
-        const returnTo = sanitizeReturnTo(c.req.query('returnTo'));
-        const loginUrl = provider.getLoginUrl(redirectUri ?? '', encodeState(returnTo));
-        return c.redirect(loginUrl);
-      },
-    }),
-    registerApiRoute('/auth/callback', {
-      method: 'GET',
-      requiresAuth: false,
-      handler: async c => {
-        const code = c.req.query('code');
-        const returnTo = decodeState(c.req.query('state'));
-        if (!code) {
-          return c.redirect('/auth/login');
-        }
-        try {
-          const result = await provider.handleCallback(code, c.req.query('state') ?? '');
-          for (const cookie of result.cookies ?? []) {
-            c.header('Set-Cookie', cookie, { append: true });
-          }
-          return c.redirect(returnTo);
-        } catch {
-          return c.redirect('/auth/login');
-        }
-      },
-    }),
-    registerApiRoute('/auth/logout', {
-      method: 'GET',
-      requiresAuth: false,
-      handler: async c => {
-        let logoutUrl: string | null = null;
-        try {
-          logoutUrl = await provider.getLogoutUrl('/', c.req.raw);
-        } catch {
-          logoutUrl = null;
-        }
-        c.header('Set-Cookie', sessionClearCookie(), { append: true });
-        return c.redirect(logoutUrl ?? '/');
-      },
-    }),
+    // `registerApiRoute` handlers see @mastra/core's bundled hono Context type,
+    // which is structurally identical to (but nominally distinct from) the
+    // local hono version the adapter handlers are typed against — cast across
+    // the seam.
+    ...adapter.publicRoutes().map(route =>
+      registerApiRoute(route.path, {
+        method: route.method,
+        requiresAuth: false,
+        handler: c => route.handler(c as unknown as Context),
+      }),
+    ),
     registerApiRoute('/auth/me', {
       method: 'GET',
       requiresAuth: false,
-      handler: async c => {
-        const token = getBearerToken(c.req.header('Authorization'));
-        let user: WebAuthUser | null = null;
-        try {
-          user = (await provider.authenticateToken(token, c.req.raw)) as WebAuthUser | null;
-        } catch {
-          user = null;
-        }
-        if (!user) {
-          return c.json({ authenticated: false, user: null });
-        }
-        return c.json({
-          authenticated: true,
-          user: {
-            userId: getWebAuthUserId(user),
-            email: user.email,
-            name: user.name,
-            organizationId: user.organizationId,
-          },
-        });
-      },
+      handler: c => handleAuthMe(adapter, c as unknown as Context),
     }),
   ];
 }
 
 /**
- * Build the WorkOS gate as a plain Hono middleware handler `(c, next)`. Protects
+ * Build the auth gate as a plain Hono middleware handler `(c, next)`. Protects
  * everything that is not a public `/auth/*` route: authenticated requests stash
  * the user on the context and continue; unauthenticated navigations redirect to
  * login and XHR/API calls get a 401 JSON. Shared by the local Hono server
  * (`mountWebAuth`) and the platform Mastra entry (`server.middleware`).
  */
-export function createWebAuthGate(provider: MastraAuthWorkos) {
+export function createWebAuthGate(adapter: WebAuthAdapter) {
   return async (c: Context, next: () => Promise<void>): Promise<Response | void> => {
     const path = c.req.path;
     if (path.startsWith('/auth/')) {
@@ -535,7 +271,7 @@ export function createWebAuthGate(provider: MastraAuthWorkos) {
     const token = getBearerToken(c.req.header('Authorization'));
     let user: WebAuthUser | null = null;
     try {
-      user = (await provider.authenticateToken(token, c.req.raw)) as WebAuthUser | null;
+      user = await adapter.authenticate(token, c.req.raw);
     } catch {
       user = null;
     }
@@ -544,7 +280,7 @@ export function createWebAuthGate(provider: MastraAuthWorkos) {
       // Bootstrap a personal org for no-org accounts so the org id resolves on
       // this request (see ensureWebAuthUser for the rationale).
       if (!getWebAuthOrgId(user)) {
-        const orgId = await ensureUserHasOrganization(provider, user);
+        const orgId = await adapter.ensureOrg(user);
         if (orgId) user.organizationId = orgId;
       }
       c.set(WEB_AUTH_USER_KEY, user);
@@ -563,17 +299,8 @@ export function createWebAuthGate(provider: MastraAuthWorkos) {
 }
 
 /**
- * Construct the WorkOS AuthKit provider used by the gate and `/auth/*` routes.
- * `fetchMemberships: true` lets `authenticateToken` resolve `organizationId`
- * from a single membership when the JWT has no org claim — required so a
- * bootstrapped personal org resolves without re-auth.
- */
-export function createWebAuthProvider(redirectUri: string | undefined): MastraAuthWorkos {
-  return new MastraAuthWorkos({ redirectUri, fetchMemberships: true });
-}
-
-/**
- * Mount WorkOS AuthKit gating onto the web app. No-op when auth is disabled.
+ * Mount web auth gating onto the web app. No-op when auth is disabled (no
+ * adapter active).
  *
  * Must be called before the Mastra adapter routes, the `/web/*` routes, and
  * the static UI handlers so the gate covers every request. Composes the shared
@@ -581,17 +308,22 @@ export function createWebAuthProvider(redirectUri: string | undefined): MastraAu
  * and the platform Mastra entry stay behavior-identical.
  */
 export function mountWebAuth(app: Hono<any>, options: MountWebAuthOptions = {}): boolean {
-  if (!isWebAuthEnabled()) return false;
-
-  const redirectUri = options.redirectUri ?? process.env.WORKOS_REDIRECT_URI;
-  const provider = createWebAuthProvider(redirectUri);
+  let adapter: WebAuthAdapter | undefined;
+  if (isRuntimeConfigSeeded()) {
+    adapter = getSeededAuthAdapter();
+  } else if (envWorkosConfigured()) {
+    // Env-fallback path: construct a fresh adapter honoring the caller's
+    // redirect URI, mirroring the pre-seam behavior.
+    adapter = new WorkOSWebAuth({ redirectUri: options.redirectUri ?? process.env.WORKOS_REDIRECT_URI });
+  }
+  if (!adapter) return false;
 
   // Public auth routes, registered before the gate so they remain reachable
   // while unauthenticated.
-  registerAuthRoutes(app, provider, redirectUri);
+  registerAuthRoutes(app, adapter);
 
   // Gate middleware: protects everything that is not a public `/auth/*` route.
-  app.use('*', createWebAuthGate(provider));
+  app.use('*', createWebAuthGate(adapter));
 
   return true;
 }

--- a/mastracode/web/src/web/auth.ts
+++ b/mastracode/web/src/web/auth.ts
@@ -191,12 +191,17 @@ async function handleAuthMe(adapter: WebAuthAdapter, c: Context): Promise<Respon
   } catch {
     user = null;
   }
+  // Provider identity for the SPA: `/signin` renders the hosted-login button
+  // for WorkOS and an email/password form for better-auth (with sign-up hidden
+  // when the adapter disables it).
+  const provider = { provider: adapter.kind, ...(adapter.signUpDisabled ? { signUpDisabled: true } : {}) };
   if (!user) {
-    return c.json({ authenticated: false, user: null });
+    return c.json({ authenticated: false, user: null, ...provider });
   }
   return c.json({
     authenticated: true,
     user: { userId: getWebAuthUserId(user), email: user.email, name: user.name, organizationId: user.organizationId },
+    ...provider,
   });
 }
 

--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -2,7 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { WebAuthAdapter, WebAuthAdapterInitContext } from './auth-adapter.js';
 import { MastraFactory } from './factory-entry.js';
-import { __resetRuntimeConfigForTests, getAppDatabaseUrl, getSeededAuthAdapter } from './runtime-config.js';
+import {
+  __resetRuntimeConfigForTests,
+  getAppDatabaseUrl,
+  getSeededAuthAdapter,
+  getSeededSandboxProvider,
+} from './runtime-config.js';
+import { LocalSandboxProvider } from './sandbox-local-provider.js';
 
 /**
  * `MastraFactory.prepare()` wiring: explicit config flows through to the SDK
@@ -58,9 +64,16 @@ describe('MastraFactory.prepare', () => {
 
   it('seeds the runtime-config registry with the explicit config', async () => {
     const auth = fakeAdapter();
-    await prepareFactory({ database: 'postgres://cfg/app', auth });
+    const sandbox = new LocalSandboxProvider({ root: '/tmp/mc-factory-test' });
+    await prepareFactory({ database: 'postgres://cfg/app', auth, sandbox });
     expect(getAppDatabaseUrl()).toBe('postgres://cfg/app');
     expect(getSeededAuthAdapter()).toBe(auth);
+    expect(getSeededSandboxProvider()).toBe(sandbox);
+  });
+
+  it('leaves the sandbox provider unset when the slot is omitted', async () => {
+    await prepareFactory({});
+    expect(getSeededSandboxProvider()).toBeUndefined();
   });
 
   it('maps database onto the pg storage config for the SDK mount', async () => {

--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { WebAuthAdapter, WebAuthAdapterInitContext } from './auth-adapter.js';
+import { MastraFactory } from './factory-entry.js';
+import { __resetRuntimeConfigForTests, getAppDatabaseUrl, getSeededAuthAdapter } from './runtime-config.js';
+
+/**
+ * `MastraFactory.prepare()` wiring: explicit config flows through to the SDK
+ * mount (storage, pubsub) and the auth adapter (registry seeding, one-time
+ * `init()` with factory context, gate + `/auth/*` routes). The SDK mount is
+ * mocked — full-boot coverage lives in `../mastra/index.test.ts`.
+ */
+
+const prepareMock = vi.fn(async (config: Record<string, unknown>) => ({
+  base: '/agents',
+  mastraArgs: { __capturedConfig: config },
+  finalize: vi.fn(async () => {}),
+}));
+
+vi.mock('@mastra/code-sdk', () => ({
+  prepareAgentControllerMount: (config: Record<string, unknown>) => prepareMock(config),
+}));
+
+function fakeAdapter(overrides: Partial<WebAuthAdapter> = {}): WebAuthAdapter {
+  return {
+    kind: 'fake',
+    init: vi.fn(async () => {}),
+    authenticate: vi.fn(async () => null),
+    ensureOrg: vi.fn(async () => undefined),
+    publicRoutes: () => [{ path: '/auth/fake-login', method: 'GET', handler: c => c.redirect('/fake') }],
+    sessionClearCookie: () => 'fake_session=; Max-Age=0',
+    ...overrides,
+  };
+}
+
+async function prepareFactory(config: ConstructorParameters<typeof MastraFactory>[0]) {
+  const factory = new MastraFactory(config);
+  await factory.prepare();
+  expect(prepareMock).toHaveBeenCalledOnce();
+  return prepareMock.mock.calls[0]![0];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetRuntimeConfigForTests();
+});
+
+afterEach(() => {
+  __resetRuntimeConfigForTests();
+});
+
+describe('MastraFactory.prepare', () => {
+  it('throws when called twice', async () => {
+    const factory = new MastraFactory({});
+    await factory.prepare();
+    await expect(factory.prepare()).rejects.toThrow(/called twice/);
+  });
+
+  it('seeds the runtime-config registry with the explicit config', async () => {
+    const auth = fakeAdapter();
+    await prepareFactory({ database: 'postgres://cfg/app', auth });
+    expect(getAppDatabaseUrl()).toBe('postgres://cfg/app');
+    expect(getSeededAuthAdapter()).toBe(auth);
+  });
+
+  it('maps database onto the pg storage config for the SDK mount', async () => {
+    const config = await prepareFactory({ database: 'postgres://cfg/app' });
+    expect(config.storage).toEqual({ backend: 'pg', connectionString: 'postgres://cfg/app' });
+  });
+
+  it('omits storage when no database is configured', async () => {
+    const config = await prepareFactory({});
+    expect(config).not.toHaveProperty('storage');
+  });
+
+  it('passes the pubsub instance through with cross-process leases enabled', async () => {
+    const pubsub = { publish: vi.fn(), subscribe: vi.fn() } as never;
+    const config = await prepareFactory({ pubsub });
+    expect(config.pubsub).toBe(pubsub);
+    expect(config.crossProcessPubSub).toBe(true);
+  });
+
+  it('calls adapter.init once with the factory context', async () => {
+    const auth = fakeAdapter();
+    await prepareFactory({ auth, database: 'postgres://cfg/app', publicUrl: 'https://factory.acme.com/' });
+    expect(auth.init).toHaveBeenCalledExactlyOnceWith({
+      databaseUrl: 'postgres://cfg/app',
+      publicUrl: 'https://factory.acme.com',
+    } satisfies WebAuthAdapterInitContext);
+  });
+
+  it('surfaces adapter init failures at prepare()', async () => {
+    const auth = fakeAdapter({ init: vi.fn(async () => Promise.reject(new Error('adapter misconfigured'))) });
+    const factory = new MastraFactory({ auth });
+    await expect(factory.prepare()).rejects.toThrow('adapter misconfigured');
+  });
+
+  it('folds the adapter /auth/* routes into buildApiRoutes when auth is configured', async () => {
+    const config = await prepareFactory({ auth: fakeAdapter() });
+    const buildApiRoutes = config.buildApiRoutes as (deps: object) => Array<{ path: string }>;
+    const paths = buildApiRoutes({ controller: {}, authStorage: {} }).map(r => r.path);
+    expect(paths).toContain('/auth/fake-login');
+    expect(paths).toContain('/auth/me');
+  });
+
+  it('omits auth routes when auth is not configured', async () => {
+    const config = await prepareFactory({});
+    const buildApiRoutes = config.buildApiRoutes as (deps: object) => Array<{ path: string }>;
+    const paths = buildApiRoutes({ controller: {}, authStorage: {} }).map(r => r.path);
+    expect(paths.some(p => p.startsWith('/auth/'))).toBe(false);
+  });
+
+  it('installs exactly one extra middleware (the auth gate) when auth is configured', async () => {
+    // The SPA static middleware is environment-dependent (present when ui/dist
+    // exists), so assert the delta: configuring auth prepends exactly one gate.
+    const openConfig = await prepareFactory({});
+    const openMiddleware = (openConfig.buildServerConfig as () => { middleware?: unknown[] })().middleware ?? [];
+
+    prepareMock.mockClear();
+    __resetRuntimeConfigForTests();
+
+    const gatedConfig = await prepareFactory({ auth: fakeAdapter() });
+    const gatedMiddleware = (gatedConfig.buildServerConfig as () => { middleware?: unknown[] })().middleware ?? [];
+    expect(gatedMiddleware).toHaveLength(openMiddleware.length + 1);
+  });
+});
+
+describe('MastraFactory.finalize', () => {
+  it('throws before prepare()', async () => {
+    const factory = new MastraFactory({});
+    await expect(factory.finalize()).rejects.toThrow(/before prepare/);
+  });
+
+  it('runs the prepared finalize after prepare()', async () => {
+    const factory = new MastraFactory({});
+    await factory.prepare();
+    await factory.finalize();
+    const prepared = await prepareMock.mock.results[0]!.value;
+    expect(prepared.finalize).toHaveBeenCalledOnce();
+  });
+});

--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -62,6 +62,18 @@ describe('MastraFactory.prepare', () => {
     await expect(factory.prepare()).rejects.toThrow(/called twice/);
   });
 
+  it('rejects overlapping concurrent calls (guard set before the first await)', async () => {
+    const auth = fakeAdapter();
+    const factory = new MastraFactory({ auth });
+    const [first, second] = await Promise.allSettled([factory.prepare(), factory.prepare()]);
+    expect(first.status).toBe('fulfilled');
+    expect(second.status).toBe('rejected');
+    expect((second as PromiseRejectedResult).reason.message).toMatch(/called twice/);
+    // The overlapping call must not double-run one-time adapter init.
+    expect(auth.init).toHaveBeenCalledOnce();
+    expect(prepareMock).toHaveBeenCalledOnce();
+  });
+
   it('seeds the runtime-config registry with the explicit config', async () => {
     const auth = fakeAdapter();
     const sandbox = new LocalSandboxProvider({ root: '/tmp/mc-factory-test' });
@@ -95,10 +107,16 @@ describe('MastraFactory.prepare', () => {
 
   it('calls adapter.init once with the factory context', async () => {
     const auth = fakeAdapter();
-    await prepareFactory({ auth, database: 'postgres://cfg/app', publicUrl: 'https://factory.acme.com/' });
+    await prepareFactory({
+      auth,
+      database: 'postgres://cfg/app',
+      publicUrl: 'https://factory.acme.com/',
+      allowedOrigins: ['https://app.acme.com/'],
+    });
     expect(auth.init).toHaveBeenCalledExactlyOnceWith({
       databaseUrl: 'postgres://cfg/app',
       publicUrl: 'https://factory.acme.com',
+      allowedOrigins: ['https://app.acme.com'],
     } satisfies WebAuthAdapterInitContext);
   });
 

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -2,9 +2,9 @@
  * `MastraFactory` — the single entry point to the whole MastraCode web factory.
  *
  * The deploy entry (`src/mastra/index.ts`) is the ONE place deployment env is
- * read: it constructs config instances (pubsub, later an auth adapter) and
- * passes them here explicitly. The factory itself never reads deployment env
- * vars and never constructs providers on the caller's behalf.
+ * read: it constructs config instances (auth adapter, pubsub) and passes them
+ * here explicitly. The factory itself never reads deployment env vars and
+ * never constructs providers on the caller's behalf.
  *
  * `prepare()` resolves feature readiness, seeds the runtime-config registry,
  * assembles the web routes/middleware, and returns the constructor args for
@@ -24,7 +24,8 @@ import type { Mastra } from '@mastra/core/mastra';
 import type { RequestContext } from '@mastra/core/request-context';
 import { prepareAgentControllerMount } from '@mastra/code-sdk';
 import { observeAgentGitAction } from './audit/agent-audit.js';
-import { buildAuthRoutes, createWebAuthGate, createWebAuthProvider, isWebAuthEnabled } from './auth.js';
+import type { WebAuthAdapter } from './auth-adapter.js';
+import { buildAuthRoutes, createWebAuthGate } from './auth.js';
 import {
   createGithubSubscriptionTools,
   parseCreatedPullRequest,
@@ -49,6 +50,13 @@ type BuildApiRoutesDeps = Pick<WebApiRoutesDeps, 'controller' | 'authStorage'>;
 export type MastraArgs = NonNullable<ConstructorParameters<typeof Mastra>[0]>;
 
 export interface MastraFactoryConfig {
+  /**
+   * Web auth adapter instance — `WorkOSWebAuth`, `BetterAuthWebAuth`, or any
+   * custom `WebAuthAdapter` implementation. Whatever instance is passed is the
+   * active provider; the factory never selects or constructs one itself.
+   * Omitted → auth disabled (open server, local-dev behavior).
+   */
+  auth?: WebAuthAdapter;
   /**
    * Postgres connection string powering BOTH agent storage (threads, messages,
    * memory, OM, recall vectors) and the app tables (github/factory/audit/
@@ -105,10 +113,17 @@ export class MastraFactory {
     const allowedOrigins = (this.#config.allowedOrigins ?? []).map(o => o.replace(/\/+$/, '')).filter(Boolean);
     const database = this.#config.database;
     const pubsub = this.#config.pubsub;
+    const auth = this.#config.auth;
 
     // Seed the registry FIRST: the readiness checks below reach the app DB
-    // through `getAppDatabaseUrl()`.
-    seedRuntimeConfig({ databaseUrl: database, publicUrl: publicOrigin });
+    // through `getAppDatabaseUrl()` and gate on the active auth adapter via
+    // `isWebAuthEnabled()`.
+    seedRuntimeConfig({ databaseUrl: database, publicUrl: publicOrigin, authAdapter: auth });
+
+    // One-time adapter initialization with factory-level context (e.g.
+    // better-auth builds its default instance on the app database). Failures
+    // surface here, at prepare() — a misconfigured adapter must not boot.
+    await auth?.init?.({ databaseUrl: database, publicUrl: publicOrigin });
 
     // GitHub App + cloud-sandbox readiness, resolved BEFORE constructing the
     // Mastra args so the github routes are simply omitted from `apiRoutes`
@@ -123,16 +138,6 @@ export class MastraFactory {
 
     // Factory work-item board — hangs off GitHub projects, same fail-soft pattern.
     const factoryReady = await resolveFactoryReady(githubReady);
-
-    // TEMP: WorkOS auth is still resolved from its own env here, verbatim from
-    // the pre-factory entry. The auth adapter slot (`auth?: WebAuthAdapter`)
-    // replaces this in the adapter-seam step.
-    const webAuthEnabled = isWebAuthEnabled();
-    const redirectUri = process.env.WORKOS_REDIRECT_URI ?? `${publicOrigin}/auth/callback`;
-    // One WorkOS provider for the process, shared by the gate middleware and
-    // the public `/auth/*` routes so session encryption/validation stays
-    // consistent.
-    const authProvider = webAuthEnabled ? createWebAuthProvider(redirectUri) : undefined;
 
     // Build the real production controller (agents, modes, tools, memory, OM,
     // MCP, providers) — identical to the terminal app. Agent state lives in
@@ -179,7 +184,7 @@ export class MastraFactory {
         // `apiRoutes` (not plain Hono routes) because the entry can't touch the
         // Hono app the deployer generates. `requiresAuth: false`; the gate
         // skips `/auth/*`.
-        ...(authProvider ? buildAuthRoutes(authProvider, redirectUri) : []),
+        ...(auth ? buildAuthRoutes(auth) : []),
         // Custom `/web/*` routes (fs / config / github / factory / audit).
         ...assembleWebApiRoutes({
           controller,
@@ -202,7 +207,7 @@ export class MastraFactory {
         // enabled) covers it; it always passes `/api`, `/web`, `/auth` through.
         const uiDist = resolveUiDistDir();
         const spa = uiDist ? [createSpaStaticMiddleware(uiDist)] : [];
-        if (!webAuthEnabled || !authProvider) {
+        if (!auth) {
           // Auth disabled: no gate. SPA + CORS only.
           return { ...(spa.length ? { middleware: spa } : {}), ...cors, ...onError };
         }
@@ -213,7 +218,7 @@ export class MastraFactory {
         //              redirects unauthenticated requests. Skips public `/auth/*`.
         //   2. spa   — serves the built UI for everything the server doesn't own.
         return {
-          middleware: [createWebAuthGate(authProvider), ...spa],
+          middleware: [createWebAuthGate(auth), ...spa],
           ...cors,
           ...onError,
         };

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -106,6 +106,7 @@ const CONTROLLER_ID = 'code';
 export class MastraFactory {
   readonly #config: MastraFactoryConfig;
   #prepared: Awaited<ReturnType<typeof prepareAgentControllerMount>> | undefined;
+  #preparing = false;
 
   constructor(config: MastraFactoryConfig = {}) {
     this.#config = config;
@@ -117,7 +118,11 @@ export class MastraFactory {
    * for the `new Mastra(...)` literal that must live in the entry file.
    */
   async prepare(): Promise<MastraArgs> {
-    if (this.#prepared) throw new Error('MastraFactory.prepare() called twice');
+    // Guard set synchronously (before the first await) so overlapping calls —
+    // not just strictly sequential ones — can't double-seed the runtime
+    // registry or double-run one-time adapter init.
+    if (this.#preparing) throw new Error('MastraFactory.prepare() called twice');
+    this.#preparing = true;
 
     const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:4111').replace(/\/+$/, '');
     const allowedOrigins = (this.#config.allowedOrigins ?? []).map(o => o.replace(/\/+$/, '')).filter(Boolean);
@@ -139,7 +144,7 @@ export class MastraFactory {
     // One-time adapter initialization with factory-level context (e.g.
     // better-auth builds its default instance on the app database). Failures
     // surface here, at prepare() — a misconfigured adapter must not boot.
-    await auth?.init?.({ databaseUrl: database, publicUrl: publicOrigin });
+    await auth?.init?.({ databaseUrl: database, publicUrl: publicOrigin, allowedOrigins });
 
     // GitHub App + cloud-sandbox readiness, resolved BEFORE constructing the
     // Mastra args so the github routes are simply omitted from `apiRoutes`

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -184,9 +184,10 @@ export class MastraFactory {
               const requestContext = (context.context as { requestContext?: RequestContext } | undefined)
                 ?.requestContext;
               // Audit externally-visible git side effects performed by the agent
-              // (commit / push / PR creation). Fire-and-forget; never throws.
+              // (commit / push / PR creation). Awaited so the local audit write
+              // completes before teardown; never throws (failures are swallowed).
               if (requestContext) {
-                void observeAgentGitAction({ ...context, context: requestContext });
+                await observeAgentGitAction({ ...context, context: requestContext });
               }
               if (pullRequestUrl && requestContext) {
                 await subscribeCurrentSessionToPullRequest(requestContext, pullRequestUrl, 'auto-gh-pr-create');

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -33,6 +33,7 @@ import {
 } from './github/session-subscriptions.js';
 import { buildLinearAgentTools } from './linear/agent-tools.js';
 import { seedRuntimeConfig } from './runtime-config.js';
+import type { WebSandboxProvider } from './sandbox-provider.js';
 import { handleServerError } from './server-error.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import {
@@ -89,6 +90,15 @@ export interface MastraFactoryConfig {
    * static host, so credentialed requests must be explicitly allowed.
    */
   allowedOrigins?: string[];
+  /**
+   * Sandbox provider instance — `RailwaySandboxProvider`, `LocalSandboxProvider`, or any
+   * custom `WebSandboxProvider` implementation. GitHub-backed projects clone
+   * and run commands inside sandboxes built by this provider. Whatever instance
+   * is passed is the active provider; the factory never selects or constructs
+   * one itself. Omitted → sandboxes disabled and GitHub-backed projects stay
+   * off.
+   */
+  sandbox?: WebSandboxProvider;
 }
 
 const CONTROLLER_ID = 'code';
@@ -116,9 +126,15 @@ export class MastraFactory {
     const auth = this.#config.auth;
 
     // Seed the registry FIRST: the readiness checks below reach the app DB
-    // through `getAppDatabaseUrl()` and gate on the active auth adapter via
-    // `isWebAuthEnabled()`.
-    seedRuntimeConfig({ databaseUrl: database, publicUrl: publicOrigin, authAdapter: auth });
+    // through `getAppDatabaseUrl()`, gate on the active auth adapter via
+    // `isWebAuthEnabled()`, and probe the sandbox provider via
+    // `isSandboxEnabled()`.
+    seedRuntimeConfig({
+      databaseUrl: database,
+      publicUrl: publicOrigin,
+      authAdapter: auth,
+      sandbox: this.#config.sandbox,
+    });
 
     // One-time adapter initialization with factory-level context (e.g.
     // better-auth builds its default instance on the app database). Failures

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -1,0 +1,238 @@
+/**
+ * `MastraFactory` — the single entry point to the whole MastraCode web factory.
+ *
+ * The deploy entry (`src/mastra/index.ts`) is the ONE place deployment env is
+ * read: it constructs config instances (pubsub, later an auth adapter) and
+ * passes them here explicitly. The factory itself never reads deployment env
+ * vars and never constructs providers on the caller's behalf.
+ *
+ * `prepare()` resolves feature readiness, seeds the runtime-config registry,
+ * assembles the web routes/middleware, and returns the constructor args for
+ * `new Mastra(...)`. The literal `export const mastra = new Mastra(...)` must
+ * stay in the entry file — the deployer's `checkConfigExport` Babel plugin
+ * only marks the config valid when it finds that literal in the entry AST —
+ * so the factory produces args instead of the instance. `finalize()` runs the
+ * post-construct boot (controller init + workers).
+ *
+ * GitHub/Linear/intake readiness stays env-resolved inside `prepare()` for
+ * now (fail-soft checks, see `./web-surface.ts`) — future slots on this
+ * config object.
+ */
+
+import type { PubSub } from '@mastra/core/events';
+import type { Mastra } from '@mastra/core/mastra';
+import type { RequestContext } from '@mastra/core/request-context';
+import { prepareAgentControllerMount } from '@mastra/code-sdk';
+import { observeAgentGitAction } from './audit/agent-audit.js';
+import { buildAuthRoutes, createWebAuthGate, createWebAuthProvider, isWebAuthEnabled } from './auth.js';
+import {
+  createGithubSubscriptionTools,
+  parseCreatedPullRequest,
+  subscribeCurrentSessionToPullRequest,
+} from './github/session-subscriptions.js';
+import { buildLinearAgentTools } from './linear/agent-tools.js';
+import { seedRuntimeConfig } from './runtime-config.js';
+import { handleServerError } from './server-error.js';
+import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
+import {
+  assembleWebApiRoutes,
+  resolveFactoryReady,
+  resolveGithubReady,
+  resolveIntakeReady,
+  resolveLinearReady,
+} from './web-surface.js';
+import type { WebApiRoutesDeps } from './web-surface.js';
+
+type BuildApiRoutesDeps = Pick<WebApiRoutesDeps, 'controller' | 'authStorage'>;
+
+/** Constructor args for the `new Mastra(...)` literal in the deploy entry. */
+export type MastraArgs = NonNullable<ConstructorParameters<typeof Mastra>[0]>;
+
+export interface MastraFactoryConfig {
+  /**
+   * Postgres connection string powering BOTH agent storage (threads, messages,
+   * memory, OM, recall vectors) and the app tables (github/factory/audit/
+   * intake). Omitted → default storage resolution applies (local libSQL file)
+   * and app-DB-gated features stay off.
+   *
+   * Stays a connection string (not a storage instance) because it fans out to
+   * independently-constructed clients: the SDK mount builds its store, vector
+   * store, maintenance, and fallback from `StorageConfig`, while the app
+   * tables need a raw drizzle/pg Pool. Instance-accepting `database` is a
+   * follow-up gated on SDK storage-injection support.
+   */
+  database?: string;
+  /**
+   * Distributed event bus instance (e.g. `new RedisStreamsPubSub({ url })`).
+   * When set, streams/workflows/signals ride it across processes and the
+   * controller drops file-based thread locks in favor of pubsub-coordinated
+   * leases. Omitted → in-process default.
+   */
+  pubsub?: PubSub;
+  /**
+   * Browser-facing origin used to build GitHub OAuth/install callback URLs and
+   * to derive the auth redirect URI. On the platform the SPA is hosted
+   * separately, so this MUST be the public API origin.
+   * Default: `http://localhost:4111`.
+   */
+  publicUrl?: string;
+  /**
+   * Allowed cross-origin SPA origins. The SPA may be served from a separate
+   * static host, so credentialed requests must be explicitly allowed.
+   */
+  allowedOrigins?: string[];
+}
+
+const CONTROLLER_ID = 'code';
+
+export class MastraFactory {
+  readonly #config: MastraFactoryConfig;
+  #prepared: Awaited<ReturnType<typeof prepareAgentControllerMount>> | undefined;
+
+  constructor(config: MastraFactoryConfig = {}) {
+    this.#config = config;
+  }
+
+  /**
+   * Resolve feature readiness, seed the runtime-config registry, and assemble
+   * everything needed to construct the server-owned Mastra. Returns the args
+   * for the `new Mastra(...)` literal that must live in the entry file.
+   */
+  async prepare(): Promise<MastraArgs> {
+    if (this.#prepared) throw new Error('MastraFactory.prepare() called twice');
+
+    const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:4111').replace(/\/+$/, '');
+    const allowedOrigins = (this.#config.allowedOrigins ?? []).map(o => o.replace(/\/+$/, '')).filter(Boolean);
+    const database = this.#config.database;
+    const pubsub = this.#config.pubsub;
+
+    // Seed the registry FIRST: the readiness checks below reach the app DB
+    // through `getAppDatabaseUrl()`.
+    seedRuntimeConfig({ databaseUrl: database, publicUrl: publicOrigin });
+
+    // GitHub App + cloud-sandbox readiness, resolved BEFORE constructing the
+    // Mastra args so the github routes are simply omitted from `apiRoutes`
+    // when unavailable. Fails soft (see resolveGithubReady).
+    const githubReady = await resolveGithubReady();
+
+    // Linear intake readiness, same fail-soft pattern as GitHub.
+    const linearReady = await resolveLinearReady();
+
+    // Intake source configuration (Settings › Intake) — needs at least one source.
+    const intakeReady = await resolveIntakeReady(githubReady || linearReady);
+
+    // Factory work-item board — hangs off GitHub projects, same fail-soft pattern.
+    const factoryReady = await resolveFactoryReady(githubReady);
+
+    // TEMP: WorkOS auth is still resolved from its own env here, verbatim from
+    // the pre-factory entry. The auth adapter slot (`auth?: WebAuthAdapter`)
+    // replaces this in the adapter-seam step.
+    const webAuthEnabled = isWebAuthEnabled();
+    const redirectUri = process.env.WORKOS_REDIRECT_URI ?? `${publicOrigin}/auth/callback`;
+    // One WorkOS provider for the process, shared by the gate middleware and
+    // the public `/auth/*` routes so session encryption/validation stays
+    // consistent.
+    const authProvider = webAuthEnabled ? createWebAuthProvider(redirectUri) : undefined;
+
+    // Build the real production controller (agents, modes, tools, memory, OM,
+    // MCP, providers) — identical to the terminal app. Agent state lives in
+    // the single app Postgres (`database`) alongside the github/app tables —
+    // one shared DB for all users, separated by `resourceId` scoping.
+    const prepared = await prepareAgentControllerMount({
+      controllerId: CONTROLLER_ID,
+      disableGithubSignals: true,
+      ...(database ? { storage: { backend: 'pg', connectionString: database } } : {}),
+      ...(githubReady || linearReady
+        ? {
+            extraTools: async ({ requestContext }: { requestContext: RequestContext }) => ({
+              ...(linearReady ? await buildLinearAgentTools({ requestContext }) : {}),
+              ...(githubReady ? createGithubSubscriptionTools(requestContext) : {}),
+            }),
+          }
+        : {}),
+      ...(githubReady
+        ? {
+            postToolObserver: async (context: {
+              toolName: string;
+              input: unknown;
+              output?: unknown;
+              error?: unknown;
+              context: unknown;
+            }) => {
+              const pullRequestUrl = parseCreatedPullRequest(context);
+              const requestContext = (context.context as { requestContext?: RequestContext } | undefined)
+                ?.requestContext;
+              // Audit externally-visible git side effects performed by the agent
+              // (commit / push / PR creation). Fire-and-forget; never throws.
+              if (requestContext) {
+                void observeAgentGitAction({ ...context, context: requestContext });
+              }
+              if (pullRequestUrl && requestContext) {
+                await subscribeCurrentSessionToPullRequest(requestContext, pullRequestUrl, 'auto-gh-pr-create');
+              }
+            },
+          }
+        : {}),
+      ...(pubsub ? { pubsub, crossProcessPubSub: true } : {}),
+      buildApiRoutes: ({ controller, authStorage }: BuildApiRoutesDeps) => [
+        // Public `/auth/*` routes (login/callback/logout/me). Folded in as
+        // `apiRoutes` (not plain Hono routes) because the entry can't touch the
+        // Hono app the deployer generates. `requiresAuth: false`; the gate
+        // skips `/auth/*`.
+        ...(authProvider ? buildAuthRoutes(authProvider, redirectUri) : []),
+        // Custom `/web/*` routes (fs / config / github / factory / audit).
+        ...assembleWebApiRoutes({
+          controller,
+          authStorage,
+          publicOrigin,
+          githubReady,
+          linearReady,
+          intakeReady,
+          factoryReady,
+        }),
+      ],
+      buildServerConfig: () => {
+        const cors = allowedOrigins.length ? { cors: { origin: allowedOrigins, credentials: true } } : {};
+        // Log route errors with method/path/stack and answer with structured
+        // JSON instead of an opaque `Internal Server Error`. Applied by the
+        // deployer to both the top-level app and the custom-route sub-app.
+        const onError = { onError: handleServerError };
+        // Same-origin SPA: when a vite build is present (see resolveUiDistDir),
+        // serve it at `/` from this server. Mounted last so the auth gate (when
+        // enabled) covers it; it always passes `/api`, `/web`, `/auth` through.
+        const uiDist = resolveUiDistDir();
+        const spa = uiDist ? [createSpaStaticMiddleware(uiDist)] : [];
+        if (!webAuthEnabled || !authProvider) {
+          // Auth disabled: no gate. SPA + CORS only.
+          return { ...(spa.length ? { middleware: spa } : {}), ...cors, ...onError };
+        }
+
+        // Ordered middleware. The deployer applies these AFTER its context
+        // middleware sets `c.set('mastra', mastra)` and BEFORE routes, so:
+        //   1. gate  — validates the auth session, stashes the user, and 401s /
+        //              redirects unauthenticated requests. Skips public `/auth/*`.
+        //   2. spa   — serves the built UI for everything the server doesn't own.
+        return {
+          middleware: [createWebAuthGate(authProvider), ...spa],
+          ...cors,
+          ...onError,
+        };
+      },
+    });
+
+    this.#prepared = prepared;
+    return prepared.mastraArgs;
+  }
+
+  /**
+   * Post-construct boot: initialize the controller (which inherits the
+   * constructed Mastra's storage) and start its workers. Call AFTER the entry
+   * has run `new Mastra(prepare()'s args)`.
+   */
+  async finalize(): Promise<void> {
+    if (!this.#prepared) {
+      throw new Error('MastraFactory.finalize() called before prepare()');
+    }
+    await this.#prepared.finalize();
+  }
+}

--- a/mastracode/web/src/web/github/db.ts
+++ b/mastracode/web/src/web/github/db.ts
@@ -2,15 +2,17 @@
  * Application database layer for the GitHub App integration.
  *
  * This is a *separate* Postgres from Mastra's own storage: it is created lazily
- * from `APP_DATABASE_URL` and holds only the GitHub installations/projects
- * tables defined in `./schema`. The connection is a singleton so the whole
- * process shares one pg Pool.
+ * from the factory-resolved database URL (`getAppDatabaseUrl()`, seeded by
+ * `MastraFactory` with an `APP_DATABASE_URL` env fallback) and holds only the
+ * GitHub installations/projects tables defined in `./schema`. The connection
+ * is a singleton so the whole process shares one pg Pool.
  */
 
 import { sql } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import type { NodePgDatabase } from 'drizzle-orm/node-postgres';
 import pkg from 'pg';
+import { getAppDatabaseUrl } from '../runtime-config';
 import { MIGRATION_SQL } from './schema';
 import * as schema from './schema';
 
@@ -26,16 +28,16 @@ let migrationPromise: Promise<void> | undefined;
  * True when the app database is configured. Required for the GitHub feature.
  */
 export function isAppDbConfigured(): boolean {
-  return Boolean(process.env.APP_DATABASE_URL);
+  return Boolean(getAppDatabaseUrl());
 }
 
 /**
- * Get (lazily creating) the Drizzle client bound to `APP_DATABASE_URL`.
- * @throws if `APP_DATABASE_URL` is not set.
+ * Get (lazily creating) the Drizzle client bound to the app database URL.
+ * @throws if no app database is configured.
  */
 export function getAppDb(): AppDb {
   if (db) return db;
-  const connectionString = process.env.APP_DATABASE_URL;
+  const connectionString = getAppDatabaseUrl();
   if (!connectionString) {
     throw new Error('APP_DATABASE_URL is not set; the GitHub App feature requires an application database.');
   }

--- a/mastracode/web/src/web/github/local-sandbox.test.ts
+++ b/mastracode/web/src/web/github/local-sandbox.test.ts
@@ -2,45 +2,32 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { getLocalSandboxRoot, LocalSandbox, sandboxEnv } from './local-sandbox';
+import { LocalSandbox, sandboxEnv } from './local-sandbox';
 
 let root: string;
 
 beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), 'mc-local-sandbox-'));
-  process.env.MASTRACODE_LOCAL_SANDBOX_ROOT = root;
 });
 
 afterEach(() => {
-  delete process.env.MASTRACODE_LOCAL_SANDBOX_ROOT;
   rmSync(root, { recursive: true, force: true });
-});
-
-describe('getLocalSandboxRoot', () => {
-  it('uses the configured root', () => {
-    expect(getLocalSandboxRoot()).toBe(root);
-  });
-
-  it('defaults under the home dir when unset', () => {
-    delete process.env.MASTRACODE_LOCAL_SANDBOX_ROOT;
-    expect(getLocalSandboxRoot()).toMatch(/\.mastracode\/web\/sandboxes$/);
-  });
 });
 
 describe('LocalSandbox', () => {
   it('surfaces a stable id keyed to the root and reattaches by id', async () => {
-    const a = new LocalSandbox();
+    const a = new LocalSandbox({ root });
     expect(a.id).toBe(`local:${root}`);
     const info = await a.getInfo();
     expect(info.metadata?.sandboxId).toBe(`local:${root}`);
     expect(info.metadata?.provider).toBe('local');
 
-    const reattached = new LocalSandbox({ sandboxId: a.id });
+    const reattached = new LocalSandbox({ root, sandboxId: a.id });
     expect(reattached.id).toBe(a.id);
   });
 
   it('runs a successful shell command', async () => {
-    const sandbox = new LocalSandbox();
+    const sandbox = new LocalSandbox({ root });
     await sandbox.start();
     const res = await sandbox.executeCommand('sh', ['-c', 'echo hello']);
     expect(res.exitCode).toBe(0);
@@ -48,7 +35,7 @@ describe('LocalSandbox', () => {
   });
 
   it('captures non-zero exit codes and stderr', async () => {
-    const sandbox = new LocalSandbox();
+    const sandbox = new LocalSandbox({ root });
     await sandbox.start();
     const res = await sandbox.executeCommand('sh', ['-c', 'echo oops 1>&2; exit 3']);
     expect(res.exitCode).toBe(3);
@@ -56,14 +43,14 @@ describe('LocalSandbox', () => {
   });
 
   it('returns 127 when the binary does not exist', async () => {
-    const sandbox = new LocalSandbox();
+    const sandbox = new LocalSandbox({ root });
     await sandbox.start();
     const res = await sandbox.executeCommand('this-binary-does-not-exist-xyz');
     expect(res.exitCode).toBe(127);
   });
 
   it('runs commands in the sandbox root', async () => {
-    const sandbox = new LocalSandbox();
+    const sandbox = new LocalSandbox({ root });
     await sandbox.start();
     const res = await sandbox.executeCommand('sh', ['-c', 'pwd']);
     // macOS /tmp symlinks to /private/tmp, so compare the basename.
@@ -71,7 +58,7 @@ describe('LocalSandbox', () => {
   });
 
   it('stop() is a no-op that does not throw', async () => {
-    const sandbox = new LocalSandbox();
+    const sandbox = new LocalSandbox({ root });
     await expect(sandbox.stop()).resolves.toBeUndefined();
   });
 
@@ -79,7 +66,7 @@ describe('LocalSandbox', () => {
     process.env.GITHUB_APP_PRIVATE_KEY = 'super-secret-key';
     process.env.WORKOS_API_KEY = 'sk_live_secret';
     try {
-      const sandbox = new LocalSandbox();
+      const sandbox = new LocalSandbox({ root });
       await sandbox.start();
       const res = await sandbox.executeCommand('sh', [
         '-c',
@@ -93,7 +80,7 @@ describe('LocalSandbox', () => {
   });
 
   it('still passes PATH so binaries resolve', async () => {
-    const sandbox = new LocalSandbox();
+    const sandbox = new LocalSandbox({ root });
     await sandbox.start();
     const res = await sandbox.executeCommand('sh', ['-c', 'echo "${PATH:-MISSING}"']);
     expect(res.stdout.trim()).not.toBe('MISSING');

--- a/mastracode/web/src/web/github/local-sandbox.ts
+++ b/mastracode/web/src/web/github/local-sandbox.ts
@@ -1,29 +1,16 @@
 /**
- * Local (host-process) sandbox provider.
+ * Local (host-process) sandbox.
  *
  * A drop-in `MaterializationSandbox` that runs commands directly on the server
  * host instead of a remote VM. The repo is cloned into a per-project directory
- * under a configurable base (`MASTRACODE_LOCAL_SANDBOX_ROOT`, default
- * `~/.mastracode/web/sandboxes`).
- *
- * WARNING: this provider does NOT isolate tenants — every project's git
- * operations run as the server process on the same host filesystem. It exists
- * for local single-user development when no Railway token is configured. Do not
- * use it for a shared multi-tenant deployment; use a real cloud sandbox there.
+ * under the root the `LocalSandboxProvider` adapter was configured with (see
+ * `../sandbox-local-provider.ts`, which also carries the tenant-isolation
+ * warning).
  */
 
 import { spawn } from 'node:child_process';
 import { mkdirSync } from 'node:fs';
-import { homedir } from 'node:os';
-import { join } from 'node:path';
-import type { MaterializationSandbox, SandboxCommandResult } from './sandbox';
-
-/** Base directory under which local sandboxes are created. */
-export function getLocalSandboxRoot(): string {
-  const configured = process.env.MASTRACODE_LOCAL_SANDBOX_ROOT;
-  if (configured && configured.trim()) return configured.trim();
-  return join(homedir(), '.mastracode', 'web', 'sandboxes');
-}
+import type { MaterializationSandbox, SandboxCommandResult } from '../sandbox-provider.js';
 
 /**
  * Environment variables that are safe to expose to sandboxed commands. The repo
@@ -77,8 +64,8 @@ export class LocalSandbox implements MaterializationSandbox {
   readonly id: string;
   private readonly root: string;
 
-  constructor(opts: { sandboxId?: string } = {}) {
-    this.root = getLocalSandboxRoot();
+  constructor(opts: { root: string; sandboxId?: string }) {
+    this.root = opts.root;
     // A stable id keyed to the host root so re-opens reattach to the same place.
     this.id = opts.sandboxId ?? `local:${this.root}`;
   }

--- a/mastracode/web/src/web/github/sandbox-fleet-scenario.test.ts
+++ b/mastracode/web/src/web/github/sandbox-fleet-scenario.test.ts
@@ -1,5 +1,7 @@
 import { Hono } from 'hono';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { __resetRuntimeConfigForTests, seedRuntimeConfig } from '../runtime-config';
+import { RailwaySandboxProvider } from '../sandbox-railway-provider';
 
 // ── Phase 7 sandbox-fleet scenario tests ─────────────────────────────────
 // These prove the lightweight per-replica sandbox budget and the per-user
@@ -157,15 +159,15 @@ function makeBindingRow(id: string): GithubProjectSandboxRow {
 afterEach(() => {
   resetSandboxFactory();
   __resetLiveSandboxCount(0);
+  __resetRuntimeConfigForTests();
   tables.projects = [];
   tables.sandboxes = [];
-  delete process.env.MASTRACODE_MAX_SANDBOXES;
   vi.restoreAllMocks();
 });
 
 describe('S7 — sandbox fleet budget', () => {
   it('cap=1: a second fresh provision is rejected, then succeeds after teardown frees a slot', async () => {
-    process.env.MASTRACODE_MAX_SANDBOXES = '1';
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'test-token', maxSandboxes: 1 }) });
     let made = 0;
     setSandboxFactory(({ providerSandboxId }) => new FakeSandbox(providerSandboxId ?? `fresh-${++made}`));
 
@@ -250,8 +252,8 @@ describe('S7 — cross-user teardown isolation (route level)', () => {
       { id: 's1', githubProjectId: 'p1', userId: 'u1', sandboxId: 'vm-u1', sandboxWorkdir: '/workspace/hello' },
     ];
     process.env.MASTRACODE_DISTRIBUTED_LOCK = '0';
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'railway';
-    process.env.RAILWAY_API_TOKEN = 'test-token'; // makes isSandboxEnabled() true
+    // A tokened Railway adapter makes isSandboxEnabled() true.
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'test-token' }) });
 
     // Real teardown/reattach run; the factory yields a fake VM so reattach starts
     // a recordable sandbox instead of hitting Railway.
@@ -262,8 +264,6 @@ describe('S7 — cross-user teardown isolation (route level)', () => {
 
   afterEach(() => {
     delete process.env.MASTRACODE_DISTRIBUTED_LOCK;
-    delete process.env.MASTRACODE_SANDBOX_PROVIDER;
-    delete process.env.RAILWAY_API_TOKEN;
   });
 
   function buildApp(workosId: string) {

--- a/mastracode/web/src/web/github/sandbox.test.ts
+++ b/mastracode/web/src/web/github/sandbox.test.ts
@@ -40,6 +40,9 @@ import {
 } from './sandbox';
 import type { MaterializationSandbox, RepoMaterializeInfo, SandboxCommandResult } from './sandbox';
 import type { GithubProjectSandboxRow } from './schema';
+import { __resetRuntimeConfigForTests, seedRuntimeConfig } from '../runtime-config';
+import { LocalSandboxProvider } from '../sandbox-local-provider';
+import { RailwaySandboxProvider } from '../sandbox-railway-provider';
 
 type Responder = (script: string) => SandboxCommandResult;
 const OK: SandboxCommandResult = { exitCode: 0, stdout: '', stderr: '' };
@@ -89,92 +92,79 @@ function makeRepoInfo(overrides: Partial<RepoMaterializeInfo> = {}): RepoMateria
 
 beforeEach(() => {
   dbUpdates.length = 0;
+  // RailwaySandboxProvider.isEnabled() honors the SDK's own env credential fallback;
+  // clear it so host-machine env can't leak into these tests.
+  delete process.env.RAILWAY_API_TOKEN;
 });
 
 afterEach(() => {
   resetSandboxFactory();
-  delete process.env.RAILWAY_API_TOKEN;
-  delete process.env.MASTRACODE_SANDBOX_PROVIDER;
-  delete process.env.MASTRACODE_SANDBOX_WORKDIR;
-  delete process.env.MASTRACODE_SANDBOX_IDLE_MINUTES;
+  __resetRuntimeConfigForTests();
 });
 
 describe('getSandboxProvider', () => {
-  it('defaults to railway when a Railway token is set', () => {
-    process.env.RAILWAY_API_TOKEN = 'tok';
+  it('reports the seeded adapter kind', () => {
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'tok' }) });
     expect(getSandboxProvider()).toBe('railway');
-  });
-
-  it('falls back to local when no Railway token is set', () => {
+    __resetRuntimeConfigForTests();
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider() });
     expect(getSandboxProvider()).toBe('local');
   });
 
-  it('honors an explicit provider override', () => {
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'railway';
-    expect(getSandboxProvider()).toBe('railway');
+  it('reports none when no sandbox provider is configured', () => {
+    expect(getSandboxProvider()).toBe('none');
   });
 });
 
 describe('isSandboxEnabled', () => {
-  it('is true for railway when a token is set', () => {
-    process.env.RAILWAY_API_TOKEN = 'tok';
+  it('is true for railway when a token is configured', () => {
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'tok' }) });
     expect(isSandboxEnabled()).toBe(true);
   });
 
-  it('is true without a token (auto-falls back to local)', () => {
-    expect(isSandboxEnabled()).toBe(true);
-  });
-
-  it('is false when railway is explicitly selected without a token', () => {
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'railway';
-    expect(isSandboxEnabled()).toBe(false);
-  });
-
-  it('is false for an unknown provider', () => {
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'mystery';
-    process.env.RAILWAY_API_TOKEN = 'tok';
+  it('is false for railway without a token', () => {
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider() });
     expect(isSandboxEnabled()).toBe(false);
   });
 
   it('is true for the local provider without any token', () => {
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'local';
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider() });
     expect(isSandboxEnabled()).toBe(true);
+  });
+
+  it('is false when no sandbox provider is configured', () => {
+    expect(isSandboxEnabled()).toBe(false);
   });
 });
 
 describe('computeSandboxWorkdir', () => {
   it('defaults to /workspace/<repo> for the railway provider', () => {
-    process.env.RAILWAY_API_TOKEN = 'tok';
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'tok' }) });
     expect(computeSandboxWorkdir('octocat/hello')).toBe('/workspace/hello');
   });
 
   it('appends the repo name to a configured base', () => {
-    process.env.RAILWAY_API_TOKEN = 'tok';
-    process.env.MASTRACODE_SANDBOX_WORKDIR = '/srv/checkouts';
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'tok', workdirBase: '/srv/checkouts' }) });
     expect(computeSandboxWorkdir('octocat/hello')).toBe('/srv/checkouts/hello');
   });
 
   it('does not double-append when the base already ends in the repo name', () => {
-    process.env.RAILWAY_API_TOKEN = 'tok';
-    process.env.MASTRACODE_SANDBOX_WORKDIR = '/srv/hello';
+    seedRuntimeConfig({ sandbox: new RailwaySandboxProvider({ token: 'tok', workdirBase: '/srv/hello' }) });
     expect(computeSandboxWorkdir('octocat/hello')).toBe('/srv/hello');
   });
 
-  it('checks out under the local sandbox root for the local provider', () => {
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'local';
-    process.env.MASTRACODE_LOCAL_SANDBOX_ROOT = '/tmp/mc-sandboxes';
+  it('checks out under the configured root for the local provider', () => {
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider({ root: '/tmp/mc-sandboxes' }) });
     expect(computeSandboxWorkdir('octocat/hello')).toBe('/tmp/mc-sandboxes/hello');
-    delete process.env.MASTRACODE_LOCAL_SANDBOX_ROOT;
   });
 
-  it('ignores the cloud-only workdir base for the local provider', () => {
-    // The schema defaults MASTRACODE_SANDBOX_WORKDIR to /workspace, which is
-    // not writable on a host filesystem — the local provider must ignore it.
-    process.env.MASTRACODE_SANDBOX_PROVIDER = 'local';
-    process.env.MASTRACODE_SANDBOX_WORKDIR = '/workspace';
-    process.env.MASTRACODE_LOCAL_SANDBOX_ROOT = '/tmp/mc-sandboxes';
-    expect(computeSandboxWorkdir('octocat/hello')).toBe('/tmp/mc-sandboxes/hello');
-    delete process.env.MASTRACODE_LOCAL_SANDBOX_ROOT;
+  it('defaults the local root to ~/.mastracode/web/sandboxes', () => {
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider() });
+    expect(computeSandboxWorkdir('octocat/hello')).toMatch(/\.mastracode\/web\/sandboxes\/hello$/);
+  });
+
+  it('throws when no sandbox provider is configured', () => {
+    expect(() => computeSandboxWorkdir('octocat/hello')).toThrow(/No sandbox provider configured/);
   });
 });
 
@@ -205,7 +195,7 @@ describe('ensureProjectSandbox', () => {
   });
 
   it('passes the idle timeout to the provider on provision', async () => {
-    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = '15';
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider({ idleMinutes: 15 }) });
     const sandbox = new FakeSandbox();
     let factoryArgs: { idleTimeoutMinutes?: number } | undefined;
     setSandboxFactory(opts => {
@@ -244,24 +234,18 @@ describe('ensureProjectSandbox', () => {
 });
 
 describe('getSandboxIdleMinutes', () => {
-  afterEach(() => {
-    delete process.env.MASTRACODE_SANDBOX_IDLE_MINUTES;
-  });
-
-  it('defaults to 30 minutes when unset', () => {
+  it('defaults to 30 minutes when the adapter does not specify one', () => {
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider() });
     expect(getSandboxIdleMinutes()).toBe(30);
   });
 
-  it('reads a positive integer from the env', () => {
-    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = '45';
+  it('defaults to 30 minutes when no adapter is configured', () => {
+    expect(getSandboxIdleMinutes()).toBe(30);
+  });
+
+  it('reads the adapter-configured window', () => {
+    seedRuntimeConfig({ sandbox: new LocalSandboxProvider({ idleMinutes: 45 }) });
     expect(getSandboxIdleMinutes()).toBe(45);
-  });
-
-  it('falls back to 30 for non-positive or invalid values', () => {
-    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = '0';
-    expect(getSandboxIdleMinutes()).toBe(30);
-    process.env.MASTRACODE_SANDBOX_IDLE_MINUTES = 'nope';
-    expect(getSandboxIdleMinutes()).toBe(30);
   });
 });
 

--- a/mastracode/web/src/web/github/sandbox.test.ts
+++ b/mastracode/web/src/web/github/sandbox.test.ts
@@ -90,16 +90,24 @@ function makeRepoInfo(overrides: Partial<RepoMaterializeInfo> = {}): RepoMateria
   return { repoFullName: 'octocat/hello', defaultBranch: 'main', ...overrides };
 }
 
+// RailwaySandboxProvider.isEnabled() honors the SDK's own env credential
+// fallback; clear it per test so host-machine env can't leak in, and restore
+// the pre-suite value afterwards so later suites see an unchanged environment.
+const ORIGINAL_RAILWAY_API_TOKEN = process.env.RAILWAY_API_TOKEN;
+
 beforeEach(() => {
   dbUpdates.length = 0;
-  // RailwaySandboxProvider.isEnabled() honors the SDK's own env credential fallback;
-  // clear it so host-machine env can't leak into these tests.
   delete process.env.RAILWAY_API_TOKEN;
 });
 
 afterEach(() => {
   resetSandboxFactory();
   __resetRuntimeConfigForTests();
+  if (ORIGINAL_RAILWAY_API_TOKEN === undefined) {
+    delete process.env.RAILWAY_API_TOKEN;
+  } else {
+    process.env.RAILWAY_API_TOKEN = ORIGINAL_RAILWAY_API_TOKEN;
+  }
 });
 
 describe('getSandboxProvider', () => {
@@ -153,14 +161,14 @@ describe('computeSandboxWorkdir', () => {
     expect(computeSandboxWorkdir('octocat/hello')).toBe('/srv/hello');
   });
 
-  it('checks out under the configured root for the local provider', () => {
+  it('checks out under the configured root for the local provider, keyed by owner + name', () => {
     seedRuntimeConfig({ sandbox: new LocalSandboxProvider({ root: '/tmp/mc-sandboxes' }) });
-    expect(computeSandboxWorkdir('octocat/hello')).toBe('/tmp/mc-sandboxes/hello');
+    expect(computeSandboxWorkdir('octocat/hello')).toBe('/tmp/mc-sandboxes/octocat/hello');
   });
 
   it('defaults the local root to ~/.mastracode/web/sandboxes', () => {
     seedRuntimeConfig({ sandbox: new LocalSandboxProvider() });
-    expect(computeSandboxWorkdir('octocat/hello')).toMatch(/\.mastracode\/web\/sandboxes\/hello$/);
+    expect(computeSandboxWorkdir('octocat/hello')).toMatch(/\.mastracode\/web\/sandboxes\/octocat\/hello$/);
   });
 
   it('throws when no sandbox provider is configured', () => {

--- a/mastracode/web/src/web/github/sandbox.ts
+++ b/mastracode/web/src/web/github/sandbox.ts
@@ -12,37 +12,21 @@
  *   (re-open) inside the sandbox, using a short-lived installation token that is
  *   scrubbed from the git remote afterwards so it never persists in the VM.
  *
- * The Railway sandbox is constructed behind a swappable factory so tests can
- * inject a fake sandbox and other providers can be added later.
+ * The provider is whatever `WebSandboxProvider` the factory was configured
+ * with (`sandbox` slot, seeded into the runtime-config registry) — this
+ * module never selects a provider or reads deployment env itself. Tests can
+ * additionally swap the low-level construction via `setSandboxFactory`.
  */
 
 import { createHash } from 'node:crypto';
-import { RailwaySandbox } from '@mastra/railway';
 import { eq } from 'drizzle-orm';
+import type { MaterializationSandbox, SandboxCommandResult, SandboxCreateOptions } from '../sandbox-provider';
+import { getSeededSandboxProvider } from '../runtime-config';
 import { getAppDb } from './db';
-import { getLocalSandboxRoot, LocalSandbox } from './local-sandbox';
 import { githubProjectSandboxes } from './schema';
 import type { GithubProjectSandboxRow } from './schema';
 
-/** Minimal command result shape we depend on. */
-export interface SandboxCommandResult {
-  exitCode: number;
-  stdout: string;
-  stderr: string;
-}
-
-/**
- * Minimal live-sandbox surface this module needs: an id, a way to start it, a
- * way to learn the provider's reattach id, and command execution.
- */
-export interface MaterializationSandbox {
-  readonly id: string;
-  start(): Promise<void>;
-  getInfo(): Promise<{ metadata?: Record<string, unknown> }>;
-  executeCommand(command: string, args?: string[], options?: { timeout?: number }): Promise<SandboxCommandResult>;
-  /** Tear down the underlying VM. Optional: providers without it are no-ops. */
-  stop?(): Promise<void>;
-}
+export type { MaterializationSandbox, SandboxCommandResult, SandboxCreateOptions } from '../sandbox-provider';
 
 /**
  * A coarse-grained step of the sandbox-preparation flow, reported as it happens
@@ -72,90 +56,55 @@ function reportProgress(onProgress: ProgressFn | undefined, event: PrepareProgre
  * provided the sandbox should reattach to that existing VM instead of
  * provisioning a new one.
  */
-export type SandboxFactory = (opts: {
-  providerSandboxId?: string;
-  env?: Record<string, string>;
-  /** Idle teardown window (minutes). The provider stops the VM after this idle period. */
-  idleTimeoutMinutes?: number;
-}) => MaterializationSandbox;
+export type SandboxFactory = (opts: SandboxCreateOptions) => MaterializationSandbox;
 
 /**
- * Resolve the active sandbox provider. An explicit `MASTRACODE_SANDBOX_PROVIDER`
- * always wins. Otherwise we pick automatically: Railway when a Railway token is
- * configured, else the local host-process provider. This means a repo can
- * always be opened — Railway in a configured cloud deploy, local in dev — with
- * no extra env wiring.
+ * Name of the active sandbox provider — the seeded provider's `kind`, or
+ * `'none'` when the factory was configured without a `sandbox` slot.
+ * Diagnostic only; feature gating goes through {@link isSandboxEnabled}.
  */
 export function getSandboxProvider(): string {
-  const explicit = process.env.MASTRACODE_SANDBOX_PROVIDER;
-  if (explicit) return explicit;
-  return process.env.RAILWAY_API_TOKEN ? 'railway' : 'local';
+  return getSeededSandboxProvider()?.kind ?? 'none';
 }
 
 /**
- * True when a sandbox provider is usable. The local provider is always usable
- * (it runs git on the host process), so this is only false when an explicit
- * provider is misconfigured (e.g. `railway` selected without a token, or an
- * unknown provider name).
+ * True when the configured sandbox provider is usable. `false` when no
+ * `sandbox` provider was configured or the provider reports itself
+ * misconfigured (e.g. Railway without a token) — GitHub-backed projects stay
+ * off in both cases.
  */
 export function isSandboxEnabled(): boolean {
-  const provider = getSandboxProvider();
-  if (provider === 'railway') {
-    return Boolean(process.env.RAILWAY_API_TOKEN);
-  }
-  if (provider === 'local') {
-    return true;
-  }
-  return false;
+  return getSeededSandboxProvider()?.isEnabled() ?? false;
 }
 
 /**
  * Compute the in-sandbox working directory for a repo. Server-side only; never
- * derived from client input.
+ * derived from client input. Delegates to the active provider, which owns the
+ * provider-specific layout (cloud `/workspace` base vs local checkout root).
  */
 export function computeSandboxWorkdir(repoFullName: string): string {
-  const repoName = repoFullName.split('/').pop() || 'repo';
-  // The local provider runs on the host filesystem, where a cloud path like
-  // `/workspace` is not writable. `MASTRACODE_SANDBOX_WORKDIR` documents
-  // itself as cloud-only (and the schema defaults it to `/workspace`), so the
-  // local provider ignores it and checks out under the local sandbox root.
-  if (getSandboxProvider() === 'local') {
-    return `${getLocalSandboxRoot().replace(/\/$/, '')}/${repoName}`;
-  }
-  const base = process.env.MASTRACODE_SANDBOX_WORKDIR;
-  if (base) {
-    // If the configured base already ends with the repo name, use it as-is.
-    return base.endsWith(`/${repoName}`) ? base : `${base.replace(/\/$/, '')}/${repoName}`;
-  }
-  return `/workspace/${repoName}`;
+  const provider = getSeededSandboxProvider();
+  if (!provider) throw new Error('No sandbox provider configured');
+  return provider.workdirFor(repoFullName);
 }
 
 /**
- * Idle teardown window for provisioned sandboxes, in minutes. Read from
- * `MASTRACODE_SANDBOX_IDLE_MINUTES`; defaults to 30. The provider stops an idle
- * VM after this window so abandoned sandboxes don't linger (GC). A re-open
- * detects the stopped VM and re-provisions cleanly.
+ * Idle teardown window for provisioned sandboxes, in minutes; defaults to 30.
+ * The provider stops an idle VM after this window so abandoned sandboxes don't
+ * linger (GC). A re-open detects the stopped VM and re-provisions cleanly.
  */
-export function getSandboxIdleMinutes(): number | undefined {
-  const raw = process.env.MASTRACODE_SANDBOX_IDLE_MINUTES;
-  if (raw === undefined || raw === '') return 30;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 30;
-  return Math.floor(parsed);
+export function getSandboxIdleMinutes(): number {
+  return getSeededSandboxProvider()?.idleMinutes ?? 30;
 }
 
 /**
- * Per-replica cap on concurrently *provisioned* sandboxes. Reads
- * `MASTRACODE_MAX_SANDBOXES`; 0 / unset means unlimited. This is a lightweight
- * per-process budget to keep a single replica from exhausting provider quota —
- * it is not a global, cross-replica scheduler (that is a deferred follow-up).
+ * Per-replica cap on concurrently *provisioned* sandboxes. 0 means unlimited.
+ * This is a lightweight per-process budget to keep a single replica from
+ * exhausting provider quota — it is not a global, cross-replica scheduler
+ * (that is a deferred follow-up).
  */
 export function getMaxSandboxes(): number {
-  const raw = process.env.MASTRACODE_MAX_SANDBOXES;
-  if (raw === undefined || raw === '') return 0;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 0;
-  return Math.floor(parsed);
+  return getSeededSandboxProvider()?.maxSandboxes ?? 0;
 }
 
 /**
@@ -180,40 +129,31 @@ export class SandboxBudgetError extends Error {
   readonly code = 'sandbox-budget-exceeded' as const;
   constructor(readonly max: number) {
     super(
-      `Sandbox budget exceeded: this server already has ${max} active sandbox(es) ` +
-        `(MASTRACODE_MAX_SANDBOXES=${max}). Close an existing project's sandbox and try again.`,
+      `Sandbox budget exceeded: this server already has ${max} active sandbox(es), ` +
+        `the configured per-replica maximum. Close an existing project's sandbox and try again.`,
     );
     this.name = 'SandboxBudgetError';
   }
 }
 
-/** Railway-backed sandbox, optionally reattaching by id. */
-const railwayFactory: SandboxFactory = ({ providerSandboxId, env, idleTimeoutMinutes }) =>
-  new RailwaySandbox({
-    ...(providerSandboxId ? { sandboxId: providerSandboxId } : {}),
-    ...(env ? { env } : {}),
-    ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
-  });
-
-/** Local host-process sandbox (single-user dev; no tenant isolation). */
-const localFactory: SandboxFactory = ({ providerSandboxId }) =>
-  new LocalSandbox(providerSandboxId ? { sandboxId: providerSandboxId } : {});
-
 /**
- * Default factory: dispatch on the configured provider. Resolved per call so
- * `MASTRACODE_SANDBOX_PROVIDER` is honored without re-importing the module.
+ * Default factory: build via the provider the factory was configured with.
+ * Resolved per call so seeding order doesn't matter at import time.
  */
-const defaultFactory: SandboxFactory = opts =>
-  getSandboxProvider() === 'local' ? localFactory(opts) : railwayFactory(opts);
+const defaultFactory: SandboxFactory = opts => {
+  const provider = getSeededSandboxProvider();
+  if (!provider) throw new Error('No sandbox provider configured');
+  return provider.create(opts);
+};
 
 let sandboxFactory: SandboxFactory = defaultFactory;
 
-/** Override the sandbox factory (tests / alternative providers). */
+/** Override the sandbox factory (tests). */
 export function setSandboxFactory(factory: SandboxFactory): void {
   sandboxFactory = factory;
 }
 
-/** Reset to the default provider-dispatching factory. */
+/** Reset to the default provider-delegating factory. */
 export function resetSandboxFactory(): void {
   sandboxFactory = defaultFactory;
 }

--- a/mastracode/web/src/web/runtime-config.test.ts
+++ b/mastracode/web/src/web/runtime-config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { __resetRuntimeConfigForTests, getAppDatabaseUrl, getPublicUrl, seedRuntimeConfig } from './runtime-config';
+
+const ORIGINAL_APP_DATABASE_URL = process.env.APP_DATABASE_URL;
+
+describe('runtime-config', () => {
+  beforeEach(() => {
+    __resetRuntimeConfigForTests();
+    delete process.env.APP_DATABASE_URL;
+  });
+
+  afterEach(() => {
+    __resetRuntimeConfigForTests();
+    if (ORIGINAL_APP_DATABASE_URL === undefined) {
+      delete process.env.APP_DATABASE_URL;
+    } else {
+      process.env.APP_DATABASE_URL = ORIGINAL_APP_DATABASE_URL;
+    }
+  });
+
+  describe('getAppDatabaseUrl', () => {
+    it('returns the seeded database URL', () => {
+      seedRuntimeConfig({ databaseUrl: 'postgres://seeded/app' });
+      expect(getAppDatabaseUrl()).toBe('postgres://seeded/app');
+    });
+
+    it('prefers the seeded config over the env fallback', () => {
+      process.env.APP_DATABASE_URL = 'postgres://env/app';
+      seedRuntimeConfig({ databaseUrl: 'postgres://seeded/app' });
+      expect(getAppDatabaseUrl()).toBe('postgres://seeded/app');
+    });
+
+    it('seeding without a database wins over env (factory config is authoritative)', () => {
+      process.env.APP_DATABASE_URL = 'postgres://env/app';
+      seedRuntimeConfig({});
+      expect(getAppDatabaseUrl()).toBeUndefined();
+    });
+
+    it('falls back to APP_DATABASE_URL when the factory has not seeded (back-compat)', () => {
+      process.env.APP_DATABASE_URL = 'postgres://env/app';
+      expect(getAppDatabaseUrl()).toBe('postgres://env/app');
+    });
+
+    it('treats an empty env var as unconfigured', () => {
+      process.env.APP_DATABASE_URL = '';
+      expect(getAppDatabaseUrl()).toBeUndefined();
+    });
+  });
+
+  describe('getPublicUrl', () => {
+    it('returns undefined before seeding', () => {
+      expect(getPublicUrl()).toBeUndefined();
+    });
+
+    it('returns the seeded public URL', () => {
+      seedRuntimeConfig({ publicUrl: 'https://factory.acme.com' });
+      expect(getPublicUrl()).toBe('https://factory.acme.com');
+    });
+  });
+
+  it('__resetRuntimeConfigForTests clears the seeded config', () => {
+    seedRuntimeConfig({ databaseUrl: 'postgres://seeded/app', publicUrl: 'https://factory.acme.com' });
+    __resetRuntimeConfigForTests();
+    expect(getPublicUrl()).toBeUndefined();
+    expect(getAppDatabaseUrl()).toBeUndefined();
+  });
+});

--- a/mastracode/web/src/web/runtime-config.test.ts
+++ b/mastracode/web/src/web/runtime-config.test.ts
@@ -1,5 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { __resetRuntimeConfigForTests, getAppDatabaseUrl, getPublicUrl, seedRuntimeConfig } from './runtime-config';
+import type { WebAuthAdapter } from './auth-adapter';
+import {
+  __resetRuntimeConfigForTests,
+  getAppDatabaseUrl,
+  getPublicUrl,
+  getSeededAuthAdapter,
+  isRuntimeConfigSeeded,
+  seedRuntimeConfig,
+} from './runtime-config';
 
 const ORIGINAL_APP_DATABASE_URL = process.env.APP_DATABASE_URL;
 
@@ -55,6 +63,27 @@ describe('runtime-config', () => {
     it('returns the seeded public URL', () => {
       seedRuntimeConfig({ publicUrl: 'https://factory.acme.com' });
       expect(getPublicUrl()).toBe('https://factory.acme.com');
+    });
+  });
+
+  describe('auth adapter slot', () => {
+    const adapter = { kind: 'fake' } as WebAuthAdapter;
+
+    it('is unseeded before the factory runs', () => {
+      expect(isRuntimeConfigSeeded()).toBe(false);
+      expect(getSeededAuthAdapter()).toBeUndefined();
+    });
+
+    it('returns the seeded adapter', () => {
+      seedRuntimeConfig({ authAdapter: adapter });
+      expect(isRuntimeConfigSeeded()).toBe(true);
+      expect(getSeededAuthAdapter()).toBe(adapter);
+    });
+
+    it('seeding without an adapter marks auth explicitly disabled', () => {
+      seedRuntimeConfig({});
+      expect(isRuntimeConfigSeeded()).toBe(true);
+      expect(getSeededAuthAdapter()).toBeUndefined();
     });
   });
 

--- a/mastracode/web/src/web/runtime-config.ts
+++ b/mastracode/web/src/web/runtime-config.ts
@@ -14,6 +14,7 @@
  */
 
 import type { WebAuthAdapter } from './auth-adapter.js';
+import type { WebSandboxProvider } from './sandbox-provider.js';
 
 export interface WebRuntimeConfig {
   /** Postgres connection string for the application database + agent storage. */
@@ -22,6 +23,8 @@ export interface WebRuntimeConfig {
   publicUrl?: string;
   /** Active web auth adapter, or `undefined` when auth is disabled. */
   authAdapter?: WebAuthAdapter;
+  /** Active sandbox provider, or `undefined` when sandboxes are disabled. */
+  sandbox?: WebSandboxProvider;
 }
 
 let seeded: WebRuntimeConfig | undefined;
@@ -58,6 +61,15 @@ export function isRuntimeConfigSeeded(): boolean {
  */
 export function getSeededAuthAdapter(): WebAuthAdapter | undefined {
   return seeded?.authAdapter;
+}
+
+/**
+ * Active sandbox provider seeded by the factory. `undefined` when the factory
+ * was configured without a `sandbox` slot (or never ran) — GitHub-backed
+ * projects stay off in that case.
+ */
+export function getSeededSandboxProvider(): WebSandboxProvider | undefined {
+  return seeded?.sandbox;
 }
 
 /** Reset the registry for test isolation. */

--- a/mastracode/web/src/web/runtime-config.ts
+++ b/mastracode/web/src/web/runtime-config.ts
@@ -1,0 +1,48 @@
+/**
+ * Process-wide registry for factory-resolved deployment configuration.
+ *
+ * `MastraFactory.prepare()` (see `./factory-entry.ts`) seeds this module with
+ * the explicit config the deploy entry passed in. Deep modules that can't be
+ * parameterized through every call site (`github/db.ts`, the auth module)
+ * consult it via getters instead of reading deployment env themselves.
+ *
+ * Once seeded, the seeded config wins unconditionally. The env fallback on the
+ * database getter applies ONLY before seeding, as back-compat for modules and
+ * test suites exercised without booting the factory (existing route suites set
+ * `APP_DATABASE_URL` directly); it is slated for removal once all consumers
+ * seed the registry.
+ */
+
+export interface WebRuntimeConfig {
+  /** Postgres connection string for the application database + agent storage. */
+  databaseUrl?: string;
+  /** Browser-facing origin, normalized without a trailing slash. */
+  publicUrl?: string;
+}
+
+let seeded: WebRuntimeConfig | undefined;
+
+/** Seed the registry with factory-resolved config. Called once by `MastraFactory.prepare()`. */
+export function seedRuntimeConfig(config: WebRuntimeConfig): void {
+  seeded = { ...config };
+}
+
+/**
+ * Postgres connection string for the app tables (github/factory/audit/intake).
+ * Falls back to `APP_DATABASE_URL` only when the factory has not seeded the
+ * registry (back-compat; see module docs).
+ */
+export function getAppDatabaseUrl(): string | undefined {
+  if (seeded) return seeded.databaseUrl;
+  return process.env.APP_DATABASE_URL || undefined;
+}
+
+/** Browser-facing origin resolved by the factory, if seeded. */
+export function getPublicUrl(): string | undefined {
+  return seeded?.publicUrl;
+}
+
+/** Reset the registry for test isolation. */
+export function __resetRuntimeConfigForTests(): void {
+  seeded = undefined;
+}

--- a/mastracode/web/src/web/runtime-config.ts
+++ b/mastracode/web/src/web/runtime-config.ts
@@ -13,11 +13,15 @@
  * seed the registry.
  */
 
+import type { WebAuthAdapter } from './auth-adapter.js';
+
 export interface WebRuntimeConfig {
   /** Postgres connection string for the application database + agent storage. */
   databaseUrl?: string;
   /** Browser-facing origin, normalized without a trailing slash. */
   publicUrl?: string;
+  /** Active web auth adapter, or `undefined` when auth is disabled. */
+  authAdapter?: WebAuthAdapter;
 }
 
 let seeded: WebRuntimeConfig | undefined;
@@ -40,6 +44,20 @@ export function getAppDatabaseUrl(): string | undefined {
 /** Browser-facing origin resolved by the factory, if seeded. */
 export function getPublicUrl(): string | undefined {
   return seeded?.publicUrl;
+}
+
+/** Whether the factory has seeded the registry. */
+export function isRuntimeConfigSeeded(): boolean {
+  return seeded !== undefined;
+}
+
+/**
+ * Active web auth adapter seeded by the factory. `undefined` either because
+ * auth is disabled (seeded without an adapter) or because the factory never
+ * ran — callers that need the distinction check {@link isRuntimeConfigSeeded}.
+ */
+export function getSeededAuthAdapter(): WebAuthAdapter | undefined {
+  return seeded?.authAdapter;
 }
 
 /** Reset the registry for test isolation. */

--- a/mastracode/web/src/web/sandbox-local-provider.ts
+++ b/mastracode/web/src/web/sandbox-local-provider.ts
@@ -1,0 +1,57 @@
+/**
+ * Local (host-process) sandbox provider for the web factory.
+ *
+ * Runs repo materialization and commands directly on the server host instead
+ * of a remote VM, checking out under a per-deploy root directory.
+ *
+ * WARNING: this provider does NOT isolate tenants — every project's git
+ * operations run as the server process on the same host filesystem. It exists
+ * for local single-user development. Do not use it for a shared multi-tenant
+ * deployment; use a real cloud sandbox there.
+ *
+ * ```ts
+ * new MastraFactory({ sandbox: new LocalSandboxProvider() });
+ * ```
+ */
+
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { LocalSandbox } from './github/local-sandbox.js';
+import type { MaterializationSandbox, SandboxCreateOptions, WebSandboxProvider } from './sandbox-provider.js';
+import { repoDirName } from './sandbox-provider.js';
+
+export interface LocalSandboxProviderOptions {
+  /** Host directory checkouts live under. Default `~/.mastracode/web/sandboxes`. */
+  root?: string;
+  /** Idle teardown window (minutes). Meaningless locally (stop is a no-op) but honored for parity. */
+  idleMinutes?: number;
+  /** Per-replica cap on concurrently provisioned sandboxes. 0/omitted = unlimited. */
+  maxSandboxes?: number;
+}
+
+export class LocalSandboxProvider implements WebSandboxProvider {
+  readonly kind = 'local';
+  readonly idleMinutes?: number;
+  readonly maxSandboxes?: number;
+  readonly #root: string;
+
+  constructor(options: LocalSandboxProviderOptions = {}) {
+    const root = options.root?.trim();
+    this.#root = (root || join(homedir(), '.mastracode', 'web', 'sandboxes')).replace(/\/+$/, '');
+    this.idleMinutes = options.idleMinutes;
+    this.maxSandboxes = options.maxSandboxes;
+  }
+
+  /** The host runs git itself, so the local provider is always usable. */
+  isEnabled(): boolean {
+    return true;
+  }
+
+  create({ providerSandboxId }: SandboxCreateOptions): MaterializationSandbox {
+    return new LocalSandbox({ root: this.#root, ...(providerSandboxId ? { sandboxId: providerSandboxId } : {}) });
+  }
+
+  workdirFor(repoFullName: string): string {
+    return `${this.#root}/${repoDirName(repoFullName)}`;
+  }
+}

--- a/mastracode/web/src/web/sandbox-local-provider.ts
+++ b/mastracode/web/src/web/sandbox-local-provider.ts
@@ -18,7 +18,6 @@ import { homedir } from 'node:os';
 import { join } from 'node:path';
 import { LocalSandbox } from './github/local-sandbox.js';
 import type { MaterializationSandbox, SandboxCreateOptions, WebSandboxProvider } from './sandbox-provider.js';
-import { repoDirName } from './sandbox-provider.js';
 
 export interface LocalSandboxProviderOptions {
   /** Host directory checkouts live under. Default `~/.mastracode/web/sandboxes`. */
@@ -51,7 +50,19 @@ export class LocalSandboxProvider implements WebSandboxProvider {
     return new LocalSandbox({ root: this.#root, ...(providerSandboxId ? { sandboxId: providerSandboxId } : {}) });
   }
 
+  /**
+   * Nested `<root>/<owner>/<name>` layout: unlike cloud providers (one VM per
+   * project), every local checkout shares this host root, so `acme/api` and
+   * `other/api` must not resolve to the same directory.
+   */
   workdirFor(repoFullName: string): string {
-    return `${this.#root}/${repoDirName(repoFullName)}`;
+    const [owner, name] = repoFullName.split('/', 2);
+    return `${this.#root}/${sanitizeSegment(owner || 'unknown')}/${sanitizeSegment(name || 'repo')}`;
   }
+}
+
+/** Keep each path piece a single safe segment (no separators or traversal). */
+function sanitizeSegment(segment: string): string {
+  const cleaned = segment.replace(/[^A-Za-z0-9._-]/g, '-').replace(/^\.+/, '');
+  return cleaned || 'repo';
 }

--- a/mastracode/web/src/web/sandbox-provider.test.ts
+++ b/mastracode/web/src/web/sandbox-provider.test.ts
@@ -77,12 +77,25 @@ describe('LocalSandboxProvider', () => {
 
   it('defaults the checkout root to ~/.mastracode/web/sandboxes', () => {
     const provider = new LocalSandboxProvider();
-    expect(provider.workdirFor('acme/widgets')).toBe(join(homedir(), '.mastracode', 'web', 'sandboxes', 'widgets'));
+    expect(provider.workdirFor('acme/widgets')).toBe(
+      join(homedir(), '.mastracode', 'web', 'sandboxes', 'acme', 'widgets'),
+    );
   });
 
   it('honors a custom root and strips trailing slashes', () => {
     const provider = new LocalSandboxProvider({ root: '/tmp/mc-sandboxes/' });
-    expect(provider.workdirFor('acme/widgets')).toBe('/tmp/mc-sandboxes/widgets');
+    expect(provider.workdirFor('acme/widgets')).toBe('/tmp/mc-sandboxes/acme/widgets');
+  });
+
+  it('keeps same-name repos from different owners on distinct checkouts', () => {
+    const provider = new LocalSandboxProvider({ root: '/tmp/mc-sandboxes' });
+    expect(provider.workdirFor('acme/api')).not.toBe(provider.workdirFor('other/api'));
+  });
+
+  it('sanitizes path-hostile owner/name segments', () => {
+    const provider = new LocalSandboxProvider({ root: '/tmp/mc-sandboxes' });
+    expect(provider.workdirFor('../etc/passwd')).toBe('/tmp/mc-sandboxes/repo/etc');
+    expect(provider.workdirFor('ow ner/re;po')).toBe('/tmp/mc-sandboxes/ow-ner/re-po');
   });
 
   it('creates sandboxes with a stable root-keyed id', () => {

--- a/mastracode/web/src/web/sandbox-provider.test.ts
+++ b/mastracode/web/src/web/sandbox-provider.test.ts
@@ -1,0 +1,104 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { LocalSandboxProvider } from './sandbox-local-provider.js';
+import { repoDirName } from './sandbox-provider.js';
+import { RailwaySandboxProvider } from './sandbox-railway-provider.js';
+
+/**
+ * The shipped `WebSandboxProvider` implementations. Getter behavior through
+ * the seeded registry is covered in `github/sandbox.test.ts`; these specs pin
+ * the providers' own contracts: enablement, workdir layout, and create()
+ * producing a sandbox that honors reattach ids.
+ */
+
+const ORIGINAL_RAILWAY_TOKEN = process.env.RAILWAY_API_TOKEN;
+
+beforeEach(() => {
+  delete process.env.RAILWAY_API_TOKEN;
+});
+
+afterEach(() => {
+  if (ORIGINAL_RAILWAY_TOKEN === undefined) delete process.env.RAILWAY_API_TOKEN;
+  else process.env.RAILWAY_API_TOKEN = ORIGINAL_RAILWAY_TOKEN;
+});
+
+describe('repoDirName', () => {
+  it('takes the repo segment of an owner/name full name', () => {
+    expect(repoDirName('acme/widgets')).toBe('widgets');
+  });
+
+  it('falls back to "repo" for an empty name', () => {
+    expect(repoDirName('')).toBe('repo');
+  });
+});
+
+describe('RailwaySandboxProvider', () => {
+  it('is enabled with a constructor token', () => {
+    expect(new RailwaySandboxProvider({ token: 'rw-token' }).isEnabled()).toBe(true);
+  });
+
+  it('is enabled via the Railway SDK env fallback', () => {
+    process.env.RAILWAY_API_TOKEN = 'rw-env-token';
+    expect(new RailwaySandboxProvider().isEnabled()).toBe(true);
+  });
+
+  it('is disabled without any token', () => {
+    expect(new RailwaySandboxProvider().isEnabled()).toBe(false);
+  });
+
+  it('computes the workdir under /workspace by default', () => {
+    expect(new RailwaySandboxProvider({ token: 't' }).workdirFor('acme/widgets')).toBe('/workspace/widgets');
+  });
+
+  it('honors a custom workdir base and strips trailing slashes', () => {
+    const provider = new RailwaySandboxProvider({ token: 't', workdirBase: '/srv/checkouts/' });
+    expect(provider.workdirFor('acme/widgets')).toBe('/srv/checkouts/widgets');
+  });
+
+  it('uses the base as-is when it already ends with the repo name', () => {
+    const provider = new RailwaySandboxProvider({ token: 't', workdirBase: '/workspace/widgets' });
+    expect(provider.workdirFor('acme/widgets')).toBe('/workspace/widgets');
+  });
+
+  it('exposes the configured budget/GC knobs', () => {
+    const provider = new RailwaySandboxProvider({ token: 't', idleMinutes: 45, maxSandboxes: 3 });
+    expect(provider.kind).toBe('railway');
+    expect(provider.idleMinutes).toBe(45);
+    expect(provider.maxSandboxes).toBe(3);
+  });
+});
+
+describe('LocalSandboxProvider', () => {
+  it('is always enabled', () => {
+    expect(new LocalSandboxProvider().isEnabled()).toBe(true);
+  });
+
+  it('defaults the checkout root to ~/.mastracode/web/sandboxes', () => {
+    const provider = new LocalSandboxProvider();
+    expect(provider.workdirFor('acme/widgets')).toBe(join(homedir(), '.mastracode', 'web', 'sandboxes', 'widgets'));
+  });
+
+  it('honors a custom root and strips trailing slashes', () => {
+    const provider = new LocalSandboxProvider({ root: '/tmp/mc-sandboxes/' });
+    expect(provider.workdirFor('acme/widgets')).toBe('/tmp/mc-sandboxes/widgets');
+  });
+
+  it('creates sandboxes with a stable root-keyed id', () => {
+    const provider = new LocalSandboxProvider({ root: '/tmp/mc-sandboxes' });
+    expect(provider.create({}).id).toBe('local:/tmp/mc-sandboxes');
+  });
+
+  it('reattaches by provider sandbox id', () => {
+    const provider = new LocalSandboxProvider({ root: '/tmp/mc-sandboxes' });
+    expect(provider.create({ providerSandboxId: 'local:/tmp/mc-sandboxes' }).id).toBe('local:/tmp/mc-sandboxes');
+  });
+
+  it('exposes the configured budget/GC knobs', () => {
+    const provider = new LocalSandboxProvider({ idleMinutes: 10, maxSandboxes: 2 });
+    expect(provider.kind).toBe('local');
+    expect(provider.idleMinutes).toBe(10);
+    expect(provider.maxSandboxes).toBe(2);
+  });
+});

--- a/mastracode/web/src/web/sandbox-provider.ts
+++ b/mastracode/web/src/web/sandbox-provider.ts
@@ -1,0 +1,89 @@
+/**
+ * Sandbox provider seam for the web factory.
+ *
+ * `WebSandboxProvider` is the public, user-implementable interface behind
+ * which sandbox providers plug into `MastraFactory` (the `sandbox` config
+ * slot). Shipped implementations:
+ *
+ *  - `RailwaySandboxProvider` (`./sandbox-railway-provider.ts`) — isolated cloud VMs.
+ *  - `LocalSandboxProvider` (`./sandbox-local-provider.ts`) — host-process checkouts
+ *    for single-user local development.
+ *
+ * The github project machinery (`./github/sandbox.ts`) consumes whatever
+ * provider the factory seeded — it never selects or constructs one itself,
+ * and it never reads deployment env. The deploy entry maps env vars onto a
+ * provider instance.
+ */
+
+/** Minimal command result shape the repo materializer depends on. */
+export interface SandboxCommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * Minimal live-sandbox surface the github machinery needs: an id, a way to
+ * start it, a way to learn the provider's reattach id, and command execution.
+ */
+export interface MaterializationSandbox {
+  readonly id: string;
+  start(): Promise<void>;
+  getInfo(): Promise<{ metadata?: Record<string, unknown> }>;
+  executeCommand(command: string, args?: string[], options?: { timeout?: number }): Promise<SandboxCommandResult>;
+  /** Tear down the underlying VM. Optional: providers without it are no-ops. */
+  stop?(): Promise<void>;
+}
+
+/** Options for building (or reattaching) one sandbox. */
+export interface SandboxCreateOptions {
+  /** Reattach to this existing provider VM instead of provisioning a new one. */
+  providerSandboxId?: string;
+  /** Environment variables baked into the sandbox. */
+  env?: Record<string, string>;
+  /** Idle teardown window (minutes). The provider stops the VM after this idle period. */
+  idleTimeoutMinutes?: number;
+}
+
+/**
+ * A sandbox provider the factory can be configured with.
+ *
+ * Implementations must be constructible without I/O — provisioning happens in
+ * `create(...)` + `sandbox.start()`, never in the constructor.
+ */
+export interface WebSandboxProvider {
+  /**
+   * Provider discriminator (`'railway'`, `'local'`, or a custom name). Shown
+   * in diagnostics and persisted on project rows so re-opens know which
+   * provider owns a stored sandbox id.
+   */
+  readonly kind: string;
+  /**
+   * Idle teardown window for provisioned sandboxes, in minutes. The consumer
+   * defaults to 30 when omitted.
+   */
+  readonly idleMinutes?: number;
+  /**
+   * Per-replica cap on concurrently provisioned sandboxes. `0`/omitted means
+   * unlimited. A lightweight per-process budget, not a cross-replica scheduler.
+   */
+  readonly maxSandboxes?: number;
+  /**
+   * Whether the provider is usable as configured. `false` keeps GitHub-backed
+   * projects off and surfaces "disabled" in the feature diagnostics instead of
+   * failing at first use (e.g. Railway selected without a token).
+   */
+  isEnabled(): boolean;
+  /** Build a (not-yet-started) sandbox, or reattach when `providerSandboxId` is set. */
+  create(opts: SandboxCreateOptions): MaterializationSandbox;
+  /**
+   * The in-sandbox working directory a repo checks out into. Server-side only;
+   * never derived from client input.
+   */
+  workdirFor(repoFullName: string): string;
+}
+
+/** The repo directory name for a `owner/name` full name. */
+export function repoDirName(repoFullName: string): string {
+  return repoFullName.split('/').pop() || 'repo';
+}

--- a/mastracode/web/src/web/sandbox-railway-provider.ts
+++ b/mastracode/web/src/web/sandbox-railway-provider.ts
@@ -1,0 +1,68 @@
+/**
+ * Railway sandbox provider for the web factory.
+ *
+ * Provisions each GitHub-backed project an isolated cloud VM via
+ * `@mastra/railway`. This is the provider for shared multi-tenant deploys —
+ * repo materialization and agent commands never touch the server host.
+ *
+ * ```ts
+ * new MastraFactory({
+ *   sandbox: new RailwaySandboxProvider({ token: process.env.RAILWAY_API_TOKEN }),
+ * });
+ * ```
+ */
+
+import { RailwaySandbox } from '@mastra/railway';
+import type { MaterializationSandbox, SandboxCreateOptions, WebSandboxProvider } from './sandbox-provider.js';
+import { repoDirName } from './sandbox-provider.js';
+
+export interface RailwaySandboxProviderOptions {
+  /**
+   * Railway API token. Optional because the Railway SDK falls back to its own
+   * `RAILWAY_API_TOKEN` env var (same pattern as the WorkOS SDK credentials).
+   */
+  token?: string;
+  /**
+   * In-sandbox base directory repos check out under. Default `/workspace`.
+   * When the base already ends with the repo name it is used as-is.
+   */
+  workdirBase?: string;
+  /** Idle teardown window (minutes). Consumer defaults to 30 when omitted. */
+  idleMinutes?: number;
+  /** Per-replica cap on concurrently provisioned sandboxes. 0/omitted = unlimited. */
+  maxSandboxes?: number;
+}
+
+export class RailwaySandboxProvider implements WebSandboxProvider {
+  readonly kind = 'railway';
+  readonly idleMinutes?: number;
+  readonly maxSandboxes?: number;
+  readonly #token: string | undefined;
+  readonly #workdirBase: string;
+
+  constructor(options: RailwaySandboxProviderOptions = {}) {
+    this.#token = options.token;
+    this.#workdirBase = (options.workdirBase ?? '/workspace').replace(/\/+$/, '');
+    this.idleMinutes = options.idleMinutes;
+    this.maxSandboxes = options.maxSandboxes;
+  }
+
+  /** Usable only with a token — from the constructor or the SDK's own env fallback. */
+  isEnabled(): boolean {
+    return Boolean(this.#token ?? process.env.RAILWAY_API_TOKEN);
+  }
+
+  create({ providerSandboxId, env, idleTimeoutMinutes }: SandboxCreateOptions): MaterializationSandbox {
+    return new RailwaySandbox({
+      ...(this.#token ? { token: this.#token } : {}),
+      ...(providerSandboxId ? { sandboxId: providerSandboxId } : {}),
+      ...(env ? { env } : {}),
+      ...(idleTimeoutMinutes !== undefined ? { idleTimeoutMinutes } : {}),
+    });
+  }
+
+  workdirFor(repoFullName: string): string {
+    const repoName = repoDirName(repoFullName);
+    return this.#workdirBase.endsWith(`/${repoName}`) ? this.#workdirBase : `${this.#workdirBase}/${repoName}`;
+  }
+}

--- a/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
@@ -1,10 +1,14 @@
 import { Button } from '@mastra/playground-ui/components/Button';
+import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { useState } from 'react';
+import type { FormEvent } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
 import { Wordmark } from '../../../ui';
-import { redirectToLogin } from '../services/auth';
+import { useWebAuth } from '../hooks/useWebAuth';
+import { navigateAfterSignIn, redirectToLogin, signInWithPassword, signUpWithPassword } from '../services/auth';
 
 /**
  * Only accept same-origin paths so a crafted `?returnTo=` can't bounce the
@@ -17,15 +21,107 @@ function safeReturnTo(raw?: string): string {
 }
 
 /**
+ * Email/password credential form for the self-hosted better-auth provider.
+ * Posts to the better-auth endpoints (which set the session cookie), then does
+ * a full navigation to `returnTo` so the app boots with the fresh session.
+ */
+function CredentialSignInForm({ returnTo, signUpDisabled }: { returnTo: string; signUpDisabled: boolean }) {
+  const { baseUrl } = useApiConfig();
+  const [mode, setMode] = useState<'sign-in' | 'sign-up'>('sign-in');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [pending, setPending] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setPending(true);
+    try {
+      if (mode === 'sign-up') {
+        await signUpWithPassword(baseUrl, { name, email, password });
+      } else {
+        await signInWithPassword(baseUrl, { email, password });
+      }
+      navigateAfterSignIn(returnTo);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Authentication failed');
+      setPending(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex w-64 flex-col gap-3">
+      {mode === 'sign-up' ? (
+        <Input
+          type="text"
+          size="sm"
+          placeholder="Name"
+          aria-label="Name"
+          autoComplete="name"
+          required
+          value={name}
+          onChange={e => setName(e.target.value)}
+        />
+      ) : null}
+      <Input
+        type="email"
+        size="sm"
+        placeholder="Email"
+        aria-label="Email"
+        autoComplete="email"
+        required
+        value={email}
+        onChange={e => setEmail(e.target.value)}
+      />
+      <Input
+        type="password"
+        size="sm"
+        placeholder="Password"
+        aria-label="Password"
+        autoComplete={mode === 'sign-up' ? 'new-password' : 'current-password'}
+        required
+        value={password}
+        onChange={e => setPassword(e.target.value)}
+      />
+      {error ? (
+        <Txt as="p" variant="ui-sm" role="alert" className="text-accent2">
+          {error}
+        </Txt>
+      ) : null}
+      <Button type="submit" variant="default" size="sm" disabled={pending}>
+        {mode === 'sign-up' ? 'Sign up' : 'Sign in'}
+      </Button>
+      {!signUpDisabled ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={() => {
+            setError(null);
+            setMode(mode === 'sign-up' ? 'sign-in' : 'sign-up');
+          }}
+        >
+          {mode === 'sign-up' ? 'Have an account? Sign in' : 'New here? Sign up'}
+        </Button>
+      ) : null}
+    </form>
+  );
+}
+
+/**
  * Dedicated `/signin` route rendered when web auth is enabled and the session
- * is unauthenticated. Reuses the sidebar's ghost Sign in button behavior:
- * clicking navigates to the hosted WorkOS login, preserving where the user
- * was headed via `?returnTo=`.
+ * is unauthenticated. Provider-aware: hosted-login providers (WorkOS) get the
+ * redirect button; the self-hosted better-auth provider gets an email/password
+ * form. Both preserve where the user was headed via `?returnTo=`.
  */
 export function SignInPage() {
   const { baseUrl } = useApiConfig();
+  const auth = useWebAuth();
   const [searchParams] = useSearchParams();
   const returnTo = safeReturnTo(searchParams.get('returnTo')?.toString());
+  const credentialForm = auth.data?.provider === 'better-auth';
 
   return (
     <main className="grid h-dvh place-items-center">
@@ -34,9 +130,13 @@ export function SignInPage() {
         <Txt as="p" variant="ui-sm" className="text-icon3">
           Sign in to continue
         </Txt>
-        <Button variant="ghost" size="sm" onClick={() => redirectToLogin(baseUrl, returnTo)}>
-          Sign in
-        </Button>
+        {credentialForm ? (
+          <CredentialSignInForm returnTo={returnTo} signUpDisabled={auth.data?.signUpDisabled === true} />
+        ) : (
+          <Button variant="ghost" size="sm" onClick={() => redirectToLogin(baseUrl, returnTo)}>
+            Sign in
+          </Button>
+        )}
       </div>
     </main>
   );

--- a/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
@@ -12,12 +12,19 @@ import { navigateAfterSignIn, redirectToLogin, signInWithPassword, signUpWithPas
 
 /**
  * Only accept same-origin paths so a crafted `?returnTo=` can't bounce the
- * user to an external site after login. `//host` is protocol-relative, so it
- * is rejected too.
+ * user to an external site after login. Prefix checks alone are not enough —
+ * browsers normalize `/\host` to the protocol-relative `//host` — so the value
+ * is resolved against the page origin and rejected when it leaves it.
  */
-function safeReturnTo(raw?: string): string {
-  if (raw && raw.startsWith('/') && !raw.startsWith('//')) return raw;
-  return '/';
+export function safeReturnTo(raw?: string): string {
+  if (!raw || !raw.startsWith('/') || raw.startsWith('//')) return '/';
+  try {
+    const resolved = new URL(raw, window.location.origin);
+    if (resolved.origin !== window.location.origin) return '/';
+    return `${resolved.pathname}${resolved.search}${resolved.hash}`;
+  } catch {
+    return '/';
+  }
 }
 
 /**

--- a/mastracode/web/src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
@@ -17,6 +17,7 @@ import { renderWithProviders, TEST_BASE_URL } from '../../../../../../../e2e/web
 import { navigateAfterSignIn, redirectToLogin } from '../../services/auth';
 import type * as AuthService from '../../services/auth';
 import { createAppRoutes } from '../../../../router';
+import { safeReturnTo } from '../SignInPage';
 
 // jsdom's `window.location.assign` is unforgeable (cannot be spied on), so the
 // service-level navigation helpers are stubbed instead; `fetchAuthState` and
@@ -131,6 +132,22 @@ describe('SignInPage', () => {
 
       expect(await screen.findByLabelText('Email')).toBeInTheDocument();
       expect(screen.queryByRole('button', { name: 'New here? Sign up' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('returnTo sanitization', () => {
+    it.each([
+      ['/factory/board?x=1#frag', '/factory/board?x=1#frag'],
+      ['//attacker.example', '/'],
+      // Browsers normalize `/\` to `//` — an encoded backslash must not
+      // become a protocol-relative cross-origin redirect.
+      ['/\\attacker.example', '/'],
+      ['/\\/attacker.example', '/'],
+      ['https://attacker.example/x', '/'],
+      ['javascript:alert(1)', '/'],
+      [undefined, '/'],
+    ])('resolves %s to %s against the page origin', (raw, expected) => {
+      expect(safeReturnTo(raw)).toBe(expected);
     });
   });
 });

--- a/mastracode/web/src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * BDD coverage for the provider-aware /signin page.
+ *
+ * Drives the real route table (SignInGate → SignInPage) through a memory
+ * router with MSW stubbing `/auth/me` and the better-auth credential
+ * endpoints. WorkOS deploys keep the hosted-login redirect button; better-auth
+ * deploys get the email/password form posting to `/auth/api/*`.
+ */
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../../../e2e/web-ui/render';
+import { navigateAfterSignIn, redirectToLogin } from '../../services/auth';
+import type * as AuthService from '../../services/auth';
+import { createAppRoutes } from '../../../../router';
+
+// jsdom's `window.location.assign` is unforgeable (cannot be spied on), so the
+// service-level navigation helpers are stubbed instead; `fetchAuthState` and
+// the credential POST helpers stay real so MSW sees the actual requests.
+vi.mock('../../services/auth', async importOriginal => {
+  const actual = await importOriginal<typeof AuthService>();
+  return { ...actual, redirectToLogin: vi.fn(), navigateAfterSignIn: vi.fn() };
+});
+
+const AUTH_ME_URL = `${TEST_BASE_URL}/auth/me`;
+
+afterEach(() => {
+  vi.mocked(redirectToLogin).mockClear();
+  vi.mocked(navigateAfterSignIn).mockClear();
+});
+
+function stubAuthMe(body: Record<string, unknown>) {
+  server.use(http.get(AUTH_ME_URL, () => HttpResponse.json({ authenticated: false, user: null, ...body })));
+}
+
+function renderSignIn(initialEntry = '/signin') {
+  const router = createMemoryRouter(createAppRoutes(), { initialEntries: [initialEntry] });
+  renderWithProviders(<RouterProvider router={router} />);
+  return router;
+}
+
+describe('SignInPage', () => {
+  describe('given a WorkOS (hosted-login) deploy', () => {
+    it('renders the hosted sign-in button and redirects to the login route', async () => {
+      stubAuthMe({ provider: 'workos' });
+      renderSignIn('/signin?returnTo=%2Ffactory%2Fboard');
+
+      const button = await screen.findByRole('button', { name: 'Sign in' });
+      expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
+
+      await userEvent.click(button);
+      expect(redirectToLogin).toHaveBeenCalledWith(TEST_BASE_URL, '/factory/board');
+    });
+  });
+
+  describe('given a better-auth (self-hosted) deploy', () => {
+    it('renders the email/password form instead of the hosted button', async () => {
+      stubAuthMe({ provider: 'better-auth' });
+      renderSignIn();
+
+      expect(await screen.findByLabelText('Email')).toBeInTheDocument();
+      expect(screen.getByLabelText('Password')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Sign in' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'New here? Sign up' })).toBeInTheDocument();
+    });
+
+    it('signs in with credentials and navigates to returnTo', async () => {
+      stubAuthMe({ provider: 'better-auth' });
+      const posted = vi.fn();
+      server.use(
+        http.post(`${TEST_BASE_URL}/auth/api/sign-in/email`, async ({ request }) => {
+          posted(await request.json());
+          return HttpResponse.json({ user: { id: 'user_1' } });
+        }),
+      );
+      renderSignIn('/signin?returnTo=%2Ffactory%2Fboard');
+
+      await userEvent.type(await screen.findByLabelText('Email'), 'ada@example.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'hunter22!');
+      await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      await waitFor(() => expect(navigateAfterSignIn).toHaveBeenCalledWith('/factory/board'));
+      expect(posted).toHaveBeenCalledWith({ email: 'ada@example.com', password: 'hunter22!' });
+    });
+
+    it('surfaces the server error message on failed sign-in', async () => {
+      stubAuthMe({ provider: 'better-auth' });
+      server.use(
+        http.post(`${TEST_BASE_URL}/auth/api/sign-in/email`, () =>
+          HttpResponse.json({ message: 'Invalid email or password' }, { status: 401 }),
+        ),
+      );
+      renderSignIn();
+
+      await userEvent.type(await screen.findByLabelText('Email'), 'ada@example.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+      await userEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('Invalid email or password');
+      expect(navigateAfterSignIn).not.toHaveBeenCalled();
+    });
+
+    it('signs up with name + credentials through the sign-up endpoint', async () => {
+      stubAuthMe({ provider: 'better-auth' });
+      const posted = vi.fn();
+      server.use(
+        http.post(`${TEST_BASE_URL}/auth/api/sign-up/email`, async ({ request }) => {
+          posted(await request.json());
+          return HttpResponse.json({ user: { id: 'user_2' } });
+        }),
+      );
+      renderSignIn();
+
+      await userEvent.click(await screen.findByRole('button', { name: 'New here? Sign up' }));
+      await userEvent.type(screen.getByLabelText('Name'), 'Ada Lovelace');
+      await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com');
+      await userEvent.type(screen.getByLabelText('Password'), 'hunter22!');
+      await userEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+
+      await waitFor(() => expect(navigateAfterSignIn).toHaveBeenCalledWith('/'));
+      expect(posted).toHaveBeenCalledWith({ name: 'Ada Lovelace', email: 'ada@example.com', password: 'hunter22!' });
+    });
+
+    it('hides the sign-up affordance when the server disables sign-up', async () => {
+      stubAuthMe({ provider: 'better-auth', signUpDisabled: true });
+      renderSignIn();
+
+      expect(await screen.findByLabelText('Email')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'New here? Sign up' })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mastracode/web/src/web/ui/domains/auth/index.ts
+++ b/mastracode/web/src/web/ui/domains/auth/index.ts
@@ -6,6 +6,8 @@ export {
   logoutUrl,
   redirectToLogin,
   redirectToLogout,
+  signInWithPassword,
+  signUpWithPassword,
   userSessionResourceId,
 } from './services/auth';
 export type { WebAuthState } from './services/auth';

--- a/mastracode/web/src/web/ui/domains/auth/services/auth.ts
+++ b/mastracode/web/src/web/ui/domains/auth/services/auth.ts
@@ -1,5 +1,5 @@
 /**
- * Client-side glue for the optional WorkOS AuthKit gate (see ../auth.ts).
+ * Client-side glue for the optional web auth gate (see src/web/auth.ts).
  *
  * The server protects the whole surface; this module makes the SPA cooperate:
  * - `fetchAuthState()` reads `/auth/me` to decide whether to show the splash
@@ -16,10 +16,14 @@
  */
 
 export interface WebAuthState {
-  /** Whether the server has WorkOS auth configured. */
+  /** Whether the server has web auth configured (any provider). */
   authEnabled: boolean;
   authenticated: boolean;
   user?: { userId?: string; email?: string; name?: string };
+  /** Active identity provider: 'workos' | 'better-auth' | custom adapter kind. */
+  provider?: string;
+  /** True when the provider hosts credential forms and sign-up is disabled. */
+  signUpDisabled?: boolean;
 }
 
 /**
@@ -62,6 +66,52 @@ export function redirectToLogout(baseUrl: string): void {
 }
 
 /**
+ * POST credentials to a better-auth endpoint (`basePath: /auth/api`). The
+ * session cookie is set by the response; the caller navigates afterwards.
+ * Throws with the server's message so the sign-in form can display it.
+ */
+async function postBetterAuthCredentials(baseUrl: string, path: string, body: Record<string, string>): Promise<void> {
+  const res = await fetch(`${baseUrl}/auth/api/${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    let message = 'Authentication failed';
+    try {
+      const data = (await res.json()) as { message?: string };
+      if (data?.message) message = data.message;
+    } catch {
+      // Non-JSON error body — keep the generic message.
+    }
+    throw new Error(message);
+  }
+}
+
+/**
+ * Full-page navigation after a successful credential sign-in, so the app boots
+ * with the fresh session cookie. Service-level (like `redirectToLogin`) because
+ * jsdom's `window.location.assign` is unforgeable in tests.
+ */
+export function navigateAfterSignIn(returnTo: string): void {
+  window.location.assign(returnTo);
+}
+
+/** Email/password sign-in against the self-hosted better-auth provider. */
+export function signInWithPassword(baseUrl: string, input: { email: string; password: string }): Promise<void> {
+  return postBetterAuthCredentials(baseUrl, 'sign-in/email', input);
+}
+
+/** Email/password sign-up against the self-hosted better-auth provider. */
+export function signUpWithPassword(
+  baseUrl: string,
+  input: { name: string; email: string; password: string },
+): Promise<void> {
+  return postBetterAuthCredentials(baseUrl, 'sign-up/email', input);
+}
+
+/**
  * Fetch the current auth state from `/auth/me`. When the route is missing (auth
  * disabled), reports `authEnabled: false` so the UI hides all auth affordances.
  */
@@ -77,11 +127,15 @@ export async function fetchAuthState(baseUrl: string): Promise<WebAuthState> {
     const data = (await res.json()) as {
       authenticated?: boolean;
       user?: { userId?: string; email?: string; name?: string } | null;
+      provider?: string;
+      signUpDisabled?: boolean;
     };
     return {
       authEnabled: true,
       authenticated: Boolean(data.authenticated),
       user: data.user ?? undefined,
+      provider: data.provider,
+      signUpDisabled: data.signUpDisabled,
     };
   } catch {
     // Network error or non-JSON response → treat as auth not configured so the

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
@@ -45,9 +45,14 @@ export function useAgentControllerEvents({
       if (connectedSnapshotRef.current === 'connected') setConnectionState('dropped');
     };
 
+    // Deliberately NOT passing `reconnect: true`: the SDK's internal reconnect
+    // swallows stream drops (onError never fires), so the drop → state re-sync
+    // → resubscribe loop in useAgentControllerConnection never runs and events
+    // emitted during the gap are lost until a full page refresh. Recovery here
+    // is owned by that loop: onError marks the stream dropped, the session
+    // sync poll repairs state, and the new `epoch` resubscribes.
     void session
       .subscribe({
-        reconnect: true,
         onEvent: event => onEventRef.current(event),
         onError: () => {
           if (!disposed) disconnect();

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
@@ -45,12 +45,14 @@ export function useAgentControllerEvents({
       if (connectedSnapshotRef.current === 'connected') setConnectionState('dropped');
     };
 
-    // Deliberately NOT passing `reconnect: true`: the SDK's internal reconnect
-    // swallows stream drops (onError never fires), so the drop → state re-sync
-    // → resubscribe loop in useAgentControllerConnection never runs and events
-    // emitted during the gap are lost until a full page refresh. Recovery here
-    // is owned by that loop: onError marks the stream dropped, the session
-    // sync poll repairs state, and the new `epoch` resubscribes.
+    // Deliberately NOT passing `reconnect`: the server does not replay events
+    // missed while disconnected, so a drop must trigger a state re-sync before
+    // resubscribing. Recovery is owned by the loop in
+    // useAgentControllerConnection: onError marks the stream dropped, the
+    // session sync poll repairs state, and the new `epoch` resubscribes. The
+    // SDK's `reconnect` + `onReconnect` could re-establish transport faster,
+    // but the epoch resubscribe would tear that stream down anyway — one
+    // recovery owner keeps this correct and simple.
     void session
       .subscribe({
         onEvent: event => onEventRef.current(event),


### PR DESCRIPTION
## Summary

MastraCode Web currently hardcodes its infrastructure: WorkOS is the only auth option (when WorkOS is down, sign-in and every org-gated feature — GitHub connect, Factory, Audit — is down with it), Railway is the only sandbox option, and deployment configuration is ~200 lines of scattered env reads in the entry module.

This PR makes the web factory configurable through a single entry point:

### `MastraFactory` — one explicit config object

```ts
// src/mastra/index.ts — the whole entry
export const factory = new MastraFactory({
  auth: new WorkOSWebAuth({ ... }),        // or BetterAuthWebAuth, or any custom WebAuthAdapter; omit → open server
  sandbox: new RailwaySandboxProvider({ ... }), // or LocalSandboxProvider, or any custom WebSandboxProvider
  database: process.env.APP_DATABASE_URL, // agent storage + app tables (one Postgres)
  pubsub: redisUrl ? new RedisStreamsPubSub({ url: redisUrl }) : undefined,
  publicUrl: process.env.MASTRACODE_PUBLIC_URL,
});

export const mastra = new Mastra(await factory.prepare());
await factory.finalize();
```

The factory never reads env and never constructs providers itself. The shipped entry maps today's env vars onto explicit instances, so existing deploys behave identically — the env → slot mapping is visible in one file instead of buried across modules. Deep modules consume the resolved config through a small runtime-config registry (`getAppDatabaseUrl()`, seeded auth/sandbox providers).

### Pluggable auth (`WebAuthAdapter`)

- **`WorkOSWebAuth`** — the existing hosted-AuthKit flow, extracted behind the interface verbatim (zero behavior change).
- **`BetterAuthWebAuth`** — new self-hosted email/password auth on the app's own Postgres (better-auth + organization plugin). No external identity vendor in the availability path. Personal-org bootstrap mirrors WorkOS semantics, so all org-scoped routes (`webAuthTenant`) work unchanged. Sign-up can be disabled via `MASTRACODE_AUTH_SIGNUP_DISABLED=1`.
- WorkOS-only capabilities (audit-log export, Admin Portal link) gate on the active adapter kind and become clean no-ops/404s under other providers.
- The SPA sign-in page is provider-aware: hosted-login button for WorkOS, email/password form (with optional sign-up) for better-auth, driven by a new `provider` field on `/auth/me`.

### Pluggable sandboxes (`WebSandboxProvider`)

- **`RailwaySandboxProvider`** — isolated cloud VMs (existing behavior).
- **`LocalSandboxProvider`** — host-process checkouts for single-user local dev.
- `github/sandbox.ts` consumes whatever provider the factory seeded — no provider selection or env reads in the module.

### Chat streaming regression fix + `subscribe()` hardening

Chat responses stopped streaming live on `main` (they only appeared after a refresh). Root cause: #19560 wired `reconnect: true` into the web's SSE hook, but the SDK's silent transport reconnect swallows stream drops — the web's recovery loop (drop → `onError` → state re-sync → resubscribe) never ran, and since the server doesn't replay missed events, the gap was silently lost. This PR:

- Removes `reconnect` from the web hook — recovery has one owner: the connection-level drop → re-sync → resubscribe loop (pinned by MSW specs and the sse-reconnect e2e scenario).
- Fixes the `@mastra/client-js` `subscribe()` contract so the reconnect feature is safe for other consumers:
  - Resolves only once the stream is actually established; rejects when it can't connect, leaving no background retry loop (reconnect governs only re-establishment after an established stream drops).
  - Fires a new `onReconnect` callback on each re-established stream so stateful consumers can re-sync missed events.
  - Backs off exponentially (`delayMs` → `maxDelayMs`, retry budget resets per outage) instead of retrying every second forever.

### Constraint

The deployer's `checkConfigExport` Babel plugin requires a literal `export const mastra = new Mastra(...)` in the entry AST, so `factory.prepare()` returns constructor args and the `new Mastra(...)` literal stays in the entry.

## Test plan

- [x] `factory-entry` specs: slot flow-through (database → storage config, pubsub passthrough + cross-process leases, auth/sandbox seeding), adapter `init()` called once with factory context, init failures surface at `prepare()`, open server when auth omitted
- [x] `BetterAuthWebAuth` unit tests: cookie + bearer authentication, personal-org bootstrap (existing membership vs create, idempotent slug, concurrent recovery), sign-up gating, logout cookie, `/auth/me` shape
- [x] Existing WorkOS `auth.test.ts` coverage passes unchanged (behavior-frozen extraction)
- [x] Audit gating specs: WorkOS sink no-ops and portal-link 404s when the active adapter isn't WorkOS
- [x] `WebSandboxProvider` specs: enablement, workdir layout, reattach ids for both shipped providers
- [x] MSW specs: SignInPage renders the hosted button under `workos` and the credential form under `better-auth`
- [x] client-js `subscribe()` specs: reject-on-initial-failure (with and without reconnect), onReconnect ordering, exponential backoff timing, reconnect/unsubscribe/consumer-error paths (28 tests, full client-js suite green)
- [x] MSW reconnect specs green again: stream drop → state re-sync → resubscribe (these were red on `main` since #19560)
- [x] Full `mastracode/web` suites: 601 unit + 89 node + 442 MSW tests passing against the rebuilt client-js dist
- [x] `pnpm check` (server + UI tsconfigs) clean, prettier clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes MastraCode easier to deploy by putting authentication, databases, sandboxes, and other settings in one configurable place. It also makes sign-in and live chat more reliable when connections fail.

## What changed

- Added `MastraFactory` and centralized runtime configuration.
- Added pluggable authentication:
  - WorkOS
  - Self-hosted Better Auth with credentials and organization setup
- Added pluggable sandbox providers:
  - Railway
  - Explicitly enabled local sandboxes
- Added provider-aware sign-in, logout, cookies, redirects, audit behavior, and organization protection.
- Added runtime configuration for databases, pub/sub, public URLs, CORS, and sandbox limits.
- Improved sandbox checkout path isolation and environment parsing.
- Hardened factory initialization and concurrent preparation handling.
- Fixed chat streaming recovery by removing SDK-level SSE reconnects from the web hook.
- Improved `client-js` subscriptions:
  - Initial connection failures reject immediately.
  - Reconnects occur only after an established stream drops.
  - Added exponential backoff with capped delays.
  - Added reconnection callbacks and terminal error handling.
  - Prevented consumer callback errors from breaking reconnect loops.
- Added extensive unit, integration, MSW, type-check, and formatting coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->