### PR TITLE
fix(mastracode): keep quiet preview height stable

### DIFF
--- a/.changeset/every-snails-bathe.md
+++ b/.changeset/every-snails-bathe.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed quiet-mode tool previews jumping during streamed updates.

--- a/mastracode/tui/e2e/fixtures/quiet-streaming-preview-height.json
+++ b/mastracode/tui/e2e/fixtures/quiet-streaming-preview-height.json
@@ -1,0 +1,40 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "hasToolResult": true
+      },
+      "response": {
+        "content": "Quiet preview height e2e complete."
+      }
+    },
+    {
+      "match": {
+        "userMessage": "Replace the quiet preview fixture content.",
+        "model": "gpt-5.4-mini",
+        "endpoint": "chat",
+        "hasToolResult": false
+      },
+      "response": {
+        "toolCalls": [
+          {
+            "id": "call_quiet_streaming_preview_height",
+            "name": "string_replace_lsp",
+            "arguments": {
+              "path": "src/quiet-preview.ts",
+              "old_string": "OLD_PREVIEW_ONE\nOLD_PREVIEW_TWO\nOLD_PREVIEW_THREE\nOLD_PREVIEW_FOUR",
+              "new_string": "NEW_PREVIEW_ONE\nNEW_PREVIEW_TWO\nNEW_PREVIEW_THREE\nNEW_PREVIEW_FOUR"
+            }
+          }
+        ]
+      },
+      "chunkSize": 61,
+      "streamingProfile": {
+        "ttft": 200,
+        "tps": 1
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -98,6 +98,7 @@ import { providerHistoryCompatScenario } from './provider-history-compat.js';
 import { providerHistoryRejectionRetryScenario } from './provider-history-rejection-retry.js';
 import { pruneCommandScenario } from './prune-command.js';
 import { quietSettingsScenario } from './quiet-settings.js';
+import { quietStreamingPreviewHeightScenario } from './quiet-streaming-preview-height.js';
 import { quietToolHistoryParityScenario } from './quiet-tool-history-parity.js';
 import { reportIssueCommandScenario } from './report-issue-command.js';
 import { requestAccessModalScenario } from './request-access-modal.js';
@@ -253,6 +254,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'prompt-queue-interleave': promptQueueInterleaveScenario,
   'prune-command': pruneCommandScenario,
   'quiet-settings': quietSettingsScenario,
+  'quiet-streaming-preview-height': quietStreamingPreviewHeightScenario,
   'quiet-tool-history-parity': quietToolHistoryParityScenario,
   'report-issue-command': reportIssueCommandScenario,
   'request-access-modal': requestAccessModalScenario,

--- a/mastracode/tui/e2e/tui/quiet-streaming-preview-height.ts
+++ b/mastracode/tui/e2e/tui/quiet-streaming-preview-height.ts
@@ -1,0 +1,121 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { McE2eScenario, McE2eTerminal, McE2eScenarioRuntime } from './types.js';
+
+type PreviewGeometry = {
+  detailRows: number;
+  editorRow: number;
+};
+
+const CHECKPOINT_SAMPLE_COUNT = 4;
+const CHECKPOINT_SAMPLE_INTERVAL_MS = 100;
+
+function readPreviewGeometry(terminal: McE2eTerminal): PreviewGeometry {
+  const rows = terminal.serialize().view.split('\n');
+  const headerRow = rows.findIndex(row => row.includes('▐edit▌') && row.includes('src/quiet-preview.ts'));
+  if (headerRow < 0) throw new Error('Expected quiet edit header while sampling preview geometry');
+
+  let detailRows = 0;
+  for (let row = headerRow + 1; row < rows.length && /^\s*│(?:\s|$)/.test(rows[row]!); row += 1) {
+    detailRows += 1;
+  }
+
+  const editorRow = rows.findLastIndex(row => /^╭─+╮$/.test(row));
+  if (editorRow < 0) throw new Error('Expected editor border while sampling preview geometry');
+
+  return { detailRows, editorRow };
+}
+
+async function sampleCheckpoint(
+  label: string,
+  marker: RegExp,
+  forbiddenMarker: RegExp | undefined,
+  terminal: McE2eTerminal,
+  runtime: McE2eScenarioRuntime,
+): Promise<PreviewGeometry[]> {
+  await runtime.waitForScreenText(marker, terminal, 8_000);
+  const samples: PreviewGeometry[] = [];
+
+  for (let index = 0; index < CHECKPOINT_SAMPLE_COUNT; index += 1) {
+    const view = terminal.serialize().view;
+    if (!marker.test(view)) throw new Error(`Checkpoint ${label} disappeared before it could be sampled`);
+    if (forbiddenMarker?.test(view)) throw new Error(`Checkpoint ${label} advanced before it could be sampled`);
+    samples.push(readPreviewGeometry(terminal));
+    await runtime.sleep(CHECKPOINT_SAMPLE_INTERVAL_MS);
+  }
+
+  return samples;
+}
+
+export const quietStreamingPreviewHeightScenario: McE2eScenario = {
+  name: 'quiet-streaming-preview-height',
+  description: 'Keep quiet preview and editor geometry stable while deterministic edit arguments stream.',
+  testName: 'keeps quiet preview detail rows monotonic through streamed argument checkpoints',
+  projectFixture: 'long-branch',
+  useOpenAIModel: true,
+  aimockFixture: 'quiet-streaming-preview-height.json',
+  prepare({ appDataDir, projectDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
+    settings.onboarding = { ...settings.onboarding, quietModePreferenceSelected: true };
+    settings.preferences = {
+      ...settings.preferences,
+      quietMode: true,
+      quietModeMaxToolPreviewLines: 4,
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+
+    mkdirSync(join(projectDir, 'src'), { recursive: true });
+    writeFileSync(
+      join(projectDir, 'src', 'quiet-preview.ts'),
+      'OLD_PREVIEW_ONE\nOLD_PREVIEW_TWO\nOLD_PREVIEW_THREE\nOLD_PREVIEW_FOUR',
+    );
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    terminal.resize(120, 30);
+    await runtime.waitForScreenText(/Project:/i, terminal);
+
+    terminal.submit('Replace the quiet preview fixture content.');
+
+    // JSON.stringify(arguments) is 201 characters. With chunkSize 61 and tps 1:
+    // chunk 2 ends at prefix 122 with four old_string rows, chunk 3 ends at
+    // prefix 183 with exactly three new_string rows, and chunk 4 regrows to four.
+    const full = await sampleCheckpoint('full old_string', /OLD_PREVIEW_FOUR/, /NEW_PREVIEW_ONE/, terminal, runtime);
+    const shorter = await sampleCheckpoint(
+      'shorter new_string',
+      /NEW_PREVIEW_THREE/,
+      /NEW_PREVIEW_FOUR/,
+      terminal,
+      runtime,
+    );
+    const regrown = await sampleCheckpoint('regrown new_string', /NEW_PREVIEW_FOUR/, undefined, terminal, runtime);
+
+    await runtime.waitForScreenText(/Quiet preview height e2e complete\./i, terminal, 8_000);
+    const complete = [readPreviewGeometry(terminal)];
+    const checkpoints = { full, shorter, regrown, complete };
+    const allSamples = Object.values(checkpoints).flat();
+    if (Object.values(checkpoints).some(samples => samples.length === 0)) {
+      throw new Error('Expected every quiet preview checkpoint to be observed');
+    }
+    if (allSamples.some(sample => sample.detailRows !== 4)) {
+      throw new Error(`Expected stable four-row quiet preview geometry, received ${JSON.stringify(checkpoints)}`);
+    }
+    const firstEditorRow = full[0]!.editorRow;
+    if (allSamples.some(sample => sample.editorRow < firstEditorRow)) {
+      throw new Error(`Expected the editor row not to move upward, received ${JSON.stringify(checkpoints)}`);
+    }
+
+    runtime.printScreen('quiet streaming preview height', terminal);
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    if (requests.length !== 2) {
+      throw new Error(`Expected quiet preview height scenario to make 2 AIMock requests, received ${requests.length}`);
+    }
+    const second = JSON.stringify(requests[1]);
+    for (const needle of ['call_quiet_streaming_preview_height', 'NEW_PREVIEW_FOUR', 'Replaced 1 occurrence']) {
+      if (!second.includes(needle)) throw new Error(`Expected second AIMock request to include ${needle}`);
+    }
+  },
+};

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -103,6 +103,7 @@ export type ScenarioName =
   | 'om-status-indicator'
   | 'om-threshold-persistence'
   | 'quiet-settings'
+  | 'quiet-streaming-preview-height'
   | 'quiet-tool-history-parity'
   | 'report-issue-command'
   | 'request-access-modal'

--- a/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
+++ b/mastracode/tui/src/tui/components/__tests__/tool-execution-enhanced.test.ts
@@ -164,6 +164,145 @@ describe('ToolExecutionComponentEnhanced quiet display', () => {
     expect(visible).not.toContain('OLD_STREAM_00000');
   });
 
+  it('keeps quiet write preview detail rows stable while streamed content changes', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: 'src/example.ts', content: 'first\nsecond\nthird\nfourth' },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    expect(component.render(100)).toHaveLength(6);
+
+    component.updateArgs({ path: 'src/example.ts', content: 'new first\nnew second\nnew third' });
+    let lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.join('\n')).toContain('new third');
+    expect(lines.join('\n')).not.toContain('fourth');
+
+    component.updateArgs({ path: 'src/example.ts', content: 'next first\nnext second\nnext third\nnext fourth' });
+    lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.join('\n')).toContain('next fourth');
+  });
+
+  it('keeps quiet edit preview detail rows stable while switching to new_string', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'string_replace_lsp',
+      { path: 'src/example.ts', old_string: 'old first\nold second\nold third\nold fourth' },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    expect(component.render(100)).toHaveLength(6);
+
+    component.updateArgs({
+      path: 'src/example.ts',
+      old_string: 'old first\nold second\nold third\nold fourth',
+      new_string: 'new first\nnew second',
+    });
+    let lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.join('\n')).toContain('new second');
+    expect(lines.join('\n')).not.toContain('old fourth');
+
+    component.updateArgs({
+      path: 'src/example.ts',
+      old_string: 'old first\nold second\nold third\nold fourth',
+      new_string: 'next first\nnext second\nnext third\nnext fourth',
+    });
+    lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.join('\n')).toContain('next fourth');
+  });
+
+  it('keeps quiet generic preview detail rows stable through completion', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'mastra_expert',
+      { question: 'Explain previews' },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    component.updateResult({ content: [{ type: 'text', text: 'first\nsecond\nthird\nfourth' }], isError: false }, true);
+    expect(component.render(100)).toHaveLength(6);
+
+    component.updateResult({ content: [{ type: 'text', text: 'complete result' }], isError: false });
+    const lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.join('\n')).toContain('complete result');
+    expect(lines.join('\n')).not.toContain('fourth');
+  });
+
+  it('does not reserve quiet preview rows before content and resets the floor at zero', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: 'src/example.ts', content: '' },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    expect(component.render(100)).toHaveLength(1);
+    expect(component.hasQuietStreamingPreview()).toBe(false);
+
+    component.updateArgs({ path: 'src/example.ts', content: 'first\nsecond\nthird\nfourth' });
+    expect(component.render(100)).toHaveLength(6);
+
+    component.setQuietPreviewLineLimit(0);
+    component.updateArgs({ path: 'src/example.ts', content: '' });
+    expect(component.render(100)).toHaveLength(1);
+    expect(component.hasQuietStreamingPreview()).toBe(false);
+
+    component.setQuietPreviewLineLimit(4);
+    expect(component.render(100)).toHaveLength(1);
+    expect(component.hasQuietStreamingPreview()).toBe(false);
+  });
+
+  it('clamps the quiet preview floor when the configured limit is lowered', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'write_file',
+      { path: 'src/example.ts', content: 'first\nsecond\nthird\nfourth' },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+
+    expect(component.render(100)).toHaveLength(6);
+    component.setQuietPreviewLineLimit(2);
+    component.updateArgs({ path: 'src/example.ts', content: 'short' });
+    expect(component.render(100)).toHaveLength(4);
+
+    component.setQuietPreviewLineLimit(4);
+    expect(component.render(100)).toHaveLength(4);
+
+    component.updateArgs({ path: 'src/example.ts', content: 'next first\nnext second\nnext third\nnext fourth' });
+    expect(component.render(100)).toHaveLength(6);
+  });
+
+  it('preserves continuation geometry when an established quiet preview becomes empty', () => {
+    const component = new ToolExecutionComponentEnhanced(
+      'mastra_expert',
+      { question: 'Explain previews' },
+      { quietDisplayMode: 'quiet', quietPreviewLineLimit: 4, collapsedByDefault: true },
+      ui,
+    );
+    component.setCompactToolHasFollowingContinuation(true);
+    component.updateResult({ content: [{ type: 'text', text: 'first\nsecond\nthird\nfourth' }], isError: false }, true);
+
+    let lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.slice(1, 5).every(line => line.includes('│'))).toBe(true);
+    expect(lines[5]).toContain('│');
+    expect(lines.join('\n')).not.toContain('╰──');
+
+    component.updateResult({ content: [{ type: 'text', text: '' }], isError: false }, true);
+    expect(component.hasQuietStreamingPreview()).toBe(true);
+    lines = component.render(100).map(stripAnsi);
+    expect(lines).toHaveLength(6);
+    expect(lines.slice(1, 5).every(line => line.trim() === '│')).toBe(true);
+    expect(lines[5]!.trim()).toBe('│');
+    expect(lines.join('\n')).not.toContain('╰──');
+  });
+
   it('shows exactly the immediate dirname and filename once continuation paths are available', () => {
     const component = new ToolExecutionComponentEnhanced(
       'view',

--- a/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
+++ b/mastracode/tui/src/tui/components/tool-execution-enhanced.ts
@@ -205,6 +205,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
   private streamingOutput = ''; // Buffer for streaming shell output
   private quietDisplayMode: QuietToolDisplayMode;
   private quietPreviewLineLimit: number;
+  private quietPreviewRowFloor = 0;
   private compactToolContinuation = false;
   private compactToolHasFollowingContinuation = false;
   private compactToolPreviousSummary: string | undefined;
@@ -280,6 +281,7 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
   setQuietPreviewLineLimit(limit: number): void {
     const normalizedLimit = Number.isFinite(limit) ? limit : 2;
     this.quietPreviewLineLimit = Math.min(8, Math.max(0, Math.floor(normalizedLimit)));
+    this.quietPreviewRowFloor = Math.min(this.quietPreviewRowFloor, this.quietPreviewLineLimit);
     this.rebuild();
   }
 
@@ -308,7 +310,12 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
   }
 
   hasQuietStreamingPreview(): boolean {
-    return this.quietDisplayMode === 'quiet' && this.quietPreviewLineLimit > 0 && this.getQuietActivePreview() !== '';
+    return (
+      this.quietDisplayMode === 'quiet' &&
+      this.toolName !== MC_TOOLS.EXECUTE_COMMAND &&
+      this.quietPreviewLineLimit > 0 &&
+      (this.quietPreviewRowFloor > 0 || this.getQuietActivePreview() !== '')
+    );
   }
 
   setCompactToolContinuation(continuation: boolean, previousSummary?: string): void {
@@ -445,22 +452,31 @@ export class ToolExecutionComponentEnhanced extends WidthAwareContainer implemen
       return [];
 
     const preview = this.getQuietActivePreview();
-    if (!preview) return [];
+    let lines: string[] = [];
 
-    if (this.isQuietCodePreviewTool()) {
-      return this.getQuietCodePreviewLines(preview, maxLineWidth);
+    if (preview) {
+      if (this.isQuietCodePreviewTool()) {
+        lines = this.getQuietCodePreviewLines(preview, maxLineWidth);
+      } else {
+        const firstLineWidth = Math.max(10, maxLineWidth - 4);
+        const continuationWidth = Math.max(10, maxLineWidth - 4);
+        const wrapped = this.wrapPreviewLines(preview, firstLineWidth, continuationWidth).slice(
+          -this.quietPreviewLineLimit,
+        );
+
+        lines = wrapped.map(line => {
+          const linePrefix = `  ${chalk.hex(this.getQuietToolRailColor())('│')} `;
+          return truncateAnsi(`${linePrefix}${this.formatQuietActivePreview(line)}`, maxLineWidth);
+        });
+      }
     }
 
-    const firstLineWidth = Math.max(10, maxLineWidth - 4);
-    const continuationWidth = Math.max(10, maxLineWidth - 4);
-    const wrapped = this.wrapPreviewLines(preview, firstLineWidth, continuationWidth).slice(
-      -this.quietPreviewLineLimit,
-    );
-
-    return wrapped.map(line => {
+    this.quietPreviewRowFloor = Math.min(this.quietPreviewLineLimit, Math.max(this.quietPreviewRowFloor, lines.length));
+    const padding = Array.from({ length: this.quietPreviewRowFloor - lines.length }, () => {
       const linePrefix = `  ${chalk.hex(this.getQuietToolRailColor())('│')} `;
-      return truncateAnsi(`${linePrefix}${this.formatQuietActivePreview(line)}`, maxLineWidth);
+      return truncateAnsi(linePrefix, maxLineWidth);
     });
+    return [...padding, ...lines];
   }
 
   private getQuietCodePreviewLines(preview: string, maxLineWidth: number): string[] {


### PR DESCRIPTION
Quiet-mode tool previews could briefly shrink as streamed tool arguments changed, moving the input and everything below the preview upward before the next frame restored the height. This keeps the greatest non-empty detail-row count for each non-shell quiet preview, bounded by the configured line limit, while continuing to show the newest content.

Before: `4 → 3 → 4` detail rows during the same streamed tool call.

After: `4 → 4 → 4`, with blank rail rows prepended only when needed. `execute_command` keeps its separate shell renderer, and changing the configured limit remains authoritative.

The behavior is covered by component tests for write, edit, generic completion, continuation, empty-content, and limit transitions. A deterministic TUI E2E scenario and built-CLI tmux proof exercise the streamed regression end to end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Quiet tool previews now keep their space while new text streams in, so the screen no longer jumps around. They still show the latest content and respect the configured line limit.

## What changed

- Added persistent quiet-preview row sizing, bounded by `quietPreviewLineLimit`.
- Preserved preview height for write, edit, generic completion, continuation, and empty-content transitions.
- Kept shell command previews on their existing dedicated renderer.
- Added unit coverage for streaming updates and line-limit changes.
- Added deterministic TUI E2E coverage for preview height stability.
- Added a patch changeset for `mastracode`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->