### PR TITLE
docs(memory): show how to consume OM extractor stream values

### DIFF
--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -300,6 +300,34 @@ new Extractor({
 })
 ```
 
+#### Read extracted values from a stream
+
+Extractor results are emitted when OM completes an observation or reflection. Read both completion data parts from the stream:
+
+```typescript title="src/mastra/run.ts"
+const stream = await agent.stream('Remember that I prefer dark mode.')
+
+for await (const chunk of stream.fullStream) {
+  if (chunk.type === 'data-om-observation-end' || chunk.type === 'data-om-buffering-end') {
+    const { operationType, extractedValues = {}, extractionFailures = [] } = chunk.data
+
+    for (const [slug, value] of Object.entries(extractedValues)) {
+      console.log(`${operationType} extractor ${slug}:`, value)
+    }
+
+    for (const failure of extractionFailures) {
+      console.error(`Extractor ${failure.slug} failed:`, failure.error)
+    }
+  }
+}
+```
+
+`extractedValues` uses each extractor's slug as its key. Both result fields are optional, and a failed extractor doesn't remove values from successful extractors.
+
+`data-om-observation-end` reports a synchronous completion. `data-om-buffering-end` reports completed background work. Its extractor metadata is persisted immediately, but the buffered content remains inactive until activation. Check `operationType` to determine whether the completed work was an observation or reflection.
+
+See the [`data-om-observation-end`](/reference/memory/observational-memory#data-om-observation-end) and [`data-om-buffering-end`](/reference/memory/observational-memory#data-om-buffering-end) reference tables for the complete payloads.
+
 ### Working memory updates
 
 Use `observationalMemory.observation.manageWorkingMemory` to let the Observer manage working memory automatically. The main agent no longer needs to call the working memory tool while it handles the user request, so working memory updates don't depend on the agent remembering to make them.

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -695,6 +695,27 @@ Async buffering isn't supported with `scope: 'resource'` and is automatically di
 
 Observational Memory emits typed data parts during agent execution that clients can use for real-time UI feedback. These are streamed alongside the agent's response.
 
+### Read extractor results
+
+Both completion events carry extractor output in their `data` payload. The extractor fields are:
+
+```typescript
+interface DataOmObservationEndPart {
+  type: 'data-om-observation-end'
+  data: {
+    /** Whether the completed work was an observation or reflection */
+    operationType: 'observation' | 'reflection'
+    /** Values extracted during this OM operation, keyed by extractor slug */
+    extractedValues?: Record<string, unknown>
+    /** Extractor failures from this OM operation. Successful extractor values are still included */
+    extractionFailures?: Array<{ slug: string; error: string }>
+    // ...other fields documented in the tables below
+  }
+}
+```
+
+Both extractor fields are optional. A completion can include values, failures, both, or neither. `data-om-observation-end` reports synchronous completion. `data-om-buffering-end` reports completed background work whose buffered content still awaits activation, although extractor metadata is already persisted. `DataOmBufferingEndPart` carries the same extractor fields, and both types are exported from `@mastra/memory/processors`. See [Read extracted values from a stream](/docs/memory/observational-memory#read-extracted-values-from-a-stream) for a consumer example.
+
 ### `data-om-status`
 
 Emitted once per agent loop step, before model generation. Provides a snapshot of the current memory state, including token usage for both context windows and the state of any async buffered content.


### PR DESCRIPTION
Observational Memory's custom extractors (shipped in #18653) persist values to thread metadata and also emit them on the `data-om-observation-end` and `data-om-buffering-end` stream data parts. The docs listed `extractedValues` and `extractionFailures` in the reference field tables, but neither page showed how to actually read them from a stream.

The guide's Extractors section now ends with a copyable `agent.stream()` consumer example that handles both completion events and tolerates absent fields:

```typescript
const stream = await agent.stream('Remember that I prefer dark mode.')

for await (const chunk of stream.fullStream) {
  if (chunk.type === 'data-om-observation-end' || chunk.type === 'data-om-buffering-end') {
    const { operationType, extractedValues = {}, extractionFailures = [] } = chunk.data

    for (const [slug, value] of Object.entries(extractedValues)) {
      console.log(`${operationType} extractor ${slug}:`, value)
    }

    for (const failure of extractionFailures) {
      console.error(`Extractor ${failure.slug} failed:`, failure.error)
    }
  }
}
```

The prose explains that values are keyed by extractor slug, that a failed extractor doesn't remove successful values, and that `data-om-buffering-end` means extractor metadata is persisted but the buffered content still awaits activation.

The reference gains a "Read extractor results" section under Streaming data parts showing the payload shape (matching how the other data parts present their types), noting both marker types are exported from `@mastra/memory/processors`, and linking back to the guide example.

Docs only, no runtime changes. Verified with prettier, remark, vale (no new findings on added lines), `pnpm validate`, and the Docusaurus build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR explains how to read useful information from the memory system while data is still streaming. It also documents what happens when extraction succeeds, fails, or waits for background processing.

## What changed

- Added a guide for handling `data-om-observation-end` and `data-om-buffering-end` events from `agent.stream()`.
- Documented extractor slug keys, partial successes, extraction failures, and buffering behavior.
- Added a streaming data parts reference covering extractor result payloads and exports.
- Linked the reference documentation to the usage example.

Docs only; no runtime or test changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->