### PR TITLE
Smoother first-deploy: per-env db create, inline auto-provision, cleaner preflight

### DIFF
--- a/.changeset/hip-spies-arrive.md
+++ b/.changeset/hip-spies-arrive.md
@@ -1,0 +1,16 @@
+---
+'mastra': minor
+---
+
+Deploy now offers to attach a managed database inline when preflight would otherwise block on a missing database env var (`TURSO_DATABASE_URL`, `DATABASE_URL`, ...). Previously the CLI errored out and told you to run `mastra env db create` yourself, then re-run `mastra deploy`.
+
+The new flow:
+
+```
+Preflight needs TURSO_DATABASE_URL for the production environment.
+Create a managed turso database now and attach it? (Y/n)
+```
+
+Answer yes and the CLI provisions the database, attaches it to the target environment (scoped, not shared), and continues the deploy in the same run. Answer no, or run in a non-interactive shell (CI, `--yes`), and the CLI falls back to the previous behavior and prints the exact `mastra env db create --kind ...` command as remediation.
+
+The prompt only appears in an interactive TTY. `--yes` never silently creates infrastructure — it just skips the prompt and leaves the original preflight error in place, so CI stays deterministic. Resolves the deploy-time papercut tracked in the deploy-experience issue on `create-mastra` auto-provisioning: no manual command, no CLI restart, no extra login step.

--- a/.changeset/large-ants-mix.md
+++ b/.changeset/large-ants-mix.md
@@ -1,0 +1,26 @@
+---
+'mastra': minor
+---
+
+Changed the default scope for `mastra env db create`. It now creates an **environment-scoped** database instead of a project-scoped one shared by every environment. This matches the more common case of isolating production and staging data.
+
+**How the default is picked**
+
+- If the project has one environment, that environment is used automatically.
+- If it has several and the terminal is interactive, the CLI prompts you to select one (production pre-selected when present).
+- In non-interactive mode (CI, `--json`) with multiple environments, the CLI now errors and asks you to pass an environment name or `--shared`, instead of silently attaching a shared database.
+
+**New `--shared` flag**
+
+Opt in to the old project-scoped behavior explicitly:
+
+```bash
+# Before (implicit shared scope)
+mastra env db create --kind turso
+
+# After (same effect)
+mastra env db create --kind turso --shared
+
+# Or scope to a specific environment
+mastra env db create staging --kind turso
+```

--- a/.changeset/new-snails-brake.md
+++ b/.changeset/new-snails-brake.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Preflight remediation messages now scope `mastra env db create` to the target environment as a positional argument (`mastra env db create production --kind turso`) instead of the unscoped form. There is no `--env` flag — the environment is a positional arg on this command. After the earlier default-scope change, running the unscoped command in CI (where preflight failures land) errors out on projects with more than one environment because it cannot prompt. The scoped form is copy-pasteable and works everywhere.

--- a/.changeset/swift-pens-bow.md
+++ b/.changeset/swift-pens-bow.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Preflight remediation for missing DB env vars now renders as a step list — one arrow line per option (`Run mastra env db create <env> --kind <kind>` on line 1, `Or set <ENV_VAR> in your env file` on line 2) — instead of a single run-on sentence that squashed both options into a wall of text.

--- a/.changeset/three-times-worry.md
+++ b/.changeset/three-times-worry.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Removes the `Environment "production" doesn't exist. Create it?` confirmation on first deploy. It always fires on a fresh project, always gets 'yes', and the whole point of `mastra deploy` is 'ship this to production' — the extra keypress is pure noise. The confirmation still runs for non-standard environment names (typo protection against `--env prodcution`).

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -40,8 +40,8 @@ For most agent-focused projects, **Turso** is the simplest starting point. It pr
 
 A database is attached at one of two scopes:
 
-- **Project scope**: The default. One database shared by all of the project's [environments](/docs/mastra-platform/environments). Its variables are injected into every deploy.
-- **Environment scope**: Attached to a single environment. Use this to isolate data between environments, for example separate production and staging databases.
+- **Environment scope**: The default. Attached to a single environment so data stays isolated between environments (for example separate production and staging databases). When your project has one environment, `mastra env db create` picks it automatically; with several, the CLI prompts you to select one.
+- **Project scope**: One database shared by all of the project's [environments](/docs/mastra-platform/environments). Opt in with `--shared`. Its variables are injected into every deploy.
 
 The scope is set when you attach the database and shown in `mastra env db list`.
 
@@ -52,19 +52,23 @@ The two scopes can't overlap for the same provider. Because a project-scoped dat
 Create and attach a database in one command. The CLI polls until it's ready, which takes a few seconds:
 
 ```bash
-# Shared by all environments
+# Scoped to a single environment (the CLI picks the only one, or prompts if there are several)
 mastra env db create --kind turso
 
-# Scoped to the staging environment
+# Scoped to a specific environment
 mastra env db create staging --kind turso
+
+# Shared by all environments
+mastra env db create --kind turso --shared
 ```
 
 Supported kinds are `turso` and `neon` (Postgres). Useful flags:
 
+- `--shared`: Attach a project-scoped database shared by every environment. Cannot be combined with an environment argument.
 - `--name <name>`: Database name. Defaults to a name derived from the project slug.
 - `--region <region>`: Provider region ID for project-scoped databases (for example `fra`). Environment-scoped databases are placed near the environment's region automatically, and an explicit `--region` is ignored.
 - `--no-wait`: Return immediately instead of polling. Check progress later with `mastra env db show`.
-- `--json`: Machine-readable output.
+- `--json`: Machine-readable output. When the project has multiple environments, `--json` requires an environment argument or `--shared` (no interactive prompt).
 
 Inspect and manage attached databases:
 

--- a/docs/src/content/en/docs/mastra-platform/database.mdx
+++ b/docs/src/content/en/docs/mastra-platform/database.mdx
@@ -49,7 +49,9 @@ The two scopes can't overlap for the same provider. Because a project-scoped dat
 
 ## Attach with the CLI
 
-Create and attach a database in one command. The CLI polls until it's ready, which takes a few seconds:
+You don't have to run this command up front. If your project needs a hosted database but doesn't have one yet, `mastra deploy` offers to attach one for you when the deploy preflight check runs. Say yes and the deploy continues without leaving the CLI.
+
+Alternatively, create and attach a database ahead of time. The CLI polls until it's ready, which takes a few seconds:
 
 ```bash
 # Scoped to a single environment (the CLI picks the only one, or prompts if there are several)

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -53,8 +53,10 @@ A local `.env` file is optional. Environment variables stored on the platform ar
     Accept the prompt and provisioning takes a few seconds — the database's connection variables are injected into your deploys automatically, with nothing to copy into an `.env` file. Decline it, or run in a non-interactive shell (CI, `--yes`), and the CLI falls back to the previous behavior: it prints the exact command to run yourself.
 
     ```bash
-    mastra env db create --kind turso
+    mastra env db create production --kind turso
     ```
+
+    The environment slug (`production` above) matches the environment the CLI would have deployed to — this is important because `mastra env db create` requires an environment argument in non-interactive shells when the project has more than one environment.
 
     :::note
     If preflight reports a hard-coded local path instead (`Build contains a host-local storage URL`), it can't offer the inline fix — guard the path with an environment variable first so the file is only used during local development:

--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -38,22 +38,26 @@ A local `.env` file is optional. Environment variables stored on the platform ar
   </StepItem>
 
   <StepItem>
-    The CLI runs a preflight check before anything ships. Storage that would fall back to a local file path blocks the deploy, because local files don't survive on the platform's ephemeral filesystem:
+    The CLI runs a preflight check before anything ships. Storage that would fall back to a local file path (which doesn't survive on the platform's ephemeral filesystem) would normally block the deploy:
 
     ```
