### PR TITLE
fix(mastracode): stop noisy auto PR-subscribe errors outside GitHub-project sessions

### DIFF
--- a/mastracode/web/src/web/github/session-subscriptions.test.ts
+++ b/mastracode/web/src/web/github/session-subscriptions.test.ts
@@ -112,6 +112,29 @@ describe('GitHub subscription entry points', () => {
     expect(createGithubSubscriptionTools(requestContext)).toEqual({});
   });
 
+  it('silently skips auto-subscription outside GitHub-project sessions', async () => {
+    const requestContext = new RequestContext();
+    requestContext.set('controller', {
+      resourceId: 'resource-1',
+      threadId: 'thread-1',
+      scope: '/worktrees/a',
+      session: { id: 'session-1', ownerId: 'user-1', modeId: 'build' },
+      getState: () => ({}),
+    });
+
+    await expect(
+      subscribeCurrentSessionToPullRequest(requestContext, 123, 'auto-gh-pr-create'),
+    ).resolves.toBeUndefined();
+    expect(mocks.subscribe).not.toHaveBeenCalled();
+  });
+
+  it('still rejects the explicit tool path outside GitHub-project sessions', async () => {
+    await expect(subscribeCurrentSessionToPullRequest(new RequestContext(), 123, 'explicit-tool')).rejects.toThrow(
+      'GitHub subscriptions require an authenticated GitHub-project session with an active thread.',
+    );
+    expect(mocks.subscribe).not.toHaveBeenCalled();
+  });
+
   it('subscribes the exact scoped session after verifying the active-project PR', async () => {
     const requestContext = authenticatedRequestContext('/worktrees/a');
 

--- a/mastracode/web/src/web/github/session-subscriptions.ts
+++ b/mastracode/web/src/web/github/session-subscriptions.ts
@@ -33,6 +33,20 @@ function parsePullRequest(value: number | string, expectedRepo: string): number 
   return Number(match[2]);
 }
 
+/**
+ * Whether the current request comes from a session that GitHub subscriptions
+ * can ever apply to: an authenticated org user on a GitHub-project session
+ * with an active thread. Mirrors the gate in `resolveSessionTarget` without
+ * throwing, for passive callers that should no-op instead of erroring.
+ */
+function isGithubProjectSession(requestContext: RequestContext): boolean {
+  const context = requestContext.get('controller') as AgentControllerRequestContext<GithubSessionState> | undefined;
+  const user = requestContext.get('user') as WebAuthUser | undefined;
+  return Boolean(
+    context?.threadId && context.getState().githubProjectId && getWebAuthOrgId(user) && getWebAuthUserId(user),
+  );
+}
+
 async function resolveSessionTarget(requestContext: RequestContext): Promise<SessionTarget> {
   const context = requestContext.get('controller') as AgentControllerRequestContext<GithubSessionState> | undefined;
   const user = requestContext.get('user') as WebAuthUser | undefined;
@@ -82,6 +96,11 @@ export async function subscribeCurrentSessionToPullRequest(
   pullRequest: number | string,
   source: 'auto-gh-pr-create' | 'explicit-tool',
 ) {
+  // The auto path observes every successful `gh pr create` in every session,
+  // including local and non-GitHub-project sessions where subscriptions can
+  // never apply. Skip silently there; only the explicit tool should surface
+  // "this session cannot subscribe" as an error.
+  if (source === 'auto-gh-pr-create' && !isGithubProjectSession(requestContext)) return undefined;
   const target = await resolveSessionTarget(requestContext);
   const number = parsePullRequest(pullRequest, target.project.repoFullName);
   await verifyPullRequest(target, number);


### PR DESCRIPTION
## Summary

When the GitHub feature is enabled, the Mastra Code web factory installs a post-tool observer that watches every `execute_command` result and auto-subscribes the current thread to a pull request whenever a `gh pr create` succeeds. That observer ran for **all** sessions — including local sessions and sessions not tied to a GitHub project — where `resolveSessionTarget` throws `GitHub subscriptions require an authenticated GitHub-project session with an active thread.` The SDK swallows observer errors, but every PR created outside a GitHub-project session logged a scary (and misleading) server error:

```
[MastraCode] Post-tool observer failed for execute_command. Error: GitHub subscriptions require an authenticated GitHub-project session with an active thread.
```

## Fix

`subscribeCurrentSessionToPullRequest` now checks session eligibility up front (authenticated org user + GitHub-project session + active thread — the same gate `resolveSessionTarget` enforces) and **silently no-ops** for the `auto-gh-pr-create` source when the session can never be subscribed. The explicit `github_subscribe_pr` tool path is unchanged and still throws, because there the user asked for a subscription and the error is actionable.

## Test plan

- New tests in `session-subscriptions.test.ts`: auto path resolves to `undefined` without subscribing for a non-GitHub-project session; explicit tool path still rejects with the original error.
- `pnpm exec vitest run src/web/github/session-subscriptions.test.ts` — 16/16 passing.
- `pnpm --filter ./mastracode/web check` (tsc for server + UI) clean; prettier clean.
