### PR TITLE
fix(mastracode-web): send projectPath as sessionScope from thread and goal mutations

### DIFF
--- a/mastracode/web/src/shared/hooks/__tests__/useAgentControllerThreadMutationsScope.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/useAgentControllerThreadMutationsScope.msw.test.tsx
@@ -1,0 +1,215 @@
+/**
+ * Regression: thread & goal mutation hooks must forward `projectPath` as the
+ * worktree `sessionScope` on the wire, so that create/delete/rename/clone/
+ * switch/goal operations hit the same server-side session as the reader hooks
+ * (`useAgentControllerThreads`, `useAgentControllerSettings`, ...).
+ *
+ * Bug being pinned down: the mutation hooks used to spread `args` into
+ * `createAgentControllerClient(args)`, which expects `scope` — not
+ * `projectPath` — so mutations silently addressed the unscoped session. New
+ * threads were written into one session and never showed up in the scoped
+ * session's list, breaking `/new` → `POST thread` → `navigate('/threads/:id')`
+ * → `useRouteThreadSync` → "thread was not found" toast.
+ */
+import { act, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../e2e/web-ui/msw-server';
+import { renderHookWithProviders, TEST_BASE_URL, waitForMutationsIdle } from '../../../../e2e/web-ui/render';
+import { useSetAgentControllerGoalMutation } from '../useAgentControllerGoalMutations';
+import {
+  useCloneAgentControllerThreadMutation,
+  useCreateAgentControllerThreadMutation,
+  useDeleteAgentControllerThreadMutation,
+  useRenameAgentControllerThreadMutation,
+  useSwitchAgentControllerThreadMutation,
+} from '../useAgentControllerThreadMutations';
+
+const controllerId = 'code';
+const resourceId = 'resource-test';
+const projectPath = '/sandbox/mastra';
+const sessionUrl = `${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions/${resourceId}`;
+const hookArgs = {
+  agentControllerId: controllerId,
+  resourceId,
+  projectPath,
+  baseUrl: TEST_BASE_URL,
+  enabled: true,
+};
+
+const encodedProjectPath = encodeURIComponent(projectPath);
+
+describe('thread & goal mutation hooks forward projectPath as sessionScope', () => {
+  it('createThread sends the projectPath as sessionScope on the wire', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.post(`${sessionUrl}/threads`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({
+          id: 'thread-new',
+          title: 'New work',
+          updatedAt: '2026-07-21T00:00:00.000Z',
+        });
+      }),
+    );
+
+    const { result, client } = renderHookWithProviders(() => ({
+      createThread: useCreateAgentControllerThreadMutation(hookArgs),
+    }));
+
+    await act(async () => result.current.createThread.mutateAsync('New work'));
+    await waitForMutationsIdle(client);
+
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain(`sessionScope=${encodedProjectPath}`);
+  });
+
+  it('deleteThread sends the projectPath as sessionScope on the wire', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.delete(`${sessionUrl}/threads/:threadId`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const { result, client } = renderHookWithProviders(() => ({
+      deleteThread: useDeleteAgentControllerThreadMutation(hookArgs),
+    }));
+
+    await act(async () => result.current.deleteThread.mutateAsync('thread-old'));
+    await waitForMutationsIdle(client);
+
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain(`sessionScope=${encodedProjectPath}`);
+  });
+
+  it('renameThread sends the projectPath as sessionScope on the wire', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.put(`${sessionUrl}/threads/:threadId`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({ ok: true });
+      }),
+    );
+
+    const { result, client } = renderHookWithProviders(() => ({
+      renameThread: useRenameAgentControllerThreadMutation(hookArgs),
+    }));
+
+    await act(async () =>
+      result.current.renameThread.mutateAsync({ threadId: 'thread-old', title: 'New title' }),
+    );
+    await waitForMutationsIdle(client);
+
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain(`sessionScope=${encodedProjectPath}`);
+  });
+
+  it('cloneThread sends the projectPath as sessionScope on the wire', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.post(`${sessionUrl}/threads/clone`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({
+          id: 'thread-clone',
+          title: 'Clone',
+          updatedAt: '2026-07-21T00:00:00.000Z',
+        });
+      }),
+    );
+
+    const { result, client } = renderHookWithProviders(() => ({
+      cloneThread: useCloneAgentControllerThreadMutation(hookArgs),
+    }));
+
+    await act(async () => result.current.cloneThread.mutateAsync({ sourceThreadId: 'thread-source' }));
+    await waitForMutationsIdle(client);
+
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain(`sessionScope=${encodedProjectPath}`);
+  });
+
+  it('switchThread sends the projectPath as sessionScope on the wire', async () => {
+    const capturedUrls: string[] = [];
+    const stateHandler = vi.fn(() => HttpResponse.json({ threadId: 'thread-target', settings: null }));
+    server.use(
+      http.post(`${sessionUrl}/thread`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({ ok: true });
+      }),
+      // switchThread mutation reads session state after the switch to refresh the cache.
+      http.get(sessionUrl, stateHandler),
+    );
+
+    const { result, client } = renderHookWithProviders(() => ({
+      switchThread: useSwitchAgentControllerThreadMutation(hookArgs),
+    }));
+
+    await act(async () => result.current.switchThread.mutateAsync('thread-target'));
+    await waitForMutationsIdle(client);
+
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain(`sessionScope=${encodedProjectPath}`);
+  });
+
+  it('setGoal sends the projectPath as sessionScope on the wire', async () => {
+    const capturedUrls: string[] = [];
+    server.use(
+      http.post(`${sessionUrl}/goal`, ({ request }) => {
+        capturedUrls.push(request.url);
+        return HttpResponse.json({ goal: { objective: 'ship it', status: 'active' } });
+      }),
+    );
+
+    const { result, client } = renderHookWithProviders(() => ({
+      setGoal: useSetAgentControllerGoalMutation(hookArgs),
+    }));
+
+    await act(async () => result.current.setGoal.mutateAsync('ship it'));
+    await waitForMutationsIdle(client);
+
+    expect(capturedUrls).toHaveLength(1);
+    expect(capturedUrls[0]).toContain(`sessionScope=${encodedProjectPath}`);
+  });
+
+  it('scoped createThread appears in the scoped list, unblocking /new → /threads/:id', async () => {
+    // End-to-end shape of the bug: create in scope A, list in scope A, id must line up.
+    let threads: Array<{ id: string; title: string; updatedAt: string }> = [];
+    let createRequestScope: string | null = null;
+    let listRequestScope: string | null = null;
+
+    server.use(
+      http.get(`${sessionUrl}/threads`, ({ request }) => {
+        listRequestScope = new URL(request.url).searchParams.get('sessionScope');
+        return HttpResponse.json({ threads });
+      }),
+      http.post(`${sessionUrl}/threads`, async ({ request }) => {
+        createRequestScope = new URL(request.url).searchParams.get('sessionScope');
+        const created = { id: 'thread-new', title: 'New work', updatedAt: '2026-07-21T00:00:00.000Z' };
+        // Server only adds the thread to the list if the create hit the same scope as the list.
+        if (createRequestScope === listRequestScope) {
+          threads = [created, ...threads];
+        }
+        return HttpResponse.json(created);
+      }),
+    );
+
+    const { useAgentControllerThreads } = await import('../useAgentControllerThreads');
+    const { result, client } = renderHookWithProviders(() => ({
+      threadsQuery: useAgentControllerThreads(hookArgs),
+      createThread: useCreateAgentControllerThreadMutation(hookArgs),
+    }));
+
+    await waitFor(() => expect(result.current.threadsQuery.isSuccess).toBe(true));
+    await act(async () => result.current.createThread.mutateAsync('New work'));
+    await waitForMutationsIdle(client);
+
+    expect(createRequestScope).toBe(projectPath);
+    expect(listRequestScope).toBe(projectPath);
+    await waitFor(() =>
+      expect(result.current.threadsQuery.data?.map(thread => thread.id)).toEqual(['thread-new']),
+    );
+  });
+});

