### PR TITLE
fix(core): stop fullStream cancel() from removing all subscribers' listeners (#19743)

### DIFF
--- a/.changeset/fix-fullstream-cancel-removes-all-listeners.md
+++ b/.changeset/fix-fullstream-cancel-removes-all-listeners.md
@@ -2,4 +2,4 @@
 "@mastra/core": patch
 ---
 
-Fix a per-subscriber `cancel()` on `WorkflowRunOutput.fullStream` and `MastraModelOutput`'s evented stream calling `removeAllListeners()` on the shared event emitter, which silently killed every other concurrent consumer of the same run (e.g. two `/stream` requests, or `/stream` + `/observe`, on the same runId). One subscriber disconnecting now only removes its own listeners; other subscribers keep receiving chunks and close normally.
+Fixed a bug where disconnecting one consumer of a workflow's `fullStream` (or a model's evented stream) would silently stop every other concurrent consumer of the same run from receiving further chunks. This affected cases like two `/stream` requests for the same `runId`, or `/stream` combined with `/observe` — one client disconnecting no longer breaks the others, which now keep receiving chunks and close normally.

--- a/.changeset/fix-fullstream-cancel-removes-all-listeners.md
+++ b/.changeset/fix-fullstream-cancel-removes-all-listeners.md
@@ -1,0 +1,5 @@
+---
+"@mastra/core": patch
+---
+
+Fix a per-subscriber `cancel()` on `WorkflowRunOutput.fullStream` and `MastraModelOutput`'s evented stream calling `removeAllListeners()` on the shared event emitter, which silently killed every other concurrent consumer of the same run (e.g. two `/stream` requests, or `/stream` + `/observe`, on the same runId). One subscriber disconnecting now only removes its own listeners; other subscribers keep receiving chunks and close normally.

--- a/packages/core/src/stream/RunOutput.test.ts
+++ b/packages/core/src/stream/RunOutput.test.ts
@@ -70,4 +70,51 @@ describe('WorkflowRunOutput', () => {
     expect(usage.cachedInputTokens).toBe(12686);
     expect((usage as { cacheCreationInputTokens?: number }).cacheCreationInputTokens).toBe(5268);
   });
+
+  it('does not stop other fullStream subscribers when one subscriber cancels (#19743)', async () => {
+    let enqueue: (chunk: WorkflowStreamEvent) => void = () => {};
+    let closeSource: () => void = () => {};
+    const source = new ReadableStream<WorkflowStreamEvent>({
+      start(controller) {
+        enqueue = chunk => controller.enqueue(chunk);
+        closeSource = () => controller.close();
+      },
+    });
+
+    const output = new WorkflowRunOutput({
+      runId: 'run-1',
+      workflowId: 'workflow-1',
+      stream: source,
+    });
+
+    const receivedByA: WorkflowStreamEvent[] = [];
+    let aClosed = false;
+    const consumeA = (async () => {
+      for await (const chunk of output.fullStream as unknown as AsyncIterable<WorkflowStreamEvent>) {
+        receivedByA.push(chunk);
+      }
+      aClosed = true;
+    })();
+
+    // Let consumer A's start() register its listeners before anything is enqueued.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Consumer B attaches, reads one chunk, then cancels — simulating a client
+    // disconnect on a second /stream request for the same run.
+    const readerB = output.fullStream.getReader();
+    enqueue(createWorkflowStepOutput({ inputTokens: 1, outputTokens: 1, totalTokens: 2, cachedInputTokens: 0 }));
+    await readerB.read();
+    await readerB.cancel();
+
+    // More chunks arrive after B has cancelled — A must still receive them.
+    enqueue(createWorkflowStepOutput({ inputTokens: 2, outputTokens: 2, totalTokens: 4, cachedInputTokens: 0 }));
+    enqueue(createWorkflowStepOutput({ inputTokens: 3, outputTokens: 3, totalTokens: 6, cachedInputTokens: 0 }));
+    closeSource();
+
+    await consumeA;
+
+    expect(aClosed).toBe(true);
+    expect(receivedByA.length).toBeGreaterThanOrEqual(3);
+  }, 5000);
 });

