### PR TITLE
fix(memory): filter cross-thread messages before title generation

### DIFF
--- a/.changeset/great-rockets-judge.md
+++ b/.changeset/great-rockets-judge.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': patch
+---
+
+Fixed dataset item endpoints to return HTTP 400 when payloads contain circular values, silently lossy JSON values (nested `undefined`, functions, symbols, bigints, and non-finite numbers), or non-plain objects (`Date`, `Map`, `Set`, class instances, and custom `toJSON()` objects) that cannot be serialized faithfully. Also fixed the add/update dataset item endpoints to persist the caller-provided `requestContext` entries instead of the live server request context instance, which contained internal server state and could fail storage serialization.

--- a/.changeset/rare-waves-argue.md
+++ b/.changeset/rare-waves-argue.md
@@ -1,0 +1,15 @@
+---
+'@mastra/core': patch
+---
+
+Fixed dataset item writes to reject circular payloads with a clear validation error before storage, instead of failing with database-specific serialization errors. Silently lossy JSON values (nested `undefined`, functions, symbols, bigints, and non-finite numbers) and non-plain objects (`Date`, `Map`, `Set`, class instances, and custom `toJSON()` objects) are now also rejected with the offending path, so identical `externalId` retries can no longer conflict with the persisted payload. Added a public `safeStringify` utility for serializing values that may contain circular references.
+
+```ts
+import { safeStringify, ensureSerializable } from '@mastra/core/utils/safe-stringify';
+
+const value: Record<string, unknown> = { prompt: 'hello' };
+value.self = value;
+
+safeStringify(value); // '{"prompt":"hello","self":"[Circular]"}'
+ensureSerializable(value); // { prompt: 'hello', self: '[Circular]' }
+```

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -721,6 +721,16 @@
         "default": "./dist/utils/collect-tool-mocks.cjs"
       }
     },
+    "./utils/safe-stringify": {
+      "import": {
+        "types": "./dist/utils/safe-stringify.d.ts",
+        "default": "./dist/utils/safe-stringify.js"
+      },
+      "require": {
+        "types": "./dist/utils/safe-stringify.d.ts",
+        "default": "./dist/utils/safe-stringify.cjs"
+      }
+    },
     "./loop/server": {
       "import": {
         "types": "./dist/loop/server.d.ts",

--- a/packages/core/src/agent/__tests__/title-generation.test.ts
+++ b/packages/core/src/agent/__tests__/title-generation.test.ts
@@ -3097,4 +3097,38 @@ describe('onTitleGenerated callback', () => {
     // Should not throw — error is caught in the .catch() handler
     await new Promise(resolve => setTimeout(resolve, 200));
   });
+
+  it('should generate title from current thread messages only, not foreign-thread messages under resource scope', async () => {
+    const { agentModel, titleModel } = createMockModels();
+    const { agent } = createAgentWithTitleGen(agentModel, titleModel);
+
+    let capturedMessages: any[] = [];
+    const originalGenTitle = agent.genTitle.bind(agent);
+    agent.genTitle = async (userMessage, reqCtx, obsCtx, model, instructions, uiMessages) => {
+      capturedMessages = uiMessages ?? [];
+      return originalGenTitle(userMessage, reqCtx, obsCtx, model, instructions, uiMessages);
+    };
+
+    // First thread — generates messages under resource 'user-1'
+    await agent.generate('Message from thread A', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-cross-1', title: 'Existing' },
+      },
+    });
+
+    // Second thread — new thread, should only see its own messages
+    await agent.generate('Message from thread B', {
+      memory: {
+        resource: 'user-1',
+        thread: { id: 'thread-cross-2', title: '' },
+      },
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 200));
+
+    // All captured messages should belong to thread-cross-2 only
+    const foreignMessages = capturedMessages.filter((m: any) => m.threadId && m.threadId !== 'thread-cross-2');
+    expect(foreignMessages).toHaveLength(0);
+  });
 });

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -7179,7 +7179,8 @@ export class Agent<
             | undefined,
         );
 
-        const uiMessages = messageList.get.all.ui();
+        const allUiMessages = messageList.get.all.ui();
+        const uiMessages = allUiMessages.filter((m: any) => !m.threadId || m.threadId === thread.id);
         const messages = messageList.get.all.core();
         const requiredMessages = minMessages ?? 1;
 

--- a/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
+++ b/packages/core/src/storage/domains/datasets/__tests__/datasets.test.ts
@@ -164,6 +164,155 @@ describe('DatasetsInMemory', () => {
       expect(item.updatedAt).toBeInstanceOf(Date);
     });
 
