### PR TITLE
fix(mastracode-web): simplify transcript tool presentation

### DIFF
--- a/.changeset/tidy-moles-listen.md
+++ b/.changeset/tidy-moles-listen.md
@@ -1,0 +1,5 @@
+---
+'mastracode-web': patch
+---
+
+Removed empty transcript bubbles and quieted successful tool cards in Mastra Code Web chat. Whitespace-only message parts no longer render as blank bubbles in streamed or hydrated history, text following a tool group gets clear spacing, tool cards no longer show a chevron or a Done pill for successful calls, and running or failed tools keep prominent status labels.

--- a/.changeset/tidy-moles-listen.md
+++ b/.changeset/tidy-moles-listen.md
@@ -1,5 +1,0 @@
----
-'mastracode-web': patch
----
-
-Removed empty transcript bubbles and quieted successful tool cards in Mastra Code Web chat. Whitespace-only message parts no longer render as blank bubbles in streamed or hydrated history, text following a tool group gets clear spacing, tool cards no longer show a chevron or a Done pill for successful calls, and running or failed tools keep prominent status labels.

--- a/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
@@ -371,7 +371,7 @@ describe('MastraCode message rendering', () => {
     renderChat();
 
     const heading = await screen.findByRole('heading', { name: 'Quality gate' });
-    expect(heading.closest('.prose')).toHaveClass('mt-3');
+    expect(heading.closest('.prose')).toHaveClass('mt-4');
   });
 
   it('renders assistant text when SSE message updates arrive after subscription', async () => {

--- a/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
@@ -292,7 +292,10 @@ describe('MastraCode message rendering', () => {
       expect(document.body).toHaveTextContent('from hydrate');
       expect(screen.getByText('checking files')).toBeInTheDocument();
       const card = screen.getByRole('group', { name: 'Tool: view' });
-      expect(within(card).getByText('Done')).toBeInTheDocument();
+      // Successful tools render no status badge; only running/failed states are labeled.
+      expect(within(card).queryByText('Done')).not.toBeInTheDocument();
+      expect(within(card).queryByText('Running')).not.toBeInTheDocument();
+      expect(within(card).queryByText('Failed')).not.toBeInTheDocument();
     });
   });
 
@@ -382,7 +385,8 @@ describe('MastraCode message rendering', () => {
     renderChat();
 
     const card = await findToolCard('execute_command');
-    expect(within(card).getByText('Done')).toBeInTheDocument();
+    // Successful tools render no status badge; only running/failed states are labeled.
+    expect(within(card).queryByText('Done')).not.toBeInTheDocument();
     expect(within(card).getByText('passing tests')).toBeInTheDocument();
   });
 

--- a/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
@@ -347,6 +347,33 @@ describe('MastraCode message rendering', () => {
     });
   });
 
