### PR TITLE
fix(core): honor tool request context from duplicate @mastra/core copies

### DIFF
--- a/.changeset/fix-tool-request-context-instanceof.md
+++ b/.changeset/fix-tool-request-context-instanceof.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed tool executions silently losing request context when a bundler or monorepo loads more than one copy of @mastra/core. Previously, a request context created by a different copy of the package was not recognized, so the tool received an empty context or the entries passed at execution time were dropped from the merge. Request context values now reach the tool regardless of which copy of the package created them. Closes #19772.

--- a/packages/core/src/tools/tool-builder/builder.test.ts
+++ b/packages/core/src/tools/tool-builder/builder.test.ts
@@ -769,4 +769,132 @@ describe('CoreToolBuilder requestContext merge', () => {
     // With no exec RC, closure RC is used directly
     expect(receivedCtx.requestContext!.get('controller')).toEqual({ controllerId: 'c-1' });
   });
+
+  // Same public API as RequestContext but a different prototype — simulates an
+  // RC constructed by a duplicate @mastra/core copy (bundlers, monorepos),
+  // where `instanceof RequestContext` is false (#19772).
+  class ForeignRequestContext {
+    private map = new Map<string, unknown>();
+    set(key: string, value: unknown) {
+      this.map.set(key, value);
+    }
+    get(key: string) {
+      return this.map.get(key);
+    }
+    has(key: string) {
+      return this.map.has(key);
+    }
+    entries() {
+      return this.map.entries();
+    }
+    size() {
+      return this.map.size;
+    }
+  }
+
+  it('uses a foreign-copy exec requestContext when no closure requestContext is provided', async () => {
+    const foreignRC = new ForeignRequestContext();
+    foreignRC.set('exec-key', 'exec-value');
+    expect(foreignRC instanceof RequestContext).toBe(false);
+
+    const receivedCtx: { requestContext?: RequestContext } = {};
+    const execute = vi.fn().mockImplementation((_args: unknown, ctx: any) => {
+      receivedCtx.requestContext = ctx.requestContext;
+      return { result: 'ok' };
+    });
+
+    const testTool = createTool({
+      id: 'test_tool',
+      description: 'Test',
+      inputSchema: z.object({}),
+      execute,
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'test_tool',
+        logger: noopLogger,
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({}, { toolCallId: 'call-1', messages: [], requestContext: foreignRC as any });
+
+    expect(receivedCtx.requestContext!.get('exec-key')).toBe('exec-value');
+  });
+
+  it('merges a foreign-copy exec requestContext with the closure requestContext', async () => {
+    const closureRC = new RequestContext();
+    closureRC.set('shared-key', 'from-closure');
+    closureRC.set('closure-only-key', 'closure-only');
+
+    const foreignRC = new ForeignRequestContext();
+    foreignRC.set('shared-key', 'from-exec');
+    foreignRC.set('exec-only-key', 42);
+    expect(foreignRC instanceof RequestContext).toBe(false);
+
+    const receivedCtx: { requestContext?: RequestContext } = {};
+    const execute = vi.fn().mockImplementation((_args: unknown, ctx: any) => {
+      receivedCtx.requestContext = ctx.requestContext;
+      return { result: 'ok' };
+    });
+
+    const testTool = createTool({
+      id: 'test_tool',
+      description: 'Test',
+      inputSchema: z.object({}),
+      execute,
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'test_tool',
+        logger: noopLogger,
+        requestContext: closureRC,
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({}, { toolCallId: 'call-1', messages: [], requestContext: foreignRC as any });
+
+    const merged = receivedCtx.requestContext!;
+    // Exec-only entries from the foreign copy are preserved
+    expect(merged.get('exec-only-key')).toBe(42);
+    // Closure value wins for shared keys (merge semantics unchanged)
+    expect(merged.get('shared-key')).toBe('from-closure');
+    expect(merged.get('closure-only-key')).toBe('closure-only');
+  });
+
+  it('passes a same-copy exec requestContext through by identity when no closure RC exists', async () => {
+    const execRC = new RequestContext();
+    execRC.set('exec-key', 'exec-value');
+
+    const receivedCtx: { requestContext?: RequestContext } = {};
+    const execute = vi.fn().mockImplementation((_args: unknown, ctx: any) => {
+      receivedCtx.requestContext = ctx.requestContext;
+      return { result: 'ok' };
+    });
+
+    const testTool = createTool({
+      id: 'test_tool',
+      description: 'Test',
+      inputSchema: z.object({}),
+      execute,
+    });
+
+    const builder = new CoreToolBuilder({
+      originalTool: testTool,
+      options: {
+        name: 'test_tool',
+        logger: noopLogger,
+      },
+    });
+
+    const builtTool = builder.build();
+    await builtTool.execute!({}, { toolCallId: 'call-1', messages: [], requestContext: execRC });
+
+    expect(receivedCtx.requestContext).toBe(execRC);
+  });
 });

--- a/packages/core/src/tools/tool-builder/builder.ts
+++ b/packages/core/src/tools/tool-builder/builder.ts
@@ -57,14 +57,30 @@ import { validateToolInput, validateToolOutput, validateToolSuspendData } from '
  * closure on top — keys that survived serialisation are preserved while
  * non-serializable keys from the closure (like `controller`) are restored.
  */
+/**
+ * Detect RequestContext-like objects structurally. We cannot use `instanceof`
+ * here because duplicate copies of @mastra/core may be loaded in the same
+ * process (bundlers, monorepos) and the prototype identity is not guaranteed.
+ */
+function isRequestContextLike(value: unknown): value is RequestContext {
+  if (!value || typeof value !== 'object') return false;
+  const rc = value as RequestContext;
+  return (
+    typeof rc.get === 'function' &&
+    typeof rc.set === 'function' &&
+    typeof rc.entries === 'function' &&
+    typeof rc.size === 'function'
+  );
+}
+
 function mergeRequestContexts(
   closureRC: RequestContext | undefined,
   execRC: RequestContext | undefined,
 ): RequestContext {
   if (closureRC && closureRC === execRC) return closureRC;
   if (!closureRC && !execRC) return new RequestContext();
-  if (!closureRC) return execRC instanceof RequestContext ? execRC : new RequestContext();
-  if (!execRC || !(execRC instanceof RequestContext) || execRC.size() === 0) return closureRC;
+  if (!closureRC) return isRequestContextLike(execRC) ? execRC : new RequestContext();
+  if (!execRC || !isRequestContextLike(execRC) || execRC.size() === 0) return closureRC;
 
   const merged = new RequestContext();
   // Start with the evented engine's serialised snapshot


### PR DESCRIPTION
Closes #19772.

## Problem

`mergeRequestContexts` in `packages/core/src/tools/tool-builder/builder.ts` gated the execution-time request context behind `instanceof RequestContext`:

```ts
if (!closureRC) return execRC instanceof RequestContext ? execRC : new RequestContext();
if (!execRC || !(execRC instanceof RequestContext) || execRC.size() === 0) return closureRC;
```

When a bundler or monorepo loads more than one copy of `@mastra/core`, a request context constructed by the other copy has a different prototype, so `instanceof` is false for a perfectly valid context. The result: with no closure context the tool silently received an empty `RequestContext`, and with a closure context present the execution-time entries were silently dropped from the merge.

## Fix

Detect request contexts structurally (`get`/`set`/`entries`/`size` methods) via an `isRequestContextLike` type guard. This mirrors the established pattern in the same file: `isZodV4Schema` exists precisely because "both Zod versions may be loaded in the same process and the prototype identity is not guaranteed" — the identical hazard, one dependency over.

Merge semantics are unchanged: closure values still win on conflicts, exec-first seeding is preserved, and the same-instance fast path still returns by identity.

## Tests

Three additions to the existing `CoreToolBuilder requestContext merge` describe block, using a `ForeignRequestContext` double (same public API, different prototype — `instanceof` asserted false):

- foreign exec context with no closure context: entries now reach the tool (previously an empty context was substituted),
- foreign exec context merged with a closure context: exec-only entries preserved, closure still wins shared keys,
- same-copy exec context passes through by identity (pins the fast path).

Both foreign-copy tests fail on `main` and pass with the fix; the full file is green (23 passed).

## Scope

Fixes recognition of request contexts from duplicate `@mastra/core` copies at the tool-execution merge boundary only; no other `instanceof` sites are touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Sometimes the app has two copies of the same toolkit, so valid request information looked unfamiliar and got lost. This change recognizes request contexts by their behavior instead of their origin, ensuring that information reaches tools correctly.

## Changes

- Updated `mergeRequestContexts` to detect request-context-like objects structurally.
- Preserved existing merge behavior:
  - Closure values override execution-context values.
  - Execution-only entries are retained.
  - Same-copy contexts preserve identity through the fast path.
- Added regression tests for duplicate-module contexts, merging behavior, and identity preservation.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->