### PR TITLE
fix(playground): handle empty tool input forms

### DIFF
--- a/.changeset/tidy-tools-smile.md
+++ b/.changeset/tidy-tools-smile.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Fixed tool execution forms to hide empty configuration tabs and label root inputs.

--- a/packages/playground/src/domains/tools/components/ToolExecutor.test.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.test.tsx
@@ -1,0 +1,51 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ZodType } from 'zod';
+import { z } from 'zod';
+
+import ToolExecutor from './ToolExecutor';
+
+afterEach(() => cleanup());
+
+function renderToolExecutor(zodInputSchema: ZodType = z.object({})) {
+  return render(
+    <ToolExecutor
+      executionResult={undefined}
+      handleExecuteTool={vi.fn()}
+      isExecutingTool={false}
+      toolDescription="Runs without configuration"
+      toolId="test-tool"
+      zodInputSchema={zodInputSchema}
+    />,
+  );
+}
+
+describe('ToolExecutor', () => {
+  describe('when the tool has no input fields or request context', () => {
+    it('does not render configuration tabs', () => {
+      renderToolExecutor();
+
+      expect(screen.queryByRole('tab')).toBeNull();
+    });
+
+    it('explains that the tool can run without input', () => {
+      renderToolExecutor();
+
+      expect(screen.getByText('No input is required to run this tool.')).not.toBeNull();
+    });
+
+    it('keeps the tool executable', () => {
+      renderToolExecutor();
+
+      expect(screen.getByRole('button', { name: 'Submit' })).not.toBeNull();
+    });
+  });
+
+  describe('when the tool has input fields', () => {
+    it('renders the Input Data tab', () => {
+      renderToolExecutor(z.object({ query: z.string() }));
+
+      expect(screen.getByRole('tab', { name: 'Input Data' })).not.toBeNull();
+    });
+  });
+});

