### PR TITLE
docs(mcp): add JWT verification example

### DIFF
--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1721,6 +1721,7 @@ const verifyToken = async (token: string) => {
     issuer,
     audience,
     algorithms: ['RS256'],
+    requiredClaims: ['exp'],
   })
 
   if (!payload.sub || typeof payload.email !== 'string') {

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1586,18 +1586,34 @@ import express from 'express'
 const app = express()
 
 // Auth middleware - set req.auth before the MCP handler
-app.use('/mcp', (req, res, next) => {
-  const token = req.headers.authorization?.replace('Bearer ', '')
-  const user = verifyToken(token)
+app.use('/mcp', async (req, res, next) => {
+  const authorization = req.headers.authorization
 
-  // This entire object becomes context.mcp.extra.authInfo
-  // @ts-ignore - req.auth is read by the MCP SDK
-  req.auth = {
-    token,
-    userId: user.userId,
-    email: user.email,
+  if (!authorization?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing bearer token' })
+    return
   }
-  next()
+
+  const token = authorization.slice('Bearer '.length)
+
+  try {
+    const user = await verifyToken(token)
+
+    // This entire object becomes context.mcp.extra.authInfo
+    // @ts-ignore - req.auth is read by the MCP SDK
+    req.auth = {
+      token,
+      clientId: user.userId,
+      scopes: user.scopes,
+      extra: {
+        userId: user.userId,
+        email: user.email,
+      },
+    }
+    next()
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' })
+  }
 })
 
 app.all('/mcp', async (req, res) => {
@@ -1675,19 +1691,46 @@ The full `context.mcp.extra` object contains:
 
 ### Complete Example
 
-Here's a complete example showing the data flow from middleware to tool:
+Install [`jose`](https://github.com/panva/jose) to verify JSON Web Tokens (JWTs) against your identity provider's JSON Web Key Set (JWKS):
+
+```shell npm2yarn
+npm install jose
+```
+
+The following example validates the token's signature, issuer, audience, algorithm, expiration, and required claims before passing its user data to the tool:
 
 ```typescript
 import express from 'express'
+import { createRemoteJWKSet, jwtVerify } from 'jose'
 import { MCPServer } from '@mastra/mcp'
 import { createTool } from '@mastra/core/tools'
 import { z } from 'zod'
 
-const verifyToken = (token: string) => {
-  // TODO: Implement token verification
+const issuer = process.env.JWT_ISSUER
+const audience = process.env.JWT_AUDIENCE
+const jwksUri = process.env.JWT_JWKS_URI
+
+if (!issuer || !audience || !jwksUri) {
+  throw new Error('JWT_ISSUER, JWT_AUDIENCE, and JWT_JWKS_URI are required')
+}
+
+const jwks = createRemoteJWKSet(new URL(jwksUri))
+
+const verifyToken = async (token: string) => {
+  const { payload } = await jwtVerify(token, jwks, {
+    issuer,
+    audience,
+    algorithms: ['RS256'],
+  })
+
+  if (!payload.sub || typeof payload.email !== 'string') {
+    throw new Error('Token must contain sub and email claims')
+  }
+
   return {
-    userId: '123',
-    email: 'test@test.com',
+    userId: payload.sub,
+    email: payload.email,
+    scopes: typeof payload.scope === 'string' ? payload.scope.split(' ') : [],
   }
 }
 
@@ -1722,18 +1765,34 @@ const server = new MCPServer({
 // 3. Set up Express with auth middleware
 const app = express()
 
-app.use('/mcp', (req, res, next) => {
-  const token = req.headers.authorization?.replace('Bearer ', '')
-  const user = verifyToken(token)
+app.use('/mcp', async (req, res, next) => {
+  const authorization = req.headers.authorization
 
-  // This entire object becomes context.mcp.extra.authInfo
-  // @ts-ignore - req.auth is read by the MCP SDK
-  req.auth = {
-    token,
-    userId: user.userId,
-    email: user.email,
+  if (!authorization?.startsWith('Bearer ')) {
+    res.status(401).json({ error: 'Missing bearer token' })
+    return
   }
-  next()
+
+  const token = authorization.slice('Bearer '.length)
+
+  try {
+    const user = await verifyToken(token)
+
+    // This entire object becomes context.mcp.extra.authInfo
+    // @ts-ignore - req.auth is read by the MCP SDK
+    req.auth = {
+      token,
+      clientId: user.userId,
+      scopes: user.scopes,
+      extra: {
+        userId: user.userId,
+        email: user.email,
+      },
+    }
+    next()
+  } catch {
+    res.status(401).json({ error: 'Invalid or expired token' })
+  }
 })
 
 app.all('/mcp', async (req, res) => {

--- a/docs/src/content/en/reference/tools/mcp-server.mdx
+++ b/docs/src/content/en/reference/tools/mcp-server.mdx
@@ -1583,6 +1583,16 @@ To pass data to your tools, populate `req.auth` on the Node.js request object in
 ```typescript
 import express from 'express'
 
+type MCPAuthenticatedRequest = express.Request & {
+  auth?: {
+    token: string
+    clientId: string
+    scopes: string[]
+    expiresAt?: number
+    extra?: Record<string, unknown>
+  }
+}
+
 const app = express()
 
 // Auth middleware - set req.auth before the MCP handler
@@ -1600,11 +1610,12 @@ app.use('/mcp', async (req, res, next) => {
     const user = await verifyToken(token)
 
     // This entire object becomes context.mcp.extra.authInfo
-    // @ts-ignore - req.auth is read by the MCP SDK
-    req.auth = {
+    const authenticatedRequest = req as MCPAuthenticatedRequest
+    authenticatedRequest.auth = {
       token,
-      clientId: user.userId,
+      clientId: user.clientId,
       scopes: user.scopes,
+      expiresAt: user.expiresAt,
       extra: {
         userId: user.userId,
         email: user.email,
@@ -1706,6 +1717,16 @@ import { MCPServer } from '@mastra/mcp'
 import { createTool } from '@mastra/core/tools'
 import { z } from 'zod'
 
+type MCPAuthenticatedRequest = express.Request & {
+  auth?: {
+    token: string
+    clientId: string
+    scopes: string[]
+    expiresAt?: number
+    extra?: Record<string, unknown>
+  }
+}
+
 const issuer = process.env.JWT_ISSUER
 const audience = process.env.JWT_AUDIENCE
 const jwksUri = process.env.JWT_JWKS_URI
@@ -1724,13 +1745,22 @@ const verifyToken = async (token: string) => {
     requiredClaims: ['exp'],
   })
 
-  if (!payload.sub || typeof payload.email !== 'string') {
-    throw new Error('Token must contain sub and email claims')
+  const clientId =
+    typeof payload.client_id === 'string'
+      ? payload.client_id
+      : typeof payload.azp === 'string'
+        ? payload.azp
+        : undefined
+
+  if (!payload.sub || typeof payload.email !== 'string' || !clientId || !payload.exp) {
+    throw new Error('Token must contain sub, email, exp, and client_id or azp claims')
   }
 
   return {
     userId: payload.sub,
+    clientId,
     email: payload.email,
+    expiresAt: payload.exp,
     scopes: typeof payload.scope === 'string' ? payload.scope.split(' ') : [],
   }
 }
@@ -1780,11 +1810,12 @@ app.use('/mcp', async (req, res, next) => {
     const user = await verifyToken(token)
 
     // This entire object becomes context.mcp.extra.authInfo
-    // @ts-ignore - req.auth is read by the MCP SDK
-    req.auth = {
+    const authenticatedRequest = req as MCPAuthenticatedRequest
+    authenticatedRequest.auth = {
       token,
-      clientId: user.userId,
+      clientId: user.clientId,
       scopes: user.scopes,
+      expiresAt: user.expiresAt,
       extra: {
         userId: user.userId,
         email: user.email,


### PR DESCRIPTION
Replaces the placeholder token verifier in the MCP server reference with a working jose/JWKS example. The example validates the token signature, issuer, audience, algorithm, expiration, and required claims, returns 401 for missing or invalid bearer tokens, and passes auth data in the MCP SDK's expected shape.\n\nCloses #19683.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates the MCP server docs so the “check your token” example actually verifies a real login token using the `jose`/JWKS approach. It also shows how to properly reject requests with missing/invalid tokens and how to pass the verified user info into MCP tool calls.

## Summary

- Replaces the `verifyToken` stub in `docs/src/content/en/reference/tools/mcp-server.mdx` with a working `jose` + JWKS JWT verification example.
- Verifies bearer tokens and rejects requests with explicit `401` JSON responses for missing, invalid, or expired tokens.
- Validates JWT signature plus issuer, audience, algorithm, expiration, and required claims (including rejecting tokens that lack an expiration claim).
- Derives authentication context (e.g., `scopes`) from token claims and maps OAuth/OIDC data into the MCP SDK’s expected `context.mcp.extra.authInfo` shape.
- Updates both the “Authentication context” and “Complete Example” flows to use an async Express middleware that attaches a richer `req.auth` (token, clientId, scopes, expiresAt, and `extra.userId`/`extra.email`) and then passes it into MCP tool calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->