### PR TITLE
fix(studio): keep model picker changes tab-scoped

### DIFF
--- a/.changeset/silver-hats-invite.md
+++ b/.changeset/silver-hats-invite.md
@@ -1,0 +1,13 @@
+---
+'@mastra/server': minor
+'@mastra/client-js': minor
+'@mastra/core': minor
+'@mastra/react': minor
+'mastra': patch
+---
+
+Added request-scoped model overrides to agent execution and approvals, and fixed Studio model selection so each tab can use a different model without changing the agent's configured default.
+
+```ts
+await agent.stream(messages, { model: 'google/gemini-2.5-flash' });
+```

--- a/client-sdks/client-js/src/resources/agent.test.ts
+++ b/client-sdks/client-js/src/resources/agent.test.ts
@@ -1546,6 +1546,16 @@ describe('Agent.stream', () => {
     global.fetch = vi.fn();
   });
 
+  it('serializes a request-scoped model override', async () => {
+    const agent = new TestAgent(mockClientOptions, 'test-agent');
+    const mockRequest = vi.fn().mockResolvedValue(new Response('data: [DONE]\n\n', { status: 200 }));
+    agent['request'] = mockRequest as (typeof agent)['request'];
+
+    await agent.stream('test message', { model: 'google/gemini-2.5-flash' });
+
+    expect(mockRequest.mock.calls[0][1].body.model).toBe('google/gemini-2.5-flash');
+  });
+
   it('should transform params.structuredOutput.schema using zodToJsonSchema when provided', async () => {
     const agent = new TestAgent(mockClientOptions, 'test-agent');
     const mockRequest = vi.fn().mockResolvedValue(new Response('data: [DONE]\n\n', { status: 200 }));

--- a/client-sdks/client-js/src/resources/agent.ts
+++ b/client-sdks/client-js/src/resources/agent.ts
@@ -9,7 +9,7 @@ import type {
   UseChatOptions,
 } from '@ai-sdk/ui-utils';
 import { v4 as uuid } from '@lukeed/uuid';
-import type { AgentExecutionOptionsBase, SerializableStructuredOutputOptions } from '@mastra/core/agent';
+import type { SerializableStructuredOutputOptions } from '@mastra/core/agent';
 import type { AIV5Type, MessageListInput } from '@mastra/core/agent/message-list';
 import { getErrorFromUnknown } from '@mastra/core/error';
 import type { GenerateReturn, CoreMessage } from '@mastra/core/llm';
@@ -2421,6 +2421,7 @@ export class Agent extends BaseResource {
 
   async approveNetworkToolCall(params: {
     runId: string;
+    model?: string;
     requestContext?: RequestContext | Record<string, any>;
   }): Promise<
     Response & {
@@ -2470,6 +2471,7 @@ export class Agent extends BaseResource {
 
   async declineNetworkToolCall(params: {
     runId: string;
+    model?: string;
     requestContext?: RequestContext | Record<string, any>;
   }): Promise<
     Response & {
@@ -2559,8 +2561,8 @@ export class Agent extends BaseResource {
   >;
   async stream<OUTPUT>(
     messagesOrParams: MessageListInput,
-    options?: AgentExecutionOptionsBase<any> & {
-      structuredOutput?: StreamParamsBaseWithoutMessages<any>;
+    options?: StreamParamsBaseWithoutMessages<any> & {
+      structuredOutput?: StructuredOutputOptions<any>;
     },
   ): Promise<
     Response & {
@@ -2680,8 +2682,8 @@ export class Agent extends BaseResource {
   >;
   async streamUntilIdle<OUTPUT>(
     messagesOrParams: MessageListInput,
-    options?: AgentExecutionOptionsBase<any> & {
-      structuredOutput?: StreamParamsBaseWithoutMessages<any>;
+    options?: StreamParamsBaseWithoutMessages<any> & {
+      structuredOutput?: StructuredOutputOptions<any>;
       maxIdleMs?: number;
     },
   ): Promise<
@@ -2781,6 +2783,7 @@ export class Agent extends BaseResource {
   async approveToolCall(params: {
     runId: string;
     toolCallId: string;
+    model?: string;
     requestContext?: RequestContext | Record<string, any>;
   }): Promise<
     Response & {
@@ -2856,6 +2859,7 @@ export class Agent extends BaseResource {
   async declineToolCall(params: {
     runId: string;
     toolCallId: string;
+    model?: string;
     requestContext?: RequestContext | Record<string, any>;
   }): Promise<
     Response & {
@@ -3167,6 +3171,7 @@ export class Agent extends BaseResource {
   async approveToolCallGenerate(params: {
     runId: string;
     toolCallId: string;
+    model?: string;
     requestContext?: RequestContext | Record<string, any>;
   }): Promise<any> {
     const { requestContext, ...rest } = params;
@@ -3183,6 +3188,7 @@ export class Agent extends BaseResource {
   async declineToolCallGenerate(params: {
     runId: string;
     toolCallId: string;
+    model?: string;
     requestContext?: RequestContext | Record<string, any>;
   }): Promise<any> {
     const { requestContext, ...rest } = params;

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -1036,6 +1036,7 @@ type Shared_Type_52 = {
   versions?: Shared_Type_44 | undefined;
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
+  model?: string | undefined;
   providerOptions?: Shared_Type_45 | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
@@ -3336,6 +3337,7 @@ export type PostAgentsAgentIdGenerate_Body = {
   versions?: Shared_Type_44 | undefined;
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
+  model?: string | undefined;
   providerOptions?: Shared_Type_45 | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
@@ -3487,6 +3489,7 @@ export type PostAgentsAgentIdStreamUntilIdle_Body = {
   versions?: Shared_Type_44 | undefined;
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
+  model?: string | undefined;
   providerOptions?: Shared_Type_45 | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
@@ -3860,6 +3863,7 @@ export type PostAgentsAgentIdApproveToolCall_PathParams = GetAgentsAgentId_PathP
 
 export type PostAgentsAgentIdApproveToolCall_Body = {
   runId: string;
+  model?: string | undefined;
   requestContext?:
     | {
         [key: string]: unknown;
@@ -4043,6 +4047,7 @@ export type PostAgentsAgentIdResumeStream_Body = {
   versions?: Shared_Type_44 | undefined;
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
+  model?: string | undefined;
   providerOptions?: Shared_Type_45 | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
@@ -4235,6 +4240,7 @@ export type PostAgentsAgentIdApproveNetworkToolCall_PathParams = GetAgentsAgentI
 
 export type PostAgentsAgentIdApproveNetworkToolCall_Body = {
   runId: string;
+  model?: string | undefined;
   requestContext?:
     | {
         [key: string]: unknown;
@@ -4316,6 +4322,7 @@ export type PostAgentsAgentIdResumeStreamUntilIdle_Body = {
   versions?: Shared_Type_44 | undefined;
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
+  model?: string | undefined;
   providerOptions?: Shared_Type_45 | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;
@@ -11579,6 +11586,7 @@ export type PostAgentsAgentIdGenerateLegacy_Body = {
   versions?: Shared_Type_44 | undefined;
   maxSteps?: number | undefined;
   stopWhen?: unknown | undefined;
+  model?: string | undefined;
   providerOptions?: Shared_Type_45 | undefined;
   modelSettings?: unknown | undefined;
   activeTools?: string[] | undefined;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -470,8 +470,9 @@ type WithoutMethods<T> = {
 
 export type NetworkStreamParams<OUTPUT = undefined> = {
   messages: MessageListInput;
+  model?: string;
   tracingOptions?: TracingOptions;
-} & MultiPrimitiveExecutionOptions<OUTPUT>;
+} & Omit<MultiPrimitiveExecutionOptions<OUTPUT>, 'model'>;
 
 export interface GetAgentResponse {
   id: string;
@@ -534,24 +535,32 @@ export interface GetAgentBrowserSessionResponse {
 
 export type GenerateLegacyParams<T extends JSONSchema7 | ZodSchema | undefined = undefined> = {
   messages: string | string[] | CoreMessage[] | AiMessageType[] | UIMessageWithMetadata[];
+  model?: string;
   output?: T;
   experimental_output?: T;
   requestContext?: RequestContext | Record<string, any>;
   clientTools?: ToolsInput;
 } & WithoutMethods<
   // Use `any` to avoid "Type instantiation is excessively deep" error from complex ZodSchema generics
-  Omit<AgentGenerateOptions<any>, 'output' | 'experimental_output' | 'requestContext' | 'clientTools' | 'abortSignal'>
+  Omit<
+    AgentGenerateOptions<any>,
+    'model' | 'output' | 'experimental_output' | 'requestContext' | 'clientTools' | 'abortSignal'
+  >
 >;
 
 export type StreamLegacyParams<T extends JSONSchema7 | ZodSchema | undefined = undefined> = {
   messages: string | string[] | CoreMessage[] | AiMessageType[] | UIMessageWithMetadata[];
+  model?: string;
   output?: T;
   experimental_output?: T;
   requestContext?: RequestContext | Record<string, any>;
   clientTools?: ToolsInput;
 } & WithoutMethods<
   // Use `any` to avoid "Type instantiation is excessively deep" error from complex ZodSchema generics
-  Omit<AgentStreamOptions<any>, 'output' | 'experimental_output' | 'requestContext' | 'clientTools' | 'abortSignal'>
+  Omit<
+    AgentStreamOptions<any>,
+    'model' | 'output' | 'experimental_output' | 'requestContext' | 'clientTools' | 'abortSignal'
+  >
 >;
 
 export type StructuredOutputOptions<OUTPUT = undefined> = Omit<
@@ -561,11 +570,15 @@ export type StructuredOutputOptions<OUTPUT = undefined> = Omit<
   schema: PublicSchema<OUTPUT>;
 };
 export type StreamParamsBase<OUTPUT = undefined> = {
+  model?: string;
   tracingOptions?: TracingOptions;
   requestContext?: RequestContext;
   clientTools?: ToolsInput;
 } & WithoutMethods<
-  Omit<AgentExecutionOptions<OUTPUT>, 'requestContext' | 'clientTools' | 'options' | 'abortSignal' | 'structuredOutput'>
+  Omit<
+    AgentExecutionOptions<OUTPUT>,
+    'model' | 'requestContext' | 'clientTools' | 'options' | 'abortSignal' | 'structuredOutput'
+  >
 >;
 export type StreamParamsBaseWithoutMessages<OUTPUT = undefined> = StreamParamsBase<OUTPUT>;
 export type StreamParams<OUTPUT = undefined> = StreamParamsBase<OUTPUT> & {

--- a/client-sdks/react/src/agent/hooks.test.ts
+++ b/client-sdks/react/src/agent/hooks.test.ts
@@ -199,6 +199,46 @@ describe('useChat forwards clientTools', () => {
     expect(streamMock).toHaveBeenCalledTimes(1);
   });
 
+  it('retains the model override for stream approval', async () => {
+    const { result } = renderHook(() => useChat({ agentId: 'test-agent' }), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage({
+        mode: 'stream',
+        message: 'hi',
+        model: 'google/gemini-2.5-flash',
+      });
+      await result.current.approveToolCall('tool-call-approval-1');
+    });
+
+    expect(streamMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ model: 'google/gemini-2.5-flash' }),
+    );
+    expect(approveToolCallMock).toHaveBeenCalledWith(expect.objectContaining({ model: 'google/gemini-2.5-flash' }));
+  });
+
+  it('retains the model override for network approval', async () => {
+    const { result } = renderHook(() => useChat({ agentId: 'test-agent' }), { wrapper });
+
+    await act(async () => {
+      await result.current.sendMessage({
+        mode: 'network',
+        message: 'hi',
+        model: 'google/gemini-2.5-flash',
+      });
+      await result.current.approveNetworkToolCall('tool', 'run-net-1');
+    });
+
+    expect(networkMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ model: 'google/gemini-2.5-flash' }),
+    );
+    expect(approveNetworkToolCallMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: 'google/gemini-2.5-flash' }),
+    );
+  });
+
   it('marks subscription streams idle while waiting for tool approval', async () => {
     nextSubscribeChunks = [
       {

--- a/client-sdks/react/src/agent/hooks.ts
+++ b/client-sdks/react/src/agent/hooks.ts
@@ -139,6 +139,7 @@ const resolveInitialMessages = (messages: MastraDBMessage[]): MastraDBMessage[] 
     });
 
 type SignalContinuationOptions = {
+  model?: string;
   maxSteps?: number;
   modelSettings?: {
     frequencyPenalty?: number;
@@ -153,6 +154,11 @@ type SignalContinuationOptions = {
   providerOptions?: ModelSettings['providerOptions'];
   requireToolApproval?: boolean;
   tracingOptions?: TracingOptions;
+};
+
+type ActiveContinuation = {
+  model?: string;
+  requestContext?: RequestContext;
 };
 
 export interface MastraChatProps {
@@ -180,6 +186,7 @@ export interface MastraChatProps {
 
 interface SharedArgs {
   coreUserMessages: CoreUserMessage[];
+  model?: string;
   requestContext?: RequestContext;
   threadId?: string;
   modelSettings?: ModelSettings;
@@ -281,7 +288,7 @@ export const useChat = ({
   const _onChunk = useRef<((chunk: ChunkType) => Promise<void>) | undefined>(undefined);
   const _networkRunId = useRef<string | undefined>(undefined);
   const _onNetworkChunk = useRef<((chunk: NetworkChunkType) => Promise<void>) | undefined>(undefined);
-  const _requestContext = useRef<RequestContext | undefined>(propsRequestContext);
+  const _activeContinuation = useRef<ActiveContinuation>({ requestContext: propsRequestContext });
   // Tracks the active stream (untilIdle) request so a subsequent stream() call
   // can abort the previous one. Without this, a still-open prior stream keeps
   // its background-task pubsub subscription alive and fans events into a second
@@ -319,7 +326,10 @@ export const useChat = ({
   }, [initialMessages]);
 
   useEffect(() => {
-    _requestContext.current = propsRequestContext;
+    _activeContinuation.current = {
+      ..._activeContinuation.current,
+      requestContext: propsRequestContext,
+    };
   }, [propsRequestContext]);
 
   type SignalContentPart =
@@ -546,6 +556,7 @@ export const useChat = ({
 
   const generate = async ({
     coreUserMessages,
+    model,
     requestContext,
     threadId,
     modelSettings,
@@ -569,7 +580,10 @@ export const useChat = ({
     } = modelSettings || {};
     const resolvedRequestContext = requestContext ?? propsRequestContext;
     const resolvedClientTools = clientTools ?? hookClientTools;
-    _requestContext.current = resolvedRequestContext;
+    _activeContinuation.current = {
+      model,
+      requestContext: resolvedRequestContext,
+    };
     setIsRunning(true);
 
     const clientWithAbort = new MastraClient({
@@ -583,6 +597,7 @@ export const useChat = ({
     _currentRunId.current = runId;
 
     const response = await agent.generate(coreUserMessages, {
+      model,
       runId,
       maxSteps,
       modelSettings: {
@@ -636,6 +651,7 @@ export const useChat = ({
 
   const stream = async ({
     coreUserMessages,
+    model,
     requestContext,
     threadId,
     onChunk,
@@ -663,6 +679,7 @@ export const useChat = ({
     const resolvedRequestContext = requestContext ?? propsRequestContext;
     const resolvedClientTools = clientTools ?? hookClientTools;
     const signalContinuationOptions: SignalContinuationOptions = {
+      model,
       maxSteps,
       modelSettings: {
         frequencyPenalty,
@@ -678,7 +695,10 @@ export const useChat = ({
       requireToolApproval,
       tracingOptions,
     };
-    _requestContext.current = resolvedRequestContext;
+    _activeContinuation.current = {
+      model,
+      requestContext: resolvedRequestContext,
+    };
     setIsRunning(true);
 
     _streamAbortRef.current?.abort();
@@ -700,6 +720,7 @@ export const useChat = ({
     const streamWithLegacyRoute = async () => {
       const runId = uuid();
       const response = await agent.stream(coreUserMessages, {
+        model,
         runId,
         maxSteps,
         untilIdle: true,
@@ -754,6 +775,7 @@ export const useChat = ({
     // index signature, so it isn't assignable to the generated `Record<string, unknown>` body type.
     const requestContextRecord = resolvedRequestContext as Record<string, unknown> | undefined;
     const streamOptions = {
+      model,
       maxSteps,
       modelSettings: {
         frequencyPenalty,
@@ -833,6 +855,7 @@ export const useChat = ({
 
   const network = async ({
     coreUserMessages,
+    model,
     requestContext,
     threadId,
     onNetworkChunk,
@@ -844,7 +867,10 @@ export const useChat = ({
       modelSettings || {};
 
     const resolvedRequestContext = requestContext ?? propsRequestContext;
-    _requestContext.current = resolvedRequestContext;
+    _activeContinuation.current = {
+      model,
+      requestContext: resolvedRequestContext,
+    };
     setIsRunning(true);
 
     const clientWithAbort = new MastraClient({
@@ -857,6 +883,7 @@ export const useChat = ({
     const runId = uuid();
 
     const response = await agent.network(coreUserMessages, {
+      model,
       maxSteps,
       modelSettings: {
         frequencyPenalty,
@@ -906,12 +933,13 @@ export const useChat = ({
     _onChunk.current = undefined;
     _networkRunId.current = undefined;
     _onNetworkChunk.current = undefined;
-    _requestContext.current = undefined;
+    _activeContinuation.current = {};
   };
 
   const approveToolCall = async (toolCallId: string, resumeData?: unknown) => {
     const onChunk = _onChunk.current;
     const currentRunId = _currentRunId.current;
+    const continuation = _activeContinuation.current;
 
     if (!currentRunId)
       return console.info('[approveToolCall] approveToolCall can only be called after a stream has started');
@@ -927,8 +955,9 @@ export const useChat = ({
           threadId,
           toolCallId,
           approved: true,
+          ...(continuation.model !== undefined ? { streamOptions: { model: continuation.model } } : {}),
           ...(resumeData !== undefined ? { resumeData } : {}),
-          requestContext: _requestContext.current,
+          requestContext: continuation.requestContext,
         });
         pendingToolApprovalIdsRef.current.delete(toolCallId);
         setIsAwaitingToolApproval(pendingToolApprovalIdsRef.current.size > 0);
@@ -948,7 +977,7 @@ export const useChat = ({
     const response = await agent.approveToolCall({
       runId: currentRunId,
       toolCallId,
-      requestContext: _requestContext.current,
+      ...continuation,
     });
 
     await response.processDataStream({
@@ -962,6 +991,7 @@ export const useChat = ({
   const declineToolCall = async (toolCallId: string) => {
     const onChunk = _onChunk.current;
     const currentRunId = _currentRunId.current;
+    const continuation = _activeContinuation.current;
 
     if (!currentRunId)
       return console.info('[declineToolCall] declineToolCall can only be called after a stream has started');
@@ -976,7 +1006,8 @@ export const useChat = ({
           threadId,
           toolCallId,
           approved: false,
-          requestContext: _requestContext.current,
+          ...(continuation.model !== undefined ? { streamOptions: { model: continuation.model } } : {}),
+          requestContext: continuation.requestContext,
         });
         pendingToolApprovalIdsRef.current.delete(toolCallId);
         setIsAwaitingToolApproval(pendingToolApprovalIdsRef.current.size > 0);
@@ -996,7 +1027,7 @@ export const useChat = ({
     const response = await agent.declineToolCall({
       runId: currentRunId,
       toolCallId,
-      requestContext: _requestContext.current,
+      ...continuation,
     });
 
     await response.processDataStream({
@@ -1009,6 +1040,7 @@ export const useChat = ({
 
   const approveToolCallGenerate = async (toolCallId: string) => {
     const currentRunId = _currentRunId.current;
+    const continuation = _activeContinuation.current;
 
     if (!currentRunId)
       return console.info(
@@ -1022,7 +1054,7 @@ export const useChat = ({
     const response = await agent.approveToolCallGenerate({
       runId: currentRunId,
       toolCallId,
-      requestContext: _requestContext.current,
+      ...continuation,
     });
 
     if (response && 'uiMessages' in response.response && response.response.uiMessages) {
@@ -1035,6 +1067,7 @@ export const useChat = ({
 
   const declineToolCallGenerate = async (toolCallId: string) => {
     const currentRunId = _currentRunId.current;
+    const continuation = _activeContinuation.current;
 
     if (!currentRunId)
       return console.info(
@@ -1048,7 +1081,7 @@ export const useChat = ({
     const response = await agent.declineToolCallGenerate({
       runId: currentRunId,
       toolCallId,
-      requestContext: _requestContext.current,
+      ...continuation,
     });
 
     if (response && 'uiMessages' in response.response && response.response.uiMessages) {
@@ -1062,6 +1095,7 @@ export const useChat = ({
   const approveNetworkToolCall = async (toolName: string, runId?: string) => {
     const onNetworkChunk = _onNetworkChunk.current;
     const networkRunId = runId || _networkRunId.current;
+    const continuation = _activeContinuation.current;
 
     if (!networkRunId)
       return console.info(
@@ -1077,7 +1111,7 @@ export const useChat = ({
     const agent = baseClient.getAgent(agentId);
     const response = await agent.approveNetworkToolCall({
       runId: networkRunId,
-      requestContext: _requestContext.current,
+      ...continuation,
     });
 
     await response.processDataStream({
@@ -1094,6 +1128,7 @@ export const useChat = ({
   const declineNetworkToolCall = async (toolName: string, runId?: string) => {
     const onNetworkChunk = _onNetworkChunk.current;
     const networkRunId = runId || _networkRunId.current;
+    const continuation = _activeContinuation.current;
 
     if (!networkRunId)
       return console.info(
@@ -1109,7 +1144,7 @@ export const useChat = ({
     const agent = baseClient.getAgent(agentId);
     const response = await agent.declineNetworkToolCall({
       runId: networkRunId,
-      requestContext: _requestContext.current,
+      ...continuation,
     });
 
     await response.processDataStream({

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -93,6 +93,7 @@ export const API_ROUTE_METADATA = {
       "maxSteps",
       "memory",
       "messages",
+      "model",
       "modelSettings",
       "output",
       "providerOptions",
@@ -132,6 +133,7 @@ export const API_ROUTE_METADATA = {
       "maxSteps",
       "memory",
       "messages",
+      "model",
       "modelSettings",
       "output",
       "providerOptions",
@@ -288,6 +290,7 @@ export const API_ROUTE_METADATA = {
     "queryParams": [],
     "bodyParams": [
       "format",
+      "model",
       "requestContext",
       "runId",
       "toolCallId"
@@ -307,6 +310,7 @@ export const API_ROUTE_METADATA = {
     "queryParams": [],
     "bodyParams": [
       "format",
+      "model",
       "requestContext",
       "runId",
       "toolCallId"
@@ -3091,6 +3095,7 @@ export const API_ROUTE_METADATA = {
       "maxSteps",
       "memory",
       "messages",
+      "model",
       "modelSettings",
       "output",
       "providerOptions",

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7230,9 +7230,10 @@ export class Agent<
       runId,
       routingAgent: this,
       routingAgentOptions: {
+        model: mergedOptions?.model,
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
-      } as unknown as AgentExecutionOptions<OUTPUT>,
+      },
       generateId: context => this.#mastra?.generateId(context) || randomUUID(),
       maxIterations: mergedOptions?.maxSteps || 1,
       messages,
@@ -7305,6 +7306,7 @@ export class Agent<
       runId,
       routingAgent: this,
       routingAgentOptions: {
+        model: mergedOptions?.model,
         modelSettings: mergedOptions?.modelSettings,
         memory: mergedOptions?.memory,
       },

--- a/packages/core/src/agent/agent.types.ts
+++ b/packages/core/src/agent/agent.types.ts
@@ -3,7 +3,7 @@ import type { ActorSignal } from '../auth/ee';
 import type { MastraScorer, MastraScorers, ScoringSamplingConfig } from '../evals';
 import type { SystemMessage } from '../llm';
 import type { ProviderOptions } from '../llm/model/provider-options';
-import type { MastraLanguageModel } from '../llm/model/shared.types';
+import type { MastraLanguageModel, MastraModelConfig } from '../llm/model/shared.types';
 import type { CompletionConfig, CompletionRunResult } from '../loop/network/validation';
 import type { LoopConfig, LoopOptions, PrepareStepFunction } from '../loop/types';
 import type { VersionOverrides } from '../mastra/types';
@@ -11,6 +11,7 @@ import type { ObservabilityContext, TracingOptions } from '../observability';
 import type { ErrorProcessorOrWorkflow, InputProcessorOrWorkflow, OutputProcessorOrWorkflow } from '../processors';
 import type { RequestContext } from '../request-context';
 import type { RequireToolApproval, ToolHooks, ToolPayloadTransformPolicy } from '../tools';
+import type { DynamicArgument } from '../types';
 import type { OutputWriter, WorkflowRunState } from '../workflows/types';
 import type { MessageListInput } from './message-list';
 import type {
@@ -341,6 +342,9 @@ export interface NetworkRoutingConfig {
  * Full configuration options for agent.network() execution.
  */
 export type NetworkOptions<OUTPUT = undefined> = {
+  /** Model used by the routing agent for this execution */
+  model?: DynamicArgument<MastraModelConfig>;
+
   /** Memory configuration for conversation persistence and retrieval */
   memory?: AgentMemoryOption;
 

--- a/packages/core/src/loop/network/index.test.ts
+++ b/packages/core/src/loop/network/index.test.ts
@@ -117,6 +117,22 @@ describe('getRoutingAgent', () => {
     } as any;
   }
 
+  it('resolves an explicit routing model through the parent agent', async () => {
+    const mockAgent = createMockAgent({});
+    const requestContext = new RequestContext();
+
+    await getRoutingAgent({
+      agent: mockAgent,
+      requestContext,
+      model: 'google/gemini-2.5-flash',
+    });
+
+    expect(mockAgent.getModel).toHaveBeenCalledWith({
+      requestContext,
+      modelConfig: 'google/gemini-2.5-flash',
+    });
+  });
+
   it('should handle workflow with undefined inputSchema without throwing', async () => {
     // Create a workflow without inputSchema (simulating the bug scenario)
     const workflowWithoutInputSchema = createWorkflow({

--- a/packages/core/src/loop/network/index.ts
+++ b/packages/core/src/loop/network/index.ts
@@ -1,7 +1,6 @@
 import { parsePartialJson } from '@internal/ai-sdk-v5';
 import { z } from 'zod/v4';
 import type { Mastra } from '../..';
-import type { AgentExecutionOptions } from '../../agent';
 import type { MultiPrimitiveExecutionOptions, NetworkOptions } from '../../agent/agent.types';
 import { Agent, tryGenerateWithJsonFallback } from '../../agent/index';
 import { MessageList } from '../../agent/message-list';
@@ -171,6 +170,7 @@ export async function getRoutingAgent({
   agent,
   routingConfig,
   memoryConfig,
+  model,
 }: {
   agent: Agent;
   requestContext: RequestContext;
@@ -178,12 +178,13 @@ export async function getRoutingAgent({
     additionalInstructions?: string;
   };
   memoryConfig?: any;
+  model?: MultiPrimitiveExecutionOptions['model'];
 }) {
   const instructionsToUse = await agent.getInstructions({ requestContext: requestContext });
   const agentsToUse = await agent.listAgents({ requestContext: requestContext });
   const workflowsToUse = await agent.listWorkflows({ requestContext: requestContext });
   const toolsToUse = await agent.listTools({ requestContext: requestContext });
-  const model = await agent.getModel({ requestContext: requestContext });
+  const resolvedModel = await agent.getModel({ requestContext, modelConfig: model });
   const memoryToUse = await agent.getMemory({ requestContext: requestContext });
   assertNetworkSupportsMemory(memoryToUse, memoryConfig);
   const clientToolsToUse = (await agent.getDefaultOptions({ requestContext: requestContext }))?.clientTools;
@@ -250,7 +251,7 @@ export async function getRoutingAgent({
     id: 'routing-agent',
     name: 'Routing Agent',
     instructions,
-    model: model,
+    model: resolvedModel,
     memory: memoryToUse,
     inputProcessors: configuredInputProcessors,
     outputProcessors: configuredOutputProcessors,
@@ -533,7 +534,7 @@ export async function createNetworkLoop({
   requestContext: RequestContext;
   runId: string;
   agent: Agent;
-  routingAgentOptions?: Pick<MultiPrimitiveExecutionOptions, 'modelSettings'>;
+  routingAgentOptions?: Pick<MultiPrimitiveExecutionOptions, 'model' | 'modelSettings'>;
   routingAgentMemoryConfig?: any;
   generateId: NetworkIdGenerator;
   routing?: {
@@ -649,6 +650,7 @@ export async function createNetworkLoop({
         agent,
         routingConfig: routing,
         memoryConfig: routingAgentMemoryConfig,
+        model: routingAgentOptions?.model,
       });
 
       // Increment iteration counter. Must use nullish coalescing (??) not ternary (?)
@@ -2100,7 +2102,8 @@ export async function networkLoop<OUTPUT = undefined>({
   requestContext: RequestContext;
   runId: string;
   routingAgent: Agent<any, any, any, any>;
-  routingAgentOptions?: AgentExecutionOptions<OUTPUT>;
+  routingAgentOptions?: Pick<NetworkOptions<OUTPUT>, 'memory' | 'model' | 'modelSettings'> &
+    Partial<ObservabilityContext>;
   generateId: NetworkIdGenerator;
   maxIterations: number;
   threadId?: string;
@@ -2195,7 +2198,10 @@ export async function networkLoop<OUTPUT = undefined>({
           const firstSuspendedTool = suspendedToolsArr[0]; //only one primitive/tool gets suspended at a time, so there'll only be one item
           if (firstSuspendedTool.resumeSchema) {
             try {
-              const llm = (await routingAgent.getLLM({ requestContext })) as MastraLLMVNext;
+              const llm = (await routingAgent.getLLM({
+                requestContext,
+                model: routingAgentOptions?.model,
+              })) as MastraLLMVNext;
               const systemInstructions = `
             You are an assistant used to resume a suspended tool call.
             Your job is to construct the resumeData for the tool call using the messages available to you and the schema passed.
@@ -2346,6 +2352,7 @@ export async function networkLoop<OUTPUT = undefined>({
             agent: routingAgent,
             routingConfig: routing,
             memoryConfig: routingAgentMemoryOptions?.options,
+            model: routingAgentOptions?.model,
           });
 
           // Use structured output generation if schema is provided
@@ -2395,6 +2402,7 @@ export async function networkLoop<OUTPUT = undefined>({
           agent: routingAgent,
           routingConfig: routing,
           memoryConfig: routingAgentMemoryOptions?.options,
+          model: routingAgentOptions?.model,
         });
         // Use the default LLM completion check
         const defaultResult = await runDefaultCompletionCheck(

--- a/packages/playground/src/domains/agents/agent-layout.tsx
+++ b/packages/playground/src/domains/agents/agent-layout.tsx
@@ -64,7 +64,11 @@ export const AgentLayout = ({ children }: { children: React.ReactNode }) => {
   return (
     <TracingSettingsProvider entityId={agentId!} entityType="agent">
       <SchemaRequestContextProvider>
-        <PlaygroundModelProvider defaultProvider={defaultProvider} defaultModel={defaultModel}>
+        <PlaygroundModelProvider
+          key={`${agentId}:${defaultProvider}/${defaultModel}`}
+          defaultProvider={defaultProvider}
+          defaultModel={defaultModel}
+        >
           <GenerationProvider>
             <ReviewQueueProvider>{content}</ReviewQueueProvider>
           </GenerationProvider>

--- a/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
@@ -1,7 +1,7 @@
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { Lock, TriangleAlert } from 'lucide-react';
 import { useState } from 'react';
-import { usePlaygroundModel } from '../context/playground-model-context';
+import { usePlaygroundModelOptional } from '../context/playground-model-context';
 import { useBuilderModelPolicy } from '@/domains/agent-builder';
 import { useAgentBuilderAllowedModels } from '@/domains/agent-builder/hooks/use-agent-builder-allowed-models';
 import { LLMProviders, LLMModels, useLLMProviders, cleanProviderId, findProviderById } from '@/domains/llm';
@@ -16,12 +16,15 @@ const COMPOSER_TRIGGER_CLASS = [
 ].join(' ');
 
 export const ComposerModelSwitcher = () => {
-  const { provider: selectedProvider, model: selectedModel, setProvider, setModel } = usePlaygroundModel();
+  const selection = usePlaygroundModelOptional();
   const { data: dataProviders, isLoading: providersLoading } = useLLMProviders();
   const policy = useBuilderModelPolicy();
 
   const [modelOpen, setModelOpen] = useState(false);
 
+  if (providersLoading || !selection) return null;
+
+  const { provider: selectedProvider, model: selectedModel, setProvider, setModel } = selection;
   const providers = dataProviders?.providers || [];
 
   const currentModelProvider = cleanProviderId(selectedProvider);
@@ -30,7 +33,6 @@ export const ComposerModelSwitcher = () => {
   const resolvedProvider = findProviderById(providers, currentModelProvider);
   const fullProviderId = resolvedProvider?.id || currentModelProvider;
 
-  // Auto-save when model changes
   const handleModelSelect = (modelId: string) => {
     if (modelId && fullProviderId) setModel(fullProviderId, modelId);
   };
@@ -44,10 +46,6 @@ export const ComposerModelSwitcher = () => {
       setModelOpen(true);
     }
   };
-
-  if (providersLoading) {
-    return null;
-  }
 
   // Admin locked the picker — surface a non-interactive chip instead.
   if (policy.active && policy.pickerVisible === false) {
@@ -97,14 +95,15 @@ export const ComposerModelSwitcher = () => {
 };
 
 export const ComposerModelWarning = () => {
-  const { provider, model } = usePlaygroundModel();
+  const selection = usePlaygroundModelOptional();
   const { data: dataProviders, isLoading: providersLoading } = useLLMProviders();
   const policy = useBuilderModelPolicy();
   const { models: allowedModels } = useAgentBuilderAllowedModels();
 
-  if (providersLoading) return null;
+  if (providersLoading || !selection) return null;
 
   const providers = dataProviders?.providers || [];
+  const { provider, model } = selection;
   const currentModelProvider = cleanProviderId(provider);
   const currentProvider = findProviderById(providers, currentModelProvider);
   const selectedModel = model;

--- a/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
+++ b/packages/playground/src/domains/agents/components/composer-model-switcher.tsx
@@ -1,9 +1,7 @@
-import type { UpdateModelParams } from '@mastra/client-js';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import { Lock, TriangleAlert } from 'lucide-react';
-import { useState, useEffect } from 'react';
-import { useAgent } from '../hooks/use-agent';
-import { useUpdateAgentModel } from '../hooks/use-agents';
+import { useState } from 'react';
+import { usePlaygroundModel } from '../context/playground-model-context';
 import { useBuilderModelPolicy } from '@/domains/agent-builder';
 import { useAgentBuilderAllowedModels } from '@/domains/agent-builder/hooks/use-agent-builder-allowed-models';
 import { LLMProviders, LLMModels, useLLMProviders, cleanProviderId, findProviderById } from '@/domains/llm';
@@ -17,30 +15,14 @@ const COMPOSER_TRIGGER_CLASS = [
   'transition-colors duration-normal',
 ].join(' ');
 
-export interface ComposerModelSwitcherProps {
-  agentId: string;
-}
-
-export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) => {
-  const { data: agent } = useAgent(agentId);
-  const { mutateAsync: updateModel } = useUpdateAgentModel(agentId);
+export const ComposerModelSwitcher = () => {
+  const { provider: selectedProvider, model: selectedModel, setProvider, setModel } = usePlaygroundModel();
   const { data: dataProviders, isLoading: providersLoading } = useLLMProviders();
   const policy = useBuilderModelPolicy();
 
-  const defaultProvider = agent?.provider || '';
-  const defaultModel = agent?.modelId || '';
-
-  const [selectedModel, setSelectedModel] = useState(defaultModel);
-  const [selectedProvider, setSelectedProvider] = useState(defaultProvider);
   const [modelOpen, setModelOpen] = useState(false);
 
   const providers = dataProviders?.providers || [];
-
-  // Update local state when agent data changes
-  useEffect(() => {
-    setSelectedModel(defaultModel);
-    setSelectedProvider(defaultProvider);
-  }, [defaultModel, defaultProvider]);
 
   const currentModelProvider = cleanProviderId(selectedProvider);
 
@@ -49,29 +31,16 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
   const fullProviderId = resolvedProvider?.id || currentModelProvider;
 
   // Auto-save when model changes
-  const handleModelSelect = async (modelId: string) => {
-    setSelectedModel(modelId);
-
-    if (modelId && fullProviderId) {
-      try {
-        await updateModel({
-          provider: fullProviderId as UpdateModelParams['provider'],
-          modelId,
-        });
-      } catch (error) {
-        console.error('Failed to update model:', error);
-      }
-    }
+  const handleModelSelect = (modelId: string) => {
+    if (modelId && fullProviderId) setModel(fullProviderId, modelId);
   };
 
   // Handle provider selection
   const handleProviderSelect = (providerId: string) => {
     const cleanedId = cleanProviderId(providerId);
-    setSelectedProvider(cleanedId);
-
     // Only clear model selection and open model combobox when switching to a different provider
     if (cleanedId !== currentModelProvider) {
-      setSelectedModel('');
+      setProvider(cleanedId);
       setModelOpen(true);
     }
   };
@@ -127,18 +96,18 @@ export const ComposerModelSwitcher = ({ agentId }: ComposerModelSwitcherProps) =
   );
 };
 
-export const ComposerModelWarning = ({ agentId }: ComposerModelSwitcherProps) => {
-  const { data: agent } = useAgent(agentId);
+export const ComposerModelWarning = () => {
+  const { provider, model } = usePlaygroundModel();
   const { data: dataProviders, isLoading: providersLoading } = useLLMProviders();
   const policy = useBuilderModelPolicy();
   const { models: allowedModels } = useAgentBuilderAllowedModels();
 
-  if (providersLoading || !agent) return null;
+  if (providersLoading) return null;
 
   const providers = dataProviders?.providers || [];
-  const currentModelProvider = cleanProviderId(agent.provider || '');
+  const currentModelProvider = cleanProviderId(provider);
   const currentProvider = findProviderById(providers, currentModelProvider);
-  const selectedModel = agent.modelId || '';
+  const selectedModel = model;
 
   const stale =
     Boolean(currentModelProvider && selectedModel) &&
@@ -166,7 +135,7 @@ export const ComposerModelWarning = ({ agentId }: ComposerModelSwitcherProps) =>
           <TriangleAlert className="w-3 h-3 shrink-0 mt-0.5" />
           <span className="min-w-0 break-words">
             <code className="px-1 py-0.5 bg-accent6Dark rounded text-accent6 break-all">
-              {agent.provider}/{selectedModel}
+              {provider}/{selectedModel}
             </code>{' '}
             is no longer allowed by admin policy. Pick a different model.
           </span>

--- a/packages/playground/src/domains/agents/context/playground-model-context.tsx
+++ b/packages/playground/src/domains/agents/context/playground-model-context.tsx
@@ -1,11 +1,19 @@
+/* eslint-disable react-refresh/only-export-components */
 import type { ReactNode } from 'react';
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useState } from 'react';
 
 interface PlaygroundModelContextType {
   provider: string;
   model: string;
+  modelOverride?: string;
   setProvider: (provider: string) => void;
-  setModel: (model: string) => void;
+  setModel: (provider: string, model: string) => void;
+}
+
+interface ModelSelection {
+  provider: string;
+  model: string;
+  explicit: boolean;
 }
 
 const PlaygroundModelContext = createContext<PlaygroundModelContextType | null>(null);
@@ -21,20 +29,27 @@ export function PlaygroundModelProvider({
   defaultProvider = '',
   defaultModel = '',
 }: PlaygroundModelProviderProps) {
-  const [provider, setProvider] = useState(defaultProvider);
-  const [model, setModel] = useState(defaultModel);
+  const [selection, setSelection] = useState<ModelSelection>({
+    provider: defaultProvider,
+    model: defaultModel,
+    explicit: false,
+  });
 
-  // Sync from form when it loads (defaultProvider/defaultModel may be empty on first render)
-  useEffect(() => {
-    if (defaultProvider && !provider) setProvider(defaultProvider);
-  }, [defaultProvider]);
+  const selectProvider = (nextProvider: string) => {
+    setSelection({ provider: nextProvider, model: '', explicit: false });
+  };
 
-  useEffect(() => {
-    if (defaultModel && !model) setModel(defaultModel);
-  }, [defaultModel]);
+  const selectModel = (nextProvider: string, nextModel: string) => {
+    setSelection({ provider: nextProvider, model: nextModel, explicit: true });
+  };
+
+  const { provider, model, explicit } = selection;
+  const modelOverride = explicit ? `${provider}/${model}` : undefined;
 
   return (
-    <PlaygroundModelContext.Provider value={{ provider, model, setProvider, setModel }}>
+    <PlaygroundModelContext.Provider
+      value={{ provider, model, modelOverride, setProvider: selectProvider, setModel: selectModel }}
+    >
       {children}
     </PlaygroundModelContext.Provider>
   );
@@ -50,5 +65,5 @@ export function usePlaygroundModel() {
 
 /** Like usePlaygroundModel but returns null outside the provider (e.g. shared session page). */
 export function usePlaygroundModelOptional() {
-  return useContext(PlaygroundModelContext);
+  return useContext(PlaygroundModelContext) ?? undefined;
 }

--- a/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx
@@ -3,16 +3,17 @@ import { useMemoryThreadMessages } from '@mastra/playground-ui/domains/memory/ho
 import { useObservationalMemory } from '@mastra/playground-ui/domains/memory/hooks/use-observational-memory';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { useEffect, useRef } from 'react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useChatMessages, useChatRunning, useChatSend } from '../chat-context';
 import { ChatProvider } from '../chat-provider';
 import { WorkingMemoryProvider } from '@/domains/agents/context/agent-working-memory-context';
+import { PlaygroundModelProvider, usePlaygroundModel } from '@/domains/agents/context/playground-model-context';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
@@ -159,6 +160,19 @@ const SendOnMount = ({ text }: { text: string }) => {
   return null;
 };
 
+const ModelSelectionHarness = () => {
+  const { setModel, setProvider } = usePlaygroundModel();
+  const send = useChatSend();
+
+  return (
+    <>
+      <button onClick={() => setModel('google', 'gemini-2.5-flash')}>Select model</button>
+      <button onClick={() => setProvider('openai')}>Change provider</button>
+      <button onClick={() => send({ message: 'Use selected model' })}>Send message</button>
+    </>
+  );
+};
+
 /**
  * Subscribes to the memory timeline panel's React Query keys (the playground-ui
  * hooks) so the test can observe whether OM stream events trigger a refetch.
@@ -179,6 +193,51 @@ describe('ChatProvider', () => {
     // Default tests target the legacy stream-until-idle route, not signals.
     (window as Window & { MASTRA_AGENT_SIGNALS?: string }).MASTRA_AGENT_SIGNALS = 'false';
     server.resetHandlers();
+  });
+
+  describe('when Studio selects a request-scoped model', () => {
+    it('only sends an explicit override without mutating the agent', async () => {
+      const captured: Captured[] = [];
+      const onMutation = vi.fn();
+      server.use(
+        ...baseHandlers(captured),
+        http.post(`${BASE_URL}/api/agents/agent-1/stream`, async ({ request }) => {
+          captured.push({ url: request.url, body: await captureBody(request) });
+          return sseResponse();
+        }),
+        http.post(`${BASE_URL}/api/agents/agent-1/model`, () => {
+          onMutation();
+          return HttpResponse.json({ message: 'unexpected mutation' });
+        }),
+      );
+
+      render(
+        <Wrapper>
+          <PlaygroundModelProvider defaultProvider="openai" defaultModel="gpt-4o-mini">
+            <ChatProvider agentId="agent-1" threadId="thread-1" initialMessages={[]}>
+              <ModelSelectionHarness />
+            </ChatProvider>
+          </PlaygroundModelProvider>
+        </Wrapper>,
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+      await waitFor(() => expect(captured).toHaveLength(1));
+      expect(captured[0].body).not.toHaveProperty('model');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Select model' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+      await waitFor(() => expect(captured).toHaveLength(2));
+      expect(captured[1].body.model).toBe('google/gemini-2.5-flash');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Change provider' }));
+      fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+      await waitFor(() => expect(captured).toHaveLength(3));
+      expect(captured[2].body).not.toHaveProperty('model');
+      expect(onMutation).not.toHaveBeenCalled();
+    });
   });
 
   it('streams via the agent stream endpoint and forwards the modelSettings', async () => {

--- a/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
+++ b/packages/playground/src/lib/ai-ui/chat/chat-provider.tsx
@@ -12,6 +12,7 @@ import type { MessagesContextValue, RunningContextValue, SendContextValue, Tasks
 import { useChatSendHandler } from './use-chat-send-handler';
 import { useObservationalMemoryContext } from '@/domains/agents/context';
 import { useWorkingMemory } from '@/domains/agents/context/agent-working-memory-context';
+import { usePlaygroundModelOptional } from '@/domains/agents/context/playground-model-context';
 import { useMemoryConfig } from '@/domains/memory/hooks';
 import { useTracingSettings } from '@/domains/observability/context/tracing-settings-context';
 import { getCanSendWhileStreaming } from '@/services/mastra-runtime-state';
@@ -49,6 +50,7 @@ export function ChatProvider({
   supportsMemory,
 }: Readonly<{ children: ReactNode }> & ChatProps) {
   const { settings: tracingSettings } = useTracingSettings();
+  const modelOverride = usePlaygroundModelOptional()?.modelOverride;
 
   // Errors emitted as `error` chunks (or thrown by sendMessage) are not persisted
   // to server memory, so they get wiped from useChat's `messages` state when
@@ -265,6 +267,7 @@ export function ChatProvider({
     agentVersionId,
     threadId,
     modelSettingsArgs,
+    model: modelOverride,
     chatWithNetwork,
     chatWithGenerate,
     maxSteps,

--- a/packages/playground/src/lib/ai-ui/chat/use-chat-send-handler.ts
+++ b/packages/playground/src/lib/ai-ui/chat/use-chat-send-handler.ts
@@ -55,6 +55,7 @@ const asHandledStreamChunk = (chunk: unknown): HandledStreamChunk | undefined =>
 };
 
 interface SendDeps {
+  model?: string;
   requestContext?: Record<string, unknown>;
   agentVersionId?: string;
   threadId?: string;
@@ -72,6 +73,7 @@ interface UseChatSendHandlerArgs {
   agentVersionId?: string;
   threadId?: string;
   modelSettingsArgs: Record<string, unknown>;
+  model?: string;
   chatWithNetwork?: boolean;
   chatWithGenerate?: boolean;
   maxSteps?: number;
@@ -118,6 +120,7 @@ export const useChatSendHandler = ({
   agentVersionId,
   threadId,
   modelSettingsArgs,
+  model,
   chatWithNetwork,
   chatWithGenerate,
   maxSteps,
@@ -146,6 +149,7 @@ export const useChatSendHandler = ({
     agentVersionId,
     threadId,
     modelSettingsArgs,
+    model,
     chatWithNetwork,
     chatWithGenerate,
     maxSteps,
@@ -157,6 +161,7 @@ export const useChatSendHandler = ({
     agentVersionId,
     threadId,
     modelSettingsArgs,
+    model,
     chatWithNetwork,
     chatWithGenerate,
     maxSteps,
@@ -246,6 +251,7 @@ export const useChatSendHandler = ({
             requestContext: requestContextInstance,
             threadId: deps.threadId,
             modelSettings: deps.modelSettingsArgs,
+            model: deps.model,
             signal: controller.signal,
             tracingOptions: deps.tracingOptions,
             onNetworkChunk: async (chunk: any) => {
@@ -266,6 +272,7 @@ export const useChatSendHandler = ({
             requestContext: requestContextInstance,
             threadId: deps.threadId,
             modelSettings: deps.modelSettingsArgs,
+            model: deps.model,
             signal: controller.signal,
             tracingOptions: deps.tracingOptions,
           });
@@ -280,6 +287,7 @@ export const useChatSendHandler = ({
             requestContext: requestContextInstance,
             threadId: deps.threadId,
             modelSettings: deps.modelSettingsArgs,
+            model: deps.model,
             tracingOptions: deps.tracingOptions,
             onChunk: async (chunk: any) => {
               if (chunk.type === 'finish') {

--- a/packages/playground/src/lib/ai-ui/thread.tsx
+++ b/packages/playground/src/lib/ai-ui/thread.tsx
@@ -315,7 +315,7 @@ const AgentComposer = ({
             }}
             disabled={!canExecuteAgent}
           />
-          {agentId && !hasModelList && !hideModelSwitcher && <ComposerModelWarning agentId={agentId} />}
+          {agentId && !hasModelList && !hideModelSwitcher && <ComposerModelWarning />}
           <ComposerActions>
             <ComposerActionRow
               canExecute={canExecuteAgent}
@@ -392,7 +392,7 @@ const ComposerActionRow = ({
           {showModelSwitcher && agentId && (
             <>
               <div className="rounded-full bg-surface3 border border-border1 transition-colors duration-normal focus-within:border-border2">
-                <ComposerModelSwitcher agentId={agentId} />
+                <ComposerModelSwitcher />
               </div>
               <ComposerModelSettings agentId={agentId} />
             </>

--- a/packages/server/src/server/schemas/agents.ts
+++ b/packages/server/src/server/schemas/agents.ts
@@ -385,6 +385,7 @@ export const agentExecutionBodySchema = z
     stopWhen: typedPermissive<StopConditionArg | StopConditionArg[]>(z.unknown()).optional(),
 
     // Model Configuration
+    model: z.string().optional(),
     providerOptions: typedPermissive<Record<string, Record<string, JSONValue>>>(
       z.object({
         anthropic: z.record(z.string(), z.unknown()).optional(),
@@ -494,12 +495,14 @@ export const executeToolContextBodySchema = executeToolDataBodySchema.extend({
  */
 const toolCallActionBodySchema = z.object({
   runId: z.string(),
+  model: z.string().optional(),
   requestContext: z.record(z.string(), z.unknown()).optional(),
   toolCallId: z.string(),
   format: z.string().optional(),
 });
 const networkToolCallActionBodySchema = z.object({
   runId: z.string(),
+  model: z.string().optional(),
   requestContext: z.record(z.string(), z.unknown()).optional(),
   format: z.string().optional(),
 });


### PR DESCRIPTION
## Description

Studio's model picker changed the agent's shared model, so choosing a model in one tab also changed it in every other tab.

The picker now keeps the selection in the current Studio tab and sends it as an optional model override with each execution. Tabs can use different models, and reloading restores the agent's default. The override is forwarded through generate, stream, network, and tool approval requests. Requests without an explicit selection still use the configured or dynamic default.

Tested with:

- `pnpm --filter @mastra/client-js test:unit src/resources/agent.test.ts`
- `pnpm --filter @mastra/react test:unit src/agent/hooks.test.ts`
- `pnpm --filter @mastra/core test:unit src/loop/network/index.test.ts`
- `pnpm --filter ./packages/playground test:run src/lib/ai-ui/chat/__tests__/chat-provider.test.tsx`
- Manual two-tab Studio check: Tab A changed to `google/gemini-2.5-flash`, Tab B stayed on `openai/gpt-4o-mini`, and reloading Tab A restored its default

## Related issue(s)

Fixes #12845

## Demo
https://cap.so/s/b03kvzsgjyg7b5m

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (release behavior is covered by the changeset)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Studio tabs can now pick different AI models without accidentally changing the model used by other tabs or users. The selected model is attached to each request, and if you refresh/reload, Studio goes back to the agent’s normal default.

## What changed

- Scoped model selection to the current tab/request by introducing request-scoped, optional `model` overrides that are sent with execution and continuation requests.
- Updated the client/React chat flow to read the selected Studio model and pass it through `generate`, `stream`, and `network` requests.
- Refactored Studio model selection to use tab-local playground model context (with remounting via a provider `key` and context-driven model switcher/warning), so switching providers/agents or reloading restores the default behavior.
- Ensured tool call approvals/declines (and idle/continuation resume paths) forward the same request context and include the same model when a model override was explicitly selected.
- Extended server request contracts and validation schemas to accept optional `model` for agent execution and tool approval/decline actions.
- Updated core network/routing to allow an explicitly selected routing-agent model and propagate it through routing/resumption/validation sub-requests.
- Added/updated tests covering request serialization of model overrides, tool approval flows in both stream and network modes, routing-model propagation, and Studio behavior for request-scoped selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->