### PR TITLE
fix(memory): support continuation within truncated recall message parts

### DIFF
--- a/.changeset/recall-part-continuation.md
+++ b/.changeset/recall-part-continuation.md
@@ -1,0 +1,11 @@
+---
+"@mastra/memory": patch
+---
+
+Added continuation support to the Observational Memory `recall` tool. When a single message part is larger than the result budget, the result now includes `nextCharOffset` and a note explaining how to fetch the next chunk, so oversized parts can be read across multiple calls instead of returning the same truncated prefix every time.
+
+```json
+{ "mode": "messages", "cursor": "<message-id>", "partIndex": 0, "detail": "high", "charOffset": 8000 }
+```
+
+Fixes [#19817](https://github.com/mastra-ai/mastra/issues/19817).

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -1106,6 +1106,14 @@ When `retrieval` is set (any truthy value), a `recall` tool is registered so the
       'Fetch a single message part at full detail by its positional index. Use this when a low-detail recall shows an interesting part at `[p1]` — call again with `partIndex: 1` to see the full content without loading every part.',
   },
   {
+    name: 'charOffset',
+    type: 'number',
+    isOptional: true,
+    defaultValue: '0',
+    description:
+      'Character position to continue reading a truncated single part. Only applies with `cursor` and `partIndex`. When a part is larger than the token budget, the result includes `nextCharOffset` — pass that exact value here in the next call to read the following chunk. The chunks concatenate to the original part text.',
+  },
+  {
     name: 'before',
     type: 'string',
     isOptional: true,
@@ -1166,13 +1174,33 @@ When `retrieval` is set (any truthy value), a `recall` tool is registered so the
     type: 'boolean',
     isOptional: true,
     description:
-      'Present and `true` when the output was capped by the token budget. The agent can paginate or use `partIndex` to access remaining content.',
+      'Present and `true` when the output was capped by the token budget. The agent can paginate or use `partIndex` to access remaining content. When a single part is itself too large, the `partIndex` result includes `nextCharOffset` for continuing within the part.',
   },
   {
     name: 'tokenOffset',
     type: 'number',
     isOptional: true,
     description: 'Approximate number of tokens that were trimmed when `truncated` is true.',
+  },
+  {
+    name: 'charOffset',
+    type: 'number',
+    isOptional: true,
+    description:
+      'On single-part results (`partIndex`), the character position this chunk starts at. `0` unless the call passed a `charOffset`.',
+  },
+  {
+    name: 'nextCharOffset',
+    type: 'number',
+    isOptional: true,
+    description:
+      'On single-part results, present when the part was truncated and more content remains. Pass this value as `charOffset` in the next call to continue reading from where this chunk ended.',
+  },
+  {
+    name: 'note',
+    type: 'string',
+    isOptional: true,
+    description: 'On truncated single-part results, the exact follow-up call for retrieving the next chunk.',
   },
 ]}
 />

