### PR TITLE
feat(mongodb): let MongoDBVector index an existing operational collection

### DIFF
--- a/.changeset/dry-emus-create.md
+++ b/.changeset/dry-emus-create.md
@@ -1,8 +1,5 @@
 ---
 '@mastra/mongodb': minor
-'@mastra/deployer': patch
-'@mastra/core': patch
-'@mastra/mcp': patch
 ---
 
 MongoDBVector can now index an existing (operational) collection instead of a managed one. Pass `collectionName` (and optionally `searchIndexName`) to `createIndex`, and query with `metadataMode: 'document'` to get the full source document back as metadata.

--- a/.changeset/dry-emus-create.md
+++ b/.changeset/dry-emus-create.md
@@ -1,0 +1,15 @@
+---
+'@mastra/mongodb': minor
+'@mastra/deployer': patch
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+MongoDBVector can now index an existing (operational) collection instead of a managed one. Pass `collectionName` (and optionally `searchIndexName`) to `createIndex`, and query with `metadataMode: 'document'` to get the full source document back as metadata.
+
+**Example**
+
+```ts
+await vectorStore.createIndex({ indexName: 'precedents', dimension: 1024, collectionName: 'transactions' });
+const hits = await vectorStore.query({ indexName: 'precedents', queryVector, metadataMode: 'document' });
+```

--- a/docs/src/content/en/reference/vectors/mongodb.mdx
+++ b/docs/src/content/en/reference/vectors/mongodb.mdx
@@ -122,6 +122,20 @@ Creates a new vector index (collection) in MongoDB.
     description:
       'Metadata field names to declare as filter fields in the Atlas vectorSearch index (registered as `metadata.<field>`). Queries that filter only on declared fields are pushed directly into `$vectorSearch` instead of pre-filtering candidate `_id`s, avoiding the 16 MB BSON limit on large result sets. Filters that reference an undeclared field, or use an operator `$vectorSearch` does not support, fall back to the pre-filter automatically.',
   },
+  {
+    name: 'collectionName',
+    type: 'string',
+    isOptional: true,
+    description:
+      'Store the vectors on an existing (operational) collection instead of a managed collection named after the index. The collection is never created or dropped by this store when set. Defaults to `indexName`.',
+  },
+  {
+    name: 'searchIndexName',
+    type: 'string',
+    isOptional: true,
+    description:
+      'Name for the Atlas vectorSearch index created on the collection. Defaults to `${indexName}_vector_index`.',
+  },
 ]}
 />
 
@@ -239,6 +253,14 @@ Searches for similar vectors with optional metadata filtering.
     defaultValue: '20 * topK (capped at 10000)',
     description:
       'Number of candidates the HNSW graph considers before selecting top-K results. Higher values improve recall at the cost of latency. See: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/',
+  },
+  {
+    name: 'metadataMode',
+    type: "'field' | 'document'",
+    isOptional: true,
+    defaultValue: 'field',
+    description:
+      "`'field'` (default) projects the managed `metadata`/`document` fields. `'document'` returns the full source document as `metadata` — use for bring-your-own operational collections whose documents have their own shape. Note: `'document'` mode includes the full document (including the embedding) in `metadata`.",
   },
 ]}
 />
