### PR TITLE
feat(platform-workspace): send sandbox id on create for platform-side recovery

### DIFF
--- a/.changeset/platform-sandbox-recovery-id.md
+++ b/.changeset/platform-sandbox-recovery-id.md
@@ -1,0 +1,7 @@
+---
+'@mastra/platform-workspace': patch
+---
+
+`PlatformSandbox` now includes its caller-facing `id` on the `POST /v1/projects/:projectId/sandbox` wire body when provisioning a new sandbox. The Mastra Platform treats this as an advisory recovery key so callers can opt into checkpoint-based sandbox recovery — if the platform recognizes the id from a previous session, the new sandbox boots from the most recent checkpoint instead of the base template. Unknown ids fall through to a fresh sandbox, so existing callers see no change in behavior.
+
+No API changes — the value sent is the same `id` you already pass to `new PlatformSandbox({ id })` (or the auto-generated one).

--- a/workspaces/platform-workspace/src/sandbox.test.ts
+++ b/workspaces/platform-workspace/src/sandbox.test.ts
@@ -50,6 +50,24 @@ describe('PlatformSandbox', () => {
     expect(body.template).toBeUndefined();
   });
 
+  it('sends the caller id on the create wire body so the platform can key recovery on it', async () => {
+    vi.stubEnv('MASTRA_WORKSPACE_PROXY_URL', 'https://proxy.test');
+    const fetchMock = vi.fn().mockResolvedValueOnce(json({ id: 'sbx_1', createdAt: '2026-06-26T00:00:00.000Z' }));
+
+    const sandbox = new PlatformSandbox({
+      id: 'mc-project-42',
+      accessToken: 'sk_test',
+      projectId: 'proj_123',
+      environmentId: 'env_123',
+      fetch: fetchMock,
+    });
+
+    await sandbox._start();
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+    expect(body.id).toBe('mc-project-42');
+  });
+
   it('reattaches when constructed with a sandbox id', async () => {
     const fetchMock = vi.fn().mockResolvedValue(json({ exitCode: 0, stdout: 'ok', stderr: '' }));
     const sandbox = new PlatformSandbox({

--- a/workspaces/platform-workspace/src/sandbox.ts
+++ b/workspaces/platform-workspace/src/sandbox.ts
@@ -175,6 +175,11 @@ export class PlatformSandbox extends MastraSandbox {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({
+        // Sent so the platform can associate the provisioned resource with a
+        // caller-stable identifier (used for opt-in checkpoint recovery). The
+        // platform treats it as an advisory key: unknown values fall through
+        // to a fresh sandbox, matching pre-existing behavior.
+        id: this.id,
         environmentId: this._environmentId,
         idleTimeoutMinutes: this._idleTimeoutMinutes,
         networkIsolation: this._networkIsolation,


### PR DESCRIPTION
Prereq OSS one-liner for Mastra Platform sandbox recovery-by-checkpoint. Platform-side implementation follows in a separate PR on the Platform repo.

## What

`PlatformSandbox.start()` now includes the caller-facing `id` on the `POST /v1/projects/:projectId/sandbox` wire body when provisioning a new sandbox.

Before:
```json
{ "environmentId": "env_123", "idleTimeoutMinutes": 30, ... }
```

After:
```json
{ "id": "mc-project-42", "environmentId": "env_123", "idleTimeoutMinutes": 30, ... }
```

## Why

The Mastra Platform will treat this value as an advisory recovery key. When it recognizes an `id` from a previous session (whose Railway sandbox has since been destroyed by idle timeout), it can boot the new sandbox from the most recent checkpoint of that id instead of from the base template — recovering most of the user's filesystem state.

## Backward compatibility

Fully backward compatible in both directions:
- Old platform + new client: platform ignores the unknown `id` field, provisions a fresh sandbox (today's behavior).
- New platform + old client: no `id` in body, platform provisions a fresh sandbox (today's behavior).

No API changes. The value sent is the same `id` you already pass to `new PlatformSandbox({ id })` (or the auto-generated one).

## Test plan

- New wire-body test asserts `body.id` is set to the caller-supplied `id`
- `pnpm --filter @mastra/platform-workspace test` → 17/17 tests pass (was 16)
- `pnpm --filter @mastra/platform-workspace exec tsc --noEmit` → clean
- `pnpm --filter @mastra/platform-workspace lint` → clean
- `pnpm --filter @mastra/platform-workspace build` → clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When creating a sandbox, we now send along its stable ID so the platform can try to restore an earlier sandbox from a checkpoint. If it cannot find one, it creates a fresh sandbox as before.

## Changes

- Include `PlatformSandbox.id` in sandbox creation requests.
- Document the ID as an advisory checkpoint-recovery key.
- Add a test verifying the ID is included in the request body.
- Add a patch changeset for `@mastra/platform-workspace`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->