### PR TITLE
Allow factory integrations to contribute Mastra workers

### DIFF
--- a/.changeset/easy-streets-learn.md
+++ b/.changeset/easy-streets-learn.md
@@ -1,0 +1,13 @@
+---
+'@mastra/core': minor
+---
+
+The 'workers' option on the Mastra class now merges with the default workers instead of replacing them. Passing custom workers (e.g. a polling worker for an integration) no longer silently drops the built-in orchestration and background-task workers — a custom worker only replaces a default when it shares its name, and 'workers: false' still disables all workers.
+
+```ts
+const mastra = new Mastra({
+  // before: only myPoller ran — orchestration was dropped
+  // after: myPoller runs alongside the default workers
+  workers: [myPoller],
+});
+```

--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { MastraWorker } from '@mastra/core/worker';
 import { LocalSandbox } from '@mastra/core/workspace';
 import type { WorkspaceSandbox } from '@mastra/core/workspace';
 import { LibSQLFactoryStorage } from '@mastra/libsql';
@@ -366,6 +367,41 @@ describe('MastraFactory.prepare integrations', () => {
     github.webhookSecret = 'hook-secret';
     await prepareFactory({ storage: fakeStorage(), integrations: [github] });
     expect(getSeededStateSigner()?.stable).toBe(true);
+  });
+
+  it("folds a ready integration's workers into the returned Mastra args", async () => {
+    const worker = { name: 'custom-poller' } as unknown as MastraWorker;
+    const workers = vi.fn((_ctx: IntegrationContext) => [worker]);
+    const factory = new MastraFactory({
+      storage: fakeStorage(),
+      integrations: [fakeIntegration({ id: 'custom', workers })],
+    });
+    const args = await factory.prepare();
+    expect(args.workers).toEqual([worker]);
+    // The workers factory gets the same integration context shape as routes().
+    const ctx = workers.mock.calls[0]![0];
+    expect(ctx.stateSigner).toBe(getSeededStateSigner());
+    expect(ctx.storage.generic).toBeDefined();
+    expect(ctx.storage.sourceControl).toBeDefined();
+  });
+
+  it('does not collect workers from integrations that are not ready', async () => {
+    const storage = fakeStorage();
+    vi.spyOn(storage, 'isDomainReady').mockReturnValue(false);
+    const workers = vi.fn(() => [{ name: 'custom-poller' } as unknown as MastraWorker]);
+    const factory = new MastraFactory({
+      storage,
+      integrations: [fakeIntegration({ id: 'custom', workers })],
+    });
+    const args = await factory.prepare();
+    expect(workers).not.toHaveBeenCalled();
+    expect(args).not.toHaveProperty('workers');
+  });
+
+  it('omits the workers option when no integration contributes workers', async () => {
+    const factory = new MastraFactory({ storage: fakeStorage(), integrations: [fakeIntegration({ id: 'custom' })] });
+    const args = await factory.prepare();
+    expect(args).not.toHaveProperty('workers');
   });
 });
 

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -45,6 +45,7 @@ import { createStateSigner } from './state-signing.js';
 import { createSpaStaticMiddleware, resolveUiDistDir } from './spa-static.js';
 import {
   assembleWebApiRoutes,
+  buildIntegrationContext,
   resolveFactoryReady,
   resolveGithubReady,
   resolveIntakeReady,
@@ -473,7 +474,34 @@ export class MastraFactory {
     });
 
     this.#prepared = prepared;
