### PR TITLE
feat(mastracode): support AWS SigV4 + /responses custom providers (Bedrock gpt-5.x)

### DIFF
--- a/.changeset/mastracode-custom-provider-responses-sigv4.md
+++ b/.changeset/mastracode-custom-provider-responses-sigv4.md
@@ -1,0 +1,15 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Custom OpenAI-compatible providers can now target AWS SigV4-signed endpoints and the OpenAI `/responses` API.
+
+`customProviders` entries gain three optional fields:
+
+- `auth: 'aws-sigv4'` — sign each request with the AWS credential chain instead of a bearer key (for AWS-hosted OpenAI-compatible endpoints such as Bedrock's, which use SigV4).
+- `api: 'responses'` — use the `/v1/responses` API instead of `/v1/chat/completions` (required by models like Bedrock's `openai.gpt-5.x`).
+- `store` — for `api: 'responses'`, control server-side state. Defaults to `false` for SigV4 endpoints so replayed history is sent self-contained rather than via `item_reference` items that can expire (which otherwise fail with `Invalid 'input': value did not match any expected variant` on resumed tool sessions).
+
+Defaults preserve prior behavior: an existing custom provider with none of these fields still resolves as a bearer-key `/chat/completions` provider.
+
+Also fixes a resolver bug where model ids cataloged as `mastracode/<custom-provider>/<model>` failed with "Could not find config for provider mastracode" — the `mastracode/` gateway prefix is now stripped for all providers, not just the legacy `amazon-bedrock` case.

--- a/mastracode/sdk/package.json
+++ b/mastracode/sdk/package.json
@@ -67,6 +67,7 @@
     "@mastra/stagehand": "workspace:*",
     "@mastra/tavily": "workspace:*",
     "ai": "^6.0.225",
+    "aws4fetch": "^1.0.20",
     "execa": "^9.6.1",
     "libsql": "^0.5.29",
     "posthog-node": "^5.37.0",

--- a/mastracode/sdk/src/agents/__tests__/model.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/model.test.ts
@@ -661,6 +661,43 @@ describe('resolveModel', () => {
         'x-resource-id': 'resource-456',
       });
     });
