### PR TITLE
fix(playground-ui): ClampedText a11y and clamp-measure cleanup follow-up

### DIFF
--- a/.changeset/cold-rice-wink.md
+++ b/.changeset/cold-rice-wink.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed the ClampedText read-more button to announce its expanded state to screen readers, and fixed clamp measurement so font-load re-measure and effect cleanup still run in browsers without ResizeObserver.

--- a/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
+++ b/packages/playground-ui/src/ds/components/ClampedText/clamped-text.tsx
@@ -48,6 +48,7 @@ export function ClampedText({
           variant="ghost"
           size="xs"
           className="mt-1 -ml-[.8em] self-start justify-self-start"
+          aria-expanded={isExpanded}
           onClick={() => setIsExpanded(v => !v)}
         >
           {isExpanded ? showLessLabel : readMoreLabel}

--- a/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
+++ b/packages/playground-ui/src/hooks/use-is-clamped.test.tsx
@@ -54,6 +54,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  Reflect.deleteProperty(document, 'fonts');
 });
 
 describe('useIsClamped', () => {
@@ -80,6 +81,27 @@ describe('useIsClamped', () => {
     act(() => result.current.ref(createClampableElement({ scrollHeight: 60, clientHeight: 40 })));
 
     expect(result.current.isClamped).toBe(true);
+  });
+
+  it('re-measures on font load even when ResizeObserver is unsupported', async () => {
+    vi.stubGlobal('ResizeObserver', undefined);
+    let fontsReady!: () => void;
+    Object.defineProperty(document, 'fonts', {
+      configurable: true,
+      value: { ready: new Promise<void>(resolve => (fontsReady = resolve)) },
+    });
+
+    const element = createClampableElement({ scrollHeight: 60, clientHeight: 40 });
+    const { result } = renderHook(() => useIsClamped());
+
+    act(() => result.current.ref(element));
+    expect(result.current.isClamped).toBe(true);
+
+    setElementSize(element, { scrollHeight: 60, clientHeight: 60 });
+    fontsReady();
+    await act(async () => {});
+
+    expect(result.current.isClamped).toBe(false);
   });
 
   it('re-measures when the element resizes', () => {

--- a/packages/playground-ui/src/hooks/use-is-clamped.ts
+++ b/packages/playground-ui/src/hooks/use-is-clamped.ts
@@ -30,16 +30,17 @@ export function useIsClamped<TElement extends HTMLElement = HTMLElement>({
 
     measure();
 
-    if (typeof ResizeObserver === 'undefined') return;
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
+    let observer: ResizeObserver | undefined;
+    if (typeof ResizeObserver !== 'undefined') {
+      observer = new ResizeObserver(measure);
+      observer.observe(element);
+    }
     // Font swaps change line wrapping without resizing the observed box.
     document.fonts?.ready.then(measure).catch(() => {});
 
     return () => {
       stopped = true;
-      observer.disconnect();
+      observer?.disconnect();
     };
   }, [element, enabled]);
 


### PR DESCRIPTION
## Summary

Follow-up to #19565 addressing the two CodeRabbit review comments:

- **ClampedText**: added `aria-expanded` to the read-more toggle so screen readers announce the disclosure state.
- **useIsClamped**: when `ResizeObserver` is unsupported, the effect returned early — skipping both the `document.fonts.ready` re-measure and the cleanup function (so the `stopped` guard never armed, allowing a state update on an unmounted component). The observer is now created conditionally so the font-load listener and cleanup always run.

## Testing

- New hook test: re-measures on font load with `ResizeObserver` unsupported (the previously skipped path).
- `vitest run src/hooks/use-is-clamped.test.tsx` → 6/6 passing; `tsc --noEmit` and `eslint --max-warnings 0` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The “read more” button now tells screen readers whether text is expanded, and text sizing updates correctly even in browsers missing a newer browser feature. Tests verify the fix and cleanup behavior.

## Changes

- Added `aria-expanded` to the `ClampedText` toggle.
- Preserved font-load remeasurement and effect cleanup when `ResizeObserver` is unavailable.
- Added test coverage for font-load remeasurement without `ResizeObserver`.
- Added a patch changeset for `@mastra/playground-ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->