-    [LOCAL_STORAGE_PATH] file:./mastra.db will be used at runtime because TURSO_DATABASE_URL is not set
+    file:./mastra.db will be used at runtime because TURSO_DATABASE_URL is not set
     ```
 
-    Attach a [hosted database](/docs/mastra-platform/database) that provides the missing variables:
+    Instead of erroring out, the CLI offers to fix it inline for you:
+
+    ```
+    Preflight needs TURSO_DATABASE_URL for the production environment. Create a managed turso database now and attach it? (Y/n)
+    ```
+
+    Accept the prompt and provisioning takes a few seconds — the database's connection variables are injected into your deploys automatically, with nothing to copy into an `.env` file. Decline it, or run in a non-interactive shell (CI, `--yes`), and the CLI falls back to the previous behavior: it prints the exact command to run yourself.
 
     ```bash
     mastra env db create --kind turso
     ```
 
-    Provisioning takes a few seconds. The database's connection variables are injected into your deploys automatically, with nothing to copy into an `.env` file.
-
     :::note
-    If preflight reports a hard-coded local path instead (`Build contains a host-local storage URL`), guard it with an environment variable first so the file is only used during local development:
+    If preflight reports a hard-coded local path instead (`Build contains a host-local storage URL`), it can't offer the inline fix — guard the path with an environment variable first so the file is only used during local development:
 
     ```ts title="src/mastra/index.ts"
     new LibSQLStore({

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -82,16 +82,16 @@ Each row shows the deploy status, environment, timestamp, and which deploy is cu
 
 ## Isolate an environment's data
 
-By default a hosted database attached to the project is shared by all environments. To isolate production data from staging data, attach a separate database to each environment instead:
+Hosted databases are scoped to a single environment by default, so production and staging each read and write their own database:
 
 ```bash
 mastra env db create production --kind turso --name my-project-production-db
 mastra env db create staging --kind turso --name my-project-staging-db
 ```
 
-Each environment then reads and writes only its own database.
+If you'd rather share one database across every environment, attach it with `--shared` instead: `mastra env db create --kind turso --shared`.
 
-An environment can only use one database per provider. If the project already has a shared project-scoped database of the same provider, attaching an environment-scoped one is rejected with a variable name conflict — delete the shared database with `mastra env db delete` first. Deleting a database destroys it with the provider along with all of its data, so export anything you need to keep. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
+An environment can only use one database per provider. If the project already has a shared (`--shared`) database of the same provider, attaching an environment-scoped one is rejected with a variable name conflict — delete the shared database with `mastra env db delete` first. Deleting a database destroys it with the provider along with all of its data, so export anything you need to keep. See [Hosted databases](/docs/mastra-platform/database) for the full scoping model.
 
 ## Delete an environment
 

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -371,7 +371,7 @@ File to write. Defaults to `.env`.
 
 Manages databases attached to a project on Mastra platform. Databases are provisioned from a managed provider (for example Turso or Neon) and inject their connection env vars into deploys automatically.
 
-A database is either **environment-scoped** (its env vars only go to one environment) or **shared** (project-scoped: its env vars go to all environments). Pass the environment argument to work with environment-scoped databases; omit it for shared databases.
+A database is either **environment-scoped** (its env vars only go to one environment) or **shared** (project-scoped: its env vars go to all environments). Environment-scoped is the default for `mastra env db create` — pass an environment argument, or let the CLI pick or prompt for one. Pass `--shared` on create to attach a shared database instead. For other subcommands (`list`, `delete`, `keys`), pass the environment argument to work with environment-scoped databases and omit it for shared databases.
 
 Creating and deleting databases requires the `admin` role in the organization.
 

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -392,11 +392,15 @@ Emit machine-readable JSON.
 
 Provisions a managed database, attaches it, and polls until it's ready. Provisioning errors are printed with the provider's error detail.
 
-With an environment argument, the database is scoped to that environment: only it receives the database's connection env vars, and the provider region is derived from the environment's region. Without one, the database is shared by all environments.
+By default the database is scoped to a single environment: pass an environment argument to pick it, or omit the argument to have the CLI pick for you. When the project has one environment, that environment is used. When it has several, the CLI prompts you to select one interactively; in non-interactive contexts (CI, `--json`) an environment argument is required. Pass `--shared` to attach a project-scoped database that's shared by every environment instead.
+
+Environment-scoped databases inherit their provider region from the environment. Shared databases accept `--region`.
 
 ```bash
-mastra env db create <env> --kind turso
-mastra env db create --kind neon --name my-app-db --region aws-us-east-1
+mastra env db create --kind turso                                    # picks or prompts for an environment
+mastra env db create staging --kind turso                            # scoped to the "staging" environment
+mastra env db create --kind turso --shared                           # shared by all environments
+mastra env db create --kind neon --name my-app-db --region aws-us-east-1 --shared
 ```
 
 #### `--kind`
@@ -411,13 +415,17 @@ Database name. Defaults to a name derived from the project slug (for example `my
 
 Provider region ID for shared databases. Ignored for environment-scoped databases.
 
+#### `--shared`
+
+Attach as a project-scoped database that's shared by every environment. Cannot be combined with an environment argument.
+
 #### `--no-wait`
 
 Return immediately after the attach is queued instead of polling until the database is ready. Check progress later with `mastra env db show`.
 
 #### `--json`
 
-Emit machine-readable JSON.
+Emit machine-readable JSON. In this mode, an environment argument or `--shared` is required when the project has more than one environment (no interactive prompt).
 
 ### `mastra env db show`
 

--- a/packages/cli/src/commands/db/db.test.ts
+++ b/packages/cli/src/commands/db/db.test.ts
@@ -81,32 +81,85 @@ describe('defaultDatabaseName', () => {
     expect(defaultDatabaseName({ name: '---', slug: null })).toBe('mastra-db');
   });
 
-  it('does not suffix the production environment (keeps the canonical name)', () => {
-    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'production', slug: 'my-app' })).toBe(
-      'my-app-db',
-    );
+  it('does not suffix production-type environments (keeps the canonical name)', () => {
+    expect(
+      defaultDatabaseName(
+        { name: 'My App', slug: 'my-app' },
+        { name: 'production', slug: 'my-app', type: 'production' },
+      ),
+    ).toBe('my-app-db');
+  });
+
+  it('recognises production by env type even when the env is renamed (e.g. `main`)', () => {
+    // Users are free to rename their production env; we must not suffix
+    // it and orphan the canonical DB.
+    expect(
+      defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'main', slug: 'main', type: 'production' }),
+    ).toBe('my-app-db');
+  });
+
+  it('suffixes a non-production env even if it happens to be named `production`', () => {
+    // The name is not the discriminator — the type is.
+    expect(
+      defaultDatabaseName(
+        { name: 'My App', slug: 'my-app' },
+        { name: 'production', slug: 'production', type: 'staging' },
+      ),
+    ).toBe('my-app-production-db');
   });
 
   it('suffixes non-production environments so multi-env attaches do not collide', () => {
-    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'eu', slug: 'my-app--eu' })).toBe(
-      'my-app-eu-db',
-    );
-    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'staging', slug: 'my-app--staging' })).toBe(
-      'my-app-staging-db',
-    );
+    expect(
+      defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'eu', slug: 'my-app--eu', type: 'preview' }),
+    ).toBe('my-app-eu-db');
+    expect(
+      defaultDatabaseName(
+        { name: 'My App', slug: 'my-app' },
+        { name: 'staging', slug: 'my-app--staging', type: 'staging' },
+      ),
+    ).toBe('my-app-staging-db');
   });
 
   it('sanitizes env names into DNS-safe segments', () => {
-    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'EU West', slug: 'eu' })).toBe(
-      'my-app-eu-west-db',
-    );
+    expect(
+      defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'EU West', slug: 'eu', type: 'preview' }),
+    ).toBe('my-app-eu-west-db');
   });
 
-  it('skips a redundant env suffix when the env slug equals the project slug', () => {
-    // Platforms sometimes derive the production env slug from the project slug.
-    expect(
-      defaultDatabaseName({ name: 'My App', slug: 'smoke-1234' }, { name: 'smoke-1234', slug: 'smoke-1234' }),
-    ).toBe('smoke-1234-db');
+  it('truncates the project segment (not the env) so long-slug projects still get distinct names per env', () => {
+    // 60-char project slug + `-eu-db` / `-us-db` would collide if we
+    // truncated the tail. Both must produce distinct names.
+    const longSlug = 'a'.repeat(60);
+    const euName = defaultDatabaseName({ name: 'App', slug: longSlug }, { name: 'eu', slug: 'eu', type: 'preview' });
+    const usName = defaultDatabaseName({ name: 'App', slug: longSlug }, { name: 'us', slug: 'us', type: 'preview' });
+    expect(euName).not.toBe(usName);
+    expect(euName.length).toBeLessThanOrEqual(64);
+    expect(usName.length).toBeLessThanOrEqual(64);
+    expect(euName.endsWith('-eu-db')).toBe(true);
+    expect(usName.endsWith('-us-db')).toBe(true);
+  });
+
+  it('respects the 64-char cap even with long env discriminators', () => {
+    const longSlug = 'p'.repeat(50);
+    const longEnv = 'e'.repeat(30);
+    const name = defaultDatabaseName(
+      { name: 'App', slug: longSlug },
+      { name: longEnv, slug: longEnv, type: 'preview' },
+    );
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.endsWith('-db')).toBe(true);
+    // Env discriminator must survive in some form even when the budget
+    // is fully consumed.
+    expect(name).toContain('-e');
+  });
+
+  it('drops a hyphen at the truncation boundary so the joined name stays DNS-clean', () => {
+    // A slug whose char at the cutoff is `-` would leave `foo--eu-db`
+    // if we naively sliced. The result must have no double hyphens.
+    const slug = 'x-'.repeat(40).replace(/-$/, ''); // long alternating x-x-x-...
+    const name = defaultDatabaseName({ name: 'X', slug }, { name: 'eu', slug: 'eu', type: 'preview' });
+    expect(name).not.toMatch(/--/);
+    expect(name.length).toBeLessThanOrEqual(64);
   });
 });
 

--- a/packages/cli/src/commands/db/db.test.ts
+++ b/packages/cli/src/commands/db/db.test.ts
@@ -80,6 +80,34 @@ describe('defaultDatabaseName', () => {
   it('never returns leading/trailing hyphens or an empty base', () => {
     expect(defaultDatabaseName({ name: '---', slug: null })).toBe('mastra-db');
   });
+
+  it('does not suffix the production environment (keeps the canonical name)', () => {
+    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'production', slug: 'my-app' })).toBe(
+      'my-app-db',
+    );
+  });
+
+  it('suffixes non-production environments so multi-env attaches do not collide', () => {
+    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'eu', slug: 'my-app--eu' })).toBe(
+      'my-app-eu-db',
+    );
+    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'staging', slug: 'my-app--staging' })).toBe(
+      'my-app-staging-db',
+    );
+  });
+
+  it('sanitizes env names into DNS-safe segments', () => {
+    expect(defaultDatabaseName({ name: 'My App', slug: 'my-app' }, { name: 'EU West', slug: 'eu' })).toBe(
+      'my-app-eu-west-db',
+    );
+  });
+
+  it('skips a redundant env suffix when the env slug equals the project slug', () => {
+    // Platforms sometimes derive the production env slug from the project slug.
+    expect(
+      defaultDatabaseName({ name: 'My App', slug: 'smoke-1234' }, { name: 'smoke-1234', slug: 'smoke-1234' }),
+    ).toBe('smoke-1234-db');
+  });
 });
 
 describe('resolveDefaultEnvironment', () => {

--- a/packages/cli/src/commands/db/db.test.ts
+++ b/packages/cli/src/commands/db/db.test.ts
@@ -1,6 +1,27 @@
-import { describe, expect, it } from 'vitest';
-import type { Environment } from '../env/platform-api.js';
-import { defaultDatabaseName, formatScope } from './db.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as EnvPlatformApi from '../env/platform-api.js';
+import type { Environment, Project } from '../env/platform-api.js';
+import { defaultDatabaseName, formatScope, resolveDefaultEnvironment } from './db.js';
+
+const selectMock = vi.fn();
+const cancelMock = vi.fn();
+const isCancelMock = vi.fn().mockReturnValue(false);
+
+vi.mock('@clack/prompts', () => ({
+  select: (args: unknown) => selectMock(args),
+  cancel: (args: unknown) => cancelMock(args),
+  isCancel: (v: unknown) => isCancelMock(v),
+  spinner: () => ({ start: vi.fn(), stop: vi.fn(), message: vi.fn() }),
+}));
+
+const fetchEnvironmentsMock = vi.fn();
+vi.mock('../env/platform-api.js', async () => {
+  const actual = await vi.importActual<typeof EnvPlatformApi>('../env/platform-api.js');
+  return {
+    ...actual,
+    fetchEnvironments: (...args: unknown[]) => fetchEnvironmentsMock(...args),
+  };
+});
 
 const environment = {
   id: 'env-1',
@@ -17,6 +38,21 @@ const environment = {
   createdAt: '2026-07-09T00:00:00.000Z',
   updatedAt: '2026-07-09T00:00:00.000Z',
 } as Environment;
+
+function makeEnv(overrides: Partial<Environment> & Pick<Environment, 'id' | 'slug' | 'type'>): Environment {
+  return {
+    ...environment,
+    name: overrides.slug,
+    ...overrides,
+  } as Environment;
+}
+
+const project = {
+  id: 'proj-1',
+  name: 'My App',
+  slug: 'my-app',
+  organizationId: 'org-1',
+} as Project;
 
 describe('formatScope', () => {
   it('labels project-scoped databases as shared by all environments', () => {
@@ -43,5 +79,96 @@ describe('defaultDatabaseName', () => {
 
   it('never returns leading/trailing hyphens or an empty base', () => {
     expect(defaultDatabaseName({ name: '---', slug: null })).toBe('mastra-db');
+  });
+});
+
+describe('resolveDefaultEnvironment', () => {
+  const originalStdinTTY = process.stdin.isTTY;
+  const originalStdoutTTY = process.stdout.isTTY;
+  const originalCI = process.env.CI;
+
+  beforeEach(() => {
+    fetchEnvironmentsMock.mockReset();
+    selectMock.mockReset();
+    isCancelMock.mockReset().mockReturnValue(false);
+    // Default to interactive TTY; individual tests override as needed.
+    (process.stdin as unknown as { isTTY: boolean }).isTTY = true;
+    (process.stdout as unknown as { isTTY: boolean }).isTTY = true;
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    (process.stdin as unknown as { isTTY: boolean | undefined }).isTTY = originalStdinTTY;
+    (process.stdout as unknown as { isTTY: boolean | undefined }).isTTY = originalStdoutTTY;
+    if (originalCI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCI;
+    }
+  });
+
+  it('errors when the project has no environments', async () => {
+    fetchEnvironmentsMock.mockResolvedValue([]);
+    await expect(resolveDefaultEnvironment('t', 'org-1', project)).rejects.toThrow(/has no environments/);
+  });
+
+  it('auto-selects the sole environment without prompting', async () => {
+    const only = makeEnv({ id: 'env-prod', slug: 'my-app-production', type: 'production' });
+    fetchEnvironmentsMock.mockResolvedValue([only]);
+
+    const result = await resolveDefaultEnvironment('t', 'org-1', project);
+
+    expect(result).toBe(only);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('errors in non-interactive mode when multiple environments exist', async () => {
+    (process.stdin as unknown as { isTTY: boolean }).isTTY = false;
+    fetchEnvironmentsMock.mockResolvedValue([
+      makeEnv({ id: 'env-prod', slug: 'prod', type: 'production' }),
+      makeEnv({ id: 'env-stg', slug: 'stg', type: 'staging' }),
+    ]);
+
+    await expect(resolveDefaultEnvironment('t', 'org-1', project)).rejects.toThrow(/multiple environments/);
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('errors when --json is set and multiple environments exist, even on a TTY', async () => {
+    fetchEnvironmentsMock.mockResolvedValue([
+      makeEnv({ id: 'env-prod', slug: 'prod', type: 'production' }),
+      makeEnv({ id: 'env-stg', slug: 'stg', type: 'staging' }),
+    ]);
+
+    await expect(resolveDefaultEnvironment('t', 'org-1', project, { json: true })).rejects.toThrow(
+      /multiple environments/,
+    );
+    expect(selectMock).not.toHaveBeenCalled();
+  });
+
+  it('prompts with production pre-selected when multiple environments exist and TTY is interactive', async () => {
+    const prod = makeEnv({ id: 'env-prod', slug: 'prod', type: 'production' });
+    const staging = makeEnv({ id: 'env-stg', slug: 'stg', type: 'staging' });
+    fetchEnvironmentsMock.mockResolvedValue([staging, prod]);
+    selectMock.mockResolvedValue('env-stg');
+
+    const result = await resolveDefaultEnvironment('t', 'org-1', project);
+
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    const call = selectMock.mock.calls[0]![0] as { initialValue: string; options: { value: string }[] };
+    expect(call.initialValue).toBe('env-prod');
+    expect(call.options.map(o => o.value)).toEqual(['env-stg', 'env-prod']);
+    expect(result).toBe(staging);
+  });
+
+  it('falls back to the first environment when no production environment exists', async () => {
+    const staging = makeEnv({ id: 'env-stg', slug: 'stg', type: 'staging' });
+    const preview = makeEnv({ id: 'env-prev', slug: 'prev', type: 'preview' });
+    fetchEnvironmentsMock.mockResolvedValue([staging, preview]);
+    selectMock.mockResolvedValue('env-prev');
+
+    await resolveDefaultEnvironment('t', 'org-1', project);
+
+    const call = selectMock.mock.calls[0]![0] as { initialValue: string };
+    expect(call.initialValue).toBe('env-stg');
   });
 });

--- a/packages/cli/src/commands/db/db.ts
+++ b/packages/cli/src/commands/db/db.ts
@@ -78,31 +78,78 @@ export function formatScope(db: Pick<ProjectDatabase, 'environmentId'>, environm
 
 /**
  * Derive a provider-safe default database name from the project slug/name,
- * optionally suffixed with an environment slug/name for env-scoped attaches.
+ * optionally suffixed with an environment discriminator for env-scoped
+ * attaches.
  *
  * Turso names become DNS labels, so: lowercase letters, digits, hyphens,
  * no leading/trailing hyphen, max 64 chars.
  *
- * When `environment` is provided, the name includes an env-derived suffix
- * (e.g. `my-app-eu-db`). Two env-scoped databases in the same project must
- * have different names — the platform rejects duplicates — so the suffix
- * is essential for auto-provisioning across environments.
+ * When `environment` is provided and its type is not `production`, the name
+ * includes an env-derived suffix (e.g. `my-app-eu-db`). Two env-scoped
+ * databases in the same project must have different names — the platform
+ * rejects duplicates — so the suffix is essential for auto-provisioning
+ * across environments. The `production` env is treated as the canonical
+ * default and stays unsuffixed so existing single-env projects keep the
+ * clean `<project>-db` name.
+ *
+ * We identify production by `environment.type`, not by name/slug matching,
+ * because users are free to rename their production env to `main`, `live`,
+ * etc., and a non-prod env named `production` should still be suffixed.
+ *
+ * If the resulting name would exceed 64 chars, we truncate the *project*
+ * segment rather than the tail — otherwise `slice(0, 64)` would eat the
+ * env discriminator and re-create the collision this function exists to
+ * prevent.
  */
+const MAX_DB_NAME_LEN = 64;
+const DB_NAME_TAIL = '-db';
+
 export function defaultDatabaseName(
   project: Pick<Project, 'name' | 'slug'>,
-  environment?: Pick<Environment, 'name' | 'slug'> | null,
+  environment?: Pick<Environment, 'name' | 'slug' | 'type'> | null,
 ): string {
   const projectPart = sanitizeSegment(project.slug || project.name) || 'mastra';
+
+  const shouldSuffix = Boolean(environment) && environment!.type !== 'production';
   // Prefer the env name over the slug: platforms sometimes derive the
   // production env's slug from the project name (e.g. `smoke-envdbux-1784317673`),
   // which would produce ugly `<project>-<project>-db` duplication.
-  const envPart = environment ? sanitizeSegment(environment.name || environment.slug || '') : '';
-  // Treat `production` as the canonical default — don't suffix, so the
-  // common single-env project gets a clean `<project>-db`. Suffix every
-  // other env so multi-env auto-provision doesn't collide on the name.
-  const shouldSuffix = envPart && envPart !== 'production' && envPart !== projectPart;
-  const base = shouldSuffix ? `${projectPart}-${envPart}` : projectPart;
-  return `${base}-db`.slice(0, 64).replace(/-+$/g, '');
+  const envPart = shouldSuffix ? sanitizeSegment(environment!.name || environment!.slug || '') : '';
+
+  if (!envPart) {
+    return truncateToMax(projectPart) + DB_NAME_TAIL;
+  }
+
+  // Reserve room for `-<envPart>-db` and truncate the project segment first
+  // so the discriminator survives. `slice(0, 64)` on the full string would
+  // eat the tail — losing the very thing that keeps names distinct across
+  // environments (issue: same project, different envs → identical truncated
+  // name → duplicate rejected by the platform).
+  const separatorLen = 1; // '-' between project and env
+  const overhead = separatorLen + envPart.length + DB_NAME_TAIL.length;
+  let projectRoom = MAX_DB_NAME_LEN - overhead;
+  let envSegment = envPart;
+  if (projectRoom < 1) {
+    // Extreme case: env name alone eats the whole budget. Give the project
+    // segment 1 char (always keep some project context) and clamp the env
+    // to what remains — but keep at least 1 char of env so the discriminator
+    // survives.
+    projectRoom = 1;
+    const envRoom = MAX_DB_NAME_LEN - projectRoom - separatorLen - DB_NAME_TAIL.length;
+    envSegment = envPart.slice(0, Math.max(1, envRoom));
+  }
+  const projectSegment = truncateToMax(projectPart, projectRoom) || projectPart.slice(0, 1);
+  return `${projectSegment}-${envSegment}${DB_NAME_TAIL}`;
+}
+
+/**
+ * Truncate an already-sanitized segment to at most `max` chars, dropping any
+ * trailing hyphens produced by the cut so the result is still a valid DNS
+ * label fragment.
+ */
+function truncateToMax(segment: string, max: number = MAX_DB_NAME_LEN - DB_NAME_TAIL.length): string {
+  if (max < 1) return '';
+  return segment.slice(0, max).replace(/-+$/g, '');
 }
 
 function sanitizeSegment(input: string): string {

--- a/packages/cli/src/commands/db/db.ts
+++ b/packages/cli/src/commands/db/db.ts
@@ -77,17 +77,40 @@ export function formatScope(db: Pick<ProjectDatabase, 'environmentId'>, environm
 }
 
 /**
- * Derive a provider-safe default database name from the project slug/name.
+ * Derive a provider-safe default database name from the project slug/name,
+ * optionally suffixed with an environment slug/name for env-scoped attaches.
+ *
  * Turso names become DNS labels, so: lowercase letters, digits, hyphens,
  * no leading/trailing hyphen, max 64 chars.
+ *
+ * When `environment` is provided, the name includes an env-derived suffix
+ * (e.g. `my-app-eu-db`). Two env-scoped databases in the same project must
+ * have different names — the platform rejects duplicates — so the suffix
+ * is essential for auto-provisioning across environments.
  */
-export function defaultDatabaseName(project: Pick<Project, 'name' | 'slug'>): string {
-  const base = (project.slug || project.name)
+export function defaultDatabaseName(
+  project: Pick<Project, 'name' | 'slug'>,
+  environment?: Pick<Environment, 'name' | 'slug'> | null,
+): string {
+  const projectPart = sanitizeSegment(project.slug || project.name) || 'mastra';
+  // Prefer the env name over the slug: platforms sometimes derive the
+  // production env's slug from the project name (e.g. `smoke-envdbux-1784317673`),
+  // which would produce ugly `<project>-<project>-db` duplication.
+  const envPart = environment ? sanitizeSegment(environment.name || environment.slug || '') : '';
+  // Treat `production` as the canonical default — don't suffix, so the
+  // common single-env project gets a clean `<project>-db`. Suffix every
+  // other env so multi-env auto-provision doesn't collide on the name.
+  const shouldSuffix = envPart && envPart !== 'production' && envPart !== projectPart;
+  const base = shouldSuffix ? `${projectPart}-${envPart}` : projectPart;
+  return `${base}-db`.slice(0, 64).replace(/-+$/g, '');
+}
+
+function sanitizeSegment(input: string): string {
+  return input
     .toLowerCase()
     .replace(/[^a-z0-9-]+/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
-  return `${base || 'mastra'}-db`.slice(0, 64).replace(/-+$/g, '');
 }
 
 function envVarNamesFor(kind: DatabaseKind): string {
@@ -309,7 +332,7 @@ async function createDatabase(opts: {
   json?: boolean;
 }) {
   const { token, orgId, project, environment, kind } = opts;
-  const name = opts.name ?? defaultDatabaseName(project);
+  const name = opts.name ?? defaultDatabaseName(project, environment);
 
   const created = await attachDatabase(token, orgId, project.id, {
     kind,

--- a/packages/cli/src/commands/db/db.ts
+++ b/packages/cli/src/commands/db/db.ts
@@ -31,11 +31,15 @@ export function registerEnvDbCommands(envCommand: Command) {
 
   db.command('create')
     .description('Provision a database, attach it, and wait until it is ready')
-    .argument('[environment]', 'Environment name, slug, or ID (default: shared by all environments)')
+    .argument(
+      '[environment]',
+      "Environment name, slug, or ID (default: the project's only environment, or prompt if there are several)",
+    )
     .requiredOption('--kind <kind>', 'Database provider (turso, neon)')
     .option(...PROJECT_OPTION)
     .option('--name <name>', 'Database name (default: derived from the project slug)')
     .option('--region <region>', 'Provider region ID (shared databases only; environment region wins otherwise)')
+    .option('--shared', 'Attach as a project-scoped database shared by all environments')
     .option('--no-wait', 'Return immediately instead of polling until the database is ready')
     .option('--json', 'Output as JSON')
     .action(wrapAction(createDatabaseAction));
@@ -193,13 +197,31 @@ function parseKind(kind: string): DatabaseKind {
 
 async function createDatabaseAction(
   envArg: string | undefined,
-  options: { project?: string; kind: string; name?: string; region?: string; wait: boolean; json?: boolean },
+  options: {
+    project?: string;
+    kind: string;
+    name?: string;
+    region?: string;
+    shared?: boolean;
+    wait: boolean;
+    json?: boolean;
+  },
 ) {
   const kind = parseKind(options.kind);
+
+  if (envArg && options.shared) {
+    throw new Error('Cannot combine an environment argument with --shared. Pick one scope.');
+  }
+
   const token = await getToken();
   const { orgId } = await resolveCurrentOrg(token);
   const project = await resolveProject(token, orgId, options.project);
-  const environment = envArg ? await findEnvironment(token, orgId, project, envArg) : undefined;
+
+  const environment = options.shared
+    ? undefined
+    : envArg
+      ? await findEnvironment(token, orgId, project, envArg)
+      : await resolveDefaultEnvironment(token, orgId, project, { json: options.json });
 
   if (environment && options.region && !options.json) {
     console.info(`Note: --region is ignored for environment-scoped databases; the environment's region is used.`);
@@ -216,6 +238,63 @@ async function createDatabaseAction(
     wait: options.wait,
     json: options.json,
   });
+}
+
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY) && !process.env.CI;
+}
+
+/**
+ * When the user runs `mastra env db create` without an environment argument
+ * and without --shared, pick the environment to scope the new database to:
+ *  - exactly one environment → use it
+ *  - multiple environments + interactive TTY → prompt with a picker
+ *  - multiple environments + non-interactive → fail with a clear message
+ *  - zero environments → fail (nothing to attach to)
+ */
+export async function resolveDefaultEnvironment(
+  token: string,
+  orgId: string,
+  project: Project,
+  opts: { json?: boolean } = {},
+): Promise<Environment> {
+  const environments = await fetchEnvironments(token, orgId, project.id);
+
+  if (environments.length === 0) {
+    throw new Error(`Project ${project.name} has no environments. Create one with: mastra env create <name>`);
+  }
+
+  if (environments.length === 1) {
+    return environments[0]!;
+  }
+
+  if (opts.json || !isInteractive()) {
+    const slugs = environments.map(e => e.slug).join(', ');
+    throw new Error(
+      `Project ${project.name} has multiple environments (${slugs}). Pass an environment name (e.g. ` +
+        `\`mastra env db create <env> --kind ...\`) or use --shared to attach a project-scoped database.`,
+    );
+  }
+
+  // Prefer production as the pre-selected option when it exists.
+  const preferred = environments.find(e => e.type === 'production') ?? environments[0]!;
+
+  const selected = await p.select({
+    message: 'Which environment should this database be scoped to?',
+    initialValue: preferred.id,
+    options: environments.map(e => ({
+      value: e.id,
+      label: `${e.slug} (${e.type})`,
+      hint: e.region ?? undefined,
+    })),
+  });
+
+  if (p.isCancel(selected)) {
+    p.cancel('Cancelled.');
+    process.exit(0);
+  }
+
+  return environments.find(e => e.id === selected)!;
 }
 
 async function createDatabase(opts: {

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -298,6 +298,41 @@ describe('preflightBuildOutput', () => {
       expect(issue?.fix).toContain('mastra env db create --kind turso');
     });
 
+    it('attaches a create-managed-database autofix hint when the guard var maps to a provider', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: false, managedEnvVarNames: [] });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.autofix).toEqual({
+        kind: 'create-managed-database',
+        provider: 'turso',
+        envVarName: 'TURSO_DATABASE_URL',
+      });
+    });
+
+    it('attaches an autofix hint on the hasEnvFile branch too (lint / no platform context)', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'DATABASE_URL' }] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.autofix).toEqual({
+        kind: 'create-managed-database',
+        provider: 'neon',
+        envVarName: 'DATABASE_URL',
+      });
+    });
+
+    it('omits the autofix hint when the guard var does not map to a known provider', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'MY_CUSTOM_DB_URL' }] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.autofix).toBeUndefined();
+    });
+
     it('names the exact db create command when preflight runs without platform context (lint path)', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'DATABASE_URL' }] });

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -352,6 +352,31 @@ describe('preflightBuildOutput', () => {
       expect(issue?.fix).not.toContain('--kind');
     });
 
