### PR TITLE
fix(stored-agents): preserve drafts unless auto-publishing

### DIFF
--- a/.changeset/frank-olives-pick.md
+++ b/.changeset/frank-olives-pick.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed stored agent draft saves to preserve the published version unless automatic publication is requested.

--- a/.changeset/hot-melons-wave.md
+++ b/.changeset/hot-melons-wave.md
@@ -1,0 +1,12 @@
+---
+'@mastra/client-js': minor
+---
+
+Added `autoPublish` to stored agent updates so callers can activate a newly created version immediately.
+
+```ts
+await client.getStoredAgent('agent-id').update({
+  instructions: 'Updated instructions',
+  autoPublish: true,
+});
+```

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -12879,6 +12879,8 @@ export type PatchStoredAgentsStoredAgentId_Body = {
     | undefined;
   /** Optional message describing the changes for the auto-created version */
   changeMessage?: string | undefined;
+  /** Immediately activate the auto-created version. Defaults to false when omitted. */
+  autoPublish?: boolean | undefined;
 };
 
 export type PatchStoredAgentsStoredAgentId_Response =

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -1471,6 +1471,8 @@ export interface UpdateStoredAgentParams {
   requestContextSchema?: Record<string, unknown>;
   /** Optional message describing the changes for the auto-created version */
   changeMessage?: string;
+  /** Immediately activate the auto-created version. Defaults to false when omitted. */
+  autoPublish?: boolean;
 }
 
 /**

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -3417,6 +3417,7 @@ export const API_ROUTE_METADATA = {
     "bodyParams": [
       "agents",
       "authorId",
+      "autoPublish",
       "browser",
       "changeMessage",
       "defaultOptions",

--- a/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
+++ b/packages/core/src/datasets/experiment/__tests__/runExperiment.test.ts
@@ -150,6 +150,28 @@ describe('runExperiment', () => {
       expect(firstCallOptions.requestContext).toBeInstanceOf(RequestContext);
       expect(firstCallOptions.requestContext.all).toEqual(requestContext);
     });
+
+    it('resolves an agent target with the requested version', async () => {
+      const mockAgent = createMockAgent('Draft response');
+      const getAgentById = vi.fn().mockReturnValue(mockAgent);
+      const localMastra = {
+        ...mastra,
+        getAgentById,
+      } as unknown as Mastra;
+
+      await runExperiment(localMastra, {
+        datasetId,
+        targetType: 'agent',
+        targetId: 'test-agent',
+        agentVersion: 'draft-version-id',
+      });
+
+      expect(getAgentById).toHaveBeenCalledWith('test-agent', { versionId: 'draft-version-id' });
+      expect(mockAgent.generate).toHaveBeenCalled();
+      const resolveOrder = getAgentById.mock.invocationCallOrder[0]!;
+      const generateOrder = mockAgent.generate.mock.invocationCallOrder[0]!;
+      expect(resolveOrder).toBeLessThan(generateOrder);
+    });
   });
 
   describe('status transitions', () => {

--- a/packages/playground/src/domains/agent-builder/hooks/__tests__/use-save-agent.test.tsx
+++ b/packages/playground/src/domains/agent-builder/hooks/__tests__/use-save-agent.test.tsx
@@ -62,6 +62,38 @@ const renderSave = ({
 };
 
 describe('useSaveAgent', () => {
+  describe('when saving an agent configuration', () => {
+    it('requests immediate publication', async () => {
+      const { hook, captured } = renderSave({
+        agentId: 'existing-id',
+        availableAgentTools: [],
+        defaultValues: {
+          name: 'Existing',
+          description: '',
+          instructions: 'Updated instructions',
+          tools: {},
+          agents: {},
+          workflows: {},
+          skills: {},
+        },
+      });
+
+      await act(async () => {
+        await hook.current.save({
+          name: 'Existing',
+          description: '',
+          instructions: 'Updated instructions',
+          tools: {},
+          agents: {},
+          workflows: {},
+          skills: {},
+        });
+      });
+
+      expect(captured.body?.autoPublish).toBe(true);
+    });
+  });
+
   describe('when updating an agent with selected tools and agents', () => {
     it('persists the selected tools as a record', async () => {
       const { hook, captured } = renderSave({

--- a/packages/playground/src/domains/agent-builder/hooks/use-save-agent.ts
+++ b/packages/playground/src/domains/agent-builder/hooks/use-save-agent.ts
@@ -41,6 +41,7 @@ export function useSaveAgent({
 
       try {
         const updated = await updateStoredAgent.mutateAsync({
+          autoPublish: true,
           name: params.name,
           description: params.description,
           instructions: params.instructions,

--- a/packages/server/src/server/handlers/stored-agents.test.ts
+++ b/packages/server/src/server/handlers/stored-agents.test.ts
@@ -1,11 +1,13 @@
 import type { Mastra } from '@mastra/core';
 import { RequestContext } from '@mastra/core/request-context';
+import { InMemoryStore } from '@mastra/core/storage';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
 import { MASTRA_RESOURCE_ID_KEY, MASTRA_USER_PERMISSIONS_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import { createStoredAgentBodySchema, updateStoredAgentBodySchema } from '../schemas/stored-agents';
 import type { ServerContext } from '../server-adapter';
+import { ACTIVATE_AGENT_VERSION_ROUTE, GET_AGENT_VERSION_ROUTE } from './agent-versions';
 import {
   LIST_STORED_AGENTS_ROUTE,
   GET_STORED_AGENT_ROUTE,
@@ -19,6 +21,7 @@ import {
 } from './stored-agents';
 
 // Mock handleAutoVersioning to prevent version creation in tests
+import { handleAutoVersioning } from './version-helpers';
 import type * as VersionHelpers from './version-helpers';
 
 vi.mock('./version-helpers', async importOriginal => {
@@ -232,6 +235,7 @@ interface MockEditor {
   prompt: {
     preview: ReturnType<typeof vi.fn>;
   };
+  getSource?: ReturnType<typeof vi.fn>;
   getSourceControlProvider?: ReturnType<typeof vi.fn>;
 }
 
@@ -298,6 +302,11 @@ function createAuthenticatedContext(mastra: MockMastra, userId: string, permissi
     ctx.requestContext.set(MASTRA_USER_PERMISSIONS_KEY, permissions);
   }
   return ctx;
+}
+
+async function useRealAutoVersioningOnce() {
+  const actual = await vi.importActual<typeof VersionHelpers>('./version-helpers');
+  vi.mocked(handleAutoVersioning).mockImplementationOnce(actual.handleAutoVersioning);
 }
 
 // =============================================================================
@@ -1224,42 +1233,150 @@ describe('Stored Agents Handlers', () => {
       }
     });
 
-    it('should auto-publish by updating activeVersionId when a new version is created', async () => {
-      const newVersionId = 'v-autopub-2';
-      mockAgentsData.set('autopub-test', {
-        id: 'autopub-test',
-        name: 'Original Name',
-        instructions: 'Original instructions',
-        model: { name: 'gpt-4', provider: 'openai' },
-        activeVersionId: 'v-autopub-1',
+    describe('version publication lifecycle', () => {
+      const setupPublishedAgent = async (agentId: string, source?: 'code') => {
+        const storage = new InMemoryStore();
+        const editor = createMockEditor();
+        if (source) {
+          editor.getSource = vi.fn().mockReturnValue(source);
+        }
+        const lifecycleMastra = createMockMastra({
+          storage: storage as unknown as MockStorage,
+          editor,
+        });
+        const agentsStore = await storage.getStore('agents');
+        await agentsStore.create({
+          agent: {
+            id: agentId,
+            name: 'Lifecycle Agent',
+            instructions: 'Published instructions',
+            model: { name: 'gpt-4', provider: 'openai' },
+          },
+        });
+        const publishedVersion = await agentsStore.getLatestVersion(agentId);
+        if (!publishedVersion) {
+          throw new Error('Expected initial agent version');
+        }
+        await agentsStore.update({
+          id: agentId,
+          activeVersionId: publishedVersion.id,
+          status: 'published',
+        });
+
+        return { agentsStore, lifecycleMastra, publishedVersion };
+      };
+
+      it('keeps a PATCH-created version as a draft until it is activated', async () => {
+        const agentId = 'draft-lifecycle-test';
+        const { agentsStore, lifecycleMastra, publishedVersion } = await setupPublishedAgent(agentId);
+        await useRealAutoVersioningOnce();
+
+        const updated = await UPDATE_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+          instructions: 'Draft instructions',
+        });
+        const draftVersion = await agentsStore.getLatestVersion(agentId);
+        if (!draftVersion) {
+          throw new Error('Expected draft agent version');
+        }
+
+        expect(updated.instructions).toBe('Draft instructions');
+        expect(draftVersion.id).not.toBe(publishedVersion.id);
+        expect((await agentsStore.getById(agentId))?.activeVersionId).toBe(publishedVersion.id);
+
+        const published = await GET_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+        });
+        const draft = await GET_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+          status: 'draft',
+        });
+        const specificDraft = await GET_AGENT_VERSION_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          agentId,
+          versionId: draftVersion.id,
+        });
+
+        expect(published.instructions).toBe('Published instructions');
+        expect(draft.instructions).toBe('Draft instructions');
+        expect(specificDraft.instructions).toBe('Draft instructions');
+
+        await ACTIVATE_AGENT_VERSION_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          agentId,
+          versionId: draftVersion.id,
+        });
+        const publishedAfterActivation = await GET_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+        });
+
+        expect(publishedAfterActivation.instructions).toBe('Draft instructions');
       });
 
-      // Override the global mock for this test to simulate a new version being created.
-      // The auto-publish branch only runs when versionCreated is true.
-      const { handleAutoVersioning } = await import('./version-helpers');
-      vi.mocked(handleAutoVersioning).mockImplementationOnce(async (_store, _id, _existing, updatedAgent) => ({
-        agent: updatedAgent as any,
-        versionCreated: true,
-      }));
+      it('auto-publishes a PATCH-created version when requested', async () => {
+        const agentId = 'auto-publish-lifecycle-test';
+        const { agentsStore, lifecycleMastra, publishedVersion } = await setupPublishedAgent(agentId);
+        await useRealAutoVersioningOnce();
+        const updateInput = {
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+          instructions: 'Auto-published instructions',
+          autoPublish: true,
+        };
 
-      // listVersions is called multiple times: once by enforceRetentionLimit
-      // inside handleAutoVersioning, then again by the auto-publish code.
-      // Return the new version each time so auto-publish can activate it.
-      mockAgentsStore.listVersions.mockResolvedValue({
-        versions: [{ id: newVersionId, versionNumber: 2 }],
-        total: 2,
+        await UPDATE_STORED_AGENT_ROUTE.handler(updateInput);
+        const latestVersion = await agentsStore.getLatestVersion(agentId);
+        if (!latestVersion) {
+          throw new Error('Expected updated agent version');
+        }
+        const published = await GET_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+        });
+
+        expect(latestVersion.id).not.toBe(publishedVersion.id);
+        expect((await agentsStore.getById(agentId))?.activeVersionId).toBe(latestVersion.id);
+        expect(published.instructions).toBe('Auto-published instructions');
       });
 
-      await UPDATE_STORED_AGENT_ROUTE.handler({
-        ...createTestContext(mockMastra),
-        storedAgentId: 'autopub-test',
-        name: 'Updated Name',
-        instructions: 'Updated instructions',
-      });
+      it('preserves the active code-source version while replacing an unpublished rolling draft', async () => {
+        const agentId = 'code-source-draft-test';
+        const { agentsStore, lifecycleMastra, publishedVersion } = await setupPublishedAgent(agentId, 'code');
+        await useRealAutoVersioningOnce();
 
-      // Verify activeVersionId was updated to the latest version
-      const stored = mockAgentsData.get('autopub-test');
-      expect(stored?.activeVersionId).toBe(newVersionId);
+        await UPDATE_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+          instructions: 'First rolling draft',
+        });
+        const firstDraft = await agentsStore.getLatestVersion(agentId);
+        if (!firstDraft) {
+          throw new Error('Expected first rolling draft');
+        }
+
+        expect(await agentsStore.getVersion(publishedVersion.id)).not.toBeNull();
+        expect((await agentsStore.getById(agentId))?.activeVersionId).toBe(publishedVersion.id);
+
+        await useRealAutoVersioningOnce();
+        await UPDATE_STORED_AGENT_ROUTE.handler({
+          ...createTestContext(lifecycleMastra),
+          storedAgentId: agentId,
+          instructions: 'Second rolling draft',
+        });
+        const secondDraft = await agentsStore.getLatestVersion(agentId);
+        if (!secondDraft) {
+          throw new Error('Expected second rolling draft');
+        }
+
+        expect(secondDraft.id).not.toBe(firstDraft.id);
+        expect(await agentsStore.getVersion(firstDraft.id)).toBeNull();
+        expect(await agentsStore.getVersion(publishedVersion.id)).not.toBeNull();
+        expect((await agentsStore.getById(agentId))?.activeVersionId).toBe(publishedVersion.id);
+      });
     });
 
     it('threads toolProviders into the auto-versioning snapshot config', async () => {

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -760,8 +760,9 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
     workspace,
     browser,
     requestContextSchema,
-    // Version metadata
+    // Version options
     changeMessage,
+    autoPublish = false,
   }) => {
     try {
       const storage = mastra.getStorage();
@@ -919,17 +920,13 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
       if (isCodeSource && autoVersionResult.versionCreated && !changeMessage) {
         const { versions } = await agentsStore.listVersions({ agentId: storedAgentId, perPage: 2 });
         const previousVersion = versions[1];
-        if (previousVersion) {
+        const isPublishedVersion = previousVersion?.id === existing.activeVersionId;
+        if (previousVersion && !isPublishedVersion) {
           await agentsStore.deleteVersion(previousVersion.id);
         }
       }
 
-      // Auto-publish: activate the latest version so the update is immediately
-      // visible in list views. The Agent Builder UI has no separate "Publish"
-      // button, so without this every edit after creation would create orphaned
-      // draft versions that never surface in the list.
-      // When a proper publish flow ships, this block can be removed.
-      if (autoVersionResult.versionCreated) {
+      if (autoVersionResult.versionCreated && autoPublish) {
         const { versions } = await agentsStore.listVersions({ agentId: storedAgentId, perPage: 1 });
         const latestVersion = versions[0];
         if (latestVersion) {

--- a/packages/server/src/server/handlers/stored-agents.ts
+++ b/packages/server/src/server/handlers/stored-agents.ts
@@ -926,6 +926,9 @@ export const UPDATE_STORED_AGENT_ROUTE: ServerRoute<
         }
       }
 
+      // Publication remains opt-in so Classic Studio can save drafts without moving the active version,
+      // while Agent Builder can preserve immediate runtime updates by sending autoPublish: true.
+      // This flag is a bridge until version creation and publication move to dedicated APIs.
       if (autoVersionResult.versionCreated && autoPublish) {
         const { versions } = await agentsStore.listVersions({ agentId: storedAgentId, perPage: 1 });
         const latestVersion = versions[0];

--- a/packages/server/src/server/schemas/stored-agents.ts
+++ b/packages/server/src/server/schemas/stored-agents.ts
@@ -375,6 +375,10 @@ export const updateStoredAgentBodySchema = agentMetadataSchema
       .max(500)
       .optional()
       .describe('Optional message describing the changes for the auto-created version'),
+    autoPublish: z
+      .boolean()
+      .optional()
+      .describe('Immediately activate the auto-created version. Defaults to false when omitted.'),
   });
 
 export const exportStoredAgentBodySchema = snapshotConfigUpdateSchema.partial();


### PR DESCRIPTION
Classic Studio's Save Draft was activating every newly created agent version, so runtime reads changed before Publish. This makes stored-agent PATCH updates draft-only by default and preserves the active version during code-source cleanup.

Agent Builder opts into its existing immediate-publication behavior through the new client option:

```ts
await client.getStoredAgent('agent-id').update({
  instructions: 'Updated instructions',
  autoPublish: true,
});
```

The server lifecycle tests cover draft, activation, auto-publish, and code-source cleanup. The Agent Builder MSW test covers the real client transport, and the dataset experiment test covers explicit agent-version resolution.

Verified the full server and playground test suites, server, playground, and client builds, TypeScript checks, ESLint, and server core-import checks.
