### PR TITLE
feat(platform-workspace): add clone() for sandbox fleet parity

### DIFF
--- a/.changeset/platform-workspace-clone.md
+++ b/.changeset/platform-workspace-clone.md
@@ -1,0 +1,22 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Added `clone()` support to `PlatformSandbox`. `clone()` constructs an unstarted sibling sandbox that inherits the template's configuration (access token, project, environment, network isolation, timeout, instructions, env, idle timeout) with per-instance overrides for `id`, `sandboxId`, `env`, and `idleTimeoutMinutes`, so one configured sandbox can act as a template for a fleet of sandbox clones (for example, one per project).
+
+```ts
+const template = new PlatformSandbox({
+  accessToken,
+  projectId,
+  environmentId,
+});
+
+const projectSandbox = template.clone({
+  id: 'mc-project-42',
+  env: { GITHUB_TOKEN: token },
+  idleTimeoutMinutes: 30,
+});
+await projectSandbox.start();
+```
+
+This brings `PlatformSandbox` up to parity with the other sandbox providers (`@mastra/railway`, `@mastra/e2b`, `@mastra/daytona`, `@mastra/modal`, `@mastra/docker`, `@mastra/blaxel`, `@mastra/apple-container`, `@mastra/vercel`) so it can be used with `MastraFactory` fleets and the MC Web factory.

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -134,4 +134,108 @@ describe('PlatformSandbox', () => {
     const handle = await sandbox.processes.spawn('sleep 10');
     await expect(handle.kill()).rejects.toThrow(/does not support killing/);
   });
+
+  describe('clone', () => {
+    it('constructs an unstarted sibling without any I/O', () => {
+      const fetchMock = vi.fn();
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      const child = template.clone({ id: 'mc-project-1' });
+
+      expect(child).toBeInstanceOf(PlatformSandbox);
+      expect(child).not.toBe(template);
+      expect(child.id).toBe('mc-project-1');
+      expect(child.status).toBe('pending');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('does not require the template to be started', () => {
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: vi.fn(),
+      });
+      expect(() => template.clone()).not.toThrow();
+    });
+
+    it('inherits credentials and applies env + idle timeout overrides on start', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_child', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        idleTimeoutMinutes: 30,
+        networkIsolation: 'PRIVATE',
+        env: { BASE: '1' },
+        fetch: fetchMock,
+      });
+
+      const child = template.clone({
+        env: { GITHUB_TOKEN: 'ghs_abc' },
+        idleTimeoutMinutes: 15,
+      });
+      await child._start();
+
+      expect(String(fetchMock.mock.calls[0]![0])).toBe('https://proxy.test/v1/projects/proj_123/sandbox');
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+      expect(body).toMatchObject({
+        environmentId: 'env_123',
+        idleTimeoutMinutes: 15,
+        networkIsolation: 'PRIVATE',
+        env: { GITHUB_TOKEN: 'ghs_abc' },
+      });
+    });
+
+    it('reattaches to a provider sandbox when sandboxId is passed', async () => {
+      const fetchMock = vi.fn().mockResolvedValue(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        fetch: fetchMock,
+      });
+
+      const child = template.clone({ sandboxId: 'sbx_existing' });
+      await child._start();
+      await child.executeCommand!('echo hello');
+
+      // First (and only) fetch call should be exec — no create POST.
+      expect(String(fetchMock.mock.calls[0]![0])).toContain('/sandbox/sbx_existing/exec');
+      const createCalls = fetchMock.mock.calls.filter(call => {
+        const url = String(call[0]);
+        return url.endsWith('/sandbox') && (call[1] as RequestInit | undefined)?.method === 'POST';
+      });
+      expect(createCalls).toHaveLength(0);
+    });
+
+    it('inherits template defaults when no overrides are passed', async () => {
+      vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+      const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_child', createdAt: '2026-06-26T00:00:00.000Z' }));
+      const template = new PlatformSandbox({
+        accessToken: 'sk_test',
+        projectId: 'proj_123',
+        environmentId: 'env_123',
+        idleTimeoutMinutes: 45,
+        env: { BASE: '1' },
+        fetch: fetchMock,
+      });
+
+      const child = template.clone();
+      await child._start();
+
+      const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+      expect(body).toMatchObject({
+        environmentId: 'env_123',
+        idleTimeoutMinutes: 45,
+        env: { BASE: '1' },
+      });
+    });
+  });
 });

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -6,6 +6,7 @@ import type {
   MastraSandboxOptions,
   ProcessInfo,
   ProviderStatus,
+  SandboxCloneOptions,
   SandboxInfo,
   SpawnProcessOptions,
 } from '@mastra/core/workspace';
