### PR TITLE
fix(cloudflare-d1): annotate D1 query result flatMap callback to avoid implicit any

### DIFF
--- a/stores/cloudflare-d1/src/storage/db/index.ts
+++ b/stores/cloudflare-d1/src/storage/db/index.ts
@@ -191,7 +191,7 @@ export class D1DB extends MastraBase {
         params: formattedParams,
       });
       const result = response.result || [];
-      const results = result.flatMap(r => r.results || []);
+      const results = result.flatMap((r: { results?: Record<string, any>[] }) => r.results || []);
 
       if (first) {
         return results[0] || null;


### PR DESCRIPTION
## Summary

The `.flatMap()` callback in `D1DB.query()` (`stores/cloudflare-d1/src/storage/db/index.ts`) had no type annotation on its parameter. When the Cloudflare SDK's return type falls back to `any` in the type environment, the callback parameter becomes an implicit `any`, which fails the strict TypeScript build for `@mastra/cloudflare-d1`.

This adds a minimal inline structural annotation (`{ results?: Record<string, any>[] }`) so the build succeeds regardless of how the SDK's types resolve. Same approach as #19666.

## Test plan

- [x] `pnpm --filter @mastra/cloudflare-d1 run build:lib` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds a clear label to some data so TypeScript knows what it is. That fixes the build without changing how the code works.

## Changes

- Added an inline structural type annotation to the `flatMap()` callback in `D1DB.query()`.
- Prevented an implicit `any` type when the Cloudflare SDK response resolves to `any`.
- Verified with `pnpm --filter `@mastra/cloudflare-d1` run build:lib`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->