### PR TITLE
fix(mastracode): propagate githubProjectId into session state for GitHub projects

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatConnectionProvider.tsx
@@ -14,11 +14,12 @@ export function ChatConnectionProvider({
   children: ReactNode;
   onEvent: (event: AgentControllerEvent) => void;
 }) {
-  const { resourceId, projectPath, sessionEnabled, baseUrl } = useChatSessionContext();
+  const { resourceId, projectPath, projectState, sessionEnabled, baseUrl } = useChatSessionContext();
   const connection = useAgentControllerConnection({
     agentControllerId: AGENT_CONTROLLER_ID,
     resourceId,
     projectPath,
+    projectState,
     baseUrl,
     enabled: sessionEnabled,
     onEvent,

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -56,6 +56,13 @@ export function ChatSessionConfigProvider({
         resourceId,
         sessionEnabled: projectSessionEnabled,
         projectPath,
+        // Session state consumed server-side: GitHub PR auto-subscription,
+        // the subscribe tools, and agent git-action auditing all gate on
+        // `githubProjectId` being present in session state.
+        projectState:
+          activeProject?.source === 'github' && activeProject.githubProjectId
+            ? { githubProjectId: activeProject.githubProjectId }
+            : undefined,
         baseUrl,
         kind: activeProject?.source === 'github' ? ('factory' as const) : ('user' as const),
         threadBasePath: '/threads' as const,

--- a/mastracode/web/src/web/ui/domains/chat/context/__tests__/ChatSessionProvider.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/__tests__/ChatSessionProvider.msw.test.tsx
@@ -677,6 +677,20 @@ describe('ChatSessionProvider', () => {
       expect(screen.getByTestId('session-project-path')).toHaveTextContent('/tmp/mastracode-github-test');
       await waitFor(() => expect(requests).toContain('create'));
     });
+
+    it('binds a GitHub project session with the githubProjectId in session state', async () => {
+      const requests: string[] = [];
+      seedProject([githubProjectWithWorktree], githubProjectWithWorktree);
+      useAgentControllerHandlers([], requests);
+
+      renderFocusedProbe(<SessionContextProbe />);
+
+      await waitFor(() =>
+        expect(requests).toContain(
+          'setState:{"state":{"projectPath":"/tmp/mastracode-github-test","githubProjectId":"github-project-id"}}',
+        ),
+      );
+    });
   });
 
   describe('when route thread messages fail to load', () => {


### PR DESCRIPTION
## Summary

Sessions started from GitHub projects in the web UI never carried their GitHub project identity in agent-controller session state. Server-side features that gate on `getState().githubProjectId` — PR auto-subscription after `gh pr create`, the `github_subscribe_pr`/`github_unsubscribe_pr` tools, and agent git-action auditing — could not resolve the session's project context and silently no-oped (surfacing as "GitHub subscriptions require an authenticated GitHub-project session" observer noise, see #19628).

## What changed

- `ChatSessionConfigProvider` now seeds `projectState: { githubProjectId }` into the chat session context for GitHub-sourced projects.
- `ChatConnectionProvider` threads `projectState` through `useAgentControllerConnection`, so the session-init `setState` call binds `{ projectPath, githubProjectId }` instead of just `projectPath`.

## Test plan

- New MSW test: GitHub-project session bind sends `githubProjectId` in the setState payload.
- Full web-ui MSW suite: 58 files / 473 tests passing.
- Web package typecheck clean.
