### PR TITLE
fix(core): sub-agent channel tool approvals fail after restart

### DIFF
--- a/.changeset/seven-lands-pay.md
+++ b/.changeset/seven-lands-pay.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed channel tool approvals for sub-agents after a server restart. When a parent agent delegates to a sub-agent whose tool has `requireApproval: true`, clicking Approve or Deny on the channel card (Slack, Telegram, Discord) after a restart — including on serverless platforms where every click hits a fresh instance — previously failed with `AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED` because the persisted approval metadata only stored the sub-agent's run. The metadata now also records the parent run, and channel approval clicks resume through it. Fixes #16861.

--- a/packages/core/src/agent/__tests__/subagent-approval-restart.test.ts
+++ b/packages/core/src/agent/__tests__/subagent-approval-restart.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Sub-agent tool approvals recovered purely from persisted metadata.
+ *
+ * When a parent agent delegates to a sub-agent whose tool requires approval,
+ * the suspension metadata stores the nested run in `runId` and the parent run
+ * in `parentRunId`. Consumers that recover after a restart (e.g. channel
+ * approval-button clicks, where the in-memory card stash is gone) must resume
+ * through the parent agent with `parentRunId ?? runId`. Resuming with the
+ * nested run id on the parent agent is rejected.
+ */
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
+import { z } from 'zod/v4';
+import { Mastra } from '../../mastra';
+import { MockMemory } from '../../memory/mock';
+import { InMemoryStore } from '../../storage';
+import { createTool } from '../../tools';
+import { Agent } from '../agent';
+
+const THREAD_ID = 'thread-restart';
+const RESOURCE_ID = 'resource-restart';
+
+const processedOrders: string[] = [];
+
+function buildSubAgent() {
+  const processOrderTool = createTool({
+    id: 'process-order',
+    description: 'Process the given order. Requires human approval.',
+    inputSchema: z.object({ orderId: z.string() }),
+    outputSchema: z.object({ orderId: z.string(), processed: z.boolean() }),
+    requireApproval: true,
+    execute: async ({ orderId }: { orderId: string }) => {
+      processedOrders.push(orderId);
+      return { orderId, processed: true };
+    },
+  });
+
+  const model = new MockLanguageModelV2({
+    doStream: async ({ prompt }) => {
+      const text = JSON.stringify(prompt);
+      const hasToolResult = text.includes('"processed"');
+      const chunks = hasToolResult
+        ? [
+            { type: 'text-start', id: 't-1' },
+            { type: 'text-delta', id: 't-1', delta: 'Processed ord_AAA.' },
+            { type: 'text-end', id: 't-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]
+        : [
+            {
+              type: 'tool-call',
+              toolCallId: 'tc-A',
+              toolName: 'process-order',
+              input: JSON.stringify({ orderId: 'ord_AAA' }),
+            },
+            { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ];
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'sub-1', modelId: 'mock-model-id', timestamp: new Date(0) },
+          ...chunks,
+        ] as any),
+      };
+    },
+  });
+
+  return new Agent({
+    id: 'sub-agent',
+    name: 'Sub Agent',
+    description: 'Processes a single order.',
+    instructions: 'Process the order by calling process-order.',
+    model,
+    tools: { processOrderTool },
+  });
+}
+
+function buildSupervisor(memory: MockMemory) {
+  // Prompt-driven (not call-counted) so a fresh instance behaves correctly on resume.
+  const model = new MockLanguageModelV2({
+    doStream: async ({ prompt }) => {
+      const text = JSON.stringify(prompt);
+      const hasDelegationResult = text.includes('Processed ord_AAA');
+      const chunks = hasDelegationResult
+        ? [
+            { type: 'text-start', id: 'sup-final-t' },
+            { type: 'text-delta', id: 'sup-final-t', delta: 'Order processed.' },
+            { type: 'text-end', id: 'sup-final-t' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ]
+        : [
+            {
+              type: 'tool-call',
+              toolCallId: 'sup-tc-A',
+              toolName: 'agent-subAgent',
+              input: JSON.stringify({ prompt: 'Process order ord_AAA.', maxSteps: 3 }),
+            },
+            { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 1, outputTokens: 1, totalTokens: 2 } },
+          ];
+      return {
+        rawCall: { rawPrompt: null, rawSettings: {} },
+        warnings: [],
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'sup-x', modelId: 'mock-model-id', timestamp: new Date(0) },
+          ...chunks,
+        ] as any),
+      };
+    },
+  });
+
+  return new Agent({
+    id: 'supervisor',
+    name: 'Supervisor',
+    instructions: 'Delegate the order to the sub agent.',
+    model,
+    agents: { subAgent: buildSubAgent() },
+    memory,
+  });
+}
+
+/** Mirrors the AgentChannels fallback: find the pending approval in persisted message metadata. */
+async function findPendingApproval(memory: MockMemory, toolCallId: string) {
+  const { messages } = await memory.recall({ threadId: THREAD_ID, resourceId: RESOURCE_ID, perPage: 50 });
+  for (const msg of messages ?? []) {
+    const pending = (msg as any).content?.metadata?.pendingToolApprovals as
+      | Record<string, { toolCallId: string; runId: string; parentRunId?: string }>
+      | undefined;
+    if (!pending) continue;
+    for (const toolData of Object.values(pending)) {
+      if (toolData.toolCallId === toolCallId) return toolData;
+    }
+  }
+  return undefined;
+}
+
+async function suspendOnFreshInstance(storage: InMemoryStore, memory: MockMemory) {
+  const mastra = new Mastra({ agents: { supervisor: buildSupervisor(memory) }, logger: false, storage });
+  const supervisor = mastra.getAgent('supervisor');
+  const stream = await supervisor.stream('Process order ord_AAA.', {
+    maxSteps: 6,
+    memory: { resource: RESOURCE_ID, thread: THREAD_ID },
+  });
+  let toolCallId = '';
+  for await (const chunk of stream.fullStream) {
+    if (chunk.type === 'tool-call-approval') toolCallId = chunk.payload.toolCallId;
+  }
+  expect(toolCallId).toBeTruthy();
+  return { parentRunId: stream.runId, toolCallId };
+}
+
+describe('sub-agent approval recovery from persisted metadata', () => {
+  it('resumes via parentRunId after a restart', async () => {
+    processedOrders.length = 0;
+    const storage = new InMemoryStore();
+    const memory = new MockMemory();
+
+    const { parentRunId, toolCallId } = await suspendOnFreshInstance(storage, memory);
+
+    const pending = await findPendingApproval(memory, toolCallId);
+    expect(pending).toBeDefined();
+    // The nested sub-agent run differs from the parent run; both are persisted.
+    expect(pending!.runId).not.toBe(parentRunId);
+    expect(pending!.parentRunId).toBe(parentRunId);
+
+    // "Restart": fresh Mastra and agent instances on the same storage.
+    const mastraB = new Mastra({ agents: { supervisor: buildSupervisor(memory) }, logger: false, storage });
+    const supervisorB = mastraB.getAgent('supervisor');
+
+    // Resume the way the channels fallback does after this fix.
+    const resumed = await supervisorB.approveToolCall({
+      runId: pending!.parentRunId ?? pending!.runId,
+      toolCallId,
+    });
+    for await (const _chunk of resumed.fullStream) {
+      // consume
+    }
+
+    expect(processedOrders).toEqual(['ord_AAA']);
+  }, 30000);
+
+  it('rejects resuming with the nested run id on the parent agent', async () => {
+    processedOrders.length = 0;
+    const storage = new InMemoryStore();
+    const memory = new MockMemory();
+
+    const { toolCallId } = await suspendOnFreshInstance(storage, memory);
+    const pending = await findPendingApproval(memory, toolCallId);
+    expect(pending).toBeDefined();
+
+    const mastraB = new Mastra({ agents: { supervisor: buildSupervisor(memory) }, logger: false, storage });
+    const supervisorB = mastraB.getAgent('supervisor');
+
+    // The pre-fix channels fallback resumed with the nested run id — that fails.
+    await expect(async () => {
+      const resumed = await supervisorB.approveToolCall({ runId: pending!.runId, toolCallId });
+      for await (const _chunk of resumed.fullStream) {
+        // consume
+      }
+    }).rejects.toMatchObject({ id: 'AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED' });
+
+    expect(processedOrders).toEqual([]);
+  }, 30000);
+});