--- a/packages/playground/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.tsx
@@ -66,7 +66,7 @@ const ToolExecutorContent = ({
               onSubmit={data => {
                 handleExecuteTool(data, schemaValues);
               }}
-              className="h-auto"
+              className="space-y-4"
             >
               {!hasInputFields && <Notice variant="info">No input is required to run this tool.</Notice>}
             </DynamicForm>

--- a/packages/playground/src/domains/tools/components/ToolExecutor.tsx
+++ b/packages/playground/src/domains/tools/components/ToolExecutor.tsx
@@ -1,6 +1,7 @@
 import type { MCPToolType } from '@mastra/core/mcp';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { MainContentContent } from '@mastra/playground-ui/components/MainContent';
+import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Tabs, Tab, TabList } from '@mastra/playground-ui/components/Tabs';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { useState } from 'react';
@@ -11,7 +12,8 @@ import {
   useSchemaRequestContext,
 } from '@/domains/request-context';
 import { ToolInformation } from '@/domains/tools/components/ToolInformation';
-import { DynamicForm } from '@/lib/form';
+import { DynamicForm } from '@/lib/form/dynamic-form';
+import { isEmptyZodObject } from '@/lib/form/is-empty-zod-object';
 
 interface ToolExecutorProps {
   isExecutingTool: boolean;
@@ -41,18 +43,22 @@ const ToolExecutorContent = ({
   const code = JSON.stringify(result ?? {}, null, 2);
   const [selectedTab, setSelectedTab] = useState('input-data');
   const { schemaValues } = useSchemaRequestContext();
+  const hasInputFields = !isEmptyZodObject(zodInputSchema);
+  const hasConfiguration = hasInputFields || Boolean(requestContextSchema);
 
   return (
     <MainContentContent>
       <div className="flex w-full flex-col items-center p-5 lg:flex-row lg:items-start lg:justify-center">
         <div className="grid w-full min-w-0 max-w-3xl content-start gap-5">
           <ToolInformation toolDescription={toolDescription} toolId={toolId} toolType={toolType} />
-          <Tabs defaultTab="input-data" value={selectedTab} onValueChange={setSelectedTab}>
-            <TabList variant="pill">
-              <Tab value="input-data">Input Data</Tab>
-              {requestContextSchema && <Tab value="request-context">Request Context</Tab>}
-            </TabList>
-          </Tabs>
+          {hasConfiguration && (
+            <Tabs defaultTab="input-data" value={selectedTab} onValueChange={setSelectedTab}>
+              <TabList variant="pill">
+                <Tab value="input-data">Input Data</Tab>
+                {requestContextSchema && <Tab value="request-context">Request Context</Tab>}
+              </TabList>
+            </Tabs>
+          )}
           <div className={cn(selectedTab !== 'input-data' && 'hidden')}>
             <DynamicForm
               isSubmitLoading={isExecutingTool}
@@ -61,7 +67,9 @@ const ToolExecutorContent = ({
                 handleExecuteTool(data, schemaValues);
               }}
               className="h-auto"
-            />
+            >
+              {!hasInputFields && <Notice variant="info">No input is required to run this tool.</Notice>}
+            </DynamicForm>
           </div>
           {requestContextSchema && (
             <div className={cn(selectedTab !== 'request-context' && 'hidden')}>

--- a/packages/playground/src/lib/form/__tests__/dynamic-form-readonly.test.tsx
+++ b/packages/playground/src/lib/form/__tests__/dynamic-form-readonly.test.tsx
@@ -7,6 +7,14 @@ import { DynamicForm } from '../dynamic-form';
 afterEach(() => cleanup());
 
 describe('DynamicForm', () => {
+  describe('when the schema is a root-level primitive', () => {
+    it('labels the generated field as Input', async () => {
+      render(<DynamicForm schema={z.string()} onSubmit={() => {}} />);
+
+      expect(await screen.findByLabelText<HTMLTextAreaElement>(/^Input/)).not.toBeNull();
+    });
+  });
+
   describe('when readOnly is set', () => {
     it('marks string fields read-only', async () => {
       render(

--- a/packages/playground/src/lib/form/dynamic-form.tsx
+++ b/packages/playground/src/lib/form/dynamic-form.tsx
@@ -8,8 +8,9 @@ import { useEffect, useRef, useCallback, useMemo } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { z } from 'zod';
 import { AutoForm } from './auto-form';
+import { isEmptyZodObject } from './is-empty-zod-object';
 import { CustomZodProvider } from './zod-provider';
-import { getShape, getIntersection } from './zod-provider/compat';
+import { getShape } from './zod-provider/compat';
 
 interface DynamicFormProps {
   schema: any;
@@ -28,20 +29,6 @@ interface DynamicFormProps {
   children?: React.ReactNode;
   submitActions?: React.ReactNode;
   leftActions?: React.ReactNode;
-}
-
-function isEmptyZodObject(schema: unknown): boolean {
-  const shape = getShape(schema);
-  if (shape) {
-    return Object.keys(shape).length === 0;
-  }
-
-  const intersection = getIntersection(schema);
-  if (intersection) {
-    return isEmptyZodObject(intersection.left) && isEmptyZodObject(intersection.right);
-  }
-
-  return false;
 }
 
 function isZodObjectLike(schema: any): boolean {
@@ -123,9 +110,11 @@ export function DynamicForm({
         return z.object({});
       }
       if (isNotZodObject) {
+        const rootSchema = s.description ? s : s.describe('Input');
+
         // using a non-printable character to avoid conflicts with the form data
         return z.object({
-          '\u200B': s,
+          '\u200B': rootSchema,
         });
       }
       return s;

--- a/packages/playground/src/lib/form/is-empty-zod-object.ts
+++ b/packages/playground/src/lib/form/is-empty-zod-object.ts
@@ -1,0 +1,15 @@
+import { getIntersection, getShape } from './zod-provider/compat';
+
+export function isEmptyZodObject(schema: unknown): boolean {
+  const shape = getShape(schema);
+  if (shape) {
+    return Object.keys(shape).length === 0;
+  }
+
+  const intersection = getIntersection(schema);
+  if (intersection) {
+    return isEmptyZodObject(intersection.left) && isEmptyZodObject(intersection.right);
+  }
+
+  return false;
+}


### PR DESCRIPTION

<img width="1662" height="442" alt="CleanShot 2026-07-16 at 19 25 08@2x" src="https://github.com/user-attachments/assets/19a07c55-4dc9-436d-83a6-e02f2ba782a0" />

<img width="1662" height="624" alt="CleanShot 2026-07-16 at 19 25 20@2x" src="https://github.com/user-attachments/assets/f1ee3a42-16ae-4d92-b25e-a2cc9af7dbc1" />


Tool execution always rendered an Input Data tab, even when there was no input schema or request context. Root-level primitive schemas were also wrapped with a zero-width internal key, which left their generated field label blank.

This hides the tab list when there is nothing to configure, shows an informational notice while keeping Submit available, and gives root primitive inputs a visible Input label.

Validated with focused Vitest coverage, Playground typecheck and lint, React Doctor, and live browser checks on both reported tool routes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Playground tool forms now avoid showing empty input sections when a tool needs no input, while still clearly explaining the situation and keeping the Submit button available. Root-level inputs are also labeled “Input” instead of appearing blank.

## Changes

- Hide Input Data and Request Context tabs when no relevant configuration exists.
- Show an informational notice for tools without required inputs.
- Add spacing around the empty-tool notice.
- Label root-level primitive inputs as “Input.”
- Add focused tests for empty tool forms, schema tabs, and primitive input labels.
- Add a patch changeset for `@internal/playground`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->