### PR TITLE
feat(playground-ui): add reusable agent interaction primitives

### DIFF
--- a/.changeset/clever-swans-bow.md
+++ b/.changeset/clever-swans-bow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added reusable Ask User and Task List components for agent interfaces.

--- a/packages/playground-ui/src/components-exports.test.ts
+++ b/packages/playground-ui/src/components-exports.test.ts
@@ -80,4 +80,14 @@ describe('components/* subpath exports', () => {
     const mod = await import('./ds/components/ai/plan');
     expect(mod.Plan).toBeDefined();
   });
+
+  it('AI ask-user entry exports AskUser', async () => {
+    const mod = await import('./ds/components/ai/ask-user');
+    expect(mod.AskUser).toBeDefined();
+  });
+
+  it('AI task-list entry exports TaskList', async () => {
+    const mod = await import('./ds/components/ai/task-list');
+    expect(mod.TaskList).toBeDefined();
+  });
 });

--- a/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { fn } from 'storybook/test';
+import { AskUser } from './ask-user';
+
+const meta: Meta<typeof AskUser> = {
+  title: 'AI/Ask User',
+  component: AskUser,
+  args: { onSubmit: fn() },
+  decorators: [
+    Story => (
+      <div className="w-full max-w-lg p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof AskUser>;
+
+export const FreeText: Story = {
+  args: { payload: { question: 'What should the agent prioritize?' } },
+};
+
+export const SingleSelect: Story = {
+  args: {
+    payload: {
+      question: 'Choose a deployment target',
+      selectionMode: 'single_select',
+      options: [
+        { label: 'Staging', description: 'Validate the release before production.' },
+        { label: 'Production', description: 'Deploy directly to users.' },
+      ],
+    },
+  },
+};
+
+export const MultiSelect: Story = {
+  args: {
+    payload: {
+      question: 'Select verification steps',
+      selectionMode: 'multi_select',
+      options: [{ label: 'Unit tests' }, { label: 'Typecheck' }, { label: 'Build' }],
+    },
+  },
+};
+
+export const Submitting: Story = {
+  args: {
+    payload: { question: 'Choose a deployment target', options: [{ label: 'Staging' }, { label: 'Production' }] },
+    isSubmitting: true,
+  },
+};
+
+export const Answered: Story = {
+  args: {
+    payload: { question: 'Choose a deployment target' },
+    result: { content: 'User answered: Staging' },
+  },
+};
+
+export const Error: Story = {
+  args: {
+    payload: { question: 'Choose a deployment target' },
+    result: { content: 'The answer could not be submitted.', isError: true },
+  },
+};

--- a/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.test.tsx
@@ -7,122 +7,187 @@ import type { AskUserPayload } from './ask-user';
 
 const renderAskUser = (payload: AskUserPayload, overrides: Partial<ComponentProps<typeof AskUser>> = {}) => {
   const onSubmit = vi.fn();
-  render(<AskUser payload={payload} onSubmit={onSubmit} {...overrides} />);
-  return { onSubmit };
+  const utils = render(<AskUser payload={payload} onSubmit={onSubmit} {...overrides} />);
+  return { ...utils, onSubmit };
 };
 
 afterEach(cleanup);
 
 describe('AskUser', () => {
-  describe('when free text is requested', () => {
-    it('submits trimmed text with Enter or the submit button', () => {
+  describe('when free text is submitted with Enter', () => {
+    it('submits the trimmed answer', () => {
       const { onSubmit } = renderAskUser({ question: 'What is your name?' });
-      const input = screen.getByRole('textbox', { name: 'What is your name?' });
+      const input = screen.getByRole<HTMLInputElement>('textbox', { name: 'What is your name?' });
 
       fireEvent.change(input, { target: { value: '  Ada  ' } });
       fireEvent.keyDown(input, { key: 'Enter' });
-      expect(onSubmit).toHaveBeenLastCalledWith('Ada');
 
-      fireEvent.change(input, { target: { value: 'Grace' } });
-      fireEvent.click(screen.getByRole('button', { name: 'Submit answer' }));
-      expect(onSubmit).toHaveBeenLastCalledWith('Grace');
+      expect(onSubmit).toHaveBeenCalledWith('Ada');
+    });
+  });
+
+  describe('when free text is submitted with the button', () => {
+    it('submits the trimmed answer', () => {
+      const { onSubmit } = renderAskUser({ question: 'What is your name?' });
+      fireEvent.change(screen.getByRole<HTMLInputElement>('textbox'), { target: { value: '  Grace  ' } });
+
+      fireEvent.click(screen.getByRole<HTMLButtonElement>('button', { name: 'Submit answer' }));
+
+      expect(onSubmit).toHaveBeenCalledWith('Grace');
+    });
+  });
+
+  describe('when free text is empty', () => {
+    it('disables the submit button', () => {
+      renderAskUser({ question: 'What is your name?' });
+
+      expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Submit answer' }).disabled).toBe(true);
     });
 
-    it('does not submit empty text', () => {
+    it('does not submit with Enter', () => {
       const { onSubmit } = renderAskUser({ question: 'What is your name?' });
-      const input = screen.getByRole('textbox');
-      const submit = screen.getByRole('button', { name: 'Submit answer' });
+      const input = screen.getByRole<HTMLInputElement>('textbox');
 
-      expect((submit as HTMLButtonElement).disabled).toBe(true);
       fireEvent.change(input, { target: { value: '   ' } });
       fireEvent.keyDown(input, { key: 'Enter' });
+
       expect(onSubmit).not.toHaveBeenCalled();
     });
   });
 
-  describe('when single selection is requested', () => {
-    it('renders descriptions and immediately submits the chosen label', () => {
-      const { onSubmit } = renderAskUser({
+  describe('when the free-text payload changes', () => {
+    it('clears text entered for the previous question', () => {
+      const { rerender, onSubmit } = renderAskUser({ question: 'What is your name?' });
+      fireEvent.change(screen.getByRole<HTMLInputElement>('textbox'), { target: { value: 'Ada' } });
+
+      rerender(<AskUser payload={{ question: 'Where do you live?' }} onSubmit={onSubmit} />);
+
+      expect(screen.getByRole<HTMLInputElement>('textbox', { name: 'Where do you live?' }).value).toBe('');
+    });
+  });
+
+  describe('when single selection includes a description', () => {
+    it('renders the option description', () => {
+      renderAskUser({
         question: 'Pick a fruit',
         options: [{ label: 'Apple', description: 'A red fruit' }, { label: 'Banana' }],
         selectionMode: 'single_select',
       });
 
       expect(screen.getByText('A red fruit')).toBeTruthy();
-      fireEvent.click(screen.getByRole('radio', { name: /Apple/ }));
-      expect(onSubmit).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('when a single selection is chosen', () => {
+    it('submits the chosen label immediately', () => {
+      const { onSubmit } = renderAskUser({
+        question: 'Pick a fruit',
+        options: [{ label: 'Apple' }, { label: 'Banana' }],
+        selectionMode: 'single_select',
+      });
+
+      fireEvent.click(screen.getByRole<HTMLInputElement>('radio', { name: 'Apple' }));
+
       expect(onSubmit).toHaveBeenCalledWith('Apple');
     });
   });
 
-  describe('when multiple selection is requested', () => {
-    it('submits selected labels only after confirmation', () => {
+  describe('when no multiple-selection option is selected', () => {
+    it('disables the confirmation button', () => {
+      renderAskUser({
+        question: 'Pick toppings',
+        options: [{ label: 'Cheese' }, { label: 'Olives' }],
+        selectionMode: 'multi_select',
+      });
+
+      expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Submit answer' }).disabled).toBe(true);
+    });
+  });
+
+  describe('when multiple selections are toggled', () => {
+    it('does not submit before confirmation', () => {
+      const { onSubmit } = renderAskUser({
+        question: 'Pick toppings',
+        options: [{ label: 'Cheese' }, { label: 'Olives' }],
+        selectionMode: 'multi_select',
+      });
+
+      fireEvent.click(screen.getByRole<HTMLInputElement>('checkbox', { name: 'Cheese' }));
+      fireEvent.click(screen.getByRole<HTMLInputElement>('checkbox', { name: 'Olives' }));
+
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when multiple selections are confirmed', () => {
+    it('submits the selected labels', () => {
       const { onSubmit } = renderAskUser({
         question: 'Pick toppings',
         options: [{ label: 'Cheese' }, { label: 'Olives' }],
         selectionMode: 'multi_select',
       });
       const group = screen.getByRole('group', { name: 'Pick toppings' });
-      const submit = within(group).getByRole('button', { name: 'Submit answer' });
+      fireEvent.click(within(group).getByRole<HTMLInputElement>('checkbox', { name: 'Cheese' }));
+      fireEvent.click(within(group).getByRole<HTMLInputElement>('checkbox', { name: 'Olives' }));
 
-      expect((submit as HTMLButtonElement).disabled).toBe(true);
-      fireEvent.click(within(group).getByRole('checkbox', { name: 'Cheese' }));
-      fireEvent.click(within(group).getByRole('checkbox', { name: 'Olives' }));
-      expect(onSubmit).not.toHaveBeenCalled();
-      fireEvent.click(submit);
+      fireEvent.click(within(group).getByRole<HTMLButtonElement>('button', { name: 'Submit answer' }));
+
       expect(onSubmit).toHaveBeenCalledWith(['Cheese', 'Olives']);
     });
   });
 
   describe('when submission is pending', () => {
-    it('disables controls and announces the pending state', () => {
-      renderAskUser(
-        { question: 'Pick a fruit', options: [{ label: 'Apple' }], selectionMode: 'single_select' },
-        { isSubmitting: true },
-      );
+    const payload: AskUserPayload = {
+      question: 'Pick a fruit',
+      options: [{ label: 'Apple' }],
+      selectionMode: 'single_select',
+    };
 
-      expect((screen.getByRole('radio', { name: 'Apple' }) as HTMLInputElement).disabled).toBe(true);
-      expect(screen.getByText('Submitting…')).toBeTruthy();
+    it('disables the option controls', () => {
+      renderAskUser(payload, { isSubmitting: true });
+
+      expect(screen.getByRole<HTMLInputElement>('radio', { name: 'Apple' }).disabled).toBe(true);
+    });
+
+    it('announces the pending state', () => {
+      renderAskUser(payload, { isSubmitting: true });
+
+      expect(screen.getByRole('status').textContent).toBe('Submitting…');
     });
   });
 
   describe('when an answer result exists', () => {
-    it('shows answered and error output without interactive controls', () => {
-      const { rerender } = render(
-        <AskUser
-          payload={{ question: 'Pick a fruit', options: [{ label: 'Apple' }] }}
-          result={{ content: 'User answered: Apple', isError: false }}
-          onSubmit={vi.fn()}
-        />,
+    it('renders the answer without option controls', () => {
+      renderAskUser(
+        { question: 'Pick a fruit', options: [{ label: 'Apple' }] },
+        { result: { content: 'User answered: Apple', isError: false } },
       );
 
-      expect(screen.getByText('Answered')).toBeTruthy();
-      expect(screen.getByText('User answered: Apple')).toBeTruthy();
       expect(screen.queryByRole('radio')).toBeNull();
+      expect(screen.getByRole('status').textContent).toContain('User answered: Apple');
+    });
+  });
 
-      rerender(
-        <AskUser
-          payload={{ question: 'Pick a fruit' }}
-          result={{ content: 'Unable to resume', isError: true }}
-          onSubmit={vi.fn()}
-        />,
-      );
-      expect(screen.getByText('Error')).toBeTruthy();
+  describe('when an error result exists', () => {
+    it('renders the error as an alert', () => {
+      renderAskUser({ question: 'Pick a fruit' }, { result: { content: 'Unable to resume', isError: true } });
+
       expect(screen.getByRole('alert').textContent).toContain('Unable to resume');
     });
   });
 
-  describe('when optional payload data is absent or malformed', () => {
-    it('falls back to free text for absent or empty options and ignores malformed options', () => {
-      const { rerender } = render(<AskUser payload={{ question: 'Answer me', options: [] }} onSubmit={vi.fn()} />);
-      expect(screen.getByRole('textbox')).toBeTruthy();
+  describe('when options are absent', () => {
+    it('renders a free-text control', () => {
+      renderAskUser({ question: 'Answer me' });
 
-      rerender(
-        <AskUser
-          payload={{ question: 'Answer me', options: [{ label: '' }, null] as unknown as AskUserPayload['options'] }}
-          onSubmit={vi.fn()}
-        />,
-      );
+      expect(screen.getByRole('textbox')).toBeTruthy();
+    });
+  });
+
+  describe('when options are empty or have empty labels', () => {
+    it('renders a free-text control', () => {
+      renderAskUser({ question: 'Answer me', options: [{ label: '' }] });
+
       expect(screen.getByRole('textbox')).toBeTruthy();
     });
   });

--- a/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { ComponentProps } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { AskUser } from './ask-user';
+import type { AskUserPayload } from './ask-user';
+
+const renderAskUser = (payload: AskUserPayload, overrides: Partial<ComponentProps<typeof AskUser>> = {}) => {
+  const onSubmit = vi.fn();
+  render(<AskUser payload={payload} onSubmit={onSubmit} {...overrides} />);
+  return { onSubmit };
+};
+
+afterEach(cleanup);
+
+describe('AskUser', () => {
+  describe('when free text is requested', () => {
+    it('submits trimmed text with Enter or the submit button', () => {
+      const { onSubmit } = renderAskUser({ question: 'What is your name?' });
+      const input = screen.getByRole('textbox', { name: 'What is your name?' });
+
+      fireEvent.change(input, { target: { value: '  Ada  ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onSubmit).toHaveBeenLastCalledWith('Ada');
+
+      fireEvent.change(input, { target: { value: 'Grace' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Submit answer' }));
+      expect(onSubmit).toHaveBeenLastCalledWith('Grace');
+    });
+
+    it('does not submit empty text', () => {
+      const { onSubmit } = renderAskUser({ question: 'What is your name?' });
+      const input = screen.getByRole('textbox');
+      const submit = screen.getByRole('button', { name: 'Submit answer' });
+
+      expect((submit as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.change(input, { target: { value: '   ' } });
+      fireEvent.keyDown(input, { key: 'Enter' });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when single selection is requested', () => {
+    it('renders descriptions and immediately submits the chosen label', () => {
+      const { onSubmit } = renderAskUser({
+        question: 'Pick a fruit',
+        options: [{ label: 'Apple', description: 'A red fruit' }, { label: 'Banana' }],
+        selectionMode: 'single_select',
+      });
+
+      expect(screen.getByText('A red fruit')).toBeTruthy();
+      fireEvent.click(screen.getByRole('radio', { name: /Apple/ }));
+      expect(onSubmit).toHaveBeenCalledOnce();
+      expect(onSubmit).toHaveBeenCalledWith('Apple');
+    });
+  });
+
+  describe('when multiple selection is requested', () => {
+    it('submits selected labels only after confirmation', () => {
+      const { onSubmit } = renderAskUser({
+        question: 'Pick toppings',
+        options: [{ label: 'Cheese' }, { label: 'Olives' }],
+        selectionMode: 'multi_select',
+      });
+      const group = screen.getByRole('group', { name: 'Pick toppings' });
+      const submit = within(group).getByRole('button', { name: 'Submit answer' });
+
+      expect((submit as HTMLButtonElement).disabled).toBe(true);
+      fireEvent.click(within(group).getByRole('checkbox', { name: 'Cheese' }));
+      fireEvent.click(within(group).getByRole('checkbox', { name: 'Olives' }));
+      expect(onSubmit).not.toHaveBeenCalled();
+      fireEvent.click(submit);
+      expect(onSubmit).toHaveBeenCalledWith(['Cheese', 'Olives']);
+    });
+  });
+
+  describe('when submission is pending', () => {
+    it('disables controls and announces the pending state', () => {
+      renderAskUser(
+        { question: 'Pick a fruit', options: [{ label: 'Apple' }], selectionMode: 'single_select' },
+        { isSubmitting: true },
+      );
+
+      expect((screen.getByRole('radio', { name: 'Apple' }) as HTMLInputElement).disabled).toBe(true);
+      expect(screen.getByText('Submitting…')).toBeTruthy();
+    });
+  });
+
+  describe('when an answer result exists', () => {
+    it('shows answered and error output without interactive controls', () => {
+      const { rerender } = render(
+        <AskUser
+          payload={{ question: 'Pick a fruit', options: [{ label: 'Apple' }] }}
+          result={{ content: 'User answered: Apple', isError: false }}
+          onSubmit={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText('Answered')).toBeTruthy();
+      expect(screen.getByText('User answered: Apple')).toBeTruthy();
+      expect(screen.queryByRole('radio')).toBeNull();
+
+      rerender(
+        <AskUser
+          payload={{ question: 'Pick a fruit' }}
+          result={{ content: 'Unable to resume', isError: true }}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByText('Error')).toBeTruthy();
+      expect(screen.getByRole('alert').textContent).toContain('Unable to resume');
+    });
+  });
+
+  describe('when optional payload data is absent or malformed', () => {
+    it('falls back to free text for absent or empty options and ignores malformed options', () => {
+      const { rerender } = render(<AskUser payload={{ question: 'Answer me', options: [] }} onSubmit={vi.fn()} />);
+      expect(screen.getByRole('textbox')).toBeTruthy();
+
+      rerender(
+        <AskUser
+          payload={{ question: 'Answer me', options: [{ label: '' }, null] as unknown as AskUserPayload['options'] }}
+          onSubmit={vi.fn()}
+        />,
+      );
+      expect(screen.getByRole('textbox')).toBeTruthy();
+    });
+  });
+});

--- a/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.tsx
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.tsx
@@ -1,0 +1,211 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ComponentProps, KeyboardEvent, ReactNode } from 'react';
+import { Badge } from '@/ds/components/Badge';
+import { Button } from '@/ds/components/Button';
+import { Input } from '@/ds/components/Input';
+import { cn } from '@/lib/utils';
+
+export type AskUserSelectionMode = 'single_select' | 'multi_select';
+export type AskUserAnswer = string | string[];
+
+export interface AskUserOption {
+  label: string;
+  description?: string;
+}
+
+export interface AskUserPayload {
+  question: string;
+  options?: AskUserOption[];
+  selectionMode?: AskUserSelectionMode;
+}
+
+export interface AskUserResult {
+  content: string;
+  isError?: boolean;
+}
+
+export const AskUserContainer = ({ className, ...props }: ComponentProps<'div'>) => (
+  <div className={cn('rounded-lg border border-border1 bg-surface2 p-3 text-sm', className)} {...props} />
+);
+
+export const AskUserQuestion = ({ className, ...props }: ComponentProps<'legend'>) => (
+  <legend className={cn('mb-3 font-medium text-neutral6', className)} {...props} />
+);
+
+export const AskUserOptionDescription = ({ className, ...props }: ComponentProps<'span'>) => (
+  <span className={cn('block text-ui-xs font-normal text-neutral3', className)} {...props} />
+);
+
+interface AskUserOptionControlProps extends Omit<ComponentProps<'input'>, 'type'> {
+  type: 'radio' | 'checkbox';
+  label: string;
+  description?: string;
+}
+
+export const AskUserOptionControl = ({ type, label, description, className, ...props }: AskUserOptionControlProps) => (
+  <label
+    className={cn(
+      'flex cursor-pointer items-start gap-2 rounded-md border border-border1 bg-surface3 px-3 py-2 text-neutral5 transition-colors hover:bg-surface4 has-[:checked]:border-border2 has-[:checked]:bg-surface4 has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50',
+      className,
+    )}
+  >
+    <input type={type} className="mt-0.5 accent-current" {...props} />
+    <span>
+      <span className="block">{label}</span>
+      {description ? <AskUserOptionDescription>{description}</AskUserOptionDescription> : null}
+    </span>
+  </label>
+);
+
+export const AskUserSubmit = ({ children = 'Submit answer', ...props }: ComponentProps<typeof Button>) => (
+  <Button type="button" size="sm" variant="primary" {...props}>
+    {children}
+  </Button>
+);
+
+export const AskUserPending = ({ children = 'Submitting…', className, ...props }: ComponentProps<'span'>) => (
+  <span role="status" className={cn('text-ui-xs text-neutral3', className)} {...props}>
+    {children}
+  </span>
+);
+
+export interface AskUserOutputProps extends ComponentProps<'div'> {
+  result: AskUserResult;
+}
+
+export const AskUserOutput = ({ result, className, ...props }: AskUserOutputProps) => (
+  <div
+    role={result.isError ? 'alert' : 'status'}
+    className={cn('space-y-2 rounded-md bg-surface3 p-3 text-neutral5', result.isError && 'text-error', className)}
+    {...props}
+  >
+    <Badge size="xs" variant={result.isError ? 'error' : 'success'}>
+      {result.isError ? 'Error' : 'Answered'}
+    </Badge>
+    <p>{result.content}</p>
+  </div>
+);
+
+export interface AskUserProps extends Omit<ComponentProps<typeof AskUserContainer>, 'children' | 'onSubmit'> {
+  payload: AskUserPayload;
+  result?: AskUserResult;
+  isAnswered?: boolean;
+  isSubmitting?: boolean;
+  onSubmit: (answer: AskUserAnswer) => void;
+  footer?: ReactNode;
+}
+
+const validOptions = (options: AskUserPayload['options']): AskUserOption[] =>
+  options?.filter((option): option is AskUserOption =>
+    Boolean(option && typeof option.label === 'string' && option.label),
+  ) ?? [];
+
+export const AskUser = ({
+  payload,
+  result,
+  isAnswered = false,
+  isSubmitting = false,
+  onSubmit,
+  footer,
+  ...props
+}: AskUserProps) => {
+  const options = useMemo(() => validOptions(payload.options), [payload.options]);
+  const [text, setText] = useState('');
+  const [selected, setSelected] = useState<string[]>([]);
+  const payloadKey = `${payload.question}:${options.map(option => option.label).join('\0')}:${payload.selectionMode ?? ''}`;
+
+  useEffect(() => {
+    setText('');
+    setSelected([]);
+  }, [payloadKey]);
+
+  if (result || isAnswered) {
+    return (
+      <AskUserContainer data-testid="ask-user" {...props}>
+        <p className="mb-2 font-medium text-neutral6">{payload.question}</p>
+        {result ? <AskUserOutput result={result} /> : <Badge variant="success">Answered</Badge>}
+      </AskUserContainer>
+    );
+  }
+
+  const submitText = () => {
+    const answer = text.trim();
+    if (answer && !isSubmitting) onSubmit(answer);
+  };
+
+  const handleTextKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      submitText();
+    }
+  };
+
+  if (options.length === 0) {
+    return (
+      <AskUserContainer data-testid="ask-user" {...props}>
+        <label className="mb-2 block font-medium text-neutral6" htmlFor={`ask-user-${payloadKey}`}>
+          {payload.question}
+        </label>
+        <div className="flex items-center gap-2">
+          <Input
+            id={`ask-user-${payloadKey}`}
+            value={text}
+            onChange={event => setText(event.target.value)}
+            onKeyDown={handleTextKeyDown}
+            placeholder="Type your answer..."
+            disabled={isSubmitting}
+            size="sm"
+          />
+          <AskUserSubmit aria-label="Submit answer" disabled={isSubmitting || !text.trim()} onClick={submitText}>
+            Submit
+          </AskUserSubmit>
+        </div>
+        {isSubmitting ? <AskUserPending className="mt-2 block" /> : null}
+        {footer}
+      </AskUserContainer>
+    );
+  }
+
+  const isMulti = payload.selectionMode === 'multi_select';
+  return (
+    <AskUserContainer data-testid="ask-user" {...props}>
+      <fieldset disabled={isSubmitting} className="space-y-2">
+        <AskUserQuestion>{payload.question}</AskUserQuestion>
+        {options.map(option => {
+          const checked = selected.includes(option.label);
+          return (
+            <AskUserOptionControl
+              key={option.label}
+              type={isMulti ? 'checkbox' : 'radio'}
+              name={`ask-user-${payloadKey}`}
+              label={option.label}
+              description={option.description}
+              disabled={isSubmitting}
+              checked={checked}
+              onChange={() => {
+                if (isSubmitting) return;
+                if (!isMulti) {
+                  setSelected([option.label]);
+                  onSubmit(option.label);
+                  return;
+                }
+                setSelected(current =>
+                  current.includes(option.label)
+                    ? current.filter(selectedLabel => selectedLabel !== option.label)
+                    : [...current, option.label],
+                );
+              }}
+            />
+          );
+        })}
+        {isMulti ? (
+          <AskUserSubmit disabled={isSubmitting || selected.length === 0} onClick={() => onSubmit(selected)}>
+            Submit answer
+          </AskUserSubmit>
+        ) : null}
+        {isSubmitting ? <AskUserPending /> : null}
+        {footer}
+      </fieldset>
+    </AskUserContainer>
+  );
+};

--- a/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.tsx
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/ask-user.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useId, useState } from 'react';
 import type { ComponentProps, KeyboardEvent, ReactNode } from 'react';
 import { Badge } from '@/ds/components/Badge';
 import { Button } from '@/ds/components/Button';
@@ -100,24 +100,23 @@ const validOptions = (options: AskUserPayload['options']): AskUserOption[] =>
     Boolean(option && typeof option.label === 'string' && option.label),
   ) ?? [];
 
-export const AskUser = ({
+interface AskUserInputProps extends AskUserProps {
+  options: AskUserOption[];
+}
+
+const AskUserInput = ({
   payload,
+  options,
   result,
   isAnswered = false,
   isSubmitting = false,
   onSubmit,
   footer,
   ...props
-}: AskUserProps) => {
-  const options = useMemo(() => validOptions(payload.options), [payload.options]);
+}: AskUserInputProps) => {
+  const inputId = useId();
   const [text, setText] = useState('');
   const [selected, setSelected] = useState<string[]>([]);
-  const payloadKey = `${payload.question}:${options.map(option => option.label).join('\0')}:${payload.selectionMode ?? ''}`;
-
-  useEffect(() => {
-    setText('');
-    setSelected([]);
-  }, [payloadKey]);
 
   if (result || isAnswered) {
     return (
@@ -143,12 +142,12 @@ export const AskUser = ({
   if (options.length === 0) {
     return (
       <AskUserContainer data-testid="ask-user" {...props}>
-        <label className="mb-2 block font-medium text-neutral6" htmlFor={`ask-user-${payloadKey}`}>
+        <label className="mb-2 block font-medium text-neutral6" htmlFor={inputId}>
           {payload.question}
         </label>
         <div className="flex items-center gap-2">
           <Input
-            id={`ask-user-${payloadKey}`}
+            id={inputId}
             value={text}
             onChange={event => setText(event.target.value)}
             onKeyDown={handleTextKeyDown}
@@ -177,7 +176,7 @@ export const AskUser = ({
             <AskUserOptionControl
               key={option.label}
               type={isMulti ? 'checkbox' : 'radio'}
-              name={`ask-user-${payloadKey}`}
+              name={inputId}
               label={option.label}
               description={option.description}
               disabled={isSubmitting}
@@ -208,4 +207,11 @@ export const AskUser = ({
       </fieldset>
     </AskUserContainer>
   );
+};
+
+export const AskUser = ({ payload, ...props }: AskUserProps) => {
+  const options = validOptions(payload.options);
+  const payloadKey = JSON.stringify([payload.question, options.map(option => option.label), payload.selectionMode]);
+
+  return <AskUserInput key={payloadKey} payload={payload} options={options} {...props} />;
 };

--- a/packages/playground-ui/src/ds/components/ai/ask-user/index.ts
+++ b/packages/playground-ui/src/ds/components/ai/ask-user/index.ts
@@ -1,0 +1,1 @@
+export * from './ask-user';

--- a/packages/playground-ui/src/ds/components/ai/task-list/index.ts
+++ b/packages/playground-ui/src/ds/components/ai/task-list/index.ts
@@ -1,0 +1,1 @@
+export * from './task-list';

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.stories.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { TaskList } from './task-list';
+
+const meta: Meta<typeof TaskList> = {
+  title: 'AI/Task List',
+  component: TaskList,
+  decorators: [
+    Story => (
+      <div className="w-full max-w-3xl p-4">
+        <Story />
+      </div>
+    ),
+  ],
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof TaskList>;
+
+export const MixedProgress: Story = {
+  args: {
+    tasks: [
+      {
+        id: 'inspect',
+        content: 'Inspect existing components',
+        status: 'completed',
+        activeForm: 'Inspecting existing components',
+      },
+      { id: 'tests', content: 'Add component tests', status: 'in_progress', activeForm: 'Adding component tests' },
+      { id: 'build', content: 'Build the package', status: 'pending', activeForm: 'Building the package' },
+    ],
+  },
+};
+
+export const OneActiveTask: Story = {
+  args: {
+    tasks: [
+      {
+        id: 'implement',
+        content: 'Implement the shared primitive',
+        status: 'in_progress',
+        activeForm: 'Implementing the shared primitive',
+      },
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: { tasks: [], hideWhenEmpty: false },
+};
+
+export const Completed: Story = {
+  args: {
+    hideWhenComplete: false,
+    tasks: [
+      { id: 'tests', content: 'Run tests', status: 'completed', activeForm: 'Running tests' },
+      { id: 'build', content: 'Build package', status: 'completed', activeForm: 'Building package' },
+    ],
+  },
+};

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskList } from './task-list';
+import type { TaskListItem } from './task-list';
+
+const mixedTasks: TaskListItem[] = [
+  { id: 'done', content: 'Inspect code', status: 'completed', activeForm: 'Inspecting code' },
+  { id: 'active', content: 'Add tests', status: 'in_progress', activeForm: 'Adding tests' },
+  { id: 'pending', content: 'Build package', status: 'pending', activeForm: 'Building package' },
+];
+
+afterEach(cleanup);
+
+describe('TaskList', () => {
+  beforeEach(() => {
+    Element.prototype.scrollIntoView = vi.fn();
+  });
+
+  describe('when tasks have mixed statuses', () => {
+    it('renders completion count, progress, status labels, and the active form', () => {
+      render(<TaskList tasks={mixedTasks} />);
+
+      expect(screen.getByText('1/3 completed')).toBeTruthy();
+      expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('1');
+      expect(screen.getByRole('progressbar').getAttribute('aria-valuemax')).toBe('3');
+      expect(screen.getByText('Adding tests')).toBeTruthy();
+      expect(screen.queryByText('Add tests')).toBeNull();
+      expect(screen.getByLabelText('Completed')).toBeTruthy();
+      expect(screen.getByLabelText('In progress')).toBeTruthy();
+      expect(screen.getByLabelText('Pending')).toBeTruthy();
+    });
+
+    it('scrolls the active task into view only when its identity changes', () => {
+      const { rerender } = render(<TaskList tasks={mixedTasks} />);
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledOnce();
+
+      rerender(<TaskList tasks={[...mixedTasks]} />);
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledOnce();
+
+      rerender(
+        <TaskList
+          tasks={mixedTasks.map(task =>
+            task.id === 'active'
+              ? { ...task, status: 'completed' }
+              : task.id === 'pending'
+                ? { ...task, status: 'in_progress' }
+                : task,
+          )}
+        />,
+      );
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('when there are no visible tasks', () => {
+    it('hides empty and completed lists by default', () => {
+      const { rerender, container } = render(<TaskList tasks={[]} />);
+      expect(container.firstChild).toBeNull();
+
+      rerender(<TaskList tasks={mixedTasks.map(task => ({ ...task, status: 'completed' }))} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('can explicitly render empty and completed lists', () => {
+      const { rerender } = render(<TaskList tasks={[]} hideWhenEmpty={false} />);
+      expect(screen.getByText('0/0 completed')).toBeTruthy();
+      expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('0');
+
+      rerender(
+        <TaskList tasks={mixedTasks.map(task => ({ ...task, status: 'completed' }))} hideWhenComplete={false} />,
+      );
+      expect(screen.getByText('3/3 completed')).toBeTruthy();
+    });
+  });
+});

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.test.tsx
@@ -10,6 +10,8 @@ const mixedTasks: TaskListItem[] = [
   { id: 'pending', content: 'Build package', status: 'pending', activeForm: 'Building package' },
 ];
 
+const completedTasks: TaskListItem[] = mixedTasks.map(task => ({ ...task, status: 'completed' }));
+
 afterEach(cleanup);
 
 describe('TaskList', () => {
@@ -18,14 +20,29 @@ describe('TaskList', () => {
   });
 
   describe('when tasks have mixed statuses', () => {
-    it('renders completion count, progress, status labels, and the active form', () => {
+    it('renders the completion count', () => {
       render(<TaskList tasks={mixedTasks} />);
 
       expect(screen.getByText('1/3 completed')).toBeTruthy();
+    });
+
+    it('renders progress for the completed tasks', () => {
+      render(<TaskList tasks={mixedTasks} />);
+
       expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('1');
       expect(screen.getByRole('progressbar').getAttribute('aria-valuemax')).toBe('3');
+    });
+
+    it('renders the active form instead of the task content', () => {
+      render(<TaskList tasks={mixedTasks} />);
+
       expect(screen.getByText('Adding tests')).toBeTruthy();
       expect(screen.queryByText('Add tests')).toBeNull();
+    });
+
+    it('renders an accessible label for each task status', () => {
+      render(<TaskList tasks={mixedTasks} />);
+
       expect(screen.getByLabelText('Completed')).toBeTruthy();
       expect(screen.getByLabelText('In progress')).toBeTruthy();
       expect(screen.getByLabelText('Pending')).toBeTruthy();
@@ -53,23 +70,34 @@ describe('TaskList', () => {
     });
   });
 
-  describe('when there are no visible tasks', () => {
-    it('hides empty and completed lists by default', () => {
-      const { rerender, container } = render(<TaskList tasks={[]} />);
-      expect(container.firstChild).toBeNull();
+  describe('when the task list is empty', () => {
+    it('hides the list by default', () => {
+      const { container } = render(<TaskList tasks={[]} />);
 
-      rerender(<TaskList tasks={mixedTasks.map(task => ({ ...task, status: 'completed' }))} />);
       expect(container.firstChild).toBeNull();
     });
+  });
 
-    it('can explicitly render empty and completed lists', () => {
-      const { rerender } = render(<TaskList tasks={[]} hideWhenEmpty={false} />);
+  describe('when every task is completed', () => {
+    it('hides the list by default', () => {
+      const { container } = render(<TaskList tasks={completedTasks} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe('when empty lists are configured to remain visible', () => {
+    it('renders an empty completion count', () => {
+      render(<TaskList tasks={[]} hideWhenEmpty={false} />);
+
       expect(screen.getByText('0/0 completed')).toBeTruthy();
-      expect(screen.getByRole('progressbar').getAttribute('aria-valuenow')).toBe('0');
+    });
+  });
 
-      rerender(
-        <TaskList tasks={mixedTasks.map(task => ({ ...task, status: 'completed' }))} hideWhenComplete={false} />,
-      );
+  describe('when completed lists are configured to remain visible', () => {
+    it('renders the completed task count', () => {
+      render(<TaskList tasks={completedTasks} hideWhenComplete={false} />);
+
       expect(screen.getByText('3/3 completed')).toBeTruthy();
     });
   });

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
@@ -1,0 +1,135 @@
+import type { TaskItem } from '@mastra/core/signals';
+import { CheckCircle2, Circle, ListChecks, Loader2 } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+export type TaskListItem = TaskItem;
+
+export const TaskListContainer = ({ className, ...props }: ComponentProps<'section'>) => (
+  <section className={cn('rounded-2xl border border-border2/40 bg-surface3 px-3 py-2.5', className)} {...props} />
+);
+
+export const TaskListHeader = ({ className, ...props }: ComponentProps<'header'>) => (
+  <header className={cn('mb-2 flex items-center gap-2', className)} {...props} />
+);
+
+export interface TaskListCountProps extends ComponentProps<'span'> {
+  completed: number;
+  total: number;
+}
+
+export const TaskListCount = ({ completed, total, className, ...props }: TaskListCountProps) => (
+  <span className={cn('ml-auto text-ui-xs text-neutral4 tabular-nums', className)} {...props}>
+    {completed}/{total} completed
+  </span>
+);
+
+export interface TaskListProgressProps extends Omit<ComponentProps<'div'>, 'children'> {
+  completed: number;
+  total: number;
+}
+
+export const TaskListProgress = ({ completed, total, className, ...props }: TaskListProgressProps) => {
+  const percentage = total === 0 ? 0 : (completed / total) * 100;
+  return (
+    <div
+      role="progressbar"
+      aria-label="Task completion"
+      aria-valuemin={0}
+      aria-valuemax={total}
+      aria-valuenow={completed}
+      className={cn('mb-2.5 h-1 w-full rounded-full bg-surface4', className)}
+      {...props}
+    >
+      <div className="h-full rounded-full bg-accent6 transition-all duration-300" style={{ width: `${percentage}%` }} />
+    </div>
+  );
+};
+
+const icons: Record<TaskListItem['status'], ReactNode> = {
+  completed: <CheckCircle2 className="size-3.5 shrink-0 text-green-500" />,
+  in_progress: <Loader2 className="size-3.5 shrink-0 animate-spin text-yellow-500" />,
+  pending: <Circle className="size-3.5 shrink-0 text-neutral4" />,
+};
+
+const statusLabels: Record<TaskListItem['status'], string> = {
+  completed: 'Completed',
+  in_progress: 'In progress',
+  pending: 'Pending',
+};
+
+const textClasses: Record<TaskListItem['status'], string> = {
+  completed: 'text-neutral4 line-through',
+  in_progress: 'font-medium text-yellow-500',
+  pending: 'text-neutral5',
+};
+
+export interface TaskListStatusIconProps extends ComponentProps<'span'> {
+  status: TaskListItem['status'];
+}
+
+export const TaskListStatusIcon = ({ status, className, ...props }: TaskListStatusIconProps) => (
+  <span aria-label={statusLabels[status]} className={cn('pt-0.5', className)} {...props}>
+    {icons[status]}
+  </span>
+);
+
+export interface TaskListRowProps extends ComponentProps<'li'> {
+  task: TaskListItem;
+}
+
+export const TaskListRow = ({ task, className, ...props }: TaskListRowProps) => (
+  <li className={cn('flex items-start gap-2 py-0.5', className)} {...props}>
+    <TaskListStatusIcon status={task.status} />
+    <span className={cn('text-ui-sm leading-ui-sm', textClasses[task.status])}>
+      {task.status === 'in_progress' ? task.activeForm : task.content}
+    </span>
+  </li>
+);
+
+export interface TaskListProps extends Omit<ComponentProps<typeof TaskListContainer>, 'children' | 'title'> {
+  tasks: TaskListItem[];
+  title?: ReactNode;
+  hideWhenEmpty?: boolean;
+  hideWhenComplete?: boolean;
+  scrollActiveIntoView?: boolean;
+}
+
+export const TaskList = ({
+  tasks,
+  title = 'Tasks',
+  hideWhenEmpty = true,
+  hideWhenComplete = true,
+  scrollActiveIntoView = true,
+  ...props
+}: TaskListProps) => {
+  const activeTaskRef = useRef<HTMLLIElement | null>(null);
+  const activeTaskId = tasks.find(task => task.status === 'in_progress')?.id;
+  const completed = tasks.filter(task => task.status === 'completed').length;
+  const total = tasks.length;
+
+  useEffect(() => {
+    if (!scrollActiveIntoView || !activeTaskRef.current || typeof activeTaskRef.current.scrollIntoView !== 'function')
+      return;
+    activeTaskRef.current.scrollIntoView({ block: 'nearest' });
+  }, [activeTaskId, scrollActiveIntoView]);
+
+  if ((hideWhenEmpty && total === 0) || (hideWhenComplete && total > 0 && completed === total)) return null;
+
+  return (
+    <TaskListContainer aria-label="Task list" data-testid="task-list" {...props}>
+      <TaskListHeader>
+        <ListChecks className="size-4 shrink-0 text-accent6" />
+        <h2 className="text-ui-sm leading-ui-sm font-medium text-neutral6">{title}</h2>
+        <TaskListCount completed={completed} total={total} />
+      </TaskListHeader>
+      <TaskListProgress completed={completed} total={total} />
+      <ul className="max-h-32 space-y-1 overflow-y-auto pr-1">
+        {tasks.map(task => (
+          <TaskListRow key={task.id} ref={task.id === activeTaskId ? activeTaskRef : undefined} task={task} />
+        ))}
+      </ul>
+    </TaskListContainer>
+  );
+};

--- a/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
+++ b/packages/playground-ui/src/ds/components/ai/task-list/task-list.tsx
@@ -48,8 +48,8 @@ export const TaskListProgress = ({ completed, total, className, ...props }: Task
 };
 
 const icons: Record<TaskListItem['status'], ReactNode> = {
-  completed: <CheckCircle2 className="size-3.5 shrink-0 text-green-500" />,
-  in_progress: <Loader2 className="size-3.5 shrink-0 animate-spin text-yellow-500" />,
+  completed: <CheckCircle2 className="size-3.5 shrink-0 text-positive1" />,
+  in_progress: <Loader2 className="size-3.5 shrink-0 text-warning1 motion-safe:animate-spin" />,
   pending: <Circle className="size-3.5 shrink-0 text-neutral4" />,
 };
 
@@ -61,7 +61,7 @@ const statusLabels: Record<TaskListItem['status'], string> = {
 
 const textClasses: Record<TaskListItem['status'], string> = {
   completed: 'text-neutral4 line-through',
-  in_progress: 'font-medium text-yellow-500',
+  in_progress: 'font-medium text-warning1',
   pending: 'text-neutral5',
 };
 

--- a/packages/playground/src/lib/ai-ui/task-panel.tsx
+++ b/packages/playground/src/lib/ai-ui/task-panel.tsx
@@ -1,79 +1,16 @@
-import type { TaskItem } from '@mastra/core/signals';
-import { CheckCircle2, Circle, ListChecks, Loader2 } from 'lucide-react';
-import { useEffect, useRef } from 'react';
-import type { ReactNode } from 'react';
-
+import { TaskList } from '@mastra/playground-ui/components/ai/task-list';
 import { useChatTasks } from './chat/chat-context';
-
-const statusIcon: Record<TaskItem['status'], ReactNode> = {
-  completed: <CheckCircle2 className="h-3.5 w-3.5 shrink-0 text-green-500" />,
-  in_progress: <Loader2 className="h-3.5 w-3.5 shrink-0 text-yellow-500 animate-spin" />,
-  pending: <Circle className="h-3.5 w-3.5 shrink-0 text-neutral4" />,
-};
-
-const statusTextClass: Record<TaskItem['status'], string> = {
-  completed: 'text-neutral4 line-through',
-  in_progress: 'text-yellow-500 font-medium',
-  pending: 'text-neutral5',
-};
 
 export const TaskPanel = () => {
   const tasks = useChatTasks();
-  const activeTaskRef = useRef<HTMLLIElement | null>(null);
-  const activeTaskId = tasks.find(task => task.status === 'in_progress')?.id;
+  const hasVisibleTasks = tasks.length > 0 && tasks.some(task => task.status !== 'completed');
 
-  useEffect(() => {
-    if (!activeTaskRef.current || typeof activeTaskRef.current.scrollIntoView !== 'function') return;
-
-    activeTaskRef.current.scrollIntoView({ block: 'nearest' });
-  }, [activeTaskId]);
-
-  if (tasks.length === 0) return null;
-
-  const completed = tasks.filter(t => t.status === 'completed').length;
-  const total = tasks.length;
-  const allDone = completed === total;
-
-  // Hide when all tasks are complete (like mastracode TUI)
-  if (allDone) return null;
+  if (!hasVisibleTasks) return null;
 
   return (
     <div className="px-2 pb-1" data-testid="task-panel">
-      <div className="max-w-3xl w-full mx-auto">
-        <div className="rounded-2xl border border-border2/40 bg-surface3 px-3 py-2.5">
-          {/* Header */}
-          <div className="flex items-center gap-2 mb-2">
-            <ListChecks className="h-4 w-4 shrink-0 text-accent6" />
-            <span className="text-ui-sm leading-ui-sm font-medium text-neutral6">Tasks</span>
-            <span className="text-ui-xs leading-ui-xs text-neutral4 ml-auto tabular-nums">
-              {completed}/{total} completed
-            </span>
-          </div>
-
-          {/* Progress bar */}
-          <div className="h-1 w-full rounded-full bg-surface4 mb-2.5">
-            <div
-              className="h-full rounded-full transition-all duration-300 bg-accent6"
-              style={{ width: `${total > 0 ? (completed / total) * 100 : 0}%` }}
-            />
-          </div>
-
-          {/* Task list */}
-          <ul className="max-h-32 space-y-1 overflow-y-auto pr-1">
-            {tasks.map(task => (
-              <li
-                key={task.id}
-                ref={task.id === activeTaskId ? activeTaskRef : undefined}
-                className="flex items-start gap-2 py-0.5"
-              >
-                <span className="pt-0.5">{statusIcon[task.status]}</span>
-                <span className={`text-ui-sm leading-ui-sm ${statusTextClass[task.status]}`}>
-                  {task.status === 'in_progress' ? task.activeForm : task.content}
-                </span>
-              </li>
-            ))}
-          </ul>
-        </div>
+      <div className="mx-auto w-full max-w-3xl">
+        <TaskList tasks={tasks} />
       </div>
     </div>
   );

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/ask-user-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/ask-user-badge.test.tsx
@@ -169,7 +169,7 @@ describe('AskUserBadge', () => {
   });
 
   describe('when a tool call is already running', () => {
-    it('disables the option buttons and does not submit on click', () => {
+    it('disables the option controls and does not submit on click', () => {
       const suspendPayload: AskUserSuspendPayload = {
         question: 'Pick a fruit',
         options: [{ label: 'Apple' }],
@@ -180,10 +180,10 @@ describe('AskUserBadge', () => {
         { isRunning: true },
       );
 
-      const optionButton = within(badge()).getByRole('button', { name: 'Apple' }) as HTMLButtonElement;
-      expect(optionButton.disabled).toBe(true);
+      const optionControl = within(badge()).getByRole<HTMLInputElement>('radio', { name: 'Apple' });
+      expect(optionControl.disabled).toBe(true);
 
-      fireEvent.click(optionButton);
+      fireEvent.click(optionControl);
       expect(approveToolcall).not.toHaveBeenCalled();
     });
 

--- a/packages/playground/src/lib/ai-ui/tools/badges/__tests__/ask-user-badge.test.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/__tests__/ask-user-badge.test.tsx
@@ -36,7 +36,7 @@ const renderBadge = (
   return { ...utils, approveToolcall };
 };
 
-const badge = () => screen.getByTestId('ask-user-badge') as HTMLElement;
+const badge = () => screen.getByTestId<HTMLElement>('ask-user-badge');
 
 afterEach(() => cleanup());
 
@@ -85,7 +85,7 @@ describe('AskUserBadge', () => {
     it('keeps the submit button disabled until something is selected', () => {
       renderBadge({ toolCallId: 'call-2', suspendPayload, result: undefined });
 
-      expect((within(badge()).getByRole('button', { name: /submit/i }) as HTMLButtonElement).disabled).toBe(true);
+      expect(within(badge()).getByRole<HTMLButtonElement>('button', { name: /submit/i }).disabled).toBe(true);
     });
 
     it('submits the selected labels as an array', () => {
@@ -120,10 +120,7 @@ describe('AskUserBadge', () => {
       const input = within(badge()).getByPlaceholderText('Type your answer...');
       fireEvent.change(input, { target: { value: 'Grace' } });
 
-      const sendButton = within(badge())
-        .getAllByRole('button')
-        .find(button => button.getAttribute('disabled') === null);
-      fireEvent.click(sendButton!);
+      fireEvent.click(within(badge()).getByRole<HTMLButtonElement>('button', { name: 'Submit answer' }));
 
       expect(approveToolcall).toHaveBeenCalledWith('call-3', 'Grace');
     });
@@ -146,7 +143,7 @@ describe('AskUserBadge', () => {
       selectionMode: 'single_select',
     };
 
-    it('renders the answer content and hides the option inputs when a result is present', () => {
+    it('renders the answer content when a result is present', () => {
       renderBadge({
         toolCallId: 'call-4',
         suspendPayload,
@@ -154,46 +151,71 @@ describe('AskUserBadge', () => {
       });
 
       expect(within(badge()).getAllByText('User answered: Apple')).toHaveLength(1);
-      expect(badge().textContent).not.toContain('{"content"');
-      expect(within(badge()).queryByRole('button', { name: 'Apple' })).toBeNull();
     });
 
-    it('hides the inputs when the approval status is approved', () => {
+    it('does not render raw result JSON when a result is present', () => {
+      renderBadge({
+        toolCallId: 'call-4',
+        suspendPayload,
+        result: { content: 'User answered: Apple', isError: false },
+      });
+
+      expect(badge().textContent).not.toContain('{"content"');
+    });
+
+    it('hides the option input when a result is present', () => {
+      renderBadge({
+        toolCallId: 'call-4',
+        suspendPayload,
+        result: { content: 'User answered: Apple', isError: false },
+      });
+
+      expect(within(badge()).queryByRole('radio', { name: 'Apple' })).toBeNull();
+    });
+
+    it('hides the option input when the approval status is approved', () => {
       renderBadge(
         { toolCallId: 'call-4', suspendPayload, result: undefined },
         { toolCallApprovals: { 'call-4': { status: 'approved' } } },
       );
 
-      expect(within(badge()).queryByRole('button', { name: 'Apple' })).toBeNull();
+      expect(within(badge()).queryByRole('radio', { name: 'Apple' })).toBeNull();
     });
   });
 
-  describe('when a tool call is already running', () => {
-    it('disables the option controls and does not submit on click', () => {
-      const suspendPayload: AskUserSuspendPayload = {
-        question: 'Pick a fruit',
-        options: [{ label: 'Apple' }],
-        selectionMode: 'single_select',
-      };
+  describe('when a tool call with options is already running', () => {
+    const suspendPayload: AskUserSuspendPayload = {
+      question: 'Pick a fruit',
+      options: [{ label: 'Apple' }],
+      selectionMode: 'single_select',
+    };
+
+    it('disables the option controls', () => {
+      renderBadge({ toolCallId: 'call-5', suspendPayload, result: undefined }, { isRunning: true });
+
+      expect(within(badge()).getByRole<HTMLInputElement>('radio', { name: 'Apple' }).disabled).toBe(true);
+    });
+
+    it('does not submit when a disabled option is clicked', () => {
       const { approveToolcall } = renderBadge(
         { toolCallId: 'call-5', suspendPayload, result: undefined },
         { isRunning: true },
       );
 
-      const optionControl = within(badge()).getByRole<HTMLInputElement>('radio', { name: 'Apple' });
-      expect(optionControl.disabled).toBe(true);
+      fireEvent.click(within(badge()).getByRole<HTMLInputElement>('radio', { name: 'Apple' }));
 
-      fireEvent.click(optionControl);
       expect(approveToolcall).not.toHaveBeenCalled();
     });
+  });
 
+  describe('when a free-text tool call is already running', () => {
     it('disables the free-text input', () => {
       renderBadge(
         { toolCallId: 'call-6', suspendPayload: { question: 'Name?' }, result: undefined },
         { isRunning: true },
       );
 
-      expect((within(badge()).getByPlaceholderText('Type your answer...') as HTMLInputElement).disabled).toBe(true);
+      expect(within(badge()).getByRole<HTMLInputElement>('textbox', { name: 'Name?' }).disabled).toBe(true);
     });
   });
 

--- a/packages/playground/src/lib/ai-ui/tools/badges/ask-user-badge.tsx
+++ b/packages/playground/src/lib/ai-ui/tools/badges/ask-user-badge.tsx
@@ -1,170 +1,30 @@
-import { Badge } from '@mastra/playground-ui/components/Badge';
-import { Button } from '@mastra/playground-ui/components/Button';
-import { Input } from '@mastra/playground-ui/components/Input';
-import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Icon } from '@mastra/playground-ui/icons/Icon';
-import { cn } from '@mastra/playground-ui/utils/cn';
-import { Check, MessageCircleQuestion, Send } from 'lucide-react';
-import { useCallback, useState } from 'react';
-import type { AskUserResult, AskUserSuspendPayload } from './types';
+import { AskUser } from '@mastra/playground-ui/components/ai/ask-user';
+import type { AskUserAnswer, AskUserResult, AskUserPayload } from '@mastra/playground-ui/components/ai/ask-user';
 import { useToolCall } from '@/services/tool-call-provider';
 
 export interface AskUserBadgeProps {
   toolCallId: string;
-  suspendPayload: AskUserSuspendPayload;
+  suspendPayload: AskUserPayload;
   result: AskUserResult | undefined;
 }
 
 export const AskUserBadge = ({ toolCallId, suspendPayload, result }: AskUserBadgeProps) => {
   const { approveToolcall, isRunning, toolCallApprovals } = useToolCall();
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
-  const [freeTextInput, setFreeTextInput] = useState('');
+  const isAnswered = toolCallApprovals?.[toolCallId]?.status === 'approved';
 
-  const { question, options, selectionMode } = suspendPayload;
-  const resolvedMode = options?.length ? (selectionMode ?? 'single_select') : undefined;
-  const isAnswered = !!result || toolCallApprovals?.[toolCallId]?.status === 'approved';
-  const subtitle = !options?.length
-    ? 'free text'
-    : resolvedMode === 'multi_select'
-      ? 'multiple choice'
-      : 'single choice';
-
-  const handleOptionSelect = useCallback(
-    (label: string) => {
-      if (isAnswered || isRunning) return;
-      if (resolvedMode === 'multi_select') {
-        setSelectedOptions(prev => (prev.includes(label) ? prev.filter(o => o !== label) : [...prev, label]));
-      } else {
-        // Single-select: submit immediately
-        approveToolcall(toolCallId, label);
-      }
-    },
-    [isAnswered, isRunning, resolvedMode, approveToolcall, toolCallId],
-  );
-
-  const handleMultiSubmit = useCallback(() => {
-    if (selectedOptions.length === 0 || isAnswered || isRunning) return;
-    approveToolcall(toolCallId, selectedOptions);
-  }, [selectedOptions, isAnswered, isRunning, approveToolcall, toolCallId]);
-
-  const handleFreeTextSubmit = useCallback(() => {
-    const trimmed = freeTextInput.trim();
-    if (!trimmed || isAnswered || isRunning) return;
-    approveToolcall(toolCallId, trimmed);
-  }, [freeTextInput, isAnswered, isRunning, approveToolcall, toolCallId]);
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !e.shiftKey) {
-        e.preventDefault();
-        handleFreeTextSubmit();
-      }
-    },
-    [handleFreeTextSubmit],
-  );
+  const submitAnswer = (answer: AskUserAnswer) => {
+    approveToolcall(toolCallId, answer);
+  };
 
   return (
-    <div
+    <AskUser
       data-testid="ask-user-badge"
-      className="mb-4 flex w-full max-w-full overflow-hidden rounded-lg border border-border1 bg-surface3"
-    >
-      <div className={cn('w-1 shrink-0', isAnswered ? 'bg-notice-success' : 'bg-accent1')} />
-
-      <div className="min-w-0 flex-1">
-        <div className="flex h-header-default items-center gap-2 border-b border-border1 px-4">
-          <span className="rounded-md border border-border1 bg-surface4 p-1">
-            <Icon>
-              <MessageCircleQuestion className="text-icon3" />
-            </Icon>
-          </span>
-          <Txt as="span" variant="ui-md" className="font-medium text-neutral6">
-            Ask User
-          </Txt>
-          <Txt as="span" variant="ui-sm" className="text-neutral3">
-            · {subtitle}
-          </Txt>
-          {isAnswered && (
-            <Badge variant="success" size="sm" icon={<span className="size-1.5 rounded-full bg-current" />}>
-              Answered
-            </Badge>
-          )}
-        </div>
-
-        <div className="flex flex-col gap-4 p-4">
-          <Txt as="p" variant="ui-xs" className="uppercase tracking-wide text-neutral3">
-            Question
-          </Txt>
-          <Txt as="p" variant="ui-lg" className="text-neutral6">
-            {question}
-          </Txt>
-
-          {isAnswered && result != null && (
-            <div className="flex items-center gap-2 rounded-md border border-border1 bg-surface4 px-3 py-2">
-              <Icon>
-                <Check className="text-notice-success-fg" />
-              </Icon>
-              <Txt as="span" variant="ui-md" className="font-medium text-neutral6">
-                {result.content}
-              </Txt>
-            </div>
-          )}
-
-          {!isAnswered && options && options.length > 0 && (
-            <div className="flex flex-col gap-2">
-              {options.map(option => {
-                const isSelected = selectedOptions.includes(option.label);
-                return (
-                  <button
-                    key={option.label}
-                    type="button"
-                    onClick={() => handleOptionSelect(option.label)}
-                    disabled={isRunning}
-                    className={cn(
-                      'rounded-md border px-3 py-2 text-left transition-colors disabled:cursor-not-allowed disabled:opacity-50',
-                      isSelected ? 'border-accent1 bg-surface4' : 'border-border1 bg-surface4 hover:bg-surface5',
-                    )}
-                  >
-                    <Txt as="span" variant="ui-md" className="font-medium text-neutral6">
-                      {option.label}
-                    </Txt>
-                    {option.description && (
-                      <Txt as="span" variant="ui-xs" className="mt-0.5 block text-neutral3">
-                        {option.description}
-                      </Txt>
-                    )}
-                  </button>
-                );
-              })}
-              {resolvedMode === 'multi_select' && (
-                <Button onClick={handleMultiSubmit} disabled={selectedOptions.length === 0 || isRunning}>
-                  <Icon>
-                    <Send />
-                  </Icon>
-                  Submit ({selectedOptions.length} selected)
-                </Button>
-              )}
-            </div>
-          )}
-
-          {!isAnswered && !options?.length && (
-            <div className="flex gap-2">
-              <Input
-                placeholder="Type your answer..."
-                value={freeTextInput}
-                onChange={e => setFreeTextInput(e.target.value)}
-                onKeyDown={handleKeyDown}
-                disabled={isRunning}
-                className="flex-1"
-              />
-              <Button onClick={handleFreeTextSubmit} disabled={!freeTextInput.trim() || isRunning}>
-                <Icon>
-                  <Send />
-                </Icon>
-              </Button>
-            </div>
-          )}
-        </div>
-      </div>
-    </div>
+      payload={suspendPayload}
+      result={result}
+      isAnswered={isAnswered}
+      isSubmitting={isRunning}
+      onSubmit={submitAnswer}
+      className="mb-4 w-full max-w-full"
+    />
   );
 };

--- a/packages/playground/src/lib/ai-ui/tools/badges/types.ts
+++ b/packages/playground/src/lib/ai-ui/tools/badges/types.ts
@@ -1,22 +1,6 @@
-export interface AskUserOption {
-  label: string;
-  description?: string;
-}
-
-export type AskUserSelectionMode = 'single_select' | 'multi_select';
-
-export interface AskUserSuspendPayload {
-  question: string;
-  options?: AskUserOption[];
-  selectionMode?: AskUserSelectionMode;
-}
-
-/**
- * Output returned by the built-in `ask_user` tool. Every return branch in
- * `packages/core/src/tools/builtin/ask-user.ts` produces this shape, so the
- * playground can render `content` directly without inspecting the runtime type.
- */
-export interface AskUserResult {
-  content: string;
-  isError: boolean;
-}
+export type {
+  AskUserOption,
+  AskUserPayload as AskUserSuspendPayload,
+  AskUserResult,
+  AskUserSelectionMode,
+} from '@mastra/playground-ui/components/ai/ask-user';


### PR DESCRIPTION
This adds reusable Ask User and Task List primitives to playground-ui and updates the playground integration to use them. Ask User supports free text, single-select, and multi-select responses, while Task List exposes progress, semantic statuses, active task copy, and accessible motion-aware feedback.

The interaction state resets when a new payload arrives, answered controls are removed from the UI, and the component tests follow the repository's BDD and type-safety conventions.

Verified with focused Vitest suites for playground-ui and playground, both package typechecks, changed-file ESLint checks, and git diff --check. The full playground-ui suite reached 650 passing tests with two known export-test timeouts; the isolated export suite passed all 10 tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR adds reusable “Ask User” and “Task List” building blocks so playground interfaces can ask questions and show task progress consistently. The playground now uses these shared components instead of maintaining its own versions.

## Summary

- Added reusable `AskUser` component supporting:
  - Free-text answers
  - Single- and multi-select options
  - Submitting, answered, and error states
  - Accessible controls and state reset for new payloads
- Added reusable `TaskList` component with:
  - Progress counts and progress bar
  - Pending, active, and completed statuses
  - Active-task text and motion-aware scrolling
  - Configurable visibility for empty and completed lists
- Added public exports, Storybook stories, focused BDD tests, and type-safety coverage.
- Updated Playground adapters:
  - `AskUserBadge` now delegates to `AskUser` for tool resumption.
  - `TaskPanel` now delegates to `TaskList` for streamed task progress.
  - Shared Ask User types are re-exported from `playground-ui`.
- Added a minor changeset for `@mastra/playground-ui`.
- Verification included focused Vitest suites, package typechecks, ESLint, `git diff --check`, and the full UI test suite: 650 tests passing, with two known export-test timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->