### PR TITLE
fix(mastracode): preserve delivered goal and steer signals

### DIFF
--- a/.changeset/bright-goals-smile.md
+++ b/.changeset/bright-goals-smile.md
@@ -1,0 +1,6 @@
+---
+'@mastra/core': patch
+'mastracode': patch
+---
+
+Fixed goal judge results rendering more than once during live goal runs.

--- a/.changeset/tough-hoops-smell.md
+++ b/.changeset/tough-hoops-smell.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed delivered steer messages disappearing from the chat after replacing their pending state.

--- a/mastracode/tui/e2e/fixtures/goal-judge-single-render.json
+++ b/mastracode/tui/e2e/fixtures/goal-judge-single-render.json
@@ -1,0 +1,25 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Goal: Complete the single-render goal judge e2e objective.",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "content": "{\"decision\":\"done\",\"reason\":\"The single-render goal judge e2e objective is complete.\"}"
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Complete the single-render goal judge e2e objective."
+      },
+      "response": {
+        "content": "Single-render goal work completed."
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/tui/active-signal-followup.ts
+++ b/mastracode/tui/e2e/tui/active-signal-followup.ts
@@ -27,6 +27,11 @@ export const activeSignalFollowupScenario: McE2eScenario = {
     await runtime.waitForScreenText(/Active signal follow-up completed\./i, terminal, 60_000);
     runtime.printScreen('after active follow-up response', terminal);
 
+    const completedView = terminal.serialize().view;
+    expect(completedView).toContain('Steer while active.');
+    expect(completedView).toContain('steer');
+    expect(completedView).not.toContain('Steer while active. pending');
+
     terminal.keyCtrlC();
     runtime.printScreen('after Ctrl-C', terminal);
   },

--- a/mastracode/tui/e2e/tui/goal-judge-single-render.ts
+++ b/mastracode/tui/e2e/tui/goal-judge-single-render.ts
@@ -1,0 +1,120 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createSignal } from '@mastra/core/signals';
+import stripAnsi from 'strip-ansi';
+import { expect } from './expect.js';
+import type { McE2eScenario } from './types.js';
+
+const OBJECTIVE = 'Complete the single-render goal judge e2e objective.';
+const HISTORY_THREAD_ID = 'thread-goal-judge-single-render-history';
+const HISTORY_THREAD_TITLE = 'E2E goal judge history fixture';
+export const GOAL_JUDGE_BOX_SIGNATURE = /Goal\s+●\s+done\s+\(1\/3\)/g;
+
+function quoteSql(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`;
+}
+
+function countJudgeBoxes(view: string): number {
+  return stripAnsi(view).match(GOAL_JUDGE_BOX_SIGNATURE)?.length ?? 0;
+}
+
+function writeProofCounts(live: number, reload: number | null): void {
+  const outputPath = process.env.MC_E2E_GOAL_JUDGE_PROOF_OUT;
+  if (outputPath) {
+    writeFileSync(outputPath, JSON.stringify({ live, reload }));
+  }
+}
+
+export const goalJudgeSingleRenderScenario: McE2eScenario = {
+  name: 'goal-judge-single-render',
+  description: 'Render one live goal judge result and reconstruct one persisted result from history.',
+  testName: 'renders one goal judge box live and one persisted box from history',
+  useOpenAIModel: true,
+  aimockFixture: 'goal-judge-single-render.json',
+  prepare({ appDataDir, dbPath, projectDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
+    settings.models = {
+      ...settings.models,
+      goalJudgeModel: 'openai/gpt-5.4-mini',
+      goalMaxTurns: 3,
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+    const createdAt = new Date('2026-07-16T12:00:00.000Z').toISOString();
+    const resourceId = 'mc-e2e-goal-judge-history';
+    const signalMessage = createSignal({
+      id: 'signal-goal-judge-single-render-history',
+      type: 'reactive',
+      tagName: 'system-reminder',
+      contents: 'done (1/3)\nThe single-render goal judge e2e objective is complete.',
+      attributes: { type: 'goal-judge' },
+      metadata: {
+        goalEvaluation: {
+          objective: OBJECTIVE,
+          iteration: 1,
+          maxRuns: 3,
+          passed: true,
+          status: 'done',
+          results: [],
+          reason: 'The single-render goal judge e2e objective is complete.',
+          duration: 0,
+          timedOut: false,
+          maxRunsReached: false,
+          suppressFeedback: false,
+        },
+      },
+    }).toDBMessage();
+    const threadMetadata = JSON.stringify({ projectPath: projectDir });
+    execFileSync('sqlite3', [
+      dbPath,
+      `insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedAt)
+       values (${quoteSql(HISTORY_THREAD_ID)}, ${quoteSql(resourceId)}, ${quoteSql(HISTORY_THREAD_TITLE)}, ${quoteSql(threadMetadata)}, ${quoteSql(createdAt)}, ${quoteSql(createdAt)});
+       insert into mastra_messages (id, thread_id, content, role, type, createdAt, resourceId)
+       values (${quoteSql(signalMessage.id)}, ${quoteSql(HISTORY_THREAD_ID)}, ${quoteSql(JSON.stringify(signalMessage.content))}, 'signal', 'v2', ${quoteSql(createdAt)}, ${quoteSql(resourceId)});`,
+    ]);
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await (expect(terminal.getByText(/Project:|Resource ID:|>/gi, { full: true, strict: false })) as any).toBeVisible();
+
+    terminal.submit(`/goal ${OBJECTIVE}`);
+    await runtime.waitForScreenText(/Single-render goal work completed\./i, terminal, 15_000);
+    await runtime.waitForScreenText(/Goal\s+●\s+done\s+\(1\/3\)/i, terminal, 15_000);
+
+    const liveView = stripAnsi(terminal.serialize().view);
+    const liveCount = countJudgeBoxes(liveView);
+    writeProofCounts(liveCount, null);
+    console.info(`[goal-judge-single-render] live=${liveCount} signature=${GOAL_JUDGE_BOX_SIGNATURE.source}`);
+    if (liveCount !== 1) {
+      throw new Error(`Expected exactly one live judge box, found ${liveCount}:\n${liveView}`);
+    }
+    terminal.submit('/new');
+    await runtime.waitForScreenText(/Ready for new conversation/i, terminal, 8_000);
+    terminal.submit('/threads');
+    await runtime.waitForScreenText(/Select Thread/i, terminal, 8_000);
+    terminal.write(HISTORY_THREAD_TITLE);
+    await runtime.waitForScreenText(new RegExp(HISTORY_THREAD_TITLE, 'i'), terminal, 8_000);
+    terminal.write('\r');
+
+    await runtime.waitForScreenText(new RegExp(`Switched to: ${HISTORY_THREAD_TITLE}`, 'i'), terminal, 8_000);
+    await runtime.waitForScreenText(/Goal\s+●\s+done\s+\(1\/3\)/i, terminal, 8_000);
+
+    const reloadCount = countJudgeBoxes(terminal.serialize().view);
+    writeProofCounts(liveCount, reloadCount);
+    console.info(`[goal-judge-single-render] reload=${reloadCount} signature=${GOAL_JUDGE_BOX_SIGNATURE.source}`);
+    expect(Array.from({ length: reloadCount })).toHaveLength(1);
+
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    if (requests.length < 2) {
+      throw new Error(`Expected an agent response and goal judge request; received ${requests.length} AIMock requests`);
+    }
+    const body = JSON.stringify(requests);
+    if (!body.includes(OBJECTIVE)) {
+      throw new Error('Expected AIMock requests to contain the goal objective');
+    }
+  },
+};

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -42,6 +42,7 @@ import { githubSignalsIncrementalScenario } from './github-signals-incremental.j
 import { githubSignalsNotificationReloadScenario } from './github-signals-notification-reload.js';
 import { githubSignalsPollingInboxScenario } from './github-signals-polling-inbox.js';
 import { githubSignalsUnsubscribeReloadScenario } from './github-signals-unsubscribe-reload.js';
+import { goalJudgeSingleRenderScenario } from './goal-judge-single-render.js';
 import { headlessMcpToolAvailabilityScenario } from './headless-mcp-tool-availability.js';
 import { integrationCommandsScenario } from './integration-commands.js';
 import { lifecycleHooksConfiguredScenario } from './lifecycle-hooks-configured.js';
@@ -196,6 +197,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'github-signals-notification-reload': githubSignalsNotificationReloadScenario,
   'github-signals-polling-inbox': githubSignalsPollingInboxScenario,
   'github-signals-unsubscribe-reload': githubSignalsUnsubscribeReloadScenario,
+  'goal-judge-single-render': goalJudgeSingleRenderScenario,
   'controller-api-config': controllerApiConfigScenario,
   'headless-mcp-tool-availability': headlessMcpToolAvailabilityScenario,
   'visible-commands': visibleCommandsScenario,

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -48,6 +48,7 @@ export type ScenarioName =
   | 'github-signals-notification-reload'
   | 'github-signals-polling-inbox'
   | 'github-signals-unsubscribe-reload'
+  | 'goal-judge-single-render'
   | 'controller-api-config'
   | 'headless-mcp-tool-availability'
   | 'openai-strict-schema'

--- a/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
+++ b/mastracode/tui/src/tui/__tests__/mastra-tui-queueing.test.ts
@@ -23,6 +23,7 @@ vi.mock('../display.js', () => ({
   notify: vi.fn(),
 }));
 
+import { JudgeDisplayComponent } from '../components/judge-display.js';
 import { GOAL_JUDGE_INPUT_LOCK_MESSAGE } from '../goal-input-lock.js';
 import { handleAgentAborted, handleAgentEnd, handleGoalEvaluation } from '../handlers/agent-lifecycle.js';
 import type { EventHandlerContext } from '../handlers/types.js';
@@ -603,6 +604,40 @@ describe('MastraTUI queueing', () => {
     expect((state.activeGoalJudge?.component as any).activity).toEqual(['read']);
     expect(state.goalManager.applyEvaluation).not.toHaveBeenCalled();
     expect(state.ui.requestRender).toHaveBeenCalled();
+  });
+
+  it('clears completed judge state and places the next iteration after continuation output', () => {
+    const applyEvaluation = vi.fn();
+    const state = createQueueState({
+      goalManager: {
+        applyEvaluation,
+        getGoal: vi.fn(() => ({
+          id: 'continuing-goal',
+          status: 'active',
+          judgeModelId: 'openai/gpt-5.4-mini',
+          turnsUsed: 1,
+          maxTurns: 20,
+        })),
+      } as any,
+    });
+    const ctx = createQueueContext(state);
+
+    handleGoalEvaluation(ctx, createGoalPayload({ iteration: 1 }));
+    expect(state.activeGoalJudge).toBeUndefined();
+
+    const continuationOutput = { kind: 'assistant-output' };
+    state.chatContainer.addChild(continuationOutput as any);
+    handleGoalEvaluation(ctx, createGoalPayload({ iteration: 2 }));
+
+    const judgeComponents = state.chatContainer.children.filter(child => child instanceof JudgeDisplayComponent);
+    expect(judgeComponents).toHaveLength(2);
+    expect(judgeComponents[1]).not.toBe(judgeComponents[0]);
+    expect(state.chatContainer.children.indexOf(judgeComponents[1]!)).toBeGreaterThan(
+      state.chatContainer.children.indexOf(continuationOutput as any),
+    );
+    expect(state.activeGoalJudge).toBeUndefined();
+    expect(applyEvaluation).toHaveBeenNthCalledWith(1, { runsUsed: 1, status: 'active' });
+    expect(applyEvaluation).toHaveBeenNthCalledWith(2, { runsUsed: 2, status: 'active' });
   });
 
   it('ignores late goal chunks after the user has aborted and paused the goal', () => {

--- a/mastracode/tui/src/tui/db-message-parts.ts
+++ b/mastracode/tui/src/tui/db-message-parts.ts
@@ -204,6 +204,34 @@ export function getSignalContentsText(message: MastraDBMessage): string {
   return contentsToText(getSignalView(message).contents);
 }
 
+export interface UserSignalView {
+  message: string;
+  imageCount: number;
+  fileCount: number;
+}
+
+/** Fields needed to render a user-kind signal as a user message. */
+export function getUserSignalView(message: MastraDBMessage): UserSignalView {
+  const contents = getSignalView(message).contents;
+  if (typeof contents === 'string') {
+    return { message: contents, imageCount: 0, fileCount: 0 };
+  }
+
+  let imageCount = 0;
+  let fileCount = 0;
+  for (const part of contents) {
+    if (part.type !== 'file') continue;
+    if (part.mediaType.startsWith('image/')) imageCount++;
+    else fileCount++;
+  }
+
+  return {
+    message: contentsToText(contents),
+    imageCount,
+    fileCount,
+  };
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return value && typeof value === 'object' && !Array.isArray(value) ? (value as Record<string, unknown>) : undefined;
 }

--- a/mastracode/tui/src/tui/db-message-parts.ts
+++ b/mastracode/tui/src/tui/db-message-parts.ts
@@ -277,6 +277,13 @@ export function getReminderView(message: MastraDBMessage): ReminderView {
   };
 }
 
+/** True for the persisted mirror of a live goal evaluation lifecycle event. */
+export function isGoalJudgeEvaluationSignal(message: MastraDBMessage): boolean {
+  if (!isSignalMessage(message) || getSignalKind(message) !== 'reminder') return false;
+  const reminder = getReminderView(message);
+  return reminder.reminderType === 'goal-judge' && reminder.goalEvaluation !== undefined;
+}
+
 export interface StateSignalView {
   stateId: string;
   mode: 'snapshot' | 'delta';

--- a/mastracode/tui/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/message.test.ts
@@ -14,13 +14,17 @@ import { SystemReminderComponent } from '../../components/system-reminder.js';
 import { TemporalGapComponent } from '../../components/temporal-gap.js';
 import { ToolExecutionComponentEnhanced } from '../../components/tool-execution-enhanced.js';
 import { UserMessageComponent } from '../../components/user-message.js';
-import { addPendingUserMessage, addUserMessage } from '../../render-messages.js';
+import { addPendingUserMessage, addUserMessage as renderUserMessage } from '../../render-messages.js';
 import type { TUIState } from '../../state.js';
 import { handleMessageEnd, handleMessageStart, handleMessageUpdate } from '../message.js';
 import type { EventHandlerContext } from '../types.js';
 
 function visibleChildren(state: TUIState) {
   return state.chatContainer.children.filter(child => !isChatBoundarySpacer(child));
+}
+
+function addUserMessage(state: TUIState, message: MastraDBMessage): void {
+  renderUserMessage(state, message);
 }
 
 type Part = Exclude<MastraDBMessage['content'], string>['parts'][number];
@@ -129,7 +133,7 @@ describe('handleMessageStart signals', () => {
 
     ctx = {
       state,
-      addUserMessage: (message: MastraDBMessage) => addUserMessage(state, message),
+      addUserMessage: message => renderUserMessage(state, message),
       addChildBeforeFollowUps: (child: any) => {
         state.chatContainer.addChild(child);
       },
@@ -162,6 +166,35 @@ describe('handleMessageStart signals', () => {
     const rendered = stripAnsi((visibleChildren(state)[0] as ReactiveSignalComponent).render(80).join('\n'));
     expect(rendered).toContain('Signal: build-status');
     expect(rendered).toContain('Build is still running');
+  });
+
+  it('confirms pending steering from the delivered DB-native user signal', () => {
+    addPendingUserMessage(state, 'steer-1', 'Change direction', [{ data: 'image-data', mimeType: 'image/png' }], {
+      isInterjection: true,
+    });
+
+    handleMessageStart(
+      ctx,
+      signalMessage(
+        {
+          id: 'steer-1',
+          type: 'user',
+          contents: [
+            { type: 'text', text: 'Change direction' },
+            { type: 'file', data: 'image-data', mediaType: 'image/png' },
+          ],
+          attributes: { delivery: 'while-active' },
+        },
+        'steer-1',
+      ),
+    );
+
+    expect(state.pendingSignalMessageComponentsById.has('steer-1')).toBe(false);
+    const component = state.messageComponentsById.get('steer-1');
+    expect(component).toBeInstanceOf(UserMessageComponent);
+    const rendered = stripAnsi((component as UserMessageComponent).render(100).join('\n'));
+    expect(rendered).toContain('steer');
+    expect(rendered).toContain('[1 image] Change direction');
   });
 
   it('does not render streamed GitHub subscribe operation signals', () => {
@@ -446,7 +479,7 @@ describe('handleMessageUpdate assistant streaming', () => {
 
     ctx = {
       state,
-      addUserMessage: (message: MastraDBMessage) => addUserMessage(state, message),
+      addUserMessage: message => renderUserMessage(state, message),
       addChildBeforeFollowUps: (child: any) => {
         state.chatContainer.addChild(child);
       },

--- a/mastracode/tui/src/tui/handlers/__tests__/message.test.ts
+++ b/mastracode/tui/src/tui/handlers/__tests__/message.test.ts
@@ -5,6 +5,7 @@ import stripAnsi from 'strip-ansi';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AssistantMessageComponent } from '../../components/assistant-message.js';
 import { isChatBoundarySpacer } from '../../components/chat-boundary-spacer.js';
+import { JudgeDisplayComponent } from '../../components/judge-display.js';
 import { NotificationSummaryComponent } from '../../components/notification-summary.js';
 import { NotificationComponent } from '../../components/notification.js';
 import { ReactiveSignalComponent } from '../../components/reactive-signal.js';
@@ -16,6 +17,7 @@ import { ToolExecutionComponentEnhanced } from '../../components/tool-execution-
 import { UserMessageComponent } from '../../components/user-message.js';
 import { addPendingUserMessage, addUserMessage as renderUserMessage } from '../../render-messages.js';
 import type { TUIState } from '../../state.js';
+import { handleGoalEvaluation } from '../agent-lifecycle.js';
 import { handleMessageEnd, handleMessageStart, handleMessageUpdate } from '../message.js';
 import type { EventHandlerContext } from '../types.js';
 
@@ -447,6 +449,98 @@ describe('handleMessageStart signals', () => {
     expect(state.allSystemReminderComponents[0]).toBeInstanceOf(TemporalGapComponent);
     expect(isChatBoundarySpacer(state.chatContainer.children[1]!)).toBe(true);
     expect(isChatBoundarySpacer(state.chatContainer.children[3]!)).toBe(true);
+  });
+});
+
+describe('goal evaluation live rendering ownership', () => {
+  const evaluation = {
+    objective: 'List whale facts',
+    iteration: 2,
+    maxRuns: 20,
+    passed: false,
+    status: 'active',
+    results: [],
+    reason: 'Need another fact.',
+    duration: 0,
+    timedOut: false,
+    maxRunsReached: false,
+    suppressFeedback: false,
+  } as Parameters<typeof handleGoalEvaluation>[1];
+
+  function createGoalJudgeSignal(): MastraDBMessage {
+    return signalMessage(
+      {
+        type: 'reactive',
+        tagName: 'system-reminder',
+        contents: '[Goal attempt 2/20] Continue.',
+        attributes: { type: 'goal-judge' },
+        metadata: { goalEvaluation: evaluation },
+      } as Parameters<typeof createSignal>[0],
+      'goal-judge-signal',
+    );
+  }
+
+  function createContext(): EventHandlerContext {
+    const state = {
+      chatContainer: new Container(),
+      followUpComponents: [],
+      ui: { requestRender: vi.fn() },
+      currentRunSystemReminderKeys: new Set(),
+      pendingTools: new Map(),
+      seenToolCallIds: new Set(),
+      subagentToolCallIds: new Set(),
+      allToolComponents: [],
+      allSlashCommandComponents: [],
+      allSystemReminderComponents: [],
+      messageComponentsById: new Map(),
+      pendingSubagents: new Map(),
+      hideThinkingBlock: false,
+      toolOutputExpanded: false,
+      pendingSignalMessageComponentsById: new Map(),
+      goalManager: {
+        getGoal: vi.fn(() => ({ id: 'goal-1', judgeModelId: 'openai/gpt-5.4-mini' })),
+        applyEvaluation: vi.fn(),
+      },
+      session: { displayState: { get: () => ({ isRunning: true }) } },
+      controller: { session: { displayState: { get: () => ({ isRunning: true }) } } },
+    } as unknown as TUIState;
+
+    return {
+      state,
+      addUserMessage: (message: MastraDBMessage) => renderUserMessage(state, message),
+      updateStatusLine: vi.fn(),
+      addChildBeforeFollowUps: (child: any) => state.chatContainer.addChild(child),
+    } as unknown as EventHandlerContext;
+  }
+
+  it.each([
+    ['goal_evaluation then live signal', true],
+    ['live signal then goal_evaluation', false],
+  ])('renders one judge component when delivery order is %s', (_label, lifecycleFirst) => {
+    const ctx = createContext();
+    const renderLifecycle = () => {
+      handleGoalEvaluation(ctx, evaluation);
+    };
+    const renderSignal = () => {
+      const signal = createGoalJudgeSignal();
+      handleMessageStart(ctx, signal);
+      handleMessageUpdate(ctx, signal);
+      handleMessageEnd(ctx, signal);
+    };
+
+    if (lifecycleFirst) {
+      renderLifecycle();
+      renderSignal();
+    } else {
+      renderSignal();
+      renderLifecycle();
+    }
+
+    const children = visibleChildren(ctx.state);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBeInstanceOf(JudgeDisplayComponent);
+    expect(ctx.state.messageComponentsById.has('goal-judge-signal')).toBe(false);
+    expect(ctx.state.goalManager.applyEvaluation).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/mastracode/tui/src/tui/handlers/message.ts
+++ b/mastracode/tui/src/tui/handlers/message.ts
@@ -14,7 +14,7 @@ import type { MastraDBMessage } from '@mastra/core/agent-controller';
 import { reconcileChatBoundarySpacers } from '../chat-boundary-reconciliation.js';
 import { AssistantMessageComponent } from '../components/assistant-message.js';
 import { ToolExecutionComponentEnhanced } from '../components/tool-execution-enhanced.js';
-import { getAssistantRenderParts } from '../db-message-parts.js';
+import { getAssistantRenderParts, isGoalJudgeEvaluationSignal } from '../db-message-parts.js';
 import type { ToolRenderPart } from '../db-message-parts.js';
 import { flushRender, requestRender } from '../render-scheduler.js';
 import { getMarkdownTheme } from '../theme.js';
@@ -118,6 +118,7 @@ export function handleMessageStart(ctx: EventHandlerContext, message: MastraDBMe
     if (message.role === 'signal') {
       if (state.currentRunSystemReminderKeys.has(message.id)) return;
       state.currentRunSystemReminderKeys.add(message.id);
+      if (isGoalJudgeEvaluationSignal(message)) return;
     }
     ctx.addUserMessage(message);
     return;
@@ -144,6 +145,7 @@ export function handleMessageUpdate(ctx: EventHandlerContext, message: MastraDBM
   // Signals arrive as their own message_start/message_end pair; if an update is
   // delivered for one, route it through the shared signal renderer (deduped by id).
   if (message.role === 'signal') {
+    if (isGoalJudgeEvaluationSignal(message)) return;
     ctx.addUserMessage(message);
     return;
   }

--- a/mastracode/tui/src/tui/render-messages.test.ts
+++ b/mastracode/tui/src/tui/render-messages.test.ts
@@ -8,6 +8,7 @@ import { createSignal } from '@mastra/core/signals';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { isChatBoundarySpacer } from './components/chat-boundary-spacer.js';
+import { JudgeDisplayComponent } from './components/judge-display.js';
 import { ReactiveSignalComponent } from './components/reactive-signal.js';
 import { SubagentExecutionComponent } from './components/subagent-execution.js';
 import { TemporalGapComponent } from './components/temporal-gap.js';
@@ -174,17 +175,42 @@ interface ReminderInput {
   message: string;
   gapText?: string;
   precedesMessageId?: string;
+  goalEvaluation?: Record<string, unknown>;
 }
 
 function createReminderMessage(reminder: ReminderInput, id = '__temporal_1'): MastraDBMessage {
-  const { reminderType, message, gapText, precedesMessageId } = reminder;
+  const { reminderType, message, gapText, precedesMessageId, goalEvaluation } = reminder;
   return createSignal({
     id,
     type: 'reactive',
     tagName: 'system-reminder',
     contents: message,
     attributes: { type: reminderType, gapText, precedesMessageId },
-  }).toDBMessage();
+    metadata: { goalEvaluation },
+  } as Parameters<typeof createSignal>[0]).toDBMessage();
+}
+
+function createGoalJudgeMessage(id = 'goal-judge-1'): MastraDBMessage {
+  return createReminderMessage(
+    {
+      reminderType: 'goal-judge',
+      message: '[Goal attempt 2/20] The goal is not yet complete. Judge feedback: Need another fact.',
+      goalEvaluation: {
+        objective: 'List whale facts',
+        iteration: 2,
+        maxRuns: 20,
+        passed: false,
+        status: 'active',
+        results: [],
+        reason: 'Need another fact.',
+        duration: 0,
+        timedOut: false,
+        maxRunsReached: false,
+        suppressFeedback: false,
+      },
+    },
+    id,
+  );
 }
 
 describe('addUserMessage', () => {
@@ -206,6 +232,17 @@ describe('addUserMessage', () => {
       '⏳ 15 minutes later',
     );
     expect(state.messageComponentsById.size).toBe(0);
+  });
+
+  it('renders and registers persisted goal-judge evaluations', () => {
+    const state = createState();
+
+    renderUserMessage(state, createGoalJudgeMessage());
+
+    const children = visibleChildren(state);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBeInstanceOf(JudgeDisplayComponent);
+    expect(state.messageComponentsById.get('goal-judge-1')).toBe(children[0]);
   });
 
   it('renders non-goal signals through the shared signal renderer', () => {
@@ -353,6 +390,30 @@ describe('renderExistingMessages startup history loading', () => {
     expect(children).toHaveLength(2);
     expect(state.messageComponentsById.get('user-1')).toBe(children[0]);
     expect(state.messageComponentsById.get('user-2')).toBe(children[1]);
+  });
+
+  it('reconstructs one persisted goal-judge evaluation from history', async () => {
+    const state = createState();
+    const listActiveMessages = vi.fn().mockResolvedValue([createGoalJudgeMessage()]);
+    state.session = {
+      ...(state.session as any),
+      thread: { getId: vi.fn(() => TEST_THREAD_ID), listActiveMessages },
+      state: createSessionState(),
+    } as unknown as TUIState['session'];
+    state.controller = {
+      session: {
+        thread: { getId: vi.fn(() => TEST_THREAD_ID), listActiveMessages },
+        displayState: { get: () => ({ isRunning: false }), restoreTasks: vi.fn() },
+      },
+      setState: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TUIState['controller'];
+
+    await renderExistingMessages(state);
+
+    const children = visibleChildren(state);
+    expect(children).toHaveLength(1);
+    expect(children[0]).toBeInstanceOf(JudgeDisplayComponent);
+    expect(state.messageComponentsById.get('goal-judge-1')).toBe(children[0]);
   });
 
   it('reconstructs a persisted DB-native user signal from history', async () => {

--- a/mastracode/tui/src/tui/render-messages.test.ts
+++ b/mastracode/tui/src/tui/render-messages.test.ts
@@ -8,14 +8,23 @@ import { createSignal } from '@mastra/core/signals';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { isChatBoundarySpacer } from './components/chat-boundary-spacer.js';
+import { ReactiveSignalComponent } from './components/reactive-signal.js';
 import { SubagentExecutionComponent } from './components/subagent-execution.js';
 import { TemporalGapComponent } from './components/temporal-gap.js';
 import { UserMessageComponent } from './components/user-message.js';
-import { addUserMessage, renderExistingMessages } from './render-messages.js';
+import {
+  addPendingUserMessage,
+  addUserMessage as renderUserMessage,
+  renderExistingMessages,
+} from './render-messages.js';
 import type { TUIState } from './state.js';
 
 function visibleChildren(state: TUIState) {
   return state.chatContainer.children.filter(child => !isChatBoundarySpacer(child));
+}
+
+function addUserMessage(state: TUIState, message: MastraDBMessage): void {
+  renderUserMessage(state, message);
 }
 
 const tmpProjects: string[] = [];
@@ -199,6 +208,70 @@ describe('addUserMessage', () => {
     expect(state.messageComponentsById.size).toBe(0);
   });
 
+  it('renders non-goal signals through the shared signal renderer', () => {
+    const state = createState();
+    const message = createSignal({
+      id: 'build-status',
+      type: 'reactive',
+      tagName: 'build-status',
+      contents: 'Build is still running',
+    }).toDBMessage();
+
+    renderUserMessage(state, message);
+
+    const component = visibleChildren(state)[0];
+    expect(component).toBeInstanceOf(ReactiveSignalComponent);
+    expect(state.messageComponentsById.get('build-status')).toBe(component);
+  });
+
+  it('renders user-kind signal text, attachments, and delivery label from signal contents', () => {
+    const state = createState();
+    const message = createSignal({
+      id: 'steer-signal',
+      type: 'user',
+      contents: [
+        { type: 'text', text: 'Use the new direction' },
+        { type: 'file', data: 'image-data', mediaType: 'image/png' },
+        { type: 'file', data: 'file-data', mediaType: 'text/plain' },
+      ],
+      attributes: { delivery: 'while-active' },
+    }).toDBMessage();
+
+    renderUserMessage(state, message);
+
+    const component = visibleChildren(state)[0];
+    expect(component).toBeInstanceOf(UserMessageComponent);
+    expect(state.messageComponentsById.get('steer-signal')).toBe(component);
+    const rendered = (component as UserMessageComponent).render(100).join('\n');
+    expect(rendered).toContain('steer');
+    expect(rendered).toContain('[1 image] [1 file] Use the new direction');
+  });
+
+  it('preserves canonical attachments when a user-kind signal confirms a pending steer', () => {
+    const state = createState();
+    addPendingUserMessage(state, 'steer-signal', 'Use the new direction', undefined, { isInterjection: true });
+    const message = createSignal({
+      id: 'steer-signal',
+      type: 'user',
+      contents: [
+        { type: 'text', text: 'Use the new direction' },
+        { type: 'file', data: 'image-data', mediaType: 'image/png' },
+        { type: 'file', data: 'file-data', mediaType: 'text/plain' },
+      ],
+      attributes: { delivery: 'while-active' },
+    }).toDBMessage();
+
+    renderUserMessage(state, message);
+
+    const component = visibleChildren(state)[0];
+    expect(component).toBeInstanceOf(UserMessageComponent);
+    expect(state.pendingSignalMessageComponentsById.size).toBe(0);
+    expect(state.messageComponentsById.get('steer-signal')).toBe(component);
+    const rendered = (component as UserMessageComponent).render(100).join('\n');
+    expect(rendered).toContain('steer');
+    expect(rendered).toContain('[1 image] [1 file] Use the new direction');
+  });
+
   it('anchors a persisted temporal-gap marker before its target message when precedesMessageId is present', () => {
     const state = createState();
 
@@ -280,6 +353,38 @@ describe('renderExistingMessages startup history loading', () => {
     expect(children).toHaveLength(2);
     expect(state.messageComponentsById.get('user-1')).toBe(children[0]);
     expect(state.messageComponentsById.get('user-2')).toBe(children[1]);
+  });
+
+  it('reconstructs a persisted DB-native user signal from history', async () => {
+    const state = createState();
+    const userSignal = createSignal({
+      id: 'steer-history',
+      type: 'user',
+      contents: 'Continue from history',
+      attributes: { delivery: 'while-active' },
+    }).toDBMessage();
+    const listActiveMessages = vi.fn().mockResolvedValue([userSignal]);
+    state.session = {
+      ...(state.session as any),
+      thread: { getId: vi.fn(() => TEST_THREAD_ID), listActiveMessages },
+      state: createSessionState(),
+    } as unknown as TUIState['session'];
+    state.controller = {
+      session: {
+        thread: { getId: vi.fn(() => TEST_THREAD_ID), listActiveMessages },
+        displayState: { get: () => ({ isRunning: false }), restoreTasks: vi.fn() },
+      },
+      setState: vi.fn().mockResolvedValue(undefined),
+    } as unknown as TUIState['controller'];
+
+    await renderExistingMessages(state);
+
+    const component = visibleChildren(state)[0];
+    expect(component).toBeInstanceOf(UserMessageComponent);
+    expect(state.messageComponentsById.get('steer-history')).toBe(component);
+    const rendered = (component as UserMessageComponent).render(100).join('\n');
+    expect(rendered).toContain('steer');
+    expect(rendered).toContain('Continue from history');
   });
 
   it('renders the interrupted line once at the end for an aborted assistant message with tool calls', async () => {

--- a/mastracode/tui/src/tui/render-messages.ts
+++ b/mastracode/tui/src/tui/render-messages.ts
@@ -43,6 +43,7 @@ import {
   getReminderView,
   getSignalKind,
   getStateSignalView,
+  getUserSignalView,
   isSignalMessage,
 } from './db-message-parts.js';
 import type { AssistantRenderPart } from './db-message-parts.js';
@@ -287,7 +288,12 @@ export function addPendingUserMessage(
   state.ui.requestRender();
 }
 
-export function confirmPendingUserMessage(state: TUIState, messageId: string, text: string): void {
+export function confirmPendingUserMessage(
+  state: TUIState,
+  messageId: string,
+  text: string,
+  attachments?: { imageCount: number; fileCount: number },
+): void {
   const pending = state.pendingSignalMessageComponentsById.get(messageId);
   if (!pending) return;
 
@@ -296,15 +302,22 @@ export function confirmPendingUserMessage(state: TUIState, messageId: string, te
     state.streamingMessage = undefined;
   }
 
-  replacePendingUserMessage(state, messageId, text);
+  replacePendingUserMessage(state, messageId, text, attachments);
 }
 
-function replacePendingUserMessage(state: TUIState, messageId: string, text: string): void {
+function replacePendingUserMessage(
+  state: TUIState,
+  messageId: string,
+  text: string,
+  attachments?: { imageCount: number; fileCount: number },
+): void {
   const pending = state.pendingSignalMessageComponentsById.get(messageId);
   if (!pending) return;
 
-  const imageCount = pending.images?.length ?? 0;
-  const prefix = imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? 's' : ''}] ` : '';
+  const prefix = formatAttachmentPrefix(
+    attachments?.imageCount ?? pending.images?.length ?? 0,
+    attachments?.fileCount ?? 0,
+  );
   const label = getPendingUserMessageLabel(pending.isInterjection);
   const confirmed = new UserMessageComponent(prefix + text, getMarkdownTheme(), {
     ...(label ? { label } : {}),
@@ -346,15 +359,24 @@ export function clearPendingUserMessages(state: TUIState): void {
   state.ui.requestRender();
 }
 
-function confirmMatchingPendingUserMessage(state: TUIState, messageId: string, text: string): boolean {
+function confirmMatchingPendingUserMessage(
+  state: TUIState,
+  messageId: string,
+  text: string,
+  attachments: { imageCount: number; fileCount: number },
+): boolean {
   const normalizedText = text.trim();
   for (const [pendingId, pending] of state.pendingSignalMessageComponentsById) {
     if (pending.text.trim() !== normalizedText) continue;
 
     const label = getPendingUserMessageLabel(pending.isInterjection);
-    const confirmed = new UserMessageComponent(text, getMarkdownTheme(), {
-      ...(label ? { label } : {}),
-    });
+    const confirmed = new UserMessageComponent(
+      formatAttachmentPrefix(attachments.imageCount, attachments.fileCount) + text,
+      getMarkdownTheme(),
+      {
+        ...(label ? { label } : {}),
+      },
+    );
     const idx = state.chatContainer.children.indexOf(pending.component as never);
     if (idx >= 0) {
       (state.chatContainer.children as unknown[]).splice(idx, 1, confirmed);
@@ -394,11 +416,19 @@ function isImagePart(part: { type?: string; mimeType?: string; mediaType?: strin
   return media.startsWith('image/');
 }
 
+function formatAttachmentPrefix(imageCount: number, fileCount: number): string {
+  const labels = [
+    imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? 's' : ''}]` : '',
+    fileCount > 0 ? `[${fileCount} file${fileCount > 1 ? 's' : ''}]` : '',
+  ].filter(Boolean);
+  return labels.length > 0 ? `${labels.join(' ')} ` : '';
+}
+
 /**
  * Render a `role: 'signal'` message into its dedicated TUI component (reminder,
  * judge, state, reactive, notification, notification-summary). Returns true when
  * the signal was fully handled; returns false for `user`-kind signals so the
- * caller falls through to the shared user-message text rendering.
+ * caller renders it through the shared user-message component path.
  */
 export function renderSignalMessage(state: TUIState, message: MastraDBMessage): boolean {
   const kind = getSignalKind(message);
@@ -536,14 +566,21 @@ export function addUserMessage(state: TUIState, message: MastraDBMessage, option
     return;
   }
 
+  let textContent: string;
+  let imageCount: number;
+  let fileCount: number;
   if (isSignalMessage(message)) {
     if (renderSignalMessage(state, message)) return;
+    const userSignal = getUserSignalView(message);
+    textContent = userSignal.message;
+    imageCount = userSignal.imageCount;
+    fileCount = userSignal.fileCount;
+  } else {
+    const parts = getUserContentParts(message);
+    textContent = getMessageText(message);
+    imageCount = parts.filter(part => isImagePart(part)).length;
+    fileCount = parts.filter(part => part.type === 'file' && !isImagePart(part)).length;
   }
-
-  const parts = getUserContentParts(message);
-  const textContent = getMessageText(message);
-  const imageCount = parts.filter(part => isImagePart(part)).length;
-  const fileCount = parts.filter(part => part.type === 'file' && !isImagePart(part)).length;
 
   // Strip [image] markers from text since we show count separately
   const displayText = imageCount > 0 ? textContent.replace(/\[image\]\s*/g, '').trim() : textContent.trim();
@@ -603,12 +640,13 @@ export function addUserMessage(state: TUIState, message: MastraDBMessage, option
     return;
   }
 
+  const attachments = { imageCount, fileCount };
   if (state.pendingSignalMessageComponentsById.has(message.id)) {
-    confirmPendingUserMessage(state, message.id, displayText);
+    confirmPendingUserMessage(state, message.id, displayText, attachments);
     return;
   }
 
-  if (confirmMatchingPendingUserMessage(state, message.id, displayText)) {
+  if (confirmMatchingPendingUserMessage(state, message.id, displayText, attachments)) {
     return;
   }
 
@@ -646,11 +684,7 @@ export function addUserMessage(state: TUIState, message: MastraDBMessage, option
     return;
   }
 
-  const attachmentLabels = [
-    imageCount > 0 ? `[${imageCount} image${imageCount > 1 ? 's' : ''}]` : '',
-    fileCount > 0 ? `[${fileCount} file${fileCount > 1 ? 's' : ''}]` : '',
-  ].filter(Boolean);
-  const prefix = attachmentLabels.length > 0 ? `${attachmentLabels.join(' ')} ` : '';
+  const prefix = formatAttachmentPrefix(imageCount, fileCount);
   if (displayText || prefix) {
     const label = getUserMessageLabel(message, options?.label);
     const userComponent = new UserMessageComponent(prefix + displayText, getMarkdownTheme(), {

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -3032,7 +3032,6 @@ export class Session<TState = unknown> {
     const signal = createSignal(
       'content' in input ? { type: 'user', tagName: 'user', contents: input.content } : input,
     );
-    const shouldForwardGoalEvaluations = signal.attributes?.type === 'goal';
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
         const thread = await this.thread.create();
@@ -3092,23 +3091,7 @@ export class Session<TState = unknown> {
       } catch (error) {
         throw error;
       }
-      void result.accepted
-        .then(accepted => {
-          if (accepted.action !== 'wake' || !shouldForwardGoalEvaluations) return;
-          // Goal evaluations are emitted after the model's finish chunk and are not forwarded by
-          // the per-thread subscription. Read only those lifecycle chunks from the owned wake output;
-          // processing the whole output here would duplicate message and suspension events.
-          void (async () => {
-            for await (const chunk of accepted.output.fullStream) {
-              if (chunk.type === 'goal') {
-                this.emit({ type: 'goal_evaluation', payload: chunk.payload });
-              }
-            }
-          })().catch(error => {
-            this.emit({ type: 'error', error: error instanceof Error ? error : new Error(String(error)) });
-          });
-        })
-        .catch(() => {});
+      void result.accepted.catch(() => {});
       return { accepted: true as const, runId: undefined };
     });
 


### PR DESCRIPTION
Fixes two regressions in Mastra Code's live signal delivery.

Goal judge results could render more than once because `Session.sendSignal()` re-emitted goal lifecycle chunks that were already delivered through the normal subscription, while the persisted goal signal could also compete with the lifecycle-owned UI.

```text
before: lifecycle event + forwarded lifecycle event + persisted signal
 after: one lifecycle event live; persisted signal reconstructs history
```

Steer messages could appear as pending and then disappear because the delivered DB-native user signal was decoded as a normal user message. The TUI now reads text and attachments from the signal payload before replacing the pending component.

```text
before: Steer while active. pending… → empty confirmed component
after:  Steer while active. pending… → persistent steer message
```

This includes focused unit coverage and headless TUI scenarios for one live/reloaded judge result and persistent delivered steer messages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR fixes the Mastra TUI so “goal judge” results only appear once (even when the app is live-updating and later reloading). It also fixes delivered “steer” messages so their text and attachments don’t disappear when the UI swaps out the “pending” version for the final one.

## What changed

- **Stopped duplicate goal-judge rendering**
  - Adjusted signal/goal-judge handling to avoid duplicate lifecycle forwarding.
  - Ensured persisted/reloaded goal-judge signals rebuild the UI history correctly instead of rendering a second time.
  - Updated session wake-action post-processing to remove wake-result forwarding that could contribute to extra lifecycle/event handling.

- **Preserved delivered steer messages (text + attachments)**
  - Added signal parsing helpers to detect the relevant goal-judge “reminder” variant and to extract user-signal views.
  - Before replacing pending UI components, the code now decodes the steer content (including attachment parts) from the signal payload so the confirmed message keeps the right text and attachment indicators.
  - Made attachment counting consistent across **images and non-image files** using a shared formatted prefix, and threaded attachment counts through the pending-confirmation replacement paths.

- **Tests + headless TUI coverage**
  - Added/expanded unit tests for:
    - live vs reloaded/persisted goal-judge “single render” behavior
    - correct render ownership across different handler/lifecycle orderings and queueing/continuation scenarios
    - delivered steer replacement preserving content/attachments and clearing pending registries
  - Added a new headless TUI E2E scenario (`goal-judge-single-render`) that verifies exactly one “Goal ● done (1/3)” box both live and after switching/reloading.

- **Release notes**
  - Added Changesets patch bumps for `@mastra/core` and `mastracode` documenting the fixes for duplicate goal-judge rendering and missing delivered steer messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->