+    it('addItem rejects circular payloads before idempotency comparison', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      await storage.addItem({ datasetId: dataset.id, externalId: 'cyclic-item', input: { prompt: 'safe' } });
+      const input: Record<string, unknown> = { prompt: 'hello' };
+      input.self = input;
+
+      await expect(storage.addItem({ datasetId: dataset.id, externalId: 'cyclic-item', input })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        message: expect.stringContaining('items[0].input.self references items[0].input'),
+      });
+    });
+
+    it('updateItem rejects circular payloads with the offending path', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const item = await storage.addItem({ datasetId: dataset.id, input: { prompt: 'hello' } });
+      const metadata: Record<string, unknown> = {};
+      metadata.self = metadata;
+
+      await expect(storage.updateItem({ id: item.id, datasetId: dataset.id, metadata })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        message: expect.stringContaining('item.metadata.self references item.metadata'),
+      });
+    });
+
+    it('batchInsertItems rejects circular payloads before insertion', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const requestContext: Record<string, unknown> = {};
+      requestContext.self = requestContext;
+
+      await expect(
+        storage.batchInsertItems({
+          datasetId: dataset.id,
+          items: [{ input: { prompt: 'safe' } }, { input: { prompt: 'cyclic' }, requestContext }],
+        }),
+      ).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        message: expect.stringContaining('items[1].requestContext.self references items[1].requestContext'),
+      });
+
+      const items = await storage.listItems({ datasetId: dataset.id, pagination: { page: 0, perPage: 10 } });
+      expect(items.items).toHaveLength(0);
+    });
+
+    it.each([
+      ['a nested undefined value', { prompt: 'hello', missing: undefined }, 'undefined value at item.input.missing'],
+      ['a function', { prompt: 'hello', callback: () => 'hi' }, 'function at item.input.callback'],
+      ['a symbol', { prompt: 'hello', token: Symbol('token') }, 'symbol at item.input.token'],
+      ['a bigint', { prompt: 'hello', count: 1n }, 'bigint at item.input.count'],
+      [
+        'a non-finite number',
+        { prompt: 'hello', score: Number.POSITIVE_INFINITY },
+        'non-finite number Infinity at item.input.score',
+      ],
+      [
+        'an undefined array entry',
+        { prompt: 'hello', steps: ['a', undefined] },
+        'undefined value at item.input.steps[1]',
+      ],
+      [
+        'a Date',
+        { prompt: 'hello', createdAt: new Date('2026-01-01T00:00:00Z') },
+        'non-plain object (Date) at item.input.createdAt',
+      ],
+      ['a Map', { prompt: 'hello', lookup: new Map([['a', 1]]) }, 'non-plain object (Map) at item.input.lookup'],
+      ['a Set', { prompt: 'hello', tags: new Set(['a']) }, 'non-plain object (Set) at item.input.tags'],
+      [
+        'a class instance',
+        { prompt: 'hello', price: new (class Money {})() },
+        'non-plain object (Money) at item.input.price',
+      ],
+      [
+        'a class instance with a custom toJSON',
+        {
+          prompt: 'hello',
+          amount: new (class Money {
+            toJSON() {
+              return { cents: 100 };
+            }
+          })(),
+        },
+        'non-plain object (Money) at item.input.amount',
+      ],
+    ] as const)('updateItem rejects payloads containing %s', async (_label, input, expectedPath) => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const item = await storage.addItem({ datasetId: dataset.id, input: { prompt: 'safe' } });
+
+      await expect(storage.updateItem({ id: item.id, datasetId: dataset.id, input })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        message: expect.stringContaining(expectedPath),
+      });
+    });
+
+    it('addItem accepts omitted optional payload fields set to undefined', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+
+      const item = await storage.addItem({ datasetId: dataset.id, input: { prompt: 'hello' }, groundTruth: undefined });
+      expect(item.input).toEqual({ prompt: 'hello' });
+    });
+
+    it('addItem rejects lossy payloads so identical externalId retries stay idempotent', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const input = { prompt: 'hello', extra: undefined };
+
+      // Without rejection, the first call would persist {prompt} (undefined dropped by
+      // serialization) while the retry compares against {prompt, extra: undefined} in
+      // memory, turning an identical retry into a spurious identity conflict.
+      await expect(storage.addItem({ datasetId: dataset.id, externalId: 'lossy-item', input })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        message: expect.stringContaining('undefined value at items[0].input.extra'),
+      });
+      await expect(storage.addItem({ datasetId: dataset.id, externalId: 'lossy-item', input })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+      });
+
+      // A JSON-safe payload stays idempotent across identical externalId retries.
+      const safeInput = { prompt: 'hello' };
+      const first = await storage.addItem({ datasetId: dataset.id, externalId: 'lossy-item', input: safeInput });
+      const retry = await storage.addItem({ datasetId: dataset.id, externalId: 'lossy-item', input: safeInput });
+      expect(retry.id).toBe(first.id);
+
+      const items = await storage.listItems({ datasetId: dataset.id, pagination: { page: 0, perPage: 10 } });
+      expect(items.items).toHaveLength(1);
+    });
+
+    it('addItem rejects non-plain objects so identical externalId retries stay idempotent', async () => {
+      const dataset = await storage.createDataset({ name: 'test' });
+      const input = { prompt: 'hello', createdAt: new Date('2026-01-01T00:00:00Z') };
+
+      // Without rejection, the first call would persist createdAt as an ISO string
+      // while the retry compares against a live Date instance in memory, turning an
+      // identical retry into a spurious identity conflict.
+      await expect(storage.addItem({ datasetId: dataset.id, externalId: 'date-item', input })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        message: expect.stringContaining('non-plain object (Date) at items[0].input.createdAt'),
+      });
+      await expect(storage.addItem({ datasetId: dataset.id, externalId: 'date-item', input })).rejects.toMatchObject({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+      });
+
+      // Explicitly converted, the payload stays idempotent across retries.
+      const safeInput = { prompt: 'hello', createdAt: input.createdAt.toISOString() };
+      const first = await storage.addItem({ datasetId: dataset.id, externalId: 'date-item', input: safeInput });
+      const retry = await storage.addItem({ datasetId: dataset.id, externalId: 'date-item', input: safeInput });
+      expect(retry.id).toBe(first.id);
+
+      const items = await storage.listItems({ datasetId: dataset.id, pagination: { page: 0, perPage: 10 } });
+      expect(items.items).toHaveLength(1);
+    });
+
     it('addItem throws for non-existent dataset', async () => {
       await expect(storage.addItem({ datasetId: 'non-existent', input: {} })).rejects.toThrow('Dataset not found');
     });

