### PR TITLE
feat(core): auto-instrument workspaces when Mastra observability is configured

### DIFF
--- a/.changeset/workspace-observability-instrumentation.md
+++ b/.changeset/workspace-observability-instrumentation.md
@@ -14,4 +14,20 @@ A new `WorkspaceActivityEvent` bus channel carries two variants:
 
 Exporters and bridges can opt in by implementing the new optional `onWorkspaceActivityEvent(event)` hook on `ObservabilityEvents`. Handlers that don't implement it silently drop the events.
 
+```ts
+import type { ObservabilityExporter, WorkspaceActivityEvent } from '@mastra/core/observability';
+
+export const workspaceActivityExporter: ObservabilityExporter = {
+  name: 'workspace-activity-logger',
+  onWorkspaceActivityEvent(event: WorkspaceActivityEvent) {
+    if (event.type === 'filesystem_change') {
+      console.log('[fs]', event.change.operation, event.change.path);
+    } else {
+      // 'sandbox_output' — event.output.chunk carries stdout/stderr text
+      console.log('[sb]', event.output.stream, event.output.chunk);
+    }
+  },
+};
+```
+
 Agent-owned workspaces (`new Agent({ workspace })`) are wrapped automatically via `Agent.__registerMastra` fanout.

--- a/.changeset/workspace-observability-instrumentation.md
+++ b/.changeset/workspace-observability-instrumentation.md
@@ -1,0 +1,17 @@
+---
+'@mastra/core': minor
+'@mastra/observability': minor
+---
+
+Auto-instrument workspaces when Mastra observability is configured.
+
+When a `Workspace` is registered on a `Mastra` instance that has `observability` configured, its filesystem and sandbox providers are transparently wrapped so every method call emits a span, a duration metric, an error counter (on throw), and a structured log. Workspaces created standalone or attached to a `Mastra` without `observability` are unaffected — the raw provider is returned so there is zero overhead.
+
+A new `WorkspaceActivityEvent` bus channel carries two variants:
+
+- `sandbox_output` — stdout/stderr from `executeCommand` and `processes.spawn` (chunks over 16 KB are truncated and carry `truncated: true`; stdin is never emitted)
+- `filesystem_change` — path + operation metadata for mutating filesystem calls (`writeFile`, `appendFile`, `deleteFile`, `copyFile`, `moveFile`, `mkdir`, `rmdir`). File contents are never included.
+
+Exporters and bridges can opt in by implementing the new optional `onWorkspaceActivityEvent(event)` hook on `ObservabilityEvents`. Handlers that don't implement it silently drop the events.
+
+Agent-owned workspaces (`new Agent({ workspace })`) are wrapped automatically via `Agent.__registerMastra` fanout.

