### PR TITLE
fix(datasets): persist review comments on experiment results

### DIFF
--- a/.changeset/afraid-walls-lick.md
+++ b/.changeset/afraid-walls-lick.md
@@ -1,0 +1,12 @@
+---
+'@mastra/client-js': patch
+'@mastra/server': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Fixed review comments on experiment results not being saved. Comments written in the Studio review tab were lost on reload because there was no comment column on experiment results. Experiment results now have a persisted comment field, and updateExperimentResult accepts a comment alongside status and tags. Fixes https://github.com/mastra-ai/mastra/issues/19857

--- a/.changeset/afraid-walls-lick.md
+++ b/.changeset/afraid-walls-lick.md
@@ -1,12 +1,5 @@
 ---
-'@mastra/client-js': patch
-'@mastra/server': patch
-'@mastra/mongodb': patch
-'@mastra/spanner': patch
 '@mastra/core': patch
-'@mastra/libsql': patch
-'@mastra/mysql': patch
-'@mastra/pg': patch
 ---
 
 Fixed review comments on experiment results not being saved. Comments written in the Studio review tab were lost on reload because there was no comment column on experiment results. Experiment results now have a persisted comment field, and updateExperimentResult accepts a comment alongside status and tags. Fixes https://github.com/mastra-ai/mastra/issues/19857

--- a/.changeset/afraid-walls-lick.md
+++ b/.changeset/afraid-walls-lick.md
@@ -2,4 +2,13 @@
 '@mastra/core': patch
 ---
 
-Fixed review comments on experiment results not being saved. Comments written in the Studio review tab were lost on reload because there was no comment column on experiment results. Experiment results now have a persisted comment field, and updateExperimentResult accepts a comment alongside status and tags. Fixes https://github.com/mastra-ai/mastra/issues/19857
+Fixed review comments on experiment results not being saved. Experiment results now have a persisted comment field, and updateExperimentResult accepts a comment alongside status and tags. Fixes https://github.com/mastra-ai/mastra/issues/19857
+
+```ts
+const experimentsStore = await storage.getStore('experiments');
+await experimentsStore.updateExperimentResult({
+  id: resultId,
+  experimentId,
+  comment: 'Agent hallucinated an API that does not exist',
+});
+```

--- a/.changeset/better-cats-move.md
+++ b/.changeset/better-cats-move.md
@@ -1,12 +1,9 @@
 ---
-'@mastra/client-js': patch
-'@mastra/server': patch
-'@mastra/mongodb': patch
-'@mastra/spanner': patch
-'@mastra/core': patch
+'@mastra/pg': patch
 '@mastra/libsql': patch
 '@mastra/mysql': patch
