### PR TITLE
fix(auth-better-auth): sign bearer session tokens and implement getUser

### DIFF
--- a/.changeset/lemon-gifts-roll.md
+++ b/.changeset/lemon-gifts-roll.md
@@ -1,0 +1,13 @@
+---
+'@mastra/auth-better-auth': patch
+---
+
+Fixed Better Auth bearer token authentication and implemented user lookup in `@mastra/auth-better-auth` (fixes [#19110](https://github.com/mastra-ai/mastra/issues/19110)).
+
+**Bearer tokens now work after credentials sign-in**
+
+`signIn`/`signUp` return Better Auth's raw session token, but Better Auth only accepts _signed_ session cookies. Sending that token as `Authorization: Bearer <token>` previously always failed authentication. The provider now signs unsigned tokens with the Better Auth secret before verifying the session — matching the semantics of Better Auth's bearer plugin. The session cookie name is also resolved from the Better Auth instance, so secure-cookie setups (`__Secure-` prefix) work too.
+
+**`getUser()` and `getUsers()` are now implemented**
+
+Previously `getUser()` was a stub that always returned `null`, breaking Studio user lookup and author enrichment. It now resolves users by ID through Better Auth's internal database adapter, and `getUsers()` supports batch lookups.

--- a/auth/better-auth/src/index.test.ts
+++ b/auth/better-auth/src/index.test.ts
@@ -1,3 +1,6 @@
+import { betterAuth } from 'better-auth';
+import { memoryAdapter } from 'better-auth/adapters/memory';
+import { makeSignature } from 'better-auth/crypto';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MastraAuthBetterAuth } from './index';
 import type { BetterAuthUser } from './index';
@@ -280,6 +283,82 @@ describe('MastraAuthBetterAuth', () => {
       expect(call.headers.get('Cookie')).toBe('better-auth.session_token=hono-token');
     });
 
+    it('should sign unsigned Bearer tokens with the instance secret before setting the session cookie', async () => {
+      const secret = 'test-secret-that-is-at-least-32-chars';
+      const authWithContext = {
+        ...mockAuth,
+        $context: Promise.resolve({
+          secret,
+          authCookies: { sessionToken: { name: 'better-auth.session_token' } },
+          internalAdapter: { findUserById: vi.fn() },
+        }),
+      };
+      authWithContext.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+
+      const auth = new MastraAuthBetterAuth({
+        auth: authWithContext as any,
+      });
+      await auth.authenticateToken('my-unsigned-token', mockRawRequest());
+
+      const expectedSignature = await makeSignature('my-unsigned-token', secret);
+      const call = authWithContext.api.getSession.mock.calls[0][0];
+      expect(call.headers.get('Cookie')).toBe(
+        `better-auth.session_token=${encodeURIComponent(`my-unsigned-token.${expectedSignature}`)}`,
+      );
+    });
+
+    it('should pass already-signed tokens through without re-signing', async () => {
+      const secret = 'test-secret-that-is-at-least-32-chars';
+      const authWithContext = {
+        ...mockAuth,
+        $context: Promise.resolve({
+          secret,
+          authCookies: { sessionToken: { name: 'better-auth.session_token' } },
+          internalAdapter: { findUserById: vi.fn() },
+        }),
+      };
+      authWithContext.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+
+      const auth = new MastraAuthBetterAuth({
+        auth: authWithContext as any,
+      });
+      const signedToken = `some-token.${await makeSignature('some-token', secret)}`;
+      await auth.authenticateToken(signedToken, mockRawRequest());
+
+      const call = authWithContext.api.getSession.mock.calls[0][0];
+      expect(call.headers.get('Cookie')).toBe(`better-auth.session_token=${encodeURIComponent(signedToken)}`);
+    });
+
+    it('should use the session cookie name from the Better Auth context (e.g. __Secure- prefix)', async () => {
+      const secret = 'test-secret-that-is-at-least-32-chars';
+      const authWithContext = {
+        ...mockAuth,
+        $context: Promise.resolve({
+          secret,
+          authCookies: { sessionToken: { name: '__Secure-better-auth.session_token' } },
+          internalAdapter: { findUserById: vi.fn() },
+        }),
+      };
+      authWithContext.api.getSession.mockResolvedValue({
+        session: mockSession,
+        user: mockUser,
+      });
+
+      const auth = new MastraAuthBetterAuth({
+        auth: authWithContext as any,
+      });
+      await auth.authenticateToken('my-unsigned-token', mockRawRequest());
+
+      const call = authWithContext.api.getSession.mock.calls[0][0];
+      expect(call.headers.get('Cookie')).toMatch(/^__Secure-better-auth\.session_token=/);
+    });
+
     it('should inject session cookie when session name appears only inside a cookie value', async () => {
       mockAuth.api.getSession.mockResolvedValue({
         session: mockSession,
@@ -443,6 +522,151 @@ describe('MastraAuthBetterAuth', () => {
 
       expect(auth.public).toEqual(publicRoutes);
       expect(auth.protected).toEqual(protectedRoutes);
+    });
+  });
+
+  describe('getUser', () => {
+    it('should look up users via the internal adapter', async () => {
+      const findUserById = vi.fn().mockResolvedValue(mockUser);
+      const authWithContext = {
+        ...mockAuth,
+        $context: Promise.resolve({
+          secret: 'test-secret-that-is-at-least-32-chars',
+          authCookies: { sessionToken: { name: 'better-auth.session_token' } },
+          internalAdapter: { findUserById },
+        }),
+      };
+
+      const auth = new MastraAuthBetterAuth({
+        auth: authWithContext as any,
+      });
+      const user = await auth.getUser('user-123');
+
+      expect(findUserById).toHaveBeenCalledWith('user-123');
+      expect(user).toMatchObject({
+        id: 'user-123',
+        email: 'test@example.com',
+        name: 'Test User',
+      });
+    });
+
+    it('should return null when the user is not found', async () => {
+      const authWithContext = {
+        ...mockAuth,
+        $context: Promise.resolve({
+          secret: 'test-secret-that-is-at-least-32-chars',
+          authCookies: { sessionToken: { name: 'better-auth.session_token' } },
+          internalAdapter: { findUserById: vi.fn().mockResolvedValue(null) },
+        }),
+      };
+
+      const auth = new MastraAuthBetterAuth({
+        auth: authWithContext as any,
+      });
+      expect(await auth.getUser('missing')).toBeNull();
+    });
+
+    it('should return null when the auth context is unavailable', async () => {
+      const auth = new MastraAuthBetterAuth({
+        auth: mockAuth as any,
+      });
+      expect(await auth.getUser('user-123')).toBeNull();
+    });
+
+    it('should batch look up users with getUsers, preserving order and nulls', async () => {
+      const findUserById = vi.fn().mockImplementation((id: string) => (id === 'user-123' ? mockUser : null));
+      const authWithContext = {
+        ...mockAuth,
+        $context: Promise.resolve({
+          secret: 'test-secret-that-is-at-least-32-chars',
+          authCookies: { sessionToken: { name: 'better-auth.session_token' } },
+          internalAdapter: { findUserById },
+        }),
+      };
+
+      const auth = new MastraAuthBetterAuth({
+        auth: authWithContext as any,
+      });
+      const users = await auth.getUsers(['missing', 'user-123']);
+
+      expect(users).toHaveLength(2);
+      expect(users[0]).toBeNull();
+      expect(users[1]).toMatchObject({ id: 'user-123' });
+    });
+  });
+
+  describe('end-to-end with a real Better Auth instance', () => {
+    const createRealAuth = () =>
+      betterAuth({
+        baseURL: 'http://localhost:3000',
+        secret: 'test-secret-that-is-at-least-32-chars',
+        database: memoryAdapter({ user: [], session: [], account: [], verification: [] }),
+        emailAndPassword: { enabled: true },
+      });
+
+    it('authenticates the unsigned token returned by signUp/signIn (issue #19110)', async () => {
+      const provider = new MastraAuthBetterAuth({ auth: createRealAuth() });
+
+      const signUpResult = await provider.signUp(
+        'e2e@example.com',
+        'super-secure-password',
+        'E2E User',
+        new Request('http://localhost:3000/signup'),
+      );
+      expect(signUpResult.token).toBeTruthy();
+      // signUp/signIn return the RAW session token — no signature
+      expect(signUpResult.token).not.toContain('.');
+
+      // Bearer-style request: no cookies, just the raw token
+      const result = await provider.authenticateToken(signUpResult.token!, new Request('http://localhost:3000/api'));
+
+      expect(result).not.toBeNull();
+      expect(result?.user.email).toBe('e2e@example.com');
+      expect(result?.session.token).toBe(signUpResult.token);
+    });
+
+    it('resolves the current user from an Authorization: Bearer header', async () => {
+      const provider = new MastraAuthBetterAuth({ auth: createRealAuth() });
+
+      const signUpResult = await provider.signUp(
+        'bearer@example.com',
+        'super-secure-password',
+        'Bearer User',
+        new Request('http://localhost:3000/signup'),
+      );
+
+      const user = await provider.getCurrentUser(
+        new Request('http://localhost:3000/api', {
+          headers: { Authorization: `Bearer ${signUpResult.token}` },
+        }),
+      );
+
+      expect(user).not.toBeNull();
+      expect(user?.email).toBe('bearer@example.com');
+    });
+
+    it('looks up users by ID via getUser/getUsers (issue #19110)', async () => {
+      const provider = new MastraAuthBetterAuth({ auth: createRealAuth() });
+
+      const signUpResult = await provider.signUp(
+        'lookup@example.com',
+        'super-secure-password',
+        'Lookup User',
+        new Request('http://localhost:3000/signup'),
+      );
+
+      const user = await provider.getUser(signUpResult.user.id);
+      expect(user).toMatchObject({
+        id: signUpResult.user.id,
+        email: 'lookup@example.com',
+        name: 'Lookup User',
+      });
+
+      expect(await provider.getUser('does-not-exist')).toBeNull();
+
+      const users = await provider.getUsers([signUpResult.user.id, 'does-not-exist']);
+      expect(users[0]).toMatchObject({ id: signUpResult.user.id });
+      expect(users[1]).toBeNull();
     });
   });
 });

--- a/auth/better-auth/src/index.ts
+++ b/auth/better-auth/src/index.ts
@@ -4,6 +4,7 @@ import type { MastraAuthProviderOptions } from '@internal/auth/provider';
 import { MastraAuthProvider } from '@internal/auth/provider';
 
 import type { Auth, Session, User } from 'better-auth';
+import { makeSignature } from 'better-auth/crypto';
 
 type HonoRequestLike = {
   raw?: Request;
@@ -12,6 +13,16 @@ type HonoRequestLike = {
 };
 
 type MastraAuthRequest = Request | HonoRequestLike;
+
+type BetterAuthContext = Awaited<Auth['$context']>;
+
+function tryDecode(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
 
 function getRequestHeader(request: MastraAuthRequest, name: string): string | null {
   if (request instanceof Request) {
@@ -144,13 +155,25 @@ export class MastraAuthBetterAuth
    * Get current user from request.
    * Implements IUserProvider for EE user awareness in Studio.
    *
+   * Supports both cookie-based sessions and `Authorization: Bearer <token>`
+   * requests (e.g. API clients using the token returned by `signIn`).
+   *
    * @param request - Incoming HTTP request
    * @returns EE User object or null if not authenticated
    */
   async getCurrentUser(request: Request): Promise<EEUser | null> {
     try {
+      const headers = new Headers(request.headers);
+
+      // If the request authenticates via Bearer token instead of cookies,
+      // convert the token to a signed session cookie so getSession accepts it.
+      const authHeader = headers.get('Authorization');
+      const bearerToken =
+        authHeader && authHeader.slice(0, 7).toLowerCase() === 'bearer ' ? authHeader.slice(7).trim() : undefined;
+      await this.ensureSessionCookie(headers, bearerToken);
+
       const result = await this.auth.api.getSession({
-        headers: request.headers,
+        headers,
       });
 
       if (!result?.user) return null;
@@ -164,22 +187,34 @@ export class MastraAuthBetterAuth
    * Get user by ID.
    * Implements IUserProvider for EE user awareness.
    *
-   * Note: Better Auth doesn't expose a direct getUser API.
-   * For full functionality, you may need to implement this using
-   * direct database access in a subclass.
+   * Uses Better Auth's internal adapter to look up the user record,
+   * so it works with whichever database Better Auth is configured with.
    *
    * @param userId - User identifier
    * @returns EE User object or null if not found
    */
-  async getUser(_userId: string): Promise<EEUser | null> {
-    // Better Auth doesn't have a direct getUser API
-    // Users can override this method with their own implementation
-    // that queries the database directly
-    console.warn(
-      '[MastraAuthBetterAuth] getUser() requires direct database access. ' +
-        'Override this method in a subclass for full user lookup support.',
-    );
-    return null;
+  async getUser(userId: string): Promise<EEUser | null> {
+    try {
+      const ctx = await this.getAuthContext();
+      if (!ctx) return null;
+
+      const user = await ctx.internalAdapter.findUserById(userId);
+      if (!user) return null;
+      return mapBetterAuthUserToEEUser(user);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Get multiple users by ID.
+   * Optional IUserProvider method used for batch author enrichment.
+   *
+   * @param userIds - User identifiers
+   * @returns EE User objects (null for missing users, order preserved)
+   */
+  async getUsers(userIds: string[]): Promise<Array<EEUser | null>> {
+    return Promise.all(userIds.map(userId => this.getUser(userId)));
   }
 
   /**
@@ -191,10 +226,57 @@ export class MastraAuthBetterAuth
   }
 
   /**
+   * Get the resolved Better Auth context, or null when unavailable
+   * (e.g. a partial mock without `$context`).
+   */
+  private async getAuthContext(): Promise<BetterAuthContext | null> {
+    try {
+      return (await Promise.resolve(this.auth.$context)) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Ensure the Cookie header on `headers` carries a Better Auth session cookie
+   * for the given token.
+   *
+   * Better Auth's `getSession` reads the session from a *signed* cookie
+   * (`<token>.<HMAC-SHA256 signature>`), while `signIn`/`signUp` return the
+   * raw unsigned token. Mirroring Better Auth's bearer plugin, unsigned tokens
+   * are signed with the instance secret before being set as the session cookie.
+   */
+  private async ensureSessionCookie(headers: Headers, token: string | undefined): Promise<void> {
+    if (!token) return;
+
+    const ctx = await this.getAuthContext();
+    const cookieName = ctx?.authCookies.sessionToken.name ?? this.sessionCookieName;
+    const secret = ctx?.secret;
+
+    const cookieHeader = headers.get('Cookie');
+    const hasSessionCookie = !!cookieHeader?.split(';').some(pair => {
+      const [key] = pair.trim().split('=');
+      return key?.trim() === cookieName;
+    });
+    if (hasSessionCookie) return;
+
+    // Tokens containing "." are already signed (and may be URI-encoded).
+    let cookieValue = token.includes('.') ? (token.includes('%') ? tryDecode(token) : token) : token;
+    if (!token.includes('.') && secret) {
+      cookieValue = `${token}.${await makeSignature(token, secret)}`;
+    }
+
+    const existingCookies = cookieHeader ? `${cookieHeader}; ` : '';
+    headers.set('Cookie', `${existingCookies}${cookieName}=${encodeURIComponent(cookieValue)}`);
+  }
+
+  /**
    * Authenticate a bearer token by verifying the session with Better Auth.
    *
    * This method extracts the session from the request headers using
-   * Better Auth's `api.getSession()` endpoint.
+   * Better Auth's `api.getSession()` endpoint. Raw (unsigned) session tokens —
+   * as returned by `signIn`/`signUp` — are signed before being passed to
+   * Better Auth as a session cookie, matching the bearer plugin's semantics.
    *
    * @param token - The bearer token (session token) to authenticate
    * @param request - The request containing headers
@@ -210,16 +292,9 @@ export class MastraAuthBetterAuth
         headers.set('Cookie', cookieHeader);
       }
 
-      // Convert Bearer token to a session cookie if not already present.
+      // Convert Bearer token to a signed session cookie if not already present.
       // better-auth ignores the Authorization header — it only reads from Cookie.
-      const hasSessionCookie = !!cookieHeader?.split(';').some(pair => {
-        const [key] = pair.trim().split('=');
-        return key?.trim() === this.sessionCookieName;
-      });
-      if (token && !hasSessionCookie) {
-        const existingCookies = cookieHeader ? `${cookieHeader}; ` : '';
-        headers.set('Cookie', `${existingCookies}${this.sessionCookieName}=${token}`);
-      }
+      await this.ensureSessionCookie(headers, token);
 
       const result = await this.auth.api.getSession({
         headers,


### PR DESCRIPTION
Fixes #19110

Better Auth's `getSession` only accepts signed session cookies (`token.signature`), but `signInEmail`/`signUpEmail` return the raw unsigned token. The provider set that raw token straight into the session cookie, so authenticating with the token you just got from sign-in always failed:

```ts
// before
const { token } = await provider.signIn(email, password, req);
await provider.authenticateToken(token!, req); // null

// after
const { token } = await provider.signIn(email, password, req);
await provider.authenticateToken(token!, req); // { session, user }
```

`authenticateToken` and `getCurrentUser` now sign unsigned tokens with the Better Auth secret before setting the session cookie — same semantics as Better Auth's own bearer plugin — and resolve the cookie name from `auth.$context`, so secure-cookie setups (`__Secure-` prefix) work too. Already-signed tokens pass through unchanged.

`getUser()` was a stub that always returned null, which broke Studio user lookup and author enrichment. It now resolves users through Better Auth's internal database adapter, and there's a `getUsers()` batch variant.

Verified with end-to-end tests against a real `betterAuth` instance (memory adapter) that reproduce both failures from the issue — they fail on the old implementation and pass with this change.
