### PR TITLE
fix(cli): write the api key to .env without a shell

### DIFF
--- a/.changeset/true-months-sing.md
+++ b/.changeset/true-months-sing.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed `create-mastra` writing a corrupted API key to `.env` on Windows. The key was appended with a shell `echo`, so `cmd.exe` left a stray backslash before every `=` and a trailing space on the value. Keys containing `=`, including base64-padded Google and Azure credentials, were written unusable and the scaffolded project failed to authenticate with no warning from the CLI.

--- a/.changeset/true-months-sing.md
+++ b/.changeset/true-months-sing.md
@@ -2,4 +2,4 @@
 'mastra': patch
 ---
 
-Fixed `create-mastra` writing a corrupted API key to `.env` on Windows. The key was appended with a shell `echo`, so `cmd.exe` left a stray backslash before every `=` and a trailing space on the value. Keys containing `=`, including base64-padded Google and Azure credentials, were written unusable and the scaffolded project failed to authenticate with no warning from the CLI.
+Fixed `mastra init` writing a corrupted API key to `.env` on Windows. The key was appended with a shell `echo`, so `cmd.exe` left a stray backslash before every `=` and a trailing space on the value. Keys containing `=`, including base64-padded Google and Azure credentials, were written unusable, and the project failed to authenticate with no warning from the CLI.

--- a/packages/cli/src/commands/init/utils.test.ts
+++ b/packages/cli/src/commands/init/utils.test.ts
@@ -28,7 +28,8 @@ vi.mock('../auth/orgs.js', () => ({
   resolveCurrentOrg: vi.fn(),
 }));
 
-const { getAPIKey, promptForObservability, writeObservabilityEnv, writeIndexFile } = await import('./utils');
+const { getAPIKey, promptForObservability, writeAPIKey, writeObservabilityEnv, writeIndexFile } =
+  await import('./utils');
 const prompts = await import('@clack/prompts');
 const { getToken, loadCredentials } = await import('../auth/credentials.js');
 const { resolveCurrentOrg } = await import('../auth/orgs.js');
@@ -200,6 +201,45 @@ describe('writeIndexFile', () => {
     expect(contents).toContain('url: process.env.TURSO_DATABASE_URL ?? "file:./mastra.db"');
     expect(contents).toContain('authToken: process.env.TURSO_AUTH_TOKEN');
     expect(contents).not.toContain('url: "file:./mastra.db"');
+  });
+});
+
+describe('writeAPIKey', () => {
+  const cwd = '/mock-project';
+
+  beforeEach(() => {
+    vol.reset();
+    fs.mkdirSync(cwd, { recursive: true });
+    vi.spyOn(process, 'cwd').mockReturnValue(cwd);
+  });
+
+  test.each([
+    ['sk-proj-abc123', 'plain key'],
+    ['sk-proj-a+b/c=d', 'key containing ='],
+    ['AIzaSyBx9K2mQ==', 'base64 padded key'],
+    ['sk-proj-a"b&c|d', 'key containing shell metacharacters'],
+  ])('writes %s verbatim (%s)', async apiKey => {
+    await writeAPIKey({ provider: 'openai', apiKey });
+
+    const contents = fs.readFileSync(`${cwd}/.env`, 'utf-8') as string;
+    expect(contents).toBe(`OPENAI_API_KEY=${apiKey}\n`);
+  });
+
+  test('writes a placeholder to .env.example when no key is given', async () => {
+    await writeAPIKey({ provider: 'anthropic' });
+
+    expect(fs.existsSync(`${cwd}/.env`)).toBe(false);
+    const contents = fs.readFileSync(`${cwd}/.env.example`, 'utf-8') as string;
+    expect(contents).toBe('ANTHROPIC_API_KEY=your-api-key\n');
+  });
+
+  test('appends without disturbing existing entries', async () => {
+    fs.writeFileSync(`${cwd}/.env`, 'EXISTING=1\n');
+
+    await writeAPIKey({ provider: 'openai', apiKey: 'sk-proj-abc123' });
+
+    const contents = fs.readFileSync(`${cwd}/.env`, 'utf-8') as string;
+    expect(contents).toBe('EXISTING=1\nOPENAI_API_KEY=sk-proj-abc123\n');
   });
 });
 

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -1,12 +1,9 @@
-import child_process from 'node:child_process';
 import fs from 'node:fs/promises';
 import path from 'node:path';
-import util from 'node:util';
 import * as p from '@clack/prompts';
 import type { ModelRouterModelId } from '@mastra/core/llm';
 import fsExtra from 'fs-extra/esm';
 import color from 'picocolors';
-import shellQuote from 'shell-quote';
 import yoctoSpinner from 'yocto-spinner';
 
 import { DepsService } from '../../services/service.deps';
