### PR TITLE
fix(tavily): use client name attribution

### DIFF
--- a/.changeset/cool-emus-hammer.md
+++ b/.changeset/cool-emus-hammer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/tavily': patch
+---
+
+Fixed Tavily request attribution to use the X-Client-Name header.

--- a/docs/src/content/en/reference/tools/tavily.mdx
+++ b/docs/src/content/en/reference/tools/tavily.mdx
@@ -51,9 +51,9 @@ All factory functions accept `TavilyClientOptions` from `@tavily/core`:
     isOptional: true,
   },
   {
-    name: 'clientSource',
+    name: 'clientName',
     type: 'string',
-    description: 'Attribution string sent with each request.',
+    description: 'Attribution string sent with each request in the `X-Client-Name` header.',
     isOptional: true,
     defaultValue: "'mastra'",
   },

--- a/integrations/tavily/README.md
+++ b/integrations/tavily/README.md
@@ -22,9 +22,10 @@ const tools = createTavilyTools();
 
 const agent = new Agent({
   id: 'realtime-information-agent',
-  name: "Realtime Information Agent",
-  instructions: "You are a realtime information agent that can search the web for the latest information and provide it to the user.",
-  model: "anthropic/claude-sonnet-4-6",
+  name: 'Realtime Information Agent',
+  instructions:
+    'You are a realtime information agent that can search the web for the latest information and provide it to the user.',
+  model: 'anthropic/claude-sonnet-4-6',
   tools,
 });
 ```
@@ -97,11 +98,11 @@ const mapTool = createTavilyMapTool();
 
 ## Configuration
 
-| Option | Type | Default | Description |
-|--------|------|---------|-------------|
+| Option   | Type     | Default                      | Description         |
+| -------- | -------- | ---------------------------- | ------------------- |
 | `apiKey` | `string` | `process.env.TAVILY_API_KEY` | Your Tavily API key |
 
-All tools accept `TavilyClientOptions` from `@tavily/core` (includes `apiKey`, `proxies`, `apiBaseURL`, `clientSource`, `projectId`). If no API key is found, the tool throws a clear error at execution time. `clientSource` defaults to `'mastra'`.
+All tools accept `TavilyClientOptions` from `@tavily/core` (includes `apiKey`, `proxies`, `apiBaseURL`, `clientName`, `projectId`). If no API key is found, the tool throws a clear error at execution time. `clientName` defaults to `'mastra'` and is sent in the `X-Client-Name` header.
 
 ## RAG Pairing Example
 
@@ -113,8 +114,8 @@ import { createTavilySearchTool, createTavilyExtractTool } from '@mastra/tavily'
 
 const agent = new Agent({
   id: 'rag-agent',
-  name: "Research Assistant",
-  model: "anthropic/claude-sonnet-4-6",
+  name: 'Research Assistant',
+  model: 'anthropic/claude-sonnet-4-6',
   instructions: `You are a research assistant. Use tavily-search to find relevant pages, then use tavily-extract to get full content from the best results.`,
   tools: {
     search: createTavilySearchTool(),

--- a/integrations/tavily/src/__tests__/client.test.ts
+++ b/integrations/tavily/src/__tests__/client.test.ts
@@ -33,24 +33,24 @@ describe('getTavilyClient', () => {
 
   it('should use the API key from config', () => {
     getTavilyClient({ apiKey: 'test-key-123' });
-    expect(tavily).toHaveBeenCalledWith({ apiKey: 'test-key-123', clientSource: 'mastra' });
+    expect(tavily).toHaveBeenCalledWith({ apiKey: 'test-key-123', clientName: 'mastra' });
   });
 
   it('should fall back to TAVILY_API_KEY env var', () => {
     process.env.TAVILY_API_KEY = 'env-key-456';
     getTavilyClient();
-    expect(tavily).toHaveBeenCalledWith({ apiKey: 'env-key-456', clientSource: 'mastra' });
+    expect(tavily).toHaveBeenCalledWith({ apiKey: 'env-key-456', clientName: 'mastra' });
   });
 
   it('should prefer config.apiKey over env var', () => {
     process.env.TAVILY_API_KEY = 'env-key-456';
     getTavilyClient({ apiKey: 'config-key-789' });
-    expect(tavily).toHaveBeenCalledWith({ apiKey: 'config-key-789', clientSource: 'mastra' });
+    expect(tavily).toHaveBeenCalledWith({ apiKey: 'config-key-789', clientName: 'mastra' });
   });
 
-  it('should allow overriding clientSource', () => {
-    getTavilyClient({ apiKey: 'test-key', clientSource: 'custom-app' });
-    expect(tavily).toHaveBeenCalledWith({ apiKey: 'test-key', clientSource: 'custom-app' });
+  it('should allow overriding clientName', () => {
+    getTavilyClient({ apiKey: 'test-key', clientName: 'custom-app' });
+    expect(tavily).toHaveBeenCalledWith({ apiKey: 'test-key', clientName: 'custom-app' });
   });
 
   it('should return a client object', () => {

--- a/integrations/tavily/src/client.ts
+++ b/integrations/tavily/src/client.ts
@@ -10,6 +10,6 @@ export function getTavilyClient(config?: TavilyClientOptions): TavilyClient {
   if (!apiKey) {
     throw new Error('Tavily API key is required. Pass { apiKey } or set TAVILY_API_KEY env var.');
   }
-  // defaulting `clientSource` to `mastra` if not provided
-  return tavily({ ...config, apiKey, clientSource: config?.clientSource ?? 'mastra' });
+  // defaulting `clientName` to `mastra` if not provided
+  return tavily({ ...config, apiKey, clientName: config?.clientName ?? 'mastra' });
 }


### PR DESCRIPTION
Send the default Mastra identifier through Tavily's clientName option so SDK requests include X-Client-Name. Update tests and public configuration docs.

Fixes: https://github.com/mastra-ai/mastra/issues/19608

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Tavily requests now identify themselves as coming from Mastra. The related tests and documentation were updated to use the new `clientName` setting and explain the `X-Client-Name` header.

## Changes

- Default Tavily client attribution is now `clientName: 'mastra'`.
- Supports overriding the client name.
- Updated tests for the renamed option and override behavior.
- Updated Tavily documentation and configuration examples.
- Added a patch changeset for `@mastra/tavily`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->