### PR TITLE
fix(inngest): give durable tool execution a tracing context — workspace/client-tool spans were skipped, tool spans duplicated

### DIFF
--- a/.changeset/inngest-tool-span-context.md
+++ b/.changeset/inngest-tool-span-context.md
@@ -1,0 +1,7 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixed durable tool execution on the Inngest engine running with no tracing context. Spans created inside tool execution — workspace `WORKSPACE_ACTION` filesystem spans, client-tool spans — were silently skipped, because the engine's `extract-tool-calls` map did not forward the LLM step's `stepSpanData` onto each tool call the way core's engine does. With the context forwarded, the tool builder creates the live `TOOL_CALL` span itself with execution-time children correctly nested, so the collect step's retroactive `TOOL_CALL` creation (which produced childless duplicate spans) was removed; its `tool-result` chunk spans and step-span bookkeeping are unchanged.
+
+Adds a cross-process regression test (real connect() worker) asserting exactly one `tool_call` span per tool and a `workspace_action` span nested under its `tool_call`.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8529,6 +8529,9 @@ importers:
       '@mastra/libsql':
         specifier: workspace:*
         version: link:../../stores/libsql
+      '@mastra/memory':
+        specifier: workspace:*
+        version: link:../../packages/memory
       '@mastra/observability':
         specifier: workspace:*
         version: link:../../observability/mastra

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -77,7 +77,8 @@
     "tsup": "^8.5.1",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@mastra/memory": "workspace:*"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.13.2-0 <2.0.0-0",

--- a/workflows/inngest/src/__tests__/durable-tool-span-tracing.test.ts
+++ b/workflows/inngest/src/__tests__/durable-tool-span-tracing.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Durable tool execution must carry a tracing context so spans created INSIDE tool
+ * execution — workspace WORKSPACE_ACTION filesystem spans, client-tool spans — nest
+ * under a live TOOL_CALL span, exactly like the non-durable agent.
+ *
+ * Previously the Inngest engine's extract-tool-calls map did not forward stepSpanData
+ * onto each tool call (core's engine does), so tools executed with no tracing context
+ * and their in-execution spans were silently skipped; the collect step then created
+ * retroactive, childless TOOL_CALL spans — duplicating the live ones once the context
+ * was supplied.
+ */
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DefaultStorage } from '@mastra/libsql';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 180_000, hookTimeout: 120_000 });
+
+const INNGEST_PORT = Number(process.env.XPROC_INNGEST_PORT ?? 4100);
+const AGENT_ID = 'tool-span-agent';
+const DB_PATH = `/tmp/mastra-tool-span-${Date.now()}.db`;
+const DB_URL = `file:${DB_PATH}`;
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const WORKER = path.join(here, 'fixtures', 'inngest-xproc-worker.ts');
+
+let worker: ChildProcess | undefined;
+
+function startWorker(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('npx', ['tsx', WORKER, DB_URL, AGENT_ID, String(INNGEST_PORT)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, INNGEST_DEV: '1', INNGEST_BASE_URL: `http://localhost:${INNGEST_PORT}` },
+    });
+    const timer = setTimeout(() => reject(new Error('worker did not become ready in 90s')), 90_000);
+    const onData = (buf: Buffer) => {
+      if (buf.toString().includes('[worker] ready')) {
+        clearTimeout(timer);
+        resolve(proc);
+      }
+    };
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+    proc.on('exit', code => {
+      clearTimeout(timer);
+      reject(new Error(`worker exited early with code ${code}`));
+    });
+  });
+}
+
+async function runTurn(prompt: string, threadId: string, resourceId: string) {
+  const { buildXprocTestAgent } = await import('./fixtures/inngest-xproc-agent');
+  const { durableAgent } = buildXprocTestAgent({
+    dbUrl: DB_URL,
+    agentId: AGENT_ID,
+    inngestPort: INNGEST_PORT,
+  });
+  const res = await durableAgent.stream([{ role: 'user', content: prompt }], {
+    memory: { thread: threadId, resource: resourceId },
+  });
+  void (async () => {
+    try {
+      for await (const _ of res.output.fullStream) {
+        /* consume */
+      }
+    } catch {
+      /* stream may tear down when the run finishes remotely */
+    } finally {
+      res.cleanup();
+    }
+  })();
+}
+
+describe('Inngest durable tool-execution tracing (cross-process worker)', () => {
+  beforeAll(async () => {
+    worker = await startWorker();
+    await new Promise(r => setTimeout(r, 3000));
+  });
+
+  afterAll(async () => {
+    worker?.kill('SIGTERM');
+    await new Promise(r => setTimeout(r, 500));
+    if (worker && !worker.killed) worker.kill('SIGKILL');
+  });
+
+  it('creates exactly one tool_call span per tool, with workspace_action nested under it', async () => {
+    const threadId = `thread-tools-${Date.now()}`;
+    const resourceId = `resource-tools-${Date.now()}`;
+    // The fixture model reacts to this prompt by calling `add` and `mastra_workspace_write_file`.
+    const prompt = 'Please use the tools: add 2 and 3, then write the result to result.txt.';
+
+    await runTurn(prompt, threadId, resourceId);
+    // NOTE: not waiting on persisted messages — on main they never persist (separate
+    // finish-side-effects bug). Fixed settle wait for the run to complete instead.
+    await new Promise(r => setTimeout(r, 15_000));
+
+    const storage = new DefaultStorage({ id: 'tool-span-reader', url: DB_URL });
+    const store: any = await storage.getStore('observability');
+
+    let spans: any[] = [];
+    for (let i = 0; i < 30; i++) {
+      try {
+        const { spans: roots } = (await store.listTraces({ pagination: { page: 0, perPage: 50 } })) ?? {};
+        for (const root of roots ?? []) {
+          const trace = await store.getTrace({ traceId: root.traceId });
+          const all = trace?.spans ?? [];
+          if (all.some((s: any) => s.spanType === 'tool_call')) {
+            spans = all;
+            break;
+          }
+        }
+        if (spans.length) break;
+      } catch {
+        /* tables appear on first export */
+      }
+      await new Promise(r => setTimeout(r, 1000));
+    }
+    expect(spans.length).toBeGreaterThan(0);
+
+    // FAILS on main (half 2, after forwarding stepSpanData): TWO tool_call spans per
+    // tool — one live (builder) + one retroactive childless duplicate (collect map).
+    const toolSpans = spans.filter((s: any) => s.spanType === 'tool_call');
+    expect(toolSpans.map((s: any) => s.name).sort()).toEqual(["tool: 'add'", "tool: 'mastra_workspace_write_file'"]);
+
+    // FAILS on main (half 1): no workspace_action span exists at all — the tool executed
+    // with no tracingContext, so startWorkspaceSpan() silently no-ops.
+    const wsAction = spans.find((s: any) => s.spanType === 'workspace_action');
+    expect(wsAction).toBeDefined();
+    const byId = new Map(spans.map((s: any) => [s.spanId, s]));
+    const wsParent = byId.get(wsAction.parentSpanId);
+    expect(wsParent?.spanType).toBe('tool_call');
+    expect(wsParent?.name).toBe("tool: 'mastra_workspace_write_file'");
+  });
+});

