### PR TITLE
feat(mastracode): add authoritative Factory rules and stage transitions

### DIFF
--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -93,6 +93,42 @@ The **Metrics** page at `/factory/metrics` shows queue health for the active Fac
 
 Queue age thresholds are server-side Factory project config in seconds. `GET /web/factory/projects/:factoryProjectId/health/thresholds` reads them from the `queue-health` storage domain. The `queue_health_settings` table keys records by `(org_id, factory_project_id)`. Defaults are `[14400, 86400, 259200]` (4h, 24h, and 72h). `saveConfig` rejects empty or non-ascending `thresholdsSeconds` values.
 
+## Factory rules
+
+`MastraFactory` accepts one authoritative `rules` tree for Work and Review stage entry and exit, completed tool results, and normalized GitHub events. Construct it with `defaultFactoryRules()` so every deployment policy has an explicit version:
+
+```ts
+import { MastraFactory } from './src/web/factory-entry.js';
+import { defaultFactoryRules } from './src/web/factory/rules/index.js';
+
+const rules = defaultFactoryRules({
+  version: '2026-07-18.1',
+  overrides: {
+    review: {
+      intake: {
+        pullRequest: {
+          onEnter: context =>
+            context.actor.type === 'github' && !context.actor.trusted
+              ? { type: 'reject', code: 'forbidden', reason: 'A trusted author is required.' }
+              : undefined,
+        },
+      },
+    },
+    tools: {
+      submit_plan: {
+        onResult: () => undefined,
+      },
+    },
+  },
+});
+
+const factory = new MastraFactory({ rules });
+```
+
+Overrides replace the exact `onEnter`, `onExit`, `onResult`, or `onEvent` leaf; they never compose implicitly with another handler. The version is configuration identity for persisted evaluations and audits, not an event-deduplication key, and Mastra never hashes function source.
+
+Rules are trusted deployment code. They receive normalized, bounded context rather than storage handles, credentials, worktree paths, or raw webhook payloads. Each handler returns one bounded `FactoryRuleDecision` or `void`: a typed rejection, transition, linked-item upsert, skill invocation, bound-session message, or notification. Every returned decision is validated and redacted before persistence; external effects are deferred rather than executed inside rule evaluation.
+
 ## GitHub pull request notifications
 
 GitHub-backed Factory sessions automatically subscribe the current thread after a successful `gh pr create`. The `github_subscribe_pr` tool is primarily for existing pull requests or recovery when automatic subscription did not occur. Use `github_unsubscribe_pr` only to stop notifications early; closing or merging the pull request retires its subscription automatically.

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -10,13 +10,11 @@ import { useActiveFactoryContext } from '../../web/ui/domains/workspaces/context
 import { deriveProjectPath, useCreateWorkspaceMutation } from './useWorkspaces';
 import type { Factory } from '../../web/ui/domains/workspaces/services/factories';
 import { isServerFactory } from '../../web/ui/domains/workspaces/services/factories';
-import { createWorkItem, startFactoryRun, transitionWorkItem } from '../../web/ui/domains/factory/services/workItems';
+import { startFactoryRun } from '../../web/ui/domains/factory/services/workItems';
 import type { WorkItemSource } from '../../web/ui/domains/factory/services/workItems';
 
 export interface StartFactoryRunWorkItem {
   id?: string;
-  revision?: number;
-  currentStage?: string;
   role: string;
   /** Retained for call-site compatibility; exact role authority no longer repoints other roles. */
   existingRoles?: string[];
@@ -110,31 +108,6 @@ export function useStartFactoryRun() {
 
       const desiredStage = workItem.stages.length === 1 ? workItem.stages[0] : undefined;
       if (!desiredStage) throw new Error('Factory runs require one exclusive destination stage');
-      let canonical = workItem.id
-        ? { id: workItem.id, revision: workItem.revision }
-        : await createWorkItem(baseUrl, factoryProjectId, {
-            source: workItem.source,
-            sourceKey: workItem.sourceKey,
-            parentWorkItemId: workItem.parentWorkItemId,
-            title: workItem.title,
-            url: workItem.url ?? null,
-            stages: ['intake'],
-            metadata: workItem.metadata,
-          });
-      if (canonical.revision === undefined) throw new Error('Factory work item revision is unavailable');
-      const currentStage = workItem.id ? workItem.currentStage : 'intake';
-      if (desiredStage !== currentStage) {
-        const moved = await transitionWorkItem(baseUrl, factoryProjectId, canonical.id, {
-          board: workItem.source === 'github-pr' ? 'review' : 'work',
-          stage: desiredStage as 'triage' | 'planning' | 'execute' | 'review' | 'done',
-          expectedRevision: canonical.revision,
-          requestId: crypto.randomUUID(),
-          cause: 'run_start',
-        });
-        if (moved.status === 'rejected') throw new Error(moved.reason);
-        canonical = { id: canonical.id, revision: moved.revision };
-      }
-
       const prepared = await startFactoryRun(baseUrl, factoryProjectId, {
         resourceId,
         projectPath,
@@ -143,8 +116,9 @@ export function useStartFactoryRun() {
         threadTags,
         kickoffKey: crypto.randomUUID(),
         kickoffMessage,
+        destinationStage: desiredStage as 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done',
         workItem: {
-          id: canonical.id,
+          id: workItem.id,
           role: workItem.role,
           input: {
             source: workItem.source,
@@ -152,7 +126,7 @@ export function useStartFactoryRun() {
             parentWorkItemId: workItem.parentWorkItemId,
             title: workItem.title,
             url: workItem.url ?? null,
-            stages: workItem.stages,
+            stages: ['intake'],
             metadata: workItem.metadata,
           },
         },

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -3,42 +3,23 @@ import { useNavigate } from 'react-router';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import type { AgentControllerSession } from '../../web/ui/domains/chat/services/agentControllerClient';
-import {
-  createAgentControllerClient,
-  prepareWorkspaceSkill,
-  requireAgentControllerSession,
-} from '../../web/ui/domains/chat/services/agentControllerClient';
+import { prepareWorkspaceSkill } from '../../web/ui/domains/chat/services/agentControllerClient';
 import { AGENT_CONTROLLER_ID } from '../../web/ui/domains/chat/services/constants';
-import {
-  queueThreadPageKickoff,
-  ThreadPageKickoffTimeoutError,
-} from '../../web/ui/domains/chat/services/threadPageReadiness';
 // Deep imports (not the workspaces barrel) to avoid provider/component cycles.
 import { useActiveFactoryContext } from '../../web/ui/domains/workspaces/context/ActiveFactoryProvider';
 import { deriveProjectPath, useCreateWorkspaceMutation } from './useWorkspaces';
 import type { Factory } from '../../web/ui/domains/workspaces/services/factories';
 import { isServerFactory } from '../../web/ui/domains/workspaces/services/factories';
-import { createWorkItem, updateWorkItem } from '../../web/ui/domains/factory/services/workItems';
+import { createWorkItem, startFactoryRun, transitionWorkItem } from '../../web/ui/domains/factory/services/workItems';
 import type { WorkItemSource } from '../../web/ui/domains/factory/services/workItems';
 
-/**
- * Board record to file once the run is underway. With an `id` the existing
- * card is PATCHed (stages + the role's session ref); without one a new card is
- * POSTed (the server upserts on `sourceKey`).
- */
 export interface StartFactoryRunWorkItem {
-  /** Existing work item to patch; omit to materialize a new card. */
   id?: string;
-  /** Session slot the run fills on the card, e.g. `work` or `review`. */
+  revision?: number;
+  currentStage?: string;
   role: string;
-  /**
-   * Roles already tracked on the card. A work item keeps a single threadId for
-   * its whole lifecycle, so filing repoints every known role at this run's
-   * thread — converging refs that diverged while session scoping was broken.
-   */
+  /** Retained for call-site compatibility; exact role authority no longer repoints other roles. */
   existingRoles?: string[];
-  /** Stages the card should hold once the run is underway. */
   stages: string[];
   source: WorkItemSource;
   sourceKey: string | null;
@@ -49,7 +30,8 @@ export interface StartFactoryRunWorkItem {
 }
 
 export type FactoryRunInvocation =
-  { type: 'prompt'; prompt: string } | { type: 'skill'; skillName: string; arguments: string };
+  | { type: 'prompt'; prompt: string }
+  | { type: 'skill'; skillName: string; arguments: string };
 
 const factoryRunMutationKey = (resourceId: string, projectId: string | undefined) =>
   ['factory', 'start-run', resourceId, projectId] as const;
@@ -74,29 +56,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export interface StartFactoryRunInput {
-  /** Feature branch for the new worktree (e.g. `factory/issue-12`). */
   branch: string;
-  /** Title for the new thread shown in the sidebar. */
   threadTitle: string;
-  /** Existing thread tags to prefer before falling back to the session thread. */
   threadTags?: Record<string, string>;
-  /** First user action dispatched to the agent. Omit to open the session without starting a run. */
   invocation?: FactoryRunInvocation;
-  /** Board card to file for this run (kanban record; optional). */
   workItem?: StartFactoryRunWorkItem;
 }
 
 /**
- * Start an agent run for a Factory item: create (or reuse) a worktree for the
- * item's branch, create a fresh thread in that workspace, send the kickoff
- * prompt, and navigate to the new thread. Without an `invocation` it opens an
- * empty session instead: same worktree/thread/card filing, but no message is
- * sent — the user lands on the thread and types the first message.
- *
- * Sessions are scoped per worktree, so the run targets the NEW worktree's own
- * session (created here with its `projectPath` tag) instead of repointing the
- * currently active one — parallel Factory runs over the same project stay
- * independent and never abort each other.
+ * Materialize the worktree in the browser, then hand session/thread creation,
+ * binding, board persistence, and kickoff delivery to the server coordinator.
+ * The coordinator commits exact authority before it dispatches any message.
  */
 export function useStartFactoryRun() {
   const { activeFactory, resourceId, sessionEnabled } = useActiveFactoryContext();
@@ -118,29 +88,11 @@ export function useStartFactoryRun() {
       );
       const projectPath = deriveProjectPath(updatedFactory);
       if (!projectPath) throw new Error('Could not resolve the new worktree path');
+      const factoryProjectId =
+        activeFactory && isServerFactory(activeFactory) ? activeFactory.binding.factoryProjectId : undefined;
+      if (!factoryProjectId || !workItem) throw new Error('Factory run requires a board work item');
 
-      // Address the new worktree's own session; create it up front so a
-      // brand-new scope is seeded with its projectPath tag before the thread
-      // is created in it.
-      const { session } = createAgentControllerClient({
-        agentControllerId: AGENT_CONTROLLER_ID,
-        resourceId,
-        scope: projectPath,
-        baseUrl,
-        enabled: sessionEnabled,
-      });
-      const scopedSession = requireAgentControllerSession(session);
-      const created = await scopedSession.create({ tags: { projectPath } });
-
-      // Worktrees hold a single conversation, so the run targets the session's
-      // own thread. Bringing a brand-new scope online seeds it with a fresh
-      // empty untitled thread (core creates one when no thread matches the
-      // scope tags) — claim it for this run by renaming it. When the session
-      // resumed a real thread (titled or with messages), i.e. a repeat run on
-      // the same item, reuse that thread: the prompt lands as a follow-up
-      // message instead of leaving a stray second thread in the worktree.
-      const threadId = await resolveRunThread(scopedSession, created.threadId, threadTitle, projectPath, threadTags);
-      let kickoffMessage: string | undefined;
+      let kickoffMessage: string | null = null;
       if (invocation?.type === 'skill') {
         const skillArguments = `${invocation.arguments.trim()}\n\nPrepared workspace context:\n- Worktree: ${projectPath}\n- Branch: ${branch}`;
         const prepared = await prepareWorkspaceSkill({
@@ -156,65 +108,63 @@ export function useStartFactoryRun() {
         kickoffMessage = invocation.prompt;
       }
 
-      // Refresh the new workspace's thread list before mounting the route so
-      // route synchronization can bind the live session to the new thread.
-      await queryClient.invalidateQueries({
-        queryKey: queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, resourceId, projectPath),
+      const desiredStage = workItem.stages.length === 1 ? workItem.stages[0] : undefined;
+      if (!desiredStage) throw new Error('Factory runs require one exclusive destination stage');
+      let canonical = workItem.id
+        ? { id: workItem.id, revision: workItem.revision }
+        : await createWorkItem(baseUrl, factoryProjectId, {
+            source: workItem.source,
+            sourceKey: workItem.sourceKey,
+            parentWorkItemId: workItem.parentWorkItemId,
+            title: workItem.title,
+            url: workItem.url ?? null,
+            stages: ['intake'],
+            metadata: workItem.metadata,
+          });
+      if (canonical.revision === undefined) throw new Error('Factory work item revision is unavailable');
+      const currentStage = workItem.id ? workItem.currentStage : 'intake';
+      if (desiredStage !== currentStage) {
+        const moved = await transitionWorkItem(baseUrl, factoryProjectId, canonical.id, {
+          board: workItem.source === 'github-pr' ? 'review' : 'work',
+          stage: desiredStage as 'triage' | 'planning' | 'execute' | 'review' | 'done',
+          expectedRevision: canonical.revision,
+          requestId: crypto.randomUUID(),
+          cause: 'run_start',
+        });
+        if (moved.status === 'rejected') throw new Error(moved.reason);
+        canonical = { id: canonical.id, revision: moved.revision };
+      }
+
+      const prepared = await startFactoryRun(baseUrl, factoryProjectId, {
+        resourceId,
+        projectPath,
+        branch,
+        threadTitle,
+        threadTags,
+        kickoffKey: crypto.randomUUID(),
+        kickoffMessage,
+        workItem: {
+          id: canonical.id,
+          role: workItem.role,
+          input: {
+            source: workItem.source,
+            sourceKey: workItem.sourceKey,
+            parentWorkItemId: workItem.parentWorkItemId,
+            title: workItem.title,
+            url: workItem.url ?? null,
+            stages: workItem.stages,
+            metadata: workItem.metadata,
+          },
+        },
       });
 
-      // Queue the kickoff before navigating so the destination page can claim it
-      // exactly once. Wait for that page's composer path to finish dispatching
-      // before filing the board card as an active run. Without an invocation
-      // (opening an empty session) there is nothing to dispatch — navigate and
-      // let the user type the first message.
-      if (kickoffMessage !== undefined) {
-        const kickoffCompleted = queueThreadPageKickoff({ resourceId, projectPath, threadId }, kickoffMessage);
-        void navigate(`/threads/${threadId}`);
-        try {
-          await kickoffCompleted;
-        } catch (error) {
-          if (error instanceof ThreadPageKickoffTimeoutError) {
-            void navigate('/new', { replace: true, state: { routeErrorNotice: error.message } });
-          }
-          throw error;
-        }
-      } else {
-        void navigate(`/threads/${threadId}`);
-      }
-
-      // File the board card now that the run is underway, hanging the run's
-      // session ref off the requested role. Best-effort: the run itself
-      // (worktree + session + thread + prompt) already succeeded, so a filing
-      // failure must not reject the mutation and strand the user off the
-      // thread that is actively running.
-      const factoryProjectId =
-        activeFactory && isServerFactory(activeFactory) ? activeFactory.binding.factoryProjectId : undefined;
-      if (workItem && factoryProjectId) {
-        try {
-          // One thread per item: stamp the run's ref onto every role the card
-          // tracks so all refs share this threadId.
-          const ref = { projectPath, branch, threadId };
-          const roles = new Set([...(workItem.existingRoles ?? []), workItem.role]);
-          const sessions = Object.fromEntries([...roles].map(role => [role, ref]));
-          if (workItem.id) {
-            await updateWorkItem(baseUrl, workItem.id, { stages: workItem.stages, sessions });
-          } else {
-            await createWorkItem(baseUrl, factoryProjectId, {
-              source: workItem.source,
-              sourceKey: workItem.sourceKey,
-              parentWorkItemId: workItem.parentWorkItemId,
-              title: workItem.title,
-              url: workItem.url ?? null,
-              stages: workItem.stages,
-              sessions,
-              metadata: workItem.metadata,
-            });
-          }
-          void queryClient.invalidateQueries({ queryKey: queryKeys.workItems(factoryProjectId) });
-        } catch (err) {
-          console.error('Failed to file the board card for this run', err);
-        }
-      }
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, resourceId, projectPath),
+        }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.workItems(factoryProjectId) }),
+      ]);
+      void navigate(`/threads/${prepared.threadId}`);
     },
   });
 
@@ -224,47 +174,4 @@ export function useStartFactoryRun() {
   }).filter(run => run !== undefined);
 
   return { start: mutation, pendingRuns, enabled: sessionEnabled };
-}
-
-/**
- * Resolve the thread a run should land on. Worktree sessions hold a single
- * conversation, so this is the session's own thread:
- *
- * - Fresh scope: the session was seeded with an empty untitled thread — claim
- *   it by renaming it to `title`.
- * - Resumed scope (repeat run on the same item): the thread already has a
- *   title or messages — reuse it as-is; the prompt becomes a follow-up.
- * - No thread on the session (unexpected): create one.
- */
-async function resolveRunThread(
-  session: AgentControllerSession,
-  threadId: string | undefined,
-  title: string,
-  projectPath: string,
-  threadTags: Record<string, string> | undefined,
-): Promise<string> {
-  const extraTags = Object.entries(threadTags ?? {}).filter(([, value]) => value);
-  if (extraTags.length > 0) {
-    const tags = { projectPath, ...Object.fromEntries(extraTags) };
-    const taggedThread = (await session.listThreads({ tags, limit: 20 }))[0];
-    if (taggedThread) {
-      await session.switchThread(taggedThread.id);
-      if (taggedThread.id === threadId && isUntitledThread(taggedThread.title)) {
-        const messages = await session.listMessages(taggedThread.id, 1);
-        if (messages.length === 0) await session.renameThread(taggedThread.id, title);
-      }
-      return taggedThread.id;
-    }
-  }
-
-  if (!threadId) return (await session.createThread(title)).id;
-  const [threads, messages] = await Promise.all([session.listThreads(), session.listMessages(threadId, 1)]);
-  const existing = threads.find(thread => thread.id === threadId);
-  if (!existing) return (await session.createThread(title)).id;
-  if (isUntitledThread(existing.title) && messages.length === 0) await session.renameThread(threadId, title);
-  return threadId;
-}
-
-function isUntitledThread(title: string | null | undefined): boolean {
-  return !title || title === 'Untitled thread';
 }

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -28,8 +28,7 @@ export interface StartFactoryRunWorkItem {
 }
 
 export type FactoryRunInvocation =
-  | { type: 'prompt'; prompt: string }
-  | { type: 'skill'; skillName: string; arguments: string };
+  { type: 'prompt'; prompt: string } | { type: 'skill'; skillName: string; arguments: string };
 
 const factoryRunMutationKey = (resourceId: string, projectId: string | undefined) =>
   ['factory', 'start-run', resourceId, projectId] as const;

--- a/mastracode/web/src/shared/hooks/useWorkItems.ts
+++ b/mastracode/web/src/shared/hooks/useWorkItems.ts
@@ -6,6 +6,7 @@ import {
   createWorkItem,
   deleteWorkItem,
   listWorkItems,
+  transitionWorkItem,
   updateWorkItem,
 } from '../../web/ui/domains/factory/services/workItems';
 import type {
@@ -82,6 +83,37 @@ export function useUpdateWorkItemMutation(factoryProjectId: string | undefined) 
       queryClient.setQueryData<WorkItem[]>(listKey, existing =>
         (existing ?? []).map(i => (i.id === item.id ? item : i)),
       );
+    },
+  });
+}
+
+export function useTransitionWorkItemMutation(githubProjectId: string | undefined) {
+  const { baseUrl } = useApiConfig();
+  const queryClient = useQueryClient();
+  const listKey = queryKeys.workItems(githubProjectId);
+  return useMutation({
+    mutationFn: ({ item, board, stage }: { item: WorkItem; board: 'work' | 'review'; stage: string }) =>
+      transitionWorkItem(baseUrl, githubProjectId!, item.id, {
+        board,
+        stage: stage as 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done',
+        expectedRevision: item.revision,
+        requestId: crypto.randomUUID(),
+        cause: 'board_drag',
+      }),
+    onMutate: async ({ item, stage }) => {
+      await queryClient.cancelQueries({ queryKey: listKey });
+      const previous = queryClient.getQueryData<WorkItem[]>(listKey);
+      queryClient.setQueryData<WorkItem[]>(listKey, existing =>
+        (existing ?? []).map(candidate => (candidate.id === item.id ? { ...candidate, stages: [stage] } : candidate)),
+      );
+      return { previous };
+    },
+    onError: (_error, _variables, context) => {
+      if (context?.previous) queryClient.setQueryData(listKey, context.previous);
+    },
+    onSuccess: (result, _variables, context) => {
+      if (result.status === 'rejected' && context?.previous) queryClient.setQueryData(listKey, context.previous);
+      void queryClient.invalidateQueries({ queryKey: listKey });
     },
   });
 }

--- a/mastracode/web/src/shared/hooks/useWorkItems.ts
+++ b/mastracode/web/src/shared/hooks/useWorkItems.ts
@@ -46,11 +46,7 @@ export function useUpsertWorkItemMutation(factoryProjectId: string | undefined) 
   });
 }
 
-/**
- * Patch a work item (stage moves, session/metadata merges). Stage moves apply
- * optimistically — the card jumps columns immediately and rolls back if the
- * server rejects the patch.
- */
+/** Patch non-stage work-item fields. Stage movement uses the transition authority below. */
 export function useUpdateWorkItemMutation(factoryProjectId: string | undefined) {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
@@ -60,18 +56,10 @@ export function useUpdateWorkItemMutation(factoryProjectId: string | undefined) 
     onMutate: async ({ id, patch }) => {
       await queryClient.cancelQueries({ queryKey: listKey });
       const previous = queryClient.getQueryData<WorkItem[]>(listKey);
-      if (previous && (patch.stages || patch.parentWorkItemId !== undefined)) {
+      if (previous && patch.parentWorkItemId !== undefined) {
         queryClient.setQueryData<WorkItem[]>(
           listKey,
-          previous.map(item =>
-            item.id === id
-              ? {
-                  ...item,
-                  ...(patch.stages ? { stages: patch.stages } : {}),
-                  ...(patch.parentWorkItemId !== undefined ? { parentWorkItemId: patch.parentWorkItemId } : {}),
-                }
-              : item,
-          ),
+          previous.map(item => (item.id === id ? { ...item, parentWorkItemId: patch.parentWorkItemId ?? null } : item)),
         );
       }
       return { previous };
@@ -87,13 +75,13 @@ export function useUpdateWorkItemMutation(factoryProjectId: string | undefined) 
   });
 }
 