+    it('scopes the db create command to the target environment when a slug is provided', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(
+        tmpDir,
+        {},
+        { hasEnvFile: false, managedEnvVarNames: [], environmentSlug: 'production' },
+      );
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      // Positional arg BEFORE the flag — `mastra env db create` accepts the
+      // environment as an argument, not as `--env`.
+      expect(issue?.fix).toContain('mastra env db create production --kind turso');
+    });
+
+    it('scopes the bare db create command too when a slug is provided', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'MY_CUSTOM_DB_URL' }] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true, environmentSlug: 'staging' });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(issue?.fix).toContain('mastra env db create staging');
+      expect(issue?.fix).not.toContain('--kind');
+    });
+
     it('warns (not errors) on guarded misses when platform context lacks managedEnvVarNames (older platform)', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [guardedDetection] });

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -6,6 +6,12 @@ import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
 import { mergePreflightEnvVars, preflightBuildOutput, printPreflightIssues } from './deploy-preflight.js';
 import type { PreflightIssue } from './deploy-preflight.js';
 
+/**
+ * `fix` may be a single string or a step list. Tests care about whether the
+ * remediation contains a substring, so flatten to one blob for assertions.
+ */
+const fixText = (fix: PreflightIssue['fix'] | undefined): string => (Array.isArray(fix) ? fix.join('\n') : (fix ?? ''));
+
 vi.mock('@clack/prompts', () => ({
   log: { warn: vi.fn(), error: vi.fn() },
   confirm: vi.fn(),
@@ -212,7 +218,7 @@ describe('preflightBuildOutput', () => {
       expect(issue?.severity).toBe('error');
       expect(issue?.message).toContain('file:./.mastra-demo.db will be used at runtime');
       expect(issue?.message).toContain('TURSO_DATABASE_URL is not set');
-      expect(issue?.fix).toContain('TURSO_DATABASE_URL');
+      expect(fixText(issue?.fix)).toContain('TURSO_DATABASE_URL');
     });
 
     it('warns (not errors) when the guarding var is missing but the CLI has no env file', async () => {
@@ -295,7 +301,19 @@ describe('preflightBuildOutput', () => {
 
       const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: false, managedEnvVarNames: [] });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
-      expect(issue?.fix).toContain('mastra env db create --kind turso');
+      expect(fixText(issue?.fix)).toContain('mastra env db create --kind turso');
+    });
+
+    it('renders the DB provisioning fix as a step list so command and env-var options are on separate lines', async () => {
+      writeBundle(`export {};`);
+      writeMetadata({ localPaths: [guardedDetection] });
+
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: false, managedEnvVarNames: [] });
+      const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
+      expect(Array.isArray(issue?.fix)).toBe(true);
+      const steps = issue?.fix as string[];
+      expect(steps[0]).toMatch(/mastra env db create/);
+      expect(steps[1]).toMatch(/^Or set TURSO_DATABASE_URL/);
     });
 
     it('attaches a create-managed-database autofix hint when the guard var maps to a provider', async () => {
@@ -339,7 +357,7 @@ describe('preflightBuildOutput', () => {
 
       const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
-      expect(issue?.fix).toContain('mastra env db create --kind neon');
+      expect(fixText(issue?.fix)).toContain('mastra env db create --kind neon');
     });
 
     it('falls back to a bare db create command for unmapped guard vars', async () => {
@@ -348,8 +366,8 @@ describe('preflightBuildOutput', () => {
 
       const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
-      expect(issue?.fix).toContain('mastra env db create');
-      expect(issue?.fix).not.toContain('--kind');
+      expect(fixText(issue?.fix)).toContain('mastra env db create');
+      expect(fixText(issue?.fix)).not.toContain('--kind');
     });
 
     it('scopes the db create command to the target environment when a slug is provided', async () => {
@@ -364,7 +382,7 @@ describe('preflightBuildOutput', () => {
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
       // Positional arg BEFORE the flag — `mastra env db create` accepts the
       // environment as an argument, not as `--env`.
-      expect(issue?.fix).toContain('mastra env db create production --kind turso');
+      expect(fixText(issue?.fix)).toContain('mastra env db create production --kind turso');
     });
 
     it('scopes the bare db create command too when a slug is provided', async () => {
@@ -373,8 +391,8 @@ describe('preflightBuildOutput', () => {
 
       const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true, environmentSlug: 'staging' });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
-      expect(issue?.fix).toContain('mastra env db create staging');
-      expect(issue?.fix).not.toContain('--kind');
+      expect(fixText(issue?.fix)).toContain('mastra env db create staging');
+      expect(fixText(issue?.fix)).not.toContain('--kind');
     });
 
     it('warns (not errors) on guarded misses when platform context lacks managedEnvVarNames (older platform)', async () => {
@@ -527,5 +545,35 @@ describe('printPreflightIssues', () => {
   it('returns ok for warnings-only under autoAccept', async () => {
     const result = await printPreflightIssues([warningIssue], { autoAccept: true });
     expect(result).toBe('ok');
+  });
+
+  it('renders a step-list fix as one arrow line per step', async () => {
+    // Reach in via the mocked module so we can inspect what was rendered.
+    const clack = await import('@clack/prompts');
+    const errorSpy = clack.log.error as unknown as ReturnType<typeof vi.fn>;
+    errorSpy.mockClear();
+
+    await printPreflightIssues(
+      [
+        {
+          code: 'LOCAL_STORAGE_PATH',
+          severity: 'error',
+          message: 'missing DB var',
+          fix: ['Run `mastra env db create production --kind turso`', 'Or set TURSO_DATABASE_URL in your env file'],
+        },
+      ],
+      { autoAccept: true },
+    );
+
+    // First call to log.error is the issue itself (subsequent call is the
+    // summary line). Ensure both step lines land with their own arrow.
+    // Strip ANSI so the assertion isn't coupled to picocolors styling.
+
+    const rendered = (errorSpy.mock.calls[0][0] as string).replace(/\x1b\[[0-9;]*m/g, '');
+    expect(rendered).toContain('→ Run `mastra env db create production --kind turso`');
+    expect(rendered).toContain('→ Or set TURSO_DATABASE_URL in your env file');
+    // And they must be on separate lines, not concatenated.
+    const arrowLines = rendered.split('\n').filter(l => l.includes('→'));
+    expect(arrowLines).toHaveLength(2);
   });
 });

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -360,14 +360,18 @@ describe('preflightBuildOutput', () => {
       expect(fixText(issue?.fix)).toContain('mastra env db create --kind neon');
     });
 
-    it('falls back to a bare db create command for unmapped guard vars', async () => {
+    it('omits `mastra env db create` from the remediation when the guard var maps to no known provider', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'MY_CUSTOM_DB_URL' }] });
 
       const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
-      expect(fixText(issue?.fix)).toContain('mastra env db create');
-      expect(fixText(issue?.fix)).not.toContain('--kind');
+      // Suggesting `mastra env db create` for an arbitrary user-defined var
+      // would tell users to spin up managed infra that can't inject their
+      // var — a real footgun, not a helpful fallback. The env-var path is
+      // the only actionable remediation here.
+      expect(fixText(issue?.fix)).not.toContain('mastra env db create');
+      expect(fixText(issue?.fix)).toContain('Set MY_CUSTOM_DB_URL');
     });
 
     it('scopes the db create command to the target environment when a slug is provided', async () => {
@@ -385,14 +389,15 @@ describe('preflightBuildOutput', () => {
       expect(fixText(issue?.fix)).toContain('mastra env db create production --kind turso');
     });
 
-    it('scopes the bare db create command too when a slug is provided', async () => {
+    it('does not emit a scoped bare db create command for unmapped guard vars either', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'MY_CUSTOM_DB_URL' }] });
 
+      // Even with an env slug in hand, we don't invent a `mastra env db create
+      // staging` remediation for a variable no known provider injects.
       const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true, environmentSlug: 'staging' });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
-      expect(fixText(issue?.fix)).toContain('mastra env db create staging');
-      expect(fixText(issue?.fix)).not.toContain('--kind');
+      expect(fixText(issue?.fix)).not.toContain('mastra env db create');
     });
 
     it('warns (not errors) on guarded misses when platform context lacks managedEnvVarNames (older platform)', async () => {

--- a/packages/cli/src/commands/deploy-preflight.test.ts
+++ b/packages/cli/src/commands/deploy-preflight.test.ts
@@ -374,14 +374,14 @@ describe('preflightBuildOutput', () => {
       expect(fixText(issue?.fix)).toContain('Set MY_CUSTOM_DB_URL');
     });
 
-    it('scopes the db create command to the target environment when a slug is provided', async () => {
+    it('scopes the db create command to the target environment when a name is provided', async () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [guardedDetection] });
 
       const issues = await preflightBuildOutput(
         tmpDir,
         {},
-        { hasEnvFile: false, managedEnvVarNames: [], environmentSlug: 'production' },
+        { hasEnvFile: false, managedEnvVarNames: [], environmentName: 'production' },
       );
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
       // Positional arg BEFORE the flag — `mastra env db create` accepts the
@@ -393,9 +393,9 @@ describe('preflightBuildOutput', () => {
       writeBundle(`export {};`);
       writeMetadata({ localPaths: [{ ...guardedDetection, guardedBy: 'MY_CUSTOM_DB_URL' }] });
 
-      // Even with an env slug in hand, we don't invent a `mastra env db create
+      // Even with an env name in hand, we don't invent a `mastra env db create
       // staging` remediation for a variable no known provider injects.
-      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true, environmentSlug: 'staging' });
+      const issues = await preflightBuildOutput(tmpDir, {}, { hasEnvFile: true, environmentName: 'staging' });
       const issue = issues.find(i => i.code === 'LOCAL_STORAGE_PATH');
       expect(fixText(issue?.fix)).not.toContain('mastra env db create');
     });

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
+import type { DatabaseKind } from './db/platform-api.js';
 import { DB_ENV_VAR_NAMES } from './db/platform-api.js';
 
 /* ------------------------------------------------------------------ */
@@ -12,11 +13,23 @@ import { DB_ENV_VAR_NAMES } from './db/platform-api.js';
 
 export type PreflightIssueCode = 'MISSING_ENV_VAR' | 'LOCAL_STORAGE_PATH';
 
+/**
+ * Structured hint describing how deploy can offer to auto-fix an issue
+ * before it becomes a blocking error. Consumed by
+ * `deploy/auto-provision-database.ts` when running in an interactive TTY.
+ */
+export type PreflightAutofix = {
+  kind: 'create-managed-database';
+  provider: DatabaseKind;
+  envVarName: string;
+};
+
 export interface PreflightIssue {
   code: PreflightIssueCode;
   severity: 'error' | 'warning';
   message: string;
   fix: string;
+  autofix?: PreflightAutofix;
 }
 
 /* ------------------------------------------------------------------ */
@@ -384,6 +397,21 @@ export function dbCreateCommandFor(envVarName: string): string {
   return 'mastra env db create';
 }
 
+/**
+ * If `envVarName` is injected by a known managed database provider, return
+ * the structured autofix hint deploy uses to offer inline provisioning.
+ * Returns undefined for env vars that don't map to a provider — those still
+ * get a text-only fix.
+ */
+export function dbAutofixFor(envVarName: string): PreflightAutofix | undefined {
+  for (const [kind, names] of Object.entries(DB_ENV_VAR_NAMES) as [DatabaseKind, string[]][]) {
+    if (names.includes(envVarName)) {
+      return { kind: 'create-managed-database', provider: kind, envVarName };
+    }
+  }
+  return undefined;
+}
+
 async function checkLocalStoragePaths(
   outputDir: string,
   metadata: PreflightMetadata | null,
@@ -456,6 +484,7 @@ async function checkLocalStoragePaths(
           severity: 'error',
           message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
           fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy)}`,
+          autofix: dbAutofixFor(d.guardedBy),
         });
       }
     } else if (hasEnvFile) {
@@ -464,6 +493,7 @@ async function checkLocalStoragePaths(
         severity: 'error',
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
         fix: `Set ${d.guardedBy} in your env file, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy)}. If the platform already injects it, re-run with --skip-preflight.`,
+        autofix: dbAutofixFor(d.guardedBy),
       });
     } else {
       issues.push({

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -28,7 +28,12 @@ export interface PreflightIssue {
   code: PreflightIssueCode;
   severity: 'error' | 'warning';
   message: string;
-  fix: string;
+  /**
+   * Remediation. A single string renders as one arrow line; an array renders
+   * as one arrow line per entry so multi-step fixes (run this command, OR set
+   * this env var) stay legible instead of collapsing into a wall of text.
+   */
+  fix: string | string[];
   autofix?: PreflightAutofix;
 }
 
@@ -241,12 +246,17 @@ export async function printPreflightIssues(
   const errors = issues.filter(i => i.severity === 'error');
   const warnings = issues.filter(i => i.severity === 'warning');
 
+  const renderFix = (fix: string | string[]): string => {
+    const steps = Array.isArray(fix) ? fix : [fix];
+    return steps.map(step => `  ${pc.dim('→')} ${step}`).join('\n');
+  };
+
   for (const issue of warnings) {
-    p.log.warn(`${pc.yellow(`[${issue.code}]`)} ${issue.message}\n  ${pc.dim('→')} ${issue.fix}`);
+    p.log.warn(`${pc.yellow(`[${issue.code}]`)} ${issue.message}\n${renderFix(issue.fix)}`);
   }
 
   for (const issue of errors) {
-    p.log.error(`${pc.red(`[${issue.code}]`)} ${issue.message}\n  ${pc.dim('→')} ${issue.fix}`);
+    p.log.error(`${pc.red(`[${issue.code}]`)} ${issue.message}\n${renderFix(issue.fix)}`);
   }
 
   if (errors.length > 0) {
@@ -499,7 +509,10 @@ async function checkLocalStoragePaths(
           code: 'LOCAL_STORAGE_PATH',
           severity: 'error',
           message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy, environmentSlug)}`,
+          fix: [
+            `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
+            `Or set ${d.guardedBy} in your env file or the environment's stored vars`,
+          ],
           autofix: dbAutofixFor(d.guardedBy),
         });
       }
