### PR TITLE
fix: handle both usage paths in convertMastraChunkToAISDKBase for persisted signal chunks

### DIFF
--- a/client-sdks/ai-sdk/src/helpers.ts
+++ b/client-sdks/ai-sdk/src/helpers.ts
@@ -171,11 +171,14 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
       };
 
     case 'finish': {
+      // Normal model runs carry usage at payload.output.usage (full FinishPayload).
+      // Synthesized finish chunks from #broadcastPersistedSignal carry usage directly
+      // at payload.usage without an output wrapper. Resolve defensively to support both.
       return {
         type: 'finish',
         finishReason: normalizeFinishReason(chunk.payload.stepResult.reason) as FinishReason,
         ...(includeRawFinishReason ? { rawFinishReason: chunk.payload.stepResult.reason } : {}),
-        totalUsage: normalizeUsage(chunk.payload.output.usage),
+        totalUsage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
       };
     }
     case 'reasoning-start':
@@ -319,7 +322,9 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
         providerMetadata: chunk.payload.providerMetadata,
       };
     case 'step-finish': {
-      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata;
+      // Defensive: synthesized chunks (e.g. from #broadcastPersistedSignal) may omit
+      // payload.metadata and carry usage at payload.usage instead of payload.output.usage.
+      const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata ?? {};
       return {
         type: 'finish-step',
         response: {
@@ -328,7 +333,7 @@ export function convertMastraChunkToAISDKBase<OUTPUT = undefined>({
           modelId: (rest.modelId as string) || '',
           ...rest,
         },
-        usage: normalizeUsage(chunk.payload.output.usage),
+        usage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
         finishReason: normalizeFinishReason(chunk.payload.stepResult.reason) as FinishReason,
         ...(includeRawFinishReason ? { rawFinishReason: chunk.payload.stepResult.reason } : {}),
         providerMetadata,


### PR DESCRIPTION
## Summary

Fixes #19721

This PR resolves a `TypeError: Cannot read properties of undefined (reading 'usage')` that crashes any `subscribeToThread` stream piped through the AI SDK converter when a persisted-signal broadcast passes through it.

The fix makes usage path resolution defensive in both the `finish` and `step-finish` cases of `convertMastraChunkToAISDKBase`, so that both normal model-run chunks and synthesized persisted-signal chunks are handled correctly.

## Root Cause Analysis

There are two distinct sources of `finish` chunks that flow through `convertMastraChunkToAISDKBase`:

1. **Normal model runs** — The agent runtime emits a full `FinishPayload` where usage lives at `chunk.payload.output.usage` (nested inside the `output` object alongside `metadata`, etc.).

2. **Persisted-signal broadcasts** — `#broadcastPersistedSignal` in `packages/core/src/agent/thread-stream-runtime.ts` synthesizes a minimal `start` / data-part / `finish` sequence to notify thread subscribers. The synthesized `finish` part places `usage` directly at `chunk.payload.usage` — there is no `output` wrapper:

```ts
// thread-stream-runtime.ts (~line 731)
{
  type: 'finish',
  runId,
  payload: {
    stepResult: { reason: 'stop' },
    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },  // <-- payload.usage
  },
}
```

The converter unconditionally reads `chunk.payload.output.usage`, so when `payload.output` is `undefined` (as in the synthesized chunk), it throws:

```
TypeError: Cannot read properties of undefined (reading 'usage')
```

With `RedisStreamsPubSub`, this is especially severe: retained topic history replays the offending chunk to every future subscriber, causing a deterministic crash loop.

## Fix

Applied defensive path resolution in two cases within `convertMastraChunkToAISDKBase`:

### `finish` case
```ts
// Before
totalUsage: normalizeUsage(chunk.payload.output.usage),

// After
totalUsage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
```

### `step-finish` case
```ts
// Before
const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata;
usage: normalizeUsage(chunk.payload.output.usage),

// After
const { request: _request, providerMetadata, ...rest } = chunk.payload.metadata ?? {};
usage: normalizeUsage(chunk.payload.output?.usage ?? chunk.payload.usage),
```

The `?? {}` guard on `chunk.payload.metadata` in `step-finish` prevents the same class of crash if a synthesized chunk omits metadata entirely.

**Existing behavior is preserved**: for normal model-run chunks, `chunk.payload.output` is defined, so `chunk.payload.output?.usage` resolves as before. The fallback to `chunk.payload.usage` only activates when `output` is absent.

## Files Changed

- `client-sdks/ai-sdk/src/helpers.ts` — Defensive usage path resolution in `finish` and `step-finish` cases of `convertMastraChunkToAISDKBase`

## Verification

The fix can be verified with the minimal converter-level repro from the issue:

```ts
import { convertMastraChunkToAISDKBase } from '@mastra/ai-sdk';

// Previously threw TypeError, now returns a valid finish chunk
const result = convertMastraChunkToAISDKBase({
  chunk: {
    type: 'finish',
    runId: 'r1',
    payload: {
      stepResult: { reason: 'stop' },
      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
    },
  } as any,
  normalizeUsage: (u: any) => u,
  normalizeFinishReason: (r: any) => r,
  normalizeWarnings: (w: any) => w || [],
});

console.log(result);
// { type: 'finish', finishReason: 'stop', totalUsage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 } }
```

End-to-end: deliver a persisted signal on an idle thread with `subscribeToThread` piped through the AI SDK stream conversion — the subscription no longer errors on the synthesized `finish` part.

---

Happy to adjust the approach if maintainers prefer a different strategy (e.g., normalizing the synthesized chunk shape at the producer side in `thread-stream-runtime.ts`). The defensive consumer-side fix was chosen here for minimal blast radius and backwards compatibility with any existing streams that already contain these chunks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some saved stream messages have a slightly different shape than live messages, which could crash the stream. This change teaches the converter to handle both shapes safely so subscribers keep receiving updates.

## Changes

- Resolve usage data from either the nested output or top-level payload for `finish` and `step-finish` chunks.
- Default missing `step-finish` metadata to an empty object.
- Preserve existing behavior for normal model-run chunks while supporting persisted-signal broadcasts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->