### PR TITLE
fix(core): make requestContext non-optional in tool execute callback

### DIFF
--- a/.changeset/dirty-pots-leave.md
+++ b/.changeset/dirty-pots-leave.md
@@ -1,0 +1,20 @@
+---
+'@mastra/core': patch
+---
+
+Fixed `requestContext` typing inside a tool's `execute` callback. It is now non-optional, matching runtime behavior: Mastra always provides a `RequestContext` (creating an empty one when the caller passed none), and when `requestContextSchema` is defined the context is validated before `execute` runs — on failure the tool returns a validation error and `execute` is never called. No more null-checks, throws, or tool factories needed to satisfy the compiler.
+
+```typescript
+const tool = createTool({
+  id: 'fetch-doc',
+  requestContextSchema: z.object({ documentId: z.string(), userId: z.string() }),
+  execute: async (input, context) => {
+    // Before: context.requestContext was RequestContext<...> | undefined,
+    // forcing ?. / ! / throw even though the runtime guarantees it exists
+    // After: typed as RequestContext<{ documentId: string; userId: string }>
+    const documentId = context.requestContext.get('documentId'); // string
+  },
+});
+```
+
+Callers of `tool.execute(...)` are unaffected — passing a context remains optional there. Fixes [#19480](https://github.com/mastra-ai/mastra/issues/19480)

--- a/packages/core/src/tools/request-context-schema-types.test-d.ts
+++ b/packages/core/src/tools/request-context-schema-types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, expectTypeOf, it } from 'vitest';
 import { z } from 'zod/v4';
 import type { RequestContext } from '../request-context';
-import { createTool } from './tool';
+import { createTool, Tool } from './tool';
 
 /**
  * Type tests to verify requestContextSchema properly types the execute function's context
@@ -106,6 +106,31 @@ describe('requestContextSchema type inference', () => {
 
         const userId = context.requestContext.get('userId');
         expectTypeOf(userId).toEqualTypeOf<string>();
+
+        return { success: true };
+      },
+    });
+  });
+
+  it('should type requestContext in execute when constructed via new Tool()', () => {
+    new Tool({
+      id: 'typed-class-tool',
+      description: 'A tool constructed directly with a typed request context',
+      requestContextSchema: z.object({
+        userId: z.string(),
+        apiKey: z.string(),
+      }),
+      execute: async (input, context) => {
+        expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<{ userId: string; apiKey: string }>>();
+
+        const userId = context.requestContext.get('userId');
+        expectTypeOf(userId).toEqualTypeOf<string>();
+
+        const all = context.requestContext.all;
+        expectTypeOf(all).toEqualTypeOf<{ userId: string; apiKey: string }>();
+
+        // @ts-expect-error - key does not exist in the request context schema
+        context.requestContext.get('nonexistentKey');
 
         return { success: true };
       },

--- a/packages/core/src/tools/request-context-schema-types.test-d.ts
+++ b/packages/core/src/tools/request-context-schema-types.test-d.ts
@@ -16,21 +16,24 @@ describe('requestContextSchema type inference', () => {
         apiKey: z.string(),
       }),
       execute: async (input, context) => {
-        // Verify context.requestContext is typed
-        expectTypeOf(context.requestContext).toEqualTypeOf<
-          RequestContext<{ userId: string; apiKey: string }> | undefined
-        >();
+        // The runtime always provides requestContext (and validates it against
+        // the schema before execute runs), so it is non-optional here.
+        expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<{ userId: string; apiKey: string }>>();
 
-        // Verify get() returns the correct type
-        const userId = context.requestContext?.get('userId');
-        expectTypeOf(userId).toEqualTypeOf<string | undefined>();
+        // Verify get() returns the correct type without null-checking
+        const userId = context.requestContext.get('userId');
+        expectTypeOf(userId).toEqualTypeOf<string>();
 
-        const apiKey = context.requestContext?.get('apiKey');
-        expectTypeOf(apiKey).toEqualTypeOf<string | undefined>();
+        const apiKey = context.requestContext.get('apiKey');
+        expectTypeOf(apiKey).toEqualTypeOf<string>();
 
         // Verify .all returns the typed object
-        const all = context.requestContext?.all;
-        expectTypeOf(all).toEqualTypeOf<{ userId: string; apiKey: string } | undefined>();
+        const all = context.requestContext.all;
+        expectTypeOf(all).toEqualTypeOf<{ userId: string; apiKey: string }>();
+
+        // Verify unknown keys are rejected
+        // @ts-expect-error - key does not exist in the request context schema
+        context.requestContext.get('nonexistentKey');
 
         return { success: true };
       },
@@ -45,11 +48,12 @@ describe('requestContextSchema type inference', () => {
       id: 'untyped-tool',
       description: 'A tool without request context schema',
       execute: async (input, context) => {
-        // Without schema, requestContext should be RequestContext<unknown>
-        expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<unknown> | undefined>();
+        // Without schema, requestContext is still always provided at runtime,
+        // just untyped: RequestContext<unknown>
+        expectTypeOf(context.requestContext).toEqualTypeOf<RequestContext<unknown>>();
 
         // get() should return unknown
-        const value = context.requestContext?.get('anyKey');
+        const value = context.requestContext.get('anyKey');
         expectTypeOf(value).toEqualTypeOf<unknown>();
 
         return { success: true };
@@ -71,11 +75,37 @@ describe('requestContextSchema type inference', () => {
         }),
       }),
       execute: async (input, context) => {
-        const user = context.requestContext?.get('user');
-        expectTypeOf(user).toEqualTypeOf<{ id: string; name: string } | undefined>();
+        const user = context.requestContext.get('user');
+        expectTypeOf(user).toEqualTypeOf<{ id: string; name: string }>();
 
-        const settings = context.requestContext?.get('settings');
-        expectTypeOf(settings).toEqualTypeOf<{ theme: 'light' | 'dark' } | undefined>();
+        const settings = context.requestContext.get('settings');
+        expectTypeOf(settings).toEqualTypeOf<{ theme: 'light' | 'dark' }>();
+
+        return { success: true };
+      },
+    });
+  });
+
+  it('should preserve readonly properties from a readonly requestContextSchema', () => {
+    createTool({
+      id: 'document-tool',
+      description: 'A tool with document request metadata',
+      requestContextSchema: z
+        .object({
+          documentId: z.string(),
+          userId: z.string(),
+        })
+        .readonly(),
+      execute: async (input, context) => {
+        expectTypeOf(context.requestContext).toEqualTypeOf<
+          RequestContext<{ readonly documentId: string; readonly userId: string }>
+        >();
+
+        const documentId = context.requestContext.get('documentId');
+        expectTypeOf(documentId).toEqualTypeOf<string>();
+
+        const userId = context.requestContext.get('userId');
+        expectTypeOf(userId).toEqualTypeOf<string>();
 
         return { success: true };
       },

--- a/packages/core/src/tools/tool.ts
+++ b/packages/core/src/tools/tool.ts
@@ -9,6 +9,7 @@ import type {
   MCPToolProperties,
   NeedsApprovalFn,
   ToolAction,
+  ToolExecuteFunction,
   ToolExecutionContext,
   ToolPayloadTransform,
 } from './types';
@@ -273,7 +274,14 @@ export class Tool<
    * });
    * ```
    */