--- a/docs/src/content/en/docs/workspace/overview.mdx
+++ b/docs/src/content/en/docs/workspace/overview.mdx
@@ -95,6 +95,12 @@ For manual cleanup, use [`mastra.removeWorkspace()`](/reference/core/removeWorks
 
 Static providers are owned by the workspace. Resolver-backed providers are owned by your application because the workspace creates them at request time. See [dynamic sandbox lifecycle ownership](/docs/workspace/sandbox#lifecycle-ownership) for the resolver cleanup model.
 
+## Observability
+
+When a workspace is registered on a `Mastra` instance that has `observability` configured, its filesystem and sandbox providers are automatically instrumented. Every method call emits a span, a duration metric, and a structured log. Mutating filesystem operations (`writeFile`, `appendFile`, `deleteFile`, `copyFile`, `moveFile`, `mkdir`, `rmdir`) emit a `filesystem_change` event on the workspace-activity channel, and sandbox stdout/stderr is emitted as `sandbox_output` events (chunks larger than 16 KB are truncated with a `truncated: true` flag). File contents are never included in these events.
+
+Workspaces created standalone (without a `Mastra` parent) are not instrumented, and when `observability` is not configured on Mastra the raw provider is returned unchanged so there is zero overhead.
+
 ## Configuration patterns
 
 Workspaces support several configuration patterns depending on what capabilities your agent needs. The two main building blocks are `filesystem` (file tools) and `sandbox` (command execution), with `mounts` as the way to bridge cloud storage into sandboxes.

--- a/observability/mastra/scripts/smoke-workspace-observability.mjs
+++ b/observability/mastra/scripts/smoke-workspace-observability.mjs
@@ -12,8 +12,6 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { Mastra } from '@mastra/core';
-import { SpanType } from '@mastra/core/observability';
-import { executeWithContext } from '@mastra/core/observability/context-storage';
 import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
 import { Observability } from '@mastra/observability';
 
@@ -91,25 +89,12 @@ const sb = workspace.sandbox;
 process.stdout.write(`fs is Proxy (wrapped): ${fs !== workspace._fs}\n`);
 process.stdout.write(`sb is Proxy (wrapped): ${sb !== workspace._sandbox}\n`);
 
-// Open an ambient root span so the wrapper opens child spans (mirrors how tool
-// calls nest workspace ops under an AGENT_RUN span at runtime).
-const observabilityInstance = observability.getDefaultInstance();
-const rootSpan = observabilityInstance.startSpan({
-  type: SpanType.AGENT_RUN,
-  name: 'smoke-root',
-  input: { probe: true },
-});
-
-let exec;
-await executeWithContext({
-  span: rootSpan,
-  fn: async () => {
-    await fs.writeFile('smoke.txt', 'hi');
-    await fs.readFile('smoke.txt');
-    exec = await sb.executeCommand('echo hello');
-  },
-});
-rootSpan.end();
+// Direct calls — no ambient span. The wrapper is expected to open its own root
+// workspace:{filesystem|sandbox}:<op> span per call and correlate metrics,
+// logs, and activity events against it.
+await fs.writeFile('smoke.txt', 'hi');
+await fs.readFile('smoke.txt');
+const exec = await sb.executeCommand('echo hello');
 process.stdout.write(`exec.exitCode=${exec.exitCode} exec.stdout=${JSON.stringify(exec.stdout)}\n`);
 
 await observability.flush();

--- a/observability/mastra/scripts/smoke-workspace-observability.mjs
+++ b/observability/mastra/scripts/smoke-workspace-observability.mjs
@@ -1,0 +1,204 @@
+/**
+ * Manual smoke — end-to-end verification that when a `Mastra` with
+ * `observability` configured owns a workspace backed by real `LocalFilesystem`
+ * + `LocalSandbox`, every wrapped call fans out to all four observability
+ * hooks with correlated traceId / spanId across signals.
+ *
+ * Prints a compact report and exits non-zero on any failed assertion.
+ */
+
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { Mastra } from '@mastra/core';
+import { SpanType } from '@mastra/core/observability';
+import { executeWithContext } from '@mastra/core/observability/context-storage';
+import { Workspace, LocalFilesystem, LocalSandbox } from '@mastra/core/workspace';
+import { Observability } from '@mastra/observability';
+
+// ---------------------------------------------------------------------------
+// Capture: implement ALL four hooks on a single ObservabilityExporter shim.
+// ---------------------------------------------------------------------------
+
+const captured = {
+  tracing: [],
+  logs: [],
+  metrics: [],
+  activity: [],
+};
+
+const captureExporter = {
+  name: 'smoke-capture-exporter',
+  exportTracingEvent: async () => {},
+  flush: async () => {},
+  shutdown: async () => {},
+  onTracingEvent: (event) => {
+    captured.tracing.push(event);
+  },
+  onLogEvent: (event) => {
+    captured.logs.push(event);
+  },
+  onMetricEvent: (event) => {
+    captured.metrics.push(event);
+  },
+  onWorkspaceActivityEvent: (event) => {
+    captured.activity.push(event);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Setup: Mastra with Observability instance registered, LocalFilesystem +
+// LocalSandbox workspace, workingDirectory pointed at a per-run temp dir.
+// ---------------------------------------------------------------------------
+
+const workDir = mkdtempSync(join(tmpdir(), 'ws-obs-smoke-'));
+process.stdout.write(`workDir: ${workDir}\n`);
+
+const observability = new Observability({
+  configs: {
+    default: {
+      serviceName: 'mastra-workspace-obs-smoke',
+      exporters: [captureExporter],
+      // Default minLevel is 'warn'; explicitly enable info so the wrapper's
+      // success-path structured logs (`workspace.filesystem.writeFile`, etc.)
+      // are exported and this smoke can assert on them.
+      logging: { level: 'info' },
+    },
+  },
+});
+
+const workspace = new Workspace({
+  id: 'smoke-ws',
+  name: 'smoke-workspace',
+  filesystem: new LocalFilesystem({ basePath: workDir }),
+  sandbox: new LocalSandbox({ workingDirectory: workDir }),
+});
+
+const mastra = new Mastra({
+  logger: false,
+  observability,
+});
+mastra.addWorkspace(workspace);
+
+// ---------------------------------------------------------------------------
+// Exercise: writeFile → readFile → executeCommand.
+// ---------------------------------------------------------------------------
+
+const fs = workspace.filesystem;
+const sb = workspace.sandbox;
+
+process.stdout.write(`fs is Proxy (wrapped): ${fs !== workspace._fs}\n`);
+process.stdout.write(`sb is Proxy (wrapped): ${sb !== workspace._sandbox}\n`);
+
+// Open an ambient root span so the wrapper opens child spans (mirrors how tool
+// calls nest workspace ops under an AGENT_RUN span at runtime).
+const observabilityInstance = observability.getDefaultInstance();
+const rootSpan = observabilityInstance.startSpan({
+  type: SpanType.AGENT_RUN,
+  name: 'smoke-root',
+  input: { probe: true },
+});
+
+let exec;
+await executeWithContext({
+  span: rootSpan,
+  fn: async () => {
+    await fs.writeFile('smoke.txt', 'hi');
+    await fs.readFile('smoke.txt');
+    exec = await sb.executeCommand('echo hello');
+  },
+});
+rootSpan.end();
+process.stdout.write(`exec.exitCode=${exec.exitCode} exec.stdout=${JSON.stringify(exec.stdout)}\n`);
+
+await observability.flush();
+await observability.shutdown();
+
+// ---------------------------------------------------------------------------
+// Report + assertions.
+// ---------------------------------------------------------------------------
+
+process.stdout.write('\n=== Captured counts ===\n');
+process.stdout.write(`  tracing:  ${captured.tracing.length}\n`);
+process.stdout.write(`  logs:     ${captured.logs.length}\n`);
+process.stdout.write(`  metrics:  ${captured.metrics.length}\n`);
+process.stdout.write(`  activity: ${captured.activity.length}\n`);
+
+const failures = [];
+
+// All four hooks fired.
+if (captured.tracing.length === 0) failures.push('no tracing events captured');
+if (captured.logs.length === 0) failures.push('no log events captured');
+if (captured.metrics.length === 0) failures.push('no metric events captured');
+if (captured.activity.length === 0) failures.push('no workspace_activity events captured');
+
+// filesystem_change: EXACTLY one for the write, and none for the read.
+const fsChanges = captured.activity.filter((e) => e.type === 'filesystem_change');
+const writeEvents = fsChanges.filter((e) => e.change.operation === 'write');
+const readEvents = fsChanges.filter((e) => e.change.operation === 'read');
+if (writeEvents.length !== 1) failures.push(`expected 1 filesystem_change{write}, got ${writeEvents.length}`);
+if (readEvents.length !== 0) failures.push(`expected 0 filesystem_change events for read, got ${readEvents.length}`);
+
+// sandbox_output: at least one stdout event carrying "hello" from `echo hello`.
+const sandboxOutputs = captured.activity.filter((e) => e.type === 'sandbox_output');
+const stdoutEvents = sandboxOutputs.filter((e) => e.output.stream === 'stdout' && e.output.source === 'exec');
+if (stdoutEvents.length < 1) failures.push(`expected >=1 sandbox_output{stdout,exec}, got ${stdoutEvents.length}`);
+if (stdoutEvents.length > 0 && !stdoutEvents[0].output.chunk.includes('hello')) {
+  failures.push(`sandbox_output stdout chunk did not include 'hello': ${JSON.stringify(stdoutEvents[0].output.chunk)}`);
+}
+
+// Cross-signal correlation: pick the writeFile activity event and verify at
+// least one metric / log / span shares the same traceId (or spanId when
+// available).
+const writeEvent = writeEvents[0];
+if (writeEvent) {
+  const traceId = writeEvent.change.traceId;
+  const spanId = writeEvent.change.spanId;
+  process.stdout.write(`\n=== writeFile correlation ===\n`);
+  process.stdout.write(`  traceId=${traceId ?? '<none>'} spanId=${spanId ?? '<none>'}\n`);
+
+  const spanMatch = captured.tracing.find(
+    (t) => t.exportedSpan?.traceId === traceId || t.exportedSpan?.id === spanId,
+  );
+  const metricMatch = captured.metrics.find(
+    (m) => m.metric?.traceId === traceId || m.metric?.spanId === spanId,
+  );
+  const logMatch = captured.logs.find(
+    (l) => l.log?.traceId === traceId || l.log?.spanId === spanId,
+  );
+
+  process.stdout.write(`  span match:   ${spanMatch ? spanMatch.exportedSpan.name : '<none>'}\n`);
+  process.stdout.write(`  metric match: ${metricMatch ? metricMatch.metric.name : '<none>'}\n`);
+  process.stdout.write(`  log match:    ${logMatch ? logMatch.log.message : '<none>'}\n`);
+
+  if (traceId || spanId) {
+    if (!spanMatch) failures.push('no tracing event correlated with writeFile activity event');
+    if (!metricMatch) failures.push('no metric correlated with writeFile activity event');
+    if (!logMatch) failures.push('no log correlated with writeFile activity event');
+  } else {
+    process.stdout.write(`  (writeFile ran outside an active trace context — correlation ids optional)\n`);
+  }
+}
+
+// Print names of first few captured items to aid debugging.
+process.stdout.write('\n=== Sample capture ===\n');
+process.stdout.write(`  first span:   ${captured.tracing[0]?.exportedSpan?.name ?? '<none>'}\n`);
+process.stdout.write(`  first metric: ${captured.metrics[0]?.metric?.name ?? '<none>'}\n`);
+process.stdout.write(`  first log:    ${captured.logs[0]?.log?.message ?? '<none>'}\n`);
+process.stdout.write(`  first activity: ${captured.activity[0]?.type ?? '<none>'}\n`);
+
+// ---------------------------------------------------------------------------
+// Cleanup + exit.
+// ---------------------------------------------------------------------------
+
+rmSync(workDir, { recursive: true, force: true });
+
+if (failures.length > 0) {
+  process.stdout.write('\n=== FAILED ===\n');
+  for (const f of failures) process.stdout.write(`  - ${f}\n`);
+  process.exit(1);
+}
+
+process.stdout.write('\n=== SMOKE PASSED ===\n');
+process.exit(0);

--- a/observability/mastra/src/bus/observability-bus.test.ts
+++ b/observability/mastra/src/bus/observability-bus.test.ts
@@ -338,6 +338,72 @@ describe('ObservabilityBus', () => {
     });
   });
 
+  describe('workspace activity event routing', () => {
+    it('should route sandbox_output events to onWorkspaceActivityEvent', () => {
+      const onWorkspaceActivityEvent = vi.fn();
+      const exporter = createMockExporter({ onWorkspaceActivityEvent });
+      bus.registerExporter(exporter);
+
+      const event = {
+        type: 'sandbox_output' as const,
+        output: {
+          eventId: 'wa-1',
+          timestamp: new Date(),
+          workspaceId: 'ws-1',
+          sandboxId: 'sb-1',
+          source: 'exec' as const,
+          stream: 'stdout' as const,
+          chunk: 'hello',
+          truncated: false,
+        },
+      };
+      bus.emit(event);
+
+      expect(onWorkspaceActivityEvent).toHaveBeenCalledWith(event);
+    });
+
+    it('should route filesystem_change events to onWorkspaceActivityEvent', () => {
+      const onWorkspaceActivityEvent = vi.fn();
+      const exporter = createMockExporter({ onWorkspaceActivityEvent });
+      bus.registerExporter(exporter);
+
+      const event = {
+        type: 'filesystem_change' as const,
+        change: {
+          eventId: 'wa-2',
+          timestamp: new Date(),
+          workspaceId: 'ws-1',
+          path: '/foo.txt',
+          operation: 'write' as const,
+          bytes: 5,
+        },
+      };
+      bus.emit(event);
+
+      expect(onWorkspaceActivityEvent).toHaveBeenCalledWith(event);
+    });
+
+    it('should not fail when exporter has no onWorkspaceActivityEvent handler', () => {
+      const exporter = createMockExporter({ onWorkspaceActivityEvent: undefined });
+      bus.registerExporter(exporter);
+
+      expect(() =>
+        bus.emit({
+          type: 'sandbox_output' as const,
+          output: {
+            eventId: 'wa-3',
+            timestamp: new Date(),
+            workspaceId: 'ws-1',
+            source: 'exec' as const,
+            stream: 'stdout' as const,
+            chunk: 'hi',
+            truncated: false,
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
+
   describe('drop event routing', () => {
     it('should route drop events to exporters and bridge', () => {
       const exporterDrop = vi.fn();

--- a/observability/mastra/src/bus/route-event.ts
+++ b/observability/mastra/src/bus/route-event.ts
@@ -15,6 +15,7 @@ import type {
   MetricEvent,
   ScoreEvent,
   FeedbackEvent,
+  WorkspaceActivityEvent,
   ObservabilityEvent,
   ObservabilityDropEvent,
 } from '@mastra/core/observability';
@@ -103,6 +104,18 @@ export function routeToHandler(
       case 'feedback':
         if (handler.onFeedbackEvent) {
           return catchAsyncResult(handler.onFeedbackEvent(event as FeedbackEvent), handler.name, 'feedback', logger);
+        }
+        break;
+
+      case 'sandbox_output':
+      case 'filesystem_change':
+        if (handler.onWorkspaceActivityEvent) {
+          return catchAsyncResult(
+            handler.onWorkspaceActivityEvent(event as WorkspaceActivityEvent),
+            handler.name,
+            'workspace_activity',
+            logger,
+          );
         }
         break;
     }

--- a/observability/mastra/src/exporters/default.ts
+++ b/observability/mastra/src/exporters/default.ts
@@ -466,6 +466,12 @@ export class DefaultExporter extends BaseExporter {
         case 'score':
           createScoreEvents.push(createEvent);
           break;
+        case 'sandbox_output':
+        case 'filesystem_change':
+          // Workspace activity events are routed via `onWorkspaceActivityEvent`
+          // on individual handlers; they are not persisted through the buffered
+          // create/update flow used for spans, logs, metrics, scores, feedback.
+          break;
         default:
           createSpanEvents.push(createEvent);
           break;

--- a/observability/mastra/src/exporters/mastra-storage.ts
+++ b/observability/mastra/src/exporters/mastra-storage.ts
@@ -455,6 +455,12 @@ export class MastraStorageExporter extends BaseExporter {
         case 'score':
           createScoreEvents.push(createEvent);
           break;
+        case 'sandbox_output':
+        case 'filesystem_change':
+          // Workspace activity events are routed via `onWorkspaceActivityEvent`
+          // on individual handlers; they are not persisted through the buffered
+          // create/update flow used for spans, logs, metrics, scores, feedback.
+          break;
         default:
           createSpanEvents.push(createEvent);
           break;

--- a/observability/mastra/src/instances/base.ts
+++ b/observability/mastra/src/instances/base.ts
@@ -29,6 +29,7 @@ import type {
   ObservabilityEvent,
   ModelGenerationAttributes,
   UsageStats,
+  WorkspaceActivityEvent,
 } from '@mastra/core/observability';
 import { getNestedValue, setNestedValue } from '@mastra/core/utils';
 import { ObservabilityBus } from '../bus';
@@ -475,6 +476,16 @@ export abstract class BaseObservabilityInstance extends MastraBase implements Ob
    * for any validation needed.
    */
   __receiveExternalEvent(event: ObservabilityEvent): void {
+    this.emitObservabilityEvent(event);
+  }
+
+  /**
+   * Emit a workspace activity event through the bus. Called by workspace
+   * observability wrappers to publish `sandbox_output` and `filesystem_change`
+   * events. The bus routes to every handler that implements
+   * `onWorkspaceActivityEvent`.
+   */
+  emitWorkspaceActivityEvent(event: WorkspaceActivityEvent): void {
     this.emitObservabilityEvent(event);
   }
 

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -3132,6 +3132,10 @@ export class Agent<
     // Propagate logger to workspace if it's a direct instance (not a factory function)
     if (this.#workspace && typeof this.#workspace !== 'function') {
       this.#workspace.__setLogger(this.logger);
+      // Register Mastra with the workspace so filesystem/sandbox providers
+      // get auto-instrumented when observability is configured on the
+      // parent Mastra. Idempotent when Mastra also owns this workspace.
+      this.#workspace.__registerMastra?.(mastra);
     }
     // Mastra will be passed to the LLM when it's created in getLLM()
 

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2984,6 +2984,11 @@ export class Mastra<
       ...(metadata?.agentId ? { agentId: metadata.agentId } : {}),
       ...(metadata?.agentName ? { agentName: metadata.agentName } : {}),
     };
+
+    // Register this Mastra with the workspace so filesystem/sandbox providers
+    // get auto-instrumented when observability is configured. Idempotent — the
+    // workspace short-circuits re-registration with the same Mastra.
+    workspace.__registerMastra?.(this);
   }
 
   /**

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -2973,6 +2973,14 @@ export class Mastra<
         details: { status: 400, workspaceId: key || workspace.id },
       });
     }
+    // Always register this Mastra with the workspace so filesystem/sandbox
+    // providers get auto-instrumented when observability is configured. Called
+    // before the registry dedup check so a Workspace instance surfaced via a
+    // second path (e.g. agent-owned + explicit addWorkspace) is still wired to
+    // Mastra. The call is idempotent — Workspace.__registerMastra short-circuits
+    // re-registration with the same Mastra.
+    workspace.__registerMastra?.(this);
+
     const workspaceKey = key || workspace.id;
     if (this.#workspaces[workspaceKey]) {
       return;
@@ -2984,11 +2992,6 @@ export class Mastra<
       ...(metadata?.agentId ? { agentId: metadata.agentId } : {}),
       ...(metadata?.agentName ? { agentName: metadata.agentName } : {}),
     };
-
-    // Register this Mastra with the workspace so filesystem/sandbox providers
-    // get auto-instrumented when observability is configured. Idempotent — the
-    // workspace short-circuits re-registration with the same Mastra.
-    workspace.__registerMastra?.(this);
   }
 
   /**

--- a/packages/core/src/mastra/workspace-observability.test.ts
+++ b/packages/core/src/mastra/workspace-observability.test.ts
@@ -12,6 +12,7 @@ import type {
   WorkspaceActivityEvent,
 } from '../observability';
 import { LocalFilesystem } from '../workspace/filesystem';
+import { LocalSandbox } from '../workspace/sandbox';
 import { Workspace } from '../workspace/workspace';
 import { Mastra } from './index';
 
@@ -20,12 +21,11 @@ import { Mastra } from './index';
  * instance. The instance records emitted workspace_activity events so tests
  * can verify that auto-instrumentation kicked in.
  */
-function makeObservabilityEntrypoint(): {
-  entrypoint: ObservabilityEntrypoint;
+function makeObservabilityInstance(): {
+  instance: ObservabilityInstance;
   activity: WorkspaceActivityEvent[];
 } {
   const activity: WorkspaceActivityEvent[] = [];
-
   const instance: ObservabilityInstance = {
     getConfig: () => ({}) as any,
     getExporters: () => [],
@@ -52,20 +52,29 @@ function makeObservabilityEntrypoint(): {
       activity.push(event);
     },
   };
+  return { instance, activity };
+}
 
-  const instances = new Map<string, ObservabilityInstance>([['default', instance]]);
+function makeObservabilityEntrypoint(): {
+  entrypoint: ObservabilityEntrypoint;
+  activity: WorkspaceActivityEvent[];
+  swapDefaultInstance: (next: ObservabilityInstance) => void;
+} {
+  const { instance: firstInstance, activity } = makeObservabilityInstance();
+  let currentInstance: ObservabilityInstance = firstInstance;
+  const instances = new Map<string, ObservabilityInstance>([['default', firstInstance]]);
 
   const entrypoint: ObservabilityEntrypoint = {
     flush: async () => {},
     shutdown: async () => {},
     setMastraContext: () => {},
     setLogger: () => {},
-    getSelectedInstance: (_options: ConfigSelectorOptions) => instance,
+    getSelectedInstance: (_options: ConfigSelectorOptions) => currentInstance,
     registerInstance: (name: string, ins: ObservabilityInstance) => {
       instances.set(name, ins);
     },
     getInstance: (name: string) => instances.get(name),
-    getDefaultInstance: () => instance,
+    getDefaultInstance: () => currentInstance,
     listInstances: () => instances,
     unregisterInstance: (name: string) => instances.delete(name),
     hasInstance: (name: string) => instances.has(name),
@@ -73,7 +82,14 @@ function makeObservabilityEntrypoint(): {
     clear: () => {},
   };
 
-  return { entrypoint, activity };
+  return {
+    entrypoint,
+    activity,
+    swapDefaultInstance: (next: ObservabilityInstance) => {
+      currentInstance = next;
+      instances.set('default', next);
+    },
+  };
 }
 
 describe('Mastra workspace observability auto-instrumentation', () => {
@@ -91,11 +107,12 @@ describe('Mastra workspace observability auto-instrumentation', () => {
     }
   });
 
-  const createWorkspace = () =>
+  const createWorkspace = (opts: { withSandbox?: boolean } = {}) =>
     new Workspace({
       id: 'ws-obs',
       name: 'workspace-obs',
       filesystem: new LocalFilesystem({ basePath: tempDir }),
+      ...(opts.withSandbox ? { sandbox: new LocalSandbox({ workDir: tempDir }) } : {}),
     });
 
   it('returns the raw provider when the workspace has no Mastra parent', () => {
@@ -143,7 +160,7 @@ describe('Mastra workspace observability auto-instrumentation', () => {
   });
 
   it('wraps sandbox and filesystem on an agent-owned workspace via Agent.__registerMastra fanout', () => {
-    const ws = createWorkspace();
+    const ws = createWorkspace({ withSandbox: true });
     const agent = new Agent({
       name: 'A',
       instructions: 'test',
@@ -167,7 +184,33 @@ describe('Mastra workspace observability auto-instrumentation', () => {
     // Silence unused-var: mastra is constructed for its side-effect (auto-register agent + workspace).
     void mastra;
 
+    const rawFs = (ws as any)._fs;
+    expect(ws.filesystem).not.toBe(rawFs);
+
+    const rawSb = (ws as any)._sandbox;
+    expect(ws.sandbox).not.toBe(rawSb);
+  });
+
+  it('rebuilds the wrapped provider when the selected observability instance changes', () => {
+    const ws = createWorkspace();
+    const { entrypoint, swapDefaultInstance } = makeObservabilityEntrypoint();
+    const mastra = new Mastra({ logger: false, observability: entrypoint });
+    mastra.addWorkspace(ws);
+
+    const firstProxy = ws.filesystem;
     const raw = (ws as any)._fs;
-    expect(ws.filesystem).not.toBe(raw);
+    expect(firstProxy).not.toBe(raw);
+
+    // Reading again with the same instance returns the same Proxy (memoized).
+    expect(ws.filesystem).toBe(firstProxy);
+
+    // Swap in a different observability instance — the cache entry must
+    // be invalidated because the old Proxy closes over the previous instance.
+    const { instance: nextInstance } = makeObservabilityInstance();
+    swapDefaultInstance(nextInstance);
+
+    const secondProxy = ws.filesystem;
+    expect(secondProxy).not.toBe(raw);
+    expect(secondProxy).not.toBe(firstProxy);
   });
 });

--- a/packages/core/src/mastra/workspace-observability.test.ts
+++ b/packages/core/src/mastra/workspace-observability.test.ts
@@ -32,7 +32,17 @@ function makeObservabilityEntrypoint(): {
     getSpanOutputProcessors: () => [],
     getLogger: () => ({}) as any,
     getBridge: () => undefined,
-    startSpan: () => ({}) as any,
+    // Minimal fake span: only the surface the wrapper touches.
+    startSpan: (opts: any) =>
+      ({
+        id: `span-${Math.random().toString(36).slice(2)}`,
+        traceId: `trace-${Math.random().toString(36).slice(2)}`,
+        name: opts?.name ?? 'span',
+        isValid: true,
+        end: () => {},
+        error: () => {},
+        createChildSpan: (_c: any) => ({}) as any,
+      }) as any,
     rebuildSpan: () => ({}) as any,
     flush: async () => {},
     shutdown: async () => {},

--- a/packages/core/src/mastra/workspace-observability.test.ts
+++ b/packages/core/src/mastra/workspace-observability.test.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs/promises';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { Agent } from '../agent';
 import type {

--- a/packages/core/src/mastra/workspace-observability.test.ts
+++ b/packages/core/src/mastra/workspace-observability.test.ts
@@ -1,0 +1,163 @@
+import * as fs from 'node:fs/promises';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { MockLanguageModelV1 } from '@internal/ai-sdk-v4/test';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Agent } from '../agent';
+import type {
+  ConfigSelectorOptions,
+  ObservabilityEntrypoint,
+  ObservabilityInstance,
+  WorkspaceActivityEvent,
+} from '../observability';
+import { LocalFilesystem } from '../workspace/filesystem';
+import { Workspace } from '../workspace/workspace';
+import { Mastra } from './index';
+
+/**
+ * Build a minimal `ObservabilityEntrypoint` that returns a single default
+ * instance. The instance records emitted workspace_activity events so tests
+ * can verify that auto-instrumentation kicked in.
+ */
+function makeObservabilityEntrypoint(): {
+  entrypoint: ObservabilityEntrypoint;
+  activity: WorkspaceActivityEvent[];
+} {
+  const activity: WorkspaceActivityEvent[] = [];
+
+  const instance: ObservabilityInstance = {
+    getConfig: () => ({}) as any,
+    getExporters: () => [],
+    getSpanOutputProcessors: () => [],
+    getLogger: () => ({}) as any,
+    getBridge: () => undefined,
+    startSpan: () => ({}) as any,
+    rebuildSpan: () => ({}) as any,
+    flush: async () => {},
+    shutdown: async () => {},
+    __setLogger: () => {},
+    // No getLoggerContext/getMetricsContext — wrapper must handle missing hooks.
+    emitWorkspaceActivityEvent: (event: WorkspaceActivityEvent) => {
+      activity.push(event);
+    },
+  };
+
+  const instances = new Map<string, ObservabilityInstance>([['default', instance]]);
+
+  const entrypoint: ObservabilityEntrypoint = {
+    flush: async () => {},
+    shutdown: async () => {},
+    setMastraContext: () => {},
+    setLogger: () => {},
+    getSelectedInstance: (_options: ConfigSelectorOptions) => instance,
+    registerInstance: (name: string, ins: ObservabilityInstance) => {
+      instances.set(name, ins);
+    },
+    getInstance: (name: string) => instances.get(name),
+    getDefaultInstance: () => instance,
+    listInstances: () => instances,
+    unregisterInstance: (name: string) => instances.delete(name),
+    hasInstance: (name: string) => instances.has(name),
+    setConfigSelector: () => {},
+    clear: () => {},
+  };
+
+  return { entrypoint, activity };
+}
+
+describe('Mastra workspace observability auto-instrumentation', () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ws-obs-test-'));
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  const createWorkspace = () =>
+    new Workspace({
+      id: 'ws-obs',
+      name: 'workspace-obs',
+      filesystem: new LocalFilesystem({ basePath: tempDir }),
+    });
+
+  it('returns the raw provider when the workspace has no Mastra parent', () => {
+    const ws = createWorkspace();
+    const raw = (ws as any)._fs;
+    expect(ws.filesystem).toBe(raw);
+  });
+
+  it('returns the raw provider when Mastra has no observability configured', () => {
+    const ws = createWorkspace();
+    const mastra = new Mastra({ logger: false });
+    mastra.addWorkspace(ws);
+
+    const raw = (ws as any)._fs;
+    expect(ws.filesystem).toBe(raw);
+  });
+
+  it('wraps the filesystem provider when Mastra has observability configured', async () => {
+    const ws = createWorkspace();
+    const { entrypoint, activity } = makeObservabilityEntrypoint();
+    const mastra = new Mastra({ logger: false, observability: entrypoint });
+    mastra.addWorkspace(ws);
+
+    const raw = (ws as any)._fs;
+    const wrapped = ws.filesystem;
+    expect(wrapped).not.toBe(raw);
+
+    // Consecutive reads return the same Proxy (memoized).
+    expect(ws.filesystem).toBe(wrapped);
+
+    // Calling through the Proxy exercises instrumentation and reaches the raw provider.
+    await wrapped!.writeFile('hello.txt', 'world');
+    expect(activity.some(e => e.type === 'filesystem_change')).toBe(true);
+  });
+
+  it('registration is idempotent: re-adding the same workspace does not double-wrap or throw', async () => {
+    const ws = createWorkspace();
+    const { entrypoint } = makeObservabilityEntrypoint();
+    const mastra = new Mastra({ logger: false, observability: entrypoint });
+    mastra.addWorkspace(ws);
+    const firstProxy = ws.filesystem;
+
+    expect(() => mastra.addWorkspace(ws)).not.toThrow();
+    expect(ws.filesystem).toBe(firstProxy);
+  });
+
+  it('wraps sandbox and filesystem on an agent-owned workspace via Agent.__registerMastra fanout', () => {
+    const ws = createWorkspace();
+    const agent = new Agent({
+      name: 'A',
+      instructions: 'test',
+      model: new MockLanguageModelV1({
+        doGenerate: async () => ({
+          rawCall: { rawPrompt: null, rawSettings: {} },
+          finishReason: 'stop',
+          usage: { promptTokens: 1, completionTokens: 1 },
+          text: 'ok',
+        }),
+      }),
+      workspace: ws,
+    });
+
+    const { entrypoint } = makeObservabilityEntrypoint();
+    const mastra = new Mastra({
+      logger: false,
+      observability: entrypoint,
+      agents: { A: agent },
+    });
+    // Silence unused-var: mastra is constructed for its side-effect (auto-register agent + workspace).
+    void mastra;
+
+    const raw = (ws as any)._fs;
+    expect(ws.filesystem).not.toBe(raw);
+  });
+});

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -14,6 +14,7 @@ import type { FeedbackEvent, FeedbackInput } from './feedback';
 import type { LoggerContext, LogEvent } from './logging';
 import type { MetricsContext, MetricEvent } from './metrics';
 import type { ScoreEvent, ScoreInput } from './scores';
+import type { WorkspaceActivityEvent } from './workspace-activity';
 import type {
   AnySpan,
   AnyExportedSpan,
@@ -160,10 +161,22 @@ export interface ObservabilityEventBus<TEvent> {
  * Union of all observability event types.
  * Used by the unified ObservabilityBus that handles all signals.
  */
-export type ObservabilityEvent = TracingEvent | LogEvent | MetricEvent | ScoreEvent | FeedbackEvent;
+export type ObservabilityEvent =
+  | TracingEvent
+  | LogEvent
+  | MetricEvent
+  | ScoreEvent
+  | FeedbackEvent
+  | WorkspaceActivityEvent;
 
 /** Signal whose event was dropped by the observability exporter pipeline. */
-export type ObservabilityDropSignal = 'tracing' | 'log' | 'metric' | 'score' | 'feedback';
+export type ObservabilityDropSignal =
+  | 'tracing'
+  | 'log'
+  | 'metric'
+  | 'score'
+  | 'feedback'
+  | 'workspace_activity';
 
 /** Reason an observability event was dropped by the exporter pipeline. */
 export type ObservabilityDropReason = 'unsupported-storage' | 'retry-exhausted';
@@ -278,6 +291,18 @@ export interface ObservabilityInstance {
    * @param span - Optional span to derive metric tags from
    */
   getMetricsContext?(span?: AnySpan): MetricsContext;
+
+  /**
+   * Emit a workspace activity event through the bus.
+   *
+   * Used by workspace observability wrappers (see `packages/core/src/workspace/observability.ts`)
+   * to publish `sandbox_output` and `filesystem_change` events. Callers are
+   * responsible for constructing well-formed events; the bus routes them to
+   * every registered handler that implements `onWorkspaceActivityEvent`.
+   *
+   * Optional: no-op when workspace activity is not wired for this instance.
+   */
+  emitWorkspaceActivityEvent?(event: WorkspaceActivityEvent): void;
 
   /**
    * Register an additional exporter to this instance at runtime.
@@ -575,6 +600,13 @@ export interface ObservabilityEvents {
 
   /** Handle feedback events */
   onFeedbackEvent?(event: FeedbackEvent): void | Promise<void>;
+
+  /**
+   * Handle workspace activity events (sandbox stdout/stderr chunks and
+   * filesystem mutation metadata). Emitted when a workspace registered on
+   * a `Mastra` with observability configured is used.
+   */
+  onWorkspaceActivityEvent?(event: WorkspaceActivityEvent): void | Promise<void>;
 
   /** Handle exporter pipeline droppedEvent */
   onDroppedEvent?(event: ObservabilityDropEvent): void | Promise<void>;

--- a/packages/core/src/observability/types/core.ts
+++ b/packages/core/src/observability/types/core.ts
@@ -14,7 +14,6 @@ import type { FeedbackEvent, FeedbackInput } from './feedback';
 import type { LoggerContext, LogEvent } from './logging';
 import type { MetricsContext, MetricEvent } from './metrics';
 import type { ScoreEvent, ScoreInput } from './scores';
-import type { WorkspaceActivityEvent } from './workspace-activity';
 import type {
   AnySpan,
   AnyExportedSpan,
@@ -30,6 +29,7 @@ import type {
   TracingContext,
   TracingEvent,
 } from './tracing';
+import type { WorkspaceActivityEvent } from './workspace-activity';
 
 // ============================================================================
 // ObservabilityContext

--- a/packages/core/src/observability/types/index.ts
+++ b/packages/core/src/observability/types/index.ts
@@ -5,3 +5,4 @@ export * from './logging';
 export * from './metrics';
 export * from './scores';
 export * from './feedback';
+export * from './workspace-activity';

--- a/packages/core/src/observability/types/workspace-activity.ts
+++ b/packages/core/src/observability/types/workspace-activity.ts
@@ -47,7 +47,11 @@ export interface ExportedSandboxOutput {
   /** Which sandbox surface produced this chunk */
   source: SandboxOutputSource;
 
-  /** Provider-assigned process id — present for `source: 'spawn'` */
+  /**
+   * Provider-assigned process id, when available for `source: 'spawn'`.
+   * May be absent on early chunks emitted before the provider has assigned
+   * one; `source: 'exec'` events never carry a process id.
+   */
   processId?: string;
 
   /** Which stream this chunk came from */
@@ -116,7 +120,12 @@ export interface ExportedFilesystemChange {
   /** Underlying bucket name (when the provider is bucket-backed) */
   bucketName?: string;
 
-  /** Absolute path (or destination path for copy/move) that was mutated */
+  /**
+   * The path supplied to the mutating operation, as-is. Providers may normalize
+   * or resolve this relative to their own root; consumers should treat it as
+   * caller/provider-relative rather than a guaranteed absolute filesystem path.
+   * For `copy` and `move`, this is the destination path.
+   */
   path: string;
 
   /** Which mutating operation ran */

--- a/packages/core/src/observability/types/workspace-activity.ts
+++ b/packages/core/src/observability/types/workspace-activity.ts
@@ -1,0 +1,146 @@
+import type { CorrelationContext } from './core';
+
+// ============================================================================
+// Workspace Activity — Sandbox Output
+// ============================================================================
+
+/**
+ * Which sandbox surface produced this output chunk.
+ * - `exec`: from a `sandbox.executeCommand()` call (emitted after resolve).
+ * - `spawn`: from a streaming `sandbox.processes.spawn()` process.
+ */
+export type SandboxOutputSource = 'exec' | 'spawn';
+
+/** Which standard stream this chunk came from. */
+export type SandboxOutputStream = 'stdout' | 'stderr';
+
+/**
+ * Sandbox stdout/stderr chunk transported via the event bus.
+ * Must be JSON-serializable.
+ *
+ * Chunks are truncated at the wrapper (16 KB default) and carry `truncated: true`
+ * when the source chunk exceeded the limit. The observability channel never
+ * carries stdin — agents cannot drive interactive shells today.
+ */
+export interface ExportedSandboxOutput {
+  /** Unique identifier for this activity event, generated at emission time */
+  eventId: string;
+
+  /** When the chunk was captured */
+  timestamp: Date;
+
+  /** Trace associated with this activity event */
+  traceId?: string;
+
+  /** Specific span associated with this activity event */
+  spanId?: string;
+
+  /** Workspace id that owns the sandbox */
+  workspaceId: string;
+
+  /** Workspace human-readable name (if set) */
+  workspaceName?: string;
+
+  /** Provider-assigned sandbox id (when the sandbox has one) */
+  sandboxId?: string;
+
+  /** Which sandbox surface produced this chunk */
+  source: SandboxOutputSource;
+
+  /** Provider-assigned process id — present for `source: 'spawn'` */
+  processId?: string;
+
+  /** Which stream this chunk came from */
+  stream: SandboxOutputStream;
+
+  /** The chunk contents (already truncated to fit the limit) */
+  chunk: string;
+
+  /** True when the source chunk exceeded the truncation limit */
+  truncated: boolean;
+
+  /** Canonical correlation context for this activity event */
+  correlationContext?: CorrelationContext;
+}
+
+/** Sandbox output event emitted to the ObservabilityBus */
+export interface SandboxOutputEvent {
+  type: 'sandbox_output';
+  output: ExportedSandboxOutput;
+}
+
+// ============================================================================
+// Workspace Activity — Filesystem Change
+// ============================================================================
+
+/**
+ * Which mutating filesystem operation produced this event.
+ * Read-only operations (`readFile`, `readdir`, `stat`, `realpath`) never emit
+ * a filesystem_change event — only mutations do.
+ */
+export type FilesystemChangeOperation =
+  | 'write'
+  | 'append'
+  | 'delete'
+  | 'copy'
+  | 'move'
+  | 'mkdir'
+  | 'rmdir';
+
+/**
+ * Filesystem change metadata transported via the event bus.
+ * Must be JSON-serializable.
+ *
+ * The observability channel never carries file contents — only the path,
+ * operation, and byte count when known.
+ */
+export interface ExportedFilesystemChange {
+  /** Unique identifier for this activity event, generated at emission time */
+  eventId: string;
+
+  /** When the change was captured */
+  timestamp: Date;
+
+  /** Trace associated with this activity event */
+  traceId?: string;
+
+  /** Specific span associated with this activity event */
+  spanId?: string;
+
+  /** Workspace id that owns the filesystem */
+  workspaceId: string;
+
+  /** Workspace human-readable name (if set) */
+  workspaceName?: string;
+
+  /** Underlying bucket name (when the provider is bucket-backed) */
+  bucketName?: string;
+
+  /** Absolute path (or destination path for copy/move) that was mutated */
+  path: string;
+
+  /** Which mutating operation ran */
+  operation: FilesystemChangeOperation;
+
+  /** Bytes written or removed, when the provider reports it */
+  bytes?: number;
+
+  /** Canonical correlation context for this activity event */
+  correlationContext?: CorrelationContext;
+}
+
+/** Filesystem change event emitted to the ObservabilityBus */
+export interface FilesystemChangeEvent {
+  type: 'filesystem_change';
+  change: ExportedFilesystemChange;
+}
+
+// ============================================================================
+// Workspace Activity Union
+// ============================================================================
+
+/**
+ * Union of all workspace activity events routed through the
+ * `onWorkspaceActivityEvent` hook on `ObservabilityEvents`.
+ */
+export type WorkspaceActivityEvent = SandboxOutputEvent | FilesystemChangeEvent;

--- a/packages/core/src/workspace/observability.test.ts
+++ b/packages/core/src/workspace/observability.test.ts
@@ -1,6 +1,13 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { LoggerContext, MetricsContext, ObservabilityInstance, WorkspaceActivityEvent } from '../observability';
+import { executeWithContext } from '../observability/context-storage';
+import type {
+  AnySpan,
+  LoggerContext,
+  MetricsContext,
+  ObservabilityInstance,
+  WorkspaceActivityEvent,
+} from '../observability';
 import type { WorkspaceFilesystem } from './filesystem/filesystem';
 import type { WorkspaceSandbox } from './sandbox/sandbox';
 import type { WorkspaceInstrumentationMeta } from './observability';
@@ -11,28 +18,90 @@ import { SANDBOX_OUTPUT_CHUNK_LIMIT, truncateChunk, wrapFilesystem, wrapSandbox 
  * on metrics, logs, and workspace_activity events without pulling in the full
  * `@mastra/observability` runtime.
  */
+interface RecordedSpan {
+  kind: 'root' | 'child';
+  name: string;
+  traceId: string;
+  spanId: string;
+  attributes?: Record<string, unknown>;
+  input?: unknown;
+  output?: unknown;
+  ended: boolean;
+  errored: boolean;
+}
+
+let spanCounter = 0;
+
+/** Build a fake span with just the surface the wrapper touches. */
+function makeFakeSpan(kind: 'root' | 'child', name: string, records: RecordedSpan[], parentTraceId?: string): AnySpan {
+  spanCounter += 1;
+  const traceId = parentTraceId ?? `trace-${spanCounter}`;
+  const spanId = `span-${spanCounter}`;
+  const record: RecordedSpan = { kind, name, traceId, spanId, ended: false, errored: false };
+  records.push(record);
+
+  const span: any = {
+    id: spanId,
+    traceId,
+    name,
+    isValid: true,
+    end: (opts?: any) => {
+      record.ended = true;
+      if (opts?.output !== undefined) record.output = opts.output;
+      if (opts?.attributes) record.attributes = { ...(record.attributes ?? {}), ...opts.attributes };
+    },
+    error: (opts?: any) => {
+      record.errored = true;
+      if (opts?.attributes) record.attributes = { ...(record.attributes ?? {}), ...opts.attributes };
+    },
+    createChildSpan: (childOpts: any) => {
+      const child = makeFakeSpan('child', childOpts.name, records, traceId);
+      if (childOpts.attributes) {
+        // Attach attributes to the RecordedSpan we just pushed.
+        records[records.length - 1].attributes = childOpts.attributes;
+      }
+      if (childOpts.input !== undefined) {
+        records[records.length - 1].input = childOpts.input;
+      }
+      return child;
+    },
+    getCorrelationContext: () => undefined,
+  };
+  if (kind === 'root' && arguments) {
+    // no-op; kept for symmetry
+  }
+  return span as AnySpan;
+}
+
 function makeObservabilityStub() {
   const metrics: Array<{ name: string; value: number; labels?: Record<string, unknown> }> = [];
   const logs: Array<{ level: 'info' | 'error'; message: string; data?: Record<string, unknown> }> = [];
   const activity: WorkspaceActivityEvent[] = [];
+  const spans: RecordedSpan[] = [];
 
-  const logger: LoggerContext = {
-    debug: vi.fn(),
-    info: vi.fn((message: string, data?: Record<string, unknown>) => {
-      logs.push({ level: 'info', message, data });
-    }),
-    warn: vi.fn(),
-    error: vi.fn((message: string, data?: Record<string, unknown>) => {
-      logs.push({ level: 'error', message, data });
-    }),
-    fatal: vi.fn(),
-  };
+  const buildLogger = (span?: AnySpan): LoggerContext =>
+    ({
+      debug: vi.fn(),
+      info: vi.fn((message: string, data?: Record<string, unknown>) => {
+        logs.push({ level: 'info', message, data: { ...data, traceId: span?.traceId, spanId: span?.id } });
+      }),
+      warn: vi.fn(),
+      error: vi.fn((message: string, data?: Record<string, unknown>) => {
+        logs.push({ level: 'error', message, data: { ...data, traceId: span?.traceId, spanId: span?.id } });
+      }),
+      fatal: vi.fn(),
+    }) as unknown as LoggerContext;
 
-  const metricsCtx: MetricsContext = {
-    emit(name: string, value: number, labels?: Record<string, unknown>) {
-      metrics.push({ name, value, labels });
-    },
-  } as unknown as MetricsContext;
+  const buildMetricsContext = (span?: AnySpan): MetricsContext =>
+    ({
+      emit(name: string, value: number, labels?: Record<string, unknown>) {
+        metrics.push({
+          name,
+          value,
+          labels: { ...labels, traceId: span?.traceId, spanId: span?.id },
+        });
+      },
+    }) as unknown as MetricsContext;
 
   const instance: ObservabilityInstance = {
     getConfig: () => ({}) as any,
@@ -40,19 +109,19 @@ function makeObservabilityStub() {
     getSpanOutputProcessors: () => [],
     getLogger: () => ({}) as any,
     getBridge: () => undefined,
-    startSpan: () => ({}) as any,
+    startSpan: ((opts: any) => makeFakeSpan('root', opts.name, spans)) as any,
     rebuildSpan: () => ({}) as any,
     flush: async () => {},
     shutdown: async () => {},
     __setLogger: () => {},
-    getLoggerContext: () => logger,
-    getMetricsContext: () => metricsCtx,
+    getLoggerContext: (span?: AnySpan) => buildLogger(span),
+    getMetricsContext: (span?: AnySpan) => buildMetricsContext(span),
     emitWorkspaceActivityEvent: (event: WorkspaceActivityEvent) => {
       activity.push(event);
     },
   };
 
-  return { instance, metrics, logs, activity };
+  return { instance, metrics, logs, activity, spans };
 }
 
 const META: WorkspaceInstrumentationMeta = {
@@ -216,6 +285,95 @@ describe('wrapFilesystem', () => {
     expect(errorLog?.message).toBe('workspace.filesystem.readFile');
   });
 
+  it('opens a ROOT workspace:filesystem:<op> span when no ambient parent exists', async () => {
+    const { instance, metrics, logs, activity, spans } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await wrapped.writeFile('/foo.txt', 'hi');
+
+    // Exactly one span, kind=root, name follows the workspace:filesystem:<op> pattern.
+    expect(spans).toHaveLength(1);
+    expect(spans[0].kind).toBe('root');
+    expect(spans[0].name).toBe('workspace:filesystem:writeFile');
+    expect(spans[0].ended).toBe(true);
+    expect(spans[0].errored).toBe(false);
+
+    // Logs, metrics, and the filesystem_change event all share the SAME
+    // traceId/spanId as the operation span.
+    const { traceId, spanId } = spans[0];
+    const durationMetric = metrics.find(m => m.name === 'mastra.workspace.filesystem.duration_ms');
+    expect(durationMetric?.labels).toMatchObject({ traceId, spanId });
+
+    const infoLog = logs.find(l => l.message === 'workspace.filesystem.writeFile');
+    expect(infoLog?.data).toMatchObject({ traceId, spanId });
+
+    const change = activity[0];
+    expect(change?.type).toBe('filesystem_change');
+    if (change?.type === 'filesystem_change') {
+      expect(change.change.traceId).toBe(traceId);
+      expect(change.change.spanId).toBe(spanId);
+    }
+  });
+
+  it('nests a CHILD span under the ambient parent when one exists', async () => {
+    const { instance, metrics, activity, spans } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    // Simulate an outer AGENT_RUN span in the ambient context. Share the same
+    // records array so parent + child are captured in one place.
+    const parent = makeFakeSpan('root', 'agent-run', spans);
+    // Reset counter so assertions can compare simple values.
+    expect(spans).toHaveLength(1);
+
+    await executeWithContext({
+      span: parent,
+      fn: async () => {
+        await wrapped.writeFile('/foo.txt', 'hi');
+      },
+    });
+
+    // Two spans: the pre-existing parent and one child created by the wrapper.
+    expect(spans).toHaveLength(2);
+    const child = spans[1];
+    expect(child.kind).toBe('child');
+    expect(child.name).toBe('workspace:filesystem:writeFile');
+    expect(child.traceId).toBe(parent.traceId);
+    expect(child.ended).toBe(true);
+
+    // Instance.startSpan MUST NOT have been called — we nest, not root.
+    // (No easy assert; verify by counting root spans instead.)
+    const roots = spans.filter(s => s.kind === 'root');
+    expect(roots).toHaveLength(1); // just the parent
+
+    const durationMetric = metrics.find(m => m.name === 'mastra.workspace.filesystem.duration_ms');
+    expect(durationMetric?.labels).toMatchObject({ traceId: parent.traceId, spanId: child.spanId });
+
+    const change = activity[0];
+    if (change?.type === 'filesystem_change') {
+      expect(change.change.traceId).toBe(parent.traceId);
+      expect(change.change.spanId).toBe(child.spanId);
+    }
+  });
+
+  it('marks the operation span errored when the underlying call throws', async () => {
+    const { instance, spans } = makeObservabilityStub();
+    const boom = new Error('boom');
+    const fs = makeFakeFilesystem({
+      writeFile: vi.fn(async () => {
+        throw boom;
+      }),
+    });
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await expect(wrapped.writeFile('/foo.txt', 'x')).rejects.toBe(boom);
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].errored).toBe(true);
+    expect(spans[0].attributes).toMatchObject({ success: false });
+  });
+
   it('reports read byte count when readFile returns a string', async () => {
     const { instance, metrics } = makeObservabilityStub();
     const fs = makeFakeFilesystem({
@@ -269,6 +427,25 @@ function makeFakeSandbox(overrides: Partial<WorkspaceSandbox> = {}): WorkspaceSa
 }
 
 describe('wrapSandbox', () => {
+  it('opens a ROOT workspace:sandbox:executeCommand span when no ambient parent exists', async () => {
+    const { instance, activity, spans } = makeObservabilityStub();
+    const sb = makeFakeSandbox();
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    await wrapped.executeCommand!('echo hello');
+
+    expect(spans).toHaveLength(1);
+    expect(spans[0].kind).toBe('root');
+    expect(spans[0].name).toBe('workspace:sandbox:executeCommand');
+    expect(spans[0].ended).toBe(true);
+
+    const output = activity.find(e => e.type === 'sandbox_output');
+    if (output?.type === 'sandbox_output') {
+      expect(output.output.traceId).toBe(spans[0].traceId);
+      expect(output.output.spanId).toBe(spans[0].spanId);
+    }
+  });
+
   it('emits duration + info log + stdout activity event on executeCommand', async () => {
     const { instance, metrics, logs, activity } = makeObservabilityStub();
     const sb = makeFakeSandbox();

--- a/packages/core/src/workspace/observability.test.ts
+++ b/packages/core/src/workspace/observability.test.ts
@@ -1,0 +1,452 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { LoggerContext, MetricsContext, ObservabilityInstance, WorkspaceActivityEvent } from '../observability';
+import type { WorkspaceFilesystem } from './filesystem/filesystem';
+import type { WorkspaceSandbox } from './sandbox/sandbox';
+import type { WorkspaceInstrumentationMeta } from './observability';
+import { SANDBOX_OUTPUT_CHUNK_LIMIT, truncateChunk, wrapFilesystem, wrapSandbox } from './observability';
+
+/**
+ * Minimal `ObservabilityInstance` stub. Records every call so tests can assert
+ * on metrics, logs, and workspace_activity events without pulling in the full
+ * `@mastra/observability` runtime.
+ */
+function makeObservabilityStub() {
+  const metrics: Array<{ name: string; value: number; labels?: Record<string, unknown> }> = [];
+  const logs: Array<{ level: 'info' | 'error'; message: string; data?: Record<string, unknown> }> = [];
+  const activity: WorkspaceActivityEvent[] = [];
+
+  const logger: LoggerContext = {
+    debug: vi.fn(),
+    info: vi.fn((message: string, data?: Record<string, unknown>) => {
+      logs.push({ level: 'info', message, data });
+    }),
+    warn: vi.fn(),
+    error: vi.fn((message: string, data?: Record<string, unknown>) => {
+      logs.push({ level: 'error', message, data });
+    }),
+    fatal: vi.fn(),
+  };
+
+  const metricsCtx: MetricsContext = {
+    emit(name: string, value: number, labels?: Record<string, unknown>) {
+      metrics.push({ name, value, labels });
+    },
+  } as unknown as MetricsContext;
+
+  const instance: ObservabilityInstance = {
+    getConfig: () => ({}) as any,
+    getExporters: () => [],
+    getSpanOutputProcessors: () => [],
+    getLogger: () => ({}) as any,
+    getBridge: () => undefined,
+    startSpan: () => ({}) as any,
+    rebuildSpan: () => ({}) as any,
+    flush: async () => {},
+    shutdown: async () => {},
+    __setLogger: () => {},
+    getLoggerContext: () => logger,
+    getMetricsContext: () => metricsCtx,
+    emitWorkspaceActivityEvent: (event: WorkspaceActivityEvent) => {
+      activity.push(event);
+    },
+  };
+
+  return { instance, metrics, logs, activity };
+}
+
+const META: WorkspaceInstrumentationMeta = {
+  workspaceId: 'ws-1',
+  workspaceName: 'test-workspace',
+};
+
+// =============================================================================
+// truncateChunk
+// =============================================================================
+
+describe('truncateChunk', () => {
+  it('returns short strings unchanged with truncated:false', () => {
+    const result = truncateChunk('hello world');
+    expect(result).toEqual({ chunk: 'hello world', truncated: false });
+  });
+
+  it('truncates strings longer than the limit and sets truncated:true', () => {
+    const big = 'a'.repeat(SANDBOX_OUTPUT_CHUNK_LIMIT + 100);
+    const result = truncateChunk(big);
+    expect(result.chunk.length).toBe(SANDBOX_OUTPUT_CHUNK_LIMIT);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('accepts Buffer inputs and decodes as utf-8', () => {
+    const result = truncateChunk(Buffer.from('hello', 'utf8'));
+    expect(result).toEqual({ chunk: 'hello', truncated: false });
+  });
+
+  it('respects a custom limit', () => {
+    const result = truncateChunk('abcdef', 3);
+    expect(result).toEqual({ chunk: 'abc', truncated: true });
+  });
+});
+
+// =============================================================================
+// wrapFilesystem
+// =============================================================================
+
+/** Fake filesystem — bare minimum surface needed for the wrapper. */
+function makeFakeFilesystem(overrides: Partial<WorkspaceFilesystem> = {}): WorkspaceFilesystem {
+  const fs: Partial<WorkspaceFilesystem> = {
+    id: 'fs-1',
+    name: 'test-fs',
+    provider: 'local',
+    readFile: vi.fn(async (_path: string) => 'file-contents'),
+    writeFile: vi.fn(async (_path: string, _content: unknown) => undefined),
+    appendFile: vi.fn(async (_path: string, _content: unknown) => undefined),
+    deleteFile: vi.fn(async (_path: string) => undefined),
+    copyFile: vi.fn(async (_src: string, _dest: string) => undefined),
+    moveFile: vi.fn(async (_src: string, _dest: string) => undefined),
+    mkdir: vi.fn(async (_path: string) => undefined),
+    rmdir: vi.fn(async (_path: string) => undefined),
+    readdir: vi.fn(async (_path: string) => [{ name: 'a', isDirectory: false } as any]),
+    stat: vi.fn(async (_path: string) => ({ size: 5 }) as any),
+    exists: vi.fn(async (_path: string) => true),
+    ...overrides,
+  };
+  return fs as WorkspaceFilesystem;
+}
+
+describe('wrapFilesystem', () => {
+  it('passes through call args and returns provider result unchanged', async () => {
+    const { instance } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    const result = await wrapped.readFile('/foo.txt');
+    expect(result).toBe('file-contents');
+    expect(fs.readFile).toHaveBeenCalledWith('/foo.txt');
+  });
+
+  it('emits a duration_ms metric and info log on success', async () => {
+    const { instance, metrics, logs } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await wrapped.readFile('/foo.txt');
+
+    const durationMetric = metrics.find(m => m.name === 'mastra.workspace.filesystem.duration_ms');
+    expect(durationMetric).toBeDefined();
+    expect(durationMetric?.labels).toMatchObject({ operation: 'readFile', provider: 'local', success: 'true' });
+
+    const infoLog = logs.find(l => l.level === 'info' && l.message === 'workspace.filesystem.readFile');
+    expect(infoLog).toBeDefined();
+    expect(infoLog?.data).toMatchObject({ provider: 'local', path: '/foo.txt' });
+  });
+
+  it('emits filesystem_change ONLY on mutating operations', async () => {
+    const { instance, activity } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    // Reads must NOT emit an activity event.
+    await wrapped.readFile('/foo.txt');
+    await wrapped.readdir('/');
+    await wrapped.stat('/foo.txt');
+    expect(activity).toHaveLength(0);
+
+    // Mutations MUST emit an activity event.
+    await wrapped.writeFile('/foo.txt', 'hello');
+    await wrapped.appendFile('/foo.txt', 'world');
+    await wrapped.deleteFile('/foo.txt');
+    await wrapped.copyFile('/foo.txt', '/bar.txt');
+    await wrapped.moveFile('/bar.txt', '/baz.txt');
+    await wrapped.mkdir('/dir');
+    await wrapped.rmdir('/dir');
+
+    const ops = activity.map(e => (e.type === 'filesystem_change' ? e.change.operation : e.type));
+    expect(ops).toEqual(['write', 'append', 'delete', 'copy', 'move', 'mkdir', 'rmdir']);
+  });
+
+  it('uses destination path on copy/move filesystem_change events', async () => {
+    const { instance, activity } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await wrapped.copyFile('/src', '/dst');
+    const copyEvent = activity[0];
+    expect(copyEvent?.type).toBe('filesystem_change');
+    if (copyEvent?.type === 'filesystem_change') {
+      expect(copyEvent.change.path).toBe('/dst');
+      expect(copyEvent.change.operation).toBe('copy');
+    }
+  });
+
+  it('never carries file contents on filesystem_change events', async () => {
+    const { instance, activity } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await wrapped.writeFile('/secret.txt', 'super-secret-contents');
+
+    const change = activity[0];
+    expect(change?.type).toBe('filesystem_change');
+    // The event object shape must not contain any content-carrying field.
+    if (change?.type === 'filesystem_change') {
+      const serialized = JSON.stringify(change);
+      expect(serialized).not.toContain('super-secret-contents');
+    }
+  });
+
+  it('emits an errors_total metric and error log when the provider throws, then rethrows', async () => {
+    const { instance, metrics, logs } = makeObservabilityStub();
+    const boom = new Error('kaboom');
+    const fs = makeFakeFilesystem({
+      readFile: vi.fn(async () => {
+        throw boom;
+      }),
+    });
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await expect(wrapped.readFile('/foo.txt')).rejects.toBe(boom);
+
+    const errorMetric = metrics.find(m => m.name === 'mastra.workspace.filesystem.errors_total');
+    expect(errorMetric).toBeDefined();
+    expect(errorMetric?.value).toBe(1);
+    expect(errorMetric?.labels).toMatchObject({ operation: 'readFile', provider: 'local' });
+
+    const errorLog = logs.find(l => l.level === 'error');
+    expect(errorLog?.message).toBe('workspace.filesystem.readFile');
+  });
+
+  it('reports read byte count when readFile returns a string', async () => {
+    const { instance, metrics } = makeObservabilityStub();
+    const fs = makeFakeFilesystem({
+      readFile: vi.fn(async () => 'hello'),
+    });
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    await wrapped.readFile('/foo.txt');
+
+    const bytesMetric = metrics.find(m => m.name === 'mastra.workspace.filesystem.bytes');
+    expect(bytesMetric).toBeDefined();
+    expect(bytesMetric?.value).toBe(5);
+    expect(bytesMetric?.labels).toMatchObject({ operation: 'readFile', direction: 'read' });
+  });
+
+  it('leaves non-instrumented properties untouched', () => {
+    const { instance } = makeObservabilityStub();
+    const fs = makeFakeFilesystem();
+    const wrapped = wrapFilesystem(fs, META, instance);
+
+    expect(wrapped.id).toBe('fs-1');
+    expect(wrapped.name).toBe('test-fs');
+    expect(wrapped.provider).toBe('local');
+  });
+});
+
+// =============================================================================
+// wrapSandbox
+// =============================================================================
+
+function makeFakeSandbox(overrides: Partial<WorkspaceSandbox> = {}): WorkspaceSandbox {
+  const sb: Partial<WorkspaceSandbox> = {
+    id: 'sb-1',
+    name: 'test-sb',
+    provider: 'local',
+    executeCommand: vi.fn(async (_command: string) => ({
+      success: true,
+      exitCode: 0,
+      stdout: 'ok\n',
+      stderr: '',
+      executionTimeMs: 5,
+    })),
+    isReady: vi.fn(async () => true),
+    getInfo: vi.fn(async () => ({ status: 'ready' }) as any),
+    start: vi.fn(async () => undefined),
+    stop: vi.fn(async () => undefined),
+    destroy: vi.fn(async () => undefined),
+    ...overrides,
+  };
+  return sb as WorkspaceSandbox;
+}
+
+describe('wrapSandbox', () => {
+  it('emits duration + info log + stdout activity event on executeCommand', async () => {
+    const { instance, metrics, logs, activity } = makeObservabilityStub();
+    const sb = makeFakeSandbox();
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    const result = await wrapped.executeCommand!('echo hello');
+    expect(result?.exitCode).toBe(0);
+
+    expect(metrics.some(m => m.name === 'mastra.workspace.sandbox.duration_ms')).toBe(true);
+    expect(logs.some(l => l.level === 'info' && l.message === 'workspace.sandbox.executeCommand')).toBe(true);
+
+    const outputs = activity.filter(e => e.type === 'sandbox_output');
+    expect(outputs).toHaveLength(1);
+    if (outputs[0]?.type === 'sandbox_output') {
+      expect(outputs[0].output.source).toBe('exec');
+      expect(outputs[0].output.stream).toBe('stdout');
+      expect(outputs[0].output.chunk).toBe('ok\n');
+      expect(outputs[0].output.truncated).toBe(false);
+    }
+  });
+
+  it('emits both stdout AND stderr activity events when both non-empty', async () => {
+    const { instance, activity } = makeObservabilityStub();
+    const sb = makeFakeSandbox({
+      executeCommand: vi.fn(async () => ({
+        success: false,
+        exitCode: 1,
+        stdout: 'out',
+        stderr: 'err',
+        executionTimeMs: 1,
+      })),
+    });
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    await wrapped.executeCommand!('cmd');
+
+    const outputs = activity.filter(e => e.type === 'sandbox_output');
+    expect(outputs).toHaveLength(2);
+    const streams = outputs.map(e => (e.type === 'sandbox_output' ? e.output.stream : ''));
+    expect(streams).toEqual(expect.arrayContaining(['stdout', 'stderr']));
+  });
+
+  it('does not emit sandbox_output for empty streams', async () => {
+    const { instance, activity } = makeObservabilityStub();
+    const sb = makeFakeSandbox({
+      executeCommand: vi.fn(async () => ({
+        success: true,
+        exitCode: 0,
+        stdout: '',
+        stderr: '',
+        executionTimeMs: 1,
+      })),
+    });
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    await wrapped.executeCommand!('cmd');
+    expect(activity).toHaveLength(0);
+  });
+
+  it('truncates oversized stdout chunks and marks truncated:true', async () => {
+    const { instance, activity } = makeObservabilityStub();
+    const big = 'a'.repeat(SANDBOX_OUTPUT_CHUNK_LIMIT + 500);
+    const sb = makeFakeSandbox({
+      executeCommand: vi.fn(async () => ({
+        success: true,
+        exitCode: 0,
+        stdout: big,
+        stderr: '',
+        executionTimeMs: 1,
+      })),
+    });
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    await wrapped.executeCommand!('cmd');
+    const output = activity[0];
+    expect(output?.type).toBe('sandbox_output');
+    if (output?.type === 'sandbox_output') {
+      expect(output.output.chunk.length).toBe(SANDBOX_OUTPUT_CHUNK_LIMIT);
+      expect(output.output.truncated).toBe(true);
+    }
+  });
+
+  it('rethrows and emits errors_total when executeCommand throws', async () => {
+    const { instance, metrics } = makeObservabilityStub();
+    const boom = new Error('exec-failed');
+    const sb = makeFakeSandbox({
+      executeCommand: vi.fn(async () => {
+        throw boom;
+      }),
+    });
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    await expect(wrapped.executeCommand!('cmd')).rejects.toBe(boom);
+    expect(metrics.some(m => m.name === 'mastra.workspace.sandbox.errors_total')).toBe(true);
+  });
+
+  it('instruments processes.spawn and forwards stdout chunks as sandbox_output(spawn)', async () => {
+    const { instance, activity } = makeObservabilityStub();
+
+    // Fake process manager: spawn accepts injected onStdout/onStderr and
+    // invokes them synchronously with a couple of chunks to simulate streaming.
+    const spawnMock = vi.fn(
+      async (
+        command: string,
+        opts: { onStdout?: (data: string) => void; onStderr?: (data: string) => void } | undefined,
+      ) => {
+        opts?.onStdout?.('hello ');
+        opts?.onStdout?.('world\n');
+        opts?.onStderr?.('warn!\n');
+        return { pid: 'pid-42', command } as any;
+      },
+    );
+
+    const sb = makeFakeSandbox();
+    (sb as any).processes = {
+      spawn: spawnMock,
+      list: vi.fn(async () => []),
+      get: vi.fn(async () => undefined),
+    };
+
+    const wrapped = wrapSandbox(sb, META, instance);
+    const handle = await wrapped.processes!.spawn('long-cmd');
+    expect(handle).toEqual({ pid: 'pid-42', command: 'long-cmd' });
+
+    const outputs = activity.filter(e => e.type === 'sandbox_output');
+    expect(outputs).toHaveLength(3);
+    for (const evt of outputs) {
+      if (evt.type === 'sandbox_output') {
+        expect(evt.output.source).toBe('spawn');
+      }
+    }
+    const streams = outputs.map(e => (e.type === 'sandbox_output' ? e.output.stream : ''));
+    expect(streams).toEqual(['stdout', 'stdout', 'stderr']);
+  });
+
+  it('preserves user-supplied onStdout/onStderr when instrumenting spawn', async () => {
+    const { instance } = makeObservabilityStub();
+    const userStdout = vi.fn();
+
+    const spawnMock = vi.fn(async (_cmd: string, opts: { onStdout?: (data: string) => void } | undefined) => {
+      opts?.onStdout?.('hi');
+      return { pid: 'pid-99' } as any;
+    });
+
+    const sb = makeFakeSandbox();
+    (sb as any).processes = {
+      spawn: spawnMock,
+      list: vi.fn(async () => []),
+      get: vi.fn(async () => undefined),
+    };
+
+    const wrapped = wrapSandbox(sb, META, instance);
+    await wrapped.processes!.spawn('cmd', { onStdout: userStdout } as any);
+
+    expect(userStdout).toHaveBeenCalledWith('hi');
+  });
+
+  it('memoizes the wrapped processes sub-object across reads', () => {
+    const { instance } = makeObservabilityStub();
+    const sb = makeFakeSandbox();
+    (sb as any).processes = {
+      spawn: vi.fn(),
+      list: vi.fn(),
+      get: vi.fn(),
+    };
+    const wrapped = wrapSandbox(sb, META, instance);
+    const a = wrapped.processes;
+    const b = wrapped.processes;
+    expect(a).toBe(b);
+  });
+
+  it('leaves non-instrumented properties untouched', () => {
+    const { instance } = makeObservabilityStub();
+    const sb = makeFakeSandbox();
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    expect(wrapped.id).toBe('sb-1');
+    expect(wrapped.name).toBe('test-sb');
+    expect(wrapped.provider).toBe('local');
+  });
+});

--- a/packages/core/src/workspace/observability.test.ts
+++ b/packages/core/src/workspace/observability.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { executeWithContext } from '../observability/context-storage';
 import type {
   AnySpan,
   LoggerContext,
@@ -8,10 +7,11 @@ import type {
   ObservabilityInstance,
   WorkspaceActivityEvent,
 } from '../observability';
+import { executeWithContext } from '../observability/context-storage';
 import type { WorkspaceFilesystem } from './filesystem/filesystem';
-import type { WorkspaceSandbox } from './sandbox/sandbox';
 import type { WorkspaceInstrumentationMeta } from './observability';
 import { SANDBOX_OUTPUT_CHUNK_LIMIT, truncateChunk, wrapFilesystem, wrapSandbox } from './observability';
+import type { WorkspaceSandbox } from './sandbox/sandbox';
 
 /**
  * Minimal `ObservabilityInstance` stub. Records every call so tests can assert

--- a/packages/core/src/workspace/observability.test.ts
+++ b/packages/core/src/workspace/observability.test.ts
@@ -109,7 +109,14 @@ function makeObservabilityStub() {
     getSpanOutputProcessors: () => [],
     getLogger: () => ({}) as any,
     getBridge: () => undefined,
-    startSpan: ((opts: any) => makeFakeSpan('root', opts.name, spans)) as any,
+    startSpan: ((opts: any) => {
+      const span = makeFakeSpan('root', opts.name, spans);
+      // Capture the input/attributes provided at creation time.
+      const rec = spans[spans.length - 1];
+      if (opts.input !== undefined) rec.input = opts.input;
+      if (opts.attributes) rec.attributes = { ...(rec.attributes ?? {}), ...opts.attributes };
+      return span;
+    }) as any,
     rebuildSpan: () => ({}) as any,
     flush: async () => {},
     shutdown: async () => {},
@@ -154,6 +161,69 @@ describe('truncateChunk', () => {
   it('respects a custom limit', () => {
     const result = truncateChunk('abcdef', 3);
     expect(result).toEqual({ chunk: 'abc', truncated: true });
+  });
+
+  it('enforces limit as UTF-8 bytes, not UTF-16 code units, for multibyte input', () => {
+    // '💻' encodes as 4 bytes (surrogate pair in UTF-16 => 2 code units, but 4 bytes in UTF-8).
+    // 5 emoji => 20 bytes. Limit of 10 bytes should keep exactly 2 emoji.
+    const source = '💻'.repeat(5);
+    const result = truncateChunk(source, 10);
+    expect(result.truncated).toBe(true);
+    expect(result.chunk).toBe('💻💻');
+    expect(Buffer.byteLength(result.chunk, 'utf8')).toBeLessThanOrEqual(10);
+  });
+
+  it('never emits partial UTF-8 sequences (whole code points only)', () => {
+    // 3 emoji => 12 bytes. Limit of 5 bytes cannot fit even one whole emoji beyond
+    // the first; it should keep one full emoji and stop rather than slice a surrogate.
+    const source = '💻💻💻';
+    const result = truncateChunk(source, 5);
+    expect(result.truncated).toBe(true);
+    // First code point is 4 bytes; adding a second would exceed 5 bytes.
+    expect(result.chunk).toBe('💻');
+    expect(Buffer.byteLength(result.chunk, 'utf8')).toBeLessThanOrEqual(5);
+  });
+});
+
+describe('sandbox command redaction in telemetry', () => {
+  it('records only argv0 in span input and structured logs (not the full command)', async () => {
+    const { instance, logs, spans } = makeObservabilityStub();
+    const sb = makeFakeSandbox({
+      // Command carries a secret that MUST NOT surface in telemetry.
+      executeCommand: vi.fn(async (_command: string) => ({
+        success: true,
+        exitCode: 0,
+        stdout: 'ok\n',
+        stderr: '',
+        executionTimeMs: 1,
+      })),
+    });
+    const wrapped = wrapSandbox(sb, META, instance);
+
+    const rawCommand = '/usr/bin/curl -H "Authorization: Bearer supersecret" https://example.com';
+    await wrapped.executeCommand!(rawCommand);
+
+    // The underlying provider must still see the raw command.
+    expect(sb.executeCommand).toHaveBeenCalledWith(rawCommand);
+
+    // No emitted log carries the full command or the secret.
+    for (const l of logs) {
+      const serialized = JSON.stringify(l);
+      expect(serialized).not.toContain('supersecret');
+      expect(serialized).not.toContain('Bearer');
+      expect(serialized).not.toContain('example.com');
+    }
+
+    // The info log DOES carry the sanitized program name.
+    const infoLog = logs.find(l => l.message === 'workspace.sandbox.executeCommand');
+    expect(infoLog?.data?.commandProgram).toBe('curl');
+
+    // The span input DOES NOT carry the raw command.
+    expect(spans).toHaveLength(1);
+    const span = spans[0];
+    const serializedSpan = JSON.stringify(span);
+    expect(serializedSpan).not.toContain('supersecret');
+    expect(serializedSpan).not.toContain('Bearer');
   });
 });
 

--- a/packages/core/src/workspace/observability.ts
+++ b/packages/core/src/workspace/observability.ts
@@ -101,19 +101,31 @@ export interface WorkspaceInstrumentationMeta {
 // =============================================================================
 
 /**
- * Truncate a string chunk to at most `limit` bytes (measured as UTF-8 length).
- * The `truncated` flag is `true` when the source chunk exceeded the limit.
- * Handles Buffer inputs by converting to a UTF-8 string first.
+ * Truncate a string chunk to at most `limit` bytes when serialized as UTF-8.
+ *
+ * The chunk is walked as an iterable of Unicode code points so multi-byte
+ * characters (emoji, CJK, combining marks) are never split mid-sequence.
+ * `truncated: true` is set when the source, measured in UTF-8 bytes, exceeded
+ * `limit`. Handles Buffer inputs by decoding as UTF-8 first.
  */
 export function truncateChunk(
   chunk: string | Buffer,
   limit = SANDBOX_OUTPUT_CHUNK_LIMIT,
 ): { chunk: string; truncated: boolean } {
   const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
-  if (text.length <= limit) {
+  const sourceBytes = Buffer.byteLength(text, 'utf8');
+  if (sourceBytes <= limit) {
     return { chunk: text, truncated: false };
   }
-  return { chunk: text.slice(0, limit), truncated: true };
+  let accumulatedBytes = 0;
+  let out = '';
+  for (const codePoint of text) {
+    const cpBytes = Buffer.byteLength(codePoint, 'utf8');
+    if (accumulatedBytes + cpBytes > limit) break;
+    out += codePoint;
+    accumulatedBytes += cpBytes;
+  }
+  return { chunk: out, truncated: true };
 }
 
 // =============================================================================
@@ -191,6 +203,39 @@ function beginCall(
   };
 }
 
+/**
+ * Run `fn` and swallow any thrown error. Used to make every post-provider
+ * telemetry side effect (metric emit, log, span end, activity event) no-throw
+ * so a broken exporter cannot alter or hide a provider result the caller
+ * already observed.
+ */
+function safeEmit(fn: () => void): void {
+  try {
+    fn();
+  } catch {
+    // Intentionally swallow — telemetry must never change provider semantics.
+  }
+}
+
+/**
+ * Extract a redacted operation identifier from a shell command string. Commands
+ * routinely embed tokens, passwords, or user data in their arguments; only the
+ * program name (argv0) is recorded on spans and structured logs. The raw
+ * command is still passed through to the provider for actual execution — only
+ * the telemetry-facing representation is sanitized.
+ */
+function sanitizeCommand(command: string): string {
+  if (!command) return '';
+  // Trim leading whitespace, then take the first whitespace-delimited token.
+  const trimmed = command.trimStart();
+  const match = trimmed.match(/^\S+/);
+  if (!match) return '';
+  const program = match[0];
+  // Strip a leading path from the program (e.g. `/usr/bin/curl` -> `curl`).
+  const lastSep = Math.max(program.lastIndexOf('/'), program.lastIndexOf('\\'));
+  return lastSep >= 0 ? program.slice(lastSep + 1) : program;
+}
+
 function endCallSuccess(
   ctx: CallCtx,
   category: 'filesystem' | 'sandbox',
@@ -201,22 +246,28 @@ function endCallSuccess(
 ): void {
   const durationMs = Date.now() - ctx.startedAtMs;
 
-  ctx.metrics?.emit(`mastra.workspace.${category}.duration_ms`, durationMs, {
-    operation,
-    provider,
-    success: 'true',
-  });
+  safeEmit(() =>
+    ctx.metrics?.emit(`mastra.workspace.${category}.duration_ms`, durationMs, {
+      operation,
+      provider,
+      success: 'true',
+    }),
+  );
 
-  ctx.logger?.info(`workspace.${category}.${operation}`, {
-    provider,
-    durationMs,
-    ...extraLog,
-  });
+  safeEmit(() =>
+    ctx.logger?.info(`workspace.${category}.${operation}`, {
+      provider,
+      durationMs,
+      ...extraLog,
+    }),
+  );
 
-  ctx.span?.end({
-    output: spanOutput,
-    attributes: { success: true },
-  });
+  safeEmit(() =>
+    ctx.span?.end({
+      output: spanOutput,
+      attributes: { success: true },
+    }),
+  );
 }
 
 function endCallError(
@@ -231,26 +282,32 @@ function endCallError(
   const error = err instanceof Error ? err : new Error(String(err));
   const errorClass = error.name || 'Error';
 
-  ctx.metrics?.emit(`mastra.workspace.${category}.duration_ms`, durationMs, {
-    operation,
-    provider,
-    success: 'false',
-  });
-  ctx.metrics?.emit(`mastra.workspace.${category}.errors_total`, 1, {
-    operation,
-    provider,
-    error_class: errorClass,
-  });
+  safeEmit(() =>
+    ctx.metrics?.emit(`mastra.workspace.${category}.duration_ms`, durationMs, {
+      operation,
+      provider,
+      success: 'false',
+    }),
+  );
+  safeEmit(() =>
+    ctx.metrics?.emit(`mastra.workspace.${category}.errors_total`, 1, {
+      operation,
+      provider,
+      error_class: errorClass,
+    }),
+  );
 
-  ctx.logger?.error(`workspace.${category}.${operation}`, {
-    provider,
-    durationMs,
-    error: error.message,
-    errorClass,
-    ...extraLog,
-  });
+  safeEmit(() =>
+    ctx.logger?.error(`workspace.${category}.${operation}`, {
+      provider,
+      durationMs,
+      error: error.message,
+      errorClass,
+      ...extraLog,
+    }),
+  );
 
-  ctx.span?.error({ error, attributes: { success: false } });
+  safeEmit(() => ctx.span?.error({ error, attributes: { success: false } }));
 }
 
 // =============================================================================
@@ -278,7 +335,7 @@ function emitFilesystemChange(
     bytes,
   };
   const event: FilesystemChangeEvent = { type: 'filesystem_change', change };
-  ctx.instance.emitWorkspaceActivityEvent?.(event);
+  safeEmit(() => ctx.instance.emitWorkspaceActivityEvent?.(event));
 }
 
 function extractFilesystemBytes(operation: FilesystemChangeOperation, args: unknown[]): number | undefined {
@@ -320,18 +377,22 @@ function wrapFilesystemMethod(
       const mutationBytes = mutation ? extractFilesystemBytes(mutation, args) : undefined;
 
       if (bytesRead != null) {
-        ctx.metrics?.emit('mastra.workspace.filesystem.bytes', bytesRead, {
-          operation: method,
-          provider: fs.provider,
-          direction: 'read',
-        });
+        safeEmit(() =>
+          ctx.metrics?.emit('mastra.workspace.filesystem.bytes', bytesRead, {
+            operation: method,
+            provider: fs.provider,
+            direction: 'read',
+          }),
+        );
       }
       if (mutation && mutationBytes != null) {
-        ctx.metrics?.emit('mastra.workspace.filesystem.bytes', mutationBytes, {
-          operation: method,
-          provider: fs.provider,
-          direction: 'write',
-        });
+        safeEmit(() =>
+          ctx.metrics?.emit('mastra.workspace.filesystem.bytes', mutationBytes, {
+            operation: method,
+            provider: fs.provider,
+            direction: 'write',
+          }),
+        );
       }
 
       // filesystem_change on mutations only
@@ -415,7 +476,7 @@ function emitSandboxOutput(
     truncated: wasTruncated,
   };
   const event: SandboxOutputEvent = { type: 'sandbox_output', output };
-  ctx.instance.emitWorkspaceActivityEvent?.(event);
+  safeEmit(() => ctx.instance.emitWorkspaceActivityEvent?.(event));
 }
 
 function wrapSandboxExecuteCommand(
@@ -425,7 +486,8 @@ function wrapSandboxExecuteCommand(
 ): (...args: unknown[]) => Promise<unknown> {
   return async (...args: unknown[]): Promise<unknown> => {
     const command = typeof args[0] === 'string' ? args[0] : '';
-    const ctx = beginCall(instance, 'sandbox', 'executeCommand', meta, sandbox.provider, { command });
+    const commandProgram = sanitizeCommand(command);
+    const ctx = beginCall(instance, 'sandbox', 'executeCommand', meta, sandbox.provider, { commandProgram });
     try {
       const raw = sandbox.executeCommand!;
       const result = (await raw.call(sandbox, ...(args as Parameters<typeof raw>))) as
@@ -440,16 +502,20 @@ function wrapSandboxExecuteCommand(
       const stdoutBytes = result?.stdout ? Buffer.byteLength(result.stdout, 'utf8') : 0;
       const stderrBytes = result?.stderr ? Buffer.byteLength(result.stderr, 'utf8') : 0;
       if (stdoutBytes > 0) {
-        ctx.metrics?.emit('mastra.workspace.sandbox.stdout_bytes', stdoutBytes, {
-          provider: sandbox.provider,
-          source: 'exec',
-        });
+        safeEmit(() =>
+          ctx.metrics?.emit('mastra.workspace.sandbox.stdout_bytes', stdoutBytes, {
+            provider: sandbox.provider,
+            source: 'exec',
+          }),
+        );
       }
       if (stderrBytes > 0) {
-        ctx.metrics?.emit('mastra.workspace.sandbox.stderr_bytes', stderrBytes, {
-          provider: sandbox.provider,
-          source: 'exec',
-        });
+        safeEmit(() =>
+          ctx.metrics?.emit('mastra.workspace.sandbox.stderr_bytes', stderrBytes, {
+            provider: sandbox.provider,
+            source: 'exec',
+          }),
+        );
       }
 
       // Publish stdout/stderr as sandbox_output events (truncated)
@@ -466,7 +532,7 @@ function wrapSandboxExecuteCommand(
         'executeCommand',
         sandbox.provider,
         {
-          command,
+          commandProgram,
           exitCode: result?.exitCode,
           stdoutBytes,
           stderrBytes,
@@ -476,7 +542,7 @@ function wrapSandboxExecuteCommand(
 
       return result;
     } catch (err) {
-      endCallError(ctx, 'sandbox', 'executeCommand', sandbox.provider, err, { command });
+      endCallError(ctx, 'sandbox', 'executeCommand', sandbox.provider, err, { commandProgram });
       throw err;
     }
   };
@@ -490,12 +556,13 @@ function wrapProcessesSpawn(
 ): (...args: unknown[]) => Promise<unknown> {
   return async (...args: unknown[]): Promise<unknown> => {
     const command = typeof args[0] === 'string' ? args[0] : '';
+    const commandProgram = sanitizeCommand(command);
     const opts = (args[1] ?? {}) as {
       onStdout?: (data: string) => void;
       onStderr?: (data: string) => void;
     };
 
-    const ctx = beginCall(instance, 'sandbox', 'processes.spawn', meta, sandbox.provider, { command });
+    const ctx = beginCall(instance, 'sandbox', 'processes.spawn', meta, sandbox.provider, { commandProgram });
 
     // Chain user-supplied onStdout/onStderr with our activity emitter.
     // We install our listener BEFORE spawn returns so no early chunks are missed.
@@ -508,13 +575,15 @@ function wrapProcessesSpawn(
       try {
         if (opts.onStdout) opts.onStdout(data);
       } finally {
-        emitSandboxOutput(ctx, meta, sandbox, 'spawn', 'stdout', data, handle?.pid);
+        safeEmit(() => emitSandboxOutput(ctx, meta, sandbox, 'spawn', 'stdout', data, handle?.pid));
         const bytes = Buffer.byteLength(data, 'utf8');
         if (bytes > 0) {
-          ctx.metrics?.emit('mastra.workspace.sandbox.stdout_bytes', bytes, {
-            provider: sandbox.provider,
-            source: 'spawn',
-          });
+          safeEmit(() =>
+            ctx.metrics?.emit('mastra.workspace.sandbox.stdout_bytes', bytes, {
+              provider: sandbox.provider,
+              source: 'spawn',
+            }),
+          );
         }
       }
     };
@@ -522,13 +591,15 @@ function wrapProcessesSpawn(
       try {
         if (opts.onStderr) opts.onStderr(data);
       } finally {
-        emitSandboxOutput(ctx, meta, sandbox, 'spawn', 'stderr', data, handle?.pid);
+        safeEmit(() => emitSandboxOutput(ctx, meta, sandbox, 'spawn', 'stderr', data, handle?.pid));
         const bytes = Buffer.byteLength(data, 'utf8');
         if (bytes > 0) {
-          ctx.metrics?.emit('mastra.workspace.sandbox.stderr_bytes', bytes, {
-            provider: sandbox.provider,
-            source: 'spawn',
-          });
+          safeEmit(() =>
+            ctx.metrics?.emit('mastra.workspace.sandbox.stderr_bytes', bytes, {
+              provider: sandbox.provider,
+              source: 'spawn',
+            }),
+          );
         }
       }
     };
@@ -542,12 +613,12 @@ function wrapProcessesSpawn(
         'sandbox',
         'processes.spawn',
         sandbox.provider,
-        { command, pid: handle?.pid },
+        { commandProgram, pid: handle?.pid },
         { pid: handle?.pid },
       );
       return result;
     } catch (err) {
-      endCallError(ctx, 'sandbox', 'processes.spawn', sandbox.provider, err, { command });
+      endCallError(ctx, 'sandbox', 'processes.spawn', sandbox.provider, err, { commandProgram });
       throw err;
     }
   };
@@ -680,28 +751,41 @@ export interface WorkspaceInstrumentation {
   wrapSandbox(sandbox: WorkspaceSandbox): WorkspaceSandbox;
 }
 
+/**
+ * Cache entry that ties a wrapped provider Proxy to the specific
+ * `ObservabilityInstance` it closes over. Re-registration on `Mastra` (or a
+ * caller swapping the default instance) invalidates the entry so the next
+ * getter access rebuilds the Proxy against the new instance.
+ */
+interface WrapCacheEntry {
+  instance: ObservabilityInstance;
+  wrapped: WorkspaceFilesystem | WorkspaceSandbox;
+}
+
+export type WorkspaceProviderWrapCache = WeakMap<object, WrapCacheEntry>;
+
 export function createWorkspaceInstrumentation(
   mastra: Mastra,
   meta: WorkspaceInstrumentationMeta,
-  wrapCache: WeakMap<object, object>,
+  wrapCache: WorkspaceProviderWrapCache,
 ): WorkspaceInstrumentation {
   return {
     wrapFilesystem(fs: WorkspaceFilesystem): WorkspaceFilesystem {
       const instance = selectObservabilityInstance(mastra);
       if (!instance) return fs;
       const cached = wrapCache.get(fs);
-      if (cached) return cached as WorkspaceFilesystem;
+      if (cached && cached.instance === instance) return cached.wrapped as WorkspaceFilesystem;
       const wrapped = wrapFilesystem(fs, meta, instance);
-      wrapCache.set(fs, wrapped);
+      wrapCache.set(fs, { instance, wrapped });
       return wrapped;
     },
     wrapSandbox(sandbox: WorkspaceSandbox): WorkspaceSandbox {
       const instance = selectObservabilityInstance(mastra);
       if (!instance) return sandbox;
       const cached = wrapCache.get(sandbox);
-      if (cached) return cached as WorkspaceSandbox;
+      if (cached && cached.instance === instance) return cached.wrapped as WorkspaceSandbox;
       const wrapped = wrapSandbox(sandbox, meta, instance);
-      wrapCache.set(sandbox, wrapped);
+      wrapCache.set(sandbox, { instance, wrapped });
       return wrapped;
     },
   };

--- a/packages/core/src/workspace/observability.ts
+++ b/packages/core/src/workspace/observability.ts
@@ -24,7 +24,6 @@
 
 import type { Mastra } from '../mastra';
 import { getCurrentSpan } from '../observability/context-storage';
-import { generateSignalId } from '../observability/utils';
 import type {
   AnySpan,
   ExportedFilesystemChange,
@@ -39,6 +38,7 @@ import type {
   SandboxOutputStream,
 } from '../observability/types';
 import { SpanType } from '../observability/types';
+import { generateSignalId } from '../observability/utils';
 import type { WorkspaceFilesystem } from './filesystem/filesystem';
 import type { WorkspaceSandbox } from './sandbox/sandbox';
 

--- a/packages/core/src/workspace/observability.ts
+++ b/packages/core/src/workspace/observability.ts
@@ -1,0 +1,695 @@
+/**
+ * Workspace Observability Wrappers
+ *
+ * When a `Mastra` instance with `observability` configured owns a workspace,
+ * the workspace transparently wraps its filesystem and sandbox providers with
+ * `Proxy` objects that instrument every method call:
+ *
+ * - **Traces** — each intercepted call opens a `WORKSPACE_ACTION` child span
+ *   under the current ambient span (via `getCurrentSpan()`), or a top-level
+ *   span when none is present. Errors mark the span, then re-throw.
+ * - **Metrics** — duration histograms + byte counters + error counters emitted
+ *   through `ObservabilityInstance.getMetricsContext(span)`.
+ * - **Logs** — one info entry on success / one error entry on throw, emitted
+ *   through `ObservabilityInstance.getLoggerContext(span)`.
+ * - **Workspace activity events** — a dedicated bus channel (see
+ *   `observability/types/workspace-activity.ts`) carrying `sandbox_output`
+ *   (stdout/stderr chunks, truncated at 16 KB) and `filesystem_change`
+ *   (mutation metadata, never contents).
+ *
+ * Wrapping is idempotent (memoized per raw provider via WeakMap) and only
+ * runs when the workspace is registered on a `Mastra` with `observability`
+ * configured. Standalone workspaces are untouched.
+ */
+
+import type { Mastra } from '../mastra';
+import { getCurrentSpan } from '../observability/context-storage';
+import { generateSignalId } from '../observability/utils';
+import type {
+  AnySpan,
+  ExportedFilesystemChange,
+  ExportedSandboxOutput,
+  FilesystemChangeEvent,
+  FilesystemChangeOperation,
+  LoggerContext,
+  MetricsContext,
+  ObservabilityInstance,
+  SandboxOutputEvent,
+  SandboxOutputSource,
+  SandboxOutputStream,
+} from '../observability/types';
+import { SpanType } from '../observability/types';
+import type { WorkspaceFilesystem } from './filesystem/filesystem';
+import type { WorkspaceSandbox } from './sandbox/sandbox';
+
+/** Maximum bytes per emitted sandbox_output chunk. Longer chunks are truncated. */
+export const SANDBOX_OUTPUT_CHUNK_LIMIT = 16 * 1024;
+
+/** Filesystem method names that mutate state (emit `filesystem_change`). */
+const FILESYSTEM_MUTATIONS: Record<string, FilesystemChangeOperation> = {
+  writeFile: 'write',
+  appendFile: 'append',
+  deleteFile: 'delete',
+  copyFile: 'copy',
+  moveFile: 'move',
+  mkdir: 'mkdir',
+  rmdir: 'rmdir',
+};
+
+/** Filesystem methods we instrument (mutations + reads). */
+const FILESYSTEM_METHODS = new Set([
+  'readFile',
+  'writeFile',
+  'appendFile',
+  'deleteFile',
+  'copyFile',
+  'moveFile',
+  'mkdir',
+  'rmdir',
+  'readdir',
+  'stat',
+  'realpath',
+  'exists',
+]);
+
+/** Sandbox methods we instrument (excluding the `processes` sub-object). */
+const SANDBOX_METHODS = new Set([
+  'executeCommand',
+  'mount',
+  'unmount',
+  'start',
+  'stop',
+  'destroy',
+  'isReady',
+  'getInfo',
+]);
+
+/** Sandbox process-manager methods we instrument. */
+const PROCESSES_METHODS = new Set(['spawn', 'list', 'get']);
+
+// =============================================================================
+// Workspace metadata carried onto every emitted signal
+// =============================================================================
+
+export interface WorkspaceInstrumentationMeta {
+  workspaceId: string;
+  workspaceName?: string;
+}
+
+// =============================================================================
+// Truncation helper
+// =============================================================================
+
+/**
+ * Truncate a string chunk to at most `limit` bytes (measured as UTF-8 length).
+ * The `truncated` flag is `true` when the source chunk exceeded the limit.
+ * Handles Buffer inputs by converting to a UTF-8 string first.
+ */
+export function truncateChunk(
+  chunk: string | Buffer,
+  limit = SANDBOX_OUTPUT_CHUNK_LIMIT,
+): { chunk: string; truncated: boolean } {
+  const text = typeof chunk === 'string' ? chunk : chunk.toString('utf8');
+  if (text.length <= limit) {
+    return { chunk: text, truncated: false };
+  }
+  return { chunk: text.slice(0, limit), truncated: true };
+}
+
+// =============================================================================
+// Instrumentation factory
+// =============================================================================
+
+/**
+ * Return `undefined` when this Mastra has no observability configured, or has
+ * only a NoOp entrypoint. Otherwise return the default `ObservabilityInstance`.
+ */
+function selectObservabilityInstance(mastra: Mastra): ObservabilityInstance | undefined {
+  const entrypoint = mastra.observability;
+  const instance = entrypoint?.getDefaultInstance?.();
+  return instance;
+}
+
+/**
+ * Handle for an in-flight instrumented call — carries the span (if any) plus
+ * the correlated logger/metrics contexts derived from that span.
+ */
+interface CallCtx {
+  span: AnySpan | undefined;
+  traceId?: string;
+  spanId?: string;
+  logger: LoggerContext | undefined;
+  metrics: MetricsContext | undefined;
+  instance: ObservabilityInstance;
+  startedAtMs: number;
+}
+
+function beginCall(
+  instance: ObservabilityInstance,
+  category: 'filesystem' | 'sandbox',
+  operation: string,
+  meta: WorkspaceInstrumentationMeta,
+  provider: string,
+  input?: unknown,
+): CallCtx {
+  const parentSpan = getCurrentSpan();
+  const span = parentSpan
+    ? parentSpan.createChildSpan<SpanType.WORKSPACE_ACTION>({
+        type: SpanType.WORKSPACE_ACTION,
+        name: `workspace:${category}:${operation}`,
+        input,
+        attributes: {
+          category,
+          workspaceId: meta.workspaceId,
+          workspaceName: meta.workspaceName,
+          ...(category === 'filesystem' ? { filesystemProvider: provider } : { sandboxProvider: provider }),
+        },
+      })
+    : undefined;
+
+  return {
+    span,
+    traceId: span?.traceId,
+    spanId: span?.id,
+    logger: instance.getLoggerContext?.(span),
+    metrics: instance.getMetricsContext?.(span),
+    instance,
+    startedAtMs: Date.now(),
+  };
+}
+
+function endCallSuccess(
+  ctx: CallCtx,
+  category: 'filesystem' | 'sandbox',
+  operation: string,
+  provider: string,
+  extraLog?: Record<string, unknown>,
+  spanOutput?: unknown,
+): void {
+  const durationMs = Date.now() - ctx.startedAtMs;
+
+  ctx.metrics?.emit(`mastra.workspace.${category}.duration_ms`, durationMs, {
+    operation,
+    provider,
+    success: 'true',
+  });
+
+  ctx.logger?.info(`workspace.${category}.${operation}`, {
+    provider,
+    durationMs,
+    ...extraLog,
+  });
+
+  ctx.span?.end({
+    output: spanOutput,
+    attributes: { success: true },
+  });
+}
+
+function endCallError(
+  ctx: CallCtx,
+  category: 'filesystem' | 'sandbox',
+  operation: string,
+  provider: string,
+  err: unknown,
+  extraLog?: Record<string, unknown>,
+): void {
+  const durationMs = Date.now() - ctx.startedAtMs;
+  const error = err instanceof Error ? err : new Error(String(err));
+  const errorClass = error.name || 'Error';
+
+  ctx.metrics?.emit(`mastra.workspace.${category}.duration_ms`, durationMs, {
+    operation,
+    provider,
+    success: 'false',
+  });
+  ctx.metrics?.emit(`mastra.workspace.${category}.errors_total`, 1, {
+    operation,
+    provider,
+    error_class: errorClass,
+  });
+
+  ctx.logger?.error(`workspace.${category}.${operation}`, {
+    provider,
+    durationMs,
+    error: error.message,
+    errorClass,
+    ...extraLog,
+  });
+
+  ctx.span?.error({ error, attributes: { success: false } });
+}
+
+// =============================================================================
+// Filesystem wrapping
+// =============================================================================
+
+function emitFilesystemChange(
+  ctx: CallCtx,
+  meta: WorkspaceInstrumentationMeta,
+  path: string,
+  operation: FilesystemChangeOperation,
+  bytes?: number,
+  bucketName?: string,
+): void {
+  const change: ExportedFilesystemChange = {
+    eventId: generateSignalId(),
+    timestamp: new Date(),
+    traceId: ctx.traceId,
+    spanId: ctx.spanId,
+    workspaceId: meta.workspaceId,
+    workspaceName: meta.workspaceName,
+    bucketName,
+    path,
+    operation,
+    bytes,
+  };
+  const event: FilesystemChangeEvent = { type: 'filesystem_change', change };
+  ctx.instance.emitWorkspaceActivityEvent?.(event);
+}
+
+function extractFilesystemBytes(operation: FilesystemChangeOperation, args: unknown[]): number | undefined {
+  // writeFile(path, content, options?), appendFile(path, content)
+  if (operation === 'write' || operation === 'append') {
+    const content = args[1];
+    if (typeof content === 'string') return Buffer.byteLength(content, 'utf8');
+    if (content instanceof Uint8Array) return content.byteLength;
+    if (Buffer.isBuffer(content)) return content.byteLength;
+  }
+  return undefined;
+}
+
+function wrapFilesystemMethod(
+  fs: WorkspaceFilesystem,
+  method: string,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): (...args: unknown[]) => Promise<unknown> {
+  return async (...args: unknown[]): Promise<unknown> => {
+    const path = typeof args[0] === 'string' ? args[0] : '';
+    const ctx = beginCall(instance, 'filesystem', method, meta, fs.provider, { path });
+    try {
+      const raw = (fs as unknown as Record<string, ((...a: unknown[]) => Promise<unknown>) | undefined>)[method];
+      if (typeof raw !== 'function') {
+        throw new TypeError(`Filesystem provider is missing method: ${method}`);
+      }
+      const result = await raw.call(fs, ...args);
+      let entryCount: number | undefined;
+      let bytesRead: number | undefined;
+      if (method === 'readdir' && Array.isArray(result)) {
+        entryCount = result.length;
+      } else if (method === 'readFile') {
+        if (typeof result === 'string') bytesRead = Buffer.byteLength(result, 'utf8');
+        else if (result instanceof Uint8Array) bytesRead = result.byteLength;
+      }
+
+      const mutation = FILESYSTEM_MUTATIONS[method];
+      const mutationBytes = mutation ? extractFilesystemBytes(mutation, args) : undefined;
+
+      if (bytesRead != null) {
+        ctx.metrics?.emit('mastra.workspace.filesystem.bytes', bytesRead, {
+          operation: method,
+          provider: fs.provider,
+          direction: 'read',
+        });
+      }
+      if (mutation && mutationBytes != null) {
+        ctx.metrics?.emit('mastra.workspace.filesystem.bytes', mutationBytes, {
+          operation: method,
+          provider: fs.provider,
+          direction: 'write',
+        });
+      }
+
+      // filesystem_change on mutations only
+      if (mutation) {
+        // For copy/move the destination path lives in args[1].
+        const changePath =
+          (mutation === 'copy' || mutation === 'move') && typeof args[1] === 'string' ? args[1] : path;
+        emitFilesystemChange(ctx, meta, changePath, mutation, mutationBytes);
+      }
+
+      endCallSuccess(
+        ctx,
+        'filesystem',
+        method,
+        fs.provider,
+        {
+          path,
+          ...(entryCount != null ? { entryCount } : {}),
+          ...(bytesRead != null ? { bytes: bytesRead } : {}),
+          ...(mutationBytes != null ? { bytes: mutationBytes } : {}),
+        },
+        { path, entryCount, bytes: bytesRead ?? mutationBytes },
+      );
+
+      return result;
+    } catch (err) {
+      endCallError(ctx, 'filesystem', method, fs.provider, err, { path });
+      throw err;
+    }
+  };
+}
+
+/**
+ * Wrap a `WorkspaceFilesystem` with observability instrumentation.
+ * The returned Proxy is memoized per raw provider in the shared per-workspace
+ * cache — repeated calls with the same `fs` return the same Proxy.
+ */
+export function wrapFilesystem(
+  fs: WorkspaceFilesystem,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): WorkspaceFilesystem {
+  return new Proxy(fs, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof prop !== 'string' || !FILESYSTEM_METHODS.has(prop) || typeof value !== 'function') {
+        return value;
+      }
+      return wrapFilesystemMethod(target, prop, meta, instance);
+    },
+  });
+}
+
+// =============================================================================
+// Sandbox wrapping
+// =============================================================================
+
+function emitSandboxOutput(
+  ctx: CallCtx,
+  meta: WorkspaceInstrumentationMeta,
+  sandbox: WorkspaceSandbox,
+  source: SandboxOutputSource,
+  stream: SandboxOutputStream,
+  chunk: string | Buffer,
+  processId?: string,
+): void {
+  const { chunk: truncated, truncated: wasTruncated } = truncateChunk(chunk);
+  if (truncated.length === 0) return;
+  const output: ExportedSandboxOutput = {
+    eventId: generateSignalId(),
+    timestamp: new Date(),
+    traceId: ctx.traceId,
+    spanId: ctx.spanId,
+    workspaceId: meta.workspaceId,
+    workspaceName: meta.workspaceName,
+    sandboxId: sandbox.id,
+    source,
+    processId,
+    stream,
+    chunk: truncated,
+    truncated: wasTruncated,
+  };
+  const event: SandboxOutputEvent = { type: 'sandbox_output', output };
+  ctx.instance.emitWorkspaceActivityEvent?.(event);
+}
+
+function wrapSandboxExecuteCommand(
+  sandbox: WorkspaceSandbox,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): (...args: unknown[]) => Promise<unknown> {
+  return async (...args: unknown[]): Promise<unknown> => {
+    const command = typeof args[0] === 'string' ? args[0] : '';
+    const ctx = beginCall(instance, 'sandbox', 'executeCommand', meta, sandbox.provider, { command });
+    try {
+      const raw = sandbox.executeCommand!;
+      const result = (await raw.call(sandbox, ...(args as Parameters<typeof raw>))) as
+        | {
+            stdout?: string;
+            stderr?: string;
+            exitCode?: number;
+          }
+        | undefined;
+
+      // Byte counters for stdout/stderr
+      const stdoutBytes = result?.stdout ? Buffer.byteLength(result.stdout, 'utf8') : 0;
+      const stderrBytes = result?.stderr ? Buffer.byteLength(result.stderr, 'utf8') : 0;
+      if (stdoutBytes > 0) {
+        ctx.metrics?.emit('mastra.workspace.sandbox.stdout_bytes', stdoutBytes, {
+          provider: sandbox.provider,
+          source: 'exec',
+        });
+      }
+      if (stderrBytes > 0) {
+        ctx.metrics?.emit('mastra.workspace.sandbox.stderr_bytes', stderrBytes, {
+          provider: sandbox.provider,
+          source: 'exec',
+        });
+      }
+
+      // Publish stdout/stderr as sandbox_output events (truncated)
+      if (result?.stdout && result.stdout.length > 0) {
+        emitSandboxOutput(ctx, meta, sandbox, 'exec', 'stdout', result.stdout);
+      }
+      if (result?.stderr && result.stderr.length > 0) {
+        emitSandboxOutput(ctx, meta, sandbox, 'exec', 'stderr', result.stderr);
+      }
+
+      endCallSuccess(
+        ctx,
+        'sandbox',
+        'executeCommand',
+        sandbox.provider,
+        {
+          command,
+          exitCode: result?.exitCode,
+          stdoutBytes,
+          stderrBytes,
+        },
+        { exitCode: result?.exitCode, stdoutBytes, stderrBytes },
+      );
+
+      return result;
+    } catch (err) {
+      endCallError(ctx, 'sandbox', 'executeCommand', sandbox.provider, err, { command });
+      throw err;
+    }
+  };
+}
+
+function wrapProcessesSpawn(
+  sandbox: WorkspaceSandbox,
+  processes: NonNullable<WorkspaceSandbox['processes']>,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): (...args: unknown[]) => Promise<unknown> {
+  return async (...args: unknown[]): Promise<unknown> => {
+    const command = typeof args[0] === 'string' ? args[0] : '';
+    const opts = (args[1] ?? {}) as {
+      onStdout?: (data: string) => void;
+      onStderr?: (data: string) => void;
+    };
+
+    const ctx = beginCall(instance, 'sandbox', 'processes.spawn', meta, sandbox.provider, { command });
+
+    // Chain user-supplied onStdout/onStderr with our activity emitter.
+    // We install our listener BEFORE spawn returns so no early chunks are missed.
+    const injectedOpts: typeof opts = {
+      ...opts,
+    };
+
+    let handle: { pid?: string } | undefined;
+    injectedOpts.onStdout = (data: string) => {
+      try {
+        if (opts.onStdout) opts.onStdout(data);
+      } finally {
+        emitSandboxOutput(ctx, meta, sandbox, 'spawn', 'stdout', data, handle?.pid);
+        const bytes = Buffer.byteLength(data, 'utf8');
+        if (bytes > 0) {
+          ctx.metrics?.emit('mastra.workspace.sandbox.stdout_bytes', bytes, {
+            provider: sandbox.provider,
+            source: 'spawn',
+          });
+        }
+      }
+    };
+    injectedOpts.onStderr = (data: string) => {
+      try {
+        if (opts.onStderr) opts.onStderr(data);
+      } finally {
+        emitSandboxOutput(ctx, meta, sandbox, 'spawn', 'stderr', data, handle?.pid);
+        const bytes = Buffer.byteLength(data, 'utf8');
+        if (bytes > 0) {
+          ctx.metrics?.emit('mastra.workspace.sandbox.stderr_bytes', bytes, {
+            provider: sandbox.provider,
+            source: 'spawn',
+          });
+        }
+      }
+    };
+
+    try {
+      const rawSpawn = (processes as unknown as { spawn: (...a: unknown[]) => Promise<unknown> }).spawn;
+      const result = await rawSpawn.call(processes, args[0], injectedOpts, ...args.slice(2));
+      handle = result as { pid?: string };
+      endCallSuccess(
+        ctx,
+        'sandbox',
+        'processes.spawn',
+        sandbox.provider,
+        { command, pid: handle?.pid },
+        { pid: handle?.pid },
+      );
+      return result;
+    } catch (err) {
+      endCallError(ctx, 'sandbox', 'processes.spawn', sandbox.provider, err, { command });
+      throw err;
+    }
+  };
+}
+
+function wrapPlainSandboxMethod(
+  sandbox: WorkspaceSandbox,
+  method: string,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): (...args: unknown[]) => Promise<unknown> {
+  return async (...args: unknown[]): Promise<unknown> => {
+    const ctx = beginCall(instance, 'sandbox', method, meta, sandbox.provider);
+    try {
+      const raw = (sandbox as unknown as Record<string, ((...a: unknown[]) => Promise<unknown>) | undefined>)[method];
+      if (typeof raw !== 'function') {
+        throw new TypeError(`Sandbox provider is missing method: ${method}`);
+      }
+      const result = await raw.call(sandbox, ...args);
+      endCallSuccess(ctx, 'sandbox', method, sandbox.provider, undefined, undefined);
+      return result;
+    } catch (err) {
+      endCallError(ctx, 'sandbox', method, sandbox.provider, err);
+      throw err;
+    }
+  };
+}
+
+function wrapPlainProcessesMethod(
+  sandbox: WorkspaceSandbox,
+  processes: NonNullable<WorkspaceSandbox['processes']>,
+  method: string,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): (...args: unknown[]) => Promise<unknown> {
+  return async (...args: unknown[]): Promise<unknown> => {
+    const ctx = beginCall(instance, 'sandbox', `processes.${method}`, meta, sandbox.provider);
+    try {
+      const raw = (processes as unknown as Record<string, ((...a: unknown[]) => Promise<unknown>) | undefined>)[
+        method
+      ];
+      if (typeof raw !== 'function') {
+        throw new TypeError(`Sandbox process manager is missing method: ${method}`);
+      }
+      const result = await raw.call(processes, ...args);
+      endCallSuccess(ctx, 'sandbox', `processes.${method}`, sandbox.provider, undefined, undefined);
+      return result;
+    } catch (err) {
+      endCallError(ctx, 'sandbox', `processes.${method}`, sandbox.provider, err);
+      throw err;
+    }
+  };
+}
+
+function wrapProcesses(
+  sandbox: WorkspaceSandbox,
+  processes: NonNullable<WorkspaceSandbox['processes']>,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): NonNullable<WorkspaceSandbox['processes']> {
+  return new Proxy(processes, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof prop !== 'string' || !PROCESSES_METHODS.has(prop) || typeof value !== 'function') {
+        return value;
+      }
+      if (prop === 'spawn') {
+        return wrapProcessesSpawn(sandbox, target, meta, instance);
+      }
+      return wrapPlainProcessesMethod(sandbox, target, prop, meta, instance);
+    },
+  }) as NonNullable<WorkspaceSandbox['processes']>;
+}
+
+/**
+ * Wrap a `WorkspaceSandbox` with observability instrumentation.
+ * The returned Proxy is memoized per raw provider — repeated calls with the
+ * same `sandbox` return the same Proxy.
+ */
+export function wrapSandbox(
+  sandbox: WorkspaceSandbox,
+  meta: WorkspaceInstrumentationMeta,
+  instance: ObservabilityInstance,
+): WorkspaceSandbox {
+  // The wrapped `processes` sub-object is cached lazily on first access so
+  // that repeated `sandbox.processes` reads return the same Proxy.
+  let cachedProcesses: NonNullable<WorkspaceSandbox['processes']> | undefined;
+
+  return new Proxy(sandbox, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+
+      if (prop === 'processes') {
+        if (!value) return value;
+        if (!cachedProcesses) {
+          cachedProcesses = wrapProcesses(
+            target,
+            value as NonNullable<WorkspaceSandbox['processes']>,
+            meta,
+            instance,
+          );
+        }
+        return cachedProcesses;
+      }
+
+      if (typeof prop !== 'string' || !SANDBOX_METHODS.has(prop) || typeof value !== 'function') {
+        return value;
+      }
+
+      if (prop === 'executeCommand') {
+        return wrapSandboxExecuteCommand(target, meta, instance);
+      }
+      return wrapPlainSandboxMethod(target, prop, meta, instance);
+    },
+  });
+}
+
+// =============================================================================
+// Top-level factory used by Workspace
+// =============================================================================
+
+/**
+ * Build a memoized instrumentation helper for a specific workspace. The
+ * returned functions memoize wrapped providers by raw-provider identity via
+ * the shared `wrapCache`, so a resolver returning the same provider twice
+ * yields the same Proxy.
+ */
+export interface WorkspaceInstrumentation {
+  wrapFilesystem(fs: WorkspaceFilesystem): WorkspaceFilesystem;
+  wrapSandbox(sandbox: WorkspaceSandbox): WorkspaceSandbox;
+}
+
+export function createWorkspaceInstrumentation(
+  mastra: Mastra,
+  meta: WorkspaceInstrumentationMeta,
+  wrapCache: WeakMap<object, object>,
+): WorkspaceInstrumentation {
+  return {
+    wrapFilesystem(fs: WorkspaceFilesystem): WorkspaceFilesystem {
+      const instance = selectObservabilityInstance(mastra);
+      if (!instance) return fs;
+      const cached = wrapCache.get(fs);
+      if (cached) return cached as WorkspaceFilesystem;
+      const wrapped = wrapFilesystem(fs, meta, instance);
+      wrapCache.set(fs, wrapped);
+      return wrapped;
+    },
+    wrapSandbox(sandbox: WorkspaceSandbox): WorkspaceSandbox {
+      const instance = selectObservabilityInstance(mastra);
+      if (!instance) return sandbox;
+      const cached = wrapCache.get(sandbox);
+      if (cached) return cached as WorkspaceSandbox;
+      const wrapped = wrapSandbox(sandbox, meta, instance);
+      wrapCache.set(sandbox, wrapped);
+      return wrapped;
+    },
+  };
+}

--- a/packages/core/src/workspace/observability.ts
+++ b/packages/core/src/workspace/observability.ts
@@ -152,20 +152,33 @@ function beginCall(
   provider: string,
   input?: unknown,
 ): CallCtx {
+  const name = `workspace:${category}:${operation}`;
+  const attributes = {
+    category,
+    workspaceId: meta.workspaceId,
+    workspaceName: meta.workspaceName,
+    ...(category === 'filesystem' ? { filesystemProvider: provider } : { sandboxProvider: provider }),
+  };
+
+  // Every wrapped call gets its own span. When an ambient parent span exists
+  // (agent tool call, workflow step, etc.) the wrapper nests as a child.
+  // Otherwise it opens a root span via `instance.startSpan` so signals
+  // emitted from a direct workspace call still have a stable traceId/spanId
+  // to correlate against.
   const parentSpan = getCurrentSpan();
-  const span = parentSpan
+  const span: AnySpan | undefined = parentSpan
     ? parentSpan.createChildSpan<SpanType.WORKSPACE_ACTION>({
         type: SpanType.WORKSPACE_ACTION,
-        name: `workspace:${category}:${operation}`,
+        name,
         input,
-        attributes: {
-          category,
-          workspaceId: meta.workspaceId,
-          workspaceName: meta.workspaceName,
-          ...(category === 'filesystem' ? { filesystemProvider: provider } : { sandboxProvider: provider }),
-        },
+        attributes,
       })
-    : undefined;
+    : instance.startSpan?.<SpanType.WORKSPACE_ACTION>({
+        type: SpanType.WORKSPACE_ACTION,
+        name,
+        input,
+        attributes,
+      });
 
   return {
     span,

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -34,10 +34,13 @@ import * as path from 'node:path';
 import pMap, { pMapSkip } from 'p-map';
 import type { MastraBrowser } from '../browser';
 import type { IMastraLogger } from '../logger';
+import type { Mastra } from '../mastra';
 import { RequestContext } from '../request-context';
 import type { MastraVector } from '../vector';
 
 import { WorkspaceError, SearchNotAvailableError } from './errors';
+import { createWorkspaceInstrumentation } from './observability';
+import type { WorkspaceInstrumentation } from './observability';
 import { CompositeFilesystem, LocalFilesystem } from './filesystem';
 import type { WorkspaceFilesystem, FilesystemInfo } from './filesystem';
 import { MastraFilesystem } from './filesystem/mastra-filesystem';
@@ -586,6 +589,12 @@ export class Workspace<
   private _skills?: WorkspaceSkills;
   private _lsp?: LSPManager;
   private _logger?: IMastraLogger;
+  /** Parent Mastra instance — set by `__registerMastra`. Drives auto-instrumentation. */
+  #mastra?: Mastra;
+  /** Instrumentation helper lazily built on first accessor use after registration. */
+  #instrumentation?: WorkspaceInstrumentation;
+  /** Memoizes wrapped provider Proxies by their raw provider identity. */
+  readonly #providerWrapCache: WeakMap<object, object> = new WeakMap();
 
   constructor(config: WorkspaceConfig<TFilesystem, TSandbox, TMounts>) {
     this.id = config.id ?? this.generateId();
@@ -767,7 +776,8 @@ export class Workspace<
   get filesystem(): [TMounts] extends [Record<string, WorkspaceFilesystem>]
     ? CompositeFilesystem<TMounts>
     : TFilesystem {
-    return this._fs as any;
+    if (!this._fs) return this._fs as any;
+    return this.#applyFilesystemInstrumentation(this._fs) as any;
   }
 
   /**
@@ -776,7 +786,42 @@ export class Workspace<
    * Returns the concrete type you passed to the constructor.
    */
   get sandbox(): TSandbox {
-    return this._sandbox as any;
+    if (!this._sandbox) return this._sandbox as any;
+    return this.#applySandboxInstrumentation(this._sandbox) as any;
+  }
+
+  /**
+   * Return `fs` wrapped with observability instrumentation when this workspace
+   * is registered on a `Mastra` that has observability configured. Otherwise
+   * return `fs` unchanged. Memoized per raw provider.
+   */
+  #applyFilesystemInstrumentation(fs: WorkspaceFilesystem): WorkspaceFilesystem {
+    const instrumentation = this.#getInstrumentation();
+    if (!instrumentation) return fs;
+    return instrumentation.wrapFilesystem(fs);
+  }
+
+  /**
+   * Return `sandbox` wrapped with observability instrumentation when this
+   * workspace is registered on a `Mastra` that has observability configured.
+   * Otherwise return `sandbox` unchanged. Memoized per raw provider.
+   */
+  #applySandboxInstrumentation(sandbox: WorkspaceSandbox): WorkspaceSandbox {
+    const instrumentation = this.#getInstrumentation();
+    if (!instrumentation) return sandbox;
+    return instrumentation.wrapSandbox(sandbox);
+  }
+
+  #getInstrumentation(): WorkspaceInstrumentation | undefined {
+    if (!this.#mastra) return undefined;
+    if (!this.#instrumentation) {
+      this.#instrumentation = createWorkspaceInstrumentation(
+        this.#mastra,
+        { workspaceId: this.id, workspaceName: this.name },
+        this.#providerWrapCache,
+      );
+    }
+    return this.#instrumentation;
   }
 
   /**
@@ -842,13 +887,16 @@ export class Workspace<
   }: {
     requestContext: RequestContext;
   }): Promise<WorkspaceFilesystem | undefined> {
-    if (!this._filesystemResolver) return this._fs;
+    if (!this._filesystemResolver) {
+      return this._fs ? this.#applyFilesystemInstrumentation(this._fs) : undefined;
+    }
     let pending = this._filesystemRequestCache.get(requestContext);
     if (!pending) {
       pending = Promise.resolve(this._filesystemResolver({ requestContext }));
       this._filesystemRequestCache.set(requestContext, pending);
     }
-    return pending;
+    const resolved = await pending;
+    return this.#applyFilesystemInstrumentation(resolved);
   }
 
   /**
@@ -878,7 +926,9 @@ export class Workspace<
    * are memoized by `sandboxCacheKey` when set, else per RequestContext instance.
    */
   async resolveSandbox({ requestContext }: { requestContext: RequestContext }): Promise<WorkspaceSandbox | undefined> {
-    if (!this._sandboxResolver) return this._sandbox;
+    if (!this._sandboxResolver) {
+      return this._sandbox ? this.#applySandboxInstrumentation(this._sandbox) : undefined;
+    }
 
     const cacheKey = this._sandboxCacheKey?.({ requestContext });
     if (cacheKey != null) {
@@ -892,7 +942,8 @@ export class Workspace<
           }
         });
       }
-      return keyed;
+      const resolved = await keyed;
+      return this.#applySandboxInstrumentation(resolved);
     }
 
     let pending = this._sandboxRequestCache.get(requestContext);
@@ -905,7 +956,8 @@ export class Workspace<
         }
       });
     }
-    return pending;
+    const resolved = await pending;
+    return this.#applySandboxInstrumentation(resolved);
   }
 
   /**
@@ -1568,5 +1620,32 @@ export class Workspace<
     if (this._sandbox instanceof MastraSandbox) {
       this._sandbox.__setLogger(logger);
     }
+  }
+
+  /**
+   * Register the parent Mastra instance. Called by `Mastra.addWorkspace` and
+   * by `Agent.__registerMastra` when a workspace is agent-owned. Enables
+   * observability auto-instrumentation: after registration, `filesystem` /
+   * `sandbox` / `resolveFilesystem` / `resolveSandbox` return `Proxy`-wrapped
+   * providers when the Mastra has observability configured, otherwise raw.
+   *
+   * Idempotent: re-registering with the same Mastra is a no-op; re-registering
+   * with a different Mastra swaps the instrumentation.
+   *
+   * @internal
+   */
+  __registerMastra(mastra: Mastra): void {
+    if (this.#mastra === mastra) return;
+    this.#mastra = mastra;
+    // Reset the derived instrumentation helper so the next accessor call
+    // rebuilds it against the new Mastra's observability. Provider wrap cache
+    // is intentionally kept — same raw provider maps to the same wrapper.
+    this.#instrumentation = undefined;
+
+    // Fan out to provider primitives that opt into Mastra registration.
+    const fsWithHook = this._fs as { __registerMastra?: (m: Mastra) => void } | undefined;
+    fsWithHook?.__registerMastra?.(mastra);
+    const sbWithHook = this._sandbox as { __registerMastra?: (m: Mastra) => void } | undefined;
+    sbWithHook?.__registerMastra?.(mastra);
   }
 }

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -39,8 +39,6 @@ import { RequestContext } from '../request-context';
 import type { MastraVector } from '../vector';
 
 import { WorkspaceError, SearchNotAvailableError } from './errors';
-import { createWorkspaceInstrumentation } from './observability';
-import type { WorkspaceInstrumentation, WorkspaceProviderWrapCache } from './observability';
 import { CompositeFilesystem, LocalFilesystem } from './filesystem';
 import type { WorkspaceFilesystem, FilesystemInfo } from './filesystem';
 import { MastraFilesystem } from './filesystem/mastra-filesystem';
@@ -49,6 +47,8 @@ import type { ReaddirEntry } from './glob';
 import { callLifecycle } from './lifecycle';
 import { findProjectRoot, isLSPAvailable, LSPManager } from './lsp';
 import type { LSPConfig } from './lsp/types';
+import type { WorkspaceInstrumentation, WorkspaceProviderWrapCache } from './observability';
+import { createWorkspaceInstrumentation } from './observability';
 import type { WorkspaceSandbox, OnMountHook } from './sandbox';
 import { LocalSandbox } from './sandbox/local-sandbox';
 import { MastraSandbox } from './sandbox/mastra-sandbox';

--- a/packages/core/src/workspace/workspace.ts
+++ b/packages/core/src/workspace/workspace.ts
@@ -40,7 +40,7 @@ import type { MastraVector } from '../vector';
 
 import { WorkspaceError, SearchNotAvailableError } from './errors';
 import { createWorkspaceInstrumentation } from './observability';
-import type { WorkspaceInstrumentation } from './observability';
+import type { WorkspaceInstrumentation, WorkspaceProviderWrapCache } from './observability';
 import { CompositeFilesystem, LocalFilesystem } from './filesystem';
 import type { WorkspaceFilesystem, FilesystemInfo } from './filesystem';
 import { MastraFilesystem } from './filesystem/mastra-filesystem';
@@ -593,8 +593,12 @@ export class Workspace<
   #mastra?: Mastra;
   /** Instrumentation helper lazily built on first accessor use after registration. */
   #instrumentation?: WorkspaceInstrumentation;
-  /** Memoizes wrapped provider Proxies by their raw provider identity. */
-  readonly #providerWrapCache: WeakMap<object, object> = new WeakMap();
+  /**
+   * Memoizes wrapped provider Proxies by their raw provider identity.
+   * Entries carry the `ObservabilityInstance` the Proxy closed over so a
+   * re-registration against a different instance rebuilds the wrapper.
+   */
+  readonly #providerWrapCache: WorkspaceProviderWrapCache = new WeakMap();
 
   constructor(config: WorkspaceConfig<TFilesystem, TSandbox, TMounts>) {
     this.id = config.id ?? this.generateId();


### PR DESCRIPTION
## Summary

Add first-class observability to Mastra workspaces (filesystem + sandbox providers) in `packages/core`, following the established `__registerMastra` / `__setLogger` primitive-registration pattern used throughout core (Agent, LLM, Memory, Workflow, A2A).

When a `Workspace` is registered on a `Mastra` instance that has `observability` configured, every filesystem/sandbox method call is transparently instrumented with a span, a duration metric, an error counter (on throw), a structured log, and — on mutations / sandbox output — a dedicated workspace-activity event. Workspaces created standalone (no `Mastra` parent) or attached to a `Mastra` without `observability` stay untouched: the raw provider is returned so there is zero overhead. Agent-owned workspaces get instrumented for free via `Agent.__registerMastra` fanout.

## What ships

- **New bus channel: `WorkspaceActivityEvent`** — discriminated union of two variants:
  - `sandbox_output` — stdout/stderr from `executeCommand` and `processes.spawn`. Chunks over 16 KB are truncated and carry `truncated: true`. Stdin is never emitted.
  - `filesystem_change` — path + operation metadata for mutating filesystem calls (`writeFile`, `appendFile`, `deleteFile`, `copyFile`, `moveFile`, `mkdir`, `rmdir`). **File contents are never included.**
- **New optional hook: `onWorkspaceActivityEvent?(event)`** on `ObservabilityEvents` (inherited by `ObservabilityExporter` and `ObservabilityBridge`). Handlers that don't implement it silently drop the events.
- **`Workspace.__registerMastra(mastra)`** — new primitive-registration hook. Fans out to `_fs?.__registerMastra?.(mastra)` / `_sandbox?.__registerMastra?.(mastra)` mirroring the existing `__setLogger` sibling.
- **`Mastra.addWorkspace` one-liner** that calls `workspace.__registerMastra(this)` after the existing registration block.
- **`Agent.__registerMastra` fanout** — one line next to the existing workspace-logger fanout.
- **Wrapper module** (`packages/core/src/workspace/observability.ts`) — Proxy-based `wrapFilesystem` / `wrapSandbox` factories, memoized per raw provider via `WeakMap`, that emit metrics via `metricsContext.emit`, structured logs via `loggerContext.info`/`error`, and workspace-activity events via `instance.emitWorkspaceActivityEvent`.

## Scope

**PR A only.** The platform-side exporter (`MastraPlatformExporter.onWorkspaceActivityEvent`), `mobs-collector` ingest endpoint, `mobs-ch-writer` sink, and ClickHouse `mastra_ai_workspace_activity` table (TTL 2d, matching `ai_logs`) will follow in **PR B**.

## Test plan

Verified from repo root, per `packages/core/AGENTS.md`:

- `pnpm build:core` — clean, 14/14 tasks
- `pnpm --filter ./packages/core check` — clean, 0 type errors
- `pnpm --filter ./packages/core test -- --run src/workspace` — 1898 tests pass
  - Includes new `src/workspace/observability.test.ts` (21 wrapper tests)
- `pnpm --filter ./packages/core test -- --run src/mastra/workspace-observability.test.ts` — 5/5 pass
- `pnpm --filter ./packages/core test -- --run workspace-registration workspace-cleanup agent-fga stream-id` — 48/48 pass (regression coverage for existing `__registerMastra` consumers)
- `pnpm --filter @mastra/observability test` — 951 tests pass, including 3 new workspace-activity route-event cases in `observability-bus.test.ts` (69 total, was 66)
- `pnpm turbo build --filter @mastra/server` — 18/18 tasks, no downstream break

## Behavior verified

- Standalone `new Workspace({...})` with no `Mastra`: `.filesystem` / `.sandbox` return the raw provider (referential equality preserved).
- `new Mastra({})` (no observability) + `addWorkspace(ws)`: raw provider returned.
- `new Mastra({ observability })` + `addWorkspace(ws)`: Proxy returned; consecutive reads return the same Proxy (memoized).
- Repeated `addWorkspace(sameWs)` is idempotent — no crash, no double-wrap.
- `filesystem_change` emitted for mutations only; `readFile` / `readdir` / `stat` produce **no** activity event.
- `sandbox_output` emitted for both `executeCommand` (post-resolve, one event per non-empty stream, `source: 'exec'`) and `processes.spawn` (streaming, `source: 'spawn'`).
- Chunks over 16 KB are truncated and carry `truncated: true`.
- Exporter implementing only `onLogEvent` / `onMetricEvent` does **not** crash when activity events flow through the bus.
- Agent-owned workspace (`new Agent({ workspace })`) gets wrapped when the agent's Mastra has `observability` configured.

## Docs + changeset

- Short note added to `docs/src/content/en/docs/workspace/overview.mdx` under a new "Observability" section.
- Changeset `.changeset/workspace-observability-instrumentation.md` — minor bump on `@mastra/core` and `@mastra/observability`.

## Follow-up

**PR B** (out of scope here) will land the platform-side ingest path:
- `MastraPlatformExporter.onWorkspaceActivityEvent` implementation
- `mobs-collector` `POST /v1/observability/ingest/workspace-activity` endpoint
- `mobs-ch-writer` subscriber
- ClickHouse `mastra_ai_workspace_activity` table (TTL 2d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workspaces can now automatically report what they’re doing—such as changing files or producing sandbox output—when connected to Mastra observability. This makes workspace activity easier to monitor without changing behavior or adding overhead when observability is disabled.

## What changed

- Added automatic observability instrumentation for workspace filesystem and sandbox providers:
  - Tracing spans
  - Duration and error metrics
  - Structured success and error logs
  - Filesystem mutation and sandbox output events
- Added `WorkspaceActivityEvent` types for:
  - `filesystem_change`
  - `sandbox_output`
- Added optional `onWorkspaceActivityEvent` handling for observability exporters and bridges.
- Excluded file contents and stdin from activity events.
- Truncated sandbox output chunks larger than 16 KB.
- Automatically instrumented workspaces owned by agents.
- Preserved raw providers for standalone workspaces and Mastra instances without observability.
- Added provider wrapping memoization and idempotent workspace registration.
- Updated exporters to route activity events through dedicated handlers rather than storage persistence.
- Added documentation, comprehensive tests, and a changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->