### PR TITLE
fix(durable): emit canonical step-start chunk with payload wrapper

### DIFF
--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -11,6 +11,7 @@ import type {
   MastraOnStepFinishCallback,
   LanguageModelUsage,
 } from '../../stream/types';
+import { ChunkFrom } from '../../stream/types';
 import { MessageList } from '../message-list';
 import type { StructuredOutputOptions } from '../types';
 import { AGENT_STREAM_TOPIC, AgentStreamEventTypes } from './constants';
@@ -219,9 +220,24 @@ export function createDurableAgentStream<OUTPUT = undefined>(
         }
 
         case AgentStreamEventTypes.STEP_START: {
-          // Step start - enqueue if it's a chunk type
-          const chunk = streamEvent.data as ChunkType<OUTPUT>;
-          if (chunk && 'type' in chunk) {
+          // Step start - enqueue as a canonical ChunkType.
+          // Older publishers flattened fields onto the root; normalize so
+          // consumers always see `payload` (see #19574).
+          const raw = streamEvent.data as any;
+          if (raw && typeof raw === 'object' && 'type' in raw) {
+            const chunk =
+              raw.payload !== undefined
+                ? (raw as ChunkType<OUTPUT>)
+                : ({
+                    runId: raw.runId ?? streamEvent.runId,
+                    from: raw.from ?? ChunkFrom.AGENT,
+                    type: 'step-start' as const,
+                    payload: {
+                      request: raw.request ?? {},
+                      warnings: raw.warnings ?? [],
+                      ...(raw.messageId !== undefined ? { messageId: raw.messageId } : {}),
+                    },
+                  } as ChunkType<OUTPUT>);
             safeEnqueue(controller, chunk);
           }
           break;
@@ -496,18 +512,31 @@ export async function emitChunkEvent<OUTPUT = undefined>(
 
 /**
  * Helper to emit a step start event to pubsub.
- * The `data` payload must include `type: 'step-start'` so the stream-adapter
- * consumer recognises it as a `ChunkType` and enqueues it onto the client stream.
+ *
+ * Emits the canonical `ChunkType` shape (`type` + `payload` + `runId`/`from`) so
+ * consumers such as `@mastra/ai-sdk` can read `chunk.payload` safely. The durable
+ * path previously flattened fields onto the chunk root, which crashed converters
+ * that destructure `payload` (see #19574).
  */
 export async function emitStepStartEvent(
   pubsub: PubSub,
   runId: string,
-  data: { stepId?: string; request?: unknown; warnings?: unknown[] },
+  data: { stepId?: string; request?: unknown; warnings?: unknown[]; messageId?: string },
 ): Promise<void> {
+  const { stepId: _stepId, request, warnings, messageId } = data;
   await pubsub.publish(AGENT_STREAM_TOPIC(runId), {
     type: AgentStreamEventTypes.STEP_START,
     runId,
-    data: { type: 'step-start', ...data },
+    data: {
+      runId,
+      from: ChunkFrom.AGENT,
+      type: 'step-start',
+      payload: {
+        request: request ?? {},
+        warnings: warnings ?? [],
+        ...(messageId !== undefined ? { messageId } : {}),
+      },
+    },
   });
 }
 

--- a/packages/core/src/agent/durable/stream-adapter.ts
+++ b/packages/core/src/agent/durable/stream-adapter.ts
@@ -224,7 +224,7 @@ export function createDurableAgentStream<OUTPUT = undefined>(
           // Older publishers flattened fields onto the root; normalize so
           // consumers always see `payload` (see #19574).
           const raw = streamEvent.data as any;
-          if (raw && typeof raw === 'object' && 'type' in raw) {
+          if (raw && typeof raw === 'object') {
             const chunk =
               raw.payload !== undefined
                 ? (raw as ChunkType<OUTPUT>)


### PR DESCRIPTION
## Description

Durable agents emit `step-start` through `emitStepStartEvent` as a **flat** object:

```ts
{ type: 'step-start', stepId, request, warnings }
```

The canonical `ChunkType` contract (and the non-durable agent loop) uses:

```ts
{ runId, from: ChunkFrom.AGENT, type: 'step-start', payload: { request, warnings, messageId? } }
```

`@mastra/ai-sdk` then does `const { messageId, ...rest } = chunk.payload` and throws:

```text
TypeError: Cannot destructure property 'messageId' of 'chunk.payload' as it is undefined.
```

## Fix

1. **`emitStepStartEvent`** — publish the canonical payload-wrapped shape.
2. **`STEP_START` consumer** — if an older flat event is observed, wrap it into `payload` before enqueue.

## Linked Issue

Closes #19574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Durable agents now send `step-start` messages in the same format as other agents. Older messages are converted automatically, so consumers do not fail when they read them.

## What changed

- Emit canonical `step-start` chunks with:
  - `from: ChunkFrom.AGENT`
  - `type`
  - `runId`
  - `payload`
- Include `request`, `warnings`, and optional `messageId` inside `payload`.
- Normalize legacy flat or incomplete `STEP_START` events before enqueueing them.
- Normalize legacy events even when they do not contain a `type` field.
- Extend `emitStepStartEvent` to accept `messageId`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->