### PR TITLE
fix(core): route tool result media for AI SDK v7

### DIFF
--- a/.changeset/wacky-baboons-mix.md
+++ b/.changeset/wacky-baboons-mix.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed AI SDK v7 providers receiving screenshot and file tool results in an older content format. Tool result media is now sent in the file content shape expected by v7 providers such as Bedrock.

--- a/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-execution.ts
@@ -502,9 +502,11 @@ export function createDurableLLMExecutionStep(_options?: DurableLLMExecutionStep
               model: currentModel,
             });
             const llmPromptForModel =
-              currentModel.specificationVersion === 'v3' || currentModel.specificationVersion === 'v4'
-                ? messageList.get.all.aiV6.llmPrompt
-                : messageList.get.all.aiV5.llmPrompt;
+              currentModel.specificationVersion === 'v4'
+                ? messageList.get.all.aiV7.llmPrompt
+                : currentModel.specificationVersion === 'v3'
+                  ? messageList.get.all.aiV6.llmPrompt
+                  : messageList.get.all.aiV5.llmPrompt;
             let inputMessages = (await llmPromptForModel(messageListPromptArgs)) as LanguageModelV2Prompt;
 
             // Inject the auto-resume directive into the leading system message when

--- a/packages/core/src/agent/message-list/conversion/index.ts
+++ b/packages/core/src/agent/message-list/conversion/index.ts
@@ -2,6 +2,7 @@ export {
   aiV4CoreMessageToV1PromptMessage,
   aiV5ModelMessageToV2PromptMessage,
   aiV5PromptToAIV6Prompt,
+  aiV5PromptToAIV7Prompt,
 } from './to-prompt';
 export { coreContentToString, messagesAreEqual } from './utils';
 export {

--- a/packages/core/src/agent/message-list/conversion/to-prompt.ts
+++ b/packages/core/src/agent/message-list/conversion/to-prompt.ts
@@ -287,29 +287,18 @@ export function aiV5ModelMessageToV2PromptMessage(modelMessage: AIV5Type.ModelMe
 }
 
 /**
- * Convert a V2 (AI SDK v5 / spec `v2`) prompt into the shape AI SDK v6
- * (spec `v3`) providers expect, by translating tool-result `media` parts into
- * the `image-data`/`file-data` content parts that v6 providers consume.
- *
- * This is a single-responsibility conversion meant to be chained after the
- * base v5 prompt build: `aiV6.llmPrompt()` = `aiV5.llmPrompt()` -> this.
+ * Convert tool-result `media` parts in a V2 (AI SDK v5 / spec `v2`) prompt
+ * using a caller-provided target content-part shape.
  *
  * Mastra's `toModelOutput` and the vendored AI SDK v5 use `{ type: 'media' }`
- * as the authored multimodal tool-result content type. AI SDK v6 added a
- * `mapToolResultOutput` step that converts `media` -> `image-data` (for
- * `image/*` media types) or `file-data` (everything else) before the prompt
- * reaches the provider, and v6 providers (e.g. `@ai-sdk/anthropic@3`) only
- * recognize `image-data`/`file-data` — they have no `media` case. The vendored
- * v5 converter does not run that translation, so a v5-built prompt handed to a
- * v6 provider drops the raw `media` part (image tool results arrive empty).
- *
- * This MUST only run for v6 (`v3`) providers: v5 providers (spec `v2`) accept
- * `media` and have no `image-data`/`file-data` case, so translating for them
- * would re-break v5.
- *
- * See: https://github.com/mastra-ai/mastra/issues/17876
+ * as the authored multimodal tool-result content type. Newer AI SDK provider
+ * specs use different content-part shapes, so callers provide the target
+ * conversion for their provider spec.
  */
-export function aiV5PromptToAIV6Prompt(prompt: LanguageModelV2Prompt): LanguageModelV2Prompt {
+function convertToolResultContent(
+  prompt: LanguageModelV2Prompt,
+  convertMediaPart: (contentPart: Record<string, unknown>, mediaType: string) => unknown,
+): LanguageModelV2Prompt {
   return prompt.map(message => {
     if (message.role !== `tool`) return message;
 
@@ -326,9 +315,7 @@ export function aiV5PromptToAIV6Prompt(prompt: LanguageModelV2Prompt): LanguageM
         if (contentPart.type !== `media` || typeof contentPart.data !== `string`) return item;
         outputModified = true;
         const mediaType = typeof contentPart.mediaType === `string` ? contentPart.mediaType : ``;
-        return mediaType.startsWith(`image/`)
-          ? { type: `image-data`, data: contentPart.data, mediaType }
-          : { type: `file-data`, data: contentPart.data, mediaType };
+        return convertMediaPart(contentPart, mediaType);
       });
 
       if (!outputModified) return part;
@@ -338,4 +325,27 @@ export function aiV5PromptToAIV6Prompt(prompt: LanguageModelV2Prompt): LanguageM
 
     return messageModified ? { ...message, content } : message;
   }) as LanguageModelV2Prompt;
+}
+
+/**
+ * Convert v5-authored media tool results to the `image-data`/`file-data` shape
+ * expected only by AI SDK v6 (`v3`) providers. V5 providers accept `media`, and
+ * V7 providers expect `file` parts with tagged data instead.
+ *
+ * See: https://github.com/mastra-ai/mastra/issues/17876
+ */
+export function aiV5PromptToAIV6Prompt(prompt: LanguageModelV2Prompt): LanguageModelV2Prompt {
+  return convertToolResultContent(prompt, (contentPart, mediaType) =>
+    mediaType.startsWith(`image/`)
+      ? { type: `image-data`, data: contentPart.data, mediaType }
+      : { type: `file-data`, data: contentPart.data, mediaType },
+  );
+}
+
+export function aiV5PromptToAIV7Prompt(prompt: LanguageModelV2Prompt): LanguageModelV2Prompt {
+  return convertToolResultContent(prompt, (contentPart, mediaType) => ({
+    type: `file`,
+    data: { type: `data`, data: contentPart.data },
+    mediaType,
+  }));
 }

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -15,6 +15,7 @@ import {
   aiV4CoreMessageToV1PromptMessage,
   aiV5ModelMessageToV2PromptMessage,
   aiV5PromptToAIV6Prompt,
+  aiV5PromptToAIV7Prompt,
   coreContentToString,
   messagesAreEqual,
   inputToMastraDBMessage as convertInputToMastraDBMessage,
@@ -691,6 +692,17 @@ export class MessageList {
         downloadRetries?: number;
         supportedUrls?: Record<string, RegExp[]>;
       }): Promise<LanguageModelV2Prompt> => aiV5PromptToAIV6Prompt(await this.all.aiV5.llmPrompt(options)),