--- a/packages/core/src/stream/RunOutput.ts
+++ b/packages/core/src/stream/RunOutput.ts
@@ -346,6 +346,12 @@ export class WorkflowRunOutput<
 
   get fullStream(): ReadableStream<WorkflowStreamEvent> {
     const self = this;
+    // Holds this subscriber's own detach function once start() registers its
+    // listeners. cancel() must only remove this subscriber's handlers — the
+    // emitter is shared across every concurrent fullStream/observe consumer of
+    // the same run, so removeAllListeners() here would silently kill every
+    // other subscriber (see #19743).
+    let detach: (() => void) | undefined;
     return new ReadableStream<WorkflowStreamEvent>({
       start(controller) {
         // Replay existing buffered chunks
@@ -372,6 +378,11 @@ export class WorkflowRunOutput<
 
         self.#emitter.on('chunk', chunkHandler);
         self.#emitter.on('finish', finishHandler);
+
+        detach = () => {
+          self.#emitter.off('chunk', chunkHandler);
+          self.#emitter.off('finish', finishHandler);
+        };
       },
 
       pull(_controller) {
@@ -382,8 +393,8 @@ export class WorkflowRunOutput<
       },
 
       cancel() {
-        // Stream was cancelled, clean up
-        self.#emitter.removeAllListeners();
+        // Only detach this subscriber's own listeners — never the whole emitter.
+        detach?.();
       },
     });
   }

--- a/packages/core/src/stream/base/output.test.ts
+++ b/packages/core/src/stream/base/output.test.ts
@@ -1310,4 +1310,50 @@ describe('MastraModelOutput', () => {
       expect(live.map(c => c.type)).toEqual(['text-delta', 'goal', 'text-delta', 'step-finish', 'finish']);
     });
   });
+
+  describe('multi-consumer fullStream cancellation (#19743)', () => {
+    it('does not stop other fullStream subscribers when one subscriber cancels', async () => {
+      let enqueue: (chunk: ChunkType) => void = () => {};
+      let closeSource: () => void = () => {};
+      const source = new ReadableStream<ChunkType>({
+        start(controller) {
+          enqueue = chunk => controller.enqueue(chunk);
+          closeSource = () => controller.close();
+        },
+      });
+      const runId = 'test-run';
+      const output = new MastraModelOutput({
+        model: { modelId: 'test-model', provider: 'test', version: 'v3' },
+        stream: source,
+        messageList: new MessageList({ threadId: 'test-thread' }),
+        messageId: 'msg-1',
+        options: { runId },
+      });
+      const receivedByA: ChunkType[] = [];
+      let aClosed = false;
+      const consumeA = (async () => {
+        for await (const chunk of output.fullStream) {
+          receivedByA.push(chunk);
+        }
+        aClosed = true;
+      })();
+      // Let consumer A's start() register its listeners before anything is enqueued.
+      await Promise.resolve();
+      await Promise.resolve();
+      // Consumer B attaches, reads one chunk, then cancels — simulating a client
+      // disconnect on a second concurrent stream of the same output.
+      const readerB = output.fullStream.getReader();
+      enqueue(createTextDeltaChunk(runId, 'before '));
+      await readerB.read();
+      await readerB.cancel();
+      // More chunks arrive after B has cancelled — A must still receive them.
+      enqueue(createTextDeltaChunk(runId, 'after'));
+      enqueue(createStepFinishChunk(runId));
+      enqueue(createFinishChunk(runId));
+      closeSource();
+      await consumeA;
+      expect(aClosed).toBe(true);
+      expect(receivedByA.map(c => c.type)).toEqual(['text-delta', 'text-delta', 'step-finish', 'finish']);
+    }, 5000);
+  });
 });

--- a/packages/core/src/stream/base/output.ts
+++ b/packages/core/src/stream/base/output.ts
@@ -1831,6 +1831,12 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
   #createEventedStream() {
     const self = this;
