### PR TITLE
fix(deployer): resolve Missing "." specifier for subpath-only workspace exports

### DIFF
--- a/.changeset/subpath-only-workspace-exports.md
+++ b/.changeset/subpath-only-workspace-exports.md
@@ -1,0 +1,21 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` failing with `Missing "." specifier` when a workspace package declares only subpath exports.
+
+In a monorepo, a build using `bundler: { externals: true }` crashed during analysis if any transitive workspace dependency declared an `exports` map with no `"."` entry — a common convention for internal utility packages:
+
+```jsonc
+// packages/leaf/package.json
+{
+  "name": "@scope/leaf",
+  "exports": {
+    "./sub/*": "./src/*.ts"
+  }
+}
+```
+
+The build failed with `Failed to analyze: Missing "." specifier in "@scope/leaf" package` even though no code imported the package root.
+
+The transitive workspace walk was registering every workspace dependency as a root-level import, including packages only ever used through a subpath. The subpaths that are actually imported were already tracked separately, so the redundant root entry is now skipped for packages that have no root export. Internal packages can keep subpath-only exports maps as they are, instead of needing stub `"."` entries pointing at empty files.

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -360,6 +360,103 @@ describe('analyzeEntry', () => {
     expect(analyzeCache.size).toBe(1);
   });
 
+  it('should not register a root export for transitive workspace packages that only declare subpath exports', async () => {
+    const root = join(import.meta.dirname, '__fixtures__', 'nested-workspace');
+    const entryFilePath = join(root, 'apps', 'mastra', 'src', 'shared-transitive.ts');
+    vi.spyOn(process, 'cwd').mockReturnValue(join(root, 'apps', 'mastra'));
+
+    const workspaceMap = new Map<string, WorkspacePackageInfo>([
+      [
+        '@internal/a',
+        {
+          location: `${root}/packages/a`,
+          dependencies: {
+            '@internal/shared': '1.0.0',
+          },
+          version: '1.0.0',
+        },
+      ],
+      [
+        '@internal/b',
+        {
+          location: `${root}/packages/b`,
+          dependencies: {
+            '@internal/shared': '1.0.0',
+          },
+          version: '1.0.0',
+        },
+      ],
+      [
+        '@internal/shared',
+        {
+          location: `${root}/packages/shared`,
+          dependencies: {},
+          version: '1.0.0',
+          // Only subpath entries, no "." — asking a resolver for the root here throws.
+          exports: {
+            './sub/*': './src/*.ts',
+          },
+        },
+      ],
+    ]);
+
+    const result = await analyzeEntry({ entry: entryFilePath, isVirtualFile: false }, '', {
+      shouldCheckTransitiveDependencies: true,
+      logger: noopLogger,
+      sourcemapEnabled: false,
+      workspaceMap,
+      projectRoot: root,
+    });
+
+    // The packages actually imported at their root are still registered...
+    expect(result.dependencies.get('@internal/a')?.exports).toEqual(['a']);
+    expect(result.dependencies.get('@internal/b')?.exports).toEqual(['b']);
+    // ...but the subpath-only package gets no root entry, so nothing asks for its ".".
+    expect(result.dependencies.has('@internal/shared')).toBe(false);
+    expect(result.dependencies.size).toBe(2);
+  });
+
+  it('should still register transitive workspace packages whose exports map has a root entry', async () => {
+    const root = join(import.meta.dirname, '__fixtures__', 'nested-workspace');
+    const entryFilePath = join(root, 'apps', 'mastra', 'src', 'shared-transitive.ts');
+    vi.spyOn(process, 'cwd').mockReturnValue(join(root, 'apps', 'mastra'));
+
+    const workspaceMap = new Map<string, WorkspacePackageInfo>([
+      [
+        '@internal/a',
+        {
+          location: `${root}/packages/a`,
+          dependencies: {
+            '@internal/shared': '1.0.0',
+          },
+          version: '1.0.0',
+        },
+      ],
+      [
+        '@internal/shared',
+        {
+          location: `${root}/packages/shared`,
+          dependencies: {},
+          version: '1.0.0',
+          exports: {
+            '.': './src/index.ts',
+            './sub/*': './src/*.ts',
+          },
+        },
+      ],
+    ]);
+
+    const result = await analyzeEntry({ entry: entryFilePath, isVirtualFile: false }, '', {
+      shouldCheckTransitiveDependencies: true,
+      logger: noopLogger,
+      sourcemapEnabled: false,
+      workspaceMap,
+      projectRoot: root,
+    });
+
+    expect(result.dependencies.get('@internal/shared')?.exports).toEqual(['*']);
+  });
+
   it('should not cache virtual file entries', async () => {
     const entryCode = `
       import { Mastra } from '@mastra/core/mastra';

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -12,7 +12,7 @@ import { protocolExternalResolver } from '../plugins/protocol-external-resolver'
 import { removeDeployer } from '../plugins/remove-deployer';
 import { tsConfigPaths } from '../plugins/tsconfig-paths';
 import type { DependencyMetadata } from '../types';