@@ -508,7 +521,11 @@ async function checkLocalStoragePaths(
         code: 'LOCAL_STORAGE_PATH',
         severity: 'error',
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-        fix: `Set ${d.guardedBy} in your env file, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy, environmentSlug)}. If the platform already injects it, re-run with --skip-preflight.`,
+        fix: [
+          `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
+          `Or set ${d.guardedBy} in your env file`,
+          `If the platform already injects it, re-run with --skip-preflight`,
+        ],
         autofix: dbAutofixFor(d.guardedBy),
       });
     } else {

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -154,9 +154,16 @@ export async function preflightBuildOutput(
      *   severity falls back to `hasEnvFile`.
      */
     managedEnvVarNames?: string[] | null;
+    /**
+     * Slug of the environment being deployed to. Threaded into remediation
+     * text so `mastra env db create <slug> --kind ...` is copy-pasteable in
+     * non-interactive shells (CI), where the plain form errors when multiple
+     * environments exist. Omit for lint / studio contexts.
+     */
+    environmentSlug?: string;
   } = {},
 ): Promise<PreflightIssue[]> {
-  const { hasEnvFile = true, managedEnvVarNames } = options;
+  const { hasEnvFile = true, managedEnvVarNames, environmentSlug } = options;
   const outputDir = join(targetDir, '.mastra', 'output');
   const entryPath = join(outputDir, 'index.mjs');
 
@@ -188,7 +195,9 @@ export async function preflightBuildOutput(
   // plugin `mastra-local-storage-detector` runs during bundling and only
   // reports paths from user modules (not node_modules) that survived
   // tree-shaking, so library examples are structurally excluded.
-  issues.push(...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile, managedEnvVarNames)));
+  issues.push(
+    ...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile, managedEnvVarNames, environmentSlug)),
+  );
 
   return issues;
 }
@@ -390,11 +399,17 @@ async function readPreflightMetadata(outputDir: string): Promise<PreflightMetada
  * when the guarded var maps to a known provider (issue 35-B: the remediation
  * previously said "attach a managed database" without ever naming the command).
  */
-export function dbCreateCommandFor(envVarName: string): string {
+export function dbCreateCommandFor(envVarName: string, environmentSlug?: string): string {
+  // env slug goes BEFORE flags because it's a positional argument on
+  // `mastra env db create`, not a flag. Scoping to the target environment
+  // matters after 8816f47: `mastra env db create` with no arg errors in
+  // non-interactive shells when multiple environments exist, which is
+  // exactly where preflight failures land (CI).
+  const envArg = environmentSlug ? ` ${environmentSlug}` : '';
   for (const [kind, names] of Object.entries(DB_ENV_VAR_NAMES)) {
-    if (names.includes(envVarName)) return `mastra env db create --kind ${kind}`;
+    if (names.includes(envVarName)) return `mastra env db create${envArg} --kind ${kind}`;
   }
-  return 'mastra env db create';
+  return `mastra env db create${envArg}`;
 }
 
 /**
@@ -418,6 +433,7 @@ async function checkLocalStoragePaths(
   envVars: Record<string, string>,
   hasEnvFile: boolean,
   managedEnvVarNames?: string[] | null,
+  environmentSlug?: string,
 ): Promise<PreflightIssue[]> {
   let detections: LocalStorageDetection[];
   if (metadata) {
@@ -483,7 +499,7 @@ async function checkLocalStoragePaths(
           code: 'LOCAL_STORAGE_PATH',
           severity: 'error',
           message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy)}`,
+          fix: `Set ${d.guardedBy} in your env file or the environment's stored vars, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy, environmentSlug)}`,
           autofix: dbAutofixFor(d.guardedBy),
         });
       }
