### PR TITLE
feat(mastracode): enable prompt caching on the Amazon Bedrock path

### DIFF
--- a/.changeset/mastracode-bedrock-prompt-cache.md
+++ b/.changeset/mastracode-bedrock-prompt-cache.md
@@ -1,0 +1,9 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Enable prompt caching on the Amazon Bedrock path.
+
+mastracode only wired prompt caching for its Anthropic providers (via `providerOptions.anthropic.cacheControl`); the Bedrock path had none. Because `@ai-sdk/amazon-bedrock` reads a different key (`providerOptions.bedrock.cachePoint`), long agentic threads on Bedrock re-paid full-price input on every turn instead of the cache-read rate — a ~10x input-cost increase on large threads.
+
+`AmazonBedrockGateway` now wraps its models with a middleware that inserts Bedrock cache points at the last system message and the most recent message (mirroring the Anthropic path's two breakpoints). Models that don't support cache points ignore the field.

--- a/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
+++ b/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { bedrockCacheMiddleware } from '../amazon-bedrock-gateway.js';
+
+// The middleware marks cache breakpoints with `providerOptions.bedrock.cachePoint`
+// so Bedrock bills the re-sent prefix at the cache-read rate. Bedrock reads this
+// key (not Anthropic's `cacheControl`), which is why the general prompt-cache
+// middleware never applied on the Bedrock path.
+const CACHE_POINT = { cachePoint: { type: 'default' } };
+
+async function transform(prompt: Array<{ role: string; content: unknown; providerOptions?: unknown }>) {
+  const result = await bedrockCacheMiddleware.transformParams!({
+    type: 'generate',
+    params: { prompt } as never,
+    model: {} as never,
+  });
+  return result.prompt as Array<{ role: string; providerOptions?: { bedrock?: unknown } }>;
+}
+
+describe('bedrockCacheMiddleware', () => {
+  it('marks the last system message and the most recent message as cache points', async () => {
+    const out = await transform([
+      { role: 'system', content: 'you are helpful' },
+      { role: 'user', content: 'first' },
+      { role: 'assistant', content: 'ok' },
+      { role: 'user', content: 'latest' },
+    ]);
+
+    expect(out[0]!.providerOptions?.bedrock).toEqual(CACHE_POINT); // system
+    expect(out[3]!.providerOptions?.bedrock).toEqual(CACHE_POINT); // most recent
+    expect(out[1]!.providerOptions?.bedrock).toBeUndefined(); // untouched middle
+    expect(out[2]!.providerOptions?.bedrock).toBeUndefined();
+  });
+
+  it('marks only the last message when there is no system message', async () => {
+    const out = await transform([
+      { role: 'user', content: 'a' },
+      { role: 'user', content: 'b' },
+    ]);
+
+    expect(out[0]!.providerOptions?.bedrock).toBeUndefined();
+    expect(out[1]!.providerOptions?.bedrock).toEqual(CACHE_POINT);
+  });
+
+  it('preserves existing providerOptions when adding the cache point', async () => {
+    const out = await transform([{ role: 'user', content: 'hi', providerOptions: { openai: { store: false } } }]);
+
+    expect(out[0]!.providerOptions).toEqual({ openai: { store: false }, bedrock: CACHE_POINT });
+  });
+});

--- a/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
+++ b/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
@@ -4,9 +4,47 @@ import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { fromNodeProviderChain } from '@aws-sdk/credential-providers';
 import { MastraModelGateway } from '@mastra/core/llm';
 import type { GatewayAuthRequest, GatewayAuthResult, GatewayLanguageModel, ProviderConfig } from '@mastra/core/llm';
+import { wrapLanguageModel } from 'ai';
+import type { LanguageModelMiddleware } from 'ai';
 import { getBedrockModelCatalog } from './amazon-bedrock.js';
 
 type ModelRequestHeaders = Record<string, string>;
+
+/**
+ * Insert Bedrock prompt-cache breakpoints so long agentic threads bill the
+ * re-sent prefix at the cache-read rate instead of full-price input every turn.
+ *
+ * Bedrock uses `providerOptions.bedrock.cachePoint` ({ type: 'default' }) — a
+ * different key from Anthropic's `providerOptions.anthropic.cacheControl`, which
+ * is why the general prompt-cache middleware (Anthropic-only) never applied here.
+ * We mark the last system message and the most recent message, matching how the
+ * Anthropic path places its two breakpoints. Models that don't support cache
+ * points ignore the field, so this is safe to always apply.
+ */
+export const bedrockCacheMiddleware: LanguageModelMiddleware = {
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => {
+    const prompt = [...params.prompt];
+    const cachePoint = { bedrock: { cachePoint: { type: 'default' as const } } };
+    const mark = (msg: (typeof prompt)[number]) => ({
+      ...msg,
+      providerOptions: { ...msg.providerOptions, ...cachePoint },
+    });
+
+    for (let i = prompt.length - 1; i >= 0; i--) {
+      if (prompt[i]!.role === 'system') {
+        prompt[i] = mark(prompt[i]!);
+        break;
+      }
+    }
+    const lastIdx = prompt.length - 1;
+    if (lastIdx >= 0) {
+      prompt[lastIdx] = mark(prompt[lastIdx]!);
+    }
+
+    return { ...params, prompt };
+  },
+};
 
 export const AMAZON_BEDROCK_GATEWAY_ID = 'amazon-bedrock';
 
@@ -64,7 +102,13 @@ function bedrockProvider(modelId: string, headers?: ModelRequestHeaders) {
     credentialProvider: fromNodeProviderChain(),
     headers,
   });
