### PR TITLE
Add Kubernetes SRE Copilot template

### DIFF
--- a/templates/template-kubernetes-sre-copilot/.env.example
+++ b/templates/template-kubernetes-sre-copilot/.env.example
@@ -1,0 +1,10 @@
+OPENAI_API_KEY=
+
+# Optional: path to a kubeconfig file. If unset, kubernetes-mcp-server resolves
+# the default kubeconfig location (or in-cluster config) itself.
+KUBECONFIG=
+
+# Optional: point at an already-running kubernetes-mcp-server instance in
+# Streamable HTTP / SSE mode instead of launching one locally via npx.
+# Example: http://localhost:8080/sse
+KUBE_MCP_SERVER_URL=

--- a/templates/template-kubernetes-sre-copilot/.gitignore
+++ b/templates/template-kubernetes-sre-copilot/.gitignore
@@ -1,0 +1,10 @@
+output.txt
+node_modules
+dist
+.mastra
+.env.development
+.env
+*.db
+*.db-*
+.netlify
+.vercel

--- a/templates/template-kubernetes-sre-copilot/CONTRIBUTING.md
+++ b/templates/template-kubernetes-sre-copilot/CONTRIBUTING.md
@@ -1,0 +1,12 @@
+# Contributing
+
+This repository is auto-generated from the [Mastra monorepo](https://github.com/mastra-ai/mastra). Pull requests opened here will be ignored.
+
+To contribute:
+
+1. Fork the [Mastra monorepo](https://github.com/mastra-ai/mastra)
+2. Find this template in `templates/template-kubernetes-sre-copilot`
+3. Make your changes
+4. Open a pull request against the monorepo
+
+A bot syncs accepted changes to this repository.

--- a/templates/template-kubernetes-sre-copilot/README.md
+++ b/templates/template-kubernetes-sre-copilot/README.md
@@ -1,0 +1,205 @@
+# Kubernetes SRE Copilot
+
+A read-only Kubernetes SRE copilot built with [Mastra](https://mastra.ai/) that diagnoses the four
+most common Pod failure patterns — CrashLoopBackOff, ImagePullBackOff, OOMKilled, and
+Pending/PVC-stuck — and returns a structured, auditable diagnosis instead of a paragraph of prose.
+
+## Why we built this
+
+Most "AI + Kubernetes" demos let you chat with your cluster. None of them encode a structured
+diagnostic process, enforce safety boundaries on writes, or produce evidence you can verify —
+they give you a verdict and ask you to trust it. SRE teams don't work that way: they trust a chain
+of evidence, not an assertion.
+
+This template encodes *how experienced SREs actually debug* these four failure patterns as
+editable runbooks (`workspace/skills/*/SKILL.md`), runs a fixed diagnostic workflow per failure
+type instead of letting a model free-associate over cluster state, and returns every diagnosis as
+an **evidence graph** — each claim in the output traces back to the specific tool call that
+produced it.
+
+```
+Service Unavailable
+  → Deployment not Ready
+    → Pod CrashLoopBackOff
+      → Container Exit Code 137
+        → OOMKilled Event
+          → Memory Limit: 128Mi
+            → Recommendation: increase to 512Mi
+```
+
+## Architecture
+
+```
+User
+  ↓
+Mastra Agent (read-only instructions, no write tools registered)
+  ↓
+MCPClient → kubernetes-mcp-server (github.com/containers/kubernetes-mcp-server), launched with --read-only
+  ↓
+Router step: classify failure type from Pod status
+  ↓
+Fixed-step diagnostic workflow (one checklist per failure type, from workspace/skills/*/SKILL.md)
+  ↓
+Structured Zod-typed output: root cause, evidence chain, confidence, suggested fix (text only, never executed)
+```
+
+Cluster access goes exclusively through
+[`kubernetes-mcp-server`](https://github.com/containers/kubernetes-mcp-server) — an existing,
+independently maintained MCP server — via `@mastra/mcp`'s `MCPClient`. This template does not wrap
+`kubectl` and does not talk to the Kubernetes API directly.
+
+**Read-only by architecture, not by prompt instruction.** The MCP server is launched with
+`--read-only`, which rejects every write operation (create, update, delete, exec, scale) at the
+server itself. A second, redundant policy gate (`src/mastra/lib/policy.ts`) filters and classifies
+every tool call client-side before it reaches the server. Neither the chat agent nor the workflow
+has a single write tool registered anywhere — there's nothing to remove to make this safe, because
+nothing unsafe was ever wired in.
+
+## Prerequisites
+
+- Node.js >= 22.13.0
+- Access to a Kubernetes cluster and a working `kubeconfig` (a local cluster via Docker Desktop's
+  Kubernetes, kind, or minikube works fine for trying this out)
+- An [OpenAI API Key](https://platform.openai.com/api-keys)
+- `npx` available on your PATH (used to launch `kubernetes-mcp-server` — no separate install
+  required, see [Getting started](#getting-started))
+
+## Getting started
+
+```shell
+npm install
+cp .env.example .env
+```
+
+Fill in your `.env`:
+
+```
+OPENAI_API_KEY=sk-...
+# Optional — omit to use your default kubeconfig / in-cluster config
+KUBECONFIG=
+# Optional — point at an already-running kubernetes-mcp-server instead of launching one via npx
+KUBE_MCP_SERVER_URL=
+```
+
+Start the dev server:
+
+```shell
+npm run dev
+```
+
+Open [http://localhost:4111](http://localhost:4111) to access Mastra Studio. On first run, the
+server launches `kubernetes-mcp-server` via `npx -y kubernetes-mcp-server@latest --read-only`
+automatically — no separate install step.
+
+## Usage
+
+### Agent (Chat)
+
+Open the **Kubernetes SRE Copilot** agent and give it a Pod:
+
+```
+Diagnose payment-service-7d4f8b9c6-x2mqp in the checkout namespace
+```
+
+The agent fetches the Pod, classifies the failure type, follows the matching workspace runbook,
+and returns a structured diagnosis with an evidence chain. Working memory keeps track of the
+namespace/cluster context so a follow-up like "check it again" doesn't require re-specifying
+scope; observational memory compresses large log/event dumps between turns so a chatty CrashLoop
+with pages of stack trace doesn't blow out the context window.
+
+### Workflow
+
+Open the **Workflows** tab and run **diagnosis-workflow** with `namespace` and `podName` inputs
+(and optionally `context` for a specific kubeconfig context). The workflow runs the fixed pipeline
+— fetch, classify, branch into the matching checklist, report — and returns the same structured
+JSON diagnosis, useful for calling from CI, an alert webhook, or your own UI without going through
+chat.
+
+## Customization
+
+### Change diagnostic runbooks
+
+Edit the files in `workspace/skills/`. Each `SKILL.md` defines the checklist for one failure type
+— what to check, in what order, how to weigh conflicting signals, and how to set the confidence
+score. The workflow's "classify cause" step reads directly from the matching file; editing the
+runbook changes the diagnosis without touching any TypeScript.
+
+### Add a failure type not yet covered
+
+1. Add a new `workspace/skills/<name>/SKILL.md` following the format of the existing four.
+2. Add the failure type to `failureTypeSchema` in `src/mastra/lib/schemas.ts`.
+3. Add a classification pattern to `CLASSIFICATION_PATTERNS` in
+   `src/mastra/workflows/diagnosis-workflow.ts`.
+4. Add a `createStep` that gathers the evidence your new checklist calls for (mirror
+   `diagnoseCrashLoop` or one of the others) and a new `.branch()` arm dispatching to it.
+
+### Point at a different Kubernetes MCP server
+
+`src/mastra/mcp/k8s-mcp-client.ts` launches `kubernetes-mcp-server` locally via `npx` by default.
+Set `KUBE_MCP_SERVER_URL` to point at a remote instance instead (e.g. one deployed via that
+project's Helm chart with `read_only = true` set in its own config, for production use where you
+want read-only enforced at the server regardless of how the client is launched). If you swap to a
+different Kubernetes MCP server implementation entirely, update `READ_ONLY_TOOL_NAMES` in the same
+file to match its actual read-tool names.
+
+### Swap models
+
+Change the `model` field in the agent files. `sre-agent.ts` uses `openai/gpt-5.2` for the
+interactive chat agent; `workflow-diagnosis-agent.ts` also defaults to `gpt-5.2` since diagnosis
+quality is this template's core value — swap to `gpt-5-mini` there if you want faster/cheaper
+workflow runs and are fine trading off some synthesis quality. Any provider Mastra supports
+(Anthropic, OpenAI, others) works — just match the `model` string format and the corresponding
+API key env var.
+
+## Non-Goals (v1)
+
+Stated explicitly so scope is clear to reviewers and contributors:
+
+- **No write/remediation actions** (scale, restart, delete) — not even behind approval, in v1.
+- **No multi-agent orchestration / coordinator architecture.**
+- **No autonomous incident response** ("alert → diagnose → execute → close").
+- **No custom `kubectl` wrapping** — all cluster access goes through the existing, independently
+  audited `kubernetes-mcp-server`.
+
+## Testing status
+
+Verified against a real cluster, not just type-checked. `tsc --noEmit` passes clean, and the
+template was run end-to-end against a local Docker Desktop Kubernetes cluster (`kind` provider)
+with one Pod seeded per failure type in a dedicated namespace: a container that exits immediately
+(CrashLoopBackOff), a Pod referencing a nonexistent image tag (ImagePullBackOff), a container with
+a memory limit far below its actual allocation (OOMKilled), and a Pod referencing a PVC bound to a
+nonexistent StorageClass (PVCPending). For all four: the router classified the failure type
+correctly, every branch's tool calls against the real `kubernetes-mcp-server` succeeded, and the
+returned diagnosis was independently confirmed correct against the pod's actual raw status, not
+just structurally well-formed.
+
+Two real bugs were found and fixed during this pass, both worth knowing about if you're extending
+this template: `kubernetes-mcp-server` returns pod/resource data as YAML text, not JSON — code
+that parses tool output with a JSON-shaped regex (quoted keys) will silently match nothing against
+real output. And bundling (`mastra dev`/`mastra build` via esbuild) flattens all source into a
+single file at `.mastra/output/`, so any code resolving a path relative to `import.meta.dirname`
+must account for the bundle's own directory depth, not the original source file's depth — see the
+comment in `src/mastra/lib/skills.ts` for the specific fix.
+
+Not yet tested: multi-node clusters, RBAC-restricted ServiceAccounts, and OpenShift.
+
+## Roadmap
+
+Not shipped — direction only, listed here so it's visible without being implied by the code:
+
+- **Phase 4:** Write actions (scale, restart — never delete) behind mandatory human approval.
+- **Phase 5:** Multi-agent architecture (coordinator + specialist agents per failure domain).
+- **Phase 6:** Autonomous incident mode (alert → diagnose → execute → verify → close).
+
+None of this is committed or in progress. Building it would be a different project, months out —
+this template ships v1 only.
+
+## About Mastra templates
+
+[Mastra templates](https://mastra.ai/templates) are ready-to-use projects that show off what you
+can build — clone one, poke around, and make it yours. They live in the
+[Mastra monorepo](https://github.com/mastra-ai/mastra) and are automatically synced to standalone
+repositories for easier cloning.
+
+Want to contribute? See
+[CONTRIBUTING.md](https://github.com/mastra-ai/mastra/blob/main/templates/template-kubernetes-sre-copilot/CONTRIBUTING.md).

--- a/templates/template-kubernetes-sre-copilot/package.json
+++ b/templates/template-kubernetes-sre-copilot/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "template-kubernetes-sre-copilot",
+  "version": "1.0.0",
+  "description": "A read-only Kubernetes SRE copilot built with Mastra that diagnoses common pod failures with structured, auditable evidence",
+  "scripts": {
+    "test": "tsc --noEmit",
+    "dev": "mastra dev",
+    "build": "mastra build",
+    "start": "mastra start",
+    "format": "prettier --write ."
+  },
+  "keywords": [
+    "mastra",
+    "kubernetes",
+    "sre",
+    "devops",
+    "mcp",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "packageManager": "pnpm@11.3.0",
+  "type": "module",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "dependencies": {
+    "@mastra/core": "^1.4.0",
+    "@mastra/libsql": "^1.4.0",
+    "@mastra/loggers": "^1.0.1",
+    "@mastra/mcp": "latest",
+    "@mastra/memory": "^1.3.0",
+    "zod": "^4.3.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.19.7",
+    "mastra": "^1.3.1",
+    "prettier": "^3.8.1",
+    "typescript": "^5.9.3"
+  }
+}

--- a/templates/template-kubernetes-sre-copilot/src/mastra/agents/sre-agent.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/agents/sre-agent.ts
@@ -1,0 +1,66 @@
+import { Agent } from '@mastra/core/agent';
+import { Memory } from '@mastra/memory';
+import { z } from 'zod';
+import { readOnlyTools } from '../mcp/tools';
+
+export const sreAgent = new Agent({
+  id: 'kubernetes-sre-agent',
+  name: 'Kubernetes SRE Copilot',
+  model: 'openai/gpt-5.2',
+  instructions: `You are an SRE copilot that diagnoses Kubernetes Pod failures the way an experienced on-call engineer would: by gathering evidence in a specific order, not by guessing from a pod name alone.
+
+## What you can do
+
+You have **read-only** access to the cluster through kubernetes-mcp-server: list/get Pods, fetch
+logs (current and previous container), list Events, get/list generic resources (Deployments,
+PersistentVolumeClaims, StorageClasses, Nodes), and view node resource stats. You have **no
+write, restart, scale, or delete capability** — this is enforced by the MCP server's
+\`--read-only\` flag and, redundantly, by a client-side policy gate. If a user asks you to fix,
+restart, scale, or delete something, say plainly that this template doesn't do that in v1 and
+explain what you found instead — never imply you took an action you didn't take.
+
+## Diagnostic process
+
+1. Get the Pod the user is asking about (use working memory's \`namespace\`/\`context\` if the user
+   doesn't repeat it — e.g. "check the payment service again" should reuse the last namespace and
+   context without asking).
+2. Classify the failure pattern from the Pod's status: CrashLoopBackOff, ImagePullBackOff,
+   OOMKilled, or Pending/PVC-stuck. If it doesn't match one of these four, say so — this template
+   only covers these four patterns in v1, and a generic answer for anything else would be a guess
+   dressed up as a diagnosis.
+3. Follow the matching workspace skill's checklist (\`crashloopbackoff\`, \`imagepullbackoff\`,
+   \`oomkilled\`, or \`pvc-pending\`) exactly — it defines the tool call order and what each result
+   means. Don't skip steps or jump to a conclusion before gathering the evidence the checklist
+   calls for.
+4. Report a root cause, a confidence level, and the evidence chain that supports it — not a
+   paragraph of prose. Every claim in your answer should trace back to a specific tool call's
+   output; if you're inferring rather than observing, say so.
+
+## Output
+
+Structure your answer as: failure type, root cause, confidence (with the reasoning behind that
+confidence level per the skill's guidance), the evidence chain (each item: what you observed,
+which tool call produced it), and a suggested fix stated as **text only** — you're recommending
+an action for a human to take, never implying you can or will execute it.
+
+Update your working memory with the cluster context, namespace, and Pod name you're currently
+looking at whenever they're established, so follow-up questions in this conversation don't
+require re-specifying scope.`,
+  tools: readOnlyTools,
+  memory: new Memory({
+    options: {
+      workingMemory: {
+        enabled: true,
+        scope: 'resource',
+        schema: z.object({
+          clusterContext: z.string().optional().describe('kubeconfig context currently in scope'),
+          namespace: z.string().optional().describe('Namespace currently in scope'),
+          lastDiagnosedPod: z.string().optional().describe('Most recently diagnosed Pod name'),
+        }),
+      },
+      observationalMemory: {
+        model: 'openai/gpt-5-mini',
+      },
+    },
+  }),
+});

--- a/templates/template-kubernetes-sre-copilot/src/mastra/agents/workflow-diagnosis-agent.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/agents/workflow-diagnosis-agent.ts
@@ -1,0 +1,41 @@
+import { Agent } from '@mastra/core/agent';
+
+/**
+ * Lightweight diagnosis synthesizer used exclusively by `diagnosisWorkflow`.
+ *
+ * Key differences from the main `sreAgent`:
+ * - Has NO tools — the workflow's steps already made every MCP tool call and feed the raw
+ *   results into this agent's prompt. This agent only reasons over evidence it's handed, it
+ *   never fetches anything itself.
+ * - The "classify cause" step reads its diagnostic checklist from the matching workspace
+ *   SKILL.md file and passes it into the prompt below — swap the SKILL.md, not this file, to
+ *   change how a given failure type gets diagnosed.
+ */
+export const workflowDiagnosisAgent = new Agent({
+  id: 'workflow-diagnosis-agent',
+  name: 'Workflow Diagnosis Synthesizer',
+  model: 'openai/gpt-5.2',
+  instructions: `You synthesize a structured Kubernetes Pod failure diagnosis from evidence a workflow already gathered. You do not have tools and cannot fetch anything further — work only from what's in the prompt.
+
+You will be given: the failure type already classified by an earlier workflow step, a runbook
+checklist (from the matching workspace SKILL.md) describing what each piece of evidence means and
+how to weigh it, and the raw tool output the workflow collected by following that checklist.
+
+## Rules
+
+- Every node in \`evidenceChain\` must cite a specific piece of the raw data you were given in
+  \`supportingData\`, and name which tool call it came from in \`source\`. Do not fabricate
+  evidence that wasn't provided.
+- \`rootCause\` must follow the runbook's "Classification Rule" section — state the specific cause,
+  not a restatement of the symptom (e.g. "container exceeded its 128Mi memory limit under
+  sustained load" is a root cause; "pod was OOMKilled" is just the symptom you were already told).
+- Set \`confidence\` following the runbook's "Confidence Guidance" section exactly — don't default
+  to a high confidence just because a diagnosis was reached.
+- \`suggestedFix\` is text only. You are not able to execute it and must never imply otherwise.
+- Set \`riskLevel\` based on blast radius if the suggested fix were applied: \`low\` for a single
+  Pod's resource tuning, \`medium\` for a Deployment-wide config change, \`high\` for anything
+  touching shared infrastructure (StorageClass, node pool, cluster-wide policy).
+- If the gathered evidence is insufficient or contradictory, say so directly in \`rootCause\` and
+  reflect it with a low \`confidence\` — do not force a confident-sounding answer onto ambiguous
+  evidence.`,
+});

--- a/templates/template-kubernetes-sre-copilot/src/mastra/index.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/index.ts
@@ -1,0 +1,29 @@
+import { resolve } from 'node:path';
+import { Mastra } from '@mastra/core/mastra';
+import { PinoLogger } from '@mastra/loggers';
+import { LibSQLStore } from '@mastra/libsql';
+import { Workspace, LocalFilesystem } from '@mastra/core/workspace';
+import { sreAgent } from './agents/sre-agent';
+import { workflowDiagnosisAgent } from './agents/workflow-diagnosis-agent';
+import { diagnosisWorkflow } from './workflows/diagnosis-workflow';
+
+const workspace = new Workspace({
+  filesystem: new LocalFilesystem({
+    basePath: resolve(import.meta.dirname, '../../workspace'),
+  }),
+  skills: ['/skills'],
+});
+
+export const mastra = new Mastra({
+  workspace,
+  agents: { sreAgent, workflowDiagnosisAgent },
+  workflows: { diagnosisWorkflow },
+  storage: new LibSQLStore({
+    id: 'mastra-storage',
+    url: 'file:./mastra.db',
+  }),
+  logger: new PinoLogger({
+    name: 'Mastra',
+    level: 'info',
+  }),
+});

--- a/templates/template-kubernetes-sre-copilot/src/mastra/lib/policy.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/lib/policy.ts
@@ -1,0 +1,98 @@
+import type { Tool } from '@mastra/core/tools';
+
+/**
+ * Safety/policy gate.
+ *
+ * v1 has no write tools registered anywhere in this template — there is nothing for this module
+ * to "allow." It exists anyway, built and tested now, so that v2's write capability (Phase 4 in
+ * the README roadmap: scale/restart behind mandatory human approval) slots into an existing gate
+ * instead of getting bolted on under time pressure later.
+ *
+ * Every tool call this agent makes flows through `enforceReadOnly` before it reaches the MCP
+ * server:
+ *
+ *   tool call -> classifyAction -> reject anything that isn't a read -> log the attempt
+ *
+ * This is deliberately redundant with `kubernetes-mcp-server --read-only` at the transport layer
+ * (see ../mcp/k8s-mcp-client.ts). Defense in depth: if the MCP server were ever misconfigured
+ * without `--read-only`, this gate still blocks the call before it leaves the process.
+ */
+
+export class PolicyViolationError extends Error {
+  constructor(
+    public readonly toolName: string,
+    public readonly action: ActionType,
+  ) {
+    super(`Policy denied "${toolName}" (classified as "${action}"). v1 permits read-only actions only.`);
+    this.name = 'PolicyViolationError';
+  }
+}
+
+export type ActionType = 'read' | 'write';
+
+/**
+ * A tool name is classified as a write if it doesn't look like one of the known-safe read verbs.
+ * This is intentionally conservative: unknown tool names default to "write" and get rejected,
+ * rather than silently allowed through.
+ */
+const READ_VERBS = ['list', 'get', 'log', 'logs', 'top', 'view', 'describe', 'stats', 'contexts'];
+
+export function classifyAction(toolName: string): ActionType {
+  const normalized = toolName.toLowerCase();
+  return READ_VERBS.some(verb => normalized.includes(verb)) ? 'read' : 'write';
+}
+
+export interface PolicyLogEntry {
+  timestamp: string;
+  toolName: string;
+  action: ActionType;
+  allowed: boolean;
+}
+
+/** In-memory log of every policy decision made this process. Exposed for the agent/UI to inspect. */
+export const policyLog: PolicyLogEntry[] = [];
+
+function logAttempt(toolName: string, action: ActionType, allowed: boolean) {
+  const entry: PolicyLogEntry = { timestamp: new Date().toISOString(), toolName, action, allowed };
+  policyLog.push(entry);
+  if (!allowed) {
+    console.warn(`[policy] rejected non-read tool call: ${toolName}`);
+  }
+}
+
+/**
+ * Wraps a set of MCP tools so every execution is checked against `allowedNames` (an explicit
+ * read-only allowlist — see READ_ONLY_TOOL_NAMES in ../mcp/k8s-mcp-client.ts) and against
+ * `classifyAction`. Both checks must pass, or the call is rejected before the underlying tool
+ * ever runs. Every attempt, allowed or rejected, is recorded in `policyLog`.
+ */
+export function enforceReadOnly<T extends Record<string, Tool<any, any, any, any>>>(
+  tools: T,
+  allowedNames: readonly string[],
+): T {
+  const guarded = {} as T;
+
+  for (const [key, tool] of Object.entries(tools)) {
+    const action = classifyAction(key);
+    const isAllowlisted = allowedNames.some(name => key === name || key.endsWith(`_${name}`) || key.endsWith(name));
+
+    const originalExecute = tool.execute?.bind(tool);
+
+    (guarded as Record<string, Tool<any, any, any, any>>)[key] = Object.assign(Object.create(Object.getPrototypeOf(tool)), tool, {
+      execute: async (inputData: unknown, context: unknown) => {
+        const allowed = action === 'read' && isAllowlisted;
+        logAttempt(key, action, allowed);
+
+        if (!allowed) {
+          throw new PolicyViolationError(key, action);
+        }
+        if (!originalExecute) {
+          throw new Error(`Tool "${key}" has no execute function.`);
+        }
+        return originalExecute(inputData as never, context as never);
+      },
+    });
+  }
+
+  return guarded;
+}

--- a/templates/template-kubernetes-sre-copilot/src/mastra/lib/schemas.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/lib/schemas.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared Zod schemas used across tools, workflows, and agents.
+ */
+
+import { z } from 'zod';
+
+/** Identifies a single Pod to diagnose. */
+export const podIdentifierSchema = z.object({
+  namespace: z.string().describe('Kubernetes namespace the Pod lives in'),
+  podName: z.string().describe('Name of the Pod to diagnose'),
+  context: z.string().optional().describe('Optional kubeconfig context / cluster to target'),
+});
+
+/** The four failure patterns this template knows how to triage. v1 covers exactly these. */
+export const failureTypeSchema = z.enum(['CrashLoopBackOff', 'ImagePullBackOff', 'OOMKilled', 'PVCPending']);
+
+/** Raw Pod status data pulled from the cluster via the read-only MCP tools. */
+export const podContextSchema = z.object({
+  namespace: z.string(),
+  podName: z.string(),
+  context: z.string().optional(),
+  podJson: z.string().describe('Raw JSON/YAML of `pods_get` output for this Pod'),
+});
+
+export const classifiedPodSchema = podContextSchema.extend({
+  failureType: failureTypeSchema,
+  classificationReason: z.string().describe('Short explanation of why this pod status matched the failure type'),
+});
+
+/** One node in the evidence graph. Carries the raw tool output that supports it. */
+export const evidenceNodeSchema = z.object({
+  symptom: z.string().describe('A single observed fact, stated plainly, e.g. "Container Exit Code 137"'),
+  supportingData: z.string().describe('Raw tool output (or a relevant excerpt of it) backing this node'),
+  source: z.string().describe('Which read-only tool call produced this evidence, e.g. "pods_log(previous=true)"'),
+});
+
+/** Final structured diagnosis. Matches the PRD output schema (§7) exactly. */
+export const diagnosisOutputSchema = z.object({
+  failureType: failureTypeSchema,
+  rootCause: z.string(),
+  confidence: z.number().min(0).max(1),
+  evidenceChain: z.array(evidenceNodeSchema),
+  suggestedFix: z.string().describe('Text-only recommendation. Never executed by this template — v1 has no write tools.'),
+  riskLevel: z.enum(['low', 'medium', 'high']),
+});
+
+export type PodIdentifier = z.infer<typeof podIdentifierSchema>;
+export type FailureType = z.infer<typeof failureTypeSchema>;
+export type PodContext = z.infer<typeof podContextSchema>;
+export type ClassifiedPod = z.infer<typeof classifiedPodSchema>;
+export type EvidenceNode = z.infer<typeof evidenceNodeSchema>;
+export type DiagnosisOutput = z.infer<typeof diagnosisOutputSchema>;

--- a/templates/template-kubernetes-sre-copilot/src/mastra/lib/skills.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/lib/skills.ts
@@ -1,0 +1,19 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+
+/**
+ * Loads a workspace runbook's SKILL.md content by name (e.g. "crashloopbackoff"). The diagnosis
+ * workflow's "classify cause" step for each failure type reads from the matching file here
+ * instead of a hardcoded prompt — edit `workspace/skills/<name>/SKILL.md` and the workflow's
+ * output changes accordingly, no code change required.
+ *
+ * IMPORTANT: `mastra dev`/`mastra build` bundle all source into a single file at
+ * `.mastra/output/index.mjs`, two directories deep from the project root. `import.meta.dirname`
+ * inside that bundle reflects the bundle's own location, not this file's original path under
+ * `src/mastra/lib/` — so the relative path here must match `index.ts`'s `../../workspace` depth
+ * (2 levels up from the bundle), not this file's original 3-levels-deep source location.
+ */
+export async function loadSkill(name: string): Promise<string> {
+  const path = resolve(import.meta.dirname, '../../workspace/skills', name, 'SKILL.md');
+  return readFile(path, 'utf-8');
+}

--- a/templates/template-kubernetes-sre-copilot/src/mastra/mcp/k8s-mcp-client.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/mcp/k8s-mcp-client.ts
@@ -1,0 +1,67 @@
+import { MCPClient } from '@mastra/mcp';
+
+/**
+ * Connects to `kubernetes-mcp-server` (https://github.com/containers/kubernetes-mcp-server) —
+ * an existing, audited Kubernetes MCP server. This template never talks to the Kubernetes API
+ * directly and never wraps `kubectl` itself; every cluster read goes through this client.
+ *
+ * Two ways to point this at a cluster:
+ *
+ * 1. Default (stdio): launches `kubernetes-mcp-server` locally via `npx` with `--read-only`.
+ *    The server resolves your kubeconfig the normal way (`KUBECONFIG` env, `--kubeconfig` flag,
+ *    or in-cluster config). This is what `mastra dev` uses out of the box.
+ * 2. Remote (HTTP/SSE): set `KUBE_MCP_SERVER_URL` to point at an already-running instance
+ *    (e.g. one deployed via the project's Helm chart with `read_only = true` in its config).
+ *    Use this in production so the read-only flag is enforced at the server's config file,
+ *    not by whoever launches the client.
+ *
+ * Either way, read-only is enforced at the MCP server level, not by prompt instruction — the
+ * `--read-only` flag (or `read_only = true` in the server's TOML config) makes every write tool
+ * (`pods_delete`, `resources_delete`, `resources_create_or_update`, `resources_scale`,
+ * `helm_install`, `pods_exec`, ...) reject at the server before it ever reaches the cluster.
+ * `READ_ONLY_TOOL_NAMES` below is a second, defense-in-depth layer on the client side — see
+ * `../lib/policy.ts` for how it's enforced.
+ */
+export const k8sMcpClient = new MCPClient({
+  id: 'kubernetes-sre-copilot-mcp',
+  servers: {
+    kubernetes: process.env.KUBE_MCP_SERVER_URL
+      ? {
+          url: new URL(process.env.KUBE_MCP_SERVER_URL),
+        }
+      : {
+          command: 'npx',
+          args: [
+            '-y',
+            'kubernetes-mcp-server@latest',
+            '--read-only',
+            ...(process.env.KUBECONFIG ? ['--kubeconfig', process.env.KUBECONFIG] : []),
+          ],
+        },
+  },
+});
+
+/**
+ * Allowlist of `kubernetes-mcp-server` tools this template is allowed to use. All of them are
+ * reads (list/get/log/stats) from the server's `core` and `config` toolsets — nothing here can
+ * mutate cluster state. Kept explicit (rather than "everything the read-only server exposes")
+ * so the allowlist stays correct even if a future server version adds a new tool under `core`.
+ *
+ * See ../lib/policy.ts for where this list is actually enforced against live tool calls.
+ */
+export const READ_ONLY_TOOL_NAMES = [
+  'pods_list',
+  'pods_list_in_namespace',
+  'pods_get',
+  'pods_log',
+  'pods_top',
+  'events_list',
+  'namespaces_list',
+  'resources_get',
+  'resources_list',
+  'nodes_top',
+  'nodes_stats_summary',
+  'nodes_log',
+  'configuration_view',
+  'configuration_contexts_list',
+] as const;

--- a/templates/template-kubernetes-sre-copilot/src/mastra/mcp/tools.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/mcp/tools.ts
@@ -1,0 +1,39 @@
+import { noopObserve } from '@mastra/core/tools';
+import { k8sMcpClient, READ_ONLY_TOOL_NAMES } from './k8s-mcp-client';
+import { enforceReadOnly } from '../lib/policy';
+
+const allTools = await k8sMcpClient.listTools();
+
+// Only the explicitly allowlisted read tools are usable anywhere in this template — by the
+// chat agent (via function-calling) and by the diagnosis workflow (via direct `.execute()`
+// calls below). See ../lib/policy.ts for what enforceReadOnly actually checks.
+const allowlisted = Object.fromEntries(
+  Object.entries(allTools).filter(([name]) => READ_ONLY_TOOL_NAMES.some(allowed => name.endsWith(allowed))),
+);
+
+export const readOnlyTools = enforceReadOnly(allowlisted, READ_ONLY_TOOL_NAMES);
+
+/**
+ * Look up one of the guarded read-only tools by its unqualified `kubernetes-mcp-server` name
+ * (e.g. `"pods_get"`), regardless of the `${serverName}_` namespace prefix `listTools()` adds.
+ * Throws if the tool isn't present — a missing tool at workflow-build time is a config problem
+ * worth failing loudly on, not silently skipping a diagnostic step for.
+ */
+export function getTool(unqualifiedName: (typeof READ_ONLY_TOOL_NAMES)[number]) {
+  const entry = Object.entries(readOnlyTools).find(([name]) => name.endsWith(unqualifiedName));
+  if (!entry) {
+    throw new Error(
+      `Tool "${unqualifiedName}" was not found among the MCP server's read-only tools. Is kubernetes-mcp-server reachable and running the expected version?`,
+    );
+  }
+  return entry[1];
+}
+
+/** Minimal call signature for invoking a guarded tool directly from inside a workflow step. */
+export async function callTool(unqualifiedName: (typeof READ_ONLY_TOOL_NAMES)[number], inputData: unknown) {
+  const tool = getTool(unqualifiedName);
+  if (!tool.execute) {
+    throw new Error(`Tool "${unqualifiedName}" has no execute function.`);
+  }
+  return tool.execute(inputData as never, { observe: noopObserve } as never);
+}

--- a/templates/template-kubernetes-sre-copilot/src/mastra/workflows/diagnosis-workflow.ts
+++ b/templates/template-kubernetes-sre-copilot/src/mastra/workflows/diagnosis-workflow.ts
@@ -1,0 +1,242 @@
+import { createStep, createWorkflow } from '@mastra/core/workflows';
+import { z } from 'zod';
+import { callTool } from '../mcp/tools';
+import { loadSkill } from '../lib/skills';
+import { podIdentifierSchema, podContextSchema, classifiedPodSchema, diagnosisOutputSchema } from '../lib/schemas';
+import type { FailureType } from '../lib/schemas';
+
+/**
+ * Fixed diagnostic workflow: fetch the Pod, classify which of the 4 v1 failure patterns it
+ * matches, then run exactly the checklist for that pattern (see the matching workspace SKILL.md)
+ * and return a structured, evidence-backed diagnosis.
+ *
+ *   get pod -> classify -> [branch: crashloop | imagepull | oomkilled | pvc-pending] -> report
+ */
+
+// ---------------------------------------------------------------------------
+// Step 1: fetch the Pod
+// ---------------------------------------------------------------------------
+
+const fetchPod = createStep({
+  id: 'fetch-pod',
+  description: 'Fetch the Pod from the cluster via the read-only kubernetes-mcp-server tools',
+  inputSchema: podIdentifierSchema,
+  outputSchema: podContextSchema,
+  execute: async ({ inputData }) => {
+    const { namespace, podName, context } = inputData;
+    const result = await callTool('pods_get', { name: podName, namespace, context });
+    return { namespace, podName, context, podJson: JSON.stringify(result) };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 2: classify the failure type from the Pod's status
+// ---------------------------------------------------------------------------
+
+/**
+ * Ordered so a failure that could match more than one keyword resolves to the more specific
+ * cause. Notably OOMKilled is checked before CrashLoopBackOff — a container OOM-killed
+ * repeatedly *also* shows CrashLoopBackOff in its waiting reason, but OOMKilled is the more
+ * specific and more useful classification (see workspace/skills/crashloopbackoff/SKILL.md,
+ * which tells the agent to reclassify and hand off when it sees exit code 137).
+ */
+const CLASSIFICATION_PATTERNS: Array<{ failureType: FailureType; pattern: RegExp; reason: string }> = [
+  { failureType: 'OOMKilled', pattern: /oomkilled|exit ?code.{0,20}137/i, reason: 'Pod status references OOMKilled / exit code 137' },
+  {
+    failureType: 'ImagePullBackOff',
+    pattern: /imagepullbackoff|errimagepull/i,
+    reason: 'Pod status references ImagePullBackOff / ErrImagePull',
+  },
+  {
+    failureType: 'CrashLoopBackOff',
+    pattern: /crashloopbackoff/i,
+    reason: 'Pod status references CrashLoopBackOff',
+  },
+  {
+    failureType: 'PVCPending',
+    pattern: /"phase"\s*:\s*"pending"|unbound.{0,40}persistentvolumeclaim|unschedulable/i,
+    reason: 'Pod is Pending with an unbound PersistentVolumeClaim / unschedulable condition',
+  },
+];
+
+const classifyFailure = createStep({
+  id: 'classify-failure',
+  description: 'Classify the Pod status into one of the 4 failure patterns this template covers',
+  inputSchema: podContextSchema,
+  outputSchema: classifiedPodSchema,
+  execute: async ({ inputData }) => {
+    const match = CLASSIFICATION_PATTERNS.find(({ pattern }) => pattern.test(inputData.podJson));
+    if (!match) {
+      throw new Error(
+        `Could not classify "${inputData.podName}" into one of the 4 patterns this template covers in v1 ` +
+          `(CrashLoopBackOff, ImagePullBackOff, OOMKilled, Pending/PVC-stuck). Raw status: ${inputData.podJson.slice(0, 500)}`,
+      );
+    }
+    return { ...inputData, failureType: match.failureType, classificationReason: match.reason };
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 3 (branch arms): one diagnostic chain per failure type. Each arm gathers the evidence its
+// SKILL.md checklist calls for, then hands it to workflowDiagnosisAgent for structured synthesis.
+// ---------------------------------------------------------------------------
+
+async function synthesize(mastra: any, failureType: FailureType, skillName: string, evidence: Record<string, unknown>) {
+  const checklist = await loadSkill(skillName);
+  const agent = mastra.getAgentById('workflow-diagnosis-agent');
+
+  const prompt = `## Failure Type\n${failureType}\n\n## Runbook Checklist\n${checklist}\n\n## Gathered Evidence\n${JSON.stringify(evidence, null, 2)}\n\nSynthesize the structured diagnosis per the runbook's Classification Rule and Confidence Guidance sections.`;
+
+  const response = await agent.generate(prompt, { structuredOutput: { schema: diagnosisOutputSchema } });
+
+  return (
+    response.object ?? {
+      failureType,
+      rootCause: 'Diagnosis synthesis failed to return structured output.',
+      confidence: 0,
+      evidenceChain: [],
+      suggestedFix: 'Re-run the diagnosis; if this persists, check the workflow-diagnosis-agent model configuration.',
+      riskLevel: 'low' as const,
+    }
+  );
+}
+
+const diagnoseCrashLoop = createStep({
+  id: 'diagnose-crashloopbackoff',
+  description: 'CrashLoopBackOff checklist: describe pod -> events -> previous logs -> classify',
+  inputSchema: classifiedPodSchema,
+  outputSchema: diagnosisOutputSchema,
+  execute: async ({ inputData, mastra }) => {
+    const { namespace, podName, context, podJson } = inputData;
+    const [events, previousLogs] = await Promise.all([
+      callTool('events_list', { namespace, fieldSelector: `involvedObject.name=${podName}`, context }),
+      callTool('pods_log', { name: podName, namespace, previous: true, tail: 200, context }),
+    ]);
+    return synthesize(mastra, 'CrashLoopBackOff', 'crashloopbackoff', { podJson, events, previousLogs });
+  },
+});
+
+const diagnoseImagePull = createStep({
+  id: 'diagnose-imagepullbackoff',
+  description: 'ImagePullBackOff checklist: image reference -> events -> imagePullSecret presence',
+  inputSchema: classifiedPodSchema,
+  outputSchema: diagnosisOutputSchema,
+  execute: async ({ inputData, mastra }) => {
+    const { namespace, podName, context, podJson } = inputData;
+    const events = await callTool('events_list', { namespace, fieldSelector: `involvedObject.name=${podName}`, context });
+    // The image reference and imagePullSecrets presence are both already in podJson from
+    // fetch-pod — no separate tool call needed, the checklist's steps 1 and 3 are read directly
+    // off the Pod spec already in hand.
+    return synthesize(mastra, 'ImagePullBackOff', 'imagepullbackoff', { podJson, events });
+  },
+});
+
+const diagnoseOomKilled = createStep({
+  id: 'diagnose-oomkilled',
+  description: 'OOMKilled checklist: exit code 137 check -> events -> memory limit vs usage',
+  inputSchema: classifiedPodSchema,
+  outputSchema: diagnosisOutputSchema,
+  execute: async ({ inputData, mastra }) => {
+    const { namespace, podName, context, podJson } = inputData;
+    const [events, usage] = await Promise.all([
+      callTool('events_list', { namespace, fieldSelector: `involvedObject.name=${podName}`, context }),
+      callTool('pods_top', { namespace, name: podName, context }).catch(err => ({
+        error: `metrics-server unavailable or pods_top failed: ${String(err)}`,
+      })),
+    ]);
+    return synthesize(mastra, 'OOMKilled', 'oomkilled', { podJson, events, usage });
+  },
+});
+
+/**
+ * Pulls a scalar field's value out of MCP tool output text, tolerant of both YAML
+ * (`field: value`, no quotes — what kubernetes-mcp-server actually returns by default) and JSON
+ * (`"field": "value"`) formatting. A regex that only matched JSON-quoted syntax silently found
+ * nothing against real YAML output — this is the fix for that.
+ */
+function extractField(text: string, field: string): string[] {
+  const pattern = new RegExp(`${field}"?\\s*:\\s*"?([\\w.-]+)"?`, 'g');
+  return Array.from(text.matchAll(pattern)).map(m => m[1]);
+}
+
+const diagnosePvcPending = createStep({
+  id: 'diagnose-pvc-pending',
+  description: 'PVC-stuck checklist: describe pod -> PVC status -> StorageClass -> node capacity',
+  inputSchema: classifiedPodSchema,
+  outputSchema: diagnosisOutputSchema,
+  execute: async ({ inputData, mastra }) => {
+    const { namespace, podName, context, podJson } = inputData;
+    const events = await callTool('events_list', { namespace, fieldSelector: `involvedObject.name=${podName}`, context });
+
+    // Pull PVC names referenced by the Pod spec so we know which PVCs/StorageClasses to check.
+    const claimNames = extractField(podJson, 'claimName');
+
+    // A missing PVC or StorageClass (e.g. one referencing a StorageClass that was never created)
+    // is itself a valid, common diagnosis for this failure type — catch and surface it as
+    // evidence rather than letting Promise.all reject and take down the whole step.
+    const pvcs = await Promise.all(
+      claimNames.map(name =>
+        callTool('resources_get', { apiVersion: 'v1', kind: 'PersistentVolumeClaim', name, namespace, context }).catch(
+          err => ({ error: `PersistentVolumeClaim "${name}" could not be fetched: ${String(err)}` }),
+        ),
+      ),
+    );
+
+    const storageClassNames = Array.from(
+      new Set(pvcs.flatMap(pvc => extractField(JSON.stringify(pvc), 'storageClassName'))),
+    );
+
+    const [storageClasses, nodes] = await Promise.all([
+      Promise.all(
+        storageClassNames.map(name =>
+          callTool('resources_get', { apiVersion: 'storage.k8s.io/v1', kind: 'StorageClass', name, context }).catch(
+            err => ({ error: `StorageClass "${name}" could not be fetched: ${String(err)}` }),
+          ),
+        ),
+      ),
+      callTool('resources_list', { apiVersion: 'v1', kind: 'Node', context }).catch(err => ({
+        error: `Node list could not be fetched: ${String(err)}`,
+      })),
+    ]);
+
+    return synthesize(mastra, 'PVCPending', 'pvc-pending', { podJson, events, pvcs, storageClasses, nodes });
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Step 4: normalize the branch's single populated result back into one shape
+// ---------------------------------------------------------------------------
+
+const normalizeReport = createStep({
+  id: 'normalize-report',
+  description: 'Pick out whichever branch arm actually ran and return it as the final diagnosis',
+  inputSchema: z.record(z.string(), z.unknown()),
+  outputSchema: diagnosisOutputSchema,
+  execute: async ({ inputData }) => {
+    const results = inputData as Record<string, unknown>;
+    const result =
+      results['diagnose-crashloopbackoff'] ??
+      results['diagnose-imagepullbackoff'] ??
+      results['diagnose-oomkilled'] ??
+      results['diagnose-pvc-pending'];
+
+    return diagnosisOutputSchema.parse(result);
+  },
+});
+
+export const diagnosisWorkflow = createWorkflow({
+  id: 'diagnosis-workflow',
+  description: 'Structured Pod failure diagnosis: fetch -> classify -> [branch by failure type] -> report',
+  inputSchema: podIdentifierSchema,
+  outputSchema: diagnosisOutputSchema,
+})
+  .then(fetchPod)
+  .then(classifyFailure)
+  .branch([
+    [async ({ inputData }) => inputData.failureType === 'CrashLoopBackOff', diagnoseCrashLoop],
+    [async ({ inputData }) => inputData.failureType === 'ImagePullBackOff', diagnoseImagePull],
+    [async ({ inputData }) => inputData.failureType === 'OOMKilled', diagnoseOomKilled],
+    [async ({ inputData }) => inputData.failureType === 'PVCPending', diagnosePvcPending],
+  ])
+  .then(normalizeReport)
+  .commit();

--- a/templates/template-kubernetes-sre-copilot/tsconfig.json
+++ b/templates/template-kubernetes-sre-copilot/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/templates/template-kubernetes-sre-copilot/workspace/skills/crashloopbackoff/SKILL.md
+++ b/templates/template-kubernetes-sre-copilot/workspace/skills/crashloopbackoff/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: crashloopbackoff
+description: Diagnostic checklist for Pods stuck in CrashLoopBackOff
+version: 1.0.0
+metadata:
+  tags:
+    - kubernetes
+    - pod-failure
+    - crashloopbackoff
+---
+
+# CrashLoopBackOff
+
+A container is starting, exiting, and being restarted by the kubelet on an exponential backoff.
+The goal is to find out *why* the container exits, not just confirm that it does.
+
+## Diagnostic Checklist
+
+1. **Get the Pod.** Confirm `status.phase`, `containerStatuses[].state.waiting.reason`
+   (`CrashLoopBackOff`), and `restartCount`. A high `restartCount` with a low pod age means it's
+   failing fast and repeatedly — that's the pattern to explain.
+2. **Describe the Pod.** Read `containerStatuses[].lastState.terminated` for the previous
+   container instance: `exitCode`, `reason`, `startedAt`/`finishedAt`. The exit code narrows the
+   cause:
+   - `0` — the process exited cleanly. Usually a misconfigured entrypoint/command, or a process
+     that isn't meant to be long-running (missing `command: ["tail", "-f", ...]` etc.).
+   - `1` — generic application error. Go to logs.
+   - `137` — SIGKILL, almost always OOMKilled. This is a different failure type — reclassify and
+     hand off to the OOMKilled checklist instead of continuing here.
+   - `139` — segfault (SIGSEGV). Native code / binary issue, not application logic.
+   - `143` — SIGTERM, often a graceful shutdown that took too long and got killed on the second
+     signal, or a liveness probe kill.
+3. **Fetch recent Events for the Pod.** Look for `BackOff`, `Failed`, `Unhealthy` (liveness probe
+   failures causing kubelet-initiated restarts look identical to app crashes from the outside —
+   events disambiguate the two), and `FailedMount`/`FailedScheduling` noise that might be a
+   red herring.
+4. **Fetch the previous container's logs** (`previous=true`). This is the single most important
+   piece of evidence — the *current* container's logs are usually empty because it just started.
+   Look for the last few lines before exit: stack traces, "connection refused" to a dependency,
+   config/env var errors, missing file errors.
+5. **Cross-check readiness/liveness probes** on the Pod spec. If a probe is too aggressive
+   (short `initialDelaySeconds` on a slow-starting app), the kubelet itself is the one killing the
+   container — the "crash" is the probe, not the application.
+
+## Classification Rule
+
+Root cause is a genuine application crash only if: exit code is non-zero (or the process
+legitimately exited when it shouldn't have), the previous logs show a clear failure signal, and
+there is no liveness-probe-triggered `Killing` event immediately preceding the exit. Otherwise,
+the root cause is the probe configuration, not the application.
+
+## Confidence Guidance
+
+- **High (0.8+):** Previous logs show an explicit unhandled exception/stack trace matching the
+  exit reason, and no probe events precede it.
+- **Medium (0.4–0.79):** Exit code and events are consistent with a cause, but previous logs are
+  empty, truncated, or ambiguous.
+- **Low (<0.4):** Conflicting signals (e.g. exit code 0 but events suggest an OOM) — say so
+  explicitly in `rootCause` rather than guessing.

--- a/templates/template-kubernetes-sre-copilot/workspace/skills/imagepullbackoff/SKILL.md
+++ b/templates/template-kubernetes-sre-copilot/workspace/skills/imagepullbackoff/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: imagepullbackoff
+description: Diagnostic checklist for Pods stuck in ImagePullBackOff / ErrImagePull
+version: 1.0.0
+metadata:
+  tags:
+    - kubernetes
+    - pod-failure
+    - imagepullbackoff
+---
+
+# ImagePullBackOff
+
+The kubelet can't pull the container image the Pod spec references. This is almost always one
+of three things: a bad reference, an unreachable registry, or missing/wrong pull credentials.
+The diagnostic job is to figure out which one from the event message text — it's usually explicit.
+
+## Diagnostic Checklist
+
+1. **Check the image reference on the Pod spec.** Look at `spec.containers[].image` for each
+   container (don't forget `initContainers`). Common mistakes: typo'd tag, a tag that was deleted
+   from the registry, `:latest` pointing at nothing because it was never pushed, or a private
+   registry hostname without the registry prefix.
+2. **Fetch recent Events for the Pod.** The event message under `reason=Failed` or
+   `reason=InspectFailed` almost always states the exact failure verbatim:
+   - `"manifest unknown"` / `"not found"` — the tag or repo doesn't exist. Reference problem.
+   - `"no such host"` / `"i/o timeout"` / `"connection refused"` — registry unreachable from the
+     node (DNS, network policy, egress firewall, private registry with no route).
+   - `"unauthorized"` / `"pull access denied"` / `"authentication required"` — credentials
+     problem: missing, wrong, or expired `imagePullSecret`.
+3. **Check for an `imagePullSecrets` entry** on the Pod spec (or on the Pod's ServiceAccount, if
+   the Pod spec doesn't set one directly — Kubernetes falls back to the ServiceAccount's secrets).
+   Its *absence* combined with an `unauthorized` event message is close to conclusive for a
+   private registry.
+4. **Sanity-check reachability, if event text points to network.** `resources_list` for the
+   node the Pod is scheduled on and check for `NetworkUnavailable`/`Ready` conditions — a
+   node-level network problem produces this symptom across every Pod trying to pull an image on
+   that node, not just this one.
+
+## Classification Rule
+
+State the specific sub-cause (bad reference vs. registry unreachable vs. missing/invalid
+credentials) in `rootCause` — "can't pull the image" alone isn't a diagnosis, it's a restatement
+of the symptom. The event message text is the primary evidence; quote it in `supportingData`.
+
+## Confidence Guidance
+
+- **High (0.8+):** Event message explicitly states the failure category (manifest unknown /
+  unauthorized / no such host) and it's consistent with what you see on the Pod spec (e.g. no
+  imagePullSecrets + "unauthorized").
+- **Medium (0.4–0.79):** Event message is present but generic ("Failed to pull image"), and you're
+  inferring the sub-cause from the image reference or secret presence alone.
+- **Low (<0.4):** No usable event message text was retrievable — say so and recommend checking
+  the node's container runtime logs directly (out of scope for this template's read tools).

--- a/templates/template-kubernetes-sre-copilot/workspace/skills/oomkilled/SKILL.md
+++ b/templates/template-kubernetes-sre-copilot/workspace/skills/oomkilled/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: oomkilled
+description: Diagnostic checklist for Pods killed by the OOM killer (exit code 137)
+version: 1.0.0
+metadata:
+  tags:
+    - kubernetes
+    - pod-failure
+    - oomkilled
+---
+
+# OOMKilled
+
+The container exceeded its memory limit (or the node ran out of memory) and the kernel's OOM
+killer terminated it. The diagnostic job is to confirm it really was memory, not a generic
+SIGKILL, and to quantify the gap between what the workload needs and what it's allowed.
+
+## Diagnostic Checklist
+
+1. **Describe the Pod, check the terminated container state.** Confirm
+   `lastState.terminated.exitCode == 137` **and** `reason == "OOMKilled"`. Exit code 137 alone is
+   just "received SIGKILL" — the explicit `OOMKilled` reason field is what actually confirms this
+   failure type rather than, say, a manual `kubectl delete pod --force` or a node-level eviction
+   for a different reason. If `reason` isn't `OOMKilled`, reclassify.
+2. **Fetch recent Events for the Pod.** Look for an `Evicted` event (node-pressure eviction,
+   different from a container-level OOM kill — the node ran low on memory overall, not just this
+   container exceeding its own limit) versus no eviction event (container-level cgroup limit hit,
+   the more common case). This distinction changes the fix: container-level means raise this
+   Pod's memory limit; node-level eviction means the node is oversubscribed and other Pods are
+   competing for the same memory.
+3. **Check the memory limit vs. actual usage.** Read `resources.limits.memory` and
+   `resources.requests.memory` from the Pod spec. Where available, compare against recent usage
+   (`pods_top` / `nodes_stats_summary`) — a container that's consistently running close to its
+   limit before the kill is a strong confirming signal; a container killed while usage looks low
+   suggests a sudden spike (e.g. batch job, large file load, memory leak building up between
+   restarts) rather than a simply-undersized limit.
+4. **Check restart pattern.** Repeated OOM kills at roughly the same wall-clock interval since
+   Pod start often indicates a memory leak (usage climbs steadily until it hits the limit) rather
+   than a one-time undersized limit for peak load.
+
+## Classification Rule
+
+`rootCause` must state both: (a) whether the limit itself is too low for the workload's genuine
+peak usage, or the workload has a leak / unbounded growth pattern, and (b) the specific limit
+value observed, so the recommendation in `suggestedFix` is a concrete number, not "increase
+memory" with no target.
+
+## Confidence Guidance
+
+- **High (0.8+):** `reason: OOMKilled` confirmed on the terminated state, and usage-vs-limit data
+  is available and consistent with the story.
+- **Medium (0.4–0.79):** Exit code 137 confirmed but `reason` field or usage metrics weren't
+  retrievable — evidence is consistent with OOM but not fully confirmed.
+- **Low (<0.4):** Only the exit code is available; recommend the on-call SRE check
+  `dmesg`/kubelet logs on the node directly (out of scope for this template's read tools) to
+  confirm the OOM killer fired, rather than asserting it from exit code alone.

--- a/templates/template-kubernetes-sre-copilot/workspace/skills/pvc-pending/SKILL.md
+++ b/templates/template-kubernetes-sre-copilot/workspace/skills/pvc-pending/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: pvc-pending
+description: Diagnostic checklist for Pods stuck Pending due to unbound PersistentVolumeClaims
+version: 1.0.0
+metadata:
+  tags:
+    - kubernetes
+    - pod-failure
+    - pending
+    - pvc
+---
+
+# Pending / PVC-stuck
+
+The Pod is stuck in `Pending` and never gets scheduled. This checklist covers the
+storage-related cause specifically: an unbound `PersistentVolumeClaim` blocking the scheduler.
+(A Pending Pod can also be stuck on plain resource scarcity or taints/tolerations — rule storage
+in or out first via the events, since the fix is completely different.)
+
+## Diagnostic Checklist
+
+1. **Describe the Pod.** Confirm `status.phase == "Pending"` and check
+   `status.conditions[].reason` for `Unschedulable`. Note every PVC referenced under
+   `spec.volumes[].persistentVolumeClaim.claimName`.
+2. **Fetch recent Events for the Pod.** The scheduler's `FailedScheduling` event message usually
+   names the blocking PVC directly (e.g. `"pod has unbound immediate PersistentVolumeClaims"`).
+   This confirms storage is the actual blocker before you spend time checking node capacity.
+3. **Check each referenced PVC's status.** `resources_get` the PVC
+   (`apiVersion: v1, kind: PersistentVolumeClaim`) and read `status.phase`:
+   - `Pending` — no PersistentVolume has been bound yet. Check the reason under
+     `status.conditions` or recent Events on the PVC itself (not just the Pod) —
+     `ProvisioningFailed` events on the PVC carry the underlying error from the provisioner.
+   - `Bound` — the PVC itself is fine; the Pod being Pending has a different cause (go back to
+     step 2's event message and re-read it — this checklist doesn't apply).
+4. **Check the PVC's StorageClass.** `resources_get`
+   (`apiVersion: storage.k8s.io/v1, kind: StorageClass`) for `spec.storageClassName` referenced by
+   the PVC (or the cluster's default StorageClass if the PVC didn't specify one — and check
+   whether a default even exists, since "no default StorageClass and PVC didn't specify one" is
+   itself a common root cause). Confirm the `provisioner` field names a driver that's actually
+   installed/running in this cluster.
+5. **If the StorageClass and provisioner look fine, check node capacity** for the specific
+   scenario of a `WaitForFirstConsumer` binding mode with zonal/topology constraints: the PVC may
+   be waiting for a Pod to be scheduled first to determine its zone, while the Pod is waiting for
+   the PVC to bind first — a deadlock that shows up when the only nodes with capacity are in a
+   different zone than where the storage can be provisioned. `resources_list`
+   (`apiVersion: v1, kind: Node`) and check zone labels against the StorageClass's
+   `allowedTopologies`, if set.
+
+## Classification Rule
+
+`rootCause` must name which layer failed: no PV available to bind (capacity/provisioner issue),
+StorageClass misconfigured or missing, provisioner not running, or a topology/zone mismatch under
+`WaitForFirstConsumer`. "PVC is pending" restates the symptom, not the cause.
+
+## Confidence Guidance
+
+- **High (0.8+):** PVC's own Events (not just the Pod's) show an explicit `ProvisioningFailed` or
+  binding error message.
+- **Medium (0.4–0.79):** PVC status and StorageClass config are consistent with a specific cause,
+  but no explicit provisioner error message was retrievable.
+- **Low (<0.4):** PVC is `Bound` and the Pending cause is something else entirely — say this
+  explicitly rather than forcing a storage-shaped answer onto a non-storage problem.


### PR DESCRIPTION
Read-only Kubernetes SRE copilot built with Mastra. Diagnoses the 4 most common Pod failure patterns (CrashLoopBackOff, ImagePullBackOff, OOMKilled, PVCPending) via a fixed diagnostic workflow with a classification router, returning structured root cause + confidence + evidence chain + suggested fix. Cluster access goes exclusively through kubernetes-mcp-server launched read-only; zero write/remediation capability in v1.

Diagnostic checklists are editable per-failure-type via workspace/skills/*/SKILL.md, decoupling runbook customization from code.

Verified end-to-end against a local Docker Desktop (kind) cluster with one seeded Pod per failure type; see README Testing status section for details.

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Adds a read-only helper that investigates why Kubernetes Pods are failing, gathers supporting clues, and explains the likely cause and next steps. It supports four common failure patterns and produces structured, auditable diagnoses without changing the cluster.

## Summary

- Adds a Mastra-based Kubernetes SRE Copilot template.
- Connects to `kubernetes-mcp-server` in read-only mode with layered tool allowlists and policy enforcement.
- Diagnoses:
  - `CrashLoopBackOff`
  - `ImagePullBackOff`
  - `OOMKilled`
  - PVC-related `Pending` Pods
- Implements a fixed workflow for fetching Pod data, classifying failures, gathering targeted evidence, and generating validated diagnosis output.
- Returns root cause, confidence, evidence chain, risk level, and non-executable suggested fixes.
- Adds editable, failure-specific runbooks under `workspace/skills/*/SKILL.md`.
- Documents setup, customization, limitations, and local Kubernetes validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->