### PR TITLE
feat(voice-mistral): add Mistral voice provider with Voxtral TTS and STT

### DIFF
--- a/.changeset/voice-mistral-provider.md
+++ b/.changeset/voice-mistral-provider.md
@@ -1,0 +1,26 @@
+---
+'@mastra/voice-mistral': minor
+---
+
+Added Mistral voice provider (`@mastra/voice-mistral`) with text-to-speech and speech-to-text support using Mistral's Voxtral audio models.
+
+**Text-to-speech** via `speak()` supports buffered and streaming output, multiple audio formats (mp3, wav, pcm, flac, opus), and one-off voice cloning via reference audio.
+
+**Speech-to-text** via `listen()` supports batch transcription with speaker diarization, context biasing, and timestamp granularity.
+
+**Voice discovery** via `getSpeakers()` fetches available preset voices from the Mistral Voices API.
+
+```ts
+import { MistralVoice } from '@mastra/voice-mistral'
+
+const voice = new MistralVoice()
+
+// Text-to-speech
+const audio = await voice.speak('Hello from Mistral')
+
+// Speech-to-text
+const text = await voice.listen(audioStream, { language: 'en' })
+
+// Streaming TTS
+const stream = await voice.speak('Hello', { stream: true, responseFormat: 'pcm' })
+```

--- a/.changeset/voice-mistral-provider.md
+++ b/.changeset/voice-mistral-provider.md
@@ -16,7 +16,7 @@ import { MistralVoice } from '@mastra/voice-mistral'
 const voice = new MistralVoice()
 
 // Text-to-speech
-const audio = await voice.speak('Hello from Mistral')
+const audioStream = await voice.speak('Hello from Mistral')
 
 // Speech-to-text
 const text = await voice.listen(audioStream, { language: 'en' })

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -767,6 +767,7 @@ const sidebars = {
         { type: 'doc', id: 'voice/inworld-realtime', label: 'Inworld Realtime' },
         { type: 'doc', id: 'voice/livekit', label: 'LiveKit' },
         { type: 'doc', id: 'voice/mastra-voice', label: 'Mastra Voice' },
+        { type: 'doc', id: 'voice/mistral', label: 'Mistral' },
         { type: 'doc', id: 'voice/murf', label: 'Murf' },
         { type: 'doc', id: 'voice/openai', label: 'OpenAI' },
         { type: 'doc', id: 'voice/openai-realtime', label: 'OpenAI Realtime' },

--- a/docs/src/content/en/reference/voice/mistral.mdx
+++ b/docs/src/content/en/reference/voice/mistral.mdx
@@ -266,7 +266,7 @@ Fetches available preset voices from the Mistral Voices API. Each entry contains
   },
   {
     name: 'gender',
-    type: 'string',
+    type: 'string | null',
     description: 'Gender of the voice.',
     isOptional: true,
   },

