### PR TITLE
fix(core): prevent retained output from blocking the event loop

### DIFF
--- a/.changeset/bright-ends-dress.md
+++ b/.changeset/bright-ends-dress.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed bounded process output stalling other requests while high-volume commands continue streaming.

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.test.ts
@@ -1,6 +1,6 @@
 import { once } from 'node:events';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { MastraSandbox } from '../mastra-sandbox';
 import type { CommandResult } from '../types';
@@ -144,6 +144,13 @@ describe('ProcessHandle output retention', () => {
 
     expect(handle.stdout).toBe('-after');
     expect(handle.stdoutDroppedBytes).toBe(Buffer.byteLength('before'));
+
+    handle.emitStdout('🙂');
+
+    expect(handle.stdout).toBe('er🙂');
+    expect(Buffer.byteLength(handle.stdout)).toBe(6);
+    expect(handle.stdoutTruncated).toBe(true);
+    expect(handle.stdoutDroppedBytes).toBe(Buffer.byteLength('before-aft'));
   });
 
   it('does not split multibyte characters when trimming to a byte limit', () => {
@@ -175,6 +182,40 @@ describe('ProcessHandle output retention', () => {
 
     expect(handle.stdout).toBe('0123456789');
     expect(handle.stdoutDroppedBytes).toBe(140);
+  });
+
+  it('advances through compacted multibyte output across repeated appends', () => {
+    const retainedCodePoints = 256;
+    const output = Array.from({ length: retainedCodePoints + 150 }, (_, index) => ['🙂', '🚀', '🧠'][index % 3]!);
+    const handle = new TestProcessHandle({ maxRetainedBytes: retainedCodePoints * 4 });
+
+    for (const chunk of output) {
+      handle.emitStdout(chunk);
+    }
+
+    expect(handle.stdout).toBe(output.slice(-retainedCodePoints).join(''));
+    expect(Buffer.byteLength(handle.stdout)).toBe(retainedCodePoints * 4);
+    expect(handle.stdoutDroppedBytes).toBe(150 * 4);
+  });
+
+  it('does not rescan retained output for a small overflow after compaction', () => {
+    const maxRetainedBytes = 1024;
+    const handle = new TestProcessHandle({ maxRetainedBytes });
+
+    for (let index = 0; index < maxRetainedBytes; index += 1) {
+      handle.emitStdout('a');
+    }
+
+    const byteLengthSpy = vi.spyOn(Buffer, 'byteLength');
+    try {
+      handle.emitStdout('b');
+
+      expect(byteLengthSpy.mock.calls.length).toBeLessThan(10);
+      expect(handle.stdout).toBe(`${'a'.repeat(maxRetainedBytes - 1)}b`);
+      expect(handle.stdoutDroppedBytes).toBe(1);
+    } finally {
+      byteLengthSpy.mockRestore();
+    }
   });
 
   it('returns retained output from wait after output is truncated', async () => {

--- a/packages/core/src/workspace/sandbox/process-manager/process-handle.ts
+++ b/packages/core/src/workspace/sandbox/process-manager/process-handle.ts
@@ -24,42 +24,37 @@ export function validateMaxRetainedProcessOutputBytes(maxRetainedBytes: number):
   return maxRetainedBytes;
 }
 
-function getPreviousCodePointStart(value: string, end: number): number {
-  let start = end - 1;
-  const codeUnit = value.charCodeAt(start);
+function advanceStartByUtf8Bytes(
+  value: string,
+  start: number,
+  minimumBytesToDrop: number,
+): { start: number; droppedBytes: number } {
+  let nextStart = start;
+  let droppedBytes = 0;
 
-  if (codeUnit >= 0xdc00 && codeUnit <= 0xdfff && start > 0) {
-    const previousCodeUnit = value.charCodeAt(start - 1);
-    if (previousCodeUnit >= 0xd800 && previousCodeUnit <= 0xdbff) {
-      start -= 1;
-    }
+  while (nextStart < value.length && droppedBytes < minimumBytesToDrop) {
+    const codePoint = value.codePointAt(nextStart)!;
+
+    if (codePoint < 0x80) droppedBytes += 1;
+    else if (codePoint < 0x800) droppedBytes += 2;
+    else if (codePoint < 0x10000) droppedBytes += 3;
+    else droppedBytes += 4;
+
+    nextStart += codePoint > 0xffff ? 2 : 1;
   }
 
-  return start;
+  return { start: nextStart, droppedBytes };
 }
 
-function trimToMaxBytes(value: string, maxBytes: number): string {
-  if (maxBytes <= 0) return '';
-
-  let retainedBytes = 0;
-  let end = value.length;
-  let start = end;
-
-  while (start > 0) {
-    const characterStart = getPreviousCodePointStart(value, start);
-    const characterBytes = Buffer.byteLength(value.slice(characterStart, end));
-    if (retainedBytes + characterBytes > maxBytes) break;
-    retainedBytes += characterBytes;
-    end = characterStart;
-    start = characterStart;
-  }
-
-  const retained = value.slice(start);
-  return retained.length === value.length ? retained : Buffer.from(retained, 'utf8').toString('utf8');
+interface RetainedOutputChunk {
+  data: string;
+  start: number;
+  bytes: number;
+  dataBytes: number;
 }
 
 class RetainedOutputBuffer {
-  private chunks: Array<{ data: string; bytes: number }> = [];
+  private chunks: RetainedOutputChunk[] = [];
   private bytes = 0;
   private droppedBytes = 0;
   private cachedValue: string | undefined;
@@ -74,7 +69,7 @@ class RetainedOutputBuffer {
       return;
     }
 
-    this.chunks.push({ data, bytes: dataBytes });
+    this.chunks.push({ data, start: 0, bytes: dataBytes, dataBytes });
     this.bytes += dataBytes;
     this.cachedValue = undefined;
 
@@ -83,7 +78,7 @@ class RetainedOutputBuffer {
   }
 
   toString(): string {
-    this.cachedValue ??= this.chunks.map(chunk => chunk.data).join('');
+    this.cachedValue ??= this.chunks.map(chunk => chunk.data.slice(chunk.start)).join('');
     return this.cachedValue;
   }
 
@@ -109,20 +104,23 @@ class RetainedOutputBuffer {
         continue;
       }
 
-      const retainedData = trimToMaxBytes(firstChunk.data, firstChunk.bytes - overflowBytes);
-      const retainedBytes = Buffer.byteLength(retainedData);
-      const droppedBytes = firstChunk.bytes - retainedBytes;
+      const { start, droppedBytes } = advanceStartByUtf8Bytes(firstChunk.data, firstChunk.start, overflowBytes);
+      firstChunk.start = start;
+      firstChunk.bytes -= droppedBytes;
+      this.bytes -= droppedBytes;
+      this.droppedBytes += droppedBytes;
 
-      if (retainedBytes === 0) {
+      if (firstChunk.bytes === 0) {
         this.chunks.shift();
-        this.bytes -= droppedBytes;
-        this.droppedBytes += droppedBytes;
         continue;
       }
 
-      this.chunks[0] = { data: retainedData, bytes: retainedBytes };
-      this.bytes -= droppedBytes;
-      this.droppedBytes += droppedBytes;
+      if (firstChunk.dataBytes > this.maxBytes) {
+        // V8 sliced strings retain their parent, so detach a bounded suffix from an oversized source chunk.
+        firstChunk.data = Buffer.from(firstChunk.data.slice(firstChunk.start), 'utf8').toString('utf8');
+        firstChunk.start = 0;
+        firstChunk.dataBytes = firstChunk.bytes;
+      }
     }
   }
 
@@ -130,7 +128,7 @@ class RetainedOutputBuffer {
     if (this.chunks.length <= RETAINED_OUTPUT_COMPACT_CHUNK_THRESHOLD) return;
     const data = this.toString();
     this.bytes = Buffer.byteLength(data);
-    this.chunks = this.bytes === 0 ? [] : [{ data, bytes: this.bytes }];
+    this.chunks = this.bytes === 0 ? [] : [{ data, start: 0, bytes: this.bytes, dataBytes: this.bytes }];
     this.cachedValue = data;
   }
 }


### PR DESCRIPTION
Bounded process output currently rescans almost the entire retained buffer whenever a small streamed chunk crosses the limit. Once a command reaches the 1 MiB cap, that synchronous work can delay unrelated requests on the Node.js event loop.

Before:

```ts
trimToMaxBytes(firstChunk.data, firstChunk.bytes - overflowBytes)
```

After:

```ts
advanceStartByUtf8Bytes(firstChunk.data, firstChunk.start, overflowBytes)
```

The retained buffer now advances a chunk-local offset by only the newly dropped bytes. It keeps Unicode boundaries and dropped-byte metadata intact, periodically compacts chunks, and detaches retained suffixes from oversized source strings so the memory bound remains effective.

The focused tests cover complexity, repeated multibyte trimming, compaction, and oversized chunks. In a local benchmark, 200 post-cap 1 KiB appends dropped from about 2.3 seconds to about 1 millisecond while retaining the same byte counts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a command produces lots of output, the system now removes old text without repeatedly rereading everything it has kept. This prevents slowdowns while preserving complete characters and accurate dropped-byte counts.

## Summary

- Reworked bounded process-output trimming to incrementally advance UTF-8 offsets instead of rescanning retained data.
- Preserved Unicode boundaries, retained byte limits, and dropped-byte metadata.
- Added periodic chunk compaction and detached suffixes for oversized source chunks to limit memory retention.
- Added regression tests for multibyte output, compaction, oversized chunks, and trimming complexity.
- Added a `@mastra/core` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->