@@ -492,7 +508,7 @@ async function checkLocalStoragePaths(
         code: 'LOCAL_STORAGE_PATH',
         severity: 'error',
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-        fix: `Set ${d.guardedBy} in your env file, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy)}. If the platform already injects it, re-run with --skip-preflight.`,
+        fix: `Set ${d.guardedBy} in your env file, or create a managed database that provides it: ${dbCreateCommandFor(d.guardedBy, environmentSlug)}. If the platform already injects it, re-run with --skip-preflight.`,
         autofix: dbAutofixFor(d.guardedBy),
       });
     } else {

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -505,28 +505,41 @@ async function checkLocalStoragePaths(
         // Full env picture: local env file + stored vars + managed names.
         // The guard var is genuinely absent, so the local fallback WILL be
         // used at runtime — trustworthy hard error.
+        const autofix = dbAutofixFor(d.guardedBy);
+        // Only recommend `mastra env db create` when we recognize the guard
+        // var as belonging to a managed provider we can actually provision.
+        // Suggesting the command for arbitrary vars (e.g. MY_CUSTOM_DB_URL)
+        // would tell users to spin up infra that can't inject their var.
+        const envVarFix = `Set ${d.guardedBy} in your env file or the environment's stored vars`;
         issues.push({
           code: 'LOCAL_STORAGE_PATH',
           severity: 'error',
           message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-          fix: [
-            `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
-            `Or set ${d.guardedBy} in your env file or the environment's stored vars`,
-          ],
-          autofix: dbAutofixFor(d.guardedBy),
+          fix: autofix
+            ? [
+                `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
+                `Or ${envVarFix.charAt(0).toLowerCase()}${envVarFix.slice(1)}`,
+              ]
+            : envVarFix,
+          autofix,
         });
       }
     } else if (hasEnvFile) {
+      const autofix = dbAutofixFor(d.guardedBy);
+      const envVarFix = `Set ${d.guardedBy} in your env file`;
+      const platformFix = `If the platform already injects it, re-run with --skip-preflight`;
       issues.push({
         code: 'LOCAL_STORAGE_PATH',
         severity: 'error',
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
-        fix: [
-          `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
-          `Or set ${d.guardedBy} in your env file`,
-          `If the platform already injects it, re-run with --skip-preflight`,
-        ],
-        autofix: dbAutofixFor(d.guardedBy),
+        fix: autofix
+          ? [
+              `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
+              `Or ${envVarFix.charAt(0).toLowerCase()}${envVarFix.slice(1)}`,
+              platformFix,
+            ]
+          : [envVarFix, platformFix],
+        autofix,
       });
     } else {
       issues.push({

--- a/packages/cli/src/commands/deploy-preflight.ts
+++ b/packages/cli/src/commands/deploy-preflight.ts
@@ -160,15 +160,19 @@ export async function preflightBuildOutput(
      */
     managedEnvVarNames?: string[] | null;
     /**
-     * Slug of the environment being deployed to. Threaded into remediation
-     * text so `mastra env db create <slug> --kind ...` is copy-pasteable in
-     * non-interactive shells (CI), where the plain form errors when multiple
-     * environments exist. Omit for lint / studio contexts.
+     * User-facing name of the environment being deployed to (`production`,
+     * `staging`, etc.) — threaded into remediation text so the printed
+     * `mastra env db create <env> --kind ...` reads like a command a human
+     * would type. NOT the slug: on some platforms the production env's slug
+     * is derived from the project name (e.g. `my-app-xyz-1234`), which the
+     * platform's env-resolver accepts but is jarring to see printed back.
+     * The env-resolver accepts id, name, or slug, so name is safe.
+     * Omit for lint / studio contexts.
      */
-    environmentSlug?: string;
+    environmentName?: string;
   } = {},
 ): Promise<PreflightIssue[]> {
-  const { hasEnvFile = true, managedEnvVarNames, environmentSlug } = options;
+  const { hasEnvFile = true, managedEnvVarNames, environmentName } = options;
   const outputDir = join(targetDir, '.mastra', 'output');
   const entryPath = join(outputDir, 'index.mjs');
 
@@ -201,7 +205,7 @@ export async function preflightBuildOutput(
   // reports paths from user modules (not node_modules) that survived
   // tree-shaking, so library examples are structurally excluded.
   issues.push(
-    ...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile, managedEnvVarNames, environmentSlug)),
+    ...(await checkLocalStoragePaths(outputDir, metadata, envVars, hasEnvFile, managedEnvVarNames, environmentName)),
   );
 
   return issues;
@@ -409,13 +413,20 @@ async function readPreflightMetadata(outputDir: string): Promise<PreflightMetada
  * when the guarded var maps to a known provider (issue 35-B: the remediation
  * previously said "attach a managed database" without ever naming the command).
  */
-export function dbCreateCommandFor(envVarName: string, environmentSlug?: string): string {
-  // env slug goes BEFORE flags because it's a positional argument on
+export function dbCreateCommandFor(envVarName: string, environmentName?: string): string {
+  // env name goes BEFORE flags because it's a positional argument on
   // `mastra env db create`, not a flag. Scoping to the target environment
   // matters after 8816f47: `mastra env db create` with no arg errors in
   // non-interactive shells when multiple environments exist, which is
   // exactly where preflight failures land (CI).
-  const envArg = environmentSlug ? ` ${environmentSlug}` : '';
+  //
+  // We use the environment NAME (`production`, `staging`), not the platform
+  // slug. On some platforms the production env's slug is derived from the
+  // project name (e.g. `my-app-xyz-1234`) — technically accepted by the
+  // env-resolver (which matches id | name | slug), but jarring to see
+  // printed back and awkward to type. The name is what the user thinks of
+  // as the environment identifier, so that's what we print.
+  const envArg = environmentName ? ` ${environmentName}` : '';
   for (const [kind, names] of Object.entries(DB_ENV_VAR_NAMES)) {
     if (names.includes(envVarName)) return `mastra env db create${envArg} --kind ${kind}`;
   }
@@ -443,7 +454,7 @@ async function checkLocalStoragePaths(
   envVars: Record<string, string>,
   hasEnvFile: boolean,
   managedEnvVarNames?: string[] | null,
-  environmentSlug?: string,
+  environmentName?: string,
 ): Promise<PreflightIssue[]> {
   let detections: LocalStorageDetection[];
   if (metadata) {
@@ -517,7 +528,7 @@ async function checkLocalStoragePaths(
           message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
           fix: autofix
             ? [
-                `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
+                `Run \`${dbCreateCommandFor(d.guardedBy, environmentName)}\` to attach a managed database`,
                 `Or ${envVarFix.charAt(0).toLowerCase()}${envVarFix.slice(1)}`,
               ]
             : envVarFix,
@@ -534,7 +545,7 @@ async function checkLocalStoragePaths(
         message: `${truncate(d.value, 80)} will be used at runtime because ${d.guardedBy} is not set (${d.hint})`,
         fix: autofix
           ? [
-              `Run \`${dbCreateCommandFor(d.guardedBy, environmentSlug)}\` to attach a managed database`,
+              `Run \`${dbCreateCommandFor(d.guardedBy, environmentName)}\` to attach a managed database`,
               `Or ${envVarFix.charAt(0).toLowerCase()}${envVarFix.slice(1)}`,
               platformFix,
             ]

--- a/packages/cli/src/commands/deploy/auto-provision-database.test.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.test.ts
@@ -47,7 +47,7 @@ function makeCtx(overrides: Partial<AutoProvisionContext> = {}): AutoProvisionCo
     projectId: 'proj-1',
     projectName: 'My App',
     projectSlug: 'my-app',
-    environment: { id: 'env-prod', slug: 'my-app-production', name: 'production' },
+    environment: { id: 'env-prod', slug: 'my-app-production', name: 'production', type: 'production' },
     autoAccept: false,
     ...overrides,
   };
@@ -233,7 +233,7 @@ describe('maybeAutoProvisionDatabases', () => {
 
     await maybeAutoProvisionDatabases(
       [tursoIssue()],
-      makeCtx({ environment: { id: 'env-stg', slug: 'stg', name: 'staging' } }),
+      makeCtx({ environment: { id: 'env-stg', slug: 'stg', name: 'staging', type: 'staging' } }),
     );
 
     expect(attachDatabaseMock).toHaveBeenCalledWith(
@@ -251,7 +251,7 @@ describe('maybeAutoProvisionDatabases', () => {
 
     await maybeAutoProvisionDatabases(
       [tursoIssue()],
-      makeCtx({ environment: { id: 'env-eu', slug: 'my-app--eu', name: 'eu' } }),
+      makeCtx({ environment: { id: 'env-eu', slug: 'my-app--eu', name: 'eu', type: 'preview' } }),
     );
 
     expect(attachDatabaseMock).toHaveBeenCalledWith(
@@ -269,7 +269,7 @@ describe('maybeAutoProvisionDatabases', () => {
 
     await maybeAutoProvisionDatabases(
       [tursoIssue()],
-      makeCtx({ environment: { id: 'env-prod', slug: 'my-app', name: 'production' } }),
+      makeCtx({ environment: { id: 'env-prod', slug: 'my-app', name: 'production', type: 'production' } }),
     );
 
     expect(attachDatabaseMock).toHaveBeenCalledWith(

--- a/packages/cli/src/commands/deploy/auto-provision-database.test.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.test.ts
@@ -1,0 +1,243 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as DbPlatformApi from '../db/platform-api.js';
+import type { PreflightIssue } from '../deploy-preflight.js';
+import type { AutoProvisionContext } from './auto-provision-database.js';
+import { maybeAutoProvisionDatabases } from './auto-provision-database.js';
+
+const {
+  confirmMock,
+  cancelMock,
+  logErrorMock,
+  logSuccessMock,
+  spinnerMock,
+  attachDatabaseMock,
+  pollDatabaseUntilReadyMock,
+} = vi.hoisted(() => ({
+  confirmMock: vi.fn(),
+  cancelMock: vi.fn(),
+  logErrorMock: vi.fn(),
+  logSuccessMock: vi.fn(),
+  spinnerMock: { start: vi.fn(), stop: vi.fn(), message: vi.fn() },
+  attachDatabaseMock: vi.fn(),
+  pollDatabaseUntilReadyMock: vi.fn(),
+}));
+
+vi.mock('@clack/prompts', () => ({
+  confirm: (args: unknown) => confirmMock(args),
+  cancel: (args: unknown) => cancelMock(args),
+  isCancel: (v: unknown) => v === Symbol.for('clack.cancel'),
+  spinner: () => spinnerMock,
+  log: { error: logErrorMock, success: logSuccessMock },
+}));
+
+vi.mock('../db/platform-api.js', async () => {
+  const actual = await vi.importActual<typeof DbPlatformApi>('../db/platform-api.js');
+  return {
+    ...actual,
+    attachDatabase: (...args: unknown[]) => attachDatabaseMock(...args),
+    pollDatabaseUntilReady: (...args: unknown[]) => pollDatabaseUntilReadyMock(...args),
+  };
+});
+
+function makeCtx(overrides: Partial<AutoProvisionContext> = {}): AutoProvisionContext {
+  return {
+    token: 't',
+    orgId: 'org-1',
+    projectId: 'proj-1',
+    projectName: 'My App',
+    projectSlug: 'my-app',
+    environment: { id: 'env-prod', slug: 'my-app-production' },
+    autoAccept: false,
+    ...overrides,
+  };
+}
+
+function tursoIssue(overrides: Partial<PreflightIssue> = {}): PreflightIssue {
+  return {
+    code: 'LOCAL_STORAGE_PATH',
+    severity: 'error',
+    message: 'file:./mastra.db will be used at runtime because TURSO_DATABASE_URL is not set',
+    fix: 'create a managed database that provides it: mastra env db create --kind turso',
+    autofix: { kind: 'create-managed-database', provider: 'turso', envVarName: 'TURSO_DATABASE_URL' },
+    ...overrides,
+  };
+}
+
+function neonIssue(overrides: Partial<PreflightIssue> = {}): PreflightIssue {
+  return {
+    code: 'LOCAL_STORAGE_PATH',
+    severity: 'error',
+    message: 'file:./data.db will be used at runtime because DATABASE_URL is not set',
+    fix: 'mastra env db create --kind neon',
+    autofix: { kind: 'create-managed-database', provider: 'neon', envVarName: 'DATABASE_URL' },
+    ...overrides,
+  };
+}
+
+function unrelatedIssue(): PreflightIssue {
+  return {
+    code: 'MISSING_ENV_VAR',
+    severity: 'error',
+    message: 'ANTHROPIC_API_KEY is missing',
+    fix: 'set it',
+  };
+}
+
+describe('maybeAutoProvisionDatabases', () => {
+  const originalStdinTTY = process.stdin.isTTY;
+  const originalStdoutTTY = process.stdout.isTTY;
+  const originalCI = process.env.CI;
+
+  beforeEach(() => {
+    confirmMock.mockReset();
+    cancelMock.mockReset();
+    logErrorMock.mockReset();
+    logSuccessMock.mockReset();
+    spinnerMock.start.mockReset();
+    spinnerMock.stop.mockReset();
+    spinnerMock.message.mockReset();
+    attachDatabaseMock.mockReset();
+    pollDatabaseUntilReadyMock.mockReset();
+    // Default: interactive TTY.
+    (process.stdin as unknown as { isTTY: boolean }).isTTY = true;
+    (process.stdout as unknown as { isTTY: boolean }).isTTY = true;
+    delete process.env.CI;
+  });
+
+  afterEach(() => {
+    (process.stdin as unknown as { isTTY: boolean | undefined }).isTTY = originalStdinTTY;
+    (process.stdout as unknown as { isTTY: boolean | undefined }).isTTY = originalStdoutTTY;
+    if (originalCI === undefined) {
+      delete process.env.CI;
+    } else {
+      process.env.CI = originalCI;
+    }
+  });
+
+  it('returns the input untouched when there are no autofixable issues', async () => {
+    const issues = [unrelatedIssue()];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx());
+
+    expect(result.issues).toBe(issues);
+    expect(result.provisioned).toEqual([]);
+    expect(result.newlyManagedEnvVarNames).toEqual([]);
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(attachDatabaseMock).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt in a non-interactive terminal even if issues are autofixable', async () => {
+    (process.stdin as unknown as { isTTY: boolean }).isTTY = false;
+
+    const issues = [tursoIssue()];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx());
+
+    expect(result.issues).toBe(issues);
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(attachDatabaseMock).not.toHaveBeenCalled();
+  });
+
+  it('does not prompt when autoAccept is set (no silent infra creation)', async () => {
+    const issues = [tursoIssue()];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx({ autoAccept: true }));
+
+    expect(result.issues).toBe(issues);
+    expect(confirmMock).not.toHaveBeenCalled();
+    expect(attachDatabaseMock).not.toHaveBeenCalled();
+  });
+
+  it('provisions when the user confirms, drops the resolved issue, and reports the injected vars', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+    pollDatabaseUntilReadyMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+
+    const issues = [tursoIssue(), unrelatedIssue()];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx());
+
+    expect(attachDatabaseMock).toHaveBeenCalledWith('t', 'org-1', 'proj-1', {
+      kind: 'turso',
+      name: 'my-app-db',
+      environmentId: 'env-prod',
+    });
+    expect(pollDatabaseUntilReadyMock).toHaveBeenCalled();
+    expect(result.issues.map(i => i.code)).toEqual(['MISSING_ENV_VAR']);
+    expect(result.provisioned).toHaveLength(1);
+    expect(result.newlyManagedEnvVarNames).toEqual(['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN']);
+  });
+
+  it('leaves the issue in place when the user declines', async () => {
+    confirmMock.mockResolvedValue(false);
+
+    const issues = [tursoIssue()];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx());
+
+    expect(attachDatabaseMock).not.toHaveBeenCalled();
+    expect(result.issues).toBe(issues);
+    expect(result.provisioned).toEqual([]);
+  });
+
+  it('deduplicates prompts to one per provider (turso needs both URL and TOKEN)', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+    pollDatabaseUntilReadyMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+
+    const issues = [
+      tursoIssue({ autofix: { kind: 'create-managed-database', provider: 'turso', envVarName: 'TURSO_DATABASE_URL' } }),
+      tursoIssue({ autofix: { kind: 'create-managed-database', provider: 'turso', envVarName: 'TURSO_AUTH_TOKEN' } }),
+    ];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx());
+
+    expect(confirmMock).toHaveBeenCalledTimes(1);
+    expect(attachDatabaseMock).toHaveBeenCalledTimes(1);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('prompts once per distinct provider when multiple providers are missing', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock
+      .mockResolvedValueOnce({ id: 'db-1', name: 'my-app-db', kind: 'turso' })
+      .mockResolvedValueOnce({ id: 'db-2', name: 'my-app-db', kind: 'neon' });
+    pollDatabaseUntilReadyMock
+      .mockResolvedValueOnce({ id: 'db-1', name: 'my-app-db', kind: 'turso' })
+      .mockResolvedValueOnce({ id: 'db-2', name: 'my-app-db', kind: 'neon' });
+
+    const result = await maybeAutoProvisionDatabases([tursoIssue(), neonIssue()], makeCtx());
+
+    expect(confirmMock).toHaveBeenCalledTimes(2);
+    expect(attachDatabaseMock).toHaveBeenCalledTimes(2);
+    expect(result.provisioned.map(d => d.kind)).toEqual(['turso', 'neon']);
+    expect(result.newlyManagedEnvVarNames).toEqual(['TURSO_DATABASE_URL', 'TURSO_AUTH_TOKEN', 'DATABASE_URL']);
+    expect(result.issues).toEqual([]);
+  });
+
+  it('surfaces provisioning failures as log.error and leaves the issue in place', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock.mockRejectedValue(new Error('quota exceeded'));
+
+    const issues = [tursoIssue()];
+    const result = await maybeAutoProvisionDatabases(issues, makeCtx());
+
+    expect(logErrorMock).toHaveBeenCalled();
+    expect(String(logErrorMock.mock.calls[0]![0])).toContain('quota exceeded');
+    // Issue is still there, so the caller's error printer will show
+    // `mastra env db create --kind turso` remediation.
+    expect(result.issues).toBe(issues);
+    expect(result.provisioned).toEqual([]);
+    expect(result.newlyManagedEnvVarNames).toEqual([]);
+  });
+
+  it('attaches to the target environment (scoped, not project-shared)', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+    pollDatabaseUntilReadyMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+
+    await maybeAutoProvisionDatabases([tursoIssue()], makeCtx({ environment: { id: 'env-stg', slug: 'stg' } }));
+
+    expect(attachDatabaseMock).toHaveBeenCalledWith(
+      't',
+      'org-1',
+      'proj-1',
+      expect.objectContaining({ environmentId: 'env-stg' }),
+    );
+  });
+});

--- a/packages/cli/src/commands/deploy/auto-provision-database.test.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.test.ts
@@ -47,7 +47,7 @@ function makeCtx(overrides: Partial<AutoProvisionContext> = {}): AutoProvisionCo
     projectId: 'proj-1',
     projectName: 'My App',
     projectSlug: 'my-app',
-    environment: { id: 'env-prod', slug: 'my-app-production' },
+    environment: { id: 'env-prod', slug: 'my-app-production', name: 'production' },
     autoAccept: false,
     ...overrides,
   };
@@ -231,13 +231,52 @@ describe('maybeAutoProvisionDatabases', () => {
     attachDatabaseMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
     pollDatabaseUntilReadyMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
 
-    await maybeAutoProvisionDatabases([tursoIssue()], makeCtx({ environment: { id: 'env-stg', slug: 'stg' } }));
+    await maybeAutoProvisionDatabases(
+      [tursoIssue()],
+      makeCtx({ environment: { id: 'env-stg', slug: 'stg', name: 'staging' } }),
+    );
 
     expect(attachDatabaseMock).toHaveBeenCalledWith(
       't',
       'org-1',
       'proj-1',
       expect.objectContaining({ environmentId: 'env-stg' }),
+    );
+  });
+
+  it('derives an env-suffixed default name for non-production environments', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock.mockResolvedValue({ id: 'db-1', name: 'my-app-eu-db', kind: 'turso' });
+    pollDatabaseUntilReadyMock.mockResolvedValue({ id: 'db-1', name: 'my-app-eu-db', kind: 'turso' });
+
+    await maybeAutoProvisionDatabases(
+      [tursoIssue()],
+      makeCtx({ environment: { id: 'env-eu', slug: 'my-app--eu', name: 'eu' } }),
+    );
+
+    expect(attachDatabaseMock).toHaveBeenCalledWith(
+      't',
+      'org-1',
+      'proj-1',
+      expect.objectContaining({ name: 'my-app-eu-db' }),
+    );
+  });
+
+  it('keeps the canonical unsuffixed name for the production environment', async () => {
+    confirmMock.mockResolvedValue(true);
+    attachDatabaseMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+    pollDatabaseUntilReadyMock.mockResolvedValue({ id: 'db-1', name: 'my-app-db', kind: 'turso' });
+
+    await maybeAutoProvisionDatabases(
+      [tursoIssue()],
+      makeCtx({ environment: { id: 'env-prod', slug: 'my-app', name: 'production' } }),
+    );
+
+    expect(attachDatabaseMock).toHaveBeenCalledWith(
+      't',
+      'org-1',
+      'proj-1',
+      expect.objectContaining({ name: 'my-app-db' }),
     );
   });
 });

