### PR TITLE
fix(libsql): add depth limit to safeStringify to prevent RangeError

### DIFF
--- a/.changeset/libsql-safestringify-depth-limit.md
+++ b/.changeset/libsql-safestringify-depth-limit.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': patch
+---
+
+Fixed an uncaught `RangeError: Maximum call stack size exceeded` when writing deeply-nested values (such as a long chained `Error.cause`) to LibSQL storage. `safeStringify` now caps its recursion depth and substitutes a `"[Max depth exceeded]"` sentinel instead of overflowing the stack.

--- a/stores/libsql/src/storage/db/safe-stringify.test.ts
+++ b/stores/libsql/src/storage/db/safe-stringify.test.ts
@@ -122,4 +122,38 @@ describe('safeStringify', () => {
       expect(parsed.branchB.shared).toEqual({ id: 'shared', back: {} });
     });
   });
+
+  describe('guards against unbounded recursion', () => {
+    // Regression test for https://github.com/mastra-ai/mastra/issues/19594:
+    // deeply-nested values (e.g. a long chained Error.cause) used to overflow
+    // the call stack with an uncaught `RangeError: Maximum call stack size
+    // exceeded`. safeStringify must cap the recursion and emit a sentinel
+    // instead of throwing.
+    it('serializes a deeply-nested object without throwing and inserts a sentinel at depth', () => {
+      // Build nesting far past the internal MAX_DEPTH cap. Without the depth
+      // guard this recursion overflows the call stack with a RangeError.
+      let deep: Record<string, any> = { leaf: true };
+      for (let i = 0; i < 50_000; i++) {
+        deep = { next: deep };
+      }
+
+      let json = '';
+      expect(() => {
+        json = safeStringify(deep);
+      }).not.toThrow();
+
+      expect(json).toContain('[Max depth exceeded]');
+
+      // The shallow portion of the graph is still walked normally.
+      const parsed = JSON.parse(json);
+      expect(parsed.next.next.next).toBeDefined();
+    });
+
+    it('leaves shallow values untouched (no false sentinel)', () => {
+      const value = { a: { b: { c: { d: 1 } } } };
+
+      expect(safeStringify(value)).toBe('{"a":{"b":{"c":{"d":1}}}}');
+      expect(safeStringify(value)).not.toContain('[Max depth exceeded]');
+    });
+  });
 });

--- a/stores/libsql/src/storage/db/utils.ts
+++ b/stores/libsql/src/storage/db/utils.ts
@@ -4,6 +4,11 @@ import { safelyParseJSON, TABLE_SCHEMAS } from '@mastra/core/storage';
 import type { StorageColumn, TABLE_NAMES } from '@mastra/core/storage';
 import { parseSqlIdentifier } from '@mastra/core/utils';
 
+// Guards against unbounded recursion on pathologically deep values (e.g. long
+// chained Error.cause), which would otherwise throw an uncaught
+// `RangeError: Maximum call stack size exceeded`.
+const MAX_DEPTH = 100;
+
 /**
  * Safely serializes a value to JSON string with pre-sanitization.
  * Handles RPC proxies (Cloudflare Workers), functions, symbols, BigInt, and circular references.
@@ -21,12 +26,16 @@ export const safeStringify = (value: unknown): string => {
   // of the same object graph.
   const ancestors = new Set<object>();
 
-  const sanitize = (val: unknown): unknown => {
+  const sanitize = (val: unknown, depth: number = 0): unknown => {
     if (val === null || val === undefined) return val;
     if (typeof val === 'function') return undefined;
     if (typeof val === 'symbol') return undefined;
     if (typeof val === 'bigint') return val.toString();
     if (typeof val !== 'object') return val;
+
+    // Depth guard: stop recursing once the nesting exceeds the cap and return a
+    // sentinel instead of overflowing the call stack.
+    if (depth > MAX_DEPTH) return '[Max depth exceeded]';
 
     // Circular reference check: only drop if this object is an ancestor on the
     // current path. Shared sibling references must still be serialized.
@@ -42,20 +51,20 @@ export const safeStringify = (value: unknown): string => {
 
     // Call toJSON if available (like RequestContext)
     if (typeof (val as Record<string, unknown>).toJSON === 'function') {
-      return sanitize((val as { toJSON: () => unknown }).toJSON());
+      return sanitize((val as { toJSON: () => unknown }).toJSON(), depth + 1);
     }
 
     ancestors.add(val);
     try {
       // Recursively sanitize arrays
       if (Array.isArray(val)) {
-        return val.map(item => sanitize(item));
+        return val.map(item => sanitize(item, depth + 1));
       }
 
       // Recursively sanitize objects
       const result: Record<string, unknown> = {};
       for (const key of Object.keys(val)) {
-        const sanitized = sanitize((val as Record<string, unknown>)[key]);
+        const sanitized = sanitize((val as Record<string, unknown>)[key], depth + 1);
         if (sanitized !== undefined) {
           result[key] = sanitized;
         }


### PR DESCRIPTION
Fixes #19594

The `sanitize` recursion inside `safeStringify` (`stores/libsql/src/storage/db/utils.ts`) had no depth limit, so deeply-nested values (e.g. a long chained `Error.cause`) threw an uncaught `RangeError: Maximum call stack size exceeded` when written to LibSQL storage.

This adds a `MAX_DEPTH` cap (100) threaded through the recursion; once exceeded, `sanitize` returns a `"[Max depth exceeded]"` sentinel instead of recursing further. Existing sanitization behavior (circular refs, shared refs, toJSON, RPC proxies, BigInt) is unchanged.

Extended `safe-stringify.test.ts` with a regression test that serializes a 50k-deep object without throwing (fails with a RangeError before the fix) plus a guard that shallow values are untouched. Added a patch changeset for `@mastra/libsql`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Very deeply nested data could crash the server while being saved. This change safely stops processing after 100 levels and marks the rest instead of overflowing the call stack.

## Summary

- Added a maximum recursion depth of 100 to LibSQL’s `safeStringify`.
- Replaces values beyond the limit with `[Max depth exceeded]`.
- Preserves existing handling for circular references, `toJSON`, RPC proxies, shared references, and `BigInt`.
- Added regression tests for 50,000-level nesting and unchanged shallow serialization.
- Added a patch changeset for `@mastra/libsql`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->