-    return prepared.mastraArgs;
+
+    // Integration lifecycle workers (e.g. polling an upstream without
+    // webhooks): collected from READY integrations only, folded into the
+    // constructor args so `new Mastra(...)` merges them with the default
+    // workers and `finalize()`'s `startWorkers()` starts them alongside the
+    // built-ins. Never passed for the disabled/not-ready case — a worker for
+    // an unavailable integration must not run.
+    const integrationWorkers = readyIntegrations
+      .filter(({ integration, ready }) => ready && integration.workers)
+      .flatMap(({ integration }) =>
+        integration.workers!(
+          buildIntegrationContext(
+            {
+              controller: prepared.base.controller,
+              publicOrigin,
+              stateSigner,
+              integrationStorage,
+              sourceControlStorage,
+            },
+            integration.id,
+          ),
+        ),
+      );
+
+    return {
+      ...prepared.mastraArgs,
+      ...(integrationWorkers.length > 0 ? { workers: integrationWorkers } : {}),
+    };
   }
 
   /**

--- a/mastracode/web/src/web/factory-integration.ts
+++ b/mastracode/web/src/web/factory-integration.ts
@@ -20,6 +20,7 @@
 import type { MastraCodeConfig, MountedMastraCode } from '@mastra/code-sdk';
 import type { RequestContext } from '@mastra/core/request-context';
 import type { ApiRoute } from '@mastra/core/server';
+import type { MastraWorker } from '@mastra/core/worker';
 
 import type { StateSigner } from './state-signing.js';
 import type { IntegrationStorageHandle } from './storage/domains/integrations/base.js';
@@ -109,6 +110,16 @@ export interface FactoryIntegration {
    * capability, resolved synchronously per request.
    */
   sessionTools?(requestContext: RequestContext): IntegrationTools;
+  /**
+   * Background workers the integration needs running for its lifecycle
+   * (e.g. polling an upstream that doesn't support webhooks). Optional
+   * capability: called once at boot for READY integrations only; the factory
+   * folds the returned workers into the server Mastra's `workers` option, so
+   * they are merged with the built-in workers and started with them
+   * (`startWorkers()`). Worker names must be unique across integrations —
+   * duplicates fail the `new Mastra(...)` construction loudly.
+   */
+  workers?(ctx: IntegrationContext): MastraWorker[];
   /**
    * Non-secret config snapshot (booleans + names only, never values). The
    * factory merges it into system diagnostics/startup logs.

--- a/mastracode/web/src/web/web-surface.ts
+++ b/mastracode/web/src/web/web-surface.ts
@@ -16,7 +16,12 @@ import type { MastraCodeState } from '@mastra/code-sdk/schema';
 
 import { buildAuditRoutes } from './audit/routes.js';
 import { buildConfigRoutes } from './config-routes.js';
-import type { FactoryIntegration, IssueTriageRunInput, IssueTriageRunResult } from './factory-integration.js';
+import type {
+  FactoryIntegration,
+  IntegrationContext,
+  IssueTriageRunInput,
+  IssueTriageRunResult,
+} from './factory-integration.js';
 import { buildFsRoutes } from './fs-routes.js';
 import { buildOAuthRoutes } from './oauth-routes.js';
 import { getGithubFeatureDiagnostics, isGithubFeatureEnabled } from './github/config.js';
@@ -333,6 +338,30 @@ async function runIssueTriage(
 }
 
 /**
+ * Build the {@link IntegrationContext} handed to an integration when the
+ * factory collects its capabilities (routes, workers). One shape everywhere:
+ * `assembleWebApiRoutes` uses it per registration, and `MastraFactory` uses it
+ * when collecting integration workers at finalize.
+ */
+export function buildIntegrationContext(
+  deps: Pick<WebApiRoutesDeps, 'controller' | 'publicOrigin' | 'integrationStorage' | 'sourceControlStorage'> & {
+    stateSigner: StateSigner;
+  },
+  integrationId: string,
+): IntegrationContext {
+  return {
+    baseUrl: deps.publicOrigin,
+    controller: deps.controller,
+    stateSigner: deps.stateSigner,
+    storage: {
+      generic: deps.integrationStorage.forIntegration(integrationId),
+      sourceControl: deps.sourceControlStorage.forIntegration(integrationId),
+    },
+    hooks: { runIssueTriage: (input: IssueTriageRunInput) => runIssueTriage(deps, input) },
+  };
+}
+
+/**
  * Disabled-status stub for the well-known integration ids. The SPA polls
  * `/web/github/status` and `/web/linear/status` unconditionally, so when an
  * integration is absent (or not ready) the status contract must still hold.
@@ -388,16 +417,7 @@ export function assembleWebApiRoutes(deps: WebApiRoutesDeps): ApiRoute[] {
   const integrationRoutes = registrations.flatMap(registration => {
     const { integration, ready, ensureReady } = registration;
     if (!deps.stateSigner) return disabledIntegrationStatusRoutes(integration.id);
-    const ctx = {
-      baseUrl: deps.publicOrigin,
-      controller: deps.controller,
-      stateSigner: deps.stateSigner,
-      storage: {
-        generic: deps.integrationStorage.forIntegration(integration.id),
-        sourceControl: deps.sourceControlStorage.forIntegration(integration.id),
-      },
-      hooks: { runIssueTriage: (input: IssueTriageRunInput) => runIssueTriage(deps, input) },
-    };
+    const ctx = buildIntegrationContext({ ...deps, stateSigner: deps.stateSigner }, integration.id);
     if (ready) return integration.routes(ctx);
     if (!ensureReady) return disabledIntegrationStatusRoutes(integration.id);
     return integration.routes(ctx).map(route => {

--- a/packages/core/src/mastra/index.ts
+++ b/packages/core/src/mastra/index.ts
@@ -565,7 +565,9 @@ export interface Config<
    *
    * - `undefined` (default): Auto-creates default workers (existing behavior)
    * - `false`: Disables all event processing — useful when running standalone workers separately
-   * - `MastraWorker[]`: Use exactly these workers
+   * - `MastraWorker[]`: Additional workers merged with the auto-created
+   *   defaults. A custom worker replaces a default with the same `name`;
+   *   duplicate names within the array throw. Use `false` to run no workers.
    */
   workers?: MastraWorker[] | false;
 
