### PR TITLE
fix(voyageai): correct multimodal input shape and add baseUrl

### DIFF
--- a/.changeset/deep-eggs-invite.md
+++ b/.changeset/deep-eggs-invite.md
@@ -1,0 +1,23 @@
+---
+'@mastra/voyageai': minor
+'@mastra/deployer': patch
+'@mastra/core': patch
+'@mastra/mcp': patch
+---
+
+Fixed VoyageAI multimodal embeddings sending text as bare strings (the API rejected the payload) and added a `baseUrl` option so you can point the embedder, reranker, and contextualized models at a provider-hosted Voyage endpoint.
+
+**Before**
+
+```ts
+// multimodal text was serialized as inputs: [["text"]] -> HTTP 400
+```
+
+**After**
+
+```ts
+const embedder = voyage.multimodalEmbedding({
+  model: 'voyage-multimodal-3.5',
+  baseUrl: 'https://ai.mongodb.com/v1',
+});
+```

--- a/.changeset/deep-eggs-invite.md
+++ b/.changeset/deep-eggs-invite.md
@@ -1,8 +1,5 @@
 ---
 '@mastra/voyageai': minor
-'@mastra/deployer': patch
-'@mastra/core': patch
-'@mastra/mcp': patch
 ---
 
 Fixed VoyageAI multimodal embeddings sending text as bare strings (the API rejected the payload) and added a `baseUrl` option so you can point the embedder, reranker, and contextualized models at a provider-hosted Voyage endpoint.