@@ -19,8 +16,6 @@ import {
   antigravityGlobalMCPConfigPath,
 } from './mcp-docs-server-install';
 import type { Editor } from './mcp-docs-server-install';
-
-const exec = util.promisify(child_process.exec);
 
 export const LLMProvider = ['openai', 'anthropic', 'groq', 'google', 'cerebras', 'mistral'] as const;
 export const COMPONENTS = ['agents', 'workflows', 'tools', 'scorers'] as const;
@@ -678,9 +673,7 @@ export const writeAPIKey = async ({ provider, apiKey }: { provider: LLMProvider;
   const envFileName = apiKey ? '.env' : '.env.example';
 
   const key = await getAPIKey(provider);
-  const escapedKey = shellQuote.quote([key]);
-  const escapedApiKey = shellQuote.quote([apiKey ? apiKey : 'your-api-key']);
-  await exec(`echo ${escapedKey}=${escapedApiKey} >> ${envFileName}`);
+  await fs.appendFile(envFileName, `${key}=${apiKey ? apiKey : 'your-api-key'}\n`, 'utf-8');
 };
 
 /**

--- a/packages/cli/src/commands/init/utils.ts
+++ b/packages/cli/src/commands/init/utils.ts
@@ -673,7 +673,7 @@ export const writeAPIKey = async ({ provider, apiKey }: { provider: LLMProvider;
   const envFileName = apiKey ? '.env' : '.env.example';
 
   const key = await getAPIKey(provider);
-  await fs.appendFile(envFileName, `${key}=${apiKey ? apiKey : 'your-api-key'}\n`, 'utf-8');
+  await fs.appendFile(envFileName, `${key}=${apiKey || 'your-api-key'}\n`, 'utf-8');
 };
 
 /**


### PR DESCRIPTION
## Description

`writeAPIKey` appended the key to `.env` by shelling out:

```ts
const escapedKey = shellQuote.quote([key]);
const escapedApiKey = shellQuote.quote([apiKey ? apiKey : 'your-api-key']);
await exec(`echo ${escapedKey}=${escapedApiKey} >> ${envFileName}`);
```

On Windows `child_process.exec` runs `cmd.exe`, where `shell-quote`'s POSIX escaping means nothing, so `=` was written as `\=`. `cmd.exe` `echo` also keeps the space before the redirect, so every value picked up a trailing space:

```
key passed in      ubuntu (correct)                   windows (before this PR)
sk-proj-abc123     OPENAI_API_KEY=sk-proj-abc123\n    OPENAI_API_KEY=sk-proj-abc123 \r\n
sk-proj-a+b/c=d    OPENAI_API_KEY=sk-proj-a+b/c=d\n   OPENAI_API_KEY=sk-proj-a+b/c\=d \r\n
AIzaSyBx9K2mQ==    OPENAI_API_KEY=AIzaSyBx9K2mQ==\n   OPENAI_API_KEY=AIzaSyBx9K2mQ\=\= \r\n
```

Any key containing `=` arrived unusable, which covers base64-padded Google and Azure credentials. The scaffold exited 0 with no warning, so it surfaced later as an auth error with nothing pointing back at the CLI.

`fs.appendFile` writes the value verbatim on every platform. It also removes the shell interpolation of the key, and makes the function testable with the `memfs` mock the rest of `utils.test.ts` already uses. `fs` was already imported here.

The tests fail against the previous implementation and pass with this change. Worth noting why they fail: the old version shelled out, so it wrote real files next to the package instead of into `memfs`, which is what made this function untested until now.

`shell-quote` stays a dependency of the package, since `clone-template.ts` still uses it. That file has its own Windows problem and its own PR (#17645), so it's untouched here.

## Related issue(s)

Fixes #19736

Reproduction with a windows/ubuntu CI matrix: https://github.com/tehfreak/repro-mastra-writeapikey-windows

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Previously, the CLI used the computer’s shell to “echo” API keys into `.env`, which behaved differently on Windows and could mangle keys (especially ones containing `=`). Now it writes the `.env` line directly as text, so the key is saved exactly as entered.

## Changes

- Fixed `writeAPIKey` to append `KEY=value` to `.env` using `fs.appendFile` (no shell `echo`), preserving special characters byte-for-byte across platforms (Windows included).
- Updated fallback behavior for missing keys to match existing style (`apiKey || 'your-api-key'`).
- Added `writeAPIKey` tests using the existing `memfs` mock to verify:
  - keys (including ones containing `=` and base64-padded values) are written verbatim,
  - no `.env` is created when no key is provided, and `.env.example` gets the placeholder,
  - new entries are appended without overwriting existing `.env` content.
- Added a changeset documenting that `mastra init` on Windows previously wrote a corrupted API key to `.env`.
- Removed now-unused shell/execution-related imports from `utils.ts` (kept `shell-quote` for other existing usages).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->