### PR TITLE
fix(mastracode-web): hide closed files panel label

### DIFF
--- a/mastracode/web/src/web/ui/ui/ChatLayout.tsx
+++ b/mastracode/web/src/web/ui/ui/ChatLayout.tsx
@@ -68,14 +68,13 @@ export function ChatLayout({
         {!rightPanel && rightPanelAvailable ? (
           <button
             type="button"
-            className="absolute right-2 top-2 hidden items-center gap-1 text-icon6 lg:inline-flex"
+            className="absolute right-2 top-2 hidden items-center text-icon6 lg:inline-flex"
             onClick={onRightPanelOpen}
             aria-label="Open workspace files"
           >
             <span className="inline-flex h-6 w-6 items-center justify-center rounded-md border border-border2 bg-surface1 shadow-sm hover:bg-surface2">
               <FilledArrowLeft />
             </span>
-            <span className="text-xs text-icon3">Files</span>
           </button>
         ) : null}
       </div>


### PR DESCRIPTION
Removes the visible "Files" text from the collapsed workspace files panel opener so the closed state shows only the icon button. The button keeps its aria-label, so screen readers still announce the action.

Before: closed workspace panel opener showed an icon plus "Files" text.
After: closed workspace panel opener shows only the icon button.

Tested with:
- pnpm check:ui
- pnpm web:ui:test src/web/ui/__tests__/thread-page.msw.test.tsx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When the workspace files panel is closed, its button now shows only an icon instead of the word “Files,” making the interface cleaner while remaining accessible to screen readers.

## Changes

- Removed the visible “Files” label from the collapsed workspace files opener.
- Preserved the button’s `aria-label`, click behavior, and accessibility.
- Updated the button’s inner layout styling.

## Tests

- `pnpm check:ui`
- `pnpm web:ui:test src/web/ui/__tests__/thread-page.msw.test.tsx`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->