### PR TITLE
docs: keep leaf component props strict

### DIFF
--- a/.claude/skills/react-best-practices/SKILL.md
+++ b/.claude/skills/react-best-practices/SKILL.md
@@ -82,7 +82,7 @@ Rules are prioritized by impact:
 **Type Safety:**
 
 - No `as` type assertions anywhere — production **or tests**; narrow with real type guards, query generics (`querySelector<T>`, `getByRole<T>`), typed fixture factories, or `implements` on mocks. `as const` is the only allowed form. Do not replace a cast with a domain-type predicate that only checks `typeof value === 'object'`; call that an `isRecord` helper or validate the fields used (`types-no-type-assertions`)
-- Use `undefined` and optional `?` for absence, not `null`; convert external `null` at boundaries with `?? undefined` (`types-no-null`)
+- Use `undefined` and optional `?` for absence, not `null`; convert external `null` at boundaries, and keep leaf props strict so callers own absence and fallback rendering (`types-no-null`)
 
 ### Rendering Patterns
 

--- a/.claude/skills/react-best-practices/references/rules/types-no-null.md
+++ b/.claude/skills/react-best-practices/references/rules/types-no-null.md
@@ -11,6 +11,8 @@ Model missing values as `undefined`, not `null`. In TypeScript code, optional pr
 
 External systems may still emit `null` — REST payloads, database rows, or third-party APIs. Convert those values at the boundary with `?? undefined` and keep internal types null-free. Do not let `null` propagate inward.
 
+Keep leaf display components strict when their UI requires a value: accept a required prop and let the caller decide whether to render the component or its missing-value fallback. Make a prop optional only when absence is part of the component's explicit UI contract.
+
 **Incorrect (null leaks through the component API):**
 
 ```tsx
@@ -88,3 +90,4 @@ Legitimate exceptions are narrow boundary cases: an external API requires `null`
 - Returning or storing `null` because a lookup did not find anything.
 - Passing `null` through multiple layers instead of converting once with `?? undefined`.
 - `null` literals outside boundary adapters, third-party API requirements, DB-specific semantics, or React `return null`.
+- Leaf display components accepting optional props only to choose a generic fallback that belongs to the caller.


### PR DESCRIPTION
Clarifies the existing `types-no-null` guidance so leaf display components require concrete values and callers own missing-value fallbacks. This captures the pattern found in platform#1607 without adding another rule.

Validated with the skill validator and Prettier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Small display components should get the values they need. The people using them should handle missing values and decide what fallback to show.

## Changes

- Clarified `types-no-null` guidance for strict leaf component props.
- Documented that callers own missing-value fallbacks.
- Added a review smell for optional props used only to select generic fallback UI.
- Updated related Type Safety guidance to use `undefined`/optional props appropriately.

## Validation

- Skill validator
- Prettier

<!-- end of auto-generated comment: release notes by coderabbit.ai -->