### PR TITLE
Fix toAISdkStream payload-less step-start chunks

### DIFF
--- a/.changeset/plenty-garlics-shave.md
+++ b/.changeset/plenty-garlics-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed toAISdkStream so DurableAgent streams no longer crash when a step-start chunk has no payload.

--- a/client-sdks/ai-sdk/src/__tests__/step-start-payload.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/step-start-payload.test.ts
@@ -1,0 +1,85 @@
+import { ReadableStream } from 'node:stream/web';
+import { ChunkFrom } from '@mastra/core/stream';
+import type { ChunkType, MastraModelOutput } from '@mastra/core/stream';
+import { describe, expect, it } from 'vitest';
+
+import { toAISdkStream } from '../convert-streams';
+import { convertMastraChunkToAISDKv5, convertMastraChunkToAISDKv6 } from '../helpers';
+
+async function collectChunks(stream: ReadableStream) {
+  const chunks: any[] = [];
+
+  for await (const chunk of stream as any) {
+    chunks.push(chunk);
+  }
+
+  return chunks;
+}
+
+function createPayloadlessStepStartStream() {
+  return new ReadableStream<ChunkType>({
+    start(controller) {
+      controller.enqueue({
+        type: 'start',
+        runId: 'run-1',
+        from: ChunkFrom.AGENT,
+        payload: { messageId: 'msg-1' },
+      } as ChunkType);
+      controller.enqueue({
+        type: 'step-start',
+        runId: 'run-1',
+        from: ChunkFrom.AGENT,
+      } as unknown as ChunkType);
+      controller.close();
+    },
+  });
+}
+
+describe('step-start chunk conversion', () => {
+  it('converts payload-less step-start chunks for v5', () => {
+    const chunk = {
+      type: 'step-start',
+      runId: 'run-1',
+      from: ChunkFrom.AGENT,
+    } as unknown as ChunkType;
+
+    expect(convertMastraChunkToAISDKv5({ chunk, mode: 'stream' })).toEqual({
+      type: 'start-step',
+      request: undefined,
+      warnings: [],
+    });
+  });
+
+  it('converts payload-less step-start chunks for v6', () => {
+    const chunk = {
+      type: 'step-start',
+      runId: 'run-1',
+      from: ChunkFrom.AGENT,
+    } as unknown as ChunkType;
+
+    expect(convertMastraChunkToAISDKv6({ chunk, mode: 'stream' })).toEqual({
+      type: 'start-step',
+      request: undefined,
+      warnings: [],
+    });
+  });
+
+  it('keeps v5 agent UI streams open when DurableAgent emits payload-less step-start', async () => {
+    const chunks = await collectChunks(
+      toAISdkStream(createPayloadlessStepStartStream() as unknown as MastraModelOutput, { from: 'agent' }),
+    );
+
+    expect(chunks).toEqual([{ type: 'start', messageId: 'msg-1' }, { type: 'start-step' }]);
+  });
+
+  it('keeps v6 agent UI streams open when DurableAgent emits payload-less step-start', async () => {
+    const chunks = await collectChunks(
+      toAISdkStream(createPayloadlessStepStartStream() as unknown as MastraModelOutput, {
+        from: 'agent',
+        version: 'v6',
+      }),
+    );
+
+    expect(chunks).toEqual([{ type: 'start', messageId: 'msg-1' }, { type: 'start-step' }]);
+  });
+});

--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -158,7 +158,7 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         ...(chunk.payload?.messageId ? { messageId: chunk.payload.messageId } : {}),
       };
     case 'step-start':
-      const { messageId: _messageId, ...rest } = chunk.payload;
+      const { messageId: _messageId, ...rest } = chunk.payload ?? {};
       return {
         type: 'start-step',
         request: rest.request,


### PR DESCRIPTION
## Description

Fixes `toAISdkStream` / `toAISdkV5Stream` conversion for DurableAgent streams that emit a `step-start` chunk without a `payload`. The converter now treats a missing step-start payload as an empty object, preserving existing request/warning behavior when payload metadata is present.

Added regression coverage for both v5 and v6 conversion helpers and agent UI stream paths.

## Related issue(s)

Fixes #19670

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Tests

- `pnpm --filter @mastra/ai-sdk test src/__tests__/step-start-payload.test.ts`
- `pnpm --filter @mastra/ai-sdk test src/__tests__/step-start-payload.test.ts src/__tests__/background-task-stream.test.ts src/__tests__/tool-call-approval.test.ts`
- `pnpm --filter @mastra/ai-sdk lint`
- `pnpm turbo build --filter @mastra/ai-sdk`
- `pnpm exec prettier --check client-sdks/ai-sdk/src/helpers.ts client-sdks/ai-sdk/src/__tests__/step-start-payload.test.ts .changeset/plenty-garlics-shave.md`

Validation note: I also tried `pnpm --filter @mastra/ai-sdk test`. In this local isolated pnpm install it was blocked by existing tests importing `ai/test` without a local resolvable `ai` package, and by an unrelated `src/middleware.test.ts` LibSQL memory assertion (`storedMessages.length` was 0). The focused converter/stream tests above pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some agent messages were missing optional details, causing the stream to crash early. This fix treats those details as empty and lets the complete message continue through.

## Changes

- Prevents `toAISdkStream` and `toAISdkV5Stream` from crashing on payload-less `step-start` chunks.
- Preserves request and warning metadata when payloads are present.
- Adds regression tests for v5, v6, and agent UI stream conversions.
- Adds a patch changeset for `@mastra/ai-sdk`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->