### PR TITLE
fix(mastracode): use MOONSHOT_API_KEY for moonshot models

### DIFF
--- a/.changeset/cold-ways-take.md
+++ b/.changeset/cold-ways-take.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed Moonshot AI API key resolution so keys saved via /api-keys (MOONSHOT_API_KEY) work when selecting moonshot models

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -225,6 +225,7 @@ describe('resolveModel', () => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
     delete process.env.OPENAI_BASE_URL;
+    delete process.env.MOONSHOT_API_KEY;
     delete process.env.MOONSHOT_AI_API_KEY;
     delete process.env.MASTRA_GATEWAY_API_KEY;
     delete process.env.MASTRA_GATEWAY_URL;
@@ -499,6 +500,65 @@ describe('resolveModel', () => {
         headers: undefined,
         authStorage: mockAuthStorageInstance,
       });
+    });
+  });
+
+  describe('moonshotai/* models', () => {
+    it('uses a stored moonshot API key with the Anthropic-compatible endpoint', () => {
+      mockAuthStorageInstance.getStoredApiKey.mockImplementation((provider: string) =>
+        provider === 'moonshotai' ? 'sk-moonshot-stored' : undefined,
+      );
+
+      const result = resolveModel('moonshotai/kimi-k2.6') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(result.modelId).toBe('kimi-k2.6');
+      expect(createAnthropic).toHaveBeenCalledWith({
+        apiKey: 'sk-moonshot-stored',
+        baseURL: 'https://api.moonshot.ai/anthropic/v1',
+        name: 'moonshotai.anthropicv1',
+        headers: undefined,
+      });
+    });
+
+    it('falls back to MOONSHOT_API_KEY when no stored credential exists', () => {
+      process.env.MOONSHOT_API_KEY = 'sk-moonshot-env';
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+      mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
+
+      const result = resolveModel('moonshotai/kimi-k2.6') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(result.modelId).toBe('kimi-k2.6');
+      expect(createAnthropic).toHaveBeenCalledWith({
+        apiKey: 'sk-moonshot-env',
+        baseURL: 'https://api.moonshot.ai/anthropic/v1',
+        name: 'moonshotai.anthropicv1',
+        headers: undefined,
+      });
+    });
+
+    it('falls back to legacy MOONSHOT_AI_API_KEY for compatibility', () => {
+      process.env.MOONSHOT_AI_API_KEY = 'sk-moonshot-legacy';
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+      mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
+
+      const result = resolveModel('moonshotai/kimi-k2.6') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('anthropic-direct');
+      expect(createAnthropic).toHaveBeenCalledWith({
+        apiKey: 'sk-moonshot-legacy',
+        baseURL: 'https://api.moonshot.ai/anthropic/v1',
+        name: 'moonshotai.anthropicv1',
+        headers: undefined,
+      });
+    });
+
+    it('throws Need MOONSHOT_API_KEY when no key is available', () => {
+      mockAuthStorageInstance.get.mockReturnValue(undefined);
+      mockAuthStorageInstance.getStoredApiKey.mockReturnValue(undefined);
+
+      expect(() => resolveModel('moonshotai/kimi-k2.6')).toThrow(/Need MOONSHOT_API_KEY/);
     });
   });
 

--- a/mastracode/sdk/src/agents/mastracode-gateway.ts
+++ b/mastracode/sdk/src/agents/mastracode-gateway.ts
@@ -453,11 +453,16 @@ export class MastraCodeGateway extends MastraModelGateway {
     }
 
     if (args.providerId === 'moonshotai') {
-      if (!process.env.MOONSHOT_AI_API_KEY) {
-        throw new Error(`Need MOONSHOT_AI_API_KEY`);
+      // Prefer the gateway-resolved key (stored credentials), then the canonical
+      // registry env var. Keep the legacy typo name as a fallback for anyone who
+      // set it because of the previous error message.
+      const apiKey =
+        args.apiKey?.trim() || process.env.MOONSHOT_API_KEY?.trim() || process.env.MOONSHOT_AI_API_KEY?.trim();
+      if (!apiKey) {
+        throw new Error('Need MOONSHOT_API_KEY');
       }
       return createAnthropic({
-        apiKey: process.env.MOONSHOT_AI_API_KEY,
+        apiKey,
         baseURL: 'https://api.moonshot.ai/anthropic/v1',
         name: 'moonshotai.anthropicv1',
         headers: args.headers,


### PR DESCRIPTION
Saving a Moonshot AI key in the TUI shows a green check for `MOONSHOT_API_KEY`, but selecting a `moonshotai/*` model failed with `Need MOONSHOT_AI_API_KEY`.

The gateway special-case was looking for the wrong env var and ignoring the key already resolved from stored credentials. It now prefers the resolved key, then `MOONSHOT_API_KEY`, with the old typo name kept as a fallback.

```ts
// before
if (!process.env.MOONSHOT_AI_API_KEY) {
  throw new Error(`Need MOONSHOT_AI_API_KEY`);
}

// after
const apiKey =
  args.apiKey?.trim() ||
  process.env.MOONSHOT_API_KEY?.trim() ||
  process.env.MOONSHOT_AI_API_KEY?.trim();
if (!apiKey) {
  throw new Error('Need MOONSHOT_API_KEY');
}
```
