### PR TITLE
fix(cli): bound stderr buffer in mastra worker start to prevent RangeError

### DIFF
--- a/.changeset/icy-books-sniff.md
+++ b/.changeset/icy-books-sniff.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed a crash in mastra worker start when a worker subprocess writes a very large amount of stderr output. The output is now capped to the most recent 1MB instead of growing without limit.

--- a/packages/cli/src/commands/worker/start.test.ts
+++ b/packages/cli/src/commands/worker/start.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const spawnMock = vi.fn();
@@ -82,5 +83,86 @@ describe('mastra worker start', () => {
     expect(spawnMock).not.toHaveBeenCalled();
     expect(errorLogMock).toHaveBeenCalledWith(expect.stringContaining('mastra worker build'));
     expect(exitMock).toHaveBeenCalledWith(1);
+  });
+});
+
+describe('mastra worker start - stderr buffer handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    existsSyncMock.mockReturnValue(true);
+
+    vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      exitMock(code);
+      throw new Error(`__exit_${code}`);
+    }) as typeof process.exit);
+  });
+
+  function createFakeChild() {
+    const child = new EventEmitter() as EventEmitter & {
+      stderr: EventEmitter;
+      kill: ReturnType<typeof vi.fn>;
+    };
+    child.stderr = new EventEmitter();
+    child.kill = vi.fn();
+    return child;
+  }
+
+  it('keeps the retained stderr buffer bounded when the worker floods stderr', async () => {
+    const { boundStderr, MAX_STDERR_BUFFER } = await import('./start');
+
+    // Simulate a long-running worker streaming far more stderr than the cap.
+    // 500 x 100KB = ~50MB of output, 50x the 1MB bound. Without a bound this
+    // grows until it exceeds V8's max string length and throws RangeError.
+    const chunk = 'x'.repeat(100_000);
+    let buffer = '';
+    for (let i = 0; i < 500; i++) {
+      buffer = boundStderr(buffer, chunk);
+    }
+
+    expect(buffer.length).toBe(MAX_STDERR_BUFFER);
+    expect(buffer.length).toBeLessThanOrEqual(MAX_STDERR_BUFFER);
+  });
+
+  it('still detects a module-not-found error on the retained tail after a flood', async () => {
+    const { boundStderr } = await import('./start');
+
+    // A crashing worker prints the module error at the END of its stderr,
+    // so the bounded tail must still contain it after a large flood.
+    const filler = 'x'.repeat(100_000);
+    let buffer = '';
+    for (let i = 0; i < 500; i++) {
+      buffer = boundStderr(buffer, filler);
+    }
+    buffer = boundStderr(buffer, "Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'some-pkg'\n");
+
+    expect(buffer.includes('ERR_MODULE_NOT_FOUND')).toBe(true);
+    expect(buffer.match(/Cannot find package '([^']+)'/)?.[1]).toBe('some-pkg');
+  });
+
+  it('surfaces a module-not-found crash through startWorker() even after a large stderr flood', async () => {
+    const child = createFakeChild();
+    spawnMock.mockReturnValue(child);
+    const writeSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+
+    try {
+      const { startWorker } = await import('./start');
+      const started = startWorker({});
+
+      // Flood ~10MB of stderr, then emit the crash marker at the tail.
+      const chunk = Buffer.from('x'.repeat(100_000));
+      for (let i = 0; i < 100; i++) {
+        child.stderr.emit('data', chunk);
+      }
+      child.stderr.emit('data', Buffer.from("Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'some-pkg'\n"));
+
+      expect(() => child.emit('exit', 1)).toThrow('__exit_1');
+      await started;
+
+      expect(errorLogMock).toHaveBeenCalledWith('Module not found while starting Mastra worker', {
+        package: 'some-pkg',
+      });
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 });

--- a/packages/cli/src/commands/worker/start.ts
+++ b/packages/cli/src/commands/worker/start.ts
@@ -11,6 +11,20 @@ interface StartWorkerOptions {
   env?: string;
 }
 
+// Cap the retained stderr buffer at 1MB. The buffer is only inspected for
+// crash diagnostics (the ERR_MODULE_NOT_FOUND marker and the "Cannot find
+// package" match), which live at the tail of a failing process's output, so
+// keeping only the most recent bytes is sufficient. Without a bound, a
+// long-running worker that streams a lot of stderr grows the buffer until it
+// exceeds V8's max string length and throws `RangeError: Invalid string length`.
+export const MAX_STDERR_BUFFER = 1_000_000;
+
+// Append a stderr chunk while keeping only the last `max` characters, so the
+// retained buffer can never grow without bound.
+export function boundStderr(buffer: string, chunk: string, max: number = MAX_STDERR_BUFFER): string {
+  return (buffer + chunk).slice(-max);
+}
+
 export async function startWorker(options: StartWorkerOptions = {}) {
   if (!shouldSkipDotenvLoading()) {
     config({ path: [options.env || '.env.production', '.env'], quiet: true });
@@ -37,7 +51,7 @@ export async function startWorker(options: StartWorkerOptions = {}) {
 
   let stderrBuffer = '';
   child.stderr?.on('data', data => {
-    stderrBuffer += data.toString();
+    stderrBuffer = boundStderr(stderrBuffer, data.toString());
     process.stderr.write(data);
   });
 


### PR DESCRIPTION
Fixes #19674

## Root cause

`mastra worker start` collects the spawned worker subprocess's stderr into `stderrBuffer` with an unbounded `stderrBuffer += data.toString()` (`packages/cli/src/commands/worker/start.ts`). For a long-running or noisy worker, this buffer grows without limit until it exceeds V8's maximum string length, throwing an uncaught `RangeError: Invalid string length` inside the `data` event handler and crashing the whole worker host process.

This is the same pattern already fixed for `mastra start` in #19581 / #19604, but `mastra worker start` spawns its child process independently and has its own copy of the same unbounded accumulation, which wasn't covered by that fix.

## Fix

Reused the same approach as the `mastra start` fix: `stderrBuffer` is only ever read for a crash diagnostic (the `ERR_MODULE_NOT_FOUND` marker and the `Cannot find package` match), which appears at the tail of a failing process's output. I added a small pure `boundStderr` helper (with a `MAX_STDERR_BUFFER` of 1MB) that appends each chunk and keeps only the most recent bytes, so the retained buffer can never grow past that cap while still holding the diagnostics it's read for. Live stderr streaming to the terminal is unaffected — only the retained copy used for diagnostics is bounded.

## Tests

Extended `packages/cli/src/commands/worker/start.test.ts`:
- a flood of ~50MB of stderr keeps the buffer capped at 1MB
- the `ERR_MODULE_NOT_FOUND` package name is still detected on the retained tail after a flood
- an end-to-end `startWorker()` test confirms the crash hint still fires after a large flood

Verified red before the fix (buffer grew past the cap) and green after. Added a `mastra` patch changeset.

<!-- ELI5 -->
## ELI5

A worker process that logged a lot of error output could crash the whole worker host. This change keeps only the latest 1MB of that output instead of remembering everything, preventing the crash while still catching the errors it was meant to detect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Workers could crash when they printed too much error text. This change keeps only the latest 1 MB of errors while still showing them live and preserving useful diagnostics.

## What changed

- Added bounded stderr buffering for `mastra worker start`.
- Retains the most recent 1 MB of stderr output.
- Preserves module-not-found detection and crash hints.
- Added tests for large stderr output, tail retention, and end-to-end diagnostics.
- Added a `mastra` patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->