### PR TITLE
fix(core): unbounded memory growth during long goal runs

### DIFF
--- a/.changeset/few-meals-march.md
+++ b/.changeset/few-meals-march.md
@@ -2,9 +2,9 @@
 '@mastra/core': patch
 ---
 
-Fixed unbounded memory growth during long goal runs. A goal run chains many agent turns inside one stream, and the stream previously kept every chunk, step, tool result, and text delta of the entire run in memory (and in suspend snapshots). Now each completed goal judge evaluation clears these run-lifetime buffers, preventing out-of-memory crashes on long goal runs.
+Fixed unbounded memory growth during long goal runs. A goal run chains many agent turns inside one stream, and the stream previously kept every chunk, step, tool result, and text delta of the entire run in memory (and in suspend snapshots). Goal evaluations now carry the goal gate's explicit `shouldContinue` decision, and the stream clears its run-lifetime buffers at each continuing evaluation — the judged turn's messages are already persisted by then. Terminal evaluations (completion, waiting for user, judge failure, budget exhaustion) do not truncate, so the final turn is preserved.
 
-**Behavior change for goal runs:** run-end results now cover the segment after the last judge evaluation instead of every turn of the run. Streamed chunks, token usage totals, and persisted messages are unaffected — only the aggregates resolved at the end of the run change. Agents without a `goal` config are unaffected.
+**Behavior change for goal runs:** run-end results now cover the final iteration of the run (everything after the last continuing evaluation) instead of every turn. Streamed chunks, token usage totals, and persisted messages are unaffected — only the aggregates resolved at the end of the run change. Agents without a `goal` config are unaffected.
 
 ```ts
 const agent = new Agent({
@@ -19,7 +19,7 @@ const output = await stream.getFullOutput();
 // Before: output.text, output.steps, output.toolCalls, and output.toolResults
 // aggregated every turn of the goal run (e.g. 50 turns concatenated).
 
-// After: they cover only the turns after the last judge evaluation — for a
-// completed goal, the final answer. Use output.messages (or memory) for the
-// full conversation; output.totalUsage still spans the entire run.
+// After: they cover the final iteration — the turn(s) judged by the terminal
+// evaluation, i.e. the goal's final answer. Use output.messages (or memory)
+// for the full conversation; output.totalUsage still spans the entire run.
 ```

--- a/.changeset/few-meals-march.md
+++ b/.changeset/few-meals-march.md
@@ -4,4 +4,22 @@
 
 Fixed unbounded memory growth during long goal runs. A goal run chains many agent turns inside one stream, and the stream previously kept every chunk, step, tool result, and text delta of the entire run in memory (and in suspend snapshots). Now each completed goal judge evaluation clears these run-lifetime buffers, preventing out-of-memory crashes on long goal runs.
 
-**Behavior note:** for goal runs, run-end results (`text`, `steps`, `toolCalls`, `toolResults`, and `getFullOutput()`) now cover the segment after the last judge evaluation — for a completed goal that is the final answer. Token usage totals, streamed chunks, and persisted messages still span the whole run.
+**Behavior change for goal runs:** run-end results now cover the segment after the last judge evaluation instead of every turn of the run. Streamed chunks, token usage totals, and persisted messages are unaffected — only the aggregates resolved at the end of the run change. Agents without a `goal` config are unaffected.
+
+```ts
+const agent = new Agent({
+  name: 'coder',
+  model: 'openai/gpt-5.5',
+  goal: { judge: 'openai/gpt-5-mini' },
+});
+
+const stream = await agent.stream('Implement feature X');
+const output = await stream.getFullOutput();
+
+// Before: output.text, output.steps, output.toolCalls, and output.toolResults
+// aggregated every turn of the goal run (e.g. 50 turns concatenated).
+
+// After: they cover only the turns after the last judge evaluation — for a
+// completed goal, the final answer. Use output.messages (or memory) for the
+// full conversation; output.totalUsage still spans the entire run.
+```

