### PR TITLE
feat(turbopuffer): make query consistency level configurable

### DIFF
--- a/.changeset/all-peaches-wear.md
+++ b/.changeset/all-peaches-wear.md
@@ -1,0 +1,24 @@
+---
+'@mastra/turbopuffer': minor
+---
+
+Added a `consistency` option to the Turbopuffer vector store. Queries previously always used strong consistency, which adds latency. You can now opt into eventual consistency for lower-latency queries, either for all queries via the constructor or per query.
+
+```typescript
+import { TurbopufferVector } from '@mastra/turbopuffer';
+
+const vectorStore = new TurbopufferVector({
+  id: 'turbopuffer',
+  apiKey: process.env.TURBOPUFFER_API_KEY!,
+  consistency: 'eventual', // default for all queries (defaults to 'strong')
+});
+
+// Per-query override
+await vectorStore.query({
+  indexName: 'my-index',
+  queryVector: embedding,
+  consistency: 'strong',
+});
+```
+
+Fixes https://github.com/mastra-ai/mastra/issues/19591

--- a/.changeset/turbopuffer-rag-config.md
+++ b/.changeset/turbopuffer-rag-config.md
@@ -1,0 +1,18 @@
+---
+'@mastra/rag': patch
+---
+
+Added a typed `turbopuffer` entry to the `databaseConfig` option of `createVectorQueryTool`. This lets you set the Turbopuffer consistency level for vector queries.
+
+```typescript
+const vectorTool = createVectorQueryTool({
+  vectorStoreName: 'turbopuffer',
+  indexName: 'documents',
+  model: embedModel,
+  databaseConfig: {
+    turbopuffer: {
+      consistency: 'eventual', // lower latency, recently written data may not be visible yet
+    },
+  },
+});
+```