+
+    it('strips a legacy mastracode/amazon-bedrock/ prefix and resolves through the Bedrock gateway', () => {
+      const result = resolveModel(`mastracode/${MODEL_TOKENS.__GATEWAY_BEDROCK_MODEL_OPUS__}`) as Record<
+        string,
+        unknown
+      >;
+
+      expect(result.__provider).toBe('amazon-bedrock');
+      expect(result.modelId).toBe(MODEL_TOKENS.__BEDROCK_MODEL_OPUS_BARE__);
+    });
+  });
+
+  describe('custom provider model ids (mastracode/ prefix)', () => {
+    beforeEach(() => {
+      mockLoadSettings.mockReturnValue({
+        customProviders: [{ name: 'bedrock-mantle', url: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1' }],
+        memoryGateway: {},
+      });
+    });
+
+    // Regression for defect 5: the catalog produces `mastracode/<custom>/<model>`
+    // ids, but resolveModel only stripped the `mastracode/` prefix for the legacy
+    // amazon-bedrock case, so a custom-provider id mis-parsed as provider
+    // "mastracode" and failed with "Could not find config for provider mastracode".
+    it('strips the mastracode/ prefix so a custom-provider id parses to <provider>/<model>', () => {
+      const result = resolveModel('mastracode/bedrock-mantle/some-model') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('custom-openai-compatible');
+      expect(result.modelId).toBe('some-model');
+    });
+
+    it('resolves a bare custom-provider id (no prefix) unchanged', () => {
+      const result = resolveModel('bedrock-mantle/some-model') as Record<string, unknown>;
+
+      expect(result.__provider).toBe('custom-openai-compatible');
+      expect(result.modelId).toBe('some-model');
+    });
   });
 
   describe('mastra gateway enabled (gateway API key stored)', () => {

--- a/mastracode/sdk/src/agents/mastracode-gateway.test.ts
+++ b/mastracode/sdk/src/agents/mastracode-gateway.test.ts
@@ -21,6 +21,27 @@ const { appDataDir } = vi.hoisted(() => {
   return { appDataDir: dir };
 });
 
+// Spy on the AI SDK factories so custom-provider routing (chat vs responses,
+// bearer vs SigV4) is observable without live network calls. Each returns a
+// tagged object identifying which factory/method produced the model.
+const { createOpenAIMock, createOpenAICompatibleMock } = vi.hoisted(() => {
+  const createOpenAIMock = vi.fn((opts: Record<string, unknown>) => ({
+    responses: (modelId: string) => ({ __kind: 'openai.responses', modelId, opts }),
+    chat: (modelId: string) => ({ __kind: 'openai.chat', modelId, opts }),
+  }));
+  const createOpenAICompatibleMock = vi.fn((opts: Record<string, unknown>) => ({
+    chatModel: (modelId: string) => ({ __kind: 'compatible.chatModel', modelId, opts }),
+  }));
+  return { createOpenAIMock, createOpenAICompatibleMock };
+});
+
+vi.mock('@ai-sdk/openai', () => ({ createOpenAI: createOpenAIMock }));
+vi.mock('@ai-sdk/openai-compatible', () => ({ createOpenAICompatible: createOpenAICompatibleMock }));
+vi.mock('@aws-sdk/credential-providers', () => ({
+  fromNodeProviderChain: () => async () => ({ accessKeyId: 'AKIA', secretAccessKey: 'secret', sessionToken: 'token' }),
+}));
+
+import type { MastraCodeCustomProvider } from './mastracode-gateway.js';
 import { MastraCodeGateway, reloadAuthStorage } from './mastracode-gateway.js';
 
 mkdirSync(appDataDir, { recursive: true });
@@ -30,12 +51,22 @@ function writeAuthJson(data: Record<string, unknown>): void {
   reloadAuthStorage();
 }
 
-function createGateway(): MastraCodeGateway {
+function createGateway(customProviders: MastraCodeCustomProvider[] = []): MastraCodeGateway {
   return new MastraCodeGateway({
     mastraGatewayBaseUrl: 'https://gateway.example.com',
     routeThroughMastraGateway: false,
-    customProviders: [],
+    customProviders,
     settingsPath: join(tmpdir(), 'nonexistent-settings.json'),
+  });
+}
+
+const BEDROCK_URL = 'https://bedrock-mantle.us-east-1.api.aws/openai/v1';
+
+function resolveCustomModel(provider: MastraCodeCustomProvider, modelId: string, apiKey = ''): any {
+  return createGateway([provider]).resolveLanguageModel({
+    providerId: 'bedrock-mantle',
+    modelId,
+    apiKey,
   });
 }
 
@@ -147,6 +178,72 @@ describe('MastraCodeGateway', () => {
 
       const getMemoryGatewayApiKey = MastraCodeGateway.getMemoryGatewayApiKey;
       expect(getMemoryGatewayApiKey()).toBe('msk-test');
+    });
+  });
+
+  describe('custom provider resolveAuth', () => {
+    it('reports a synthetic AWS credential for a SigV4 provider (so the catalog marks it usable)', () => {
+      const auth = createGateway([{ name: 'bedrock-mantle', url: BEDROCK_URL, auth: 'aws-sigv4' }]).resolveAuth({
+        gatewayId: 'mastracode',
+        providerId: 'bedrock-mantle',
+        modelId: 'openai.gpt-5.6-terra',
+        routerId: 'mastracode/bedrock-mantle/openai.gpt-5.6-terra',
+      });
+      expect(auth).toEqual({ apiKey: 'aws-credential-chain', source: 'gateway' });
+    });
+
+    it('returns the configured bearer key for a non-SigV4 provider', () => {
+      const auth = createGateway([{ name: 'my-llm', url: 'https://api.example.com/v1', apiKey: 'sk-abc' }]).resolveAuth(
+        {
+          gatewayId: 'mastracode',
+          providerId: 'my-llm',
+          modelId: 'some-model',
+          routerId: 'mastracode/my-llm/some-model',
+        },
+      );
+      expect(auth).toEqual({ apiKey: 'sk-abc', source: 'gateway' });
+    });
+  });
+
+  describe('custom provider resolveLanguageModel', () => {
+    beforeEach(() => {
+      createOpenAIMock.mockClear();
+      createOpenAICompatibleMock.mockClear();
+    });
+
+    it('uses createOpenAICompatible().chatModel for a default (bearer + chat) provider', () => {
+      const model = resolveCustomModel(
+        { name: 'bedrock-mantle', url: 'https://api.example.com/v1' },
+        'some-model',
+        'sk',
+      );
+      expect(model.__kind).toBe('compatible.chatModel');
+      expect(createOpenAICompatibleMock).toHaveBeenCalledTimes(1);
+      expect(createOpenAIMock).not.toHaveBeenCalled();
+    });
+
+    it('uses openai.responses with a SigV4 fetch for auth:aws-sigv4 + api:responses', () => {
+      const model = resolveCustomModel(
+        { name: 'bedrock-mantle', url: BEDROCK_URL, auth: 'aws-sigv4', api: 'responses' },
+        'openai.gpt-5.6-terra',
+      );
+      // wrapped by store:false middleware, so unwrap to find the tagged model.
+      expect(createOpenAIMock).toHaveBeenCalledTimes(1);
+      const opts = createOpenAIMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(opts.baseURL).toBe(BEDROCK_URL);
+      expect(typeof opts.fetch).toBe('function');
+      expect(createOpenAICompatibleMock).not.toHaveBeenCalled();
+      expect(model).toBeDefined();
+    });
+
+    it('does not pass a fetch for a bearer + responses provider', () => {
+      resolveCustomModel(
+        { name: 'bedrock-mantle', url: 'https://api.example.com/v1', api: 'responses', store: false },
+        'some-model',
+        'sk',
+      );
+      const opts = createOpenAIMock.mock.calls[0]![0] as Record<string, unknown>;
+      expect(opts.fetch).toBeUndefined();
     });
   });
 });

--- a/mastracode/sdk/src/agents/mastracode-gateway.ts
+++ b/mastracode/sdk/src/agents/mastracode-gateway.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from '@ai-sdk/anthropic';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
+import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import type { CustomAvailableModel, CustomModelCatalogProvider } from '@mastra/core/agent-controller';
 import {
   GATEWAY_AUTH_HEADER,
@@ -17,6 +18,8 @@ import type {
   ProviderConfig,
 } from '@mastra/core/llm';
 import { wrapLanguageModel } from 'ai';
+import type { LanguageModelMiddleware } from 'ai';
+import { AwsClient } from 'aws4fetch';
 import { AuthStorage } from '../auth/storage.js';
 import type { CredentialStore } from '../auth/types.js';
 import { getCustomProviderId, loadSettings, MASTRA_GATEWAY_PROVIDER } from '../onboarding/settings.js';
@@ -51,7 +54,15 @@ const CODEX_OPENAI_MODEL_REMAPS: Record<string, string> = {
 
 type ModelRequestHeaders = Record<string, string>;
 
-export type MastraCodeCustomProvider = { name: string; url: string; apiKey?: string; models?: string[] };
+export type MastraCodeCustomProvider = {
+  name: string;
+  url: string;
+  apiKey?: string;
+  models?: string[];
+  auth?: 'bearer' | 'aws-sigv4';
+  api?: 'chat' | 'responses';
+  store?: boolean;
+};
 
 export type MastraCodeGatewayOptions = {
   mastraGatewayBaseUrl: string;
@@ -77,6 +88,68 @@ export function reloadAuthStorage() {
 export function stripMastraGatewayPrefix(modelId: string): string {
   return modelId.startsWith(MASTRA_GATEWAY_PREFIX) ? modelId.substring(MASTRA_GATEWAY_PREFIX.length) : modelId;
 }
+
+/** True when a custom provider authenticates with AWS SigV4 rather than a key. */
+function isSigV4Provider(provider: MastraCodeCustomProvider): boolean {
+  return provider.auth === 'aws-sigv4';
+}
+
+/**
+ * Region for signing an AWS-hosted endpoint. Parsed from the host
+ * (`bedrock-mantle.<region>.api.aws`), falling back to AWS_REGION then us-east-1
+ * (the AWS SDK default).
+ */
+function regionForUrl(url: string): string {
+  const host = (() => {
+    try {
+      return new URL(url).host;
+    } catch {
+      return '';
+    }
+  })();
+  const match = host.match(/\.([a-z]{2}-[a-z]+-\d+)\./);
+  return match?.[1] ?? process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? 'us-east-1';
+}
+
+/**
+ * A `fetch` that signs each request with AWS SigV4 (service `bedrock`) using the
+ * standard AWS credential chain — env vars, shared `~/.aws` config/SSO profiles,
+ * and container/instance roles. Used for custom providers with `auth: 'aws-sigv4'`
+ * (e.g. Bedrock's OpenAI-compatible endpoint, which signs rather than using a key).
+ */
+function createSigV4Fetch(region: string): typeof fetch {
+  const credentials = fromNodeProviderChain();
+  return (async (url: string | URL | Request, init?: Parameters<typeof fetch>[1]) => {
+    const c = await credentials();
+    const aws = new AwsClient({
+      accessKeyId: c.accessKeyId,
+      secretAccessKey: c.secretAccessKey,
+      sessionToken: c.sessionToken,
+      service: 'bedrock',
+      region,
+    });
+    return aws.fetch(url as any, init as any);
+  }) as typeof fetch;
+}
+
+/**
+ * Middleware forcing `store: false` for `/responses` requests. The OpenAI
+ * `/responses` SDK defaults to `store: true` and replays prior turns as
+ * `item_reference` items pointing at server-side state. Endpoints with short
+ * retention (e.g. Bedrock) then reject a resumed thread or expired item with
+ * `Invalid 'input': value did not match any expected variant`. Forcing
+ * `store: false` sends self-contained history instead.
+ */
+const storeFalseMiddleware: LanguageModelMiddleware = {
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => ({
+    ...params,
+    providerOptions: {
+      ...params.providerOptions,
+      openai: { ...params.providerOptions?.openai, store: false },
+    },
+  }),
+};
 
 function normalizeAnthropicModelId(modelId: string): string {
   return modelId.replace(/\.(?=\d)/g, '-');
@@ -420,6 +493,12 @@ export class MastraCodeGateway extends MastraModelGateway {
     if (customProvider?.apiKey) {
       return { apiKey: customProvider.apiKey, source: 'gateway' };
     }
+    // SigV4 custom providers have no API key — auth is the AWS credential chain,
+    // signed per-request. Report a synthetic credential so the model catalog
+    // marks them usable (otherwise `--mode`/`--model` validation rejects them).
+    if (customProvider && isSigV4Provider(customProvider)) {
+      return { apiKey: 'aws-credential-chain', source: 'gateway' };
+    }
 
     return MastraCodeGateway.resolveProviderAuth(request, undefined, this.#credentials);
   }
@@ -436,13 +515,7 @@ export class MastraCodeGateway extends MastraModelGateway {
       provider => args.providerId === getCustomProviderId(provider.name),
     );
     if (customProvider) {
-      const provider = createOpenAICompatible({
-        name: args.providerId,
-        baseURL: customProvider.url,
-        apiKey: args.apiKey,
-        headers: args.headers,
-      });
-      return provider.chatModel(args.modelId) as unknown as GatewayLanguageModel;
+      return this.#resolveCustomProviderModel(customProvider, args);
     }
 
     if (args.providerId === 'github-copilot') {
@@ -493,6 +566,57 @@ export class MastraCodeGateway extends MastraModelGateway {
       id: `${args.providerId}/${args.modelId}` as `${string}/${string}`,
       headers: args.headers,
     }) as unknown as GatewayLanguageModel;
+  }
+
+  /**
+   * Resolve a model served by a user-configured custom provider.
+   *
+   * Defaults preserve the original behavior: a bearer-key OpenAI-compatible
+   * `/chat/completions` provider. Opt-in fields extend it for AWS-hosted
+   * OpenAI-compatible endpoints (e.g. Bedrock):
+   * - `auth: 'aws-sigv4'` signs requests with the AWS credential chain.
+   * - `api: 'responses'` uses the `/responses` API (required by some models).
+   * - `store: false` sends self-contained history (see storeFalseMiddleware).
+   */
+  #resolveCustomProviderModel(
+    provider: MastraCodeCustomProvider,
+    args: { modelId: string; providerId: string; apiKey: string; headers?: Record<string, string> },
+  ): GatewayLanguageModel {
+    const useResponses = provider.api === 'responses';
+    const sigv4 = isSigV4Provider(provider);
+
+    // Bearer + chat: the original path, unchanged for existing providers.
+    if (!useResponses && !sigv4) {
+      const openaiCompatible = createOpenAICompatible({
+        name: args.providerId,
+        baseURL: provider.url,
+        apiKey: args.apiKey,
+        headers: args.headers,
+      });
+      return openaiCompatible.chatModel(args.modelId) as unknown as GatewayLanguageModel;
+    }
+
+    const openai = createOpenAI({
+      name: args.providerId,
+      baseURL: provider.url,
+      // SigV4 endpoints sign per-request via `fetch`; the key is unused but the
+      // SDK requires a non-empty value.
+      apiKey: sigv4 ? 'aws-sigv4' : args.apiKey,
+      headers: args.headers,
+      ...(sigv4 ? { fetch: createSigV4Fetch(regionForUrl(provider.url)) } : {}),
+    });
+
+    if (!useResponses) {
+      return openai.chat(args.modelId) as unknown as GatewayLanguageModel;
+    }
+
+    const model = openai.responses(args.modelId);
+    // Default store:false for SigV4 endpoints (short server-side retention);
+    // otherwise honor an explicit `store` and leave the SDK default when unset.
+    const forceStoreFalse = provider.store === false || (sigv4 && provider.store === undefined);
+    return (forceStoreFalse
+      ? wrapLanguageModel({ model, middleware: [storeFalseMiddleware] })
+      : model) as unknown as GatewayLanguageModel;
   }
 
   #resolveAnthropicModel(args: {

--- a/mastracode/sdk/src/agents/model.ts
+++ b/mastracode/sdk/src/agents/model.ts
@@ -78,14 +78,13 @@ export function resolveModel(
   reloadAuthStorage();
   const headers = getAgentControllerHeaders(options?.requestContext);
   const settings = loadSettings();
-  // Bedrock was previously cataloged under the MastraCode gateway namespace
-  // (`mastracode/amazon-bedrock/<model>`). Normalize any legacy saved ids to the
-  // standalone `amazon-bedrock/<model>` form so they resolve through the
-  // dedicated Bedrock gateway.
-  const bedrockLegacyPrefix = `${MASTRACODE_GATEWAY_ID}/amazon-bedrock/`;
-  const normalizedInput = modelId.startsWith(bedrockLegacyPrefix)
-    ? modelId.slice(MASTRACODE_GATEWAY_ID.length + 1)
-    : modelId;
+  // The model catalog prefixes gateway-routed ids with the MastraCode gateway id
+  // (`mastracode/<provider>/<model>`) — including custom providers and the legacy
+  // Bedrock namespace (`mastracode/amazon-bedrock/<model>`). Strip that prefix so
+  // the id parses to `<provider>/<model>`; otherwise `providerId` mis-parses as
+  // "mastracode" and resolution fails with "Could not find config for provider".
+  const mastracodePrefix = `${MASTRACODE_GATEWAY_ID}/`;
+  const normalizedInput = modelId.startsWith(mastracodePrefix) ? modelId.slice(mastracodePrefix.length) : modelId;
   const isMastraGatewayModel = normalizedInput.startsWith(MASTRA_GATEWAY_PREFIX);
   const normalizedModelId = stripMastraGatewayPrefix(normalizedInput);
   const [providerId, ...modelParts] = normalizedModelId.split('/');

--- a/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
+++ b/mastracode/sdk/src/onboarding/__tests__/settings.test.ts
@@ -442,6 +442,47 @@ describe('customProviders parsing/persistence', () => {
     ]);
   });
 
+  it('parses optional auth/api/store fields and defaults them off', () => {
+    const providers = parseCustomProviders([
+      {
+        name: 'Bedrock Mantle',
+        url: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+        auth: 'aws-sigv4',
+        api: 'responses',
+        store: false,
+        models: ['openai.gpt-5.6-terra'],
+      },
+      {
+        name: 'Plain',
+        url: 'https://api.example.com/v1',
+        models: ['m1'],
+      },
+      {
+        name: 'Bad Enums',
+        url: 'https://api.example.com/v1',
+        auth: 'basic',
+        api: 'grpc',
+        store: 'yes',
+        models: ['m2'],
+      },
+    ]);
+
+    expect(providers).toEqual([
+      {
+        name: 'Bedrock Mantle',
+        url: 'https://bedrock-mantle.us-east-1.api.aws/openai/v1',
+        models: ['openai.gpt-5.6-terra'],
+        auth: 'aws-sigv4',
+        api: 'responses',
+        store: false,
+      },
+      // No optional fields → none added (backward-compatible).
+      { name: 'Plain', url: 'https://api.example.com/v1', models: ['m1'] },
+      // Invalid enum/type values are dropped, not coerced.
+      { name: 'Bad Enums', url: 'https://api.example.com/v1', models: ['m2'] },
+    ]);
+  });
+
   it('creates custom provider ids without custom- prefix', () => {
     expect(getCustomProviderId('Acme Provider')).toBe('acme-provider');
     expect(getCustomProviderId('  !!!  ')).toBe('provider');

--- a/mastracode/sdk/src/onboarding/settings.ts
+++ b/mastracode/sdk/src/onboarding/settings.ts
@@ -20,12 +20,35 @@ export interface CustomPack {
   createdAt: string;
 }
 
+/** How a custom provider authenticates. */
+export type CustomProviderAuth = 'bearer' | 'aws-sigv4';
+/** Which OpenAI-compatible API a custom provider's models speak. */
+export type CustomProviderApi = 'chat' | 'responses';
+
 /** A saved custom provider for OpenAI-compatible endpoints. */
 export interface CustomProviderSetting {
   name: string;
   url: string;
   apiKey?: string;
   models: string[];
+  /**
+   * Auth mode. `bearer` (default) sends `apiKey` as a bearer token; `aws-sigv4`
+   * signs each request with the AWS credential chain (for AWS-hosted endpoints
+   * such as Bedrock's OpenAI-compatible API, which use SigV4 rather than a key).
+   */
+  auth?: CustomProviderAuth;
+  /**
+   * API the models speak: `chat` (default) uses `/v1/chat/completions`;
+   * `responses` uses `/v1/responses` (required by e.g. the Bedrock gpt-5.x models).
+   */
+  api?: CustomProviderApi;
+  /**
+   * For `api: 'responses'`, whether the endpoint stores conversation state
+   * server-side. Defaults to the SDK default (`true`). Set `false` for endpoints
+   * with short server-side retention (e.g. Bedrock), so replayed history is sent
+   * self-contained instead of via `item_reference` items that can expire.
+   */
+  store?: boolean;
 }
 
 /** Storage backend type. */
@@ -471,11 +494,18 @@ export function parseCustomProviders(rawProviders: unknown): CustomProviderSetti
     const apiKey =
       typeof candidate.apiKey === 'string' && candidate.apiKey.trim().length > 0 ? candidate.apiKey.trim() : undefined;
 
+    const auth = candidate.auth === 'aws-sigv4' ? 'aws-sigv4' : undefined;
+    const api = candidate.api === 'responses' ? 'responses' : undefined;
+    const store = typeof candidate.store === 'boolean' ? candidate.store : undefined;
+
     parsedProviders.push({
       name,
       url,
       ...(apiKey ? { apiKey } : {}),
       models,
+      ...(auth ? { auth } : {}),
+      ...(api ? { api } : {}),
+      ...(store !== undefined ? { store } : {}),
     });
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2259,6 +2259,9 @@ importers:
       ai:
         specifier: ^6.0.225
         version: 6.0.228(zod@4.4.3)
+      aws4fetch:
+        specifier: ^1.0.20
+        version: 1.0.20
       execa:
         specifier: ^9.6.1
         version: 9.6.1


### PR DESCRIPTION
Fixes #19664

## What

Lets `customProviders` reach OpenAI-compatible endpoints that authenticate with **AWS SigV4** and/or serve models only via the **`/v1/responses`** API — most notably AWS Bedrock's OpenAI-compatible endpoint (`https://bedrock-mantle.<region>.api.aws/openai/v1`), which serves the `gpt-5.x` family. Complements #17937 (native `amazon-bedrock/` Converse provider), which can't reach the `/responses` models.

## Changes

Three **optional** fields on each `customProviders` entry (defaults preserve current behavior — an existing bearer + `/chat/completions` provider is unchanged):

| Field | Values | Effect |
|-------|--------|--------|
| `auth` | `'bearer'` (default) \| `'aws-sigv4'` | SigV4-sign each request via the AWS credential chain (`fromNodeProviderChain` + `aws4fetch`), region parsed from the URL host |
| `api` | `'chat'` (default) \| `'responses'` | Use `createOpenAI(...).responses()` instead of `createOpenAICompatible(...).chatModel()` |
| `store` | boolean (default `false` for SigV4) | Force self-contained history via a `transformParams` middleware, avoiding `item_reference` items that expire |

Plus:
- `resolveAuth` reports a synthetic `aws-credential-chain` credential for SigV4 providers, so the model catalog marks them usable (otherwise `--mode`/`--model` validation rejects them as keyless).
- `resolveModel` now strips the `mastracode/` gateway prefix for **all** providers, not just the legacy `amazon-bedrock` case — fixing catalog ids like `mastracode/<custom>/<model>` that otherwise failed with *"Could not find config for provider mastracode"*.

## Why the four defects (detail in #19664)

1. resolver hardcoded `.chatModel()` → `/responses`-only models 400
2. no SigV4 signing for custom providers
3. keyless custom providers rejected by catalog validation
4. `/responses` `store:true` replays `item_reference` items that Bedrock expires → `Invalid 'input': value did not match any expected variant` on resumed/multi-turn tool sessions

## Testing

- New unit tests: `mastracode-gateway.test.ts` (custom-provider resolveAuth + resolveLanguageModel routing: bearer/chat unchanged, SigV4+responses uses `createOpenAI` with a signed `fetch`), `settings.test.ts` (new field parsing + defaults + invalid-value rejection), `model.test.ts` (prefix-strip regression for both legacy Bedrock and custom-provider ids).
- Full SDK suite: 1000+ tests pass; `tsc --noEmit` and `eslint` clean.
- Verified end-to-end against live Bedrock: single tool call, multi-tool loop, and resumed thread (`--thread`) all succeed with `terra`/`sol`/`luna`; `gpt-oss` remains Converse-only.

## Notes

- Adds one dependency: `aws4fetch` (already transitively present) for the per-request SigV4 `fetch`.
- General by design: the same endpoint also serves `google.gemma*` and `xai.grok*` via `/responses`, reachable by config with no further code changes.