+    },
+    aiV7: {
+      ui: () => this.toAIV6UIMessages(this.all.db()),
+
+      // Builds the v5 prompt, then converts tool-result `media` parts to the
+      // file content shape AI SDK v7 (spec 'v4') providers require.
+      llmPrompt: async (options?: {
+        downloadConcurrency?: number;
+        downloadRetries?: number;
+        supportedUrls?: Record<string, RegExp[]>;
+      }): Promise<LanguageModelV2Prompt> => aiV5PromptToAIV7Prompt(await this.all.aiV5.llmPrompt(options)),
     },
 
     /* @deprecated use list.get.all.aiV4.prompt() instead */

--- a/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
+++ b/packages/core/src/agent/message-list/tests/message-list-v5.test.ts
@@ -1982,6 +1982,90 @@ describe('MessageList V5 Support', () => {
       });
     });
 
+    it('translates image tool-result media to file content for v7 (spec v4) models', async () => {
+      const list = new MessageList({ threadId, resourceId });
+
+      list.add('Take a screenshot', 'input');
+
+      const continuationMessage: AIV5ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-v7-1',
+            toolName: 'screenshotTool',
+            input: { url: 'https://example.com' },
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-v7-1',
+            toolName: 'screenshotTool',
+            output: { type: 'json', value: { ok: true } },
+            providerOptions: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [{ type: 'media', data: 'base64imagedata', mediaType: 'image/png' }],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      list.add(continuationMessage, 'input');
+
+      const prompt = await list.get.all.aiV7.llmPrompt();
+      const toolRole = prompt.find(m => m.role === 'tool');
+      const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
+      expect(toolResultPart.output).toEqual({
+        type: 'content',
+        value: [{ type: 'file', data: { type: 'data', data: 'base64imagedata' }, mediaType: 'image/png' }],
+      });
+    });
+
+    it('translates non-image tool-result media to file content for v7 (spec v4) models', async () => {
+      const list = new MessageList({ threadId, resourceId });
+
+      list.add('Fetch a document', 'input');
+
+      const continuationMessage: AIV5ModelMessage = {
+        role: 'assistant',
+        content: [
+          {
+            type: 'tool-call',
+            toolCallId: 'call-v7-2',
+            toolName: 'docTool',
+            input: {},
+          },
+          {
+            type: 'tool-result',
+            toolCallId: 'call-v7-2',
+            toolName: 'docTool',
+            output: { type: 'json', value: { ok: true } },
+            providerOptions: {
+              mastra: {
+                modelOutput: {
+                  type: 'content',
+                  value: [{ type: 'media', data: 'base64pdfdata', mediaType: 'application/pdf' }],
+                },
+              },
+            },
+          },
+        ],
+      };
+
+      list.add(continuationMessage, 'input');
+
+      const prompt = await list.get.all.aiV7.llmPrompt();
+      const toolRole = prompt.find(m => m.role === 'tool');
+      const toolResultPart = (toolRole as any).content.find((p: any) => p.type === 'tool-result');
+      expect(toolResultPart.output).toEqual({
+        type: 'content',
+        value: [{ type: 'file', data: { type: 'data', data: 'base64pdfdata' }, mediaType: 'application/pdf' }],
+      });
+    });
+
     it('should convert MCP content-array tool results to multimodal model output without providerMetadata duplication', async () => {
       const list = new MessageList({ threadId, resourceId });
 

--- a/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
+++ b/packages/core/src/loop/workflows/agentic-execution/llm-execution-step.ts
@@ -1294,9 +1294,11 @@ export function createLLMExecutionStep<TOOLS extends ToolSet = ToolSet, OUTPUT =
             downloadConcurrency,
           });
           const llmPromptForModel =