--- a/workflows/inngest/src/__tests__/fixtures/inngest-xproc-agent.ts
+++ b/workflows/inngest/src/__tests__/fixtures/inngest-xproc-agent.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared agent definition for the cross-process message-persistence test.
+ *
+ * Both the driver (test process, calls `stream()`) and the worker (separate process, executes the
+ * durable loop) build the SAME agent from this factory — mirroring production, where a web replica
+ * and a worker pool each construct the agent from the same code but keep their own in-memory
+ * `globalRunRegistry`.
+ *
+ * The model is deterministic and STATELESS: it replies `recall:yes` when any message in its prompt
+ * mentions "Zebra", else `recall:no`. Turn 1's user message contains the marker, so turn 2 (which
+ * doesn't) proves memory recall: the model can only see "Zebra" if turn-1 history was loaded.
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Agent } from '@mastra/core/agent';
+import { createScorer } from '@mastra/core/evals';
+import { Mastra } from '@mastra/core/mastra';
+import { createSkill } from '@mastra/core/skills';
+import { createTool } from '@mastra/core/tools';
+import { Workspace, LocalFilesystem } from '@mastra/core/workspace';
+import { DefaultStorage } from '@mastra/libsql';
+import { Memory } from '@mastra/memory';
+import { Observability, MastraStorageExporter } from '@mastra/observability';
+import { simulateReadableStream } from 'ai';
+import { Inngest } from 'inngest';
+import { z } from 'zod';
+
+import { createInngestAgent } from '../../durable-agent';
+import { createInngestDurableAgenticWorkflow } from '../../durable-agent/create-inngest-agentic-workflow';
+
+/**
+ * Prompt-scripted, STATELESS mock model (no per-process call counters — the driver and the
+ * connect worker each construct their own instance):
+ *
+ * - Prompt asks to "use the tools" and carries no tool results yet → emit two tool calls
+ *   (`add` and `mastra_workspace_write_file`), finishReason `tool-calls`.
+ * - Prompt asks to "use the tools" and already carries tool results → reply `tools:done`.
+ * - Otherwise: the recall probe — reply `recall:yes` iff the prompt contains "Zebra".
+ */
+function recallProbeModel(): any {
+  return {
+    specificationVersion: 'v2',
+    provider: 'mock',
+    modelId: 'mock-model',
+    supportedUrls: {},
+    // Thread-title generation uses generate (not stream).
+    async doGenerate() {
+      return {
+        content: [{ type: 'text', text: 'Test Thread Title' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+        warnings: [],
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+    },
+    async doStream(options: any) {
+      const promptText = JSON.stringify(options?.prompt ?? []);
+      const wantsTools = promptText.includes('use the tools');
+      const hasToolResults = promptText.includes('tool-result');
+
+      let chunks: any[];
+      if (wantsTools && !hasToolResults) {
+        chunks = [
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-t', modelId: 'mock-model', timestamp: new Date(0) },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-add',
+            toolName: 'add',
+            input: JSON.stringify({ a: 2, b: 3 }),
+            providerExecuted: false,
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-write',
+            toolName: 'mastra_workspace_write_file',
+            input: JSON.stringify({ path: 'result.txt', content: '5' }),
+            providerExecuted: false,
+          },
+          { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+        ];
+      } else {
+        const reply = wantsTools ? 'tools:done' : promptText.includes('Zebra') ? 'recall:yes' : 'recall:no';
+        chunks = [
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 't1' },
+          { type: 'text-delta', id: 't1', delta: reply },
+          { type: 'text-end', id: 't1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+        ];
+      }
+      return {
+        stream: simulateReadableStream({ chunks }),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+    },
+  };
+}
+
+/**
+ * Pass-through CUSTOM processor implementing all four span-producing phases. Exists purely
+ * so the span test can assert custom processors trace in the durable path exactly like the
+ * non-durable one: `input processor` (preparation), `input step processor` + `output step
+ * processor` (per LLM step, on the worker), `output processor` (finish, on the worker).
+ */
+export const customProbeProcessor: any = {
+  id: 'custom-probe',
+  processInput: async ({ messages }: any) => messages,
+  processInputStep: async () => undefined,
+  processOutputStep: async ({ messages }: any) => messages,
+  processOutputResult: async ({ messages }: any) => messages,
+};
+
+/** Trivial deterministic tool so the durable path exercises a real tool_call span. */
+const addTool = createTool({
+  id: 'add',
+  description: 'Add two numbers and return the sum.',
+  inputSchema: z.object({ a: z.number(), b: z.number() }),
+  outputSchema: z.object({ sum: z.number() }),
+  execute: async (input: any) => ({ sum: (input?.a ?? 0) + (input?.b ?? 0) }),
+});
+
+export function buildXprocTestAgent({
+  dbUrl,
+  agentId,
+  inngestPort,
+}: {
+  dbUrl: string;
+  agentId: string;
+  inngestPort: number;
+}) {
+  const inngest = new Inngest({ id: 'message-persistence-test', baseUrl: `http://localhost:${inngestPort}` });
+
+  const storage = new DefaultStorage({ id: `msg-persist-${agentId}`, url: dbUrl });
+
+  // Full agent surface so the span test covers every durable span source: a regular
+  // tool (tool_call), a workspace (workspace-instructions step processor + the
+  // mastra_workspace_* tools and their WORKSPACE_ACTION child spans), and an inline
+  // skill (skills-processor step processor).
+  const workspace = new Workspace({
+    id: `ws-${agentId}`,
+    name: 'Test Workspace',
+    filesystem: new LocalFilesystem({ basePath: mkdtempSync(path.join(tmpdir(), 'msg-persist-ws-')) }),
+  });
+
+  // Trivial deterministic scorer so the scorer-execution test can assert the durable
+  // engine runs configured scorers (fire-and-forget, scores persisted via storage).
+  const probeScorer = createScorer({
+    id: 'xproc-probe-scorer',
+    name: 'xprocProbeScorer',
+    description: 'Always scores 0.95 — presence of a persisted score proves execution.',
+  }).generateScore(() => 0.95);
+
+  const agent = new Agent({
+    id: agentId,
+    name: 'Message Persistence Agent',
+    instructions: 'Reply briefly.',
+    model: recallProbeModel(),
+    scorers: { probe: { scorer: probeScorer } },
+    // generateTitle exercises the cross-process thread-title path: the connect worker's
+    // finish step must rebuild agent + memory and generate/persist the title.
+    memory: new Memory({ storage, options: { generateTitle: true } }),
+    tools: { add: addTool },
+    inputProcessors: [customProbeProcessor],
+    outputProcessors: [customProbeProcessor],
+    workspace,
+    skills: [
+      createSkill({
+        name: 'test-skill',
+        description: 'A trivial skill so the skills-processor runs.',
+        instructions: '# Test Skill\n\nNo-op.',
+      }),
+    ],
+  });
+
+  const durableAgent = createInngestAgent({ agent, inngest });
+  const workflow = createInngestDurableAgenticWorkflow({ inngest });
+
+  const mastra = new Mastra({
+    storage,
+    scorers: { xprocProbeScorer: probeScorer } as any,
+    agents: { [agentId]: durableAgent } as any,
+    workflows: { [workflow.id]: workflow } as any,
+    // Storage-backed tracing so the span test can assert the durable span tree
+    // (agent_run root, parented processor/memory spans) from the shared sqlite db.
+    observability: new Observability({
+      configs: { default: { serviceName: 'msg-persist-test', exporters: [new MastraStorageExporter()] } },
+    }),
+  });
+
+  return { inngest, mastra, durableAgent, storage };
+}

--- a/workflows/inngest/src/__tests__/fixtures/inngest-xproc-worker.ts
+++ b/workflows/inngest/src/__tests__/fixtures/inngest-xproc-worker.ts
@@ -1,0 +1,28 @@
+/**
+ * Connect worker for the message-persistence test — runs in a SEPARATE process.
+ *
+ * With `@mastra/inngest` the durable agentic loop executes here, NOT in the process that called
+ * `stream()`. `globalRunRegistry` is process-local, so steps here start with an EMPTY registry —
+ * the condition that made finish-time memory persistence silently no-op.
+ *
+ * Usage: tsx inngest-xproc-worker.ts <dbUrl> <agentId> <inngestPort>
+ */
+import { connect } from '../../connect';
+import { buildXprocTestAgent } from './inngest-xproc-agent';
+
+const dbUrl = process.argv[2];
+const agentId = process.argv[3];
+const inngestPort = Number(process.argv[4] ?? 4100);
+
+if (!dbUrl || !agentId) {
+  console.error('[worker] usage: worker.ts <dbUrl> <agentId> [inngestPort]');
+  process.exit(1);
+}
+
+const { mastra, inngest } = buildXprocTestAgent({ dbUrl, agentId, inngestPort });
+
+await connect({ mastra, inngest });
+console.log('[worker] ready');
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/workflows/inngest/src/durable-agent/create-inngest-agentic-workflow.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agentic-workflow.ts
@@ -20,7 +20,7 @@ import type {
   DurableToolCallInput,
 } from '@mastra/core/agent/durable';
 import type { PubSub } from '@mastra/core/events';
-import { SpanType, EntityType, InternalSpans } from '@mastra/core/observability';
+import { SpanType, InternalSpans } from '@mastra/core/observability';
 import type { ExportedSpan } from '@mastra/core/observability';
 import { PUBSUB_SYMBOL } from '@mastra/core/workflows/_constants';
 import type { Inngest } from 'inngest';
@@ -161,11 +161,17 @@ export function createInngestDurableAgenticWorkflow(options: InngestDurableAgent
     )
     // Step 1: Execute LLM
     .then(llmExecutionStep)
-    // Step 2: Extract tool calls as array for foreach
+    // Step 2: Extract tool calls as array for foreach (forward model_step span for nesting).
+    // Without stepSpanData each tool executes with NO tracing context, so spans created
+    // INSIDE tool execution (workspace WORKSPACE_ACTION spans, client-tool spans) are
+    // silently skipped. Mirrors core's createDurableAgenticWorkflow.
     .map(
       async ({ inputData }) => {
         const llmOutput = inputData as DurableLLMStepOutput;
-        return (llmOutput.toolCalls ?? []) as DurableToolCallInput[];
+        return (llmOutput.toolCalls ?? []).map(toolCall => ({
+          ...toolCall,
+          stepSpanData: llmOutput.stepSpanData,
+        })) as DurableToolCallInput[];
       },
       { id: 'extract-tool-calls' },
     )
@@ -193,37 +199,19 @@ export function createInngestDurableAgenticWorkflow(options: InngestDurableAgent
         const llmOutput = getStepResult(llmExecutionStep.id) as DurableLLMStepOutput;
         const initData = getInitData() as IterationState;
 
-        // Create observability spans retroactively for each tool result
-        // In the foreach pattern, individual tool calls don't have access to
-        // the observability context, so we create spans here in the collection step
+        // TOOL_CALL spans are NOT created here: the tool-call step forwards the
+        // model_step span as each tool's tracing context (see extract-tool-calls),
+        // so the tool builder creates the live TOOL_CALL span itself — with
+        // execution-time children (workspace WORKSPACE_ACTION spans, client-tool
+        // spans) correctly nested, exactly like the non-durable agent. Creating a
+        // second, retroactive span here produced childless duplicates.
         const observability = mastra?.observability?.getSelectedInstance({});
-
-        const modelSpanData = (llmOutput as any)?.modelSpanData as ExportedSpan<SpanType.MODEL_GENERATION> | undefined;
         const stepSpanData = (llmOutput as any)?.stepSpanData as ExportedSpan<SpanType.MODEL_STEP> | undefined;
-
-        const modelSpan = modelSpanData ? observability?.rebuildSpan(modelSpanData) : undefined;
         const stepSpan = stepSpanData ? observability?.rebuildSpan(stepSpanData) : undefined;
-        const agentSpan = initData.agentSpanData ? observability?.rebuildSpan(initData.agentSpanData) : undefined;
-        const toolParentSpan = stepSpan ?? modelSpan ?? agentSpan;
 
-        // Create tool call + tool result spans for each tool result
+        // Create tool-result chunk spans as children of model_step (parity with the
+        // non-durable model-span tracker's chunk events).
         for (const tr of toolResults) {
-          const toolSpan = toolParentSpan?.createChildSpan({
-            type: SpanType.TOOL_CALL,
-            name: `tool: '${tr.toolName}'`,
-            entityType: EntityType.TOOL,
-            entityId: tr.toolName,
-            entityName: tr.toolName,
-            input: tr.args,
-          });
-
-          if (tr.error) {
-            toolSpan?.error({ error: new Error(tr.error.message) });
-          } else {
-            toolSpan?.end({ output: tr.result });
-          }
-
-          // Create tool-result chunk span as child of model_step
           if (!tr.error) {
             stepSpan?.createEventSpan({
               type: SpanType.MODEL_CHUNK,

--- a/workflows/inngest/tsconfig.build.json
+++ b/workflows/inngest/tsconfig.build.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts", "src/__tests__/**"]
 }


### PR DESCRIPTION
## Description

On the Inngest engine, durable tool execution runs with no tracing context. Anything a tool traces during execution — workspace `WORKSPACE_ACTION` filesystem spans (`workspace:filesystem:writeFile`, `workspace:skill:activate`), client-tool spans — is silently skipped, because `startWorkspaceSpan()` no-ops when `context.tracingContext?.currentSpan` is undefined. The visible symptom in the traces UI is workspace and skill operations simply missing from durable traces while the same agent shows them fine non-durably.

The cause is a one-line drift from core: `createDurableAgenticWorkflow`'s `extract-tool-calls` map forwards the LLM step's `stepSpanData` onto each tool call ("forward model_step span for nesting"), and `createDurableToolCallStep` rebuilds it into the tool's tracing context. The Inngest workflow's copy of that map returns `llmOutput.toolCalls` bare. Same engine-drift family as #19317, where the concurrency option was lost in the same copied workflow.

Forwarding the context surfaces a second problem: the collect step was creating `TOOL_CALL` spans retroactively ("individual tool calls don't have access to the observability context" — no longer true), so each tool call now produced two spans — the live one from the tool builder with its children correctly nested, and a childless retroactive duplicate. This PR removes the retroactive creation and keeps the collect step's `tool-result` chunk spans and step-span handling unchanged, which lands durable tool traces in exactly the non-durable shape: one `tool_call` per call, `workspace_action` nested under it.

The regression test runs a real connect worker (same harness as #19713), drives a turn where the model calls a regular tool and `mastra_workspace_write_file`, and asserts exactly one `tool_call` span per tool with the `workspace_action` span nested under its `tool_call`. Fails on `main` (no `workspace_action` span exists at all), passes with the fix.

Minimal repro: https://gist.github.com/devangpadhiyar/ff9d4df26a2611412c313797f60d42d1

## Related issue(s)

Fixes #19842

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Verified locally: the new cross-process test passes, inngest tsc and eslint clean. Independent of my other open durable PRs; the only shared files are byte-identical test fixtures, so merge order doesn't matter.
