### PR TITLE
fix(ci): exclude docs from workspace dependency rewrite in snapshot publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -457,17 +457,32 @@ jobs:
 
       - name: Update workspace dependencies
         run: |
-          for file in $(find . -type f -name package.json -not -path "./node_modules/*" -not -path "./package.json" -not -path "./docs/*"); do
-            content="$(< "$file")"
-            updated="$(echo "$content" | sed -E 's/"workspace:\^"/"workspace:*"/g')"
-            updated="$(echo "$updated" | sed 's/"@mastra\/\([^"]*\)":[[:space:]]"[^"]*"/"@mastra\/\1": "workspace:*"/g')"
-            if [ "$content" != "$updated" ]; then
-              echo "Updating $file"
-              echo "$updated" > "$file"
-              changed_count=$((changed_count + 1))
-            fi
-          done
-          echo "Finished updating workspace dependencies. $changed_count files updated."
+          node <<'EOF'
+          const { execSync } = require('child_process');
+          const fs = require('fs');
+          const workspacePackages = new Set(
+            JSON.parse(execSync('pnpm m ls --depth -1 --json', { maxBuffer: 64 * 1024 * 1024 }))
+              .map(pkg => pkg.name)
+              .filter(Boolean),
+          );
+          const files = execSync('git ls-files "*/package.json"').toString().trim().split('\n');
+          let changedCount = 0;
+          for (const file of files) {
+            const content = fs.readFileSync(file, 'utf8');
+            let updated = content.replace(/"workspace:\^"/g, '"workspace:*"');
+            // Only rewrite @mastra/* deps that are actual workspace packages;
+            // some (e.g. @mastra/docusaurus-plugin-*) are published from other repos.
+            updated = updated.replace(/"(@mastra\/[^"]*)":\s*"[^"]*"/g, (match, name) =>
+              workspacePackages.has(name) ? `"${name}": "workspace:*"` : match,
+            );
+            if (updated !== content) {
+              console.log(`Updating ${file}`);
+              fs.writeFileSync(file, updated);
+              changedCount++;
+            }
+          }
+          console.log(`Finished updating workspace dependencies. ${changedCount} files updated.`);
+          EOF
         shell: bash
 
       - name: Update lockfile

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -457,7 +457,7 @@ jobs:
 
       - name: Update workspace dependencies
         run: |
-          for file in $(find . -type f -name package.json -not -path "./node_modules/*" -not -path "./package.json"); do
+          for file in $(find . -type f -name package.json -not -path "./node_modules/*" -not -path "./package.json" -not -path "./docs/*"); do
             content="$(< "$file")"
             updated="$(echo "$content" | sed -E 's/"workspace:\^"/"workspace:*"/g')"
             updated="$(echo "$updated" | sed 's/"@mastra\/\([^"]*\)":[[:space:]]"[^"]*"/"@mastra\/\1": "workspace:*"/g')"


### PR DESCRIPTION
## Summary

Snapshot publishes via the **Publish to npm** workflow currently fail during the `Update lockfile` step with:

```
ERR_PNPM_WORKSPACE_PKG_NOT_FOUND In docs: "@mastra/docusaurus-plugin-algolia@workspace:*" is in the dependencies but no package named "@mastra/docusaurus-plugin-algolia" is present in the workspace
```

Example failing run: https://github.com/mastra-ai/mastra/actions/runs/29597666695

The `Update workspace dependencies` step rewrote **every** `@mastra/*` dependency in every `package.json` to `workspace:*`. Since #19117 / #19128, `docs/package.json` depends on `@mastra/docusaurus-plugin-algolia` and `@mastra/docusaurus-plugin-kapa`, which are published to npm from a separate repo and don't exist in this workspace. Rewriting them breaks `pnpm install --lockfile-only`.

## Fix

Replace the blanket sed rewrite with a script that queries the actual workspace package list (`pnpm m ls --depth -1 --json`) and only rewrites `@mastra/*` deps that are real workspace packages. External `@mastra/*` packages (like the docusaurus plugins) are left untouched, wherever they appear.

## Test plan

- Ran the new script locally against a clean checkout: 163 files rewritten, `docs/package.json` external plugin deps left intact, workspace deps like `@mastra/core` correctly rewritten to `workspace:*`
- Verified workflow YAML still parses
- Confirm by re-running a snapshot publish after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When publishing a “snapshot,” the workflow updates package dependency versions so local workspace packages use `workspace:*`. It now checks which `@mastra/*` packages actually exist in this pnpm workspace before rewriting them, so dependencies from other repositories (like certain Docusaurus plugins) don’t get wrongly converted and break `pnpm install`.

## Changes

- Updated `.github/workflows/npm-publish.yml` (“Update workspace dependencies”) to use an inline Node.js script that:
  - Reads workspace package names via `pnpm m ls --json`.
  - Rewrites `"workspace:^"` → `"workspace:*"` in `*/package.json`.
  - Rewrites `@mastra/*` dependency specs to `"workspace:*"` only if that dependency name is present in the workspace package set.
- Removes the previous blanket `@mastra/*` rewrite approach, making the snapshot dependency rewrite robust for externally published `@mastra/*` docs dependencies.
- Prevents snapshot publishes from failing due to workspace rewrite of packages that aren’t actually part of the current pnpm workspace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->