### PR TITLE
fix(mastracode): retry dropped provider connections

### DIFF
--- a/.changeset/grumpy-sheep-win.md
+++ b/.changeset/grumpy-sheep-win.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed Mastra Code retries for EPIPE and closed provider connections. (#19691)

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -795,20 +795,22 @@ describe('createMastraCode', () => {
     expect(badRequestPolicy.maxRetries).toBe(1);
     expect(badRequestPolicy.delayMs).toBe(2000);
 
-    // Second matcher: ECONNRESET with maxRetries 2 and exponential backoff.
-    const econnresetPolicy = options!.matchers![1] as {
-      match?: unknown;
+    // Second matcher: transient connection failures with maxRetries 2 and exponential backoff.
+    const transientConnectionPolicy = options!.matchers![1] as {
+      match?: (error: unknown) => boolean;
       maxRetries?: number;
       delayMs?: (args: { retryCount: number }) => number;
     };
-    expect(typeof econnresetPolicy.match).toBe('function');
-    expect(econnresetPolicy.maxRetries).toBe(2);
-    expect(typeof econnresetPolicy.delayMs).toBe('function');
-    expect(econnresetPolicy.delayMs!({ retryCount: 0 })).toBe(1000);
-    expect(econnresetPolicy.delayMs!({ retryCount: 1 })).toBe(2000);
-    expect(econnresetPolicy.delayMs!({ retryCount: 2 })).toBe(4000);
+    expect(typeof transientConnectionPolicy.match).toBe('function');
+    expect(transientConnectionPolicy.match!(Object.assign(new Error('write EPIPE'), { code: 'EPIPE' }))).toBe(true);
+    expect(transientConnectionPolicy.match!(new Error('Cannot connect to API: other side closed'))).toBe(true);
+    expect(transientConnectionPolicy.maxRetries).toBe(2);
+    expect(typeof transientConnectionPolicy.delayMs).toBe('function');
+    expect(transientConnectionPolicy.delayMs!({ retryCount: 0 })).toBe(1000);
+    expect(transientConnectionPolicy.delayMs!({ retryCount: 1 })).toBe(2000);
+    expect(transientConnectionPolicy.delayMs!({ retryCount: 2 })).toBe(4000);
     // High retry counts are capped at the max delay (30000ms).
-    expect(econnresetPolicy.delayMs!({ retryCount: 10 })).toBe(30000);
+    expect(transientConnectionPolicy.delayMs!({ retryCount: 10 })).toBe(30000);
   });
 
   it('configures ProviderHistoryCompat for prompt and API error compatibility', async () => {

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -106,30 +106,30 @@ import { acquireThreadLock, releaseThreadLock } from './utils/thread-lock.js';
 
 const CODE_AGENT_ID = 'code-agent';
 
-// Global retry policy for transient network resets (e.g. provider sockets dropping mid-stream).
+// Global retry policy for transient connection failures (e.g. provider sockets dropping mid-stream).
 // Applied centrally to every model call via StreamErrorRetryProcessor, independent of model-pack
-// settings, so all modes/subagents benefit from a short wait before retrying an ECONNRESET.
+// settings, so all modes/subagents benefit from a short wait before retrying a dropped connection.
 // Delay uses exponential backoff: initialDelay * 2^retryCount, capped at maxDelay.
-const MASTRACODE_ECONNRESET_MAX_RETRIES = 2;
-const MASTRACODE_ECONNRESET_RETRY_INITIAL_DELAY_MS = 1000;
-const MASTRACODE_ECONNRESET_RETRY_MAX_DELAY_MS = 30000;
+const MASTRACODE_TRANSIENT_CONNECTION_MAX_RETRIES = 2;
+const MASTRACODE_TRANSIENT_CONNECTION_RETRY_INITIAL_DELAY_MS = 1000;
+const MASTRACODE_TRANSIENT_CONNECTION_RETRY_MAX_DELAY_MS = 30000;
 
-const ECONNRESET_MESSAGE_PATTERN = /econnreset|socket hang up/i;
+const TRANSIENT_CONNECTION_ERROR_CODES = new Set(['ECONNRESET', 'EPIPE']);
+const TRANSIENT_CONNECTION_MESSAGE_PATTERN = /econnreset|socket hang up|write epipe|other side closed/i;
 
 /**
- * Matcher for transient network-reset failures. Checks the immediate error for
- * an `ECONNRESET` code or a `socket hang up` message. Cause-chain traversal is
- * handled by `StreamErrorRetryProcessor.isRetryableStreamError`, which calls
- * each matcher at every level of the cause chain.
+ * Matcher for transient connection failures. Cause-chain traversal is handled
+ * by `StreamErrorRetryProcessor.isRetryableStreamError`, which calls each
+ * matcher at every level of the cause chain.
  */
-function isECONNRESETError(error: unknown): boolean {
+function isTransientConnectionError(error: unknown): boolean {
   if (!error) return false;
 
   const code = typeof error === 'object' && 'code' in error ? (error as { code?: unknown }).code : undefined;
-  if (typeof code === 'string' && code.toUpperCase() === 'ECONNRESET') return true;
+  if (typeof code === 'string' && TRANSIENT_CONNECTION_ERROR_CODES.has(code.toUpperCase())) return true;
 
   const message = error instanceof Error ? error.message : undefined;
-  if (typeof message === 'string' && ECONNRESET_MESSAGE_PATTERN.test(message)) return true;
+  if (typeof message === 'string' && TRANSIENT_CONNECTION_MESSAGE_PATTERN.test(message)) return true;
 
   return false;
 }
@@ -669,12 +669,12 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
         matchers: [
           { match: isBadRequestError, maxRetries: 1, delayMs: 2000 },
           {
-            match: isECONNRESETError,
-            maxRetries: MASTRACODE_ECONNRESET_MAX_RETRIES,
+            match: isTransientConnectionError,
+            maxRetries: MASTRACODE_TRANSIENT_CONNECTION_MAX_RETRIES,
             delayMs: ({ retryCount }) =>
               Math.min(
-                MASTRACODE_ECONNRESET_RETRY_INITIAL_DELAY_MS * Math.pow(2, retryCount),
-                MASTRACODE_ECONNRESET_RETRY_MAX_DELAY_MS,
+                MASTRACODE_TRANSIENT_CONNECTION_RETRY_INITIAL_DELAY_MS * Math.pow(2, retryCount),
+                MASTRACODE_TRANSIENT_CONNECTION_RETRY_MAX_DELAY_MS,
               ),
           },
         ],

--- a/mastracode/tui/e2e/tui/stream-error-retry.ts
+++ b/mastracode/tui/e2e/tui/stream-error-retry.ts
@@ -27,10 +27,7 @@ export const streamErrorRetryScenario = {
     patches.setProperty(globalThis, 'fetch', async (input, init) => {
       if (!failedOnce && requestUrl(input).includes('/chat/completions')) {
         failedOnce = true;
-        return new Response(
-          'data: {"type":"error","sequence_number":1,"error":{"type":"server_error","code":"internal_error","message":"An internal error occurred."}}\n\n',
-          { status: 200, headers: { 'content-type': 'text/event-stream' } },
-        );
+        throw Object.assign(new Error('Cannot connect to API: write EPIPE'), { code: 'EPIPE' });
       }
       return originalFetch(input, init);
     });


### PR DESCRIPTION
## Description

Mastra Code retries `ECONNRESET` and `socket hang up`, but equivalent dropped-connection errors from OpenAI such as `write EPIPE` and `other side closed` stop the run and require a manual `continue` prompt.

This expands the existing transient connection matcher to cover those errors while preserving the same two-retry exponential backoff policy. It adds SDK regression coverage and updates the TUI retry scenario to inject a real `EPIPE` failure before recovering.

Before: `Cannot connect to API: write EPIPE` stops the run.

After: Mastra Code retries automatically and completes the response.

## Related issue(s)

Closes #19691

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR

Verified with the full Code SDK test suite (995 passed), SDK and TUI typechecks/lints, and the focused `stream-error-retry` TUI E2E scenario.