### PR TITLE
chore(mastracode): fix web formatting

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/Chat.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/Chat.tsx
@@ -7,10 +7,7 @@ import { ChatLayout } from '../../ui/ChatLayout';
 
 import { OverlaysProvider, useOverlays } from '../../lib/overlays';
 import { FactoriesPanel } from '../workspaces/components/FactoriesPanel';
-import {
-  ActiveFactoryProvider,
-  useActiveFactoryContext,
-} from '../workspaces/context/ActiveFactoryProvider';
+import { ActiveFactoryProvider, useActiveFactoryContext } from '../workspaces/context/ActiveFactoryProvider';
 import { useGithubStatusQuery } from '../../../../shared/hooks/useGithubStatus';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatOverlays } from './components/ChatOverlays';
@@ -57,8 +54,7 @@ function ChatShell() {
   const githubStatus = useGithubStatusQuery().data;
   const githubEnabled = !!githubStatus && (githubStatus.enabled || !!githubStatus.authRequired);
   const factorySetupRequired = factories.length === 0 && !factoriesPending;
-  const factoriesOpen =
-    (overlays.isOpen('factories') || factorySetupRequired) && !overlays.isOpen('github');
+  const factoriesOpen = (overlays.isOpen('factories') || factorySetupRequired) && !overlays.isOpen('github');
   const content = factoriesOpen ? (
     <ChatLayout
       sidebar={<Sidebar />}

--- a/mastracode/web/src/web/ui/domains/chat/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/ThreadPage.tsx
@@ -8,10 +8,7 @@ import { renderedPaths } from '../workspace-viewer/config';
 import { WorkspaceViewerPanel } from '../workspace-viewer/components/WorkspaceViewerPanel';
 import { EmptyFactoryState } from '../workspaces/components/EmptyFactoryState';
 import { useActiveFactoryContext } from '../workspaces/context/ActiveFactoryProvider';
-import {
-  activeWorkspacePath,
-  findUserSessionByThreadId,
-} from '../workspaces/services/factories';
+import { activeWorkspacePath, findUserSessionByThreadId } from '../workspaces/services/factories';
 import { ChatHeader } from './components/ChatHeader';
 import { ChatMessageList } from './components/ChatMessageList';
 import { ComposerPanel } from './components/ComposerPanel';

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatOverlays.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatOverlays.msw.test.tsx
@@ -56,5 +56,4 @@ describe('ChatOverlays', () => {
     expect(await screen.findByRole('dialog', { name: 'Keyboard shortcuts' })).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Close' }));
   });
-
 });

--- a/mastracode/web/src/web/ui/domains/workspaces/components/DirectoryPicker.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/DirectoryPicker.tsx
@@ -50,10 +50,7 @@ interface NavigationState {
   index: number;
 }
 
-type NavigationAction =
-  | { type: 'browse'; path: string | undefined }
-  | { type: 'back' }
-  | { type: 'forward' };
+type NavigationAction = { type: 'browse'; path: string | undefined } | { type: 'back' } | { type: 'forward' };
 
 const initialNavigationState: NavigationState = {
   paths: [undefined],
@@ -199,7 +196,6 @@ export function DirectoryBrowser({ onPick, onCancel, busy = false, error: pickEr
           {pickError}
         </Txt>
       )}
-
     </div>
   );
 }

--- a/mastracode/web/src/web/ui/domains/workspaces/components/FactoriesPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/FactoriesPanel.tsx
@@ -32,10 +32,7 @@ export function FactoriesPanel({ onOpenGithub, onClose }: FactoriesPanelProps) {
   };
 
   return (
-    <section
-      aria-labelledby="create-factory-title"
-      className="flex min-h-0 flex-1 overflow-hidden p-4 md:p-6"
-    >
+    <section aria-labelledby="create-factory-title" className="flex min-h-0 flex-1 overflow-hidden p-4 md:p-6">
       <div className="flex min-h-0 w-full flex-1 flex-col gap-3">
         <Txt id="create-factory-title" as="h1" variant="header-md">
           Create factory


### PR DESCRIPTION
## Description

Applies Prettier formatting to five Mastra Code web chat and workspace files that caused `pnpm lint` to fail on main. This is formatting-only and does not change runtime behavior. Validated with `pnpm lint:format`, all ESLint tasks, `git diff --check`, and the pre-commit lint-staged hook.

## Related Issue(s)

No related issue.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR tidies up the formatting in five chat and workspace files so the project’s checks pass. It changes appearance only—not how the app works.

## Summary

- Applied Prettier formatting to chat, workspace, and related test files.
- Preserved all runtime behavior, test logic, APIs, and component props.
- Verified with formatting lint, ESLint, `git diff --check`, and the pre-commit hook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->