### PR TITLE
fix(ai-sdk): guard `step-start` payload in convertMastraChunkToAISDKBase (durable stream only emits `start`)

### DIFF
--- a/.changeset/guard-durable-step-start-payload.md
+++ b/.changeset/guard-durable-step-start-payload.md
@@ -2,6 +2,4 @@
 '@mastra/ai-sdk': patch
 ---
 
-Fix durable agent streaming: guard the `step-start` branch of `convertMastraChunkToAISDKBase` against a missing `payload`.
-
-`@mastra/core` >= 1.49 emits a durable `step-start` chunk with `payload: undefined`. The `step-start` case destructured `chunk.payload` directly (unlike the neighbouring `start` case, which guards with `chunk.payload?.messageId`), so `toAISdkStream` threw `Cannot destructure property 'messageId' of 'chunk.payload' as it is undefined` immediately after the `start` frame — a client received only `start` and the stream tore down. Guard with `chunk.payload ?? {}`.
+Fix durable agent streams that could terminate right after the initial `start` event, leaving the client with an empty response. Streams now continue through step boundaries and deliver the full reasoning, tool, and text output.

--- a/.changeset/guard-durable-step-start-payload.md
+++ b/.changeset/guard-durable-step-start-payload.md
@@ -1,0 +1,7 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fix durable agent streaming: guard the `step-start` branch of `convertMastraChunkToAISDKBase` against a missing `payload`.
+
+`@mastra/core` >= 1.49 emits a durable `step-start` chunk with `payload: undefined`. The `step-start` case destructured `chunk.payload` directly (unlike the neighbouring `start` case, which guards with `chunk.payload?.messageId`), so `toAISdkStream` threw `Cannot destructure property 'messageId' of 'chunk.payload' as it is undefined` immediately after the `start` frame — a client received only `start` and the stream tore down. Guard with `chunk.payload ?? {}`.

--- a/client-sdks/ai-sdk/src/helpers.test.ts
+++ b/client-sdks/ai-sdk/src/helpers.test.ts
@@ -218,3 +218,14 @@ describe('client observability carrier propagation', () => {
     });
   });
 });
+
+describe('durable step-start with missing payload', () => {
+  it('does not throw when a step-start chunk has no payload (@mastra/core >= 1.49)', () => {
+    // @mastra/core >= 1.49 emits a durable `step-start` chunk with no `payload`.
+    // The converter must not throw when destructuring it (regression: only the
+    // `start` frame reached the client and the stream tore down).
+    const chunk = { type: 'step-start', runId: 'run-1', from: ChunkFrom.AGENT } as any;
+    expect(() => convertMastraChunkToAISDKv6({ chunk })).not.toThrow();
+    expect((convertMastraChunkToAISDKv6({ chunk }) as any).type).toBe('start-step');
+  });
+});

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -158,7 +158,7 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         ...(chunk.payload?.messageId ? { messageId: chunk.payload.messageId } : {}),
       };
     case 'step-start':
-      const { messageId: _messageId, ...rest } = chunk.payload;
+      const { messageId: _messageId, ...rest } = chunk.payload ?? {};
       return {
         type: 'start-step',
         request: rest.request,

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -157,13 +157,14 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         // Preserve messageId from the payload so it can be sent to useChat
         ...(chunk.payload?.messageId ? { messageId: chunk.payload.messageId } : {}),
       };