@@ -1336,13 +1338,8 @@ export class Mastra<
       // runtime triggers (e.g. schedules.create()) don't lazily inject
       // scheduler / agent-schedule workers behind the user's back.
       this.#workersDisabled = true;
-    } else if (Array.isArray(workersOption)) {
-      this.#workers = workersOption;
-      for (const w of this.#workers) {
-        w.__registerMastra(this);
-      }
     } else {
-      // Default: auto-create workers based on config.
+      // Auto-create default workers based on config.
       //
       // Skip OrchestrationWorker when the configured pubsub doesn't support
       // pull delivery (e.g. EventEmitter, GCP Pub/Sub push) — those transports
@@ -1359,7 +1356,18 @@ export class Mastra<
       if (config?.backgroundTasks?.enabled) {
         defaultWorkers.push(new BackgroundTaskWorker(config.backgroundTasks));
       }
-      this.#workers = defaultWorkers;
+      // Merge custom workers with the defaults: a custom worker replaces a
+      // default sharing its name (e.g. a custom OrchestrationWorker), and
+      // duplicate names within the custom array fail loud.
+      const customWorkers = workersOption ?? [];
+      const customNames = new Set<string>();
+      for (const w of customWorkers) {
+        if (customNames.has(w.name)) {
+          throw new Error(`Duplicate worker name "${w.name}" in the 'workers' option`);
+        }
+        customNames.add(w.name);
+      }
+      this.#workers = [...defaultWorkers.filter(w => !customNames.has(w.name)), ...customWorkers];
       for (const w of this.#workers) {
         w.__registerMastra(this);
       }

--- a/packages/core/src/mastra/workers-option.test.ts
+++ b/packages/core/src/mastra/workers-option.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { MastraWorker } from '../worker';
+import { Mastra } from './index';
+
+class FakeWorker extends MastraWorker {
+  #running = false;
+
+  constructor(readonly name: string) {
+    super();
+  }
+
+  async start() {
+    this.#running = true;
+  }
+
+  async stop() {
+    this.#running = false;
+  }
+
+  get isRunning() {
+    return this.#running;
+  }
+}
+
+describe('Mastra workers option (merge semantics)', () => {
+  it('merges custom workers with the auto-created defaults', () => {
+    const poller = new FakeWorker('github-poller');
+    const registerSpy = vi.spyOn(poller, '__registerMastra');
+
+    const mastra = new Mastra({ logger: false, workers: [poller] });
+
+    const names = mastra.workers.map(w => w.name);
+    // Default orchestration worker survives the merge...
+    expect(names).toContain('orchestration');
+    // ...and the custom worker is appended and registered.
+    expect(names).toContain('github-poller');
+    expect(registerSpy).toHaveBeenCalledWith(mastra);
+    expect(mastra.getWorker('github-poller')).toBe(poller);
+  });
+
+  it('a custom worker replaces the default sharing its name', () => {
+    const custom = new FakeWorker('orchestration');
+
+    const mastra = new Mastra({ logger: false, workers: [custom] });
+
+    const orchestrators = mastra.workers.filter(w => w.name === 'orchestration');
+    expect(orchestrators).toEqual([custom]);
+  });
+
+  it('throws on duplicate names within the custom workers array', () => {
+    expect(() => new Mastra({ logger: false, workers: [new FakeWorker('dup'), new FakeWorker('dup')] })).toThrow(
+      /Duplicate worker name "dup"/,
+    );
+  });
+
+  it('workers: false still disables all workers', () => {
+    const mastra = new Mastra({ logger: false, workers: false });
+    expect(mastra.workers).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Lets factory integrations contribute background workers to Mastra. Integrations sometimes need lifecycle logic beyond request handling — e.g. polling an upstream service that doesn't support webhooks. There was previously no way for an integration to run such a process: the factory never passed custom workers to Mastra, and the `workers` constructor option replaced the built-in workers entirely.

### What changed

- **`FactoryIntegration.workers?(ctx)`** (`mastracode/web`): integrations can return `MastraWorker[]`. Workers get the same `IntegrationContext` (signer, scoped storage, controller) as routes, via a shared `buildIntegrationContext` helper.
- **`MastraFactory.prepare()`**: collects workers from *ready* integrations only and folds them into the returned `MastraArgs.workers`. `finalize()`'s existing `startWorkers()` call starts them with the built-ins — no post-construction hooks.
- **`@mastra/core`**: the `workers` constructor option now merges custom workers with the config-derived defaults (orchestration, background tasks) instead of replacing them. A custom worker overrides a default only when it shares its name; duplicate names in the custom array throw; `workers: false` still disables all workers. This is additive — supplying custom workers no longer silently drops the defaults.

## Test plan

- New `packages/core/src/mastra/workers-option.test.ts`: merge with defaults, name-collision override, duplicate-name throw, `workers: false`.
- New factory tests in `mastracode/web/src/web/factory-entry.test.ts`: workers folded into `mastraArgs` with correct context, not-ready integrations skipped, `workers` omitted when none.
- Existing suites pass: core worker tests, workers-filter, scheduler-integration, cross-process-workflow (48 tests), web-surface tests.
- `pnpm --filter ./packages/core check` and `tsc --noEmit` in `mastracode/web` clean.
- Changeset: `@mastra/core` minor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra integrations can now add background workers, which are tasks that run behind the scenes. Custom workers join the built-in workers, can replace them by name, and are safely checked for duplicates.

## What changed

- Added optional `FactoryIntegration.workers(ctx)` support.
- Shared integration context creation between routes and workers.
- Collected workers from ready integrations during `MastraFactory.prepare()`.
- Updated worker configuration to:
  - Merge custom workers with defaults.
  - Override defaults with matching names.
  - Reject duplicate custom worker names.
  - Preserve `workers: false` as a way to disable all workers.
- Added tests for worker merging, overrides, duplicates, integration context, readiness filtering, and omitted workers.
- Added an `@mastra/core` minor changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->