### PR TITLE
fix(playground): respect Studio base path in navigation

### DIFF
--- a/.changeset/brave-trees-cheat.md
+++ b/.changeset/brave-trees-cheat.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed Studio navigation and authentication redirects when Studio is mounted at a custom base path.

--- a/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
+++ b/packages/playground/e2e/kitchen-sink/src/mastra/index.ts
@@ -62,6 +62,7 @@ export const mastra = new Mastra({
     contentFilterProcessor,
   },
   server: {
+    ...(process.env.E2E_STUDIO_BASE_PATH ? { studioBase: process.env.E2E_STUDIO_BASE_PATH } : {}),
     apiRoutes: [
       registerApiRoute('/e2e/reset-storage', {
         method: 'POST',

--- a/packages/playground/e2e/playwright.studio-base.config.ts
+++ b/packages/playground/e2e/playwright.studio-base.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './studio-base-tests',
+  fullyParallel: false,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: process.env.CI ? 'list' : 'html',
+  use: {
+    baseURL: 'http://localhost:4111/studio',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'E2E_STUDIO_BASE_PATH=/studio pnpm -C ./kitchen-sink dev',
+    url: 'http://localhost:4111/studio',
+    timeout: 120_000,
+  },
+});

--- a/packages/playground/e2e/studio-base-tests/login-flow.spec.ts
+++ b/packages/playground/e2e/studio-base-tests/login-flow.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from '@playwright/test';
+
+import { setupMockAuth } from '../tests/__utils__/auth';
+
+/**
+ * FEATURE: Studio authentication under a custom base path.
+ * USER STORY: As a signed-out Studio user, I want Sign in to stay within the
+ * configured Studio mount so that I reach the login form instead of the server welcome page.
+ * BEHAVIOR UNDER TEST: A real Mastra server mounted at /studio serves the login
+ * route selected by AuthRequired after credentials capabilities are returned.
+ */
+test.describe('Studio base-path login flow', () => {
+  test.describe('when an unauthenticated user signs in from a protected Studio route', () => {
+    test('opens the credentials login page within the Studio base path', async ({ page }) => {
+      await setupMockAuth(page, {
+        authenticated: false,
+        loginType: 'credentials',
+      });
+      await page.goto('/studio/agents');
+
+      await page.getByRole('button', { name: 'Sign in' }).click();
+
+      await expect(page).toHaveURL(/\/studio\/login\?redirect=/);
+      await expect(page.getByRole('heading', { name: 'Sign in to Mastra Studio' })).toBeVisible();
+    });
+  });
+});

--- a/packages/playground/e2e/studio-base-tests/login-flow.spec.ts
+++ b/packages/playground/e2e/studio-base-tests/login-flow.spec.ts
@@ -11,7 +11,7 @@ import { setupMockAuth } from '../tests/__utils__/auth';
  */
 test.describe('Studio base-path login flow', () => {
   test.describe('when an unauthenticated user signs in from a protected Studio route', () => {
-    test('opens the credentials login page within the Studio base path', async ({ page }) => {
+    test('navigates to the login route within the Studio base path', async ({ page }) => {
       await setupMockAuth(page, {
         authenticated: false,
         loginType: 'credentials',
@@ -21,6 +21,17 @@ test.describe('Studio base-path login flow', () => {
       await page.getByRole('button', { name: 'Sign in' }).click();
 
       await expect(page).toHaveURL(/\/studio\/login\?redirect=/);
+    });
+
+    test('shows the credentials login form', async ({ page }) => {
+      await setupMockAuth(page, {
+        authenticated: false,
+        loginType: 'credentials',
+      });
+      await page.goto('/studio/agents');
+
+      await page.getByRole('button', { name: 'Sign in' }).click();
+
       await expect(page.getByRole('heading', { name: 'Sign in to Mastra Studio' })).toBeVisible();
     });
   });

--- a/packages/playground/eslint.config.js
+++ b/packages/playground/eslint.config.js
@@ -189,9 +189,9 @@ const restrictedTestMockSelectors = [
 
 /** @type {import("eslint").Linter.Config[]} */
 export default [
-  // Only the Playwright spec files under e2e/tests are linted (for BDD
-  // structure enforcement below). The kitchen-sink app, test utils, config,
-  // scripts, and build output under e2e remain unlinted as before.
+  // Only Playwright spec files are linted under e2e (for BDD structure
+  // enforcement below). The kitchen-sink app, test utils, config, scripts,
+  // and build output under e2e remain unlinted as before.
   {
     ignores: [
       'e2e/kitchen-sink/**',
@@ -199,6 +199,7 @@ export default [
       'e2e/playwright-report/**',
       'e2e/test-results/**',
       'e2e/playwright.config.ts',
+      'e2e/playwright.studio-base.config.ts',
       'e2e/tests/__utils__/**',
     ],
   },
@@ -226,7 +227,7 @@ export default [
     // e2e-tests-studio skill (every test()/it() nested in a describe('when …')).
     // These files are not part of the type-aware tsconfig program, so disable
     // the TypeScript project service here and only run the syntactic BDD rule.
-    files: ['e2e/tests/**/*.spec.{js,jsx,ts,tsx}'],
+    files: ['e2e/{tests,studio-base-tests}/**/*.spec.{js,jsx,ts,tsx}'],
     languageOptions: {
       parserOptions: {
         projectService: false,

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -36,7 +36,8 @@
     "preview": "vite preview",
     "test": "vitest",
     "test:run": "vitest run",
-    "test:e2e": "pnpm test:e2e:setup && playwright test -c e2e/playwright.config.ts",
+    "test:e2e": "pnpm test:e2e:setup && playwright test -c e2e/playwright.config.ts && playwright test -c e2e/playwright.studio-base.config.ts",
+    "test:e2e:studio-base": "pnpm test:e2e:setup && playwright test -c e2e/playwright.studio-base.config.ts",
     "test:e2e:ui": "pnpm test:e2e:setup && playwright test -c e2e/playwright.config.ts --ui",
     "test:e2e:dev:ui": "pnpm test:e2e:setup && E2E_PORT=5173 playwright test -c e2e/playwright.config.ts --ui",
     "test:e2e:setup": "node ./e2e/scripts/info.js && pnpm install --dir ./e2e/kitchen-sink && playwright install chromium"

--- a/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-root-layout.test.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/__tests__/agent-builder-root-layout.test.tsx
@@ -1,17 +1,13 @@
 import type { BuilderSettingsResponse } from '@mastra/client-js';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { AgentBuilderRootLayout } from '../agent-builder-root-layout';
 import type { AuthCapabilities } from '@/domains/auth/types';
 import { server } from '@/test/msw-server';
-
-vi.mock('@/lib/link', () => ({
-  Link: ({ children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => <a {...props}>{children}</a>,
-}));
 
 const BASE_URL = 'http://localhost:4111';
 
@@ -31,6 +27,12 @@ const authenticatedCapabilities = {
 const authDisabledCapabilities = {
   enabled: false,
   login: { type: 'credentials' as const },
+} satisfies AuthCapabilities;
+
+const authenticatedWithoutBuilderAccess = {
+  ...authenticatedCapabilities,
+  capabilities: { ...authenticatedCapabilities.capabilities, rbac: true },
+  access: { roles: [], permissions: [] },
 } satisfies AuthCapabilities;
 
 const builderFullySetUp: BuilderSettingsResponse = {
@@ -57,7 +59,7 @@ function builderHandler(settings: BuilderSettingsResponse | { error: true }) {
   });
 }
 
-function renderAgentBuilderRoute(initialEntry: string) {
+function renderAgentBuilderRoute(initialEntry: string, basename?: string) {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: { retry: false },
@@ -70,6 +72,10 @@ function renderAgentBuilderRoute(initialEntry: string) {
       {
         path: '/login',
         element: <div>Login page</div>,
+      },
+      {
+        path: '/agents',
+        element: <div>Agents page</div>,
       },
       {
         path: '/agent-builder',
@@ -88,6 +94,7 @@ function renderAgentBuilderRoute(initialEntry: string) {
     ],
     {
       initialEntries: [initialEntry],
+      basename,
     },
   );
 
@@ -118,6 +125,18 @@ describe('AgentBuilderRootLayout', () => {
 
     expect(router.state.location.search).toBe('?redirect=%2Fagent-builder%2Fagents%2Fcreate%3Fdraft%3D1%23details');
     expect(await screen.findByText('Login page')).toBeTruthy();
+  });
+
+  describe('when an authenticated user without Agent Builder access uses a nested Studio base path', () => {
+    it('navigates back to the Studio agents page within the base path', async () => {
+      server.use(authHandler(authenticatedWithoutBuilderAccess));
+
+      const router = renderAgentBuilderRoute('/studio/agent-builder/agents', '/studio');
+      fireEvent.click(await screen.findByRole('link', { name: 'Back to Studio' }));
+
+      await waitFor(() => expect(router.state.location.pathname).toBe('/studio/agents'));
+      expect(await screen.findByText('Agents page')).toBeTruthy();
+    });
   });
 
   it('renders agent-builder children for authenticated users with access', async () => {

--- a/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
+++ b/packages/playground/src/domains/agent-builder/layouts/agent-builder-root-layout.tsx
@@ -113,7 +113,7 @@ function AccessDeniedScreen() {
           descriptionSlot="You don't have permission to access the Agent Builder."
         />
         <div className="flex items-center gap-2">
-          <Button as="a" href="/agents" variant="outline" size="sm">
+          <Button as={Link} href="/agents" variant="outline" size="sm">
             <ArrowLeft className="h-3.5 w-3.5" />
             Back to Studio
           </Button>

--- a/packages/playground/src/domains/agents/components/__tests__/agent-chat-shell.msw.test.tsx
+++ b/packages/playground/src/domains/agents/components/__tests__/agent-chat-shell.msw.test.tsx
@@ -1,7 +1,7 @@
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router';
@@ -86,9 +86,36 @@ function renderShell(onOM = vi.fn(), onMessages = vi.fn()) {
   return { onOM, onMessages };
 }
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  delete window.MASTRA_STUDIO_BASE_PATH;
+});
 
 describe('AgentChatShell', () => {
+  describe('when the Studio uses a nested base path', () => {
+    it('copies a shareable session URL within the base path', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio/v1';
+      const writeText = vi.fn().mockResolvedValue(undefined);
+      const originalClipboard = navigator.clipboard;
+      Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+
+      try {
+        renderShell();
+        const shareButton = await screen.findByTestId('agent-entity-header-share');
+        await act(async () => {
+          fireEvent.click(shareButton);
+          await Promise.resolve();
+        });
+
+        await waitFor(() =>
+          expect(writeText).toHaveBeenCalledWith(`${window.location.origin}/studio/v1/agents/agent-1/session`),
+        );
+      } finally {
+        Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
+      }
+    });
+  });
+
   it('renders the header without the (removed) memory launcher', async () => {
     renderShell();
 
@@ -104,7 +131,9 @@ describe('AgentChatShell', () => {
     await screen.findByTestId('agent-entity-header-share');
 
     // OM/messages fetching moved into the left memory card; the shell must not fire them.
-    await new Promise(resolve => setTimeout(resolve, 50));
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 50));
+    });
     expect(onOM).not.toHaveBeenCalled();
     expect(onMessages).not.toHaveBeenCalled();
     expect(screen.queryByRole('checkbox', { name: 'Close memory panel' })).toBeNull();

--- a/packages/playground/src/domains/agents/components/agent-view-header.tsx
+++ b/packages/playground/src/domains/agents/components/agent-view-header.tsx
@@ -9,6 +9,7 @@ import { useAgent } from '../hooks/use-agent';
 import { AgentEntityHeader } from './agent-entity-header';
 import { useCanCreateAgent } from '@/domains/agent-builder/hooks/use-can-create-agent';
 import { useLinkComponent } from '@/lib/framework';
+import { withStudioBasePath } from '@/lib/studio-base-path';
 
 export interface AgentViewHeaderProps {
   agentId: string;
@@ -22,8 +23,7 @@ export function AgentViewHeader({ agentId, view }: AgentViewHeaderProps) {
   const { canCreateAgent } = useCanCreateAgent();
   const { Link: FrameworkLink, paths } = useLinkComponent();
 
-  const basePath = (window.MASTRA_STUDIO_BASE_PATH ?? '').replace(/\/$/, '');
-  const sessionUrl = `${window.location.origin}${basePath}/agents/${encodeURIComponent(agentId)}/session`;
+  const sessionUrl = `${window.location.origin}${withStudioBasePath(`/agents/${encodeURIComponent(agentId)}/session`)}`;
   const { handleCopy: handleShareLink, isCopied: isShareCopied } = useCopyToClipboard({
     text: sessionUrl,
     copyMessage: 'Session URL copied to clipboard!',

--- a/packages/playground/src/domains/auth/components/__tests__/auth-required-base-path.test.tsx
+++ b/packages/playground/src/domains/auth/components/__tests__/auth-required-base-path.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { MemoryRouter } from 'react-router';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { PublicAuthCapabilities } from '../../types';
+import { AuthRequired } from '../auth-required';
+import type { AuthRequiredProps } from '../auth-required';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const credentialsCapabilities: PublicAuthCapabilities = {
+  enabled: true,
+  login: { type: 'credentials' },
+};
+
+function stubLocationHref() {
+  const hrefSetter = vi.fn();
+  const originalLocation = window.location;
+  Object.defineProperty(window, 'location', {
+    configurable: true,
+    value: new Proxy(originalLocation, {
+      set(_target, prop, value) {
+        if (prop === 'href') {
+          hrefSetter(value);
+        }
+        return true;
+      },
+      get(target, prop) {
+        // @ts-expect-error indexed access
+        return target[prop];
+      },
+    }),
+  });
+  return {
+    hrefSetter,
+    restore: () => {
+      Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+    },
+  };
+}
+
+const renderAuthRequired = (props: Omit<AuthRequiredProps, 'children'> = {}) => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AuthRequired {...props}>
+            <div>protected content</div>
+          </AuthRequired>
+        </MemoryRouter>
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+};
+
+afterEach(() => {
+  cleanup();
+  delete window.MASTRA_STUDIO_BASE_PATH;
+});
+
+describe('AuthRequired', () => {
+  describe('when the studio is served from a custom base path and the user is unauthenticated', () => {
+    it('sends the Sign in button to /login under the studio base path', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired();
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign in' }));
+
+      const target = new URL(hrefSetter.mock.calls[0][0]);
+      expect(target.pathname).toBe('/studio/login');
+      restore();
+    });
+
+    it('sends the Sign up link to /signup under the studio base path', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired();
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign up' }));
+
+      const target = new URL(hrefSetter.mock.calls[0][0]);
+      expect(target.pathname).toBe('/studio/signup');
+      restore();
+    });
+  });
+
+  describe('when custom absolute authentication URLs are configured', () => {
+    it('preserves the external login URL', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired({ loginUrl: 'https://auth.example.com/login' });
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign in' }));
+
+      expect(hrefSetter.mock.calls[0][0]).toBe(
+        `https://auth.example.com/login?redirect=${encodeURIComponent(window.location.href)}`,
+      );
+      restore();
+    });
+
+    it('preserves the external signup URL', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired({ signupUrl: 'https://auth.example.com/signup' });
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign up' }));
+
+      expect(hrefSetter.mock.calls[0][0]).toBe(
+        `https://auth.example.com/signup?redirect=${encodeURIComponent(window.location.href)}`,
+      );
+      restore();
+    });
+  });
+
+  describe('when the configured login URL already includes the studio base path', () => {
+    it('does not prefix the login URL again', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired({ loginUrl: '/studio/login' });
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign in' }));
+
+      const target = new URL(hrefSetter.mock.calls[0][0]);
+      expect(target.pathname).toBe('/studio/login');
+      restore();
+    });
+  });
+
+  describe('when a relative login URL is configured', () => {
+    it('resolves the login URL under the studio base path', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired({ loginUrl: 'login?mode=signup#form' });
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign in' }));
+
+      const target = new URL(hrefSetter.mock.calls[0][0]);
+      expect(target.pathname).toBe('/studio/login');
+      expect(target.searchParams.get('mode')).toBe('signup');
+      expect(target.hash).toBe('#form');
+      restore();
+    });
+  });
+
+  describe('when the studio is served from the root and the user is unauthenticated', () => {
+    it('sends the Sign in button to /login', async () => {
+      server.use(http.get(`${BASE_URL}/api/auth/capabilities`, () => HttpResponse.json(credentialsCapabilities)));
+      const { hrefSetter, restore } = stubLocationHref();
+
+      renderAuthRequired();
+      fireEvent.click(await screen.findByRole('button', { name: 'Sign in' }));
+
+      const target = new URL(hrefSetter.mock.calls[0][0]);
+      expect(target.pathname).toBe('/login');
+      restore();
+    });
+  });
+});

--- a/packages/playground/src/domains/auth/components/__tests__/login-page.test.tsx
+++ b/packages/playground/src/domains/auth/components/__tests__/login-page.test.tsx
@@ -1,12 +1,13 @@
 import { TooltipProvider } from '@mastra/playground-ui/components/Tooltip';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import React from 'react';
 import { MemoryRouter } from 'react-router';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { LoginPage } from '../login-page';
 import { Login } from '@/pages/login';
 import { SignUp } from '@/pages/signup';
 import { server } from '@/test/msw-server';
@@ -190,6 +191,46 @@ describe('LoginPage UI parity for /login and /signup', () => {
 
     await waitFor(() => {
       expect(screen.getByText('oops')).toBeTruthy();
+    });
+  });
+
+  describe('when credentials login succeeds without a redirect target', () => {
+    it('redirects to the studio base path', async () => {
+      window.MASTRA_STUDIO_BASE_PATH = '/studio';
+      mockCapabilities(credentialsCapabilities);
+      server.use(
+        http.post(`${BASE_URL}/api/auth/credentials/sign-in`, () =>
+          HttpResponse.json({ user: { id: 'user-1', email: 'user@example.com' } }),
+        ),
+      );
+
+      const originalLocation = window.location;
+      const hrefSetter = vi.fn();
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: new Proxy(originalLocation, {
+          set(_target, prop, value) {
+            if (prop === 'href') hrefSetter(value);
+            return true;
+          },
+          get(target, prop) {
+            // @ts-expect-error indexed access
+            return target[prop];
+          },
+        }),
+      });
+
+      try {
+        renderRoute('/login', <LoginPage />);
+        fireEvent.change(await screen.findByLabelText('Email'), { target: { value: 'user@example.com' } });
+        fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'password' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Sign in' }));
+
+        await waitFor(() => expect(hrefSetter).toHaveBeenCalledWith('/studio/'));
+      } finally {
+        Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+        delete window.MASTRA_STUDIO_BASE_PATH;
+      }
     });
   });
 });

--- a/packages/playground/src/domains/auth/components/auth-required.tsx
+++ b/packages/playground/src/domains/auth/components/auth-required.tsx
@@ -3,6 +3,7 @@ import { Lock } from 'lucide-react';
 import { useAuthCapabilities } from '../hooks/use-auth-capabilities';
 import { isAuthenticated } from '../types';
 import { LoginButton } from './login-button';
+import { withStudioBasePath } from '@/lib/studio-base-path';
 
 export type AuthRequiredProps = {
   children: React.ReactNode;
@@ -71,7 +72,7 @@ export function AuthRequired({ children, loginUrl = '/login', signupUrl = '/sign
 
   // Login capability available - show sign in prompt
   const handleSignUp = () => {
-    const url = new URL(signupUrl, window.location.origin);
+    const url = new URL(withStudioBasePath(signupUrl), window.location.origin);
     if (redirectUri) {
       url.searchParams.set('redirect', redirectUri);
     }

--- a/packages/playground/src/domains/auth/components/login-button.tsx
+++ b/packages/playground/src/domains/auth/components/login-button.tsx
@@ -1,6 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { useSSOLogin } from '../hooks';
 import type { LoginConfig, SSOConfig } from '../types';
+import { withStudioBasePath } from '@/lib/studio-base-path';
 
 export type LoginButtonProps = {
   config: LoginConfig;
@@ -66,7 +67,7 @@ export function LoginButton({ config, redirectUri, className, loginUrl = '/login
 
   // For credentials login - redirect to login page
   const handleCredentialsLogin = () => {
-    const url = new URL(loginUrl, window.location.origin);
+    const url = new URL(withStudioBasePath(loginUrl), window.location.origin);
     if (redirectUri) {
       url.searchParams.set('redirect', redirectUri);
     }

--- a/packages/playground/src/domains/auth/components/login-page.tsx
+++ b/packages/playground/src/domains/auth/components/login-page.tsx
@@ -8,6 +8,7 @@ import { useCredentialsLogin } from '../hooks/use-credentials-login';
 import { useCredentialsSignUp } from '../hooks/use-credentials-signup';
 import type { SSOConfig } from '../types';
 import { LoginLayout } from './login-layout';
+import { withStudioBasePath } from '@/lib/studio-base-path';
 
 export type LoginPageProps = {
   /** URL to redirect to after successful login */
@@ -85,7 +86,7 @@ export function LoginPage({ redirectUri, onSuccess, initialMode = 'signin', erro
     } else if (redirectUri) {
       window.location.href = redirectUri;
     } else {
-      window.location.href = '/';
+      window.location.href = withStudioBasePath('/');
     }
   };
 

--- a/packages/playground/src/lib/studio-base-path.ts
+++ b/packages/playground/src/lib/studio-base-path.ts
@@ -1,0 +1,19 @@
+/**
+ * Prefix a same-origin app URL with the studio base path (server `studioBase` option).
+ *
+ * Needed for full-page navigations via `window.location` which bypass the
+ * react-router basename (e.g. redirecting to the login page). External URLs
+ * and URLs which already include the studio base path are preserved.
+ */
+export function withStudioBasePath(path: string): string {
+  const basePath = (window.MASTRA_STUDIO_BASE_PATH ?? '').replace(/\/$/, '');
+  if (!basePath) return path;
+
+  const url = new URL(path, window.location.origin);
+  if (url.origin !== window.location.origin) return path;
+
+  const appPath = `${url.pathname}${url.search}${url.hash}`;
+  if (url.pathname === basePath || url.pathname.startsWith(`${basePath}/`)) return appPath;
+
+  return `${basePath}${url.pathname}${url.search}${url.hash}`;
+}


### PR DESCRIPTION
Studio login and signup links used root-relative paths, so mounting Studio under `server.studioBase` could send users to the Mastra Server page instead of the login form.

Before: `/studio/agents` → `/login`

After: `/studio/agents` → `/studio/login`

This also keeps the Agent Builder back link and shared agent session URLs within the configured Studio base path. It includes focused unit coverage and a real-server Playwright regression for the login journey.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If your Studio is hosted under a custom path like `/studio`, links and redirects should still work. This PR makes login, signup, “Back to Studio”, and shared session links all stay under that base path, and it adds automated tests to prove it.

## What changed

- Added `withStudioBasePath(path)` helper that safely applies `window.MASTRA_STUDIO_BASE_PATH` to internal Studio URLs (without double-prefixing).
- Updated auth navigation to respect the Studio base path:
  - Signup and credentials-login redirects now use `withStudioBasePath`.
  - Default post-login redirect now goes to the Studio base-path root (e.g. `/studio/`) instead of `/`.
- Updated Agent Builder navigation:
  - “Back to Studio” now uses a `Link` component.
  - Added tests for nested Studio base paths (including users who lack builder access).
- Updated shared agent session URL handling:
  - Session share links are now generated via `withStudioBasePath`.
  - Added regression coverage for the clipboard URL including the configured base path.
- Added and wired a dedicated Playwright “studio-base” E2E setup:
  - New config (`playwright.studio-base.config.ts`) and new spec covering login flow under `/studio`.
  - Added `test:e2e:studio-base` script to run these tests.
- Added focused unit tests for base-path-aware redirects, including cases for absolute vs relative login URLs and preserving query/hash.
- Updated E2E kitchen-sink Mastra instance to conditionally use `E2E_STUDIO_BASE_PATH`.
- Added a patch changeset for the `mastra` package documenting the Studio navigation/auth fix for custom base paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->