### PR TITLE
feat(evals): add context-recall LLM scorer

### DIFF
--- a/.changeset/sunny-windows-care.md
+++ b/.changeset/sunny-windows-care.md
@@ -5,6 +5,7 @@
 Added context-recall LLM scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer. Complements the existing context-precision scorer by measuring retrieval completeness rather than relevance ranking.
 
 ```typescript
+import { openai } from '@ai-sdk/openai'
 import { createContextRecallScorer } from '@mastra/evals/scorers/prebuilt'
 
 const scorer = createContextRecallScorer({

--- a/.changeset/sunny-windows-care.md
+++ b/.changeset/sunny-windows-care.md
@@ -3,3 +3,17 @@
 ---
 
 Added context-recall LLM scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer. Complements the existing context-precision scorer by measuring retrieval completeness rather than relevance ranking.
+
+```typescript
+import { createContextRecallScorer } from '@mastra/evals/scorers/prebuilt'
+
+const scorer = createContextRecallScorer({
+  model: openai('gpt-4o-mini'),
+  options: {
+    context: [
+      'Einstein was born on 14 March 1879 in Ulm, Germany.',
+      'Einstein developed the theory of special relativity in 1905.',
+    ],
+  },
+})
+```

--- a/.changeset/sunny-windows-care.md
+++ b/.changeset/sunny-windows-care.md
@@ -5,11 +5,10 @@
 Added context-recall LLM scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer. Complements the existing context-precision scorer by measuring retrieval completeness rather than relevance ranking.
 
 ```typescript
