### PR TITLE
fix(vectorize): annotate listIndexes map callback to avoid implicit any

### DIFF
--- a/.changeset/rich-eyes-agree.md
+++ b/.changeset/rich-eyes-agree.md
@@ -1,0 +1,5 @@
+---
+'@mastra/vectorize': patch
+---
+
+Fixed implicit any type error in listIndexes callback that broke the Vectorize package build

--- a/.changeset/rich-eyes-agree.md
+++ b/.changeset/rich-eyes-agree.md
@@ -1,5 +1,0 @@
----
-'@mastra/vectorize': patch
----
-
-Fixed implicit any type error in listIndexes callback that broke the Vectorize package build

--- a/stores/vectorize/src/vector/index.ts
+++ b/stores/vectorize/src/vector/index.ts
@@ -170,7 +170,7 @@ export class CloudflareVector extends MastraVector<VectorizeVectorFilter> {
         account_id: this.accountId,
       });
 
-      return res?.result?.map(index => index.name!) || [];
+      return res?.result?.map((index: { name?: string }) => index.name!) || [];
     } catch (error) {
       throw new MastraError(
         {


### PR DESCRIPTION
## Summary

The `.map()` callback in `CloudflareVector.listIndexes()` (`stores/vectorize/src/vector/index.ts`) had no type annotation on its parameter. When the Cloudflare SDK's return type falls back to `any` in the type environment, the callback parameter becomes an implicit `any`, which fails the strict TypeScript build for `@mastra/vectorize`.

This adds a minimal inline type annotation (`{ name?: string }`) so the build succeeds regardless of how the SDK's types resolve.

## Test plan

- [x] `pnpm --filter @mastra/vectorize run build:lib` succeeds
- [x] `tsc --noEmit` in `stores/vectorize` is clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This fixes a small TypeScript error by telling the code what each Cloudflare index looks like. This helps strict builds succeed even when Cloudflare’s types aren’t available.

## Changes

- Added an explicit `{ name?: string }` type to the `listIndexes()` mapping callback.
- Added a patch Changesets entry for `@mastra/vectorize`.
- Verified the Vectorize build and `tsc --noEmit` checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->