### PR TITLE
fix(@mastra/core): prevent orphaned agent persistence on stream failure (#19715)

### DIFF
--- a/.changeset/cozy-colts-build.md
+++ b/.changeset/cozy-colts-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed an issue in the agentic loop where an aborted or failed LLM stream would still trigger output processors and improperly persist the user's input message as an orphaned record.

--- a/packages/core/src/agent/agent.test.ts
+++ b/packages/core/src/agent/agent.test.ts
@@ -3572,12 +3572,8 @@ function agentTests({ version }: { version: 'v1' | 'v2' }) {
         resourceId: 'resource-3-generate',
       });
 
-      // TODO: output processors in v2 still run when the model throws an error! that doesn't seem right.
-      // it means in v2 our message history processor saves the input message.
-      if (version === `v1`) {
-        expect(result.messages.length).toBe(0);
-        expect(saveCallCount).toBe(0);
-      }
+      expect(result.messages.length).toBe(0);
+      expect(saveCallCount).toBe(0);
     });
 
     it('should save thread but not messages if error occurs during LLM generation', async () => {

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -835,7 +835,9 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               controller.terminate();
               return;
             case 'finish':
-              self.#status = 'success';
+              if (self.#status !== 'failed' && self.#status !== 'suspended') {
+                self.#status = 'success';
+              }
               if (chunk.payload.stepResult.reason) {
                 self.#finishReason = chunk.payload.stepResult.reason;
               }
@@ -936,14 +938,16 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                     steps: [...self.#bufferedSteps] as LLMStepResult[],
                   };
 
-                  self.messageList = await self.processorRunner.runOutputProcessors(
-                    self.messageList,
-                    resolveObservabilityContext(options),
-                    self.#options.requestContext,
-                    0,
-                    outputResultWriter,
-                    outputResult,
-                  );
+                  if (self.#status !== 'failed') {
+                    self.messageList = await self.processorRunner.runOutputProcessors(
+                      self.messageList,
+                      resolveObservabilityContext(options),
+                      self.#options.requestContext,
+                      0,
+                      outputResultWriter,
+                      outputResult,
+                    );
+                  }
 
                   // Get text from the latest response message (the last assistant message)
                   const responseMessages = self.messageList.get.response.aiV4.core();

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -835,7 +835,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
               controller.terminate();
               return;
             case 'finish':
-              if (self.#status !== 'failed' && self.#status !== 'suspended') {
+              if (self.#status !== 'failed' && self.#status !== 'suspended' && self.#status !== 'canceled') {
                 self.#status = 'success';
               }
               if (chunk.payload.stepResult.reason) {
@@ -938,7 +938,7 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
                     steps: [...self.#bufferedSteps] as LLMStepResult[],
                   };
 
-                  if (self.#status !== 'failed') {
+                  if (self.#status !== 'failed' && self.#status !== 'canceled') {
                     self.messageList = await self.processorRunner.runOutputProcessors(
                       self.messageList,
                       resolveObservabilityContext(options),


### PR DESCRIPTION
In the agentic loop workflow, an aborted LLM stream gracefully handles the error and emits a finish chunk. MastraModelOutput was unconditionally treating this finish chunk as a success signal, overwriting the stream status and executing output processors. This led to orphaned input messages persisting to storage despite generation failure. We now gate the output processor execution by verifying the stream didn't already encounter an error.

## Description

This PR fixes the orphaned agent persistence bug in the `v2` Agentic Loop architecture. 

**Changes:**
1. Added state-gating inside `MastraModelOutput`'s transformer (`packages/core/src/stream/base/output.ts`) so that the trailing `'finish'` lifecycle chunk no longer blindly overwrites the internal state to `'success'` if it was previously marked as `'failed'`.
2. Gated the execution of `runOutputProcessors` behind `if (self.#status !== 'failed')` to ensure `MessageHistory` is completely bypassed during an aborted workflow, preventing the user's input messages from being incorrectly persisted to the database.
3. Updated `packages/core/src/agent/agent.test.ts` to remove the `TODO` and `if (version === 'v1')` escape hatch on the regression test `should not save any message if interrupted before any part is emitted`. The zero-persistence assertions now run unconditionally and pass successfully for both `v1` and `v2`.

## Related issue(s)

Fixes #19715

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When an AI reply gets cut off or errors mid-stream, this update stops the system from saving a “half-finished” message and from treating the turn as successful. It also prevents history/output handlers from running after the failure.

## Changes
- Fix v2 Agentic Loop orphaned agent persistence by keeping the internal stream status as `failed` (and not overwriting it to `success`) when a trailing `finish` chunk arrives after an interrupted/aborted stream.
- Skip output processors (including `MessageHistory`) when the stream `finish` path sees `failed` or `canceled`, so failed turns don’t produce persisted side effects.
- Update regression test to unconditionally verify zero message persistence (`result.messages` empty and no save calls) for both v1 and v2 when interruption happens before any output is emitted.
- Add/adjust abort handling to account for canceled status.
- Include a patch changeset for `@mastra/core` documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->