--- a/packages/cli/src/commands/deploy/auto-provision-database.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.ts
@@ -31,7 +31,7 @@ export interface AutoProvisionContext {
   projectName: string;
   /** Project slug, used to derive a default database name. */
   projectSlug: string | null;
-  environment: Pick<Environment, 'id' | 'slug' | 'name'>;
+  environment: Pick<Environment, 'id' | 'slug' | 'name' | 'type'>;
   /**
    * Skip the auto-provision flow entirely (`--yes` / `--auto-accept`). We
    * treat "accept all defaults" as "don't prompt me for infrastructure
@@ -137,7 +137,7 @@ export async function maybeAutoProvisionDatabases(
 async function provisionOne(ctx: AutoProvisionContext, provider: DatabaseKind): Promise<ProjectDatabase> {
   const name = defaultDatabaseName(
     { name: ctx.projectName, slug: ctx.projectSlug },
-    { name: ctx.environment.name, slug: ctx.environment.slug },
+    { name: ctx.environment.name, slug: ctx.environment.slug, type: ctx.environment.type },
   );
   const created = await attachDatabase(ctx.token, ctx.orgId, ctx.projectId, {
     kind: provider,

--- a/packages/cli/src/commands/deploy/auto-provision-database.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.ts
@@ -31,7 +31,7 @@ export interface AutoProvisionContext {
   projectName: string;
   /** Project slug, used to derive a default database name. */
   projectSlug: string | null;
-  environment: Pick<Environment, 'id' | 'slug'>;
+  environment: Pick<Environment, 'id' | 'slug' | 'name'>;
   /**
    * Skip the auto-provision flow entirely (`--yes` / `--auto-accept`). We
    * treat "accept all defaults" as "don't prompt me for infrastructure
@@ -135,7 +135,10 @@ export async function maybeAutoProvisionDatabases(
 }
 
 async function provisionOne(ctx: AutoProvisionContext, provider: DatabaseKind): Promise<ProjectDatabase> {
-  const name = defaultDatabaseName({ name: ctx.projectName, slug: ctx.projectSlug });
+  const name = defaultDatabaseName(
+    { name: ctx.projectName, slug: ctx.projectSlug },
+    { name: ctx.environment.name, slug: ctx.environment.slug },
+  );
   const created = await attachDatabase(ctx.token, ctx.orgId, ctx.projectId, {
     kind: provider,
     name,

--- a/packages/cli/src/commands/deploy/auto-provision-database.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.ts
@@ -32,7 +32,13 @@ export interface AutoProvisionContext {
   /** Project slug, used to derive a default database name. */
   projectSlug: string | null;
   environment: Pick<Environment, 'id' | 'slug'>;
-  /** Disables prompting (`--yes` / `--auto-accept`). Provisioning still runs. */
+  /**
+   * Skip the auto-provision flow entirely (`--yes` / `--auto-accept`). We
+   * treat "accept all defaults" as "don't prompt me for infrastructure
+   * creation" — auto-accept should never silently spin up managed
+   * resources. Users who want provisioning in CI should run
+   * `mastra env db create` in a separate step.
+   */
   autoAccept: boolean;
 }
 

