### PR TITLE
docs: add Firecrawl browser provider documentation

### DIFF
--- a/docs/src/content/en/docs/browser/agent-browser.mdx
+++ b/docs/src/content/en/docs/browser/agent-browser.mdx
@@ -94,5 +94,6 @@ This adds `browser_record` and `browser_record_caption` to the agent's toolset. 
 
 - [Browser overview](/docs/browser/overview)
 - [Stagehand](/docs/browser/stagehand)
+- [Firecrawl](/docs/browser/firecrawl)
 - [Browser recording (alpha)](/docs/browser/recording)
 - [AgentBrowser reference](/reference/browser/agent-browser)

--- a/docs/src/content/en/docs/browser/firecrawl.mdx
+++ b/docs/src/content/en/docs/browser/firecrawl.mdx
@@ -1,0 +1,118 @@
+---
+title: "Firecrawl | Browser"
+description: "Use the Firecrawl provider to run agent browser sessions in the Firecrawl Browser Sandbox."
+packages:
+  - "@mastra/browser-firecrawl"
+---
+
+# Firecrawl
+
+The `@mastra/browser-firecrawl` package provides browser automation using the [Firecrawl Browser Sandbox](https://docs.firecrawl.dev/features/browser). It provisions remote browser sessions through the Firecrawl API and drives them with the same deterministic, accessibility-first tools as [AgentBrowser](/docs/browser/agent-browser).
+
+`FirecrawlBrowser` extends `AgentBrowser`, so agents get the same toolset (`browser_goto`, `browser_snapshot`, `browser_click`, and so on) while the browser itself runs in Firecrawl's hosted infrastructure. No local Chromium install is needed.
+
+## When to use Firecrawl
+
+Use Firecrawl when you need:
+
+- Hosted browser sessions without managing local Chromium binaries
+- Browser automation in environments that can't launch a local browser
+- Per-thread sandbox isolation with automatic session cleanup
+- Named Firecrawl profiles that persist cookies and login state between sessions
+
+## Quickstart
+
+Install the package:
+
+```bash npm2yarn
+npm install @mastra/browser-firecrawl
+```
+
+Set your Firecrawl API key:
+
+```bash title=".env"
+FIRECRAWL_API_KEY=fc-...
+```
+
+Create a browser instance and assign it to an agent:
+
+```typescript title="src/mastra/agents/firecrawl-agent.ts"
+import { Agent } from '@mastra/core/agent'
+import { FirecrawlBrowser } from '@mastra/browser-firecrawl'
+
+const browser = new FirecrawlBrowser({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+})
+
+export const firecrawlAgent = new Agent({
+  id: 'firecrawl-agent',
+  name: 'Firecrawl Agent',
+  model: '__GATEWAY_OPENAI_MODEL__',
+  browser,
+  instructions: `You are a web automation assistant.
+
+When interacting with pages:
+1. Use browser_snapshot to get the current page state and element refs
+2. Use the refs (like @e1, @e2) to target elements for clicks and typing
+3. After actions, take another snapshot to verify the result`,
+})
+```
+
+If `apiKey` is omitted, the provider reads `FIRECRAWL_API_KEY` from the environment.
+
+## Session scope
+
+`FirecrawlBrowser` follows the same `scope` option as `AgentBrowser`:
+
+- `'thread'` (default): Each conversation thread gets its own Firecrawl sandbox session. Sessions are deleted when the thread's browser closes.
+- `'shared'`: One Firecrawl sandbox session is shared across all threads and deleted when the browser closes.
+
+```typescript
+const browser = new FirecrawlBrowser({
+  scope: 'shared',
+})
+```
+
+## Session options
+
+Pass Firecrawl-specific session options under the `firecrawl` key. These map to the Firecrawl `browser()` API:
+
+```typescript
+const browser = new FirecrawlBrowser({
+  firecrawl: {
+    ttl: 600,
+    activityTtl: 120,
+    profile: {
+      name: 'my-profile',
+      saveChanges: true,
+    },
+  },
+})
+```
+
+- `ttl`: Maximum session lifetime in seconds.
+- `activityTtl`: Idle timeout in seconds before Firecrawl recycles the session.
+- `profile`: Named Firecrawl profile that persists cookies and login state. Set `saveChanges: true` to save profile changes when the session ends.
+
+:::note
+
+The nested `firecrawl.profile` option refers to a profile stored in Firecrawl's infrastructure. It's different from the top-level `profile` option inherited from `AgentBrowser`, which is a local Playwright user-data directory path.
+
+:::
+
+## Self-hosted Firecrawl
+
+To use a self-hosted Firecrawl API, set `apiUrl`:
+
+```typescript
+const browser = new FirecrawlBrowser({
+  apiUrl: 'https://firecrawl.internal.example.com',
+})
+```
+
+## Related
+
+- [Browser overview](/docs/browser/overview)
+- [AgentBrowser](/docs/browser/agent-browser)
+- [Browser recording (alpha)](/docs/browser/recording)
+- [FirecrawlBrowser reference](/reference/browser/firecrawl-browser)

--- a/docs/src/content/en/docs/browser/overview.mdx
+++ b/docs/src/content/en/docs/browser/overview.mdx
@@ -5,6 +5,7 @@ packages:
   - "@mastra/core"
   - "@mastra/agent-browser"
   - "@mastra/stagehand"
+  - "@mastra/browser-firecrawl"
   - "@mastra/browser-viewer"
 ---
 
@@ -12,10 +13,11 @@ packages:
 
 Browser support enables agents to navigate websites, interact with page elements, fill forms, and extract data. Mastra provides browser capabilities through SDK providers that wrap browser automation libraries and a CLI provider for agents that drive browsers through command-line tools.
 
-Mastra supports two SDK providers and one CLI provider:
+Mastra supports three SDK providers and one CLI provider:
 
 - [**AgentBrowser**](/docs/browser/agent-browser): A Playwright-based provider with accessibility-first element targeting. Best for general web automation and scraping.
 - [**Stagehand**](/docs/browser/stagehand): A Browserbase provider with AI-powered element detection. Best for complex interactions that benefit from natural language selectors.
+- [**FirecrawlBrowser**](/docs/browser/firecrawl): A Firecrawl Browser Sandbox provider that runs AgentBrowser tools against hosted browser sessions. Best for running automation on hosted browser sessions without managing local browser infrastructure.
 - [**BrowserViewer**](/docs/browser/browser-viewer): A CLI provider that launches Chrome and injects CDP URLs into CLI tools like agent-browser, browser-use, and browse. Best for workspace agents that drive browsers through shell commands.
 - [**Browser recording (alpha)**](/docs/browser/recording): An opt-in tool layer that saves browser sessions as Motion-JPEG AVI videos with optional captions.
 
@@ -74,7 +76,19 @@ The agent automatically receives all browser tools from the provider.
 
 ## Cloud providers
 
-Both SDK providers support connecting to cloud browser services instead of launching a local browser.
+All SDK providers support connecting to cloud browser services instead of launching a local browser.
+
+### Firecrawl Browser Sandbox (FirecrawlBrowser native)
+
+FirecrawlBrowser provisions hosted sessions through the Firecrawl API:
+
+```typescript
+import { FirecrawlBrowser } from '@mastra/browser-firecrawl'
+
+const browser = new FirecrawlBrowser({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+})
+```
 
 ### Browserbase (Stagehand native)
 
@@ -139,6 +153,7 @@ const browser = new AgentBrowser({
 
 - [AgentBrowser](/docs/browser/agent-browser)
 - [Stagehand](/docs/browser/stagehand)
+- [Firecrawl](/docs/browser/firecrawl)
 - [Browser recording (alpha)](/docs/browser/recording)
 - [BrowserViewer](/docs/browser/browser-viewer)
 - [MastraBrowser reference](/reference/browser/mastra-browser)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -388,6 +388,11 @@ const sidebars = {
             },
             {
               type: 'doc',
+              id: 'browser/firecrawl',
+              label: 'Firecrawl',
+            },
+            {
+              type: 'doc',
               id: 'browser/recording',
               label: 'Recording',
               customProps: {

--- a/docs/src/content/en/reference/browser/firecrawl-browser.mdx
+++ b/docs/src/content/en/reference/browser/firecrawl-browser.mdx
@@ -1,0 +1,126 @@
+---
+title: "Reference: FirecrawlBrowser class | Browser"
+description: "API reference for FirecrawlBrowser, a browser automation provider that runs agent-browser sessions in the Firecrawl Browser Sandbox."
+packages:
+  - "@mastra/browser-firecrawl"
+---
+
+# FirecrawlBrowser class
+
+The `FirecrawlBrowser` class provides browser automation backed by the [Firecrawl Browser Sandbox](https://docs.firecrawl.dev/features/browser). It provisions remote browser sessions through the Firecrawl API and connects to them over the Chrome DevTools Protocol (CDP).
+
+`FirecrawlBrowser` extends [`AgentBrowser`](/reference/browser/agent-browser) and exposes the same deterministic toolset. Use it when you want hosted browser sessions instead of a local Chromium install. For local automation, see [`AgentBrowser`](/reference/browser/agent-browser). For AI-powered interactions using natural language, see [`StagehandBrowser`](/reference/browser/stagehand-browser).
+
+## Usage example
+
+```typescript title="src/mastra/agents/index.ts"
+import { Agent } from '@mastra/core/agent'
+import { FirecrawlBrowser } from '@mastra/browser-firecrawl'
+
+const browser = new FirecrawlBrowser({
+  apiKey: process.env.FIRECRAWL_API_KEY,
+  firecrawl: {
+    ttl: 600,
+  },
+})
+
+export const browserAgent = new Agent({
+  id: 'browser-agent',
+  name: 'Browser Agent',
+  instructions: `You can browse the web. Use browser_snapshot to see the page structure,
+then interact with elements using their refs (e.g., @e5).`,
+  model: '__GATEWAY_OPENAI_MODEL__',
+  browser,
+})
+```
+
+## Constructor parameters
+
+`FirecrawlBrowser` accepts all [`AgentBrowser` constructor parameters](/reference/browser/agent-browser) plus the following:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'apiKey',
+    type: 'string',
+    description:
+      'Firecrawl API key. Falls back to the FIRECRAWL_API_KEY environment variable. The constructor throws if neither is set.',
+    isOptional: true,
+  },
+  {
+    name: 'apiUrl',
+    type: 'string',
+    description: 'Base URL for a self-hosted Firecrawl API.',
+    isOptional: true,
+  },
+  {
+    name: 'firecrawl',
+    type: 'FirecrawlBrowserSessionOptions',
+    description: 'Session options passed to the Firecrawl browser() API when creating sandbox sessions.',
+    isOptional: true,
+    properties: [
+      {
+        type: 'FirecrawlBrowserSessionOptions',
+        parameters: [
+          {
+            name: 'ttl',
+            type: 'number',
+            description: 'Maximum session lifetime in seconds.',
+            isOptional: true,
+          },
+          {
+            name: 'activityTtl',
+            type: 'number',
+            description: 'Idle timeout in seconds before the sandbox recycles the session.',
+            isOptional: true,
+          },
+          {
+            name: 'streamWebView',
+            type: 'boolean',
+            description: 'When true, Firecrawl may stream WebView frames for the remote session.',
+            isOptional: true,
+          },
+          {
+            name: 'profile',
+            type: '{ name: string; saveChanges?: boolean }',
+            description:
+              'Named Firecrawl sandbox profile. Persists cookies and login state between sessions. Distinct from the top-level AgentBrowser profile option, which is a local Playwright user-data directory path.',
+            isOptional: true,
+          },
+          {
+            name: 'integration',
+            type: 'string',
+            description: 'Integration label for Firecrawl analytics and routing.',
+            isOptional: true,
+          },
+          {
+            name: 'origin',
+            type: 'string',
+            description: 'Origin hint for the Firecrawl browser session.',
+            isOptional: true,
+          },
+        ],
+      },
+    ],
+  },
+]}
+/>
+
+## Session lifecycle
+
+Session provisioning depends on the `scope` option inherited from `AgentBrowser`:
+
+- `'thread'` (default): Each conversation thread gets its own Firecrawl sandbox session, created on first use and deleted when the thread's browser session is destroyed.
+- `'shared'`: One Firecrawl sandbox session is created when the browser launches and shared across all threads. The session is deleted when the browser closes.
+
+In both cases, `FirecrawlBrowser` deletes the remote Firecrawl session when the browser closes, including when session creation or connection fails partway through.
+
+## Tools
+
+`FirecrawlBrowser` provides the same toolset as `AgentBrowser`, including `browser_goto`, `browser_snapshot`, `browser_click`, `browser_type`, and `browser_screenshot`. See the [`AgentBrowser` tool reference](/reference/browser/agent-browser) for the full list and tool parameters.
+
+## Related
+
+- [Firecrawl docs](/docs/browser/firecrawl)
+- [`AgentBrowser` reference](/reference/browser/agent-browser)
+- [Browser overview](/docs/browser/overview)

--- a/docs/src/content/en/reference/browser/firecrawl-browser.mdx
+++ b/docs/src/content/en/reference/browser/firecrawl-browser.mdx
@@ -84,7 +84,7 @@ then interact with elements using their refs (e.g., @e5).`,
             name: 'profile',
             type: '{ name: string; saveChanges?: boolean }',
             description:
-              'Named Firecrawl sandbox profile. Persists cookies and login state between sessions. Distinct from the top-level AgentBrowser profile option, which is a local Playwright user-data directory path.',
+              'Named Firecrawl sandbox profile. Set saveChanges: true to persist cookies and login state when the session ends; naming a profile alone does not save changes. Distinct from the top-level AgentBrowser profile option, which is a local Playwright user-data directory path.',
             isOptional: true,
           },
           {

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -125,6 +125,7 @@ const sidebars = {
       items: [
         { type: 'doc', id: 'browser/agent-browser', label: 'AgentBrowser' },
         { type: 'doc', id: 'browser/browser-viewer', label: 'BrowserViewer' },
+        { type: 'doc', id: 'browser/firecrawl-browser', label: 'FirecrawlBrowser' },
         { type: 'doc', id: 'browser/mastra-browser', label: 'MastraBrowser Class' },
         { type: 'doc', id: 'browser/stagehand-browser', label: 'StagehandBrowser' },
       ],


### PR DESCRIPTION
Adds docs for the `@mastra/browser-firecrawl` package, which was missing from the docs site. There's now a usage guide at `docs/browser/firecrawl` covering setup, session scopes, and Firecrawl session options, plus an API reference for the `FirecrawlBrowser` class. The browser overview and both sidebars now link to the new pages.

```typescript
import { FirecrawlBrowser } from '@mastra/browser-firecrawl'

const browser = new FirecrawlBrowser({
  apiKey: process.env.FIRECRAWL_API_KEY,
})
```

Docs-only change, so no changeset. Verified with `pnpm validate` and `pnpm lint:prose`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR adds a new documentation page and API reference for using Mastra with Firecrawl’s hosted browser automation. It also explains how session scopes work, and (importantly) that you must set `saveChanges: true` if you want cookies and login state to persist.

## What changed

- Added docs for `@mastra/browser-firecrawl`, including:
  - Setup/quickstart (including `FIRECRAWL_API_KEY`)
  - Session scoping and lifecycle (`thread` vs `shared`)
  - Firecrawl session options (under the `firecrawl` key), including named profiles
  - Guidance for pointing to a self-hosted Firecrawl API via `apiUrl`
  - Clear distinction between nested `firecrawl.profile` and the top-level `AgentBrowser` profile option
  - Explicit clarification: naming a Firecrawl profile alone does **not** persist changes—`saveChanges: true` is required to save cookies/login state
- Added an API reference page for `FirecrawlBrowser` (constructor options, session behavior, and toolset parity with `AgentBrowser`)
- Linked the new Firecrawl browser docs and API reference from:
  - Browser overview
  - Browser-related “related” content
  - Both browser and reference sidebars
- Documentation-only change, validated with `pnpm validate` and `pnpm lint:prose`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->