### PR TITLE
fix(mastracode): restore goal skill commands

### DIFF
--- a/.changeset/fresh-goals-appear.md
+++ b/.changeset/fresh-goals-appear.md
@@ -1,5 +1,0 @@
----
-'mastracode': patch
----
-
-Fixed goal-enabled skills so their `/goal/*` commands appear and run correctly.

--- a/.changeset/fresh-goals-appear.md
+++ b/.changeset/fresh-goals-appear.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed goal-enabled skills so their `/goal/*` commands appear and run correctly.

--- a/.mastracode/skills/gh-bulk-issues/SKILL.md
+++ b/.mastracode/skills/gh-bulk-issues/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: gh-bulk-issues
 description: Orchestrate parallel Mastra Code headless instances to debug and fix multiple GitHub issues simultaneously
-goal: true
+metadata:
+  goal: true
 ---
 
 # Bulk Issue Solver

--- a/.mastracode/skills/understand-issue/SKILL.md
+++ b/.mastracode/skills/understand-issue/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: understand-issue
 description: Collaboratively investigate a GitHub issue or bug — trace history, understand architecture, diagnose root cause
-goal: true
+metadata:
+  goal: true
 ---
 
 # Understand Issue

--- a/.mastracode/skills/understand-pr/SKILL.md
+++ b/.mastracode/skills/understand-pr/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: understand-pr
 description: Guided interactive PR review — understand the history and context before forming opinions
-goal: true
+metadata:
+  goal: true
 ---
 
 # Understand PR

--- a/mastracode/web/src/mastra/public/factory-skills/understand-issue/SKILL.md
+++ b/mastracode/web/src/mastra/public/factory-skills/understand-issue/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: understand-issue
 description: Collaboratively investigate a GitHub issue or bug — trace history, understand architecture, diagnose root cause
-goal: true
+metadata:
+  goal: true
 ---
 
 # Understand Issue

--- a/mastracode/web/src/mastra/public/factory-skills/understand-pr/SKILL.md
+++ b/mastracode/web/src/mastra/public/factory-skills/understand-pr/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: understand-pr
 description: Guided interactive PR review — understand the history and context before forming opinions
-goal: true
+metadata:
+  goal: true
 ---
 
 # Understand PR

--- a/mastracode/web/src/web/factory/workspace.test.ts
+++ b/mastracode/web/src/web/factory/workspace.test.ts
@@ -78,7 +78,9 @@ describe('getFactoryWorkspace', () => {
     expect(workspace.id).toContain('-web-factory');
     expect(understandIssue?.instructions).toContain('# Understand Issue');
     expect(understandIssue?.instructions).not.toContain('# Shadowed Project Skill');
+    expect(understandIssue?.metadata).toMatchObject({ goal: true });
     expect(understandPr?.instructions).toContain('# Understand PR');
+    expect(understandPr?.metadata).toMatchObject({ goal: true });
     expect(filesystem.allowedPaths).not.toContain('/__mastracode_factory_skills__');
     await expect(filesystem.writeFile(path.join(understandIssue!.path, 'SKILL.md'), 'mutated')).rejects.toMatchObject({
       name: 'PermissionError',


### PR DESCRIPTION
Goal-enabled skills migrated from slash commands were declaring `goal: true` at the top level, but the workspace skill loader only exposes values nested under `metadata`. As a result, commands such as `/goal/understand-pr` disappeared from current Mastra Code instances.

Before:

```yaml
goal: true
```

After:

```yaml
metadata:
  goal: true
```

This updates the project and packaged factory skills and adds regression coverage confirming the factory copies remain goal-enabled.

Validated with `pnpm build:mastracode`, the focused Web Factory test suite, Web typechecking, and a runtime skill-discovery check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra Code looks for a “goal” setting on certain skills so it can show commands like `/goal/understand-pr`. This PR fixes those skill files so the `goal: true` flag lives where the loader expects it (`metadata`), and adds tests to make sure goal commands keep working.

## Changes

- Updated multiple skill `SKILL.md` files to move `goal: true` from the top level into `metadata: { goal: true }` (project skills and packaged Web Factory skills).
- Strengthened `getFactoryWorkspace` regression tests to assert `metadata.goal === true` for packaged `understand-issue` and `understand-pr`.
- Added a Changeset entry for the `mastracode` package noting the goal-enabled skills fix.
- Validated via Mastra Code build, focused Web Factory tests, Web typechecking, and a runtime skill-discovery check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->