### PR TITLE
fix: isolate goal judge request context

### DIFF
--- a/.changeset/funky-dogs-hide.md
+++ b/.changeset/funky-dogs-hide.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed goal judges changing the parent agent's observational-memory model state.

--- a/mastracode/tui/e2e/fixtures/goal-judge-om-model-isolation.json
+++ b/mastracode/tui/e2e/fixtures/goal-judge-om-model-isolation.json
@@ -1,0 +1,89 @@
+{
+  "fixtures": [
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "## New Message History to Observe"
+      },
+      "response": {
+        "content": "<observations>\nDate: Jul 18, 2026\n* Long goal run checkpoint observed.\n</observations>\n<current-task>\nWait for explicit user approval.\n</current-task>\n<suggested-response>\nAcknowledge the approval.\n</suggested-response>\n<thread-title>\nGoal judge OM isolation\n</thread-title>"
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Prepare the goal judge OM isolation result",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "content": "Initial goal work is ready for the first judge pass."
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.5",
+        "userMessage": "Goal: Prepare the goal judge OM isolation result",
+        "sequenceIndex": 0
+      },
+      "response": {
+        "content": {
+          "decision": "continue",
+          "reason": "Continue once more before requesting explicit user approval."
+        }
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Prepare the goal judge OM isolation result",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": "The goal judge OM isolation result is ready. Waiting for explicit user approval."
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.5",
+        "userMessage": "Goal: Prepare the goal judge OM isolation result",
+        "sequenceIndex": 1
+      },
+      "response": {
+        "content": {
+          "decision": "waiting",
+          "reason": "Waiting for explicit user approval before completing the objective."
+        }
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.4-mini",
+        "userMessage": "Prepare the goal judge OM isolation result",
+        "sequenceIndex": 2
+      },
+      "response": {
+        "content": "Follow-up main response received; the approved goal is complete."
+      }
+    },
+    {
+      "match": {
+        "endpoint": "chat",
+        "model": "gpt-5.5",
+        "userMessage": "Goal: Prepare the goal judge OM isolation result",
+        "sequenceIndex": 2
+      },
+      "response": {
+        "content": {
+          "decision": "done",
+          "reason": "The user approved the result and the objective is complete."
+        }
+      }
+    }
+  ]
+}

