### PR TITLE
docs(platform): document supported regions

### DIFF
--- a/docs/src/content/en/docs/mastra-platform/deploy.mdx
+++ b/docs/src/content/en/docs/mastra-platform/deploy.mdx
@@ -100,7 +100,7 @@ Pass `--region` when a deploy creates a new environment to control where it runs
 mastra deploy --env production --region eu
 ```
 
-The region is fixed when the environment is created. Databases attached to an environment are placed near that environment's region automatically.
+The region is fixed when the environment is created. Databases attached to an environment are placed near that environment's region automatically, and observability data is routed to the ingest region that matches the environment's residency zone. See [Regions](/docs/mastra-platform/regions) for the full list of supported regions, database placement, and observability co-location.
 
 ## Preflight checks
 
@@ -162,6 +162,7 @@ mastra deploy --env production --yes
 ## Related
 
 - [Environments](/docs/mastra-platform/environments)
+- [Regions](/docs/mastra-platform/regions)
 - [Hosted databases](/docs/mastra-platform/database)
 - [`mastra deploy` CLI reference](/reference/cli/mastra#mastra-deploy)
 - [Configuration](/docs/mastra-platform/configuration)

--- a/docs/src/content/en/docs/mastra-platform/environments.mdx
+++ b/docs/src/content/en/docs/mastra-platform/environments.mdx
@@ -29,7 +29,7 @@ mastra deploy --env staging
 mastra env create eu-preview --type preview --region eu
 ```
 
-Each project has a single `production` environment, created by your first deploy. The region is fixed at creation. Databases attached to an environment are placed near the environment's region automatically. The number of environments per project depends on your plan.
+Each project has a single `production` environment, created by your first deploy. The region is fixed at creation. Databases attached to an environment are placed near the environment's region automatically, and observability data is routed to the ingest region for the matching residency zone. See [Regions](/docs/mastra-platform/regions) for the supported regions, database placement, and observability co-location. The number of environments per project depends on your plan.
 
 ## List environments
 
@@ -104,5 +104,6 @@ The CLI asks for confirmation before deleting. Deleting an environment removes i
 ## Related
 
 - [Deploy](/docs/mastra-platform/deploy)