-import { openai } from '@ai-sdk/openai'
 import { createContextRecallScorer } from '@mastra/evals/scorers/prebuilt'
 
 const scorer = createContextRecallScorer({
-  model: openai('gpt-4o-mini'),
+  model: 'openai/gpt-5-mini',
   options: {
     context: [
       'Einstein was born on 14 March 1879 in Ulm, Germany.',

--- a/.changeset/sunny-windows-care.md
+++ b/.changeset/sunny-windows-care.md
@@ -1,0 +1,5 @@
+---
+'@mastra/evals': minor
+---
+
+Added context-recall LLM scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer. Complements the existing context-precision scorer by measuring retrieval completeness rather than relevance ranking.

--- a/docs/src/content/en/reference/evals/context-recall.mdx
+++ b/docs/src/content/en/reference/evals/context-recall.mdx
@@ -1,0 +1,255 @@
+---
+title: "Reference: Context recall scorer | Evals"
+description: Documentation for the Context Recall Scorer in Mastra. Evaluates how well retrieved context covers the claims in a ground-truth reference answer.
+packages:
+  - "@mastra/core"
+  - "@mastra/evals"
+---
+
+import PropertiesTable from "@site/src/components/PropertiesTable";
+
+# Context recall scorer
+
+The `createContextRecallScorer()` function creates a scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer. It measures retrieval completeness by checking what fraction of the ground truth's claims are attributable to the retrieved context.
+
+This scorer requires a ground-truth reference answer, making it suitable for labeled datasets in CI or test environments.
+
+## RAG retrieval evaluation
+
+Ideal for evaluating retrieval completeness in RAG pipelines where:
+
+- You need to verify the retriever fetches all necessary information
+- You have labeled datasets with known-correct answers
+- You want to catch regressions in what the retriever returns
+
+## Dataset-driven testing
+
+Use when running evaluations against curated test sets:
+
+- CI pipelines with ground-truth labeled questions
+- A/B testing retrieval strategies
+- Benchmarking embedding models for coverage
+
+## Parameters
+
+<PropertiesTable
+  content={[
+  {
+    name: 'model',
+    type: 'MastraModelConfig',
+    description: 'The language model to use for evaluating claim attribution',
+    required: true,
+  },
+  {
+    name: 'options',
+    type: 'ContextRecallMetricOptions',
+    description: 'Configuration options for the scorer',
+    required: true,
+    children: [
+      {
+        name: 'context',
+        type: 'string[]',
+        description: 'Array of retrieved context pieces to check claims against',
+        required: false,
+      },
+      {
+        name: 'contextExtractor',
+        type: '(input, output) => string[]',
+        description: 'Function to dynamically extract context from the run input and output',
+        required: false,
+      },
+      {
+        name: 'scale',
+        type: 'number',
+        description: 'Scale factor to multiply the final score (default: 1)',
+        required: false,
+      },
+    ],
+  },
+]}
+/>
+
+**Note**: Either `context` or `contextExtractor` must be provided. If both are provided, `contextExtractor` takes precedence.
+
+## `.run()` returns
+
+<PropertiesTable
+  content={[
+  {
+    name: 'score',
+    type: 'number',
+    description:
+      'Recall score between 0 and scale (default 0-1), representing the fraction of ground-truth claims covered by the context',
+  },
+  {
+    name: 'reason',
+    type: 'string',
+    description: 'Human-readable explanation of which ground-truth claims were and were not found in the context',
+  },
+]}
+/>
+
+## Scoring details
+
+### Claim attribution
+
+Context Recall uses a two-step LLM evaluation:
+
+1. **Claim extraction**: The ground-truth answer is decomposed into atomic claims
+1. **Attribution check**: Each claim is checked against the retrieval context for support
+1. **Score calculation**: Ratio of attributed claims to total claims, multiplied by scale
+
+### Scoring formula
+
+```
+Context Recall = attributed_claims / total_claims × scale
+
+Where:
+- attributed_claims = number of ground-truth claims supported by the context
+- total_claims = total number of claims extracted from the ground truth
+- Attribution is binary: a claim is either supported (yes) or not (no)
+```
+
+### Score interpretation
+
+- **0.9-1.0**: Excellent recall — context covers nearly all ground-truth claims
+- **0.7-0.8**: Good recall — most claims are covered, minor gaps
+- **0.4-0.6**: Moderate recall — significant information missing from context
+- **0.1-0.3**: Poor recall — most ground-truth claims not found in context
+- **0.0**: No recall — none of the ground-truth claims are in the context
+
+### Reason analysis
+
+The reason field explains:
+
+- Which ground-truth claims were found in the context
+- Which claims were missing and what information gaps exist
+- Specific context pieces that supported attributed claims
+
+### Optimization insights
+
+Use results to:
+
+- **Improve retrieval**: Identify what types of information the retriever misses
+- **Tune chunk size**: Ensure chunks contain enough detail to cover ground-truth claims
+- **Evaluate embeddings**: Test different embedding models for better information coverage
+- **Expand knowledge base**: Add documents that cover frequently missed claims
+
+### Example calculation
+
+Given ground truth: "Einstein was born in 1879. He developed relativity. He won the Nobel Prize."
+
+Claims extracted: 3
+
+- "Einstein was born in 1879" → attributed (context mentions birthdate)
+- "Einstein developed relativity" → attributed (context covers relativity)
+- "Einstein won the Nobel Prize" → not attributed (context doesn't mention Nobel Prize)
+
+Recall = 2/3 = 0.67
+
+## Scorer configuration
+
+### Dynamic context extraction
+
+```typescript
+const scorer = createContextRecallScorer({
+  model: '__GATEWAY_OPENAI_MODEL__',
+  options: {
+    contextExtractor: (input, output) => {
+      const query = input?.inputMessages?.[0]?.content || ''
+      const searchResults = vectorDB.search(query, { limit: 10 })
+      return searchResults.map(result => result.content)
+    },
+    scale: 1,
+  },
+})
+```
+
+### Static context evaluation
+
+```typescript
+const scorer = createContextRecallScorer({
+  model: '__GATEWAY_OPENAI_MODEL__',
+  options: {
+    context: [
+      'Document 1: Einstein was born on 14 March 1879 in Ulm, Germany.',
+      'Document 2: Einstein published the theory of special relativity in 1905.',
+      'Document 3: Einstein moved to the United States in 1933.',
+    ],
+  },
+})
+```
+
+## Example
+
+Evaluate RAG retrieval completeness against a labeled dataset:
+
+```typescript title="src/example-context-recall.ts"
+import { runEvals } from '@mastra/core/evals'
+import { createContextRecallScorer } from '@mastra/evals/scorers/prebuilt'
+import { myAgent } from './agent'
+
+const scorer = createContextRecallScorer({
+  model: '__GATEWAY_OPENAI_MODEL__',
+  options: {
+    contextExtractor: (input, output) => {
+      // Extract context from tool invocation results in the agent output
+      return output
+        .filter(msg => msg?.role === 'assistant')
+        .flatMap(msg => msg?.content?.toolInvocations ?? [])
+        .filter((tool: any) => tool.state === 'result')
+        .map((tool: any) => JSON.stringify(tool.result))
+    },
+  },
+})
+
+const result = await runEvals({
+  data: [
+    {
+      input: 'What are the health benefits of green tea?',
+      groundTruth:
+        'Green tea contains antioxidants that reduce inflammation, L-theanine that improves focus, and catechins that boost metabolism.',
+    },
+    {
+      input: 'How does photosynthesis work?',
+      groundTruth:
+        'Photosynthesis converts sunlight into chemical energy using chlorophyll in chloroplasts, producing glucose and oxygen from carbon dioxide and water.',
+    },
+  ],
+  scorers: [scorer],
+  target: myAgent,
+  onItemComplete: ({ scorerResults }) => {
+    console.log({
+      score: scorerResults[scorer.id].score,
+      reason: scorerResults[scorer.id].reason,
+    })
+  },
+})
+
+console.log(result.scores)
+```
+
+For more details on `runEvals`, see the [runEvals reference](/reference/evals/run-evals).
+
+To add this scorer to an agent, see the [Scorers overview](/docs/evals/overview#adding-scorers-to-agents) guide.
+
+## Comparison with context precision
+
+Choose the right scorer for your needs:
+
+| Use case | Context Recall | Context Precision |
+| - | - | - |
+| **What it measures** | Coverage of ground truth | Relevance of retrieved chunks |
+| **Direction** | Ground truth → context | Context → ground truth |
+| **Position sensitive** | No | Yes (rewards early placement) |
+| **Requires ground truth** | Yes | Yes |
+| **Failure mode caught** | Missing information | Irrelevant noise |
+
+Use both together for a complete picture of retrieval quality: precision catches junk in the context, recall catches gaps.
+
+## Related
+
+- [Context Precision Scorer](/reference/evals/context-precision): Evaluates if retrieved context is relevant and well-ranked
+- [Context Relevance Scorer](/reference/evals/context-relevance): Evaluates context usage and quality
+- [Faithfulness Scorer](/reference/evals/faithfulness): Measures answer groundedness in context
+- [Custom Scorers](/docs/evals/custom-scorers): Creating your own evaluation metrics

--- a/docs/src/content/en/reference/evals/context-recall.mdx
+++ b/docs/src/content/en/reference/evals/context-recall.mdx
@@ -12,7 +12,7 @@ import PropertiesTable from "@site/src/components/PropertiesTable";
 
 The `createContextRecallScorer()` function creates a scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer. It measures retrieval completeness by checking what fraction of the ground truth's claims are attributable to the retrieved context.
 
-This scorer requires a ground-truth reference answer, making it suitable for labeled datasets in CI or test environments.
+This scorer requires a ground-truth reference answer, making it suitable for labeled datasets in CI or test environments. When `groundTruth` is not provided in the run, the scorer returns a score of 0 rather than throwing an error.
 
 ## RAG retrieval evaluation
 
@@ -69,7 +69,7 @@ Use when running evaluations against curated test sets:
 ]}
 />
 
-**Note**: Either `context` or `contextExtractor` must be provided. If both are provided, `contextExtractor` takes precedence.
+**Note**: Either `context` or `contextExtractor` must be provided. When both are provided, `contextExtractor` is used only if the run input and output are agent-shaped (`MastraDBMessage[]`); otherwise the scorer falls back to `context`.
 
 ## `.run()` returns
 
@@ -111,6 +111,8 @@ Where:
 ```
 
 ### Score interpretation
+
+These ranges assume the default `scale` of 1. When using a custom scale, multiply accordingly.
 
 - **0.9-1.0**: Excellent recall — context covers nearly all ground-truth claims
 - **0.7-0.8**: Good recall — most claims are covered, minor gaps

--- a/docs/src/content/en/reference/evals/context-recall.mdx
+++ b/docs/src/content/en/reference/evals/context-recall.mdx
@@ -93,11 +93,12 @@ Use when running evaluations against curated test sets:
 
 ### Claim attribution
 
-Context Recall uses a two-step LLM evaluation:
+Context Recall uses a two-step LLM evaluation followed by a deterministic score calculation:
 
 1. **Claim extraction**: The ground-truth answer is decomposed into atomic claims
 1. **Attribution check**: Each claim is checked against the retrieval context for support
-1. **Score calculation**: Ratio of attributed claims to total claims, multiplied by scale
+
+The score is then calculated as the ratio of attributed claims to total claims, multiplied by scale.
 
 ### Scoring formula
 

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -312,6 +312,7 @@ const sidebars = {
             { type: 'doc', id: 'evals/completeness', label: 'Completeness' },
             { type: 'doc', id: 'evals/content-similarity', label: 'Content Similarity Scorer' },
             { type: 'doc', id: 'evals/context-precision', label: 'Context Precision Scorer' },
+            { type: 'doc', id: 'evals/context-recall', label: 'Context Recall Scorer' },
             { type: 'doc', id: 'evals/context-relevance', label: 'Context Relevance Scorer' },
             { type: 'doc', id: 'evals/faithfulness', label: 'Faithfulness' },
             { type: 'doc', id: 'evals/hallucination', label: 'Hallucination' },

--- a/packages/evals/src/scorers/llm/context-recall/index.test.ts
+++ b/packages/evals/src/scorers/llm/context-recall/index.test.ts
@@ -1,0 +1,259 @@
+import { openai } from '@ai-sdk/openai';
+import { getLLMTestMode } from '@internal/llm-recorder';
+import { setupDummyApiKeys } from '@internal/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { createAgentTestRun, createTestMessage } from '../../utils';
+import { createContextRecallScorer } from './index';
+
+setupDummyApiKeys(getLLMTestMode(), ['openai']);
+
+const mockModel = openai('gpt-4o-mini');
+
+describe('createContextRecallScorer', () => {
+  it('should throw error when no context is provided', () => {
+    expect(() =>
+      createContextRecallScorer({
+        model: mockModel,
+        options: {},
+      }),
+    ).toThrow('Either context or contextExtractor is required for Context Recall scoring');
+  });
+
+  it('should throw error when context array is empty', () => {
+    expect(() =>
+      createContextRecallScorer({
+        model: mockModel,
+        options: { context: [] },
+      }),
+    ).toThrow('Context array cannot be empty if provided');
+  });
+
+  it('should create a scorer with proper configuration', () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: ['Test context 1', 'Test context 2'],
+        scale: 1,
+      },
+    });
+
+    expect(scorer).toBeDefined();
+    expect(scorer.id).toBe('context-recall-scorer');
+    expect(scorer.name).toBe('Context Recall Scorer');
+    expect(scorer.description).toBe(
+      'A scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer',
+    );
+  });
+
+  it('should create scorer with context extractor', () => {
+    const contextExtractor = () => ['Dynamic context 1', 'Dynamic context 2'];
+
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        contextExtractor,
+        scale: 1,
+      },
+    });
+
+    expect(scorer).toBeDefined();
+    expect(scorer.id).toBe('context-recall-scorer');
+    expect(scorer.name).toBe('Context Recall Scorer');
+  });
+
+  it('should handle perfect recall', async () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: [
+          'Albert Einstein was born on 14 March 1879 in Ulm, Germany.',
+          'Einstein developed the theory of relativity.',
+        ],
+        scale: 1,
+      },
+    });
+
+    scorer.run = vi.fn().mockResolvedValue({
+      score: 1.0,
+      reason:
+        'The score is 1.0 because all claims in the ground-truth answer are fully supported by the retrieval context.',
+    });
+
+    const testRun = createAgentTestRun({
+      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
+      output: [
+        createTestMessage({
+          id: '2',
+          role: 'assistant',
+          content: 'Albert Einstein was born in 1879 in Ulm and developed the theory of relativity.',
+        }),
+      ],
+    });
+
+    const runWithGroundTruth = {
+      ...testRun,
+      groundTruth: 'Albert Einstein was born on 14 March 1879 in Ulm, Germany. He developed the theory of relativity.',
+    };
+
+    const result = await scorer.run(runWithGroundTruth);
+
+    expect(result.score).toBe(1.0);
+    expect(result.reason).toContain('The score is 1.0');
+  });
+
+  it('should handle partial recall', async () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: [
+          'Albert Einstein was born on 14 March 1879 in Ulm, Germany.',
+          'Einstein published his theory of special relativity in 1905.',
+        ],
+        scale: 1,
+      },
+    });
+
+    scorer.run = vi.fn().mockResolvedValue({
+      score: 0.67,
+      reason:
+        'The score is 0.67 because 2 out of 3 ground-truth claims are supported. The claim about the Nobel Prize is not in the context.',
+    });
+
+    const testRun = createAgentTestRun({
+      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
+      output: [
+        createTestMessage({
+          id: '2',
+          role: 'assistant',
+          content: 'Einstein was born in 1879 and developed special relativity.',
+        }),
+      ],
+    });
+
+    const runWithGroundTruth = {
+      ...testRun,
+      groundTruth:
+        'Albert Einstein was born on 14 March 1879 in Ulm. He developed the theory of relativity. He won the Nobel Prize in 1921.',
+    };
+
+    const result = await scorer.run(runWithGroundTruth);
+
+    expect(result.score).toBeCloseTo(0.67, 2);
+    expect(result.reason).toContain('The score is');
+  });
+
+  it('should handle no recall', async () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: ['The weather is sunny today.', 'Cats are popular pets.'],
+        scale: 1,
+      },
+    });
+
+    scorer.run = vi.fn().mockResolvedValue({
+      score: 0,
+      reason: 'The score is 0 because none of the ground-truth claims could be attributed to the retrieval context.',
+    });
+
+    const testRun = createAgentTestRun({
+      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
+      output: [
+        createTestMessage({
+          id: '2',
+          role: 'assistant',
+          content: 'I could not find relevant information about Einstein.',
+        }),
+      ],
+    });
+
+    const runWithGroundTruth = {
+      ...testRun,
+      groundTruth: 'Albert Einstein was born in 1879 and developed the theory of relativity.',
+    };
+
+    const result = await scorer.run(runWithGroundTruth);
+
+    expect(result.score).toBe(0);
+    expect(result.reason).toContain('The score is 0');
+  });
+
+  it('should respect custom scale', async () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: ['Einstein was born in 1879.', 'Einstein developed relativity.'],
+        scale: 10,
+      },
+    });
+
+    scorer.run = vi.fn().mockResolvedValue({
+      score: 10.0,
+      reason: 'The score is 10.0 because all ground-truth claims are fully covered (perfect recall with scale 10).',
+    });
+
+    const testRun = createAgentTestRun({
+      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
+      output: [createTestMessage({ id: '2', role: 'assistant', content: 'Einstein was born in 1879.' })],
+    });
+
+    const runWithGroundTruth = {
+      ...testRun,
+      groundTruth: 'Albert Einstein was born in 1879. He developed the theory of relativity.',
+    };
+
+    const result = await scorer.run(runWithGroundTruth);
+
+    expect(result.score).toBe(10.0);
+  });
+
+  it('should handle missing ground truth', async () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: ['Some context here.'],
+        scale: 1,
+      },
+    });
+
+    scorer.run = vi.fn().mockResolvedValue({
+      score: 0,
+      reason: 'No ground truth was provided for evaluation.',
+    });
+
+    const testRun = createAgentTestRun({
+      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Test query' })],
+      output: [createTestMessage({ id: '2', role: 'assistant', content: 'Test response' })],
+    });
+
+    const result = await scorer.run(testRun);
+
+    expect(result.score).toBe(0);
+  });
+
+  it('should handle empty analyze results', async () => {
+    const scorer = createContextRecallScorer({
+      model: mockModel,
+      options: {
+        context: ['Test context'],
+        scale: 1,
+      },
+    });
+
+    scorer.run = vi.fn().mockResolvedValue({
+      score: 0,
+      reason: 'No claims could be extracted from the ground truth.',
+    });
+
+    const testRun = createAgentTestRun({
+      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Test query' })],
+      output: [createTestMessage({ id: '2', role: 'assistant', content: 'Test response' })],
+    });
+
+    const runWithGroundTruth = { ...testRun, groundTruth: '' };
+
+    const result = await scorer.run(runWithGroundTruth);
+
+    expect(result.score).toBe(0);
+  });
+});

--- a/packages/evals/src/scorers/llm/context-recall/index.test.ts
+++ b/packages/evals/src/scorers/llm/context-recall/index.test.ts
@@ -1,259 +1,290 @@
-import { openai } from '@ai-sdk/openai';
-import { getLLMTestMode } from '@internal/llm-recorder';
-import { setupDummyApiKeys } from '@internal/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { describe, expect, it } from 'vitest';
 import { createAgentTestRun, createTestMessage } from '../../utils';
 import { createContextRecallScorer } from './index';
 
-setupDummyApiKeys(getLLMTestMode(), ['openai']);
+/**
+ * Build a mock model that returns predetermined JSON for each pipeline step.
+ * The scorer pipeline calls the model three times (preprocess, analyze, reason).
+ * Internally, each call first attempts streaming, then falls back to doGenerate
+ * when structured output parsing fails on the stream. We provide enough responses
+ * in both doStream and doGenerate arrays to handle this retry pattern.
+ */
+function mockJudge(responses: {
+  claims?: string[];
+  verdicts?: { verdict: string; reason: string }[];
+  reason?: string;
+}) {
+  const preprocessJson = JSON.stringify({ claims: responses.claims ?? [] });
+  const analyzeJson = JSON.stringify({ verdicts: responses.verdicts ?? [] });
+  const reasonText = responses.reason ?? 'No reason provided.';
+  const jsons = [preprocessJson, analyzeJson, reasonText];
 
-const mockModel = openai('gpt-4o-mini');
+  function makeGenerateResult(text: string) {
+    return {
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      finishReason: 'stop' as const,
+      usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+      content: [{ type: 'text' as const, text }],
+      warnings: [] as never[],
+    };
+  }
+
+  function makeStreamResult(text: string) {
+    return {
+      rawCall: { rawPrompt: null, rawSettings: {} },
+      warnings: [] as never[],
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start' as const, warnings: [] as never[] },
+        {
+          type: 'response-metadata' as const,
+          id: 'id-0',
+          modelId: 'mock-model-id',
+          timestamp: new Date(0),
+        },
+        { type: 'text-start' as const, id: 'text-1' },
+        { type: 'text-delta' as const, id: 'text-1', delta: text },
+        { type: 'text-end' as const, id: 'text-1' },
+        {
+          type: 'finish' as const,
+          finishReason: 'stop' as const,
+          usage: { inputTokens: 10, outputTokens: 20, totalTokens: 30 },
+        },
+      ]),
+    };
+  }
+
+  // Provide plenty of responses for both paths — the pipeline may try
+  // stream then fall back to generate for each step, consuming entries
+  // from both arrays in unpredictable order. Over-provision to be safe.
+  const allGenerate = jsons.flatMap(j => [makeGenerateResult(j), makeGenerateResult(j), makeGenerateResult(j)]);
+  const allStream = jsons.flatMap(j => [makeStreamResult(j), makeStreamResult(j), makeStreamResult(j)]);
+
+  return new MockLanguageModelV2({
+    doGenerate: allGenerate,
+    doStream: allStream,
+  });
+}
+
+function run(content: string) {
+  return createAgentTestRun({
+    inputMessages: [createTestMessage({ id: 'u1', role: 'user', content: 'Test query' })],
+    output: [createTestMessage({ id: 'a1', role: 'assistant', content })],
+  });
+}
 
 describe('createContextRecallScorer', () => {
-  it('should throw error when no context is provided', () => {
-    expect(() =>
-      createContextRecallScorer({
-        model: mockModel,
-        options: {},
-      }),
-    ).toThrow('Either context or contextExtractor is required for Context Recall scoring');
-  });
-
-  it('should throw error when context array is empty', () => {
-    expect(() =>
-      createContextRecallScorer({
-        model: mockModel,
-        options: { context: [] },
-      }),
-    ).toThrow('Context array cannot be empty if provided');
-  });
-
-  it('should create a scorer with proper configuration', () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: ['Test context 1', 'Test context 2'],
-        scale: 1,
-      },
-    });
-
-    expect(scorer).toBeDefined();
-    expect(scorer.id).toBe('context-recall-scorer');
-    expect(scorer.name).toBe('Context Recall Scorer');
-    expect(scorer.description).toBe(
-      'A scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer',
-    );
-  });
-
-  it('should create scorer with context extractor', () => {
-    const contextExtractor = () => ['Dynamic context 1', 'Dynamic context 2'];
-
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        contextExtractor,
-        scale: 1,
-      },
-    });
-
-    expect(scorer).toBeDefined();
-    expect(scorer.id).toBe('context-recall-scorer');
-    expect(scorer.name).toBe('Context Recall Scorer');
-  });
-
-  it('should handle perfect recall', async () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: [
-          'Albert Einstein was born on 14 March 1879 in Ulm, Germany.',
-          'Einstein developed the theory of relativity.',
-        ],
-        scale: 1,
-      },
-    });
-
-    scorer.run = vi.fn().mockResolvedValue({
-      score: 1.0,
-      reason:
-        'The score is 1.0 because all claims in the ground-truth answer are fully supported by the retrieval context.',
-    });
-
-    const testRun = createAgentTestRun({
-      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
-      output: [
-        createTestMessage({
-          id: '2',
-          role: 'assistant',
-          content: 'Albert Einstein was born in 1879 in Ulm and developed the theory of relativity.',
+  describe('configuration', () => {
+    it('should throw error when no context is provided', () => {
+      expect(() =>
+        createContextRecallScorer({
+          model: mockJudge({}),
+          options: {},
         }),
-      ],
+      ).toThrow('Either context or contextExtractor is required for Context Recall scoring');
     });
 
-    const runWithGroundTruth = {
-      ...testRun,
-      groundTruth: 'Albert Einstein was born on 14 March 1879 in Ulm, Germany. He developed the theory of relativity.',
-    };
-
-    const result = await scorer.run(runWithGroundTruth);
-
-    expect(result.score).toBe(1.0);
-    expect(result.reason).toContain('The score is 1.0');
-  });
-
-  it('should handle partial recall', async () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: [
-          'Albert Einstein was born on 14 March 1879 in Ulm, Germany.',
-          'Einstein published his theory of special relativity in 1905.',
-        ],
-        scale: 1,
-      },
-    });
-
-    scorer.run = vi.fn().mockResolvedValue({
-      score: 0.67,
-      reason:
-        'The score is 0.67 because 2 out of 3 ground-truth claims are supported. The claim about the Nobel Prize is not in the context.',
-    });
-
-    const testRun = createAgentTestRun({
-      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
-      output: [
-        createTestMessage({
-          id: '2',
-          role: 'assistant',
-          content: 'Einstein was born in 1879 and developed special relativity.',
+    it('should throw error when context array is empty', () => {
+      expect(() =>
+        createContextRecallScorer({
+          model: mockJudge({}),
+          options: { context: [] },
         }),
-      ],
+      ).toThrow('Context array cannot be empty if provided');
     });
 
-    const runWithGroundTruth = {
-      ...testRun,
-      groundTruth:
-        'Albert Einstein was born on 14 March 1879 in Ulm. He developed the theory of relativity. He won the Nobel Prize in 1921.',
-    };
+    it('should create a scorer with proper configuration', () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({}),
+        options: {
+          context: ['Test context 1', 'Test context 2'],
+          scale: 1,
+        },
+      });
 
-    const result = await scorer.run(runWithGroundTruth);
+      expect(scorer).toBeDefined();
+      expect(scorer.id).toBe('context-recall-scorer');
+      expect(scorer.name).toBe('Context Recall Scorer');
+      expect(scorer.description).toBe(
+        'A scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer',
+      );
+    });
 
-    expect(result.score).toBeCloseTo(0.67, 2);
-    expect(result.reason).toContain('The score is');
+    it('should create scorer with context extractor', () => {
+      const contextExtractor = () => ['Dynamic context 1', 'Dynamic context 2'];
+
+      const scorer = createContextRecallScorer({
+        model: mockJudge({}),
+        options: {
+          contextExtractor,
+          scale: 1,
+        },
+      });
+
+      expect(scorer).toBeDefined();
+      expect(scorer.id).toBe('context-recall-scorer');
+    });
   });
 
-  it('should handle no recall', async () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: ['The weather is sunny today.', 'Cats are popular pets.'],
-        scale: 1,
-      },
-    });
-
-    scorer.run = vi.fn().mockResolvedValue({
-      score: 0,
-      reason: 'The score is 0 because none of the ground-truth claims could be attributed to the retrieval context.',
-    });
-
-    const testRun = createAgentTestRun({
-      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
-      output: [
-        createTestMessage({
-          id: '2',
-          role: 'assistant',
-          content: 'I could not find relevant information about Einstein.',
+  describe('scoring pipeline', () => {
+    it('scores 1 when all ground-truth claims are attributed', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({
+          claims: ['Einstein was born in 1879', 'Einstein developed relativity'],
+          verdicts: [
+            { verdict: 'yes', reason: 'Context mentions birthdate' },
+            { verdict: 'yes', reason: 'Context covers relativity' },
+          ],
+          reason: 'The score is 1 because all claims are covered.',
         }),
-      ],
+        options: {
+          context: ['Einstein was born on 14 March 1879.', 'Einstein developed relativity.'],
+        },
+      });
+
+      const result = await scorer.run({
+        ...run('Einstein was a physicist.'),
+        groundTruth: 'Einstein was born in 1879. He developed relativity.',
+      });
+
+      expect(result.score).toBe(1);
     });
 
-    const runWithGroundTruth = {
-      ...testRun,
-      groundTruth: 'Albert Einstein was born in 1879 and developed the theory of relativity.',
-    };
+    it('scores the correct ratio for partial recall', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({
+          claims: ['Einstein was born in 1879', 'Einstein developed relativity', 'Einstein won the Nobel Prize'],
+          verdicts: [
+            { verdict: 'yes', reason: 'Birthdate found' },
+            { verdict: 'yes', reason: 'Relativity found' },
+            { verdict: 'no', reason: 'Nobel Prize not mentioned' },
+          ],
+          reason: '2 of 3 claims covered.',
+        }),
+        options: {
+          context: ['Einstein was born in 1879.', 'Einstein developed relativity.'],
+        },
+      });
 
-    const result = await scorer.run(runWithGroundTruth);
+      const result = await scorer.run({
+        ...run('Einstein was a physicist.'),
+        groundTruth: 'Einstein was born in 1879. He developed relativity. He won the Nobel Prize.',
+      });
 
-    expect(result.score).toBe(0);
-    expect(result.reason).toContain('The score is 0');
-  });
-
-  it('should respect custom scale', async () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: ['Einstein was born in 1879.', 'Einstein developed relativity.'],
-        scale: 10,
-      },
+      expect(result.score).toBeCloseTo(0.67, 2);
     });
 
-    scorer.run = vi.fn().mockResolvedValue({
-      score: 10.0,
-      reason: 'The score is 10.0 because all ground-truth claims are fully covered (perfect recall with scale 10).',
+    it('scores 0 when no claims are attributed', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({
+          claims: ['Einstein was born in 1879', 'Einstein developed relativity'],
+          verdicts: [
+            { verdict: 'no', reason: 'Not in context' },
+            { verdict: 'no', reason: 'Not in context' },
+          ],
+          reason: 'No claims covered.',
+        }),
+        options: {
+          context: ['The weather is sunny today.'],
+        },
+      });
+
+      const result = await scorer.run({
+        ...run('No relevant info.'),
+        groundTruth: 'Einstein was born in 1879. He developed relativity.',
+      });
+
+      expect(result.score).toBe(0);
     });
 
-    const testRun = createAgentTestRun({
-      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Tell me about Einstein.' })],
-      output: [createTestMessage({ id: '2', role: 'assistant', content: 'Einstein was born in 1879.' })],
+    it('applies custom scale to the score', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({
+          claims: ['Paris is the capital', 'Eiffel Tower is in Paris'],
+          verdicts: [
+            { verdict: 'yes', reason: 'Found' },
+            { verdict: 'yes', reason: 'Found' },
+          ],
+          reason: 'Perfect recall.',
+        }),
+        options: {
+          context: ['Paris is the capital of France.', 'The Eiffel Tower is in Paris.'],
+          scale: 10,
+        },
+      });
+
+      const result = await scorer.run({
+        ...run('Paris is great.'),
+        groundTruth: 'Paris is the capital. The Eiffel Tower is in Paris.',
+      });
+
+      expect(result.score).toBe(10);
     });
 
-    const runWithGroundTruth = {
-      ...testRun,
-      groundTruth: 'Albert Einstein was born in 1879. He developed the theory of relativity.',
-    };
+    it('clamps score when judge returns extra verdicts', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({
+          claims: ['Claim A', 'Claim B'],
+          verdicts: [
+            { verdict: 'yes', reason: 'Found' },
+            { verdict: 'yes', reason: 'Found' },
+            { verdict: 'yes', reason: 'Extra verdict' },
+          ],
+          reason: 'All covered.',
+        }),
+        options: { context: ['Some context.'] },
+      });
 
-    const result = await scorer.run(runWithGroundTruth);
+      const result = await scorer.run({
+        ...run('Response.'),
+        groundTruth: 'Claim A. Claim B.',
+      });
 
-    expect(result.score).toBe(10.0);
-  });
-
-  it('should handle missing ground truth', async () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: ['Some context here.'],
-        scale: 1,
-      },
+      expect(result.score).toBe(1);
     });
 
-    scorer.run = vi.fn().mockResolvedValue({
-      score: 0,
-      reason: 'No ground truth was provided for evaluation.',
+    it('returns 0 when ground truth is missing', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({ claims: [], verdicts: [], reason: 'No ground truth.' }),
+        options: { context: ['Some context.'] },
+      });
+
+      const result = await scorer.run(run('Response.'));
+
+      expect(result.score).toBe(0);
     });
 
-    const testRun = createAgentTestRun({
-      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Test query' })],
-      output: [createTestMessage({ id: '2', role: 'assistant', content: 'Test response' })],
+    it('returns 0 when no claims are extracted', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({ claims: [], verdicts: [], reason: 'No claims extracted.' }),
+        options: { context: ['Some context.'] },
+      });
+
+      const result = await scorer.run({
+        ...run('Response.'),
+        groundTruth: 'Some ground truth text.',
+      });
+
+      expect(result.score).toBe(0);
     });
 
-    const result = await scorer.run(testRun);
+    it('handles fewer verdicts than claims conservatively', async () => {
+      const scorer = createContextRecallScorer({
+        model: mockJudge({
+          claims: ['Claim A', 'Claim B', 'Claim C'],
+          verdicts: [{ verdict: 'yes', reason: 'Found' }],
+          reason: 'Partial evaluation.',
+        }),
+        options: { context: ['Context.'] },
+      });
 
-    expect(result.score).toBe(0);
-  });
+      const result = await scorer.run({
+        ...run('Response.'),
+        groundTruth: 'Claim A. Claim B. Claim C.',
+      });
 
-  it('should handle empty analyze results', async () => {
-    const scorer = createContextRecallScorer({
-      model: mockModel,
-      options: {
-        context: ['Test context'],
-        scale: 1,
-      },
+      // 1 yes out of 3 claims = 0.33
+      expect(result.score).toBeCloseTo(0.33, 2);
     });
-
-    scorer.run = vi.fn().mockResolvedValue({
-      score: 0,
-      reason: 'No claims could be extracted from the ground truth.',
-    });
-
-    const testRun = createAgentTestRun({
-      inputMessages: [createTestMessage({ id: '1', role: 'user', content: 'Test query' })],
-      output: [createTestMessage({ id: '2', role: 'assistant', content: 'Test response' })],
-    });
-
-    const runWithGroundTruth = { ...testRun, groundTruth: '' };
-
-    const result = await scorer.run(runWithGroundTruth);
-
-    expect(result.score).toBe(0);
   });
 });

--- a/packages/evals/src/scorers/llm/context-recall/index.ts
+++ b/packages/evals/src/scorers/llm/context-recall/index.ts
@@ -104,13 +104,13 @@ export function createContextRecallScorer({
         return 0;
       }
 
-      const verdicts = results.analyzeStepResult?.verdicts || [];
-      const totalClaims = verdicts.length;
+      const totalClaims = results.preprocessStepResult?.claims?.length ?? 0;
 
       if (totalClaims === 0) {
         return 0;
       }
 
+      const verdicts = results.analyzeStepResult?.verdicts || [];
       const attributedClaims = verdicts.filter(v => v.verdict.toLowerCase().trim() === 'yes').length;
       const score = (attributedClaims / totalClaims) * (options.scale || 1);
 

--- a/packages/evals/src/scorers/llm/context-recall/index.ts
+++ b/packages/evals/src/scorers/llm/context-recall/index.ts
@@ -1,0 +1,142 @@
+import { compileSchema } from '@internal/types-builder/compile-zod';
+import { createScorer } from '@mastra/core/evals';
+import type { ScorerRunInputForAgent, ScorerRunOutputForAgent } from '@mastra/core/evals';
+import type { MastraModelConfig } from '@mastra/core/llm';
+import { z } from 'zod/v4';
+import { roundToTwoDecimals, isScorerRunInputForAgent, isScorerRunOutputForAgent } from '../../utils';
+import type { ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge } from '../../utils';
+import {
+  createClaimExtractionPrompt,
+  createClaimAttributionPrompt,
+  createContextRecallReasonPrompt,
+  CONTEXT_RECALL_AGENT_INSTRUCTIONS,
+} from './prompts';
+
+export interface ContextRecallMetricOptions {
+  scale?: number;
+  context?: string[];
+  contextExtractor?: (input: ScorerRunInputForAgent, output: ScorerRunOutputForAgent) => string[];
+}
+
+const claimExtractionOutputSchema = compileSchema(
+  z.object({
+    claims: z.array(z.string()),
+  }),
+);
+
+const claimAttributionOutputSchema = compileSchema(
+  z.object({
+    verdicts: z.array(
+      z.object({
+        verdict: z.string(),
+        reason: z.string(),
+      }),
+    ),
+  }),
+);
+
+const getContext = ({
+  input,
+  output,
+  options,
+}: {
+  input?: ScorerRunInputForLLMJudge;
+  output: ScorerRunOutputForLLMJudge;
+  options: ContextRecallMetricOptions;
+}) => {
+  if (options.contextExtractor && isScorerRunInputForAgent(input) && isScorerRunOutputForAgent(output)) {
+    return options.contextExtractor(input, output);
+  }
+
+  return options.context ?? [];
+};
+
+export function createContextRecallScorer({
+  model,
+  options,
+}: {
+  model: MastraModelConfig;
+  options: ContextRecallMetricOptions;
+}) {
+  if (!options.context && !options.contextExtractor) {
+    throw new Error('Either context or contextExtractor is required for Context Recall scoring');
+  }
+  if (options.context && options.context.length === 0) {
+    throw new Error('Context array cannot be empty if provided');
+  }
+
+  return createScorer<ScorerRunInputForLLMJudge, ScorerRunOutputForLLMJudge>({
+    id: 'context-recall-scorer',
+    name: 'Context Recall Scorer',
+    description:
+      'A scorer that evaluates how well retrieved context covers the claims in a ground-truth reference answer',
+    judge: {
+      model,
+      instructions: CONTEXT_RECALL_AGENT_INSTRUCTIONS,
+    },
+    type: 'agent',
+  })
+    .preprocess({
+      description: 'Extract atomic claims from the ground-truth answer',
+      outputSchema: claimExtractionOutputSchema,
+      createPrompt: ({ run }) => {
+        if (!run.groundTruth) {
+          return createClaimExtractionPrompt({ groundTruth: '' });
+        }
+
+        const groundTruth = typeof run.groundTruth === 'string' ? run.groundTruth : JSON.stringify(run.groundTruth);
+        return createClaimExtractionPrompt({ groundTruth });
+      },
+    })
+    .analyze({
+      description: 'Check if each ground-truth claim is attributable to the retrieval context',
+      outputSchema: claimAttributionOutputSchema,
+      createPrompt: ({ results, run }) => {
+        const context = getContext({ input: run.input, output: run.output, options });
+        return createClaimAttributionPrompt({
+          claims: results.preprocessStepResult?.claims || [],
+          context,
+        });
+      },
+    })
+    .generateScore(({ results, run }) => {
+      if (!run.groundTruth) {
+        return 0;
+      }
+
+      const verdicts = results.analyzeStepResult?.verdicts || [];
+      const totalClaims = verdicts.length;
+
+      if (totalClaims === 0) {
+        return 0;
+      }
+
+      const attributedClaims = verdicts.filter(v => v.verdict.toLowerCase().trim() === 'yes').length;
+      const score = (attributedClaims / totalClaims) * (options.scale || 1);
+
+      return roundToTwoDecimals(score);
+    })
+    .generateReason({
+      description: 'Explain the context recall evaluation results',
+      createPrompt: ({ run, results, score }) => {
+        const groundTruth = run.groundTruth
+          ? typeof run.groundTruth === 'string'
+            ? run.groundTruth
+            : JSON.stringify(run.groundTruth)
+          : '';
+
+        const context = getContext({ input: run.input, output: run.output, options });
+
+        return createContextRecallReasonPrompt({
+          groundTruth,
+          context,
+          score,
+          scale: options.scale || 1,
+          verdicts: (results.analyzeStepResult?.verdicts || []) as {
+            verdict: string;
+            reason: string;
+          }[],
+        });
+      },
+    });
+}

--- a/packages/evals/src/scorers/llm/context-recall/index.ts
+++ b/packages/evals/src/scorers/llm/context-recall/index.ts
@@ -112,7 +112,7 @@ export function createContextRecallScorer({
 
       const verdicts = results.analyzeStepResult?.verdicts || [];
       const attributedClaims = verdicts.filter(v => v.verdict.toLowerCase().trim() === 'yes').length;
-      const score = (attributedClaims / totalClaims) * (options.scale || 1);
+      const score = Math.min(1, attributedClaims / totalClaims) * (options.scale || 1);
 
       return roundToTwoDecimals(score);
     })

--- a/packages/evals/src/scorers/llm/context-recall/prompts.ts
+++ b/packages/evals/src/scorers/llm/context-recall/prompts.ts
@@ -1,0 +1,147 @@
+export const CONTEXT_RECALL_AGENT_INSTRUCTIONS = `You are a precise context recall evaluator. Your job is to determine if the retrieved context contains enough information to support all the claims in a ground-truth reference answer.
+
+Key Principles:
+1. First extract all atomic claims/sentences from the ground-truth answer
+2. Then verify each claim against the provided retrieval context
+3. A claim is attributable if any part of the retrieval context directly supports it
+4. A claim is not attributable if no part of the retrieval context mentions or implies it
+5. Focus on information coverage, not exact wording
+6. Be strict in attribution - the context must actually contain supporting information
+7. Never use prior knowledge in judgments - only use the provided context`;
+
+export function createClaimExtractionPrompt({ groundTruth }: { groundTruth: string }) {
+  return `Extract all atomic claims from the given ground-truth answer. A claim is any single statement that asserts one piece of information.
+
+Guidelines for claim extraction:
+- Break down compound statements into individual claims
+- Each claim should be self-contained and verifiable independently
+- Include all factual assertions, including numbers, dates, and quantities
+- Keep relationships between entities intact within each claim
+- Exclude questions, commands, and purely stylistic text
+- Preserve the original meaning without adding interpretation
+
+Example:
+Text: "Albert Einstein was born on 14 March 1879 in Ulm, Germany. He developed the theory of relativity and won the Nobel Prize in Physics in 1921."
+
+{
+    "claims": [
+        "Albert Einstein was born on 14 March 1879",
+        "Albert Einstein was born in Ulm, Germany",
+        "Albert Einstein developed the theory of relativity",
+        "Albert Einstein won the Nobel Prize in Physics",
+        "Albert Einstein won the Nobel Prize in 1921"
+    ]
+}
+
+Please return only JSON format with "claims" array.
+Return empty list for empty input.
+
+Ground-Truth Answer:
+${groundTruth}
+
+JSON:
+`;
+}
+
+export function createClaimAttributionPrompt({ claims, context }: { claims: string[]; context: string[] }) {
+  return `Determine if each claim from the ground-truth answer can be attributed to the provided retrieval context. A claim is attributable if any part of the context directly supports or contains the information in that claim.
+
+Retrieval Context:
+${context.map((ctx, index) => `[${index}] ${ctx}`).join('\n')}
+
+Number of claims: ${claims.length}
+
+Claims to verify:
+${claims.map((claim, index) => `[${index}] ${claim}`).join('\n')}
+
+For each claim, provide a verdict and reasoning. The verdict must be one of:
+- "yes" if the claim can be attributed to information in the retrieval context
+- "no" if the claim cannot be attributed to any part of the retrieval context
+
+The number of verdicts MUST MATCH the number of claims exactly.
+
+Format:
+{
+    "verdicts": [
+        {
+            "verdict": "yes/no",
+            "reason": "explanation of why this claim is or isn't attributable to the context"
+        }
+    ]
+}
+
+Rules:
+- Only use information from the provided retrieval context
+- Mark claims as "yes" if the context contains supporting information, even if the wording differs
+- Mark claims as "no" if the context does not mention or imply the information
+- Never use prior knowledge in your judgment
+- Provide clear reasoning that references specific context pieces
+
+Example:
+Context:
+[0] "Albert Einstein was born on 14 March 1879 in Ulm, Germany."
+[1] "Einstein published his theory of special relativity in 1905."
+
+Claims:
+[0] "Albert Einstein was born on 14 March 1879"
+[1] "Albert Einstein won the Nobel Prize in 1921"
+
+{
+    "verdicts": [
+        {
+            "verdict": "yes",
+            "reason": "Context node [0] explicitly states Einstein was born on 14 March 1879"
+        },
+        {
+            "verdict": "no",
+            "reason": "No part of the retrieval context mentions Einstein winning the Nobel Prize"
+        }
+    ]
+}`;
+}
+
+export function createContextRecallReasonPrompt({
+  groundTruth,
+  context,
+  score,
+  scale,
+  verdicts,
+}: {
+  groundTruth: string;
+  context: string[];
+  score: number;
+  scale: number;
+  verdicts: { verdict: string; reason: string }[];
+}) {
+  return `Explain the context recall score for the retrieval context based on how well it covers the claims in the ground-truth answer.
+
+Ground-Truth Answer:
+${groundTruth}
+
+Retrieval Context:
+${context.map((ctx, index) => `[${index}] ${ctx}`).join('\n')}
+
+Score: ${score} out of ${scale}
+Verdicts:
+${JSON.stringify(verdicts, null, 2)}
+
+Context Recall measures what fraction of the ground-truth answer's claims are supported by the retrieved context. The score is calculated as:
+- Extract all claims from the ground-truth answer
+- Check each claim against the retrieval context
+- Score = (attributed claims / total claims) × scale
+
+Rules for explanation:
+- Explain which claims were and were not found in the context
+- Mention specific context pieces that supported attributed claims
+- Highlight what information was missing for unattributed claims
+- Keep explanation concise and focused on coverage gaps
+- Use the given score, don't recalculate
+
+Format:
+"The score is ${score} because {explanation of context recall}"
+
+Example responses:
+"The score is 0.67 because 2 out of 3 ground-truth claims are supported by the retrieval context. The claims about Einstein's birthdate and birthplace are covered by context node [0], but the claim about the Nobel Prize is not mentioned in any context node."
+"The score is 1.0 because all claims in the ground-truth answer are fully supported by the retrieval context."
+"The score is 0.0 because none of the ground-truth claims could be attributed to the retrieval context."`;
+}

--- a/packages/evals/src/scorers/llm/index.ts
+++ b/packages/evals/src/scorers/llm/index.ts
@@ -7,6 +7,7 @@ export * from './toxicity';
 export * from './tool-call-accuracy';
 export * from './context-relevance';
 export * from './context-precision';
+export * from './context-recall';
 export * from './noise-sensitivity';
 export * from './prompt-alignment';
 export * from './rubric';


### PR DESCRIPTION
## Description

Add a context-recall LLM-as-judge scorer to `@mastra/evals` that evaluates how well retrieved context covers the claims in a ground-truth reference answer. This complements the existing context-precision scorer by measuring retrieval completeness rather than relevance ranking.

- Add `createContextRecallScorer` factory under `packages/evals/src/scorers/llm/context-recall/` with a `preprocess → analyze → generateScore → generateReason` pipeline
- Preprocess step extracts atomic claims from `run.groundTruth`, analyze step checks each claim against context chunks with binary (yes/no) attribution
- Score formula: `attributed_claims / total_claims × scale` (no position sensitivity, unlike precision's MAP)
- Supports `context` and `contextExtractor` options matching the context-precision option shape
- Add reference documentation and sidebar entry
- Add unit tests covering validation, perfect/partial/zero recall, custom scale, missing ground truth, and empty results

## Related Issue(s)

Fixes #19731

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR adds a new “context recall” checker to `@mastra/evals` that looks at a question’s ground-truth answer and asks: “Did the retrieved text include the important facts?” It scores how completely the retrieved context covers those facts so you can catch retrieval regressions.

## Summary
- Added `createContextRecallScorer` to `packages/evals/src/scorers/llm/context-recall/` and exported it via `packages/evals/src/scorers/llm/index.ts`.
- Implements an LLM-judge pipeline: **`preprocess → analyze → generateScore → generateReason`**:
  - **Preprocess**: extracts atomic **`claims`** from `run.groundTruth` (string or JSON-stringified); safely handles missing/empty ground truth.
  - **Analyze**: checks each claim against retrieved context with **binary attribution** (a **`verdict`** array with `yes/no` per claim).
    - Context comes from `options.context` or `options.contextExtractor` (when the run input/output are agent-shaped; otherwise it falls back to `options.context`).
  - **Score**: `min(1, attributedClaims/totalClaims) * scale` (default `scale=1`), rounded to 2 decimals; returns **`0`** when `groundTruth` is missing or when no claims are extracted.
  - **Reason**: explains the result using ground truth, selected context, the computed score/scale, and per-claim verdicts/reasons.
- Added `ContextRecallMetricOptions` (`context?: string[]`, `contextExtractor?: (input, output) => string[]`, `scale?: number`) with validation that **either non-empty `context` or a `contextExtractor`** must be provided.
- Added new prompts in `packages/evals/src/scorers/llm/context-recall/prompts.ts` for claim extraction, claim attribution, and reason generation.
- Added reference docs and navigation:
  - `docs/src/content/en/reference/evals/context-recall.mdx`
  - Sidebar entry in `docs/src/content/en/reference/sidebars.js`
- Added a Changesets entry bumping `@mastra/evals` and documenting the new built-in **`context-recall`** scorer.
- Updated/added unit tests in `packages/evals/src/scorers/llm/context-recall/index.test.ts` to run the real pipeline using `MockLanguageModelV2`, covering:
  - invalid configuration (missing context/contextExtractor, empty context)
  - perfect/partial/zero recall scoring
  - custom `scale`
  - clamping behavior and edge cases around verdict/claim counts
  - missing ground truth and cases where no claims are extracted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->