### PR TITLE
test(core): cover storage lazy-init rejection handling

### DIFF
--- a/packages/core/src/storage/storageWithInit.test.ts
+++ b/packages/core/src/storage/storageWithInit.test.ts
@@ -281,5 +281,43 @@ describe('augmentWithInit', () => {
       expect(init).toHaveBeenCalledTimes(2);
       expect(listMessages).toHaveBeenCalledTimes(3);
     });
+
+    it('does not float a rejection from the internal cache when init fails and the caller handles its call', async () => {
+      const unhandled: unknown[] = [];
+      const on = (r: unknown) => unhandled.push(r);
+      process.on('unhandledRejection', on);
+      try {
+        const inner = {
+          init: vi.fn().mockRejectedValue(new Error('boom')),
+          listMessages: vi.fn().mockResolvedValue({ messages: [], total: 0, hasMore: false }),
+        } as unknown as MastraStorage;
+        const store = augmentWithInit(inner);
+        // Caller handles its own call (awaits + expects rejection) — the realistic pattern.
+        await expect(store.listMessages({ threadId: 't' })).rejects.toThrow('boom');
+        await new Promise(resolve => setTimeout(resolve, 50));
+      } finally {
+        process.off('unhandledRejection', on);
+      }
+      expect(unhandled).toEqual([]);
+    });
+
+    it('fires no background init (and floats nothing) when a store is constructed but never called', async () => {
+      const unhandled: unknown[] = [];
+      const on = (r: unknown) => unhandled.push(r);
+      process.on('unhandledRejection', on);
+      const inner = {
+        init: vi.fn().mockRejectedValue(new Error('boom')),
+        listMessages: vi.fn(),
+      } as unknown as MastraStorage;
+      try {
+        augmentWithInit(inner); // construct only — lazy init must not fire on its own
+        await new Promise(resolve => setTimeout(resolve, 50));
+      } finally {
+        process.off('unhandledRejection', on);
+      }
+      expect(unhandled).toEqual([]);
+      // init is lazy: never called because no storage method was invoked.
+      expect(inner.init).not.toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
## What this adds

Two regression tests in `packages/core/src/storage/storageWithInit.test.ts` that lock in the storage lazy-init behavior from #16427 and #19697:

1. When init fails and the caller awaits its own storage call, no rejection floats from the internal cached init promise.
2. Constructing an augmented store and never calling anything fires no background init, so nothing floats.

## Why

An app that builds a `MongoDBStore` against an unreachable or placeholder URI used to see a process-level unhandled rejection from the background `createDefaultIndexes()` path after its test run finished. The fix landed upstream; these tests guard against regressing it. This is the exact failure that forced a downstream `unhandledRejection` filter as a workaround.

## Note on test design

These do not use a caller-side fire-and-forget (`void store.method()`). In JavaScript, `void <rejecting-async-call>()` always produces an `unhandledRejection` regardless of library code, because the caller discarded the promise, so asserting otherwise would be impossible to satisfy. The tests assert the properties the fix actually guarantees.

No production code changes, no changeset. Open only if the extra coverage is wanted; otherwise it documents that the fix holds.
