### PR TITLE
fix(mastracode): avoid web dev port conflicts

### DIFF
--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -14,10 +14,10 @@
 #   - WorkOS:  <MASTRACODE_PUBLIC_URL>/auth/callback
 #   - GitHub:  <MASTRACODE_PUBLIC_URL>/auth/github/callback
 #   - Linear:  <MASTRACODE_PUBLIC_URL>/auth/linear/callback
-# In dev the SPA is served by Vite on :5173 and proxies to the server (:4111),
-# so set this to the SPA origin (http://localhost:5173). Falls back to the
-# server bind when unset. Restart `web:dev` after changing this — varlock
-# re-reads .env on each start.
+# In dev the SPA is served by Vite on :5173 and proxies to the server (:4120
+# by default), so set this to the SPA origin (http://localhost:5173). Falls
+# back to the server bind when unset. Restart `web:dev` after changing this —
+# varlock re-reads .env on each start.
 # @public @type=url
 MASTRACODE_PUBLIC_URL=
 # Comma-separated origins allowed for credentialed cross-origin requests; only

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -20,8 +20,19 @@ pnpm install
 pnpm web:dev
 ```
 
-- API server (`mastra dev`) on **:4111**, env loaded/validated by varlock from `.env` against `.env.schema` (package root).
-- Vite SPA on **:5173**, proxying `/api`, `/web`, and `/auth/` to the API server.
+- API server (`mastra dev`) on **:4120** by default, env loaded/validated by varlock from `.env` against `.env.schema` (package root).
+- Vite SPA on **:5173**, proxying `/api`, `/web`, and `/auth/` to the configured API server. It fails fast when the port is occupied so OAuth callbacks cannot silently reach the wrong app.
+
+Run concurrent development sessions with an explicit port pair:
+
+```bash
+MASTRACODE_DEV_SERVER_PORT=4121 \
+MASTRACODE_DEV_UI_PORT=5174 \
+MASTRACODE_PUBLIC_URL=http://localhost:5174 \
+pnpm web:dev
+```
+
+When WorkOS auth is enabled, add the alternate `<MASTRACODE_PUBLIC_URL>/auth/callback` to the allowed redirect URIs.
 
 For the GitHub/sandbox features, start the app database first: `pnpm web:dev:github` (Postgres via docker compose on :54329).
 

--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -10,7 +10,7 @@
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",
     "prebuild": "cd ../.. && pnpm turbo build --filter ./mastracode/sdk --filter ./packages/playground-ui --filter ./client-sdks/client-js --filter ./client-sdks/react --filter ./stores/libsql --filter ./stores/pg --filter ./auth/workos --filter ./server-adapters/hono --filter ./workspaces/railway --filter ./pubsub/redis-streams --filter ./packages/cli",
-    "web:dev": "concurrently --kill-others-on-fail --names server,ui \"PORT=4111 MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra dev --dir src/mastra\" \"vite --config src/web/vite.config.ts\"",
+    "web:dev": "concurrently --kill-others-on-fail --names server,ui \"PORT=${MASTRACODE_DEV_SERVER_PORT:-4120} MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra dev --dir src/mastra\" \"vite --config src/web/vite.config.ts\"",
     "web:dev:github": "pnpm db:up && pnpm web:dev",
     "web:ui:build": "pnpm run prebuild && vite --config src/web/vite.config.ts build",
     "web:build": "pnpm run web:ui:build && node scripts/monorepo-deps.mjs run -- mastra build --dir src/mastra",

--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -76,6 +76,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __resetRuntimeConfigForTests();
+  vi.unstubAllEnvs();
 });
 
 describe('MastraFactory.prepare', () => {
@@ -198,6 +199,19 @@ describe('MastraFactory.prepare', () => {
       storage,
       publicUrl: 'https://factory.acme.com',
       allowedOrigins: ['https://app.acme.com'],
+    } satisfies WebAuthAdapterInitContext);
+  });
+
+  it('derives the default public URL from the bound server port', async () => {
+    vi.stubEnv('PORT', '4121');
+    const auth = fakeAdapter();
+
+    await prepareFactory({ auth });
+
+    expect(auth.init).toHaveBeenCalledExactlyOnceWith({
+      storage: undefined,
+      publicUrl: 'http://localhost:4121',
+      allowedOrigins: [],
     } satisfies WebAuthAdapterInitContext);
   });
 

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -96,7 +96,7 @@ export interface MastraFactoryConfig {
    * Browser-facing origin used to build GitHub OAuth/install callback URLs and
    * to derive the auth redirect URI. On the platform the SPA is hosted
    * separately, so this MUST be the public API origin.
-   * Default: `http://localhost:4111`.
+   * Default: `http://localhost:<PORT>` (`PORT` defaults to `4120` in `web:dev`).
    */
   publicUrl?: string;
   /**
@@ -184,7 +184,7 @@ export class MastraFactory {
     if (this.#preparing) throw new Error('MastraFactory.prepare() called twice');
     this.#preparing = true;
 
-    const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:4111').replace(/\/+$/, '');
+    const publicOrigin = (this.#config.publicUrl ?? `http://localhost:${process.env.PORT || 4120}`).replace(/\/+$/, '');
     const allowedOrigins = (this.#config.allowedOrigins ?? []).map(o => o.replace(/\/+$/, '')).filter(Boolean);
     const storage = this.#config.storage;
     const vector = this.#config.vector;

--- a/mastracode/web/src/web/spa-static.ts
+++ b/mastracode/web/src/web/spa-static.ts
@@ -2,7 +2,7 @@
  * Same-origin SPA serving for production.
  *
  * In dev the SPA is served by Vite (:5173) which proxies API paths to the
- * server (:4111) — this module is effectively idle there. In production the
+ * configured server (on :4120 by default) — this module is effectively idle there. In production the
  * built SPA (vite output) is served by the API server itself at `/`, so the
  * app is a single origin and no CORS / separate static host is required.
  *

--- a/mastracode/web/src/web/ui/main.tsx
+++ b/mastracode/web/src/web/ui/main.tsx
@@ -14,7 +14,7 @@ import { ToastProvider } from './ui';
 
 // The web app talks to the Mastra server same-origin (`baseUrl=""`): in prod
 // the server serves this build itself, and in dev Vite proxies `/api` + `/auth`
-// to :4111. The served index.html also carries `window.__MASTRACODE_CONFIG__`
+// to the configured API server. The served index.html also carries `window.__MASTRACODE_CONFIG__`
 // (injected by the server in prod, by the Vite plugin in dev) so the UI knows
 // whether auth is enabled without probing `/auth/me`. A future React Native
 // entry mounts the same providers with its own absolute base URL and fetch

--- a/mastracode/web/src/web/vite.config.test.ts
+++ b/mastracode/web/src/web/vite.config.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+
+import { createViteConfig } from './vite.config';
+
+const proxyTargets = (port: number) => ({
+  '/api': { target: `http://localhost:${port}` },
+  '/web': { target: `http://localhost:${port}` },
+  '^/auth/': { target: `http://localhost:${port}` },
+});
+
+describe('createViteConfig', () => {
+  it('uses MastraCode-specific development ports by default', () => {
+    const config = createViteConfig('development', {});
+
+    expect(config.server).toMatchObject({
+      port: 5173,
+      strictPort: true,
+      proxy: proxyTargets(4120),
+    });
+  });
+
+  it('keeps every proxy route aligned with overridden development ports', () => {
+    const config = createViteConfig('development', {
+      MASTRACODE_DEV_SERVER_PORT: '4121',
+      MASTRACODE_DEV_UI_PORT: '5174',
+    });
+
+    expect(config.server).toMatchObject({
+      port: 5174,
+      strictPort: true,
+      proxy: proxyTargets(4121),
+    });
+  });
+
+  it.each([
+    ['MASTRACODE_DEV_SERVER_PORT', '0'],
+    ['MASTRACODE_DEV_SERVER_PORT', '65536'],
+    ['MASTRACODE_DEV_SERVER_PORT', 'not-a-port'],
+    ['MASTRACODE_DEV_UI_PORT', '0'],
+    ['MASTRACODE_DEV_UI_PORT', '65536'],
+    ['MASTRACODE_DEV_UI_PORT', 'not-a-port'],
+  ])('rejects invalid %s value %s', (variable, value) => {
+    expect(() => createViteConfig('development', { [variable]: value })).toThrowError(
+      `${variable} must be an integer between 1 and 65535`,
+    );
+  });
+});

--- a/mastracode/web/src/web/vite.config.ts
+++ b/mastracode/web/src/web/vite.config.ts
@@ -4,9 +4,26 @@ import { fileURLToPath } from 'node:url';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv } from 'vite';
-import type { Plugin } from 'vite';
+import type { Plugin, UserConfig } from 'vite';
 
 const here = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULT_DEV_SERVER_PORT = 4120;
+const DEFAULT_DEV_UI_PORT = 5173;
+
+type DevEnvironment = Record<string, string | undefined>;
+type DevPortVariable = 'MASTRACODE_DEV_SERVER_PORT' | 'MASTRACODE_DEV_UI_PORT';
+
+function getDevPort(name: DevPortVariable, fallback: number, env: DevEnvironment): number {
+  const configuredPort = env[name]?.trim();
+  const port = Number(configuredPort || fallback);
+
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(`${name} must be an integer between 1 and 65535`);
+  }
+
+  return port;
+}
 
 /**
  * Dev-only injection of `window.__MASTRACODE_CONFIG__` into index.html, from
@@ -38,8 +55,8 @@ function runtimeConfigPlugin(mode: string): Plugin {
  * Vite config for the MastraCode web UI.
  *
  * In dev, `pnpm web:dev` runs `mastra dev` (the API server from
- * `src/mastra/index.ts` on :4111) and Vite (:5173) side by side; API paths are
- * proxied to that server so the browser uses same-origin requests in dev.
+ * `src/mastra/index.ts` on :4120 by default) and Vite (:5173) side by side;
+ * API paths are proxied to that server so the browser uses same-origin requests.
  *
  * The production build outputs the static SPA to `src/mastra/public/ui`.
  * `mastra build` copies the `public/` dir next to the Mastra entry into
@@ -48,44 +65,52 @@ function runtimeConfigPlugin(mode: string): Plugin {
  * Hosting the SPA separately (static host / CDN, cross-origin via
  * MASTRACODE_ALLOWED_ORIGINS) remains possible.
  */
