### PR TITLE
fix(mastracode-web): keep transcript follow intent stable

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/TranscriptPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/TranscriptPanel.tsx
@@ -9,7 +9,7 @@ import { EmptyThreadState } from './EmptyThreadState';
 import { WorkingIndicator } from './WorkingIndicator';
 
 const transcriptScrollClass =
-  'flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-y-auto scroll-smooth px-3 pb-2 pt-6 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:min-w-0 [&>*]:max-w-[80ch]';
+  'flex min-h-0 min-w-0 flex-1 flex-col gap-4 overflow-y-auto px-3 pb-2 pt-6 md:px-5 [&>*]:mx-auto [&>*]:w-full [&>*]:min-w-0 [&>*]:max-w-[80ch]';
 
 export function TranscriptPanel() {
   const { transcript, showWorkingIndicator } = useChatTranscript();

--- a/mastracode/web/src/web/ui/domains/chat/hooks/__tests__/useTranscriptScroll.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/__tests__/useTranscriptScroll.msw.test.tsx
@@ -12,6 +12,32 @@ interface HookSnapshot {
   scrollToBottom: (behavior?: ScrollBehavior) => void;
 }
 
+const resizeObservers: TestResizeObserver[] = [];
+
+class TestResizeObserver {
+  readonly observed = new Set<Element>();
+
+  constructor(private readonly callback: ResizeObserverCallback) {
+    resizeObservers.push(this);
+  }
+
+  observe(target: Element) {
+    this.observed.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.observed.delete(target);
+  }
+
+  disconnect() {
+    this.observed.clear();
+  }
+
+  trigger() {
+    this.callback([], this as unknown as ResizeObserver);
+  }
+}
+
 function assistantMessage(id: string, text: string): MastraDBMessage {
   return {
     id,
@@ -53,7 +79,11 @@ function Harness({
     onSnapshot({ showScrollDown: scroll.showScrollDown, scrollToBottom: scroll.scrollToBottom });
   }, [onSnapshot, scroll.showScrollDown, scroll.scrollToBottom]);
 
-  return <div data-testid="thread" ref={scroll.threadRef} />;
+  return (
+    <div data-testid="thread" ref={scroll.threadRef}>
+      <div data-testid="transcript-content" />
+    </div>
+  );
 }
 
 function setScrollMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
@@ -78,7 +108,11 @@ function dispatchScroll(el: HTMLElement) {
 }
 
 function dispatchUserScroll(el: HTMLElement) {
+  const targetScrollTop = el.scrollTop;
   act(() => {
+    el.scrollTop = el.scrollHeight - el.clientHeight;
+    el.dispatchEvent(new Event('scroll'));
+    el.scrollTop = targetScrollTop;
     el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120 }));
     el.dispatchEvent(new Event('scroll'));
   });
@@ -91,8 +125,34 @@ function flushAnimationFrame() {
 }
 
 describe('useTranscriptScroll', () => {
-  beforeEach(() => vi.useFakeTimers());
-  afterEach(() => vi.useRealTimers());
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resizeObservers.length = 0;
+    vi.stubGlobal('ResizeObserver', TestResizeObserver);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps following when an existing tool entry grows in place', () => {
+    const snapshots: HookSnapshot[] = [];
+    render(<Harness transcriptState={transcript('hello')} onSnapshot={snapshot => snapshots.push(snapshot)} />);
+    const el = screen.getByTestId('thread');
+    const content = screen.getByTestId('transcript-content');
+
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    dispatchScroll(el);
+    const scrollTo = installScrollTo(el);
+    setScrollMetrics(el, { scrollHeight: 1400, clientHeight: 400, scrollTop: 600 });
+
+    expect(resizeObservers[0]?.observed.has(content)).toBe(true);
+    act(() => resizeObservers[0]?.trigger());
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1400, behavior: 'auto' });
+    expect(snapshots.at(-1)?.showScrollDown).toBe(false);
+  });
+
   it('keeps following when attached content grows without user scroll', () => {
     const snapshots: HookSnapshot[] = [];
     const { rerender } = render(
@@ -113,7 +173,7 @@ describe('useTranscriptScroll', () => {
       />,
     );
 
-    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1300, behavior: 'smooth' });
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1300, behavior: 'auto' });
     expect(snapshots.at(-1)?.showScrollDown).toBe(false);
   });
 