-            currentStep.model?.specificationVersion === 'v3' || currentStep.model?.specificationVersion === 'v4'
-              ? messageList.get.all.aiV6.llmPrompt
-              : messageList.get.all.aiV5.llmPrompt;
+            currentStep.model?.specificationVersion === 'v4'
+              ? messageList.get.all.aiV7.llmPrompt
+              : currentStep.model?.specificationVersion === 'v3'
+                ? messageList.get.all.aiV6.llmPrompt
+                : messageList.get.all.aiV5.llmPrompt;
           let inputMessages = await llmPromptForModel(messageListPromptArgs);
 
           inputMessages = applyAutoResumeSystemMessage({

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.test.ts
@@ -56,6 +56,28 @@ describe('prepareToolsAndToolChoice', () => {
       });
     });
 
+    it('should use provider type for v4 target version', () => {
+      const providerTool = {
+        id: 'openai.web_search',
+        type: 'provider-defined',
+        args: {},
+      };
+
+      const result = prepareToolsAndToolChoice({
+        tools: { search: providerTool as any },
+        toolChoice: undefined,
+        activeTools: undefined,
+        targetVersion: 'v4',
+      });
+
+      expect(result.tools).toBeDefined();
+      expect(result.tools![0]).toMatchObject({
+        type: 'provider',
+        name: 'search',
+        id: 'openai.web_search',
+      });
+    });
+
     it('should handle nested provider tool names correctly', () => {
       // Tool with nested name like 'provider.category.tool_name'
       const providerTool = {

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -116,13 +116,13 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
       .map(([name, tool]) => {
         try {
           // Check if this is a provider tool BEFORE calling toolFn
-          // V6 provider tools (like openaiV6.tools.webSearch()) have type='function' but
+          // Newer provider tools (like openaiV6.tools.webSearch()) have type='function' but
           // contain an 'id' property with format '<provider>.<tool_name>'
           if (isProviderDefinedTool(tool)) {
             // V5 SDK factories set a hardcoded `.name` (e.g. "web_search"
-            // for anthropic.web_search_20250305). V6 factories don't, so
-            // we fall back to the user-provided key. Either way, the V6
-            // provider's bidirectional toolNameMapping will map correctly.
+            // for anthropic.web_search_20250305). Newer factories don't, so
+            // we fall back to the user-provided key. Either way, the provider's
+            // bidirectional toolNameMapping will map correctly.
             const toolName = (tool as any).name ?? name;
             return {
               type: providerToolType,

--- a/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
+++ b/packages/core/src/stream/aisdk/v5/compat/prepare-tools.ts
@@ -14,7 +14,7 @@ import { isStandardSchemaWithJSON, standardSchemaToJSONSchema } from '../../../.
 import { isProviderDefinedTool } from '../../../../tools/toolchecks';
 
 /** Model specification version for tool type conversion */
-export type ModelSpecVersion = 'v2' | 'v3';
+export type ModelSpecVersion = 'v2' | 'v3' | 'v4';
 
 /** Combined tool types for both V2 and V3 */
 type PreparedTool =
@@ -78,7 +78,7 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
   tools: TOOLS | undefined;
   toolChoice: ToolChoice<TOOLS> | undefined;
   activeTools: Array<keyof TOOLS> | undefined;
-  /** Target model version: 'v2' for AI SDK v5, 'v3' for AI SDK v6. Defaults to 'v2'. */
+  /** Target model version: 'v2' for AI SDK v5, 'v3' for AI SDK v6, 'v4' for AI SDK v7. Defaults to 'v2'. */
   targetVersion?: ModelSpecVersion;
 }): {
   tools: PreparedTool[] | undefined;
@@ -108,8 +108,8 @@ export function prepareToolsAndToolChoice<TOOLS extends Record<string, Tool>>({
 
   // Provider tool type differs between versions:
   // - V2 (AI SDK v5): 'provider-defined'
-  // - V3 (AI SDK v6): 'provider'
-  const providerToolType = targetVersion === 'v3' ? 'provider' : 'provider-defined';
+  // - V3/V4 (AI SDK v6/v7): 'provider'
+  const providerToolType = targetVersion === 'v2' ? 'provider-defined' : 'provider';
 
   return {
     tools: filteredTools

--- a/packages/core/src/stream/aisdk/v5/execute.ts
+++ b/packages/core/src/stream/aisdk/v5/execute.ts
@@ -120,7 +120,7 @@ export function execute<OUTPUT = undefined>({
   // Determine target version based on model's specificationVersion
   // V3 (AI SDK v6) and V4 (AI SDK v7) models need 'provider' type, V2 models need 'provider-defined'
   const targetVersion: ModelSpecVersion =
-    model.specificationVersion === 'v3' || model.specificationVersion === 'v4' ? 'v3' : 'v2';
+    model.specificationVersion === 'v4' ? 'v4' : model.specificationVersion === 'v3' ? 'v3' : 'v2';
 
   const toolsAndToolChoice = prepareToolsAndToolChoice({
     tools,


### PR DESCRIPTION
## Description

Fixes AI SDK v7/spec-v4 providers receiving tool-result media in the older spec-v3 `image-data`/`file-data` format. This ensures screenshot and file tool results are converted to the spec-v4 `file` content shape expected by providers such as Bedrock.

- Adds an `aiV7` message-list prompt builder that emits spec-v4 tool-result file content
- Routes spec-v4 models through `aiV7.llmPrompt()` instead of the spec-v3 `aiV6` prompt path
- Updates durable and non-durable LLM execution paths to preserve v2/v3/v4 prompt routing separately
- Updates AI SDK stream tool preparation to recognize `v4` targets and use spec-v4-compatible provider tool types
- Adds regression coverage for v7 media conversion and v4 tool preparation
- Adds a patch changeset for `@mastra/core`

## Related Issue(s)

Fixes #19658

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Some AI providers (like certain “spec v4” ones) only understand screenshots/files if they’re packaged in a specific newer shape. This PR converts tool-results into that newer “v7” file format for spec-v4 models, so screenshots/files stop breaking with unsupported content errors.

## What changed
- Added an **AI SDK v7 prompt builder** (`aiV7.llmPrompt`) that converts tool-result `media` (images and other documents) into **spec-v4 compatible `file` content** using tagged `{ type: 'data', data: ... }`.
- Introduced a dedicated converter (`aiV5PromptToAIV7Prompt`) and refactored the existing conversion pipeline to share common traversal logic for tool-result content.
- Updated **prompt routing** so **spec-v4 models use the v7 prompt path** (instead of going through the older v6/spec-v3 path) in both:
  - durable LLM execution, and
  - non-durable/agentic LLM execution.
- Updated **stream tool preparation** for `v4` targets:
  - `execute` now maps `v4 -> v4` (not `v3`)
  - `prepareToolsAndToolChoice` now treats `v3`/`v4` as `provider` tools (while only `v2` remains `provider-defined`), and extends the accepted spec versions to include `v4`.
- Added **regression tests** for:
  - converting **image** tool results into the v7 `file` format, and
  - converting **non-image** tool results (e.g., PDFs) into the same v7 `file` format.
- Added a **patch changeset** for `@mastra/core` publishing this fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->