-export default defineConfig(({ mode }) => ({
-  root: resolve(here, 'ui'),
-  plugins: [react(), tailwindcss(), runtimeConfigPlugin(mode)],
-  resolve: {
-    // Monorepo packages arrive via `link:` and would otherwise resolve their
-    // own react copy from the monorepo store — force a single copy from here.
-    dedupe: ['react', 'react-dom', '@tanstack/react-query'],
-  },
-  build: {
-    outDir: resolve(here, '../mastra/public/ui'),
-    emptyOutDir: true,
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:4111',
-        changeOrigin: true,
-      },
-      // Web surface routes (fs/config/github) live under `/web/*` on the API
-      // server after the `/api/web` → `/web` path migration. Proxy them so the
-      // dev UI (:5173) can reach them on :4111.
-      '/web': {
-        target: 'http://localhost:4111',
-        changeOrigin: true,
-      },
-      // Optional WorkOS auth routes live on the API server too; proxy them so
-      // the dev UI (:5173) can reach login/callback/logout/me on :4111.
-      //
-      // Match only the `/auth/<route>` paths — NOT a bare `/auth` prefix.
-      // A plain `'/auth'` key prefix-matches Vite module requests like
-      // `/auth.ts` (the client auth module) and wrongly proxies them to the
-      // API server, which 401s / ECONNREFUSEs. The trailing-slash regex keeps
-      // module imports on Vite while still forwarding real auth routes.
-      '^/auth/': {
-        target: 'http://localhost:4111',
-        changeOrigin: true,
+export function createViteConfig(mode: string, env: DevEnvironment = process.env): UserConfig {
+  const devServerPort = getDevPort('MASTRACODE_DEV_SERVER_PORT', DEFAULT_DEV_SERVER_PORT, env);
+  const devUiPort = getDevPort('MASTRACODE_DEV_UI_PORT', DEFAULT_DEV_UI_PORT, env);
+  const devServerTarget = `http://localhost:${devServerPort}`;
+  return {
+    root: resolve(here, 'ui'),
+    plugins: [react(), tailwindcss(), runtimeConfigPlugin(mode)],
+    resolve: {
+      // Monorepo packages arrive via `link:` and would otherwise resolve their
+      // own react copy from the monorepo store — force a single copy from here.
+      dedupe: ['react', 'react-dom', '@tanstack/react-query'],
+    },
+    build: {
+      outDir: resolve(here, '../mastra/public/ui'),
+      emptyOutDir: true,
+    },
+    server: {
+      port: devUiPort,
+      strictPort: true,
+      proxy: {
+        '/api': {
+          target: devServerTarget,
+          changeOrigin: true,
+        },
+        // Web surface routes (fs/config/github) live under `/web/*` on the API
+        // server after the `/api/web` → `/web` path migration. Proxy them so the
+        // dev UI can reach the API server.
+        '/web': {
+          target: devServerTarget,
+          changeOrigin: true,
+        },
+        // Optional WorkOS auth routes live on the API server too; proxy them so
+        // the dev UI can reach login/callback/logout/me.
+        //
+        // Match only the `/auth/<route>` paths — NOT a bare `/auth` prefix.
+        // A plain `'/auth'` key prefix-matches Vite module requests like
+        // `/auth.ts` (the client auth module) and wrongly proxies them to the
+        // API server, which 401s / ECONNREFUSEs. The trailing-slash regex keeps
+        // module imports on Vite while still forwarding real auth routes.
+        '^/auth/': {
+          target: devServerTarget,
+          changeOrigin: true,
+        },
       },
     },
-  },
-}));
+  };
+}
+
+export default defineConfig(({ mode }) => createViteConfig(mode));


### PR DESCRIPTION
MastraCode Web used the default `mastra dev` port, so running another Mastra project could start the UI against the wrong backend and return HTML where JSON was expected.

The API server now defaults to port 4120. `MASTRACODE_DEV_SERVER_PORT` keeps the server and every Vite proxy target aligned, while `MASTRACODE_DEV_UI_PORT` supports concurrent UI sessions. Vite also fails fast instead of silently changing an OAuth callback port, and the fallback public origin follows the bound server port.

Before:

```bash
pnpm web:dev # collided with another server on 4111
```

After:

```bash
MASTRACODE_DEV_SERVER_PORT=4121 \
MASTRACODE_DEV_UI_PORT=5174 \
MASTRACODE_PUBLIC_URL=http://localhost:5174 \
pnpm web:dev
```

Verified with `pnpm check`, 41 focused unit tests, and a live request through the Vite proxy while another Mastra server continued listening on port 4111.