@@ -160,7 +220,7 @@ describe('useTranscriptScroll', () => {
       />,
     );
 
-    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'auto' });
     expect(snapshots.at(-1)?.showScrollDown).toBe(false);
   });
 
@@ -180,7 +240,7 @@ describe('useTranscriptScroll', () => {
       <Harness transcriptState={transcript('hello after jump')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
     );
 
-    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'auto' });
     expect(snapshots.at(-1)?.showScrollDown).toBe(false);
   });
 

--- a/mastracode/web/src/web/ui/domains/chat/hooks/__tests__/useTranscriptScroll.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/__tests__/useTranscriptScroll.msw.test.tsx
@@ -1,0 +1,210 @@
+import type { MastraDBMessage } from '@mastra/core/agent-controller';
+import { act, render, screen } from '@testing-library/react';
+import { useEffect } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TranscriptState } from '../../services/transcript';
+import { initialTranscript } from '../../services/transcript';
+import { useTranscriptScroll } from '../useTranscriptScroll';
+
+interface HookSnapshot {
+  showScrollDown: boolean;
+  scrollToBottom: (behavior?: ScrollBehavior) => void;
+}
+
+function assistantMessage(id: string, text: string): MastraDBMessage {
+  return {
+    id,
+    role: 'assistant',
+    createdAt: new Date(0),
+    content: {
+      format: 2,
+      parts: [{ type: 'text', text }],
+    },
+  } satisfies MastraDBMessage;
+}
+
+function transcript(text: string): TranscriptState {
+  return {
+    ...initialTranscript,
+    entries: [
+      {
+        kind: 'message',
+        id: 'assistant-1',
+        message: assistantMessage('assistant-1', text),
+        streaming: true,
+      },
+    ],
+  };
+}
+
+function Harness({
+  transcriptState,
+  threadId = 'thread-a',
+  onSnapshot,
+}: {
+  transcriptState: TranscriptState;
+  threadId?: string;
+  onSnapshot: (snapshot: HookSnapshot) => void;
+}) {
+  const scroll = useTranscriptScroll(transcriptState, threadId);
+
+  useEffect(() => {
+    onSnapshot({ showScrollDown: scroll.showScrollDown, scrollToBottom: scroll.scrollToBottom });
+  }, [onSnapshot, scroll.showScrollDown, scroll.scrollToBottom]);
+
+  return <div data-testid="thread" ref={scroll.threadRef} />;
+}
+
+function setScrollMetrics(el: HTMLElement, metrics: { scrollHeight: number; clientHeight: number; scrollTop: number }) {
+  Object.defineProperty(el, 'scrollHeight', { configurable: true, value: metrics.scrollHeight });
+  Object.defineProperty(el, 'clientHeight', { configurable: true, value: metrics.clientHeight });
+  el.scrollTop = metrics.scrollTop;
+}
+
+function installScrollTo(el: HTMLElement) {
+  const scrollTo = vi.fn((options?: ScrollToOptions | number) => {
+    if (typeof options === 'object' && typeof options.top === 'number') el.scrollTop = options.top;
+    if (typeof options === 'number') el.scrollTop = options;
+  });
+  el.scrollTo = scrollTo;
+  return scrollTo;
+}
+
+function dispatchScroll(el: HTMLElement) {
+  act(() => {
+    el.dispatchEvent(new Event('scroll'));
+  });
+}
+
+function dispatchUserScroll(el: HTMLElement) {
+  act(() => {
+    el.dispatchEvent(new WheelEvent('wheel', { deltaY: -120 }));
+    el.dispatchEvent(new Event('scroll'));
+  });
+}
+
+function flushAnimationFrame() {
+  act(() => {
+    vi.advanceTimersByTime(16);
+  });
+}
+
+describe('useTranscriptScroll', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+  it('keeps following when attached content grows without user scroll', () => {
+    const snapshots: HookSnapshot[] = [];
+    const { rerender } = render(
+      <Harness transcriptState={transcript('hello')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
+    );
+    const el = screen.getByTestId('thread');
+
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    dispatchScroll(el);
+    flushAnimationFrame();
+    const scrollTo = installScrollTo(el);
+
+    setScrollMetrics(el, { scrollHeight: 1300, clientHeight: 400, scrollTop: 600 });
+    rerender(
+      <Harness
+        transcriptState={transcript('hello with more streamed text')}
+        onSnapshot={snapshot => snapshots.push(snapshot)}
+      />,
+    );
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1300, behavior: 'smooth' });
+    expect(snapshots.at(-1)?.showScrollDown).toBe(false);
+  });
+
+  it('does not follow streaming updates after intentional user scroll-away', () => {
+    const snapshots: HookSnapshot[] = [];
+    const { rerender } = render(
+      <Harness transcriptState={transcript('hello')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
+    );
+    const el = screen.getByTestId('thread');
+
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+    flushAnimationFrame();
+    dispatchUserScroll(el);
+    flushAnimationFrame();
+    const scrollTo = installScrollTo(el);
+    rerender(
+      <Harness
+        transcriptState={transcript('hello with more streamed text')}
+        onSnapshot={snapshot => snapshots.push(snapshot)}
+      />,
+    );
+
+    expect(scrollTo).not.toHaveBeenCalled();
+    expect(snapshots.at(-1)?.showScrollDown).toBe(true);
+  });
+
+  it('reattaches after returning to the bottom', () => {
+    const snapshots: HookSnapshot[] = [];
+    const { rerender } = render(
+      <Harness transcriptState={transcript('hello')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
+    );
+    const el = screen.getByTestId('thread');
+
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+    flushAnimationFrame();
+    dispatchUserScroll(el);
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 600 });
+    dispatchScroll(el);
+    const scrollTo = installScrollTo(el);
+    rerender(
+      <Harness
+        transcriptState={transcript('hello after returning to bottom')}
+        onSnapshot={snapshot => snapshots.push(snapshot)}
+      />,
+    );
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
+    expect(snapshots.at(-1)?.showScrollDown).toBe(false);
+  });
+
+  it('reattaches when the scroll-down control jumps to the latest message', () => {
+    const snapshots: HookSnapshot[] = [];
+    const { rerender } = render(
+      <Harness transcriptState={transcript('hello')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
+    );
+    const el = screen.getByTestId('thread');
+
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+    flushAnimationFrame();
+    dispatchUserScroll(el);
+    const scrollTo = installScrollTo(el);
+    act(() => snapshots.at(-1)?.scrollToBottom('auto'));
+    rerender(
+      <Harness transcriptState={transcript('hello after jump')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
+    );
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'smooth' });
+    expect(snapshots.at(-1)?.showScrollDown).toBe(false);
+  });
+
+  it('reattaches on thread switch', () => {
+    const snapshots: HookSnapshot[] = [];
+    const { rerender } = render(
+      <Harness transcriptState={transcript('hello')} onSnapshot={snapshot => snapshots.push(snapshot)} />,
+    );
+    const el = screen.getByTestId('thread');
+
+    setScrollMetrics(el, { scrollHeight: 1000, clientHeight: 400, scrollTop: 200 });
+    flushAnimationFrame();
+    dispatchUserScroll(el);
+    const scrollTo = installScrollTo(el);
+    rerender(
+      <Harness
+        transcriptState={transcript('new thread text')}
+        threadId="thread-b"
+        onSnapshot={snapshot => snapshots.push(snapshot)}
+      />,
+    );
+    flushAnimationFrame();
+
+    expect(scrollTo).toHaveBeenLastCalledWith({ top: 1000, behavior: 'auto' });
+    expect(snapshots.at(-1)?.showScrollDown).toBe(false);
+  });
+});

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useTranscriptScroll.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useTranscriptScroll.ts
@@ -20,7 +20,7 @@ function nearBottom(el: HTMLDivElement) {
 export function useTranscriptScroll(transcript: TranscriptState, threadId?: string) {
   const threadRef = useRef<HTMLDivElement>(null);
   const attachedRef = useRef(true);
-  const programmaticScrollRef = useRef(false);
+  const lastScrollTopRef = useRef(0);
   const [showScrollDown, setShowScrollDown] = useState(false);
   const streamingLen = getStreamingLength(transcript);
 
@@ -32,40 +32,24 @@ export function useTranscriptScroll(transcript: TranscriptState, threadId?: stri
   const scrollToBottom = (behavior: ScrollBehavior = 'smooth') => {
     const el = threadRef.current;
     if (!el) return;
-    programmaticScrollRef.current = behavior === 'smooth' && el.scrollHeight > el.clientHeight;
     setAttached(true);
     el.scrollTo({ top: el.scrollHeight, behavior });
-    if (behavior === 'smooth') requestAnimationFrame(() => (programmaticScrollRef.current = false));
   };
 
-  // Scroll position is DOM state; user-initiated upward scrolls detach follow intent, while
-  // layout growth alone cannot detach an already attached transcript.
+  // Scroll position is DOM state. Only upward movement detaches follow intent; downward
+  // movement may come from smooth scrolling or browser scroll anchoring as content grows.
   useEffect(() => {
     const el = threadRef.current;
     if (!el) return;
-    const markUserScrollIntent = () => {
-      programmaticScrollRef.current = false;
-    };
     const onScroll = () => {
-      if (nearBottom(el)) {
-        programmaticScrollRef.current = false;
-        setAttached(true);
-        return;
-      }
-      if (programmaticScrollRef.current) return;
-      setAttached(false);
+      const scrollTop = el.scrollTop;
+      if (nearBottom(el)) setAttached(true);
+      else if (scrollTop < lastScrollTopRef.current) setAttached(false);
+      lastScrollTopRef.current = scrollTop;
     };
-    el.addEventListener('wheel', markUserScrollIntent, { passive: true });
-    el.addEventListener('touchmove', markUserScrollIntent, { passive: true });
-    el.addEventListener('keydown', markUserScrollIntent);
     el.addEventListener('scroll', onScroll, { passive: true });
     onScroll();
-    return () => {
-      el.removeEventListener('wheel', markUserScrollIntent);
-      el.removeEventListener('touchmove', markUserScrollIntent);
-      el.removeEventListener('keydown', markUserScrollIntent);
-      el.removeEventListener('scroll', onScroll);
-    };
+    return () => el.removeEventListener('scroll', onScroll);
   }, []);
 
   const scrollToBottomOnThreadChange = useEffectEvent(scrollToBottom);
@@ -80,18 +64,42 @@ export function useTranscriptScroll(transcript: TranscriptState, threadId?: stri
     return () => cancelAnimationFrame(raf);
   }, [threadId]);
 
-  // Streaming updates should follow while explicitly attached. Distance-to-bottom can change
-  // because a tool/result expanded; that layout movement is not user intent.
+  // Streaming updates should follow immediately while attached. Repeated smooth-scroll
+  // animations lag behind fast token and tool-output updates.
   useEffect(() => {
-    if (attachedRef.current) scrollToBottom('smooth');
+    if (attachedRef.current) scrollToBottom('auto');
   }, [transcript.entries.length, transcript.pending, streamingLen]);
 
   useEffect(() => {
     const el = threadRef.current;
     if (!el || typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(() => followLayoutChange());
-    observer.observe(el);
-    return () => observer.disconnect();
+
+    const observedChildren = new Set<Element>();
+    const resizeObserver = new ResizeObserver(() => followLayoutChange());
+    const syncObservedChildren = () => {
+      const children = new Set(Array.from(el.children));
+      for (const child of observedChildren) {
+        if (!children.has(child)) {
+          resizeObserver.unobserve(child);
+          observedChildren.delete(child);
+        }
+      }
+      for (const child of children) {
+        if (!observedChildren.has(child)) {
+          resizeObserver.observe(child);
+          observedChildren.add(child);
+        }
+      }
+    };
+    const mutationObserver = new MutationObserver(syncObservedChildren);
+
+    resizeObserver.observe(el);
+    syncObservedChildren();
+    mutationObserver.observe(el, { childList: true });
+    return () => {
+      mutationObserver.disconnect();
+      resizeObserver.disconnect();
+    };
   }, []);
 
   return { threadRef, showScrollDown, scrollToBottom };

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useTranscriptScroll.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useTranscriptScroll.ts
@@ -13,46 +13,86 @@ function getStreamingLength(transcript: TranscriptState) {
     : 0;
 }
 
+function nearBottom(el: HTMLDivElement) {
+  return el.scrollHeight - el.scrollTop - el.clientHeight < 160;
+}
+
 export function useTranscriptScroll(transcript: TranscriptState, threadId?: string) {
   const threadRef = useRef<HTMLDivElement>(null);
+  const attachedRef = useRef(true);
+  const programmaticScrollRef = useRef(false);
   const [showScrollDown, setShowScrollDown] = useState(false);
   const streamingLen = getStreamingLength(transcript);
+
+  const setAttached = (attached: boolean) => {
+    attachedRef.current = attached;
+    setShowScrollDown(!attached);
+  };
 
   const scrollToBottom = (behavior: ScrollBehavior = 'smooth') => {
     const el = threadRef.current;
     if (!el) return;
+    programmaticScrollRef.current = behavior === 'smooth' && el.scrollHeight > el.clientHeight;
+    setAttached(true);
     el.scrollTo({ top: el.scrollHeight, behavior });
+    if (behavior === 'smooth') requestAnimationFrame(() => (programmaticScrollRef.current = false));
   };
 
-  // Scroll position is DOM state; subscribe to scroll events and mirror bottom proximity for UI controls.
+  // Scroll position is DOM state; user-initiated upward scrolls detach follow intent, while
+  // layout growth alone cannot detach an already attached transcript.
   useEffect(() => {
     const el = threadRef.current;
     if (!el) return;
-    const onScroll = () => {
-      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160;
-      setShowScrollDown(!nearBottom);
+    const markUserScrollIntent = () => {
+      programmaticScrollRef.current = false;
     };
+    const onScroll = () => {
+      if (nearBottom(el)) {
+        programmaticScrollRef.current = false;
+        setAttached(true);
+        return;
+      }
+      if (programmaticScrollRef.current) return;
+      setAttached(false);
+    };
+    el.addEventListener('wheel', markUserScrollIntent, { passive: true });
+    el.addEventListener('touchmove', markUserScrollIntent, { passive: true });
+    el.addEventListener('keydown', markUserScrollIntent);
     el.addEventListener('scroll', onScroll, { passive: true });
     onScroll();
-    return () => el.removeEventListener('scroll', onScroll);
+    return () => {
+      el.removeEventListener('wheel', markUserScrollIntent);
+      el.removeEventListener('touchmove', markUserScrollIntent);
+      el.removeEventListener('keydown', markUserScrollIntent);
+      el.removeEventListener('scroll', onScroll);
+    };
   }, []);
 
   const scrollToBottomOnThreadChange = useEffectEvent(scrollToBottom);
+  const followLayoutChange = useEffectEvent(() => {
+    if (attachedRef.current) scrollToBottom('auto');
+  });
 
   // Thread changes require imperative DOM scrolling after the new transcript has rendered.
   useEffect(() => {
-    setShowScrollDown(false);
+    setAttached(true);
     const raf = requestAnimationFrame(() => scrollToBottomOnThreadChange('auto'));
     return () => cancelAnimationFrame(raf);
   }, [threadId]);
 
-  // Streaming updates should imperatively follow the DOM scroll only while the user is already near the bottom.
+  // Streaming updates should follow while explicitly attached. Distance-to-bottom can change
+  // because a tool/result expanded; that layout movement is not user intent.
+  useEffect(() => {
+    if (attachedRef.current) scrollToBottom('smooth');
+  }, [transcript.entries.length, transcript.pending, streamingLen]);
+
   useEffect(() => {
     const el = threadRef.current;
-    if (!el) return;
-    const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 160;
-    if (nearBottom) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-  }, [transcript.entries.length, transcript.pending, streamingLen]);
+    if (!el || typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(() => followLayoutChange());
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   return { threadRef, showScrollDown, scrollToBottom };
 }


### PR DESCRIPTION
## Summary
- Track explicit transcript follow intent instead of deriving it only from distance-to-bottom.
- Keep attached transcripts following through streaming and tool/layout growth.
- Preserve intentional detach/reattach behavior for user scroll-away, bottom return, jump-to-latest, and thread switches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The transcript now keeps up with new messages and expanding tool output unless you intentionally scroll away. Returning to the bottom, jumping to the latest message, or switching threads automatically turns following back on.

## What changed

- Track explicit transcript follow intent instead of relying only on distance from the bottom.
- Keep attached transcripts synchronized with streaming updates, DOM mutations, and layout growth.
- Detach when users scroll upward and reattach when they return to the bottom.
- Reattach on jump-to-latest and thread changes.
- Remove smooth scrolling from the transcript container.
- Add comprehensive tests covering streaming growth, user scrolling, layout changes, jump-to-latest, and thread switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->