--- a/packages/core/src/channels/agent-channels.ts
+++ b/packages/core/src/channels/agent-channels.ts
@@ -326,12 +326,9 @@ export class AgentChannels {
           });
 
           // Look up the runId for this toolCallId. Prefer the in-memory
-          // `pendingApprovalCards` map (set when the approval card was posted)
-          // because it's keyed by toolCallId and survives parallel same-tool
-          // approvals. Fall back to the persisted `pendingToolApprovals`
-          // metadata for cases where the bot restarted between card post and
-          // click (the metadata path is lossy for parallel same-tool calls
-          // since core keys those by toolName — only the latest survives).
+          // `pendingApprovalCards` map (set when the approval card was posted).
+          // Fall back to the persisted `pendingToolApprovals` metadata for
+          // cases where the bot restarted between card post and click.
           let runId: string | undefined;
           let toolName: string | undefined;
           let toolArgs: Record<string, unknown> | undefined;
@@ -356,12 +353,24 @@ export class AgentChannels {
 
             for (const msg of messages) {
               const pending = msg.content?.metadata?.pendingToolApprovals as
-                | Record<string, { toolCallId: string; runId: string; toolName: string; args: Record<string, unknown> }>
+                | Record<
+                    string,
+                    {
+                      toolCallId: string;
+                      runId: string;
+                      parentRunId?: string;
+                      toolName: string;
+                      args: Record<string, unknown>;
+                    }
+                  >
                 | undefined;
               if (pending) {
                 for (const toolData of Object.values(pending)) {
                   if (toolData.toolCallId === toolCallId) {
-                    runId = toolData.runId;
+                    // Sub-agent approvals store the nested run in `runId` and the
+                    // channel-owning parent run in `parentRunId`. Resume APIs must
+                    // be called on this channel's agent with its own run.
+                    runId = toolData.parentRunId ?? toolData.runId;
                     toolName = toolData.toolName;
                     toolArgs = toolData.args;
                     break;

--- a/packages/core/src/loop/shared/auto-resume-system-message.test.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.test.ts
@@ -85,6 +85,15 @@ describe('buildAutoResumeSystemMessageSuffix', () => {
     expect(suffix!).toContain('Analyse the suspended tools');
     expect(suffix!).toContain('fooTool');
   });
+
+  it('keeps parentRunId out of the prompt-facing serialization', () => {
+    const suffix = buildAutoResumeSystemMessageSuffix([
+      { toolName: 'fooTool', runId: 'nested-run', parentRunId: 'parent-run' },
+    ]);
+    expect(suffix!).toContain('nested-run');
+    expect(suffix!).not.toContain('parentRunId');
+    expect(suffix!).not.toContain('parent-run');
+  });
 });
 
 describe('appendSuffixToLeadingSystemMessage', () => {

--- a/packages/core/src/loop/shared/auto-resume-system-message.ts
+++ b/packages/core/src/loop/shared/auto-resume-system-message.ts
@@ -88,7 +88,9 @@ export function buildAutoResumeSystemMessageSuffix(
   suspendedTools: ReadonlyArray<Record<string, unknown>>,
 ): string | null {
   if (suspendedTools.length === 0) return null;
-  return `\n\nAnalyse the suspended tools: ${JSON.stringify(suspendedTools)}, using the messages available to you and the resumeSchema of each suspended tool, find the tool whose resumeData you can construct properly.
+  // The model must resume with `runId`; keep the bookkeeping-only `parentRunId` out of the prompt.
+  const promptFacingTools = suspendedTools.map(({ parentRunId: _parentRunId, ...rest }) => rest);
+  return `\n\nAnalyse the suspended tools: ${JSON.stringify(promptFacingTools)}, using the messages available to you and the resumeSchema of each suspended tool, find the tool whose resumeData you can construct properly.
                       resumeData can not be an empty object nor null/undefined.
                       When you find that and call that tool, add the resumeData to the tool call arguments/input.
                       Also, add the runId of the suspended tool as suspendedToolRunId to the tool call arguments/input.

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.test.ts
@@ -484,6 +484,96 @@ describe('createToolCallStep tool approval workflow', () => {
   });
 });
 
+describe('createToolCallStep delegated agent tool approvals', () => {
+  let controller: { enqueue: Mock };
+  let suspend: Mock;
+  let streamState: { serialize: Mock };
+  let assistantMessage: { role: string; content: { metadata: Record<string, any> } };
+  let messageList: MessageList;
+
+  beforeEach(() => {
+    controller = { enqueue: vi.fn() };
+    suspend = vi.fn().mockReturnValue(new Promise(() => {}));
+    streamState = { serialize: vi.fn().mockReturnValue('serialized-state') };
+    assistantMessage = {
+      role: 'assistant',
+      content: { metadata: {} },
+    };
+    messageList = {
+      get: {
+        input: { aiV5: { model: () => [] } },
+        response: { db: () => [assistantMessage] },
+        all: { db: () => [assistantMessage], aiV5: { model: () => [] } },
+      },
+    } as unknown as MessageList;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+  });
+
+  const runDelegatedApproval = async (subAgentRunId: string) => {
+    const tools = {
+      'agent-subAgent': {
+        execute: vi.fn(async (_args: unknown, opts: MastraToolInvocationOptions) => {
+          await opts.suspend?.({}, { requireToolApproval: true, runId: subAgentRunId });
+          return { text: 'done' };
+        }),
+      },
+    } as unknown as ToolSet;
+
+    const toolCallStep = createToolCallStep({
+      tools,
+      messageList,
+      controller,
+      runId: 'parent-run-id',
+      streamState,
+    });
+
+    const inputData = {
+      toolCallId: 'parent-tool-call-id',
+      toolName: 'agent-subAgent',
+      args: { prompt: 'do thing' },
+    };
+
+    const executePromise = toolCallStep.execute({
+      ...makeBaseExecuteParams(suspend),
+      writer: new ToolStream({
+        prefix: 'tool',
+        callId: inputData.toolCallId,
+        name: inputData.toolName,
+        runId: 'parent-run-id',
+      }),
+      inputData,
+    });
+    await new Promise(resolve => setImmediate(resolve));
+    await expect(Promise.race([executePromise, Promise.resolve('suspended')])).resolves.toBe('suspended');
+
+    return assistantMessage.content.metadata.pendingToolApprovals?.['parent-tool-call-id'];
+  };
+
+  it('stores parentRunId when the suspended run belongs to a nested agent', async () => {
+    const pending = await runDelegatedApproval('sub-agent-run-id');
+
+    expect(pending).toMatchObject({
+      toolCallId: 'parent-tool-call-id',
+      runId: 'sub-agent-run-id',
+      parentRunId: 'parent-run-id',
+    });
+  });
+
+  it('omits parentRunId when the suspended run is the current run', async () => {
+    const pending = await runDelegatedApproval('parent-run-id');
+
+    expect(pending).toMatchObject({
+      toolCallId: 'parent-tool-call-id',
+      runId: 'parent-run-id',
+    });
+    expect(pending).not.toHaveProperty('parentRunId');
+  });
+});
+
 describe('createToolCallStep needsApprovalFn enriched context', () => {
   let controller: { enqueue: Mock };
   let suspend: Mock;

--- a/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/tool-call-step.ts
@@ -217,6 +217,12 @@ export function createToolCallStep<Tools extends ToolSet = ToolSet, OUTPUT = und
             args: transformedArgs,
             type,
             runId: suspendedToolRunId ?? runId, // Store the runId so we can resume after page refresh
+            // Sub-agent suspensions store the nested run in `runId`. Resume APIs
+            // (approveToolCall/declineToolCall) must be called on the delegating
+            // agent with ITS run, so also store the parent run for consumers that
+            // recover purely from persisted metadata (e.g. channel approval
+            // clicks after a restart).
+            ...(suspendedToolRunId && suspendedToolRunId !== runId ? { parentRunId: runId } : {}),
             ...(type === 'suspension' ? { suspendPayload: transformedSuspendPayload } : {}),
             resumeSchema,
             ...(toolStateTransformMetadata ? { metadata: toolStateTransformMetadata } : {}),


### PR DESCRIPTION
## Description

Clicking Approve/Deny on a channel approval card (Slack, Telegram, Discord) for a sub-agent's tool failed with `AGENT_RESUME_TOOL_CALL_NOT_SUSPENDED` whenever the click was served by a different instance than the one that posted the card — after a server restart, or on serverless where every click hits a fresh instance. The persisted `pendingToolApprovals` metadata only stored the nested sub-agent run id, which the internal resume plumbing needs, but which is not resumable via `approveToolCall` on the channel-owning parent agent.

- `tool-call-step.ts`: when the suspended run belongs to a nested agent (`suspendedToolRunId !== runId`), also persist the delegating agent's run as `parentRunId` in the `pendingToolApprovals` metadata; `runId` keeps holding the nested run since the auto-resume path still requires it
- `agent-channels.ts`: the restart fallback now resumes with `toolData.parentRunId ?? toolData.runId`, so sub-agent approvals resume through the parent run while plain tool approvals are unchanged; also corrected a stale comment that predated the toolCallId re-keying in #16937
- Added unit tests asserting `parentRunId` is written for delegated suspensions and omitted for same-run suspensions
- Added an end-to-end test that suspends a sub-agent approval, simulates a restart with a fresh Mastra instance on the same storage, and verifies resuming via `parentRunId` executes the tool while resuming with the nested run id is rejected
- Verified with a real model (openai/gpt-4o-mini) and with three-level nesting (supervisor → mid agent → sub-agent) across a restart

## Related Issue(s)

Fixes #16861

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a helper agent pauses to ask for approval, clicking the approval button now reliably continues that exact paused task—even after a server restart or on another server.

## What changed

- Persisted both the nested sub-agent tool `runId` and the parent `parentRunId` for delegated tool approvals.
- Updated channel approval handling to resume the correct suspended tool call by preferring `parentRunId` when resuming sub-agent approvals (while keeping existing behavior for approvals within the same run).
- Ensured auto-resume prompt serialization stays the same for model instructions (it omits `parentRunId` from the prompt-facing suffix).
- Added unit and end-to-end tests covering delegated and nested approvals across restarts, including a negative test that verifies the wrong `runId` is rejected.
- Added a patch changeset for `@mastra/core`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->