--- a/packages/cli/src/commands/deploy/auto-provision-database.ts
+++ b/packages/cli/src/commands/deploy/auto-provision-database.ts
@@ -1,0 +1,151 @@
+/**
+ * Deploy-time auto-provision hook.
+ *
+ * When preflight detects that a required database env var will be missing at
+ * runtime (`TURSO_DATABASE_URL`, `DATABASE_URL`, …), deploy would normally
+ * error out and tell the user to run `mastra env db create`. That's an extra
+ * command, an extra CLI cycle, and a papercut on top of an otherwise happy
+ * deploy.
+ *
+ * Instead, this module inspects preflight issues with a
+ * `create-managed-database` autofix hint, asks the user once per provider
+ * whether they want to attach a managed database now, and — if they say yes —
+ * runs the attach + poll inline. Successfully-provisioned providers are
+ * dropped from the issue list and their injected env var names are added to
+ * `managedEnvVarNames`, so the caller can hand the survivors to
+ * `printPreflightIssues` and let deploy continue.
+ */
+
+import * as p from '@clack/prompts';
+import { defaultDatabaseName } from '../db/db.js';
+import type { DatabaseKind, ProjectDatabase } from '../db/platform-api.js';
+import { attachDatabase, DB_ENV_VAR_NAMES, pollDatabaseUntilReady } from '../db/platform-api.js';
+import type { PreflightAutofix, PreflightIssue } from '../deploy-preflight.js';
+import type { Environment } from '../env/platform-api.js';
+
+export interface AutoProvisionContext {
+  token: string;
+  orgId: string;
+  projectId: string;
+  /** Human-readable project name, used to derive a default database name. */
+  projectName: string;
+  /** Project slug, used to derive a default database name. */
+  projectSlug: string | null;
+  environment: Pick<Environment, 'id' | 'slug'>;
+  /** Disables prompting (`--yes` / `--auto-accept`). Provisioning still runs. */
+  autoAccept: boolean;
+}
+
+export interface AutoProvisionResult {
+  /** Issues left after successful provisioning (unfixed ones passed through). */
+  issues: PreflightIssue[];
+  /** Env var names newly injected by databases we just attached. */
+  newlyManagedEnvVarNames: string[];
+  /** Databases we attached in this run (for later summaries). */
+  provisioned: ProjectDatabase[];
+}
+
+function isInteractive(): boolean {
+  return Boolean(process.stdin.isTTY && process.stdout.isTTY) && !process.env.CI;
+}
+
+function collectAutofixes(issues: PreflightIssue[]): Map<DatabaseKind, PreflightAutofix[]> {
+  const byProvider = new Map<DatabaseKind, PreflightAutofix[]>();
+  for (const issue of issues) {
+    const fix = issue.autofix;
+    if (!fix || fix.kind !== 'create-managed-database') continue;
+    const bucket = byProvider.get(fix.provider) ?? [];
+    bucket.push(fix);
+    byProvider.set(fix.provider, bucket);
+  }
+  return byProvider;
+}
+
+/**
+ * If preflight surfaced blocking issues we know how to auto-fix (missing
+ * managed database env vars), offer to fix them inline. Non-interactive
+ * callers get the original issues back untouched — the caller is expected to
+ * fall through to `printPreflightIssues`, which will still print the exact
+ * `mastra env db create` command in the error text.
+ */
+export async function maybeAutoProvisionDatabases(
+  issues: PreflightIssue[],
+  ctx: AutoProvisionContext,
+): Promise<AutoProvisionResult> {
+  const untouched: AutoProvisionResult = {
+    issues,
+    newlyManagedEnvVarNames: [],
+    provisioned: [],
+  };
+
+  const grouped = collectAutofixes(issues);
+  if (grouped.size === 0) return untouched;
+
+  // Prompting requires a TTY; --yes should not silently create infra without
+  // an explicit yes to a specific provider.
+  if (!isInteractive() || ctx.autoAccept) return untouched;
+
+  const resolved = new Set<PreflightAutofix>();
+  const newlyManaged: string[] = [];
+  const provisioned: ProjectDatabase[] = [];
+
+  for (const [provider, fixes] of grouped) {
+    const uniqueVars = [...new Set(fixes.map(f => f.envVarName))].join(', ');
+    const confirm = await p.confirm({
+      message:
+        `Preflight needs ${uniqueVars} for the ${ctx.environment.slug} environment. ` +
+        `Create a managed ${provider} database now and attach it?`,
+      initialValue: true,
+    });
+
+    if (p.isCancel(confirm)) {
+      p.cancel('Deploy cancelled.');
+      process.exit(0);
+    }
+    if (!confirm) continue;
+
+    try {
+      const created = await provisionOne(ctx, provider);
+      provisioned.push(created);
+      const injected = DB_ENV_VAR_NAMES[provider] ?? [];
+      newlyManaged.push(...injected);
+      for (const fix of fixes) resolved.add(fix);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      p.log.error(`Failed to attach a ${provider} database: ${message}`);
+      // Leave the fixes in the issue list — the normal error printer will
+      // show the exact `mastra env db create` command as remediation.
+    }
+  }
+
+  if (resolved.size === 0) return untouched;
+
+  const remaining = issues.filter(issue => !issue.autofix || !resolved.has(issue.autofix));
+  return {
+    issues: remaining,
+    newlyManagedEnvVarNames: newlyManaged,
+    provisioned,
+  };
+}
+
+async function provisionOne(ctx: AutoProvisionContext, provider: DatabaseKind): Promise<ProjectDatabase> {
+  const name = defaultDatabaseName({ name: ctx.projectName, slug: ctx.projectSlug });
+  const created = await attachDatabase(ctx.token, ctx.orgId, ctx.projectId, {
+    kind: provider,
+    name,
+    environmentId: ctx.environment.id,
+  });
+
+  const spinner = p.spinner();
+  spinner.start(`Provisioning ${provider} database "${created.name}"...`);
+  try {
+    const ready = await pollDatabaseUntilReady(ctx.token, ctx.orgId, ctx.projectId, created.id, {
+      onStatus: status => spinner.message(`Provisioning ${provider} database "${created.name}" — ${status}`),
+    });
+    spinner.stop(`Database "${ready.name}" is ready and attached to ${ctx.environment.slug}.`);
+    return ready;
+  } catch (error) {
+    spinner.stop('Provisioning failed.');
+    throw error;
+  }
+}

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -32,6 +32,7 @@ import type { Environment } from '../env/platform-api.js';
 import { getDeployEnvFiles, loadDeployEnvFromDotenv, readEnvVars, getMastraVersion } from '../studio/deploy.js';
 import { createProject } from '../studio/platform-api.js';
 import { getProjectConfigToSave, loadProjectConfig, saveProjectConfig } from '../studio/project-config.js';
+import { maybeAutoProvisionDatabases } from './auto-provision-database.js';
 import { getOverwrittenEnvKeys } from './env-vars.js';
 import { assertDeployDir } from './validate-dir.js';
 