--- a/docs/src/content/en/reference/voice/mistral.mdx
+++ b/docs/src/content/en/reference/voice/mistral.mdx
@@ -1,0 +1,288 @@
+---
+title: "Reference: Mistral | Voice"
+description: "API reference for MistralVoice, providing text-to-speech and speech-to-text capabilities using Mistral's Voxtral models."
+packages:
+  - "@mastra/voice-mistral"
+---
+
+# Mistral
+
+The MistralVoice class provides text-to-speech and speech-to-text capabilities using Mistral's Voxtral audio models. It supports buffered and streaming TTS, batch transcription with diarization, and voice cloning via reference audio.
+
+## Usage example
+
+```typescript
+import { MistralVoice } from '@mastra/voice-mistral'
+
+const voice = new MistralVoice()
+
+// Text-to-speech
+const audioStream = await voice.speak('Hello, how can I help you?', {
+  responseFormat: 'mp3',
+})
+
+// Speech-to-text
+const text = await voice.listen(audioStream, {
+  language: 'en',
+})
+
+// List available voices
+const speakers = await voice.getSpeakers()
+```
+
+```typescript
+import { MistralVoice } from '@mastra/voice-mistral'
+
+// Initialize with specific configuration
+const voice = new MistralVoice({
+  speechModel: {
+    name: 'voxtral-mini-tts-2603',
+    apiKey: 'your-mistral-api-key',
+  },
+  listeningModel: {
+    name: 'voxtral-mini-latest',
+    apiKey: 'your-mistral-api-key',
+  },
+  speaker: 'en_paul_neutral',
+})
+```
+
+## Constructor parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'speechModel',
+    type: 'MistralModelConfig',
+    description: 'Configuration for text-to-speech synthesis.',
+    isOptional: true,
+    defaultValue: "{ name: 'voxtral-mini-tts-2603' }",
+    properties: [
+      {
+        type: 'MistralModelConfig',
+        parameters: [
+          {
+            name: 'name',
+            type: 'string',
+            description: 'Model ID for speech synthesis.',
+            isOptional: true,
+            defaultValue: "'voxtral-mini-tts-2603'",
+          },
+          {
+            name: 'apiKey',
+            type: 'string',
+            description: 'Mistral API key. Falls back to MISTRAL_API_KEY environment variable.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'listeningModel',
+    type: 'MistralModelConfig',
+    description: 'Configuration for speech-to-text recognition.',
+    isOptional: true,
+    defaultValue: "{ name: 'voxtral-mini-latest' }",
+    properties: [
+      {
+        type: 'MistralModelConfig',
+        parameters: [
+          {
+            name: 'name',
+            type: 'string',
+            description: "Model ID for transcription. Use 'voxtral-mini-2507' for a pinned version.",
+            isOptional: true,
+            defaultValue: "'voxtral-mini-latest'",
+          },
+          {
+            name: 'apiKey',
+            type: 'string',
+            description: 'Mistral API key. Falls back to MISTRAL_API_KEY environment variable.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    name: 'speaker',
+    type: 'string',
+    description: 'Default voice ID for speech synthesis. Retrieve available IDs from getSpeakers().',
+    isOptional: true,
+    defaultValue: "'en_paul_neutral'",
+  },
+]}
+/>
+
+## Methods
+
+### `speak(input, options?)`
+
+Converts text to speech using Mistral's Voxtral TTS model. Supports both buffered and streaming output.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'input',
+    type: 'string | NodeJS.ReadableStream',
+    description: 'Text or text stream to convert to speech.',
+    isOptional: false,
+  },
+  {
+    name: 'options',
+    type: 'MistralSpeakOptions',
+    description: 'Configuration options.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'MistralSpeakOptions',
+        parameters: [
+          {
+            name: 'speaker',
+            type: 'string',
+            description: 'Voice ID to use. Overrides the constructor default.',
+            isOptional: true,
+          },
+          {
+            name: 'responseFormat',
+            type: "'pcm' | 'wav' | 'mp3' | 'flac' | 'opus'",
+            description: "Audio output format. Use 'pcm' for lowest latency streaming.",
+            isOptional: true,
+          },
+          {
+            name: 'refAudio',
+            type: 'string',
+            description: 'Base64-encoded reference audio for one-off voice cloning (minimum 2-3 seconds).',
+            isOptional: true,
+          },
+          {
+            name: 'model',
+            type: 'string',
+            description: 'Override the speech model for this call.',
+            isOptional: true,
+          },
+          {
+            name: 'stream',
+            type: 'boolean',
+            description: 'Enable streaming TTS. Audio chunks are written to the stream as they arrive.',
+            isOptional: true,
+            defaultValue: 'false',
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+Returns: `Promise<NodeJS.ReadableStream>`
+
+### `listen(audioStream, options?)`
+
+Transcribes audio using Mistral's Voxtral transcription model. Supports diarization, context biasing, and timestamp granularity.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'audioStream',
+    type: 'NodeJS.ReadableStream',
+    description: 'Audio stream to transcribe.',
+    isOptional: false,
+  },
+  {
+    name: 'options',
+    type: 'MistralListenOptions',
+    description: 'Configuration options.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'MistralListenOptions',
+        parameters: [
+          {
+            name: 'language',
+            type: 'string',
+            description: "Language code (e.g., 'en'). Improves accuracy when specified.",
+            isOptional: true,
+          },
+          {
+            name: 'diarize',
+            type: 'boolean',
+            description: 'Enable speaker diarization.',
+            isOptional: true,
+            defaultValue: 'false',
+          },
+          {
+            name: 'contextBias',
+            type: 'string[]',
+            description: 'Up to 100 words or phrases for vocabulary guidance.',
+            isOptional: true,
+          },
+          {
+            name: 'timestampGranularities',
+            type: "('segment' | 'word')[]",
+            description: 'Timestamp detail level for transcription segments.',
+            isOptional: true,
+          },
+          {
+            name: 'filetype',
+            type: 'string',
+            description: 'Audio file extension hint for the input stream.',
+            isOptional: true,
+            defaultValue: "'mp3'",
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+Returns: `Promise<string>`
+
+### `getSpeakers()`
+
+Fetches available preset voices from the Mistral Voices API. Each entry contains:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'voiceId',
+    type: 'string',
+    description: 'Unique identifier for the voice.',
+    isOptional: false,
+  },
+  {
+    name: 'name',
+    type: 'string',
+    description: 'Display name of the voice.',
+    isOptional: false,
+  },
+  {
+    name: 'languages',
+    type: 'string[]',
+    description: 'Languages supported by the voice.',
+    isOptional: true,
+  },
+  {
+    name: 'gender',
+    type: 'string',
+    description: 'Gender of the voice.',
+    isOptional: true,
+  },
+]}
+/>
+
+### `getListener()`
+
+Returns `{ enabled: true }`.
+
+## Notes
+
+- API keys can be provided via constructor options or the `MISTRAL_API_KEY` environment variable
+- TTS supports 9 languages: English, French, Spanish, Portuguese, Italian, Dutch, German, Hindi, Arabic
+- STT supports 13 languages: English, Chinese, Hindi, Spanish, Arabic, French, Portuguese, Russian, German, Japanese, Korean, Italian, Dutch
+- TTS input text should be kept under 300 words per request for best results
+- STT supports up to 3 hours of audio per request
+- Voice cloning via `refAudio` requires a minimum of 2-3 seconds of reference audio
+- `language` and `timestampGranularities` cannot be used together in `listen()`

--- a/docs/src/content/en/reference/voice/mistral.mdx
+++ b/docs/src/content/en/reference/voice/mistral.mdx
@@ -215,7 +215,7 @@ Transcribes audio using Mistral's Voxtral transcription model. Supports diarizat
           {
             name: 'contextBias',
             type: 'string[]',
-            description: 'Up to 100 words or phrases for vocabulary guidance.',
+            description: 'Words or phrases for vocabulary guidance.',
             isOptional: true,
           },
           {
@@ -285,4 +285,4 @@ Returns `{ enabled: true }`.
 - TTS input text should be kept under 300 words per request for best results
 - STT supports up to 3 hours of audio per request
 - Voice cloning via `refAudio` requires a minimum of 2-3 seconds of reference audio
-- `language` and `timestampGranularities` cannot be used together in `listen()`
+- `getSpeakers()` returns preset voices with UUID identifiers. The default `en_paul_neutral` is a named alias accepted by the TTS endpoint but not included in the list

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8011,6 +8011,49 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  voice/mistral:
+    dependencies:
+      '@mistralai/mistralai':
+        specifier: ^2.4.1
+        version: 2.4.1(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)
+      zod:
+        specifier: ^3.25.0 || ^4.0.0
+        version: 3.25.76
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@internal/voice':
+        specifier: workspace:*
+        version: link:../../packages/_internals/voice
+      '@types/node':
+        specifier: 22.19.15
+        version: 22.19.15
+      '@vitest/coverage-v8':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      '@vitest/ui':
+        specifier: 'catalog:'
+        version: 4.1.10(vitest@4.1.10)
+      eslint:
+        specifier: ^10.4.1
+        version: 10.6.0(jiti@2.7.0)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.9(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.7.0)(postcss@8.5.16)(tsx@4.22.4)(typescript@6.0.3)(yaml@2.9.0)
+      tsx:
+        specifier: 'catalog:'
+        version: 4.22.4
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.22.4)(yaml@2.9.0))
+
   voice/modelslab:
     devDependencies:
       '@internal/lint':
@@ -14573,6 +14616,14 @@ packages:
 
   '@microsoft/tsdoc@0.16.0':
     resolution: {integrity: sha512-xgAyonlVVS+q7Vc7qLW0UrJU7rSFcETRWsqdXZtjzRU8dF+6CkozTK4V4y1LwOX7j8r/vHphjDeMeGI4tNGeGA==}
+
+  '@mistralai/mistralai@2.4.1':
+    resolution: {integrity: sha512-vNpR2GR76aW7fK8Dcu1NRx3fdSPO1QruRDo4GbfXfkro2mvp194xIAvJ2BP4ZykzyWtJoDmBe+Qsk9D443aqlg==}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
@@ -37157,6 +37208,18 @@ snapshots:
       resolve: 1.22.12
 
   '@microsoft/tsdoc@0.16.0': {}
+
+  '@mistralai/mistralai@2.4.1(@opentelemetry/api@1.9.1)(bufferutil@4.1.0)':
+    dependencies:
+      '@opentelemetry/semantic-conventions': 1.42.0
+      ws: 8.21.0(bufferutil@4.1.0)
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@mixmark-io/domino@2.2.0': {}
 

--- a/voice/mistral/README.md
+++ b/voice/mistral/README.md
@@ -1,0 +1,83 @@
+# @mastra/voice-mistral
+
+[Mistral](https://mistral.ai) voice provider for [Mastra](https://mastra.ai) — text-to-speech and speech-to-text using Mistral's Voxtral audio models.
+
+## Installation
+
+```bash
+npm install @mastra/voice-mistral @mastra/core
+```
+
+## Quick Start
+
+```typescript
+import { MistralVoice } from '@mastra/voice-mistral';
+
+const voice = new MistralVoice(); // uses MISTRAL_API_KEY
+
+// Text-to-Speech
+const audioStream = await voice.speak('Hello from Mistral!');
+
+// Speech-to-Text
+const transcript = await voice.listen(audioStream);
+
+// List available preset voices
+const speakers = await voice.getSpeakers();
+```
+
+## Configuration
+
+```typescript
+const voice = new MistralVoice({
+  speechModel: {
+    name: 'voxtral-mini-tts-2603', // default TTS model
+    apiKey: 'your-key', // or set MISTRAL_API_KEY env var
+  },
+  listeningModel: {
+    name: 'voxtral-mini-latest', // default STT model
+  },
+  speaker: 'en_paul_neutral', // default voice
+});
+```
+
+## Speak Options
+
+```typescript
+const stream = await voice.speak('Hello', {
+  speaker: 'en_paul_neutral', // override voice
+  responseFormat: 'wav', // pcm | wav | mp3 | flac | opus
+  refAudio: base64Audio, // one-off voice cloning (2-3s minimum)
+  model: 'voxtral-mini-tts-2603', // per-call model override
+  stream: true, // stream audio chunks as they arrive
+});
+```
+
+## Listen Options
+
+```typescript
+const text = await voice.listen(audioStream, {
+  language: 'en',
+  diarize: true, // speaker diarization
+  contextBias: ['Mastra', 'Voxtral'], // vocabulary guidance
+  timestampGranularities: ['segment'],
+  filetype: 'mp3', // extension hint for the input stream
+});
+```
+
+## CompositeVoice
+
+Mix Mistral with other providers:
+
+```typescript
+import { CompositeVoice } from '@mastra/core/voice';
+import { MistralVoice } from '@mastra/voice-mistral';
+
+const voice = new CompositeVoice({
+  input: new MistralVoice(), // Voxtral for STT
+  output: new MistralVoice(), // Voxtral for TTS
+});
+```
+
+## Authentication
+
+Set your API key via the `MISTRAL_API_KEY` environment variable or pass it in the config. Get your key from [console.mistral.ai](https://console.mistral.ai).

--- a/voice/mistral/README.md
+++ b/voice/mistral/README.md
@@ -5,7 +5,7 @@
 ## Installation
 
 ```bash
-npm install @mastra/voice-mistral @mastra/core
+npm install @mastra/voice-mistral
 ```
 
 ## Quick Start

--- a/voice/mistral/eslint.config.js
+++ b/voice/mistral/eslint.config.js
@@ -1,0 +1,25 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [
+  ...config,
+  {
+    files: ['src/**/*.{ts,tsx,js,jsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              group: ['@mastra/core', '@mastra/core/*'],
+              message:
+                'Voice packages must import shared voice/core primitives from @internal/voice or @internal/core, not @mastra/core.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/voice/mistral/lint-staged.config.js
+++ b/voice/mistral/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['eslint --fix', 'prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/voice/mistral/package.json
+++ b/voice/mistral/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@mastra/voice-mistral",
+  "version": "0.1.0",
+  "description": "Mastra Mistral voice integration",
+  "type": "module",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsup --silent --config tsup.config.ts",
+    "prepack": "tsx ../../scripts/generate-package-docs.ts",
+    "build:watch": "tsup --watch --silent --config tsup.config.ts",
+    "test": "vitest run",
+    "lint": "eslint ."
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@mistralai/mistralai": "^2.4.1"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@internal/voice": "workspace:*",
+    "@types/node": "22.20.1",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "eslint": "^10.4.1",
+    "tsup": "^8.5.1",
+    "tsx": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "zod": "^3.25.0 || ^4.0.0"
+  },
+  "homepage": "https://mastra.ai",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "voice/mistral"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "engines": {
+    "node": ">=22.13.0"
+  }
+}

--- a/voice/mistral/package.json
+++ b/voice/mistral/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mastra/voice-mistral",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "Mastra Mistral voice integration",
   "type": "module",
   "files": [

--- a/voice/mistral/src/index.test.ts
+++ b/voice/mistral/src/index.test.ts
@@ -90,6 +90,18 @@ describe('MistralVoice Integration Tests', () => {
       expect(Buffer.concat(chunks).length).toBeGreaterThan(0);
     }, 15000);
 
+    it('should stream audio chunks when stream is enabled', async () => {
+      const audioStream = await voice.speak('Streaming test.', {
+        stream: true,
+      });
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of audioStream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).length).toBeGreaterThan(0);
+    }, 15000);
+
     it('should throw on empty text', async () => {
       await expect(voice.speak('')).rejects.toThrow('Input text is empty');
     });

--- a/voice/mistral/src/index.test.ts
+++ b/voice/mistral/src/index.test.ts
@@ -1,0 +1,142 @@
+import { writeFileSync, mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { PassThrough } from 'node:stream';
+import { describe, expect, it, beforeAll } from 'vitest';
+
+import { MistralVoice } from './index.js';
+
+describe('MistralVoice Integration Tests', () => {
+  let voice: MistralVoice;
+  const outputDir = path.join(process.cwd(), 'test-outputs');
+
+  beforeAll(() => {
+    try {
+      mkdirSync(outputDir, { recursive: true });
+    } catch (err) {
+      console.log('Directory already exists: ', err);
+    }
+
+    voice = new MistralVoice();
+  });
+
+  describe('getSpeakers', () => {
+    it('should list available preset voices', async () => {
+      const speakers = await voice.getSpeakers();
+      expect(speakers).toBeInstanceOf(Array);
+      expect(speakers.length).toBeGreaterThan(0);
+      expect(speakers[0]).toHaveProperty('voiceId');
+      expect(speakers[0]).toHaveProperty('name');
+    });
+  });
+
+  it('should initialize with default parameters', () => {
+    const defaultVoice = new MistralVoice();
+    expect(defaultVoice).toBeInstanceOf(MistralVoice);
+  });
+
+  describe('speak', () => {
+    it('should generate audio from text', async () => {
+      const audioStream = await voice.speak('Hello from Mistral.');
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of audioStream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      const audioBuffer = Buffer.concat(chunks);
+
+      expect(audioBuffer.length).toBeGreaterThan(0);
+
+      const outputPath = path.join(outputDir, 'mistral-speech.mp3');
+      writeFileSync(outputPath, audioBuffer);
+    }, 15000);
+
+    it('should accept a speaker option', async () => {
+      const speakers = await voice.getSpeakers();
+      if (speakers.length === 0) return;
+
+      const audioStream = await voice.speak('Hello with a preset voice.', {
+        speaker: speakers[0]!.voiceId,
+      });
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of audioStream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).length).toBeGreaterThan(0);
+    }, 15000);
+
+    it('should accept a text stream as input', async () => {
+      const inputStream = new PassThrough();
+      inputStream.end('Hello from a stream.');
+
+      const audioStream = await voice.speak(inputStream);
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of audioStream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).length).toBeGreaterThan(0);
+    }, 15000);
+
+    it('should support responseFormat option', async () => {
+      const audioStream = await voice.speak('Format test.', {
+        responseFormat: 'wav',
+      });
+
+      const chunks: Buffer[] = [];
+      for await (const chunk of audioStream) {
+        chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+      }
+      expect(Buffer.concat(chunks).length).toBeGreaterThan(0);
+    }, 15000);
+
+    it('should throw on empty text', async () => {
+      await expect(voice.speak('')).rejects.toThrow('Input text is empty');
+    });
+  });
+
+  describe('listen', () => {
+    it('should transcribe audio', async () => {
+      const audioStream = await voice.speak('This is a transcription test.');
+
+      const text = await voice.listen(audioStream);
+
+      expect(text).toBeTruthy();
+      expect(typeof text).toBe('string');
+      expect(text.length).toBeGreaterThan(0);
+    }, 30000);
+
+    it('should accept language option', async () => {
+      const audioStream = await voice.speak('Testing with language option.');
+
+      const text = await voice.listen(audioStream, {
+        language: 'en',
+      });
+
+      expect(text).toBeTruthy();
+      expect(typeof text).toBe('string');
+    }, 30000);
+  });
+
+  describe('getListener', () => {
+    it('should report listening as enabled', async () => {
+      const result = await voice.getListener();
+      expect(result).toEqual({ enabled: true });
+    });
+  });
+
+  describe('error handling', () => {
+    it('should throw when no API key is available', () => {
+      const originalKey = process.env.MISTRAL_API_KEY;
+      delete process.env.MISTRAL_API_KEY;
+
+      try {
+        expect(() => new MistralVoice()).toThrow();
+      } finally {
+        if (originalKey) {
+          process.env.MISTRAL_API_KEY = originalKey;
+        }
+      }
+    });
+  });
+});

--- a/voice/mistral/src/index.ts
+++ b/voice/mistral/src/index.ts
@@ -32,7 +32,8 @@ export interface MistralListenOptions {
 }
 
 export class MistralVoice extends MastraVoice {
-  private client: Mistral;
+  private speechClient: Mistral;
+  private listeningClient: Mistral;
 
   constructor({
     speechModel,
@@ -57,16 +58,21 @@ export class MistralVoice extends MastraVoice {
       speaker: speaker ?? DEFAULT_SPEAKER,
     });
 
-    const apiKey = speechModel?.apiKey ?? listeningModel?.apiKey ?? defaultApiKey;
-    if (!apiKey) {
-      throw new Error('No API key provided. Set MISTRAL_API_KEY or pass apiKey in speechModel/listeningModel.');
+    const speechApiKey = speechModel?.apiKey ?? defaultApiKey;
+    if (!speechApiKey) {
+      throw new Error('No API key provided for speech model. Set MISTRAL_API_KEY or pass apiKey in speechModel.');
     }
+    this.speechClient = new Mistral({ apiKey: speechApiKey });
 
-    this.client = new Mistral({ apiKey });
+    const listeningApiKey = listeningModel?.apiKey ?? defaultApiKey;
+    if (!listeningApiKey) {
+      throw new Error('No API key provided for listening model. Set MISTRAL_API_KEY or pass apiKey in listeningModel.');
+    }
+    this.listeningClient = new Mistral({ apiKey: listeningApiKey });
   }
 
   async getSpeakers(): Promise<Array<{ voiceId: string; name: string; languages?: string[]; gender?: string | null }>> {
-    const response = await this.client.audio.voices.list({ type: 'preset', limit: 100 });
+    const response = await this.speechClient.audio.voices.list({ type: 'preset', limit: 100 });
     return response.items.map(voice => ({
       voiceId: voice.id,
       name: voice.name,
@@ -91,7 +97,7 @@ export class MistralVoice extends MastraVoice {
       return this.speakStreaming(text, speechModel, voiceId, responseFormat, refAudio, rest);
     }
 
-    const response = await this.client.audio.speech.complete({
+    const response = await this.speechClient.audio.speech.complete({
       input: text,
       model: speechModel,
       voiceId,
@@ -115,7 +121,7 @@ export class MistralVoice extends MastraVoice {
     refAudio?: string,
     rest?: Record<string, any>,
   ): Promise<NodeJS.ReadableStream> {
-    const eventStream = await this.client.audio.speech.complete({
+    const eventStream = await this.speechClient.audio.speech.complete({
       input: text,
       model,
       voiceId,
@@ -155,7 +161,7 @@ export class MistralVoice extends MastraVoice {
 
     const { language, diarize, contextBias, timestampGranularities, filetype, ...rest } = options ?? {};
 
-    const response = await this.client.audio.transcriptions.complete({
+    const response = await this.listeningClient.audio.transcriptions.complete({
       model: this.listeningModel?.name ?? 'voxtral-mini-latest',
       file: {
         fileName: `audio.${filetype ?? 'mp3'}`,

--- a/voice/mistral/src/index.ts
+++ b/voice/mistral/src/index.ts
@@ -1,0 +1,197 @@
+import { PassThrough } from 'node:stream';
+
+import { MastraVoice } from '@internal/voice';
+import { Mistral } from '@mistralai/mistralai';
+
+type MistralSpeechModel = 'voxtral-mini-tts-2603' | (string & {});
+type MistralOutputFormat = 'pcm' | 'wav' | 'mp3' | 'flac' | 'opus';
+
+const DEFAULT_SPEAKER = 'en_paul_neutral';
+
+export interface MistralModelConfig {
+  name?: string;
+  apiKey?: string;
+}
+
+export interface MistralSpeakOptions {
+  speaker?: string;
+  responseFormat?: MistralOutputFormat;
+  refAudio?: string;
+  model?: MistralSpeechModel;
+  stream?: boolean;
+  [key: string]: any;
+}
+
+export interface MistralListenOptions {
+  language?: string;
+  diarize?: boolean;
+  contextBias?: string[];
+  timestampGranularities?: ('segment' | 'word')[];
+  filetype?: string;
+  [key: string]: any;
+}
+
+export class MistralVoice extends MastraVoice {
+  private client: Mistral;
+
+  constructor({
+    speechModel,
+    listeningModel,
+    speaker,
+  }: {
+    speechModel?: MistralModelConfig;
+    listeningModel?: MistralModelConfig;
+    speaker?: string;
+  } = {}) {
+    const defaultApiKey = process.env.MISTRAL_API_KEY;
+
+    super({
+      speechModel: {
+        name: speechModel?.name ?? 'voxtral-mini-tts-2603',
+        apiKey: speechModel?.apiKey ?? defaultApiKey,
+      },
+      listeningModel: {
+        name: listeningModel?.name ?? 'voxtral-mini-latest',
+        apiKey: listeningModel?.apiKey ?? defaultApiKey,
+      },
+      speaker: speaker ?? DEFAULT_SPEAKER,
+    });
+
+    const apiKey = speechModel?.apiKey ?? listeningModel?.apiKey ?? defaultApiKey;
+    if (!apiKey) {
+      throw new Error('No API key provided. Set MISTRAL_API_KEY or pass apiKey in speechModel/listeningModel.');
+    }
+
+    this.client = new Mistral({ apiKey });
+  }
+
+  async getSpeakers(): Promise<Array<{ voiceId: string; name: string; languages?: string[]; gender?: string | null }>> {
+    const response = await this.client.audio.voices.list({ type: 'preset', limit: 100 });
+    return response.items.map(voice => ({
+      voiceId: voice.id,
+      name: voice.name,
+      languages: voice.languages,
+      gender: voice.gender,
+    }));
+  }
+
+  async speak(input: string | NodeJS.ReadableStream, options?: MistralSpeakOptions): Promise<NodeJS.ReadableStream> {
+    const text = typeof input === 'string' ? input : await this.streamToString(input);
+
+    if (text.trim().length === 0) {
+      throw new Error('Input text is empty');
+    }
+
+    const { speaker, responseFormat, refAudio, model, stream: useStreaming, ...rest } = options ?? {};
+
+    const voiceId = speaker ?? this.speaker ?? undefined;
+    const speechModel = model ?? this.speechModel?.name ?? 'voxtral-mini-tts-2603';
+
+    if (useStreaming) {
+      return this.speakStreaming(text, speechModel, voiceId, responseFormat, refAudio, rest);
+    }
+
+    const response = await this.client.audio.speech.complete({
+      input: text,
+      model: speechModel,
+      voiceId,
+      refAudio,
+      responseFormat,
+      stream: false,
+      ...rest,
+    });
+
+    const audioBuffer = Buffer.from(response.audioData, 'base64');
+    const passThrough = new PassThrough();
+    passThrough.end(audioBuffer);
+    return passThrough;
+  }
+
+  private async speakStreaming(
+    text: string,
+    model: string,
+    voiceId?: string,
+    responseFormat?: MistralOutputFormat,
+    refAudio?: string,
+    rest?: Record<string, any>,
+  ): Promise<NodeJS.ReadableStream> {
+    const eventStream = await this.client.audio.speech.complete({
+      input: text,
+      model,
+      voiceId,
+      refAudio,
+      responseFormat,
+      stream: true,
+      ...rest,
+    });
+
+    const passThrough = new PassThrough();
+
+    (async () => {
+      try {
+        for await (const event of eventStream) {
+          if (event.data.type === 'speech.audio.delta') {
+            const chunk = Buffer.from(event.data.audioData, 'base64');
+            passThrough.write(chunk);
+          }
+        }
+        passThrough.end();
+      } catch (error) {
+        passThrough.destroy(error as Error);
+      }
+    })().catch(error => {
+      passThrough.destroy(error as Error);
+    });
+
+    return passThrough;
+  }
+
+  async getListener() {
+    return { enabled: true };
+  }
+
+  async listen(audioStream: NodeJS.ReadableStream, options?: MistralListenOptions): Promise<string> {
+    const audioBuffer = await this.streamToBuffer(audioStream);
+
+    const { language, diarize, contextBias, timestampGranularities, filetype, ...rest } = options ?? {};
+
+    const response = await this.client.audio.transcriptions.complete({
+      model: this.listeningModel?.name ?? 'voxtral-mini-latest',
+      file: {
+        fileName: `audio.${filetype ?? 'mp3'}`,
+        content: new Uint8Array(audioBuffer),
+      },
+      language,
+      diarize,
+      contextBias,
+      timestampGranularities,
+      ...rest,
+    });
+
+    return response.text;
+  }
+
+  private async streamToString(stream: NodeJS.ReadableStream): Promise<string> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      if (typeof chunk === 'string') {
+        chunks.push(Buffer.from(chunk));
+      } else {
+        chunks.push(chunk);
+      }
+    }
+    return Buffer.concat(chunks).toString('utf-8');
+  }
+
+  private async streamToBuffer(stream: NodeJS.ReadableStream): Promise<Buffer> {
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) {
+      if (typeof chunk === 'string') {
+        chunks.push(Buffer.from(chunk));
+      } else {
+        chunks.push(chunk);
+      }
+    }
+    return Buffer.concat(chunks);
+  }
+}

--- a/voice/mistral/tsconfig.build.json
+++ b/voice/mistral/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+}

--- a/voice/mistral/tsconfig.json
+++ b/voice/mistral/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/voice/mistral/tsup.config.ts
+++ b/voice/mistral/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd(), new Set(['@internal/voice']));
+  },
+});

--- a/voice/mistral/vitest.config.ts
+++ b/voice/mistral/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'e2e:voice/mistral',
+    globals: true,
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Description

Adds `@mastra/voice-mistral`, a new voice provider backed by Mistral's Voxtral audio models, so agents can use a Mistral-centered stack for speech via the existing `MastraVoice` / `CompositeVoice` patterns.

- `speak()` for text-to-speech using `voxtral-mini-tts-2603`, with buffered and streaming output (`stream: true`), multiple audio formats (mp3, wav, pcm, flac, opus), and one-off voice cloning via `refAudio`
- `listen()` for batch speech-to-text using `voxtral-mini-latest`, with language, speaker diarization, context biasing, and timestamp granularity options
- `getSpeakers()` fetches available preset voices from the Mistral Voices API
- `MISTRAL_API_KEY` as the default environment variable, with per-model `apiKey` overrides
- Package follows the `voice/openai` structure: `@internal/voice` base class bundled at build time, no runtime `@mastra/core` dependency, eslint guard against `@mastra/core` imports
- Reference docs page at `reference/voice/mistral` registered in the docs sidebar
- Integration test suite (12 tests) covering TTS, STT roundtrip, speakers, and error handling

## Related Issue(s)

Fixes #18920

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new “Mistral” voice helper to Mastra. It lets your app turn text into speech, turn speech into text, and fetch a list of available voices—using `MISTRAL_API_KEY`.

## What changed
- Added a new `@mastra/voice-mistral` package implementing Mastra’s `MastraVoice` / `CompositeVoice` patterns.
- Implemented **text-to-speech** (`speak()` with Voxtral TTS):
  - Buffered and streaming output
  - Multiple audio formats (`responseFormat`)
  - One-off voice cloning via `refAudio`
  - Per-call options (speaker/model/format, plus streaming)
  - Supports `MISTRAL_API_KEY` by default, with per-model `apiKey` overrides
- Implemented **speech-to-text** (`listen()` with Voxtral STT):
  - Batch transcription with options for `language`, `diarize`, `contextBias`, and `timestampGranularities`
  - `filetype` hint support for the input audio payload
- Implemented **voice discovery** (`getSpeakers()`) using Mistral’s Voices API (returns preset voices with `voiceId` and `name`, plus optional metadata).
- Added package/developer support:
  - ESLint guard in the `voice/mistral` package to prevent importing `@mastra/core`
  - Package docs and reference docs, plus registration in the Docusaurus voice sidebar
  - Build/test/lint configuration for the new package (Vitest + tsup + TS configs)
  - Type generation for the `@internal/voice` scope
- Added integration/e2e tests covering:
  - `getSpeakers()`, `speak()` (buffered + streaming, options, invalid empty input), `listen()` (including language override), `getListener()`, and missing `MISTRAL_API_KEY` error behavior
- Added a minor changeset announcing `@mastra/voice-mistral`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