-export function useTransitionWorkItemMutation(githubProjectId: string | undefined) {
+export function useTransitionWorkItemMutation(factoryProjectId: string | undefined) {
   const { baseUrl } = useApiConfig();
   const queryClient = useQueryClient();
-  const listKey = queryKeys.workItems(githubProjectId);
+  const listKey = queryKeys.workItems(factoryProjectId);
   return useMutation({
     mutationFn: ({ item, board, stage }: { item: WorkItem; board: 'work' | 'review'; stage: string }) =>
-      transitionWorkItem(baseUrl, githubProjectId!, item.id, {
+      transitionWorkItem(baseUrl, factoryProjectId!, item.id, {
         board,
         stage: stage as 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done',
         expectedRevision: item.revision,

--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -8,12 +8,14 @@ import type { VersionControl } from './capabilities/version-control.js';
 import { PgVector } from '@mastra/pg';
 import type { AuthInitContext, IMastraAuthProvider } from '@mastra/core/server';
 import { MastraFactory } from './factory-entry.js';
+import { defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './factory/rules/index.js';
 import { getFactoryWorkspace } from './factory/workspace.js';
 import type { FactoryIntegration, IntegrationContext } from './factory-integration.js';
 import {
   __resetRuntimeConfigForTests,
   getFactoryStorage,
   getSeededAuthProvider,
+  getSeededFactoryRules,
   getSeededIntegration,
   getSeededSandbox,
   getSeededStateSigner,
@@ -120,6 +122,28 @@ describe('MastraFactory.prepare', () => {
     expect(getFactoryStorage()).toBe(storage);
     expect(getSeededAuthProvider()).toBe(auth);
     expect(getSeededSandbox()?.machine).toBe(sandbox);
+  });
+
+  it('seeds conservative versioned Factory rules when the slot is omitted', async () => {
+    await prepareFactory({ storage: fakeStorage() });
+    expect(getSeededFactoryRules()).toEqual({
+      version: DEFAULT_FACTORY_RULE_VERSION,
+      work: {},
+      review: {},
+      tools: {},
+      github: {},
+    });
+  });
+
+  it('seeds explicitly configured Factory rules without composing handler leaves', async () => {
+    const onResult = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'customer-policy-3',
+      overrides: { tools: { submit_plan: { onResult } } },
+    });
+    await prepareFactory({ storage: fakeStorage(), rules });
+    expect(getSeededFactoryRules()).toBe(rules);
+    expect(getSeededFactoryRules()?.tools.submit_plan?.onResult).toBe(onResult);
   });
 
   it('registers and initializes factory domains through the storage lifecycle', async () => {

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -31,6 +31,9 @@ import { observeAgentGitAction } from './audit/agent-audit.js';
 import { AuditDomain } from './audit/domain.js';
 import { buildAuthRoutes, createWebAuthGate, isWebAuthEnabled } from './auth.js';
 import type { FactoryIntegration, IntegrationPostToolContext, IntegrationTools } from './factory-integration.js';
+import { builtInFactoryRules } from './factory/rules/defaults.js';
+import type { FactoryRules } from './factory/rules/types.js';
+import { assertFactoryRules } from './factory/rules/validation.js';
 import { getFactoryWorkspace } from './factory/workspace.js';
 import { ProjectDomain } from './projects/domain.js';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
@@ -124,6 +127,13 @@ export interface MastraFactoryConfig {
    * never mount, its tools never register, and the server boots fine.
    */
   integrations?: FactoryIntegration[];
+  /**
+   * Authoritative Factory board, tool-result, and GitHub-event rules. Construct
+   * with `defaultFactoryRules({ version, overrides })` so deployment policy has
+   * an explicit version and exact handler leaves replace rather than compose.
+   * Omitted → conservative built-in rules for the current deployment.
+   */
+  rules?: FactoryRules;
 }
 
 export interface MastraFactorySandboxConfig {
@@ -282,6 +292,9 @@ export class MastraFactory {
       }
       integrationIds.add(integration.id);
     }
+    const rules = this.#config.rules ?? builtInFactoryRules();
+    assertFactoryRules(rules);
+
     // FactoryStorage owns every app-table domain and initializes them through
     // the same lifecycle as the backend connection.
     storage.registerDomain(new IntakeStorage());
@@ -341,6 +354,7 @@ export class MastraFactory {
       storage,
       vector,
       integrations,
+      rules,
       publicUrl: publicOrigin,
       authProvider: auth,
       stateSigner,

--- a/mastracode/web/src/web/factory/routes.test.ts
+++ b/mastracode/web/src/web/factory/routes.test.ts
@@ -306,7 +306,7 @@ describe('POST /web/factory/projects/:id/work-items/:workItemId/transition', () 
       board: 'work',
       stage: 'execute',
       expectedRevision: item.revision,
-      requestId: 'request-1',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa1',
       cause: 'board_drag',
       ...overrides,
     });
@@ -335,7 +335,7 @@ describe('POST /web/factory/projects/:id/work-items/:workItemId/transition', () 
   it('returns typed stale without overwriting the winner', async () => {
     const item = await createItem();
     expect((await transition(item)).status).toBe(200);
-    const stale = await transition(item, { requestId: 'request-2', stage: 'planning' });
+    const stale = await transition(item, { requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa2', stage: 'planning' });
     expect(stale.status).toBe(409);
     expect(await stale.json()).toMatchObject({ result: { status: 'rejected', code: 'stale' } });
     expect((await listItems())[0]?.stages).toEqual(['execute']);
@@ -347,6 +347,12 @@ describe('POST /web/factory/projects/:id/work-items/:workItemId/transition', () 
     const replay = await transition(item, { stage: 'planning' });
     expect(await replay.json()).toEqual(await first.json());
     expect((await listItems())[0]?.stages).toEqual(['execute']);
+  });
+
+  it('rejects non-UUID human request identities before they can collide across work items', async () => {
+    const item = await createItem();
+    const res = await transition(item, { requestId: 'reused-human-request' });
+    expect(res.status).toBe(400);
   });
 
   it('rejects a work item addressed through the Review board', async () => {
@@ -364,8 +370,9 @@ describe('POST /web/factory/projects/:id/runs/start', () => {
     branch: 'factory/issue-42',
     threadTitle: 'Investigate issue 42',
     threadTags: { role: 'plan' },
-    kickoffKey: 'kickoff-1',
+    kickoffKey: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbb1',
     kickoffMessage: 'Start',
+    destinationStage: 'planning',
     workItem: {
       id: workItemId,
       role: 'plan',
@@ -406,6 +413,20 @@ describe('POST /web/factory/projects/:id/runs/start', () => {
         metadata: expect.objectContaining({ bindingId: 'binding-1', role: 'plan' }),
       }),
     );
+  });
+
+  it('rejects a non-UUID kickoff identity before coordination', async () => {
+    const prepare = vi.fn();
+    const app = buildApp(orgUser, { prepare });
+
+    const res = await app.request(`/web/factory/projects/${PROJECT_ID}/runs/start`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ ...startBody(), kickoffKey: 'reused-kickoff' }),
+    });
+
+    expect(res.status).toBe(400);
+    expect(prepare).not.toHaveBeenCalled();
   });
 
   it('refuses non-Intake creation before the coordinator can bypass transition authority', async () => {
@@ -568,7 +589,7 @@ describe('GET /web/factory/projects/:id/metrics', () => {
       board: 'work',
       stage: 'done',
       expectedRevision: workItem.revision,
-      requestId: 'metrics-complete',
+      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa3',
       cause: 'board_drag',
     });
     await json(
@@ -736,7 +757,7 @@ describe('audit events', () => {
         board: 'work',
         stage: 'done',
         expectedRevision: workItem.revision,
-        requestId: 'audit-failure-transition',
+        requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa4',
         cause: 'board_drag',
       },
     );

--- a/mastracode/web/src/web/factory/routes.test.ts
+++ b/mastracode/web/src/web/factory/routes.test.ts
@@ -429,6 +429,24 @@ describe('POST /web/factory/projects/:id/runs/start', () => {
     expect(prepare).not.toHaveBeenCalled();
   });
 
+  it.each(['', 'not-a-uuid', 'x'.repeat(65), 42])(
+    'rejects an explicitly supplied invalid work item identity: %o',
+    async id => {
+      const prepare = vi.fn();
+      const app = buildApp(orgUser, { prepare });
+      const body = startBody();
+
+      const res = await app.request(`/web/factory/projects/${PROJECT_ID}/runs/start`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ ...body, workItem: { ...body.workItem, id } }),
+      });
+
+      expect(res.status).toBe(400);
+      expect(prepare).not.toHaveBeenCalled();
+    },
+  );
+
   it('refuses non-Intake creation before the coordinator can bypass transition authority', async () => {
     const prepare = vi.fn();
     const app = buildApp(orgUser, { prepare });

--- a/mastracode/web/src/web/factory/routes.test.ts
+++ b/mastracode/web/src/web/factory/routes.test.ts
@@ -35,17 +35,29 @@ const audit: AuditEmitter = {
 import { seedFactoryStorageForTests } from '../storage/test-utils';
 import type { FactoryStorageTestSeed } from '../storage/test-utils';
 import { mountApiRoutes } from '../test-utils';
+import { builtInFactoryRules } from './rules/defaults';
+import { FactoryTransitionService } from './rules/transition-service';
 import { buildFactoryRoutes } from './routes';
 import { parseCreateWorkItem, parseUpdateWorkItem } from './store';
 
 // ── Test harness ─────────────────────────────────────────────────────────
-function buildApp(user: { workosId: string; organizationId?: string } | null) {
+function buildApp(
+  user: { workosId: string; organizationId?: string } | null,
+  startCoordinator?: { prepare: (input: any) => Promise<any> },
+) {
   const app = new Hono();
   app.use('*', async (c, next) => {
     if (user) c.set('webAuthUser' as never, user as never);
     await next();
   });
-  mountApiRoutes(app as any, buildFactoryRoutes({ audit }));
+  mountApiRoutes(
+    app as any,
+    buildFactoryRoutes({
+      audit,
+      transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
+      startCoordinator,
+    }),
+  );
   return app;
 }
 
@@ -157,7 +169,7 @@ describe('POST /web/factory/projects/:id/work-items', () => {
     expect(workItem.stageHistory[0].exitedAt).toBeUndefined();
   });
 
-  it('upserts on the external source identity instead of duplicating', async () => {
+  it('rejects an external-source upsert that tries to bypass governed stage transition', async () => {
     await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
     const res = await json(
       'POST',
@@ -167,21 +179,12 @@ describe('POST /web/factory/projects/:id/work-items', () => {
         sessions: { work: { projectPath: '/sb/wt/issue-42', branch: 'factory/issue-42', threadId: 't-1' } },
       }),
     );
-    const { workItem } = await res.json();
-    expect(await listItems()).toHaveLength(1);
-    expect(workItem.stages).toEqual(['execute']);
-    // History: intake entered+exited, execute entered.
-    expect(workItem.stageHistory.map((e: any) => [e.stage, e.exitedAt !== undefined])).toEqual([
-      ['intake', true],
-      ['execute', false],
-    ]);
-    // Session got the acting user stamped server-side.
-    expect(workItem.sessions.work).toMatchObject({
-      projectPath: '/sb/wt/issue-42',
-      branch: 'factory/issue-42',
-      threadId: 't-1',
-      startedBy: 'u1',
-    });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: 'governed_transition_required' });
+    const [workItem] = await listItems();
+    expect(workItem?.stages).toEqual(['intake']);
+    expect(workItem?.stageHistory).toHaveLength(1);
+    expect(workItem?.sessions).toEqual({});
   });
 
   it('never dedupes manual cards without an external source', async () => {
@@ -209,7 +212,7 @@ describe('PATCH /web/factory/work-items/:id', () => {
     return (await res.json()).workItem;
   }
 
-  it('moves stages and appends history with the acting user', async () => {
+  it('rejects direct stage mutation and leaves the canonical item unchanged', async () => {
     const item = await createItem();
     const res = await buildApp({ workosId: 'u2', organizationId: 'org1' }).request(
       `/web/factory/work-items/${item.id}`,
@@ -219,21 +222,21 @@ describe('PATCH /web/factory/work-items/:id', () => {
         body: JSON.stringify({ stages: ['execute'] }),
       },
     );
-    const { workItem } = await res.json();
-    expect(workItem.stages).toEqual(['execute']);
-    expect(workItem.stageHistory).toHaveLength(2);
-    expect(workItem.stageHistory[0]).toMatchObject({ stage: 'intake', by: 'u1' });
-    expect(workItem.stageHistory[0].exitedAt).toBeTruthy();
-    expect(workItem.stageHistory[1]).toMatchObject({ stage: 'execute', by: 'u2' });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toMatchObject({ error: 'governed_transition_required' });
+    const [canonical] = await listItems();
+    expect(canonical?.stages).toEqual(['intake']);
+    expect(canonical?.stageHistory).toHaveLength(1);
   });
 
-  it('keeps concurrent stages untouched when moving one of them', async () => {
-    const item = await createItem({ stages: ['execute', 'review'] });
-    const res = await json('PATCH', `/web/factory/work-items/${item.id}`, { stages: ['done'] });
-    const { workItem } = await res.json();
-    expect(workItem.stages).toEqual(['done']);
-    const open = workItem.stageHistory.filter((e: any) => e.exitedAt === undefined);
-    expect(open.map((e: any) => e.stage)).toEqual(['done']);
+  it('rejects creation outside exclusive intake', async () => {
+    const res = await json(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/work-items`,
+      createBody({ stages: ['intake', 'execute'] }),
+    );
+    expect(res.status).toBe(409);
+    expect(await listItems()).toHaveLength(0);
   });
 
   it('merges sessions and metadata instead of replacing', async () => {
@@ -279,7 +282,7 @@ describe('PATCH /web/factory/work-items/:id', () => {
       {
         method: 'PATCH',
         headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ stages: ['done'] }),
+        body: JSON.stringify({ title: 'Cross-tenant mutation' }),
       },
     );
     expect(res.status).toBe(404);
@@ -289,6 +292,136 @@ describe('PATCH /web/factory/work-items/:id', () => {
     const item = await createItem();
     expect((await json('PATCH', `/web/factory/work-items/${item.id}`, {})).status).toBe(400);
     expect((await json('PATCH', `/web/factory/work-items/${item.id}`, { title: '' })).status).toBe(400);
+  });
+});
+
+describe('POST /web/factory/projects/:id/work-items/:workItemId/transition', () => {
+  async function createItem(overrides: Record<string, unknown> = {}) {
+    const res = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody(overrides));
+    return (await res.json()).workItem;
+  }
+
+  const transition = (item: { id: string; revision: number }, overrides: Record<string, unknown> = {}) =>
+    json('POST', `/web/factory/projects/${PROJECT_ID}/work-items/${item.id}/transition`, {
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: item.revision,
+      requestId: 'request-1',
+      cause: 'board_drag',
+      ...overrides,
+    });
+
+  it('moves through the rule authority and preserves storage-owned history', async () => {
+    const item = await createItem();
+    auditRecorded = [];
+    const res = await transition(item);
+    expect(res.status).toBe(200);
+    const { result } = await res.json();
+    expect(result).toMatchObject({ status: 'accepted', itemId: item.id, revision: 2, stage: 'execute' });
+    const [canonical] = await listItems();
+    expect(canonical?.stages).toEqual(['execute']);
+    expect(canonical?.stageHistory.map(entry => [entry.stage, entry.exitedAt !== undefined])).toEqual([
+      ['intake', true],
+      ['execute', false],
+    ]);
+    expect(auditRecorded).toContainEqual(
+      expect.objectContaining({
+        action: 'factory.work_item.stage_moved',
+        metadata: expect.objectContaining({ ingressType: 'human', ruleSetVersion: 'factory-default-v1' }),
+      }),
+    );
+  });
+
+  it('returns typed stale without overwriting the winner', async () => {
+    const item = await createItem();
+    expect((await transition(item)).status).toBe(200);
+    const stale = await transition(item, { requestId: 'request-2', stage: 'planning' });
+    expect(stale.status).toBe(409);
+    expect(await stale.json()).toMatchObject({ result: { status: 'rejected', code: 'stale' } });
+    expect((await listItems())[0]?.stages).toEqual(['execute']);
+  });
+
+  it('replays immutable ingress without evaluating a second destination', async () => {
+    const item = await createItem();
+    const first = await transition(item);
+    const replay = await transition(item, { stage: 'planning' });
+    expect(await replay.json()).toEqual(await first.json());
+    expect((await listItems())[0]?.stages).toEqual(['execute']);
+  });
+
+  it('rejects a work item addressed through the Review board', async () => {
+    const item = await createItem();
+    const res = await transition(item, { board: 'review' });
+    expect(res.status).toBe(422);
+    expect(await res.json()).toMatchObject({ result: { status: 'rejected', code: 'invalid_transition' } });
+  });
+});
+
+describe('POST /web/factory/projects/:id/runs/start', () => {
+  const startBody = (workItemId?: string) => ({
+    resourceId: 'resource-1',
+    projectPath: '/worktrees/issue-42',
+    branch: 'factory/issue-42',
+    threadTitle: 'Investigate issue 42',
+    threadTags: { role: 'plan' },
+    kickoffKey: 'kickoff-1',
+    kickoffMessage: 'Start',
+    workItem: {
+      id: workItemId,
+      role: 'plan',
+      input: createBody({ stages: ['intake'] }),
+    },
+  });
+
+  it('passes authenticated tenant identity to the coordinator and audits the prepared binding', async () => {
+    const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
+    const { workItem } = await created.json();
+    auditRecorded = [];
+    const prepare = vi.fn(async (input: any) => ({
+      workItemId: input.workItem.id,
+      bindingId: 'binding-1',
+      threadId: 'thread-1',
+      resourceId: input.resourceId,
+      projectPath: input.projectPath,
+      branch: input.branch,
+      revision: 2,
+      kickoffStatus: 'pending',
+      replayed: false,
+    }));
+    const app = buildApp(orgUser, { prepare });
+
+    const res = await app.request(`/web/factory/projects/${PROJECT_ID}/runs/start`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(startBody(workItem.id)),
+    });
+
+    expect(res.status).toBe(202);
+    expect(prepare).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org1', userId: 'u1', factoryProjectId: PROJECT_ID }),
+    );
+    expect(auditRecorded).toContainEqual(
+      expect.objectContaining({
+        action: 'factory.run.started',
+        metadata: expect.objectContaining({ bindingId: 'binding-1', role: 'plan' }),
+      }),
+    );
+  });
+
+  it('refuses non-Intake creation before the coordinator can bypass transition authority', async () => {
+    const prepare = vi.fn();
+    const app = buildApp(orgUser, { prepare });
+    const body = startBody();
+    body.workItem.input.stages = ['planning'];
+
+    const res = await app.request(`/web/factory/projects/${PROJECT_ID}/runs/start`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
+    expect(res.status).toBe(409);
+    expect(prepare).not.toHaveBeenCalled();
   });
 });
 
@@ -431,7 +564,13 @@ describe('GET /web/factory/projects/:id/metrics', () => {
     // One card completed today (intake → done), one still in intake.
     const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
     const { workItem } = await created.json();
-    await json('PATCH', `/web/factory/work-items/${workItem.id}`, { stages: ['done'] });
+    await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items/${workItem.id}/transition`, {
+      board: 'work',
+      stage: 'done',
+      expectedRevision: workItem.revision,
+      requestId: 'metrics-complete',
+      cause: 'board_drag',
+    });
     await json(
       'POST',
       `/web/factory/projects/${PROJECT_ID}/work-items`,
@@ -519,40 +658,25 @@ describe('audit events', () => {
     });
   });
 
-  it('records updated (not created) when a POST reuses an existing sourceKey', async () => {
+  it('audits only the bounded non-stage refresh when a source-key POST reuses the canonical item', async () => {
     const item = await createItem();
     auditRecorded = [];
 
-    const session = { projectPath: '/sb/wt/issue-42', branch: 'factory/issue-42', threadId: 't-1' };
-    await json(
-      'POST',
-      `/web/factory/projects/${PROJECT_ID}/work-items`,
-      createBody({ stages: ['execute'], sessions: { work: session } }),
-    );
-    expect(auditRecorded.map(e => e.action)).toEqual([
-      'factory.work_item.updated',
-      'factory.work_item.stage_moved',
-      'factory.run.started',
-    ]);
-    expect(auditRecorded[1]).toMatchObject({
-      targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
-      metadata: { from: ['intake'], to: ['execute'] },
-    });
-    expect(auditRecorded[2].metadata).toMatchObject({ role: 'work', branch: 'factory/issue-42' });
+    const reused = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
+    expect(reused.status).toBe(200);
+    expect((await reused.json()).workItem.id).toBe(item.id);
+    expect(auditRecorded.map(event => event.action)).toEqual(['factory.work_item.updated']);
+    expect(auditRecorded[0]?.metadata.fields).not.toContain('stages');
+    expect(auditRecorded[0]?.metadata.fields).not.toContain('sessions');
   });
 
-  it('records updated + stage_moved with the server-diffed from/to on a stage PATCH', async () => {
+  it('does not audit a rejected legacy stage PATCH as a movement', async () => {
     const item = await createItem();
     auditRecorded = [];
 
-    await json('PATCH', `/web/factory/work-items/${item.id}`, { stages: ['execute'] });
-    expect(auditRecorded.map(e => e.action)).toEqual(['factory.work_item.updated', 'factory.work_item.stage_moved']);
-    expect(auditRecorded[0].metadata).toEqual({ fields: ['stages'] });
-    expect(auditRecorded[1]).toMatchObject({
-      factoryProjectId: PROJECT_ID,
-      targets: [{ type: 'work_item', id: item.id, name: 'Fix the login flow' }],
-      metadata: { from: ['intake'], to: ['execute'] },
-    });
+    const rejected = await json('PATCH', `/web/factory/work-items/${item.id}`, { stages: ['execute'] });
+    expect(rejected.status).toBe(409);
+    expect(auditRecorded).toEqual([]);
   });
 
   it('records run.started when a PATCH introduces a new session role, but not on re-file', async () => {
@@ -605,8 +729,18 @@ describe('audit events', () => {
     expect(created.status).toBe(200);
     const { workItem } = await created.json();
 
-    const patched = await json('PATCH', `/web/factory/work-items/${workItem.id}`, { stages: ['done'] });
-    expect(patched.status).toBe(200);
+    const transitioned = await json(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/work-items/${workItem.id}/transition`,
+      {
+        board: 'work',
+        stage: 'done',
+        expectedRevision: workItem.revision,
+        requestId: 'audit-failure-transition',
+        cause: 'board_drag',
+      },
+    );
+    expect(transitioned.status).toBe(200);
 
     const deleted = await json('DELETE', `/web/factory/work-items/${workItem.id}`);
     expect(deleted.status).toBe(200);

--- a/mastracode/web/src/web/factory/routes.ts
+++ b/mastracode/web/src/web/factory/routes.ts
@@ -18,6 +18,12 @@ import { getFactoryProjectsStorage, getQueueHealthStorage } from '../storage/dom
 import { clampMetricsWindow, computeFactoryMetrics } from './metrics';
 import type { WorkItemRow } from '../storage/domains/work-items/base';
 import { thresholdsOrDefault } from '../storage/domains/queue-health/base';
+import { FactoryStartCoordinator } from './rules/start-coordinator';
+import type { FactoryStartRequest } from './rules/start-coordinator';
+import { FactoryTransitionService } from './rules/transition-service';
+import type { FactoryTransitionRequest } from './rules/transition-service';
+import { FACTORY_RULE_BOARDS, FACTORY_RULE_STAGES } from './rules/types';
+import type { FactoryRuleBoard, FactoryRuleStage } from './rules/types';
 import type { WorkItemPriorState } from './store';
 import {
   deleteWorkItem,
@@ -152,8 +158,110 @@ async function auditWorkItemPatch({
   }
 }
 
+interface FactoryRoutesOptions {
+  transitionService?: Pick<FactoryTransitionService, 'transition' | 'ruleSetVersion'>;
+  startCoordinator?: Pick<FactoryStartCoordinator, 'prepare'>;
+}
+
+function plainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function boundedText(value: unknown, max: number): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= max ? normalized : undefined;
+}
+
+function parseTransitionBody(
+  body: unknown,
+): Omit<FactoryTransitionRequest, 'orgId' | 'factoryProjectId' | 'workItemId' | 'actor'> | null {
+  if (!plainObject(body)) return null;
+  const board = FACTORY_RULE_BOARDS.includes(body.board as FactoryRuleBoard)
+    ? (body.board as FactoryRuleBoard)
+    : undefined;
+  const stage = FACTORY_RULE_STAGES.includes(body.stage as FactoryRuleStage)
+    ? (body.stage as FactoryRuleStage)
+    : undefined;
+  const requestId = boundedText(body.requestId, 256);
+  const cause = boundedText(body.cause, 256);
+  if (
+    !board ||
+    !stage ||
+    !requestId ||
+    !cause ||
+    !Number.isInteger(body.expectedRevision) ||
+    Number(body.expectedRevision) < 1
+  ) {
+    return null;
+  }
+  return {
+    board,
+    stage,
+    expectedRevision: Number(body.expectedRevision),
+    ingress: { type: 'human', identity: requestId },
+    cause,
+  };
+}
+
+function parseStartBody(
+  body: unknown,
+  tenant: { orgId: string; userId: string },
+  factoryProjectId: string,
+): FactoryStartRequest | null {
+  if (!plainObject(body) || !plainObject(body.workItem)) return null;
+  const input = parseCreateWorkItem(body.workItem.input);
+  const resourceId = boundedText(body.resourceId, 256);
+  const projectPath = boundedText(body.projectPath, 2_048);
+  const branch = boundedText(body.branch, 256);
+  const threadTitle = boundedText(body.threadTitle, 512);
+  const kickoffKey = boundedText(body.kickoffKey, 256);
+  const role = boundedText(body.workItem.role, 32);
+  const id = body.workItem.id === undefined ? undefined : boundedText(body.workItem.id, 64);
+  const kickoffMessage = body.kickoffMessage === null ? null : boundedText(body.kickoffMessage, 16_384);
+  if (
+    !input ||
+    !resourceId ||
+    !projectPath ||
+    !branch ||
+    !threadTitle ||
+    !kickoffKey ||
+    !role ||
+    kickoffMessage === undefined
+  ) {
+    return null;
+  }
+  if (id && !UUID_RE.test(id)) return null;
+  const threadTags = plainObject(body.threadTags)
+    ? Object.fromEntries(
+        Object.entries(body.threadTags)
+          .filter(
+            (entry): entry is [string, string] =>
+              boundedText(entry[0], 64) !== undefined && boundedText(entry[1], 256) !== undefined,
+          )
+          .map(([key, value]) => [key, value.trim()]),
+      )
+    : undefined;
+  return {
+    ...tenant,
+    factoryProjectId,
+    resourceId,
+    projectPath,
+    branch,
+    threadTitle,
+    threadTags,
+    kickoffKey,
+    kickoffMessage,
+    workItem: { id, role, input },
+  };
+}
+
 /** Build the Factory work-item routes as Mastra `apiRoutes`. */
-export function buildFactoryRoutes({ audit }: { audit: AuditEmitter }): ApiRoute[] {
+export function buildFactoryRoutes({
+  audit,
+  transitionService,
+  startCoordinator,
+}: { audit: AuditEmitter } & FactoryRoutesOptions): ApiRoute[] {
   return [
     // ── List the org's work items for a project ─────────────────────────────
     registerApiRoute('/web/factory/projects/:id/work-items', {
@@ -210,6 +318,12 @@ export function buildFactoryRoutes({ audit }: { audit: AuditEmitter }): ApiRoute
         if (body === undefined) return c.json({ error: 'Invalid JSON body' }, 400);
         const input = parseCreateWorkItem(body);
         if (!input) return c.json({ error: 'invalid_work_item' }, 400);
+        if ((input.stages ?? ['intake']).length !== 1 || (input.stages ?? ['intake'])[0] !== 'intake') {
+          return c.json(
+            { error: 'governed_transition_required', message: 'New work items must enter through Factory intake.' },
+            409,
+          );
+        }
 
         try {
           const result = await upsertWorkItem({
@@ -217,6 +331,7 @@ export function buildFactoryRoutes({ audit }: { audit: AuditEmitter }): ApiRoute
             userId: resolved.userId,
             factoryProjectId: resolved.factoryProjectId,
             input,
+            reuseMode: 'non-stage',
           });
           const item = result.item;
           if (result.created) {
@@ -230,12 +345,13 @@ export function buildFactoryRoutes({ audit }: { audit: AuditEmitter }): ApiRoute
               },
             });
           } else {
+            const { stages: _stages, sessions: _sessions, ...boundedPatch } = input;
             await auditWorkItemPatch({
               audit,
               context: loose(c),
               item,
               previous: result.previous,
-              patch: input as unknown as Record<string, unknown>,
+              patch: boundedPatch as unknown as Record<string, unknown>,
             });
           }
           return c.json({ workItem: item });
@@ -248,7 +364,94 @@ export function buildFactoryRoutes({ audit }: { audit: AuditEmitter }): ApiRoute
       },
     }),
 
-    // ── Patch stages / sessions / metadata / title ───────────────────────────
+    // ── Authoritative stage transition ──────────────────────────────────────
+    registerApiRoute('/web/factory/projects/:id/work-items/:workItemId/transition', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        const resolved = await resolveProject(loose(c));
+        if ('response' in resolved) return resolved.response;
+        const workItemId = loose(c).req.param('workItemId');
+        if (!workItemId || !UUID_RE.test(workItemId)) return c.json({ error: 'Work item not found' }, 404);
+        const parsed = parseTransitionBody(await readJson(loose(c)));
+        if (!parsed) return c.json({ error: 'invalid_transition_request' }, 400);
+        const service = transitionService ?? new FactoryTransitionService();
+        const result = await service.transition({
+          ...parsed,
+          orgId: resolved.orgId,
+          factoryProjectId: resolved.factoryProjectId,
+          workItemId,
+          actor: { type: 'human', id: resolved.userId },
+          ingress: {
+            ...parsed.ingress,
+            identity: `human:${resolved.userId}:${parsed.ingress.identity}`,
+          },
+        });
+        await audit.emit({
+          context: loose(c),
+          input: {
+            action:
+              result.status === 'accepted' ? 'factory.work_item.stage_moved' : 'factory.work_item.transition_rejected',
+            factoryProjectId: resolved.factoryProjectId,
+            targets: [{ type: 'work_item', id: workItemId }],
+            metadata: {
+              transitionId: result.transitionId,
+              ingressType: parsed.ingress.type,
+              ruleSetVersion: service.ruleSetVersion,
+              ...(result.status === 'accepted'
+                ? { to: result.stage, revision: result.revision }
+                : { code: result.code, reason: result.reason }),
+            },
+          },
+        });
+        if (result.status === 'accepted') return c.json({ result });
+        return c.json({ result }, result.code === 'stale' ? 409 : 422);
+      },
+    }),
+
+    // ── Bind a Factory run before dispatching its kickoff ────────────────────
+    registerApiRoute('/web/factory/projects/:id/runs/start', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        const resolved = await resolveProject(loose(c));
+        if ('response' in resolved) return resolved.response;
+        if (!startCoordinator) {
+          return c.json({ error: 'factory_start_unavailable' }, 503);
+        }
+        const input = parseStartBody(await readJson(loose(c)), resolved, resolved.factoryProjectId);
+        if (!input) return c.json({ error: 'invalid_factory_start' }, 400);
+        if (
+          !input.workItem.id &&
+          ((input.workItem.input.stages ?? ['intake']).length !== 1 ||
+            (input.workItem.input.stages ?? ['intake'])[0] !== 'intake')
+        ) {
+          return c.json(
+            { error: 'governed_transition_required', message: 'Create the work item in Intake before starting it.' },
+            409,
+          );
+        }
+        const prepared = await startCoordinator.prepare(input);
+        await audit.emit({
+          context: loose(c),
+          input: {
+            action: 'factory.run.started',
+            factoryProjectId: resolved.factoryProjectId,
+            targets: [{ type: 'work_item', id: prepared.workItemId }],
+            metadata: {
+              role: input.workItem.role,
+              branch: prepared.branch,
+              threadId: prepared.threadId,
+              projectPath: prepared.projectPath,
+              bindingId: prepared.bindingId,
+            },
+          },
+        });
+        return c.json({ prepared }, 202);
+      },
+    }),
+
+    // ── Patch non-stage metadata / sessions / title ──────────────────────────
     registerApiRoute('/web/factory/work-items/:id', {
       method: 'PATCH',
       requiresAuth: false,
@@ -263,6 +466,12 @@ export function buildFactoryRoutes({ audit }: { audit: AuditEmitter }): ApiRoute
         if (body === undefined) return c.json({ error: 'Invalid JSON body' }, 400);
         const patch = parseUpdateWorkItem(body);
         if (!patch) return c.json({ error: 'invalid_work_item_patch' }, 400);
+        if (patch.stages !== undefined) {
+          return c.json(
+            { error: 'governed_transition_required', message: 'Use the Factory transition endpoint to move stages.' },
+            409,
+          );
+        }
 
         try {
           const updated = await updateWorkItem({ orgId: tenant.orgId, id, userId: tenant.userId, patch });

--- a/mastracode/web/src/web/factory/routes.ts
+++ b/mastracode/web/src/web/factory/routes.ts
@@ -223,6 +223,7 @@ function parseStartBody(
   const role = boundedText(body.workItem.role, 32);
   const id = body.workItem.id === undefined ? undefined : boundedText(body.workItem.id, 64);
   const kickoffMessage = body.kickoffMessage === null ? null : boundedText(body.kickoffMessage, 16_384);
+  if (body.workItem.id !== undefined && (!id || !UUID_RE.test(id))) return null;
   if (
     !input ||
     !resourceId ||
@@ -237,7 +238,6 @@ function parseStartBody(
   ) {
     return null;
   }
-  if (id && !UUID_RE.test(id)) return null;
   const threadTags = plainObject(body.threadTags)
     ? Object.fromEntries(
         Object.entries(body.threadTags)

--- a/mastracode/web/src/web/factory/routes.ts
+++ b/mastracode/web/src/web/factory/routes.ts
@@ -18,8 +18,8 @@ import { getFactoryProjectsStorage, getQueueHealthStorage } from '../storage/dom
 import { clampMetricsWindow, computeFactoryMetrics } from './metrics';
 import type { WorkItemRow } from '../storage/domains/work-items/base';
 import { thresholdsOrDefault } from '../storage/domains/queue-health/base';
-import { FactoryStartCoordinator } from './rules/start-coordinator';
-import type { FactoryStartRequest } from './rules/start-coordinator';
+import { FactoryStartCoordinator, FactoryStartTransitionError } from './rules/start-coordinator';
+import type { FactoryStartPreparedResult, FactoryStartRequest } from './rules/start-coordinator';
 import { FactoryTransitionService } from './rules/transition-service';
 import type { FactoryTransitionRequest } from './rules/transition-service';
 import { FACTORY_RULE_BOARDS, FACTORY_RULE_STAGES } from './rules/types';
@@ -189,6 +189,7 @@ function parseTransitionBody(
     !board ||
     !stage ||
     !requestId ||
+    !UUID_RE.test(requestId) ||
     !cause ||
     !Number.isInteger(body.expectedRevision) ||
     Number(body.expectedRevision) < 1
@@ -216,6 +217,9 @@ function parseStartBody(
   const branch = boundedText(body.branch, 256);
   const threadTitle = boundedText(body.threadTitle, 512);
   const kickoffKey = boundedText(body.kickoffKey, 256);
+  const destinationStage = FACTORY_RULE_STAGES.includes(body.destinationStage as FactoryRuleStage)
+    ? (body.destinationStage as FactoryRuleStage)
+    : undefined;
   const role = boundedText(body.workItem.role, 32);
   const id = body.workItem.id === undefined ? undefined : boundedText(body.workItem.id, 64);
   const kickoffMessage = body.kickoffMessage === null ? null : boundedText(body.kickoffMessage, 16_384);
@@ -226,6 +230,8 @@ function parseStartBody(
     !branch ||
     !threadTitle ||
     !kickoffKey ||
+    !UUID_RE.test(kickoffKey) ||
+    !destinationStage ||
     !role ||
     kickoffMessage === undefined
   ) {
@@ -252,6 +258,7 @@ function parseStartBody(
     threadTags,
     kickoffKey,
     kickoffMessage,
+    destinationStage,
     workItem: { id, role, input },
   };
 }
@@ -431,7 +438,15 @@ export function buildFactoryRoutes({
             409,
           );
         }
-        const prepared = await startCoordinator.prepare(input);
+        let prepared: FactoryStartPreparedResult;
+        try {
+          prepared = await startCoordinator.prepare(input);
+        } catch (error) {
+          if (error instanceof FactoryStartTransitionError) {
+            return c.json({ result: error.result }, error.result.code === 'stale' ? 409 : 422);
+          }
+          throw error;
+        }
         await audit.emit({
           context: loose(c),
           input: {

--- a/mastracode/web/src/web/factory/rules/defaults.test.ts
+++ b/mastracode/web/src/web/factory/rules/defaults.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defaultFactoryRules, mergeFactoryRuleOverrides } from './defaults.js';
+import type { FactoryBoardRuleLeaf, FactoryRulesOverrides } from './types.js';
+
+const passThrough = vi.fn(() => undefined);
+
+function reject() {
+  return { type: 'reject', code: 'forbidden', reason: 'Not allowed.' } as const;
+}
+
+describe('defaultFactoryRules', () => {
+  it('requires an explicit deployment version', () => {
+    expect(() => defaultFactoryRules({ version: '' })).toThrow(/version is required/i);
+  });
+
+  it('returns one rules tree with pass-through defaults', () => {
+    expect(defaultFactoryRules({ version: 'deployment-7' })).toEqual({
+      version: 'deployment-7',
+      work: {},
+      review: {},
+      tools: {},
+      github: {},
+    });
+  });
+
+  it('replaces exact handler leaves while preserving siblings', () => {
+    const workEnter = vi.fn(reject);
+    const workExit = vi.fn(() => undefined);
+    const reviewEnter = vi.fn(() => undefined);
+    const toolResult = vi.fn(() => undefined);
+    const githubEvent = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'deployment-8',
+      overrides: {
+        work: { planning: { issue: { onEnter: workEnter, onExit: workExit } } },
+        review: { intake: { pullRequest: { onEnter: reviewEnter } } },
+        tools: { submit_plan: { onResult: toolResult } },
+        github: { pullRequestMerged: { onEvent: githubEvent } },
+      },
+    });
+
+    expect(rules.work.planning?.issue?.onEnter).toBe(workEnter);
+    expect(rules.work.planning?.issue?.onExit).toBe(workExit);
+    expect(rules.review.intake?.pullRequest?.onEnter).toBe(reviewEnter);
+    expect(rules.tools.submit_plan?.onResult).toBe(toolResult);
+    expect(rules.github.pullRequestMerged?.onEvent).toBe(githubEvent);
+    expect(rules.work.planning?.pullRequest).toBeUndefined();
+  });
+
+  it('merges defaults and overrides at each exact handler leaf', () => {
+    const defaultEnter = vi.fn(() => undefined);
+    const defaultExit = vi.fn(() => undefined);
+    const overrideEnter = vi.fn(reject);
+    const unrelatedDefault = vi.fn(() => undefined);
+    const merged = mergeFactoryRuleOverrides(
+      {
+        work: {
+          planning: {
+            issue: { onEnter: defaultEnter, onExit: defaultExit },
+            manual: { onEnter: unrelatedDefault },
+          },
+        },
+      },
+      { work: { planning: { issue: { onEnter: overrideEnter } } } },
+    );
+
+    expect(merged.work.planning?.issue).toEqual({ onEnter: overrideEnter, onExit: defaultExit });
+    expect(merged.work.planning?.manual?.onEnter).toBe(unrelatedDefault);
+  });
+
+  it('copies override containers so later mutation cannot replace configured leaves', () => {
+    const leaf: FactoryBoardRuleLeaf = { onEnter: passThrough };
+    const overrides: FactoryRulesOverrides = { work: { intake: { issue: leaf } } };
+    const rules = defaultFactoryRules({ version: 'deployment-9', overrides });
+    leaf.onEnter = vi.fn(reject);
+    expect(rules.work.intake?.issue?.onEnter).toBe(passThrough);
+  });
+});

--- a/mastracode/web/src/web/factory/rules/defaults.ts
+++ b/mastracode/web/src/web/factory/rules/defaults.ts
@@ -1,0 +1,107 @@
+import { assertFactoryRules, FactoryRuleValidationError } from './validation.js';
+import type {
+  FactoryBoardRuleLeaf,
+  FactoryBoardRules,
+  FactoryGithubRuleLeaf,
+  FactoryGithubEventName,
+  FactoryRules,
+  FactoryRulesOverrides,
+  FactoryRuleSource,
+  FactoryRuleStage,
+  FactoryToolRuleLeaf,
+} from './types.js';
+
+export const DEFAULT_FACTORY_RULE_VERSION = 'factory-default-v1';
+
+const PASS_THROUGH_DEFAULTS: FactoryRulesOverrides = {};
+
+function mergeBoardRules(
+  base: FactoryBoardRules | undefined,
+  overrides: FactoryBoardRules | undefined,
+): FactoryBoardRules {
+  const result: FactoryBoardRules = {};
+  const stages = new Set([...Object.keys(base ?? {}), ...Object.keys(overrides ?? {})]) as Set<FactoryRuleStage>;
+  for (const stage of stages) {
+    const baseSources = base?.[stage];
+    const overrideSources = overrides?.[stage];
+    const sources = new Set([
+      ...Object.keys(baseSources ?? {}),
+      ...Object.keys(overrideSources ?? {}),
+    ]) as Set<FactoryRuleSource>;
+    const mergedSources: Partial<Record<FactoryRuleSource, FactoryBoardRuleLeaf>> = {};
+    for (const source of sources) {
+      const baseLeaf = baseSources?.[source];
+      const overrideLeaf = overrideSources?.[source];
+      mergedSources[source] = {
+        ...(baseLeaf?.onEnter ? { onEnter: baseLeaf.onEnter } : {}),
+        ...(baseLeaf?.onExit ? { onExit: baseLeaf.onExit } : {}),
+        ...(overrideLeaf && 'onEnter' in overrideLeaf ? { onEnter: overrideLeaf.onEnter } : {}),
+        ...(overrideLeaf && 'onExit' in overrideLeaf ? { onExit: overrideLeaf.onExit } : {}),
+      };
+    }
+    result[stage] = mergedSources;
+  }
+  return result;
+}
+
+function mergeToolRules(
+  base: Record<string, FactoryToolRuleLeaf> | undefined,
+  overrides: Record<string, FactoryToolRuleLeaf> | undefined,
+): Record<string, FactoryToolRuleLeaf> {
+  const result: Record<string, FactoryToolRuleLeaf> = {};
+  for (const name of new Set([...Object.keys(base ?? {}), ...Object.keys(overrides ?? {})])) {
+    const baseLeaf = base?.[name];
+    const overrideLeaf = overrides?.[name];
+    result[name] = {
+      ...(baseLeaf?.onResult ? { onResult: baseLeaf.onResult } : {}),
+      ...(overrideLeaf && 'onResult' in overrideLeaf ? { onResult: overrideLeaf.onResult } : {}),
+    };
+  }
+  return result;
+}
+
+function mergeGithubRules(
+  base: FactoryRulesOverrides['github'],
+  overrides: FactoryRulesOverrides['github'],
+): NonNullable<FactoryRulesOverrides['github']> {
+  const result: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>> = {};
+  const events = new Set([...Object.keys(base ?? {}), ...Object.keys(overrides ?? {})]) as Set<FactoryGithubEventName>;
+  for (const event of events) {
+    const baseLeaf = base?.[event];
+    const overrideLeaf = overrides?.[event];
+    result[event] = {
+      ...(baseLeaf?.onEvent ? { onEvent: baseLeaf.onEvent } : {}),
+      ...(overrideLeaf && 'onEvent' in overrideLeaf ? { onEvent: overrideLeaf.onEvent } : {}),
+    };
+  }
+  return result;
+}
+
+export function mergeFactoryRuleOverrides(
+  base: FactoryRulesOverrides,
+  overrides: FactoryRulesOverrides = {},
+): Omit<FactoryRules, 'version'> {
+  return {
+    work: mergeBoardRules(base.work, overrides.work),
+    review: mergeBoardRules(base.review, overrides.review),
+    tools: mergeToolRules(base.tools, overrides.tools),
+    github: mergeGithubRules(base.github, overrides.github),
+  };
+}
+
+export function defaultFactoryRules(input: { version: string; overrides?: FactoryRulesOverrides }): FactoryRules {
+  if (typeof input?.version !== 'string' || input.version.trim().length === 0) {
+    throw new FactoryRuleValidationError('Factory rule version is required.');
+  }
+
+  const rules: FactoryRules = {
+    version: input.version.trim(),
+    ...mergeFactoryRuleOverrides(PASS_THROUGH_DEFAULTS, input.overrides),
+  };
+  assertFactoryRules(rules);
+  return rules;
+}
+
+export function builtInFactoryRules(): FactoryRules {
+  return defaultFactoryRules({ version: DEFAULT_FACTORY_RULE_VERSION });
+}

--- a/mastracode/web/src/web/factory/rules/index.ts
+++ b/mastracode/web/src/web/factory/rules/index.ts
@@ -1,0 +1,52 @@
+export { builtInFactoryRules, defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './defaults.js';
+export { resolveFactoryGithubRule, resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
+export type { ResolvedFactoryStageRule, ResolvedFactoryToolRule } from './resolve.js';
+export {
+  FACTORY_GITHUB_EVENTS,
+  FACTORY_RULE_BOARDS,
+  FACTORY_RULE_SOURCES,
+  FACTORY_RULE_STAGES,
+  factoryRuleSourceForWorkItem,
+} from './types.js';
+export type {
+  FactoryBoardRuleLeaf,
+  FactoryBoardRules,
+  FactoryBoundRuleContext,
+  FactoryCommitDecision,
+  FactoryGithubEventName,
+  FactoryGithubRuleContext,
+  FactoryGithubRuleLeaf,
+  FactoryInvokeSkillDecision,
+  FactoryNotifyDecision,
+  FactoryRuleActor,
+  FactoryRuleBoard,
+  FactoryRuleCausalEntry,
+  FactoryRuleContextBase,
+  FactoryRuleDecision,
+  FactoryRuleHandler,
+  FactoryRuleIngressIdentity,
+  FactoryRuleItemContext,
+  FactoryRuleJsonValue,
+  FactoryRuleRejectionCode,
+  FactoryRuleRejectDecision,
+  FactoryRuleSource,
+  FactoryRules,
+  FactoryRulesOverrides,
+  FactoryRuleStage,
+  FactorySendMessageDecision,
+  FactoryStageRuleContext,
+  FactoryToolResultRuleContext,
+  FactoryToolRuleLeaf,
+  FactoryTransitionDecision,
+  FactoryTransitionResult,
+  FactoryTransitionResultAccepted,
+  FactoryTransitionResultRejected,
+  FactoryUpsertLinkedWorkItemDecision,
+} from './types.js';
+export {
+  assertFactoryRules,
+  FactoryRuleValidationError,
+  MAX_FACTORY_RULE_CAUSAL_DEPTH,
+  validateFactoryRuleDecision,
+  validateFactoryRuleDecisions,
+} from './validation.js';

--- a/mastracode/web/src/web/factory/rules/resolve.test.ts
+++ b/mastracode/web/src/web/factory/rules/resolve.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from 'vitest';
+import { defaultFactoryRules } from './defaults.js';
+import { resolveFactoryGithubRule, resolveFactoryStageRules, resolveFactoryToolRule } from './resolve.js';
+
+describe('Factory rule resolution', () => {
+  it('resolves a board stage transition in exit-before-enter order', () => {
+    const onExit = vi.fn(() => undefined);
+    const onEnter = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'resolve-v1',
+      overrides: {
+        work: {
+          planning: { issue: { onExit } },
+          execute: { issue: { onEnter } },
+        },
+      },
+    });
+
+    expect(
+      resolveFactoryStageRules(rules, {
+        board: 'work',
+        source: 'issue',
+        fromStage: 'planning',
+        toStage: 'execute',
+      }),
+    ).toEqual([
+      { phase: 'exit', handler: onExit },
+      { phase: 'enter', handler: onEnter },
+    ]);
+  });
+
+  it('matches board and source exactly and skips unchanged stages', () => {
+    const reviewEnter = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'resolve-v2',
+      overrides: { review: { review: { pullRequest: { onEnter: reviewEnter } } } },
+    });
+
+    expect(
+      resolveFactoryStageRules(rules, {
+        board: 'work',
+        source: 'pullRequest',
+        fromStage: 'intake',
+        toStage: 'review',
+      }),
+    ).toEqual([]);
+    expect(
+      resolveFactoryStageRules(rules, {
+        board: 'review',
+        source: 'issue',
+        fromStage: 'intake',
+        toStage: 'review',
+      }),
+    ).toEqual([]);
+    expect(
+      resolveFactoryStageRules(rules, {
+        board: 'review',
+        source: 'pullRequest',
+        fromStage: 'review',
+        toStage: 'review',
+      }),
+    ).toEqual([]);
+  });
+
+  it('resolves open tool names and closed GitHub event leaves', () => {
+    const onResult = vi.fn(() => undefined);
+    const onEvent = vi.fn(() => undefined);
+    const rules = defaultFactoryRules({
+      version: 'resolve-v3',
+      overrides: {
+        tools: { submit_plan: { onResult } },
+        github: { pullRequestMerged: { onEvent } },
+      },
+    });
+
+    expect(resolveFactoryToolRule(rules, 'submit_plan')).toBe(onResult);
+    expect(resolveFactoryToolRule(rules, 'unknown_tool')).toBeUndefined();
+    expect(resolveFactoryGithubRule(rules, 'pullRequestMerged')).toBe(onEvent);
+    expect(resolveFactoryGithubRule(rules, 'issueOpened')).toBeUndefined();
+  });
+});

--- a/mastracode/web/src/web/factory/rules/resolve.ts
+++ b/mastracode/web/src/web/factory/rules/resolve.ts
@@ -1,0 +1,49 @@
+import type {
+  FactoryGithubEventName,
+  FactoryGithubRuleLeaf,
+  FactoryRuleBoard,
+  FactoryRuleHandler,
+  FactoryRuleSource,
+  FactoryRuleStage,
+  FactoryRules,
+  FactoryStageRuleContext,
+  FactoryToolResultRuleContext,
+  FactoryToolRuleLeaf,
+} from './types.js';
+
+export interface ResolvedFactoryStageRule {
+  phase: 'exit' | 'enter';
+  handler: FactoryRuleHandler<FactoryStageRuleContext>;
+}
+
+export function resolveFactoryStageRules(
+  rules: FactoryRules,
+  input: {
+    board: FactoryRuleBoard;
+    source: FactoryRuleSource;
+    fromStage: FactoryRuleStage;
+    toStage: FactoryRuleStage;
+  },
+): ResolvedFactoryStageRule[] {
+  if (input.fromStage === input.toStage) return [];
+  const boardRules = rules[input.board];
+  const resolved: ResolvedFactoryStageRule[] = [];
+  const onExit = boardRules[input.fromStage]?.[input.source]?.onExit;
+  if (onExit) resolved.push({ phase: 'exit', handler: onExit });
+  const onEnter = boardRules[input.toStage]?.[input.source]?.onEnter;
+  if (onEnter) resolved.push({ phase: 'enter', handler: onEnter });
+  return resolved;
+}
+
+export function resolveFactoryToolRule(rules: FactoryRules, toolName: string): FactoryToolRuleLeaf['onResult'] {
+  return rules.tools[toolName]?.onResult;
+}
+
+export function resolveFactoryGithubRule(
+  rules: FactoryRules,
+  event: FactoryGithubEventName,
+): FactoryGithubRuleLeaf['onEvent'] {
+  return rules.github[event]?.onEvent;
+}
+
+export type ResolvedFactoryToolRule = FactoryRuleHandler<FactoryToolResultRuleContext>;

--- a/mastracode/web/src/web/factory/rules/start-coordinator.test.ts
+++ b/mastracode/web/src/web/factory/rules/start-coordinator.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { seedFactoryStorageForTests } from '../../storage/test-utils';
+import { defaultFactoryRules } from './defaults';
 import { FactoryStartCoordinator } from './start-coordinator';
+import { FactoryTransitionService } from './transition-service';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
 
@@ -46,6 +48,7 @@ function startRequest(
     threadTags: { role: overrides.role ?? 'work' },
     kickoffKey: overrides.kickoffKey ?? 'kickoff-1',
     kickoffMessage: overrides.kickoffMessage === undefined ? 'Start work' : overrides.kickoffMessage,
+    destinationStage: 'intake' as const,
     workItem: {
       id: overrides.id,
       role: overrides.role ?? 'work',
@@ -110,6 +113,37 @@ describe('FactoryStartCoordinator', () => {
     });
   });
 
+  it('binds before requesting the governed run-stage transition', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    let bindingsDuringRule = 0;
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: {
+            execute: {
+              issue: {
+                onEnter: async () => {
+                  bindingsDuringRule = (await storage.listRunBindings('org-1', PROJECT_ID)).length;
+                },
+              },
+            },
+          },
+        },
+      }),
+    });
+    const { controller, sendMessage } = makeController();
+    const coordinator = new FactoryStartCoordinator(controller as never, storage, transitionService);
+
+    const prepared = await coordinator.prepare({ ...startRequest(), destinationStage: 'execute' });
+
+    expect(prepared.revision).toBe(2);
+    expect((await storage.get({ orgId: 'org-1', id: prepared.workItemId }))?.stages).toEqual(['execute']);
+    expect(bindingsDuringRule).toBe(1);
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+  });
+
   it('reuses the newest server-resolved tagged thread instead of creating one in the browser', async () => {
     const storage = (await seedFactoryStorageForTests()).workItems;
     const { controller, session } = makeController(
@@ -126,6 +160,29 @@ describe('FactoryStartCoordinator', () => {
     expect(prepared.threadId).toBe('thread-new');
     expect(session.thread.switch).toHaveBeenCalledWith({ threadId: 'thread-new' });
     expect(session.thread.create).not.toHaveBeenCalled();
+  });
+
+  it('keeps the bound pending start recoverable and sends nothing when the governed transition rejects', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: { execute: { issue: { onEnter: () => ({ type: 'reject', code: 'forbidden', reason: 'Blocked' }) } } },
+        },
+      }),
+    });
+    const { controller, sendMessage } = makeController();
+    const coordinator = new FactoryStartCoordinator(controller as never, storage, transitionService);
+
+    await expect(coordinator.prepare({ ...startRequest(), destinationStage: 'execute' })).rejects.toMatchObject({
+      result: { status: 'rejected', code: 'forbidden' },
+    });
+
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(await storage.listRunBindings('org-1', PROJECT_ID)).toHaveLength(1);
+    expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]).toMatchObject({ status: 'failed' });
   });
 
   it('never sends a kickoff when the binding transaction fails', async () => {

--- a/mastracode/web/src/web/factory/rules/start-coordinator.test.ts
+++ b/mastracode/web/src/web/factory/rules/start-coordinator.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { seedFactoryStorageForTests } from '../../storage/test-utils';
+import { FactoryStartCoordinator } from './start-coordinator';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+
+function makeController(sendMessage = vi.fn(async () => {}), threads: Array<{ id: string; updatedAt: Date }> = []) {
+  let threadId: string | undefined;
+  const session = {
+    thread: {
+      list: vi.fn(async () => threads),
+      switch: vi.fn(async ({ threadId: id }: { threadId: string }) => {
+        threadId = id;
+      }),
+      create: vi.fn(async () => {
+        threadId = 'thread-1';
+        return { id: threadId };
+      }),
+      setSetting: vi.fn(async () => {}),
+      requireId: vi.fn(() => {
+        if (!threadId) throw new Error('missing thread');
+        return threadId;
+      }),
+    },
+    sendMessage,
+  };
+  return {
+    controller: { createSession: vi.fn(async () => session) },
+    session,
+    sendMessage,
+  };
+}
+
+function startRequest(
+  overrides: Partial<{ kickoffKey: string; role: string; kickoffMessage: string | null; id: string }> = {},
+) {
+  return {
+    orgId: 'org-1',
+    userId: 'user-1',
+    factoryProjectId: PROJECT_ID,
+    resourceId: 'resource-1',
+    projectPath: '/worktrees/issue-1',
+    branch: 'factory/issue-1',
+    threadTitle: 'Investigate issue 1',
+    threadTags: { role: overrides.role ?? 'work' },
+    kickoffKey: overrides.kickoffKey ?? 'kickoff-1',
+    kickoffMessage: overrides.kickoffMessage === undefined ? 'Start work' : overrides.kickoffMessage,
+    workItem: {
+      id: overrides.id,
+      role: overrides.role ?? 'work',
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue' as const,
+          externalId: '1',
+        },
+        title: 'Fix issue 1',
+        stages: ['intake'],
+        sessions: {},
+        metadata: {},
+      },
+    },
+  };
+}
+
+async function eventually(assertion: () => Promise<void>): Promise<void> {
+  let failure: unknown;
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    try {
+      await assertion();
+      return;
+    } catch (error) {
+      failure = error;
+      await new Promise(resolve => setTimeout(resolve, 0));
+    }
+  }
+  throw failure;
+}
+
+describe('FactoryStartCoordinator', () => {
+  it('commits the item session, exact binding, and pending start before kickoff', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    let bindingsAtSend = 0;
+    let pendingAtSend = 0;
+    const sendMessage = vi.fn(async () => {
+      bindingsAtSend = (await storage.listRunBindings('org-1', PROJECT_ID)).length;
+      pendingAtSend = (await storage.listPendingStarts('org-1', PROJECT_ID)).length;
+    });
+    const { controller } = makeController(sendMessage);
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+
+    const prepared = await coordinator.prepare(startRequest());
+
+    expect(prepared).toMatchObject({
+      threadId: 'thread-1',
+      kickoffStatus: 'pending',
+      replayed: false,
+    });
+    await eventually(async () =>
+      expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent'),
+    );
+    expect(bindingsAtSend).toBe(1);
+    expect(pendingAtSend).toBe(1);
+    const item = await storage.get({ orgId: 'org-1', id: prepared.workItemId });
+    expect(item?.sessions.work).toMatchObject({
+      threadId: 'thread-1',
+      projectPath: '/worktrees/issue-1',
+      startedBy: 'user-1',
+    });
+  });
+
+  it('reuses the newest server-resolved tagged thread instead of creating one in the browser', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController(
+      vi.fn(async () => {}),
+      [
+        { id: 'thread-old', updatedAt: new Date('2026-01-01T00:00:00Z') },
+        { id: 'thread-new', updatedAt: new Date('2026-02-01T00:00:00Z') },
+      ],
+    );
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+
+    const prepared = await coordinator.prepare(startRequest({ kickoffMessage: null }));
+
+    expect(prepared.threadId).toBe('thread-new');
+    expect(session.thread.switch).toHaveBeenCalledWith({ threadId: 'thread-new' });
+    expect(session.thread.create).not.toHaveBeenCalled();
+  });
+
+  it('never sends a kickoff when the binding transaction fails', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    vi.spyOn(storage, 'prepareRunStart').mockRejectedValueOnce(new Error('commit failed'));
+    const { controller, sendMessage } = makeController();
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+
+    await expect(coordinator.prepare(startRequest())).rejects.toThrow('commit failed');
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('persists post-commit send failure and retries idempotently against the same binding', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const sendMessage = vi
+      .fn<() => Promise<void>>()
+      .mockRejectedValueOnce(new Error('model unavailable'))
+      .mockResolvedValueOnce();
+    const { controller } = makeController(sendMessage);
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+    const input = startRequest();
+
+    const first = await coordinator.prepare(input);
+    await eventually(async () => {
+      const [pending] = await storage.listPendingStarts('org-1', PROJECT_ID);
+      expect(pending).toMatchObject({ status: 'failed', lastError: 'model unavailable' });
+    });
+
+    const replay = await coordinator.prepare(input);
+    expect(replay).toMatchObject({ workItemId: first.workItemId, bindingId: first.bindingId, replayed: true });
+    await eventually(async () =>
+      expect((await storage.listPendingStarts('org-1', PROJECT_ID))[0]?.status).toBe('sent'),
+    );
+    expect(sendMessage).toHaveBeenCalledTimes(2);
+    expect(await storage.listRunBindings('org-1', PROJECT_ID)).toHaveLength(1);
+  });
+
+  it('revokes only the prior binding for the same item role', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+    const first = await coordinator.prepare(startRequest({ kickoffMessage: null }));
+
+    await coordinator.prepare(
+      startRequest({ id: first.workItemId, kickoffKey: 'kickoff-2', role: 'work', kickoffMessage: null }),
+    );
+    const bindings = await storage.listRunBindings('org-1', PROJECT_ID, first.workItemId);
+    expect(bindings.map(binding => binding.status).sort()).toEqual(['active', 'revoked']);
+    expect(bindings.every(binding => binding.role === 'work')).toBe(true);
+  });
+
+  it('scopes kickoff idempotency to tenant and project', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const { controller } = makeController();
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+    const first = await coordinator.prepare(startRequest({ kickoffMessage: null }));
+    const second = await coordinator.prepare({
+      ...startRequest({ kickoffMessage: null }),
+      orgId: 'org-2',
+      workItem: {
+        ...startRequest().workItem,
+        input: {
+          ...startRequest().workItem.input,
+          externalSource: { integrationId: 'github', type: 'issue' as const, externalId: '2' },
+        },
+      },
+    });
+
+    expect(second.replayed).toBe(false);
+    expect(second.workItemId).not.toBe(first.workItemId);
+    expect(await storage.listPendingStarts('org-1', PROJECT_ID)).toHaveLength(1);
+    expect(await storage.listPendingStarts('org-2', PROJECT_ID)).toHaveLength(1);
+  });
+});

--- a/mastracode/web/src/web/factory/rules/start-coordinator.test.ts
+++ b/mastracode/web/src/web/factory/rules/start-coordinator.test.ts
@@ -158,8 +158,30 @@ describe('FactoryStartCoordinator', () => {
     const prepared = await coordinator.prepare(startRequest({ kickoffMessage: null }));
 
     expect(prepared.threadId).toBe('thread-new');
+    expect(session.thread.list).toHaveBeenCalledWith({ metadata: { projectPath: '/worktrees/issue-1' } });
     expect(session.thread.switch).toHaveBeenCalledWith({ threadId: 'thread-new' });
     expect(session.thread.create).not.toHaveBeenCalled();
+  });
+
+  it('reuses one work-item thread across roles and converges every session ref', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController();
+    const coordinator = new FactoryStartCoordinator(controller as never, storage);
+
+    const triage = await coordinator.prepare(
+      startRequest({ role: 'triage', kickoffKey: 'triage-1', kickoffMessage: null }),
+    );
+    const plan = await coordinator.prepare(
+      startRequest({ id: triage.workItemId, role: 'plan', kickoffKey: 'plan-1', kickoffMessage: null }),
+    );
+
+    expect(plan.threadId).toBe(triage.threadId);
+    expect(session.thread.create).toHaveBeenCalledTimes(1);
+    expect(session.thread.switch).toHaveBeenCalledWith({ threadId: triage.threadId });
+    expect(session.thread.setSetting).toHaveBeenCalledWith({ key: 'factoryWorkItemId', value: triage.workItemId });
+    const item = await storage.get({ orgId: 'org-1', id: triage.workItemId });
+    expect(item?.sessions.triage?.threadId).toBe(triage.threadId);
+    expect(item?.sessions.plan?.threadId).toBe(triage.threadId);
   });
 
   it('keeps the bound pending start recoverable and sends nothing when the governed transition rejects', async () => {

--- a/mastracode/web/src/web/factory/rules/start-coordinator.ts
+++ b/mastracode/web/src/web/factory/rules/start-coordinator.ts
@@ -1,0 +1,129 @@
+import type { AgentController } from '@mastra/core/agent-controller';
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+
+import type { CreateWorkItemInput, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
+import { getFactoryStorage } from '../../runtime-config.js';
+
+const MAX_KICKOFF_ERROR_LENGTH = 512;
+
+export interface FactoryStartRequest {
+  orgId: string;
+  userId: string;
+  factoryProjectId: string;
+  resourceId: string;
+  projectPath: string;
+  branch: string;
+  threadTitle: string;
+  threadTags?: Record<string, string>;
+  kickoffKey: string;
+  kickoffMessage: string | null;
+  workItem: {
+    id?: string;
+    role: string;
+    input: CreateWorkItemInput;
+  };
+}
+
+export interface FactoryStartPreparedResult {
+  workItemId: string;
+  bindingId: string;
+  threadId: string;
+  resourceId: string;
+  projectPath: string;
+  branch: string;
+  revision: number;
+  kickoffStatus: 'pending' | 'sent' | 'failed';
+  replayed: boolean;
+}
+
+type FactoryController = AgentController<MastraCodeState>;
+type ScopedSession = Awaited<ReturnType<FactoryController['createSession']>>;
+
+type CreateSessionWithScope = (input: {
+  id: string;
+  ownerId: string;
+  resourceId: string;
+  scope: string;
+  tags: Record<string, string>;
+}) => ReturnType<FactoryController['createSession']>;
+
+function createScopedSession(
+  controller: FactoryController,
+  request: FactoryStartRequest,
+): ReturnType<CreateSessionWithScope> {
+  return (controller.createSession as CreateSessionWithScope)({
+    id: request.projectPath,
+    ownerId: request.userId,
+    resourceId: request.resourceId,
+    scope: request.projectPath,
+    tags: { projectPath: request.projectPath },
+  });
+}
+
+async function resolveThread(session: ScopedSession, request: FactoryStartRequest): Promise<string> {
+  const tags = {
+    projectPath: request.projectPath,
+    factoryWorkItemRole: request.workItem.role,
+    ...(request.threadTags ?? {}),
+  };
+  const matching = await session.thread.list({ metadata: tags });
+  const thread = [...matching].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+  if (thread) await session.thread.switch({ threadId: thread.id });
+  else await session.thread.create({ title: request.threadTitle });
+  await Promise.all(Object.entries(tags).map(([key, value]) => session.thread.setSetting({ key, value })));
+  return session.thread.requireId();
+}
+
+export class FactoryStartCoordinator {
+  readonly #controller: FactoryController;
+  readonly #storage?: WorkItemsStorage;
+
+  constructor(controller: FactoryController, storage?: WorkItemsStorage) {
+    this.#controller = controller;
+    this.#storage = storage;
+  }
+
+  async prepare(request: FactoryStartRequest): Promise<FactoryStartPreparedResult> {
+    const session = await createScopedSession(this.#controller, request);
+    const threadId = await resolveThread(session, request);
+    const storage = this.#storage ?? getFactoryStorage().getDomain<WorkItemsStorage>('work-items');
+    const prepared = await storage.prepareRunStart({
+      orgId: request.orgId,
+      userId: request.userId,
+      factoryProjectId: request.factoryProjectId,
+      workItem: { id: request.workItem.id, input: request.workItem.input },
+      role: request.workItem.role,
+      session: { projectPath: request.projectPath, branch: request.branch, threadId },
+      resourceId: request.resourceId,
+      kickoffKey: request.kickoffKey,
+      kickoffMessage: request.kickoffMessage,
+    });
+
+    if (request.kickoffMessage === null) {
+      await storage.markPendingStart(prepared.binding.id, 'sent');
+      prepared.pendingStart.status = 'sent';
+    } else if (!prepared.replayed || prepared.pendingStart.status === 'failed') {
+      void session.sendMessage({ content: request.kickoffMessage }).then(
+        () => storage.markPendingStart(prepared.binding.id, 'sent'),
+        (error: unknown) =>
+          storage.markPendingStart(
+            prepared.binding.id,
+            'failed',
+            (error instanceof Error ? error.message : String(error)).slice(0, MAX_KICKOFF_ERROR_LENGTH),
+          ),
+      );
+    }
+
+    return {
+      workItemId: prepared.item.id,
+      bindingId: prepared.binding.id,
+      threadId,
+      resourceId: request.resourceId,
+      projectPath: request.projectPath,
+      branch: request.branch,
+      revision: prepared.item.revision,
+      kickoffStatus: prepared.pendingStart.status,
+      replayed: prepared.replayed,
+    };
+  }
+}

--- a/mastracode/web/src/web/factory/rules/start-coordinator.ts
+++ b/mastracode/web/src/web/factory/rules/start-coordinator.ts
@@ -73,17 +73,25 @@ function createScopedSession(
   });
 }
 
-async function resolveThread(session: ScopedSession, request: FactoryStartRequest): Promise<string> {
-  const tags = {
+async function resolveThread(
+  session: ScopedSession,
+  request: FactoryStartRequest,
+  existingThreadId?: string,
+): Promise<string> {
+  const identityTags = {
     projectPath: request.projectPath,
-    factoryWorkItemRole: request.workItem.role,
-    ...(request.threadTags ?? {}),
+    ...(request.workItem.id ? { factoryWorkItemId: request.workItem.id } : {}),
   };
-  const matching = await session.thread.list({ metadata: tags });
-  const thread = [...matching].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
-  if (thread) await session.thread.switch({ threadId: thread.id });
-  else await session.thread.create({ title: request.threadTitle });
-  await Promise.all(Object.entries(tags).map(([key, value]) => session.thread.setSetting({ key, value })));
+  if (existingThreadId) {
+    await session.thread.switch({ threadId: existingThreadId });
+  } else {
+    const matching = await session.thread.list({ metadata: identityTags });
+    const thread = [...matching].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0];
+    if (thread) await session.thread.switch({ threadId: thread.id });
+    else await session.thread.create({ title: request.threadTitle });
+  }
+  const settings = { ...(request.threadTags ?? {}), ...identityTags };
+  await Promise.all(Object.entries(settings).map(([key, value]) => session.thread.setSetting({ key, value })));
   return session.thread.requireId();
 }
 
@@ -103,9 +111,13 @@ export class FactoryStartCoordinator {
   }
 
   async prepare(request: FactoryStartRequest): Promise<FactoryStartPreparedResult> {
-    const session = await createScopedSession(this.#controller, request);
-    const threadId = await resolveThread(session, request);
     const storage = this.#storage ?? getFactoryStorage().getDomain<WorkItemsStorage>('work-items');
+    const existingItem = request.workItem.id
+      ? await storage.get({ orgId: request.orgId, id: request.workItem.id })
+      : null;
+    const existingThreadId = existingItem ? Object.values(existingItem.sessions).at(-1)?.threadId : undefined;
+    const session = await createScopedSession(this.#controller, request);
+    const threadId = await resolveThread(session, request, existingThreadId);
     const prepared = await storage.prepareRunStart({
       orgId: request.orgId,
       userId: request.userId,
@@ -117,6 +129,7 @@ export class FactoryStartCoordinator {
       kickoffKey: request.kickoffKey,
       kickoffMessage: request.kickoffMessage,
     });
+    await session.thread.setSetting({ key: 'factoryWorkItemId', value: prepared.item.id });
 
     let revision = prepared.item.revision;
     if (prepared.item.stages.length !== 1 || prepared.item.stages[0] !== request.destinationStage) {

--- a/mastracode/web/src/web/factory/rules/start-coordinator.ts
+++ b/mastracode/web/src/web/factory/rules/start-coordinator.ts
@@ -3,6 +3,8 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 
 import type { CreateWorkItemInput, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
 import { getFactoryStorage } from '../../runtime-config.js';
+import type { FactoryRuleStage, FactoryTransitionResult } from './types.js';
+import type { FactoryTransitionService } from './transition-service.js';
 
 const MAX_KICKOFF_ERROR_LENGTH = 512;
 
@@ -17,11 +19,22 @@ export interface FactoryStartRequest {
   threadTags?: Record<string, string>;
   kickoffKey: string;
   kickoffMessage: string | null;
+  destinationStage: FactoryRuleStage;
   workItem: {
     id?: string;
     role: string;
     input: CreateWorkItemInput;
   };
+}
+
+export class FactoryStartTransitionError extends Error {
+  readonly result: Extract<FactoryTransitionResult, { status: 'rejected' }>;
+
+  constructor(result: Extract<FactoryTransitionResult, { status: 'rejected' }>) {
+    super(result.reason);
+    this.name = 'FactoryStartTransitionError';
+    this.result = result;
+  }
 }
 
 export interface FactoryStartPreparedResult {
@@ -77,10 +90,16 @@ async function resolveThread(session: ScopedSession, request: FactoryStartReques
 export class FactoryStartCoordinator {
   readonly #controller: FactoryController;
   readonly #storage?: WorkItemsStorage;
+  readonly #transitionService?: Pick<FactoryTransitionService, 'transition'>;
 
-  constructor(controller: FactoryController, storage?: WorkItemsStorage) {
+  constructor(
+    controller: FactoryController,
+    storage?: WorkItemsStorage,
+    transitionService?: Pick<FactoryTransitionService, 'transition'>,
+  ) {
     this.#controller = controller;
     this.#storage = storage;
+    this.#transitionService = transitionService;
   }
 
   async prepare(request: FactoryStartRequest): Promise<FactoryStartPreparedResult> {
@@ -98,6 +117,27 @@ export class FactoryStartCoordinator {
       kickoffKey: request.kickoffKey,
       kickoffMessage: request.kickoffMessage,
     });
+
+    let revision = prepared.item.revision;
+    if (prepared.item.stages.length !== 1 || prepared.item.stages[0] !== request.destinationStage) {
+      if (!this.#transitionService) throw new Error('Factory transition service is unavailable.');
+      const transition = await this.#transitionService.transition({
+        orgId: request.orgId,
+        factoryProjectId: request.factoryProjectId,
+        workItemId: prepared.item.id,
+        board: prepared.item.externalSource?.type === 'pull-request' ? 'review' : 'work',
+        stage: request.destinationStage,
+        expectedRevision: prepared.item.revision,
+        actor: { type: 'human', id: request.userId },
+        ingress: { type: 'human', identity: `start:${request.kickoffKey}:transition` },
+        cause: 'run_start',
+      });
+      if (transition.status === 'rejected') {
+        await storage.markPendingStart(prepared.binding.id, 'failed', transition.reason);
+        throw new FactoryStartTransitionError(transition);
+      }
+      revision = transition.revision;
+    }
 
     if (request.kickoffMessage === null) {
       await storage.markPendingStart(prepared.binding.id, 'sent');
@@ -121,7 +161,7 @@ export class FactoryStartCoordinator {
       resourceId: request.resourceId,
       projectPath: request.projectPath,
       branch: request.branch,
-      revision: prepared.item.revision,
+      revision,
       kickoffStatus: prepared.pendingStart.status,
       replayed: prepared.replayed,
     };

--- a/mastracode/web/src/web/factory/rules/transition-service.test.ts
+++ b/mastracode/web/src/web/factory/rules/transition-service.test.ts
@@ -151,14 +151,21 @@ describe('FactoryTransitionService', () => {
       overrides: { work: { execute: { issue: { onEnter: () => lateRule } } } },
     });
 
-    const result = await new FactoryTransitionService({ rules, storage, timeoutMs: 5 }).transition(request(item));
-    expect(result).toMatchObject({ status: 'rejected', code: 'timeout' });
+    vi.useFakeTimers();
+    try {
+      const transition = new FactoryTransitionService({ rules, storage }).transition(request(item));
+      await vi.advanceTimersByTimeAsync(5_000);
+      const result = await transition;
+      expect(result).toMatchObject({ status: 'rejected', code: 'timeout' });
 
-    resolveRule({ type: 'notify', idempotencyKey: 'too-late', title: 'Too late' });
-    await lateRule;
-    await Promise.resolve();
-    expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
-    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+      resolveRule({ type: 'notify', idempotencyKey: 'too-late', title: 'Too late' });
+      await lateRule;
+      await Promise.resolve();
+      expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
+      expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('always returns typed stale on CAS loss and never overwrites canonical state', async () => {

--- a/mastracode/web/src/web/factory/rules/transition-service.test.ts
+++ b/mastracode/web/src/web/factory/rules/transition-service.test.ts
@@ -1,0 +1,278 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkItemsStorage } from '../../storage/domains/work-items/base';
+import { seedFactoryStorageForTests } from '../../storage/test-utils';
+import { defaultFactoryRules } from './defaults';
+import { FactoryTransitionService } from './transition-service';
+import type { FactoryRuleBoard, FactoryRuleStage } from './types';
+import { MAX_FACTORY_RULE_CAUSAL_DEPTH } from './validation';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+
+async function createItem(
+  storage: WorkItemsStorage,
+  overrides: Partial<{ orgId: string; source: 'github-issue' | 'github-pr'; sourceKey: string; stages: string[] }> = {},
+) {
+  const orgId = overrides.orgId ?? 'org-1';
+  return (
+    await storage.upsert({
+      orgId,
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: (overrides.source ?? 'github-issue') === 'github-pr' ? 'pull-request' : 'issue',
+          externalId: overrides.sourceKey ?? '1',
+        },
+        title: 'Fix the bug',
+        stages: overrides.stages ?? ['intake'],
+        sessions: {},
+        metadata: {},
+      },
+    })
+  ).item;
+}
+
+function request(
+  item: { id: string; revision: number },
+  overrides: Partial<{
+    orgId: string;
+    board: FactoryRuleBoard;
+    stage: FactoryRuleStage;
+    expectedRevision: number;
+    identity: string;
+    causalChain: Array<{ ingressId: string; decisionType: 'transition' }>;
+  }> = {},
+) {
+  return {
+    orgId: overrides.orgId ?? 'org-1',
+    factoryProjectId: PROJECT_ID,
+    workItemId: item.id,
+    board: overrides.board ?? ('work' as const),
+    stage: overrides.stage ?? ('execute' as const),
+    expectedRevision: overrides.expectedRevision ?? item.revision,
+    actor: { type: 'human' as const, id: 'user-1' },
+    ingress: { type: 'human' as const, identity: overrides.identity ?? 'request-1' },
+    cause: 'test',
+    causalChain: overrides.causalChain,
+  };
+}
+
+describe('FactoryTransitionService', () => {
+  it('runs onExit before onEnter and atomically persists accepted decisions', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const order: string[] = [];
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          intake: {
+            issue: {
+              onExit: () => {
+                order.push('exit');
+                return { type: 'notify', idempotencyKey: 'notify-exit', title: 'Leaving intake' };
+              },
+            },
+          },
+          execute: {
+            issue: {
+              onEnter: () => {
+                order.push('enter');
+                return { type: 'sendMessage', idempotencyKey: 'message-enter', role: 'work', message: 'Build it.' };
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage }).transition(request(item));
+
+    expect(order).toEqual(['exit', 'enter']);
+    expect(result).toMatchObject({ status: 'accepted', revision: 2, stage: 'execute' });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stageHistory.map(entry => entry.stage)).toEqual([
+      'intake',
+      'execute',
+    ]);
+    expect((await storage.listDeferredDecisions('org-1', PROJECT_ID)).map(entry => entry.idempotencyKey)).toEqual([
+      'notify-exit',
+      'message-enter',
+    ]);
+  });
+
+  it('persists rule rejection without moving or queuing decisions', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          execute: {
+            issue: { onEnter: () => ({ type: 'reject', code: 'forbidden', reason: 'Approval is required.' }) },
+          },
+        },
+      },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage }).transition(request(item));
+
+    expect(result).toMatchObject({ status: 'rejected', code: 'forbidden', reason: 'Approval is required.' });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+    expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
+  });
+
+  it('turns thrown rules into bounded safe rejection', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: { execute: { issue: { onEnter: () => Promise.reject(new Error('provider unavailable')) } } },
+      },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage }).transition(request(item));
+
+    expect(result).toMatchObject({ status: 'rejected', code: 'rule_error' });
+    expect(result.status === 'rejected' ? result.reason : '').toContain('provider unavailable');
+  });
+
+  it('applies one timeout to the full primary evaluation and ignores late resolution', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    let resolveRule!: (value: { type: 'notify'; idempotencyKey: string; title: string }) => void;
+    const lateRule = new Promise<{ type: 'notify'; idempotencyKey: string; title: string }>(resolve => {
+      resolveRule = resolve;
+    });
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: { work: { execute: { issue: { onEnter: () => lateRule } } } },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage, timeoutMs: 5 }).transition(request(item));
+    expect(result).toMatchObject({ status: 'rejected', code: 'timeout' });
+
+    resolveRule({ type: 'notify', idempotencyKey: 'too-late', title: 'Too late' });
+    await lateRule;
+    await Promise.resolve();
+    expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+  });
+
+  it('always returns typed stale on CAS loss and never overwrites canonical state', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const service = new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage });
+    await storage.update({ orgId: 'org-1', id: item.id, userId: 'user-2', patch: { title: 'Changed concurrently' } });
+
+    const result = await service.transition(request(item));
+
+    expect(result).toMatchObject({ status: 'rejected', code: 'stale' });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+  });
+
+  it('replays immutable ingress across rule version changes without re-evaluation', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const first = await new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    }).transition(request(item));
+    const laterRule = vi.fn(() => ({ type: 'reject' as const, code: 'forbidden' as const, reason: 'new policy' }));
+    const rulesV2 = defaultFactoryRules({
+      version: 'rules-v2',
+      overrides: { work: { execute: { issue: { onEnter: laterRule } } } },
+    });
+
+    const replay = await new FactoryTransitionService({ rules: rulesV2, storage }).transition(
+      request(item, { stage: 'planning' }),
+    );
+
+    expect(replay).toEqual(first);
+    expect(laterRule).not.toHaveBeenCalled();
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['execute']);
+  });
+
+  it('durably deduplicates missing-item rejection before any rule evaluation', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const handler = vi.fn(() => ({ type: 'notify' as const, idempotencyKey: 'never', title: 'Never' }));
+    const service = new FactoryTransitionService({
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: { work: { execute: { issue: { onEnter: handler } } } },
+      }),
+      storage,
+    });
+    const missing = { id: '00000000-0000-4000-8000-000000000099', revision: 1 };
+
+    const first = await service.transition(request(missing, { identity: 'missing-event' }));
+    const replay = await service.transition(request(missing, { identity: 'missing-event', stage: 'done' }));
+
+    expect(first).toMatchObject({ status: 'rejected', code: 'invalid_transition' });
+    expect(replay).toEqual(first);
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('accepts unchanged-stage no-op without revising history', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const result = await new FactoryTransitionService({
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      storage,
+    }).transition(request(item, { stage: 'intake' }));
+
+    expect(result).toMatchObject({ status: 'accepted', revision: 1, stage: 'intake' });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stageHistory).toHaveLength(1);
+  });
+
+  it('rejects excessive causal depth and wrong Work/Review authority', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const workItem = await createItem(storage);
+    const reviewItem = await createItem(storage, {
+      source: 'github-pr',
+      sourceKey: 'github-pr:2',
+    });
+    const service = new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage });
+    const causalChain = Array.from({ length: MAX_FACTORY_RULE_CAUSAL_DEPTH + 1 }, (_, index) => ({
+      ingressId: `ingress-${index}`,
+      decisionType: 'transition' as const,
+    }));
+
+    await expect(service.transition(request(workItem, { identity: 'causal', causalChain }))).resolves.toMatchObject({
+      status: 'rejected',
+      code: 'causal_depth_exceeded',
+    });
+    await expect(
+      service.transition(request(workItem, { identity: 'wrong-work', board: 'review' })),
+    ).resolves.toMatchObject({
+      status: 'rejected',
+      code: 'invalid_transition',
+    });
+    await expect(
+      service.transition(request(reviewItem, { identity: 'wrong-review', board: 'work' })),
+    ).resolves.toMatchObject({
+      status: 'rejected',
+      code: 'invalid_transition',
+    });
+  });
+
+  it('scopes ingress replay and deferred idempotency to the tenant', async () => {
+    const storage = (await seedFactoryStorageForTests()).workItems;
+    const first = await createItem(storage, { orgId: 'org-1', sourceKey: 'github-issue:one' });
+    const second = await createItem(storage, { orgId: 'org-2', sourceKey: 'github-issue:two' });
+    const handler = () => ({ type: 'notify' as const, idempotencyKey: 'same-effect-key', title: 'Moved' });
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: { work: { execute: { issue: { onEnter: handler } } } },
+    });
+    const service = new FactoryTransitionService({ rules, storage });
+
+    await service.transition(request(first, { identity: 'same-ingress' }));
+    await service.transition(request(second, { orgId: 'org-2', identity: 'same-ingress' }));
+
+    expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toHaveLength(1);
+    expect(await storage.listDeferredDecisions('org-2', PROJECT_ID)).toHaveLength(1);
+  });
+});

--- a/mastracode/web/src/web/factory/rules/transition-service.ts
+++ b/mastracode/web/src/web/factory/rules/transition-service.ts
@@ -1,0 +1,256 @@
+import { randomUUID } from 'node:crypto';
+
+import { getFactoryStorage, getSeededFactoryRules } from '../../runtime-config.js';
+import type { ExternalWorkItemSource, WorkItemsStorage } from '../../storage/domains/work-items/base.js';
+import { resolveFactoryStageRules } from './resolve.js';
+import type {
+  FactoryCommitDecision,
+  FactoryRuleActor,
+  FactoryRuleBoard,
+  FactoryRuleCausalEntry,
+  FactoryRuleRejectionCode,
+  FactoryRuleStage,
+  FactoryRules,
+  FactoryStageRuleContext,
+  FactoryTransitionResult,
+} from './types.js';
+import { FACTORY_RULE_STAGES, factoryRuleSourceForWorkItem } from './types.js';
+import {
+  MAX_FACTORY_RULE_CAUSAL_DEPTH,
+  validateFactoryRuleDecision,
+  validateFactoryRuleDecisions,
+} from './validation.js';
+
+const RULE_TIMEOUT_MS = 5_000;
+const MAX_REJECTION_REASON = 512;
+
+export interface FactoryTransitionRequest {
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  board: FactoryRuleBoard;
+  stage: FactoryRuleStage;
+  expectedRevision: number;
+  actor: FactoryRuleActor;
+  ingress: { type: 'human' | 'agent' | 'toolResult' | 'github' | 'rule'; identity: string; transitionId?: string };
+  cause: string;
+  causalChain?: readonly FactoryRuleCausalEntry[];
+}
+
+export interface FactoryTransitionServiceOptions {
+  rules?: FactoryRules;
+  storage?: WorkItemsStorage;
+  timeoutMs?: number;
+}
+
+function rejection(
+  transitionId: string,
+  itemId: string,
+  code: FactoryRuleRejectionCode,
+  reason: string,
+): FactoryTransitionResult {
+  return { status: 'rejected', transitionId, itemId, code, reason: reason.slice(0, MAX_REJECTION_REASON) };
+}
+
+function actorId(actor: FactoryRuleActor): string {
+  switch (actor.type) {
+    case 'human':
+    case 'system':
+      return actor.id;
+    case 'agent':
+      return `agent:${actor.bindingId}`;
+    case 'github':
+      return `github:${actor.login}`;
+  }
+}
+
+function currentStage(stages: readonly string[]): FactoryRuleStage | undefined {
+  if (stages.length !== 1) return undefined;
+  const stage = stages[0];
+  return FACTORY_RULE_STAGES.includes(stage as FactoryRuleStage) ? (stage as FactoryRuleStage) : undefined;
+}
+
+function workItemSource(source: ExternalWorkItemSource | null) {
+  if (!source) return 'manual' as const;
+  if (source.integrationId === 'linear') return 'linear-issue' as const;
+  return source.type === 'pull-request' ? ('github-pr' as const) : ('github-issue' as const);
+}
+
+function ruleFailure(error: unknown): { code: FactoryRuleRejectionCode; reason: string } {
+  return {
+    code: 'rule_error',
+    reason: error instanceof Error ? `Factory rule failed: ${error.message}` : 'Factory rule failed.',
+  };
+}
+
+async function withRuleTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('FACTORY_RULE_TIMEOUT')), timeoutMs);
+  });
+  try {
+    return await Promise.race([operation, timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+export class FactoryTransitionService {
+  readonly #rules: FactoryRules;
+  readonly #storage: WorkItemsStorage;
+  readonly #timeoutMs: number;
+
+  constructor(options: FactoryTransitionServiceOptions = {}) {
+    const rules = options.rules ?? getSeededFactoryRules();
+    if (!rules) throw new Error('Factory rules are unavailable.');
+    this.#rules = rules;
+    this.#storage = options.storage ?? getFactoryStorage().getDomain<WorkItemsStorage>('work-items');
+    this.#timeoutMs = options.timeoutMs ?? RULE_TIMEOUT_MS;
+  }
+
+  get ruleSetVersion(): string {
+    return this.#rules.version;
+  }
+
+  async transition(request: FactoryTransitionRequest): Promise<FactoryTransitionResult> {
+    const replay = await this.#storage.getTransitionResultByIngress(
+      request.orgId,
+      request.factoryProjectId,
+      request.ingress.identity,
+    );
+    if (replay) return replay as unknown as FactoryTransitionResult;
+
+    const transitionId = request.ingress.transitionId ?? randomUUID();
+    const item = await this.#storage.get({ orgId: request.orgId, id: request.workItemId });
+    if (!item) {
+      return this.#commitRejection(request, transitionId, 'invalid_transition', 'Work item not found.');
+    }
+
+    if (request.causalChain && request.causalChain.length > MAX_FACTORY_RULE_CAUSAL_DEPTH) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'causal_depth_exceeded',
+        'Factory rule causal depth exceeded.',
+      );
+    }
+    const itemSource = workItemSource(item.externalSource);
+    const source = factoryRuleSourceForWorkItem(itemSource);
+    if ((request.board === 'review') !== (source === 'pullRequest')) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'invalid_transition',
+        'The work item does not belong to the requested board.',
+      );
+    }
+    const fromStage = currentStage(item.stages);
+    if (!fromStage) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'invalid_transition',
+        'The work item does not have one canonical Factory stage.',
+      );
+    }
+
+    const contextBase = {
+      tenant: { orgId: request.orgId, projectId: request.factoryProjectId },
+      actor: request.actor,
+      ingress: { type: request.ingress.type, id: request.ingress.identity },
+      cause: request.cause,
+      causalChain: request.causalChain ?? [],
+      ruleSetVersion: this.#rules.version,
+      item: {
+        id: item.id,
+        source: itemSource,
+        sourceKey: item.externalSource
+          ? `${item.externalSource.integrationId}:${item.externalSource.type}:${item.externalSource.externalId}`
+          : null,
+        parentWorkItemId: item.parentWorkItemId,
+        title: item.title,
+        url: item.externalSource?.url ?? null,
+        stages: [...item.stages],
+      },
+      board: request.board,
+      itemRevision: item.revision,
+      source,
+      fromStage,
+      toStage: request.stage,
+    } satisfies Omit<FactoryStageRuleContext, 'stage'>;
+
+    let evaluation:
+      | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
+      | { outcome: 'rejected'; code: string; reason: string };
+    try {
+      evaluation = await withRuleTimeout(
+        (async () => {
+          const decisions: FactoryCommitDecision[] = [];
+          for (const rule of resolveFactoryStageRules(this.#rules, {
+            board: request.board,
+            source,
+            fromStage,
+            toStage: request.stage,
+          })) {
+            const context: FactoryStageRuleContext = Object.freeze({
+              ...contextBase,
+              stage: rule.phase === 'exit' ? fromStage : request.stage,
+            });
+            const raw = await rule.handler(context);
+            if (raw === undefined) continue;
+            const decision = validateFactoryRuleDecision(raw, context.causalChain.length);
+            if (decision.type === 'reject') {
+              return { outcome: 'rejected' as const, code: decision.code, reason: decision.reason };
+            }
+            decisions.push(decision);
+          }
+          return {
+            outcome: 'accepted' as const,
+            decisions: validateFactoryRuleDecisions(decisions) as unknown as Record<string, unknown>[],
+          };
+        })(),
+        this.#timeoutMs,
+      );
+    } catch (error) {
+      const failed =
+        error instanceof Error && error.message === 'FACTORY_RULE_TIMEOUT'
+          ? { code: 'timeout' as const, reason: 'Factory rule evaluation timed out.' }
+          : ruleFailure(error);
+      evaluation = { outcome: 'rejected', ...failed };
+    }
+    return this.#commit(request, transitionId, evaluation);
+  }
+
+  async #commitRejection(
+    request: FactoryTransitionRequest,
+    transitionId: string,
+    code: FactoryRuleRejectionCode,
+    reason: string,
+  ): Promise<FactoryTransitionResult> {
+    return this.#commit(request, transitionId, { outcome: 'rejected', code, reason });
+  }
+
+  async #commit(
+    request: FactoryTransitionRequest,
+    transitionId: string,
+    evaluation:
+      | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
+      | { outcome: 'rejected'; code: string; reason: string },
+  ): Promise<FactoryTransitionResult> {
+    const committed = await this.#storage.commitTransition({
+      orgId: request.orgId,
+      factoryProjectId: request.factoryProjectId,
+      workItemId: request.workItemId,
+      expectedRevision: request.expectedRevision,
+      destinationStage: request.stage,
+      actorId: actorId(request.actor),
+      ingress: { identity: request.ingress.identity, triggerType: request.ingress.type, transitionId },
+      ruleSetVersion: this.#rules.version,
+      evaluation,
+    });
+    if (committed.status === 'missing') {
+      return rejection(transitionId, request.workItemId, 'invalid_transition', 'Work item not found.');
+    }
+    return committed.result as unknown as FactoryTransitionResult;
+  }
+}

--- a/mastracode/web/src/web/factory/rules/types.ts
+++ b/mastracode/web/src/web/factory/rules/types.ts
@@ -19,12 +19,7 @@ export const FACTORY_GITHUB_EVENTS = [
 export type FactoryGithubEventName = (typeof FACTORY_GITHUB_EVENTS)[number];
 
 export type FactoryRuleJsonValue =
-  | null
-  | boolean
-  | number
-  | string
-  | FactoryRuleJsonValue[]
-  | { [key: string]: FactoryRuleJsonValue };
+  null | boolean | number | string | FactoryRuleJsonValue[] | { [key: string]: FactoryRuleJsonValue };
 
 export interface FactoryRuleItemContext {
   id: string;

--- a/mastracode/web/src/web/factory/rules/types.ts
+++ b/mastracode/web/src/web/factory/rules/types.ts
@@ -1,4 +1,4 @@
-import type { WorkItemSource } from '../../storage/domains/work-items/base.js';
+export type WorkItemSource = 'github-issue' | 'github-pr' | 'linear-issue' | 'manual';
 
 export const FACTORY_RULE_STAGES = ['intake', 'triage', 'planning', 'execute', 'review', 'done'] as const;
 export type FactoryRuleStage = (typeof FACTORY_RULE_STAGES)[number];

--- a/mastracode/web/src/web/factory/rules/types.ts
+++ b/mastracode/web/src/web/factory/rules/types.ts
@@ -1,0 +1,239 @@
+import type { WorkItemSource } from '../../storage/domains/work-items/base.js';
+
+export const FACTORY_RULE_STAGES = ['intake', 'triage', 'planning', 'execute', 'review', 'done'] as const;
+export type FactoryRuleStage = (typeof FACTORY_RULE_STAGES)[number];
+
+export const FACTORY_RULE_BOARDS = ['work', 'review'] as const;
+export type FactoryRuleBoard = (typeof FACTORY_RULE_BOARDS)[number];
+
+export const FACTORY_RULE_SOURCES = ['issue', 'pullRequest', 'linearIssue', 'manual'] as const;
+export type FactoryRuleSource = (typeof FACTORY_RULE_SOURCES)[number];
+
+export const FACTORY_GITHUB_EVENTS = [
+  'issueOpened',
+  'pullRequestOpened',
+  'pullRequestUpdated',
+  'pullRequestReviewRequested',
+  'pullRequestMerged',
+] as const;
+export type FactoryGithubEventName = (typeof FACTORY_GITHUB_EVENTS)[number];
+
+export type FactoryRuleJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | FactoryRuleJsonValue[]
+  | { [key: string]: FactoryRuleJsonValue };
+
+export interface FactoryRuleItemContext {
+  id: string;
+  source: WorkItemSource;
+  sourceKey: string | null;
+  parentWorkItemId: string | null;
+  title: string;
+  url: string | null;
+  stages: readonly string[];
+}
+
+export type FactoryRuleActor =
+  | { type: 'human'; id: string }
+  | { type: 'agent'; bindingId: string; role: string }
+  | { type: 'github'; login: string; trusted: boolean; factoryAuthored: boolean }
+  | { type: 'system'; id: string };
+
+export interface FactoryRuleIngressIdentity {
+  type: 'human' | 'agent' | 'toolResult' | 'github' | 'rule';
+  id: string;
+}
+
+export interface FactoryRuleCausalEntry {
+  ingressId: string;
+  decisionType: FactoryCommitDecision['type'];
+}
+
+export interface FactoryRuleContextBase {
+  tenant: { orgId: string; projectId: string };
+  actor: FactoryRuleActor;
+  ingress: FactoryRuleIngressIdentity;
+  cause: string;
+  causalChain: readonly FactoryRuleCausalEntry[];
+  ruleSetVersion: string;
+}
+
+export interface FactoryBoundRuleContext extends FactoryRuleContextBase {
+  item: FactoryRuleItemContext;
+  board: FactoryRuleBoard;
+  itemRevision: number;
+}
+
+export interface FactoryStageRuleContext extends FactoryBoundRuleContext {
+  source: FactoryRuleSource;
+  stage: FactoryRuleStage;
+  fromStage: FactoryRuleStage;
+  toStage: FactoryRuleStage;
+}
+
+export interface FactoryToolResultRuleContext extends FactoryBoundRuleContext {
+  toolName: string;
+  threadId: string;
+  assistantMessageId: string;
+  toolCallId: string;
+  result: {
+    status: 'success' | 'error';
+    value: FactoryRuleJsonValue;
+  };
+}
+
+export interface FactoryGithubRuleContext extends FactoryRuleContextBase {
+  item?: FactoryRuleItemContext;
+  board?: FactoryRuleBoard;
+  itemRevision?: number;
+  event: FactoryGithubEventName;
+  deliveryId: string;
+  repository: { id: number; fullName: string };
+  issue?: { number: number; title: string; url: string };
+  pullRequest?: {
+    number: number;
+    title: string;
+    url: string;
+    state: 'open' | 'closed';
+    merged: boolean;
+    headBranch: string;
+    baseBranch: string;
+  };
+}
+
+export type FactoryRuleHandler<TContext> = (
+  context: Readonly<TContext>,
+) => FactoryRuleDecision | void | Promise<FactoryRuleDecision | void>;
+
+export interface FactoryBoardRuleLeaf {
+  onEnter?: FactoryRuleHandler<FactoryStageRuleContext>;
+  onExit?: FactoryRuleHandler<FactoryStageRuleContext>;
+}
+
+export interface FactoryToolRuleLeaf {
+  onResult?: FactoryRuleHandler<FactoryToolResultRuleContext>;
+}
+
+export interface FactoryGithubRuleLeaf {
+  onEvent?: FactoryRuleHandler<FactoryGithubRuleContext>;
+}
+
+export type FactoryBoardRules = Partial<
+  Record<FactoryRuleStage, Partial<Record<FactoryRuleSource, FactoryBoardRuleLeaf>>>
+>;
+
+export interface FactoryRules {
+  version: string;
+  work: FactoryBoardRules;
+  review: FactoryBoardRules;
+  tools: Record<string, FactoryToolRuleLeaf>;
+  github: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>>;
+}
+
+export interface FactoryRulesOverrides {
+  work?: FactoryBoardRules;
+  review?: FactoryBoardRules;
+  tools?: Record<string, FactoryToolRuleLeaf>;
+  github?: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>>;
+}
+
+export type FactoryRuleRejectionCode =
+  | 'forbidden'
+  | 'invalid_transition'
+  | 'missing_binding'
+  | 'stale'
+  | 'timeout'
+  | 'rule_error'
+  | 'causal_depth_exceeded'
+  | 'repeated_transition';
+
+export interface FactoryRuleRejectDecision {
+  type: 'reject';
+  code: FactoryRuleRejectionCode;
+  reason: string;
+}
+
+interface FactoryCommitDecisionBase {
+  idempotencyKey: string;
+}
+
+export interface FactoryTransitionDecision extends FactoryCommitDecisionBase {
+  type: 'transition';
+  board: FactoryRuleBoard;
+  stage: FactoryRuleStage;
+}
+
+export interface FactoryUpsertLinkedWorkItemDecision extends FactoryCommitDecisionBase {
+  type: 'upsertLinkedWorkItem';
+  board: FactoryRuleBoard;
+  source: WorkItemSource;
+  sourceKey: string;
+  title: string;
+  url: string | null;
+  stage: FactoryRuleStage;
+  metadata?: Record<string, FactoryRuleJsonValue>;
+}
+
+export interface FactoryInvokeSkillDecision extends FactoryCommitDecisionBase {
+  type: 'invokeSkill';
+  role: string;
+  skillName: string;
+  arguments?: string;
+}
+
+export interface FactorySendMessageDecision extends FactoryCommitDecisionBase {
+  type: 'sendMessage';
+  role: string;
+  message: string;
+}
+
+export interface FactoryNotifyDecision extends FactoryCommitDecisionBase {
+  type: 'notify';
+  title: string;
+  body?: string;
+  level?: 'info' | 'warning' | 'error';
+}
+
+export type FactoryCommitDecision =
+  | FactoryTransitionDecision
+  | FactoryUpsertLinkedWorkItemDecision
+  | FactoryInvokeSkillDecision
+  | FactorySendMessageDecision
+  | FactoryNotifyDecision;
+
+export type FactoryRuleDecision = FactoryRuleRejectDecision | FactoryCommitDecision;
+
+export interface FactoryTransitionResultAccepted {
+  status: 'accepted';
+  transitionId: string;
+  itemId: string;
+  revision: number;
+  stage: FactoryRuleStage;
+  decisions: FactoryCommitDecision[];
+}
+
+export interface FactoryTransitionResultRejected {
+  status: 'rejected';
+  transitionId: string;
+  itemId: string;
+  code: FactoryRuleRejectionCode;
+  reason: string;
+}
+
+export type FactoryTransitionResult = FactoryTransitionResultAccepted | FactoryTransitionResultRejected;
+
+export function factoryRuleSourceForWorkItem(source: WorkItemSource): FactoryRuleSource {
+  switch (source) {
+    case 'github-issue':
+      return 'issue';
+    case 'github-pr':
+      return 'pullRequest';
+    case 'linear-issue':
+      return 'linearIssue';
+    case 'manual':
+      return 'manual';
+  }
+}

--- a/mastracode/web/src/web/factory/rules/validation.test.ts
+++ b/mastracode/web/src/web/factory/rules/validation.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+import { defaultFactoryRules } from './defaults.js';
+import {
+  assertFactoryRules,
+  FactoryRuleValidationError,
+  MAX_FACTORY_RULE_CAUSAL_DEPTH,
+  validateFactoryRuleDecision,
+  validateFactoryRuleDecisions,
+} from './validation.js';
+
+describe('Factory rule validation', () => {
+  it('validates each bounded serializable commit decision', () => {
+    const decisions = [
+      { type: 'transition', idempotencyKey: 'transition-1', board: 'work', stage: 'execute' },
+      {
+        type: 'upsertLinkedWorkItem',
+        idempotencyKey: 'linked-1',
+        board: 'review',
+        source: 'github-pr',
+        sourceKey: 'github-pr:42',
+        title: 'Review PR 42',
+        url: 'https://github.com/acme/repo/pull/42',
+        stage: 'intake',
+        metadata: { pullRequestNumber: 42 },
+      },
+      { type: 'invokeSkill', idempotencyKey: 'skill-1', role: 'review', skillName: 'understand-pr' },
+      { type: 'sendMessage', idempotencyKey: 'message-1', role: 'work', message: 'Assess completion.' },
+      { type: 'notify', idempotencyKey: 'notify-1', title: 'Factory update', level: 'info' },
+    ];
+
+    const validated = validateFactoryRuleDecisions(decisions);
+    expect(validated).toHaveLength(5);
+    expect(JSON.parse(JSON.stringify(validated))).toEqual(validated);
+  });
+
+  it('keeps rejection exclusive from commit-only fields and decisions', () => {
+    expect(validateFactoryRuleDecision({ type: 'reject', code: 'forbidden', reason: 'Not authorized.' })).toEqual({
+      type: 'reject',
+      code: 'forbidden',
+      reason: 'Not authorized.',
+    });
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'reject',
+        code: 'forbidden',
+        reason: 'Not authorized.',
+        idempotencyKey: 'must-not-exist',
+      }),
+    ).toThrow(/unsupported field/i);
+    expect(() =>
+      validateFactoryRuleDecisions([
+        { type: 'reject', code: 'forbidden', reason: 'Not authorized.' },
+        { type: 'transition', idempotencyKey: 'transition-1', board: 'work', stage: 'execute' },
+      ]),
+    ).toThrow(/rejection cannot be persisted/i);
+  });
+
+  it('enforces bounds, serializability, and causal depth', () => {
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'sendMessage',
+        idempotencyKey: 'message-1',
+        role: 'work',
+        message: 'x'.repeat(8_193),
+      }),
+    ).toThrow(/message is invalid/i);
+    expect(() =>
+      validateFactoryRuleDecision(
+        { type: 'transition', idempotencyKey: 'transition-1', board: 'work', stage: 'execute' },
+        MAX_FACTORY_RULE_CAUSAL_DEPTH + 1,
+      ),
+    ).toThrow(/causal depth/i);
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'upsertLinkedWorkItem',
+        idempotencyKey: 'linked-1',
+        board: 'review',
+        source: 'github-pr',
+        sourceKey: 'github-pr:42',
+        title: 'Review PR 42',
+        url: null,
+        stage: 'intake',
+        metadata: { createdAt: new Date() },
+      }),
+    ).toThrow(/plain objects/i);
+  });
+
+  it('redacts sensitive metadata without exposing rejected values in errors', () => {
+    const secret = 'do-not-persist-this-token';
+    const decision = validateFactoryRuleDecision({
+      type: 'upsertLinkedWorkItem',
+      idempotencyKey: 'linked-2',
+      board: 'review',
+      source: 'github-pr',
+      sourceKey: 'github-pr:43',
+      title: 'Review PR 43',
+      url: null,
+      stage: 'intake',
+      metadata: { accessToken: secret, nested: { cookie: secret, safe: 'visible' } },
+    });
+    expect(decision).toMatchObject({
+      metadata: { accessToken: '[REDACTED]', nested: { cookie: '[REDACTED]', safe: 'visible' } },
+    });
+
+    let error: unknown;
+    try {
+      validateFactoryRuleDecision({ type: 'sendMessage', idempotencyKey: secret, role: 'bad role', message: secret });
+    } catch (caught) {
+      error = caught;
+    }
+    expect(error).toBeInstanceOf(FactoryRuleValidationError);
+    expect(String(error)).not.toContain(secret);
+  });
+
+  it('requires unique decision idempotency keys', () => {
+    expect(() =>
+      validateFactoryRuleDecisions([
+        { type: 'notify', idempotencyKey: 'same', title: 'First' },
+        { type: 'notify', idempotencyKey: 'same', title: 'Second' },
+      ]),
+    ).toThrow(/unique idempotency keys/i);
+  });
+
+  it('rejects unknown rule keys and non-handler leaves at boot', () => {
+    const rules = defaultFactoryRules({ version: 'validation-v1' });
+    expect(() => assertFactoryRules({ ...rules, actions: {} })).toThrow(/unsupported field/i);
+    expect(() =>
+      assertFactoryRules({
+        ...rules,
+        work: { intake: { issue: { onEnter: 'not-a-function' } } },
+      }),
+    ).toThrow(/handlers must be functions/i);
+    expect(() =>
+      assertFactoryRules({
+        ...rules,
+        github: { madeUpEvent: { onEvent: () => undefined } },
+      }),
+    ).toThrow(/GitHub event is invalid/i);
+  });
+});

--- a/mastracode/web/src/web/factory/rules/validation.ts
+++ b/mastracode/web/src/web/factory/rules/validation.ts
@@ -1,0 +1,295 @@
+import { FACTORY_GITHUB_EVENTS, FACTORY_RULE_BOARDS, FACTORY_RULE_SOURCES, FACTORY_RULE_STAGES } from './types.js';
+import type {
+  FactoryBoardRules,
+  FactoryCommitDecision,
+  FactoryRuleDecision,
+  FactoryRuleJsonValue,
+  FactoryRules,
+  FactoryRuleRejectionCode,
+} from './types.js';
+import type { WorkItemSource } from '../../storage/domains/work-items/base.js';
+
+export const MAX_FACTORY_RULE_CAUSAL_DEPTH = 8;
+
+const MAX_VERSION_LENGTH = 128;
+const MAX_IDEMPOTENCY_KEY_LENGTH = 256;
+const MAX_REASON_LENGTH = 512;
+const MAX_TITLE_LENGTH = 512;
+const MAX_MESSAGE_LENGTH = 8_192;
+const MAX_ARGUMENTS_LENGTH = 4_096;
+const MAX_ROLE_LENGTH = 32;
+const MAX_SKILL_NAME_LENGTH = 128;
+const MAX_SOURCE_KEY_LENGTH = 256;
+const MAX_URL_LENGTH = 2_048;
+const MAX_METADATA_JSON_LENGTH = 16_384;
+const MAX_JSON_DEPTH = 8;
+const MAX_JSON_COLLECTION_SIZE = 100;
+
+const IDENTIFIER_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+const SKILL_NAME_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+const SENSITIVE_KEY_RE = /(?:authorization|cookie|credential|password|secret|token)/i;
+const WORK_ITEM_SOURCES: readonly WorkItemSource[] = ['github-issue', 'github-pr', 'linear-issue', 'manual'];
+const REJECTION_CODES: readonly FactoryRuleRejectionCode[] = [
+  'forbidden',
+  'invalid_transition',
+  'missing_binding',
+  'stale',
+  'timeout',
+  'rule_error',
+  'causal_depth_exceeded',
+  'repeated_transition',
+];
+
+export class FactoryRuleValidationError extends Error {
+  readonly code = 'invalid_factory_rule';
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'FactoryRuleValidationError';
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertExactKeys(value: Record<string, unknown>, keys: readonly string[], label: string): void {
+  const allowed = new Set(keys);
+  if (Object.keys(value).some(key => !allowed.has(key))) {
+    throw new FactoryRuleValidationError(`${label} contains an unsupported field.`);
+  }
+}
+
+function boundedString(value: unknown, label: string, max: number, pattern?: RegExp): string {
+  if (typeof value !== 'string') throw new FactoryRuleValidationError(`${label} must be a string.`);
+  const normalized = value.trim();
+  if (normalized.length === 0 || normalized.length > max || (pattern && !pattern.test(normalized))) {
+    throw new FactoryRuleValidationError(`${label} is invalid.`);
+  }
+  return normalized;
+}
+
+function optionalBoundedString(value: unknown, label: string, max: number): string | undefined {
+  if (value === undefined) return undefined;
+  return boundedString(value, label, max);
+}
+
+function enumValue<T extends string>(value: unknown, allowed: readonly T[], label: string): T {
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw new FactoryRuleValidationError(`${label} is invalid.`);
+  }
+  return value as T;
+}
+
+function sanitizeJsonValue(value: unknown, depth = 0, seen = new Set<object>()): FactoryRuleJsonValue {
+  if (value === null || typeof value === 'boolean' || typeof value === 'string') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new FactoryRuleValidationError('Rule metadata must contain finite numbers.');
+    return value;
+  }
+  if (depth >= MAX_JSON_DEPTH || (typeof value !== 'object' && !Array.isArray(value))) {
+    throw new FactoryRuleValidationError('Rule metadata is not bounded JSON.');
+  }
+  if (seen.has(value as object)) throw new FactoryRuleValidationError('Rule metadata must not contain cycles.');
+  seen.add(value as object);
+  try {
+    if (Array.isArray(value)) {
+      if (value.length > MAX_JSON_COLLECTION_SIZE) {
+        throw new FactoryRuleValidationError('Rule metadata contains too many entries.');
+      }
+      return value.map(entry => sanitizeJsonValue(entry, depth + 1, seen));
+    }
+    if (!isPlainObject(value)) throw new FactoryRuleValidationError('Rule metadata must use plain objects.');
+    const entries = Object.entries(value);
+    if (entries.length > MAX_JSON_COLLECTION_SIZE) {
+      throw new FactoryRuleValidationError('Rule metadata contains too many fields.');
+    }
+    const sanitized: Record<string, FactoryRuleJsonValue> = {};
+    for (const [key, entry] of entries) {
+      const normalizedKey = boundedString(key, 'Rule metadata key', 128, IDENTIFIER_RE);
+      sanitized[normalizedKey] = SENSITIVE_KEY_RE.test(normalizedKey)
+        ? '[REDACTED]'
+        : sanitizeJsonValue(entry, depth + 1, seen);
+    }
+    return sanitized;
+  } finally {
+    seen.delete(value as object);
+  }
+}
+
+function sanitizeMetadata(value: unknown): Record<string, FactoryRuleJsonValue> | undefined {
+  if (value === undefined) return undefined;
+  const sanitized = sanitizeJsonValue(value);
+  if (!isPlainObject(sanitized)) throw new FactoryRuleValidationError('Rule metadata must be an object.');
+  if (JSON.stringify(sanitized).length > MAX_METADATA_JSON_LENGTH) {
+    throw new FactoryRuleValidationError('Rule metadata is too large.');
+  }
+  return sanitized;
+}
+
+function validateBoardRules(rules: unknown, label: string): asserts rules is FactoryBoardRules {
+  if (!isPlainObject(rules)) throw new FactoryRuleValidationError(`${label} must be an object.`);
+  for (const [stage, sources] of Object.entries(rules)) {
+    enumValue(stage, FACTORY_RULE_STAGES, `${label} stage`);
+    if (!isPlainObject(sources)) throw new FactoryRuleValidationError(`${label}.${stage} must be an object.`);
+    for (const [source, leaf] of Object.entries(sources)) {
+      enumValue(source, FACTORY_RULE_SOURCES, `${label}.${stage} source`);
+      if (!isPlainObject(leaf)) throw new FactoryRuleValidationError(`${label}.${stage}.${source} must be an object.`);
+      assertExactKeys(leaf, ['onEnter', 'onExit'], `${label}.${stage}.${source}`);
+      for (const handler of Object.values(leaf)) {
+        if (handler !== undefined && typeof handler !== 'function') {
+          throw new FactoryRuleValidationError(`${label}.${stage}.${source} handlers must be functions.`);
+        }
+      }
+    }
+  }
+}
+
+export function assertFactoryRules(rules: unknown): asserts rules is FactoryRules {
+  if (!isPlainObject(rules)) throw new FactoryRuleValidationError('Factory rules must be an object.');
+  assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'github'], 'Factory rules');
+  boundedString(rules.version, 'Factory rule version', MAX_VERSION_LENGTH);
+  validateBoardRules(rules.work, 'Factory rules.work');
+  validateBoardRules(rules.review, 'Factory rules.review');
+
+  if (!isPlainObject(rules.tools)) throw new FactoryRuleValidationError('Factory rules.tools must be an object.');
+  for (const [toolName, leaf] of Object.entries(rules.tools)) {
+    boundedString(toolName, 'Factory tool name', 128, IDENTIFIER_RE);
+    if (!isPlainObject(leaf))
+      throw new FactoryRuleValidationError(`Factory rules.tools.${toolName} must be an object.`);
+    assertExactKeys(leaf, ['onResult'], `Factory rules.tools.${toolName}`);
+    if (leaf.onResult !== undefined && typeof leaf.onResult !== 'function') {
+      throw new FactoryRuleValidationError(`Factory rules.tools.${toolName}.onResult must be a function.`);
+    }
+  }
+
+  if (!isPlainObject(rules.github)) throw new FactoryRuleValidationError('Factory rules.github must be an object.');
+  for (const [event, leaf] of Object.entries(rules.github)) {
+    enumValue(event, FACTORY_GITHUB_EVENTS, 'Factory GitHub event');
+    if (!isPlainObject(leaf)) throw new FactoryRuleValidationError(`Factory rules.github.${event} must be an object.`);
+    assertExactKeys(leaf, ['onEvent'], `Factory rules.github.${event}`);
+    if (leaf.onEvent !== undefined && typeof leaf.onEvent !== 'function') {
+      throw new FactoryRuleValidationError(`Factory rules.github.${event}.onEvent must be a function.`);
+    }
+  }
+}
+
+function commonCommitFields(value: Record<string, unknown>): { idempotencyKey: string } {
+  return {
+    idempotencyKey: boundedString(value.idempotencyKey, 'Factory decision idempotencyKey', MAX_IDEMPOTENCY_KEY_LENGTH),
+  };
+}
+
+export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): FactoryRuleDecision {
+  if (causalDepth > MAX_FACTORY_RULE_CAUSAL_DEPTH) {
+    throw new FactoryRuleValidationError('Factory rule causal depth exceeded.');
+  }
+  if (!isPlainObject(value)) throw new FactoryRuleValidationError('Factory rule decision must be an object.');
+  const type = value.type;
+  if (typeof type !== 'string') throw new FactoryRuleValidationError('Factory rule decision type is required.');
+
+  switch (type) {
+    case 'reject': {
+      assertExactKeys(value, ['type', 'code', 'reason'], 'Factory reject decision');
+      return {
+        type,
+        code: enumValue(value.code, REJECTION_CODES, 'Factory rejection code'),
+        reason: boundedString(value.reason, 'Factory rejection reason', MAX_REASON_LENGTH),
+      };
+    }
+    case 'transition': {
+      assertExactKeys(value, ['type', 'idempotencyKey', 'board', 'stage'], 'Factory transition decision');
+      return {
+        type,
+        ...commonCommitFields(value),
+        board: enumValue(value.board, FACTORY_RULE_BOARDS, 'Factory transition board'),
+        stage: enumValue(value.stage, FACTORY_RULE_STAGES, 'Factory transition stage'),
+      };
+    }
+    case 'upsertLinkedWorkItem': {
+      assertExactKeys(
+        value,
+        ['type', 'idempotencyKey', 'board', 'source', 'sourceKey', 'title', 'url', 'stage', 'metadata'],
+        'Factory linked work item decision',
+      );
+      const url = value.url;
+      if (url !== null && (typeof url !== 'string' || url.length > MAX_URL_LENGTH || !/^https?:\/\//.test(url))) {
+        throw new FactoryRuleValidationError('Factory linked work item URL is invalid.');
+      }
+      const metadata = sanitizeMetadata(value.metadata);
+      return {
+        type,
+        ...commonCommitFields(value),
+        board: enumValue(value.board, FACTORY_RULE_BOARDS, 'Factory linked work item board'),
+        source: enumValue(value.source, WORK_ITEM_SOURCES, 'Factory linked work item source'),
+        sourceKey: boundedString(value.sourceKey, 'Factory linked work item sourceKey', MAX_SOURCE_KEY_LENGTH),
+        title: boundedString(value.title, 'Factory linked work item title', MAX_TITLE_LENGTH),
+        url,
+        stage: enumValue(value.stage, FACTORY_RULE_STAGES, 'Factory linked work item stage'),
+        ...(metadata ? { metadata } : {}),
+      };
+    }
+    case 'invokeSkill': {
+      assertExactKeys(
+        value,
+        ['type', 'idempotencyKey', 'role', 'skillName', 'arguments'],
+        'Factory invoke skill decision',
+      );
+      const args = optionalBoundedString(value.arguments, 'Factory skill arguments', MAX_ARGUMENTS_LENGTH);
+      return {
+        type,
+        ...commonCommitFields(value),
+        role: boundedString(value.role, 'Factory skill role', MAX_ROLE_LENGTH, IDENTIFIER_RE),
+        skillName: boundedString(value.skillName, 'Factory skill name', MAX_SKILL_NAME_LENGTH, SKILL_NAME_RE),
+        ...(args ? { arguments: args } : {}),
+      };
+    }
+    case 'sendMessage': {
+      assertExactKeys(value, ['type', 'idempotencyKey', 'role', 'message'], 'Factory send message decision');
+      return {
+        type,
+        ...commonCommitFields(value),
+        role: boundedString(value.role, 'Factory message role', MAX_ROLE_LENGTH, IDENTIFIER_RE),
+        message: boundedString(value.message, 'Factory message', MAX_MESSAGE_LENGTH),
+      };
+    }
+    case 'notify': {
+      assertExactKeys(value, ['type', 'idempotencyKey', 'title', 'body', 'level'], 'Factory notify decision');
+      const body = optionalBoundedString(value.body, 'Factory notification body', MAX_MESSAGE_LENGTH);
+      const level =
+        value.level === undefined
+          ? undefined
+          : enumValue(value.level, ['info', 'warning', 'error'] as const, 'Factory notification level');
+      return {
+        type,
+        ...commonCommitFields(value),
+        title: boundedString(value.title, 'Factory notification title', MAX_TITLE_LENGTH),
+        ...(body ? { body } : {}),
+        ...(level ? { level } : {}),
+      };
+    }
+    default:
+      throw new FactoryRuleValidationError('Factory rule decision type is unsupported.');
+  }
+}
+
+export function validateFactoryRuleDecisions(values: readonly unknown[], causalDepth = 0): FactoryCommitDecision[] {
+  if (values.length > MAX_JSON_COLLECTION_SIZE) {
+    throw new FactoryRuleValidationError('Factory rule produced too many decisions.');
+  }
+  const decisions: FactoryCommitDecision[] = [];
+  for (const value of values) {
+    const decision = validateFactoryRuleDecision(value, causalDepth);
+    if (decision.type === 'reject') {
+      throw new FactoryRuleValidationError('A rejection cannot be persisted with commit decisions.');
+    }
+    decisions.push(decision);
+  }
+  const keys = decisions.map(decision => decision.idempotencyKey);
+  if (new Set(keys).size !== keys.length) {
+    throw new FactoryRuleValidationError('Factory decisions require unique idempotency keys.');
+  }
+  return decisions;
+}

--- a/mastracode/web/src/web/factory/rules/validation.ts
+++ b/mastracode/web/src/web/factory/rules/validation.ts
@@ -6,8 +6,8 @@ import type {
   FactoryRuleJsonValue,
   FactoryRules,
   FactoryRuleRejectionCode,
+  WorkItemSource,
 } from './types.js';
-import type { WorkItemSource } from '../../storage/domains/work-items/base.js';
 
 export const MAX_FACTORY_RULE_CAUSAL_DEPTH = 8;
 

--- a/mastracode/web/src/web/factory/store.ts
+++ b/mastracode/web/src/web/factory/store.ts
@@ -6,8 +6,13 @@ import { getFactoryStorage } from '../runtime-config';
 import { getWorkItemsStorage } from '../storage/domains';
 import { WorkItemRelationError } from '../storage/domains/work-items/base';
 import type {
+  CommitFactoryTransitionInput,
+  CommitFactoryTransitionResult,
   CreateWorkItemInput,
   ExternalWorkItemSource,
+  FactoryPendingStartRecord,
+  PrepareFactoryRunStartInput,
+  PrepareFactoryRunStartResult,
   UpsertWorkItemResult,
   UpdateWorkItemInput,
   WorkItemPriorState,
@@ -170,6 +175,7 @@ export async function upsertWorkItem(params: {
   userId: string;
   factoryProjectId: string;
   input: CreateWorkItemInput;
+  reuseMode?: 'update' | 'preserve' | 'non-stage';
 }): Promise<UpsertWorkItemResult> {
   return (await workItemsDomain()).upsert(params);
 }
@@ -181,6 +187,38 @@ export async function updateWorkItem(params: {
   patch: UpdateWorkItemInput;
 }): Promise<{ item: WorkItemRow; previous: WorkItemPriorState } | null> {
   return (await workItemsDomain()).update(params);
+}
+
+export async function getWorkItem({
+  orgId,
+  factoryProjectId,
+  id,
+}: {
+  orgId: string;
+  factoryProjectId: string;
+  id: string;
+}): Promise<WorkItemRow | null> {
+  return (await workItemsDomain()).getForProject(orgId, factoryProjectId, id);
+}
+
+export async function commitFactoryTransition(
+  input: CommitFactoryTransitionInput,
+): Promise<CommitFactoryTransitionResult> {
+  return (await workItemsDomain()).commitTransition(input);
+}
+
+export async function prepareFactoryRunStart(
+  input: PrepareFactoryRunStartInput,
+): Promise<PrepareFactoryRunStartResult> {
+  return (await workItemsDomain()).prepareRunStart(input);
+}
+
+export async function markFactoryPendingStart(
+  bindingId: string,
+  status: 'sent' | 'failed',
+  lastError?: string,
+): Promise<FactoryPendingStartRecord | null> {
+  return (await workItemsDomain()).markPendingStart(bindingId, status, lastError);
 }
 
 export async function deleteWorkItem({ orgId, id }: { orgId: string; id: string }): Promise<WorkItemRow | null> {

--- a/mastracode/web/src/web/runtime-config.ts
+++ b/mastracode/web/src/web/runtime-config.ts
@@ -16,6 +16,7 @@ import type { FactoryStorage } from '@mastra/core/storage';
 import type { MastraVector } from '@mastra/core/vector';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 import type { FactoryIntegration } from './factory-integration.js';
+import type { FactoryRules } from './factory/rules/types.js';
 import type { GithubIntegration } from './github/integration.js';
 import type { LinearIntegration } from './linear/integration.js';
 import type { StateSigner } from './state-signing.js';
@@ -56,6 +57,8 @@ export interface WebRuntimeConfig {
   sandbox?: WebSandboxRuntime;
   /** Registered integrations (GitHub, Linear, third-party), keyed by their stable id. */
   integrations?: FactoryIntegration[];
+  /** Resolved authoritative Factory rules for this deployment. */
+  rules?: FactoryRules;
   /** Shared OAuth state signer created by the factory (see `./state-signing.ts`). */
   stateSigner?: StateSigner;
 }
@@ -116,6 +119,11 @@ export function getSeededAuthProvider(): IMastraAuthProvider | undefined {
  */
 export function getSeededSandbox(): WebSandboxRuntime | undefined {
   return seeded?.sandbox;
+}
+
+/** Resolved Factory rules seeded by the factory, if preparation has run. */
+export function getSeededFactoryRules(): FactoryRules | undefined {
+  return seeded?.rules;
 }
 
 /** Look up a registered integration by its stable id. */

--- a/mastracode/web/src/web/storage/domains/work-items/base.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/base.ts
@@ -4,7 +4,8 @@
  * Work items belong to a first-class Factory project. External intake items use
  * a provider-neutral source reference; manual work items have no source.
  * Stage history is server-owned, while session and metadata patches merge
- * atomically so concurrent actors do not overwrite each other.
+ * atomically so concurrent actors do not overwrite each other. The authoritative
+ * Factory transition path keeps one exclusive current stage per item.
  */
 
 import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage';
@@ -33,6 +34,108 @@ export interface WorkItemSessionRef {
   startedBy: string;
 }
 
+export interface FactoryRuleIngressRecord {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  identity: string;
+  triggerType: string;
+  transitionId: string;
+  result: Record<string, unknown>;
+  createdAt: Date;
+}
+
+export interface FactoryRuleEvaluationRecord {
+  id: string;
+  ingressId: string;
+  workItemId: string;
+  ruleSetVersion: string;
+  expectedRevision: number;
+  outcome: 'accepted' | 'rejected';
+  code: string | null;
+  reason: string | null;
+  createdAt: Date;
+}
+
+export interface FactoryDeferredDecisionRecord {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  evaluationId: string;
+  workItemId: string;
+  idempotencyKey: string;
+  decision: Record<string, unknown>;
+  status: 'pending';
+  createdAt: Date;
+}
+
+export interface FactoryRunBindingRecord {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  role: string;
+  threadId: string;
+  resourceId: string;
+  projectPath: string;
+  branch: string;
+  status: 'active' | 'revoked';
+  createdAt: Date;
+  revokedAt: Date | null;
+}
+
+export interface FactoryPendingStartRecord {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  bindingId: string;
+  kickoffKey: string;
+  message: string | null;
+  status: 'pending' | 'sent' | 'failed';
+  lastError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CommitFactoryTransitionInput {
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  expectedRevision: number;
+  destinationStage: string;
+  actorId: string;
+  ingress: { identity: string; triggerType: string; transitionId: string };
+  ruleSetVersion: string;
+  evaluation:
+    | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
+    | { outcome: 'rejected'; code: string; reason: string };
+}
+
+export type CommitFactoryTransitionResult =
+  | { status: 'committed'; item: WorkItemRow | null; result: Record<string, unknown> }
+  | { status: 'replayed'; item: WorkItemRow | null; result: Record<string, unknown> }
+  | { status: 'missing' };
+
+export interface PrepareFactoryRunStartInput {
+  orgId: string;
+  userId: string;
+  factoryProjectId: string;
+  workItem: { id?: string; input: CreateWorkItemInput };
+  role: string;
+  session: WorkItemSessionInput;
+  resourceId: string;
+  kickoffKey: string;
+  kickoffMessage: string | null;
+}
+
+export interface PrepareFactoryRunStartResult {
+  item: WorkItemRow;
+  binding: FactoryRunBindingRecord;
+  pendingStart: FactoryPendingStartRecord;
+  replayed: boolean;
+}
+
+/** Session ref as accepted from clients — `startedBy` is stamped server-side. */
 export interface WorkItemSessionInput {
   projectPath: string;
   branch: string;
@@ -52,6 +155,7 @@ export interface WorkItemRow {
   stageHistory: WorkItemStageEntry[];
   sessions: WorkItemSessions;
   metadata: Record<string, unknown> | null;
+  revision: number;
   createdBy: string;
   createdAt: Date;
   updatedAt: Date;
@@ -99,6 +203,7 @@ export const WORK_ITEMS_SCHEMA: CollectionSchema = {
     stage_history: { type: 'json' },
     sessions: { type: 'json' },
     metadata: { type: 'json', nullable: true },
+    revision: { type: 'integer', default: 1 },
     created_by: { type: 'text' },
     created_at: { type: 'timestamp' },
     updated_at: { type: 'timestamp' },
@@ -133,6 +238,7 @@ interface WorkItemDbRow extends Record<string, unknown> {
   stage_history: WorkItemStageEntry[];
   sessions: WorkItemSessions;
   metadata: Record<string, unknown> | null;
+  revision: number;
   created_by: string;
   created_at: Date;
   updated_at: Date;
@@ -154,9 +260,25 @@ function toWorkItem(row: WorkItemDbRow): WorkItemRow {
     stageHistory: row.stage_history,
     sessions: row.sessions,
     metadata: row.metadata,
+    revision: row.revision,
     createdBy: row.created_by,
     createdAt: row.created_at,
     updatedAt: row.updated_at,
+  };
+}
+
+const toRow = toWorkItem;
+
+function patchColumns(changes: Partial<WorkItemRow>): Partial<WorkItemDbRow> {
+  return {
+    ...(changes.parentWorkItemId !== undefined ? { parent_work_item_id: changes.parentWorkItemId } : {}),
+    ...(changes.title !== undefined ? { title: changes.title } : {}),
+    ...(changes.stages !== undefined ? { stages: changes.stages } : {}),
+    ...(changes.stageHistory !== undefined ? { stage_history: changes.stageHistory } : {}),
+    ...(changes.sessions !== undefined ? { sessions: changes.sessions } : {}),
+    ...(changes.metadata !== undefined ? { metadata: changes.metadata } : {}),
+    ...(changes.revision !== undefined ? { revision: changes.revision } : {}),
+    ...(changes.updatedAt !== undefined ? { updated_at: changes.updatedAt } : {}),
   };
 }
 
@@ -249,6 +371,7 @@ function applyUpdate({
     ...(input.metadata !== undefined
       ? { metadata: input.metadata === null ? null : { ...(current.metadata ?? {}), ...input.metadata } }
       : {}),
+    revision: current.revision + 1,
     updated_at: now,
   };
 }
@@ -269,13 +392,156 @@ function withInProcessProjectLock<T>(key: string, fn: () => Promise<T>): Promise
   return result;
 }
 
+const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
+  {
+    name: 'factory_rule_ingress',
+    columns: {
+      id: { type: 'uuid-pk' },
+      org_id: { type: 'text' },
+      factory_project_id: { type: 'text' },
+      identity: { type: 'text' },
+      trigger_type: { type: 'text' },
+      transition_id: { type: 'text' },
+      result: { type: 'json' },
+      created_at: { type: 'timestamp' },
+    },
+    uniqueIndexes: [
+      { name: 'factory_rule_ingress_tenant_identity_unique', columns: ['org_id', 'factory_project_id', 'identity'] },
+    ],
+  },
+  {
+    name: 'factory_rule_evaluations',
+    columns: {
+      id: { type: 'uuid-pk' },
+      ingress_id: { type: 'text' },
+      work_item_id: { type: 'text' },
+      rule_set_version: { type: 'text' },
+      expected_revision: { type: 'integer' },
+      outcome: { type: 'text' },
+      code: { type: 'text', nullable: true },
+      reason: { type: 'text', nullable: true },
+      created_at: { type: 'timestamp' },
+    },
+  },
+  {
+    name: 'factory_deferred_decisions',
+    columns: {
+      id: { type: 'uuid-pk' },
+      org_id: { type: 'text' },
+      factory_project_id: { type: 'text' },
+      evaluation_id: { type: 'text' },
+      work_item_id: { type: 'text' },
+      idempotency_key: { type: 'text' },
+      decision: { type: 'json' },
+      status: { type: 'text' },
+      created_at: { type: 'timestamp' },
+    },
+    uniqueIndexes: [
+      {
+        name: 'factory_deferred_decisions_tenant_key_unique',
+        columns: ['org_id', 'factory_project_id', 'idempotency_key'],
+      },
+    ],
+  },
+  {
+    name: 'factory_run_bindings',
+    columns: {
+      id: { type: 'uuid-pk' },
+      org_id: { type: 'text' },
+      factory_project_id: { type: 'text' },
+      work_item_id: { type: 'text' },
+      role: { type: 'text' },
+      thread_id: { type: 'text' },
+      resource_id: { type: 'text' },
+      project_path: { type: 'text' },
+      branch: { type: 'text' },
+      status: { type: 'text' },
+      created_at: { type: 'timestamp' },
+      revoked_at: { type: 'timestamp', nullable: true },
+    },
+  },
+  {
+    name: 'factory_pending_starts',
+    columns: {
+      id: { type: 'uuid-pk' },
+      org_id: { type: 'text' },
+      factory_project_id: { type: 'text' },
+      binding_id: { type: 'text' },
+      kickoff_key: { type: 'text' },
+      message: { type: 'text', nullable: true },
+      status: { type: 'text' },
+      last_error: { type: 'text', nullable: true },
+      created_at: { type: 'timestamp' },
+      updated_at: { type: 'timestamp' },
+    },
+    uniqueIndexes: [
+      {
+        name: 'factory_pending_starts_tenant_kickoff_unique',
+        columns: ['org_id', 'factory_project_id', 'kickoff_key'],
+      },
+    ],
+  },
+];
+
+interface GovernanceDbRow extends Record<string, unknown> {
+  id: string;
+  org_id: string;
+  factory_project_id: string;
+  created_at: Date;
+  [key: string]: unknown;
+}
+
+function toBinding(row: GovernanceDbRow): FactoryRunBindingRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    factoryProjectId: row.factory_project_id,
+    workItemId: String(row.work_item_id),
+    role: String(row.role),
+    threadId: String(row.thread_id),
+    resourceId: String(row.resource_id),
+    projectPath: String(row.project_path),
+    branch: String(row.branch),
+    status: row.status as FactoryRunBindingRecord['status'],
+    createdAt: row.created_at,
+    revokedAt: (row.revoked_at as Date | null) ?? null,
+  };
+}
+function toDeferredDecision(row: GovernanceDbRow): FactoryDeferredDecisionRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    factoryProjectId: row.factory_project_id,
+    evaluationId: String(row.evaluation_id),
+    workItemId: String(row.work_item_id),
+    idempotencyKey: String(row.idempotency_key),
+    decision: row.decision as Record<string, unknown>,
+    status: 'pending',
+    createdAt: row.created_at,
+  };
+}
+function toPendingStart(row: GovernanceDbRow): FactoryPendingStartRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    factoryProjectId: row.factory_project_id,
+    bindingId: String(row.binding_id),
+    kickoffKey: String(row.kickoff_key),
+    message: (row.message as string | null) ?? null,
+    status: row.status as FactoryPendingStartRecord['status'],
+    lastError: (row.last_error as string | null) ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at as Date,
+  };
+}
+
 export class WorkItemsStorage extends FactoryStorageDomain {
   constructor() {
     super('work-items');
   }
 
   async init(): Promise<void> {
-    await this.ensureCollections([WORK_ITEMS_SCHEMA]);
+    await this.ensureCollections([WORK_ITEMS_SCHEMA, ...FACTORY_GOVERNANCE_SCHEMAS]);
   }
 
   async dangerouslyClearAll(): Promise<void> {
@@ -307,11 +573,340 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     return row ? toWorkItem(row) : null;
   }
 
+  async getForProject(orgId: string, factoryProjectId: string, id: string): Promise<WorkItemRow | null> {
+    const row = await this.#db.findOne<WorkItemDbRow>('work_items', {
+      id,
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+    });
+    return row ? toRow(row) : null;
+  }
+
+  async getTransitionResultByIngress(
+    orgId: string,
+    factoryProjectId: string,
+    identity: string,
+  ): Promise<Record<string, unknown> | null> {
+    const row = await this.#db.findOne<GovernanceDbRow>('factory_rule_ingress', {
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+      identity,
+    });
+    return (row?.result as Record<string, unknown> | undefined) ?? null;
+  }
+
+  async commitTransition(input: CommitFactoryTransitionInput): Promise<CommitFactoryTransitionResult> {
+    const commit = (): Promise<CommitFactoryTransitionResult> =>
+      this.storage.withTransaction<CommitFactoryTransitionResult>(async ops => {
+        const prior = await ops.findOne<GovernanceDbRow>('factory_rule_ingress', {
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+          identity: input.ingress.identity,
+        });
+        if (prior)
+          return {
+            status: 'replayed',
+            item: await this.getForProject(input.orgId, input.factoryProjectId, input.workItemId),
+            result: prior.result as Record<string, unknown>,
+          };
+
+        const now = new Date();
+        let item: WorkItemRow | null = null;
+        let code: string | null = null;
+        let reason: string | null = null;
+        let result: Record<string, unknown>;
+        const updated = await ops.updateAtomic<WorkItemDbRow>(
+          'work_items',
+          {
+            id: input.workItemId,
+            org_id: input.orgId,
+            factory_project_id: input.factoryProjectId,
+          },
+          row => {
+            const existing = toRow(row);
+            item = existing;
+            if (existing.revision !== input.expectedRevision) {
+              code = 'stale';
+              reason = 'The work item changed before this transition committed.';
+              return null;
+            }
+            if (input.evaluation.outcome === 'rejected') {
+              code = input.evaluation.code;
+              reason = input.evaluation.reason;
+              return null;
+            }
+            if (existing.stages.length === 1 && existing.stages[0] === input.destinationStage) return null;
+            return patchColumns({
+              stages: [input.destinationStage],
+              stageHistory: applyStageTransition(
+                existing.stageHistory,
+                existing.stages,
+                [input.destinationStage],
+                input.actorId,
+                now,
+              ),
+              revision: existing.revision + 1,
+              updatedAt: now,
+            });
+          },
+        );
+        if (updated) item = toRow(updated);
+        if (!item) {
+          code = input.evaluation.outcome === 'rejected' ? input.evaluation.code : 'invalid_transition';
+          reason = input.evaluation.outcome === 'rejected' ? input.evaluation.reason : 'Work item not found.';
+        }
+        const outcome: 'accepted' | 'rejected' =
+          item && code === null && input.evaluation.outcome === 'accepted' ? 'accepted' : 'rejected';
+        result =
+          outcome === 'accepted'
+            ? {
+                status: 'accepted',
+                transitionId: input.ingress.transitionId,
+                itemId: item!.id,
+                revision: item!.revision,
+                stage: input.destinationStage,
+                decisions: input.evaluation.outcome === 'accepted' ? input.evaluation.decisions : [],
+              }
+            : { status: 'rejected', transitionId: input.ingress.transitionId, itemId: input.workItemId, code, reason };
+        const ingress = await ops.insertOne<GovernanceDbRow>('factory_rule_ingress', {
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+          identity: input.ingress.identity,
+          trigger_type: input.ingress.triggerType,
+          transition_id: input.ingress.transitionId,
+          result,
+          created_at: now,
+        });
+        if (item) {
+          const evaluation = await ops.insertOne<GovernanceDbRow>('factory_rule_evaluations', {
+            ingress_id: ingress.id,
+            work_item_id: item.id,
+            rule_set_version: input.ruleSetVersion,
+            expected_revision: input.expectedRevision,
+            outcome,
+            code,
+            reason,
+            created_at: now,
+          });
+          if (outcome === 'accepted' && input.evaluation.outcome === 'accepted') {
+            for (const [index, decision] of input.evaluation.decisions.entries()) {
+              await ops.insertOne<GovernanceDbRow>('factory_deferred_decisions', {
+                org_id: input.orgId,
+                factory_project_id: input.factoryProjectId,
+                evaluation_id: evaluation.id,
+                work_item_id: item.id,
+                idempotency_key: String(decision.idempotencyKey),
+                decision,
+                status: 'pending',
+                created_at: new Date(now.getTime() + index),
+              });
+            }
+          }
+        }
+        return { status: 'committed', item, result };
+      });
+    return this.storage.withDistributedLock
+      ? this.storage.withDistributedLock(
+          `factory-ingress:${input.orgId}:${input.factoryProjectId}:${input.ingress.identity}`,
+          commit,
+        )
+      : commit();
+  }
+
+  async listDeferredDecisions(orgId: string, factoryProjectId: string): Promise<FactoryDeferredDecisionRecord[]> {
+    return (
+      await this.#db.findMany<GovernanceDbRow>(
+        'factory_deferred_decisions',
+        { org_id: orgId, factory_project_id: factoryProjectId },
+        { orderBy: [['created_at', 'asc']] },
+      )
+    ).map(toDeferredDecision);
+  }
+
+  async listRunBindings(
+    orgId: string,
+    factoryProjectId: string,
+    workItemId?: string,
+  ): Promise<FactoryRunBindingRecord[]> {
+    return (
+      await this.#db.findMany<GovernanceDbRow>(
+        'factory_run_bindings',
+        {
+          org_id: orgId,
+          factory_project_id: factoryProjectId,
+          ...(workItemId ? { work_item_id: workItemId } : {}),
+        },
+        { orderBy: [['created_at', 'asc']] },
+      )
+    ).map(toBinding);
+  }
+
+  async listPendingStarts(orgId: string, factoryProjectId: string): Promise<FactoryPendingStartRecord[]> {
+    return (
+      await this.#db.findMany<GovernanceDbRow>(
+        'factory_pending_starts',
+        { org_id: orgId, factory_project_id: factoryProjectId },
+        { orderBy: [['created_at', 'asc']] },
+      )
+    ).map(toPendingStart);
+  }
+
+  async prepareRunStart(input: PrepareFactoryRunStartInput): Promise<PrepareFactoryRunStartResult> {
+    const prepare = () =>
+      this.storage.withTransaction(async ops => {
+        const prior = await ops.findOne<GovernanceDbRow>('factory_pending_starts', {
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+          kickoff_key: input.kickoffKey,
+        });
+        if (prior) {
+          const bindingRow = await ops.findOne<GovernanceDbRow>('factory_run_bindings', {
+            id: String(prior.binding_id),
+            org_id: input.orgId,
+            factory_project_id: input.factoryProjectId,
+          });
+          const itemRow =
+            bindingRow &&
+            (await ops.findOne<WorkItemDbRow>('work_items', {
+              id: String(bindingRow.work_item_id),
+              org_id: input.orgId,
+              factory_project_id: input.factoryProjectId,
+            }));
+          if (!bindingRow || !itemRow) throw new Error('Factory start replay references missing state.');
+          return {
+            item: toRow(itemRow),
+            binding: toBinding(bindingRow),
+            pendingStart: toPendingStart(prior),
+            replayed: true,
+          };
+        }
+        const now = new Date();
+        const create = input.workItem.input;
+        let row = input.workItem.id
+          ? await ops.findOne<WorkItemDbRow>('work_items', {
+              id: input.workItem.id,
+              org_id: input.orgId,
+              factory_project_id: input.factoryProjectId,
+            })
+          : sourceKey(create.externalSource)
+            ? await ops.findOne<WorkItemDbRow>('work_items', {
+                org_id: input.orgId,
+                factory_project_id: input.factoryProjectId,
+                source_key: sourceKey(create.externalSource),
+              })
+            : null;
+        let item: WorkItemRow;
+        if (row) {
+          row = await ops.updateAtomic<WorkItemDbRow>('work_items', { id: row.id }, current =>
+            applyUpdate({
+              current,
+              userId: input.userId,
+              input: { sessions: { [input.role]: input.session } },
+            }),
+          );
+          item = toRow(row!);
+        } else {
+          if (create.parentWorkItemId)
+            validateParentRelation(
+              (
+                await ops.findMany<WorkItemDbRow>('work_items', {
+                  org_id: input.orgId,
+                  factory_project_id: input.factoryProjectId,
+                })
+              ).map(toRow),
+              undefined,
+              create.parentWorkItemId,
+            );
+          row = await ops.insertOne<WorkItemDbRow>('work_items', {
+            org_id: input.orgId,
+            created_by: input.userId,
+            factory_project_id: input.factoryProjectId,
+            external_source: create.externalSource ?? null,
+            source_key: sourceKey(create.externalSource),
+            parent_work_item_id: create.parentWorkItemId ?? null,
+            title: create.title,
+            stages: create.stages ?? [],
+            stage_history: applyStageTransition([], [], create.stages ?? [], input.userId, now),
+            sessions: stampSessions({ [input.role]: input.session }, input.userId),
+            metadata: create.metadata ?? null,
+            revision: 1,
+            created_at: now,
+            updated_at: now,
+          });
+          item = toRow(row);
+        }
+        await ops.updateMany(
+          'factory_run_bindings',
+          {
+            org_id: input.orgId,
+            factory_project_id: input.factoryProjectId,
+            work_item_id: item.id,
+            role: input.role,
+            status: 'active',
+          },
+          { status: 'revoked', revoked_at: now },
+        );
+        const bindingRow = await ops.insertOne<GovernanceDbRow>('factory_run_bindings', {
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+          work_item_id: item.id,
+          role: input.role,
+          thread_id: input.session.threadId,
+          resource_id: input.resourceId,
+          project_path: input.session.projectPath,
+          branch: input.session.branch,
+          status: 'active',
+          created_at: now,
+          revoked_at: null,
+        });
+        const pendingRow = await ops.insertOne<GovernanceDbRow>('factory_pending_starts', {
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+          binding_id: bindingRow.id,
+          kickoff_key: input.kickoffKey,
+          message: input.kickoffMessage,
+          status: 'pending',
+          last_error: null,
+          created_at: now,
+          updated_at: now,
+        });
+        return { item, binding: toBinding(bindingRow), pendingStart: toPendingStart(pendingRow), replayed: false };
+      });
+    return this.storage.withDistributedLock
+      ? this.storage.withDistributedLock(
+          `factory-start:${input.orgId}:${input.factoryProjectId}:${input.kickoffKey}`,
+          prepare,
+        )
+      : prepare();
+  }
+
+  async markPendingStart(
+    bindingId: string,
+    status: 'sent' | 'failed',
+    lastError?: string,
+  ): Promise<FactoryPendingStartRecord | null> {
+    const row = await this.#db.updateAtomic<GovernanceDbRow>(
+      'factory_pending_starts',
+      { binding_id: bindingId },
+      () => ({ status, last_error: lastError ?? null, updated_at: new Date() }),
+    );
+    return row ? toPendingStart(row) : null;
+  }
+
+  /**
+   * Create a work item, reusing the existing record when `sourceKey` already
+   * has one for the project (acting twice on the same issue must not duplicate
+   * the card). On reuse the provided stages replace the current ones (with the
+   * transition recorded in history) and sessions/metadata are merged in. The
+   * result discriminates insert from reuse so callers can audit the actual
+   * outcome.
+   */
   async upsert(params: {
     orgId: string;
     userId: string;
     factoryProjectId: string;
     input: CreateWorkItemInput;
+    reuseMode?: 'update' | 'preserve' | 'non-stage';
   }): Promise<UpsertWorkItemResult> {
     const run = () => this.#upsert(params);
     return params.input.parentWorkItemId
@@ -370,6 +965,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
         stage_history: stages.map(stage => ({ stage, enteredAt: now.toISOString(), by: userId })),
         sessions: stampSessions(input.sessions ?? {}, userId),
         metadata: input.metadata ?? null,
+        revision: 1,
         created_by: userId,
         created_at: now,
         updated_at: now,

--- a/mastracode/web/src/web/storage/domains/work-items/base.ts
+++ b/mastracode/web/src/web/storage/domains/work-items/base.ts
@@ -797,13 +797,11 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             : null;
         let item: WorkItemRow;
         if (row) {
-          row = await ops.updateAtomic<WorkItemDbRow>('work_items', { id: row.id }, current =>
-            applyUpdate({
-              current,
-              userId: input.userId,
-              input: { sessions: { [input.role]: input.session } },
-            }),
-          );
+          row = await ops.updateAtomic<WorkItemDbRow>('work_items', { id: row.id }, current => {
+            const roles = new Set([...Object.keys(current.sessions), input.role]);
+            const sessions = Object.fromEntries([...roles].map(role => [role, input.session]));
+            return applyUpdate({ current, userId: input.userId, input: { sessions } });
+          });
           item = toRow(row!);
         } else {
           if (create.parentWorkItemId)

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -29,6 +29,7 @@ import { useStartFactoryRun } from '../../../../shared/hooks/useStartFactoryRun'
 import type { FactoryRunInvocation } from '../../../../shared/hooks/useStartFactoryRun';
 import {
   useDeleteWorkItemMutation,
+  useTransitionWorkItemMutation,
   useUpdateWorkItemMutation,
   useUpsertWorkItemMutation,
 } from '../../../../shared/hooks/useWorkItems';
@@ -127,28 +128,6 @@ function itemStageOptions(item: WorkItem): ReadonlyArray<{ id: BoardStageId; lab
 
 function itemStageLabel(item: WorkItem, stage: string): string {
   return itemStageOptions(item).find(candidate => candidate.id === stage)?.label ?? stageLabel(stage);
-}
-
-/**
- * Stage list after moving a card out of `from` into `to`. Other concurrent
- * stages are kept — except `done`, which replaces everything (the item is
- * finished, all open stages exit).
- */
-function stagesAfterMove(stages: string[], from: string | null, to: string): string[] {
-  if (to === 'done') return ['done'];
-  const rest = stages.filter(stage => stage !== from && stage !== to && stage !== 'done');
-  return [...rest, to];
-}
-
-/** Pre-work stages a card exits when a run starts on it. */
-const PRE_RUN_STAGES: string[] = ['intake', 'triage', 'planning'];
-
-function stagesAfterRunStart(stages: string[], to: string): string[] {
-  return stagesAfterMove(
-    stages.filter(stage => !PRE_RUN_STAGES.includes(stage)),
-    null,
-    to,
-  );
 }
 
 /**
@@ -540,6 +519,7 @@ function BoardContent({
   const linearIssues = useLinearIssuesQuery(activeIntakeSource === 'linear');
 
   const upsert = useUpsertWorkItemMutation(factoryProjectId);
+  const transition = useTransitionWorkItemMutation(factoryProjectId);
   const update = useUpdateWorkItemMutation(factoryProjectId);
   const remove = useDeleteWorkItemMutation(factoryProjectId);
   const { start, pendingRuns, enabled: runEnabled } = useStartFactoryRun();
@@ -616,14 +596,10 @@ function BoardContent({
     container.scrollTo?.({ left: Math.max(0, lane.offsetLeft - container.offsetLeft), behavior: 'auto' });
   }, [boardDataPending, boardPositionKey, candidates, stages, workItems]);
 
-  const moveItem = (id: string, fromStage: string | null, toStage: string) => {
+  const moveItem = (id: string, _fromStage: string | null, toStage: string) => {
     const item = workItems.find(i => i.id === id);
-    if (!item) return;
-    const allowedStages = new Set<string>(stages.map(stage => stage.id));
-    const currentStages = item.stages.filter(stage => allowedStages.has(stage));
-    const next = stagesAfterMove(currentStages, fromStage, toStage);
-    if (next.length === item.stages.length && next.every(stage => item.stages.includes(stage))) return;
-    update.mutate({ id, patch: { stages: next } });
+    if (!item || (item.stages.length === 1 && item.stages[0] === toStage)) return;
+    transition.mutate({ item, board: review ? 'review' : 'work', stage: toStage });
   };
 
   const handleDrop = (payload: DragPayload, toStage: BoardStageId) => {
@@ -635,7 +611,18 @@ function BoardContent({
     // Filing a candidate never starts a run — it only creates the card.
     const { source, sourceKey, title, url, metadata } = payload.candidate;
     const parentWorkItemId = source === 'github-pr' ? inferredParentWorkItemId(metadata, allWorkItems) : undefined;
-    upsert.mutate({ source, sourceKey, parentWorkItemId, title, url, stages: [toStage], metadata });
+    void (async () => {
+      const item = await upsert.mutateAsync({
+        source,
+        sourceKey,
+        parentWorkItemId,
+        title,
+        url,
+        stages: ['intake'],
+        metadata,
+      });
+      if (toStage !== 'intake') transition.mutate({ item, board: review ? 'review' : 'work', stage: toStage });
+    })();
   };
 
   if (items.isPending) return <SkeletonRows label="Loading board" rows={4} rowClassName="h-24 w-full" />;
@@ -647,7 +634,9 @@ function BoardContent({
     );
   }
 
-  const mutationError = [start, triage, upsert, update, remove, selectWorkspace].find(m => m.isError)?.error;
+  const mutationError = [start, triage, upsert, transition, update, remove, selectWorkspace].find(
+    m => m.isError,
+  )?.error;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-3">
@@ -736,6 +725,8 @@ function BoardContent({
                       threadTitle: spec.threadTitle,
                       workItem: {
                         id: item.id,
+                        revision: item.revision,
+                        currentStage: item.stages.length === 1 ? item.stages[0] : undefined,
                         // File only the neutral chat role. The title is a
                         // create button only when every existing role ref is
                         // stale (worktree gone); repointing those roles here
@@ -757,9 +748,11 @@ function BoardContent({
                       invocation: action.invocation,
                       workItem: {
                         id: item.id,
+                        revision: item.revision,
+                        currentStage: item.stages.length === 1 ? item.stages[0] : undefined,
                         role: action.role,
                         existingRoles: Object.keys(item.sessions),
-                        stages: stagesAfterRunStart(item.stages, action.stage),
+                        stages: [action.stage],
                         source: item.source,
                         sourceKey: item.sourceKey,
                         title: item.title,

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -725,8 +725,6 @@ function BoardContent({
                       threadTitle: spec.threadTitle,
                       workItem: {
                         id: item.id,
-                        revision: item.revision,
-                        currentStage: item.stages.length === 1 ? item.stages[0] : undefined,
                         // File only the neutral chat role. The title is a
                         // create button only when every existing role ref is
                         // stale (worktree gone); repointing those roles here
@@ -748,8 +746,6 @@ function BoardContent({
                       invocation: action.invocation,
                       workItem: {
                         id: item.id,
-                        revision: item.revision,
-                        currentStage: item.stages.length === 1 ? item.stages[0] : undefined,
                         role: action.role,
                         existingRoles: Object.keys(item.sessions),
                         stages: [action.stage],

--- a/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/BoardPage.tsx
@@ -731,7 +731,7 @@ function BoardContent({
                         // would make them look live again and hide the card's
                         // run actions even though no run happened.
                         role: 'chat',
-                        stages: item.stages,
+                        stages: [stage.id],
                         source: item.source,
                         sourceKey: item.sourceKey,
                         title: item.title,

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -912,7 +912,7 @@ describe('Factory item actions', () => {
 });
 
 describe('Factory Board — persisted cards', () => {
-  it('given a work item in multiple stages, when the Board renders, then it shows a card in each column with a chip for the other stage', async () => {
+  it('given a work item in multiple stages, when its title opens a session, then it targets the clicked column', async () => {
     useBoardHandlers({
       workItems: [
         makeWorkItem({
@@ -924,6 +924,7 @@ describe('Factory Board — persisted cards', () => {
         }),
       ],
     });
+    const captured = useFactoryRunHandlers('item-wi-1');
     renderAt('/factory/work');
 
     await screen.findByTestId('board-column-intake');
@@ -934,6 +935,15 @@ describe('Factory Board — persisted cards', () => {
     // Each card chips the item's other stage.
     expect(within(executeCard).getByText('Review')).toBeInTheDocument();
     expect(within(reviewCard).getByText('Building')).toBeInTheDocument();
+
+    await userEvent.click(within(executeCard).getByRole('button', { name: 'Issue: Parallel effort' }));
+    await waitFor(() =>
+      expect(captured.starts).toContainEqual({
+        kickoffMessage: null,
+        destinationStage: 'execute',
+        workItem: expect.objectContaining({ id: 'wi-1', role: 'chat' }),
+      }),
+    );
   });
 
   it('given related issue and PR items, when switching workflows, then each stays on its own board with a reciprocal relation marker', async () => {

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -239,13 +239,15 @@ function makeWorkItem(overrides: Partial<WorkItem> & Pick<WorkItem, 'id' | 'titl
     createdAt: '2026-07-10T00:00:00Z',
     updatedAt: '2026-07-10T00:00:00Z',
     ...overrides,
+    revision: overrides.revision ?? 1,
   };
 }
 
 interface BoardState {
   items: WorkItem[];
   posts: CreateWorkItemInput[];
-  patches: Array<{ id: string } & UpdateWorkItemInput>;
+  patches: Array<{ id: string; stages?: string[] } & UpdateWorkItemInput>;
+  starts: Array<{ kickoffMessage: string | null; workItem: { id: string; role: string } }>;
   deletes: string[];
   triageRequests: Array<{ number: number; body: unknown }>;
   issueRequests: Array<string | null>;
@@ -269,6 +271,7 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
     items: [...(options.workItems ?? [])],
     posts: [],
     patches: [],
+    starts: [],
     deletes: [],
     triageRequests: [],
     issueRequests: [],
@@ -318,6 +321,68 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
       state.items = [...state.items.filter(i => i.sourceKey !== item.sourceKey || item.sourceKey === null), item];
       return HttpResponse.json({ workItem: item }, { status: 201 });
     }),
+    http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/runs/start`, async ({ request }) => {
+      const body = (await request.json()) as {
+        resourceId: string;
+        projectPath: string;
+        branch: string;
+        kickoffMessage: string | null;
+        workItem: { id: string; role: string };
+      };
+      state.starts.push({ kickoffMessage: body.kickoffMessage, workItem: body.workItem });
+      const existing = state.items.find(item => item.id === body.workItem.id);
+      if (!existing) return HttpResponse.json({ error: 'Work item not found' }, { status: 404 });
+      const session = {
+        projectPath: body.projectPath,
+        branch: body.branch,
+        threadId: 'thread-factory',
+        startedBy: 'user-1',
+      };
+      const updated = {
+        ...existing,
+        revision: existing.revision + 1,
+        sessions: { ...existing.sessions, [body.workItem.role]: session },
+      };
+      state.items = state.items.map(item => (item.id === existing.id ? updated : item));
+      state.patches.push({ id: existing.id, sessions: { [body.workItem.role]: session } });
+      return HttpResponse.json(
+        {
+          prepared: {
+            workItemId: existing.id,
+            bindingId: 'binding-1',
+            threadId: 'thread-factory',
+            resourceId: body.resourceId,
+            projectPath: body.projectPath,
+            branch: body.branch,
+            revision: updated.revision,
+            kickoffStatus: 'pending',
+            replayed: false,
+          },
+        },
+        { status: 202 },
+      );
+    }),
+    http.post(
+      `${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/work-items/:id/transition`,
+      async ({ request, params }) => {
+        const id = params.id as string;
+        const body = (await request.json()) as { stage: string; expectedRevision: number };
+        state.patches.push({ id, stages: [body.stage] });
+        const existing = state.items.find(item => item.id === id) ?? makeWorkItem({ id, title: 'unknown' });
+        const updated = { ...existing, stages: [body.stage], revision: existing.revision + 1 };
+        state.items = state.items.map(item => (item.id === id ? updated : item));
+        return HttpResponse.json({
+          result: {
+            status: 'accepted',
+            transitionId: 'transition-1',
+            itemId: id,
+            revision: updated.revision,
+            stage: body.stage,
+            decisions: [],
+          },
+        });
+      },
+    ),
     http.patch(`${TEST_BASE_URL}/web/factory/work-items/:id`, async ({ request, params }) => {
       const id = params.id as string;
       const body = (await request.json()) as UpdateWorkItemInput;
@@ -330,7 +395,6 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
         ...existing,
         ...(body.title !== undefined ? { title: body.title } : {}),
         ...(body.parentWorkItemId !== undefined ? { parentWorkItemId: body.parentWorkItemId } : {}),
-        ...(body.stages !== undefined ? { stages: body.stages } : {}),
         sessions: { ...existing.sessions, ...stampedSessions },
         metadata: { ...existing.metadata, ...(body.metadata ?? {}) },
       };
@@ -1084,17 +1148,14 @@ describe('Factory Board — persisted cards', () => {
       ...projectWithIssueWorktree,
       binding: {
         ...projectWithIssueWorktree.binding,
-        repositories: [
-          {
-            ...githubRepository,
-            selectedWorktreePath: reviewWorktreePath,
-            worktrees: [
-              ...githubRepository.worktrees,
-              { branch: 'factory/issue-12', worktreePath: issueWorktreePath, baseBranch: 'main' },
-              { branch: 'factory/pr-34', worktreePath: reviewWorktreePath, baseBranch: 'main' },
-            ],
-          },
-        ],
+        repositories: projectWithIssueWorktree.binding.repositories.map(repository => ({
+          ...repository,
+          selectedWorktreePath: reviewWorktreePath,
+          worktrees: [
+            ...repository.worktrees,
+            { branch: 'factory/pr-34', worktreePath: reviewWorktreePath, baseBranch: 'main' },
+          ],
+        })),
       },
     };
     useBoardHandlers({ workItems: relatedWorkItems });
@@ -1324,7 +1385,7 @@ describe('Factory Board — persisted cards', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
-    await waitFor(() => expect(state.patches).toMatchObject([{ id: 'wi-1', stages: ['planning'] }]));
+    await waitFor(() => expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-1', stages: ['planning'] }])));
   });
 
   it('given a persisted issue card needing approval, when Prepare approval is chosen, then the triage session ref is recorded without leaving Triage', async () => {
@@ -1351,20 +1412,13 @@ describe('Factory Board — persisted cards', () => {
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-21' });
     await waitFor(() =>
-      expect(captured.messages[0]!.message).toContain(
+      expect(captured.messages[0]?.message).toContain(
         'Prepare approval for GitHub issue #21 (https://github.com/mastra-ai/mastra/issues/21)',
       ),
     );
-    expect(captured.messages[0]!.message).not.toContain('Add OAuth support');
-    await waitFor(() =>
-      expect(state.patches).toMatchObject([
-        {
-          id: 'wi-approval',
-          stages: ['triage'],
-          sessions: { triage: { branch: 'factory/issue-21', threadId: 'thread-factory' } },
-        },
-      ]),
-    );
+    expect(captured.messages[0]?.message).not.toContain('Add OAuth support');
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-approval', role: 'triage' } }]);
+    expect(state.patches).toEqual([]);
   });
 
   it('given a card in Triage, when Move to Planning is chosen from the menu, then the card lands in the Planning swimlane', async () => {
@@ -1620,8 +1674,8 @@ describe('Factory Board — persisted cards', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
-    await waitFor(() => expect(captured.messages[0]!.message).toContain('Implement a fix for GitHub issue #12'));
-    await waitFor(() => expect(state.patches).toMatchObject([{ id: 'wi-1', stages: ['execute'] }]));
+    await waitFor(() => expect(captured.messages[0]?.message).toContain('Implement a fix for GitHub issue #12'));
+    await waitFor(() => expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-1', stages: ['execute'] }])));
   });
 
   it('given a card in Intake, when Mark done is chosen from the menu, then the stages PATCH to done and the card moves', async () => {
@@ -1716,7 +1770,7 @@ describe('Factory Board — drag and drop', () => {
     expect(within(column('execute')).queryByTestId('work-item-card')).not.toBeInTheDocument();
   });
 
-  it('given an unmaterialized candidate, when dragged to Building, then a work item is filed with that stage and no run starts', async () => {
+  it('given an unmaterialized candidate, when dragged to Building, then it is filed in Intake and moved through authority without a run', async () => {
     const state = useBoardHandlers({ issues });
     renderAt('/factory/work');
 
@@ -1726,9 +1780,10 @@ describe('Factory Board — drag and drop', () => {
 
     await waitFor(() =>
       expect(state.posts).toMatchObject([
-        { source: 'github-issue', sourceKey: 'github-issue:12', title: 'Fix flaky test', stages: ['execute'] },
+        { source: 'github-issue', sourceKey: 'github-issue:12', title: 'Fix flaky test', stages: ['intake'] },
       ]),
     );
+    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['execute'] }]));
     expect(await within(column('execute')).findByText('Fix flaky test')).toBeInTheDocument();
     // No worktree/run side effects from a drop: the card is filed, nothing else.
     expect(within(column('intake')).queryByText('Fix flaky test')).not.toBeInTheDocument();
@@ -1755,12 +1810,13 @@ interface CapturedRun {
   worktree?: Record<string, unknown>;
   threadTitles: string[];
   messages: Record<string, unknown>[];
+  starts: Array<{ workItem: { id: string; role: string }; kickoffMessage: string | null }>;
   skillInvocations: Record<string, unknown>[];
 }
 
 /** Registers handlers for the investigate flow: worktree + thread + message. */
 function useFactoryRunHandlers(branchDir: string): CapturedRun {
-  const captured: CapturedRun = { threadTitles: [], messages: [], skillInvocations: [] };
+  const captured: CapturedRun = { threadTitles: [], messages: [], starts: [], skillInvocations: [] };
   server.use(
     http.post(`${TEST_BASE_URL}/web/github/projects/${PROJECT_REPOSITORY_ID}/worktree`, async ({ request }) => {
       captured.worktree = (await request.json()) as Record<string, unknown>;
@@ -1784,6 +1840,35 @@ function useFactoryRunHandlers(branchDir: string): CapturedRun {
     http.post(`${SESSION}/messages`, async ({ request }) => {
       captured.messages.push((await request.json()) as Record<string, unknown>);
       return HttpResponse.json({ ok: true });
+    }),
+    http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/runs/start`, async ({ request }) => {
+      const body = (await request.json()) as {
+        resourceId: string;
+        projectPath: string;
+        branch: string;
+        threadTitle: string;
+        kickoffMessage: string | null;
+        workItem: { id: string; role: string };
+      };
+      captured.threadTitles.push(body.threadTitle);
+      captured.starts.push({ workItem: body.workItem, kickoffMessage: body.kickoffMessage });
+      if (body.kickoffMessage !== null) captured.messages.push({ message: body.kickoffMessage });
+      return HttpResponse.json(
+        {
+          prepared: {
+            workItemId: body.workItem.id,
+            bindingId: 'binding-1',
+            threadId: 'thread-factory',
+            resourceId: body.resourceId,
+            projectPath: body.projectPath,
+            branch: body.branch,
+            revision: 3,
+            kickoffStatus: 'pending',
+            replayed: false,
+          },
+        },
+        { status: 202 },
+      );
     }),
     http.post(`${TEST_BASE_URL}/web/agent-controller/code/skills/prepare`, async ({ request }) => {
       const body = (await request.json()) as Record<string, unknown>;
@@ -1865,88 +1950,88 @@ describe('Factory Board — investigate flow', () => {
       },
     ]);
     expect(JSON.stringify(captured.skillInvocations)).not.toContain('Fix flaky test');
-    // The run files a board record in the planning stage with the plan session ref.
+    // New candidates are materialized in Intake, then moved through the authoritative transition endpoint.
     await waitFor(() => expect(state.posts).toHaveLength(1));
     expect(state.posts).toMatchObject([
       {
         source: 'github-issue',
         sourceKey: 'github-issue:12',
         title: 'Fix flaky test',
-        stages: ['planning'],
-        sessions: {
-          plan: {
-            projectPath: '/sandbox/mastra/worktrees/factory-issue-12',
-            branch: 'factory/issue-12',
-            threadId: 'thread-factory',
-          },
-        },
+        stages: ['intake'],
       },
     ]);
+    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['planning'] }]));
   });
 
-  it('given a prepared skill, when Factory starts the run, then the mounted thread projects it before exactly one dispatch settles', async () => {
+  it('given a prepared skill, when Factory starts the run, then the browser navigates only after the server coordinator accepts one kickoff', async () => {
     const state = useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    let pathWhenDispatched: string | undefined;
-    let releaseDispatch!: () => void;
-    const dispatchResponse = new Promise<void>(resolve => {
-      releaseDispatch = resolve;
+    let releaseStart!: () => void;
+    const startResponse = new Promise<void>(resolve => {
+      releaseStart = resolve;
     });
-    let router!: ReturnType<typeof renderAt>['router'];
+    const startBodies: Array<{
+      resourceId: string;
+      projectPath: string;
+      branch: string;
+      kickoffMessage: string | null;
+      workItem: { id: string };
+    }> = [];
     server.use(
-      http.post(`${SESSION}/messages`, async ({ request }) => {
-        pathWhenDispatched = router.state.location.pathname;
-        captured.messages.push((await request.json()) as Record<string, unknown>);
-        await dispatchResponse;
-        return HttpResponse.json({ ok: true });
+      http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/runs/start`, async ({ request }) => {
+        const body = (await request.json()) as (typeof startBodies)[number];
+        startBodies.push(body);
+        await startResponse;
+        return HttpResponse.json(
+          {
+            prepared: {
+              workItemId: body.workItem.id,
+              bindingId: 'binding-1',
+              threadId: 'thread-factory',
+              resourceId: body.resourceId,
+              projectPath: body.projectPath,
+              branch: body.branch,
+              revision: 3,
+              kickoffStatus: 'pending',
+              replayed: false,
+            },
+          },
+          { status: 202 },
+        );
       }),
     );
-    ({ router } = renderAt('/factory/work'));
-
-    try {
-      const intake = await screen.findByTestId('board-column-intake');
-      await within(intake).findByText('Fix flaky test');
-      await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
-
-      expect(await screen.findByRole('button', { name: /Show understand-issue skill contents/ })).toBeInTheDocument();
-      await waitFor(() => expect(captured.messages).toHaveLength(1));
-      expect(pathWhenDispatched).toBe('/threads/thread-factory');
-      expect(captured.skillInvocations).toHaveLength(1);
-      expect(captured.messages[0]?.message).toContain('<skill name="understand-issue">');
-      expect(state.posts).toHaveLength(0);
-      releaseDispatch();
-      await waitFor(() => expect(state.posts).toHaveLength(1));
-      expect(captured.messages).toHaveLength(1);
-    } finally {
-      releaseDispatch();
-    }
-  });
-
-  it('given a mounted kickoff whose dispatch fails, then the skill stays visible without leaving the transcript pending', async () => {
-    useBoardHandlers({ issues });
-    useFactoryRunHandlers('factory-issue-12');
-    let releaseDispatch!: () => void;
-    const dispatchResponse = new Promise<void>(resolve => {
-      releaseDispatch = resolve;
-    });
-    server.use(
-      http.post(`${SESSION}/messages`, async () => {
-        await dispatchResponse;
-        return HttpResponse.json({ error: 'kickoff failed' }, { status: 500 });
-      }),
-    );
-    renderAt('/factory/work');
+    const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
     await within(intake).findByText('Fix flaky test');
     await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
 
-    expect(await screen.findByRole('button', { name: /Show understand-issue skill contents/ })).toBeInTheDocument();
-    expect(screen.getByText('Thinking…')).toBeInTheDocument();
-    releaseDispatch();
-    await waitFor(() => expect(screen.queryByText('Thinking…')).not.toBeInTheDocument());
-    expect(await screen.findByText(/kickoff failed|500/i)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Show understand-issue skill contents/ })).toBeInTheDocument();
+    await waitFor(() => expect(startBodies).toHaveLength(1));
+    expect(router.state.location.pathname).toBe('/factory/work');
+    expect(captured.skillInvocations).toHaveLength(1);
+    expect(startBodies[0]?.kickoffMessage).toContain('<skill name="understand-issue">');
+    expect(state.posts).toHaveLength(1);
+    releaseStart();
+    await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
+    expect(startBodies).toHaveLength(1);
+  });
+
+  it('given a server coordinator failure, when a run is requested, then the browser stays on the board and shows the failure', async () => {
+    useBoardHandlers({ issues });
+    useFactoryRunHandlers('factory-issue-12');
+    server.use(
+      http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/runs/start`, () =>
+        HttpResponse.json({ error: 'kickoff failed' }, { status: 500 }),
+      ),
+    );
+    const { router } = renderAt('/factory/work');
+
+    const intake = await screen.findByTestId('board-column-intake');
+    await within(intake).findByText('Fix flaky test');
+    await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
+
+    expect(await screen.findByText(/kickoff failed/i)).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/factory/work');
   });
 
   it('given a missing workspace skill, when Investigate is clicked, then the error is visible and no fallback prompt or card is dispatched', async () => {
@@ -1974,25 +2059,9 @@ describe('Factory Board — investigate flow', () => {
     expect(state.posts).toHaveLength(0);
   });
 
-  it('given an issue candidate, when Build is chosen from the menu, then navigation happens while the prompt runs and a work item materializes into Building', async () => {
+  it('given an issue candidate, when Build is chosen, then the item moves through authority before the server-bound kickoff', async () => {
     const state = useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    let releasePrompt!: () => void;
-    let markPromptRequested!: () => void;
-    const promptRequested = new Promise<void>(resolve => {
-      markPromptRequested = resolve;
-    });
-    const promptResponse = new Promise<void>(resolve => {
-      releasePrompt = resolve;
-    });
-    server.use(
-      http.post(`${SESSION}/messages`, async ({ request }) => {
-        captured.messages.push((await request.json()) as Record<string, unknown>);
-        markPromptRequested();
-        await promptResponse;
-        return HttpResponse.json({ ok: true });
-      }),
-    );
     const { router } = renderAt('/factory/work');
 
     const intake = await screen.findByTestId('board-column-intake');
@@ -2000,10 +2069,7 @@ describe('Factory Board — investigate flow', () => {
     await userEvent.click(within(intake).getByRole('button', { name: 'More actions for Fix flaky test' }));
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Build' }));
 
-    await promptRequested;
-    expect(router.state.location.pathname).toBe('/threads/thread-factory');
-    releasePrompt();
-    await waitFor(() => expect(state.posts).toHaveLength(1));
+    await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
     expect(captured.skillInvocations).toHaveLength(0);
     expect(captured.messages[0]!.message).toContain('Implement a fix for GitHub issue #12');
@@ -2011,38 +2077,31 @@ describe('Factory Board — investigate flow', () => {
       {
         source: 'github-issue',
         sourceKey: 'github-issue:12',
-        stages: ['execute'],
-        sessions: { work: { branch: 'factory/issue-12', threadId: 'thread-factory' } },
+        stages: ['intake'],
       },
     ]);
+    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['execute'] }]));
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-post-1', role: 'work' } }]);
   });
 
-  it('given board-card filing that fails, when Investigate is clicked, then the run still succeeds and navigates to the thread', async () => {
+  it('given work-item persistence failure, when Investigate is clicked, then no kickoff is bound or dispatched', async () => {
     useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
-    // The card filing endpoint blows up, but the run itself already succeeded.
     server.use(
       http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/work-items`, () =>
-        HttpResponse.json({ error: 'boom' }, { status: 500 }),
+        HttpResponse.json({ error: 'board persistence failed' }, { status: 500 }),
       ),
     );
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    try {
-      const { router } = renderAt('/factory/work');
+    const { router } = renderAt('/factory/work');
 
-      const intake = await screen.findByTestId('board-column-intake');
-      await within(intake).findByText('Fix flaky test');
-      await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
+    const intake = await screen.findByTestId('board-column-intake');
+    await within(intake).findByText('Fix flaky test');
+    await userEvent.click(within(intake).getByRole('button', { name: 'Investigate Fix flaky test' }));
 
-      // Filing is best-effort: the user still lands on the running thread.
-      await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
-      expect(captured.skillInvocations).toHaveLength(1);
-      await waitFor(() =>
-        expect(errorSpy).toHaveBeenCalledWith('Failed to file the board card for this run', expect.anything()),
-      );
-    } finally {
-      errorSpy.mockRestore();
-    }
+    expect(await screen.findByText(/board persistence failed/i)).toBeInTheDocument();
+    expect(router.state.location.pathname).toBe('/factory/work');
+    expect(captured.starts).toEqual([]);
+    expect(captured.messages).toEqual([]);
   });
 
   it('given a PR candidate in Review Intake, when Review is clicked, then the review prompt runs and a work item materializes into Reviewing with a review session', async () => {
@@ -2078,11 +2137,12 @@ describe('Factory Board — investigate flow', () => {
         {
           source: 'github-pr',
           sourceKey: 'github-pr:34',
-          stages: ['review'],
-          sessions: { review: { branch: 'factory/pr-34', threadId: 'thread-factory' } },
+          stages: ['intake'],
         },
       ]),
     );
+    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['review'] }]));
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-post-1', role: 'review' } }]);
   });
 
   it('given a Linear candidate, when Investigate is clicked, then the prompt mentions the linear_get_issue tool', async () => {
@@ -2140,7 +2200,7 @@ describe('Factory Board — investigate flow', () => {
     expect(captured.messages[0]!.message).not.toContain('understand-issue skill');
   });
 
-  it('given a persisted issue card without a plan session, when Investigate is chosen, then the run starts and the card PATCHes into Planning with the session ref', async () => {
+  it('given a persisted issue card without a plan session, when Investigate is chosen, then authority moves it before the server binds the plan role', async () => {
     const state = useBoardHandlers({
       workItems: [
         makeWorkItem({
@@ -2172,16 +2232,11 @@ describe('Factory Board — investigate flow', () => {
     });
     expect(JSON.stringify(captured.skillInvocations)).not.toContain('Fix flaky test');
     await waitFor(() => expect(state.patches).toHaveLength(1));
-    expect(state.patches).toMatchObject([
-      {
-        id: 'wi-1',
-        stages: ['planning'],
-        sessions: { plan: { branch: 'factory/issue-12', threadId: 'thread-factory' } },
-      },
-    ]);
+    expect(state.patches).toMatchObject([{ id: 'wi-1', stages: ['planning'] }]);
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-1', role: 'plan' } }]);
   });
 
-  it('given a card with a legacy plan ref, when Build is chosen, then filing repoints every role at the run thread', async () => {
+  it('given a card with a legacy plan ref, when Build is chosen, then only the exact work role is bound server-side', async () => {
     const state = useBoardHandlers({
       workItems: [
         makeWorkItem({
@@ -2213,22 +2268,11 @@ describe('Factory Board — investigate flow', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
-    // One thread per item: every role ref converges onto the run's thread.
-    await waitFor(() =>
-      expect(state.patches).toMatchObject([
-        {
-          id: 'wi-1',
-          stages: ['execute'],
-          sessions: {
-            plan: { branch: 'factory/issue-12', threadId: 'thread-factory' },
-            work: { branch: 'factory/issue-12', threadId: 'thread-factory' },
-          },
-        },
-      ]),
-    );
+    await waitFor(() => expect(state.patches).toMatchObject([{ id: 'wi-1', stages: ['execute'] }]));
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-1', role: 'work' } }]);
   });
 
-  it('given a repeat run on the same item, when the worktree session already has a thread, then the prompt lands on that thread instead of creating a new one', async () => {
+  it('given a repeat run on the same item, when Review is chosen, then the browser delegates exact-thread reuse to the server coordinator', async () => {
     const state = useBoardHandlers({
       workItems: [
         makeWorkItem({
@@ -2244,28 +2288,12 @@ describe('Factory Board — investigate flow', () => {
     });
     const captured = useFactoryRunHandlers('factory-pr-34');
     const { router } = renderAt('/factory/review');
-    // The worktree session resumes a real (titled) thread from a previous run.
-    // Registered after renderAt so it takes precedence over the default empty
-    // thread list from useAppHandlers (MSW resolves newest-first).
-    server.use(
-      http.post(`${API}/sessions`, () =>
-        HttpResponse.json({ controllerId: 'code', resourceId: RESOURCE_ID, threadId: THREAD_ID }),
-      ),
-      http.get(`${SESSION}/threads`, () =>
-        HttpResponse.json({
-          threads: [{ id: THREAD_ID, resourceId: RESOURCE_ID, title: 'PR #34: Add factory pages' }],
-        }),
-      ),
-      http.post(`${SESSION}/thread`, () => HttpResponse.json({ ok: true })),
-    );
-
     await screen.findByTestId('board-column-review');
     await userEvent.click(within(column('review')).getByRole('button', { name: 'Actions for Add factory pages' }));
     await userEvent.click(await screen.findByRole('menuitem', { name: 'Review' }));
 
-    await waitFor(() => expect(router.state.location.pathname).toBe(`/threads/${THREAD_ID}`));
-    // No new thread was created — the resumed thread carried the follow-up run.
-    expect(captured.threadTitles).toEqual([]);
+    await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
+    expect(captured.threadTitles).toEqual(['PR #34: Add factory pages']);
     await waitFor(() => expect(captured.messages).toHaveLength(1));
     expect(captured.messages[0]?.message).toContain('<skill name="understand-pr">');
     expect(captured.skillInvocations).toHaveLength(1);
@@ -2275,15 +2303,8 @@ describe('Factory Board — investigate flow', () => {
         'Check out the PR in this worktree first with `gh pr checkout 34`. Expected head branch: feat/factory-pages.',
       ),
     });
-    await waitFor(() =>
-      expect(state.patches).toMatchObject([
-        {
-          id: 'wi-pr',
-          stages: ['review'],
-          sessions: { review: { branch: 'factory/pr-34', threadId: THREAD_ID } },
-        },
-      ]),
-    );
+    expect(state.patches).toEqual([]);
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-pr', role: 'review' } }]);
   });
 
   it('given the worktree call fails, when Investigate is clicked, then an error notice renders and no work item is filed', async () => {
@@ -2325,7 +2346,7 @@ describe('Factory Board — open session from the card title', () => {
     },
   };
 
-  it('given a persisted card without a session, when the title is clicked, then an empty session is created and filed under chat with no prompt sent', async () => {
+  it('given a persisted card without a session, when the title is clicked, then the server binds an empty chat session with no prompt', async () => {
     const state = useBoardHandlers({
       workItems: [
         makeWorkItem({
@@ -2351,14 +2372,9 @@ describe('Factory Board — open session from the card title', () => {
     expect(captured.threadTitles).toEqual(['Issue #12: Fix flaky test']);
     // No agent run: nothing was sent to the session.
     expect(captured.messages).toEqual([]);
-    // Opening a session is not a run: the card keeps its stages.
-    expect(state.patches).toMatchObject([
-      {
-        id: 'wi-1',
-        stages: ['intake'],
-        sessions: { chat: { branch: 'factory/issue-12', threadId: 'thread-factory' } },
-      },
-    ]);
+    // Opening a session is not a stage transition; only the exact chat role is sent to the coordinator.
+    expect(state.patches).toEqual([]);
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-1', role: 'chat' }, kickoffMessage: null }]);
   });
 
   it('given a card whose run refs went stale, when the title is clicked, then only chat is filed and the stale roles are not revived', async () => {
@@ -2393,12 +2409,9 @@ describe('Factory Board — open session from the card title', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.messages).toEqual([]);
-    // The fresh thread is filed under chat only — repointing the stale `work`
-    // role would make it look live and hide Investigate/Build again.
-    expect(state.patches).toHaveLength(1);
-    expect(state.patches[0].sessions).toEqual({
-      chat: expect.objectContaining({ branch: 'factory/issue-12', threadId: 'thread-factory' }),
-    });
+    // The browser delegates only the fresh chat role; the stale work role is not inferred as authority.
+    expect(state.patches).toEqual([]);
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-1', role: 'chat' }, kickoffMessage: null }]);
   });
 
   it('given a candidate, when the title is clicked, then the card materializes with a chat session in its own column and no prompt is sent', async () => {
@@ -2421,9 +2434,9 @@ describe('Factory Board — open session from the card title', () => {
         url: 'https://github.com/mastra-ai/mastra/issues/12',
         stages: ['intake'],
         metadata: { number: 12 },
-        sessions: { chat: { branch: 'factory/issue-12', threadId: 'thread-factory' } },
       },
     ]);
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-post-1', role: 'chat' }, kickoffMessage: null }]);
   });
 
   it('given a manual card without run metadata, when the title is clicked, then the session opens on an id-derived branch', async () => {
@@ -2441,9 +2454,8 @@ describe('Factory Board — open session from the card title', () => {
     expect(captured.worktree).toMatchObject({ branch: 'factory/item-wi-manual' });
     expect(captured.threadTitles).toEqual(['Manual card']);
     expect(captured.messages).toEqual([]);
-    expect(state.patches).toMatchObject([
-      { id: 'wi-manual', stages: ['intake'], sessions: { chat: { branch: 'factory/item-wi-manual' } } },
-    ]);
+    expect(state.patches).toEqual([]);
+    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-manual', role: 'chat' }, kickoffMessage: null }]);
   });
 
   it('given a card whose only session is a chat session, when the Board renders, then the title links to the thread and runs are still offered', async () => {

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx
@@ -247,7 +247,7 @@ interface BoardState {
   items: WorkItem[];
   posts: CreateWorkItemInput[];
   patches: Array<{ id: string; stages?: string[] } & UpdateWorkItemInput>;
-  starts: Array<{ kickoffMessage: string | null; workItem: { id: string; role: string } }>;
+  starts: Array<{ kickoffMessage: string | null; destinationStage: string; workItem: { id: string; role: string } }>;
   deletes: string[];
   triageRequests: Array<{ number: number; body: unknown }>;
   issueRequests: Array<string | null>;
@@ -327,9 +327,14 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
         projectPath: string;
         branch: string;
         kickoffMessage: string | null;
+        destinationStage: string;
         workItem: { id: string; role: string };
       };
-      state.starts.push({ kickoffMessage: body.kickoffMessage, workItem: body.workItem });
+      state.starts.push({
+        kickoffMessage: body.kickoffMessage,
+        destinationStage: body.destinationStage,
+        workItem: body.workItem,
+      });
       const existing = state.items.find(item => item.id === body.workItem.id);
       if (!existing) return HttpResponse.json({ error: 'Work item not found' }, { status: 404 });
       const session = {
@@ -341,10 +346,15 @@ function useBoardHandlers(options: BoardHandlerOptions = {}): BoardState {
       const updated = {
         ...existing,
         revision: existing.revision + 1,
+        stages: [body.destinationStage],
         sessions: { ...existing.sessions, [body.workItem.role]: session },
       };
       state.items = state.items.map(item => (item.id === existing.id ? updated : item));
-      state.patches.push({ id: existing.id, sessions: { [body.workItem.role]: session } });
+      state.patches.push({
+        id: existing.id,
+        stages: [body.destinationStage],
+        sessions: { [body.workItem.role]: session },
+      });
       return HttpResponse.json(
         {
           prepared: {
@@ -1385,7 +1395,7 @@ describe('Factory Board — persisted cards', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
-    await waitFor(() => expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-1', stages: ['planning'] }])));
+    expect(captured.starts).toMatchObject([{ destinationStage: 'planning', workItem: { id: 'wi-1' } }]);
   });
 
   it('given a persisted issue card needing approval, when Prepare approval is chosen, then the triage session ref is recorded without leaving Triage', async () => {
@@ -1675,7 +1685,7 @@ describe('Factory Board — persisted cards', () => {
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
     await waitFor(() => expect(captured.messages[0]?.message).toContain('Implement a fix for GitHub issue #12'));
-    await waitFor(() => expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-1', stages: ['execute'] }])));
+    expect(captured.starts).toMatchObject([{ destinationStage: 'execute', workItem: { id: 'wi-1' } }]);
   });
 
   it('given a card in Intake, when Mark done is chosen from the menu, then the stages PATCH to done and the card moves', async () => {
@@ -1810,7 +1820,11 @@ interface CapturedRun {
   worktree?: Record<string, unknown>;
   threadTitles: string[];
   messages: Record<string, unknown>[];
-  starts: Array<{ workItem: { id: string; role: string }; kickoffMessage: string | null }>;
+  starts: Array<{
+    workItem: { id: string; role: string };
+    kickoffMessage: string | null;
+    destinationStage: string;
+  }>;
   skillInvocations: Record<string, unknown>[];
 }
 
@@ -1848,10 +1862,15 @@ function useFactoryRunHandlers(branchDir: string): CapturedRun {
         branch: string;
         threadTitle: string;
         kickoffMessage: string | null;
+        destinationStage: string;
         workItem: { id: string; role: string };
       };
       captured.threadTitles.push(body.threadTitle);
-      captured.starts.push({ workItem: body.workItem, kickoffMessage: body.kickoffMessage });
+      captured.starts.push({
+        workItem: body.workItem,
+        kickoffMessage: body.kickoffMessage,
+        destinationStage: body.destinationStage,
+      });
       if (body.kickoffMessage !== null) captured.messages.push({ message: body.kickoffMessage });
       return HttpResponse.json(
         {
@@ -1950,17 +1969,10 @@ describe('Factory Board — investigate flow', () => {
       },
     ]);
     expect(JSON.stringify(captured.skillInvocations)).not.toContain('Fix flaky test');
-    // New candidates are materialized in Intake, then moved through the authoritative transition endpoint.
-    await waitFor(() => expect(state.posts).toHaveLength(1));
-    expect(state.posts).toMatchObject([
-      {
-        source: 'github-issue',
-        sourceKey: 'github-issue:12',
-        title: 'Fix flaky test',
-        stages: ['intake'],
-      },
-    ]);
-    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['planning'] }]));
+    // One server-owned start request creates the Intake card, binds it, and requests Planning.
+    expect(state.posts).toEqual([]);
+    expect(state.patches).toEqual([]);
+    expect(captured.starts).toMatchObject([{ destinationStage: 'planning', workItem: { role: 'plan' } }]);
   });
 
   it('given a prepared skill, when Factory starts the run, then the browser navigates only after the server coordinator accepts one kickoff', async () => {
@@ -1975,7 +1987,8 @@ describe('Factory Board — investigate flow', () => {
       projectPath: string;
       branch: string;
       kickoffMessage: string | null;
-      workItem: { id: string };
+      destinationStage: string;
+      workItem: { id?: string };
     }> = [];
     server.use(
       http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/runs/start`, async ({ request }) => {
@@ -2009,8 +2022,12 @@ describe('Factory Board — investigate flow', () => {
     await waitFor(() => expect(startBodies).toHaveLength(1));
     expect(router.state.location.pathname).toBe('/factory/work');
     expect(captured.skillInvocations).toHaveLength(1);
-    expect(startBodies[0]?.kickoffMessage).toContain('<skill name="understand-issue">');
-    expect(state.posts).toHaveLength(1);
+    expect(startBodies[0]).toMatchObject({
+      kickoffMessage: expect.stringContaining('<skill name="understand-issue">'),
+      destinationStage: 'planning',
+      workItem: { role: 'plan', input: { stages: ['intake'] } },
+    });
+    expect(state.posts).toHaveLength(0);
     releaseStart();
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(startBodies).toHaveLength(1);
@@ -2073,22 +2090,15 @@ describe('Factory Board — investigate flow', () => {
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
     expect(captured.skillInvocations).toHaveLength(0);
     expect(captured.messages[0]!.message).toContain('Implement a fix for GitHub issue #12');
-    expect(state.posts).toMatchObject([
-      {
-        source: 'github-issue',
-        sourceKey: 'github-issue:12',
-        stages: ['intake'],
-      },
-    ]);
-    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['execute'] }]));
-    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-post-1', role: 'work' } }]);
+    expect(state.posts).toEqual([]);
+    expect(captured.starts).toMatchObject([{ destinationStage: 'execute', workItem: { role: 'work' } }]);
   });
 
-  it('given work-item persistence failure, when Investigate is clicked, then no kickoff is bound or dispatched', async () => {
+  it('given server start coordination failure, when Investigate is clicked, then no kickoff is accepted', async () => {
     useBoardHandlers({ issues });
     const captured = useFactoryRunHandlers('factory-issue-12');
     server.use(
-      http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/work-items`, () =>
+      http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/runs/start`, () =>
         HttpResponse.json({ error: 'board persistence failed' }, { status: 500 }),
       ),
     );
@@ -2132,17 +2142,8 @@ describe('Factory Board — investigate flow', () => {
       },
     ]);
     expect(JSON.stringify(captured.skillInvocations)).not.toContain('Add factory pages');
-    await waitFor(() =>
-      expect(state.posts).toMatchObject([
-        {
-          source: 'github-pr',
-          sourceKey: 'github-pr:34',
-          stages: ['intake'],
-        },
-      ]),
-    );
-    expect(state.patches).toEqual(expect.arrayContaining([{ id: 'wi-post-1', stages: ['review'] }]));
-    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-post-1', role: 'review' } }]);
+    expect(state.posts).toEqual([]);
+    expect(captured.starts).toMatchObject([{ destinationStage: 'review', workItem: { role: 'review' } }]);
   });
 
   it('given a Linear candidate, when Investigate is clicked, then the prompt mentions the linear_get_issue tool', async () => {
@@ -2231,9 +2232,8 @@ describe('Factory Board — investigate flow', () => {
       arguments: expect.stringContaining('GitHub issue #12 (https://github.com/mastra-ai/mastra/issues/12)'),
     });
     expect(JSON.stringify(captured.skillInvocations)).not.toContain('Fix flaky test');
-    await waitFor(() => expect(state.patches).toHaveLength(1));
-    expect(state.patches).toMatchObject([{ id: 'wi-1', stages: ['planning'] }]);
-    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-1', role: 'plan' } }]);
+    expect(state.patches).toEqual([]);
+    expect(captured.starts).toMatchObject([{ destinationStage: 'planning', workItem: { id: 'wi-1', role: 'plan' } }]);
   });
 
   it('given a card with a legacy plan ref, when Build is chosen, then only the exact work role is bound server-side', async () => {
@@ -2268,7 +2268,7 @@ describe('Factory Board — investigate flow', () => {
 
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
-    await waitFor(() => expect(state.patches).toMatchObject([{ id: 'wi-1', stages: ['execute'] }]));
+    expect(captured.starts).toMatchObject([{ destinationStage: 'execute', workItem: { id: 'wi-1' } }]);
     expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-1', role: 'work' } }]);
   });
 
@@ -2426,17 +2426,10 @@ describe('Factory Board — open session from the card title', () => {
     await waitFor(() => expect(router.state.location.pathname).toBe('/threads/thread-factory'));
     expect(captured.worktree).toMatchObject({ branch: 'factory/issue-12' });
     expect(captured.messages).toEqual([]);
-    expect(state.posts).toMatchObject([
-      {
-        source: 'github-issue',
-        sourceKey: 'github-issue:12',
-        title: 'Fix flaky test',
-        url: 'https://github.com/mastra-ai/mastra/issues/12',
-        stages: ['intake'],
-        metadata: { number: 12 },
-      },
+    expect(state.posts).toEqual([]);
+    expect(captured.starts).toMatchObject([
+      { destinationStage: 'intake', workItem: { role: 'chat' }, kickoffMessage: null },
     ]);
-    expect(captured.starts).toMatchObject([{ workItem: { id: 'wi-post-1', role: 'chat' }, kickoffMessage: null }]);
   });
 
   it('given a manual card without run metadata, when the title is clicked, then the session opens on an id-derived branch', async () => {

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/OverviewPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/OverviewPage.msw.test.tsx
@@ -88,6 +88,7 @@ function makeWorkItem(overrides: Partial<WorkItem> & Pick<WorkItem, 'id' | 'titl
     stageHistory: [],
     sessions: {},
     metadata: {},
+    revision: 1,
     createdAt: ago(30 * HOUR_S),
     updatedAt: ago(30 * HOUR_S),
     ...overrides,

--- a/mastracode/web/src/web/ui/domains/factory/queue-health.test.ts
+++ b/mastracode/web/src/web/ui/domains/factory/queue-health.test.ts
@@ -26,6 +26,7 @@ function makeItem(overrides: Partial<QueueHealthWorkItem> = {}): QueueHealthWork
     stageHistory: [],
     sessions: {},
     metadata: {},
+    revision: 1,
     createdAt: new Date(NOW.getTime() - 1000),
     updatedAt: NOW,
     ...overrides,

--- a/mastracode/web/src/web/ui/domains/factory/services/relationships.test.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/relationships.test.ts
@@ -22,6 +22,7 @@ function workItem(overrides: Partial<WorkItem> & Pick<WorkItem, 'id' | 'source'>
     createdAt: '2026-07-17T00:00:00.000Z',
     updatedAt: '2026-07-17T00:00:00.000Z',
     ...rest,
+    revision: rest.revision ?? 1,
   };
 }
 

--- a/mastracode/web/src/web/ui/domains/factory/services/workItems.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/workItems.ts
@@ -37,6 +37,7 @@ export interface WorkItem {
   stageHistory: WorkItemStageEntry[];
   sessions: Record<string, WorkItemSessionRef>;
   metadata: Record<string, unknown>;
+  revision: number;
   createdAt: string;
   updatedAt: string;
 }
@@ -58,6 +59,20 @@ export interface CreateWorkItemInput {
   sessions?: Record<string, WorkItemSessionInput>;
   metadata?: Record<string, unknown>;
 }
+
+export type FactoryBoard = 'work' | 'review';
+export type FactoryStage = 'intake' | 'triage' | 'planning' | 'execute' | 'review' | 'done';
+
+export type FactoryTransitionResult =
+  | {
+      status: 'accepted';
+      transitionId: string;
+      itemId: string;
+      revision: number;
+      stage: FactoryStage;
+      decisions: unknown[];
+    }
+  | { status: 'rejected'; transitionId: string; itemId: string; code: string; reason: string };
 
 export interface UpdateWorkItemInput {
   parentWorkItemId?: string | null;
@@ -109,13 +124,72 @@ export async function createWorkItem(
   return data.workItem;
 }
 
-/** Patch a work item (stage moves, session/metadata merges, title). */
+export async function transitionWorkItem(
+  baseUrl: string,
+  githubProjectId: string,
+  id: string,
+  input: { board: FactoryBoard; stage: FactoryStage; expectedRevision: number; requestId: string; cause: string },
+): Promise<FactoryTransitionResult> {
+  const res = await fetch(
+    `${baseUrl}/web/factory/projects/${encodeURIComponent(githubProjectId)}/work-items/${encodeURIComponent(id)}/transition`,
+    {
+      method: 'POST',
+      headers: { Accept: 'application/json', 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(input),
+    },
+  );
+  const body = (await res.json()) as { result?: FactoryTransitionResult; error?: string };
+  if (body.result) return body.result;
+  throw new Error(body.error ?? `Request failed (${res.status})`);
+}
+
+/** Patch a work item's non-stage metadata, session refs, or title. */
 export async function updateWorkItem(baseUrl: string, id: string, patch: UpdateWorkItemInput): Promise<WorkItem> {
   const data = await requestJson<{ workItem: WorkItem }>(
     `${baseUrl}/web/factory/work-items/${encodeURIComponent(id)}`,
     { method: 'PATCH', body: JSON.stringify(patch) },
   );
   return data.workItem;
+}
+
+export interface StartFactoryRunRequest {
+  resourceId: string;
+  projectPath: string;
+  branch: string;
+  threadTitle: string;
+  threadTags?: Record<string, string>;
+  kickoffKey: string;
+  kickoffMessage: string | null;
+  workItem: {
+    id?: string;
+    role: string;
+    input: CreateWorkItemInput;
+  };
+}
+
+export interface StartFactoryRunPrepared {
+  workItemId: string;
+  bindingId: string;
+  threadId: string;
+  resourceId: string;
+  projectPath: string;
+  branch: string;
+  revision: number;
+  kickoffStatus: 'pending' | 'sent' | 'failed';
+  replayed: boolean;
+}
+
+export async function startFactoryRun(
+  baseUrl: string,
+  githubProjectId: string,
+  input: StartFactoryRunRequest,
+): Promise<StartFactoryRunPrepared> {
+  const data = await requestJson<{ prepared: StartFactoryRunPrepared }>(
+    `${baseUrl}/web/factory/projects/${encodeURIComponent(githubProjectId)}/runs/start`,
+    { method: 'POST', body: JSON.stringify(input) },
+  );
+  return data.prepared;
 }
 
 /** Remove a work item from the board. */

--- a/mastracode/web/src/web/ui/domains/factory/services/workItems.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/workItems.ts
@@ -78,7 +78,6 @@ export interface UpdateWorkItemInput {
   parentWorkItemId?: string | null;
   title?: string;
   url?: string | null;
-  stages?: string[];
   sessions?: Record<string, WorkItemSessionInput>;
   metadata?: Record<string, unknown>;
 }
@@ -161,6 +160,7 @@ export interface StartFactoryRunRequest {
   threadTags?: Record<string, string>;
   kickoffKey: string;
   kickoffMessage: string | null;
+  destinationStage: FactoryStage;
   workItem: {
     id?: string;
     role: string;

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/WorkspacesSection.msw.test.tsx
@@ -115,6 +115,7 @@ const relatedWorkItems: WorkItem[] = [
       },
     },
     metadata: { number: 24 },
+    revision: 1,
     createdAt: '2026-07-17T00:00:00Z',
     updatedAt: '2026-07-17T00:00:00Z',
   },
@@ -139,6 +140,7 @@ const relatedWorkItems: WorkItem[] = [
       },
     },
     metadata: { number: 25 },
+    revision: 1,
     createdAt: '2026-07-17T00:00:00Z',
     updatedAt: '2026-07-17T00:00:00Z',
   },
@@ -320,6 +322,7 @@ describe('WorkspacesSection', () => {
           },
         },
         metadata: {},
+        revision: 1,
         createdAt: `2026-07-17T00:00:${String(index).padStart(2, '0')}Z`,
         updatedAt: `2026-07-17T00:00:${String(index).padStart(2, '0')}Z`,
       };

--- a/mastracode/web/src/web/web-surface.ts
+++ b/mastracode/web/src/web/web-surface.ts
@@ -11,9 +11,13 @@ import type { FactoryIntegration, IntegrationContext } from './factory-integrati
 import { getGithubFeatureDiagnostics } from './github/config.js';
 import { getLinearFeatureDiagnostics } from './linear/config.js';
 import { buildFactoryRoutes } from './factory/routes.js';
+import { FactoryStartCoordinator } from './factory/rules/start-coordinator.js';
+import { FactoryTransitionService } from './factory/rules/transition-service.js';
 import { buildFsRoutes } from './fs-routes.js';
 import { buildIntakeRoutes } from './intake/routes.js';
 import { buildOAuthRoutes } from './oauth-routes.js';
+import { getFactoryStorage, getSeededFactoryRules } from './runtime-config.js';
+import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import { registerSandboxReattach } from './sandbox-reattach-registration.js';
 import { buildSkillRoutes } from './skills/routes.js';
 import type { StateSigner } from './state-signing.js';
@@ -200,6 +204,18 @@ export function assembleWebApiRoutes(deps: WebApiRoutesDeps): ApiRoute[] {
           ),
         })
       : []),
-    ...(deps.factoryReady ? buildFactoryRoutes({ audit: deps.audit }) : []),
+    ...(deps.factoryReady
+      ? buildFactoryRoutes({
+          audit: deps.audit,
+          transitionService: new FactoryTransitionService({
+            rules: getSeededFactoryRules(),
+            storage: getFactoryStorage().getDomain<WorkItemsStorage>('work-items'),
+          }),
+          startCoordinator: new FactoryStartCoordinator(
+            deps.controller,
+            getFactoryStorage().getDomain<WorkItemsStorage>('work-items'),
+          ),
+        })
+      : []),
   ];
 }

--- a/mastracode/web/src/web/web-surface.ts
+++ b/mastracode/web/src/web/web-surface.ts
@@ -183,7 +183,16 @@ export function assembleWebApiRoutes(deps: WebApiRoutesDeps): ApiRoute[] {
   const absentStubs = ['github', 'linear']
     .filter(id => !registrations.some(({ integration }) => integration.id === id))
     .flatMap(disabledIntegrationStatusRoutes);
-
+  const factoryRoutes = (() => {
+    if (!deps.factoryReady) return [];
+    const workItems = getFactoryStorage().getDomain<WorkItemsStorage>('work-items');
+    const transitionService = new FactoryTransitionService({ rules: getSeededFactoryRules(), storage: workItems });
+    return buildFactoryRoutes({
+      audit: deps.audit,
+      transitionService,
+      startCoordinator: new FactoryStartCoordinator(deps.controller, workItems, transitionService),
+    });
+  })();
   return [
     ...buildFsRoutes({ root: deps.fsRoot }),
     ...buildConfigRoutes({ controller: deps.controller, authStorage: deps.authStorage }),
@@ -204,18 +213,6 @@ export function assembleWebApiRoutes(deps: WebApiRoutesDeps): ApiRoute[] {
           ),
         })
       : []),
-    ...(deps.factoryReady
-      ? buildFactoryRoutes({
-          audit: deps.audit,
-          transitionService: new FactoryTransitionService({
-            rules: getSeededFactoryRules(),
-            storage: getFactoryStorage().getDomain<WorkItemsStorage>('work-items'),
-          }),
-          startCoordinator: new FactoryStartCoordinator(
-            deps.controller,
-            getFactoryStorage().getDomain<WorkItemsStorage>('work-items'),
-          ),
-        })
-      : []),
+    ...factoryRoutes,
   ];
 }

--- a/packages/core/src/storage/factory-storage.test.ts
+++ b/packages/core/src/storage/factory-storage.test.ts
@@ -30,6 +30,10 @@ class TestFactoryStorage extends FactoryStorage {
     return this.ensureCollectionsSpy(schemas);
   }
 
+  withTransaction<T>(fn: (transactionOps: FactoryStorageOps) => Promise<T>): Promise<T> {
+    return fn(this.ops);
+  }
+
   async close(): Promise<void> {}
 }
 

--- a/packages/core/src/storage/factory-storage.ts
+++ b/packages/core/src/storage/factory-storage.ts
@@ -325,6 +325,13 @@ export abstract class FactoryStorage {
   /** The generic query surface domains are written against. */
   abstract readonly ops: FactoryStorageOps;
 
+  /**
+   * Run a group of app-table operations atomically. The callback receives an
+   * ops instance bound to the transaction; callers must not use `this.ops`
+   * inside it.
+   */
+  abstract withTransaction<T>(fn: (ops: FactoryStorageOps) => Promise<T>): Promise<T>;
+
   /** Release the backend's connections (tests, shutdown). */
   abstract close(): Promise<void>;
 

--- a/stores/libsql/src/storage/factory-storage.ts
+++ b/stores/libsql/src/storage/factory-storage.ts
@@ -101,12 +101,14 @@ class Mutex {
   }
 }
 
+type LibSQLExecutor = Pick<Client, 'execute'>;
+
 class LibSQLFactoryStorageOps implements FactoryStorageOps {
-  readonly #client: Client;
+  readonly #client: LibSQLExecutor;
   readonly #schemas: Map<string, CollectionSchema>;
   readonly #writeMutex = new Mutex();
 
-  constructor(client: Client, schemas: Map<string, CollectionSchema>) {
+  constructor(client: LibSQLExecutor, schemas: Map<string, CollectionSchema>) {
     this.#client = client;
     this.#schemas = schemas;
   }
@@ -426,6 +428,21 @@ export class LibSQLFactoryStorage extends FactoryStorage {
 
   protected async initStorage(): Promise<void> {
     await this.#client.execute('SELECT 1');
+  }
+
+  async withTransaction<T>(fn: (ops: FactoryStorageOps) => Promise<T>): Promise<T> {
+    if (this.#config.url.includes(':memory:')) return fn(this.ops);
+    const transaction = await this.#client.transaction('write');
+    try {
+      const result = await fn(new LibSQLFactoryStorageOps(transaction, this.#schemas));
+      await transaction.commit();
+      return result;
+    } catch (error) {
+      await transaction.rollback();
+      throw error;
+    } finally {
+      transaction.close();
+    }
   }
 
   async ensureCollections(schemas: CollectionSchema[]): Promise<void> {

--- a/stores/pg/src/storage/factory-storage.ts
+++ b/stores/pg/src/storage/factory-storage.ts
@@ -104,11 +104,13 @@ export function hashAdvisoryLockKey(key: string): [number, number] {
 type Queryable = Pick<Pool, 'query'> | Pick<PoolClient, 'query'>;
 
 class PgFactoryStorageOps implements FactoryStorageOps {
-  readonly #pool: Pool;
+  readonly #queryable: Queryable;
+  readonly #transactionClient?: PoolClient;
   readonly #schemas: Map<string, CollectionSchema>;
 
-  constructor(pool: Pool, schemas: Map<string, CollectionSchema>) {
-    this.#pool = pool;
+  constructor(queryable: Queryable, schemas: Map<string, CollectionSchema>, transactionClient?: PoolClient) {
+    this.#queryable = queryable;
+    this.#transactionClient = transactionClient;
     this.#schemas = schemas;
   }
 
@@ -290,7 +292,7 @@ class PgFactoryStorageOps implements FactoryStorageOps {
   }
 
   async findOne<T extends Record<string, unknown>>(collection: string, where: CollectionWhere): Promise<T | null> {
-    const rows = await this.#select<T>(this.#pool, collection, where, { limit: 1 });
+    const rows = await this.#select<T>(this.#queryable, collection, where, { limit: 1 });
     return rows[0] ?? null;
   }
 
@@ -299,7 +301,7 @@ class PgFactoryStorageOps implements FactoryStorageOps {
     where: CollectionWhere,
     opts?: CollectionListOptions,
   ): Promise<T[]> {
-    return this.#select<T>(this.#pool, collection, where, opts);
+    return this.#select<T>(this.#queryable, collection, where, opts);
   }
 
   async insertOne<T extends Record<string, unknown>>(collection: string, row: Partial<T>): Promise<T> {
@@ -320,7 +322,7 @@ class PgFactoryStorageOps implements FactoryStorageOps {
     const args = columns.map(column => this.#serialize(this.#column(schema, column), values[column]));
 
     try {
-      const result = await this.#pool.query(sql, args);
+      const result = await this.#queryable.query(sql, args);
       return this.#deserializeRow<T>(schema, result.rows[0] as Record<string, unknown>);
     } catch (error) {
       if (isUniqueViolation(error)) throw new UniqueViolationError(collection, { cause: error });
@@ -365,7 +367,7 @@ class PgFactoryStorageOps implements FactoryStorageOps {
   }
 
   async updateMany(collection: string, where: CollectionWhere, set: Record<string, unknown>): Promise<number> {
-    return this.#updateMany(this.#pool, collection, where, set);
+    return this.#updateMany(this.#queryable, collection, where, set);
   }
 
   async #updateMany(
@@ -387,7 +389,7 @@ class PgFactoryStorageOps implements FactoryStorageOps {
   async deleteMany(collection: string, where: CollectionWhere): Promise<number> {
     const schema = this.#schema(collection);
     const filter = this.#buildWhere(schema, where);
-    const result = await this.#pool.query(`DELETE FROM "${schema.name}" WHERE ${filter.sql}`, filter.args);
+    const result = await this.#queryable.query(`DELETE FROM "${schema.name}" WHERE ${filter.sql}`, filter.args);
     return result.rowCount ?? 0;
   }
 
@@ -396,26 +398,28 @@ class PgFactoryStorageOps implements FactoryStorageOps {
     where: CollectionWhere,
     fn: (row: T) => Partial<T> | null | Promise<Partial<T> | null>,
   ): Promise<T | null> {
-    const schema = this.#schema(collection);
-    const pk = primaryKeyOf(schema);
-    const client = await this.#pool.connect();
+    const run = async (client: PoolClient): Promise<T | null> => {
+      const schema = this.#schema(collection);
+      const pk = primaryKeyOf(schema);
+      const rows = await this.#select<T>(client, collection, where, { limit: 1 }, true);
+      const row = rows[0];
+      if (!row) return null;
+      const patch = await fn(row);
+      if (patch === null) return row;
+      const pkWhere = { [pk]: row[pk] as CollectionValue } as CollectionWhere;
+      await this.#updateMany(client, collection, pkWhere, patch);
+      const updated = await this.#select<T>(client, collection, pkWhere, { limit: 1 });
+      return updated[0] ?? null;
+    };
+
+    if (this.#transactionClient) return run(this.#transactionClient);
+
+    const pool = this.#queryable as Pool;
+    const client = await pool.connect();
     try {
       await client.query('BEGIN');
       try {
-        const rows = await this.#select<T>(client, collection, where, { limit: 1 }, true);
-        const row = rows[0];
-        if (!row) {
-          await client.query('COMMIT');
-          return null;
-        }
-        const patch = await fn(row);
-        let result: T | null = row;
-        if (patch !== null) {
-          const pkWhere = { [pk]: row[pk] as CollectionValue } as CollectionWhere;
-          await this.#updateMany(client, collection, pkWhere, patch);
-          const updated = await this.#select<T>(client, collection, pkWhere, { limit: 1 });
-          result = updated[0] ?? null;
-        }
+        const result = await run(client);
         await client.query('COMMIT');
         return result;
       } catch (error) {
@@ -473,6 +477,23 @@ export class PgFactoryStorage extends FactoryStorage {
 
   protected async initStorage(): Promise<void> {
     await this.#pool.query('SELECT 1');
+  }
+
+  async withTransaction<T>(fn: (ops: FactoryStorageOps) => Promise<T>): Promise<T> {
+    const client = await this.#pool.connect();
+    try {
+      await client.query('BEGIN');
+      try {
+        const result = await fn(new PgFactoryStorageOps(client, this.#schemas, client));
+        await client.query('COMMIT');
+        return result;
+      } catch (error) {
+        await client.query('ROLLBACK');
+        throw error;
+      }
+    } finally {
+      client.release();
+    }
   }
 
   async ensureCollections(schemas: CollectionSchema[]): Promise<void> {


### PR DESCRIPTION
## Summary

- add one typed, configurable Factory `rules` tree for board lifecycle, completed tool results, and GitHub event policy
- route Work and Review stage changes through a server-owned transition authority with immutable ingress dedupe, optimistic concurrency, bounded decisions, and storage-owned stage history
- persist exact work-item/session/role bindings and recoverable pending starts before kickoff, with run startup requesting its destination through the same transition authority
- close legacy stage PATCH bypasses while keeping Work and Review cards exclusive and independent

This is Segment 01 of the Factory Unified Rules stack and is based on #19551.

## Test plan

- `cd mastracode/web && pnpm exec vitest run src/web/factory/rules/defaults.test.ts src/web/factory/rules/resolve.test.ts src/web/factory/rules/validation.test.ts src/web/factory/rules/transition-service.test.ts src/web/factory/rules/start-coordinator.test.ts src/web/factory/routes.test.ts src/web/storage/domains/work-items/inmemory.test.ts src/web/storage/domains/work-items/pg.test.ts --reporter=dot --bail=1`
- `cd mastracode/web && pnpm exec vitest run --config e2e/web-ui/vitest.config.ts src/web/ui/domains/factory/__tests__/FactoryPages.msw.test.tsx --reporter=dot --bail=1`
- `cd mastracode/web && pnpm check`
- `cd mastracode/web && pnpm web:build` using the documented temporary published-version substitution for currently unpublished workspace alpha packages; manifests restored afterward


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR makes Factory card moves (Work/Review stages) and run start happen through one trusted server “rulebook,” so the browser can’t bypass the required workflow. It also adds configurable, typed rules (with versioning and validation) plus safer storage and retry/replay behavior so runs and transitions behave consistently.

## What changed

- Added a typed, versioned Factory `rules` configuration with defaults, overrides, validation, resolution, and runtime seeding.
- Added authoritative Work and Review stage transitions with:
  - Server-owned rule evaluation (including exit-before-enter ordering)
  - Immutable ingress deduplication and replay protection
  - Optimistic concurrency/stale handling
  - Bounded decisions with causal-depth limits and metadata sanitization
  - Durable storage-owned stage history and deferred decisions
- Added a coordinated run startup flow that:
  - Persists work-item/session/role bindings and “pending start” records before kickoff
  - Supports recoverable pending starts and idempotent replay
  - Prevents kickoff when transition/storage rules reject the start
- Closed legacy client PATCH bypasses for stage changes; PATCH now rejects requests that include `stages`.
- Extended work-item storage with revisions, factory governance records, atomic transaction support, run bindings, and pending-start tracking.
- Updated Factory web APIs, hooks, and UI flows to use the new transition and `/runs/start` endpoints (and route behavior for sessions/cards).
- Added comprehensive tests covering rules defaults/resolution/validation, transition and startup services, routes, storage, UI behavior, and web build/type checking.
- Documented Factory rules configuration, override semantics, and the meaning of rule `version`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- stack-navigation:start -->
## Stack navigation

- Previous: [#19551 — Separate Factory Work and Review workflows](https://github.com/mastra-ai/mastra/pull/19551)
- Next: [#19702 — Dispatch Factory rules and signal bound agent phase](https://github.com/mastra-ai/mastra/pull/19702)
<!-- stack-navigation:end -->
