### PR TITLE
fix(inngest): restore nested workflow resume path

### DIFF
--- a/.changeset/tender-shoes-clean.md
+++ b/.changeset/tender-shoes-clean.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixed nested Inngest workflows to resume the suspended child step when only the parent workflow step is provided.

--- a/workflows/inngest/src/execution-engine.test.ts
+++ b/workflows/inngest/src/execution-engine.test.ts
@@ -98,56 +98,52 @@ describe('InngestExecutionEngine.executeStepWithRetry', () => {
   });
 });
 
-describe('InngestExecutionEngine.executeWorkflowStep', () => {
-  it('restores the suspended child path when resuming with only the nested workflow id', async () => {
-    const inngest = new Inngest({ id: 'nested-resume-test' });
-    const { createWorkflow, createStep } = init(inngest);
-    const suspendedStep = createStep({
-      id: 'suspended-child-step',
-      inputSchema: z.object({ value: z.string() }),
-      outputSchema: z.object({ value: z.string() }),
-      execute: async ({ inputData }) => inputData,
-    });
-    const nestedWorkflow = createWorkflow({
-      id: 'nested-resume-workflow',
-      inputSchema: z.object({ value: z.string() }),
-      outputSchema: z.object({ value: z.string() }),
-      steps: [suspendedStep],
-    })
-      .then(suspendedStep)
-      .commit();
+function createNestedResumeFixture(suspendedPaths: Record<string, number[]>) {
+  const inngest = new Inngest({ id: 'nested-resume-test' });
+  const { createWorkflow, createStep } = init(inngest);
+  const suspendedStep = createStep({
+    id: 'suspended-child-step',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+    execute: async ({ inputData }) => inputData,
+  });
+  const nestedWorkflow = createWorkflow({
+    id: 'nested-resume-workflow',
+    inputSchema: z.object({ value: z.string() }),
+    outputSchema: z.object({ value: z.string() }),
+    steps: [suspendedStep],
+  })
+    .then(suspendedStep)
+    .commit();
 
-    const nestedRunId = 'nested-run';
-    const nestedStepResults = {
-      [suspendedStep.id]: {
-        status: 'suspended',
-        payload: { value: 'before-suspend' },
-      },
-    };
-    const loadWorkflowSnapshot = vi.fn().mockResolvedValue({
-      value: { count: 1 },
-      context: nestedStepResults,
-      suspendedPaths: { [suspendedStep.id]: [1, 0] },
-    });
-    const mastra = {
-      getStorage: () => ({
-        getStore: async () => ({ loadWorkflowSnapshot }),
-      }),
-    } as unknown as Mastra;
-    const invoke = vi.fn().mockResolvedValue({
-      result: { status: 'success', result: { value: 'resumed' }, state: { count: 2 } },
-      runId: nestedRunId,
-    });
-    const inngestStep = {
-      invoke,
-      run: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
-      sleep: vi.fn(),
-      sleepUntil: vi.fn(),
-    };
-    const engine = new InngestExecutionEngine(mastra, inngestStep as any, 0, {});
-    const resumePayload = { approved: true };
-
-    await engine.executeWorkflowStep({
+  const nestedRunId = 'nested-run';
+  const nestedStepResults = Object.fromEntries(
+    Object.keys(suspendedPaths).map(stepId => [stepId, { status: 'suspended', payload: { value: 'before-suspend' } }]),
+  );
+  const loadWorkflowSnapshot = vi.fn().mockResolvedValue({
+    value: { count: 1 },
+    context: nestedStepResults,
+    suspendedPaths,
+  });
+  const mastra = {
+    getStorage: () => ({
+      getStore: async () => ({ loadWorkflowSnapshot }),
+    }),
+  } as unknown as Mastra;
+  const invoke = vi.fn().mockResolvedValue({
+    result: { status: 'success', result: { value: 'resumed' }, state: { count: 2 } },
+    runId: nestedRunId,
+  });
+  const inngestStep = {
+    invoke,
+    run: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
+    sleep: vi.fn(),
+    sleepUntil: vi.fn(),
+  };
+  const engine = new InngestExecutionEngine(mastra, inngestStep as any, 0, {});
+  const resumePayload = { approved: true };
+  const execute = () =>
+    engine.executeWorkflowStep({
       step: nestedWorkflow as any,
       stepResults: {
         [nestedWorkflow.id]: {
@@ -169,6 +165,34 @@ describe('InngestExecutionEngine.executeWorkflowStep', () => {
       startedAt: Date.now(),
     });
 
+  return {
+    execute,
+    invoke,
+    loadWorkflowSnapshot,
+    nestedRunId,
+    nestedStepResults,
+    nestedWorkflow,
+    resumePayload,
+    suspendedStep,
+  };
+}
+
+describe('InngestExecutionEngine.executeWorkflowStep', () => {
+  it('restores the suspended child path when resuming with only the nested workflow id', async () => {
+    const fixture = createNestedResumeFixture({ 'suspended-child-step': [1, 0] });
+    const {
+      execute,
+      invoke,
+      loadWorkflowSnapshot,
+      nestedRunId,
+      nestedStepResults,
+      nestedWorkflow,
+      resumePayload,
+      suspendedStep,
+    } = fixture;
+
+    await execute();
+
     expect(loadWorkflowSnapshot).toHaveBeenCalledWith({
       workflowName: nestedWorkflow.id,
       runId: nestedRunId,
@@ -180,6 +204,30 @@ describe('InngestExecutionEngine.executeWorkflowStep', () => {
       stepResults: nestedStepResults,
       resumePayload,
       resumePath: [1, 0],
+    });
+  });
+
+  it.each([
+    {
+      name: 'no suspended child',
+      suspendedPaths: {},
+      message: 'No suspended steps found in nested workflow: nested-resume-workflow',
+    },
+    {
+      name: 'multiple suspended children',
+      suspendedPaths: { 'first-child': [1, 0], 'second-child': [1, 1] },
+      message:
+        'Multiple suspended steps found: [first-child], [second-child]. Please specify which step to resume using the "step" parameter.',
+    },
+  ])('does not guess a resume target with $name', async ({ suspendedPaths, message }) => {
+    const { execute, invoke } = createNestedResumeFixture(suspendedPaths);
+
+    const result = await execute();
+
+    expect(invoke).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      status: 'failed',
+      error: expect.objectContaining({ message }),
     });
   });
 });

--- a/workflows/inngest/src/execution-engine.test.ts
+++ b/workflows/inngest/src/execution-engine.test.ts
@@ -1,7 +1,10 @@
 import { MastraNonRetryableError } from '@mastra/core/error';
-import { NonRetriableError } from 'inngest';
+import type { Mastra } from '@mastra/core/mastra';
+import { Inngest, NonRetriableError } from 'inngest';
 import { describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
 import { InngestExecutionEngine } from './execution-engine';
+import { init } from './index';
 
 function createEngine() {
   const inngestStep = {
@@ -92,5 +95,91 @@ describe('InngestExecutionEngine.executeStepWithRetry', () => {
     if (!result.ok) {
       expect(result.error.nonRetryable).toBeUndefined();
     }
+  });
+});
+
+describe('InngestExecutionEngine.executeWorkflowStep', () => {
+  it('restores the suspended child path when resuming with only the nested workflow id', async () => {
+    const inngest = new Inngest({ id: 'nested-resume-test' });
+    const { createWorkflow, createStep } = init(inngest);
+    const suspendedStep = createStep({
+      id: 'suspended-child-step',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      execute: async ({ inputData }) => inputData,
+    });
+    const nestedWorkflow = createWorkflow({
+      id: 'nested-resume-workflow',
+      inputSchema: z.object({ value: z.string() }),
+      outputSchema: z.object({ value: z.string() }),
+      steps: [suspendedStep],
+    })
+      .then(suspendedStep)
+      .commit();
+
+    const nestedRunId = 'nested-run';
+    const nestedStepResults = {
+      [suspendedStep.id]: {
+        status: 'suspended',
+        payload: { value: 'before-suspend' },
+      },
+    };
+    const loadWorkflowSnapshot = vi.fn().mockResolvedValue({
+      value: { count: 1 },
+      context: nestedStepResults,
+      suspendedPaths: { [suspendedStep.id]: [1, 0] },
+    });
+    const mastra = {
+      getStorage: () => ({
+        getStore: async () => ({ loadWorkflowSnapshot }),
+      }),
+    } as unknown as Mastra;
+    const invoke = vi.fn().mockResolvedValue({
+      result: { status: 'success', result: { value: 'resumed' }, state: { count: 2 } },
+      runId: nestedRunId,
+    });
+    const inngestStep = {
+      invoke,
+      run: vi.fn(async (_id: string, fn: () => Promise<unknown>) => fn()),
+      sleep: vi.fn(),
+      sleepUntil: vi.fn(),
+    };
+    const engine = new InngestExecutionEngine(mastra, inngestStep as any, 0, {});
+    const resumePayload = { approved: true };
+
+    await engine.executeWorkflowStep({
+      step: nestedWorkflow as any,
+      stepResults: {
+        [nestedWorkflow.id]: {
+          status: 'suspended',
+          suspendPayload: { __workflow_meta: { runId: nestedRunId } },
+        },
+      },
+      executionContext: {
+        workflowId: 'parent-workflow',
+        runId: 'parent-run',
+        executionPath: [0],
+        suspendedPaths: {},
+        state: {},
+      } as any,
+      resume: { steps: [nestedWorkflow.id], resumePayload },
+      prevOutput: {},
+      inputData: { value: 'start' },
+      pubsub: { publish: vi.fn().mockResolvedValue(undefined) } as any,
+      startedAt: Date.now(),
+    });
+
+    expect(loadWorkflowSnapshot).toHaveBeenCalledWith({
+      workflowName: nestedWorkflow.id,
+      runId: nestedRunId,
+    });
+    expect(invoke).toHaveBeenCalledTimes(1);
+    expect(invoke.mock.calls[0]?.[1].data.resume).toEqual({
+      runId: nestedRunId,
+      steps: [suspendedStep.id],
+      stepResults: nestedStepResults,
+      resumePayload,
+      resumePath: [1, 0],
+    });
   });
 });

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -523,6 +523,15 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
           runId: runId,
         });
 
+        const nestedResumeSteps = resume.steps.slice(1);
+        if (nestedResumeSteps.length === 0) {
+          const suspendedStepId = Object.keys(snapshot?.suspendedPaths ?? {})[0];
+          if (suspendedStepId) {
+            nestedResumeSteps.push(suspendedStepId);
+          }
+        }
+        const nestedResumeStepId = nestedResumeSteps[0];
+
         const invokeResp = (await this.inngestStep.invoke(`workflow.${executionContext.workflowId}.step.${step.id}`, {
           function: step.getFunction(),
           data: {
@@ -532,10 +541,10 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
             runId: runId,
             resume: {
               runId: runId,
-              steps: resume.steps.slice(1),
+              steps: nestedResumeSteps,
               stepResults: snapshot?.context as any,
               resumePayload: resume.resumePayload,
-              resumePath: resume.steps?.[1] ? (snapshot?.suspendedPaths?.[resume.steps?.[1]] as any) : undefined,
+              resumePath: nestedResumeStepId ? (snapshot?.suspendedPaths?.[nestedResumeStepId] as any) : undefined,
             },
             outputOptions: { includeState: true },
             perStep,

--- a/workflows/inngest/src/execution-engine.ts
+++ b/workflows/inngest/src/execution-engine.ts
@@ -525,10 +525,18 @@ export class InngestExecutionEngine extends DefaultExecutionEngine {
 
         const nestedResumeSteps = resume.steps.slice(1);
         if (nestedResumeSteps.length === 0) {
-          const suspendedStepId = Object.keys(snapshot?.suspendedPaths ?? {})[0];
-          if (suspendedStepId) {
-            nestedResumeSteps.push(suspendedStepId);
+          const suspendedStepIds = Object.keys(snapshot?.suspendedPaths ?? {});
+          if (suspendedStepIds.length === 0) {
+            throw new Error(`No suspended steps found in nested workflow: ${step.id}`);
           }
+          if (suspendedStepIds.length > 1) {
+            const pathStrings = suspendedStepIds.map(stepId => `[${stepId}]`);
+            throw new Error(
+              `Multiple suspended steps found: ${pathStrings.join(', ')}. ` +
+                'Please specify which step to resume using the "step" parameter.',
+            );
+          }
+          nestedResumeSteps.push(suspendedStepIds[0]!);
         }
         const nestedResumeStepId = nestedResumeSteps[0];
 


### PR DESCRIPTION
## Description

Nested Inngest workflows received an empty child resume path when the parent was resumed with only the nested workflow ID. This restores the suspended child step and its path from the nested snapshot before invoking the child workflow, so the original tool receives the resume payload instead of starting a fresh execution.

This addresses Issue 1 in the upstream defect report submitted directly by Interfere. It is independent of #19429 and does not change actor propagation or durable trigger/resume event fields.

Validation: the focused execution-engine and actor-signal suites pass with 12 tests, package lint passes, and CodeRabbit reported no findings. The package build remains blocked by existing generated-type errors involving `RequestContext` and `EntityType` across unchanged Inngest files.

## Related issue(s)

No public GitHub issue; reported directly by Interfere as Issue 1 of their upstream defect report.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If one workflow pauses inside another, resuming it now reliably continues the inner workflow from the exact spot it stopped. It does this by reloading the saved “where it was paused” info from the inner workflow’s snapshot, instead of starting fresh or guessing.

## Summary

- Restores nested Inngest workflow resume-path handling for “resume with only the nested workflow id”.
- When nested resume details are incomplete, `executeWorkflowStep`:
  - Loads the nested workflow snapshot (`suspendedPaths`) to reconstruct the suspended child step list.
  - Sets the nested `resumePath` from that snapshot.
- Rejects ambiguous nested resumes:
  - Errors if no suspended child steps exist in the nested snapshot.
  - Errors if multiple suspended child steps exist (requiring the caller to specify the `step` parameter), and avoids invoking the nested workflow.
- Adds/updates tests covering:
  - Execution-engine restoration of the suspended child path and forwarding of the correct nested resume payload.
  - Actor-signal threading through nested workflow resume (ensuring `actor` is present on the nested `RESUME` invoke payload).
- Updates the `@mastra/inngest` changeset for a patch release.

## Validation

- 12 focused tests passing.
- Package lint passing.
- Package build remains blocked by existing generated-type errors involving `RequestContext` and `EntityType`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->