--- a/mastracode/web/src/shared/hooks/useAgentControllerGoalMutations.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerGoalMutations.ts
@@ -7,6 +7,7 @@ import {
 interface AgentControllerGoalMutationArgs {
   agentControllerId: string;
   resourceId: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }

--- a/mastracode/web/src/shared/hooks/useAgentControllerModels.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerModels.ts
@@ -21,7 +21,7 @@ export function useAgentControllerModels({
   const { controller } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerModes.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerModes.ts
@@ -21,7 +21,7 @@ export function useAgentControllerModes({
   const { controller } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerPermissionMutations.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerPermissionMutations.ts
@@ -26,7 +26,7 @@ export function useSetPermissionForCategoryMutation({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerPermissions.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerPermissions.ts
@@ -21,7 +21,7 @@ export function useAgentControllerPermissions({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerRunMutations.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerRunMutations.ts
@@ -15,16 +15,6 @@ interface AgentControllerRunMutationArgs {
   enabled?: boolean;
 }
 
-function toClientArgs({
-  agentControllerId,
-  resourceId,
-  projectPath,
-  baseUrl,
-  enabled,
-}: AgentControllerRunMutationArgs) {
-  return { agentControllerId, resourceId, scope: projectPath, baseUrl, enabled };
-}
-
 function useSessionInvalidation({ agentControllerId, resourceId, projectPath }: AgentControllerRunMutationArgs) {
   const queryClient = useQueryClient();
   return async () => {
@@ -42,7 +32,7 @@ export interface SendAgentControllerMessageInput {
 }
 
 export function useSendAgentControllerMessageMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(toClientArgs(args));
+  const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (input: SendAgentControllerMessageInput | string) => {
@@ -56,7 +46,7 @@ export function useSendAgentControllerMessageMutation(args: AgentControllerRunMu
 }
 
 export function useSteerAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(toClientArgs(args));
+  const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (text: string) => requireAgentControllerSession(session).steer(text),
@@ -65,7 +55,7 @@ export function useSteerAgentControllerMutation(args: AgentControllerRunMutation
 }
 
 export function useFollowUpAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(toClientArgs(args));
+  const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (text: string) => requireAgentControllerSession(session).followUp(text),
@@ -74,7 +64,7 @@ export function useFollowUpAgentControllerMutation(args: AgentControllerRunMutat
 }
 
 export function useAbortAgentControllerMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(toClientArgs(args));
+  const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: () => requireAgentControllerSession(session).abort(),
@@ -83,7 +73,7 @@ export function useAbortAgentControllerMutation(args: AgentControllerRunMutation
 }
 
 export function useApproveAgentControllerToolMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(toClientArgs(args));
+  const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: ({ toolCallId, approved }: { toolCallId: string; approved: boolean }) =>
@@ -93,7 +83,7 @@ export function useApproveAgentControllerToolMutation(args: AgentControllerRunMu
 }
 
 export function useRespondAgentControllerSuspensionMutation(args: AgentControllerRunMutationArgs) {
-  const { session } = createAgentControllerClient(toClientArgs(args));
+  const { session } = createAgentControllerClient(args);
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: ({ toolCallId, resumeData }: { toolCallId: string; resumeData: string | string[] | PlanResume }) =>

--- a/mastracode/web/src/shared/hooks/useAgentControllerSessionInit.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerSessionInit.ts
@@ -26,7 +26,7 @@ export function useAgentControllerSessionInit({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerSessionSync.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerSessionSync.ts
@@ -29,7 +29,7 @@ export function useAgentControllerSessionSync({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerSettings.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerSettings.ts
@@ -21,7 +21,7 @@ export function useAgentControllerSettings({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerThreadMessages.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerThreadMessages.ts
@@ -23,7 +23,7 @@ export function useAgentControllerThreadMessages({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useAgentControllerThreads.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerThreads.ts
@@ -23,7 +23,7 @@ export function useAgentControllerThreads({
   const { session } = createAgentControllerClient({
     agentControllerId,
     resourceId,
-    scope: projectPath,
+    projectPath,
     baseUrl,
     enabled,
   });

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -124,7 +124,7 @@ export function useStartFactoryRun() {
       const { session } = createAgentControllerClient({
         agentControllerId: AGENT_CONTROLLER_ID,
         resourceId,
-        scope: projectPath,
+        projectPath,
         baseUrl,
         enabled: sessionEnabled,
       });

--- a/mastracode/web/src/shared/hooks/useWorkspaceActivity.ts
+++ b/mastracode/web/src/shared/hooks/useWorkspaceActivity.ts
@@ -46,7 +46,7 @@ function useWorkspaceThreadsQuery({
       const { session } = createAgentControllerClient({
         agentControllerId,
         resourceId,
-        scope: projectPath,
+        projectPath,
         baseUrl,
       });
       return requireAgentControllerSession(session).listThreads();

--- a/mastracode/web/src/web/ui/domains/chat/services/agentControllerClient.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/agentControllerClient.ts
@@ -7,11 +7,19 @@ export interface CreateAgentControllerClientArgs {
   agentControllerId: string;
   resourceId: string;
   /**
-   * Per-worktree session scope (the worktree's project path). Sessions sharing
-   * a resourceId but scoped differently are independent server-side sessions,
-   * so the client cache must be keyed by scope too.
+   * Per-worktree session scope. Every server-side session is keyed by
+   * `(resourceId, projectPath)`, so sessions sharing a resourceId but running
+   * in different worktrees are independent — and the client-side cache and
+   * `sessionScope` query param must be keyed by the same projectPath.
+   *
+   * Callers name this field `projectPath` universally (it's what the sidebar,
+   * chat context, and mutation hooks already carry). We deliberately use the
+   * caller's name here so `createAgentControllerClient({ ...hookArgs })` and
+   * `createAgentControllerClient(args)` "just work" without a rename step —
+   * missing that mapping silently addresses the unscoped session, which lands
+   * mutations and reads in different places (see `useRouteThreadSync` bug).
    */
-  scope?: string;
+  projectPath?: string;
   baseUrl?: string;
   enabled?: boolean;
 }
@@ -24,8 +32,8 @@ type AgentControllerClientEntry = {
 
 const clientCache = new Map<string, AgentControllerClientEntry>();
 
-const cacheKey = (agentControllerId: string, resourceId: string, baseUrl: string, scope: string | undefined) =>
-  JSON.stringify([baseUrl, agentControllerId, resourceId, scope ?? null]);
+const cacheKey = (agentControllerId: string, resourceId: string, baseUrl: string, projectPath: string | undefined) =>
+  JSON.stringify([baseUrl, agentControllerId, resourceId, projectPath ?? null]);
 
 export function requireAgentControllerSession(session: AgentControllerSession | null) {
   if (!session) throw new Error('Agent controller session is not available');
@@ -35,20 +43,20 @@ export function requireAgentControllerSession(session: AgentControllerSession | 
 export function createAgentControllerClient({
   agentControllerId,
   resourceId,
-  scope,
+  projectPath,
   baseUrl = '',
   enabled = true,
 }: CreateAgentControllerClientArgs) {
   if (!enabled) return { client: null, controller: null, session: null };
 
-  const normalizedScope = scope || undefined;
-  const key = cacheKey(agentControllerId, resourceId, baseUrl, normalizedScope);
+  const normalizedProjectPath = projectPath || undefined;
+  const key = cacheKey(agentControllerId, resourceId, baseUrl, normalizedProjectPath);
   const cached = clientCache.get(key);
   if (cached) return cached;
 
   const client = new MastraClient({ baseUrl, credentials: 'include' });
   const controller = client.getAgentController(agentControllerId);
-  const session = controller.session(resourceId, normalizedScope);
+  const session = controller.session(resourceId, normalizedProjectPath);
   const entry = { client, controller, session };
   clientCache.set(key, entry);
   return entry;


### PR DESCRIPTION
Threads created from `/new` never appeared in the sidebar list, and navigating to `/threads/:newId` immediately redirected back to `/new` with a "thread was not found" toast.

Root cause was a client-side seam mismatch: `createAgentControllerClient` accepted `scope`, but every caller carries `projectPath`. The mutation hooks (`createThread`, `deleteThread`, `renameThread`, `cloneThread`, `switchThread`, all four goal hooks) did `createAgentControllerClient(args)` — TypeScript's excess-prop handling let `projectPath` pass structurally, and the factory read the missing `scope` as `undefined`. Mutations addressed the root-scoped session while reader hooks addressed the worktree-scoped session, so the new thread existed on the server but wasn't in the list `useRouteThreadSync` checked.

Fix is a rename: `CreateAgentControllerClientArgs.scope` → `projectPath`, so `{ ...hookArgs }` and `createAgentControllerClient(args)` naturally line up. Wire contract is unchanged (`?sessionScope=<value>` on every request).

Before:

```ts
export function useCreateAgentControllerThreadMutation(args) {
  // args.projectPath is silently ignored — factory reads args.scope (undefined)
  const { session } = createAgentControllerClient(args);
  // ...
}
```

After:

```ts
export function useCreateAgentControllerThreadMutation(args) {
  // args.projectPath now matches the factory input — sessionScope goes on the wire
  const { session } = createAgentControllerClient(args);
  // ...
}
```

Regression coverage: `useAgentControllerThreadMutationsScope.msw.test.tsx` (7 tests) asserts each mutation sends `?sessionScope=<projectPath>` and that a scoped `createThread` shows up in the scoped list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The app now uses the correct project-specific session when creating or changing threads and goals. This keeps new threads visible in the sidebar and prevents navigation from opening the wrong page.

## Summary

- Renamed the client session option from `scope` to `projectPath` across agent-controller hooks and client creation.
- Ensured thread and goal mutations forward the correct project path as `sessionScope` while preserving the existing wire contract.
- Updated session caching and controller initialization to use project-scoped sessions consistently.
- Added seven regression tests covering thread and goal mutations, plus scoped thread listing after creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->