### PR TITLE
ci: on-demand Storybook previews via /storybook PR comment

### DIFF
--- a/.github/workflows/storybook-preview.yml
+++ b/.github/workflows/storybook-preview.yml
@@ -1,0 +1,101 @@
+name: Storybook preview
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+concurrency:
+  group: storybook-preview-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  preview:
+    name: Deploy Storybook preview
+    runs-on: starsling-ubuntu-24.04
+    timeout-minutes: 30
+    if: >
+      github.repository == 'mastra-ai/mastra' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/storybook') &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+      TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+      TURBO_CACHE: remote:rw
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PLAYGROUND_UI_PROJECT_ID }}
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Acknowledge comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket',
+            });
+
+      - name: Resolve PR head
+        id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            core.setOutput('sha', pr.head.sha);
+
+      - name: Checkout PR head
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        with:
+          ref: ${{ steps.pr.outputs.sha }}
+
+      - name: Setup pnpm and Node.js
+        uses: ./.github/actions/setup-pnpm-node
+
+      - name: Build workspace dependencies
+        run: pnpm turbo build --filter ./packages/playground-ui
+
+      - name: Build Storybook
+        run: pnpm --filter @mastra/playground-ui build-storybook
+
+      - name: Deploy to Vercel
+        id: deploy
+        working-directory: packages/playground-ui
+        run: |
+          mkdir -p .vercel/output/static
+          echo '{"version":3}' > .vercel/output/config.json
+          cp -R storybook-static/. .vercel/output/static/
+          url=$(pnpm dlx vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `📖 Storybook preview ready: ${{ steps.deploy.outputs.url }} (commit ${{ steps.pr.outputs.sha }})`,
+            });
+
+      - name: Comment on failure
+        if: failure()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `❌ Storybook preview failed: https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+            });

--- a/packages/playground-ui/vercel.json
+++ b/packages/playground-ui/vercel.json
@@ -1,0 +1,7 @@
+{
+  "git": {
+    "deploymentEnabled": {
+      "main": true
+    }
+  }
+}


### PR DESCRIPTION
Right now the mastra-playground-ui Vercel project builds Storybook on every PR push. The \"skip when root directory unchanged\" setting doesn't help much because playground-ui depends on @mastra/core (workspace), so nearly every PR (and every lockfile bump) triggers a full build anyway — see e.g. #19584 (Dependabot, zero playground files) which still got a full deployment.

This switches Storybook previews to on-demand. Comment \`/storybook\` on any PR (maintainers only) and a workflow builds Storybook in Actions, deploys the static output to Vercel via CLI (\`--prebuilt\`, so no Vercel build minutes), and comments the preview URL back on the PR. The \`vercel.json\` in \`packages/playground-ui\` keeps Git-integration deploys for \`main\` only, so production is unchanged.

Needs three repo secrets before merge: \`VERCEL_TOKEN\`, \`VERCEL_ORG_ID\`, \`VERCEL_PLAYGROUND_UI_PROJECT_ID\`. Note the workflow only becomes triggerable once merged to main (\`issue_comment\` workflows run from the default branch), and already-open PRs branched before the \`vercel.json\` will keep auto-deploying until they pick it up via rebase/merge.