### PR TITLE
fix(core): stop goal loops after API errors

### DIFF
--- a/.changeset/fifty-cougars-float.md
+++ b/.changeset/fifty-cougars-float.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed native Agent goals continuing to invoke the judge after an unretried API error.

--- a/mastracode/tui/e2e/fixtures/goal-api-error-stops-loop.json
+++ b/mastracode/tui/e2e/fixtures/goal-api-error-stops-loop.json
@@ -1,0 +1,36 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Goal: Preserve terminal API errors without autonomous continuation.",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "content": "{\"decision\":\"continue\",\"reason\":\"Continue once so the next primary turn can fail mid-stream.\"}"
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Goal: Preserve terminal API errors without autonomous continuation.",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "{\"decision\":\"continue\",\"reason\":\"The failed primary turn did not complete the objective.\"}"
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Preserve terminal API errors without autonomous continuation."
+      },
+      "response": {
+        "content": "Initial goal work completed before the injected failure."
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/tui/goal-api-error-stops-loop.ts
+++ b/mastracode/tui/e2e/tui/goal-api-error-stops-loop.ts
@@ -1,0 +1,216 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import stripAnsi from 'strip-ansi';
+import { createGlobalPatchScope } from './global-patches.js';
+import type { McE2eInProcessApp, McE2eScenario } from './types.js';
+
+const OBJECTIVE = 'Preserve terminal API errors without autonomous continuation.';
+const ERROR_MESSAGE = 'Terminal goal API error from the e2e provider.';
+const SCORER_PREFIX = `Goal: ${OBJECTIVE}`;
+
+type RequestCounters = {
+  successfulPrimaryCalls: number;
+  scorerCallsBeforeFailure: number;
+  failedPrimaryAttempts: number;
+  scorerCallsAfterFailure: number;
+  autonomousPrimaryFollowups: number;
+  classificationErrors: string[];
+};
+
+let counters: RequestCounters;
+
+function requestUrl(input: RequestInfo | URL): string {
+  if (typeof input === 'string') return input;
+  if (input instanceof URL) return input.href;
+  return input.url;
+}
+
+function requestBodyText(body: BodyInit | null | undefined): string {
+  if (typeof body === 'string') return body;
+  if (body instanceof Uint8Array) return new TextDecoder().decode(body);
+  return '';
+}
+
+function classifyRequest(rawBody: string): 'primary' | 'scorer' {
+  try {
+    JSON.parse(rawBody);
+  } catch {
+    throw new Error(`Could not parse model request body: ${rawBody.slice(0, 500)}`);
+  }
+
+  const hasObjective = rawBody.includes(OBJECTIVE);
+  const isScorer = rawBody.includes(SCORER_PREFIX);
+  const isPrimary = hasObjective && !isScorer;
+
+  if (isPrimary === isScorer) {
+    throw new Error(
+      `Expected exactly one request class (primary=${isPrimary}, scorer=${isScorer}): ${rawBody.slice(0, 1000)}`,
+    );
+  }
+  return isScorer ? 'scorer' : 'primary';
+}
+
+function terminalErrorResponse(url: string): Response {
+  if (url.includes('/responses')) {
+    const partialChunk = {
+      type: 'response.output_text.delta',
+      content_index: 0,
+      delta: 'Partial goal work before failure.',
+      item_id: 'msg-goal-api-error',
+      logprobs: [],
+      output_index: 0,
+      sequence_number: 1,
+    };
+    const errorChunk = {
+      type: 'error',
+      code: 'invalid_api_key',
+      message: ERROR_MESSAGE,
+      param: null,
+      sequence_number: 2,
+    };
+    return new Response(
+      `event: response.output_text.delta\ndata: ${JSON.stringify(partialChunk)}\n\nevent: error\ndata: ${JSON.stringify(errorChunk)}\n\n`,
+      { status: 200, headers: { 'content-type': 'text/event-stream' } },
+    );
+  }
+
+  const partialChunk = {
+    id: 'chatcmpl-goal-api-error',
+    object: 'chat.completion.chunk',
+    created: 0,
+    model: 'gpt-5.4-mini',
+    choices: [
+      { index: 0, delta: { role: 'assistant', content: 'Partial goal work before failure.' }, finish_reason: null },
+    ],
+  };
+  const errorChunk = {
+    type: 'error',
+    sequence_number: 2,
+    error: { type: 'authentication_error', code: 'invalid_api_key', message: ERROR_MESSAGE },
+  };
+  return new Response(`data: ${JSON.stringify(partialChunk)}\n\ndata: ${JSON.stringify(errorChunk)}\n\n`, {
+    status: 200,
+    headers: { 'content-type': 'text/event-stream' },
+  });
+}
+
+function writeProofCounters(): void {
+  const outputPath = process.env.MC_E2E_GOAL_API_ERROR_PROOF_OUT;
+  if (outputPath) writeFileSync(outputPath, JSON.stringify(counters, null, 2));
+}
+
+export const goalApiErrorStopsLoopScenario = {
+  name: 'goal-api-error-stops-loop',
+  description: 'Keep a non-retryable primary-agent stream error terminal while a goal remains active.',
+  testName: 'does not judge or autonomously continue a goal after a terminal API error',
+  useOpenAIModel: true,
+  aimockFixture: 'goal-api-error-stops-loop.json',
+  prepare({ appDataDir }) {
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as any;
+    settings.models = {
+      ...settings.models,
+      goalJudgeModel: 'openai/gpt-5.4-mini',
+      goalMaxTurns: 2,
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  },
+  async inProcessApp({ startMastraCodeApp }): Promise<McE2eInProcessApp> {
+    counters = {
+      successfulPrimaryCalls: 0,
+      scorerCallsBeforeFailure: 0,
+      failedPrimaryAttempts: 0,
+      scorerCallsAfterFailure: 0,
+      autonomousPrimaryFollowups: 0,
+      classificationErrors: [],
+    };
+    writeProofCounters();
+
+    const patches = createGlobalPatchScope();
+    const originalFetch = globalThis.fetch.bind(globalThis);
+    patches.setProperty(globalThis, 'fetch', async (input, init) => {
+      const url = requestUrl(input);
+      if (!url.includes('/chat/completions') && !url.includes('/responses')) return originalFetch(input, init);
+
+      const rawBody = requestBodyText(init?.body);
+      let requestClass: 'primary' | 'scorer';
+      try {
+        requestClass = classifyRequest(rawBody);
+      } catch (error) {
+        counters.classificationErrors.push(error instanceof Error ? error.message : String(error));
+        writeProofCounters();
+        throw error;
+      }
+
+      if (requestClass === 'scorer') {
+        if (counters.failedPrimaryAttempts === 0) counters.scorerCallsBeforeFailure += 1;
+        else counters.scorerCallsAfterFailure += 1;
+        writeProofCounters();
+        return originalFetch(input, init);
+      }
+
+      if (counters.successfulPrimaryCalls === 0) {
+        counters.successfulPrimaryCalls = 1;
+        writeProofCounters();
+        return originalFetch(input, init);
+      }
+      if (counters.failedPrimaryAttempts === 0) counters.failedPrimaryAttempts = 1;
+      else counters.autonomousPrimaryFollowups += 1;
+      writeProofCounters();
+      return terminalErrorResponse(url);
+    });
+
+    try {
+      const app = await startMastraCodeApp({
+        config: { disableHooks: true, disableMcp: true, unixSocketPubSub: false },
+      });
+      return { stop: () => patches.stopApp(app.stop) };
+    } catch (error) {
+      patches.restore();
+      throw error;
+    }
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Resource ID:/i, terminal);
+
+    terminal.submit(`/goal ${OBJECTIVE}`);
+    await runtime.waitForScreenText(new RegExp(ERROR_MESSAGE), terminal, 15_000);
+    await new Promise(resolve => setTimeout(resolve, 3_000));
+
+    writeProofCounters();
+    console.info(
+      `[goal-api-error-stops-loop] successful=${counters.successfulPrimaryCalls} preFailureScorer=${counters.scorerCallsBeforeFailure} failed=${counters.failedPrimaryAttempts} postFailureScorer=${counters.scorerCallsAfterFailure} followups=${counters.autonomousPrimaryFollowups}`,
+    );
+    if (counters.classificationErrors.length > 0) {
+      throw new Error(`Request classification failed: ${counters.classificationErrors.join('\n')}`);
+    }
+    if (
+      counters.successfulPrimaryCalls !== 1 ||
+      counters.scorerCallsBeforeFailure !== 1 ||
+      counters.failedPrimaryAttempts !== 1 ||
+      counters.scorerCallsAfterFailure !== 0 ||
+      counters.autonomousPrimaryFollowups !== 0
+    ) {
+      throw new Error(`Terminal error escaped its boundary: ${JSON.stringify(counters)}`);
+    }
+
+    terminal.submit('/goal status');
+    await runtime.waitForScreenText(
+      /Goal \(active\): "Preserve terminal API errors without autonomous continuation\." — 1\/2 turns used/i,
+      terminal,
+      8_000,
+    );
+
+    const view = stripAnsi(terminal.serialize().view);
+    if (!view.includes(ERROR_MESSAGE)) throw new Error(`Expected visible terminal error state:\n${view}`);
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    if (requests.length !== 2) {
+      throw new Error(
+        `Expected one successful primary request and one pre-failure scorer request: ${JSON.stringify(requests)}`,
+      );
+    }
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -42,6 +42,7 @@ import { githubSignalsIncrementalScenario } from './github-signals-incremental.j
 import { githubSignalsNotificationReloadScenario } from './github-signals-notification-reload.js';
 import { githubSignalsPollingInboxScenario } from './github-signals-polling-inbox.js';
 import { githubSignalsUnsubscribeReloadScenario } from './github-signals-unsubscribe-reload.js';
+import { goalApiErrorStopsLoopScenario } from './goal-api-error-stops-loop.js';
 import { goalJudgeSingleRenderScenario } from './goal-judge-single-render.js';
 import { headlessMcpToolAvailabilityScenario } from './headless-mcp-tool-availability.js';
 import { integrationCommandsScenario } from './integration-commands.js';
@@ -197,6 +198,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'github-signals-notification-reload': githubSignalsNotificationReloadScenario,
   'github-signals-polling-inbox': githubSignalsPollingInboxScenario,
   'github-signals-unsubscribe-reload': githubSignalsUnsubscribeReloadScenario,
+  'goal-api-error-stops-loop': goalApiErrorStopsLoopScenario,
   'goal-judge-single-render': goalJudgeSingleRenderScenario,
   'controller-api-config': controllerApiConfigScenario,
   'headless-mcp-tool-availability': headlessMcpToolAvailabilityScenario,

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -48,6 +48,7 @@ export type ScenarioName =
   | 'github-signals-notification-reload'
   | 'github-signals-polling-inbox'
   | 'github-signals-unsubscribe-reload'
+  | 'goal-api-error-stops-loop'
   | 'goal-judge-single-render'
   | 'controller-api-config'
   | 'headless-mcp-tool-availability'

--- a/packages/core/src/agent/durable/__tests__/durable-agent-goal.test.ts
+++ b/packages/core/src/agent/durable/__tests__/durable-agent-goal.test.ts
@@ -22,6 +22,22 @@ import { Agent } from '../../agent';
 import { createDurableAgent } from '../create-durable-agent';
 import { createEventedAgent } from '../create-evented-agent';
 
+function createErrorModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'id-error', modelId: 'mock-model-id', timestamp: new Date(0) },
+        { type: 'text-start', id: 'text-error' },
+        { type: 'text-delta', id: 'text-error', delta: 'Partial work before failure.' },
+        { type: 'error', error: new Error('Terminal provider failure') },
+      ]),
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
 function createTextModel(text: string) {
   return new MockLanguageModelV2({
     doStream: async () => ({
@@ -290,6 +306,59 @@ describe('DurableAgent goal step', () => {
     const record = await durableAgent.getObjective({ threadId: THREAD });
     expect(record?.status).toBe('done');
     expect(record?.runsUsed).toBe(1);
+  });
+
+  it('preserves a terminal primary-agent error without judging or emitting goal progress', async () => {
+    const scorerRun = vi.fn().mockResolvedValue({ score: 1, reason: 'Goal achieved' });
+    const memory = new MockMemory();
+    const THREAD = 'goal-error-thread';
+    const RESOURCE = 'user-1';
+
+    const baseAgent = new Agent({
+      id: 'goal-error-agent',
+      name: 'Goal Error Agent',
+      instructions: 'You are a helpful agent.',
+      model: createErrorModel() as LanguageModelV2,
+      memory,
+      goal: {
+        judge: 'mock-judge',
+        maxRuns: 5,
+        scorer: { id: 'goal-scorer', name: 'Goal Scorer', run: scorerRun } as any,
+      },
+    });
+    const durableAgent = createDurableAgent({ agent: baseAgent, pubsub });
+    new Mastra({
+      agents: { 'goal-error-agent': durableAgent as any },
+      logger: false,
+      storage: new InMemoryStore(),
+      pubsub,
+    });
+
+    const initialObjective = await durableAgent.setObjective('Preserve this active objective', {
+      threadId: THREAD,
+      resourceId: RESOURCE,
+    });
+    const result = await durableAgent.stream('Fail this primary turn', {
+      maxSteps: 3,
+      memory: { thread: THREAD, resource: RESOURCE },
+    });
+    const chunks = await drain(result.fullStream);
+
+    expect(scorerRun).not.toHaveBeenCalled();
+    expect(chunks.filter((chunk: any) => chunk.type === 'goal')).toEqual([]);
+    const finishChunk = chunks.findLast((chunk: any) => chunk.type === 'step-finish');
+    expect(finishChunk?.payload?.stepResult).toMatchObject({ reason: 'error', isContinued: false });
+
+    const objective = await durableAgent.getObjective({ threadId: THREAD });
+    expect(objective).toEqual(initialObjective);
+    expect(objective).toMatchObject({ status: 'active', runsUsed: 0 });
+
+    const { messages } = await memory.recall({ threadId: THREAD, resourceId: RESOURCE });
+    const goalSignals = messages.filter(
+      (message: any) =>
+        message.role === 'signal' && message.content?.metadata?.signal?.attributes?.type === 'goal-judge',
+    );
+    expect(goalSignals).toEqual([]);
   });
 
   it('no-ops when no goal is configured', async () => {

--- a/packages/core/src/agent/durable/workflows/steps/goal.ts
+++ b/packages/core/src/agent/durable/workflows/steps/goal.ts
@@ -127,10 +127,12 @@ export function createDurableGoalStep() {
           toolCalls?: Array<{ toolName?: string; args?: unknown }>;
           toolResults?: Array<{ toolName?: string; result?: unknown }>;
         }>;
-        lastStepResult?: { isContinued?: boolean };
+        lastStepResult?: { isContinued?: boolean; reason?: string };
         options?: { maxSteps?: number };
         backgroundTaskPending?: boolean;
       };
+      if (state.lastStepResult?.reason === 'error') return state;
+
       const pubsub = (params as any)[PUBSUB_SYMBOL] as PubSub | undefined;
       const initData = getInitData() as {
         agentId?: string;

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
@@ -50,6 +50,8 @@ async function runGoalStep(
     undefinedJudgeResolver?: boolean;
     dbMessages?: any[];
     useMemory?: boolean;
+    scorer?: any;
+    stepResult?: any;
   },
 ) {
   const store = createStore(record);
@@ -103,7 +105,7 @@ async function runGoalStep(
   // isContinued must start false: a truthy value trips the "mid-tool-loop
   // continuation" gate and the step returns before scoring. The goal gate is
   // what sets it back to true to force another iteration.
-  const stepResult: any = { isContinued: false };
+  const stepResult: any = opts?.stepResult ?? { isContinued: false };
   const inputData: any = {
     messageId: 'response-1',
     output: { text: 'I did X', toolCalls: [], toolResults: [] },
@@ -127,6 +129,7 @@ async function runGoalStep(
         ? () => undefined
         : (createMockModel({ objectGenerationMode: 'json', mockText: { decision, reason: `r:${decision}` } }) as any),
       ...(opts?.throwingScorer ? { scorer: throwingScorer } : {}),
+      ...(opts?.scorer ? { scorer: opts.scorer } : {}),
       // A `goal.tools` resolver that throws exercises a resolution-time judge
       // failure (before scoring) — the default scorer resolves tools eagerly.
       ...(opts?.throwingToolsResolver
@@ -153,7 +156,7 @@ async function runGoalStep(
     agentName: 'Agent',
   } as any);
 
-  await (step as any).execute({ inputData });
+  const executionResult = await (step as any).execute({ inputData });
 
   // The goal step emits a pending chunk (loading indicator) followed by the
   // final result chunk. Pick the result chunk (non-pending) for assertions.
@@ -169,6 +172,7 @@ async function runGoalStep(
     messages,
     dataParts,
     inputData,
+    executionResult,
   };
 }
 
@@ -295,6 +299,26 @@ describe('goal step waiting semantics', () => {
     expect(stepResult.isContinued).toBe(true);
     expect(chunk.payload.passed).toBe(false);
     expect(chunk.payload.status).toBe('active');
+  });
+
+  it('preserves a terminal primary-agent error without judging or emitting goal progress', async () => {
+    const initialRecord = makeRecord({ id: 'goal-error', runsUsed: 4 });
+    const terminalStepResult = { reason: 'error', isContinued: false };
+    const scorerRun = vi.fn().mockResolvedValue({ score: 0, reason: 'keep working' });
+
+    const result = await runGoalStep('continue', initialRecord, {
+      scorer: { id: 'goal-scorer', name: 'Goal (LLM)', run: scorerRun },
+      stepResult: terminalStepResult,
+    });
+
+    expect(scorerRun).not.toHaveBeenCalled();
+    expect(result.goalChunks).toEqual([]);
+    expect(result.messages).toEqual([]);
+    expect(result.dataParts).toEqual([]);
+    expect(result.record).toEqual(initialRecord);
+    expect(result.stepResult).toBe(terminalStepResult);
+    expect(result.stepResult).toEqual({ reason: 'error', isContinued: false });
+    expect(result.executionResult).toBe(result.inputData);
   });
 
   it('persists waiting feedback as a goal-judge signal, not assistant-authored transcript text', async () => {

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -108,6 +108,8 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
     inputSchema: llmIterationOutputSchema,
     outputSchema: llmIterationOutputSchema,
     execute: async ({ inputData }) => {
+      if (inputData.stepResult?.reason === 'error') return inputData;
+
       // No goal configured on the agent → nothing to do.
       if (!goal) return inputData;
 


### PR DESCRIPTION
Native Agent goals could treat an unretried provider error as completed output, invoke the goal judge, and turn a `continue` decision into another autonomous turn. This preserves the terminal LLM result instead: regular and durable goal steps now return immediately for `reason: 'error'`, without judging, emitting goal progress, incrementing `runsUsed`, or changing the active objective.

Before: `{ reason: 'error', isContinued: false }` could reach the judge and become `{ isContinued: true }`. After: the original terminal result is returned unchanged and remains available for an explicit user retry.

This includes red-first regular and durable regression tests plus a real in-process MastraCode TUI scenario that injects a non-retryable mid-stream provider error and counts post-failure judge and primary-agent requests. The new regressions, existing retryable-stream scenario, package builds, typechecks, and lints pass. Broad package suites retain only the documented environment-sensitive baseline failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When an agent hits an unrecoverable provider error, it now stops instead of repeatedly trying to continue the same goal. The error is reported immediately, without judging progress or consuming another run.

## Changes

- Short-circuit regular and durable goal steps when the primary agent ends with `reason: 'error'`.
- Preserve terminal error results without invoking the goal judge, emitting progress, incrementing `runsUsed`, or changing the active objective.
- Add regression coverage for regular and durable goals.
- Add an in-process MastraCode TUI scenario and fixture covering non-retryable mid-stream errors.
- Add a patch release note for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->