-'@mastra/pg': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
 ---
 
 Added a comment column to experiment results so review comments persist. The column is added automatically and non-destructively on startup for existing databases (https://github.com/mastra-ai/mastra/issues/19857).

--- a/.changeset/better-cats-move.md
+++ b/.changeset/better-cats-move.md
@@ -1,0 +1,12 @@
+---
+'@mastra/client-js': patch
+'@mastra/server': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Added a comment column to experiment results so review comments persist. The column is added automatically and non-destructively on startup for existing databases (https://github.com/mastra-ai/mastra/issues/19857).

--- a/.changeset/cyan-bees-fold.md
+++ b/.changeset/cyan-bees-fold.md
@@ -1,0 +1,12 @@
+---
+'@mastra/client-js': patch
+'@mastra/server': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+---
+
+Added comment support to the experiment result API. The PATCH experiment result endpoint and the client updateDatasetExperimentResult method now accept and return a comment field, so review comments persist server-side instead of being lost on reload (https://github.com/mastra-ai/mastra/issues/19857).

--- a/.changeset/cyan-bees-fold.md
+++ b/.changeset/cyan-bees-fold.md
@@ -4,3 +4,12 @@
 ---
 
 Added comment support to the experiment result API. The PATCH experiment result endpoint and the client updateDatasetExperimentResult method now accept and return a comment field, so review comments persist server-side instead of being lost on reload (https://github.com/mastra-ai/mastra/issues/19857).
+
+```ts
+const result = await client.updateDatasetExperimentResult({
+  datasetId,
+  experimentId,
+  resultId,
+  comment: 'Agent hallucinated an API that does not exist',
+});
+```

--- a/.changeset/cyan-bees-fold.md
+++ b/.changeset/cyan-bees-fold.md
@@ -1,12 +1,6 @@
 ---
-'@mastra/client-js': patch
 '@mastra/server': patch
-'@mastra/mongodb': patch
-'@mastra/spanner': patch
-'@mastra/core': patch
-'@mastra/libsql': patch
-'@mastra/mysql': patch
-'@mastra/pg': patch
+'@mastra/client-js': patch
 ---
 
 Added comment support to the experiment result API. The PATCH experiment result endpoint and the client updateDatasetExperimentResult method now accept and return a comment field, so review comments persist server-side instead of being lost on reload (https://github.com/mastra-ai/mastra/issues/19857).

--- a/.changeset/shaggy-plants-guess.md
+++ b/.changeset/shaggy-plants-guess.md
@@ -1,5 +1,5 @@
 ---
-'mastra': patch
+'@internal/playground': patch
 ---
 
 Fixed the Studio review tab losing comments on reload. Comments on experiment results are now saved to the database like tags, in both the dataset review view and the agent review queue (https://github.com/mastra-ai/mastra/issues/19857).

--- a/.changeset/shaggy-plants-guess.md
+++ b/.changeset/shaggy-plants-guess.md
@@ -1,0 +1,13 @@
+---
+'@mastra/client-js': patch
+'@mastra/server': patch
+'@mastra/mongodb': patch
+'@mastra/spanner': patch
+'@mastra/core': patch
+'@mastra/libsql': patch
+'@mastra/mysql': patch
+'@mastra/pg': patch
+'mastra': patch
+---
+
+Fixed the Studio review tab losing comments on reload. Comments on experiment results are now saved to the database like tags, in both the dataset review view and the agent review queue (https://github.com/mastra-ai/mastra/issues/19857).

--- a/.changeset/shaggy-plants-guess.md
+++ b/.changeset/shaggy-plants-guess.md
@@ -1,12 +1,4 @@
 ---
-'@mastra/client-js': patch
-'@mastra/server': patch
-'@mastra/mongodb': patch
-'@mastra/spanner': patch
-'@mastra/core': patch
-'@mastra/libsql': patch
-'@mastra/mysql': patch
-'@mastra/pg': patch
 'mastra': patch
 ---
 

--- a/client-sdks/client-js/src/client.ts
+++ b/client-sdks/client-js/src/client.ts
@@ -2060,7 +2060,7 @@ export class MastraClient extends BaseResource {
   }
 
   /**
-   * Updates an experiment result's status and/or tags
+   * Updates an experiment result's status, tags, and/or comment
    */
   public updateDatasetExperimentResult(params: UpdateExperimentResultParams): Promise<DatasetExperimentResult> {
     const { datasetId, experimentId, resultId, ...body } = params;
@@ -2111,7 +2111,7 @@ export class MastraClient extends BaseResource {
   }
 
   /**
-   * Updates the status and/or tags on an experiment result
+   * Updates the status, tags, and/or comment on an experiment result
    */
   public updateExperimentResult(params: UpdateExperimentResultParams): Promise<DatasetExperimentResult> {
     const { datasetId, experimentId, resultId, ...body } = params;

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -2964,6 +2964,7 @@ type Shared_Type_134 = {
   traceId: string | null;
   status?: (('needs-review' | 'reviewed' | 'complete') | null) | undefined;
   tags?: (string[] | null) | undefined;
+  comment?: (string | null) | undefined;
   /** Diagnostic receipt for item-level tool mocks */
   toolMockReport?: (Shared_Type_133 | undefined) | null;
   createdAt: Date;
@@ -17617,6 +17618,7 @@ export type PatchDatasetsDatasetIdExperimentsExperimentIdResultsResultId_PathPar
 export type PatchDatasetsDatasetIdExperimentsExperimentIdResultsResultId_Body = {
   status?: (('needs-review' | 'reviewed' | 'complete') | null) | undefined;
   tags?: string[] | undefined;
+  comment?: (string | null) | undefined;
 };
 
 export type PatchDatasetsDatasetIdExperimentsExperimentIdResultsResultId_Response = Shared_Type_134;

--- a/client-sdks/client-js/src/types.ts
+++ b/client-sdks/client-js/src/types.ts
@@ -2678,6 +2678,7 @@ export interface DatasetExperimentResult {
   traceId: string | null;
   status: 'needs-review' | 'reviewed' | 'complete' | null;
   tags: string[] | null;
+  comment?: string | null;
   toolMockReport?: ToolMockReport | null;
   scores: Array<{
     scorerId: string;
@@ -2695,6 +2696,7 @@ export interface UpdateExperimentResultParams {
   resultId: string;
   status?: 'needs-review' | 'reviewed' | 'complete' | null;
   tags?: string[];
+  comment?: string | null;
 }
 
 export interface CreateDatasetParams {

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -5148,6 +5148,7 @@ export const API_ROUTE_METADATA = {
     ],
     "queryParams": [],
     "bodyParams": [
+      "comment",
       "status",
       "tags"
     ],

--- a/packages/core/src/storage/constants.ts
+++ b/packages/core/src/storage/constants.ts
@@ -606,6 +606,7 @@ export const EXPERIMENT_RESULTS_SCHEMA: Record<string, StorageColumn> = {
   traceId: { type: 'text', nullable: true },
   status: { type: 'text', nullable: true },
   tags: { type: 'jsonb', nullable: true },
+  comment: { type: 'text', nullable: true },
   toolMockReport: { type: 'jsonb', nullable: true },
   organizationId: { type: 'text', nullable: true },
   projectId: { type: 'text', nullable: true },

--- a/packages/core/src/storage/domains/experiments/inmemory.ts
+++ b/packages/core/src/storage/domains/experiments/inmemory.ts
@@ -177,6 +177,7 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       traceId: input.traceId ?? null,
       status: input.status ?? null,
       tags: input.tags ?? null,
+      comment: null,
       toolMockReport: input.toolMockReport ?? null,
       organizationId: input.organizationId ?? null,
       projectId: input.projectId ?? null,
@@ -198,6 +199,7 @@ export class ExperimentsInMemory extends ExperimentsStorage {
       ...existing,
       status: input.status !== undefined ? input.status : existing.status,
       tags: input.tags !== undefined ? input.tags : existing.tags,
+      comment: input.comment !== undefined ? input.comment : existing.comment,
     };
     this.db.experimentResults.set(input.id, updated);
     return updated;

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -2783,6 +2783,7 @@ export interface ExperimentResult {
   traceId: string | null;
   status: ExperimentResultStatus | null;
   tags: string[] | null;
+  comment?: string | null;
   toolMockReport?: DatasetToolMockReport | null;
   /** Multi-tenant organization/account scope. Denormalized from the parent experiment for efficient tenancy-scoped queries. */
   organizationId?: string | null;
@@ -2797,6 +2798,7 @@ export interface UpdateExperimentResultInput {
   experimentId?: string;
   status?: ExperimentResultStatus | null;
   tags?: string[] | null;
+  comment?: string | null;
 }
 
 export interface CreateExperimentInput {

--- a/packages/playground/src/domains/agents/context/review-queue-context.tsx
+++ b/packages/playground/src/domains/agents/context/review-queue-context.tsx
@@ -198,7 +198,16 @@ export function ReviewQueueProvider({ children }: { children: ReactNode }) {
   const commentItem = useCallback(
     (id: string, comment: string) => {
       const item = items.find(i => i.id === id);
-      // Persist comment via feedback API if we have a traceId
+      if (item?.experimentId && item?.datasetId) {
+        // Persist comment on the experiment result so it survives reloads
+        updateExperimentResult.mutate({
+          datasetId: item.datasetId,
+          experimentId: item.experimentId,
+          resultId: item.id,
+          comment,
+        });
+      }
+      // Also record the comment via feedback API if we have a traceId
       if (item?.traceId) {
         client
           .createFeedback({
@@ -219,7 +228,7 @@ export function ReviewQueueProvider({ children }: { children: ReactNode }) {
       }
       setItems(prev => prev.map(i => (i.id === id ? { ...i, comment } : i)));
     },
-    [items, client],
+    [items, client, updateExperimentResult],
   );
 
   const assignCluster = useCallback((itemId: string, clusterId: string) => {

--- a/packages/playground/src/domains/agents/hooks/use-completed-items.ts
+++ b/packages/playground/src/domains/agents/hooks/use-completed-items.ts
@@ -32,7 +32,7 @@ export const useCompletedItems = (agentId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: r.comment ?? '',
               }));
           } catch {
             return [];

--- a/packages/playground/src/domains/agents/hooks/use-review-items.ts
+++ b/packages/playground/src/domains/agents/hooks/use-review-items.ts
@@ -33,7 +33,7 @@ export const useReviewItems = (agentId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: r.comment ?? '',
               }));
           } catch {
             return [];

--- a/packages/playground/src/domains/review/components/dataset-review.tsx
+++ b/packages/playground/src/domains/review/components/dataset-review.tsx
@@ -215,6 +215,14 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
   const commentItem = useCallback(
     (itemId: string, comment: string) => {
       const item = items.find(i => i.id === itemId);
+      if (item?.experimentId && item?.datasetId) {
+        updateExperimentResult.mutate({
+          datasetId: item.datasetId,
+          experimentId: item.experimentId,
+          resultId: item.id,
+          comment,
+        });
+      }
       if (item?.traceId) {
         client
           .createFeedback({
@@ -233,7 +241,7 @@ export function DatasetReview({ datasetId, experimentId, featuredItemId: feature
       }
       setLocalItems(prev => (prev ?? []).map(i => (i.id === itemId ? { ...i, comment } : i)));
     },
-    [items, client],
+    [items, client, updateExperimentResult],
   );
 
   const removeItem = useCallback(

--- a/packages/playground/src/domains/review/hooks/__tests__/fixtures/dataset-review-items.ts
+++ b/packages/playground/src/domains/review/hooks/__tests__/fixtures/dataset-review-items.ts
@@ -1,0 +1,65 @@
+import type { DatasetExperiment, DatasetExperimentResult } from '@mastra/client-js';
+import type { PaginationInfo } from '@mastra/core/storage';
+
+export const DATASET_ID = 'ds-1';
+export const EXPERIMENT_ID = 'exp-1';
+export const RESULT_ID = 'result-1';
+
+const pagination: PaginationInfo = {
+  total: 1,
+  page: 0,
+  perPage: 100,
+  hasMore: false,
+};
+
+const experiment: DatasetExperiment = {
+  id: EXPERIMENT_ID,
+  datasetId: DATASET_ID,
+  datasetVersion: 1,
+  agentVersion: null,
+  targetType: 'agent',
+  targetId: 'agent-1',
+  status: 'completed',
+  totalItems: 1,
+  succeededCount: 1,
+  failedCount: 0,
+  startedAt: '2026-07-21T00:00:00.000Z',
+  completedAt: '2026-07-21T00:01:00.000Z',
+  createdAt: '2026-07-21T00:00:00.000Z',
+  updatedAt: '2026-07-21T00:01:00.000Z',
+};
+
+export const experimentsResponse: { experiments: DatasetExperiment[]; pagination: PaginationInfo } = {
+  experiments: [experiment],
+  pagination,
+};
+
+export const needsReviewResultWithComment: DatasetExperimentResult = {
+  id: RESULT_ID,
+  experimentId: EXPERIMENT_ID,
+  itemId: 'item-1',
+  itemDatasetVersion: 1,
+  input: { q: 'hello' },
+  output: { a: 'world' },
+  groundTruth: null,
+  error: null,
+  startedAt: '2026-07-21T00:00:10.000Z',
+  completedAt: '2026-07-21T00:00:20.000Z',
+  retryCount: 0,
+  traceId: null,
+  status: 'needs-review',
+  tags: ['hallucination'],
+  comment: 'The agent ignored the second question',
+  scores: [],
+  createdAt: '2026-07-21T00:00:20.000Z',
+};
+
+export const resultsResponse: { results: DatasetExperimentResult[]; pagination: PaginationInfo } = {
+  results: [needsReviewResultWithComment],
+  pagination,
+};
+
+export const updatedResultResponse = (comment: string | null): DatasetExperimentResult => ({
+  ...needsReviewResultWithComment,
+  comment,
+});

--- a/packages/playground/src/domains/review/hooks/__tests__/use-dataset-review-items.msw.test.tsx
+++ b/packages/playground/src/domains/review/hooks/__tests__/use-dataset-review-items.msw.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import type { UpdateExperimentResultParams } from '@mastra/client-js';
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
+import { useDatasetReviewItems } from '../use-dataset-review-items';
+import {
+  DATASET_ID,
+  EXPERIMENT_ID,
+  RESULT_ID,
+  experimentsResponse,
+  resultsResponse,
+  updatedResultResponse,
+} from './fixtures/dataset-review-items';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+const makeWrapper = () => {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) => (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+};
+
+afterEach(() => cleanup());
+
+describe('useDatasetReviewItems', () => {
+  it('hydrates the persisted comment (and tags) from the experiment result', async () => {
+    server.use(
+      http.get(`${BASE_URL}/api/datasets/${DATASET_ID}/experiments`, () => HttpResponse.json(experimentsResponse)),
+      http.get(`${BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results`, () =>
+        HttpResponse.json(resultsResponse),
+      ),
+    );
+
+    const { result } = renderHook(() => useDatasetReviewItems(DATASET_ID), { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.data).toHaveLength(1);
+    });
+
+    const item = result.current.data![0];
+    expect(item.id).toBe(RESULT_ID);
+    expect(item.tags).toEqual(['hallucination']);
+    // Regression guard for #19857: the comment used to be hardcoded to ''
+    // on rehydrate, wiping saved comments on every reload.
+    expect(item.comment).toBe('The agent ignored the second question');
+  });
+});
+
+describe('useDatasetMutations().updateExperimentResult', () => {
+  it('sends the comment in the PATCH body so it persists server-side', async () => {
+    const onPatch = vi.fn<(body: unknown) => void>();
+    server.use(
+      http.patch(
+        `${BASE_URL}/api/datasets/${DATASET_ID}/experiments/${EXPERIMENT_ID}/results/${RESULT_ID}`,
+        async ({ request }) => {
+          const body = await request.json();
+          onPatch(body);
+          return HttpResponse.json(updatedResultResponse('a fresh note'));
+        },
+      ),
+    );
+
+    const { result } = renderHook(() => useDatasetMutations(), { wrapper: makeWrapper() });
+
+    const params: UpdateExperimentResultParams = {
+      datasetId: DATASET_ID,
+      experimentId: EXPERIMENT_ID,
+      resultId: RESULT_ID,
+      comment: 'a fresh note',
+    };
+    const updated = await result.current.updateExperimentResult.mutateAsync(params);
+
+    expect(onPatch).toHaveBeenCalledWith({ comment: 'a fresh note' });
+    expect(updated.comment).toBe('a fresh note');
+  });
+});

--- a/packages/playground/src/domains/review/hooks/__tests__/use-dataset-review-items.msw.test.tsx
+++ b/packages/playground/src/domains/review/hooks/__tests__/use-dataset-review-items.msw.test.tsx
@@ -7,7 +7,6 @@ import { http, HttpResponse } from 'msw';
 import type { ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { useDatasetReviewItems } from '../use-dataset-review-items';
 import {
   DATASET_ID,
@@ -17,6 +16,7 @@ import {
   resultsResponse,
   updatedResultResponse,
 } from './fixtures/dataset-review-items';
+import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';

--- a/packages/playground/src/domains/review/hooks/use-dataset-review-items.ts
+++ b/packages/playground/src/domains/review/hooks/use-dataset-review-items.ts
@@ -34,7 +34,7 @@ export const useDatasetReviewItems = (datasetId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: r.comment ?? '',
               }));
           } catch {
             return [];
@@ -80,7 +80,7 @@ export const useDatasetCompletedItems = (datasetId: string) => {
                 traceId: r.traceId ?? undefined,
                 scores: r.scores ? Object.fromEntries(r.scores.map(s => [s.scorerId, s.score ?? 0])) : {},
                 tags: r.tags ?? [],
-                comment: '',
+                comment: r.comment ?? '',
               }));
           } catch {
             return [];

--- a/packages/server/src/server/handlers/datasets.ts
+++ b/packages/server/src/server/handlers/datasets.ts
@@ -790,7 +790,7 @@ export const UPDATE_EXPERIMENT_RESULT_ROUTE = createRoute({
   bodySchema: updateExperimentResultBodySchema,
   responseSchema: experimentResultResponseSchema,
   summary: 'Update an experiment result',
-  description: 'Updates the status and/or tags on an experiment result',
+  description: 'Updates the status, tags, and/or comment on an experiment result',
   tags: ['Datasets'],
   requiresAuth: true,
   handler: async ({ mastra, resultId, experimentId, ...params }) => {
@@ -810,6 +810,7 @@ export const UPDATE_EXPERIMENT_RESULT_ROUTE = createRoute({
         experimentId,
         status: params.status,
         tags: params.tags,
+        comment: params.comment,
       });
 
       return result;

--- a/packages/server/src/server/schemas/datasets.ts
+++ b/packages/server/src/server/schemas/datasets.ts
@@ -438,6 +438,7 @@ export const experimentResultResponseSchema = z.object({
   traceId: z.string().nullable(),
   status: z.enum(['needs-review', 'reviewed', 'complete']).nullable().optional(),
   tags: z.array(z.string()).nullable().optional(),
+  comment: z.string().nullable().optional(),
   toolMockReport: toolMockReportSchema.nullable(),
   createdAt: z.coerce.date(),
 });
@@ -445,6 +446,7 @@ export const experimentResultResponseSchema = z.object({
 export const updateExperimentResultBodySchema = z.object({
   status: z.enum(['needs-review', 'reviewed', 'complete']).nullable().optional(),
   tags: z.array(z.string()).optional(),
+  comment: z.string().nullable().optional(),
 });
 
 // Comparison item schema (MVP shape)

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -434,6 +434,9 @@ export function createExperimentsTests({
           comment: null,
         });
         expect(cleared.comment).toBeNull();
+
+        const clearedRefetched = await experimentsStorage.getExperimentResultById({ id: created.id });
+        expect(clearedRefetched!.comment).toBeNull();
       });
 
       it('getExperimentResultById returns result or null', async () => {

--- a/stores/_test-utils/src/domains/experiments/index.ts
+++ b/stores/_test-utils/src/domains/experiments/index.ts
@@ -389,6 +389,53 @@ export function createExperimentsTests({
         ).rejects.toThrow();
       });
 
+      it('updateExperimentResult persists status, tags, and comment and reads them back', async () => {
+        const created = await experimentsStorage.addExperimentResult({
+          experimentId: exp.id,
+          itemId: 'item-review',
+          itemDatasetVersion: null,
+          input: { q: 'hello' },
+          output: { a: 'world' },
+          groundTruth: null,
+          error: null,
+          startedAt: new Date(),
+          completedAt: new Date(),
+          retryCount: 0,
+        });
+
+        const updated = await experimentsStorage.updateExperimentResult({
+          id: created.id,
+          experimentId: exp.id,
+          status: 'needs-review',
+          tags: ['hallucination'],
+          comment: 'The agent ignored the second question',
+        });
+        expect(updated.status).toBe('needs-review');
+        expect(updated.tags).toEqual(['hallucination']);
+        expect(updated.comment).toBe('The agent ignored the second question');
+
+        const found = await experimentsStorage.getExperimentResultById({ id: created.id });
+        expect(found!.comment).toBe('The agent ignored the second question');
+
+        // Updating only the comment leaves status/tags untouched
+        const commentOnly = await experimentsStorage.updateExperimentResult({
+          id: created.id,
+          experimentId: exp.id,
+          comment: 'revised note',
+        });
+        expect(commentOnly.comment).toBe('revised note');
+        expect(commentOnly.status).toBe('needs-review');
+        expect(commentOnly.tags).toEqual(['hallucination']);
+
+        // Comment can be cleared with null
+        const cleared = await experimentsStorage.updateExperimentResult({
+          id: created.id,
+          experimentId: exp.id,
+          comment: null,
+        });
+        expect(cleared.comment).toBeNull();
+      });
+
       it('getExperimentResultById returns result or null', async () => {
         const result = await experimentsStorage.addExperimentResult({
           experimentId: exp.id,

--- a/stores/libsql/src/storage/domains/experiments/index.ts
+++ b/stores/libsql/src/storage/domains/experiments/index.ts
@@ -75,7 +75,7 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId'],
+      ifNotExists: ['status', 'tags', 'comment', 'toolMockReport', 'organizationId', 'projectId'],
     });
 
     // Indexes — idempotent, safe to run on every init
@@ -218,6 +218,7 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       traceId: (row.traceId as string | null) ?? null,
       status: (row.status as ExperimentResult['status']) ?? null,
       tags: row.tags ? safelyParseJSON(row.tags as string) : null,
+      comment: (row.comment as string | null) ?? null,
       toolMockReport: row.toolMockReport ? safelyParseJSON(row.toolMockReport as string) : null,
       createdAt: ensureDate(row.createdAt as string | Date)!,
     };
@@ -582,6 +583,10 @@ export class ExperimentsLibSQL extends ExperimentsStorage {
       if (input.tags !== undefined) {
         setClauses.push(`"tags" = ?`);
         values.push(JSON.stringify(input.tags));
+      }
+      if (input.comment !== undefined) {
+        setClauses.push(`"comment" = ?`);
+        values.push(input.comment);
       }
 
       if (setClauses.length === 0) {

--- a/stores/mongodb/src/storage/domains/experiments/index.ts
+++ b/stores/mongodb/src/storage/domains/experiments/index.ts
@@ -99,6 +99,7 @@ function transformExperimentResultRow(row: Record<string, unknown>): ExperimentR
     traceId: (row.traceId as string | null) ?? null,
     status: (row.status as ExperimentResultStatus | null) ?? null,
     tags: Array.isArray(row.tags) ? row.tags : (parseJsonField(row.tags) ?? null),
+    comment: (row.comment as string | null) ?? null,
     toolMockReport: (parseJsonField(row.toolMockReport) as ExperimentResult['toolMockReport']) ?? null,
     createdAt: toDate(row.createdAt),
   };
@@ -569,6 +570,7 @@ export class MongoDBExperimentsStorage extends ExperimentsStorage {
 
     if (input.status !== undefined) updateFields.status = input.status;
     if (input.tags !== undefined) updateFields.tags = input.tags;
+    if (input.comment !== undefined) updateFields.comment = input.comment;
 
     if (Object.keys(updateFields).length === 0) {
       const existing = await this.getExperimentResultById({ id: input.id });

--- a/stores/mysql/src/storage/domains/experiments/index.ts
+++ b/stores/mysql/src/storage/domains/experiments/index.ts
@@ -85,6 +85,7 @@ interface ExperimentResultRow {
   traceId: string | null;
   status: string | null;
   tags: string | null;
+  comment: string | null;
   createdAt: Date | string;
 }
 
@@ -185,7 +186,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
     await this.operations.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['organizationId', 'projectId'],
+      ifNotExists: ['comment', 'organizationId', 'projectId'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -239,6 +240,7 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       traceId: row.traceId ?? null,
       status: (row.status as ExperimentResultStatus | null) ?? null,
       tags: row.tags ? (parseJSON<string[]>(row.tags) ?? null) : null,
+      comment: row.comment ?? null,
       createdAt: parseDateTime(row.createdAt) ?? new Date(),
     };
   }
@@ -647,6 +649,9 @@ export class ExperimentsMySQL extends ExperimentsStorage {
       }
       if (input.tags !== undefined) {
         updateData.tags = input.tags ? JSON.stringify(input.tags) : null;
+      }
+      if (input.comment !== undefined) {
+        updateData.comment = input.comment;
       }
 
       if (Object.keys(updateData).length > 0) {

--- a/stores/pg/src/storage/domains/experiments/index.ts
+++ b/stores/pg/src/storage/domains/experiments/index.ts
@@ -95,7 +95,7 @@ export class ExperimentsPG extends ExperimentsStorage {
     await this.#db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: EXPERIMENT_RESULTS_SCHEMA,
-      ifNotExists: ['status', 'tags', 'toolMockReport', 'organizationId', 'projectId'],
+      ifNotExists: ['status', 'tags', 'comment', 'toolMockReport', 'organizationId', 'projectId'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -272,6 +272,7 @@ export class ExperimentsPG extends ExperimentsStorage {
       traceId: (row.traceId as string | null) ?? null,
       status: (row.status as ExperimentResult['status']) ?? null,
       tags: row.tags ? safelyParseJSON(row.tags) : null,
+      comment: (row.comment as string | null) ?? null,
       toolMockReport: row.toolMockReport ? safelyParseJSON(row.toolMockReport) : null,
       createdAt: ensureDate(row.createdAtZ || row.createdAt)!,
     };
@@ -646,6 +647,10 @@ export class ExperimentsPG extends ExperimentsStorage {
       if (input.tags !== undefined) {
         setClauses.push(`"tags" = $${paramIndex++}`);
         values.push(JSON.stringify(input.tags));
+      }
+      if (input.comment !== undefined) {
+        setClauses.push(`"comment" = $${paramIndex++}`);
+        values.push(input.comment);
       }
 
       if (setClauses.length === 0) {

--- a/stores/spanner/src/storage/domains/experiments/index.ts
+++ b/stores/spanner/src/storage/domains/experiments/index.ts
@@ -79,6 +79,7 @@ function rowToExperimentResult(row: Record<string, any>): ExperimentResult {
     traceId: t.traceId ?? null,
     status: (t.status ?? null) as ExperimentResult['status'],
     tags: (t.tags ?? null) as string[] | null,
+    comment: (t.comment ?? null) as string | null,
     toolMockReport: (t.toolMockReport ?? null) as ExperimentResult['toolMockReport'],
     createdAt: toDate(t.createdAt),
   };
@@ -119,7 +120,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
     await this.db.alterTable({
       tableName: TABLE_EXPERIMENT_RESULTS,
       schema: TABLE_SCHEMAS[TABLE_EXPERIMENT_RESULTS],
-      ifNotExists: ['organizationId', 'projectId'],
+      ifNotExists: ['comment', 'organizationId', 'projectId'],
     });
     await this.createDefaultIndexes();
     await this.createCustomIndexes();
@@ -536,7 +537,7 @@ export class ExperimentsSpanner extends ExperimentsStorage {
 
   async updateExperimentResult(input: UpdateExperimentResultInput): Promise<ExperimentResult> {
     try {
-      if (input.status === undefined && input.tags === undefined) {
+      if (input.status === undefined && input.tags === undefined && input.comment === undefined) {
         const existing = await this.getExperimentResultById({ id: input.id });
         // Honor the experimentId scope even on the no-op path: a result that
         // belongs to a different experiment must not be returned.
@@ -564,6 +565,11 @@ export class ExperimentsSpanner extends ExperimentsStorage {
         setClauses.push(`${quoteIdent('tags', 'column name')} = @tags`);
         params.tags = input.tags === null ? null : JSON.stringify(input.tags);
         types.tags = 'json';
+      }
+      if (input.comment !== undefined) {
+        setClauses.push(`${quoteIdent('comment', 'column name')} = @comment`);
+        params.comment = input.comment;
+        if (input.comment === null) types.comment = 'string';
       }
       const whereClauses = [`${quoteIdent('id', 'column name')} = @id`];
       if (input.experimentId !== undefined) {

--- a/stores/spanner/src/storage/index.test.ts
+++ b/stores/spanner/src/storage/index.test.ts
@@ -737,7 +737,7 @@ if (ENABLE_TESTS) {
       );
     });
 
-    it('updateExperimentResult sets review status/tags and is a no-op without changes', async () => {
+    it('updateExperimentResult sets review status/tags/comment and is a no-op without changes', async () => {
       const exp = await experiments.createExperiment(baseExp());
       const r = await experiments.addExperimentResult(baseResult(exp.id, { itemId: 'i1' }));
       const updated = await experiments.updateExperimentResult({
@@ -745,12 +745,15 @@ if (ENABLE_TESTS) {
         experimentId: exp.id,
         status: 'reviewed',
         tags: ['a', 'b'],
+        comment: 'note',
       });
       expect(updated.status).toBe('reviewed');
       expect(updated.tags).toEqual(['a', 'b']);
-      // No-op (no status/tags) returns the existing row.
+      expect(updated.comment).toBe('note');
+      // No-op (no status/tags/comment) returns the existing row.
       const same = await experiments.updateExperimentResult({ id: r.id });
       expect(same.status).toBe('reviewed');
+      expect(same.comment).toBe('note');
       await expect(experiments.updateExperimentResult({ id: 'missing', status: 'complete' })).rejects.toThrow();
     });
 


### PR DESCRIPTION
## Description

Comments written in the Studio review UI were lost on every reload: they were only sent to the observability feedback API (silently dropped when the result had no traceId) and rehydrated as a hardcoded empty string. This PR adds a persisted `comment` field to experiment results end-to-end so comments survive reloads and server restarts, matching how tags already work.

https://github.com/user-attachments/assets/f21b6556-21a6-47ea-a4ab-ef66d061f0da

## Related Issue(s)

Fixes #19857

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When you leave a review comment on an experiment result in Studio, it now gets saved to the database. That way, the comment still shows up after you refresh the page or restart the app—even if you don’t have a `traceId`—just like the existing tags.

## What changed

- Added a persisted, nullable `comment` field to experiment results end-to-end (core types, storage schemas, server response/body schemas, and PATCH API + client SDK params).
- Updated all storage adapters (in-memory, Postgres, LibSQL, MySQL, MongoDB, Spanner) to round-trip the comment, including support for clearing it with `comment: null`.
- Kept schema initialization/migrations non-destructive (new `comment` column is created on startup where needed).
- Updated Studio flows (dataset review and agent review queue) to save and hydrate comments from experiment results during review-item updates, while retaining existing observability feedback behavior.
- Added tests for adapter round-tripping, Spanner persistence/migration behavior, comment hydration, PATCH request bodies, and null-clearing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->