--- a/packages/memory/src/processors/observational-memory/constants.ts
+++ b/packages/memory/src/processors/observational-memory/constants.ts
@@ -105,13 +105,15 @@ By default recall returns **low** detail: truncated text and tool names only. Ea
 - Use \`detail: "high"\` to get full message content including tool arguments and results. This will only return the high detail version of a single message part at a time.
 - Use \`partIndex\` with a cursor to fetch a single part at full detail — for example, to read one specific tool result or code block without loading every part.
 
-If the result says \`truncated: true\`, the output was cut to fit the token budget. You can paginate or use \`partIndex\` to target specific content.
+If the result says \`truncated: true\`, the output was cut to fit the token budget. You can paginate or use \`partIndex\` to target specific content. If a single part is itself too large, follow the returned \`nextCharOffset\` as described below.
 
 ### Following up on truncated parts
 Low-detail results may include truncation hints like:
 \`[truncated — call recall cursor="..." partIndex=N detail="high" for full content]\`
 
 **When you see these hints and need the full content, make the exact call described in the hint.** This is the normal workflow: first recall at low detail to scan, then drill into specific parts at high detail. Do not stop at the low-detail result if the user asked for exact content.
+
+If a single part is larger than the token budget, the \`partIndex\` result is \`truncated: true\` and includes \`nextCharOffset\`. Repeat the same call with \`charOffset\` set to that exact value to read the next chunk from where the previous one ended. Keep following \`nextCharOffset\` until the result no longer includes it — the chunks together contain the full part. Retrying without \`charOffset\` returns the same prefix again.
 
 ### When recall is NOT needed
 - The user is asking for a high-level summary and your observations already cover it

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -1205,19 +1205,70 @@ describe('om-tools', () => {
       let nextCharOffset: number | undefined = 0;
 
       while (nextCharOffset !== undefined) {
+        const charOffset: number = nextCharOffset;
         const result = await recallPart({
           memory: memory as any,
           threadId,
           cursor: 'msg-exact-chunks',
           partIndex: 0,
-          charOffset: nextCharOffset,
+          charOffset,
           maxTokens: 10,
         });
 
+        if (result.nextCharOffset !== undefined) {
+          expect(result.nextCharOffset).toBeGreaterThan(charOffset);
+        }
         chunks.push(result.text);
         nextCharOffset = result.nextCharOffset;
       }
 
+      expect(chunks.join('')).toBe(fullText);
+    });
+
+    it('should truncate an oversized part using the default token budget', async () => {
+      const fullText = Array.from(
+        { length: 1500 },
+        (_, index) => `default-budget-segment-${index.toString().padStart(4, '0')}`,
+      ).join(' ');
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-default-budget',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: fullText }],
+            },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+        ],
+      });
+
+      const chunks: string[] = [];
+      let nextCharOffset: number | undefined = 0;
+
+      while (nextCharOffset !== undefined) {
+        const charOffset: number = nextCharOffset;
+        const result = await recallPart({
+          memory: memory as any,
+          threadId,
+          cursor: 'msg-default-budget',
+          partIndex: 0,
+          charOffset,
+        });
+
+        if (result.nextCharOffset !== undefined) {
+          expect(result.truncated).toBe(true);
+          expect(result.nextCharOffset).toBeGreaterThan(charOffset);
+          expect(result.note).toContain(`charOffset=${result.nextCharOffset}`);
+        }
+        chunks.push(result.text);
+        nextCharOffset = result.nextCharOffset;
+      }
+
+      expect(chunks.length).toBeGreaterThan(1);
       expect(chunks.join('')).toBe(fullText);
     });
 
@@ -1300,19 +1351,21 @@ describe('om-tools', () => {
       let nextCharOffset: number | undefined = 0;
 
       while (nextCharOffset !== undefined) {
+        const charOffset: number = nextCharOffset;
         const result = await recallPart({
           memory: memory as any,
           threadId,
           resourceId,
           cursor: 'msg-ff-source',
           partIndex: 1,
-          charOffset: nextCharOffset,
+          charOffset,
           maxTokens: 50,
         });
 
         expect(result.messageId).toBe('msg-ff-next');
         if (result.nextCharOffset !== undefined) {
           expect(result.truncated).toBe(true);
+          expect(result.nextCharOffset).toBeGreaterThan(charOffset);
           expect(result.note).toContain('cursor="msg-ff-source" partIndex=1');
           expect(result.note).toContain(`charOffset=${result.nextCharOffset}`);
           expect(result.text).not.toContain('To continue');

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -1267,6 +1267,66 @@ describe('om-tools', () => {
       expect(result.text).toContain('This is the next visible message');
     });
 
+    it('should continue a truncated fall-forward part via charOffset', async () => {
+      const nextText = Array.from({ length: 200 }, (_, i) => `next-line ${i}`).join('\n');
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-ff-source',
+            threadId,
+            resourceId,
+            role: 'assistant',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: 'Only part here' }],
+            },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+          {
+            id: 'msg-ff-next',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: nextText }],
+            },
+            createdAt: new Date('2024-01-01T10:03:00Z'),
+          },
+        ],
+      });
+
+      const chunks: string[] = [];
+      let nextCharOffset: number | undefined = 0;
+
+      while (nextCharOffset !== undefined) {
+        const result = await recallPart({
+          memory: memory as any,
+          threadId,
+          resourceId,
+          cursor: 'msg-ff-source',
+          partIndex: 1,
+          charOffset: nextCharOffset,
+          maxTokens: 50,
+        });
+
+        expect(result.messageId).toBe('msg-ff-next');
+        if (result.nextCharOffset !== undefined) {
+          expect(result.truncated).toBe(true);
+          expect(result.note).toContain('cursor="msg-ff-source" partIndex=1');
+          expect(result.note).toContain(`charOffset=${result.nextCharOffset}`);
+          expect(result.text).not.toContain('To continue');
+        }
+        chunks.push(result.text);
+        nextCharOffset = result.nextCharOffset;
+      }
+
+      expect(chunks.length).toBeGreaterThan(1);
+      expect(chunks.join('')).toBe(
+        `Part index 1 not found in message msg-ff-source; showing partIndex 0 from next message msg-ff-next.\n\n${nextText}`,
+      );
+    });
+
     it('should skip data-only messages when falling forward to the next visible message', async () => {
       await memory.saveMessages({
         messages: [

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -1134,6 +1134,93 @@ describe('om-tools', () => {
       expect(result.text).toContain('export function main()');
     });
 
+    it('should continue an oversized part from charOffset', async () => {
+      const fullText = Array.from({ length: 120 }, (_, index) => `segment-${index.toString().padStart(3, '0')}`).join(
+        ' ',
+      );
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-large-part',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: fullText }],
+            },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+        ],
+      });
+
+      const firstChunk = await recallPart({
+        memory: memory as any,
+        threadId,
+        cursor: 'msg-large-part',
+        partIndex: 0,
+        maxTokens: 12,
+      });
+
+      expect(firstChunk.truncated).toBe(true);
+      expect(firstChunk.charOffset).toBe(0);
+      expect(firstChunk.nextCharOffset).toBeGreaterThan(0);
+      expect(firstChunk.note).toContain('charOffset=');
+      expect(firstChunk.text).not.toContain('To continue');
+
+      const secondChunk = await recallPart({
+        memory: memory as any,
+        threadId,
+        cursor: 'msg-large-part',
+        partIndex: 0,
+        charOffset: firstChunk.nextCharOffset,
+        maxTokens: 12,
+      });
+
+      expect(secondChunk.charOffset).toBe(firstChunk.nextCharOffset);
+      expect(secondChunk.text).not.toBe(firstChunk.text);
+      expect(fullText).toContain(firstChunk.text);
+      expect(fullText).toContain(secondChunk.text);
+    });
+
+    it('should reproduce the original oversized part when chunks are concatenated', async () => {
+      const fullText = Array.from({ length: 45 }, (_, index) => `chunk-${index.toString().padStart(3, '0')}`).join(' ');
+      await memory.saveMessages({
+        messages: [
+          {
+            id: 'msg-exact-chunks',
+            threadId,
+            resourceId,
+            role: 'user',
+            content: {
+              format: 2,
+              parts: [{ type: 'text', text: fullText }],
+            },
+            createdAt: new Date('2024-01-01T10:02:00Z'),
+          },
+        ],
+      });
+
+      const chunks: string[] = [];
+      let nextCharOffset: number | undefined = 0;
+
+      while (nextCharOffset !== undefined) {
+        const result = await recallPart({
+          memory: memory as any,
+          threadId,
+          cursor: 'msg-exact-chunks',
+          partIndex: 0,
+          charOffset: nextCharOffset,
+          maxTokens: 10,
+        });
+
+        chunks.push(result.text);
+        nextCharOffset = result.nextCharOffset;
+      }
+
+      expect(chunks.join('')).toBe(fullText);
+    });
+
     it('should fall forward to the first part of the next visible message when partIndex overflows', async () => {
       await memory.saveMessages({
         messages: [

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -4,6 +4,7 @@ import { createTool } from '@mastra/core/tools';
 import type { JSONSchema7 } from 'json-schema';
 import { estimateTokenCount } from 'tokenx';
 
+import { safeSlice } from '../processors/observational-memory/string-utils';
 import {
   formatToolResultForObserver,
   resolveToolResultValue,
@@ -458,6 +459,48 @@ function truncateByTokens(text: string, maxTokens: number, hint?: string): { tex
   return { text: truncated + suffix, wasTruncated: true };
 }
 
+function chunkTextByTokens(
+  text: string,
+  maxTokens: number,
+  charOffset = 0,
+): { text: string; nextCharOffset?: number; charOffset: number; truncated: boolean } {
+  let startOffset = Math.max(0, Math.min(Math.floor(charOffset), text.length));
+  // Caller-provided offsets can land between the two halves of a surrogate
+  // pair; skip the lone low surrogate so the chunk stays valid JSON text.
+  const startCode = text.charCodeAt(startOffset);
+  if (startCode >= 0xdc00 && startCode <= 0xdfff) startOffset += 1;
+  const remaining = text.slice(startOffset);
+
+  if (!remaining || estimateTokenCount(remaining) <= maxTokens) {
+    return { text: remaining, charOffset: startOffset, truncated: false };
+  }
+
+  let low = 0;
+  let high = remaining.length;
+  let best = '';
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+    const candidate = safeSlice(remaining, mid);
+    const candidateTokens = estimateTokenCount(candidate);
+
+    if (candidate && candidateTokens <= maxTokens) {
+      best = candidate;
+      low = mid + 1;
+    } else {
+      high = mid - 1;
+    }
+  }
+
+  const nextCharOffset = startOffset + best.length;
+  return {
+    text: best,
+    charOffset: startOffset,
+    nextCharOffset,
+    truncated: nextCharOffset < text.length,
+  };
+}
+
 function lowDetailPartLimit(type: string): number {
   if (type === 'text') return AUTO_EXPAND_TEXT_TOKENS;
   if (type === 'tool-result' || type === 'tool-call') return AUTO_EXPAND_TOOL_TOKENS;
@@ -719,6 +762,7 @@ export async function recallPart({
   resourceId,
   cursor,
   partIndex,
+  charOffset,
   threadScope,
   maxTokens = DEFAULT_MAX_RESULT_TOKENS,
 }: {
@@ -727,9 +771,20 @@ export async function recallPart({
   resourceId?: string;
   cursor: string;
   partIndex: number;
+  charOffset?: number;
   threadScope?: string;
   maxTokens?: number;
-}): Promise<{ text: string; messageId: string; partIndex: number; role: string; type: string; truncated: boolean }> {
+}): Promise<{
+  text: string;
+  messageId: string;
+  partIndex: number;
+  role: string;
+  type: string;
+  truncated: boolean;
+  charOffset: number;
+  nextCharOffset?: number;
+  note?: string;
+}> {
   if (!memory || typeof memory.getMemoryStore !== 'function') {
     throw new Error('Memory instance is required for recall');
   }
@@ -787,6 +842,7 @@ export async function recallPart({
             role: firstNextPart.role,
             type: firstNextPart.type,
             truncated: wasTruncated,
+            charOffset: 0,
           };
         }
       }
@@ -795,16 +851,21 @@ export async function recallPart({
     throw new Error(`Part index ${partIndex} not found in message ${cursor}. Available indices: ${availableIndices}`);
   }
 
-  const truncatedText = truncateStringByTokens(target.text, maxTokens);
-  const wasTruncated = truncatedText !== target.text;
+  const chunk = chunkTextByTokens(target.text, maxTokens, charOffset);
+  const note = chunk.nextCharOffset
+    ? `To continue this part, call recall cursor="${target.messageId}" partIndex=${target.partIndex} detail="high" charOffset=${chunk.nextCharOffset}.`
+    : undefined;
 
   return {
-    text: truncatedText,
+    text: chunk.text,
     messageId: target.messageId,
     partIndex: target.partIndex,
     role: target.role,
     type: target.type,
-    truncated: wasTruncated,
+    truncated: chunk.truncated,
+    charOffset: chunk.charOffset,
+    nextCharOffset: chunk.nextCharOffset,
+    note,
   };
 }
 
@@ -1248,6 +1309,12 @@ export const recallTool = (
           description:
             'Fetch a single part from the cursor message by its positional index. When provided, returns only that part at high detail. Indices are shown as [p0], [p1], etc. in recall results.',
         },
+        charOffset: {
+          type: 'integer',
+          minimum: 0,
+          description:
+            'Continue reading a truncated single part from this position. Pass the exact nextCharOffset value returned by a previous call; do not compute it yourself. Only applies with cursor and partIndex in mode="messages".',
+        },
       },
     } satisfies JSONSchema7,
     execute: async (inputData, context) => {
@@ -1263,6 +1330,7 @@ export const recallTool = (
         partType,
         toolName,
         partIndex,
+        charOffset,
         before,
         after,
       } = inputData as {
@@ -1277,6 +1345,7 @@ export const recallTool = (
         partType?: 'text' | 'tool-call' | 'tool-result' | 'reasoning' | 'image' | 'file';
         toolName?: string;
         partIndex?: number;
+        charOffset?: number;
         before?: string;
         after?: string;
       };
@@ -1450,6 +1519,7 @@ export const recallTool = (
           resourceId: isResourceScope ? resourceId : undefined,
           cursor,
           partIndex,
+          charOffset,
           threadScope,
         });
       }

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -832,17 +832,21 @@ export async function recallPart({
         if (firstNextPart) {
           const fallbackNote = `Part index ${partIndex} not found in message ${cursor}; showing partIndex ${firstNextPart.partIndex} from next message ${firstNextPart.messageId}.\n\n`;
           const fallbackText = `${fallbackNote}${firstNextPart.text}`;
-          const truncatedText = truncateStringByTokens(fallbackText, maxTokens);
-          const wasTruncated = truncatedText !== fallbackText;
+          const fallbackChunk = chunkTextByTokens(fallbackText, maxTokens, charOffset);
+          const fallbackContinuation = fallbackChunk.nextCharOffset
+            ? `To continue this part, call recall cursor="${cursor}" partIndex=${partIndex} detail="high" charOffset=${fallbackChunk.nextCharOffset}.`
+            : undefined;
 
           return {
-            text: truncatedText,
+            text: fallbackChunk.text,
             messageId: firstNextPart.messageId,
             partIndex: firstNextPart.partIndex,
             role: firstNextPart.role,
             type: firstNextPart.type,
-            truncated: wasTruncated,
-            charOffset: 0,
+            truncated: fallbackChunk.truncated,
+            charOffset: fallbackChunk.charOffset,
+            nextCharOffset: fallbackChunk.nextCharOffset,
+            note: fallbackContinuation,
           };
         }
       }


### PR DESCRIPTION
## Description

Fixes the Observational Memory `recall` tool so a single oversized message part can be read across multiple ordered calls. Previously, when one part exceeded the result budget (~2,000 estimated tokens), every call returned the same truncated prefix with no way to retrieve the remainder — a gap present since the tool was introduced in #14437.

## Before
<img width="893" height="316" alt="image" src="https://github.com/user-attachments/assets/a06e113c-9ad9-4a9b-891b-e10d0992729c" />

## After
<img width="918" height="581" alt="image" src="https://github.com/user-attachments/assets/148919af-fd81-42df-986e-893f294e046b" />

## Related Issue(s)

Fixes #19817

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

If a saved chat message is too long, `recall` can now fetch it in smaller pieces. Each call starts where the previous call stopped, so the full text can be reconstructed.

## What changed

- Added optional `charOffset` support to message-mode `recall`.
- Added token-budgeted chunking with surrogate-pair-safe string boundaries.
- Added continuation metadata:
  - `charOffset`
  - `nextCharOffset`
  - `note`
- Updated fall-forward retrieval to support continuation.
- Preserved existing `cursor`, `page`, `detail`, and `partIndex` behavior.
- Updated recall documentation and observer instructions.
- Added tests for:
  - exact reconstruction across multiple chunks
  - the default approximately 2,000-token budget
  - fall-forward continuation
  - continuation metadata and loop prevention.
- Added a patch-release changeset with a continuation example for issue `#19817`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->