+- [Regions](/docs/mastra-platform/regions)
 - [Hosted databases](/docs/mastra-platform/database)
 - [`mastra env` CLI reference](/reference/cli/mastra#mastra-env)

--- a/docs/src/content/en/docs/mastra-platform/regions.mdx
+++ b/docs/src/content/en/docs/mastra-platform/regions.mdx
@@ -1,0 +1,78 @@
+---
+title: "Regions | Mastra platform"
+description: Choose where a Mastra platform environment runs, where its hosted database is placed, and where its observability data is stored.
+---
+
+# Regions
+
+A region controls where a platform environment runs, where its [hosted database](/docs/mastra-platform/database) is placed, and where its observability data is stored. The region is fixed when the environment is created and can't be changed later.
+
+Mastra platform offers two residency zones today, `us` and `eu`, backed by specific compute regions on Railway. Databases and observability follow the environment's region automatically.
+
+## Choose a region
+
+Pass `--region` when creating or first deploying to an environment:
+
+```bash
+mastra deploy --env production --region eu
+mastra env create staging --region us
+```
+
+Both `mastra deploy --region` and `mastra env create --region` accept either the `us` / `eu` shorthand or a canonical Railway region code from the table below. Shorthand is the recommended form.
+
+The default when no region is passed is `us`, which resolves to `pdx` (Portland, Oregon).
+
+## Available regions
+
+The residency selector offers four Railway regions across two zones. `us` and `eu` shorthand resolve to the underlined default in each zone.
+
+| Zone | Railway code | Location |
+| - | - | - |
+| `us` | `pdx` (default) | Portland, Oregon |
+| `us` | `iad` | Ashburn, Virginia |
+| `us` | `sfo` | San Francisco, California |
+| `eu` | `ams` (default) | Amsterdam, Netherlands |
+
+Pass a Railway code directly when you need to pin an environment to a specific data center. Passing `us` selects `pdx`, and passing `eu` selects `ams`.
+
+:::note
+Additional Railway regions exist in the deploy pipeline (for example Singapore, `sin`) but aren't offered in the residency selector yet, because hosted databases and observability don't have local placement outside the US and EU. Passing an unrecognized region falls back to the US default rather than pinning to it.
+:::
+
+## Hosted database placement
+
+When you attach an [environment-scoped database](/docs/mastra-platform/database), the platform picks the provider region closest to the environment. This is server-authoritative, so an explicit `--region` on `mastra env db create <env>` is ignored. The environment's region is the source of truth.
+
+| Environment region | Turso region | Postgres (Neon) region |
+| - | - | - |
+| `pdx` | `sjc` (San Jose) | `aws-us-west-2` (Oregon) |
+| `iad` | `iad` (Ashburn) | `aws-us-east-1` (N. Virginia) |
+| `sfo` | `sjc` (San Jose) | `aws-us-west-2` (Oregon) |
+| `ams` | `ams` (Amsterdam) | `aws-eu-central-1` (Frankfurt) |
+
+Project-scoped databases (shared across environments) accept an explicit `--region` because they aren't bound to a single environment. Use a provider region ID for the flag, not the `us` / `eu` shorthand:
+
+```bash
+mastra env db create --kind turso --region fra
+mastra env db create --kind neon --region aws-us-east-1
+```
+
+Turso offers 20+ regions and Postgres (Neon) is available across AWS and Azure regions in the US, EU, and APAC. See the [Turso regions list](https://docs.turso.tech/features/data-edge#locations) and [Neon regions list](https://neon.com/docs/introduction/regions) for the full set. Passing a code not offered by the provider fails at attach time with the provider's error.
+
+## Observability co-location
+
+Observability ingest runs in two regions today: **US** (Iowa, `us-central1`) and **EU** (Amsterdam). Every environment's traces, logs, and metrics are routed to the ingest region that matches its residency zone:
+
+| Environment region | Observability region |
+| - | - |
+| `pdx`, `iad`, `sfo`, `us` shorthand | US (Iowa) |
+| `ams`, `eu` shorthand | EU (Amsterdam) |
+
+Compute and databases can be placed in more Railway and provider regions than observability supports, so co-location isn't perfect for every combination. A `us`-zone environment always sends telemetry to US ingest, and an `eu`-zone environment always sends telemetry to EU ingest, even if the underlying Railway region is a specific city not directly served by an ingest endpoint. Data residency is preserved at the zone level. Telemetry from an `eu` environment never crosses into the US.
+
+## Related
+
+- [Deploy](/docs/mastra-platform/deploy)
+- [Environments](/docs/mastra-platform/environments)
+- [Hosted databases](/docs/mastra-platform/database)
+- [Observability](/docs/mastra-platform/observability)

--- a/docs/src/content/en/docs/sidebars.js
+++ b/docs/src/content/en/docs/sidebars.js
@@ -1030,6 +1030,14 @@ const sidebars = {
         },
         {
           type: 'doc',
+          id: 'mastra-platform/regions',
+          label: 'Regions',
+          customProps: {
+            tags: ['new'],
+          },
+        },
+        {
+          type: 'doc',
           id: 'mastra-platform/observability',
           label: 'Observability',
         },


### PR DESCRIPTION
Adds a dedicated Regions page under **Mastra platform** docs so users can see, in one place, where their environments run, where the hosted database ends up, and where telemetry is stored.

## What's new

- **New page:** `docs/src/content/en/docs/mastra-platform/regions.mdx`
  - Lists the four supported compute regions (`pdx`, `iad`, `sfo`, `ams`) with locations and zones
  - Explains the `us` / `eu` shorthand and which canonical Railway code each resolves to
  - Documents server-authoritative database placement (env-scoped DBs ignore `--region`; project-scoped DBs accept a provider region ID)
  - Clarifies observability co-location: ingest exists only in US and EU, so telemetry follows the residency zone even when compute is in a specific city
  - Notes the APAC placement gap honestly (Singapore has no local hosted DB or observability yet)
- **Deploy page** links to Regions from the region-selection prose and the Related footer
- **Environments page** links to Regions from the environment-creation prose and the Related footer
- **Platform sidebar** gains a Regions entry between Environments and Observability

Region tables were derived from `RAILWAY_REGIONS` and the environment-to-database placement map (the platform's single source of truth), not hand-typed, so the docs match the deploy pipeline exactly.

## Test plan

- `pnpm validate` — passes (all 572 docs pass frontmatter validation; new page linked in sidebar; all sidebar items sorted)
- `pnpm lint:remark` — clean
- `pnpm lint:prose` (vale) — new page has zero AI-tell or style violations
- `pnpm build` — builds successfully

## Notes

Docs-only change, no changeset needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds a Regions page explaining where Mastra environments, databases, and observability data are located. It also links to the new page from related documentation and the platform sidebar.

## Summary

- Documents supported regions: `pdx`, `iad`, `sfo`, and `ams`.
- Explains region locations, zones, `us`/`eu` shorthand, and default behavior.
- Documents server-authoritative database placement and US/EU observability co-location.
- Notes current APAC placement limitations.
- Links Deploy and Environments documentation to the Regions page.
- Adds Regions to the platform sidebar.
- Validation, linting, and build checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->