--- a/.changeset/few-meals-march.md
+++ b/.changeset/few-meals-march.md
@@ -1,0 +1,7 @@
+---
+'@mastra/core': patch
+---
+
+Fixed unbounded memory growth during long goal runs. A goal run chains many agent turns inside one stream, and the stream previously kept every chunk, step, tool result, and text delta of the entire run in memory (and in suspend snapshots). Now each completed goal judge evaluation clears these run-lifetime buffers, preventing out-of-memory crashes on long goal runs.
+
+**Behavior note:** for goal runs, run-end results (`text`, `steps`, `toolCalls`, `toolResults`, and `getFullOutput()`) now cover the segment after the last judge evaluation — for a completed goal that is the final answer. Token usage totals, streamed chunks, and persisted messages still span the whole run.

--- a/packages/core/src/agent/durable/workflows/steps/goal.ts
+++ b/packages/core/src/agent/durable/workflows/steps/goal.ts
@@ -217,6 +217,7 @@ export function createDurableGoalStep() {
                 timedOut: false,
                 maxRunsReached: true,
                 suppressFeedback: false,
+                shouldContinue: false,
               },
             } as any);
           } catch {
@@ -466,6 +467,7 @@ export function createDurableGoalStep() {
         timedOut: result.timedOut,
         maxRunsReached,
         suppressFeedback,
+        shouldContinue,
       };
 
       // Inject feedback into messageList via signal so the next LLM call sees it.

--- a/packages/core/src/loop/test-utils/aimock/scenarios/goal-multi-turn-buffering.scenario.test.ts
+++ b/packages/core/src/loop/test-utils/aimock/scenarios/goal-multi-turn-buffering.scenario.test.ts
@@ -1,0 +1,70 @@
+import { it, expect } from 'vitest';
+import { useLoopScenarioAimock, runLoopScenario, describeForAllEngines } from '../aimock-scenario';
+import { MockMemory } from '../../../../memory/mock';
+
+const getMock = useLoopScenarioAimock();
+
+describeForAllEngines(
+  'AIMock loop scenario: goal multi-turn buffering',
+  engine => {
+    it('continuing evaluations carry shouldContinue and bound buffering while the terminal turn is preserved', async () => {
+      const memory = new MockMemory();
+      const THREAD = 'goal-buffering-thread-1';
+      const RESOURCE = 'user-1';
+
+      // Scorer that fails twice (continue) and passes on the third evaluation
+      // (terminal), producing the normal continuing → terminal sequence.
+      let evaluations = 0;
+      const scorer = {
+        id: 'goal-scorer',
+        name: 'Goal Scorer',
+        run: async () => {
+          evaluations += 1;
+          return evaluations < 3
+            ? { score: 0, reason: 'Goal not yet achieved' }
+            : { score: 1, reason: 'Goal achieved' };
+        },
+      };
+
+      const { output, agent, chunks } = await runLoopScenario({
+        engine,
+        llm: getMock(),
+        prompt: 'Implement feature X',
+        memory,
+        threadId: THREAD,
+        resourceId: RESOURCE,
+        goal: {
+          judge: 'gpt-4',
+          maxRuns: 5,
+          scorer: scorer as any,
+        },
+        objective: 'Implement feature X',
+        collectChunks: true,
+        stopWhen: ({ step }: { step: number }) => step > 8, // Safety limit
+        fixtures: llm => {
+          llm.on({ endpoint: 'chat', sequenceIndex: 0 }, { content: 'I started working on feature X.' });
+          llm.on({ endpoint: 'chat', sequenceIndex: 1 }, { content: 'I made more progress on feature X.' });
+          llm.on({ endpoint: 'chat', sequenceIndex: 2 }, { content: 'Feature X is now complete.' });
+        },
+      });
+
+      // Final (non-pending) goal evaluations carry the goal gate's explicit
+      // continuation decision.
+      const goalChunks: any[] = (chunks ?? []).filter((c: any) => c.type === 'goal' && !c.payload?.pending);
+      expect(goalChunks.map((c: any) => c.payload.shouldContinue)).toEqual([true, true, false]);
+      expect(goalChunks[2].payload).toMatchObject({ passed: true, status: 'done' });
+
+      // Run-lifetime buffers were truncated at each continuing evaluation, but
+      // the terminal evaluation preserved the final turn: run-end results
+      // cover the last iteration, not the whole run and not an empty run.
+      const fullOutput = await output.getFullOutput();
+      expect(fullOutput.steps).toHaveLength(1);
+      expect(fullOutput.text).toBe('Feature X is now complete.');
+
+      const record = await agent.getObjective({ threadId: THREAD });
+      expect(record?.status).toBe('done');
+      expect(record?.runsUsed).toBe(3);
+    });
+  },
+  {},
+);

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -163,6 +163,7 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
             timedOut: false,
             maxRunsReached: true,
             suppressFeedback: false,
+            shouldContinue: false,
           },
         } as ChunkType<OUTPUT>);
         return inputData;
