### PR TITLE
fix(server): handle Agent Controller background failures

### DIFF
--- a/.changeset/good-rockets-shout.md
+++ b/.changeset/good-rockets-shout.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Prevent Agent Controller background operation failures from causing unhandled rejections.

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -53,6 +53,14 @@ describe('agent-controller routes', () => {
     ({ mastra } = makeMastra());
   });
 
+  async function getRouteSession(resourceId: string) {
+    const controller = mastra.getAgentController('code')!;
+    await controller.init();
+    // Same get-or-create call the route handlers make, so this returns the
+    // exact session instance the handler will operate on.
+    return controller.createSession({ resourceId, id: resourceId, ownerId: controller.id });
+  }
+
   describe('LIST_AGENT_CONTROLLERS_ROUTE', () => {
     it('lists registered agent controllers by id', async () => {
       const res = await LIST_AGENT_CONTROLLERS_ROUTE.handler({ mastra } as any);
@@ -218,6 +226,30 @@ describe('agent-controller routes', () => {
       } as any);
       expect(res).toEqual({ ok: true });
     });
+
+    it('logs a rejected background send instead of leaving an unhandled rejection', async () => {
+      const resourceId = 'user-rejected-send';
+      const session = await getRouteSession(resourceId);
+      const error = new Error('signal submission failed');
+      const loggerError = vi.spyOn(mastra.getLogger(), 'error').mockImplementation(() => {});
+      vi.spyOn(session, 'sendMessage').mockRejectedValue(error);
+
+      const res = await SEND_AGENT_CONTROLLER_MESSAGE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId,
+        message: 'hello',
+      } as any);
+
+      expect(res).toEqual({ ok: true });
+      await vi.waitFor(() => {
+        expect(loggerError).toHaveBeenCalledWith('Failed to send Agent Controller message', {
+          controllerId: 'code',
+          resourceId,
+          error,
+        });
+      });
+    });
   });
 
   describe('requestContext forwarding', () => {
@@ -225,14 +257,6 @@ describe('agent-controller routes', () => {
     // `requestContext`; the session-write routes must thread it through to the
     // session methods (which pass it to the run engine) or dynamic
     // instructions/tools see an empty context (see mastra-ai/mastra#18916).
-    async function getRouteSession(resourceId: string) {
-      const controller = mastra.getAgentController('code')!;
-      await controller.init();
-      // Same get-or-create call the route handlers make, so this returns the
-      // exact session instance the handler will operate on.
-      return controller.createSession({ resourceId, id: resourceId, ownerId: controller.id });
-    }
-
     function makeRequestContext() {
       const requestContext = new RequestContext();
       requestContext.set('tenantId', 'acme');
@@ -302,6 +326,30 @@ describe('agent-controller routes', () => {
       expect(spy).toHaveBeenCalledWith({ content: 'change course', requestContext });
     });
 
+    it('logs a rejected background steer instead of leaving an unhandled rejection', async () => {
+      const resourceId = 'user-rejected-steer';
+      const session = await getRouteSession(resourceId);
+      const error = new Error('steer failed');
+      const loggerError = vi.spyOn(mastra.getLogger(), 'error').mockImplementation(() => {});
+      vi.spyOn(session, 'steer').mockRejectedValue(error);
+
+      const res = await STEER_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId,
+        message: 'change course',
+      } as any);
+
+      expect(res).toEqual({ ok: true });
+      await vi.waitFor(() => {
+        expect(loggerError).toHaveBeenCalledWith('Failed to steer Agent Controller session', {
+          controllerId: 'code',
+          resourceId,
+          error,
+        });
+      });
+    });
+
     it('forwards requestContext to session.followUp', async () => {
       const session = await getRouteSession('user-rc');
       const spy = vi.spyOn(session, 'followUp').mockResolvedValue(undefined);
@@ -316,6 +364,30 @@ describe('agent-controller routes', () => {
       } as any);
 
       expect(spy).toHaveBeenCalledWith({ content: 'and another thing', requestContext });
+    });
+
+    it('logs a rejected background follow-up instead of leaving an unhandled rejection', async () => {
+      const resourceId = 'user-rejected-follow-up';
+      const session = await getRouteSession(resourceId);
+      const error = new Error('follow-up failed');
+      const loggerError = vi.spyOn(mastra.getLogger(), 'error').mockImplementation(() => {});
+      vi.spyOn(session, 'followUp').mockRejectedValue(error);
+
+      const res = await FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId,
+        message: 'and another thing',
+      } as any);
+
+      expect(res).toEqual({ ok: true });
+      await vi.waitFor(() => {
+        expect(loggerError).toHaveBeenCalledWith('Failed to queue Agent Controller follow-up', {
+          controllerId: 'code',
+          resourceId,
+          error,
+        });
+      });
     });
 
     it('forwards requestContext to session.respondToToolApproval', async () => {

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -497,7 +497,9 @@ export const SEND_AGENT_CONTROLLER_MESSAGE_ROUTE = createRoute({
       // Forward the server middleware's requestContext so identity injected in
       // `server.middleware` reaches dynamic instructions and tools (same as the
       // plain agent message route).
-      void session.sendMessage({ content: message, files, requestContext });
+      void session.sendMessage({ content: message, files, requestContext }).catch(error => {
+        mastra.getLogger().error('Failed to send Agent Controller message', { controllerId, resourceId, error });
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error sending controller message');
@@ -602,7 +604,9 @@ export const STEER_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId, { scope: sessionScope });
-      void session.steer({ content: message, requestContext });
+      void session.steer({ content: message, requestContext }).catch(error => {
+        mastra.getLogger().error('Failed to steer Agent Controller session', { controllerId, resourceId, error });
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error steering controller session');
@@ -1076,7 +1080,9 @@ export const FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId, { scope: sessionScope });
-      void session.followUp({ content: message, requestContext });
+      void session.followUp({ content: message, requestContext }).catch(error => {
+        mastra.getLogger().error('Failed to queue Agent Controller follow-up', { controllerId, resourceId, error });
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error queuing controller follow-up');


### PR DESCRIPTION
Fixes #19734.\n\nAgent Controller message, steer, and follow-up routes still acknowledge requests immediately, but now catch and log rejected session operations. This avoids unhandled promise rejections that can terminate a Node process after a successful HTTP response.\n\nTests:\n- pnpm --filter @mastra/server exec vitest run src/server/handlers/agent-controller.test.ts\n- targeted ESLint and Prettier checks\n- pnpm --filter @mastra/server build:lib

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The server now quietly handles background session failures instead of letting them crash the app, while still quickly telling callers that their request was accepted.

## What changed

- Added error logging for rejected background `sendMessage`, `steer`, and `followUp` operations.
- Preserved immediate `{ ok: true }` responses for all three routes.
- Added regression tests verifying failures are logged without causing unhandled promise rejections.
- Added a patch changeset for `@mastra/server`.
- Server build checks and regression tests passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->