--- a/mastracode/tui/e2e/tui/goal-judge-om-model-isolation.ts
+++ b/mastracode/tui/e2e/tui/goal-judge-om-model-isolation.ts
@@ -1,0 +1,172 @@
+import { readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import stripAnsi from 'strip-ansi';
+import { installOpenAIFetchCapture } from './openai-fetch-capture.js';
+import type { McE2eScenario } from './types.js';
+
+const OBJECTIVE_PREFIX = 'Prepare the goal judge OM isolation result, then stop and wait for explicit user approval.';
+const OBJECTIVE = `${OBJECTIVE_PREFIX}${' goal judge context retention marker'.repeat(900)}`;
+const FOLLOW_UP = 'I approve the goal judge OM isolation result.';
+const WAITING_REASON = 'Waiting for explicit user approval before completing the objective.';
+const FIRST_RESPONSE = 'Initial goal work is ready for the first judge pass.';
+const INITIAL_RESPONSE = 'The goal judge OM isolation result is ready. Waiting for explicit user approval.';
+const FOLLOW_UP_RESPONSE = 'Follow-up main response received; the approved goal is complete.';
+const PROVIDER_CHANGE_MARKER = 'Model changed openai/gpt-5.5 → openai/gpt-5.4-mini, activating observations';
+const RAW_REQUEST_CAPTURE_PATH = join(process.cwd(), '.tmp-mc-e2e', 'goal-judge-om-model-isolation-requests.jsonl');
+
+let observedMarkerCount: number | undefined;
+let reachedWaiting = false;
+let reachedFollowUp = false;
+
+type AimockRequest = {
+  body?: { model?: string; [key: string]: unknown };
+  response?: {
+    fixture?: {
+      match?: { model?: string; userMessage?: string; sequenceIndex?: number; toolCallId?: string };
+      response?: unknown;
+    };
+    source?: string;
+  };
+};
+
+function matchesFixture(request: AimockRequest, model: string, userMessage: string, content: string): boolean {
+  const fixture = request.response?.fixture;
+  return (
+    fixture?.match?.model === model &&
+    typeof fixture.match.userMessage === 'string' &&
+    userMessage.includes(fixture.match.userMessage) &&
+    JSON.stringify(fixture.response).includes(content)
+  );
+}
+
+export const goalJudgeOmModelIsolationScenario = {
+  name: 'goal-judge-om-model-isolation',
+  description: 'Keeps the main OM model state isolated across a distinct-model goal judge waiting checkpoint.',
+  testName: 'does not activate OM for the goal judge model after waiting and a user follow-up',
+  useOpenAIModel: true,
+  aimockFixture: 'goal-judge-om-model-isolation.json',
+  env() {
+    return { MASTRACODE_DISABLE_MEMORY: '0' };
+  },
+  prepare({ appDataDir }) {
+    observedMarkerCount = undefined;
+    reachedWaiting = false;
+    reachedFollowUp = false;
+    rmSync(RAW_REQUEST_CAPTURE_PATH, { force: true });
+    const settingsPath = join(appDataDir, 'settings.json');
+    const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
+    settings.models = {
+      ...((typeof settings.models === 'object' && settings.models !== null ? settings.models : {}) as Record<
+        string,
+        unknown
+      >),
+      goalJudgeModel: 'openai/gpt-5.5',
+      goalMaxTurns: 3,
+      observerModelOverride: 'openai/gpt-5.4-mini',
+      reflectorModelOverride: 'openai/gpt-5.4-mini',
+      omObservationThreshold: 10_000,
+      omReflectionThreshold: 100_000,
+    };
+    writeFileSync(settingsPath, JSON.stringify(settings, null, 2));
+  },
+  async inProcessApp({ startMastraCodeApp }) {
+    const restoreFetch = installOpenAIFetchCapture({
+      capturePath: RAW_REQUEST_CAPTURE_PATH,
+      append: true,
+      inputTokens: 2600,
+    });
+    const app = await startMastraCodeApp();
+    return {
+      stop: async () => {
+        await app.stop?.();
+        restoreFetch();
+      },
+    };
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForScreenText(/Mastra Code|Project:/i, terminal);
+
+    terminal.submit(`/goal ${OBJECTIVE}`);
+    await runtime.waitForScreenText(new RegExp(INITIAL_RESPONSE, 'i'), terminal, 60_000);
+    await runtime.waitForScreenText(/Goal\s+.*waiting\s+.*\(2\/3\)/i, terminal, 60_000);
+    reachedWaiting = true;
+
+    terminal.submit(FOLLOW_UP);
+    await runtime.waitForScreenText(new RegExp(FOLLOW_UP_RESPONSE, 'i'), terminal, 30_000);
+    reachedFollowUp = true;
+
+    await terminal.flushInput?.();
+    const history = stripAnsi(
+      (terminal as unknown as { serializeHistory(): { output: string } }).serializeHistory().output,
+    );
+    const markerCount = history.split(PROVIDER_CHANGE_MARKER).length - 1;
+    observedMarkerCount = markerCount;
+    if (markerCount !== 0) {
+      throw new Error(`Expected provider-change marker count 0, received ${markerCount}: ${PROVIDER_CHANGE_MARKER}`);
+    }
+
+    terminal.keyCtrlC();
+  },
+  verifyAimockRequests(requests) {
+    const typedRequests = requests as AimockRequest[];
+    const unmatched = typedRequests.filter(request => !request.response?.fixture);
+    if (unmatched.length > 0) {
+      throw new Error(
+        `Expected every AIMock request to match a fixture; ${unmatched.length} request(s) were unmatched`,
+      );
+    }
+
+    const initialMain = typedRequests.filter(request =>
+      matchesFixture(request, 'gpt-5.4-mini', OBJECTIVE, FIRST_RESPONSE),
+    );
+    const continuingJudge = typedRequests.filter(request =>
+      matchesFixture(
+        request,
+        'gpt-5.5',
+        `Goal: ${OBJECTIVE}`,
+        'Continue once more before requesting explicit user approval.',
+      ),
+    );
+    const waitingJudge = typedRequests.filter(request =>
+      matchesFixture(request, 'gpt-5.5', `Goal: ${OBJECTIVE}`, WAITING_REASON),
+    );
+    const followUpMain = typedRequests.filter(
+      request =>
+        matchesFixture(request, 'gpt-5.4-mini', OBJECTIVE, FOLLOW_UP_RESPONSE) &&
+        JSON.stringify(request.body).includes(FOLLOW_UP),
+    );
+
+    if (initialMain.length < 1) {
+      throw new Error(
+        `Expected a matched initial main-agent chat request: ${JSON.stringify(typedRequests.map(request => request.response?.fixture))}`,
+      );
+    }
+    if (continuingJudge.length !== 1) {
+      throw new Error(`Expected exactly one matched continuing judge request, received ${continuingJudge.length}`);
+    }
+    if (waitingJudge.length !== 1) {
+      throw new Error(`Expected exactly one matched waiting judge request, received ${waitingJudge.length}`);
+    }
+    if (followUpMain.length !== 1) {
+      throw new Error(`Expected exactly one matched follow-up main-agent response, received ${followUpMain.length}`);
+    }
+
+    const modelCounts = typedRequests.reduce<Record<string, number>>((counts, request) => {
+      const model = request.body?.model ?? 'unknown';
+      counts[model] = (counts[model] ?? 0) + 1;
+      return counts;
+    }, {});
+    if (!modelCounts['gpt-5.4-mini'] || !modelCounts['gpt-5.5']) {
+      throw new Error(`Expected requests to both distinct models, received ${JSON.stringify(modelCounts)}`);
+    }
+
+    console.info(
+      `[goal-judge-om-model-isolation] models=openai/gpt-5.4-mini,openai/gpt-5.5 request-counts=${JSON.stringify(modelCounts)}`,
+    );
+    console.info(
+      `[goal-judge-om-model-isolation] waiting=${reachedWaiting} follow-up=${reachedFollowUp} provider-change marker count=${observedMarkerCount}`,
+    );
+    console.info('[goal-judge-om-model-isolation] matched waiting decision and follow-up main response');
+  },
+} satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/goal-judge-om-model-isolation.ts
+++ b/mastracode/tui/e2e/tui/goal-judge-om-model-isolation.ts
@@ -8,6 +8,8 @@ const OBJECTIVE_PREFIX = 'Prepare the goal judge OM isolation result, then stop 
 const OBJECTIVE = `${OBJECTIVE_PREFIX}${' goal judge context retention marker'.repeat(900)}`;
 const FOLLOW_UP = 'I approve the goal judge OM isolation result.';
 const WAITING_REASON = 'Waiting for explicit user approval before completing the objective.';
+const DONE_REASON = 'The user approved the result and the objective is complete.';
+const OBSERVATION_RESPONSE = 'Long goal run checkpoint observed.';
 const FIRST_RESPONSE = 'Initial goal work is ready for the first judge pass.';
 const INITIAL_RESPONSE = 'The goal judge OM isolation result is ready. Waiting for explicit user approval.';
 const FOLLOW_UP_RESPONSE = 'Follow-up main response received; the approved goal is complete.';
@@ -17,6 +19,8 @@ const RAW_REQUEST_CAPTURE_PATH = join(process.cwd(), '.tmp-mc-e2e', 'goal-judge-
 let observedMarkerCount: number | undefined;
 let reachedWaiting = false;
 let reachedFollowUp = false;
+let reachedDone = false;
+let completedObservationCycle = false;
 
 type AimockRequest = {
   body?: { model?: string; [key: string]: unknown };
@@ -52,6 +56,8 @@ export const goalJudgeOmModelIsolationScenario = {
     observedMarkerCount = undefined;
     reachedWaiting = false;
     reachedFollowUp = false;
+    reachedDone = false;
+    completedObservationCycle = false;
     rmSync(RAW_REQUEST_CAPTURE_PATH, { force: true });
     const settingsPath = join(appDataDir, 'settings.json');
     const settings = JSON.parse(readFileSync(settingsPath, 'utf8')) as Record<string, unknown>;
@@ -95,11 +101,17 @@ export const goalJudgeOmModelIsolationScenario = {
     terminal.submit(FOLLOW_UP);
     await runtime.waitForScreenText(new RegExp(FOLLOW_UP_RESPONSE, 'i'), terminal, 30_000);
     reachedFollowUp = true;
+    await runtime.waitForScreenText(/Goal\s+.*done\s+.*\(3\/3\)/i, terminal, 30_000);
+    reachedDone = true;
 
     await terminal.flushInput?.();
     const history = stripAnsi(
       (terminal as unknown as { serializeHistory(): { output: string } }).serializeHistory().output,
     );
+    completedObservationCycle = /Buffered observation/i.test(history) && /Activated observations/i.test(history);
+    if (!completedObservationCycle) {
+      throw new Error('Expected the TUI history to show both buffered and activated observational-memory markers');
+    }
     const markerCount = history.split(PROVIDER_CHANGE_MARKER).length - 1;
     observedMarkerCount = markerCount;
     if (markerCount !== 0) {
@@ -117,6 +129,9 @@ export const goalJudgeOmModelIsolationScenario = {
       );
     }
 
+    const observerRequests = typedRequests.filter(request =>
+      matchesFixture(request, 'gpt-5.4-mini', '## New Message History to Observe', OBSERVATION_RESPONSE),
+    );
     const initialMain = typedRequests.filter(request =>
       matchesFixture(request, 'gpt-5.4-mini', OBJECTIVE, FIRST_RESPONSE),
     );
@@ -131,12 +146,18 @@ export const goalJudgeOmModelIsolationScenario = {
     const waitingJudge = typedRequests.filter(request =>
       matchesFixture(request, 'gpt-5.5', `Goal: ${OBJECTIVE}`, WAITING_REASON),
     );
+    const doneJudge = typedRequests.filter(request =>
+      matchesFixture(request, 'gpt-5.5', `Goal: ${OBJECTIVE}`, DONE_REASON),
+    );
     const followUpMain = typedRequests.filter(
       request =>
         matchesFixture(request, 'gpt-5.4-mini', OBJECTIVE, FOLLOW_UP_RESPONSE) &&
         JSON.stringify(request.body).includes(FOLLOW_UP),
     );
 
+    if (observerRequests.length < 1) {
+      throw new Error('Expected at least one matched observational-memory request');
+    }
     if (initialMain.length < 1) {
       throw new Error(
         `Expected a matched initial main-agent chat request: ${JSON.stringify(typedRequests.map(request => request.response?.fixture))}`,
@@ -147,6 +168,9 @@ export const goalJudgeOmModelIsolationScenario = {
     }
     if (waitingJudge.length !== 1) {
       throw new Error(`Expected exactly one matched waiting judge request, received ${waitingJudge.length}`);
+    }
+    if (doneJudge.length !== 1) {
+      throw new Error(`Expected exactly one matched done judge request, received ${doneJudge.length}`);
     }
     if (followUpMain.length !== 1) {
       throw new Error(`Expected exactly one matched follow-up main-agent response, received ${followUpMain.length}`);
@@ -165,8 +189,8 @@ export const goalJudgeOmModelIsolationScenario = {
       `[goal-judge-om-model-isolation] models=openai/gpt-5.4-mini,openai/gpt-5.5 request-counts=${JSON.stringify(modelCounts)}`,
     );
     console.info(
-      `[goal-judge-om-model-isolation] waiting=${reachedWaiting} follow-up=${reachedFollowUp} provider-change marker count=${observedMarkerCount}`,
+      `[goal-judge-om-model-isolation] observation=${completedObservationCycle} waiting=${reachedWaiting} follow-up=${reachedFollowUp} done=${reachedDone} provider-change marker count=${observedMarkerCount}`,
     );
-    console.info('[goal-judge-om-model-isolation] matched waiting decision and follow-up main response');
+    console.info('[goal-judge-om-model-isolation] matched observer, waiting, follow-up, and done responses');
   },
 } satisfies McE2eScenario;

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -43,6 +43,7 @@ import { githubSignalsNotificationReloadScenario } from './github-signals-notifi
 import { githubSignalsPollingInboxScenario } from './github-signals-polling-inbox.js';
 import { githubSignalsUnsubscribeReloadScenario } from './github-signals-unsubscribe-reload.js';
 import { goalApiErrorStopsLoopScenario } from './goal-api-error-stops-loop.js';
+import { goalJudgeOmModelIsolationScenario } from './goal-judge-om-model-isolation.js';
 import { goalJudgeSingleRenderScenario } from './goal-judge-single-render.js';
 import { headlessMcpToolAvailabilityScenario } from './headless-mcp-tool-availability.js';
 import { integrationCommandsScenario } from './integration-commands.js';
@@ -200,6 +201,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'github-signals-polling-inbox': githubSignalsPollingInboxScenario,
   'github-signals-unsubscribe-reload': githubSignalsUnsubscribeReloadScenario,
   'goal-api-error-stops-loop': goalApiErrorStopsLoopScenario,
+  'goal-judge-om-model-isolation': goalJudgeOmModelIsolationScenario,
   'goal-judge-single-render': goalJudgeSingleRenderScenario,
   'controller-api-config': controllerApiConfigScenario,
   'headless-mcp-tool-availability': headlessMcpToolAvailabilityScenario,

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -49,6 +49,7 @@ export type ScenarioName =
   | 'github-signals-polling-inbox'
   | 'github-signals-unsubscribe-reload'
   | 'goal-api-error-stops-loop'
+  | 'goal-judge-om-model-isolation'
   | 'goal-judge-single-render'
   | 'controller-api-config'
   | 'headless-mcp-tool-availability'

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.test.ts
@@ -52,12 +52,16 @@ async function runGoalStep(
     useMemory?: boolean;
     scorer?: any;
     stepResult?: any;
+    requestContext?: RequestContext;
+    judge?: any;
+    tools?: any;
   },
 ) {
   const store = createStore(record);
   const chunks: any[] = [];
   const messages: any[] = [];
   const dataParts: any[] = [];
+  const requestContext = opts?.requestContext ?? new RequestContext();
 
   const mastra: any = {
     generateId: () => `id-${Math.random().toString(36).slice(2)}`,
@@ -125,9 +129,14 @@ async function runGoalStep(
 
   const step = createGoalStep({
     goal: {
-      judge: opts?.undefinedJudgeResolver
-        ? () => undefined
-        : (createMockModel({ objectGenerationMode: 'json', mockText: { decision, reason: `r:${decision}` } }) as any),
+      judge:
+        opts?.judge ??
+        (opts?.undefinedJudgeResolver
+          ? () => undefined
+          : (createMockModel({
+              objectGenerationMode: 'json',
+              mockText: { decision, reason: `r:${decision}` },
+            }) as any)),
       ...(opts?.throwingScorer ? { scorer: throwingScorer } : {}),
       ...(opts?.scorer ? { scorer: opts.scorer } : {}),
       // A `goal.tools` resolver that throws exercises a resolution-time judge
@@ -138,10 +147,12 @@ async function runGoalStep(
               throw new Error(opts.throwingToolsResolver);
             },
           }
-        : {}),
+        : opts?.tools
+          ? { tools: opts.tools }
+          : {}),
     },
     messageList,
-    requestContext: new RequestContext(),
+    requestContext,
     mastra,
     controller: { enqueue: (c: any) => chunks.push(c) },
     runId: 'run-1',
@@ -173,6 +184,7 @@ async function runGoalStep(
     dataParts,
     inputData,
     executionResult,
+    requestContext,
   };
 }
 
@@ -205,6 +217,85 @@ describe('goal step waiting semantics', () => {
         title: 'Goal judge: implement X, then stop and wait for my review',
         metadata: { forkedSubagent: true, goalJudge: true, parentThreadId: THREAD_ID, goalId: 'goal-1' },
       });
+    } finally {
+      streamSpy.mockRestore();
+    }
+  });
+
+  it('isolates the default judge request context while preserving inherited values and parent resolver context', async () => {
+    const parentMemory = { thread: { id: THREAD_ID }, resource: 'resource-1' };
+    const parentContext = new RequestContext();
+    parentContext.set('tenantId', 'tenant-1');
+    parentContext.set('MastraMemory', parentMemory);
+    const judgeModel = createMockModel({ objectGenerationMode: 'json', mockText: 'unused' });
+    const judgeResolver = vi.fn(({ requestContext }: { requestContext: RequestContext }) => {
+      expect(requestContext).toBe(parentContext);
+      return judgeModel;
+    });
+    const toolsResolver = vi.fn(({ requestContext }: { requestContext: RequestContext }) => {
+      expect(requestContext).toBe(parentContext);
+      return {};
+    });
+    let judgeContext: RequestContext | undefined;
+    const streamSpy = vi.spyOn(Agent.prototype, 'stream').mockImplementation((async (
+      _prompt: unknown,
+      options: any,
+    ) => {
+      judgeContext = options.requestContext;
+      judgeContext!.set('MastraMemory', { thread: { id: `${THREAD_ID}-goal-1` }, resource: 'resource-1' });
+      return { object: Promise.resolve({ decision: 'waiting', reason: 'need user input' }) } as any;
+    }) as any);
+
+    try {
+      const { record } = await runGoalStep('waiting', makeRecord({ id: 'goal-1' }), {
+        requestContext: parentContext,
+        judge: judgeResolver,
+        tools: toolsResolver,
+        useMemory: true,
+      });
+
+      expect(record.status).toBe('active');
+      expect(judgeResolver).toHaveBeenCalledOnce();
+      expect(toolsResolver).toHaveBeenCalledOnce();
+      expect(judgeContext).toBeInstanceOf(RequestContext);
+      expect(judgeContext).not.toBe(parentContext);
+      expect(judgeContext?.get('tenantId')).toBe('tenant-1');
+      expect(judgeContext?.get('MastraMemory')).toEqual({
+        thread: { id: `${THREAD_ID}-goal-1` },
+        resource: 'resource-1',
+      });
+      expect(parentContext.get('MastraMemory')).toBe(parentMemory);
+    } finally {
+      streamSpy.mockRestore();
+    }
+  });
+
+  it('keeps judge request-context mutations isolated when default judge execution fails', async () => {
+    const parentMemory = { thread: { id: THREAD_ID }, resource: 'resource-1' };
+    const parentContext = new RequestContext();
+    parentContext.set('tenantId', 'tenant-1');
+    parentContext.set('MastraMemory', parentMemory);
+    let judgeContext: RequestContext | undefined;
+    const streamSpy = vi.spyOn(Agent.prototype, 'stream').mockImplementation((async (
+      _prompt: unknown,
+      options: any,
+    ) => {
+      judgeContext = options.requestContext;
+      judgeContext!.set('MastraMemory', { thread: { id: `${THREAD_ID}-goal-1` }, resource: 'resource-1' });
+      throw new Error('judge model exploded');
+    }) as any);
+
+    try {
+      const { record, chunk } = await runGoalStep('done', makeRecord({ id: 'goal-1' }), {
+        requestContext: parentContext,
+        useMemory: true,
+      });
+
+      expect(record.status).toBe('paused');
+      expect(chunk.payload.judgeFailed).toBe(true);
+      expect(judgeContext).not.toBe(parentContext);
+      expect(judgeContext?.get('tenantId')).toBe('tenant-1');
+      expect(parentContext.get('MastraMemory')).toBe(parentMemory);
     } finally {
       streamSpy.mockRestore();
     }

--- a/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/goal-step.ts
@@ -15,6 +15,7 @@ import type { MastraScorer } from '../../../evals';
 import { resolveModelConfig } from '../../../llm';
 import type { MastraLanguageModel } from '../../../llm/model/shared.types';
 import { createProcessorSendSignal } from '../../../processors/send-signal';
+import { RequestContext } from '../../../request-context';
 import type { GoalObjectiveRecord } from '../../../storage/domains/thread-state/base';
 import { safeEnqueue } from '../../../stream/base';
 import type { ChunkType, GoalEvaluationActivity } from '../../../stream/types';
@@ -287,12 +288,13 @@ export function createGoalStep<Tools extends ToolSet = ToolSet, OUTPUT = undefin
               ? ((await (goal.tools as (args: any) => unknown)({ requestContext, mastra })) as ToolsInput | undefined)
               : goal.tools;
           const goalId = record.id ?? `${threadId}:${record.startedAt}`;
+          const judgeRequestContext = requestContext ? new RequestContext(requestContext.entries()) : undefined;
           scorer = createGoalScorer({
             mastra,
             judgeModel,
             prompt: effective.prompt,
             tools: goalTools,
-            requestContext,
+            requestContext: judgeRequestContext,
             onStream: observeJudgeStream,
             ...(effective.maxSteps ? { maxSteps: effective.maxSteps } : {}),
             ...(_internal?.memory


### PR DESCRIPTION
Goal judges currently receive the parent's live `RequestContext`, so nested judge memory preparation can replace the main agent's `MastraMemory` binding. This gives the default judge an inherited clone instead, while model and tool resolvers still use the original parent context.

```ts
requestContext
```

becomes:

```ts
requestContext
  ? new RequestContext(requestContext.entries())
  : undefined
```

Focused tests cover successful and failed judge execution, and the Mastra Code E2E exercises distinct main/judge models through continue, waiting, user follow-up, an observational-memory cycle, and completion without a false provider-change marker.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a goal judge runs inside an agent, it now gets its own copy of the request information instead of changing the agent’s original information. This prevents memory settings from getting mixed up and adds tests to ensure the main agent and judge continue using the right models.

## What changed

- Isolated the default goal judge’s `RequestContext` while preserving inherited values.
- Added tests covering successful and failed judge execution and memory binding isolation.
- Added a Mastra Code end-to-end regression scenario covering waiting, follow-up, observational-memory processing, and completion.
- Verified distinct main and judge models are used without emitting a false provider-change marker.
- Registered the new scenario and added a core patch changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->