-import { getPackageName, isBareModuleSpecifier, slash } from '../utils';
+import { getPackageName, hasRootExport, isBareModuleSpecifier, slash } from '../utils';
 import { DEPS_TO_IGNORE } from './constants';
 
 /**
@@ -155,6 +155,19 @@ async function captureDependenciesToOptimize(
       for (const [innerDep, _innerDepVersion] of Object.entries(workspaceInfo.dependencies)) {
         const innerWorkspaceInfo = workspaceMap.get(innerDep);
         if (!innerWorkspaceInfo) {
+          continue;
+        }
+
+        /**
+         * Packages that only declare subpath exports have no root to import. Registering a
+         * root-level `export *` for them makes the resolver ask for the `"."` specifier,
+         * which throws. The subpaths that are actually imported were already captured
+         * per-specifier from the entry analysis, so skipping the root loses nothing.
+         */
+        if (!hasRootExport(innerWorkspaceInfo)) {
+          logger.debug(
+            `Skipping root export of workspace package "${innerDep}" (imported by "${pkgName}"): it declares subpath exports only.`,
+          );
           continue;
         }
 

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -221,7 +221,19 @@ async function getInputPlugins(
             }
 
             const pkgName = pkgJson.name || '';
-            let resolvedPath: string | undefined = resolve.exports(pkgJson, id.replace(pkgName, '.'))?.[0];
+            let resolvedPath: string | undefined;
+            try {
+              resolvedPath = resolve.exports(pkgJson, id.replace(pkgName, '.'))?.[0];
+            } catch {
+              /**
+               * `resolve.exports` throws (rather than returning undefined) when the package
+               * declares an `exports` map that has no matching entry — including the `"."`
+               * root of a subpath-only map. Swallowing it here is what makes the `main`
+               * fallback below reachable at all. Note `unsafe: true` is not an escape hatch:
+               * the throw is unconditional, that option only skips condition defaults.
+               */
+              resolvedPath = undefined;
+            }
             if (!resolvedPath) {
               resolvedPath = pkgJson!.main ?? 'index.js';
             }

--- a/packages/deployer/src/build/utils.test.ts
+++ b/packages/deployer/src/build/utils.test.ts
@@ -10,6 +10,7 @@ import {
   findNativePackageModule,
   normalizeStudioBase,
   detectRuntime,
+  hasRootExport,
   injectStudioHtmlConfig,
   escapeStudioHtmlValue,
 } from './utils';
