### PR TITLE
fix(deployer): preserve pnpm patchedDependencies in bundled output

### DIFF
--- a/.changeset/deployer-copy-patched-dependencies.md
+++ b/.changeset/deployer-copy-patched-dependencies.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Preserve `patchedDependencies` when bundling the build output. `mastra build` regenerates a `pnpm-workspace.yaml` for `.mastra/output` by copying an allowlist of pnpm settings, which previously dropped `patchedDependencies`. The deploy-time `pnpm install` then reinstalled unpatched packages, silently discarding local patches (e.g. an `@ai-sdk/*` provider patch). The referenced patch files are now copied into `<output>/patches/`, their paths are rewritten relative to the output dir, and `allowUnusedPatches: true` is emitted so patches targeting packages absent from the bundled dependency tree don't fail the install.

--- a/packages/deployer/src/services/deps.test.ts
+++ b/packages/deployer/src/services/deps.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { copyPnpmWorkspaceSettings } from './deps';
+import { copyPnpmWorkspaceSettings, extractPnpmPatchedDependencies } from './deps';
 
 describe('copyPnpmWorkspaceSettings', () => {
   it('copies pnpm install policy without copying source workspace packages', () => {
@@ -19,5 +19,51 @@ describe('copyPnpmWorkspaceSettings', () => {
     );
 
     expect(output).toBe(`packages:\n  - '.'\n\nsupportedArchitectures:\n  os: [\"darwin\"]\n  cpu: [\"arm64\"]\n`);
+  });
+
+  it('emits provided patchedDependencies with allowUnusedPatches', () => {
+    const output = copyPnpmWorkspaceSettings(`packages:\n  - packages/*\n`, {
+      patchedDependencies: {
+        'foo@1.0.0': 'patches/foo.patch',
+        '@scope/bar@2.3.4': 'patches/scope_bar.patch',
+      },
+    });
+
+    expect(output).toBe(
+      `packages:\n  - '.'\n\npatchedDependencies:\n  'foo@1.0.0': patches/foo.patch\n  '@scope/bar@2.3.4': patches/scope_bar.patch\n\nallowUnusedPatches: true\n`,
+    );
+  });
+
+  it('does not emit a patchedDependencies block when none are provided', () => {
+    const output = copyPnpmWorkspaceSettings(
+      `packages:\n  - packages/*\n\npatchedDependencies:\n  foo@1.0.0: patches/foo.patch\n`,
+    );
+
+    expect(output).toBe(`packages:\n  - '.'\n`);
+    expect(output).not.toContain('patchedDependencies');
+    expect(output).not.toContain('allowUnusedPatches');
+  });
+});
+
+describe('extractPnpmPatchedDependencies', () => {
+  it('parses unquoted and quoted (scoped) specs', () => {
+    const patches = extractPnpmPatchedDependencies(
+      `packages:\n  - packages/*\n\npatchedDependencies:\n  foo@1.0.0: patches/foo.patch\n  '@scope/bar@2.3.4': ../../patches/@scope__bar@2.3.4.patch\n\nallowBuilds:\n  esbuild: true\n`,
+    );
+
+    expect(patches).toEqual({
+      'foo@1.0.0': 'patches/foo.patch',
+      '@scope/bar@2.3.4': '../../patches/@scope__bar@2.3.4.patch',
+    });
+  });
+
+  it('returns an empty object when there is no patchedDependencies block', () => {
+    expect(extractPnpmPatchedDependencies(`packages:\n  - packages/*\n`)).toEqual({});
+  });
+
+  it('strips quotes from both keys and values', () => {
+    const patches = extractPnpmPatchedDependencies(`patchedDependencies:\n  "foo@1.0.0": "patches/foo.patch"\n`);
+
+    expect(patches).toEqual({ 'foo@1.0.0': 'patches/foo.patch' });
   });
 });

--- a/packages/deployer/src/services/deps.ts
+++ b/packages/deployer/src/services/deps.ts
@@ -34,7 +34,55 @@ function getTopLevelYamlKey(line: string) {
   return match?.[1];
 }
 
-export function copyPnpmWorkspaceSettings(source: string, options: ArchitectureOptions = {}) {
+/**
+ * Parses the `patchedDependencies:` block of a pnpm-workspace.yaml into a map of
+ * `<dependency spec>` -> `<patch file path>`. Uses the same line-based approach as
+ * {@link copyPnpmWorkspaceSettings} so the deployer stays free of a YAML dependency.
+ *
+ * Keys and values may be quoted (scoped specs such as `'@scope/pkg@1.2.3'` require it);
+ * surrounding single/double quotes are stripped.
+ */
+export function extractPnpmPatchedDependencies(source: string): Record<string, string> {
+  const lines = source.split(/\r?\n/);
+  const patches: Record<string, string> = {};
+
+  const stripQuotes = (value: string) => value.replace(/^['"]|['"]$/g, '');
+
+  for (let index = 0; index < lines.length;) {
+    const key = getTopLevelYamlKey(lines[index] ?? '');
+    if (key !== 'patchedDependencies') {
+      index += 1;
+      continue;
+    }
+
+    index += 1;
+    while (index < lines.length && !getTopLevelYamlKey(lines[index] ?? '')) {
+      const entry = lines[index] ?? '';
+      // Match `  <spec>: <path>` where <spec> may be quoted and contain a colon.
+      const match = /^\s+(?:(['"])(.*?)\1|([^:]+)):\s*(.+?)\s*$/.exec(entry);
+      if (match) {
+        const spec = stripQuotes((match[2] ?? match[3] ?? '').trim());
+        const patchPath = stripQuotes((match[4] ?? '').trim());
+        if (spec && patchPath) {
+          patches[spec] = patchPath;
+        }
+      }
+      index += 1;
+    }
+  }
+
+  return patches;
+}
+
+interface PnpmWorkspaceSettingsOptions extends ArchitectureOptions {
+  /**
+   * Patched dependencies to emit in the generated workspace file. Paths are written
+   * verbatim, so callers are responsible for rewriting them relative to the output dir.
+   */
+  patchedDependencies?: Record<string, string>;
+}
+
+export function copyPnpmWorkspaceSettings(source: string, options: PnpmWorkspaceSettingsOptions = {}) {
   const hasArchitecture = Boolean(options.os?.length || options.cpu?.length || options.libc?.length);
   const lines = source.split(/\r?\n/);
   const blocks: string[] = [];
@@ -60,6 +108,20 @@ export function copyPnpmWorkspaceSettings(source: string, options: ArchitectureO
     if (block) {
       blocks.push(block);
     }
+  }
+
+  const patchedDependencies = options.patchedDependencies ?? {};
+  const patchEntries = Object.entries(patchedDependencies);
+  if (patchEntries.length > 0) {
+    const patchedBlock = [
+      'patchedDependencies:',
+      ...patchEntries.map(([spec, patchPath]) => `  '${spec}': ${patchPath}`),
+    ];
+    blocks.push(patchedBlock.join('\n'));
+    // The bundled output only installs the app's runtime dependencies, so a copied
+    // patch may target a package that is no longer in the tree. pnpm treats unused
+    // patches as a hard error by default, which would fail the deploy install.
+    blocks.push('allowUnusedPatches: true');
   }
 
   if (hasArchitecture) {
@@ -173,11 +235,59 @@ export class Deps extends MastraBase {
       ? await fsPromises.readFile(sourceWorkspaceYamlPath, 'utf-8')
       : '';
 
+    const patchedDependencies = sourceWorkspaceYamlPath
+      ? await this.copyPatchedDependencies(sourceWorkspaceYamlPath, sourceWorkspaceYaml, dir)
+      : {};
+
     await fsPromises.writeFile(
       path.join(dir, 'pnpm-workspace.yaml'),
-      copyPnpmWorkspaceSettings(sourceWorkspaceYaml, options),
+      copyPnpmWorkspaceSettings(sourceWorkspaceYaml, { ...options, patchedDependencies }),
       'utf-8',
     );
+  }
+
+  /**
+   * Copies the patch files referenced by `patchedDependencies` in the source workspace
+   * into `<dir>/patches/` so the bundled output is self-contained, and returns a map of
+   * dependency spec -> output-relative patch path suitable for the generated workspace file.
+   */
+  private async copyPatchedDependencies(
+    sourceWorkspaceYamlPath: string,
+    sourceWorkspaceYaml: string,
+    dir: string,
+  ): Promise<Record<string, string>> {
+    const patchedDependencies = extractPnpmPatchedDependencies(sourceWorkspaceYaml);
+    const entries = Object.entries(patchedDependencies);
+    if (entries.length === 0) {
+      return {};
+    }
+
+    const sourceRoot = path.dirname(sourceWorkspaceYamlPath);
+    const patchesDir = path.join(dir, 'patches');
+    const rewritten: Record<string, string> = {};
+    const usedNames = new Map<string, string>();
+
+    for (const [spec, patchPath] of entries) {
+      const sourcePatchPath = path.resolve(sourceRoot, patchPath);
+      if (!fs.existsSync(sourcePatchPath)) {
+        this.logger.warn(`Skipping patch for "${spec}": patch file not found at ${sourcePatchPath}`);
+        continue;
+      }
+
+      // Avoid collisions when two patches share a basename (e.g. from nested workspaces).
+      let destName = path.basename(sourcePatchPath);
+      const existing = usedNames.get(destName);
+      if (existing && existing !== sourcePatchPath) {
+        destName = `${spec.replace(/[^\w.-]+/g, '_')}-${destName}`;
+      }
+      usedNames.set(destName, sourcePatchPath);
+
+      await ensureFile(path.join(patchesDir, destName));
+      await fsPromises.copyFile(sourcePatchPath, path.join(patchesDir, destName));
+      rewritten[spec] = `patches/${destName}`;
+    }
+
+    return rewritten;
   }
 
   private async writeYarnConfig(dir: string, options: ArchitectureOptions) {


### PR DESCRIPTION
Fixes #19822

## Problem

`mastra build` regenerates `.mastra/output/pnpm-workspace.yaml` via `copyPnpmWorkspaceSettings` in `packages/deployer/src/services/deps.ts`, which copies only an allowlist of pnpm settings and drops `patchedDependencies`. The deploy-time `pnpm install` in the output dir then reinstalls the **unpatched** package, silently discarding local `pnpm patch` patches (e.g. a patched `@ai-sdk/*` provider).

Simply copying the block verbatim is insufficient because:
- patch paths are relative to the **source** workspace root and would dangle in the output dir, and
- pnpm treats unused patches as a hard error, but the bundled output only installs the app's runtime deps.

## Solution

- Add `extractPnpmPatchedDependencies()` (line-based parser, keeps the deployer free of a YAML dependency; handles quoted/scoped specs).
- `copyPnpmWorkspaceSettings()` now accepts a `patchedDependencies` map and emits the block plus `allowUnusedPatches: true`.
- `Deps.writePnpmConfig()` copies each referenced patch file into `<output>/patches/` (de-duping basename collisions), rewrites the paths relative to the output dir, and warns + skips any missing patch file. The output dir stays self-contained.

## Tests

- Updated/added `deps.test.ts` cases: emission of `patchedDependencies` + `allowUnusedPatches`, no block when none provided, and extraction of unquoted/quoted/scoped specs.
- `pnpm --filter @mastra/deployer test` (7 passing), plus build and `eslint` pass.

## Notes

Behavior is unchanged when a project has no `patchedDependencies`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When `mastra build` bundles an app for deployment, it now also includes pnpm’s “patched dependency” files—so the deployed app keeps the same dependency fixes you had locally. This prevents deployment from silently reinstalling unpatched packages.

## What changed

- Extracts `patchedDependencies` from the source `pnpm-workspace.yaml`.
- Copies the referenced patch files into the build output at `<output>/patches/`.
- Rewrites patch paths so they correctly point to the copied patches inside the output bundle and de-duplicates any filename collisions.
- Generates pnpm workspace config with `allowUnusedPatches: true` so bundling doesn’t fail when some patched packages aren’t present in the bundled dependency tree.
- Warns and skips missing patch files instead of breaking the bundle.
- Adds/updates tests to cover:
  - parsing/extraction of `patchedDependencies` (including quoted/scoped specs)
  - emitted pnpm YAML containing (or omitting) `patchedDependencies` and `allowUnusedPatches` depending on the source config.
- Ships as a deployer patch release so `mastra build` output in `.mastra/output` preserves pnpm patches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->