### PR TITLE
fix(playground-ui): restore Storybook build with Babel 8

### DIFF
--- a/.changeset/tidy-books-build.md
+++ b/.changeset/tidy-books-build.md
@@ -1,0 +1,5 @@
+---
+'@mastra/playground-ui': patch
+---
+
+Fixed Storybook builds in Babel 8 workspaces.

--- a/.changeset/tidy-books-build.md
+++ b/.changeset/tidy-books-build.md
@@ -1,5 +1,0 @@
----
-'@mastra/playground-ui': patch
----
-
-Fixed Storybook builds in Babel 8 workspaces.

--- a/packages/playground-ui/.storybook/main.ts
+++ b/packages/playground-ui/.storybook/main.ts
@@ -13,6 +13,9 @@ const config: StorybookConfig = {
     name: getAbsolutePath('@storybook/react-vite'),
     options: {},
   },
+  typescript: {
+    reactDocgen: 'react-docgen-typescript',
+  },
 };
 
 export default config;


### PR DESCRIPTION
Storybook's default react-docgen parser calls a Babel 7 synchronous API, which fails after the workspace's Babel 8 upgrade. This switches Playground UI to Storybook's TypeScript docgen parser and leaves the Babel 8 resolution unchanged.

Before, the build stopped while transforming the AlertDialog story. After, Storybook processes all 4,626 modules and completes successfully.

Verified with `pnpm --filter @mastra/playground-ui build-storybook`, the Playground UI typecheck, focused ESLint, and a frozen install.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Storybook now uses a parser that works with the workspace’s newer Babel version, so the Playground UI stories can build successfully instead of stopping at `AlertDialog`.

## Changes

- Configured Storybook to use `react-docgen-typescript`.
- Added a patch changeset for `@mastra/playground-ui`.
- Verified with:
  - Storybook build
  - Playground UI typecheck
  - Focused ESLint
  - Frozen install

<!-- end of auto-generated comment: release notes by coderabbit.ai -->