-  return bedrock(modelId);
+  // `@ai-sdk/amazon-bedrock` returns a LanguageModelV2 while `wrapLanguageModel`
+  // is typed for V3; the SDK wraps both at runtime, so cast to bridge the types
+  // (same pattern the gateway uses elsewhere).
+  return wrapLanguageModel({
+    model: bedrock(modelId) as any,
+    middleware: [bedrockCacheMiddleware],
+  });
 }
 
 /**


### PR DESCRIPTION
Fixes #19672

## What

Enables prompt caching on the Amazon Bedrock path. mastracode only wired caching for its Anthropic providers, so long agentic threads on Bedrock re-paid full-price input on every turn instead of the cache-read rate — a ~10x input-cost increase on large threads.

## Root cause

Prompt caching was applied only via `providerOptions.anthropic.cacheControl` in the Anthropic API-key and OAuth branches. The Bedrock gateway (`amazon-bedrock-gateway.ts`) returned a bare `createAmazonBedrock()(modelId)` with no cache middleware — and `@ai-sdk/amazon-bedrock` reads a **different** key, `providerOptions.bedrock.cachePoint` (`{ type: 'default' }`), so even the existing middleware wouldn't have applied.

## Fix

`bedrockProvider()` now wraps its model with `bedrockCacheMiddleware`, which inserts a Bedrock cache point at the last system message and the most recent message (the same two-breakpoint placement the Anthropic path uses). Models that don't support cache points ignore the field.

## Verification

Live against Bedrock Opus 4.8, raw Converse `usage` on an identical prefix across two calls:

```
call 1:  cacheWriteInputTokens = 9013,  cacheReadInputTokens = 0
call 2:  cacheReadInputTokens  = 9013,  inputTokens = 2
```

Call 2 served the 9,013-token prefix from cache (billed at the cache-read rate) instead of re-billing it as standard input. Without the middleware, no cache usage is reported on any call.

- New unit test `amazon-bedrock-cache.test.ts` (3 tests): breakpoint placement with/without a system message, and preservation of existing `providerOptions`.
- Existing Bedrock tests unchanged and green; `tsc --noEmit` and `eslint` clean.

## Notes

- Type cast on `bedrock(modelId)`: `@ai-sdk/amazon-bedrock` returns `LanguageModelV2` while `wrapLanguageModel` is typed for V3 (wrapped at runtime for both) — same bridge the gateway uses elsewhere.
- Found while auditing a real Bedrock bill where cache hit-rate fell from ~100% to ~30-50% the day Bedrock became the active provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Amazon Bedrock can now remember parts of long conversations, so repeated prompts cost less and work faster. The change adds cache markers while preserving existing settings.

## What changed

- Added Bedrock prompt-cache middleware using `providerOptions.bedrock.cachePoint`.
- Places cache points on the last system message and newest message.
- Preserves existing provider options.
- Wraps Bedrock models with the middleware; unsupported models can ignore the metadata.
- Added unit tests and a changeset.

## Verification

- Confirmed a 9,013-token prefix was served from cache on a second live Bedrock call.
- TypeScript and ESLint checks pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->