@@ -696,5 +697,45 @@ describe('escapeStudioHtmlValue', () => {
   it('leaves benign values byte-identical', () => {
     expect(escapeStudioHtmlValue('org-123')).toBe('org-123');
     expect(escapeStudioHtmlValue('https://observability.example.com')).toBe('https://observability.example.com');
+  });
+});
+
+describe('hasRootExport', () => {
+  it('treats a package without an exports map as root-importable', () => {
+    expect(hasRootExport({})).toBe(true);
+    expect(hasRootExport({ main: 'src/index.ts' })).toBe(true);
+    expect(hasRootExport({ exports: undefined })).toBe(true);
+    expect(hasRootExport({ exports: null })).toBe(true);
+  });
+
+  it('treats string and array exports as defining the root', () => {
+    expect(hasRootExport({ exports: './src/index.ts' })).toBe(true);
+    expect(hasRootExport({ exports: ['./src/index.ts', './src/index.js'] })).toBe(true);
+  });
+
+  it('treats a conditions-only map as applying to the root', () => {
+    expect(hasRootExport({ exports: { import: './esm.js', require: './cjs.js' } })).toBe(true);
+    expect(hasRootExport({ exports: { types: './index.d.ts', default: './index.js' } })).toBe(true);
+  });
+
+  it('detects a subpath map with an explicit root entry', () => {
+    expect(hasRootExport({ exports: { '.': './src/index.ts', './sub/*': './src/*.ts' } })).toBe(true);
+  });
+
+  it('rejects a subpath-only map', () => {
+    expect(hasRootExport({ exports: { './sub/*': './src/*.ts' } })).toBe(false);
+    expect(hasRootExport({ exports: { './a': './a.ts', './b': './b.ts' } })).toBe(false);
+    // A `main` alongside a subpath-only map does not resurrect the root: an exports
+    // map, once present, fully replaces `main` for resolution.
+    expect(hasRootExport({ main: 'src/index.ts', exports: { './sub/*': './src/*.ts' } })).toBe(false);
+  });
+
+  it('rejects an empty exports map', () => {
+    expect(hasRootExport({ exports: {} })).toBe(false);
+  });
+
+  it('rejects a missing package manifest', () => {
+    expect(hasRootExport(null)).toBe(false);
+    expect(hasRootExport(undefined)).toBe(false);
   });
 });

--- a/packages/deployer/src/build/utils.ts
+++ b/packages/deployer/src/build/utils.ts
@@ -61,6 +61,51 @@ export function upsertMastraDir({ dir = process.cwd() }: { dir?: string }) {
   }
 }
 
