### PR TITLE
docs(inngest): document generate suspension behavior

### DIFF
--- a/docs/src/content/en/reference/agents/inngest-agent.mdx
+++ b/docs/src/content/en/reference/agents/inngest-agent.mdx
@@ -77,7 +77,7 @@ Returns: [`InngestAgent`](#inngestagent-interface)
     type: 'Agent',
     isOptional: false,
     description:
-      'The Agent to wrap with Inngest durable execution. Agent methods (e.g., `generate()`, `listTools()`, `getMemory()`) delegate to this agent via a Proxy.',
+      'The Agent to wrap with Inngest durable execution. Methods not implemented by `InngestAgent` (e.g., `listTools()` and `getMemory()`) delegate to this agent via a Proxy.',
   },
   {
     name: 'inngest',
@@ -126,7 +126,7 @@ Returns: [`InngestAgent`](#inngestagent-interface)
 
 ## `InngestAgent` interface
 
-The object returned by `createInngestAgent()`. It implements the full `Agent` interface via a Proxy: any property or method not explicitly defined (e.g., `generate()`, `listTools()`, `getMemory()`) is forwarded to the underlying agent.
+The object returned by `createInngestAgent()`. It provides the durable execution methods below. Any property or method not explicitly defined (e.g., `listTools()` and `getMemory()`) is forwarded to the underlying agent via a Proxy.
 
 ### Properties
 
@@ -252,6 +252,32 @@ The third argument accepts `threadId` and `resourceId` in addition to the lifecy
 />
 
 Returns: [`Promise<InngestAgentStreamResult>`](#inngestagentstreamresult)
+
+#### `generate(messages, options?)`
+
+Runs a response on Inngest's durable execution engine and resolves with a single `FullOutput`. If the run suspends, `generate()` resolves with `finishReason: 'suspended'`. Continue the run with [`resumeGenerate()`](#resumegeneraterunid-resumedata-options). Use [`stream()`](#streammessages-options) with `onSuspended` when the caller needs a suspension callback.
+
+```typescript
+const runId = crypto.randomUUID()
+const result = await durableAgent.generate('Delete the old records', {
+  runId,
+  requireToolApproval: true,
+})
+
+result.finishReason // 'suspended' when approval is required
+```
+
+Returns: `Promise<FullOutput<TOutput>>`
+
+#### `resumeGenerate(runId, resumeData, options?)`
+
+Resumes a suspended `generate()` run and resolves with a single `FullOutput`.
+
+```typescript
+const result = await durableAgent.resumeGenerate(runId, { approved: true })
+```
+
+Returns: `Promise<FullOutput<TOutput>>`
 
 #### `observe(runId, options?)`
 

--- a/docs/src/content/en/reference/agents/inngest-agent.mdx
+++ b/docs/src/content/en/reference/agents/inngest-agent.mdx
@@ -255,15 +255,14 @@ Returns: [`Promise<InngestAgentStreamResult>`](#inngestagentstreamresult)
 
 #### `generate(messages, options?)`
 
-Runs a response on Inngest's durable execution engine and resolves with a single `FullOutput`. If the run suspends, `generate()` resolves with `finishReason: 'suspended'`. Continue the run with [`resumeGenerate()`](#resumegeneraterunid-resumedata-options). Use [`stream()`](#streammessages-options) with `onSuspended` when the caller needs a suspension callback.
+Runs a response on Inngest's durable execution engine and resolves with a single `FullOutput`. If the run suspends, `generate()` resolves with `finishReason: 'suspended'`. The `runId` option is optional. If you omit it, `generate()` creates a run ID and returns it in `result.runId`. Continue the run with [`resumeGenerate()`](#resumegeneraterunid-resumedata-options). Use [`stream()`](#streammessages-options) with `onSuspended` when the caller needs a suspension callback.
 
 ```typescript
-const runId = crypto.randomUUID()
 const result = await durableAgent.generate('Delete the old records', {
-  runId,
   requireToolApproval: true,
 })
 
+result.runId // Generated automatically
 result.finishReason // 'suspended' when approval is required
 ```
 
@@ -274,7 +273,11 @@ Returns: `Promise<FullOutput<TOutput>>`
 Resumes a suspended `generate()` run and resolves with a single `FullOutput`.
 
 ```typescript
-const result = await durableAgent.resumeGenerate(runId, { approved: true })
+if (!result.runId) {
+  throw new Error('Run ID is missing')
+}
+
+const resumedResult = await durableAgent.resumeGenerate(result.runId, { approved: true })
 ```
 
 Returns: `Promise<FullOutput<TOutput>>`


### PR DESCRIPTION
The `InngestAgent` reference currently describes `generate()` as a method forwarded to the underlying agent and does not document the durable `generate()` or `resumeGenerate()` methods.

This documents both methods, including that `generate()` resolves with `finishReason: 'suspended'`, and points callback-driven approval flows to `stream({ onSuspended })`. It also corrects the proxy wording in the reference.

This is documentation-only. It does not change runtime behavior and does not overlap with #19429.

Validated with targeted Prettier, Remark, and Vale checks, the docs metadata validators, and a production Docusaurus build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR updates the Inngest agent docs to show how long-running AI tasks can “pause” for approval and then “continue” later using the same run ID. It also clarifies how methods not implemented by `InngestAgent` get forwarded to the underlying `Agent`.

## What changed
- Documented durable `generate(messages, options?)` and `resumeGenerate(runId, resumeData, options?)` on `InngestAgent`.
- Explained that when a durable `generate()` call suspends, it resolves with `finishReason: 'suspended'`, and that `generate()` can optionally create/return a `runId` for resuming.
- Directed callback/approval-based suspension handling to `stream({ onSuspended })`.
- Corrected and clarified proxy delegation wording for `createInngestAgent()` (what gets forwarded and when).
- Added/updated examples for using `runId` to resume suspended runs.

## Validation
- Targeted formatting and documentation validation completed.
- Production Docusaurus build checks completed successfully.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->