### PR TITLE
fix(mastracode): enable Bedrock prompt caching

### DIFF
--- a/.changeset/smart-snakes-grin.md
+++ b/.changeset/smart-snakes-grin.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed Amazon Bedrock prompt caching for long Mastra Code conversations.

--- a/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
+++ b/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
@@ -50,6 +50,16 @@ describe('addBedrockCachePoints', () => {
     expect(prompt[1]!.providerOptions?.bedrock).toEqual({ cachePoint: { type: 'default' } });
   });
 
+  it('marks the latest non-system message when a system message is last', () => {
+    const prompt = addBedrockCachePoints([
+      { role: 'user', content: [{ type: 'text', text: 'latest message' }] },
+      { role: 'system', content: 'system prompt' },
+    ]);
+
+    expect(prompt[0]!.providerOptions?.bedrock).toEqual({ cachePoint: { type: 'default' } });
+    expect(prompt[1]!.providerOptions?.bedrock).toEqual({ cachePoint: { type: 'default' } });
+  });
+
   it('preserves existing Bedrock and unrelated provider options', () => {
     const prompt = addBedrockCachePoints([
       {

--- a/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
+++ b/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
@@ -1,20 +1,26 @@
-import { describe, expect, it } from 'vitest';
-import { addBedrockCachePoints, supportsBedrockPromptCaching } from '../amazon-bedrock-gateway.js';
+import { describe, expect, it, vi } from 'vitest';
+import { addBedrockCachePoints, supportsBedrockPromptCaching, withBedrockCache } from '../amazon-bedrock-gateway.js';
 
 describe('supportsBedrockPromptCaching', () => {
   it.each([
+    'us.anthropic.claude-3-5-haiku-20241022-v1:0',
     'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
     'eu.anthropic.claude-3-7-sonnet-20250219-v1:0',
+    'global.anthropic.claude-fable-5',
     'us.anthropic.claude-haiku-4-5-20251001-v1:0',
     'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
-    'us.anthropic.claude-opus-4-6-v1',
+    'global.anthropic.claude-sonnet-5',
+    'us.anthropic.claude-opus-4-8',
   ])('enables caching for %s', modelId => {
     expect(supportsBedrockPromptCaching(modelId)).toBe(true);
   });
 
-  it('leaves unsupported models unchanged', () => {
-    expect(supportsBedrockPromptCaching('meta.llama3-70b-instruct-v1:0')).toBe(false);
-  });
+  it.each(['anthropic.claude-3-haiku-20240307-v1:0', 'amazon.nova-lite-v1:0', 'meta.llama3-70b-instruct-v1:0'])(
+    'leaves unsupported model %s unchanged',
+    modelId => {
+      expect(supportsBedrockPromptCaching(modelId)).toBe(false);
+    },
+  );
 });
 
 describe('addBedrockCachePoints', () => {
@@ -63,5 +69,41 @@ describe('addBedrockCachePoints', () => {
       },
       openai: { store: false },
     });
+  });
+});
+
+describe('withBedrockCache', () => {
+  const prompt = [
+    { role: 'system' as const, content: 'system prompt' },
+    { role: 'user' as const, content: [{ type: 'text' as const, text: 'latest message' }] },
+  ];
+
+  const expectedPrompt = [
+    {
+      ...prompt[0],
+      providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+    },
+    {
+      ...prompt[1],
+      providerOptions: { bedrock: { cachePoint: { type: 'default' } } },
+    },
+  ];
+
+  it('adds cache points before doGenerate', async () => {
+    const doGenerate = vi.fn().mockResolvedValue({});
+    const model = withBedrockCache({ doGenerate } as unknown as Parameters<typeof withBedrockCache>[0]);
+
+    await model.doGenerate({ prompt } as Parameters<typeof model.doGenerate>[0]);
+
+    expect(doGenerate).toHaveBeenCalledWith({ prompt: expectedPrompt });
+  });
+
+  it('adds cache points before doStream', async () => {
+    const doStream = vi.fn().mockResolvedValue({});
+    const model = withBedrockCache({ doStream } as unknown as Parameters<typeof withBedrockCache>[0]);
+
+    await model.doStream({ prompt } as Parameters<typeof model.doStream>[0]);
+
+    expect(doStream).toHaveBeenCalledWith({ prompt: expectedPrompt });
   });
 });

--- a/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
+++ b/mastracode/sdk/src/providers/__tests__/amazon-bedrock-cache.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { addBedrockCachePoints, supportsBedrockPromptCaching } from '../amazon-bedrock-gateway.js';
+
+describe('supportsBedrockPromptCaching', () => {
+  it.each([
+    'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+    'eu.anthropic.claude-3-7-sonnet-20250219-v1:0',
+    'us.anthropic.claude-haiku-4-5-20251001-v1:0',
+    'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+    'us.anthropic.claude-opus-4-6-v1',
+  ])('enables caching for %s', modelId => {
+    expect(supportsBedrockPromptCaching(modelId)).toBe(true);
+  });
+
+  it('leaves unsupported models unchanged', () => {
+    expect(supportsBedrockPromptCaching('meta.llama3-70b-instruct-v1:0')).toBe(false);
+  });
+});
+
+describe('addBedrockCachePoints', () => {
+  it('marks the last system message and most recent message as cache points', () => {
+    const prompt = addBedrockCachePoints([
+      { role: 'system', content: 'first system prompt' },
+      { role: 'system', content: 'latest system prompt' },
+      { role: 'user', content: [{ type: 'text', text: 'first message' }] },
+      { role: 'assistant', content: [{ type: 'text', text: 'response' }] },
+      { role: 'user', content: [{ type: 'text', text: 'latest message' }] },
+    ]);
+
+    expect(prompt[0]!.providerOptions?.bedrock).toBeUndefined();
+    expect(prompt[1]!.providerOptions?.bedrock).toEqual({ cachePoint: { type: 'default' } });
+    expect(prompt[2]!.providerOptions?.bedrock).toBeUndefined();
+    expect(prompt[3]!.providerOptions?.bedrock).toBeUndefined();
+    expect(prompt[4]!.providerOptions?.bedrock).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  it('marks only the last message when there is no system message', () => {
+    const prompt = addBedrockCachePoints([
+      { role: 'user', content: [{ type: 'text', text: 'first message' }] },
+      { role: 'user', content: [{ type: 'text', text: 'latest message' }] },
+    ]);
+
+    expect(prompt[0]!.providerOptions?.bedrock).toBeUndefined();
+    expect(prompt[1]!.providerOptions?.bedrock).toEqual({ cachePoint: { type: 'default' } });
+  });
+
+  it('preserves existing Bedrock and unrelated provider options', () => {
+    const prompt = addBedrockCachePoints([
+      {
+        role: 'user',
+        content: [{ type: 'text', text: 'latest message' }],
+        providerOptions: {
+          bedrock: { guardrailConfig: { guardrailIdentifier: 'guardrail-id', guardrailVersion: '1' } },
+          openai: { store: false },
+        },
+      },
+    ]);
+
+    expect(prompt[0]!.providerOptions).toEqual({
+      bedrock: {
+        guardrailConfig: { guardrailIdentifier: 'guardrail-id', guardrailVersion: '1' },
+        cachePoint: { type: 'default' },
+      },
+      openai: { store: false },
+    });
+  });
+});

--- a/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
+++ b/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
@@ -50,9 +50,16 @@ export function addBedrockCachePoints(prompt: BedrockPrompt): BedrockPrompt {
     result[lastSystemIndex] = markCachePoint(result[lastSystemIndex]!);
   }
 
-  const lastIndex = result.length - 1;
-  if (lastIndex >= 0 && lastIndex !== lastSystemIndex) {
-    result[lastIndex] = markCachePoint(result[lastIndex]!);
+  let lastNonSystemIndex = -1;
+  for (let index = result.length - 1; index >= 0; index--) {
+    if (result[index]!.role !== 'system') {
+      lastNonSystemIndex = index;
+      break;
+    }
+  }
+
+  if (lastNonSystemIndex >= 0) {
+    result[lastNonSystemIndex] = markCachePoint(result[lastNonSystemIndex]!);
   }
 
   return result;

--- a/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
+++ b/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
@@ -11,11 +11,14 @@ type BedrockModel = ReturnType<ReturnType<typeof createAmazonBedrock>>;
 type BedrockPrompt = Parameters<BedrockModel['doGenerate']>[0]['prompt'];
 
 const CACHEABLE_BEDROCK_MODEL_IDS = [
+  'anthropic.claude-3-5-haiku-',
   'anthropic.claude-3-5-sonnet-20241022-v2:0',
   'anthropic.claude-3-7-sonnet-',
+  'anthropic.claude-fable-5',
   'anthropic.claude-haiku-4-5-',
   'anthropic.claude-opus-4-',
   'anthropic.claude-sonnet-4-',
+  'anthropic.claude-sonnet-5',
 ];
 
 export function supportsBedrockPromptCaching(modelId: string): boolean {
@@ -55,7 +58,7 @@ export function addBedrockCachePoints(prompt: BedrockPrompt): BedrockPrompt {
   return result;
 }
 
-function withBedrockCache(model: BedrockModel): BedrockModel {
+export function withBedrockCache(model: BedrockModel): BedrockModel {
   return new Proxy(model, {
     get(target, property, receiver) {
       if (property === 'doGenerate') {

--- a/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
+++ b/mastracode/sdk/src/providers/amazon-bedrock-gateway.ts
@@ -7,6 +7,69 @@ import type { GatewayAuthRequest, GatewayAuthResult, GatewayLanguageModel, Provi
 import { getBedrockModelCatalog } from './amazon-bedrock.js';
 
 type ModelRequestHeaders = Record<string, string>;
+type BedrockModel = ReturnType<ReturnType<typeof createAmazonBedrock>>;
+type BedrockPrompt = Parameters<BedrockModel['doGenerate']>[0]['prompt'];
+
+const CACHEABLE_BEDROCK_MODEL_IDS = [
+  'anthropic.claude-3-5-sonnet-20241022-v2:0',
+  'anthropic.claude-3-7-sonnet-',
+  'anthropic.claude-haiku-4-5-',
+  'anthropic.claude-opus-4-',
+  'anthropic.claude-sonnet-4-',
+];
+
+export function supportsBedrockPromptCaching(modelId: string): boolean {
+  return CACHEABLE_BEDROCK_MODEL_IDS.some(cacheableModelId => modelId.includes(cacheableModelId));
+}
+
+export function addBedrockCachePoints(prompt: BedrockPrompt): BedrockPrompt {
+  const result = [...prompt];
+  const markCachePoint = (message: (typeof result)[number]) => ({
+    ...message,
+    providerOptions: {
+      ...message.providerOptions,
+      bedrock: {
+        ...message.providerOptions?.bedrock,
+        cachePoint: { type: 'default' },
+      },
+    },
+  });
+
+  let lastSystemIndex = -1;
+  for (let index = result.length - 1; index >= 0; index--) {
+    if (result[index]!.role === 'system') {
+      lastSystemIndex = index;
+      break;
+    }
+  }
+
+  if (lastSystemIndex >= 0) {
+    result[lastSystemIndex] = markCachePoint(result[lastSystemIndex]!);
+  }
+
+  const lastIndex = result.length - 1;
+  if (lastIndex >= 0 && lastIndex !== lastSystemIndex) {
+    result[lastIndex] = markCachePoint(result[lastIndex]!);
+  }
+
+  return result;
+}
+
+function withBedrockCache(model: BedrockModel): BedrockModel {
+  return new Proxy(model, {
+    get(target, property, receiver) {
+      if (property === 'doGenerate') {
+        return (options: Parameters<BedrockModel['doGenerate']>[0]) =>
+          target.doGenerate({ ...options, prompt: addBedrockCachePoints(options.prompt) });
+      }
+      if (property === 'doStream') {
+        return (options: Parameters<BedrockModel['doStream']>[0]) =>
+          target.doStream({ ...options, prompt: addBedrockCachePoints(options.prompt) });
+      }
+      return Reflect.get(target, property, receiver);
+    },
+  });
+}
 
 export const AMAZON_BEDROCK_GATEWAY_ID = 'amazon-bedrock';
 
@@ -64,7 +127,8 @@ function bedrockProvider(modelId: string, headers?: ModelRequestHeaders) {
     credentialProvider: fromNodeProviderChain(),
     headers,
   });
-  return bedrock(modelId);
+  const model = bedrock(modelId);
+  return supportsBedrockPromptCaching(modelId) ? withBedrockCache(model) : model;
 }
 
 /**


### PR DESCRIPTION
Fixes #19672.

Before this change, the standalone Amazon Bedrock path sent the full conversation without cache points. This adds cache points to the last system message and most recent message for supported Bedrock Claude models while preserving existing Bedrock options such as guardrails and leaving unsupported models unchanged.

Verified with the full @mastra/code-sdk test suite, package typecheck, lint, and build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Long conversations with supported Amazon Bedrock Claude models can now reuse previously processed prompts, reducing repeated input costs. Unsupported models continue to behave as before.

## What changed

- Added Bedrock prompt-cache points to:
  - The last system message.
  - The latest prompt message.
- Enabled caching for supported Bedrock Claude models only.
- Preserved existing Bedrock and unrelated provider options.
- Applied caching to both streaming and non-streaming generation.
- Added tests covering supported models, unsupported models, prompts without system messages, and option preservation.
- Added a patch changeset for `@mastra/code-sdk`.

## Validation

- Full `@mastra/code-sdk` test suite
- Typecheck
- Lint
- Build

<!-- end of auto-generated comment: release notes by coderabbit.ai -->