+/**
+ * Whether a package can be imported at its root (`import x from 'pkg'`).
+ *
+ * A package that declares an `exports` map with only subpath entries — a common
+ * convention for internal workspace utilities — has no root entry, and asking a
+ * resolver for `'.'` throws rather than falling back to `main`.
+ *
+ * Follows Node's rule for disambiguating the two shapes an `exports` object can take:
+ * keys starting with `.` make it a subpath map, anything else makes it a conditions
+ * map that applies to the root.
+ */
+export function hasRootExport(pkgJson: { exports?: unknown; main?: unknown } | null | undefined): boolean {
+  if (!pkgJson) {
+    return false;
+  }
+
+  const { exports } = pkgJson;
+
+  // No exports map at all: root resolves via `main`/`index.js`.
+  if (exports === null || exports === undefined) {
+    return true;
+  }
+
+  // `"exports": "./index.js"` or an array of fallbacks both define the root.
+  if (typeof exports === 'string' || Array.isArray(exports)) {
+    return true;
+  }
+
+  if (typeof exports !== 'object') {
+    return true;
+  }
+
+  const keys = Object.keys(exports as Record<string, unknown>);
+  if (keys.length === 0) {
+    return false;
+  }
+
+  // A conditions map (`{ "import": ..., "require": ... }`) applies to the root.
+  if (!keys.some(key => key.startsWith('.'))) {
+    return true;
+  }
+
+  return keys.includes('.');
+}
+
 export function isDependencyPartOfPackage(dep: string, packageName: string) {
   if (dep === packageName) {
     return true;

--- a/packages/deployer/src/bundler/workspaceDependencies.ts
+++ b/packages/deployer/src/bundler/workspaceDependencies.ts
@@ -11,6 +11,9 @@ export type WorkspacePackageInfo = {
   location: string;
   dependencies: Record<string, string> | undefined;
   version: string | undefined;
+  /** Raw `exports` field, used to tell whether the package can be imported at its root. */
+  exports?: unknown;
+  main?: unknown;
 };
 
 type TransitiveDependencyResult = {
@@ -54,6 +57,8 @@ export async function getWorkspaceInformation({
         location: workspace.location,
         dependencies: workspace.package.dependencies,
         version: workspace.package.version,
+        exports: (workspace.package as { exports?: unknown }).exports,
+        main: (workspace.package as { main?: unknown }).main,
       },
     ]) ?? [],
   );


### PR DESCRIPTION
## Description

  <!-- Required: Provide a brief description of the changes in this PR. -->

  ## Related issue(s)

  <!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

  ## Type of change

  - [ ] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (non-breaking change that adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [ ] Documentation update
  - [ ] Code refactoring
  - [ ] Performance improvement
  - [ ] Test update

  ## Checklist

  - [ ] I have linked the related issue(s) in the description above
  - [ ] I have made corresponding changes to the documentation (if applicable)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I have addressed all Coderabbit comments on this PR


## Description

`mastra build` with `bundler: { externals: true }` crashed during analysis with `Failed to analyze: Missing "." specifier in "@scope/leaf" package` whenever a transitive workspace dependency declared an `exports` map with no `"."` entry — a common convention for internal utility packages — even though nothing imported the package root.

Fixes both links in the chain the issue identified:

**1. `analyzeEntry.ts` — root cause.** `checkTransitiveDependencies` registered every transitive workspace dependency as a root-level `exports: ['*']` virtual module, including packages only ever reached through a subpath. It now skips packages that have no root export. The subpaths actually imported are already keyed separately in `depsToOptimize` by full specifier (`@scope/leaf/sub/foo`), so the root entry was pure redundancy that happened to be fatal — nothing is lost by dropping it.

**2. `bundleExternals.ts` — latent bug.** The `resolve.exports(pkgJson, '.')` call in the `alias-optimized-deps` plugin had no try/catch, which made the `pkgJson.main ?? 'index.js'` fallback on the very next line unreachable. `resolve.exports` throws rather than returning `undefined` for a missing entry, so the fallback the author clearly intended never ran. Now guarded, with a comment recording that `unsafe: true` is *not* an escape hatch here — the throw is unconditional in resolve.exports 2.0.3, that option only skips condition defaults.

**Supporting changes:** `hasRootExport()` in `utils.ts` implements Node's rule for disambiguating a subpath map (`{"./sub/*": ...}`) from a conditions map (`{"import": ..., "require": ...}`, which does apply to the root). `WorkspacePackageInfo` now carries `exports`/`main` — optional so existing fixtures compile unchanged, and free at runtime since `workspace.package` is the already-parsed manifest, which keeps the walk synchronous.

Internal packages can now keep subpath-only exports maps exactly as they are, instead of needing stub `"."` entries pointing at empty files, discovered one build failure at a time.

## Related issue(s)

Closes #19379

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable) — n/a, no user-facing API change
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Testing

- **New regression test** in `analyzeEntry.test.ts` reproducing the issue's exact shape (app → `@internal/a` → `@internal/shared`, where the leaf declares subpath-only exports and is never root-imported), plus a companion asserting packages *with* a `"."` entry are still registered.
- **Red/green verified**: stashed the fix and confirmed the regression test fails with exactly the reported behavior, then passes with it restored — the test pins the bug rather than merely passing alongside it.
- **`hasRootExport` unit matrix** in `utils.test.ts`: no exports field, string/array exports, conditions-only map, subpath map with and without `"."`, empty map, and `main` alongside a subpath-only map (which does *not* resurrect the root, since an exports map fully replaces `main`).
- 146 tests pass across `utils`, `analyzeEntry`, `bundleExternals`, `bundlerOptions`. `tsc --noEmit` clean.

## Not included

- **The `e2e-tests/monorepo` fixture.** The issue reporter mentioned they were preparing one; separately, my environment cannot create symlinks (`EPERM`), which is how those fixtures construct workspaces, so I could not run one I wrote. Happy to add it if a maintainer can verify it, or if CI is the intended proving ground.
- **Importer-chain diagnostics** (`app -> @scope/mid -> @scope/leaf`), the issue's second "Expected Behavior" bullet. That needs provenance threaded through `DependencyMetadata` and is a distinct enhancement; with this fix the error no longer escapes at all. Suggest a follow-up issue rather than bundling speculative plumbing into a bug fix — happy to do it here instead if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some workspace packages only work through specific paths, not from their package root. This change stops the build from incorrectly treating them as root-importable and adds a fallback so `mastra build` no longer crashes.

## Summary

- Skips root-level registration for workspace packages with subpath-only `exports`.
- Safely handles failed `resolve.exports` lookups so `main` or `index.js` fallback resolution can run.
- Adds `hasRootExport` to detect whether a package supports root imports.
- Stores `exports` and `main` metadata in `WorkspacePackageInfo`.
- Adds regression and unit tests for subpath-only and root exports.
- Adds a Changesets patch release entry for `@mastra/deployer`.
- Verified with 146 passing tests and successful `tsc --noEmit`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->