### PR TITLE
fix(cloudflare-d1): match Cloudflare SDK QueryResult.results type in flatMap callback

### DIFF
--- a/stores/cloudflare-d1/src/storage/db/index.ts
+++ b/stores/cloudflare-d1/src/storage/db/index.ts
@@ -191,7 +191,7 @@ export class D1DB extends MastraBase {
         params: formattedParams,
       });
       const result = response.result || [];
-      const results = result.flatMap((r: { results?: Record<string, any>[] }) => r.results || []);
+      const results = result.flatMap((r: { results?: unknown[] }) => (r.results || []) as Record<string, any>[]);
 
       if (first) {
         return results[0] || null;


### PR DESCRIPTION
## Summary

Follow-up to #19827. That PR annotated the `.flatMap()` callback param in `D1DB.executeRestQuery()` as `{ results?: Record<string, any>[] }`, but the Cloudflare SDK's real `QueryResult.results` type is `unknown[]`. In environments where the SDK's types resolve correctly (i.e. CI), this triggered a TS2345 mismatch:

```
Type 'QueryResult' is not assignable to type '{ results?: Record<string, any>[] | undefined; }'.
  Types of property 'results' are incompatible.
    Type 'unknown[] | undefined' is not assignable to type 'Record<string, any>[] | undefined'.
```

This PR loosens the callback param annotation to `{ results?: unknown[] }` to match the SDK's real shape, then casts the return to `Record<string, any>[]` so `.flatMap` still resolves to the type expected by the enclosing function.

## Test plan

- [x] `pnpm --filter @mastra/cloudflare-d1 run build:lib` succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Cloudflare changed the type of data returned by its database API. This update adjusts our code to understand the new format while keeping the same results for callers.

## Changes

- Updated `D1DB.executeRestQuery()` to accept `results` as `unknown[]`.
- Cast flattened results to `Record<string, any>[]` to preserve the existing return type.
- Confirmed the Cloudflare D1 library builds successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->