--- a/packages/core/src/storage/domains/datasets/base.ts
+++ b/packages/core/src/storage/domains/datasets/base.ts
@@ -23,6 +23,7 @@ import type {
 import { StorageDomain } from '../base';
 import { planDatasetItemBatch as createDatasetItemBatchPlan, validateDatasetItemExternalId } from './identity';
 import type { DatasetItemBatchPlan } from './identity';
+import { validateDatasetItemPayloadSerialization } from './serialization';
 
 const DATASET_IMMUTABLE_FIELDS = ['organizationId', 'projectId', 'candidateKey', 'candidateId'] as const;
 
@@ -174,6 +175,9 @@ export abstract class DatasetsStorage extends StorageDomain {
       throw new Error(`Dataset not found: ${args.datasetId}`);
     }
 
+    const { id: _id, datasetId: _datasetId, filters: _filters, ...payload } = args;
+    validateDatasetItemPayloadSerialization(payload, 'item');
+
     // Validate new values against schemas if enabled
     const validator = getSchemaValidator();
     const cacheKey = `dataset:${args.datasetId}`;
@@ -236,8 +240,9 @@ export abstract class DatasetsStorage extends StorageDomain {
     const validator = getSchemaValidator();
     const cacheKey = `dataset:${input.datasetId}`;
 
-    for (const itemData of input.items) {
+    for (const [index, itemData] of input.items.entries()) {
       validateDatasetItemExternalId(itemData.externalId);
+      validateDatasetItemPayloadSerialization(itemData, `items[${index}]`);
       if (dataset.inputSchema) {
         validator.validate(itemData.input, dataset.inputSchema, 'input', `${cacheKey}:input`);
       }

--- a/packages/core/src/storage/domains/datasets/serialization.ts
+++ b/packages/core/src/storage/domains/datasets/serialization.ts
@@ -1,0 +1,106 @@
+import { MastraError } from '../../../error';
+import type { DatasetItemPayload } from '../../types';
+
+interface SerializationIssue {
+  path: string;
+  reason: string;
+  referencePath?: string;
+}
+
+function formatPath(parent: string, key: string): string {
+  return /^[A-Za-z_$][\w$]*$/.test(key) ? `${parent}.${key}` : `${parent}[${JSON.stringify(key)}]`;
+}
+
+function findSerializationIssue(
+  value: unknown,
+  path: string,
+  ancestors: WeakMap<object, string>,
+): SerializationIssue | undefined {
+  switch (typeof value) {
+    case 'undefined':
+      return { path, reason: `undefined value at ${path} would be silently dropped or nulled` };
+    case 'function':
+      return { path, reason: `function at ${path} would be silently dropped` };
+    case 'symbol':
+      return { path, reason: `symbol at ${path} would be silently dropped` };
+    case 'bigint':
+      return { path, reason: `bigint at ${path} cannot be serialized` };
+    case 'number':
+      return Number.isFinite(value)
+        ? undefined
+        : { path, reason: `non-finite number ${value} at ${path} would become null` };
+  }
+
+  if (value === null || typeof value !== 'object') return undefined;
+
+  const referencePath = ancestors.get(value);
+  if (referencePath) {
+    return { path, referencePath, reason: `circular reference at ${path} references ${referencePath}` };
+  }
+
+  if (!Array.isArray(value)) {
+    const proto = Object.getPrototypeOf(value);
+    if (proto !== Object.prototype && proto !== null) {
+      // Date, Map, Set, class instances, custom toJSON() objects, etc. change
+      // shape during JSON persistence, so identical retries would no longer
+      // deep-equal the persisted payload. Require explicit conversion instead.
+      const constructorName = (value as object).constructor?.name || 'unknown class';
+      return { path, reason: `non-plain object (${constructorName}) at ${path} would change during JSON persistence` };
+    }
+  }
+
+  ancestors.set(value, path);
+  try {
+    if (Array.isArray(value)) {
+      for (const [index, item] of value.entries()) {
+        const issue = findSerializationIssue(item, `${path}[${index}]`, ancestors);
+        if (issue) return issue;
+      }
+    } else {
+      for (const key of Object.keys(value)) {
+        const issue = findSerializationIssue((value as Record<string, unknown>)[key], formatPath(path, key), ancestors);
+        if (issue) return issue;
+      }
+    }
+  } finally {
+    ancestors.delete(value);
+  }
+
+  return undefined;
+}
+
+export function validateDatasetItemPayloadSerialization(payload: Partial<DatasetItemPayload>, path: string): void {
+  const ancestors = new WeakMap<object, string>();
+  ancestors.set(payload, path);
+
+  for (const key of Object.keys(payload)) {
+    const fieldValue = (payload as Record<string, unknown>)[key];
+    // Omitted optional fields: only nested undefined values are lossy.
+    if (fieldValue === undefined) continue;
+
+    const issue = findSerializationIssue(fieldValue, formatPath(path, key), ancestors);
+    if (issue) {
+      throw new MastraError({
+        id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+        text: `Dataset item payload must be JSON-serializable: ${issue.reason}.`,
+        domain: 'STORAGE',
+        category: 'USER',
+        details: issue.referencePath
+          ? { path: issue.path, referencePath: issue.referencePath }
+          : { path: issue.path, reason: issue.reason },
+      });
+    }
+  }
+
+  try {
+    JSON.stringify(payload);
+  } catch (error) {
+    throw new MastraError({
+      id: 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE',
+      text: `Dataset item payload at ${path} must be JSON-serializable: ${error instanceof Error ? error.message : String(error)}`,
+      domain: 'STORAGE',
+      category: 'USER',
+      details: { path },
+    });
+  }
+}

--- a/packages/core/src/utils.test.ts
+++ b/packages/core/src/utils.test.ts
@@ -762,6 +762,12 @@ describe('safeStringify', () => {
     const result = safeStringify(obj);
     expect(JSON.parse(result)).toEqual({ count: '42', name: 'test' });
   });
+
+  it('should normalize unsupported top-level values to "null"', () => {
+    expect(safeStringify(undefined)).toBe('null');
+    expect(safeStringify(() => {})).toBe('null');
+    expect(safeStringify(Symbol('test'))).toBe('null');
+  });
 });
 
 describe('ensureSerializable', () => {

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -26,47 +26,9 @@ export { getZodTypeName, getZodDef, isZodArray, isZodObject } from './utils/zod-
 export { fetchWithRetry } from './utils/fetchWithRetry';
 export type { FetchWithRetryOptions } from './utils/fetchWithRetry';
 
+export { ensureSerializable, safeStringify } from './utils/safe-stringify';
+
 export const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-
-/**
- * Safely JSON-stringifies a value, replacing circular references with "[Circular]".
- * Uses a stack-based approach so shared (non-circular) references are preserved.
- */
-export function safeStringify(value: unknown, space?: string | number): string {
-  const stack: unknown[] = [];
-  return JSON.stringify(
-    value,
-    function (this: unknown, _key: string, val: unknown) {
-      if (typeof val === 'bigint') return val.toString();
-      if (val !== null && typeof val === 'object') {
-        // Trim the stack: pop entries that are no longer ancestors of the current path.
-        // `this` is the parent object containing the current key.
-        while (stack.length > 0 && stack[stack.length - 1] !== this) {
-          stack.pop();
-        }
-        if (stack.includes(val)) return '[Circular]';
-        stack.push(val);
-      }
-      return val;
-    },
-    space,
-  );
-}
-
-/**
- * Returns a JSON-serializable copy of a value by stripping circular references.
- * If the value is already serializable, returns it unchanged (no cloning overhead).
- */
-export function ensureSerializable(value: unknown): unknown {
-  if (value === null || typeof value !== 'object') return value;
-
-  try {
-    JSON.stringify(value);
-    return value;
-  } catch {
-    return JSON.parse(safeStringify(value));
-  }
-}
 
 /**
  * Checks if a value is a plain object (not an array, function, Date, RegExp, etc.)

--- a/packages/core/src/utils/safe-stringify.ts
+++ b/packages/core/src/utils/safe-stringify.ts
@@ -1,0 +1,39 @@
+/**
+ * Safely JSON-stringifies a value, replacing circular references with "[Circular]".
+ * Uses a stack-based approach so shared (non-circular) references are preserved.
+ */
+export function safeStringify(value: unknown, space?: string | number): string {
+  const stack: unknown[] = [];
+  const result: string | undefined = JSON.stringify(
+    value,
+    function (this: unknown, _key: string, val: unknown) {
+      if (typeof val === 'bigint') return val.toString();
+      if (val !== null && typeof val === 'object') {
+        while (stack.length > 0 && stack[stack.length - 1] !== this) {
+          stack.pop();
+        }
+        if (stack.includes(val)) return '[Circular]';
+        stack.push(val);
+      }
+      return val;
+    },
+    space,
+  );
+  // JSON.stringify returns undefined for unsupported top-level values (undefined, functions, symbols).
+  return result ?? 'null';
+}
+
+/**
+ * Returns a JSON-serializable copy of a value by stripping circular references.
+ * If the value is already serializable, returns it unchanged (no cloning overhead).
+ */
+export function ensureSerializable(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+
+  try {
+    JSON.stringify(value);
+    return value;
+  } catch {
+    return JSON.parse(safeStringify(value));
+  }
+}

--- a/packages/core/tsup.config.ts
+++ b/packages/core/tsup.config.ts
@@ -62,6 +62,7 @@ export default defineConfig({
     'src/processors/index.ts',
     'src/zod-to-json.ts',
     'src/utils/collect-tool-mocks.ts',
+    'src/utils/safe-stringify.ts',
     'src/evals/scoreTraces/index.ts',
     'src/agent/message-list/index.ts',
     'src/agent/durable/index.ts',

--- a/packages/playground/src/domains/observability/components/__tests__/fixtures/trace-as-item.ts
+++ b/packages/playground/src/domains/observability/components/__tests__/fixtures/trace-as-item.ts
@@ -1,0 +1,22 @@
+import type { MastraClient } from '@mastra/client-js';
+import { SpanType } from '@mastra/core/observability';
+
+type GetSpanResponse = Awaited<ReturnType<MastraClient['getSpan']>>;
+
+export function createTraceDetails(input: unknown, output: unknown): GetSpanResponse['span'] {
+  const timestamp = new Date('2026-07-16T12:00:00.000Z');
+
+  return {
+    traceId: 'trace-1',
+    spanId: 'span-1',
+    name: 'Agent run',
+    spanType: SpanType.AGENT_RUN,
+    isEvent: false,
+    startedAt: timestamp,
+    endedAt: timestamp,
+    input,
+    output,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}

--- a/packages/playground/src/domains/observability/components/__tests__/trace-as-item-dialog.test.tsx
+++ b/packages/playground/src/domains/observability/components/__tests__/trace-as-item-dialog.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ChangeEvent, HTMLAttributes, PropsWithChildren, SelectHTMLAttributes } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TraceAsItemDialog } from '../trace-as-item-dialog';
+import { createTraceDetails } from './fixtures/trace-as-item';
+import { buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+type CodeEditorProps = {
+  value?: string;
+  onChange?: (value: string) => void;
+};
+
+// @mastra/playground-ui is a heavy presentational dependency (SideDialog,
+// CodeEditor, Select primitives) with its own dedicated tests; stub it as a
+// thin seam so this suite can focus on trace-to-dataset payload preparation.
+// The dataset hooks are driven through the real @mastra/client-js + React
+// Query stack via MSW.
+vi.mock('@mastra/playground-ui/components/Select', () => ({
+  Select: ({ children }: PropsWithChildren<SelectHTMLAttributes<HTMLSelectElement>>) => <div>{children}</div>,
+  SelectTrigger: ({ children }: PropsWithChildren<HTMLAttributes<HTMLButtonElement>>) => (
+    <button type="button">{children}</button>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children }: PropsWithChildren<{ value: string }>) => <div>{children}</div>,
+}));
+
+vi.mock('@mastra/playground-ui/utils/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@mastra/playground-ui/components/SideDialog', () => ({
+  SideDialog: Object.assign(
+    ({ isOpen, children }: PropsWithChildren<{ isOpen: boolean }>) => (isOpen ? <div>{children}</div> : null),
+    {
+      Top: ({ children }: PropsWithChildren) => <div>{children}</div>,
+      Content: ({ children }: PropsWithChildren) => <div>{children}</div>,
+      Header: ({ children }: PropsWithChildren) => <div>{children}</div>,
+      Heading: ({ children }: PropsWithChildren) => <h2>{children}</h2>,
+    },
+  ),
+}));
+
+vi.mock('@mastra/playground-ui/components/CodeEditor', () => ({
+  CodeEditor: ({ value, onChange }: CodeEditorProps) => (
+    <textarea
+      value={value ?? ''}
+      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock('@mastra/playground-ui/components/Text', () => ({
+  TextAndIcon: ({ children }: PropsWithChildren) => <span>{children}</span>,
+  getShortId: (id?: string) => id ?? '',
+}));
+
+beforeEach(() => {
+  server.use(http.get(`${BASE_URL}/api/datasets`, () => HttpResponse.json(buildListDatasetsResponse())));
+});
+
+afterEach(() => cleanup());
+
+function renderDialog(input: unknown, output: unknown) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <TraceAsItemDialog
+          rootSpanId="span-1"
+          traceDetails={createTraceDetails(input, output)}
+          isOpen
+          onClose={vi.fn()}
+        />
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+function getEditors() {
+  return screen.getAllByRole('textbox') as HTMLTextAreaElement[];
+}
+
+describe('TraceAsItemDialog', () => {
+  describe('when trace input and output contain circular references', () => {
+    it('prepares JSON-safe dataset fields instead of crashing', async () => {
+      const input: Record<string, unknown> = { prompt: 'hello' };
+      const output: Record<string, unknown> = { answer: 'world' };
+      input.self = input;
+      output.self = output;
+
+      renderDialog(input, output);
+
+      await waitFor(() => {
+        const [inputEditor, groundTruthEditor] = getEditors();
+        expect(inputEditor.value).toContain('"self": "[Circular]"');
+        expect(groundTruthEditor.value).toContain('"self": "[Circular]"');
+      });
+    });
+  });
+});

--- a/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/add-trace-mocks-to-item-dialog.tsx
@@ -1,5 +1,6 @@
 import type { DatasetItemToolMock } from '@mastra/client-js';
 import { collectToolMocks } from '@mastra/core/utils/collect-tool-mocks';
+import { safeStringify } from '@mastra/core/utils/safe-stringify';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Label } from '@mastra/playground-ui/components/Label';
@@ -48,7 +49,7 @@ export function AddTraceMocksToItemDialog({ traceId, isOpen, onClose, level = 2 
   });
 
   const derivedMocks: DatasetItemToolMock[] = trajectory?.steps ? collectToolMocks(trajectory.steps) : [];
-  const initialMocksJson = derivedMocks.length > 0 ? JSON.stringify(derivedMocks, null, 2) : '';
+  const initialMocksJson = derivedMocks.length > 0 ? safeStringify(derivedMocks, 2) : '';
 
   return (
     <SideDialog

--- a/packages/playground/src/domains/observability/components/trace-as-item-dialog.tsx
+++ b/packages/playground/src/domains/observability/components/trace-as-item-dialog.tsx
@@ -2,6 +2,7 @@
 
 import type { SpanRecord } from '@mastra/core/storage';
 import { collectToolMocks } from '@mastra/core/utils/collect-tool-mocks';
+import { safeStringify } from '@mastra/core/utils/safe-stringify';
 import type { SideDialogRootProps } from '@mastra/playground-ui/components/SideDialog';
 import { TextAndIcon, getShortId } from '@mastra/playground-ui/components/Text';
 import { useSpanDetail } from '@mastra/playground-ui/domains/traces/hooks/use-span-detail';
@@ -34,7 +35,7 @@ function getInitialInput(traceDetails?: SpanRecord): string {
     'messages' in spanInput;
   const rawInput = isWrappedAgentInput ? (spanInput.messages ?? traceDetails.input) : traceDetails.input;
 
-  return JSON.stringify(rawInput, null, 2);
+  return safeStringify(rawInput, 2);
 }
 
 export function TraceAsItemDialog({
@@ -64,7 +65,7 @@ export function TraceAsItemDialog({
   // Convert trajectory to a TrajectoryExpectation JSON string
   const initialTrajectory =
     trajectory?.steps && trajectory.steps.length > 0
-      ? JSON.stringify(
+      ? safeStringify(
           {
             steps: trajectory.steps.map(step => {
               const { name, stepType, children, ...rest } = step as Record<string, unknown>;
@@ -78,19 +79,18 @@ export function TraceAsItemDialog({
             }),
             ordering: 'relaxed',
           },
-          null,
           2,
         )
       : undefined;
 
   // Derive item-level tool mocks from the recorded tool calls in the trajectory
   const toolMocks = trajectory?.steps ? collectToolMocks(trajectory.steps) : [];
-  const initialToolMocks = toolMocks.length > 0 ? JSON.stringify(toolMocks, null, 2) : undefined;
+  const initialToolMocks = toolMocks.length > 0 ? safeStringify(toolMocks, 2) : undefined;
 
   return (
     <SaveAsDatasetItemDialog
       initialInput={getInitialInput(traceDetails)}
-      initialGroundTruth={traceDetails?.output != null ? JSON.stringify(traceDetails.output, null, 2) : ''}
+      initialGroundTruth={traceDetails?.output != null ? safeStringify(traceDetails.output, 2) : ''}
       initialTrajectory={initialTrajectory}
       trajectoryLoading={isTrajectoryLoading}
       initialToolMocks={initialToolMocks}

--- a/packages/playground/src/domains/scores/components/__tests__/fixtures/score-as-item.ts
+++ b/packages/playground/src/domains/scores/components/__tests__/fixtures/score-as-item.ts
@@ -1,0 +1,25 @@
+import type { ComponentProps } from 'react';
+
+import type { ScoreAsItemDialog } from '../../score-as-item-dialog';
+
+type ScoreAsItemDialogScore = NonNullable<ComponentProps<typeof ScoreAsItemDialog>['score']>;
+
+export function createScore(input: unknown, output: unknown): ScoreAsItemDialogScore {
+  const timestamp = new Date('2026-07-16T12:00:00.000Z');
+
+  return {
+    id: 'score-1',
+    scorerId: 'scorer-1',
+    entityId: 'agent-1',
+    runId: 'run-1',
+    input,
+    output,
+    score: 1,
+    scorer: {},
+    source: 'LIVE',
+    entity: {},
+    traceId: 'trace-1',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  };
+}

--- a/packages/playground/src/domains/scores/components/__tests__/score-as-item-dialog.test.tsx
+++ b/packages/playground/src/domains/scores/components/__tests__/score-as-item-dialog.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ChangeEvent, HTMLAttributes, PropsWithChildren, SelectHTMLAttributes } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ScoreAsItemDialog } from '../score-as-item-dialog';
+import { createScore } from './fixtures/score-as-item';
+import { buildListDatasetsResponse } from '@/domains/datasets/components/__tests__/fixtures/datasets';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+type CodeEditorProps = {
+  value?: string;
+  onChange?: (value: string) => void;
+};
+
+// @mastra/playground-ui is a heavy presentational dependency (SideDialog,
+// CodeEditor, Select primitives) with its own dedicated tests; stub it as a
+// thin seam so this suite can focus on score-to-dataset payload preparation.
+// The dataset hooks are driven through the real @mastra/client-js + React
+// Query stack via MSW.
+vi.mock('@mastra/playground-ui/components/Select', () => ({
+  Select: ({ children }: PropsWithChildren<SelectHTMLAttributes<HTMLSelectElement>>) => <div>{children}</div>,
+  SelectTrigger: ({ children }: PropsWithChildren<HTMLAttributes<HTMLButtonElement>>) => (
+    <button type="button">{children}</button>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  SelectContent: ({ children }: PropsWithChildren) => <div>{children}</div>,
+  SelectItem: ({ children }: PropsWithChildren<{ value: string }>) => <div>{children}</div>,
+}));
+
+vi.mock('@mastra/playground-ui/utils/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock('@mastra/playground-ui/components/SideDialog', () => ({
+  SideDialog: Object.assign(
+    ({ isOpen, children }: PropsWithChildren<{ isOpen: boolean }>) => (isOpen ? <div>{children}</div> : null),
+    {
+      Top: ({ children }: PropsWithChildren) => <div>{children}</div>,
+      Content: ({ children }: PropsWithChildren) => <div>{children}</div>,
+      Header: ({ children }: PropsWithChildren) => <div>{children}</div>,
+      Heading: ({ children }: PropsWithChildren) => <h2>{children}</h2>,
+    },
+  ),
+}));
+
+vi.mock('@mastra/playground-ui/components/CodeEditor', () => ({
+  CodeEditor: ({ value, onChange }: CodeEditorProps) => (
+    <textarea
+      value={value ?? ''}
+      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value)}
+    />
+  ),
+}));
+
+vi.mock('@mastra/playground-ui/components/Text', () => ({
+  TextAndIcon: ({ children }: PropsWithChildren) => <span>{children}</span>,
+  getShortId: (id?: string) => id ?? '',
+}));
+
+beforeEach(() => {
+  server.use(http.get(`${BASE_URL}/api/datasets`, () => HttpResponse.json(buildListDatasetsResponse())));
+});
+
+afterEach(() => cleanup());
+
+function renderDialog(input: unknown, output: unknown) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  return render(
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>
+        <ScoreAsItemDialog score={createScore(input, output)} isOpen onClose={vi.fn()} />
+      </QueryClientProvider>
+    </MastraReactProvider>,
+  );
+}
+
+function getEditors() {
+  return screen.getAllByRole('textbox') as HTMLTextAreaElement[];
+}
+
+describe('ScoreAsItemDialog', () => {
+  describe('when a trace-linked score contains circular input and output', () => {
+    it('prepares JSON-safe dataset input instead of crashing', async () => {
+      const input: Record<string, unknown> = { prompt: 'hello' };
+      const output: Record<string, unknown> = { answer: 'world' };
+      input.self = input;
+      output.self = output;
+
+      renderDialog(input, output);
+
+      await waitFor(() => {
+        const [inputEditor] = getEditors();
+        expect(inputEditor.value).toContain('"self": "[Circular]"');
+      });
+    });
+  });
+});

--- a/packages/playground/src/domains/scores/components/score-as-item-dialog.tsx
+++ b/packages/playground/src/domains/scores/components/score-as-item-dialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import type { ScoreRowData } from '@mastra/core/evals';
+import { safeStringify } from '@mastra/core/utils/safe-stringify';
 import type { SideDialogRootProps } from '@mastra/playground-ui/components/SideDialog';
 import { TextAndIcon, getShortId } from '@mastra/playground-ui/components/Text';
 import { CalculatorIcon } from 'lucide-react';
@@ -18,13 +19,13 @@ function getInitialInput(score?: ScoreRowData): string {
   // input = the full scorer.run() payload: { input, output, groundTruth }
   // groundTruth from the original experiment is not available on ScoreRowData,
   // so we omit it — user can add it manually in the editor
-  return JSON.stringify({ input: score.input, output: score.output, groundTruth: null }, null, 2);
+  return safeStringify({ input: score.input, output: score.output, groundTruth: null }, 2);
 }
 
 function getInitialGroundTruth(score?: ScoreRowData): string {
   if (!score) return '';
   // ground truth = expected scorer result — pre-fill with actual score/reason so user can adjust
-  return JSON.stringify({ score: score.score, reason: score.reason ?? null }, null, 2);
+  return safeStringify({ score: score.score, reason: score.reason ?? null }, 2);
 }
 
 export function ScoreAsItemDialog({ score, isOpen, onClose, level = 2 }: ScoreAsItemDialogProps) {

--- a/packages/server/src/server/handlers/datasets.test.ts
+++ b/packages/server/src/server/handlers/datasets.test.ts
@@ -348,6 +348,87 @@ describe('Datasets Handlers', () => {
       expect((error as HTTPException).cause).toEqual({ field: 'externalId' });
     });
 
+    it('maps circular dataset item payloads to HTTP 400', async () => {
+      const dataset = await mastra.datasets.create({ name: 'Circular Payload DS' });
+      const input: Record<string, unknown> = { q: 'cyclic' };
+      input.self = input;
+
+      const error = await ADD_ITEM_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        input,
+      } as any).then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(HTTPException);
+      expect((error as HTTPException).status).toBe(400);
+      expect((error as HTTPException).message).toContain('items[0].input.self references items[0].input');
+    });
+
+    it('maps lossy dataset item payloads to HTTP 400', async () => {
+      const dataset = await mastra.datasets.create({ name: 'Lossy Payload DS' });
+
+      const error = await ADD_ITEM_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        input: { q: 'lossy', extra: undefined },
+      } as any).then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(HTTPException);
+      expect((error as HTTPException).status).toBe(400);
+      expect((error as HTTPException).message).toContain('undefined value at items[0].input.extra');
+    });
+
+    it('persists caller request context entries instead of the live server RequestContext', async () => {
+      const dataset = await mastra.datasets.create({ name: 'Request Context DS' });
+
+      // Adapters merge the body's requestContext entries into the live server
+      // RequestContext and pass that instance to the handler in place of the
+      // body field. The handler must recover the caller entries (reserved
+      // mastra__* keys excluded) rather than persisting the live instance.
+      const serverContext = createTestServerContext({ mastra });
+      serverContext.requestContext.set('locale', 'fr-FR');
+      serverContext.requestContext.set('mastra__authMode', 'server');
+
+      const added = await ADD_ITEM_ROUTE.handler({
+        ...serverContext,
+        datasetId: dataset.id,
+        input: { q: 'ctx' },
+      } as any);
+
+      expect(added.requestContext).toEqual({ locale: 'fr-FR' });
+
+      // An empty live RequestContext must not persist an empty object.
+      const bare = await ADD_ITEM_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        input: { q: 'no-ctx' },
+      } as any);
+      expect(bare.requestContext).toBeUndefined();
+    });
+
+    it('maps non-plain-object dataset item payloads to HTTP 400', async () => {
+      const dataset = await mastra.datasets.create({ name: 'Non-Plain Payload DS' });
+
+      const error = await ADD_ITEM_ROUTE.handler({
+        ...createTestServerContext({ mastra }),
+        datasetId: dataset.id,
+        input: { q: 'date', createdAt: new Date('2026-01-01T00:00:00Z') },
+      } as any).then(
+        () => null,
+        (caught: unknown) => caught,
+      );
+
+      expect(error).toBeInstanceOf(HTTPException);
+      expect((error as HTTPException).status).toBe(400);
+      expect((error as HTTPException).message).toContain('non-plain object (Date) at items[0].input.createdAt');
+    });
+
     it('maps incompatible externalId reuse in a batch to HTTP 409', async () => {
       const dataset = await mastra.datasets.create({ name: 'Batch Conflict DS' });
       await BATCH_INSERT_ITEMS_ROUTE.handler({

--- a/packages/server/src/server/handlers/datasets.ts
+++ b/packages/server/src/server/handlers/datasets.ts
@@ -5,6 +5,7 @@ import { resolveModelConfig } from '@mastra/core/llm';
 import { RequestContext } from '@mastra/core/request-context';
 import type { DatasetItemSource, DatasetItemToolMock, TargetType } from '@mastra/core/storage';
 import { z } from 'zod';
+import { isReservedRequestContextKey } from '../constants';
 import { HTTPException } from '../http-exception';
 import type { StatusCode } from '../http-exception';
 import { successResponseSchema } from '../schemas/common';
@@ -59,6 +60,24 @@ function assertDatasetsAvailable(): void {
   }
 }
 
+/**
+ * Recovers the caller-provided request context for a dataset item.
+ *
+ * Server adapters overwrite the body's `requestContext` field with the live
+ * server `RequestContext` instance (so bodies cannot spoof auth context), after
+ * merging the body's entries into it. Persisting that live instance as item
+ * data stores internal server state and fails JSON/BSON serialization, so
+ * convert it back to the plain caller-provided entries (reserved `mastra__*`
+ * keys excluded) before it reaches storage.
+ */
+function toItemRequestContext(
+  requestContext: Record<string, unknown> | RequestContext | undefined,
+): Record<string, unknown> | undefined {
+  if (!(requestContext instanceof RequestContext)) return requestContext;
+  const entries = Object.entries(requestContext.toJSON()).filter(([key]) => !isReservedRequestContextKey(key));
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
 interface SchemaValidationLike extends Error {
   field: 'input' | 'groundTruth';
   errors: Array<{ path: string; code: string; message: string }>;
@@ -92,6 +111,7 @@ function getHttpStatusForMastraError(errorId: string): number {
       return 404;
     case 'EXPERIMENT_NO_ITEMS':
     case 'DATASET_ITEM_EXTERNAL_ID_INVALID':
+    case 'DATASET_ITEM_PAYLOAD_NOT_SERIALIZABLE':
       return 400;
     case 'DATASET_ITEM_IDENTITY_CONFLICT':
       return 409;
@@ -384,7 +404,7 @@ export const ADD_ITEM_ROUTE = createRoute({
           externalId?: string | null;
           input: unknown;
           groundTruth?: unknown;
-          requestContext?: Record<string, unknown>;
+          requestContext?: Record<string, unknown> | RequestContext;
           metadata?: Record<string, unknown>;
           source?: DatasetItemSource;
           expectedTrajectory?: unknown;
@@ -395,7 +415,7 @@ export const ADD_ITEM_ROUTE = createRoute({
         externalId: externalId ?? undefined,
         input,
         groundTruth,
-        requestContext,
+        requestContext: toItemRequestContext(requestContext),
         metadata,
         source,
         expectedTrajectory,
@@ -470,7 +490,7 @@ export const UPDATE_ITEM_ROUTE = createRoute({
       const { input, groundTruth, requestContext, metadata, expectedTrajectory, toolMocks } = params as {
         input?: unknown;
         groundTruth?: unknown;
-        requestContext?: Record<string, unknown>;
+        requestContext?: Record<string, unknown> | RequestContext;
         metadata?: Record<string, unknown>;
         expectedTrajectory?: unknown;
         toolMocks?: DatasetItemToolMock[];
@@ -485,7 +505,7 @@ export const UPDATE_ITEM_ROUTE = createRoute({
         itemId,
         input,
         groundTruth,
-        requestContext,
+        requestContext: toItemRequestContext(requestContext),
         metadata,
         expectedTrajectory,
         toolMocks,


### PR DESCRIPTION
## Summary
With resource-scoped memory, `messageList.get.all.ui()` returns messages from ALL threads of the same resource. `genTitle` was receiving the full unfiltered list and using foreign-thread messages to generate titles — causing new threads to get titled after unrelated older conversations (including wrong-language titles).

Fix: filter `uiMessages` to the active `threadId` before passing to `genTitle`. Messages without a `threadId` pass through unchanged.

Fixes #19833

## Why
The issue is in `agent.ts` at the call site:
```ts
// Before
const uiMessages = messageList.get.all.ui();

// After  
const allUiMessages = messageList.get.all.ui();
const uiMessages = allUiMessages.filter((m: any) => !m.threadId || m.threadId === thread.id);
```

## Testing
Added regression test covering cross-thread contamination scenario with resource-scoped memory.

## Checklist
- [x] Regression test added
- [x] Lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR keeps messages from different conversations from getting mixed up when naming a new conversation. It also safely handles unusual data when saving dataset items, preventing crashes and confusing storage errors.

## What changed

- Filtered title-generation messages to the active thread while retaining messages without a `threadId`.
- Added regression coverage for resource-scoped cross-thread title generation.
- Added dataset payload validation for circular, lossy, non-JSON-safe, and non-plain-object values, returning HTTP 400 for invalid requests.
- Added the public `safeStringify` utility and used it across playground trace, score, and tool-mock editors to safely serialize circular data.
- Ensured dataset item writes persist only caller-provided `requestContext` entries, excluding internal server keys.
- Added tests covering dataset validation, request context handling, and safe serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->