-    case 'step-start':
+    case 'step-start': {
       const { messageId: _messageId, ...rest } = chunk.payload ?? {};
       return {
         type: 'start-step',
         request: rest.request,
         warnings: normalizeWarnings(rest.warnings),
       };
+    }
     case 'raw':
       return {
         type: 'raw',


### PR DESCRIPTION
Closes #19670

## Describe the bug

A `DurableAgent`'s live output, consumed via `toAISdkStream` (`@mastra/ai-sdk`), crashes right after the `start` frame — a streaming client receives only `start` and the stream tears down. The run itself completes.

On `@mastra/core` **≥ 1.49**, the durable output emits a **`step-start` chunk with `payload: undefined`**. In `convertMastraChunkToAISDKBase` (`client-sdks/ai-sdk/src/helpers.ts`), the `step-start` case destructures `chunk.payload` **without guarding it** — unlike the neighbouring `start` case, which guards with `chunk.payload?.messageId`:

```ts
case 'start':
  return { type: 'start', ...(chunk.payload?.messageId ? { messageId: chunk.payload.messageId } : {}) };
case 'step-start':
  const { messageId: _messageId, ...rest } = chunk.payload;  // throws when payload is undefined
```

So the converter throws:

```
TypeError: Cannot destructure property 'messageId' of 'chunk.payload' as it is undefined.
    at convertMastraChunkToAISDKBase (client-sdks/ai-sdk/src/helpers.ts)
```

Because it throws on the chunk immediately after `start`, the AI SDK UI-message stream delivers only `{type:"start"}` and then errors out.

## Steps to reproduce

Minimal, no API key (uses `ai/test` `MockLanguageModelV3`):

```js
import { Agent } from "@mastra/core/agent";
import { createDurableAgent } from "@mastra/core/agent/durable";
import { Mastra } from "@mastra/core";
import { InMemoryStore } from "@mastra/core/storage";
import { InMemoryServerCache } from "@mastra/core/cache";
import { toAISdkStream } from "@mastra/ai-sdk";
import { MockLanguageModelV3, simulateReadableStream } from "ai/test";

const model = new MockLanguageModelV3({
  doStream: async () => ({ stream: simulateReadableStream({ chunks: [
    { type: "text-start", id: "t1" },
    { type: "text-delta", id: "t1", delta: "Hello" },
    { type: "text-end", id: "t1" },
    { type: "finish", finishReason: "stop", usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
  ] }) }),
});
const durable = createDurableAgent({ agent: new Agent({ name: "r", instructions: "t", model }) });
new Mastra({ agents: { r: durable }, storage: new InMemoryStore(), cache: new InMemoryServerCache() });

const { output } = await durable.stream([{ role: "user", content: "hi" }]);
for await (const chunk of toAISdkStream(output, { from: "agent", version: "v6" })) {
  console.log(chunk.type); // -> "start", then throws
}
```

The raw `output.fullStream` shows the offending chunk: `step-start` with `payload: undefined`.

## Expected behavior

`toAISdkStream` relays the full turn (`start` → `start-step` → text deltas → `finish`), as it does on `@mastra/core` 1.48.0. Bisected on `@mastra/core` with everything else held constant: **1.48.0 streams, 1.49.0+ only `start`**.

## The fix

Guard the destructure, mirroring the `start` case:

```diff
- const { messageId: _messageId, ...rest } = chunk.payload;
+ const { messageId: _messageId, ...rest } = chunk.payload ?? {};
```

Included: a unit test in `helpers.test.ts` (a payload-less `step-start` chunk converts to `start-step` without throwing) and a changeset (`@mastra/ai-sdk` patch).

(Alternatively/additionally, `@mastra/core` could emit the durable `step-start` chunk with a `payload` again, as it did ≤ 1.48 — but guarding the converter is the minimal, defensive fix and matches the `start` case.)

## Environment

```
@mastra/core: 1.51.0 · @mastra/ai-sdk: 1.6.2 · ai: 7.0.28 · Node 24
Repro is provider-agnostic (ai/test MockLanguageModelV3).
```

- [x] I have searched the existing issues/PRs
- [x] I have provided a minimal reproduction and a fix + test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Some “durable agents” were crashing mid-stream because a `step-start` message arrived without a `payload`. This PR makes the converter safely treat that missing payload as empty, so streaming can continue and clients still receive the expected frames.

## Changes

- Guarded `step-start` payload destructuring in `convertMastraChunkToAISDKBase` by defaulting `chunk.payload` to `{}` (using `chunk.payload ?? {}`).
- Added a regression test (“durable step-start with missing payload”) verifying a payload-less `step-start` does not throw and converts to `start-step`.
- Added a patch changeset for `@mastra/ai-sdk` describing the durable-stream continuation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
