### PR TITLE
feat(agent-controller): support exact thread bindings

### DIFF
--- a/.changeset/two-lions-laugh.md
+++ b/.changeset/two-lions-laugh.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': minor
+---
+
+Added an optional `threadId` parameter to AgentController session creation so hosts can create or resume a session bound to an exact thread ID.

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -337,6 +337,7 @@ export class AgentController<TState = {}> {
     id,
     scope,
     tags,
+    threadId,
     workspace,
     browser,
     requestContext,
@@ -362,6 +363,8 @@ export class AgentController<TState = {}> {
      * changing the API. Falls back to `initialState` when omitted.
      */
     tags?: Record<string, string>;
+    /** Exact thread id to bind during session creation. Existing threads are resumed; missing threads are created with this id. */
+    threadId?: string;
     workspace?: Workspace;
     browser?: MastraBrowser;
     requestContext?: RequestContext;
@@ -384,6 +387,7 @@ export class AgentController<TState = {}> {
 
     const creation = this.#createSessionForResource(effectiveOwnerId, effectiveSessionId, effectiveResourceId, tags, {
       scope,
+      threadId,
       workspace,
       browser,
       requestContext,
@@ -409,6 +413,7 @@ export class AgentController<TState = {}> {
     tags?: Record<string, string>,
     overrides?: {
       scope?: string;
+      threadId?: string;
       workspace?: Workspace;
       browser?: MastraBrowser;
       requestContext?: RequestContext;
@@ -512,38 +517,53 @@ export class AgentController<TState = {}> {
       }
     }
 
-    // Bring the session online with a current thread. Selection is tag-aware so
-    // worktrees sharing a resourceId each resume their own thread without
-    // claiming threads owned by another scope. A thread is a candidate only when
-    // its metadata matches every provided tag; with no tags every thread
-    // qualifies. Tags default to the controller-global state when omitted.
-    const selectionTags: Record<string, string> = {};
-    if (tags && Object.keys(tags).length > 0) {
-      Object.assign(selectionTags, tags);
+    if (overrides?.threadId) {
+      const existingThread = await session.thread.getById({ threadId: overrides.threadId });
+      if (existingThread) {
+        if (existingThread.resourceId !== effectiveResourceId) {
+          throw new Error(`Thread not found: ${overrides.threadId}`);
+        }
+        await this.config.threadLock?.acquire(existingThread.id);
+        session.thread.set({ threadId: existingThread.id });
+        await session.thread.loadMetadata();
+        await session.thread.ensureCurrentSubscription();
+      } else {
+        await session.thread.create({ id: overrides.threadId });
+      }
     } else {
-      const projectPath = (this.config.initialState as any)?.projectPath as string | undefined;
-      if (projectPath) selectionTags.projectPath = projectPath;
-    }
-    const tagEntries = Object.entries(selectionTags);
+      // Bring the session online with a current thread. Selection is tag-aware so
+      // worktrees sharing a resourceId each resume their own thread without
+      // claiming threads owned by another scope. A thread is a candidate only when
+      // its metadata matches every provided tag; with no tags every thread
+      // qualifies. Tags default to the controller-global state when omitted.
+      const selectionTags: Record<string, string> = {};
+      if (tags && Object.keys(tags).length > 0) {
+        Object.assign(selectionTags, tags);
+      } else {
+        const projectPath = (this.config.initialState as any)?.projectPath as string | undefined;
+        if (projectPath) selectionTags.projectPath = projectPath;
+      }
+      const tagEntries = Object.entries(selectionTags);
 
-    const threads = await session.thread.list();
-    const candidates =
-      tagEntries.length > 0
-        ? threads.filter(t => {
-            const metadata = (t.metadata as Record<string, unknown> | undefined) ?? {};
-            return tagEntries.every(([key, value]) => metadata[key] === value);
-          })
-        : threads;
+      const threads = await session.thread.list();
+      const candidates =
+        tagEntries.length > 0
+          ? threads.filter(t => {
+              const metadata = (t.metadata as Record<string, unknown> | undefined) ?? {};
+              return tagEntries.every(([key, value]) => metadata[key] === value);
+            })
+          : threads;
 
-    // Resume the most recent same-resource candidate, or create a new thread.
-    if (candidates.length === 0) {
-      await session.thread.create();
-    } else {
-      const mostRecent = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]!;
-      await this.config.threadLock?.acquire(mostRecent.id);
-      session.thread.set({ threadId: mostRecent.id });
-      await session.thread.loadMetadata();
-      await session.thread.ensureCurrentSubscription();
+      // Resume the most recent same-resource candidate, or create a new thread.
+      if (candidates.length === 0) {
+        await session.thread.create();
+      } else {
+        const mostRecent = [...candidates].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime())[0]!;
+        await this.config.threadLock?.acquire(mostRecent.id);
+        session.thread.set({ threadId: mostRecent.id });
+        await session.thread.loadMetadata();
+        await session.thread.ensureCurrentSubscription();
+      }
     }
 
     return session;

--- a/packages/core/src/agent-controller/exact-thread-id.test.ts
+++ b/packages/core/src/agent-controller/exact-thread-id.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
+import { AgentController } from './agent-controller';
+import { createMockWorkspace } from './test-utils';
+
+function createAgent() {
+  return new Agent({
+    name: 'test-agent',
+    instructions: 'You are a test agent.',
+    model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+  });
+}
+
+async function createController(storage: InMemoryStore) {
+  const controller = new AgentController({
+    workspace: createMockWorkspace(),
+    id: 'test-controller',
+    storage,
+    modes: [{ id: 'default', name: 'Default', default: true, agent: createAgent() }],
+  });
+  await controller.init();
+  return controller;
+}
+
+describe('AgentController exact thread id creation', () => {
+  it('creates and binds the requested thread id', async () => {
+    const controller = await createController(new InMemoryStore());
+    const session = await controller.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+    });
+
+    expect(session.identity.getId()).toBe('session-1');
+    expect(session.identity.getResourceId()).toBe('session-1');
+    expect(session.thread.getId()).toBe('session-1');
+    expect((await session.thread.getById({ threadId: 'session-1' }))?.resourceId).toBe('session-1');
+  });
+
+  it('resumes the requested thread id after restart', async () => {
+    const storage = new InMemoryStore();
+    const first = await createController(storage);
+    const firstSession = await first.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+    });
+    expect(firstSession.thread.getId()).toBe('session-1');
+
+    const second = await createController(storage);
+    const resumed = await second.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'session-1',
+      threadId: 'session-1',
+    });
+
+    expect(resumed.thread.getId()).toBe('session-1');
+    expect(await resumed.thread.list()).toHaveLength(1);
+  });
+
+  it('rejects binding an existing exact thread owned by another resource', async () => {
+    const storage = new InMemoryStore();
+    const first = await createController(storage);
+    await first.createSession({
+      id: 'session-1',
+      ownerId: 'owner-1',
+      resourceId: 'resource-a',
+      threadId: 'shared-thread',
+    });
+
+    const second = await createController(storage);
+    await expect(
+      second.createSession({
+        id: 'session-2',
+        ownerId: 'owner-1',
+        resourceId: 'resource-b',
+        threadId: 'shared-thread',
+      }),
+    ).rejects.toThrow('Thread not found: shared-thread');
+  });
+
+  it('deduplicates concurrent exact thread creation for the same resource', async () => {
+    const controller = await createController(new InMemoryStore());
+    const [a, b] = await Promise.all([
+      controller.createSession({ id: 'session-1', ownerId: 'owner-1', resourceId: 'session-1', threadId: 'session-1' }),
+      controller.createSession({ id: 'session-1', ownerId: 'owner-1', resourceId: 'session-1', threadId: 'session-1' }),
+    ]);
+
+    expect(a).toBe(b);
+    expect(a.thread.getId()).toBe('session-1');
+    expect(await a.thread.list()).toHaveLength(1);
+  });
+
+  it('keeps default multi-thread behavior when threadId is omitted', async () => {
+    const controller = await createController(new InMemoryStore());
+    const session = await controller.createSession({ id: 'session-1', ownerId: 'owner-1', resourceId: 'resource-1' });
+
+    expect(session.thread.getId()).toBeTruthy();
+    expect(session.thread.getId()).not.toBe('session-1');
+    const secondThread = await session.thread.create({ title: 'second' });
+    expect(secondThread.id).not.toBe('session-1');
+    expect(await session.thread.list()).toHaveLength(2);
+  });
+});

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -518,13 +518,13 @@ export class SessionThread {
   }
 
   /** Create a new thread, bind the session to it, and rebind the agent stream. */
-  async create({ title }: { title?: string } = {}): Promise<AgentControllerThread> {
+  async create({ title, id }: { title?: string; id?: string } = {}): Promise<AgentControllerThread> {
     const session = this.#owner;
     const store = this.#store;
     this.cleanupSubscription();
     const now = new Date();
     const thread: AgentControllerThread = {
-      id: session.machinery.generateId(),
+      id: id ?? session.machinery.generateId(),
       resourceId: session.identity.getResourceId(),
       title: title || '',
       createdAt: now,


### PR DESCRIPTION
This is PR 1 of 4. It adds an optional  to , allowing hosts to create or resume a session against an exact thread while preserving existing scoped-session and multi-thread behavior.\n\nThe stack continues with:\n- #19902 — server and JavaScript client transport\n- #19907 — provider-specific sandbox workspace state\n- #19908 — Factory session workspace provisioning\n\nVerified with the focused exact-thread tests, the core typecheck, and the full core suite (12,214 tests passed).