-  constructor(opts: ToolAction<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext, TId, TRequestContext>) {
+  constructor(
+    opts: Omit<
+      ToolAction<TSchemaIn, TSchemaOut, TSuspendSchema, TResumeSchema, TContext, TId, TRequestContext>,
+      'execute'
+    > & {
+      execute?: ToolExecuteFunction<TSchemaIn, TSchemaOut, TContext, TRequestContext>;
+    },
+  ) {
     (this as any)[MASTRA_TOOL_MARKER] = true;
     this.id = opts.id;
     this.description = opts.description;
@@ -565,12 +573,13 @@ type CreateToolOpts<
     TId,
     TRequestContext
   >,
-  'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema'
+  'inputSchema' | 'outputSchema' | 'suspendSchema' | 'resumeSchema' | 'execute'
 > & {
   inputSchema?: TInputSchema;
   outputSchema?: TOutputSchema;
   suspendSchema?: TSuspendSchema;
   resumeSchema?: TResumeSchema;
+  execute?: ToolExecuteFunction<InferSchema<TInputSchema>, InferSchema<TOutputSchema>, TContext, TRequestContext>;
 };
 export function createTool<
   TId extends string = string,

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -593,10 +593,9 @@ export interface ToolExecutionContext<
  * `requestContext` (an empty one is created if the caller passed none), so it
  * is non-optional here — like `observe`. No null-checking needed.
  */
-export type ToolExecuteContext<
-  TContext,
-  TRequestContext extends Record<string, any> | unknown = unknown,
-> = TContext & { requestContext: RequestContext<TRequestContext> };
+export type ToolExecuteContext<TContext, TRequestContext extends Record<string, any> | unknown = unknown> = TContext & {
+  requestContext: RequestContext<TRequestContext>;
+};
 
 /** The `execute` callback signature used by `createTool` and `new Tool(...)`. */
 export type ToolExecuteFunction<

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -593,7 +593,10 @@ export interface ToolExecutionContext<
  * `requestContext` (an empty one is created if the caller passed none), so it
  * is non-optional here — like `observe`. No null-checking needed.
  */
-export type ToolExecuteContext<TContext, TRequestContext extends Record<string, any> | unknown = unknown> = TContext & {
+export type ToolExecuteContext<TContext, TRequestContext extends Record<string, any> | unknown = unknown> = Omit<
+  TContext,
+  'requestContext'
+> & {
   requestContext: RequestContext<TRequestContext>;
 };
 

--- a/packages/core/src/tools/types.ts
+++ b/packages/core/src/tools/types.ts
@@ -588,6 +588,27 @@ export interface ToolExecutionContext<
   observe: ToolObserve;
 }
 
+/**
+ * Context received by a tool's `execute` callback. The runtime always provides
+ * `requestContext` (an empty one is created if the caller passed none), so it
+ * is non-optional here — like `observe`. No null-checking needed.
+ */
+export type ToolExecuteContext<
+  TContext,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+> = TContext & { requestContext: RequestContext<TRequestContext> };
+
+/** The `execute` callback signature used by `createTool` and `new Tool(...)`. */
+export type ToolExecuteFunction<
+  TSchemaIn,
+  TSchemaOut,
+  TContext,
+  TRequestContext extends Record<string, any> | unknown = unknown,
+> = (
+  inputData: TSchemaIn,
+  context: ToolExecuteContext<TContext, TRequestContext>,
+) => Promise<TSchemaOut | ValidationError | void>;
+
 export interface ToolAction<
   TSchemaIn,
   TSchemaOut,


### PR DESCRIPTION
## Description

Fixes the `requestContext` typing inside a tool's `execute` callback. It was typed `RequestContext<T> | undefined` even though the runtime always provides it — an empty `RequestContext` is created when the caller passes none, and when `requestContextSchema` is defined the context is validated before `execute` runs (on failure the tool returns a validation error and `execute` is never called). The optional typing forced users into `?.` / `!` / throws / tool factories for a case that cannot occur.

```typescript
const tool = createTool({
  id: 'fetch-doc',
  requestContextSchema: z.object({ documentId: z.string(), userId: z.string() }),
  execute: async (input, context) => {
    // Before: context.requestContext was RequestContext<...> | undefined
    // After: typed as RequestContext<{ documentId: string; userId: string }>
    const documentId = context.requestContext.get('documentId'); // string
  },
});
```

- Added `ToolExecuteContext` and `ToolExecuteFunction` types in `packages/core/src/tools/types.ts` — the callback-facing context with `requestContext` required (same precedent as the already-required `observe` field, and workflow step params in `workflows/types.ts`)
- Narrowed only the callback side: `Tool` constructor opts and `CreateToolOpts` (`createTool`) now use `ToolExecuteFunction` via the existing `Omit & override` pattern
- Caller-facing `ToolAction['execute']` and the public `Tool.execute` are unchanged — passing a context when invoking a tool remains optional, so this is not breaking
- Zero runtime changes; type-only fix
- Updated `request-context-schema-types.test-d.ts` to assert non-optional types, reject unknown keys, and cover readonly schemas

**Verification**

- Full `tsc --noEmit` on `@mastra/core`; all 18 test-d files (149 type tests); `src/tools` suite (374 tests); `workflow.test.ts` (276 tests, covers createStep-from-tool)
- Downstream typecheck clean: `@mastra/memory`, `@mastra/rag`, `@mastra/mcp` against the rebuilt core
- Live agent E2E (real model calls): agent forwards requestContext into the tool; with required keys missing, validation gates `execute` (never runs) and returns a validation error; direct `tool.execute` calls unchanged
- Negative control: the same consumer file fails to compile against unpatched core with `'context.requestContext' is possibly 'undefined'`

## Related Issue(s)

Fixes #19480

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool runs, it always gets a `context` object—and it always includes `requestContext`. This PR updates the tool callback types so TypeScript matches that reality, removing the need for optional checks or “it might be undefined” workarounds.

## What changed

- Added `ToolExecuteContext` and `ToolExecuteFunction` types so `context.requestContext` is always non-optional inside tool `execute` callbacks.
- Updated `Tool` and `createTool` typings so `execute` uses the new callback types (caller-facing execution APIs remain unchanged).
- Ensured the typed-constructor path omits the base untyped `requestContext` before applying the typed override, so unknown keys are rejected consistently.
- Updated type tests to reflect required contexts and to cover unknown keys, nested schemas, and readonly schemas.
- Added a changeset documenting the typing fix and the runtime guarantee (schema validation happens before `execute`, and empty `requestContext` is always provided when missing).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->