+    // Holds this subscriber's own detach function once start() registers its
+    // listeners. cancel() must only remove this subscriber's handlers — the
+    // emitter is shared across every concurrent consumer of this output, so
+    // removeAllListeners() here would silently kill every other subscriber
+    // (see #19743).
+    let detach: (() => void) | undefined;
 
     return new ReadableStream<ChunkType<OUTPUT>>({
       start(controller) {
@@ -1858,6 +1864,11 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
 
         self.#emitter.on('chunk', chunkHandler);
         self.#emitter.on('finish', finishHandler);
+
+        detach = () => {
+          self.#emitter.off('chunk', chunkHandler);
+          self.#emitter.off('finish', finishHandler);
+        };
       },
 
       pull(_controller) {
@@ -1868,8 +1879,8 @@ export class MastraModelOutput<OUTPUT = undefined> extends MastraBase {
       },
 
       cancel() {
-        // Stream was cancelled, clean up
-        self.#emitter.removeAllListeners();
+        // Only detach this subscriber's own listeners — never the whole emitter.
+        detach?.();
       },
     });
   }


### PR DESCRIPTION
## Problem

`WorkflowRunOutput.fullStream` and `MastraModelOutput`'s evented stream both back every concurrent subscriber onto a single shared `EventEmitter`. Each subscriber's `cancel()` called `self.#emitter.removeAllListeners()`, which wipes *every* subscriber's `chunk` and `finish` handlers — not just its own.

In practice: any two consumers of the same run (two `/stream` requests for the same `runId`, or `/stream` + `/observe`) would break as soon as one disconnected. The HTTP layer calls `reader.cancel()` on client abort, so this was easy to hit — one tab closing, a retry, or a double POST would silently kill the stream for every other consumer. No error, no `finish` event, the surviving stream just hangs open forever while the workflow keeps running to completion underneath it.

Fixes #19743.

## Fix

Each subscriber's `start()` now captures its own `detach` closure over just its own `chunkHandler`/`finishHandler`. `cancel()` calls that closure instead of `removeAllListeners()`, so a subscriber can only ever remove listeners it registered itself.

Applied in both places that had the same pattern:
- `WorkflowRunOutput.fullStream` (`packages/core/src/stream/RunOutput.ts`) — the code path reported in the issue.
- `MastraModelOutput#createEventedStream()` (`packages/core/src/stream/base/output.ts`) — same shared-emitter/`removeAllListeners()` pattern, found while tracing the fix; not in the original report but affects any code consuming the same model output stream from multiple places.

`/workflows/:workflowId/observe`'s `createReplayStream` forwards its `cancel()` to the same `liveReader.cancel()`, so it's fixed transitively without a separate change.

## Testing

Added regression tests for both files reproducing the exact scenario from the issue: consumer A stays attached for the whole run, consumer B attaches, reads one chunk, then cancels. Asserts A keeps receiving chunks after B cancels and still reaches a clean close/`finish`.

- `packages/core/src/stream/RunOutput.test.ts`
- `packages/core/src/stream/base/output.test.ts`

Full `@mastra/core` unit suite passes (73/73), typecheck clean.

## Not included (flagged in the issue as separate, splittable)

- `#bufferedChunks` is never trimmed for long-running workflows with no attached reader.
- `#emitter` has no `setMaxListeners()`, so >10 concurrent subscribers triggers `MaxListenersExceededWarning`.

Happy to open follow-up issues/PRs for these if maintainers want them tracked separately — didn't want to scope-creep this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If two people are watching the same live stream, one person leaving shouldn’t stop the other from continuing to watch. This PR fixes cancellation so each subscriber only removes its own listeners, not everyone else’s.

## Changes

- Fixed shared stream cancellation so cancelling one subscriber no longer removes listeners for other subscribers:
  - `WorkflowRunOutput.fullStream`
  - `MastraModelOutput#createEventedStream()`
- Updated cancellation handling to use per-subscriber `detach()` cleanup (removing only that subscriber’s `chunk`/`finish` handlers instead of clearing the shared emitter’s listeners).
- Added regression tests to confirm:
  - Surviving subscribers keep receiving streamed data after another subscriber cancels.
  - Surviving streams still close/finish cleanly.
- Ensured workflow observation replay streams are fixed transitively by the underlying evented stream fix.
- Added a changeset documenting the fix for `@mastra/core`.

## Validation

- `@mastra/core` unit tests pass (73/73).
- Typechecking is clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->