### PR TITLE
fix(core,inngest): execute agent scorers on the Inngest durable engine

### DIFF
--- a/.changeset/inngest-execute-scorers.md
+++ b/.changeset/inngest-execute-scorers.md
@@ -1,0 +1,10 @@
+---
+'@mastra/core': patch
+'@mastra/inngest': patch
+---
+
+Fixed the Inngest durable engine never executing an agent's configured scorers. Core's `createDurableAgenticWorkflow` runs scorers in a post-finish `execute-scorers` step, but that step was never ported to `createInngestDurableAgenticWorkflow` — `initData.scorers` was serialized onto the workflow input and then silently ignored: no scorer runs, no persisted scores, no scorer spans.
+
+Scorer execution now lives in a shared `runDurableScorers` (exported from `@mastra/core/agent/durable`) used by both engines' post-finish steps. Scorers are serialized by name and resolved from the Mastra instance at execution time, so the step is cross-process safe by construction; scorer spans are parented under the run's rebuilt `AGENT_RUN` span rather than the terminal step's internal workflow span.
+
+Adds a cross-process regression test (real connect() worker) asserting a configured scorer executes after the run completes and its score is persisted.

--- a/packages/core/src/agent/durable/index.ts
+++ b/packages/core/src/agent/durable/index.ts
@@ -168,7 +168,7 @@ export {
 } from './utils/resolve-runtime';
 
 // Workflow creation
