### PR TITLE
fix(cli): bound stderr buffer in mastra start to prevent RangeError

### DIFF
--- a/.changeset/bound-start-stderr-buffer.md
+++ b/.changeset/bound-start-stderr-buffer.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed a crash where `mastra start` could exit with `RangeError: Invalid string length`. The command retained every byte a running server wrote to stderr in an ever-growing buffer; on long-running or noisy servers this eventually exceeded the maximum string length and took down the process. The retained buffer is now capped at its most recent 1MB, which still contains the crash diagnostics it is inspected for ([#19581](https://github.com/mastra-ai/mastra/issues/19581)).

--- a/packages/cli/src/commands/start/start.test.ts
+++ b/packages/cli/src/commands/start/start.test.ts
@@ -147,4 +147,64 @@ describe('start command - server stderr handling', () => {
       writeSpy.mockRestore();
     }
   });
+
+  it('keeps the retained stderr buffer bounded when the server floods stderr', async () => {
+    const { boundStderr, MAX_STDERR_BUFFER } = await import('./start');
+
+    // Simulate a long-running server streaming far more stderr than the cap.
+    // 500 x 100KB = ~50MB of output, 50x the 1MB bound. Without a bound this
+    // grows until it exceeds V8's max string length and throws RangeError.
+    const chunk = 'x'.repeat(100_000);
+    let buffer = '';
+    for (let i = 0; i < 500; i++) {
+      buffer = boundStderr(buffer, chunk);
+    }
+
+    expect(buffer.length).toBe(MAX_STDERR_BUFFER);
+    expect(buffer.length).toBeLessThanOrEqual(MAX_STDERR_BUFFER);
+  });
+
+  it('still detects a module-not-found error on the retained tail after a flood', async () => {
+    const { boundStderr } = await import('./start');
+
+    // A crashing process prints the module error at the END of its stderr,
+    // so the bounded tail must still contain it after a large flood.
+    const filler = 'x'.repeat(100_000);
+    let buffer = '';
+    for (let i = 0; i < 500; i++) {
+      buffer = boundStderr(buffer, filler);
+    }
+    buffer = boundStderr(buffer, "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'some-pkg'\n");
+
+    expect(buffer.includes('ERR_MODULE_NOT_FOUND')).toBe(true);
+    expect(buffer.match(/Cannot find package '([^']+)'/)?.[1]).toBe('some-pkg');
+  });
+
+  it('surfaces a module-not-found crash through start() even after a large stderr flood', async () => {
+    const server = createFakeServer();
+    spawnMock.mockReturnValue(server);
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+
+    try {
+      const { logger } = await import('../../utils/logger');
+      const { start } = await import('./start');
+      await start({ dir: 'output' });
+
+      // Flood ~10MB of stderr, then emit the crash marker at the tail.
+      const chunk = Buffer.from('x'.repeat(100_000));
+      for (let i = 0; i < 100; i++) {
+        server.stderr.emit('data', chunk);
+      }
+      server.stderr.emit('data', Buffer.from("Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'some-pkg'\n"));
+      server.emit('exit', 1);
+
+      expect(logger.error).toHaveBeenCalledWith('Module not found while starting Mastra server', {
+        package: 'some-pkg',
+      });
+    } finally {
+      writeSpy.mockRestore();
+      exitSpy.mockRestore();
+    }
+  });
 });

--- a/packages/cli/src/commands/start/start.ts
+++ b/packages/cli/src/commands/start/start.ts
@@ -11,6 +11,20 @@ interface StartOptions {
   customArgs?: string[];
 }
 
+// Cap the retained stderr buffer at 1MB. The buffer is only inspected for
+// crash diagnostics (the ERR_MODULE_NOT_FOUND marker and the "Cannot find
+// package" match), which live at the tail of a failing process's output, so
+// keeping only the most recent bytes is sufficient. Without a bound, a
+// long-running server that streams a lot of stderr grows the buffer until it
+// exceeds V8's max string length and throws `RangeError: Invalid string length`.
+export const MAX_STDERR_BUFFER = 1_000_000;
+
+// Append a stderr chunk while keeping only the last `max` characters, so the
+// retained buffer can never grow without bound.
+export function boundStderr(buffer: string, chunk: string, max: number = MAX_STDERR_BUFFER): string {
+  return (buffer + chunk).slice(-max);
+}
+
 export async function start(options: StartOptions = {}) {
   // Load environment variables from .env files
   if (!shouldSkipDotenvLoading()) {
@@ -48,7 +62,7 @@ export async function start(options: StartOptions = {}) {
 
     let stderrBuffer = '';
     server.stderr.on('data', data => {
-      stderrBuffer += data.toString();
+      stderrBuffer = boundStderr(stderrBuffer, data.toString());
       // Stream the server's stderr through live so logs from a healthy,
       // running process (warnings, channel/adapter errors) are visible.
       // The buffer above is retained only for the non-zero exit diagnostics.


### PR DESCRIPTION
Fixes #19581

## Root cause
`mastra start` collects the child server's stderr into `stderrBuffer` with an unbounded `stderrBuffer += data.toString()`. For a long-running or noisy server this grows without limit until it exceeds V8's maximum string length, throwing an uncaught `RangeError: Invalid string length` that crashes the whole process.

## Fix
The buffer is only inspected for crash diagnostics — the `ERR_MODULE_NOT_FOUND` marker and the `Cannot find package '…'` match — which appear at the tail of a failing process's output. I extracted a small pure `boundStderr` helper that appends each chunk and keeps only the most recent `MAX_STDERR_BUFFER` (1MB) characters, so the retained buffer can never grow past that cap while still holding the diagnostics it's read for.

## Tests
Extended `packages/cli/src/commands/start/start.test.ts`: a flood of ~50MB of stderr keeps the buffer capped at 1MB, the `ERR_MODULE_NOT_FOUND` package name is still detected on the retained tail, and an end-to-end `start()` test confirms the crash hint still fires after a large flood. Verified red before the fix (buffer grew to 50MB) and green after. Added a `mastra` patch changeset.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`mastra start` could remember too much error text and eventually crash. This PR keeps only the latest 1 MB, preserving useful error details while preventing memory growth.

## Changes

- Added `boundStderr` and `MAX_STDERR_BUFFER` to cap retained stderr output.
- Preserved detection of `ERR_MODULE_NOT_FOUND` and missing package names.
- Added tests for large stderr floods, retained diagnostics, and end-to-end crash reporting.
- Added a `mastra` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->