### PR TITLE
feat(mastracode-web): guard Review board moves with lifecycle transitions

### DIFF
--- a/mastracode/web/src/shared/hooks/useWorkItems.ts
+++ b/mastracode/web/src/shared/hooks/useWorkItems.ts
@@ -56,10 +56,18 @@ export function useUpdateWorkItemMutation(githubProjectId: string | undefined) {
     onMutate: async ({ id, patch }) => {
       await queryClient.cancelQueries({ queryKey: listKey });
       const previous = queryClient.getQueryData<WorkItem[]>(listKey);
-      if (previous && patch.stages) {
+      if (previous && (patch.stages || patch.parentWorkItemId !== undefined)) {
         queryClient.setQueryData<WorkItem[]>(
           listKey,
-          previous.map(item => (item.id === id ? { ...item, stages: patch.stages! } : item)),
+          previous.map(item =>
+            item.id === id
+              ? {
+                  ...item,
+                  ...(patch.stages ? { stages: patch.stages } : {}),
+                  ...(patch.parentWorkItemId !== undefined ? { parentWorkItemId: patch.parentWorkItemId } : {}),
+                }
+              : item,
+          ),
         );
       }
       return { previous };

--- a/mastracode/web/src/web/factory/routes.test.ts
+++ b/mastracode/web/src/web/factory/routes.test.ts
@@ -317,6 +317,101 @@ describe('DELETE /web/factory/work-items/:id', () => {
   });
 });
 
+// ── Related Work / Review items ──────────────────────────────────────────
+describe('work item relations', () => {
+  const create = async (overrides: Record<string, unknown>) => {
+    const response = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody(overrides));
+    return { response, body: await response.json() };
+  };
+
+  it('creates separate related items and preserves the relation on source-key reuse', async () => {
+    const { body: parent } = await create({ sourceKey: 'github-issue:parent' });
+    const { body: child } = await create({
+      source: 'github-pr',
+      sourceKey: 'github-pr:child',
+      parentWorkItemId: parent.workItem.id,
+    });
+
+    expect(child.workItem.parentWorkItemId).toBe(parent.workItem.id);
+
+    const { body: repeated } = await create({
+      source: 'github-pr',
+      sourceKey: 'github-pr:child',
+      parentWorkItemId: null,
+      title: 'Updated review title',
+    });
+    expect(repeated.workItem).toMatchObject({
+      id: child.workItem.id,
+      parentWorkItemId: parent.workItem.id,
+      title: 'Updated review title',
+    });
+  });
+
+  it('attaches a parent when a repeated source-key upsert supplies one', async () => {
+    const { body: parent } = await create({ sourceKey: 'github-issue:late-parent' });
+    const { body: existing } = await create({ source: 'github-pr', sourceKey: 'github-pr:late-child' });
+    const { body: related } = await create({
+      source: 'github-pr',
+      sourceKey: 'github-pr:late-child',
+      parentWorkItemId: parent.workItem.id,
+    });
+
+    expect(related.workItem).toMatchObject({ id: existing.workItem.id, parentWorkItemId: parent.workItem.id });
+  });
+
+  it('rejects missing, cross-project, self, and cyclic relations', async () => {
+    const missing = await create({
+      sourceKey: 'github-pr:missing',
+      parentWorkItemId: '00000000-0000-4000-8000-000000000099',
+    });
+    expect(missing.response.status).toBe(400);
+
+    const otherProjectId = '22222222-3333-4444-8555-666666666666';
+    seedProject('org1', otherProjectId);
+    const otherParentResponse = await json(
+      'POST',
+      `/web/factory/projects/${otherProjectId}/work-items`,
+      createBody({ sourceKey: 'github-issue:other-project' }),
+    );
+    const otherParent = (await otherParentResponse.json()).workItem;
+    const crossProject = await create({ sourceKey: 'github-pr:cross-project', parentWorkItemId: otherParent.id });
+    expect(crossProject.response.status).toBe(400);
+
+    const { body: first } = await create({ sourceKey: 'github-issue:first' });
+    const { body: second } = await create({ sourceKey: 'github-pr:second', parentWorkItemId: first.workItem.id });
+    expect(
+      (
+        await json('PATCH', `/web/factory/work-items/${first.workItem.id}`, {
+          parentWorkItemId: first.workItem.id,
+        })
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await json('PATCH', `/web/factory/work-items/${first.workItem.id}`, {
+          parentWorkItemId: second.workItem.id,
+        })
+      ).status,
+    ).toBe(400);
+  });
+
+  it('clears a relation explicitly and when the parent is deleted', async () => {
+    const { body: parent } = await create({ sourceKey: 'github-issue:delete-parent' });
+    const { body: child } = await create({
+      source: 'github-pr',
+      sourceKey: 'github-pr:delete-child',
+      parentWorkItemId: parent.workItem.id,
+    });
+
+    const cleared = await json('PATCH', `/web/factory/work-items/${child.workItem.id}`, { parentWorkItemId: null });
+    expect((await cleared.json()).workItem.parentWorkItemId).toBeNull();
+
+    await json('PATCH', `/web/factory/work-items/${child.workItem.id}`, { parentWorkItemId: parent.workItem.id });
+    expect((await json('DELETE', `/web/factory/work-items/${parent.workItem.id}`)).status).toBe(200);
+    expect((await listItems())[0]?.parentWorkItemId).toBeNull();
+  });
+});
+
 // ── Metrics ──────────────────────────────────────────────────────────────
 describe('GET /web/factory/projects/:id/metrics', () => {
   it('401s without a user and 404s for projects outside the org', async () => {

--- a/mastracode/web/src/web/factory/routes.ts
+++ b/mastracode/web/src/web/factory/routes.ts
@@ -24,6 +24,7 @@ import {
   parseUpdateWorkItem,
   updateWorkItem,
   upsertWorkItem,
+  WorkItemRelationError,
 } from './store';
 
 function loose(c: unknown): Context {
@@ -178,26 +179,33 @@ export function buildFactoryRoutes(storage?: GithubStorage): ApiRoute[] {
         const input = parseCreateWorkItem(body);
         if (!input) return c.json({ error: 'invalid_work_item' }, 400);
 
-        const result = await upsertWorkItem({
-          orgId: resolved.orgId,
-          userId: resolved.userId,
-          githubProjectId: resolved.projectId,
-          input,
-        });
-        const item = result.item;
-        if (result.created) {
-          await emitAudit(loose(c), {
-            action: 'factory.work_item.created',
-            projectId: resolved.projectId,
-            targets: [{ type: 'work_item', id: item.id, name: item.title }],
-            metadata: { source: item.source, sourceKey: item.sourceKey, stages: item.stages },
+        try {
+          const result = await upsertWorkItem({
+            orgId: resolved.orgId,
+            userId: resolved.userId,
+            githubProjectId: resolved.projectId,
+            input,
           });
-        } else {
-          // Source-key reuse: the POST updated an existing card, so audit it
-          // as an update (plus stage/run events) instead of a false creation.
-          await auditWorkItemPatch(loose(c), item, result.previous, input as unknown as Record<string, unknown>);
+          const item = result.item;
+          if (result.created) {
+            await emitAudit(loose(c), {
+              action: 'factory.work_item.created',
+              projectId: resolved.projectId,
+              targets: [{ type: 'work_item', id: item.id, name: item.title }],
+              metadata: { source: item.source, sourceKey: item.sourceKey, stages: item.stages },
+            });
+          } else {
+            // Source-key reuse: the POST updated an existing card, so audit it
+            // as an update (plus stage/run events) instead of a false creation.
+            await auditWorkItemPatch(loose(c), item, result.previous, input as unknown as Record<string, unknown>);
+          }
+          return c.json({ workItem: item });
+        } catch (error) {
+          if (error instanceof WorkItemRelationError) {
+            return c.json({ error: error.code, message: error.message }, 400);
+          }
+          throw error;
         }
-        return c.json({ workItem: item });
       },
     }),
 
@@ -217,10 +225,17 @@ export function buildFactoryRoutes(storage?: GithubStorage): ApiRoute[] {
         const patch = parseUpdateWorkItem(body);
         if (!patch) return c.json({ error: 'invalid_work_item_patch' }, 400);
 
-        const updated = await updateWorkItem(tenant.orgId, id, tenant.userId, patch);
-        if (!updated) return c.json({ error: 'Work item not found' }, 404);
-        await auditWorkItemPatch(loose(c), updated.item, updated.previous, patch as Record<string, unknown>);
-        return c.json({ workItem: updated.item });
+        try {
+          const updated = await updateWorkItem(tenant.orgId, id, tenant.userId, patch);
+          if (!updated) return c.json({ error: 'Work item not found' }, 404);
+          await auditWorkItemPatch(loose(c), updated.item, updated.previous, patch as Record<string, unknown>);
+          return c.json({ workItem: updated.item });
+        } catch (error) {
+          if (error instanceof WorkItemRelationError) {
+            return c.json({ error: error.code, message: error.message }, 400);
+          }
+          throw error;
+        }
       },
     }),
 

--- a/mastracode/web/src/web/factory/store.ts
+++ b/mastracode/web/src/web/factory/store.ts
@@ -11,6 +11,7 @@
  */
 
 import { getFactoryStore } from '../runtime-config';
+import { WorkItemRelationError } from '../storage/domains/work-items/base';
 import type {
   CreateWorkItemInput,
   UpdateWorkItemInput,
@@ -21,6 +22,7 @@ import type {
   WorkItemSource,
 } from '../storage/domains/work-items/base';
 
+export { WorkItemRelationError };
 export type {
   CreateWorkItemInput,
   UpdateWorkItemInput,
@@ -81,6 +83,14 @@ function sanitizeSourceKey(value: unknown): string | null | undefined {
   return value;
 }
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function sanitizeParentWorkItemId(value: unknown): string | null | undefined {
+  if (value === null || value === undefined) return null;
+  if (typeof value !== 'string' || !UUID_RE.test(value)) return undefined;
+  return value;
+}
+
 /** Role-keyed session refs with bounded string fields, or `undefined` when invalid. */
 function sanitizeSessions(value: unknown): Record<string, WorkItemSessionInput> | undefined {
   if (value === undefined) return {};
@@ -119,14 +129,25 @@ export function parseCreateWorkItem(body: unknown): CreateWorkItemInput | null {
   if (typeof source !== 'string' || !WORK_ITEM_SOURCES.includes(source as WorkItemSource)) return null;
 
   const sourceKey = sanitizeSourceKey(body.sourceKey);
+  const hasParentWorkItemId = 'parentWorkItemId' in body;
+  const parentWorkItemId = hasParentWorkItemId ? sanitizeParentWorkItemId(body.parentWorkItemId) : undefined;
   const title = sanitizeTitle(body.title);
   const url = sanitizeUrl(body.url);
   const stages = sanitizeStages(body.stages);
   const sessions = sanitizeSessions(body.sessions);
   const metadata = sanitizeMetadata(body.metadata);
-  if (sourceKey === undefined || !title || url === undefined || !stages || !sessions || !metadata) return null;
+  if (
+    sourceKey === undefined ||
+    (hasParentWorkItemId && parentWorkItemId === undefined) ||
+    !title ||
+    url === undefined ||
+    !stages ||
+    !sessions ||
+    !metadata
+  )
+    return null;
 
-  return { source: source as WorkItemSource, sourceKey, title, url, stages, sessions, metadata };
+  return { source: source as WorkItemSource, sourceKey, parentWorkItemId, title, url, stages, sessions, metadata };
 }
 
 /** Validate an untrusted PATCH body into an {@link UpdateWorkItemInput}, or `null`. */
@@ -134,6 +155,11 @@ export function parseUpdateWorkItem(body: unknown): UpdateWorkItemInput | null {
   if (!isPlainObject(body)) return null;
   const patch: UpdateWorkItemInput = {};
 
+  if ('parentWorkItemId' in body) {
+    const parentWorkItemId = sanitizeParentWorkItemId(body.parentWorkItemId);
+    if (parentWorkItemId === undefined) return null;
+    patch.parentWorkItemId = parentWorkItemId;
+  }
   if ('title' in body) {
     const title = sanitizeTitle(body.title);
     if (!title) return null;

--- a/mastracode/web/src/web/storage/domains/work-items/base.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/base.ts
@@ -56,6 +56,8 @@ export interface WorkItemRow {
   source: WorkItemSource;
   /** Dedupe key (e.g. 'github-issue:123', 'linear:ENG-42'); null for manual cards. */
   sourceKey: string | null;
+  /** Optional originating issue item for a separate PR review item. */
+  parentWorkItemId: string | null;
   title: string;
   /** External link (issue/PR); null for manual cards. */
   url: string | null;
@@ -81,6 +83,7 @@ export interface WorkItemSessionInput {
 export interface CreateWorkItemInput {
   source: WorkItemSource;
   sourceKey: string | null;
+  parentWorkItemId?: string | null;
   title: string;
   url: string | null;
   stages: string[];
@@ -89,6 +92,7 @@ export interface CreateWorkItemInput {
 }
 
 export interface UpdateWorkItemInput {
+  parentWorkItemId?: string | null;
   title?: string;
   url?: string | null;
   stages?: string[];
@@ -106,6 +110,33 @@ export interface WorkItemPriorState {
 export type UpsertWorkItemResult =
   | { created: true; item: WorkItemRow }
   | { created: false; item: WorkItemRow; previous: WorkItemPriorState };
+
+export class WorkItemRelationError extends Error {
+  readonly code = 'invalid_work_item_relation';
+}
+
+export function validateParentRelation(
+  projectItems: WorkItemRow[],
+  itemId: string | undefined,
+  parentWorkItemId: string | null,
+): void {
+  if (parentWorkItemId === null) return;
+  const byId = new Map(projectItems.map(item => [item.id, item]));
+  const parent = byId.get(parentWorkItemId);
+  if (!parent) throw new WorkItemRelationError('Related work item not found in this project.');
+  if (itemId === parentWorkItemId) throw new WorkItemRelationError('A work item cannot relate to itself.');
+
+  const visited = new Set<string>();
+  let cursor: WorkItemRow | undefined = parent;
+  while (cursor?.parentWorkItemId) {
+    if (cursor.parentWorkItemId === itemId) {
+      throw new WorkItemRelationError('This relationship would create a cycle.');
+    }
+    if (visited.has(cursor.id)) throw new WorkItemRelationError('The related work item chain contains a cycle.');
+    visited.add(cursor.id);
+    cursor = byId.get(cursor.parentWorkItemId);
+  }
+}
 
 /**
  * Diff `oldStages` → `newStages` and return the updated history: exited stages
@@ -168,6 +199,7 @@ export function computeWorkItemPatch(
     sessionRoles: Object.keys(existing.sessions),
   };
   const changes: Partial<WorkItemRow> = { updatedAt: now };
+  if (patch.parentWorkItemId !== undefined) changes.parentWorkItemId = patch.parentWorkItemId;
   if (patch.title !== undefined) changes.title = patch.title;
   if (patch.url !== undefined) changes.url = patch.url;
   if (patch.stages !== undefined) {

--- a/mastracode/web/src/web/storage/domains/work-items/inmemory.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/inmemory.ts
@@ -6,7 +6,13 @@
 
 import { randomUUID } from 'node:crypto';
 
-import { WorkItemsStorage, applyStageTransition, computeWorkItemPatch, stampSessions } from './base';
+import {
+  WorkItemsStorage,
+  applyStageTransition,
+  computeWorkItemPatch,
+  stampSessions,
+  validateParentRelation,
+} from './base';
 import type {
   CreateWorkItemInput,
   UpdateWorkItemInput,
@@ -24,6 +30,10 @@ export class WorkItemsStorageInMemory extends WorkItemsStorage {
 
   #clone(row: WorkItemRow): WorkItemRow {
     return structuredClone(row);
+  }
+
+  #projectItems(orgId: string, githubProjectId: string): WorkItemRow[] {
+    return [...this.#items.values()].filter(item => item.orgId === orgId && item.githubProjectId === githubProjectId);
   }
 
   async list(orgId: string, githubProjectId: string): Promise<WorkItemRow[]> {
@@ -47,11 +57,13 @@ export class WorkItemsStorageInMemory extends WorkItemsStorage {
         item => item.orgId === orgId && item.githubProjectId === githubProjectId && item.sourceKey === input.sourceKey,
       );
       if (existing) {
-        const updated = this.#applyPatch(existing, input, userId, now);
+        const patch = input.parentWorkItemId === null ? { ...input, parentWorkItemId: undefined } : input;
+        const updated = this.#applyPatch(existing, patch, userId, now);
         return { created: false, item: updated.item, previous: updated.previous };
       }
     }
 
+    validateParentRelation(this.#projectItems(orgId, githubProjectId), undefined, input.parentWorkItemId ?? null);
     const row: WorkItemRow = {
       id: randomUUID(),
       orgId,
@@ -59,6 +71,7 @@ export class WorkItemsStorageInMemory extends WorkItemsStorage {
       githubProjectId,
       source: input.source,
       sourceKey: input.sourceKey,
+      parentWorkItemId: input.parentWorkItemId ?? null,
       title: input.title,
       url: input.url,
       stages: input.stages,
@@ -78,6 +91,13 @@ export class WorkItemsStorageInMemory extends WorkItemsStorage {
     userId: string,
     now: Date,
   ): { item: WorkItemRow; previous: WorkItemPriorState } {
+    if (patch.parentWorkItemId !== undefined) {
+      validateParentRelation(
+        this.#projectItems(existing.orgId, existing.githubProjectId),
+        existing.id,
+        patch.parentWorkItemId,
+      );
+    }
     const { changes, previous } = computeWorkItemPatch(existing, patch, userId, now);
     const updated = { ...existing, ...changes };
     this.#items.set(updated.id, structuredClone(updated));
@@ -99,6 +119,12 @@ export class WorkItemsStorageInMemory extends WorkItemsStorage {
     const existing = this.#items.get(id);
     if (!existing || existing.orgId !== orgId) return null;
     this.#items.delete(id);
+    for (const item of this.#items.values()) {
+      if (item.orgId === orgId && item.parentWorkItemId === id) {
+        item.parentWorkItemId = null;
+        item.updatedAt = new Date();
+      }
+    }
     return this.#clone(existing);
   }
 }

--- a/mastracode/web/src/web/storage/domains/work-items/pg.test.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/pg.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import type { FactoryStorageContext } from '../../domain';
 import { WORK_ITEMS_DDL, WorkItemsStoragePG } from './pg';
@@ -147,5 +147,68 @@ describe('WorkItemsStoragePG', () => {
     await domain.init(ctx);
     expect(await domain.delete('org1', 'wi-9')).toBeNull();
     expect(queries.at(-1)!.values).toEqual(['wi-9', 'org1']);
+  });
+});
+
+const ITEM_ID = '00000000-0000-4000-8000-000000000001';
+const PARENT_ID = '00000000-0000-4000-8000-000000000002';
+
+function dbRow(id: string, parentWorkItemId: string | null = null) {
+  return {
+    id,
+    org_id: 'org-1',
+    created_by: 'user-1',
+    github_project_id: '00000000-0000-4000-8000-000000000010',
+    source: 'github-issue',
+    source_key: `github-issue:${id}`,
+    parent_work_item_id: parentWorkItemId,
+    title: `Item ${id}`,
+    url: null,
+    stages: ['intake'],
+    stage_history: [],
+    sessions: {},
+    metadata: {},
+    created_at: new Date('2026-01-01T00:00:00Z'),
+    updated_at: new Date('2026-01-01T00:00:00Z'),
+  };
+}
+
+describe('WorkItemsStoragePG relations', () => {
+  it('ships additive relation DDL with scoped ownership lookup and non-cascading deletion', () => {
+    expect(WORK_ITEMS_DDL).toContain('ADD COLUMN IF NOT EXISTS parent_work_item_id uuid');
+    expect(WORK_ITEMS_DDL).toContain('ON DELETE SET NULL');
+    expect(WORK_ITEMS_DDL).toContain('ON work_items (org_id, github_project_id, parent_work_item_id)');
+    expect(WORK_ITEMS_DDL).toContain("conrelid = 'work_items'::regclass");
+  });
+
+  it('takes the project advisory lock before locking and validating a relation update', async () => {
+    const queries: string[] = [];
+    const item = dbRow(ITEM_ID);
+    const parent = dbRow(PARENT_ID);
+    const client = {
+      query: vi.fn(async (sql: string) => {
+        queries.push(sql);
+        if (sql.startsWith('SELECT * FROM work_items WHERE id = $1 AND org_id = $2')) return { rows: [item] };
+        if (sql === 'SELECT * FROM work_items WHERE id = $1 FOR UPDATE') return { rows: [item] };
+        if (sql.startsWith('SELECT * FROM work_items WHERE org_id = $1')) return { rows: [item, parent] };
+        if (sql.startsWith('UPDATE work_items SET')) return { rows: [{ ...item, parent_work_item_id: PARENT_ID }] };
+        return { rows: [] };
+      }),
+      release: vi.fn(),
+    };
+    const pool = {
+      query: vi.fn(async () => ({ rows: [] })),
+      connect: vi.fn(async () => client),
+    };
+    const storage = new WorkItemsStoragePG();
+    await storage.init({ pool } as never);
+
+    const result = await storage.update('org-1', ITEM_ID, 'user-1', { parentWorkItemId: PARENT_ID });
+
+    expect(result?.item.parentWorkItemId).toBe(PARENT_ID);
+    const advisoryIndex = queries.findIndex(sql => sql.startsWith('SELECT pg_advisory_xact_lock'));
+    const rowLockIndex = queries.findIndex(sql => sql === 'SELECT * FROM work_items WHERE id = $1 FOR UPDATE');
+    expect(advisoryIndex).toBeGreaterThan(-1);
+    expect(rowLockIndex).toBeGreaterThan(advisoryIndex);
   });
 });

--- a/mastracode/web/src/web/storage/domains/work-items/pg.test.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/pg.test.ts
@@ -70,7 +70,7 @@ describe('WorkItemsStoragePG', () => {
     expect(result.item.sourceKey).toBe('github-issue:42');
 
     const insert = queries.find(q => q.text.includes('INSERT INTO work_items'))!;
-    const history = JSON.parse(insert.values![8] as string);
+    const history = JSON.parse(insert.values![9] as string);
     expect(history).toHaveLength(1);
     expect(history[0]).toMatchObject({ stage: 'intake', by: 'u1' });
   });

--- a/mastracode/web/src/web/storage/domains/work-items/pg.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/pg.ts
@@ -11,7 +11,13 @@
 import type pg from 'pg';
 
 import type { FactoryStorageContext } from '../../domain';
-import { WorkItemsStorage, applyStageTransition, computeWorkItemPatch, stampSessions } from './base';
+import {
+  WorkItemsStorage,
+  applyStageTransition,
+  computeWorkItemPatch,
+  stampSessions,
+  validateParentRelation,
+} from './base';
 import type {
   CreateWorkItemInput,
   UpdateWorkItemInput,
@@ -28,6 +34,7 @@ CREATE TABLE IF NOT EXISTS work_items (
   github_project_id uuid NOT NULL,
   source text NOT NULL,
   source_key text,
+  parent_work_item_id uuid,
   title text NOT NULL,
   url text,
   stages jsonb NOT NULL,
@@ -38,10 +45,30 @@ CREATE TABLE IF NOT EXISTS work_items (
   updated_at timestamptz NOT NULL DEFAULT now()
 );
 
+ALTER TABLE work_items
+  ADD COLUMN IF NOT EXISTS parent_work_item_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'work_items_parent_work_item_id_fkey'
+      AND conrelid = 'work_items'::regclass
+  ) THEN
+    ALTER TABLE work_items
+      ADD CONSTRAINT work_items_parent_work_item_id_fkey
+      FOREIGN KEY (parent_work_item_id) REFERENCES work_items(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
 CREATE UNIQUE INDEX IF NOT EXISTS work_items_org_project_source_key_unique
   ON work_items (org_id, github_project_id, source_key)
   WHERE source_key IS NOT NULL;
 DROP INDEX IF EXISTS work_items_project_source_key_unique;
+
+CREATE INDEX IF NOT EXISTS work_items_project_parent_idx
+  ON work_items (org_id, github_project_id, parent_work_item_id);
 `;
 
 interface WorkItemDbRow {
@@ -51,6 +78,7 @@ interface WorkItemDbRow {
   github_project_id: string;
   source: WorkItemRow['source'];
   source_key: string | null;
+  parent_work_item_id: string | null;
   title: string;
   url: string | null;
   stages: WorkItemRow['stages'];
@@ -69,6 +97,7 @@ function toRow(db: WorkItemDbRow): WorkItemRow {
     githubProjectId: db.github_project_id,
     source: db.source,
     sourceKey: db.source_key,
+    parentWorkItemId: db.parent_work_item_id,
     title: db.title,
     url: db.url,
     stages: db.stages,
@@ -83,6 +112,7 @@ function toRow(db: WorkItemDbRow): WorkItemRow {
 /** Serializer per patchable column: jsonb columns are stringified + cast. */
 const PATCH_COLUMNS: Record<string, { column: string; jsonb?: boolean }> = {
   updatedAt: { column: 'updated_at' },
+  parentWorkItemId: { column: 'parent_work_item_id' },
   title: { column: 'title' },
   url: { column: 'url' },
   stages: { column: 'stages', jsonb: true },
@@ -119,6 +149,18 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
     }
   }
 
+  async #lockProjectRelations(client: pg.PoolClient, orgId: string, githubProjectId: string): Promise<void> {
+    await client.query('SELECT pg_advisory_xact_lock(hashtext($1))', [`${orgId}:${githubProjectId}`]);
+  }
+
+  async #projectItems(client: pg.PoolClient, orgId: string, githubProjectId: string): Promise<WorkItemRow[]> {
+    const { rows } = await client.query<WorkItemDbRow>(
+      'SELECT * FROM work_items WHERE org_id = $1 AND github_project_id = $2',
+      [orgId, githubProjectId],
+    );
+    return rows.map(toRow);
+  }
+
   async list(orgId: string, githubProjectId: string): Promise<WorkItemRow[]> {
     const { rows } = await this.#db.query<WorkItemDbRow>(
       'SELECT * FROM work_items WHERE org_id = $1 AND github_project_id = $2',
@@ -138,12 +180,13 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
 
     const reuseExisting = async (): Promise<UpsertWorkItemResult | null> => {
       if (input.sourceKey === null) return null;
+      const patch = input.parentWorkItemId === null ? { ...input, parentWorkItemId: undefined } : input;
       const updated = await this.#withTx(client =>
         this.#applyUpdateLocked(
           client,
           'org_id = $1 AND github_project_id = $2 AND source_key = $3',
           [orgId, githubProjectId, input.sourceKey],
-          input,
+          patch,
           userId,
           now,
         ),
@@ -154,12 +197,12 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
     const reused = await reuseExisting();
     if (reused) return reused;
 
-    try {
-      const { rows } = await this.#db.query<WorkItemDbRow>(
+    const insert = async (db: pg.Pool | pg.PoolClient): Promise<UpsertWorkItemResult> => {
+      const { rows } = await db.query<WorkItemDbRow>(
         `INSERT INTO work_items
-           (org_id, created_by, github_project_id, source, source_key, title, url,
+           (org_id, created_by, github_project_id, source, source_key, parent_work_item_id, title, url,
             stages, stage_history, sessions, metadata, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9::jsonb, $10::jsonb, $11::jsonb, $12, $13)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10::jsonb, $11::jsonb, $12::jsonb, $13, $14)
          RETURNING *`,
         [
           orgId,
@@ -167,6 +210,7 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
           githubProjectId,
           input.source,
           input.sourceKey,
+          input.parentWorkItemId ?? null,
           input.title,
           input.url,
           JSON.stringify(input.stages),
@@ -178,6 +222,15 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
         ],
       );
       return { created: true, item: toRow(rows[0]!) };
+    };
+
+    try {
+      if (input.parentWorkItemId == null) return await insert(this.#db);
+      return await this.#withTx(async client => {
+        await this.#lockProjectRelations(client, orgId, githubProjectId);
+        validateParentRelation(await this.#projectItems(client, orgId, githubProjectId), undefined, input.parentWorkItemId!);
+        return insert(client);
+      });
     } catch (err) {
       // Concurrent create for the same sourceKey: the partial unique index won
       // the race — fall back to updating the row it protected.
@@ -200,12 +253,31 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
     userId: string,
     now: Date,
   ): Promise<{ item: WorkItemRow; previous: WorkItemPriorState } | null> {
-    const { rows } = await client.query<WorkItemDbRow>(
-      `SELECT * FROM work_items WHERE ${whereSql} FOR UPDATE`,
-      whereParams,
-    );
-    if (!rows[0]) return null;
-    const existing = toRow(rows[0]);
+    let dbRow: WorkItemDbRow | undefined;
+    if (patch.parentWorkItemId === undefined) {
+      const { rows } = await client.query<WorkItemDbRow>(
+        `SELECT * FROM work_items WHERE ${whereSql} FOR UPDATE`,
+        whereParams,
+      );
+      dbRow = rows[0];
+    } else {
+      const candidate = await client.query<WorkItemDbRow>(`SELECT * FROM work_items WHERE ${whereSql}`, whereParams);
+      if (!candidate.rows[0]) return null;
+      await this.#lockProjectRelations(client, candidate.rows[0].org_id, candidate.rows[0].github_project_id);
+      const locked = await client.query<WorkItemDbRow>('SELECT * FROM work_items WHERE id = $1 FOR UPDATE', [
+        candidate.rows[0].id,
+      ]);
+      dbRow = locked.rows[0];
+    }
+    if (!dbRow) return null;
+    const existing = toRow(dbRow);
+    if (patch.parentWorkItemId !== undefined) {
+      validateParentRelation(
+        await this.#projectItems(client, existing.orgId, existing.githubProjectId),
+        existing.id,
+        patch.parentWorkItemId,
+      );
+    }
     const { changes, previous } = computeWorkItemPatch(existing, patch, userId, now);
 
     const sets: string[] = [];

--- a/mastracode/web/src/web/storage/domains/work-items/pg.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/pg.ts
@@ -228,7 +228,11 @@ export class WorkItemsStoragePG extends WorkItemsStorage {
       if (input.parentWorkItemId == null) return await insert(this.#db);
       return await this.#withTx(async client => {
         await this.#lockProjectRelations(client, orgId, githubProjectId);
-        validateParentRelation(await this.#projectItems(client, orgId, githubProjectId), undefined, input.parentWorkItemId!);
+        validateParentRelation(
+          await this.#projectItems(client, orgId, githubProjectId),
+          undefined,
+          input.parentWorkItemId!,
+        );
         return insert(client);
       });
     } catch (err) {

--- a/mastracode/web/src/web/ui/domains/chat/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/ThreadPage.tsx
@@ -12,6 +12,7 @@ import {
   useActiveProjectContext,
 } from '../workspaces';
 import { ChatHeader } from './components/ChatHeader';
+import { RelatedFactorySessions } from '../factory/components/RelatedFactorySessions';
 import { ChatMessageList } from './components/ChatMessageList';
 import { ChatOverlays } from './components/ChatOverlays';
 import { ComposerPanel } from './components/ComposerPanel';
@@ -95,5 +96,12 @@ function ThreadPageContent() {
   useRouteThreadSync();
   useThreadPageKickoffs();
 
-  return <ChatMessageList />;
+  return (
+    <div className="flex min-h-0 flex-col">
+      <RelatedFactorySessions />
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ChatMessageList />
+      </div>
+    </div>
+  );
 }

--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/ChatMessageList.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/ChatMessageList.tsx
@@ -9,7 +9,7 @@ export function ChatMessageList() {
   if (!activeProject) return null;
 
   return (
-    <div className="flex min-h-0 flex-col overflow-y-auto">
+    <div className="flex h-full min-h-0 flex-col overflow-y-auto">
       <GoalPanel />
       <ConnectionNotice />
       <TranscriptPanel />

--- a/mastracode/web/src/web/ui/domains/chat/services/__tests__/runtime.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/services/__tests__/runtime.msw.test.tsx
@@ -40,7 +40,6 @@ describe('chat runtime reducer', () => {
       message: {
         id: 'assistant-1',
         role: 'assistant',
-        createdAt: new Date(),
         content: { format: 2, parts: [{ type: 'text', text: 'Working' }] },
       },
     });

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -2,7 +2,7 @@ import { Button, buttonVariants } from '@mastra/playground-ui/components/Button'
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { CircleDot, EllipsisVertical, ExternalLink, GitPullRequest, Plus } from 'lucide-react';
+import { CircleDot, EllipsisVertical, ExternalLink, GitCompareArrows, Link2, Plus } from 'lucide-react';
 import type { ComponentType, DragEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -40,6 +40,26 @@ import type { BoardStageId } from './stages';
 
 const AUTO_TRIAGED_LABEL = 'auto-triaged';
 const NEEDS_APPROVAL_LABEL = 'needs-approval';
+
+const SOURCE_LABELS: Record<WorkItemSource, string> = {
+  'github-issue': 'Issue',
+  'github-pr': 'PR Review',
+  'linear-issue': 'Linear',
+  manual: 'Manual',
+};
+
+function displayTitle(source: WorkItemSource, title: string): string {
+  return `${SOURCE_LABELS[source]}: ${title}`;
+}
+
+function SourceTitle({ source, title }: { source: WorkItemSource; title: string }) {
+  return (
+    <>
+      <span>{SOURCE_LABELS[source]}: </span>
+      <span>{title}</span>
+    </>
+  );
+}
 
 function hasLabel(labels: readonly string[], label: string): boolean {
   return labels.some(item => item.toLowerCase() === label);
@@ -224,7 +244,7 @@ function pullRequestCandidate(pr: GithubPullRequest): BoardCandidate {
     title: pr.title,
     url: pr.url,
     meta: `#${pr.number}${pr.author ? ` · ${pr.author}` : ''} · ${pr.headBranch} → ${pr.baseBranch}`,
-    icon: GitPullRequest,
+    icon: GitCompareArrows,
     iconClassName: 'text-accent1',
     column: 'intake',
     runActions: [
@@ -620,6 +640,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
                   key={`${item.id}:${stage.id}`}
                   item={item}
                   columnStage={stage.id}
+                  allItems={workItems}
                   liveWorktreePaths={liveWorktreePaths}
                   // Until the worktree listing settles, liveness is unknown and
                   // every session ref looks stale — the title would render as a
@@ -798,7 +819,7 @@ const SOURCE_ICONS: Record<
   { icon: ComponentType<{ size?: number; className?: string }>; className: string }
 > = {
   'github-issue': { icon: CircleDot, className: 'text-accent1' },
-  'github-pr': { icon: GitPullRequest, className: 'text-accent1' },
+  'github-pr': { icon: GitCompareArrows, className: 'text-accent1' },
   'linear-issue': { icon: CircleDot, className: 'text-accent3' },
   manual: { icon: CircleDot, className: 'text-icon3' },
 };
@@ -818,6 +839,7 @@ function itemThreadSession(sessions: Record<string, WorkItemSessionRef>): WorkIt
 function WorkItemCard({
   item,
   columnStage,
+  allItems,
   liveWorktreePaths,
   runDisabled,
   runStarting,
@@ -829,6 +851,7 @@ function WorkItemCard({
 }: {
   item: WorkItem;
   columnStage: BoardStageId;
+  allItems: WorkItem[];
   /** Worktrees that still exist; session refs outside this set are stale. */
   liveWorktreePaths: ReadonlySet<string>;
   runDisabled: boolean;
@@ -851,14 +874,23 @@ function WorkItemCard({
   // Offer only runs whose session slot hasn't been used yet on this card.
   const runActions = runSpec === null ? [] : runSpec.actions.filter(action => !(action.role in liveSessions));
   const threadSession = itemThreadSession(liveSessions);
+  const relatedItems = allItems.filter(
+    other =>
+      other.id !== item.id &&
+      other.stages.includes(columnStage) &&
+      (other.parentWorkItemId === item.id || item.parentWorkItemId === other.id),
+  );
 
   return (
     <article
       draggable
       aria-label={item.title}
       data-testid="work-item-card"
+      data-related={relatedItems.length > 0 ? 'true' : undefined}
       onDragStart={event => setDragPayload(event, { kind: 'work-item', id: item.id, fromStage: columnStage })}
-      className="flex cursor-grab flex-col gap-1.5 rounded-md border border-border1 bg-surface4 p-2 active:cursor-grabbing"
+      className={`flex cursor-grab flex-col gap-1.5 rounded-md border bg-surface4 p-2 active:cursor-grabbing ${
+        relatedItems.length > 0 ? 'border-accent2/50 ring-1 ring-accent2/20' : 'border-border1'
+      }`}
     >
       <div className="flex items-start gap-2">
         <Icon size={14} className={`mt-0.5 shrink-0 ${iconClassName}`} aria-hidden />
@@ -871,7 +903,7 @@ function WorkItemCard({
             }}
             className="min-w-0 flex-1 truncate text-ui-sm text-icon6 no-underline hover:underline"
           >
-            {item.title}
+            <SourceTitle source={item.source} title={item.title} />
           </a>
         ) : (
           <button
@@ -881,7 +913,7 @@ function WorkItemCard({
             onClick={() => onCreateSession(itemSessionSpec(item))}
             className="min-w-0 flex-1 truncate text-left text-ui-sm text-icon6 hover:underline disabled:opacity-60"
           >
-            {item.title}
+            <SourceTitle source={item.source} title={item.title} />
           </button>
         )}
         {item.url !== null && (
@@ -923,6 +955,18 @@ function WorkItemCard({
           </DropdownMenu.Content>
         </DropdownMenu>
       </div>
+      {relatedItems.map(related => {
+        const relationText =
+          related.parentWorkItemId === item.id
+            ? `Related ${displayTitle(related.source, related.title)}`
+            : `Related to ${displayTitle(related.source, related.title)}`;
+        return (
+          <div key={related.id} className="flex items-center gap-1 text-ui-xs text-accent2" aria-label={relationText}>
+            <Link2 size={11} aria-hidden />
+            <span className="truncate">{relationText}</span>
+          </div>
+        );
+      })}
       {otherStages.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
           {otherStages.map(stage => (
@@ -990,7 +1034,7 @@ function CandidateCard({
             onClick={onOpenSession}
             className="truncate text-left text-ui-sm text-icon6 hover:underline disabled:opacity-60"
           >
-            {candidate.title}
+            <SourceTitle source={candidate.source} title={candidate.title} />
           </button>
           <span className="block truncate text-ui-xs text-icon3">{candidate.meta}</span>
         </div>

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -96,6 +96,34 @@ const INTAKE_SOURCES = [
 ] as const;
 
 type IntakeSource = (typeof INTAKE_SOURCES)[number]['id'];
+type BoardKind = 'work' | 'review';
+
+const REVIEW_BOARD_STAGES: ReadonlyArray<{ id: BoardStageId; label: string }> = [
+  { id: 'intake', label: 'Intake' },
+  { id: 'review', label: 'Reviewing' },
+  { id: 'done', label: 'Done' },
+];
+
+function boardStages(kind: BoardKind): ReadonlyArray<{ id: BoardStageId; label: string }> {
+  return kind === 'review' ? REVIEW_BOARD_STAGES : BOARD_STAGES;
+}
+
+function belongsToBoard(item: WorkItem, kind: BoardKind): boolean {
+  return kind === 'review' ? item.source === 'github-pr' : item.source !== 'github-pr';
+}
+
+function itemAppearsInStage(item: WorkItem, stage: BoardStageId, stages: ReadonlyArray<{ id: BoardStageId }>): boolean {
+  if (item.stages.includes(stage)) return true;
+  return stage === 'intake' && !stages.some(candidate => item.stages.includes(candidate.id));
+}
+
+function itemStageOptions(item: WorkItem): ReadonlyArray<{ id: BoardStageId; label: string }> {
+  return boardStages(item.source === 'github-pr' ? 'review' : 'work');
+}
+
+function itemStageLabel(item: WorkItem, stage: string): string {
+  return itemStageOptions(item).find(candidate => candidate.id === stage)?.label ?? stageLabel(stage);
+}
 
 /**
  * Stage list after moving a card out of `from` into `to`. Other concurrent
@@ -415,16 +443,39 @@ function readDragPayload(event: DragEvent): DragPayload | null {
  * by drag-and-drop or the card menu; moves only file/move cards, never start
  * agent runs.
  */
+export function WorkBoardPage() {
+  return <FactoryBoardPage kind="work" />;
+}
+
+export function ReviewBoardPage() {
+  return <FactoryBoardPage kind="review" />;
+}
+
+/** @deprecated Use WorkBoardPage. */
 export function BoardPage() {
+  return <WorkBoardPage />;
+}
+
+function FactoryBoardPage({ kind }: { kind: BoardKind }) {
+  const review = kind === 'review';
   return (
-    <FactoryPageShell title="Board" description="Issues and pull requests across intake, work, review, and done.">
-      {project => <Board project={project} />}
+    <FactoryPageShell
+      title={review ? 'Review' : 'Work'}
+      description={
+        review
+          ? 'Pull requests moving through review intake, active review, and completion.'
+          : 'Issues moving through intake, planning, building, receiving review, and completion.'
+      }
+    >
+      {project => <Board project={project} kind={kind} />}
     </FactoryPageShell>
   );
 }
 
-function Board({ project }: { project: Project & { githubProjectId: string } }) {
+function Board({ project, kind }: { project: Project & { githubProjectId: string }; kind: BoardKind }) {
   const githubProjectId = project.githubProjectId;
+  const review = kind === 'review';
+  const stages = boardStages(kind);
   const items = useWorkItemsQuery(githubProjectId);
   const configQuery = useIntakeConfigQuery();
   const linearStatusQuery = useLinearStatusQuery();
@@ -440,16 +491,15 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   const linearReady =
     (config?.linear.enabled ?? false) && linearConnected && (config?.linear.projectIds?.length ?? 0) > 0;
 
-  // The Intake swimlane browses one candidate feed at a time; a pill switcher
-  // inside the column filters between Issues, PRs, and Linear as available.
+  // Work intake owns issues; Review intake owns pull requests. Keeping the
+  // feeds on separate routes prevents review-producing PR work from being
+  // confused with the Work board's review-receiving lane.
   const githubIntakeActive = githubEnabled && githubSelected;
-  const availableIntakeSources: IntakeSource[] = [
-    ...(githubIntakeActive ? (['github'] as const) : []),
-    'github-prs' as const,
-    ...(linearReady ? (['linear'] as const) : []),
-  ];
-  const newIssueUrl = config && githubIntakeActive ? githubNewIssueUrl(project.name) : undefined;
-  const [intakeSource, setIntakeSource] = useState<IntakeSource>('github');
+  const availableIntakeSources: IntakeSource[] = review
+    ? ['github-prs']
+    : [...(githubIntakeActive ? (['github'] as const) : []), ...(linearReady ? (['linear'] as const) : [])];
+  const newIssueUrl = !review && config && githubIntakeActive ? githubNewIssueUrl(project.name) : undefined;
+  const [intakeSource, setIntakeSource] = useState<IntakeSource>(review ? 'github-prs' : 'github');
   const showIntakeSourceSwitch = availableIntakeSources.length > 1;
   const activeIntakeSource: IntakeSource | null = availableIntakeSources.includes(intakeSource)
     ? intakeSource
@@ -457,7 +507,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
 
   // Only the active intake feed fetches; the other feeds load on switch.
   const issues = useProjectIssuesQuery(activeIntakeSource === 'github' ? githubProjectId : undefined);
-  const triageIssues = useProjectIssuesQuery(githubProjectId, AUTO_TRIAGED_LABEL);
+  const triageIssues = useProjectIssuesQuery(!review ? githubProjectId : undefined, AUTO_TRIAGED_LABEL);
   const pulls = useProjectPullRequestsQuery(activeIntakeSource === 'github-prs' ? githubProjectId : undefined);
   const linearIssues = useLinearIssuesQuery(activeIntakeSource === 'linear');
 
@@ -493,22 +543,24 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
     navigate(`/threads/${session.threadId}`);
   };
 
-  const workItems = useMemo(() => items.data ?? [], [items.data]);
+  const allWorkItems = useMemo(() => items.data ?? [], [items.data]);
+  const workItems = allWorkItems.filter(item => belongsToBoard(item, kind));
 
-  // Live candidates minus anything already on the board (any stage).
+  // Live candidates minus anything already persisted in either workflow.
   const candidates = useMemo(() => {
-    const known = new Set(workItems.map(item => item.sourceKey).filter(Boolean));
+    const known = new Set(allWorkItems.map(item => item.sourceKey).filter(Boolean));
     const intakeIssues = (activeIntakeSource === 'github' ? (issues.data ?? []) : []).filter(
       issue => !hasLabel(issue.labels, AUTO_TRIAGED_LABEL),
     );
-    const all: BoardCandidate[] = [
-      ...intakeIssues.map(issueCandidate),
-      ...(triageIssues.data ?? []).map(issueCandidate),
-      ...(activeIntakeSource === 'github-prs' ? (pulls.data ?? []).map(pullRequestCandidate) : []),
-      ...(activeIntakeSource === 'linear' ? (linearIssues.data ?? []).map(linearCandidate) : []),
-    ];
+    const all: BoardCandidate[] = review
+      ? (pulls.data ?? []).map(pullRequestCandidate)
+      : [
+          ...intakeIssues.map(issueCandidate),
+          ...(triageIssues.data ?? []).map(issueCandidate),
+          ...(activeIntakeSource === 'linear' ? (linearIssues.data ?? []).map(linearCandidate) : []),
+        ];
     return all.filter(candidate => !known.has(candidate.sourceKey));
-  }, [workItems, issues.data, triageIssues.data, pulls.data, linearIssues.data, activeIntakeSource]);
+  }, [allWorkItems, issues.data, triageIssues.data, pulls.data, linearIssues.data, activeIntakeSource, review]);
 
   const boardDataPending =
     items.isPending ||
@@ -538,7 +590,9 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
   const moveItem = (id: string, fromStage: string | null, toStage: string) => {
     const item = workItems.find(i => i.id === id);
     if (!item) return;
-    const next = stagesAfterMove(item.stages, fromStage, toStage);
+    const allowedStages = new Set<string>(stages.map(stage => stage.id));
+    const currentStages = item.stages.filter(stage => allowedStages.has(stage));
+    const next = stagesAfterMove(currentStages, fromStage, toStage);
     if (next.length === item.stages.length && next.every(stage => item.stages.includes(stage))) return;
     update.mutate({ id, patch: { stages: next } });
   };
@@ -587,7 +641,7 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
           if (autoPositionedProjectRef.current !== project.id) userPositionedProjectRef.current = project.id;
         }}
       >
-        {BOARD_STAGES.map(stage => (
+        {stages.map(stage => (
           <BoardColumn
             key={stage.id}
             stage={stage.id}
@@ -634,13 +688,13 @@ function Board({ project }: { project: Project & { githubProjectId: string } }) 
             }
           >
             {workItems
-              .filter(item => item.stages.includes(stage.id))
+              .filter(item => itemAppearsInStage(item, stage.id, stages))
               .map(item => (
                 <WorkItemCard
                   key={`${item.id}:${stage.id}`}
                   item={item}
                   columnStage={stage.id}
-                  allItems={workItems}
+                  allItems={allWorkItems}
                   liveWorktreePaths={liveWorktreePaths}
                   // Until the worktree listing settles, liveness is unknown and
                   // every session ref looks stale — the title would render as a
@@ -875,10 +929,7 @@ function WorkItemCard({
   const runActions = runSpec === null ? [] : runSpec.actions.filter(action => !(action.role in liveSessions));
   const threadSession = itemThreadSession(liveSessions);
   const relatedItems = allItems.filter(
-    other =>
-      other.id !== item.id &&
-      other.stages.includes(columnStage) &&
-      (other.parentWorkItemId === item.id || item.parentWorkItemId === other.id),
+    other => other.id !== item.id && (other.parentWorkItemId === item.id || item.parentWorkItemId === other.id),
   );
 
   return (
@@ -946,11 +997,13 @@ function WorkItemCard({
                   {runStarting ? 'Starting…' : action.label}
                 </DropdownMenu.Item>
               ))}
-            {BOARD_STAGES.filter(stage => stage.id !== columnStage).map(stage => (
-              <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
-                {stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}
-              </DropdownMenu.Item>
-            ))}
+            {itemStageOptions(item)
+              .filter(stage => stage.id !== columnStage)
+              .map(stage => (
+                <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
+                  {stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}
+                </DropdownMenu.Item>
+              ))}
             <DropdownMenu.Item onClick={onRemove}>Remove</DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu>
@@ -971,7 +1024,7 @@ function WorkItemCard({
         <div className="flex flex-wrap items-center gap-1.5">
           {otherStages.map(stage => (
             <span key={stage} className="rounded-full bg-surface5 px-1.5 py-0.5 text-ui-xs text-icon4">
-              {stageLabel(stage)}
+              {itemStageLabel(item, stage)}
             </span>
           ))}
         </div>

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -1,8 +1,18 @@
+import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Button, buttonVariants } from '@mastra/playground-ui/components/Button';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { CircleDot, EllipsisVertical, ExternalLink, GitCompareArrows, Link2, Plus } from 'lucide-react';
+import {
+  CircleDot,
+  EllipsisVertical,
+  ExternalLink,
+  GitCompareArrows,
+  GitMerge,
+  GitPullRequestClosed,
+  Link2,
+  Plus,
+} from 'lucide-react';
 import type { ComponentType, DragEvent } from 'react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
@@ -112,7 +122,20 @@ function belongsToBoard(item: WorkItem, kind: BoardKind): boolean {
   return kind === 'review' ? item.source === 'github-pr' : item.source !== 'github-pr';
 }
 
-function itemAppearsInStage(item: WorkItem, stage: BoardStageId, stages: ReadonlyArray<{ id: BoardStageId }>): boolean {
+function itemAppearsInStage(
+  item: WorkItem,
+  stage: BoardStageId,
+  stages: ReadonlyArray<{ id: BoardStageId }>,
+  /** Review board only: whether the item has a live review session. */
+  reviewSessionExists?: boolean,
+): boolean {
+  // Review lifecycle: Intake is the only sessionless lane. A card with a live
+  // review session renders in its recorded stage; without one it renders in
+  // Intake regardless of what its stages say (e.g. pre-lifecycle seed data).
+  if (reviewSessionExists !== undefined) {
+    if (reviewSessionExists) return item.stages.includes(stage);
+    return stage === 'intake';
+  }
   if (item.stages.includes(stage)) return true;
   return stage === 'intake' && !stages.some(candidate => item.stages.includes(candidate.id));
 }
@@ -123,6 +146,184 @@ function itemStageOptions(item: WorkItem): ReadonlyArray<{ id: BoardStageId; lab
 
 function itemStageLabel(item: WorkItem, stage: string): string {
   return itemStageOptions(item).find(candidate => candidate.id === stage)?.label ?? stageLabel(stage);
+}
+
+// ── Review lifecycle (Review board only) ────────────────────────────────────
+
+/**
+ * Review board columns are Factory review lifecycle states, not GitHub status:
+ * Intake holds PRs with no review session, Reviewing holds PRs a separate
+ * review Worker is actively producing feedback on, Done holds reviews that
+ * reached an explicit terminal outcome (completed or canceled). GitHub's
+ * open/merged/closed state is card provenance only and never moves the card.
+ */
+type ReviewTransitionKind = 'start-review' | 'complete-review' | 'cancel-review' | 'abandon-review';
+
+interface ReviewTransition {
+  kind: ReviewTransitionKind;
+  item: WorkItem;
+  /** Board stage the card moves from. */
+  fromStage: BoardStageId;
+  /** Board stage the card moves to once the transition is confirmed. */
+  toStage: BoardStageId;
+  title: string;
+  description: string;
+  confirmLabel: string;
+}
+
+/**
+ * A sessionless item renders in Intake (see `itemAppearsInStage`), so any
+ * persisted stage beyond Intake is only a label until a review session
+ * actually exists — moving out of it abandons nothing and needs no prompt.
+ */
+function hasReviewSession(item: WorkItem, liveWorktreePaths: ReadonlySet<string>): boolean {
+  const session = item.sessions.review;
+  return session !== undefined && liveWorktreePaths.has(session.projectPath);
+}
+
+/**
+ * The guarded transition a Review-board move requests, or `null` when the
+ * move is an ordinary stage patch (filing a candidate, or dragging a
+ * sessionless card whose non-Intake stage is only a label).
+ */
+function reviewTransitionForMove(
+  item: WorkItem,
+  fromStage: BoardStageId,
+  toStage: BoardStageId,
+  liveWorktreePaths: ReadonlySet<string>,
+): ReviewTransition | null {
+  if (fromStage === toStage) return null;
+  const sessionExists = hasReviewSession(item, liveWorktreePaths);
+  if (toStage === 'review') {
+    return sessionExists
+      ? null
+      : {
+          kind: 'start-review',
+          item,
+          fromStage,
+          toStage,
+          title: 'Start review?',
+          description: `Start a Factory review of "${item.title}"? A review session will be created and the review Worker will be dispatched.`,
+          confirmLabel: 'Start review',
+        };
+  }
+  if (toStage === 'done') {
+    const terminal = item.metadata.prState === 'merged' || item.metadata.prState === 'closed';
+    return terminal
+      ? {
+          kind: 'complete-review',
+          item,
+          fromStage,
+          toStage,
+          title: 'Mark review complete?',
+          description: `Mark the Factory review of "${item.title}" as complete? The pull request is ${item.metadata.prState as string}.`,
+          confirmLabel: 'Mark complete',
+        }
+      : {
+          kind: 'cancel-review',
+          item,
+          fromStage,
+          toStage,
+          title: 'Cancel review?',
+          description: `This pull request is still open — mark the Factory review of "${item.title}" as canceled?`,
+          confirmLabel: 'Cancel review',
+        };
+  }
+  if (toStage === 'intake' && sessionExists) {
+    return {
+      kind: 'abandon-review',
+      item,
+      fromStage,
+      toStage,
+      title: 'Abandon review?',
+      description: `Abandon the in-progress Factory review of "${item.title}"? The card returns to Intake; the review session is kept but no longer attached.`,
+      confirmLabel: 'Abandon review',
+    };
+  }
+  return null;
+}
+
+/** Menu transitions a Review card offers, replacing raw column targets. */
+function reviewMenuTransitions(
+  item: WorkItem,
+  columnStage: BoardStageId,
+  liveWorktreePaths: ReadonlySet<string>,
+): ReviewTransition[] {
+  const transitions: Array<ReviewTransition | null> = [];
+  if (columnStage !== 'review') {
+    // Re-entering Reviewing with a live session just moves the card — no new
+    // dispatch — so offer it as a plain resume without a confirmation.
+    transitions.push(
+      hasReviewSession(item, liveWorktreePaths)
+        ? {
+            kind: 'start-review',
+            item,
+            fromStage: columnStage,
+            toStage: 'review',
+            title: 'Resume review?',
+            description: `Move "${item.title}" back to Reviewing? Its existing review session is reused — no new dispatch.`,
+            confirmLabel: 'Resume review',
+          }
+        : columnStage === 'intake'
+          ? reviewTransitionForMove(item, 'intake', 'review', liveWorktreePaths)
+          : null,
+    );
+  }
+  if (columnStage !== 'done') {
+    transitions.push(reviewTransitionForMove(item, columnStage, 'done', liveWorktreePaths));
+  }
+  if (columnStage === 'review') {
+    transitions.push(reviewTransitionForMove(item, 'review', 'intake', liveWorktreePaths));
+  }
+  return transitions.filter((transition): transition is ReviewTransition => transition !== null);
+}
+
+/** Menu label for a transition, phrased as the lifecycle action it performs. */
+function reviewTransitionLabel(transition: ReviewTransition): string {
+  switch (transition.kind) {
+    case 'start-review':
+      return transition.title === 'Resume review?' ? 'Resume review…' : 'Start review…';
+    case 'complete-review':
+      return 'Mark review complete…';
+    case 'cancel-review':
+      return 'Cancel review…';
+    case 'abandon-review':
+      return 'Abandon review…';
+  }
+}
+
+/**
+ * GitHub pull-request state badge on a Review card: pure provenance, never a
+ * lifecycle input. `metadata.prState` is written by GitHub ingestion (Segment
+ * 12); until then open PRs render no badge, and terminal states show whenever
+ * the card was filed with the state recorded.
+ */
+function prStateBadge(item: WorkItem): React.ReactNode {
+  if (item.source !== 'github-pr') return null;
+  const state = item.metadata.prState;
+  if (state === 'merged') {
+    return (
+      <span
+        className="flex items-center gap-1 rounded-full bg-surface5 px-1.5 py-0.5 text-ui-xs text-accent3"
+        aria-label="Pull request merged"
+      >
+        <GitMerge size={11} aria-hidden />
+        Merged
+      </span>
+    );
+  }
+  if (state === 'closed') {
+    return (
+      <span
+        className="flex items-center gap-1 rounded-full bg-surface5 px-1.5 py-0.5 text-ui-xs text-icon4"
+        aria-label="Pull request closed"
+      >
+        <GitPullRequestClosed size={11} aria-hidden />
+        Closed
+      </span>
+    );
+  }
+  return null;
 }
 
 /**
@@ -597,9 +798,71 @@ function Board({ project, kind }: { project: Project & { githubProjectId: string
     update.mutate({ id, patch: { stages: next } });
   };
 
+  // Review board moves are lifecycle transitions, not raw stage patches:
+  // starting a review dispatches a review session, terminal moves confirm the
+  // outcome first, and abandoning detaches the review session from the card.
+  const [pendingTransition, setPendingTransition] = useState<ReviewTransition | null>(null);
+
+  /** Perform a confirmed (or unguarded) Review-board move. */
+  const applyReviewMove = (transition: ReviewTransition) => {
+    const { item, fromStage, toStage } = transition;
+    if (transition.kind === 'start-review') {
+      // A live review session means this is a resume: just move the card.
+      if (hasReviewSession(item, liveWorktreePaths)) {
+        moveItem(item.id, fromStage, toStage);
+        return;
+      }
+      const spec = itemRunSpec(item);
+      const action = spec?.actions.find(candidate => candidate.role === 'review');
+      if (spec === null || action === undefined) return;
+      start.mutate({
+        branch: spec.branch,
+        threadTitle: spec.threadTitle,
+        threadTags: action.threadTags,
+        invocation: action.invocation,
+        workItem: {
+          id: item.id,
+          role: action.role,
+          existingRoles: Object.keys(item.sessions),
+          stages: stagesAfterRunStart(item.stages, action.stage),
+          source: item.source,
+          sourceKey: item.sourceKey,
+          title: item.title,
+        },
+      });
+      return;
+    }
+    if (transition.kind === 'abandon-review') {
+      const sessions = { ...item.sessions };
+      delete sessions.review;
+      update.mutate({ id: item.id, patch: { stages: ['intake'], sessions } });
+      return;
+    }
+    // complete-review / cancel-review: the confirmed move itself.
+    moveItem(item.id, fromStage, toStage);
+  };
+
+  /**
+   * Entry point for Review-board moves (drops and menu picks). Guarded
+   * transitions open the confirmation dialog; everything else applies at once.
+   */
+  const requestReviewMove = (item: WorkItem, fromStage: BoardStageId, toStage: BoardStageId) => {
+    const transition = reviewTransitionForMove(item, fromStage, toStage, liveWorktreePaths);
+    if (transition === null) {
+      moveItem(item.id, fromStage, toStage);
+      return;
+    }
+    setPendingTransition(transition);
+  };
+
   const handleDrop = (payload: DragPayload, toStage: BoardStageId) => {
     if (payload.kind === 'work-item') {
       if (payload.fromStage === toStage) return;
+      if (review) {
+        const item = workItems.find(i => i.id === payload.id);
+        if (item) requestReviewMove(item, payload.fromStage as BoardStageId, toStage);
+        return;
+      }
       moveItem(payload.id, payload.fromStage, toStage);
       return;
     }
@@ -688,7 +951,14 @@ function Board({ project, kind }: { project: Project & { githubProjectId: string
             }
           >
             {workItems
-              .filter(item => itemAppearsInStage(item, stage.id, stages))
+              .filter(item =>
+                itemAppearsInStage(
+                  item,
+                  stage.id,
+                  stages,
+                  review ? hasReviewSession(item, liveWorktreePaths) : undefined,
+                ),
+              )
               .map(item => (
                 <WorkItemCard
                   key={`${item.id}:${stage.id}`}
@@ -740,8 +1010,26 @@ function Board({ project, kind }: { project: Project & { githubProjectId: string
                       },
                     })
                   }
-                  onMove={toStage => moveItem(item.id, stage.id, toStage)}
+                  onMove={toStage =>
+                    review
+                      ? requestReviewMove(item, stage.id, toStage as BoardStageId)
+                      : moveItem(item.id, stage.id, toStage)
+                  }
                   onRemove={() => remove.mutate(item.id)}
+                  moveMenu={
+                    review ? (
+                      <>
+                        {reviewMenuTransitions(item, stage.id, liveWorktreePaths).map(transition => (
+                          <DropdownMenu.Item
+                            key={`${transition.kind}:${transition.toStage}`}
+                            onClick={() => setPendingTransition(transition)}
+                          >
+                            {reviewTransitionLabel(transition)}
+                          </DropdownMenu.Item>
+                        ))}
+                      </>
+                    ) : undefined
+                  }
                 />
               ))}
             {candidates
@@ -805,6 +1093,33 @@ function Board({ project, kind }: { project: Project & { githubProjectId: string
           </BoardColumn>
         ))}
       </div>
+      <AlertDialog
+        open={pendingTransition !== null}
+        onOpenChange={open => {
+          if (!open) setPendingTransition(null);
+        }}
+      >
+        <AlertDialog.Content>
+          <AlertDialog.Header>
+            <AlertDialog.Title>{pendingTransition?.title}</AlertDialog.Title>
+          </AlertDialog.Header>
+          <AlertDialog.Body>
+            <AlertDialog.Description>{pendingTransition?.description}</AlertDialog.Description>
+          </AlertDialog.Body>
+          <AlertDialog.Footer>
+            <AlertDialog.Cancel>No, keep as is</AlertDialog.Cancel>
+            <AlertDialog.Action
+              onClick={() => {
+                const transition = pendingTransition;
+                setPendingTransition(null);
+                if (transition) applyReviewMove(transition);
+              }}
+            >
+              {pendingTransition?.confirmLabel}
+            </AlertDialog.Action>
+          </AlertDialog.Footer>
+        </AlertDialog.Content>
+      </AlertDialog>
     </div>
   );
 }
@@ -902,6 +1217,7 @@ function WorkItemCard({
   onStartRun,
   onMove,
   onRemove,
+  moveMenu,
 }: {
   item: WorkItem;
   columnStage: BoardStageId;
@@ -916,6 +1232,11 @@ function WorkItemCard({
   onStartRun: (spec: ItemRunSpec, action: RunAction) => void;
   onMove: (toStage: string) => void;
   onRemove: () => void;
+  /**
+   * Lifecycle transition menu items replacing the raw column list (Review
+   * board). When omitted, the default per-stage "Move to …" items render.
+   */
+  moveMenu?: React.ReactNode;
 }) {
   const { icon: Icon, className: iconClassName } = SOURCE_ICONS[item.source];
   const otherStages = item.stages.filter(stage => stage !== columnStage);
@@ -997,13 +1318,14 @@ function WorkItemCard({
                   {runStarting ? 'Starting…' : action.label}
                 </DropdownMenu.Item>
               ))}
-            {itemStageOptions(item)
-              .filter(stage => stage.id !== columnStage)
-              .map(stage => (
-                <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
-                  {stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}
-                </DropdownMenu.Item>
-              ))}
+            {moveMenu ??
+              itemStageOptions(item)
+                .filter(stage => stage.id !== columnStage)
+                .map(stage => (
+                  <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
+                    {stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}
+                  </DropdownMenu.Item>
+                ))}
             <DropdownMenu.Item onClick={onRemove}>Remove</DropdownMenu.Item>
           </DropdownMenu.Content>
         </DropdownMenu>
@@ -1020,8 +1342,9 @@ function WorkItemCard({
           </div>
         );
       })}
-      {otherStages.length > 0 && (
+      {(otherStages.length > 0 || prStateBadge(item) !== null) && (
         <div className="flex flex-wrap items-center gap-1.5">
+          {prStateBadge(item)}
           {otherStages.map(stage => (
             <span key={stage} className="rounded-full bg-surface5 px-1.5 py-0.5 text-ui-xs text-icon4">
               {itemStageLabel(item, stage)}

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -373,17 +373,16 @@ function dragTo(card: HTMLElement, target: HTMLElement) {
 }
 
 describe('Factory sidebar section', () => {
-  it('given a GitHub project, when the app renders, then the Factory heading exposes the Board link', async () => {
+  it('given a GitHub project, when the app renders, then Factory exposes sibling Work and Review links', async () => {
     useBoardHandlers();
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     const nav = await screen.findByRole('navigation', { name: 'Factory' });
     expect(within(nav).getByText('Factory')).toBeInTheDocument();
-    // The Board link appears once the GitHub status query resolves as connected.
-    expect(await within(nav).findByRole('link', { name: /Board/ })).toHaveAttribute('href', '/factory/board');
+    expect(await within(nav).findByRole('link', { name: 'Work' })).toHaveAttribute('href', '/factory/work');
+    expect(within(nav).getByRole('link', { name: 'Review' })).toHaveAttribute('href', '/factory/review');
     expect(within(nav).getByRole('link', { name: /Metrics/ })).toHaveAttribute('href', '/factory/metrics');
     expect(within(nav).getByRole('link', { name: /Audit/ })).toHaveAttribute('href', '/factory/audit');
-    // The factory Sessions list is nested under the same menu.
     expect(within(nav).getByRole('region', { name: 'Factory sessions' })).toBeInTheDocument();
   });
 
@@ -394,57 +393,59 @@ describe('Factory sidebar section', () => {
     expect(screen.queryByRole('navigation', { name: 'Factory' })).not.toBeInTheDocument();
   });
 
-  it('given GitHub is not connected, when the app renders, then the Board link is hidden but Sessions remain', async () => {
+  it('given GitHub is not connected, when the app renders, then workflow links are hidden but Sessions remain', async () => {
     renderAt('/new', githubProject, notConnectedStatus);
 
-    // Sessions work off the project's own worktrees, so the Factory menu stays;
-    // only the Board (which needs the GitHub integration) disappears.
     const nav = await screen.findByRole('navigation', { name: 'Factory' });
     expect(within(nav).getByRole('region', { name: 'Factory sessions' })).toBeInTheDocument();
-    await waitFor(() => expect(within(nav).queryByRole('link', { name: /Board/ })).not.toBeInTheDocument());
+    await waitFor(() => expect(within(nav).queryByRole('link', { name: 'Work' })).not.toBeInTheDocument());
+    expect(within(nav).queryByRole('link', { name: 'Review' })).not.toBeInTheDocument();
     expect(within(nav).queryByRole('link', { name: /Metrics/ })).not.toBeInTheDocument();
     expect(within(nav).queryByRole('link', { name: /Audit/ })).not.toBeInTheDocument();
   });
 });
 
-describe('Factory Board routing', () => {
-  it('given the legacy intake route, when visited, then it redirects to the Board', async () => {
-    useBoardHandlers();
-    const { router } = renderAt('/factory/intake');
+describe('Factory workflow routing', () => {
+  it.each(['/factory/board', '/factory/intake'])(
+    'given the compatibility route %s, when visited, then it redirects to Work',
+    async route => {
+      useBoardHandlers();
+      const { router } = renderAt(route);
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/factory/board'));
-    expect(await screen.findByRole('heading', { name: 'Board' })).toBeInTheDocument();
-  });
+      await waitFor(() => expect(router.state.location.pathname).toBe('/factory/work'));
+      expect(await screen.findByRole('heading', { name: 'Work' })).toBeInTheDocument();
+    },
+  );
 
-  it('given the legacy review route, when visited, then it redirects to the Board', async () => {
-    useBoardHandlers();
+  it('given the Review route, when visited, then the Review workflow renders without redirecting', async () => {
+    useBoardHandlers({ pullRequests });
     const { router } = renderAt('/factory/review');
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/factory/board'));
-    expect(await screen.findByRole('heading', { name: 'Board' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Review' })).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/factory/review');
   });
 
-  it('given a local project, when visiting the Board, then a GitHub-only notice renders instead of columns', async () => {
-    renderAt('/factory/board', localProject);
+  it('given a local project, when visiting Work, then a GitHub-only notice renders instead of columns', async () => {
+    renderAt('/factory/work', localProject);
 
     expect(await screen.findByText(/only available for GitHub projects/)).toBeInTheDocument();
     expect(screen.queryByTestId('board-column-intake')).not.toBeInTheDocument();
   });
 
-  it('given GitHub is not connected, when visiting the Board, then a connect notice renders instead of columns', async () => {
-    renderAt('/factory/board', githubProject, notConnectedStatus);
+  it('given GitHub is not connected, when visiting Work, then a connect notice renders instead of columns', async () => {
+    renderAt('/factory/work', githubProject, notConnectedStatus);
 
     expect(await screen.findByText(/Factory requires a GitHub connection/)).toBeInTheDocument();
     expect(screen.queryByTestId('board-column-intake')).not.toBeInTheDocument();
   });
 });
 
-describe('Factory Board — Intake candidates', () => {
-  it('given open issues and PRs, when the Board renders, then both appear as Intake candidates behind the feed filter', async () => {
+describe('Factory Work and Review intake candidates', () => {
+  it('given open issues and PRs, when Work renders, then only issue candidates appear', async () => {
     const state = useBoardHandlers({ issues, pullRequests });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
-    expect(await screen.findByRole('heading', { name: 'Board' })).toBeInTheDocument();
+    expect(await screen.findByRole('heading', { name: 'Work' })).toBeInTheDocument();
     await waitFor(() => expect(state.issueRequests).toEqual(expect.arrayContaining([null, 'auto-triaged'])));
     const intake = await screen.findByTestId('board-column-intake');
     expect(await within(intake).findByText('Fix flaky test')).toBeInTheDocument();
@@ -458,13 +459,24 @@ describe('Factory Board — Intake candidates', () => {
       'https://github.com/mastra-ai/mastra/issues/12',
     );
     expect(within(flakyCandidate).queryByText('bug')).not.toBeInTheDocument();
-    // PRs start in Intake too — behind the PRs feed pill, never in Review.
-    expect(within(column('review')).queryByTestId('candidate-card')).not.toBeInTheDocument();
-    const sources = within(intake).getByRole('group', { name: 'Intake source' });
-    await userEvent.click(within(sources).getByRole('button', { name: 'PRs' }));
-    expect(await within(column('intake')).findByText('Add factory pages')).toBeInTheDocument();
-    expect(within(column('intake')).queryByText('Fix flaky test')).not.toBeInTheDocument();
-    expect(within(column('review')).queryByTestId('candidate-card')).not.toBeInTheDocument();
+    // PRs never appear as Work intake candidates — they live on the Review board.
+    expect(within(intake).queryByText('Add factory pages')).not.toBeInTheDocument();
+    expect(screen.queryByRole('group', { name: 'Intake source' })).not.toBeInTheDocument();
+  });
+
+  it('given an external PR, when Review renders, then it stays in Intake without an automatic session or dispatch', async () => {
+    const state = useBoardHandlers({ issues, pullRequests });
+    renderAt('/factory/review');
+
+    expect(await screen.findByRole('heading', { name: 'Review' })).toBeInTheDocument();
+    const intake = await screen.findByTestId('board-column-intake');
+    expect(await within(intake).findByText('Add factory pages')).toBeInTheDocument();
+    expect(within(intake).queryByText('Fix flaky test')).not.toBeInTheDocument();
+    expect(screen.getByTestId('board-column-review')).toHaveAccessibleName('Reviewing');
+    expect(screen.queryByTestId('board-column-triage')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('board-column-planning')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('board-column-execute')).not.toBeInTheDocument();
+    expect(state.posts).toHaveLength(0);
   });
 
   it('given GitHub Intake is configured, when the Board renders, then Intake offers repository issue creation in a new tab', async () => {
@@ -600,7 +612,7 @@ describe('Factory Board — Intake candidates', () => {
         },
       ),
     );
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     const card = within(intake).getByRole('article', { name: 'Fix flaky test' });
@@ -623,7 +635,7 @@ describe('Factory Board — Intake candidates', () => {
     const unfilteredRequestsBeforeResolve = state.issueRequests.filter(label => label === null).length;
     const autoTriagedRequestsBeforeResolve = state.issueRequests.filter(label => label === 'auto-triaged').length;
     resolveTriage();
-    await waitFor(() => expect(router.state.location.pathname).toBe('/factory/board'));
+    await waitFor(() => expect(router.state.location.pathname).toBe('/factory/work'));
     await waitFor(() => {
       expect(state.issueRequests.filter(label => label === null).length).toBeGreaterThan(
         unfilteredRequestsBeforeResolve,
@@ -636,7 +648,7 @@ describe('Factory Board — Intake candidates', () => {
 
   it('given an auto-triaged issue candidate, when the Board renders, then it appears in Triage with Investigate and no label chips', async () => {
     const state = useBoardHandlers({ triageIssues: [{ ...issues[0]!, labels: ['bug', 'auto-triaged'] }] });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await waitFor(() => expect(state.issueRequests).toContain('auto-triaged'));
     const triageColumn = await screen.findByTestId('board-column-triage');
@@ -651,7 +663,7 @@ describe('Factory Board — Intake candidates', () => {
     const state = useBoardHandlers({
       triageIssues: [{ ...issues[0]!, labels: ['bug', 'auto-triaged', 'needs-approval'] }],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await waitFor(() => expect(state.issueRequests).toContain('auto-triaged'));
     const triageColumn = await screen.findByTestId('board-column-triage');
@@ -677,7 +689,7 @@ describe('Factory Board — Intake candidates', () => {
         }),
       ],
     });
-    renderAt('/factory/board', githubProject, connectedStatus, { linearStatus: linearConnectedStatus });
+    renderAt('/factory/work', githubProject, connectedStatus, { linearStatus: linearConnectedStatus });
 
     // GitHub issues are the default feed: they show, Linear's don't.
     const intake = await screen.findByTestId('board-column-intake');
@@ -703,7 +715,7 @@ describe('Factory Board — Intake candidates', () => {
 
   it('given Linear is connected and selected, when the Linear feed is picked, then Linear issues appear as candidates', async () => {
     useBoardHandlers({ linearIssues });
-    renderAt('/factory/board', githubProject, connectedStatus, { linearStatus: linearConnectedStatus });
+    renderAt('/factory/work', githubProject, connectedStatus, { linearStatus: linearConnectedStatus });
 
     const intake = await screen.findByTestId('board-column-intake');
     const sources = await within(intake).findByRole('group', { name: 'Intake source' });
@@ -714,16 +726,14 @@ describe('Factory Board — Intake candidates', () => {
 
   it('given the Linear feature is disabled, when the Board renders, then no Linear candidates or Linear feed pill appear', async () => {
     useBoardHandlers({ issues, linearIssues });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     expect(await within(intake).findByText('Fix flaky test')).toBeInTheDocument();
     expect(within(intake).queryByText('Fix intake sync')).not.toBeInTheDocument();
-    // Issues + PRs still get a switcher, but Linear is not offered.
-    const sources = within(intake).getByRole('group', { name: 'Intake source' });
-    expect(within(sources).getByRole('button', { name: 'Issues' })).toBeInTheDocument();
-    expect(within(sources).getByRole('button', { name: 'PRs' })).toBeInTheDocument();
-    expect(within(sources).queryByRole('button', { name: 'Linear' })).not.toBeInTheDocument();
+    // Work has only the Issues feed when Linear is unavailable; PR intake is
+    // owned by the sibling Review workflow.
+    expect(within(intake).queryByRole('group', { name: 'Intake source' })).not.toBeInTheDocument();
   });
 
   it('given a work item exists for an issue, when the Board renders, then candidates from both issue feeds are deduped by source key', async () => {
@@ -740,7 +750,7 @@ describe('Factory Board — Intake candidates', () => {
         }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     // Issue #15 is still a candidate; issue #12 lives on as a card in Building.
@@ -758,13 +768,13 @@ describe('Factory Board — persisted cards', () => {
         makeWorkItem({
           id: 'wi-1',
           title: 'Parallel effort',
-          source: 'github-pr',
-          sourceKey: 'github-pr:34',
+          source: 'github-issue',
+          sourceKey: 'github-issue:34',
           stages: ['execute', 'review'],
         }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     const executeCard = within(column('execute')).getByTestId('work-item-card');
@@ -776,7 +786,7 @@ describe('Factory Board — persisted cards', () => {
     expect(within(reviewCard).getByText('Building')).toBeInTheDocument();
   });
 
-  it('given related issue and PR review items, when they share a lane, then they stay separate with explicit sources and a restrained relationship marker', async () => {
+  it('given related issue and PR items, when switching workflows, then each stays on its own board with a reciprocal relation marker', async () => {
     useBoardHandlers({
       workItems: [
         makeWorkItem({
@@ -796,17 +806,21 @@ describe('Factory Board — persisted cards', () => {
         }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
-    await screen.findByTestId('board-column-intake');
-    const cards = within(column('review')).getAllByTestId('work-item-card');
-    expect(cards).toHaveLength(2);
-    expect(within(cards[0]).getByText('Issue:')).toBeInTheDocument();
-    expect(within(cards[1]).getByText('PR Review:')).toBeInTheDocument();
-    expect(within(cards[0]).getByText(/^Related /)).toBeInTheDocument();
-    expect(within(cards[1]).getByText(/^Related /)).toBeInTheDocument();
-    expect(cards[0]).toHaveAccessibleName('Fix flaky test');
-    expect(cards[1]).toHaveAccessibleName('Fix flaky test');
+    const workColumn = await screen.findByTestId('board-column-review');
+    const workCard = within(workColumn).getByTestId('work-item-card');
+    expect(within(workCard).getByText('Issue:')).toBeInTheDocument();
+    expect(within(workCard).queryByText('PR Review:')).not.toBeInTheDocument();
+    expect(within(workCard).getByText(/^Related /)).toBeInTheDocument();
+
+    const nav = screen.getByRole('navigation', { name: 'Factory' });
+    await userEvent.click(within(nav).getByRole('link', { name: 'Review' }));
+    expect(await screen.findByRole('heading', { name: 'Review' })).toBeInTheDocument();
+    const reviewCard = within(column('review')).getByTestId('work-item-card');
+    expect(within(reviewCard).getByText('PR Review:')).toBeInTheDocument();
+    expect(within(reviewCard).queryByText('Issue:')).not.toBeInTheDocument();
+    expect(within(reviewCard).getByText(/^Related /)).toBeInTheDocument();
   });
 
   // A project that still has the worktree the cards' session refs point at:
@@ -826,6 +840,57 @@ describe('Factory Board — persisted cards', () => {
     startedBy: 'user-1',
   };
 
+  it('given related Work and Review sessions, when the related session is opened from a thread, then its worktree becomes active before navigation', async () => {
+    const reviewWorktreePath = '/sandbox/mastra/worktrees/factory-pr-34';
+    const relatedProject: Project = {
+      ...projectWithIssueWorktree,
+      selectedWorktreePath: issueWorktreePath,
+      worktrees: [
+        ...(projectWithIssueWorktree.worktrees ?? []),
+        { branch: 'factory/pr-34', worktreePath: reviewWorktreePath, baseBranch: 'main' },
+      ],
+    };
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: 'wi-issue',
+          title: 'Fix flaky test',
+          source: 'github-issue',
+          sourceKey: 'github-issue:12',
+          stages: ['review'],
+          sessions: { work: { ...issueWorkSession, threadId: THREAD_ID } },
+        }),
+        makeWorkItem({
+          id: 'wi-review',
+          parentWorkItemId: 'wi-issue',
+          title: 'Review fix flaky test',
+          source: 'github-pr',
+          sourceKey: 'github-pr:34',
+          stages: ['review'],
+          sessions: {
+            review: {
+              projectPath: reviewWorktreePath,
+              branch: 'factory/pr-34',
+              threadId: 'thread-related-review',
+              startedBy: 'user-1',
+            },
+          },
+        }),
+      ],
+    });
+    const { router } = renderAt(`/threads/${THREAD_ID}`, relatedProject);
+
+    const openRelated = await screen.findByRole('button', {
+      name: 'Open related review session: Review fix flaky test',
+    });
+    await userEvent.click(openRelated);
+
+    await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-related-review'));
+    expect(JSON.parse(localStorage.getItem('mastracode-projects') ?? '[]')).toMatchObject([
+      { selectedWorktreePath: reviewWorktreePath },
+    ]);
+  });
+
   it('given a work item with sessions, when the Board renders, then the card title links to its thread', async () => {
     useBoardHandlers({
       workItems: [
@@ -839,7 +904,7 @@ describe('Factory Board — persisted cards', () => {
         }),
       ],
     });
-    renderAt('/factory/board', projectWithIssueWorktree);
+    renderAt('/factory/work', projectWithIssueWorktree);
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
@@ -860,7 +925,7 @@ describe('Factory Board — persisted cards', () => {
         }),
       ],
     });
-    renderAt('/factory/board', projectWithIssueWorktree);
+    renderAt('/factory/work', projectWithIssueWorktree);
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
@@ -885,7 +950,7 @@ describe('Factory Board — persisted cards', () => {
         }),
       ],
     });
-    renderAt('/factory/board', projectWithIssueWorktree);
+    renderAt('/factory/work', projectWithIssueWorktree);
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
@@ -911,7 +976,7 @@ describe('Factory Board — persisted cards', () => {
       ],
     });
     // The default project does not have the ref's worktree — it was deleted.
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
@@ -949,7 +1014,7 @@ describe('Factory Board — persisted cards', () => {
         return HttpResponse.json({ ok: true });
       }),
     );
-    const { router } = renderAt('/factory/board', projectWithIssueWorktree);
+    const { router } = renderAt('/factory/work', projectWithIssueWorktree);
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
@@ -967,7 +1032,7 @@ describe('Factory Board — persisted cards', () => {
         makeWorkItem({ id: 'wi-1', title: 'Fix flaky test', source: 'github-issue', sourceKey: 'github-issue:12' }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     await userEvent.click(within(column('intake')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -992,7 +1057,7 @@ describe('Factory Board — persisted cards', () => {
       ],
     });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     await screen.findByTestId('board-column-triage');
     await userEvent.click(within(column('triage')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1018,7 +1083,7 @@ describe('Factory Board — persisted cards', () => {
       ],
     });
     const captured = useFactoryRunHandlers('factory-issue-21');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     await screen.findByTestId('board-column-triage');
     await userEvent.click(within(column('triage')).getByRole('button', { name: 'Actions for Add OAuth support' }));
@@ -1055,7 +1120,7 @@ describe('Factory Board — persisted cards', () => {
         }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-triage');
     await userEvent.click(within(column('triage')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1080,7 +1145,7 @@ describe('Factory Board — persisted cards', () => {
       ],
     });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     await screen.findByTestId('board-column-planning');
     await userEvent.click(within(column('planning')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1098,7 +1163,7 @@ describe('Factory Board — persisted cards', () => {
         makeWorkItem({ id: 'wi-1', title: 'Fix flaky test', source: 'github-issue', sourceKey: 'github-issue:12' }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     await userEvent.click(within(column('intake')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1115,7 +1180,7 @@ describe('Factory Board — persisted cards', () => {
         makeWorkItem({ id: 'wi-1', title: 'Fix flaky test', source: 'github-issue', sourceKey: 'github-issue:12' }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     await userEvent.click(within(column('intake')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1127,7 +1192,7 @@ describe('Factory Board — persisted cards', () => {
 
   it('given a candidate, when "Add to board" is chosen, then a work item is filed into Intake without starting a run', async () => {
     const state = useBoardHandlers({ issues });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
@@ -1152,7 +1217,7 @@ describe('Factory Board — drag and drop', () => {
         makeWorkItem({ id: 'wi-1', title: 'Fix flaky test', source: 'github-issue', sourceKey: 'github-issue:12' }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     dragTo(within(column('intake')).getByTestId('work-item-card'), column('execute'));
@@ -1168,13 +1233,13 @@ describe('Factory Board — drag and drop', () => {
         makeWorkItem({
           id: 'wi-1',
           title: 'Parallel effort',
-          source: 'github-pr',
-          sourceKey: 'github-pr:34',
+          source: 'github-issue',
+          sourceKey: 'github-issue:34',
           stages: ['execute', 'review'],
         }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     dragTo(within(column('review')).getByTestId('work-item-card'), column('done'));
@@ -1186,7 +1251,7 @@ describe('Factory Board — drag and drop', () => {
 
   it('given an unmaterialized candidate, when dragged to Building, then a work item is filed with that stage and no run starts', async () => {
     const state = useBoardHandlers({ issues });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
@@ -1208,7 +1273,7 @@ describe('Factory Board — drag and drop', () => {
         makeWorkItem({ id: 'wi-1', title: 'Fix flaky test', source: 'github-issue', sourceKey: 'github-issue:12' }),
       ],
     });
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     dragTo(within(column('intake')).getByTestId('work-item-card'), column('intake'));
@@ -1269,7 +1334,7 @@ describe('Factory Board — investigate flow', () => {
   it('given an issue candidate, when Investigate is clicked, then a worktree, thread, and direct skill activation are created, a work item materializes into Planning, and the app navigates to the thread', async () => {
     const state = useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
@@ -1329,7 +1394,7 @@ describe('Factory Board — investigate flow', () => {
         return HttpResponse.json({ ok: true });
       }),
     );
-    ({ router } = renderAt('/factory/board'));
+    ({ router } = renderAt('/factory/work'));
 
     try {
       const intake = await screen.findByTestId('board-column-intake');
@@ -1363,7 +1428,7 @@ describe('Factory Board — investigate flow', () => {
         return HttpResponse.json({ error: 'kickoff failed' }, { status: 500 });
       }),
     );
-    renderAt('/factory/board');
+    renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
@@ -1388,14 +1453,14 @@ describe('Factory Board — investigate flow', () => {
         );
       }),
     );
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
     await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
 
     expect(await screen.findByText('Skill not found: understand-issue.')).toBeInTheDocument();
-    expect(router.state.location.pathname).toBe('/factory/board');
+    expect(router.state.location.pathname).toBe('/factory/work');
     expect(captured.skillInvocations).toHaveLength(1);
     expect(captured.messages).toHaveLength(0);
     expect(state.posts).toHaveLength(0);
@@ -1420,7 +1485,7 @@ describe('Factory Board — investigate flow', () => {
         return HttpResponse.json({ ok: true });
       }),
     );
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
@@ -1455,7 +1520,7 @@ describe('Factory Board — investigate flow', () => {
     );
     const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     try {
-      const { router } = renderAt('/factory/board');
+      const { router } = renderAt('/factory/work');
 
       const intake = await screen.findByTestId('board-column-intake');
       await within(intake).findByText('Fix flaky test');
@@ -1472,14 +1537,12 @@ describe('Factory Board — investigate flow', () => {
     }
   });
 
-  it('given a PR candidate in Intake, when Review is clicked, then the review prompt runs and a work item materializes into Review with a review session', async () => {
+  it('given a PR candidate in Review Intake, when Review is clicked, then the review prompt runs and a work item materializes into Reviewing with a review session', async () => {
     const state = useBoardHandlers({ pullRequests });
     const captured = useFactoryRunHandlers('factory-pr-34');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/review');
 
     const intake = await screen.findByTestId('board-column-intake');
-    const sources = within(intake).getByRole('group', { name: 'Intake source' });
-    await userEvent.click(within(sources).getByRole('button', { name: 'PRs' }));
     await within(intake).findByText('Add factory pages');
     await userEvent.click(within(intake).getByRole('button', { name: 'Review Add factory pages' }));
 
@@ -1517,7 +1580,7 @@ describe('Factory Board — investigate flow', () => {
   it('given a Linear candidate, when Investigate is clicked, then the prompt mentions the linear_get_issue tool', async () => {
     useBoardHandlers({ linearIssues });
     const captured = useFactoryRunHandlers('factory-linear-eng-42');
-    const { router } = renderAt('/factory/board', githubProject, connectedStatus, {
+    const { router } = renderAt('/factory/work', githubProject, connectedStatus, {
       linearStatus: linearConnectedStatus,
     });
 
@@ -1543,7 +1606,7 @@ describe('Factory Board — investigate flow', () => {
   it('given an issue candidate, when a custom prompt is submitted, then the run keeps the issue context and adds the typed guidance', async () => {
     useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
@@ -1584,7 +1647,7 @@ describe('Factory Board — investigate flow', () => {
       ],
     });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
     await userEvent.click(within(column('intake')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1634,7 +1697,7 @@ describe('Factory Board — investigate flow', () => {
       ],
     });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     await screen.findByTestId('board-column-planning');
     await userEvent.click(within(column('planning')).getByRole('button', { name: 'Actions for Fix flaky test' }));
@@ -1672,7 +1735,7 @@ describe('Factory Board — investigate flow', () => {
       ],
     });
     const captured = useFactoryRunHandlers('factory-pr-34');
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/review');
     // The worktree session resumes a real (titled) thread from a previous run.
     // Registered after renderAt so it takes precedence over the default empty
     // thread list from useAppHandlers (MSW resolves newest-first).
@@ -1722,7 +1785,7 @@ describe('Factory Board — investigate flow', () => {
         HttpResponse.json({ error: 'git_error', message: 'worktree failed' }, { status: 502 }),
       ),
     );
-    const { router } = renderAt('/factory/board');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
@@ -1730,7 +1793,7 @@ describe('Factory Board — investigate flow', () => {
 
     expect(await screen.findByText('worktree failed')).toBeInTheDocument();
     expect(state.posts).toEqual([]);
-    expect(router.state.location.pathname).toBe('/factory/board');
+    expect(router.state.location.pathname).toBe('/factory/work');
   });
 });
 

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -209,6 +209,7 @@ function makeWorkItem(overrides: Partial<WorkItem> & Pick<WorkItem, 'id' | 'titl
     githubProjectId: GITHUB_PROJECT_ID,
     source: 'manual',
     sourceKey: null,
+    parentWorkItemId: null,
     url: null,
     stages: ['intake'],
     stageHistory: [],
@@ -287,6 +288,7 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
         title: body.title,
         source: body.source,
         sourceKey: body.sourceKey,
+        parentWorkItemId: body.parentWorkItemId ?? null,
         url: body.url ?? null,
         stages: body.stages,
         sessions,
@@ -306,6 +308,7 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
       const updated: WorkItem = {
         ...existing,
         ...(body.title !== undefined ? { title: body.title } : {}),
+        ...(body.parentWorkItemId !== undefined ? { parentWorkItemId: body.parentWorkItemId } : {}),
         ...(body.stages !== undefined ? { stages: body.stages } : {}),
         sessions: { ...existing.sessions, ...stampedSessions },
         metadata: { ...existing.metadata, ...(body.metadata ?? {}) },
@@ -771,6 +774,39 @@ describe('Factory Board — persisted cards', () => {
     // Each card chips the item's other stage.
     expect(within(executeCard).getByText('Review')).toBeInTheDocument();
     expect(within(reviewCard).getByText('Building')).toBeInTheDocument();
+  });
+
+  it('given related issue and PR review items, when they share a lane, then they stay separate with explicit sources and a restrained relationship marker', async () => {
+    useBoardHandlers({
+      workItems: [
+        makeWorkItem({
+          id: 'wi-issue',
+          title: 'Fix flaky test',
+          source: 'github-issue',
+          sourceKey: 'github-issue:12',
+          stages: ['review'],
+        }),
+        makeWorkItem({
+          id: 'wi-review',
+          parentWorkItemId: 'wi-issue',
+          title: 'Fix flaky test',
+          source: 'github-pr',
+          sourceKey: 'github-pr:34',
+          stages: ['review'],
+        }),
+      ],
+    });
+    renderAt('/factory/board');
+
+    await screen.findByTestId('board-column-intake');
+    const cards = within(column('review')).getAllByTestId('work-item-card');
+    expect(cards).toHaveLength(2);
+    expect(within(cards[0]).getByText('Issue:')).toBeInTheDocument();
+    expect(within(cards[1]).getByText('PR Review:')).toBeInTheDocument();
+    expect(within(cards[0]).getByText(/^Related /)).toBeInTheDocument();
+    expect(within(cards[1]).getByText(/^Related /)).toBeInTheDocument();
+    expect(cards[0]).toHaveAccessibleName('Fix flaky test');
+    expect(cards[1]).toHaveAccessibleName('Fix flaky test');
   });
 
   // A project that still has the worktree the cards' session refs point at:

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -160,10 +160,11 @@ const linearIssues: LinearIssue[] = [
 interface AppHandlerOptions {
   intakeConfig?: IntakeConfig;
   linearStatus?: LinearStatus;
+  sessionThreadId?: string;
 }
 
 function useAppHandlers(githubStatus: GithubStatus, options: AppHandlerOptions = {}) {
-  let boundThreadId = THREAD_ID;
+  let boundThreadId = options.sessionThreadId ?? THREAD_ID;
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () => new Response(null, { status: 404 })),
     http.get(`${TEST_BASE_URL}/web/github/status`, () => HttpResponse.json(githubStatus)),
@@ -176,7 +177,7 @@ function useAppHandlers(githubStatus: GithubStatus, options: AppHandlerOptions =
     ),
     http.post(`${API}/sessions`, async ({ request }) => {
       const body = (await request.json()) as { sessionScope?: string };
-      boundThreadId = body.sessionScope ? 'thread-factory' : THREAD_ID;
+      if (body.sessionScope) boundThreadId = 'thread-factory';
       return HttpResponse.json({ controllerId: 'code', resourceId: RESOURCE_ID, threadId: boundThreadId });
     }),
     http.get(`${API}/modes`, () => HttpResponse.json({ modes: [{ id: 'build', label: 'Build' }] })),
@@ -189,14 +190,14 @@ function useAppHandlers(githubStatus: GithubStatus, options: AppHandlerOptions =
       return HttpResponse.json({
         threads: scoped
           ? [{ id: 'thread-factory', resourceId: RESOURCE_ID, title: 'Untitled thread' }]
-          : [{ id: THREAD_ID, resourceId: RESOURCE_ID, title: 'Existing thread' }],
+          : [{ id: boundThreadId, resourceId: RESOURCE_ID, title: 'Existing thread' }],
       });
     }),
     http.post(`${SESSION}/thread`, async ({ request }) => {
       boundThreadId = ((await request.json()) as { threadId: string }).threadId;
       return HttpResponse.json({ ok: true });
     }),
-    http.get(`${SESSION}/threads/${THREAD_ID}/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${SESSION}/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
     http.get(`${SESSION}/stream`, () => emptySse()),
   );
 }
@@ -840,56 +841,75 @@ describe('Factory Board — persisted cards', () => {
     startedBy: 'user-1',
   };
 
-  it('given related Work and Review sessions, when the related session is opened from a thread, then its worktree becomes active before navigation', async () => {
-    const reviewWorktreePath = '/sandbox/mastra/worktrees/factory-pr-34';
-    const relatedProject: Project = {
-      ...projectWithIssueWorktree,
-      selectedWorktreePath: issueWorktreePath,
-      worktrees: [
-        ...(projectWithIssueWorktree.worktrees ?? []),
-        { branch: 'factory/pr-34', worktreePath: reviewWorktreePath, baseBranch: 'main' },
-      ],
-    };
-    useBoardHandlers({
-      workItems: [
-        makeWorkItem({
-          id: 'wi-issue',
-          title: 'Fix flaky test',
-          source: 'github-issue',
-          sourceKey: 'github-issue:12',
-          stages: ['review'],
-          sessions: { work: { ...issueWorkSession, threadId: THREAD_ID } },
-        }),
-        makeWorkItem({
-          id: 'wi-review',
-          parentWorkItemId: 'wi-issue',
-          title: 'Review fix flaky test',
-          source: 'github-pr',
-          sourceKey: 'github-pr:34',
-          stages: ['review'],
-          sessions: {
-            review: {
-              projectPath: reviewWorktreePath,
-              branch: 'factory/pr-34',
-              threadId: 'thread-related-review',
-              startedBy: 'user-1',
-            },
-          },
-        }),
-      ],
-    });
-    const { router } = renderAt(`/threads/${THREAD_ID}`, relatedProject);
+  const reviewWorktreePath = '/sandbox/mastra/worktrees/factory-pr-34';
+  const relatedWorkItems = [
+    makeWorkItem({
+      id: 'wi-issue',
+      title: 'Fix flaky test',
+      source: 'github-issue',
+      sourceKey: 'github-issue:12',
+      stages: ['review'],
+      sessions: { work: { ...issueWorkSession, threadId: THREAD_ID } },
+    }),
+    makeWorkItem({
+      id: 'wi-review',
+      parentWorkItemId: 'wi-issue',
+      title: 'Review fix flaky test',
+      source: 'github-pr',
+      sourceKey: 'github-pr:34',
+      stages: ['review'],
+      sessions: {
+        review: {
+          projectPath: reviewWorktreePath,
+          branch: 'factory/pr-34',
+          threadId: 'thread-related-review',
+          startedBy: 'user-1',
+        },
+      },
+    }),
+  ];
 
-    const openRelated = await screen.findByRole('button', {
-      name: 'Open related review session: Review fix flaky test',
-    });
-    await userEvent.click(openRelated);
+  it.each([
+    {
+      surface: 'Work',
+      initialThreadId: THREAD_ID,
+      initialWorktreePath: issueWorktreePath,
+      buttonName: 'Open related review session: Review fix flaky test',
+      destinationThreadId: 'thread-related-review',
+      destinationWorktreePath: reviewWorktreePath,
+    },
+    {
+      surface: 'Review',
+      initialThreadId: 'thread-related-review',
+      initialWorktreePath: reviewWorktreePath,
+      buttonName: 'Open related work session: Fix flaky test',
+      destinationThreadId: THREAD_ID,
+      destinationWorktreePath: issueWorktreePath,
+    },
+  ])(
+    'given related sessions on the $surface thread, when the related session is opened, then its worktree becomes active before navigation',
+    async ({ initialThreadId, initialWorktreePath, buttonName, destinationThreadId, destinationWorktreePath }) => {
+      const relatedProject: Project = {
+        ...projectWithIssueWorktree,
+        selectedWorktreePath: initialWorktreePath,
+        worktrees: [
+          ...(projectWithIssueWorktree.worktrees ?? []),
+          { branch: 'factory/pr-34', worktreePath: reviewWorktreePath, baseBranch: 'main' },
+        ],
+      };
+      useBoardHandlers({ workItems: relatedWorkItems });
+      const { router } = renderAt(`/threads/${initialThreadId}`, relatedProject, connectedStatus, {
+        sessionThreadId: initialThreadId,
+      });
 
-    await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-related-review'));
-    expect(JSON.parse(localStorage.getItem('mastracode-projects') ?? '[]')).toMatchObject([
-      { selectedWorktreePath: reviewWorktreePath },
-    ]);
-  });
+      await userEvent.click(await screen.findByRole('button', { name: buttonName }));
+
+      await waitFor(() => expect(router.state.location.pathname).toBe(`/threads/${destinationThreadId}`));
+      expect(JSON.parse(localStorage.getItem('mastracode-projects') ?? '[]')).toMatchObject([
+        { selectedWorktreePath: destinationWorktreePath },
+      ]);
+    },
+  );
 
   it('given a work item with sessions, when the Board renders, then the card title links to its thread', async () => {
     useBoardHandlers({

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -177,7 +177,11 @@ function useAppHandlers(githubStatus: GithubStatus, options: AppHandlerOptions =
     ),
     http.post(`${API}/sessions`, async ({ request }) => {
       const body = (await request.json()) as { sessionScope?: string };
-      if (body.sessionScope) boundThreadId = 'thread-factory';
+      if (body.sessionScope && options.sessionThreadId) {
+        boundThreadId = body.sessionScope.includes('factory-pr-34') ? 'thread-related-review' : THREAD_ID;
+      } else if (body.sessionScope) {
+        boundThreadId = 'thread-factory';
+      }
       return HttpResponse.json({ controllerId: 'code', resourceId: RESOURCE_ID, threadId: boundThreadId });
     }),
     http.get(`${API}/modes`, () => HttpResponse.json({ modes: [{ id: 'build', label: 'Build' }] })),
@@ -188,9 +192,12 @@ function useAppHandlers(githubStatus: GithubStatus, options: AppHandlerOptions =
     http.get(`${SESSION}/threads`, ({ request }) => {
       const scoped = new URL(request.url).searchParams.has('sessionScope');
       return HttpResponse.json({
-        threads: scoped
-          ? [{ id: 'thread-factory', resourceId: RESOURCE_ID, title: 'Untitled thread' }]
-          : [{ id: boundThreadId, resourceId: RESOURCE_ID, title: 'Existing thread' }],
+        threads: [
+          ...(scoped ? [{ id: 'thread-factory', resourceId: RESOURCE_ID, title: 'Untitled thread' }] : []),
+          { id: THREAD_ID, resourceId: RESOURCE_ID, title: 'Existing thread' },
+          { id: 'thread-work', resourceId: RESOURCE_ID, title: 'Worker thread' },
+          { id: 'thread-related-review', resourceId: RESOURCE_ID, title: 'Related review thread' },
+        ],
       });
     }),
     http.post(`${SESSION}/thread`, async ({ request }) => {
@@ -519,8 +526,8 @@ describe('Factory Work and Review intake candidates', () => {
         makeWorkItem({
           id: '00000000-0000-4000-8000-000000000042',
           title: 'Add factory pages',
-          source: 'github-pr',
-          sourceKey: 'github-pr:42',
+          source: 'github-issue',
+          sourceKey: 'github-issue:42',
           stages: ['review'],
         }),
       ],
@@ -563,8 +570,8 @@ describe('Factory Work and Review intake candidates', () => {
         makeWorkItem({
           id: '00000000-0000-4000-8000-000000000042',
           title: 'Add factory pages',
-          source: 'github-pr',
-          sourceKey: 'github-pr:42',
+          source: 'github-issue',
+          sourceKey: 'github-issue:42',
           stages: ['review'],
         }),
       ],

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -811,10 +811,24 @@ describe('Factory Board — persisted cards', () => {
           source: 'github-pr',
           sourceKey: 'github-pr:34',
           stages: ['review'],
+          sessions: {
+            review: {
+              projectPath: '/sandbox/mastra/worktrees/factory-pr-34',
+              branch: 'factory/pr-34',
+              threadId: 'thread-related-review',
+              startedBy: 'user-1',
+            },
+          },
         }),
       ],
     });
-    renderAt('/factory/work');
+    renderAt('/factory/work', {
+      ...githubProject,
+      worktrees: [
+        ...(githubProject.worktrees ?? []),
+        { branch: 'factory/pr-34', worktreePath: '/sandbox/mastra/worktrees/factory-pr-34', baseBranch: 'main' },
+      ],
+    });
 
     const workColumn = await screen.findByTestId('board-column-review');
     const workCard = within(workColumn).getByTestId('work-item-card');
@@ -1314,6 +1328,186 @@ describe('Factory Board — drag and drop', () => {
   });
 });
 
+describe('Factory Review board — lifecycle transitions', () => {
+  const prItem = (overrides: Partial<WorkItem> = {}) =>
+    makeWorkItem({
+      id: 'wi-pr-1',
+      title: 'Add factory pages',
+      source: 'github-pr',
+      sourceKey: 'github-pr:34',
+      url: 'https://github.com/mastra-ai/mastra/pull/34',
+      metadata: { number: 34, author: 'grace', headBranch: 'feat/factory', baseBranch: 'main' },
+      ...overrides,
+    });
+
+  const reviewSession = {
+    review: {
+      projectPath: '/sandbox/mastra/worktrees/factory-pr-34',
+      branch: 'factory/pr-34',
+      threadId: 'thread-related-review',
+      startedBy: 'user-1',
+    },
+  };
+
+  /** Project with the review worktree present so review session refs are live. */
+  const projectWithReviewWorktree: Project = {
+    ...githubProject,
+    worktrees: [
+      ...(githubProject.worktrees ?? []),
+      { branch: 'factory/pr-34', worktreePath: '/sandbox/mastra/worktrees/factory-pr-34', baseBranch: 'main' },
+    ],
+  };
+
+  it('given an Intake PR card, when dragged to Reviewing and the prompt is declined, then it stays in Intake with no session created', async () => {
+    const state = useBoardHandlers({ workItems: [prItem()] });
+    renderAt('/factory/review');
+
+    const intake = await screen.findByTestId('board-column-intake');
+    await within(intake).findByText('Add factory pages');
+    dragTo(within(intake).getByTestId('work-item-card'), column('review'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('Start review?')).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: 'No, keep as is' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+    expect(within(column('intake')).getByText('Add factory pages')).toBeInTheDocument();
+    expect(state.patches).toEqual([]);
+    expect(state.posts).toEqual([]);
+  });
+
+  it('given an Intake PR card, when dragged to Reviewing and confirmed, then a review session is created and the card moves', async () => {
+    const state = useBoardHandlers({ workItems: [prItem()] });
+    const captured = useFactoryRunHandlers('factory-pr-34');
+    renderAt('/factory/review');
+
+    const intake = await screen.findByTestId('board-column-intake');
+    await within(intake).findByText('Add factory pages');
+    dragTo(within(intake).getByTestId('work-item-card'), column('review'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Start review' }));
+
+    // The review run dispatches exactly once and files the card into Reviewing.
+    await waitFor(() => expect(captured.skillInvocations).toHaveLength(1));
+    await waitFor(() =>
+      expect(state.patches).toEqual([expect.objectContaining({ id: 'wi-pr-1', stages: ['review'] })]),
+    );
+    // The run navigated to the new thread; the card itself carries the Reviewing stage.
+    const card = state.items.find(i => i.id === 'wi-pr-1');
+    expect(card?.stages).toEqual(['review']);
+    expect(card?.sessions.review?.threadId).toBeDefined();
+  });
+
+  it('given an open PR card in Reviewing, when dragged to Done and declined, then the cancel confirmation leaves it unchanged', async () => {
+    const state = useBoardHandlers({
+      workItems: [prItem({ stages: ['review'], sessions: reviewSession })],
+    });
+    renderAt('/factory/review', projectWithReviewWorktree);
+
+    const reviewing = await screen.findByTestId('board-column-review');
+    await within(reviewing).findByText('Add factory pages');
+    dragTo(within(reviewing).getByTestId('work-item-card'), column('done'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(
+      within(dialog).getByText(/This pull request is still open — mark the Factory review .* as canceled\?/),
+    ).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: 'No, keep as is' }));
+
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument());
+    expect(within(column('review')).getByText('Add factory pages')).toBeInTheDocument();
+    expect(state.patches).toEqual([]);
+  });
+
+  it('given an open PR card in Reviewing, when dragged to Done and confirmed, then the card is canceled into Done', async () => {
+    const state = useBoardHandlers({
+      workItems: [prItem({ stages: ['review'], sessions: reviewSession })],
+    });
+    renderAt('/factory/review', projectWithReviewWorktree);
+
+    const reviewing = await screen.findByTestId('board-column-review');
+    await within(reviewing).findByText('Add factory pages');
+    dragTo(within(reviewing).getByTestId('work-item-card'), column('done'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Cancel review' }));
+
+    await waitFor(() => expect(state.patches).toEqual([{ id: 'wi-pr-1', stages: ['done'] }]));
+    expect(within(column('done')).getByText('Add factory pages')).toBeInTheDocument();
+  });
+
+  it('given a merged PR card in Reviewing, when dragged to Done, then the completion wording shows no cancel copy', async () => {
+    const state = useBoardHandlers({
+      workItems: [
+        prItem({
+          stages: ['review'],
+          sessions: reviewSession,
+          metadata: { number: 34, headBranch: 'feat/factory', prState: 'merged' },
+        }),
+      ],
+    });
+    renderAt('/factory/review', projectWithReviewWorktree);
+
+    const reviewing = await screen.findByTestId('board-column-review');
+    await within(reviewing).findByText('Add factory pages');
+    expect(within(reviewing).getByLabelText('Pull request merged')).toBeInTheDocument();
+    dragTo(within(reviewing).getByTestId('work-item-card'), column('done'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('Mark review complete?')).toBeInTheDocument();
+    expect(within(dialog).queryByText(/still open/)).not.toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Mark complete' }));
+
+    await waitFor(() => expect(state.patches).toEqual([{ id: 'wi-pr-1', stages: ['done'] }]));
+  });
+
+  it('given a Reviewing card, when dragged back to Intake and confirmed, then the review session detaches and the card returns', async () => {
+    const state = useBoardHandlers({
+      workItems: [prItem({ stages: ['review'], sessions: reviewSession })],
+    });
+    renderAt('/factory/review', projectWithReviewWorktree);
+
+    const reviewing = await screen.findByTestId('board-column-review');
+    await within(reviewing).findByText('Add factory pages');
+    dragTo(within(reviewing).getByTestId('work-item-card'), column('intake'));
+
+    const dialog = await screen.findByRole('alertdialog');
+    expect(within(dialog).getByText('Abandon review?')).toBeInTheDocument();
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Abandon review' }));
+
+    await waitFor(() =>
+      expect(state.patches).toEqual([expect.objectContaining({ id: 'wi-pr-1', stages: ['intake'] })]),
+    );
+    expect(state.patches[0]!.sessions).toEqual({});
+    await waitFor(() => expect(within(column('intake')).getByText('Add factory pages')).toBeInTheDocument());
+  });
+
+  it('given a sessionless card beyond Intake, when rendered, then it appears in Intake as the only sessionless lane', async () => {
+    useBoardHandlers({ workItems: [prItem({ stages: ['review'] })] });
+    renderAt('/factory/review');
+
+    const intake = await screen.findByTestId('board-column-intake');
+    await waitFor(() => expect(within(intake).getByText('Add factory pages')).toBeInTheDocument());
+    expect(within(column('review')).queryByText('Add factory pages')).not.toBeInTheDocument();
+  });
+
+  it('given an Intake PR card with a live review session, when the card menu opens, then it offers lifecycle transitions instead of raw column targets', async () => {
+    useBoardHandlers({ workItems: [prItem()] });
+    renderAt('/factory/review');
+
+    const intake = await screen.findByTestId('board-column-intake');
+    await within(intake).findByText('Add factory pages');
+    await userEvent.click(within(intake).getByRole('button', { name: 'Actions for Add factory pages' }));
+
+    const menu = await screen.findByRole('menu');
+    expect(within(menu).getByText('Start review…')).toBeInTheDocument();
+    expect(within(menu).getByText('Cancel review…')).toBeInTheDocument();
+    expect(within(menu).queryByText('Move to Reviewing')).not.toBeInTheDocument();
+    expect(within(menu).queryByText('Move to Intake')).not.toBeInTheDocument();
+  });
+});
+
 interface CapturedRun {
   worktree?: Record<string, unknown>;
   threadTitles: string[];
@@ -1761,6 +1955,16 @@ describe('Factory Board — investigate flow', () => {
           url: 'https://github.com/mastra-ai/mastra/pull/34',
           stages: ['review'],
           metadata: { number: 34, headBranch: 'feat/factory-pages', baseBranch: 'main' },
+          // The previous run's worktree was deleted (session ref is stale):
+          // the card keeps its Reviewing stage and the review run is re-offered.
+          sessions: {
+            review: {
+              projectPath: '/sandbox/mastra/worktrees/factory-pr-34',
+              branch: 'factory/pr-34',
+              threadId: THREAD_ID,
+              startedBy: 'user-1',
+            },
+          },
         }),
       ],
     });
@@ -1781,8 +1985,9 @@ describe('Factory Board — investigate flow', () => {
       http.post(`${SESSION}/thread`, () => HttpResponse.json({ ok: true })),
     );
 
-    await screen.findByTestId('board-column-review');
-    await userEvent.click(within(column('review')).getByRole('button', { name: 'Actions for Add factory pages' }));
+    await screen.findByTestId('board-column-intake');
+    // The stale session renders the card in Intake, where the review run is re-offered.
+    await userEvent.click(within(column('intake')).getByRole('button', { name: 'Actions for Add factory pages' }));
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Review' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe(`/threads/${THREAD_ID}`));

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -935,7 +935,10 @@ describe('Factory Board — persisted cards', () => {
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
-    expect(within(card).getByRole('link', { name: 'Fix flaky test' })).toHaveAttribute('href', '/threads/thread-work');
+    expect(within(card).getByRole('link', { name: 'Issue: Fix flaky test' })).toHaveAttribute(
+      'href',
+      '/threads/thread-work',
+    );
   });
 
   it('given plan and work sessions on the same thread, when the Board renders, then the card shows a single thread link', async () => {
@@ -958,7 +961,7 @@ describe('Factory Board — persisted cards', () => {
     const card = within(column('execute')).getByTestId('work-item-card');
     const links = within(card).getAllByRole('link');
     expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAccessibleName('Fix flaky test');
+    expect(links[0]).toHaveAccessibleName('Issue: Fix flaky test');
     expect(links[0]).toHaveAttribute('href', '/threads/thread-shared');
   });
 
@@ -983,7 +986,7 @@ describe('Factory Board — persisted cards', () => {
     const card = within(column('execute')).getByTestId('work-item-card');
     const links = within(card).getAllByRole('link');
     expect(links).toHaveLength(1);
-    expect(links[0]).toHaveAccessibleName('Fix flaky test');
+    expect(links[0]).toHaveAccessibleName('Issue: Fix flaky test');
     // The last-filed ref wins until the next run converges them.
     expect(links[0]).toHaveAttribute('href', '/threads/thread-work');
   });
@@ -1009,7 +1012,7 @@ describe('Factory Board — persisted cards', () => {
     const card = within(column('execute')).getByTestId('work-item-card');
     // The stale ref renders no thread link: the title is a create-session button.
     expect(within(card).queryByRole('link')).not.toBeInTheDocument();
-    expect(within(card).getByRole('button', { name: 'Fix flaky test' })).toBeInTheDocument();
+    expect(within(card).getByRole('button', { name: 'Issue: Fix flaky test' })).toBeInTheDocument();
     // The stale ref no longer occupies the run slot: runs are offered again.
     await userEvent.click(within(card).getByRole('button', { name: 'Actions for Fix flaky test' }));
     expect(await screen.findByRole('menuitem', { name: 'Investigate' })).toBeInTheDocument();
@@ -1045,7 +1048,7 @@ describe('Factory Board — persisted cards', () => {
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
-    await userEvent.click(within(card).getByRole('link', { name: 'Fix flaky test' }));
+    await userEvent.click(within(card).getByRole('link', { name: 'Issue: Fix flaky test' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-work'));
     const stored = JSON.parse(localStorage.getItem('mastracode-projects') ?? '[]') as Project[];
@@ -1853,7 +1856,7 @@ describe('Factory Board — open session from the card title', () => {
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('intake')).getByTestId('work-item-card');
-    await userEvent.click(within(card).getByRole('button', { name: 'Fix flaky test' }));
+    await userEvent.click(within(card).getByRole('button', { name: 'Issue: Fix flaky test' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
@@ -1898,7 +1901,7 @@ describe('Factory Board — open session from the card title', () => {
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('execute')).getByTestId('work-item-card');
-    await userEvent.click(within(card).getByRole('button', { name: 'Fix flaky test' }));
+    await userEvent.click(within(card).getByRole('button', { name: 'Issue: Fix flaky test' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.messages).toEqual([]);
@@ -1917,7 +1920,7 @@ describe('Factory Board — open session from the card title', () => {
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
-    await userEvent.click(within(intake).getByRole('button', { name: 'Fix flaky test' }));
+    await userEvent.click(within(intake).getByRole('button', { name: 'Issue: Fix flaky test' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
@@ -1944,7 +1947,7 @@ describe('Factory Board — open session from the card title', () => {
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('intake')).getByTestId('work-item-card');
-    await userEvent.click(within(card).getByRole('button', { name: 'Manual card' }));
+    await userEvent.click(within(card).getByRole('button', { name: 'Manual: Manual card' }));
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/item-wi-manual' });
@@ -1980,7 +1983,10 @@ describe('Factory Board — open session from the card title', () => {
 
     await screen.findByTestId('board-column-intake');
     const card = within(column('intake')).getByTestId('work-item-card');
-    expect(within(card).getByRole('link', { name: 'Fix flaky test' })).toHaveAttribute('href', '/threads/thread-work');
+    expect(within(card).getByRole('link', { name: 'Issue: Fix flaky test' })).toHaveAttribute(
+      'href',
+      '/threads/thread-work',
+    );
     // A chat session occupies no run slot: Investigate and Build stay offered.
     await userEvent.click(within(card).getByRole('button', { name: 'Actions for Fix flaky test' }));
     expect(await screen.findByRole('menuitem', { name: 'Investigate' })).toBeInTheDocument();

--- a/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
@@ -1,5 +1,5 @@
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ChartLine, ScrollText, SquareKanban } from 'lucide-react';
+import { ChartLine, GitPullRequest, ScrollText, SquareKanban } from 'lucide-react';
 import type { ComponentType, ReactNode } from 'react';
 import { NavLink } from 'react-router';
 
@@ -31,7 +31,8 @@ export function FactorySection({ children }: { children?: ReactNode }) {
       </div>
       {showBoard && (
         <div className="flex flex-col gap-1">
-          <FactoryLink to="/factory/board" icon={SquareKanban} label="Board" />
+          <FactoryLink to="/factory/work" icon={SquareKanban} label="Work" />
+          <FactoryLink to="/factory/review" icon={GitPullRequest} label="Review" />
           <FactoryLink to="/factory/metrics" icon={ChartLine} label="Metrics" />
           <FactoryLink to="/factory/audit" icon={ScrollText} label="Audit" />
         </div>

--- a/mastracode/web/src/web/ui/domains/factory/components/RelatedFactorySessions.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/RelatedFactorySessions.tsx
@@ -1,0 +1,70 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Link2 } from 'lucide-react';
+import { useNavigate, useParams } from 'react-router';
+
+import { useSelectWorkspaceMutation, useWorkspacesQuery } from '../../../../../shared/hooks/useWorkspaces';
+import { useWorkItemsQuery } from '../../../../../shared/hooks/useWorkItems';
+import { AGENT_CONTROLLER_ID } from '../../chat/services/constants';
+import { useActiveProjectContext } from '../../workspaces';
+import type { WorkItem, WorkItemSessionRef } from '../services/workItems';
+
+function latestLiveSession(item: WorkItem, livePaths: ReadonlySet<string>): WorkItemSessionRef | undefined {
+  return Object.values(item.sessions)
+    .filter(session => livePaths.has(session.projectPath))
+    .at(-1);
+}
+
+export function RelatedFactorySessions() {
+  const { activeProject } = useActiveProjectContext();
+  const { threadId } = useParams();
+  const navigate = useNavigate();
+  const githubProjectId = activeProject?.source === 'github' ? activeProject.githubProjectId : undefined;
+  const items = useWorkItemsQuery(githubProjectId);
+  const workspaces = useWorkspacesQuery(activeProject);
+  const selectWorkspace = useSelectWorkspaceMutation(activeProject, {
+    agentControllerId: AGENT_CONTROLLER_ID,
+    resourceId: activeProject?.resourceId,
+  });
+
+  if (!threadId || !githubProjectId) return null;
+
+  const allItems = items.data ?? [];
+  const currentItem = allItems.find(item =>
+    Object.values(item.sessions).some(session => session.threadId === threadId),
+  );
+  if (!currentItem) return null;
+
+  const relatedItems = allItems.filter(
+    item => item.id === currentItem.parentWorkItemId || item.parentWorkItemId === currentItem.id,
+  );
+  const livePaths = new Set((workspaces.data?.worktrees ?? []).map(worktree => worktree.worktreePath));
+  const destinations = relatedItems.flatMap(item => {
+    const session = latestLiveSession(item, livePaths);
+    return session ? [{ item, session }] : [];
+  });
+  if (destinations.length === 0) return null;
+
+  const openSession = async (session: WorkItemSessionRef) => {
+    await selectWorkspace.mutateAsync(session.projectPath);
+    void navigate(`/threads/${session.threadId}`);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 px-3 pt-3 md:px-5" aria-label="Related Factory sessions">
+      {destinations.map(({ item, session }) => (
+        <Button
+          key={item.id}
+          type="button"
+          variant="ghost"
+          size="sm"
+          aria-label={`Open related ${item.source === 'github-pr' ? 'review' : 'work'} session: ${item.title}`}
+          disabled={selectWorkspace.isPending}
+          onClick={() => void openSession(session)}
+        >
+          <Link2 size={13} aria-hidden />
+          Open related {item.source === 'github-pr' ? 'review' : 'work'} session
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/factory/index.ts
+++ b/mastracode/web/src/web/ui/domains/factory/index.ts
@@ -1,5 +1,5 @@
 export { AuditPage } from './AuditPage';
-export { BoardPage } from './BoardPage';
+export { BoardPage, ReviewBoardPage, WorkBoardPage } from './BoardPage';
 export { MetricsPage } from './MetricsPage';
 export { FactorySection } from './components/FactorySection';
 export * from '../../../../shared/hooks/useFactoryData';

--- a/mastracode/web/src/web/ui/domains/factory/services/workItems.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/workItems.ts
@@ -30,6 +30,7 @@ export interface WorkItem {
   githubProjectId: string;
   source: WorkItemSource;
   sourceKey: string | null;
+  parentWorkItemId: string | null;
   title: string;
   url: string | null;
   stages: string[];
@@ -50,6 +51,7 @@ export interface WorkItemSessionInput {
 export interface CreateWorkItemInput {
   source: WorkItemSource;
   sourceKey: string | null;
+  parentWorkItemId?: string | null;
   title: string;
   url?: string | null;
   stages: string[];
@@ -58,6 +60,7 @@ export interface CreateWorkItemInput {
 }
 
 export interface UpdateWorkItemInput {
+  parentWorkItemId?: string | null;
   title?: string;
   url?: string | null;
   stages?: string[];

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -20,7 +20,7 @@ import { ThreadPage } from './domains/chat/ThreadPage';
 import { useActiveProject } from '../../shared/hooks/useActiveProject';
 import { useWorkItemsQuery } from '../../shared/hooks/useWorkItems';
 import { AuditPage } from './domains/factory/AuditPage';
-import { BoardPage } from './domains/factory/BoardPage';
+import { ReviewBoardPage, WorkBoardPage } from './domains/factory/BoardPage';
 import { MetricsPage } from './domains/factory/MetricsPage';
 
 /**
@@ -111,12 +111,13 @@ export function createAppRoutes(): RouteObject[] {
             // Personal (non-factory) sessions: same thread page, but the
             // session provider binds to the user's own resourceId + worktree.
             { path: 'user/threads/:threadId', element: <ThreadPage /> },
-            { path: 'factory/board', element: <BoardPage /> },
+            { path: 'factory/work', element: <WorkBoardPage /> },
+            { path: 'factory/review', element: <ReviewBoardPage /> },
             { path: 'factory/metrics', element: <MetricsPage /> },
             { path: 'factory/audit', element: <AuditPage /> },
-            // Legacy Factory pages, folded into the Board.
-            { path: 'factory/intake', element: <Navigate to="/factory/board" replace /> },
-            { path: 'factory/review', element: <Navigate to="/factory/board" replace /> },
+            // Compatibility routes from the former combined Board.
+            { path: 'factory/board', element: <Navigate to="/factory/work" replace /> },
+            { path: 'factory/intake', element: <Navigate to="/factory/work" replace /> },
           ],
         },
         // Legacy deep links (the app used to serve everything at any path).


### PR DESCRIPTION
## Summary

Stacks on #19551. Models the Review board columns as the Factory review lifecycle rather than raw GitHub state:

- **Intake → Reviewing** prompts "Start review?" — confirming creates/reuses the review worktree + session and dispatches the understand-pr skill; declining keeps the card in Intake.
- **Reviewing → Done** requires an explicit terminal outcome: open PRs ask to mark the Factory review as canceled; merged/closed PRs complete.
- **Reviewing → Intake** prompts "Abandon review?".
- Cards without a review session cannot sit past Intake — sessionless cards render in Intake with the run offered again.
- GitHub PR state is a read-only badge on the card (open / merged / closed); it never moves the card.
- The card menu shows lifecycle transitions ("Start review", "Mark done", "Cancel review", "Abandon review") instead of raw column targets.

## Test plan

- 8 new lifecycle transition tests in FactoryPages.msw.test.tsx (prompt shown/declined/accepted for each guarded move, open vs merged Done paths, abandon path, menu labels).
- Full FactoryPages suite: 70/70 pass.
- Prettier clean; BoardPage tsc clean.

Co-Authored-By: Mastra Code (kimi-for-coding/k3) <noreply@mastra.ai>