-export { createDurableAgenticWorkflow, type DurableAgenticWorkflowOptions } from './workflows';
+export { createDurableAgenticWorkflow, runDurableScorers, type DurableAgenticWorkflowOptions } from './workflows';
 
 // Workflow steps (for advanced customization)
 export {

--- a/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
+++ b/packages/core/src/agent/durable/workflows/create-durable-agentic-workflow.ts
@@ -1,6 +1,4 @@
 import { z } from 'zod';
-import type { MastraScorer, MastraScorerEntry } from '../../../evals/base';
-import { runScorer } from '../../../evals/hooks';
 import type { PubSub } from '../../../events/pubsub';
 import { pruneAgentLoopSnapshot } from '../../../loop/workflows/prune-snapshot';
 import type { Mastra } from '../../../mastra';
@@ -19,8 +17,8 @@ import type {
   DurableAgenticExecutionOutput,
   DurableLLMStepOutput,
   DurableToolCallOutput,
-  SerializableScorersConfig,
 } from '../types';
+import { runDurableScorers } from './run-scorers';
 import {
   modelConfigSchema,
   modelListEntrySchema,
@@ -775,106 +773,24 @@ export function createDurableAgenticWorkflow(options?: DurableAgenticWorkflowOpt
         },
         { id: 'map-final-output' },
       )
-      // Execute scorers (fire-and-forget, doesn't affect main result)
+      // Execute scorers (fire-and-forget, doesn't affect main result).
+      // Shared with the Inngest engine — scorers are serialized by name and
+      // resolved from the Mastra instance, so this is cross-process safe.
       .map(
         async params => {
           const { inputData, getInitData, mastra, requestContext, tracingContext } = params;
           const finalOutput = inputData;
           const initData = getInitData() as DurableAgenticWorkflowInput;
 
-          // If no scorers configured, skip
-          const scorers = initData.scorers as SerializableScorersConfig | undefined;
-          if (!scorers || Object.keys(scorers).length === 0) {
-            return finalOutput;
-          }
-
-          const logger = mastra?.getLogger?.();
-
-          // Reconstruct input MessageList to extract scorer input
-          const inputMessageList = new MessageList();
-          inputMessageList.deserialize(initData.messageListState);
-
-          // Build scorer input (messages before generation)
-          const scorerInput = {
-            inputMessages: inputMessageList.getPersisted.input.db(),
-            rememberedMessages: inputMessageList.getPersisted.remembered.db(),
-            systemMessages: inputMessageList.getSystemMessages(),
-            taggedSystemMessages: inputMessageList.getPersisted.taggedSystemMessages,
-          };
-
-          // Reconstruct output MessageList to extract scorer output
-          const outputMessageList = new MessageList();
-          outputMessageList.deserialize(finalOutput.messageListState);
-          const scorerOutput = outputMessageList.getPersisted.response.db();
-
-          // Create request context for scorer resolution
-          const resolveContext = requestContext ?? new RequestContext();
-
-          // Execute each scorer (fire-and-forget)
-          for (const [scorerKey, scorerEntry] of Object.entries(scorers)) {
-            const { scorerName, sampling } = scorerEntry;
-
-            try {
-              // Resolve the scorer from Mastra. We serialize scorers by name,
-              // and `getScorerById` searches by id-or-name without throwing
-              // on the common path, so try it first. Fall back to the
-              // registration-key-keyed `getScorer` for older configs.
-              let scorer: MastraScorer | undefined;
-              try {
-                scorer = (mastra as Mastra)?.getScorerById?.(scorerName) as MastraScorer | undefined;
-              } catch {
-                scorer = undefined;
-              }
-              if (!scorer) {
-                try {
-                  scorer = (mastra as Mastra)?.getScorer?.(scorerName) as MastraScorer | undefined;
-                } catch {
-                  scorer = undefined;
-                }
-              }
-
-              if (!scorer) {
-                logger?.warn?.(`Scorer ${scorerName} not found in Mastra, skipping`, {
-                  runId: initData.runId,
-                  scorerKey,
-                });
-                continue;
-              }
-
-              // Create the scorer entry expected by runScorer
-              const scorerObject: MastraScorerEntry = {
-                scorer,
-                sampling,
-              };
-
-              // Call runScorer (fire-and-forget via hooks)
-              runScorer({
-                runId: initData.runId,
-                scorerId: scorerKey,
-                scorerObject,
-                input: scorerInput,
-                output: scorerOutput,
-                requestContext: resolveContext as any,
-                entity: {
-                  id: initData.agentId,
-                  name: initData.agentName ?? initData.agentId,
-                },
-                structuredOutput: false,
-                source: 'LIVE',
-                entityType: 'AGENT',
-                threadId: initData.state?.threadId,
-                resourceId: initData.state?.resourceId,
-                ...createObservabilityContext(tracingContext),
-              });
-            } catch (error) {
-              // Log but don't fail - scorer errors shouldn't affect main execution
-              logger?.warn?.(`Error executing scorer ${scorerName}`, {
-                error,
-                runId: initData.runId,
-                scorerKey,
-              });
-            }
-          }
+          await runDurableScorers({
+            initData,
+            finalMessageListState: finalOutput.messageListState,
+            mastra: mastra as Mastra | undefined,
+            requestContext,
+            tracingContext,
+            agentSpanData: initData.agentSpanData as ExportedSpan<SpanType.AGENT_RUN> | undefined,
+            logger: mastra?.getLogger?.(),
+          });
 
           return finalOutput;
         },

--- a/packages/core/src/agent/durable/workflows/index.ts
+++ b/packages/core/src/agent/durable/workflows/index.ts
@@ -1,2 +1,3 @@
 export { createDurableAgenticWorkflow, type DurableAgenticWorkflowOptions } from './create-durable-agentic-workflow';
+export { runDurableScorers } from './run-scorers';
 export { createDurableLLMExecutionStep, createDurableToolCallStep, createDurableLLMMappingStep } from './steps';

--- a/packages/core/src/agent/durable/workflows/run-scorers.ts
+++ b/packages/core/src/agent/durable/workflows/run-scorers.ts
@@ -1,0 +1,139 @@
+import type { MastraScorer, MastraScorerEntry } from '../../../evals/base';
+import { runScorer } from '../../../evals/hooks';
+import type { Mastra } from '../../../mastra';
+import { createObservabilityContext } from '../../../observability';
+import type { ExportedSpan, SpanType, TracingContext } from '../../../observability';
+import { RequestContext } from '../../../request-context';
+import { MessageList } from '../../message-list';
+import type { DurableAgenticWorkflowInput, SerializableScorersConfig } from '../types';
+
+/**
+ * Execute the run's agent scorers (fire-and-forget) — the durable equivalent of the
+ * non-durable scorer hooks. Shared by both durable engines' post-finish step: scorers
+ * are serialized BY NAME on the workflow input and resolved from the Mastra instance,
+ * so this is cross-process safe by construction. Historically only core's
+ * `createDurableAgenticWorkflow` had this step — the Inngest engine finished runs
+ * without ever running scorers.
+ *
+ * Scorer spans are parented under the run's rebuilt AGENT_RUN (when `agentSpanData`
+ * is provided) for the same reason as the finish side effects: the terminal step's
+ * own tracing context is an internal workflow span that is never exported.
+ */
+export async function runDurableScorers({
+  initData,
+  finalMessageListState,
+  mastra,
+  requestContext,
+  tracingContext,
+  agentSpanData,
+  logger,
+}: {
+  initData: DurableAgenticWorkflowInput;
+  /** FINAL serialized MessageList state (the terminal iteration's). */
+  finalMessageListState: DurableAgenticWorkflowInput['messageListState'];
+  mastra?: Mastra;
+  requestContext?: RequestContext;
+  tracingContext?: TracingContext;
+  agentSpanData?: ExportedSpan<SpanType.AGENT_RUN>;
+  logger?: { warn?: (...args: any[]) => void };
+}): Promise<void> {
+  const scorers = initData.scorers as SerializableScorersConfig | undefined;
+  if (!scorers || Object.keys(scorers).length === 0) return;
+
+  // Parent scorer spans under the run's AGENT_RUN (same rebuild as the finish
+  // side effects; falls back to the step's tracingContext).
+  let effectiveTracingContext = tracingContext;
+  if (agentSpanData && mastra) {
+    try {
+      const observability = (mastra as any).observability?.getSelectedInstance?.({ requestContext });
+      const rebuiltAgentSpan = observability?.rebuildSpan?.(agentSpanData);
+      if (rebuiltAgentSpan) effectiveTracingContext = { currentSpan: rebuiltAgentSpan };
+    } catch {
+      /* fall back to the step's tracingContext */
+    }
+  }
+
+  // Reconstruct input MessageList to extract scorer input
+  const inputMessageList = new MessageList();
+  inputMessageList.deserialize(initData.messageListState);
+
+  // Build scorer input (messages before generation)
+  const scorerInput = {
+    inputMessages: inputMessageList.getPersisted.input.db(),
+    rememberedMessages: inputMessageList.getPersisted.remembered.db(),
+    systemMessages: inputMessageList.getSystemMessages(),
+    taggedSystemMessages: inputMessageList.getPersisted.taggedSystemMessages,
+  };
+
+  // Reconstruct output MessageList to extract scorer output
+  const outputMessageList = new MessageList();
+  outputMessageList.deserialize(finalMessageListState);
+  const scorerOutput = outputMessageList.getPersisted.response.db();
+
+  const resolveContext = requestContext ?? new RequestContext();
+
+  // Execute each scorer (fire-and-forget)
+  for (const [scorerKey, scorerEntry] of Object.entries(scorers)) {
+    const { scorerName, sampling } = scorerEntry;
+
+    try {
+      // Resolve the scorer from Mastra. We serialize scorers by name, and
+      // `getScorerById` searches by id-or-name without throwing on the common
+      // path, so try it first. Fall back to the registration-key-keyed
+      // `getScorer` for older configs.
+      let scorer: MastraScorer | undefined;
+      try {
+        scorer = (mastra as Mastra)?.getScorerById?.(scorerName) as MastraScorer | undefined;
+      } catch {
+        scorer = undefined;
+      }
+      if (!scorer) {
+        try {
+          scorer = (mastra as Mastra)?.getScorer?.(scorerName) as MastraScorer | undefined;
+        } catch {
+          scorer = undefined;
+        }
+      }
+      if (!scorer) {
+        logger?.warn?.(`Scorer ${scorerName} not found in Mastra, skipping`, {
+          runId: initData.runId,
+          scorerKey,
+        });
+        continue;
+      }
+
+      // Create the scorer entry expected by runScorer
+      const scorerObject: MastraScorerEntry = {
+        scorer,
+        sampling,
+      };
+
+      // Call runScorer (fire-and-forget via hooks)
+      runScorer({
+        runId: initData.runId,
+        scorerId: scorerKey,
+        scorerObject,
+        input: scorerInput,
+        output: scorerOutput,
+        requestContext: resolveContext as any,
+        entity: {
+          id: initData.agentId,
+          name: initData.agentName ?? initData.agentId,
+        },
+        structuredOutput: false,
+        source: 'LIVE',
+        entityType: 'AGENT',
+        threadId: initData.state?.threadId,
+        resourceId: initData.state?.resourceId,
+        ...createObservabilityContext(effectiveTracingContext),
+      });
+    } catch (error) {
+      // Log but don't fail - scorer errors shouldn't affect main execution
+      logger?.warn?.(`Error executing scorer ${scorerName}`, {
+        error,
+        runId: initData.runId,
+        scorerKey,
+      });
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8529,6 +8529,9 @@ importers:
       '@mastra/libsql':
         specifier: workspace:*
         version: link:../../stores/libsql
+      '@mastra/memory':
+        specifier: workspace:*
+        version: link:../../packages/memory
       '@mastra/observability':
         specifier: workspace:*
         version: link:../../observability/mastra

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -77,7 +77,8 @@
     "tsup": "^8.5.1",
     "typescript": "catalog:",
     "vitest": "catalog:",
-    "zod": "catalog:"
+    "zod": "catalog:",
+    "@mastra/memory": "workspace:*"
   },
   "peerDependencies": {
     "@mastra/core": ">=1.13.2-0 <2.0.0-0",

--- a/workflows/inngest/src/__tests__/durable-scorer-execution.test.ts
+++ b/workflows/inngest/src/__tests__/durable-scorer-execution.test.ts
@@ -1,0 +1,118 @@
+/**
+ * The Inngest durable engine must execute the agent's configured scorers after a run
+ * completes, exactly like core's durable engine and the non-durable agent.
+ *
+ * Previously the Inngest agentic workflow ended at `map-final-output` — the
+ * `execute-scorers` step from core's `createDurableAgenticWorkflow` was never ported,
+ * so `initData.scorers` was populated on the workflow input and then silently ignored:
+ * no scorer runs, no persisted scores, no scorer spans.
+ *
+ * Why a real connect() worker: scorer execution happens in the workflow's post-finish
+ * step on the worker; scorers are serialized by name and resolved from the Mastra
+ * instance there, so this exercises the cross-process resolution path end to end.
+ */
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { DefaultStorage } from '@mastra/libsql';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 180_000, hookTimeout: 120_000 });
+
+const INNGEST_PORT = Number(process.env.XPROC_INNGEST_PORT ?? 4100);
+const AGENT_ID = 'scorer-exec-agent';
+const DB_PATH = `/tmp/mastra-scorer-exec-${Date.now()}.db`;
+const DB_URL = `file:${DB_PATH}`;
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const WORKER = path.join(here, 'fixtures', 'inngest-xproc-worker.ts');
+
+let worker: ChildProcess | undefined;
+
+/** Start the connect worker and wait until it reports ready. */
+function startWorker(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('npx', ['tsx', WORKER, DB_URL, AGENT_ID, String(INNGEST_PORT)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, INNGEST_DEV: '1', INNGEST_BASE_URL: `http://localhost:${INNGEST_PORT}` },
+    });
+    const timer = setTimeout(() => reject(new Error('worker did not become ready in 90s')), 90_000);
+    const onData = (buf: Buffer) => {
+      if (buf.toString().includes('[worker] ready')) {
+        clearTimeout(timer);
+        resolve(proc);
+      }
+    };
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+    proc.on('exit', code => {
+      clearTimeout(timer);
+      reject(new Error(`worker exited early with code ${code}`));
+    });
+  });
+}
+
+describe('Inngest durable scorer execution (cross-process worker)', () => {
+  beforeAll(async () => {
+    worker = await startWorker();
+    // Give Inngest a moment to register the worker's functions.
+    await new Promise(r => setTimeout(r, 3000));
+  });
+
+  afterAll(async () => {
+    worker?.kill('SIGTERM');
+    await new Promise(r => setTimeout(r, 500));
+    if (worker && !worker.killed) worker.kill('SIGKILL');
+  });
+
+  it('runs configured scorers after the run completes and persists their scores', async () => {
+    const threadId = `thread-scorer-${Date.now()}`;
+    const resourceId = `resource-scorer-${Date.now()}`;
+
+    const { buildXprocTestAgent } = await import('./fixtures/inngest-xproc-agent');
+    const { durableAgent } = buildXprocTestAgent({
+      dbUrl: DB_URL,
+      agentId: AGENT_ID,
+      inngestPort: INNGEST_PORT,
+    });
+
+    const res = await durableAgent.stream([{ role: 'user', content: 'My name is Zebra. Remember it.' }], {
+      memory: { thread: threadId, resource: resourceId },
+    });
+    void (async () => {
+      try {
+        for await (const _ of res.output.fullStream) {
+          /* consume */
+        }
+      } catch {
+        /* stream may tear down when the run finishes remotely */
+      } finally {
+        res.cleanup();
+      }
+    })();
+
+    // Scorers are fire-and-forget after the finish event; poll the scores store the
+    // worker's hooks write to. The fixture's probe scorer always scores 0.95, so any
+    // persisted score for this agent proves the execute-scorers step ran.
+    const storage = new DefaultStorage({ id: 'scorer-reader', url: DB_URL });
+    const store: any = await storage.getStore('scores');
+    let scores: any[] = [];
+    for (let i = 0; i < 60 && !scores.length; i++) {
+      try {
+        const resp = await store.listScoresByEntityId({
+          entityId: AGENT_ID,
+          entityType: 'AGENT',
+          pagination: { page: 0, perPage: 10 },
+        });
+        scores = resp?.scores ?? [];
+      } catch {
+        /* tables appear on first write */
+      }
+      if (!scores.length) await new Promise(r => setTimeout(r, 1000));
+    }
+
+    expect(scores.length).toBeGreaterThan(0);
+    expect(scores[0].score).toBe(0.95);
+  });
+});

