### PR TITLE
fix(memory): retry observational memory observer on OpenRouter mid-stream provider errors

### DIFF
--- a/.changeset/sparkly-cobras-shave.md
+++ b/.changeset/sparkly-cobras-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory aborting the agent run when OpenRouter injects a transient provider error into the response stream (e.g. "JSON error injected into SSE stream" with google/gemini-2.5-flash). These mid-stream errors carry the HTTP status on a numeric code property and are now recognized as retryable, so the observer retries with backoff instead of failing the turn.

--- a/packages/memory/src/processors/observational-memory/__tests__/retry.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/retry.test.ts
@@ -32,6 +32,23 @@ describe('isTransientLLMError', () => {
     expect(isTransientLLMError({ isRetryable: true })).toBe(true);
   });
 
+  it('matches OpenRouter-style mid-stream errors with a numeric code property', () => {
+    // OpenRouter injects provider errors into the SSE stream as
+    // { code: 502, message, metadata: { error_type: 'provider_unavailable' } }
+    // and Mastra's getErrorFromUnknown copies those props onto the Error.
+    const err = Object.assign(new Error('JSON error injected into SSE stream'), {
+      code: 502,
+      metadata: { error_type: 'provider_unavailable' },
+    });
+    expect(isTransientLLMError(err)).toBe(true);
+    expect(isTransientLLMError({ code: 429, message: 'rate limited' })).toBe(true);
+  });
+
+  it('does NOT retry on non-retryable numeric code properties', () => {
+    expect(isTransientLLMError({ code: 400, message: 'bad request' })).toBe(false);
+    expect(isTransientLLMError({ code: 401, message: 'unauthorized' })).toBe(false);
+  });
+
   it('walks the error.cause chain', () => {
     const cause = new TypeError('terminated');
     const wrapper = new Error('agent stream failed');

--- a/packages/memory/src/processors/observational-memory/__tests__/transient-retry.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/transient-retry.test.ts
@@ -122,8 +122,18 @@ function createMockActorModel(responseText: string) {
  * the AI SDK's built-in pRetry budget (default 2 retries → 3 attempts), the
  * call only succeeds if OM's withRetry wrapper layers additional retries on
  * top.
+ *
+ * With `failureMode: 'stream-error'` the model instead emits an
+ * OpenRouter-style mid-stream error part ({ code: 502, message, metadata })
+ * — the shape OpenRouter injects into the SSE stream when an upstream
+ * provider is unavailable. Mid-stream errors bypass the AI SDK's pRetry
+ * entirely, so OM's withRetry is the only retry layer.
  */
-function createFlakyObserverModel(observationsText: string, failuresBeforeSuccess: number) {
+function createFlakyObserverModel(
+  observationsText: string,
+  failuresBeforeSuccess: number,
+  failureMode: 'throw' | 'stream-error' = 'throw',
+) {
   let callCount = 0;
   let observerCallCount = 0;
 
@@ -152,6 +162,12 @@ function createFlakyObserverModel(observationsText: string, failuresBeforeSucces
     async doGenerate() {
       observerCallCount = ++callCount;
       if (callCount <= failuresBeforeSuccess) {
+        if (failureMode === 'stream-error') {
+          throw Object.assign(new Error('JSON error injected into SSE stream'), {
+            code: 502,
+            metadata: { error_type: 'provider_unavailable' },
+          });
+        }
         throw new TypeError('terminated');
       }
       return buildSuccessGenerate();
@@ -160,6 +176,37 @@ function createFlakyObserverModel(observationsText: string, failuresBeforeSucces
     async doStream() {
       observerCallCount = ++callCount;
       if (callCount <= failuresBeforeSuccess) {
+        if (failureMode === 'stream-error') {
+          // OpenRouter mid-stream error: HTTP 200 established, then the raw
+          // error object is injected into the SSE stream as an error part.
+          const errorParts: unknown[] = [
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'response-metadata',
+              id: 'obs-err',
+              modelId: 'mock-flaky-observer-model',
+              timestamp: new Date(),
+            },
+            {
+              type: 'error',
+              error: {
+                code: 502,
+                message: 'JSON error injected into SSE stream',
+                metadata: { error_type: 'provider_unavailable' },
+              },
+            },
+          ];
+          return {
+            stream: new ReadableStream({
+              start(controller) {
+                for (const p of errorParts) controller.enqueue(p);
+                controller.close();
+              },
+            }),
+            rawCall: { rawPrompt: null, rawSettings: {} },
+            warnings: [],
+          };
+        }
         throw new TypeError('terminated');
       }
 
@@ -272,6 +319,55 @@ describe('OM transient-error retry', { timeout: 30_000 }, () => {
     expect(result.text).toBe(longResponseText);
 
     // We were called more times than the AI SDK retry budget allows on its own.
+    expect(observerModel.__observerCallCount).toBeGreaterThan(failuresBeforeSuccess);
+  });
+
+  it('retries observation on OpenRouter-style mid-stream SSE errors (numeric code 502)', async () => {
+    // Mid-stream errors never hit the AI SDK's pRetry (the HTTP request
+    // succeeded), so OM's withRetry is the only retry layer. Previously these
+    // errors were classified as non-transient and killed the actor turn with
+    // "Observational memory observation buffering failed: JSON error injected
+    // into SSE stream".
+    const failuresBeforeSuccess = 2;
+    const store = new InMemoryStore();
+    const observerModel = createFlakyObserverModel(observationsText, failuresBeforeSuccess, 'stream-error');
+
+    const memory = new Memory({
+      storage: store,
+      options: {
+        observationalMemory: {
+          enabled: true,
+          observation: {
+            model: observerModel as any,
+            messageTokens: 20,
+            bufferTokens: false,
+          },
+          reflection: {
+            observationTokens: 50_000,
+          },
+        },
+      },
+    });
+
+    const agent = new Agent({
+      id: 'sse-error-retry-test-agent',
+      name: 'SSE Error Retry Test Agent',
+      instructions: 'You are a helpful assistant. Always use the test tool first.',
+      model: createMockActorModel(longResponseText) as any,
+      tools: { test: omTriggerTool },
+      memory,
+    });
+
+    const result = await agent.generate('Hello, I need help.', {
+      memory: {
+        thread: 'sse-error-retry-thread',
+        resource: 'sse-error-retry-resource',
+      },
+    });
+
+    // The actor turn completed normally despite mid-stream provider errors.
+    expect(result.tripwire).toBeFalsy();
+    expect(result.text).toBe(longResponseText);
     expect(observerModel.__observerCallCount).toBeGreaterThan(failuresBeforeSuccess);
   });
 });

--- a/packages/memory/src/processors/observational-memory/retry.ts
+++ b/packages/memory/src/processors/observational-memory/retry.ts
@@ -61,12 +61,18 @@ function hasTransientMessage(value: unknown): boolean {
   return false;
 }
 
+function isRetryableHttpStatus(status: number): boolean {
+  if (status === 408 || status === 425 || status === 429) return true;
+  return status >= 500 && status <= 599;
+}
+
 function hasRetryableHttpStatus(value: unknown): boolean {
   if (!isRecord(value)) return false;
-  const status = typeof value.statusCode === 'number' ? value.statusCode : undefined;
-  if (status === undefined) return false;
-  if (status === 408 || status === 425 || status === 429) return true;
-  if (status >= 500 && status <= 599) return true;
+  if (typeof value.statusCode === 'number' && isRetryableHttpStatus(value.statusCode)) return true;
+  // OpenRouter-style mid-stream SSE errors carry the HTTP status on a numeric
+  // `code` property (e.g. { code: 502, message: 'JSON error injected into SSE
+  // stream', metadata: { error_type: 'provider_unavailable' } }).
+  if (typeof value.code === 'number' && isRetryableHttpStatus(value.code)) return true;
   return false;
 }
 


### PR DESCRIPTION
When using observational memory with OpenRouter models (seen with google/gemini-2.5-flash), a transient upstream failure could kill the entire agent run with:

```
Observational memory observation buffering failed: JSON error injected into SSE stream
```

The root cause is that OpenRouter reports upstream provider errors (502 provider_unavailable) by injecting the error object into an otherwise-successful SSE stream:

```json
{ "code": 502, "message": "JSON error injected into SSE stream", "metadata": { "error_type": "provider_unavailable" } }
```

Since the HTTP request itself succeeded, these mid-stream errors never hit the AI SDK's built-in retry — OM's own retry wrapper is the only retry layer. But `isTransientLLMError` only looked at `statusCode`, and OpenRouter puts the HTTP status on a numeric `code` property, so the error was classified as non-transient and the observer failed on the first attempt, aborting the run.

Now retryable numeric `code` values (408/425/429/5xx) are recognized as transient, so the observer retries with exponential backoff and the agent turn completes normally.

Test plan: added a unit test for the OpenRouter error shape in `retry.test.ts`, and an integration test in `transient-retry.test.ts` that streams the exact mid-stream 502 error part from a mock observer model and verifies the actor turn survives and the observer is retried. All OM retry tests pass and typecheck is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Sometimes OpenRouter reports a temporary problem in the middle of a successful response. This update recognizes those problems and retries automatically instead of stopping the agent run.

## Changes

- Treats retryable numeric `code` values (`408`, `425`, `429`, and `5xx`) like `statusCode` values.
- Adds coverage for OpenRouter-style mid-stream SSE errors.
- Adds an integration test verifying observational memory retries with exponential backoff and eventually completes successfully.
- Adds a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->