--- a/docs/src/content/en/reference/rag/database-config.mdx
+++ b/docs/src/content/en/reference/rag/database-config.mdx
@@ -20,6 +20,7 @@ export type DatabaseConfig = {
   pinecone?: PineconeConfig
   pgvector?: PgVectorConfig
   chroma?: ChromaConfig
+  turbopuffer?: TurbopufferConfig
   [key: string]: any // Extensible for future databases
 }
 ```
@@ -162,6 +163,27 @@ whereDocument: { "$contains": "API documentation" }
 - Advanced metadata filtering
 - Content-based document filtering
 - Complex query combinations
+
+### `TurbopufferConfig`
+
+Configuration options specific to Turbopuffer vector store.
+
+<PropertiesTable
+  content={[
+  {
+    name: 'consistency',
+    type: "'strong' | 'eventual'",
+    description:
+      'The consistency level for queries. "strong" (default) guarantees queries see all data written before the query started, at the cost of higher latency. "eventual" offers lower latency, but recently written data may not be visible yet.',
+    isOptional: true,
+  },
+]}
+/>
+
+**Use Cases:**
+
+- Latency-sensitive queries where slightly stale data is acceptable (`eventual`)
+- Read-your-writes workflows that must see the latest data (`strong`)
 
 ## Usage examples
 

--- a/docs/src/content/en/reference/tools/vector-query-tool.mdx
+++ b/docs/src/content/en/reference/tools/vector-query-tool.mdx
@@ -462,6 +462,28 @@ The `databaseConfig` parameter allows you to leverage unique features and optimi
     - **Use Cases**: Advanced filtering, content-based search
   </TabItem>
 
+  <TabItem value="turbopuffer" label="Turbopuffer">
+    ### Turbopuffer Configuration
+
+    ```typescript
+    const turbopufferQueryTool = createVectorQueryTool({
+      vectorStoreName: 'turbopuffer',
+      indexName: 'docs',
+      model: new ModelRouterEmbeddingModel('openai/text-embedding-3-small'),
+      databaseConfig: {
+        turbopuffer: {
+          consistency: 'eventual', // Lower latency, recently written data may not be visible yet
+        },
+      },
+    })
+    ```
+
+    **Turbopuffer Features:**
+
+    - **consistency**: Choose between `strong` (default, read-your-writes) and `eventual` (lower latency)
+    - **Use Cases**: Latency-sensitive queries where slightly stale data is acceptable
+  </TabItem>
+
   <TabItem value="multiple-configs" label="Multiple Configs">
     ### Multiple Database Configurations
 

--- a/docs/src/content/en/reference/vectors/turbopuffer.mdx
+++ b/docs/src/content/en/reference/vectors/turbopuffer.mdx
@@ -54,6 +54,14 @@ The TurbopufferVector class provides vector search using [Turbopuffer](https://t
     description: 'Whether to compress requests and accept compressed responses.',
   },
   {
+    name: 'consistency',
+    type: "'strong' | 'eventual'",
+    isOptional: true,
+    defaultValue: 'strong',
+    description:
+      'The default consistency level for queries. Can be overridden per query. "strong" guarantees queries see all data written before the query started, at the cost of higher latency. "eventual" offers lower latency, but recently written data may not be visible yet.',
+  },
+  {
     name: 'schemaConfigForIndex',
     type: 'function',
     isOptional: true,
@@ -146,6 +154,13 @@ The TurbopufferVector class provides vector search using [Turbopuffer](https://t
     isOptional: true,
     defaultValue: 'false',
     description: 'Whether to include vectors in the results',
+  },
+  {
+    name: 'consistency',
+    type: "'strong' | 'eventual'",
+    isOptional: true,
+    description:
+      'The consistency level for this query. Overrides the consistency level set in the constructor. Defaults to "strong".',
   },
 ]}
 />

--- a/packages/rag/src/tools/index.ts
+++ b/packages/rag/src/tools/index.ts
@@ -10,4 +10,5 @@ export type {
   PineconeConfig,
   PgVectorConfig,
   ChromaConfig,
+  TurbopufferConfig,
 } from './types';

--- a/packages/rag/src/tools/types.ts
+++ b/packages/rag/src/tools/types.ts
@@ -85,12 +85,23 @@ export interface MongoDBConfig {
   numCandidates?: number;
 }
 
+export interface TurbopufferConfig {
+  /**
+   * The consistency level for queries.
+   * - 'strong': Queries see all data written before the query started. Higher latency (default).
+   * - 'eventual': Lower latency, but recently written data may not be visible yet.
+   * See: https://turbopuffer.com/docs/query
+   */
+  consistency?: 'strong' | 'eventual';
+}
+
 // Union type for all database-specific configs
 export type DatabaseConfig = {
   pinecone?: PineconeConfig;
   pgvector?: PgVectorConfig;
   chroma?: ChromaConfig;
   mongodb?: MongoDBConfig;
+  turbopuffer?: TurbopufferConfig;
   // Add other database configs as needed
   [key: string]: any; // Allow for future database extensions
 };

--- a/packages/rag/src/tools/vector-query-database-config.test.ts
+++ b/packages/rag/src/tools/vector-query-database-config.test.ts
@@ -206,6 +206,40 @@ describe('createVectorQueryTool with database-specific configurations', () => {
     );
   });
 
+  it('should pass Turbopuffer configuration to vectorQuerySearch', async () => {
+    const databaseConfig: DatabaseConfig = {
+      turbopuffer: {
+        consistency: 'eventual',
+      },
+    };
+
+    const tool = createVectorQueryTool({
+      vectorStoreName: 'turbopuffer',
+      indexName: 'testIndex',
+      model: mockModel,
+      databaseConfig,
+    });
+
+    const requestContext = new RequestContext();
+
+    await tool.execute(
+      {
+        queryText: 'test query',
+        topK: 5,
+      },
+      {
+        mastra: mockMastra as any,
+        requestContext,
+      },
+    );
+
+    expect(vectorQuerySearch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        databaseConfig,
+      }),
+    );
+  });
+
   it('should handle multiple database configurations', async () => {
     const databaseConfig: DatabaseConfig = {
       pinecone: {

--- a/packages/rag/src/utils/vector-search.ts
+++ b/packages/rag/src/utils/vector-search.ts
@@ -30,6 +30,7 @@ enum DatabaseType {
   PgVector = 'pgvector',
   Chroma = 'chroma',
   MongoDB = 'mongodb',
+  Turbopuffer = 'turbopuffer',
 }
 
 const DATABASE_TYPE_MAP = Object.keys(DatabaseType);
@@ -192,6 +193,13 @@ const databaseSpecificParams = (databaseConfig: DatabaseConfig) => {
     if (databaseConfig.mongodb) {
       if (databaseConfig.mongodb.numCandidates !== undefined) {
         databaseSpecificParams.numCandidates = databaseConfig.mongodb.numCandidates;
+      }
+    }
+
+    // Turbopuffer-specific configurations
+    if (databaseConfig.turbopuffer) {
+      if (databaseConfig.turbopuffer.consistency !== undefined) {
+        databaseSpecificParams.consistency = databaseConfig.turbopuffer.consistency;
       }
     }
 

--- a/stores/turbopuffer/src/vector/index.test.ts
+++ b/stores/turbopuffer/src/vector/index.test.ts
@@ -1,6 +1,6 @@
 import { createVectorTestSuite } from '@internal/storage-test-utils';
 import dotenv from 'dotenv';
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import type { TurbopufferVectorFilter } from './filter';
 import { TurbopufferVector } from './';
@@ -1067,4 +1067,55 @@ function waitUntilVectorsIndexed(vectorDB: TurbopufferVector, indexName: string,
       },
     });
   }
+});
+
+describe('TurbopufferVector consistency option', () => {
+  const indexName = 'consistency-test-index';
+
+  beforeAll(() => {
+    vi.stubEnv('TURBOPUFFER_REGION', 'gcp-us-central1');
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
+  async function setupVectorWithMockedClient(opts?: { consistency?: 'strong' | 'eventual' }) {
+    const vectorDB = new TurbopufferVector({
+      id: 'turbopuffer-consistency-test',
+      apiKey: 'fake-api-key',
+      ...opts,
+    });
+    // createIndex only registers the index in a local cache; no network calls
+    await vectorDB.createIndex({ indexName, dimension: 3 });
+    const queryMock = vi.fn().mockResolvedValue({ rows: [] });
+    (vectorDB as any).client = {
+      namespace: vi.fn(() => ({ query: queryMock })),
+    };
+    return { vectorDB, queryMock };
+  }
+
+  it('defaults to strong consistency', async () => {
+    const { vectorDB, queryMock } = await setupVectorWithMockedClient();
+    await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 10 });
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ consistency: { level: 'strong' } }));
+  });
+
+  it('uses the instance-level consistency option', async () => {
+    const { vectorDB, queryMock } = await setupVectorWithMockedClient({ consistency: 'eventual' });
+    await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 10 });
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ consistency: { level: 'eventual' } }));
+  });
+
+  it('per-query consistency overrides the instance-level option', async () => {
+    const { vectorDB, queryMock } = await setupVectorWithMockedClient({ consistency: 'eventual' });
+    await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 10, consistency: 'strong' });
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ consistency: { level: 'strong' } }));
+  });
+
+  it('per-query consistency can relax the default', async () => {
+    const { vectorDB, queryMock } = await setupVectorWithMockedClient();
+    await vectorDB.query({ indexName, queryVector: [1, 0, 0], topK: 10, consistency: 'eventual' });
+    expect(queryMock).toHaveBeenCalledWith(expect.objectContaining({ consistency: { level: 'eventual' } }));
+  });
 });

--- a/stores/turbopuffer/src/vector/index.ts
+++ b/stores/turbopuffer/src/vector/index.ts
@@ -18,7 +18,20 @@ import type { DistanceMetric, NamespaceWriteParams, Row } from '@turbopuffer/tur
 import { TurbopufferFilterTranslator } from './filter';
 import type { TurbopufferVectorFilter } from './filter';
 
-type TurbopufferQueryVectorParams = QueryVectorParams<TurbopufferVectorFilter>;
+/**
+ * The consistency level for Turbopuffer queries.
+ * - 'strong': Queries see all data written before the query started. Higher latency (default).
+ * - 'eventual': Lower latency, but recently written data may not be visible yet.
+ */
+export type TurbopufferConsistencyLevel = 'strong' | 'eventual';
+
+export interface TurbopufferQueryVectorParams extends QueryVectorParams<TurbopufferVectorFilter> {
+  /**
+   * The consistency level for this query. Overrides the instance-level
+   * `consistency` option. Defaults to 'strong'.
+   */
+  consistency?: TurbopufferConsistencyLevel;
+}
 type Schema = NonNullable<NamespaceWriteParams['schema']>;
 
 export interface TurbopufferVectorOptions {
@@ -34,6 +47,12 @@ export interface TurbopufferVectorOptions {
   warmConnections?: number;
   /** Whether to compress requests and accept compressed responses. Default is true. */
   compression?: boolean;
+  /**
+   * The default consistency level for queries. Can be overridden per query.
+   * - 'strong': Queries see all data written before the query started. Higher latency (default).
+   * - 'eventual': Lower latency, but recently written data may not be visible yet.
+   */
+  consistency?: TurbopufferConsistencyLevel;
   /**
    * A callback function that takes an index name and returns a config object for that index.
    * This allows you to define explicit schemas per index.
@@ -210,6 +229,7 @@ export class TurbopufferVector extends MastraVector<TurbopufferVectorFilter> {
     topK,
     filter,
     includeVector,
+    consistency,
   }: TurbopufferQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
@@ -258,7 +278,7 @@ export class TurbopufferVector extends MastraVector<TurbopufferVectorFilter> {
         filters: translatedFilter,
         vector_encoding: includeVector ? 'float' : undefined,
         include_attributes: true,
-        consistency: { level: 'strong' }, // todo: make this configurable somehow?
+        consistency: { level: consistency ?? this.opts.consistency ?? 'strong' },
       });
       return (results.rows ?? []).map(item => {
         const { id, vector, $dist, ...metadata } = item;


### PR DESCRIPTION
## Summary

Turbopuffer queries were hardcoded to `consistency: { level: 'strong' }` (with a `TODO: make this configurable somehow?`), which imposes a latency floor on every query even when callers can tolerate slightly stale data.

This PR makes the consistency level configurable:

- **`@mastra/turbopuffer`**: New `consistency?: 'strong' | 'eventual'` option on `TurbopufferVector`:
  - Constructor-level: sets the default for all queries from that store instance
  - Per-query: `query({ ..., consistency })` overrides the constructor default
  - Precedence: per-query > constructor > `'strong'`
- **`@mastra/rag`**: New typed `turbopuffer` entry in `DatabaseConfig` for `createVectorQueryTool`, so the consistency level flows through RAG vector queries via `databaseConfig`.

The default remains `'strong'` (matching the Turbopuffer API default and previous behavior), so this is fully backward compatible and preserves read-your-writes semantics for Memory semantic recall. Latency-sensitive users can now opt into `'eventual'`.

```typescript
const vectorStore = new TurbopufferVector({
  id: 'turbopuffer',
  apiKey: process.env.TURBOPUFFER_API_KEY!,
  consistency: 'eventual', // default for all queries
});

// Per-query override
await vectorStore.query({ indexName, queryVector, consistency: 'strong' });
```

Also updates the Turbopuffer vector store, `DatabaseConfig`, and vector query tool reference docs, and adds changesets.

Fixes #19591

## Test plan

- New unit tests in `stores/turbopuffer/src/vector/index.test.ts` (mocked client) covering: default `'strong'`, constructor-level `'eventual'`, per-query override in both directions — 4 passed
- New test in `packages/rag/src/tools/vector-query-database-config.test.ts` verifying `turbopuffer` databaseConfig passes through to `vectorQuerySearch`
- `pnpm --filter ./stores/turbopuffer test` — 31 passed (59 integration tests skipped without `TURBOPUFFER_API_KEY`)
- `pnpm --filter ./packages/rag test` — 302 passed
- `pnpm turbo build` + `lint` for both packages — clean
- Docs remark lint — clean

🤖 Generated with Mastra Code