--- a/docs/src/content/en/models/embeddings.mdx
+++ b/docs/src/content/en/models/embeddings.mdx
@@ -81,6 +81,7 @@ const customModel = voyageEmbedding({
   model: "voyage-3.5",
   inputType: "query", // or 'document'
   outputDimension: 512, // 256, 512, 1024, or 2048
+  baseUrl: "https://ai.mongodb.com/v1", // Optional: custom endpoint (e.g. MongoDB-hosted Voyage)
 });
 
 const { embeddings: customEmbeddings } = await customModel.doEmbed({

--- a/embedders/voyageai/README.md
+++ b/embedders/voyageai/README.md
@@ -86,6 +86,7 @@ const model = voyageEmbedding({
   outputDimension: 512, // 256 | 512 | 1024 | 2048
   outputDtype: 'float', // 'float' | 'int8' | 'uint8' | 'binary' | 'ubinary'
   truncation: true, // Handle long inputs
+  baseUrl: 'https://ai.mongodb.com/v1', // Optional: custom endpoint (e.g. MongoDB-hosted Voyage)
 });
 ```
 

--- a/embedders/voyageai/package.json
+++ b/embedders/voyageai/package.json
@@ -38,7 +38,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "voyageai": "^0.2.1"
+    "voyageai": "^0.3.1"
   },
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"

--- a/embedders/voyageai/src/__tests__/multimodal-embedding.test.ts
+++ b/embedders/voyageai/src/__tests__/multimodal-embedding.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { VoyageMultimodalEmbeddingModel } from '../multimodal-embedding';
+
+const mockMultimodalEmbed = vi.fn();
+const mockConstructor = vi.fn();
+
+vi.mock('voyageai', () => {
+  return {
+    VoyageAIClient: class MockVoyageAIClient {
+      constructor(opts: any) {
+        mockConstructor(opts);
+      }
+      multimodalEmbed = mockMultimodalEmbed;
+    },
+  };
+});
+
+const originalEnv = process.env;
+
+describe('VoyageMultimodalEmbeddingModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv, VOYAGE_API_KEY: 'test-api-key' };
+    mockMultimodalEmbed.mockResolvedValue({ data: [{ index: 0, embedding: [0.1, 0.2, 0.3] }] });
+  });
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('wraps each input as an object with a content array (not a bare array)', async () => {
+    const model = new VoyageMultimodalEmbeddingModel({ model: 'voyage-multimodal-3.5' });
+    await model.doEmbed({ values: [{ content: [{ type: 'text', text: 'a photo of a cat' }] }] });
+
+    const sent = mockMultimodalEmbed.mock.calls[0][0];
+    expect(sent.inputs).toEqual([{ content: [{ type: 'text', text: 'a photo of a cat' }] }]);
+  });
+
+  it('serializes text content as a typed object, never a bare string', async () => {
+    const model = new VoyageMultimodalEmbeddingModel({ model: 'voyage-multimodal-3.5' });
+    await model.doEmbed({ values: [{ content: [{ type: 'text', text: 'hello' }] }] });
+
+    const sent = mockMultimodalEmbed.mock.calls[0][0];
+    const firstContent = sent.inputs[0].content[0];
+    expect(typeof firstContent).toBe('object');
+    expect(firstContent).toMatchObject({ type: 'text', text: 'hello' });
+  });
+});

--- a/embedders/voyageai/src/__tests__/multimodal-embedding.test.ts
+++ b/embedders/voyageai/src/__tests__/multimodal-embedding.test.ts
@@ -44,4 +44,18 @@ describe('VoyageMultimodalEmbeddingModel', () => {
     expect(typeof firstContent).toBe('object');
     expect(firstContent).toMatchObject({ type: 'text', text: 'hello' });
   });
+
+  it('passes baseUrl through to the VoyageAIClient when provided', () => {
+    new VoyageMultimodalEmbeddingModel({
+      model: 'voyage-multimodal-3.5',
+      apiKey: 'custom-key',
+      baseUrl: 'https://ai.mongodb.com/v1',
+    });
+    expect(mockConstructor).toHaveBeenCalledWith({ apiKey: 'custom-key', baseUrl: 'https://ai.mongodb.com/v1' });
+  });
+
+  it('omits baseUrl from client options when not provided', () => {
+    new VoyageMultimodalEmbeddingModel({ model: 'voyage-multimodal-3.5', apiKey: 'custom-key' });
+    expect(mockConstructor).toHaveBeenCalledWith({ apiKey: 'custom-key' });
+  });
 });

--- a/embedders/voyageai/src/__tests__/text-embedding.test.ts
+++ b/embedders/voyageai/src/__tests__/text-embedding.test.ts
@@ -60,6 +60,11 @@ describe('VoyageTextEmbeddingModelV2', () => {
     expect(mockConstructor).toHaveBeenCalledWith({ apiKey: 'custom-key' });
   });
 
+  it('passes baseUrl through to the VoyageAIClient when provided', () => {
+    new VoyageTextEmbeddingModelV2({ model: 'voyage-3.5', apiKey: 'custom-key', baseUrl: 'https://ai.mongodb.com/v1' });
+    expect(mockConstructor).toHaveBeenCalledWith({ apiKey: 'custom-key', baseUrl: 'https://ai.mongodb.com/v1' });
+  });
+
   it('should throw error if no API key is available', () => {
     delete process.env.VOYAGE_API_KEY;
 

--- a/embedders/voyageai/src/contextualized-embedding.ts
+++ b/embedders/voyageai/src/contextualized-embedding.ts
@@ -82,7 +82,7 @@ export class VoyageContextualizedEmbeddingModel {
       );
     }
 
-    this.client = new VoyageAIClient({ apiKey });
+    this.client = new VoyageAIClient({ apiKey, ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}) });
   }
 
   /**

--- a/embedders/voyageai/src/multimodal-embedding.ts
+++ b/embedders/voyageai/src/multimodal-embedding.ts
@@ -94,7 +94,7 @@ export class VoyageMultimodalEmbeddingModel {
       );
     }
 
-    this.client = new VoyageAIClient({ apiKey });
+    this.client = new VoyageAIClient({ apiKey, ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}) });
   }
 
   /**

--- a/embedders/voyageai/src/multimodal-embedding.ts
+++ b/embedders/voyageai/src/multimodal-embedding.ts
@@ -16,12 +16,13 @@ import type {
 } from './types';
 
 /**
- * Convert our content format to VoyageAI SDK format
+ * Convert our content format to the VoyageAI SDK's content-item shape.
+ * The API requires typed objects (never bare strings) inside each input's `content` array.
  */
-function toSdkContent(content: VoyageMultimodalContent): unknown {
+function toSdkContent(content: VoyageMultimodalContent): Record<string, unknown> {
   switch (content.type) {
     case 'text':
-      return content.text;
+      return { type: 'text', text: content.text };
     case 'image_url':
       return { type: 'image_url', image_url: content.image_url };
     case 'image_base64':
@@ -34,10 +35,11 @@ function toSdkContent(content: VoyageMultimodalContent): unknown {
 }
 
 /**
- * Convert multimodal input to SDK format
+ * Convert a multimodal input to the SDK's input-item shape: an object with a
+ * `content` array of typed content objects.
  */
-function toSdkInput(input: VoyageMultimodalInput): unknown[] {
-  return input.content.map(toSdkContent);
+function toSdkInput(input: VoyageMultimodalInput): { content: Record<string, unknown>[] } {
+  return { content: input.content.map(toSdkContent) };
 }
 
 /**
@@ -117,13 +119,9 @@ export class VoyageMultimodalEmbeddingModel {
     // Convert inputs to SDK format
     const sdkInputs = values.map(toSdkInput);
 
-    // Use the SDK's multimodalEmbed method
-    // Note: The `as any` cast is necessary because the SDK's type definitions don't properly
-    // type the flexible multimodal input structure. The SDK accepts mixed content types:
-    // - strings for text content
-    // - objects like { type: 'image_url', image_url: '...' } for images/video
-    // Our internal `unknown[]` return type from toSdkInput needs to bridge to the SDK's
-    // expected `any[][]` format for the multimodal inputs parameter.
+    // The `as any` remains only for image/video content: the SDK's generated request type uses
+    // camelCase keys (imageUrl/imageBase64/videoUrl) while the Voyage wire API and our public
+    // VoyageMultimodalContent types use snake_case (image_url/...). Text content is fully typed.
     const response = await this.client.multimodalEmbed({
       inputs: sdkInputs as any,
       model: this.modelId,

--- a/embedders/voyageai/src/reranker.ts
+++ b/embedders/voyageai/src/reranker.ts
@@ -56,7 +56,7 @@ export class VoyageRelevanceScorer implements RelevanceScoreProvider {
       );
     }
 
-    this.client = new VoyageAIClient({ apiKey });
+    this.client = new VoyageAIClient({ apiKey, ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}) });
   }
 
   /**

--- a/embedders/voyageai/src/text-embedding.ts
+++ b/embedders/voyageai/src/text-embedding.ts
@@ -86,7 +86,7 @@ export class VoyageTextEmbeddingModelV2 {
       );
     }
 
-    this.client = new VoyageAIClient({ apiKey });
+    this.client = new VoyageAIClient({ apiKey, ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}) });
   }
 
   /**

--- a/embedders/voyageai/src/types.ts
+++ b/embedders/voyageai/src/types.ts
@@ -69,6 +69,8 @@ export interface VoyageTextEmbeddingConfig {
   model: VoyageTextModel;
   /** API key (defaults to VOYAGE_API_KEY env var) */
   apiKey?: string;
+  /** Custom base URL for the Voyage API (e.g. a provider-hosted endpoint such as https://ai.mongodb.com/v1). */
+  baseUrl?: string;
   /** Input type for retrieval optimization */
   inputType?: VoyageInputType;
   /** Output embedding dimension (model-dependent, default 1024) */
@@ -136,6 +138,8 @@ export interface VoyageMultimodalEmbeddingConfig {
   model: VoyageMultimodalModel;
   /** API key (defaults to VOYAGE_API_KEY env var) */
   apiKey?: string;
+  /** Custom base URL for the Voyage API (e.g. a provider-hosted endpoint such as https://ai.mongodb.com/v1). */
+  baseUrl?: string;
   /** Input type for retrieval optimization */
   inputType?: VoyageInputType;
   /** Whether to truncate inputs that exceed context length (default true) */
@@ -154,6 +158,8 @@ export interface VoyageContextualizedEmbeddingConfig {
   model: VoyageContextModel;
   /** API key (defaults to VOYAGE_API_KEY env var) */
   apiKey?: string;
+  /** Custom base URL for the Voyage API (e.g. a provider-hosted endpoint such as https://ai.mongodb.com/v1). */
+  baseUrl?: string;
   /** Input type for retrieval optimization */
   inputType?: VoyageInputType;
   /** Output embedding dimension (default 1024) */
@@ -380,6 +386,8 @@ export interface VoyageRerankerConfig {
   model: VoyageRerankerModel;
   /** API key (defaults to VOYAGE_API_KEY env var) */
   apiKey?: string;
+  /** Custom base URL for the Voyage API (e.g. a provider-hosted endpoint such as https://ai.mongodb.com/v1). */
+  baseUrl?: string;
   /** Whether to truncate inputs that exceed context length (default true) */
   truncation?: boolean;
 }


### PR DESCRIPTION
Fixes #19801

## What this fixes

Two problems block `@mastra/voyageai` from working against a provider-hosted Voyage endpoint (for example MongoDB Atlas's `https://ai.mongodb.com/v1`):

**1. Multimodal requests are rejected by the API.** `VoyageMultimodalEmbeddingModel.doEmbed` serialized text content to bare strings, producing `inputs: [["text"]]`. The Voyage multimodal API, and the SDK's own `MultimodalEmbedRequestInputsItem` type, require `inputs: [{ content: [{ type: 'text', text }] }]`. The old shape returns HTTP 400 ("Expected object. Received list"), so multimodal text embedding could not be used at all.

**2. No `baseUrl` passthrough.** The embedder, reranker, and contextualized models always constructed `new VoyageAIClient({ apiKey })`, with no way to point at a provider-hosted endpoint even though the underlying SDK accepts `baseUrl`.

## Changes

- `toSdkInput`/`toSdkContent` now emit `{ content: [{ type: 'text', text }, ...] }`. Text content is a typed object rather than a bare string.
- Added optional `baseUrl?: string` to all four Voyage config types (text, multimodal, contextualized, reranker) and pass it through with a conditional spread. When `baseUrl` is absent, the client is still constructed with exactly `{ apiKey }`, so existing behavior is byte-identical.
- Bumped the `voyageai` dependency from `^0.2.1` to `^0.3.1`. The 0.2.1 ESM build has a broken directory import (`export * from "../api"` with no `/index.js`) that Node's native ESM resolver rejects, which breaks any ESM app importing this package under `tsx` or `vitest`. 0.3.1 ships a working ESM build with the same client API. This surfaced while wiring the package into a live ESM app.
- Documented `baseUrl` in `models/embeddings.mdx` and the package README.

## Backward compatibility

`baseUrl` is optional and omitted from the client options when unset. The multimodal shape change corrects a payload the API always rejected, so no working call changes behavior. The `voyageai` bump `^0.2.1` → `^0.3.1` is a real range change (for 0.x, caret pins the minor, so `^0.2.1` excludes 0.3.x — which is why the manifest change is needed at all). Both 0.2.1 and 0.3.1 expose the same five client methods this package calls (`embed`, `multimodalEmbed`, `rerank`, `contextualizedEmbed`, `tokenize`), so the API surface this package depends on is unchanged.

## Testing

Unit tests assert the serialized multimodal request shape and the `baseUrl` present/absent construction. The patched embedder was also run against the live MongoDB-hosted Voyage endpoint and returned a 1024-dimension vector, where the old shape returned HTTP 400.

## One thing to flag

The `as any` cast at the `multimodalEmbed` call site stays, and it is deliberate: the SDK's generated request type uses camelCase keys for image and video content (`imageUrl`) while the wire API and this package's public `VoyageMultimodalContent` types use snake_case (`image_url`). Text content is fully typed. Aligning the image/video key casing to remove that cast is a reasonable follow-up; I kept it out of scope so this PR stays focused on the text-400 bug and `baseUrl`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

VoyageAI now sends multimodal text in the format its API expects, preventing request failures. You can also point VoyageAI models to a custom server, and the integration now uses a newer SDK that works with native ESM.

## Changes

- Fixed multimodal text serialization to use structured content objects.
- Added optional `baseUrl` support for:
  - Text embeddings
  - Multimodal embeddings
  - Contextualized embeddings
  - Reranking
- Upgraded `voyageai` from `^0.2.1` to `^0.3.1`.
- Added documentation and tests covering payload serialization and client configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