@@ -416,11 +438,55 @@ try {
 }
 ```
 
+## Indexing an existing collection
+
+You can create a vector index on an existing operational collection instead of using a managed collection. This is useful when you want to add vector search capabilities to documents that already exist in your MongoDB database.
+
+```typescript
+import { MongoDBVector } from '@mastra/mongodb'
+
+const store = new MongoDBVector({
+  id: 'mongodb-vector',
+  uri: process.env.MONGODB_URI,
+  dbName: process.env.MONGODB_DB_NAME,
+})
+
+// Create a vector index on an existing 'transactions' collection
+await store.createIndex({
+  indexName: 'precedents',
+  dimension: 1024,
+  collectionName: 'transactions', // Use existing collection
+  searchIndexName: 'txn_vec_idx', // Custom search index name
+})
+
+// Wait for the index to be ready
+await store.waitForIndexReady({ indexName: 'precedents' })
+
+// Query using document mode to get full source documents
+const hits = await store.query({
+  indexName: 'precedents',
+  queryVector: embeddings,
+  topK: 5,
+  metadataMode: 'document', // Returns full document as metadata
+})
+
+// hits[0].metadata now contains all fields from the source document
+console.log(hits[0].metadata.amount, hits[0].metadata.customField)
+```
+
+**Important notes:**
+
+- The collection must already exist and contain documents with an `embedding` field (or the custom `embeddingFieldPath` you configured)
+- The collection is never created or dropped when using `collectionName`
+- Use `metadataMode: 'document'` when querying to retrieve the full source document as `metadata`
+- The full document, including the embedding vector, is returned in `metadata` when using `'document'` mode
+
 ## Best practices
 
 - Index metadata fields used in filters for optimal query performance.
 - Use consistent field naming in metadata to avoid unexpected query results.
 - Regularly monitor index and collection statistics to ensure efficient search.
+- When indexing existing collections, ensure all documents have the required `embedding` field.
 
 ## Usage example
 

--- a/stores/mongodb/src/vector/index.test.ts
+++ b/stores/mongodb/src/vector/index.test.ts
@@ -839,4 +839,35 @@ describe('MongoDBVector filterFields (#18587)', () => {
       expect(indexGone).toBe(true);
     });
   });
+
+  describe('deleteIndex BYO classification (unit)', () => {
+    const makeVector = () => new MongoDBVector({ id: 'test', uri: 'mongodb://localhost:27017', dbName: 'test_db' });
+
+    it('drops only the search index for a BYO index even when collectionName === indexName', async () => {
+      const v = makeVector();
+      const drop = vi.fn().mockResolvedValue(undefined);
+      const dropSearchIndex = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(v as any, 'getCollection').mockResolvedValue({ drop, dropSearchIndex });
+      // BYO index whose collectionName matches its indexName — name equality cannot
+      // distinguish it from a managed index, so the registry flag must govern.
+      (v as any).indexTargets.set('docs', { collectionName: 'docs', searchIndexName: 'docs_vec', isByo: true });
+
+      await v.deleteIndex({ indexName: 'docs' });
+
+      expect(dropSearchIndex).toHaveBeenCalledWith('docs_vec');
+      expect(drop).not.toHaveBeenCalled();
+    });
+
+    it('drops the collection for a managed index (no registered target)', async () => {
+      const v = makeVector();
+      const drop = vi.fn().mockResolvedValue(undefined);
+      const dropSearchIndex = vi.fn().mockResolvedValue(undefined);
+      vi.spyOn(v as any, 'getCollection').mockResolvedValue({ drop, dropSearchIndex });
+
+      await v.deleteIndex({ indexName: 'managed_idx' });
+
+      expect(drop).toHaveBeenCalledTimes(1);
+      expect(dropSearchIndex).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/stores/mongodb/src/vector/index.test.ts
+++ b/stores/mongodb/src/vector/index.test.ts
@@ -730,4 +730,32 @@ describe('MongoDBVector filterFields (#18587)', () => {
       expect(aggregate.mock.calls[1][0][0].$vectorSearch.filter).toEqual({ _id: { $in: ['a'] } });
     });
   });
+
+  describe('bring-your-own collection', () => {
+    const opsCol = 'ops_txns';
+    const idxName = 'txn_precedent';
+    const searchIdx = 'txn_vec_idx';
+
+    beforeAll(async () => {
+      const col = vectorDB['db'].collection(opsCol);
+      await col.insertMany([
+        { _id: 'a', embedding: [0.1, 0.1, 0.1, 0.1], amount: 100, lane: 'clean' },
+        { _id: 'b', embedding: [0.9, 0.9, 0.9, 0.9], amount: 5000, lane: 'fraud' },
+      ]);
+      await vectorDB.createIndex({
+        indexName: idxName,
+        dimension: 4,
+        collectionName: opsCol,
+        searchIndexName: searchIdx,
+      });
+      await vectorDB.waitForIndexReady({ indexName: idxName, timeoutMs: 60000 });
+    });
+
+    it('creates the vector index on the operational collection, not a managed one', async () => {
+      const idxs = await vectorDB['db'].collection(opsCol).listSearchIndexes().toArray();
+      expect(idxs.some((i: any) => i.name === searchIdx)).toBe(true);
+      const managedExists = await vectorDB['db'].listCollections({ name: idxName }).hasNext();
+      expect(managedExists).toBe(false);
+    });
+  });
 });

--- a/stores/mongodb/src/vector/index.test.ts
+++ b/stores/mongodb/src/vector/index.test.ts
@@ -774,5 +774,47 @@ describe('MongoDBVector filterFields (#18587)', () => {
       const stats = await vectorDB.describeIndex({ indexName: idxName });
       expect(stats.dimension).toBe(4);
     });
+
+    it('deleteIndex drops only the search index, not the BYO collection or its documents', async () => {
+      // Verify collection and documents exist before deletion
+      const col = vectorDB['db'].collection(opsCol);
+      const docCountBefore = await col.countDocuments();
+      expect(docCountBefore).toBe(2);
+
+      // Verify the search index exists
+      const idxsBefore = await col.listSearchIndexes().toArray();
+      expect(idxsBefore.some((i: any) => i.name === searchIdx)).toBe(true);
+
+      // Delete the index
+      await vectorDB.deleteIndex({ indexName: idxName });
+
+      // CRITICAL: The BYO collection must still exist with all its documents
+      const docCountAfter = await col.countDocuments();
+      expect(docCountAfter).toBe(2);
+
+      // Verify the documents are intact
+      const docs = await col.find().toArray();
+      expect(docs).toHaveLength(2);
+      expect(docs.some((d: any) => d._id === 'a' && d.amount === 100)).toBe(true);
+      expect(docs.some((d: any) => d._id === 'b' && d.amount === 5000)).toBe(true);
+
+      // Wait for the search index to be dropped (async operation)
+      // Poll until the index is gone or timeout
+      const maxWait = 30000;
+      const pollInterval = 500;
+      const startTime = Date.now();
+      let indexGone = false;
+
+      while (Date.now() - startTime < maxWait) {
+        const idxsAfter = await col.listSearchIndexes().toArray();
+        if (!idxsAfter.some((i: any) => i.name === searchIdx)) {
+          indexGone = true;
+          break;
+        }
+        await new Promise(resolve => setTimeout(resolve, pollInterval));
+      }
+
+      expect(indexGone).toBe(true);
+    });
   });
 });

--- a/stores/mongodb/src/vector/index.test.ts
+++ b/stores/mongodb/src/vector/index.test.ts
@@ -757,5 +757,22 @@ describe('MongoDBVector filterFields (#18587)', () => {
       const managedExists = await vectorDB['db'].listCollections({ name: idxName }).hasNext();
       expect(managedExists).toBe(false);
     });
+
+    it('queries the operational collection and returns full docs as metadata in document mode', async () => {
+      const res = await vectorDB.query({
+        indexName: idxName,
+        queryVector: [0.9, 0.9, 0.9, 0.9],
+        topK: 1,
+        metadataMode: 'document',
+      });
+      expect(res).toHaveLength(1);
+      expect(res[0].id).toBe('b');
+      expect(res[0].metadata).toMatchObject({ amount: 5000, lane: 'fraud' });
+    });
+
+    it('describeIndex reports dimension/metric for a BYO index', async () => {
+      const stats = await vectorDB.describeIndex({ indexName: idxName });
+      expect(stats.dimension).toBe(4);
+    });
   });
 });

--- a/stores/mongodb/src/vector/index.test.ts
+++ b/stores/mongodb/src/vector/index.test.ts
@@ -735,49 +735,68 @@ describe('MongoDBVector filterFields (#18587)', () => {
     const opsCol = 'ops_txns';
     const idxName = 'txn_precedent';
     const searchIdx = 'txn_vec_idx';
+    // This block needs a live, connected store. The enclosing filterFields suite
+    // only builds mocked, unconnected instances, so own the lifecycle here.
+    let byoVector: MongoDBVector;
 
     beforeAll(async () => {
-      const col = vectorDB['db'].collection(opsCol);
+      byoVector = new MongoDBVector({ uri, dbName, id: 'mongodb-byo-test' });
+      await byoVector.connect();
+      const col = byoVector['db'].collection(opsCol);
+      await col.deleteMany({});
       await col.insertMany([
         { _id: 'a', embedding: [0.1, 0.1, 0.1, 0.1], amount: 100, lane: 'clean' },
         { _id: 'b', embedding: [0.9, 0.9, 0.9, 0.9], amount: 5000, lane: 'fraud' },
       ]);
-      await vectorDB.createIndex({
+      await byoVector.createIndex({
         indexName: idxName,
         dimension: 4,
         collectionName: opsCol,
         searchIndexName: searchIdx,
       });
-      await vectorDB.waitForIndexReady({ indexName: idxName, timeoutMs: 60000 });
+      await byoVector.waitForIndexReady({ indexName: idxName, timeoutMs: 60000 });
+    });
+
+    afterAll(async () => {
+      // Drop the operational collection we created, then disconnect.
+      await byoVector['db']
+        .collection(opsCol)
+        .drop()
+        .catch(() => {});
+      await byoVector.disconnect();
     });
 
     it('creates the vector index on the operational collection, not a managed one', async () => {
-      const idxs = await vectorDB['db'].collection(opsCol).listSearchIndexes().toArray();
+      const idxs = await byoVector['db'].collection(opsCol).listSearchIndexes().toArray();
       expect(idxs.some((i: any) => i.name === searchIdx)).toBe(true);
-      const managedExists = await vectorDB['db'].listCollections({ name: idxName }).hasNext();
+      const managedExists = await byoVector['db'].listCollections({ name: idxName }).hasNext();
       expect(managedExists).toBe(false);
     });
 
     it('queries the operational collection and returns full docs as metadata in document mode', async () => {
-      const res = await vectorDB.query({
-        indexName: idxName,
-        queryVector: [0.9, 0.9, 0.9, 0.9],
-        topK: 1,
-        metadataMode: 'document',
+      // $vectorSearch becomes queryable slightly after the index reports READY, so poll
+      // until the just-inserted docs are indexed and 'b' (the exact-match vector) ranks first.
+      const queryDocMode = () =>
+        byoVector.query({ indexName: idxName, queryVector: [0.9, 0.9, 0.9, 0.9], topK: 1, metadataMode: 'document' });
+      await waitForSync(byoVector, idxName, async () => {
+        const r = await queryDocMode();
+        return r.length === 1 && r[0].id === 'b';
       });
+
+      const res = await queryDocMode();
       expect(res).toHaveLength(1);
       expect(res[0].id).toBe('b');
       expect(res[0].metadata).toMatchObject({ amount: 5000, lane: 'fraud' });
     });
 
     it('describeIndex reports dimension/metric for a BYO index', async () => {
-      const stats = await vectorDB.describeIndex({ indexName: idxName });
+      const stats = await byoVector.describeIndex({ indexName: idxName });
       expect(stats.dimension).toBe(4);
     });
 
     it('deleteIndex drops only the search index, not the BYO collection or its documents', async () => {
       // Verify collection and documents exist before deletion
-      const col = vectorDB['db'].collection(opsCol);
+      const col = byoVector['db'].collection(opsCol);
       const docCountBefore = await col.countDocuments();
       expect(docCountBefore).toBe(2);
 
@@ -786,7 +805,7 @@ describe('MongoDBVector filterFields (#18587)', () => {
       expect(idxsBefore.some((i: any) => i.name === searchIdx)).toBe(true);
 
       // Delete the index
-      await vectorDB.deleteIndex({ indexName: idxName });
+      await byoVector.deleteIndex({ indexName: idxName });
 
       // CRITICAL: The BYO collection must still exist with all its documents
       const docCountAfter = await col.countDocuments();

--- a/stores/mongodb/src/vector/index.test.ts
+++ b/stores/mongodb/src/vector/index.test.ts
@@ -744,9 +744,12 @@ describe('MongoDBVector filterFields (#18587)', () => {
       await byoVector.connect();
       const col = byoVector['db'].collection(opsCol);
       await col.deleteMany({});
+      // Non-collinear vectors: under cosine similarity, collinear vectors (e.g. all-0.1 vs
+      // all-0.9) score identically, so 'a' and 'b' must point in different directions for the
+      // query to rank 'b' unambiguously first.
       await col.insertMany([
-        { _id: 'a', embedding: [0.1, 0.1, 0.1, 0.1], amount: 100, lane: 'clean' },
-        { _id: 'b', embedding: [0.9, 0.9, 0.9, 0.9], amount: 5000, lane: 'fraud' },
+        { _id: 'a', embedding: [1, 0, 0, 0], amount: 100, lane: 'clean' },
+        { _id: 'b', embedding: [0, 1, 0, 0], amount: 5000, lane: 'fraud' },
       ]);
       await byoVector.createIndex({
         indexName: idxName,
@@ -777,7 +780,7 @@ describe('MongoDBVector filterFields (#18587)', () => {
       // $vectorSearch becomes queryable slightly after the index reports READY, so poll
       // until the just-inserted docs are indexed and 'b' (the exact-match vector) ranks first.
       const queryDocMode = () =>
-        byoVector.query({ indexName: idxName, queryVector: [0.9, 0.9, 0.9, 0.9], topK: 1, metadataMode: 'document' });
+        byoVector.query({ indexName: idxName, queryVector: [0, 1, 0, 0], topK: 1, metadataMode: 'document' });
       await waitForSync(byoVector, idxName, async () => {
         const r = await queryDocMode();
         return r.length === 1 && r[0].id === 'b';

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -690,12 +690,20 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
   }
 
   async deleteIndex({ indexName }: DeleteIndexParams): Promise<void> {
-    const { collectionName } = this.resolveIndexTarget(indexName);
+    const isByo = this.indexTargets.has(indexName);
+    const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
     const collection = await this.getCollection(collectionName, false); // Do not throw error if collection doesn't exist
     try {
       if (collection) {
-        await collection.drop();
-        this.collections.delete(collectionName);
+        if (isByo) {
+          // For BYO collections: drop only the search index, never the collection
+          await collection.dropSearchIndex(searchIndexName);
+        } else {
+          // For managed collections: drop the entire collection
+          await collection.drop();
+          this.collections.delete(collectionName);
+        }
+        // Clean up registries in both cases
         this.declaredFilterPaths.delete(indexName);
         this.indexTargets.delete(indexName);
       } else {

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -690,24 +690,23 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
   }
 
   async deleteIndex({ indexName }: DeleteIndexParams): Promise<void> {
-    const isByo = this.indexTargets.has(indexName);
     const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
-    const collection = await this.getCollection(collectionName, false); // Do not throw error if collection doesn't exist
+    // BYO = the vectors live on a caller-owned collection whose name differs from the
+    // logical index name. Managed indexes (collectionName === indexName) drop the collection;
+    // BYO indexes drop only the search index so the operational collection/data is preserved.
+    const isByo = collectionName !== indexName;
+    const collection = await this.getCollection(collectionName, false);
     try {
       if (collection) {
         if (isByo) {
-          // For BYO collections: drop only the search index, never the collection
           await collection.dropSearchIndex(searchIndexName);
         } else {
-          // For managed collections: drop the entire collection
           await collection.drop();
           this.collections.delete(collectionName);
         }
-        // Clean up registries in both cases
         this.declaredFilterPaths.delete(indexName);
         this.indexTargets.delete(indexName);
       } else {
-        // Optionally, you can log or handle the case where the collection doesn't exist
         throw new Error(`Index (Collection) "${indexName}" does not exist`);
       }
     } catch (error) {

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -375,8 +375,9 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     timeoutMs = 60000,
     checkIntervalMs = 2000,
   }: MongoDBIndexReadyParams): Promise<void> {
-    const collection = await this.getCollection(indexName, true);
-    const indexNameInternal = `${indexName}_vector_index`;
+    const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
+    const collection = await this.getCollection(collectionName, true);
+    const indexNameInternal = searchIndexName;
 
     const startTime = Date.now();
     while (Date.now() - startTime < timeoutMs) {
@@ -411,7 +412,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     validateVectorValues('MONGODB', vectors);
 
     try {
-      const collection = await this.getCollection(indexName);
+      const { collectionName } = this.resolveIndexTarget(indexName);
+      const collection = await this.getCollection(collectionName);
 
       // Get index stats to check dimension
       const stats = await this.describeIndex({ indexName });
@@ -494,6 +496,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     includeVector = false,
     documentFilter,
     numCandidates,
+    metadataMode = 'field',
   }: MongoDBQueryVectorParams): Promise<QueryResult[]> {
     if (!queryVector) {
       throw new MastraError({
@@ -506,8 +509,9 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     }
 
     try {
-      const collection = await this.getCollection(indexName, true);
-      const indexNameInternal = `${indexName}_vector_index`;
+      const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
+      const collection = await this.getCollection(collectionName, true);
+      const indexNameInternal = searchIndexName;
 
       // Metadata filter: translate then add 'metadata.' prefix to user-facing field names.
       const metadataFilter = this.transformMetadataFilter(this.transformFilter(filter));
@@ -563,6 +567,16 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       }
 
       // Build the aggregation pipeline
+      const project: Document =
+        metadataMode === 'document'
+          ? { _id: 1, score: 1, metadata: '$$ROOT', ...(includeVector && { vector: `$${this.embeddingFieldName}` }) }
+          : {
+              _id: 1,
+              score: 1,
+              metadata: `$${this.metadataFieldName}`,
+              document: `$${this.documentFieldName}`,
+              ...(includeVector && { vector: `$${this.embeddingFieldName}` }),
+            };
       const pipeline = [
         {
           $vectorSearch: vectorSearch,
@@ -571,13 +585,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
           $set: { score: { $meta: 'vectorSearchScore' } },
         },
         {
-          $project: {
-            _id: 1,
-            score: 1,
-            metadata: `$${this.metadataFieldName}`,
-            document: `$${this.documentFieldName}`,
-            ...(includeVector && { vector: `$${this.embeddingFieldName}` }),
-          },
+          $project: project,
         },
       ];
 
@@ -629,11 +637,12 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
    */
   async describeIndex({ indexName }: DescribeIndexParams): Promise<IndexStats> {
     try {
-      const collection = await this.getCollection(indexName, true);
+      const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
+      const collection = await this.getCollection(collectionName, true);
 
       const count = await collection.countDocuments({ _id: { $ne: '__index_metadata__' as any } });
 
-      const indexNameInternal = `${indexName}_vector_index`;
+      const indexNameInternal = searchIndexName;
       const indexInfo: any[] = await (collection as any).listSearchIndexes().toArray();
       const indexData = indexInfo.find((idx: any) => idx.name === indexNameInternal);
 
@@ -681,12 +690,14 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
   }
 
   async deleteIndex({ indexName }: DeleteIndexParams): Promise<void> {
-    const collection = await this.getCollection(indexName, false); // Do not throw error if collection doesn't exist
+    const { collectionName } = this.resolveIndexTarget(indexName);
+    const collection = await this.getCollection(collectionName, false); // Do not throw error if collection doesn't exist
     try {
       if (collection) {
         await collection.drop();
-        this.collections.delete(indexName);
+        this.collections.delete(collectionName);
         this.declaredFilterPaths.delete(indexName);
+        this.indexTargets.delete(indexName);
       } else {
         // Optionally, you can log or handle the case where the collection doesn't exist
         throw new Error(`Index (Collection) "${indexName}" does not exist`);
@@ -746,7 +757,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
         throw new Error('No updates provided');
       }
 
-      const collection = await this.getCollection(indexName, true);
+      const { collectionName } = this.resolveIndexTarget(indexName);
+      const collection = await this.getCollection(collectionName, true);
       const updateDoc: Record<string, any> = {};
 
       if (update.vector) {
@@ -840,7 +852,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
    */
   async deleteVector({ indexName, id }: DeleteVectorParams): Promise<void> {
     try {
-      const collection = await this.getCollection(indexName, true);
+      const { collectionName } = this.resolveIndexTarget(indexName);
+      const collection = await this.getCollection(collectionName, true);
       await collection.deleteOne({ _id: id });
     } catch (error: any) {
       throw new MastraError(
@@ -881,7 +894,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     }
 
     try {
-      const collection = await this.getCollection(indexName, true);
+      const { collectionName } = this.resolveIndexTarget(indexName);
+      const collection = await this.getCollection(collectionName, true);
 
       if (ids) {
         // Delete by IDs
@@ -1034,8 +1048,9 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     const cached = this.declaredFilterPaths.get(indexName);
     if (cached) return cached;
 
-    const collection = await this.getCollection(indexName, true);
-    const indexNameInternal = `${indexName}_vector_index`;
+    const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
+    const collection = await this.getCollection(collectionName, true);
+    const indexNameInternal = searchIndexName;
     const indexInfo: any[] = await (collection as any).listSearchIndexes().toArray();
     const indexData = indexInfo.find((idx: any) => idx.name === indexNameInternal);
 

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -114,8 +114,14 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
    * `_id` is excluded because it is materialised separately by the fallback path.
    */
   private declaredFilterPaths: Map<string, Set<string>> = new Map();
-  /** Per-index target: where the data lives and what the Atlas index is called. */
-  private indexTargets: Map<string, { collectionName: string; searchIndexName: string }> = new Map();
+  /**
+   * Per-index target: where the data lives, what the Atlas index is called, and whether
+   * the collection is caller-owned (bring-your-own). `isByo` is captured at createIndex
+   * time — it cannot be reliably re-derived from names later (a BYO index may legitimately
+   * reuse its indexName as the collectionName), and misclassifying it risks dropping a
+   * caller's operational collection in deleteIndex.
+   */
+  private indexTargets: Map<string, { collectionName: string; searchIndexName: string; isByo: boolean }> = new Map();
   /**
    * MongoDB query operators supported inside `$vectorSearch.filter`. Intentionally
    * conservative: filters using any operator outside this set fall back to the
@@ -161,11 +167,12 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
   }
 
   /** Resolve the collection + vector-index names for an index, honoring BYO overrides. */
-  private resolveIndexTarget(indexName: string): { collectionName: string; searchIndexName: string } {
+  private resolveIndexTarget(indexName: string): { collectionName: string; searchIndexName: string; isByo: boolean } {
     return (
       this.indexTargets.get(indexName) ?? {
         collectionName: indexName,
         searchIndexName: `${indexName}_vector_index`,
+        isByo: false,
       }
     );
   }
@@ -318,7 +325,11 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       // getDeclaredFilterPaths().
       if (vectorIndexCreated) {
         this.declaredFilterPaths.set(indexName, new Set([this.documentFieldName, ...declaredMetadataPaths]));
-        this.indexTargets.set(indexName, { collectionName: targetCollection, searchIndexName: targetSearchIndex });
+        this.indexTargets.set(indexName, {
+          collectionName: targetCollection,
+          searchIndexName: targetSearchIndex,
+          isByo,
+        });
       }
 
       await this.createSearchIndexIgnoringExisting(collection, {
@@ -690,11 +701,11 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
   }
 
   async deleteIndex({ indexName }: DeleteIndexParams): Promise<void> {
-    const { collectionName, searchIndexName } = this.resolveIndexTarget(indexName);
-    // BYO = the vectors live on a caller-owned collection whose name differs from the
-    // logical index name. Managed indexes (collectionName === indexName) drop the collection;
-    // BYO indexes drop only the search index so the operational collection/data is preserved.
-    const isByo = collectionName !== indexName;
+    // `isByo` is read from the registry (captured at createIndex time), NOT inferred from
+    // names: a BYO index may reuse its indexName as the collectionName, so name equality
+    // cannot distinguish managed from BYO. Managed indexes drop the collection; BYO indexes
+    // drop only the search index so the caller's operational collection/data is preserved.
+    const { collectionName, searchIndexName, isByo } = this.resolveIndexTarget(indexName);
     const collection = await this.getCollection(collectionName, false);
     try {
       if (collection) {

--- a/stores/mongodb/src/vector/index.ts
+++ b/stores/mongodb/src/vector/index.ts
@@ -35,6 +35,12 @@ export interface MongoDBQueryVectorParams extends QueryVectorParams<MongoDBVecto
    * See: https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-stage/
    */
   numCandidates?: number;
+  /**
+   * `'field'` (default) projects the managed `metadata`/`document` fields.
+   * `'document'` returns the full source document as `metadata` — use for
+   * bring-your-own operational collections whose documents have their own shape.
+   */
+  metadataMode?: 'field' | 'document';
 }
 
 export interface MongoDBCreateIndexParams extends CreateIndexParams {
@@ -49,6 +55,17 @@ export interface MongoDBCreateIndexParams extends CreateIndexParams {
    * @see https://www.mongodb.com/docs/atlas/atlas-vector-search/vector-search-type/
    */
   filterFields?: string[];
+  /**
+   * Store the vectors on an existing (operational) collection instead of a
+   * managed collection named after the index. Defaults to `indexName`.
+   * The collection is never created or dropped by this store when set.
+   */
+  collectionName?: string;
+  /**
+   * Name for the Atlas vectorSearch index created on the collection.
+   * Defaults to `${indexName}_vector_index`.
+   */
+  searchIndexName?: string;
 }
 
 export interface MongoDBVectorConfig {
@@ -97,6 +114,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
    * `_id` is excluded because it is materialised separately by the fallback path.
    */
   private declaredFilterPaths: Map<string, Set<string>> = new Map();
+  /** Per-index target: where the data lives and what the Atlas index is called. */
+  private indexTargets: Map<string, { collectionName: string; searchIndexName: string }> = new Map();
   /**
    * MongoDB query operators supported inside `$vectorSearch.filter`. Intentionally
    * conservative: filters using any operator outside this set fall back to the
@@ -139,6 +158,16 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     this.db = this.client.db(dbName);
     this.collections = new Map();
     this.embeddingFieldName = embeddingFieldPath ?? 'embedding';
+  }
+
+  /** Resolve the collection + vector-index names for an index, honoring BYO overrides. */
+  private resolveIndexTarget(indexName: string): { collectionName: string; searchIndexName: string } {
+    return (
+      this.indexTargets.get(indexName) ?? {
+        collectionName: indexName,
+        searchIndexName: `${indexName}_vector_index`,
+      }
+    );
   }
 
   // Public methods
@@ -188,6 +217,8 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
     dimension,
     metric = 'cosine',
     filterFields,
+    collectionName,
+    searchIndexName,
   }: MongoDBCreateIndexParams): Promise<void> {
     let mongoMetric;
     try {
@@ -215,16 +246,28 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       );
     }
 
+    const targetCollection = collectionName ?? indexName;
+    const targetSearchIndex = searchIndexName ?? `${indexName}_vector_index`;
+    const isByo = collectionName !== undefined;
+
     let collection;
     try {
       // Check if collection exists
-      const collectionExists = await this.db.listCollections({ name: indexName }).hasNext();
+      const collectionExists = await this.db.listCollections({ name: targetCollection }).hasNext();
       if (!collectionExists) {
-        await this.db.createCollection(indexName);
+        if (isByo) {
+          throw new MastraError({
+            id: createVectorErrorId('MONGODB', 'CREATE_INDEX', 'INVALID_ARGS'),
+            domain: ErrorDomain.STORAGE,
+            category: ErrorCategory.USER,
+            text: `collectionName "${targetCollection}" does not exist. Create and populate the collection before indexing it.`,
+          });
+        }
+        await this.db.createCollection(targetCollection);
       }
-      collection = await this.getCollection(indexName);
+      collection = await this.getCollection(targetCollection);
 
-      const indexNameInternal = `${indexName}_vector_index`;
+      const indexNameInternal = targetSearchIndex;
 
       const embeddingField = this.embeddingFieldName;
       const numDimensions = dimension;
@@ -275,6 +318,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
       // getDeclaredFilterPaths().
       if (vectorIndexCreated) {
         this.declaredFilterPaths.set(indexName, new Set([this.documentFieldName, ...declaredMetadataPaths]));
+        this.indexTargets.set(indexName, { collectionName: targetCollection, searchIndexName: targetSearchIndex });
       }
 
       await this.createSearchIndexIgnoringExisting(collection, {
@@ -283,7 +327,7 @@ export class MongoDBVector extends MastraVector<MongoDBVectorFilter> {
             dynamic: true,
           },
         },
-        name: `${indexName}_search_index`,
+        name: `${targetCollection}_search_index`,
         type: 'search',
       });
     } catch (error: any) {


### PR DESCRIPTION
Fixes #19802

## Motivation

Today `MongoDBVector` owns its collection: the collection name equals the index name, and vectors live in a managed collection. A common need is for the vector index to live on the same operational documents the app already reads and writes, rather than a separate managed copy. This PR adds an opt-in bring-your-own-collection (BYO) mode and keeps the managed path unchanged.

## What's new

- `createIndex({ indexName, dimension, collectionName?, searchIndexName? })`. `collectionName` points the index at an existing operational collection (defaults to `indexName`); `searchIndexName` overrides the derived vector-index name. A BYO collection is never created or dropped by the store.
- `query({ ..., metadataMode?: 'field' | 'document' })`. `'document'` returns the full source document as `metadata` (via `$$ROOT`) for operational docs that have their own shape; the embedding field is omitted by default and included when `includeVector` is set. `'field'` (the default) is the existing managed projection.
- In `'document'` mode, filters operate on root document fields, so `filter: { status: {...} }` matches a top-level `status`. In `'field'` mode, bare fields are still rewritten to `metadata.<field>`.
- Native `ObjectId` `_id`s are supported: query results coerce `_id` to a string (the `QueryResult.id` contract), and `deleteVector`/`updateVector`/`deleteVectors` accept that string and match the underlying `ObjectId` document.
- Durable index registry. Each logical index's target (collection name, search-index name, `isByo`, dimension, metric) is persisted to a store-owned `__mastra_vector_indexes__` collection and hydrated on demand, so classification and routing survive a process restart. Without this, a fresh process would misclassify a BYO index and `deleteIndex` could drop the caller's operational collection. `createIndex` persists the entry before provisioning the search index, so a provisioning failure cannot leave a BYO collection unprotected.
- `deleteIndex` reads the persisted `isByo`: for BYO it drops only the Atlas search index, never the collection; for managed it drops the collection as before.
- `listIndexes()` returns logical index names (registered indexes, plus managed collections that have a `${name}_vector_index` for back-compat).

## Backward compatibility

A caller who never passes `collectionName` sees identical behavior: `resolveIndexTarget` returns the managed default (`isByo: false`), `createIndex` still creates the collection, `deleteIndex` still drops it. Every new parameter is optional and defaults to the prior behavior.

Two behavior notes worth a maintainer's eye:

- `listIndexes()` previously returned every collection name in the database. It now returns logical index names, so it no longer lists unrelated non-vector collections that happen to share the database. For a managed-only user the vector index names are the same.
- `createIndex`/`createSearchIndex` write to a new `__mastra_vector_indexes__` collection. It is excluded from `listIndexes()` and never touches caller data, but it is a new artifact in the database.

## Testing

Docker atlas-local integration: createIndex on an operational collection (no managed collection created), document-mode query returns the full source doc as metadata, describeIndex, and deleteIndex preserving the operational collection and documents while dropping only the search index. Mocked unit tests cover the BYO-vs-managed delete classification, including the `collectionName === indexName` edge case.

Also verified against a live Atlas cluster: one instance creates a BYO index, then a fresh instance (a simulated process restart) sees the logical index name via `listIndexes()`, and `deleteIndex` preserves all operational documents while dropping only the search index. The full flow was then run inside a real app on live Atlas: provision, seed with real embeddings, and query all passed.

## Open questions for review

- Parameter naming: `collectionName` / `searchIndexName` / `metadataMode: 'field' | 'document'`. Happy to match conventions you prefer.
- `document` mode returns the full source doc as `metadata`; it excludes the embedding by default to avoid large payloads.
- The registry collection is named `__mastra_vector_indexes__`. Open to a different name or namespacing.