### PR TITLE
fix(core): retry composite storage initialization

### DIFF
--- a/.changeset/tender-toes-punch.md
+++ b/.changeset/tender-toes-punch.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed composite storage initialization so transient failures can retry without restarting the process.

--- a/packages/core/src/storage/base.test.ts
+++ b/packages/core/src/storage/base.test.ts
@@ -168,6 +168,40 @@ describe('MastraCompositeStore — disabled domains (`false` override)', () => {
   });
 });
 
+describe('MastraCompositeStore init caching', () => {
+  it('retries init after a rejected attempt', async () => {
+    const inner = new InMemoryStore({ id: 'retry-inner' });
+    const innerInitSpy = vi
+      .spyOn(inner, 'init')
+      .mockRejectedValueOnce(new Error('transient init failure'))
+      .mockResolvedValueOnce(undefined);
+    const composite = new MastraCompositeStore({ id: 'retry-outer', default: inner });
+
+    await expect(composite.init()).rejects.toThrow('transient init failure');
+    await composite.init();
+    await composite.init();
+
+    expect(innerInitSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('coalesces concurrent failed attempts before allowing a retry', async () => {
+    const inner = new InMemoryStore({ id: 'concurrent-retry-inner' });
+    const innerInitSpy = vi
+      .spyOn(inner, 'init')
+      .mockRejectedValueOnce(new Error('shared init failure'))
+      .mockResolvedValueOnce(undefined);
+    const composite = new MastraCompositeStore({ id: 'concurrent-retry-outer', default: inner });
+
+    const results = await Promise.allSettled([composite.init(), composite.init(), composite.init()]);
+
+    expect(results.every(result => result.status === 'rejected')).toBe(true);
+    expect(innerInitSpy).toHaveBeenCalledTimes(1);
+
+    await composite.init();
+    expect(innerInitSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
 describe('MastraCompositeStore.__registerMastra', () => {
   const mastra: StorageMastraRef = { getAgentById: () => undefined };
 

--- a/packages/core/src/storage/base.ts
+++ b/packages/core/src/storage/base.ts
@@ -515,13 +515,24 @@ export class MastraCompositeStore extends MastraBase {
    * cover, so we never double-init the same domain instance.
    */
   async init(): Promise<void> {
-    // to prevent race conditions, await any current init
-    if (this.shouldCacheInit && (await this.hasInitialized)) {
+    if (!this.shouldCacheInit) {
+      await this.#runInit();
       return;
     }
 
-    this.hasInitialized = this.#runInit();
-    await this.hasInitialized;
+    if (this.hasInitialized) {
+      await this.hasInitialized;
+      return;
+    }
+
+    const initPromise = this.#runInit().catch(error => {
+      if (this.hasInitialized === initPromise) {
+        this.hasInitialized = null;
+      }
+      throw error;
+    });
+    this.hasInitialized = initPromise;
+    await initPromise;
   }
 
   async #runInit(): Promise<boolean> {


### PR DESCRIPTION
## Summary

- clear a failed `MastraCompositeStore.init()` promise so a later call can retry
- keep concurrent initialization calls coalesced into one shared attempt
- add regression coverage and an `@mastra/core` patch changeset

Fixes #19695

## Test plan

- `pnpm vitest run src/storage/base.test.ts` from `packages/core`
- `pnpm --filter ./packages/core check`
- `pnpm build:core`