+  it('separates assistant text persisted after a tool-only message', async () => {
+    seedProject();
+    useAgentControllerHandlers({
+      messages: [
+        dbMessage('assistant-tools', 'assistant', [
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-complete',
+              toolName: 'task_complete',
+              args: { id: 'quality-gate' },
+              result: 'completed',
+            },
+          },
+        ]),
+        dbMessage('completion-signal', 'signal', [{ type: 'text', text: 'Quality gate completed' }]),
+        dbMessage('assistant-summary', 'assistant', [{ type: 'text', text: '## Quality gate' }]),
+      ],
+    });
+
+    renderChat();
+
+    const heading = await screen.findByRole('heading', { name: 'Quality gate' });
+    expect(heading.closest('.prose')).toHaveClass('mt-3');
+  });
+
   it('renders assistant text when SSE message updates arrive after subscription', async () => {
     seedProject();
     const stream = delayedSse({

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -830,7 +830,7 @@ function MessageBubble({ entry, followsToolEntry }: { entry: MessageEntry; follo
       }
 
       return (
-        <div className={`prose ${followsTool || followsToolEntry ? 'mt-3' : ''}`}>
+        <div className={`prose ${followsToolEntry ? 'mt-4' : followsTool ? 'mt-3' : ''}`}>
           <Markdown>{part.text}</Markdown>
           {entry.streaming && part === lastTextPart && (
             <span className="ml-0.5 inline-block h-[1em] w-0.5 animate-pulse bg-accent1 align-text-bottom" />

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -694,6 +694,24 @@ export function Transcript() {
   return <TranscriptEntries entries={transcript.entries} onApprove={onApprove} onRespond={onRespond} />;
 }
 
+function followsToolEntry(entries: TimelineEntry[], index: number): boolean {
+  const current = entries[index];
+  if (current?.kind !== 'message' || current.message.role !== 'assistant') return false;
+
+  for (let previousIndex = index - 1; previousIndex >= 0; previousIndex--) {
+    const previous = entries[previousIndex];
+    if (previous.kind !== 'message') return false;
+    if (previous.message.role === 'user') return false;
+    if (previous.message.role === 'signal') continue;
+
+    const parts = previous.message.content.parts;
+    if (parts.some(part => part.type === 'text' && part.text.trim().length > 0)) return false;
+    if (parts.some(part => part.type === 'tool-invocation')) return true;
+  }
+
+  return false;
+}
+
 export function TranscriptEntries({
   entries,
   onApprove,
@@ -705,10 +723,10 @@ export function TranscriptEntries({
 }) {
   return (
     <>
-      {entries.map(entry => {
+      {entries.map((entry, index) => {
         switch (entry.kind) {
           case 'message':
-            return <MessageBubble key={entry.id} entry={entry} />;
+            return <MessageBubble key={entry.id} entry={entry} followsToolEntry={followsToolEntry(entries, index)} />;
           case 'notice':
             return <NoticeCard key={entry.id} entry={entry} />;
           case 'approval':
@@ -729,7 +747,7 @@ export function TranscriptEntries({
   );
 }
 
-function MessageBubble({ entry }: { entry: MessageEntry }) {
+function MessageBubble({ entry, followsToolEntry }: { entry: MessageEntry; followsToolEntry: boolean }) {
   // null = no group override; true/false = expand/collapse all in this bubble.
   const [allExpanded, setAllExpanded] = useState<boolean | undefined>(undefined);
   const parts = entry.message.content.parts ?? [];
@@ -812,7 +830,7 @@ function MessageBubble({ entry }: { entry: MessageEntry }) {
       }
 
       return (
-        <div className={`prose ${followsTool ? 'mt-3' : ''}`}>
+        <div className={`prose ${followsTool || followsToolEntry ? 'mt-3' : ''}`}>
           <Markdown>{part.text}</Markdown>
           {entry.streaming && part === lastTextPart && (
             <span className="ml-0.5 inline-block h-[1em] w-0.5 animate-pulse bg-accent1 align-text-bottom" />

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -304,18 +304,8 @@ function ToolCard({
       role="group"
       aria-label={`Tool: ${tool.toolName}`}
     >
-      {/*
-        Wrap the trigger content in a span so no icon is a *direct* child of
-        CollapsibleTrigger. The DS trigger rotates every direct-child <svg> via
-        `[&>svg]:rotate-90` on open — which would spin the tool icon (e.g. the
-        eye). Nesting keeps only the chevron animating, controlled here.
-      */}
       <CollapsibleTrigger className="w-full text-left">
         <span className="flex w-full items-center gap-2 px-2 py-1.5">
-          <ChevronDown
-            size={13}
-            className={`shrink-0 text-icon3 transition-transform duration-150 ${expanded ? 'rotate-0' : '-rotate-90'}`}
-          />
           <ToolIcon name={tool.toolName} className="shrink-0 text-icon3" />
           <Txt as="span" variant="ui-sm" font="mono" className="text-icon5">
             {tool.toolName}
@@ -330,9 +320,11 @@ function ToolCard({
               {truncate(argsPreview, 72)}
             </Txt>
           )}
-          <Badge variant={STATUS_VARIANT[tool.status]} size="xs" className="ml-auto">
-            {STATUS_LABEL[tool.status]}
-          </Badge>
+          {tool.status !== 'done' && (
+            <Badge variant={STATUS_VARIANT[tool.status]} size="xs" className="ml-auto">
+              {STATUS_LABEL[tool.status]}
+            </Badge>
+          )}
         </span>
       </CollapsibleTrigger>
       <CollapsibleContent className="flex min-w-0 max-w-full flex-col gap-2 px-2 pb-2">
@@ -804,6 +796,10 @@ function MessageBubble({ entry }: { entry: MessageEntry }) {
 
   const renderers = {
     Text: (part: TextPart) => {
+      const renderedPart: unknown = part;
+      const partIndex = parts.findIndex(candidate => candidate === renderedPart);
+      const followsTool = partIndex > 0 && parts[partIndex - 1]?.type === 'tool-invocation';
+
       if (entry.message.role === 'user') {
         const activation = parseSkillActivation(part.text);
         return activation ? (
@@ -816,7 +812,7 @@ function MessageBubble({ entry }: { entry: MessageEntry }) {
       }
 
       return (
-        <div className="prose">
+        <div className={`prose ${followsTool ? 'mt-3' : ''}`}>
           <Markdown>{part.text}</Markdown>
           {entry.streaming && part === lastTextPart && (
             <span className="ml-0.5 inline-block h-[1em] w-0.5 animate-pulse bg-accent1 align-text-bottom" />
@@ -860,7 +856,7 @@ function MessageBubble({ entry }: { entry: MessageEntry }) {
   // Some harness status parts (e.g. om_* markers) carry no text. Ignore the
   // marker while preserving any ordinary assistant content in the message.
   if (status?.text.trim()) return <StatusMetadataCard status={status} />;
-  if (entry.message.role === 'assistant' && !hasRenderablePart) return null;
+  if (!hasRenderablePart) return null;
 
   return <MessageFactory message={entry.message} roles={roles} {...renderers} fallback={() => null} />;
 }

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatMessageList.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatMessageList.msw.test.tsx
@@ -6,7 +6,8 @@
  * Driven end-to-end: real fetch/SSE transport, MSW at the network boundary.
  */
 import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
-import { screen, waitFor } from '@testing-library/react';
+import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -65,7 +66,7 @@ function sse(events: AgentControllerEvent[] = []): Response {
   );
 }
 
-function useAgentControllerHandlers(events: AgentControllerEvent[] = []) {
+function useAgentControllerHandlers(events: AgentControllerEvent[] = [], messages: MastraDBMessage[] = []) {
   server.use(
     http.post(`${API}/sessions`, () =>
       HttpResponse.json({ controllerId: 'code', resourceId: RESOURCE_ID, threadId: THREAD_ID }),
@@ -76,7 +77,7 @@ function useAgentControllerHandlers(events: AgentControllerEvent[] = []) {
     http.put(`${SESSION}/state`, () => HttpResponse.json(sessionState())),
     http.get(`${SESSION}/permissions`, () => HttpResponse.json({ categories: {}, tools: {} })),
     http.get(`${SESSION}/threads`, () => HttpResponse.json({ threads: [] })),
-    http.get(`${SESSION}/threads/${THREAD_ID}/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${SESSION}/threads/${THREAD_ID}/messages`, () => HttpResponse.json({ messages })),
     http.post(`${SESSION}/goal`, () => HttpResponse.json({})),
     http.put(`${SESSION}/goal`, () => HttpResponse.json({})),
     http.delete(`${SESSION}/goal`, () => HttpResponse.json({})),
@@ -124,6 +125,24 @@ describe('ChatMessageList', () => {
     expect(screen.getByText('/tmp/mastracode-test')).toBeInTheDocument();
   });
 
+  it('given only a whitespace message, then it still shows the welcome state', async () => {
+    seedProject();
+    useAgentControllerHandlers(
+      [],
+      [
+        {
+          id: 'assistant-empty',
+          role: 'assistant',
+          createdAt: new Date(),
+          content: { format: 2, parts: [{ type: 'text', text: '  \n ' }] },
+        },
+      ],
+    );
+    renderMessageList();
+
+    await waitFor(() => expect(screen.getByText('Ready for new conversation')).toBeInTheDocument());
+  });
+
   it('given streamed assistant text, then it renders the transcript entry', async () => {
     seedProject();
     useAgentControllerHandlers([
@@ -142,6 +161,56 @@ describe('ChatMessageList', () => {
     renderMessageList();
 
     await waitFor(() => expect(screen.getByText('Hello from the agent')).toBeInTheDocument());
+  });
+
+  it('given a completed tool followed by text, then it renders a quiet header and separates the summary', async () => {
+    seedProject();
+    useAgentControllerHandlers(
+      [],
+      [
+        {
+          id: 'assistant-tools-1',
+          role: 'assistant',
+          createdAt: new Date(),
+          content: {
+            format: 2,
+            parts: [
+              { type: 'text', text: '   ' },
+              {
+                type: 'tool-invocation',
+                toolInvocation: {
+                  state: 'result',
+                  toolCallId: 'tool-1',
+                  toolName: 'view',
+                  args: { path: 'src/index.ts' },
+                  result: 'export const value = 1;',
+                },
+              },
+              { type: 'text', text: 'Summary follows.' },
+            ],
+          },
+        },
+      ],
+    );
+    renderMessageList();
+
+    const tool = await screen.findByRole('group', { name: 'Tool: view' });
+    expect(within(tool).queryByText('Done')).not.toBeInTheDocument();
+    expect(tool.querySelector('.lucide-chevron-down')).not.toBeInTheDocument();
+    expect(screen.getByText('Summary follows.').closest('.prose')).toHaveClass('mt-3');
+  });
+
+  it('given running and failed tools, then it keeps their status prominent', async () => {
+    seedProject();
+    useAgentControllerHandlers([
+      { type: 'tool_start', toolCallId: 'tool-running', toolName: 'view', args: { path: 'src/index.ts' } },
+      { type: 'tool_start', toolCallId: 'tool-failed', toolName: 'execute_command', args: { command: 'exit 1' } },
+      { type: 'tool_end', toolCallId: 'tool-failed', result: 'failed', isError: true },
+    ]);
+    renderMessageList();
+
+    await waitFor(() => expect(screen.getByText('Running')).toBeInTheDocument());
+    expect(screen.getByText('Failed')).toBeInTheDocument();
   });
 
   it('given a streamed notification signal, then it renders the notification provenance in the transcript', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -156,6 +156,57 @@ describe('transcript reducer message entries', () => {
     expect(steered.role).toBe('signal');
   });
 
+  it('removes empty text parts while preserving surrounding tool and text content', () => {
+    const state = createInitialTranscript({
+      messages: [
+        dbMessage('assistant-1', 'assistant', [
+          { type: 'text', text: '   \n' },
+          {
+            type: 'tool-invocation',
+            toolInvocation: {
+              state: 'result',
+              toolCallId: 'tool-1',
+              toolName: 'view',
+              args: { path: 'src/index.ts' },
+              result: 'export const value = 1;',
+            },
+          },
+          { type: 'text', text: 'Summary follows.' },
+        ]),
+      ],
+    });
+
+    expect(messageParts(state.entries[0])).toEqual([
+      {
+        type: 'tool-invocation',
+        toolInvocation: {
+          state: 'result',
+          toolCallId: 'tool-1',
+          toolName: 'view',
+          args: { path: 'src/index.ts' },
+          result: 'export const value = 1;',
+        },
+      },
+      { type: 'text', text: 'Summary follows.' },
+    ]);
+  });
+
+  it('drops hydrated and streamed messages that contain only empty text', () => {
+    const hydrated = createInitialTranscript({
+      messages: [dbMessage('assistant-empty', 'assistant', [{ type: 'text', text: '  \n ' }])],
+    });
+    expect(hydrated.entries).toEqual([]);
+
+    const streamed = transcriptReducer(initialTranscript, {
+      type: 'event',
+      event: {
+        type: 'message_update',
+        message: dbMessage('assistant-empty', 'assistant', [{ type: 'text', text: '\t' }]),
+      },
+    });
+    expect(streamed.entries).toEqual([]);
+  });
+
   it('streams message updates without replacing non-message transcript state', () => {
     const withNotice = transcriptReducer(initialTranscript, {
       type: 'localNotice',

--- a/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
@@ -579,13 +579,24 @@ export function createInitialTranscript({
 }
 
 function messagesToEntries(messages: MastraDBMessage[]): TimelineEntry[] {
-  return messages.map(message => toMessageEntry(message, { streaming: false }));
+  return messages
+    .map(message => toMessageEntry(message, { streaming: false }))
+    .filter(entry => entry.message.content.parts.length > 0 || hasHarnessContent(entry.message));
+}
+
+/** Harness status/notification parts render from metadata, so a message with no visible parts can still produce output. */
+function hasHarnessContent(message: MastraDBMessage): boolean {
+  const harnessContent = message.content.metadata?.harnessContent;
+  return Array.isArray(harnessContent) && harnessContent.length > 0;
 }
 
 function toMessageEntry(
   message: MastraDBMessage,
   options: { streaming?: boolean; steer?: boolean; runtimeTools?: Record<string, ToolCall> } = {},
 ): MessageEntry {
+  const parts = message.content.parts.filter(part => part.type !== 'text' || part.text.trim().length > 0);
+  const visibleMessage =
+    parts.length === message.content.parts.length ? message : { ...message, content: { ...message.content, parts } };
   const signalMetadata = message.role === 'signal' ? message.content.metadata?.signal : undefined;
   const signal =
     signalMetadata && typeof signalMetadata === 'object' && !Array.isArray(signalMetadata)
@@ -596,7 +607,7 @@ function toMessageEntry(
     signal?.attributes && typeof signal.attributes === 'object' && !Array.isArray(signal.attributes)
       ? (signal.attributes as Record<string, unknown>)
       : undefined;
-  const displayMessage = isUserSignal ? { ...message, role: 'user' as const } : message;
+  const displayMessage = isUserSignal ? { ...visibleMessage, role: 'user' as const } : visibleMessage;
 
   return {
     kind: 'message',
@@ -624,7 +635,9 @@ function upsertMessage(state: TranscriptState, message: MastraDBMessage, streami
   const nextMessage = message.role === 'assistant' ? preserveRuntimeToolParts(message, prevEntry?.message) : message;
   const entry = toMessageEntry(nextMessage, { streaming, runtimeTools: prevEntry?.runtimeTools });
 
-  if (idx === -1) entries.push(entry);
+  if (entry.message.content.parts.length === 0 && !hasHarnessContent(entry.message)) {
+    if (idx !== -1) entries.splice(idx, 1);
+  } else if (idx === -1) entries.push(entry);
   else entries[idx] = entry;
   return { ...state, entries };
 }


### PR DESCRIPTION
## Summary

Transcript presentation cleanup for Mastra Code Web chat:

- **Empty bubbles gone**: whitespace-only text parts are filtered at transcript normalization, so streamed and hydrated histories agree and no blank bubbles render. Messages left with zero visible parts are dropped, except messages carrying harness status/notification metadata, which still render their notice.
- **Tool-to-text spacing within one message**: assistant text that directly follows a tool group in the same message gets intentional vertical separation without breaking grouped tool borders.
- **Tool-to-prose spacing across timeline entries**: persisted tool output and the following assistant prose commonly arrive as separate timeline entries, sometimes with system/signal entries between them. The transcript now detects the preceding tool-only assistant entry across those intervening signals and gives the following prose a slightly larger `mt-4` gap. This leaves ordinary message spacing and same-message tool spacing unchanged.
- **Quiet successful tools**: tool cards no longer render a `Done` pill or a chevron. `Running` and `Failed` keep prominent badges; expansion remains accessible through the collapsible header's `aria-expanded` semantics.

<img width="345" height="243" alt="Screenshot 2026-07-17 at 4 46 14 PM" src="https://github.com/user-attachments/assets/03c2f8b9-7e96-4693-af70-dec4590dfb01" />
<img width="1051" height="524" alt="Screenshot 2026-07-17 at 4 32 34 PM" src="https://github.com/user-attachments/assets/d35c6313-257a-404d-84c3-6a5edd9ff12b" />


## Test plan

- Red-first: four new assertions fail on `origin/main` (whitespace-only message hides welcome state, tool→text spacing, empty text part removal, hydrated/streamed empty message drop).
- Added regression coverage for persisted tool output followed by assistant prose in a separate timeline entry, including intervening signal entries.
- Focused transcript UI suite: 48/48 passed after the final spacing adjustment.
- Transcript service suite: 12/12 passed.
- Existing `Done`-badge assertions updated to the new quiet-success contract (negative assertions).
- `pnpm check` (tsc, both configs) exits 0; Prettier clean; `git diff --check` clean.

Co-Authored-By: Mastra Code (kimi-for-coding/k3) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This makes chat transcripts cleaner by hiding invisible messages, separating tool activity from assistant explanations, and simplifying tool status labels. Important status messages and error/running indicators remain visible.

## What changed

- Filtered whitespace-only transcript text and removed messages with no visible content, while preserving harness status and notification metadata.
- Added spacing between tool activity and following assistant text, including across timeline entries and signal events.
- Removed the `Done` badge and chevron from successful tool cards.
- Retained prominent `Running` and `Failed` statuses with accessible expansion behavior.
- Added regression coverage for transcript filtering, spacing, persisted tool output, welcome state rendering, and tool statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->