### PR TITLE
fix(playground-ui): contain hidden form inputs

### DIFF
--- a/.changeset/dry-seas-wave.md
+++ b/.changeset/dry-seas-wave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Prevent named form fields from expanding scroll containers.

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/block/field-block-layout.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/block/field-block-layout.tsx
@@ -17,7 +17,7 @@ export function FieldBlockLayout({
   return (
     <div
       className={cn(
-        'grid gap-2 text-neutral4',
+        'relative grid gap-2 text-neutral4',
         {
           'horizontal-field-block grid-cols-[auto_1fr] items-baseline': layout === 'horizontal',
         },

--- a/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/select-field-block.stories.tsx
+++ b/packages/playground-ui/src/ds/components/FormFieldBlocks/fields/select-field-block.stories.tsx
@@ -134,3 +134,27 @@ export const WithHelpTextAndError: Story = {
     errorMsg: 'Selection is required.',
   },
 };
+
+export const InBoundedScrollContainer: Story = {
+  args: {
+    name: 'fruit',
+    label: 'Fruit',
+    value: 'apple',
+  },
+  decorators: [
+    Story => (
+      <div className="h-32 overflow-auto border border-border1 p-4" data-testid="bounded-scroll-container">
+        <div className="h-16" />
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const namedInput = canvasElement.querySelector<HTMLInputElement>('input[name="fruit"]');
+    const containingBlock = namedInput?.offsetParent;
+
+    if (!(containingBlock instanceof HTMLElement) || getComputedStyle(containingBlock).position !== 'relative') {
+      throw new Error('Named field inputs must be contained by the field block layout.');
+    }
+  },
+};


### PR DESCRIPTION
Named Base UI form controls render an absolutely positioned hidden input. FieldBlock.Layout did not establish the positioned ancestor Base UI expects, so a named select near the bottom of a page could expand the outer scroll area.

This makes FieldBlock.Layout relative and adds a bounded-scroll Storybook regression with a browser assertion. It includes a patch changeset.

Validated with the Playground UI build, 625 unit tests, typecheck, lint, Prettier, React Doctor, and a browser check of the regression story.