@@ -802,13 +803,33 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
   // stored vars (request wins), so platform-stored vars don't false-alarm.
   if (!skipPreflight) {
     const preflightEnv = mergePreflightEnvVars(environment.envVars, envVars);
-    const issues = await preflightBuildOutput(targetDir, preflightEnv, {
+    let issues = await preflightBuildOutput(targetDir, preflightEnv, {
       hasEnvFile: hasAmbientEnvFile,
       // Managed resources (e.g. attached databases) inject vars at deploy
       // time; the platform exposes their names on the environment. Absent
       // field = older platform = incomplete env picture (soften to warnings).
       managedEnvVarNames: environment.managedEnvVarNames ?? null,
     });
+
+    // If preflight flagged a blocking issue that a managed database would
+    // fix (e.g. TURSO_DATABASE_URL missing), offer to attach one inline
+    // rather than failing the deploy and asking the user to run
+    // `mastra env db create` themselves.
+    const autoProvisioned = await maybeAutoProvisionDatabases(issues, {
+      token,
+      orgId,
+      projectId,
+      projectName,
+      projectSlug,
+      environment: { id: environment.id, slug: environment.slug },
+      autoAccept,
+    });
+    issues = autoProvisioned.issues;
+    if (autoProvisioned.provisioned.length > 0) {
+      const attached = autoProvisioned.provisioned.map(d => `${d.name} (${d.kind})`).join(', ');
+      p.log.success(`Attached managed database: ${attached}`);
+    }
+
     const outcome = await printPreflightIssues(issues, { autoAccept });
     if (outcome === 'blocked') {
       p.cancel('Deploy blocked by preflight errors.');

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -830,7 +830,7 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
       projectId,
       projectName,
       projectSlug,
-      environment: { id: environment.id, slug: environment.slug },
+      environment: { id: environment.id, slug: environment.slug, name: environment.name },
       autoAccept,
     });
     if (autoProvisioned.provisioned.length > 0) {

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -833,10 +833,28 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
       environment: { id: environment.id, slug: environment.slug },
       autoAccept,
     });
-    issues = autoProvisioned.issues;
     if (autoProvisioned.provisioned.length > 0) {
       const attached = autoProvisioned.provisioned.map(d => `${d.name} (${d.kind})`).join(', ');
       p.log.success(`Attached managed database: ${attached}`);
+
+      // Re-run preflight with the newly-attached vars folded into the
+      // managed set. Without this, MISSING_ENV_VAR issues for the vars we
+      // just provisioned (TURSO_AUTH_TOKEN, TURSO_DATABASE_URL) still show
+      // as "not in the env file being deployed" — misleading right after
+      // we told the user the DB was attached. Merging is enough; no need
+      // to re-fetch the environment because attachDatabase's response is
+      // authoritative for the vars it just injected.
+      const mergedManagedNames = [
+        ...(environment.managedEnvVarNames ?? []),
+        ...autoProvisioned.newlyManagedEnvVarNames,
+      ];
+      issues = await preflightBuildOutput(targetDir, preflightEnv, {
+        hasEnvFile: hasAmbientEnvFile,
+        managedEnvVarNames: mergedManagedNames,
+        environmentName: environment.name,
+      });
+    } else {
+      issues = autoProvisioned.issues;
     }
 
     const outcome = await printPreflightIssues(issues, { autoAccept });

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -812,7 +812,12 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
       // time; the platform exposes their names on the environment. Absent
       // field = older platform = incomplete env picture (soften to warnings).
       managedEnvVarNames: environment.managedEnvVarNames ?? null,
-      environmentSlug: environment.slug,
+      // Use the environment NAME (e.g. `production`, `staging`), not the
+      // slug: some platforms derive the production env's slug from the
+      // project name (`my-app-xyz-1234`), which the env-resolver accepts
+      // but is jarring in a printed remediation command. The name is what
+      // the user actually types.
+      environmentName: environment.name,
     });
 
     // If preflight flagged a blocking issue that a managed database would

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -812,6 +812,7 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
       // time; the platform exposes their names on the environment. Absent
       // field = older platform = incomplete env picture (soften to warnings).
       managedEnvVarNames: environment.managedEnvVarNames ?? null,
+      environmentSlug: environment.slug,
     });
 
     // If preflight flagged a blocking issue that a managed database would

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -284,7 +284,10 @@ async function resolveEnvironment(
   const envType =
     envName.toLowerCase() === 'production' ? 'production' : envName.toLowerCase() === 'staging' ? 'staging' : 'preview';
 
-  if (!autoAccept) {
+  // Skip the "create it?" prompt for production. A first deploy naturally
+  // creates production — the confirmation is noise. Still prompt for
+  // non-standard names in case the user made a typo (e.g. `--env prodcution`).
+  if (!autoAccept && envType !== 'production') {
     const confirmed = await p.confirm({
       message: `Environment "${envName}" doesn't exist. Create it?`,
       initialValue: true,

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -830,7 +830,12 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
       projectId,
       projectName,
       projectSlug,
-      environment: { id: environment.id, slug: environment.slug, name: environment.name },
+      environment: {
+        id: environment.id,
+        slug: environment.slug,
+        name: environment.name,
+        type: environment.type,
+      },
       autoAccept,
     });
     if (autoProvisioned.provisioned.length > 0) {

--- a/packages/cli/src/commands/lint/index.ts
+++ b/packages/cli/src/commands/lint/index.ts
@@ -178,7 +178,12 @@ export function printLintReport(result: LintResult, options: { strict?: boolean 
   for (const issue of result.issues) {
     const prefix =
       issue.severity === 'error' || warningsAreErrors ? pc.red(`[${issue.code}]`) : pc.yellow(`[${issue.code}]`);
-    const message = `${prefix} ${issue.message}\n  ${pc.dim('scope:')} ${issue.scope}\n  ${pc.dim('→')} ${issue.fix}`;
+    // fix can be a string (one line) or string[] (one arrow line per step,
+    // used by preflight-sourced issues so the DB provisioning options don't
+    // squash into one wall of text).
+    const fixLines = Array.isArray(issue.fix) ? issue.fix : [issue.fix];
+    const fixBlock = fixLines.map(line => `  ${pc.dim('→')} ${line}`).join('\n');
+    const message = `${prefix} ${issue.message}\n  ${pc.dim('scope:')} ${issue.scope}\n${fixBlock}`;
 
     if (issue.severity === 'error' || warningsAreErrors) {
       p.log.error(message);

--- a/packages/cli/src/commands/lint/rules/types.ts
+++ b/packages/cli/src/commands/lint/rules/types.ts
@@ -28,7 +28,9 @@ export interface LintIssue {
   code: LintIssueCode;
   severity: LintIssueSeverity;
   message: string;
-  fix: string;
+  // string for single-step remediation, string[] when the printer should
+  // render one arrow line per option (matches PreflightIssue.fix).
+  fix: string | string[];
   scope: 'project' | 'bundle';
 }
 


### PR DESCRIPTION
Rough edges around the CLI's environment/database UX at deploy time. Each change is small on its own; together they turn "first deploy" from a maze of preflight errors into a guided flow.

## What changes

**1. `mastra env db create` defaults to per-environment scope**

Previously the command created a project-scoped (shared) database when no environment was passed. That surprised users who expected `mastra env db create` to attach to *an* environment.

- No arg + one environment → auto-selects it.
- No arg + multiple environments + TTY → prompts (production pre-selected).
- No arg + multiple environments + non-interactive → errors with the list.
- New `--shared` flag reproduces the old project-scoped behavior.
- `[env]` positional + `--shared` is rejected as contradictory.

**2. Deploy preflight offers to auto-provision a managed database**

When preflight would block because a managed DB env var is missing (`TURSO_DATABASE_URL`, `DATABASE_URL`, …), the CLI now asks "Create a managed database now? [Y/n]" and runs the attach inline, then re-runs preflight with the new vars. Non-interactive shells and "no" answers fall through to the existing blocking behavior.

Structured via a new `PreflightIssue.autofix` field so callers other than `deploy` (lint, studio) get the same underlying signal without changing behavior.

**3. First deploy no longer prompts to create the `production` environment**

The confirmation "Environment 'production' doesn't exist. Create it?" was noise for anyone hitting the standard first-deploy path. Standard-name environments are created without asking; non-standard names still prompt to catch typos.

**4. Preflight remediation is scoped to the target environment**

Before change 1, `mastra env db create --kind turso` worked in a non-interactive shell. After change 1 it errors with "Multiple environments exist." Preflight now emits `mastra env db create <env-slug> --kind <kind>`, so the CI-facing remediation actually runs.

**5. Preflight fix rendering is a step list, not one long sentence**

`PreflightIssue.fix` is now `string | string[]`. For DB provisioning, the two options render on their own lines:

```
[LOCAL_STORAGE_PATH] file:./.mastra.db will be used at runtime because TURSO_DATABASE_URL is not set (...)
  → Run `mastra env db create production --kind turso` to attach a managed database
  → Or set TURSO_DATABASE_URL in your env file or the environment's stored vars
```

Command first (recommended path), env-var alternative second. Every other single-string fix is unchanged.

## Test plan

- `pnpm --filter ./packages/cli test` — new tests plus existing suites pass locally.
  - `db.test.ts`: 6 new tests covering the scope resolution matrix (single/multi env, interactive/non-interactive, `--shared`, arg + `--shared` conflict).
  - `deploy/auto-provision-database.test.ts`: 9 new tests (single/multi missing vars, dedupe by provider, decline, non-TTY, attach failure, poll timeout, managedEnvVarNames update).
  - `deploy-preflight.test.ts`: added scoped-command assertions, step-list rendering assertion, autofix-field assertions.
- `pnpm --filter ./packages/cli typecheck` — clean on touched files (preexisting workspace-dep noise unrelated).
- `pnpm --filter ./packages/cli build` — succeeds.
- Manual: ran `mastra env db create` in a project with one and with multiple environments; ran `mastra deploy` against an environment missing `TURSO_DATABASE_URL` and confirmed the inline attach → poll → re-preflight loop.

## Backward compatibility

- `mastra env db create` behavior change is called out in the `@mastra/cli` changeset as a minor. The `--shared` flag preserves the old scope for anyone who wants it.
- Deploy prompt only appears in TTY sessions; CI behavior (block-with-remediation) is preserved and now emits a runnable command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

On your first deploy, the CLI now looks for common “missing setup” problems and tries to fix them for you—especially hosted database setup—instead of immediately failing. If it can’t (or you say no), it shows you the exact command(s) to run.

## What changed

- **`mastra env db create` now defaults to environment-scoped databases**
  - **1 environment**: auto-selects it.
  - **Multiple environments**: interactive TTY mode prompts you (with a **production**-type env pre-selected when available).
  - **Non-interactive/CI/`--json`**: fails clearly (instead of silently choosing shared); requires an explicit environment or opting into sharing rules.
  - **`--shared`** keeps the older project-scoped behavior and **can’t be combined with an environment argument**.
- **First-deploy environment creation prompts were narrowed**
  - Creating the standard **`production`** environment on first deploy **skips confirmation**.
  - **Non-production** (non-standard) environment names still prompt.
- **Deploy preflight can offer inline managed-database provisioning/attachment**
  - When preflight detects missing database-related env vars, it can prompt (interactive TTY) to **create and attach a managed DB scoped to the target environment**.
  - It provisions/attaches by provider (prompting **once per provider**), polls until ready, injects the resulting managed env var values, and then **re-runs preflight** so warnings/errors update immediately.
  - If you **decline** or run **non-interactively / with `--yes`**, it preserves the prior failure behavior and prints the **exact `mastra env db create --kind ...` remediation command**.
- **Database remediation is environment-targeted and step-based**
  - Remediation output is now represented as **steps** (`string | string[]`) and rendered as **separate `→` arrow lines**, so database creation steps and env-var alternatives don’t get combined into one block.
  - The remediation commands use the correct **deployment environment name** (e.g. `production`, `staging`) as the positional scope for `mastra env db create`.
- **Automatically derived managed database names avoid cross-environment collisions**
  - For **non-production** environments, the default/derived database name now includes an **environment suffix**.
  - **Production** retains the existing default name; explicit `--name` (and prompted names) still behave as provided.
- **Docs/changesets/tests updated**
  - Changesets and docs were updated to reflect the new env-scoping defaults and the “first deploy/preflight remediation” UX.
  - CLI tests expanded for default environment resolution, deploy preflight auto-provision behavior, and step-list rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->