--- a/workflows/inngest/src/__tests__/fixtures/inngest-xproc-agent.ts
+++ b/workflows/inngest/src/__tests__/fixtures/inngest-xproc-agent.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared agent definition for the cross-process message-persistence test.
+ *
+ * Both the driver (test process, calls `stream()`) and the worker (separate process, executes the
+ * durable loop) build the SAME agent from this factory — mirroring production, where a web replica
+ * and a worker pool each construct the agent from the same code but keep their own in-memory
+ * `globalRunRegistry`.
+ *
+ * The model is deterministic and STATELESS: it replies `recall:yes` when any message in its prompt
+ * mentions "Zebra", else `recall:no`. Turn 1's user message contains the marker, so turn 2 (which
+ * doesn't) proves memory recall: the model can only see "Zebra" if turn-1 history was loaded.
+ */
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { Agent } from '@mastra/core/agent';
+import { createScorer } from '@mastra/core/evals';
+import { Mastra } from '@mastra/core/mastra';
+import { createSkill } from '@mastra/core/skills';
+import { createTool } from '@mastra/core/tools';
+import { Workspace, LocalFilesystem } from '@mastra/core/workspace';
+import { DefaultStorage } from '@mastra/libsql';
+import { Memory } from '@mastra/memory';
+import { Observability, MastraStorageExporter } from '@mastra/observability';
+import { simulateReadableStream } from 'ai';
+import { Inngest } from 'inngest';
+import { z } from 'zod';
+
+import { createInngestAgent } from '../../durable-agent';
+import { createInngestDurableAgenticWorkflow } from '../../durable-agent/create-inngest-agentic-workflow';
+
+/**
+ * Prompt-scripted, STATELESS mock model (no per-process call counters — the driver and the
+ * connect worker each construct their own instance):
+ *
+ * - Prompt asks to "use the tools" and carries no tool results yet → emit two tool calls
+ *   (`add` and `mastra_workspace_write_file`), finishReason `tool-calls`.
+ * - Prompt asks to "use the tools" and already carries tool results → reply `tools:done`.
+ * - Otherwise: the recall probe — reply `recall:yes` iff the prompt contains "Zebra".
+ */
+function recallProbeModel(): any {
+  return {
+    specificationVersion: 'v2',
+    provider: 'mock',
+    modelId: 'mock-model',
+    supportedUrls: {},
+    // Thread-title generation uses generate (not stream).
+    async doGenerate() {
+      return {
+        content: [{ type: 'text', text: 'Test Thread Title' }],
+        finishReason: 'stop',
+        usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+        warnings: [],
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+    },
+    async doStream(options: any) {
+      const promptText = JSON.stringify(options?.prompt ?? []);
+      const wantsTools = promptText.includes('use the tools');
+      const hasToolResults = promptText.includes('tool-result');
+
+      let chunks: any[];
+      if (wantsTools && !hasToolResults) {
+        chunks = [
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-t', modelId: 'mock-model', timestamp: new Date(0) },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-add',
+            toolName: 'add',
+            input: JSON.stringify({ a: 2, b: 3 }),
+            providerExecuted: false,
+          },
+          {
+            type: 'tool-call',
+            toolCallId: 'call-write',
+            toolName: 'mastra_workspace_write_file',
+            input: JSON.stringify({ path: 'result.txt', content: '5' }),
+            providerExecuted: false,
+          },
+          { type: 'finish', finishReason: 'tool-calls', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+        ];
+      } else {
+        const reply = wantsTools ? 'tools:done' : promptText.includes('Zebra') ? 'recall:yes' : 'recall:no';
+        chunks = [
+          { type: 'stream-start', warnings: [] },
+          { type: 'response-metadata', id: 'id-0', modelId: 'mock-model', timestamp: new Date(0) },
+          { type: 'text-start', id: 't1' },
+          { type: 'text-delta', id: 't1', delta: reply },
+          { type: 'text-end', id: 't1' },
+          { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+        ];
+      }
+      return {
+        stream: simulateReadableStream({ chunks }),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+    },
+  };
+}
+
+/**
+ * Pass-through CUSTOM processor implementing all four span-producing phases. Exists purely
+ * so the span test can assert custom processors trace in the durable path exactly like the
+ * non-durable one: `input processor` (preparation), `input step processor` + `output step
+ * processor` (per LLM step, on the worker), `output processor` (finish, on the worker).
+ */
+export const customProbeProcessor: any = {
+  id: 'custom-probe',
+  processInput: async ({ messages }: any) => messages,
+  processInputStep: async () => undefined,
+  processOutputStep: async ({ messages }: any) => messages,
+  processOutputResult: async ({ messages }: any) => messages,
+};
+
+/** Trivial deterministic tool so the durable path exercises a real tool_call span. */
+const addTool = createTool({
+  id: 'add',
+  description: 'Add two numbers and return the sum.',
+  inputSchema: z.object({ a: z.number(), b: z.number() }),
+  outputSchema: z.object({ sum: z.number() }),
+  execute: async (input: any) => ({ sum: (input?.a ?? 0) + (input?.b ?? 0) }),
+});
+
+export function buildXprocTestAgent({
+  dbUrl,
+  agentId,
+  inngestPort,
+}: {
+  dbUrl: string;
+  agentId: string;
+  inngestPort: number;
+}) {
+  const inngest = new Inngest({ id: 'message-persistence-test', baseUrl: `http://localhost:${inngestPort}` });
+
+  const storage = new DefaultStorage({ id: `msg-persist-${agentId}`, url: dbUrl });
+
+  // Full agent surface so the span test covers every durable span source: a regular
+  // tool (tool_call), a workspace (workspace-instructions step processor + the
+  // mastra_workspace_* tools and their WORKSPACE_ACTION child spans), and an inline
+  // skill (skills-processor step processor).
+  const workspace = new Workspace({
+    id: `ws-${agentId}`,
+    name: 'Test Workspace',
+    filesystem: new LocalFilesystem({ basePath: mkdtempSync(path.join(tmpdir(), 'msg-persist-ws-')) }),
+  });
+
+  // Trivial deterministic scorer so the scorer-execution test can assert the durable
+  // engine runs configured scorers (fire-and-forget, scores persisted via storage).
+  const probeScorer = createScorer({
+    id: 'xproc-probe-scorer',
+    name: 'xprocProbeScorer',
+    description: 'Always scores 0.95 — presence of a persisted score proves execution.',
+  }).generateScore(() => 0.95);
+
+  const agent = new Agent({
+    id: agentId,
+    name: 'Message Persistence Agent',
+    instructions: 'Reply briefly.',
+    model: recallProbeModel(),
+    scorers: { probe: { scorer: probeScorer } },
+    // generateTitle exercises the cross-process thread-title path: the connect worker's
+    // finish step must rebuild agent + memory and generate/persist the title.
+    memory: new Memory({ storage, options: { generateTitle: true } }),
+    tools: { add: addTool },
+    inputProcessors: [customProbeProcessor],
+    outputProcessors: [customProbeProcessor],
+    workspace,
+    skills: [
+      createSkill({
+        name: 'test-skill',
+        description: 'A trivial skill so the skills-processor runs.',
+        instructions: '# Test Skill\n\nNo-op.',
+      }),
+    ],
+  });
+
+  const durableAgent = createInngestAgent({ agent, inngest });
+  const workflow = createInngestDurableAgenticWorkflow({ inngest });
+
+  const mastra = new Mastra({
+    storage,
+    scorers: { xprocProbeScorer: probeScorer } as any,
+    agents: { [agentId]: durableAgent } as any,
+    workflows: { [workflow.id]: workflow } as any,
+    // Storage-backed tracing so the span test can assert the durable span tree
+    // (agent_run root, parented processor/memory spans) from the shared sqlite db.
+    observability: new Observability({
+      configs: { default: { serviceName: 'msg-persist-test', exporters: [new MastraStorageExporter()] } },
+    }),
+  });
+
+  return { inngest, mastra, durableAgent, storage };
+}

--- a/workflows/inngest/src/__tests__/fixtures/inngest-xproc-worker.ts
+++ b/workflows/inngest/src/__tests__/fixtures/inngest-xproc-worker.ts
@@ -1,0 +1,28 @@
+/**
+ * Connect worker for the message-persistence test — runs in a SEPARATE process.
+ *
+ * With `@mastra/inngest` the durable agentic loop executes here, NOT in the process that called
+ * `stream()`. `globalRunRegistry` is process-local, so steps here start with an EMPTY registry —
+ * the condition that made finish-time memory persistence silently no-op.
+ *
+ * Usage: tsx inngest-xproc-worker.ts <dbUrl> <agentId> <inngestPort>
+ */
+import { connect } from '../../connect';
+import { buildXprocTestAgent } from './inngest-xproc-agent';
+
+const dbUrl = process.argv[2];
+const agentId = process.argv[3];
+const inngestPort = Number(process.argv[4] ?? 4100);
+
+if (!dbUrl || !agentId) {
+  console.error('[worker] usage: worker.ts <dbUrl> <agentId> [inngestPort]');
+  process.exit(1);
+}
+
+const { mastra, inngest } = buildXprocTestAgent({ dbUrl, agentId, inngestPort });
+
+await connect({ mastra, inngest });
+console.log('[worker] ready');
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/workflows/inngest/src/durable-agent/create-inngest-agentic-workflow.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agentic-workflow.ts
@@ -11,6 +11,7 @@ import {
   baseIterationStateSchema,
   createBaseIterationStateUpdate,
   resolveDurableToolCallConcurrency,
+  runDurableScorers,
 } from '@mastra/core/agent/durable';
 import type {
   DurableAgenticExecutionOutput,
@@ -434,6 +435,31 @@ export function createInngestDurableAgenticWorkflow(options: InngestDurableAgent
           return finalOutput;
         },
         { id: 'map-final-output' },
+      )
+      // Execute scorers (fire-and-forget, doesn't affect main result). Shared with
+      // core's createDurableAgenticWorkflow — scorers are serialized by name and
+      // resolved from the Mastra instance, so this is cross-process safe. This step
+      // was missing from the Inngest engine entirely: runs finished without ever
+      // executing the agent's scorers.
+      .map(
+        async params => {
+          const { inputData, getInitData, mastra, requestContext, tracingContext } = params;
+          const finalOutput = inputData as { messageListState: DurableAgenticWorkflowInput['messageListState'] };
+          const initData = getInitData() as DurableAgenticWorkflowInput;
+
+          await runDurableScorers({
+            initData,
+            finalMessageListState: finalOutput.messageListState,
+            mastra,
+            requestContext,
+            tracingContext,
+            agentSpanData: initData.agentSpanData as ExportedSpan<SpanType.AGENT_RUN> | undefined,
+            logger: mastra?.getLogger?.(),
+          });
+
+          return finalOutput;
+        },
+        { id: 'execute-scorers' },
       )
       .commit()
   );

--- a/workflows/inngest/tsconfig.build.json
+++ b/workflows/inngest/tsconfig.build.json
@@ -5,5 +5,5 @@
     "rootDir": "./src"
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts"]
+  "exclude": ["node_modules", "**/*.test.ts", "src/**/*.mock.ts", "src/__tests__/**"]
 }


### PR DESCRIPTION
## Description

An agent with `scorers` configured never has them executed when it runs on the `@mastra/inngest` engine. The run completes normally, but there are no scorer runs, no persisted scores, and no scorer spans — silently. The same agent scores fine on core's durable engine and as a plain agent.

The step just doesn't exist on the Inngest path. Core's `createDurableAgenticWorkflow` runs scorers in a dedicated post-finish `execute-scorers` step; the Inngest workflow's copy ends at `map-final-output`, so `initData.scorers` is serialized onto the workflow input and then ignored. Same engine-drift family as #19317, where `toolCallConcurrency` was lost in the same copied workflow.

Notably the step is cross-process safe by construction — scorers are serialized *by name* on the workflow input (`SerializableScorersConfig`) and resolved from the Mastra instance at execution time via `getScorerById`/`getScorer` — so there was no registry or closure obstacle to porting it; it was simply never carried over.

This PR extracts core's scorer execution into a shared `runDurableScorers` (exported from `@mastra/core/agent/durable`) and wires it into both engines' post-finish steps. Core's behavior is unchanged — its inline block just moves into the shared function. One improvement while extracting: scorer spans are parented under the run's rebuilt `AGENT_RUN` span rather than the terminal step's tracing context, which on the durable path is an internal workflow span that never exports (the same orphaning mechanism I've hit elsewhere in the durable tracing).

The regression test registers a deterministic probe scorer (always 0.95) on the agent and the Mastra instance, drives a run through a real connect worker (same harness as #19713), and polls the scores store until the persisted score appears. Fails on `main` — nothing is ever written — and passes with the fix.

Minimal repro: https://gist.github.com/devangpadhiyar/6d28b95d5daa0aa2068ccdd0a018c8be

## Related issue(s)

Fixes #19843

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

Verified locally: the new cross-process test passes, core typecheck / inngest tsc / eslint all clean. Independent of my other open durable PRs — the only shared files are byte-identical test fixtures, so merge order doesn't matter.
