### PR TITLE
fix(workflows): handle background restart failures

### DIFF
--- a/.changeset/sour-oranges-shop.md
+++ b/.changeset/sour-oranges-shop.md
@@ -1,0 +1,6 @@
+---
+'@mastra/deployer': patch
+'@mastra/server': patch
+---
+
+Prevent background workflow recovery failures from terminating the server.

--- a/packages/deployer/src/server/handlers/__tests__/restart-active-runs.test.ts
+++ b/packages/deployer/src/server/handlers/__tests__/restart-active-runs.test.ts
@@ -1,0 +1,52 @@
+import type { Mastra } from '@mastra/core/mastra';
+import type { Context } from 'hono';
+import { describe, expect, it, vi } from 'vitest';
+import { restartAllActiveWorkflowRunsHandler } from '../restart-active-runs';
+
+function createContext(mastra: Mastra) {
+  return {
+    get: vi.fn(() => mastra),
+    json: vi.fn(payload => new Response(JSON.stringify(payload))),
+  } as unknown as Context;
+}
+
+describe('restartAllActiveWorkflowRunsHandler', () => {
+  it('logs a rejected background workflow restart without failing the request', async () => {
+    const error = new Error('storage unavailable');
+    const logger = { error: vi.fn() };
+    const mastra = {
+      restartAllActiveWorkflowRuns: vi.fn(() => Promise.reject(error)),
+      getLogger: vi.fn(() => logger),
+      recoveryConfig: undefined,
+    } as unknown as Mastra;
+
+    const response = await restartAllActiveWorkflowRunsHandler(createContext(mastra));
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith('Failed to restart active workflow runs during server startup', {
+        error,
+      });
+    });
+  });
+
+  it('logs a rejected durable-agent recovery without failing the request', async () => {
+    const error = new Error('recovery unavailable');
+    const logger = { error: vi.fn() };
+    const mastra = {
+      restartAllActiveWorkflowRuns: vi.fn(() => Promise.resolve()),
+      recoverAllDurableAgents: vi.fn(() => Promise.reject(error)),
+      getLogger: vi.fn(() => logger),
+      recoveryConfig: { durableAgents: 'auto' },
+    } as unknown as Mastra;
+
+    const response = await restartAllActiveWorkflowRunsHandler(createContext(mastra));
+
+    expect(response.status).toBe(200);
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith('Failed to recover durable agent runs during server startup', {
+        error,
+      });
+    });
+  });
+});

--- a/packages/deployer/src/server/handlers/restart-active-runs.ts
+++ b/packages/deployer/src/server/handlers/restart-active-runs.ts
@@ -6,13 +6,17 @@ import { handleError } from './error';
 export async function restartAllActiveWorkflowRunsHandler(c: Context) {
   try {
     const mastra: Mastra = c.get('mastra');
-    void mastra.restartAllActiveWorkflowRuns();
+    void mastra.restartAllActiveWorkflowRuns().catch(error => {
+      mastra.getLogger().error('Failed to restart active workflow runs during server startup', { error });
+    });
 
     // Opt-in boot-time recovery for orphaned RUNNING durable-agent runs.
     // Gated by `recovery.durableAgents === 'auto'` so we don't silently
     // re-issue LLM calls / re-execute tools on restart.
     if (mastra.recoveryConfig?.durableAgents === 'auto') {
-      void mastra.recoverAllDurableAgents();
+      void mastra.recoverAllDurableAgents().catch(error => {
+        mastra.getLogger().error('Failed to recover durable agent runs during server startup', { error });
+      });
     }
 
     return c.json({ message: 'Restarting all active workflow runs...' });

--- a/packages/server/src/server/handlers/workflows.restart.test.ts
+++ b/packages/server/src/server/handlers/workflows.restart.test.ts
@@ -1,0 +1,31 @@
+import type { Mastra } from '@mastra/core';
+import { describe, expect, it, vi } from 'vitest';
+import { createTestServerContext } from './test-utils';
+import { RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE } from './workflows';
+
+describe('RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE', () => {
+  it('logs a rejected background restart while returning the accepted response', async () => {
+    const error = new Error('storage unavailable');
+    const logger = { error: vi.fn() };
+    const workflow = {
+      restartAllActiveWorkflowRuns: vi.fn(() => Promise.reject(error)),
+    };
+    const mastra = {
+      getWorkflowById: vi.fn(() => workflow),
+      getLogger: vi.fn(() => logger),
+    } as unknown as Mastra;
+
+    const response = await RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE.handler({
+      ...createTestServerContext({ mastra }),
+      workflowId: 'test-workflow',
+    });
+
+    expect(response).toEqual({ message: 'All active workflow runs restarted' });
+    await vi.waitFor(() => {
+      expect(logger.error).toHaveBeenCalledWith('Failed to restart active workflow runs', {
+        error,
+        workflowId: 'test-workflow',
+      });
+    });
+  });
+});

--- a/packages/server/src/server/handlers/workflows.ts
+++ b/packages/server/src/server/handlers/workflows.ts
@@ -933,7 +933,9 @@ export const RESTART_ALL_ACTIVE_WORKFLOW_RUNS_ROUTE = createRoute({
         throw new HTTPException(404, { message: 'Workflow not found' });
       }
 
-      void workflow.restartAllActiveWorkflowRuns();
+      void workflow.restartAllActiveWorkflowRuns().catch(error => {
+        mastra.getLogger().error('Failed to restart active workflow runs', { error, workflowId });
+      });
 
       return { message: 'All active workflow runs restarted' };
     } catch (error) {


### PR DESCRIPTION
Fixes #19634

## Summary

- Catch and log failures from boot-time active workflow restart and durable-agent recovery.
- Apply the same handling to the workflow restart API route.
- Add regression coverage that verifies the accepted response is preserved when the background operation rejects.

## Root cause

Both routes started restart work as a floating promise. A storage failure raised after the response was returned could become an unhandled rejection and terminate the Node process.

## Validation

- `pnpm exec vitest run --project unit:packages/deployer packages/deployer/src/server/handlers/__tests__/restart-active-runs.test.ts`
- `pnpm exec vitest run --project unit:packages/server packages/server/src/server/handlers/workflows.restart.test.ts`
- `pnpm --filter ./packages/deployer lint`
- `pnpm --filter ./packages/server lint`
- `pnpm exec prettier --check packages/deployer/src/server/handlers/restart-active-runs.ts packages/deployer/src/server/handlers/__tests__/restart-active-runs.test.ts packages/server/src/server/handlers/workflows.restart.test.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The server now safely handles workflow restart problems in the background instead of crashing. It logs failures while still returning successful responses and continuing to serve requests.

## Summary

- Added error handling and logging for:
  - Active workflow restarts during startup
  - Durable-agent recovery during startup
  - Active workflow restarts through the API route
- Preserved accepted/success responses when background restart operations fail.
- Added regression tests covering rejected restart and recovery promises.
- Added patch changesets for `@mastra/deployer` and `@mastra/server`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->