@@ -163,6 +164,34 @@ export class PlatformSandbox extends MastraSandbox {
 
   private generateId(): string {
     return `platform-sandbox-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+  }
+
+  /**
+   * Construct a sibling {@link PlatformSandbox} that inherits this sandbox's
+   * credentials and defaults (access token, project, environment, network
+   * isolation, timeout, instructions, env, idle timeout) with per-instance
+   * overrides from `options`.
+   *
+   * Performs no I/O and does not require this sandbox to be started — the
+   * returned sandbox is not started and provisions (or reattaches, when
+   * `sandboxId` is set) on its own `start()`. Use it when one configured
+   * sandbox acts as the template for a fleet of independent sandboxes
+   * (e.g. one per project).
+   */
+  clone(options: SandboxCloneOptions = {}): PlatformSandbox {
+    return new PlatformSandbox({
+      ...(options.id !== undefined && { id: options.id }),
+      accessToken: this._client.accessToken,
+      projectId: this._client.projectId,
+      fetch: this._client.fetch,
+      environmentId: this._environmentId,
+      ...(options.sandboxId !== undefined && { sandboxId: options.sandboxId }),
+      idleTimeoutMinutes: options.idleTimeoutMinutes ?? this._idleTimeoutMinutes,
+      ...(this._networkIsolation !== undefined && { networkIsolation: this._networkIsolation }),
+      env: options.env ?? this._env,
+      ...(this._timeout !== undefined && { timeout: this._timeout }),
+      ...(this._instructionsOverride !== undefined && { instructions: this._instructionsOverride }),
+    });
   }
 
   async start(): Promise<void> {


### PR DESCRIPTION
Brings `PlatformSandbox` up to parity with the other sandbox providers (`@mastra/railway`, `@mastra/e2b`, `@mastra/daytona`, `@mastra/modal`, `@mastra/docker`, `@mastra/blaxel`, `@mastra/apple-container`, `@mastra/vercel`) which all gained `clone()` in #19616 / #19625.

## What

`clone()` constructs an unstarted sibling `PlatformSandbox` that inherits the template's configuration (access token, project, environment, network isolation, timeout, instructions, env, idle timeout) with per-instance overrides for `id`, `sandboxId`, `env`, and `idleTimeoutMinutes`. Performs no I/O — provisioning happens on the returned sandbox's own `start()`.

```ts
const template = new PlatformSandbox({
  accessToken,
  projectId,
  environmentId,
});

const projectSandbox = template.clone({
  id: "mc-project-42",
  env: { GITHUB_TOKEN: token },
  idleTimeoutMinutes: 30,
});
await projectSandbox.start();
```

## Why

Lets one configured `PlatformSandbox` act as a template for a fleet of independent sandboxes (for example, one per project), so `PlatformSandbox` can be used with `MastraFactory` and the MC Web factory — which after #19616 accept any `WorkspaceSandbox` implementing `clone()`.

## Test plan

- 5 new colocated tests in `sandbox.test.ts` matching the shape of the tests added for `@mastra/railway`, `@mastra/e2b`, etc. in #19616:
  - Constructs an unstarted sibling without any I/O
  - Does not require the template to be started
  - Inherits credentials and applies env + idle timeout overrides on start
  - Reattaches to a provider sandbox when `sandboxId` is passed
  - Inherits template defaults when no overrides are passed
- `pnpm --filter @mastra/platform-workspace test` → 21/21 tests pass (was 16)
- `pnpm --filter @mastra/platform-workspace exec tsc --noEmit` → clean
- `pnpm --filter @mastra/platform-workspace lint` → clean
- `pnpm --filter @mastra/platform-workspace build` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A sandbox can now be used as a reusable template to quickly create similar sandboxes later. Copies start empty and only connect to the platform when explicitly started.

## What changed

- Added `PlatformSandbox.clone()` with support for:
  - Inherited credentials and configuration
  - Overrides for `id`, `sandboxId`, `env`, and `idleTimeoutMinutes`
  - Reattaching to an existing sandbox via `sandboxId`
- Cloning performs no I/O and returns an unstarted sandbox.
- Added comprehensive clone behavior tests.
- Added a minor-release changeset for `@mastra/platform-workspace`.
- Tests, type checking, linting, and build pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->