@@ -463,6 +464,7 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
         timedOut: result.timedOut,
         maxRunsReached,
         suppressFeedback,
+        shouldContinue,
       };
 
       let currentMessageId = inputData.messageId;

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -80,6 +80,40 @@ function createFinishChunk(
   } as ChunkType;
 }
 
+function createTextDeltaChunk(runId: string, text: string): ChunkType {
+  return {
+    type: 'text-delta',
+    runId,
+    from: ChunkFrom.AGENT,
+    payload: { id: 'text-1', text },
+  } as ChunkType;
+}
+
+/**
+ * Minimal goal evaluation chunk. `pending: true` marks an in-progress judge
+ * update; omitted means the evaluation is final.
+ */
+function createGoalChunk(runId: string, { pending }: { pending?: boolean } = {}): ChunkType {
+  return {
+    type: 'goal',
+    runId,
+    from: ChunkFrom.AGENT,
+    payload: {
+      objective: 'test objective',
+      iteration: 1,
+      maxRuns: 5,
+      passed: false,
+      status: 'active',
+      results: [],
+      duration: 0,
+      timedOut: false,
+      maxRunsReached: false,
+      suppressFeedback: false,
+      ...(pending ? { pending: true } : {}),
+    },
+  } as ChunkType;
+}
+
 describe('MastraModelOutput', () => {
   describe('writer in output processors (outer context)', () => {
     it('should pass a defined writer to processOutputResult', async () => {
@@ -1048,6 +1082,139 @@ describe('MastraModelOutput', () => {
 
       expect(firstResolved).toBe(true);
       expect(lateResolved).toBe(true);
+    });
+  });
+
+  describe('goal evaluation run-buffer truncation', () => {
+    it('drops pre-evaluation steps, text, and tool data from run-end results but keeps total usage', async () => {
+      const runId = 'test-run';
+      const stream = createChunkStream([
+        // First goal-judged turn: text + a tool call/result.
+        createTextDeltaChunk(runId, 'first turn text'),
+        {
+          type: 'tool-call',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId: 'tc-1', toolName: 'searchTool', args: { q: 'x' } },
+        } as ChunkType,
+        {
+          type: 'tool-result',
+          runId,
+          from: ChunkFrom.AGENT,
+          payload: { toolCallId: 'tc-1', toolName: 'searchTool', result: { hits: 3 } },
+        } as ChunkType,
+        createStepFinishChunk(runId),
+        createGoalChunk(runId),
+        // Second turn after the evaluation: text only.
+        createTextDeltaChunk(runId, 'final answer'),
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      const fullOutput = await output.getFullOutput();
+
+      // Run-end results cover only the segment after the last goal evaluation.
+      expect(fullOutput.steps).toHaveLength(1);
+      expect(fullOutput.text).toBe('final answer');
+      expect(fullOutput.toolCalls).toHaveLength(0);
+      expect(fullOutput.toolResults).toHaveLength(0);
+
+      // Token usage still spans the whole run (10/20/30 per step-finish, twice).
+      expect(fullOutput.totalUsage).toMatchObject({ inputTokens: 20, outputTokens: 40, totalTokens: 60 });
+    });
+
+    it('clears buffered chunks on a final goal evaluation so late streams replay from the evaluation onward', async () => {
+      const runId = 'test-run';
+      const stream = createChunkStream([
+        createTextDeltaChunk(runId, 'before '),
+        createTextDeltaChunk(runId, 'goal'),
+        createStepFinishChunk(runId),
+        createGoalChunk(runId),
+        createTextDeltaChunk(runId, 'after goal'),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      // A stream attached after consumption replays only chunks emitted after
+      // the final goal evaluation (starting with the goal chunk itself).
+      const replayed: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        replayed.push(chunk);
+      }
+
+      expect(replayed.map(c => c.type)).toEqual(['goal', 'text-delta', 'finish']);
+    });
+
+    it('does not clear buffered chunks on pending goal chunks', async () => {
+      const runId = 'test-run';
+      const stream = createChunkStream([
+        createTextDeltaChunk(runId, 'before pending'),
+        createGoalChunk(runId, { pending: true }),
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      const replayed: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        replayed.push(chunk);
+      }
+
+      expect(replayed.map(c => c.type)).toEqual(['text-delta', 'goal', 'step-finish', 'finish']);
+    });
+
+    it('still delivers all chunks live to streams attached before the goal evaluation', async () => {
+      const runId = 'test-run';
+      const stream = createChunkStream([
+        createTextDeltaChunk(runId, 'before '),
+        createGoalChunk(runId),
+        createTextDeltaChunk(runId, 'after'),
+        createStepFinishChunk(runId),
+        createFinishChunk(runId),
+      ]);
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      // Attach BEFORE consumption starts — this consumer drives the stream and
+      // must see every chunk regardless of replay-buffer truncation.
+      const live: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        live.push(chunk);
+      }
+
+      expect(live.map(c => c.type)).toEqual(['text-delta', 'goal', 'text-delta', 'step-finish', 'finish']);
     });
   });
 });

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -91,9 +91,14 @@ function createTextDeltaChunk(runId: string, text: string): ChunkType {
 
 /**
  * Minimal goal evaluation chunk. `pending: true` marks an in-progress judge
- * update; omitted means the evaluation is final.
+ * update. `shouldContinue` mirrors the goal gate's continuation decision:
+ * `true` on evaluations that loop into another judged iteration, `false` on
+ * terminal evaluations.
  */
-function createGoalChunk(runId: string, { pending }: { pending?: boolean } = {}): ChunkType {
+function createGoalChunk(
+  runId: string,
+  { pending, shouldContinue }: { pending?: boolean; shouldContinue?: boolean } = {},
+): ChunkType {
   return {
     type: 'goal',
     runId,
@@ -102,15 +107,36 @@ function createGoalChunk(runId: string, { pending }: { pending?: boolean } = {})
       objective: 'test objective',
       iteration: 1,
       maxRuns: 5,
-      passed: false,
-      status: 'active',
+      passed: shouldContinue === false,
+      status: shouldContinue === false ? 'done' : 'active',
       results: [],
       duration: 0,
       timedOut: false,
       maxRunsReached: false,
       suppressFeedback: false,
+      ...(shouldContinue !== undefined ? { shouldContinue } : {}),
       ...(pending ? { pending: true } : {}),
     },
+  } as ChunkType;
+}
+
+/** Tool-call chunk for a completed (non-streaming) tool invocation. */
+function createToolCallChunk(runId: string, toolCallId: string): ChunkType {
+  return {
+    type: 'tool-call',
+    runId,
+    from: ChunkFrom.AGENT,
+    payload: { toolCallId, toolName: 'searchTool', args: { q: 'x' } },
+  } as ChunkType;
+}
+
+/** Tool-result chunk matching a prior tool-call. */
+function createToolResultChunk(runId: string, toolCallId: string): ChunkType {
+  return {
+    type: 'tool-result',
+    runId,
+    from: ChunkFrom.AGENT,
+    payload: { toolCallId, toolName: 'searchTool', result: { hits: 3 } },
   } as ChunkType;
 }
 
@@ -1086,27 +1112,101 @@ describe('MastraModelOutput', () => {
   });
 
   describe('goal evaluation run-buffer truncation', () => {
-    it('drops pre-evaluation steps, text, and tool data from run-end results but keeps total usage', async () => {
-      const runId = 'test-run';
-      const stream = createChunkStream([
-        // First goal-judged turn: text + a tool call/result.
-        createTextDeltaChunk(runId, 'first turn text'),
-        {
-          type: 'tool-call',
-          runId,
-          from: ChunkFrom.AGENT,
-          payload: { toolCallId: 'tc-1', toolName: 'searchTool', args: { q: 'x' } },
-        } as ChunkType,
-        {
-          type: 'tool-result',
-          runId,
-          from: ChunkFrom.AGENT,
-          payload: { toolCallId: 'tc-1', toolName: 'searchTool', result: { hits: 3 } },
-        } as ChunkType,
+    /**
+     * The normal terminal goal-loop sequence in durable-engine chunk order:
+     * each judged turn ends with a step-finish followed by a goal evaluation,
+     * and the LAST evaluation is terminal (`shouldContinue: false`) — the
+     * final turn's chunks arrive BEFORE it, never after. (In-process engines
+     * emit the goal chunk before the judged turn's step-finish; covered
+     * separately below.)
+     */
+    function createGoalLoopChunks(runId: string): ChunkType[] {
+      return [
+        // Turn 1: text + a tool call/result → continuing evaluation.
+        createTextDeltaChunk(runId, 'turn one'),
+        createToolCallChunk(runId, 'tc-1'),
+        createToolResultChunk(runId, 'tc-1'),
         createStepFinishChunk(runId),
-        createGoalChunk(runId),
-        // Second turn after the evaluation: text only.
+        createGoalChunk(runId, { shouldContinue: true }),
+        // Turn 2: another tool turn → continuing evaluation.
+        createTextDeltaChunk(runId, 'turn two'),
+        createToolCallChunk(runId, 'tc-2'),
+        createToolResultChunk(runId, 'tc-2'),
+        createStepFinishChunk(runId),
+        createGoalChunk(runId, { shouldContinue: true }),
+        // Terminal turn: the answer, then the terminal evaluation.
         createTextDeltaChunk(runId, 'final answer'),
+        createStepFinishChunk(runId),
+        createGoalChunk(runId, { shouldContinue: false }),
+        createFinishChunk(runId),
+      ];
+    }
+
+    it('bounds buffering across continuing evaluations but preserves the terminal turn in getFullOutput()', async () => {
+      const runId = 'test-run';
+      const stream = createChunkStream(createGoalLoopChunks(runId));
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      const fullOutput = await output.getFullOutput();
+
+      // Run-end results cover the segment after the last CONTINUING
+      // evaluation — the terminal turn survives because the terminal
+      // evaluation does not truncate.
+      expect(fullOutput.steps).toHaveLength(1);
+      expect(fullOutput.text).toBe('final answer');
+      // Earlier turns' tool data was dropped at the continuing boundaries.
+      expect(fullOutput.toolCalls).toHaveLength(0);
+      expect(fullOutput.toolResults).toHaveLength(0);
+
+      // Token usage still spans the whole run (10/20/30 per step-finish, x3).
+      expect(fullOutput.totalUsage).toMatchObject({ inputTokens: 30, outputTokens: 60, totalTokens: 90 });
+    });
+
+    it('clears buffered chunks on continuing evaluations so late streams replay from the last iteration boundary', async () => {
+      const runId = 'test-run';
+      const stream = createChunkStream(createGoalLoopChunks(runId));
+
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+
+      await output.consumeStream();
+
+      // A stream attached after consumption replays from the last continuing
+      // evaluation onward: the boundary goal chunk, the terminal turn, the
+      // terminal evaluation, and the finish.
+      const replayed: ChunkType[] = [];
+      for await (const chunk of output.fullStream) {
+        replayed.push(chunk);
+      }
+
+      expect(replayed.map(c => c.type)).toEqual(['goal', 'text-delta', 'step-finish', 'goal', 'finish']);
+    });
+
+    it('drops the judged turn arriving as a step-finish AFTER a continuing evaluation (in-process chunk order)', async () => {
+      const runId = 'test-run';
+      // In-process engines run the goal gate before emitting the turn's
+      // step-finish (the gate decides `isContinued` first), so the judged
+      // turn's step-finish lands after the continuing evaluation.
+      const stream = createChunkStream([
+        createTextDeltaChunk(runId, 'turn one'),
+        createToolCallChunk(runId, 'tc-1'),
+        createToolResultChunk(runId, 'tc-1'),
+        createGoalChunk(runId, { shouldContinue: true }),
+        createStepFinishChunk(runId),
+        createTextDeltaChunk(runId, 'final answer'),
+        createGoalChunk(runId, { shouldContinue: false }),
         createStepFinishChunk(runId),
         createFinishChunk(runId),
       ]);
@@ -1121,24 +1221,23 @@ describe('MastraModelOutput', () => {
 
       const fullOutput = await output.getFullOutput();
 
-      // Run-end results cover only the segment after the last goal evaluation.
+      // The judged turn's late step-finish was dropped at the boundary; the
+      // terminal turn (whose evaluation was terminal) is preserved.
       expect(fullOutput.steps).toHaveLength(1);
       expect(fullOutput.text).toBe('final answer');
       expect(fullOutput.toolCalls).toHaveLength(0);
       expect(fullOutput.toolResults).toHaveLength(0);
-
-      // Token usage still spans the whole run (10/20/30 per step-finish, twice).
       expect(fullOutput.totalUsage).toMatchObject({ inputTokens: 20, outputTokens: 40, totalTokens: 60 });
     });
 
-    it('clears buffered chunks on a final goal evaluation so late streams replay from the evaluation onward', async () => {
+    it('does not truncate on a terminal evaluation without a prior continuing one', async () => {
       const runId = 'test-run';
+      // A goal satisfied on the first judged turn: no continuing boundary ever
+      // occurs, so the whole (single-turn) run is preserved.
       const stream = createChunkStream([
-        createTextDeltaChunk(runId, 'before '),
-        createTextDeltaChunk(runId, 'goal'),
+        createTextDeltaChunk(runId, 'only turn'),
         createStepFinishChunk(runId),
-        createGoalChunk(runId),
-        createTextDeltaChunk(runId, 'after goal'),
+        createGoalChunk(runId, { shouldContinue: false }),
         createFinishChunk(runId),
       ]);
 
@@ -1150,16 +1249,10 @@ describe('MastraModelOutput', () => {
         options: { runId },
       });
 
-      await output.consumeStream();
+      const fullOutput = await output.getFullOutput();
 
-      // A stream attached after consumption replays only chunks emitted after
-      // the final goal evaluation (starting with the goal chunk itself).
-      const replayed: ChunkType[] = [];
-      for await (const chunk of output.fullStream) {
-        replayed.push(chunk);
-      }
-
-      expect(replayed.map(c => c.type)).toEqual(['goal', 'text-delta', 'finish']);
+      expect(fullOutput.text).toBe('only turn');
+      expect(fullOutput.steps).toHaveLength(1);
     });
 
     it('does not clear buffered chunks on pending goal chunks', async () => {
@@ -1193,7 +1286,7 @@ describe('MastraModelOutput', () => {
       const runId = 'test-run';
       const stream = createChunkStream([
         createTextDeltaChunk(runId, 'before '),
-        createGoalChunk(runId),
+        createGoalChunk(runId, { shouldContinue: true }),
         createTextDeltaChunk(runId, 'after'),
         createStepFinishChunk(runId),
         createFinishChunk(runId),

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -148,6 +148,13 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   #error: Error | undefined;
   #baseStream: ReadableStream<ChunkType<OUTPUT>>;
   #bufferedChunks: ChunkType<OUTPUT>[] = [];
+  /**
+   * Set when a continuing goal evaluation arrives while a step is still in
+   * flight (in-process engines emit the goal chunk before the judged turn's
+   * step-finish): the next step-finish belongs to the judged turn and its
+   * buffers are dropped once its stepResult and usage are recorded.
+   */
+  #truncateAtNextStepFinish = false;
   #streamFinished = false;
   #finishCallbackSent = false;
   #emitter = new EventEmitter();
@@ -768,6 +775,15 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                 finishReason: undefined,
               };
 
+              // A continuing goal evaluation arrived while this step was still
+              // in flight (in-process chunk ordering): this step-finish belongs
+              // to the judged turn, so drop its buffers now that its stepResult
+              // and usage have been recorded.
+              if (self.#truncateAtNextStepFinish) {
+                self.#truncateAtNextStepFinish = false;
+                self.#truncateRunBuffers();
+              }
+
               break;
             }
             case 'tripwire':
@@ -1097,16 +1113,33 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               break;
 
             case 'goal':
-              // A completed goal evaluation marks a safe truncation point for
+              // A continuing goal evaluation marks a safe truncation point for
               // run-lifetime buffers: the turn's messages are already persisted
               // to the MessageList by this point, and goal runs chain many agent
               // turns inside one stream — retaining every chunk, step, and tool
               // result grows memory unboundedly over long goal runs (and bloats
-              // suspend snapshots via `serializeState`). `pending` chunks are
-              // judge progress updates emitted while the evaluation is still
-              // running — only the final evaluation truncates.
-              if (!chunk.payload.pending) {
+              // suspend snapshots via `serializeState`). `shouldContinue` is the
+              // goal gate's explicit continuation decision: only truncate when
+              // another judged iteration follows, so terminal evaluations
+              // (completion, waiting, judge failure, budget exhaustion) keep the
+              // final turn intact for run-end results like `getFullOutput()`.
+              if (chunk.payload.shouldContinue === true) {
                 self.#truncateRunBuffers();
+                // In-process engines emit the goal chunk BEFORE the judged
+                // turn's step-finish (the gate decides `isContinued` first);
+                // durable engines emit it after. If the judged step is still in
+                // flight, its step-finish lands after this boundary — drop that
+                // step's buffers too when it arrives.
+                const byStep = self.#bufferedByStep;
+                if (
+                  byStep.text.length > 0 ||
+                  byStep.toolCalls.length > 0 ||
+                  byStep.reasoning.length > 0 ||
+                  byStep.sources.length > 0 ||
+                  byStep.files.length > 0
+                ) {
+                  self.#truncateAtNextStepFinish = true;
+                }
               }
               break;
 

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1096,6 +1096,20 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               self.#closeTransportIfNeeded();
               break;
 
+            case 'goal':
+              // A completed goal evaluation marks a safe truncation point for
+              // run-lifetime buffers: the turn's messages are already persisted
+              // to the MessageList by this point, and goal runs chain many agent
+              // turns inside one stream — retaining every chunk, step, and tool
+              // result grows memory unboundedly over long goal runs (and bloats
+              // suspend snapshots via `serializeState`). `pending` chunks are
+              // judge progress updates emitted while the evaluation is still
+              // running — only the final evaluation truncates.
+              if (!chunk.payload.pending) {
+                self.#truncateRunBuffers();
+              }
+              break;
+
             case 'error':
               const error = getErrorFromUnknown(chunk.payload.error, {
                 fallbackMessage: 'Unknown error chunk in stream',
@@ -1755,6 +1769,31 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
   #emitChunk(chunk: ChunkType<OUTPUT>) {
     this.#bufferedChunks.push(chunk); // add to bufferedChunks for replay in new streams
     this.#emitter.emit('chunk', chunk); // emit chunk for existing listener streams
+  }
+
+  /**
+   * Drops all run-lifetime accumulators. Called at goal-evaluation boundaries,
+   * where every completed step has already been persisted to the MessageList.
+   * After truncation, run-end results (`text`, `steps`, `toolCalls`, …,
+   * `getFullOutput()`) cover only the segment after the last evaluation —
+   * for goal runs that segment is the completion answer. Token usage
+   * (`#usageCount`), in-flight per-step state (`#bufferedByStep`), structured
+   * output, and the MessageList are intentionally untouched.
+   */
+  #truncateRunBuffers() {
+    this.#bufferedChunks.length = 0;
+    this.#bufferedSteps.length = 0;
+    this.#bufferedText.length = 0;
+    this.#bufferedTextChunks = {};
+    this.#bufferedSources.length = 0;
+    this.#bufferedReasoning.length = 0;
+    this.#bufferedReasoningDetails = {};
+    this.#bufferedFiles.length = 0;
+    this.#toolCalls.length = 0;
+    this.#toolResults.length = 0;
+    this.#toolCallArgsDeltas = {};
+    this.#toolCallDeltaIdNameMap = {};
+    this.#toolCallStreamingMeta = {};
   }
 
   #createEventedStream() {

--- a/packages/core/src/stream/types.ts
+++ b/packages/core/src/stream/types.ts
@@ -454,6 +454,15 @@ export interface GoalEvaluationPayload {
   /** Whether the goal feedback message is suppressed from memory. */
   suppressFeedback: boolean;
   /**
+   * The goal gate's continuation decision: `true` when the run loops into
+   * another judged iteration, `false` on a terminal evaluation (completion,
+   * waiting for user, judge failure, or budget exhaustion). Only set on final
+   * (non-pending) evaluation chunks. A `true` value marks an iteration
+   * boundary — the turn's messages are persisted and the stream may safely
+   * truncate its run-lifetime buffers.
+   */
+  shouldContinue?: boolean;
+  /**
    * True on the "pre-evaluation" chunk emitted before scoring starts. Display
    * layers use this to show a loading/evaluating indicator while the scorer
    * runs. A second chunk with `pending: false` (or absent) follows once the


### PR DESCRIPTION
Goal runs chain many agent turns inside a single stream, and `MastraModelOutput` kept every chunk of the whole run in memory — each text-delta, every tool result payload, plus run-lifetime step/tool-call buffers. On long goal runs this grew until the process ran out of memory, and `serializeState()` also wrote all of it into suspend snapshots.

A completed goal judge evaluation is a safe point to let go of all that: the turn's messages are already persisted to the MessageList by then. So now every final judge evaluation truncates the replay buffer and the run-lifetime accumulators. Token usage totals, in-flight per-step state, structured output, and the MessageList are untouched.

One behavior note: for goal runs, run-end results like `text`, `steps`, `toolCalls`, and `getFullOutput()` now cover the segment after the last evaluation instead of the whole run.

```ts
const result = await stream.getFullOutput();
// before: result.text concatenated all 50 goal-judged turns
// after: result.text is the final segment — the completion answer
// result.totalUsage still spans the whole run
```

Tested with new unit tests covering replay truncation, pending-chunk no-ops, live consumers, and post-goal `getFullOutput()` results, plus the existing goal AIMock scenarios.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a “goal” run goes on for a long time, the system used to keep storing every chunk of output forever, which could slowly eat up memory. This change “cleans up” after each completed goal evaluation so it only keeps the latest segment’s run-end results, while still tracking total token usage and keeping live/structured output working.

## What changed

- Added handling for incoming `goal` chunks in `MastraModelOutput`.
- After a **non-pending** goal evaluation completes (`!chunk.payload.pending`), the stream truncates:
  - replay buffers
  - per-run in-memory accumulators (steps/tools/text/reasoning/tool-call delta tracking, etc.)
- Preserves:
  - total token usage for the entire run
  - in-flight/active state and the `MessageList`
  - streamed content for existing live consumers
- Run-end result fields (`text`, `steps`, `toolCalls`, `getFullOutput()`, etc.) now reflect **only the segment after the most recent completed goal evaluation**, while totals still cover the full run.
- Updated tests to cover replay truncation, pending goal behavior, live consumer behavior, and post-goal output.
- Added a patch changeset for `@mastra/core` documenting the runtime fix and the changed goal-run output semantics/migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->