### PR TITLE
Improve Agent Learning Signals context and layout

### DIFF
--- a/.changeset/big-houses-appear.md
+++ b/.changeset/big-houses-appear.md
@@ -1,0 +1,9 @@
+---
+'@mastra/client-js': minor
+---
+
+Added Agent Learning response types for entity discovery, snapshots, flows, theme details, examples, history, and noise.
+
+```ts
+import type { ThemeDetailResponse, ThemeFlowResponse } from '@mastra/client-js';
+```

--- a/.changeset/cold-cases-worry.md
+++ b/.changeset/cold-cases-worry.md
@@ -5,12 +5,12 @@
 Added separate Sankey node identity and display label accessors, plus constrained labels with full hover text.
 
 ```tsx
-<SankeyChartProvider
+<Sankey
   data={records}
   columns={columns}
   getRecordNodeId={(record, column) => String(record[`${column.id}Id`])}
   getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
 >
   <SankeyChart />
-</SankeyChartProvider>
+</Sankey>
 ```

--- a/.changeset/cold-cases-worry.md
+++ b/.changeset/cold-cases-worry.md
@@ -1,0 +1,16 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added separate Sankey node identity and display label accessors, plus constrained labels with full hover text.
+
+```tsx
+<SankeyChartProvider
+  data={records}
+  columns={columns}
+  getRecordNodeId={(record, column) => String(record[`${column.id}Id`])}
+  getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
+>
+  <SankeyChart />
+</SankeyChartProvider>
+```

--- a/.changeset/cold-cases-worry.md
+++ b/.changeset/cold-cases-worry.md
@@ -2,7 +2,7 @@
 '@mastra/playground-ui': minor
 ---
 
-Added separate Sankey node identity and display label accessors, plus constrained labels with full hover text.
+Added separate Sankey node identity, display label, and display value accessors, plus constrained labels with full hover text.
 
 ```tsx
 <Sankey
@@ -10,6 +10,7 @@ Added separate Sankey node identity and display label accessors, plus constraine
   columns={columns}
   getRecordNodeId={(record, column) => String(record[`${column.id}Id`])}
   getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
+  getRecordNodeValue={(record, column) => Number(record[`${column.id}Count`])}
 >
   <SankeyChart />
 </Sankey>

--- a/.changeset/cold-cases-worry.md
+++ b/.changeset/cold-cases-worry.md
@@ -2,7 +2,7 @@
 '@mastra/playground-ui': minor
 ---
 
-Added separate Sankey node identity, display label, and display value accessors, plus constrained labels with full hover text.
+Added separate Sankey node identity, display label, display value, and layout weight accessors, plus constrained labels with full hover text. Stable layout weights can now keep node positions fixed while current record weights animate bar and ribbon sizes.
 
 ```tsx
 <Sankey
@@ -11,6 +11,8 @@ Added separate Sankey node identity, display label, and display value accessors,
   getRecordNodeId={(record, column) => String(record[`${column.id}Id`])}
   getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
   getRecordNodeValue={(record, column) => Number(record[`${column.id}Count`])}
+  getRecordWeight={record => Number(record.count)}
+  getRecordLayoutWeight={record => Number(record.windowMaxCount)}
 >
   <SankeyChart />
 </Sankey>

--- a/client-sdks/client-js/src/agent-learning.ts
+++ b/client-sdks/client-js/src/agent-learning.ts
@@ -1,0 +1,166 @@
+export type TraceSignalName = 'goal' | 'sentiment' | 'behavior' | 'outcome';
+
+export interface ThemeLearningEntity {
+  entityId: string;
+  entityType: string;
+  availableSignals: TraceSignalName[];
+  latestWindow?: {
+    startedAt: string;
+    endedAt: string;
+  };
+}
+
+export interface ThemeSnapshot {
+  snapshotId: string;
+  ordinal: number;
+  total: number;
+  startedAt: string;
+  endedAt: string;
+  traceCount: number;
+}
+
+export type ThemeNode =
+  | {
+      nodeId: string;
+      kind: 'theme';
+      themeId: string;
+      label: string;
+      description?: string;
+      traceCount: number;
+      stageShare: number;
+    }
+  | {
+      nodeId: string;
+      kind: 'noise' | 'other';
+      label: string;
+      description?: string;
+      traceCount: number;
+      stageShare: number;
+    };
+
+export interface ThemeFlowResponse {
+  snapshot: ThemeSnapshot;
+  stages: Array<{
+    signalName: TraceSignalName;
+    traceCount: number;
+    nodes: ThemeNode[];
+  }>;
+  links: Array<{
+    sourceNodeId: string;
+    targetNodeId: string;
+    traceCount: number;
+    sourceShare: number;
+    targetShare: number;
+  }>;
+}
+
+export interface ThemeSnapshotsResponse {
+  snapshots: Array<ThemeSnapshot & { availableSignals: TraceSignalName[] }>;
+  nextCursor?: string;
+}
+
+export interface ThemeEntitiesResponse {
+  entities: ThemeLearningEntity[];
+}
+
+export interface ThemePathTheme {
+  signalName: TraceSignalName;
+  themeId: string;
+  label: string;
+  description?: string;
+}
+
+export interface ThemePathsResponse {
+  snapshot: ThemeSnapshot;
+  signals: TraceSignalName[];
+  themes: Record<string, ThemePathTheme>;
+  paths: Array<{
+    traceId: string;
+    assignments: Record<string, string>;
+  }>;
+  nextOffset?: number;
+}
+
+export type ActiveThemeState = 'birth' | 'continue' | 'split' | 'merge' | 'resurrection';
+export type ThemeHistoryState = ActiveThemeState | 'death';
+
+export interface ThemeTrend {
+  popularity: number;
+  signalScore: number;
+  strength: 'none' | 'weak' | 'strong';
+}
+
+export interface SnapshotTheme {
+  themeId: string;
+  label: string;
+  description?: string;
+  state: ActiveThemeState;
+  traceCount: number;
+  coverage: number;
+  trend?: ThemeTrend;
+}
+
+export interface ThemesResponse {
+  snapshot: ThemeSnapshot;
+  signalName: TraceSignalName;
+  themes: SnapshotTheme[];
+  noise: {
+    traceCount: number;
+    coverage: number;
+  };
+}
+
+export interface ThemeDetailResponse {
+  snapshot: ThemeSnapshot;
+  theme?: SnapshotTheme & { signalName: TraceSignalName };
+}
+
+export interface ThemeExample {
+  traceId: string;
+  extractedTraceId: string;
+  signalText: string;
+  traceStartedAt?: string;
+}
+
+export interface ThemeExamplesResponse {
+  examples: ThemeExample[];
+  nextOffset?: number;
+}
+
+export type NoiseExamplesResponse = ThemeExamplesResponse;
+
+export interface ThemeHistoryResponse {
+  theme: {
+    themeId: string;
+    signalName: TraceSignalName;
+    label: string;
+    description?: string;
+  };
+  points: Array<{
+    snapshotId: string;
+    startedAt: string;
+    endedAt: string;
+    state: ThemeHistoryState;
+    traceCount: number;
+    coverage: number;
+    trend?: ThemeTrend;
+  }>;
+  relationships: Array<{
+    snapshotId: string;
+    kind: 'split-from' | 'split-into' | 'merged-from' | 'merged-into';
+    relatedTheme: {
+      themeId: string;
+      label: string;
+    };
+  }>;
+  nextCursor?: string;
+}
+
+export interface NoiseResponse {
+  snapshot: ThemeSnapshot;
+  noise: {
+    signalName: TraceSignalName;
+    traceCount: number;
+    coverage: number;
+  };
+}

--- a/client-sdks/client-js/src/index.ts
+++ b/client-sdks/client-js/src/index.ts
@@ -1,3 +1,4 @@
+export * from './agent-learning';
 export * from './client';
 export * from './types';
 export * from './tools';

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -176,9 +176,16 @@ describe('SankeyChart utilities', () => {
         record => Number(record.layoutCount),
       );
 
-      const geometry = buildFixedSankeyGeometry(graph, { top: 0, bottom: 200, nodePadding: 20 });
+      const geometry = buildFixedSankeyGeometry(graph, {
+        top: 0,
+        bottom: 200,
+        left: 100,
+        right: 500,
+        nodePadding: 20,
+      });
       const sourceA = geometry.nodes.get(graph.nodes.find(node => node.name === 'A')?.id ?? '');
       const sourceB = geometry.nodes.get(graph.nodes.find(node => node.name === 'B')?.id ?? '');
+      const targetX = geometry.nodes.get(graph.nodes.find(node => node.name === 'X')?.id ?? '');
       const aToX = geometry.links.get(
         graph.links.find(link => link.sourceNode.name === 'A' && link.targetNode.name === 'X')?.id ?? '',
       );
@@ -189,6 +196,9 @@ describe('SankeyChart utilities', () => {
         graph.links.find(link => link.sourceNode.name === 'B' && link.targetNode.name === 'X')?.id ?? '',
       );
 
+      expect(sourceA?.x).toBe(100);
+      expect(sourceB?.x).toBe(100);
+      expect(targetX?.x).toBe(500);
       expect(sourceA?.centerY).toBe(45);
       expect(sourceB?.centerY).toBe(155);
       expect(sourceA?.height).toBe(54);

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -142,6 +142,22 @@ describe('SankeyChart utilities', () => {
     });
   });
 
+  describe('when node display values differ from layout weights', () => {
+    it('preserves the supplied node values independently of link weights', () => {
+      const graph = buildSankeyChartGraph(
+        [{ source: 'source-1', sourceCount: 0, model: 'model-1', modelCount: 3, layoutWeight: 0.01 }],
+        columns.slice(0, 2),
+        record => Number(record.layoutWeight),
+        undefined,
+        undefined,
+        (record, column) => Number(record[`${column.id}Count`]),
+      );
+
+      expect(graph.links[0]?.value).toBe(0.01);
+      expect(graph.nodes.map(node => node.displayValue)).toEqual([0, 3]);
+    });
+  });
+
   describe('when only one optional node accessor is provided', () => {
     it('keeps record values as labels when only identity is customized', () => {
       const graph = buildSankeyChartGraph(

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -142,6 +142,37 @@ describe('SankeyChart utilities', () => {
     });
   });
 
+  describe('when only one optional node accessor is provided', () => {
+    it('keeps record values as labels when only identity is customized', () => {
+      const graph = buildSankeyChartGraph(
+        [{ source: 'Readable source', sourceId: 'source-1', model: 'Readable model', modelId: 'model-1' }],
+        columns.slice(0, 2),
+        undefined,
+        (record, column) => String(record[`${column.id}Id`]),
+      );
+
+      expect(graph.nodes.map(node => ({ label: node.label, value: node.value }))).toEqual([
+        { label: 'Readable source', value: 'source-1' },
+        { label: 'Readable model', value: 'model-1' },
+      ]);
+    });
+
+    it('keeps record values as identities when only labels are customized', () => {
+      const graph = buildSankeyChartGraph(
+        [{ source: 'source-1', sourceLabel: 'Readable source', model: 'model-1', modelLabel: 'Readable model' }],
+        columns.slice(0, 2),
+        undefined,
+        undefined,
+        (record, column) => String(record[`${column.id}Label`]),
+      );
+
+      expect(graph.nodes.map(node => ({ label: node.label, value: node.value }))).toEqual([
+        { label: 'Readable source', value: 'source-1' },
+        { label: 'Readable model', value: 'model-1' },
+      ]);
+    });
+  });
+
   describe('when values cannot form a flow', () => {
     it('ignores blank, non-finite, and non-primitive dimension values', () => {
       const data = [

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -191,6 +191,7 @@ describe('SankeyChart utilities', () => {
 
       expect(sourceA?.centerY).toBe(45);
       expect(sourceB?.centerY).toBe(155);
+      expect(sourceA?.height).toBe(54);
       expect(sourceA?.height).toBeGreaterThan(sourceB?.height ?? 0);
       expect((aToX?.sourceY ?? 0) + (aToX?.sourceWidth ?? 0) / 2).toBeCloseTo(
         (aToY?.sourceY ?? 0) - (aToY?.sourceWidth ?? 0) / 2,

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -113,6 +113,35 @@ describe('SankeyChart utilities', () => {
     });
   });
 
+  describe('when records have equal display labels with distinct identities', () => {
+    it('creates distinct nodes with their own weights', () => {
+      const data = [
+        { source: 'source-1', sourceLabel: 'Shared', model: 'model-1', modelLabel: 'Model', count: 2 },
+        { source: 'source-2', sourceLabel: 'Shared', model: 'model-1', modelLabel: 'Model', count: 3 },
+      ];
+      const getNodeId = (record: Record<string, unknown>, column: { id: string }) => String(record[column.id]);
+      const getNodeLabel = (record: Record<string, unknown>, column: { id: string }) =>
+        String(record[`${column.id}Label`]);
+
+      const graph = buildSankeyChartGraph(
+        data,
+        columns.slice(0, 2),
+        record => Number(record.count),
+        getNodeId,
+        getNodeLabel,
+      );
+      const sourceNodes = graph.nodes.filter(node => node.column.id === 'source');
+      const weights = getSankeyChartNodeWeights(graph);
+
+      expect(sourceNodes.map(node => ({ label: node.label, value: node.value, weight: weights.get(node.id) }))).toEqual(
+        [
+          { label: 'Shared', value: 'source-1', weight: 2 },
+          { label: 'Shared', value: 'source-2', weight: 3 },
+        ],
+      );
+    });
+  });
+
   describe('when values cannot form a flow', () => {
     it('ignores blank, non-finite, and non-primitive dimension values', () => {
       const data = [

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -142,18 +142,19 @@ describe('SankeyChart utilities', () => {
     });
   });
 
-  describe('when node display values differ from layout weights', () => {
-    it('preserves the supplied node values independently of link weights', () => {
+  describe('when display values differ from layout weights', () => {
+    it('preserves current link and node values independently of stable layout weights', () => {
       const graph = buildSankeyChartGraph(
-        [{ source: 'source-1', sourceCount: 0, model: 'model-1', modelCount: 3, layoutWeight: 0.01 }],
+        [{ source: 'source-1', sourceCount: 0, model: 'model-1', modelCount: 3, count: 2, layoutWeight: 5 }],
         columns.slice(0, 2),
-        record => Number(record.layoutWeight),
+        record => Number(record.count),
         undefined,
         undefined,
         (record, column) => Number(record[`${column.id}Count`]),
+        record => Number(record.layoutWeight),
       );
 
-      expect(graph.links[0]?.value).toBe(0.01);
+      expect(graph.links[0]).toMatchObject({ value: 5, displayValue: 2 });
       expect(graph.nodes.map(node => node.displayValue)).toEqual([0, 3]);
     });
   });

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -201,7 +201,7 @@ describe('SankeyChart utilities', () => {
       expect(targetX?.x).toBe(500);
       expect(sourceA?.centerY).toBe(45);
       expect(sourceB?.centerY).toBe(155);
-      expect(sourceA?.height).toBe(54);
+      expect(sourceA?.height).toBe(43.2);
       expect(sourceA?.height).toBeGreaterThan(sourceB?.height ?? 0);
       expect((aToX?.sourceY ?? 0) + (aToX?.sourceWidth ?? 0) / 2).toBeCloseTo(
         (aToY?.sourceY ?? 0) - (aToY?.sourceWidth ?? 0) / 2,
@@ -209,6 +209,36 @@ describe('SankeyChart utilities', () => {
       expect((aToX?.targetY ?? 0) + (aToX?.targetWidth ?? 0) / 2).toBeCloseTo(
         (bToX?.targetY ?? 0) - (bToX?.targetWidth ?? 0) / 2,
       );
+    });
+
+    it('scales percentages against one chart-wide maximum height', () => {
+      const graph = buildSankeyChartGraph(
+        [
+          { source: 'A', sourceCount: 70, model: 'X', modelCount: 100, count: 70, layoutCount: 100 },
+          { source: 'B', sourceCount: 30, model: 'X', modelCount: 100, count: 30, layoutCount: 100 },
+          { source: 'B', sourceCount: 30, model: 'Y', modelCount: 0, count: 0, layoutCount: 1 },
+          { source: 'B', sourceCount: 30, model: 'Z', modelCount: 0, count: 0, layoutCount: 1 },
+          { source: 'B', sourceCount: 30, model: 'W', modelCount: 0, count: 0, layoutCount: 1 },
+        ],
+        columns.slice(0, 2),
+        record => Number(record.count),
+        undefined,
+        undefined,
+        (record, column) => Number(record[`${column.id}Count`]),
+        record => Number(record.layoutCount),
+      );
+      const geometry = buildFixedSankeyGeometry(graph, {
+        top: 0,
+        bottom: 200,
+        left: 100,
+        right: 500,
+        nodePadding: 20,
+      });
+      const sourceA = geometry.nodes.get(graph.nodes.find(node => node.name === 'A')?.id ?? '');
+      const targetX = geometry.nodes.get(graph.nodes.find(node => node.name === 'X')?.id ?? '');
+
+      expect(targetX?.height).toBeGreaterThan(sourceA?.height ?? 0);
+      expect((sourceA?.height ?? 0) / (targetX?.height ?? 1)).toBeCloseTo(0.7);
     });
   });
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  buildFixedSankeyGeometry,
   buildSankeyChartGraph,
   getSankeyChartCurveSelection,
   getSankeyChartNodeWeights,
@@ -156,6 +157,47 @@ describe('SankeyChart utilities', () => {
 
       expect(graph.links[0]).toMatchObject({ value: 5, displayValue: 2 });
       expect(graph.nodes.map(node => node.displayValue)).toEqual([0, 3]);
+    });
+  });
+
+  describe('when fixed theme slots render current values', () => {
+    it('keeps node centers fixed and packs ribbons contiguously inside resized bars', () => {
+      const graph = buildSankeyChartGraph(
+        [
+          { source: 'A', sourceCount: 8, model: 'X', modelCount: 8, count: 6, layoutCount: 10 },
+          { source: 'A', sourceCount: 8, model: 'Y', modelCount: 2, count: 2, layoutCount: 10 },
+          { source: 'B', sourceCount: 2, model: 'X', modelCount: 8, count: 2, layoutCount: 10 },
+        ],
+        columns.slice(0, 2),
+        record => Number(record.count),
+        undefined,
+        undefined,
+        (record, column) => Number(record[`${column.id}Count`]),
+        record => Number(record.layoutCount),
+      );
+
+      const geometry = buildFixedSankeyGeometry(graph, { top: 0, bottom: 200, nodePadding: 20 });
+      const sourceA = geometry.nodes.get(graph.nodes.find(node => node.name === 'A')?.id ?? '');
+      const sourceB = geometry.nodes.get(graph.nodes.find(node => node.name === 'B')?.id ?? '');
+      const aToX = geometry.links.get(
+        graph.links.find(link => link.sourceNode.name === 'A' && link.targetNode.name === 'X')?.id ?? '',
+      );
+      const aToY = geometry.links.get(
+        graph.links.find(link => link.sourceNode.name === 'A' && link.targetNode.name === 'Y')?.id ?? '',
+      );
+      const bToX = geometry.links.get(
+        graph.links.find(link => link.sourceNode.name === 'B' && link.targetNode.name === 'X')?.id ?? '',
+      );
+
+      expect(sourceA?.centerY).toBe(45);
+      expect(sourceB?.centerY).toBe(155);
+      expect(sourceA?.height).toBeGreaterThan(sourceB?.height ?? 0);
+      expect((aToX?.sourceY ?? 0) + (aToX?.sourceWidth ?? 0) / 2).toBeCloseTo(
+        (aToY?.sourceY ?? 0) - (aToY?.sourceWidth ?? 0) / 2,
+      );
+      expect((aToX?.targetY ?? 0) + (aToX?.targetWidth ?? 0) / 2).toBeCloseTo(
+        (bToX?.targetY ?? 0) - (bToX?.targetWidth ?? 0) / 2,
+      );
     });
   });
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -224,7 +224,7 @@ export function buildFixedSankeyGeometry(
     columnNodes.forEach((node, index) => {
       const value = node.displayValue ?? currentNodeWeights.get(node.id) ?? 0;
       const centerY = top + index * (slotHeight + nodePadding) + slotHeight / 2;
-      const height = value > 0 ? Math.max(slotHeight * 0.1, slotHeight * 0.94 * (value / maximumValue)) : 0;
+      const height = value > 0 ? Math.max(slotHeight * 0.08, slotHeight * 0.6 * (value / maximumValue)) : 0;
       nodes.set(node.id, { centerY, y: centerY - height / 2, height });
     });
   }

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -11,6 +11,7 @@ export type SankeyChartNode = {
   label: string;
   column: SankeyChartColumn;
   value: string | number;
+  displayValue?: number;
 };
 
 export type SankeyChartLink = {
@@ -81,6 +82,7 @@ export function buildSankeyChartGraph(
   getRecordWeight: (record: SankeyChartRecord) => number = () => 1,
   getRecordNodeId?: (record: SankeyChartRecord, column: SankeyChartColumn) => string,
   getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string,
+  getRecordNodeValue?: (record: SankeyChartRecord, column: SankeyChartColumn) => number,
 ): SankeyChartGraph {
   if (columns.length < 2 || data.length === 0) return EMPTY_GRAPH;
 
@@ -92,13 +94,14 @@ export function buildSankeyChartGraph(
     column: SankeyChartColumn,
     value: string | number,
     label: string,
+    displayValue: number | undefined,
   ): { node: SankeyChartNode; index: number } => {
     const id = createNodeId(column.id, value);
     const existingIndex = nodeIndexes.get(id);
     const existingNode = existingIndex === undefined ? undefined : nodes[existingIndex];
     if (existingIndex !== undefined && existingNode) return { node: existingNode, index: existingIndex };
 
-    const node: SankeyChartNode = { id, name: String(value), label, column, value };
+    const node: SankeyChartNode = { id, name: String(value), label, column, value, displayValue };
     const index = nodes.length;
     nodes.push(node);
     nodeIndexes.set(id, index);
@@ -128,8 +131,24 @@ export function buildSankeyChartGraph(
 
       const sourceLabel = getRecordNodeLabel?.(record, sourceColumn) ?? String(sourceRecordValue);
       const targetLabel = getRecordNodeLabel?.(record, targetColumn) ?? String(targetRecordValue);
-      const source = getNode(sourceColumn, sourceValue, sourceLabel);
-      const target = getNode(targetColumn, targetValue, targetLabel);
+      const sourceDisplayValue = getRecordNodeValue?.(record, sourceColumn);
+      const targetDisplayValue = getRecordNodeValue?.(record, targetColumn);
+      const source = getNode(
+        sourceColumn,
+        sourceValue,
+        sourceLabel,
+        sourceDisplayValue !== undefined && Number.isFinite(sourceDisplayValue) && sourceDisplayValue >= 0
+          ? sourceDisplayValue
+          : undefined,
+      );
+      const target = getNode(
+        targetColumn,
+        targetValue,
+        targetLabel,
+        targetDisplayValue !== undefined && Number.isFinite(targetDisplayValue) && targetDisplayValue >= 0
+          ? targetDisplayValue
+          : undefined,
+      );
       const id = `${source.node.id}->${target.node.id}`;
       const existingLink = linksById.get(id);
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -19,6 +19,7 @@ export type SankeyChartLink = {
   source: number;
   target: number;
   value: number;
+  displayValue: number;
   sourceNode: SankeyChartNode;
   targetNode: SankeyChartNode;
   records: Array<SankeyChartRecord>;
@@ -83,6 +84,7 @@ export function buildSankeyChartGraph(
   getRecordNodeId?: (record: SankeyChartRecord, column: SankeyChartColumn) => string,
   getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string,
   getRecordNodeValue?: (record: SankeyChartRecord, column: SankeyChartColumn) => number,
+  getRecordLayoutWeight?: (record: SankeyChartRecord) => number,
 ): SankeyChartGraph {
   if (columns.length < 2 || data.length === 0) return EMPTY_GRAPH;
 
@@ -114,8 +116,11 @@ export function buildSankeyChartGraph(
     if (!sourceColumn || !targetColumn) continue;
 
     for (const record of data) {
-      const weight = getRecordWeight(record);
-      if (!Number.isFinite(weight) || weight < 0) continue;
+      const displayWeight = getRecordWeight(record);
+      const layoutWeight = getRecordLayoutWeight?.(record) ?? displayWeight;
+      if (!Number.isFinite(displayWeight) || displayWeight < 0 || !Number.isFinite(layoutWeight) || layoutWeight < 0) {
+        continue;
+      }
 
       const sourceRecordValue = getSankeyChartValue(record[sourceColumn.id]);
       const targetRecordValue = getSankeyChartValue(record[targetColumn.id]);
@@ -153,14 +158,16 @@ export function buildSankeyChartGraph(
       const existingLink = linksById.get(id);
 
       if (existingLink) {
-        existingLink.value += weight;
+        existingLink.value += layoutWeight;
+        existingLink.displayValue += displayWeight;
         existingLink.records.push(record);
       } else {
         linksById.set(id, {
           id,
           source: source.index,
           target: target.index,
-          value: weight,
+          value: layoutWeight,
+          displayValue: displayWeight,
           sourceNode: source.node,
           targetNode: target.node,
           records: [record],

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -8,6 +8,7 @@ export type SankeyChartColumn = {
 export type SankeyChartNode = {
   id: string;
   name: string;
+  label: string;
   column: SankeyChartColumn;
   value: string | number;
 };
@@ -78,6 +79,8 @@ export function buildSankeyChartGraph(
   data: Array<SankeyChartRecord>,
   columns: Array<SankeyChartColumn>,
   getRecordWeight: (record: SankeyChartRecord) => number = () => 1,
+  getRecordNodeId?: (record: SankeyChartRecord, column: SankeyChartColumn) => string,
+  getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string,
 ): SankeyChartGraph {
   if (columns.length < 2 || data.length === 0) return EMPTY_GRAPH;
 
@@ -85,13 +88,17 @@ export function buildSankeyChartGraph(
   const nodeIndexes = new Map<string, number>();
   const linksById = new Map<string, SankeyChartLink>();
 
-  const getNode = (column: SankeyChartColumn, value: string | number): { node: SankeyChartNode; index: number } => {
+  const getNode = (
+    column: SankeyChartColumn,
+    value: string | number,
+    label: string,
+  ): { node: SankeyChartNode; index: number } => {
     const id = createNodeId(column.id, value);
     const existingIndex = nodeIndexes.get(id);
     const existingNode = existingIndex === undefined ? undefined : nodes[existingIndex];
     if (existingIndex !== undefined && existingNode) return { node: existingNode, index: existingIndex };
 
-    const node: SankeyChartNode = { id, name: String(value), column, value };
+    const node: SankeyChartNode = { id, name: String(value), label, column, value };
     const index = nodes.length;
     nodes.push(node);
     nodeIndexes.set(id, index);
@@ -107,12 +114,22 @@ export function buildSankeyChartGraph(
       const weight = getRecordWeight(record);
       if (!Number.isFinite(weight) || weight < 0) continue;
 
-      const sourceValue = getSankeyChartValue(record[sourceColumn.id]);
-      const targetValue = getSankeyChartValue(record[targetColumn.id]);
+      const sourceRecordValue = getSankeyChartValue(record[sourceColumn.id]);
+      const targetRecordValue = getSankeyChartValue(record[targetColumn.id]);
+      if (sourceRecordValue === undefined || targetRecordValue === undefined) continue;
+
+      const sourceValue = getRecordNodeId
+        ? getSankeyChartValue(getRecordNodeId(record, sourceColumn))
+        : sourceRecordValue;
+      const targetValue = getRecordNodeId
+        ? getSankeyChartValue(getRecordNodeId(record, targetColumn))
+        : targetRecordValue;
       if (sourceValue === undefined || targetValue === undefined) continue;
 
-      const source = getNode(sourceColumn, sourceValue);
-      const target = getNode(targetColumn, targetValue);
+      const sourceLabel = getRecordNodeLabel?.(record, sourceColumn) ?? String(sourceValue);
+      const targetLabel = getRecordNodeLabel?.(record, targetColumn) ?? String(targetValue);
+      const source = getNode(sourceColumn, sourceValue, sourceLabel);
+      const target = getNode(targetColumn, targetValue, targetLabel);
       const id = `${source.node.id}->${target.node.id}`;
       const existingLink = linksById.get(id);
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -31,6 +31,7 @@ export type SankeyChartGraph = {
 };
 
 export type FixedSankeyNodeGeometry = {
+  x: number;
   centerY: number;
   y: number;
   height: number;
@@ -199,7 +200,13 @@ export function buildSankeyChartGraph(
 
 export function buildFixedSankeyGeometry(
   graph: SankeyChartGraph,
-  { top, bottom, nodePadding }: { top: number; bottom: number; nodePadding: number },
+  {
+    top,
+    bottom,
+    left,
+    right,
+    nodePadding,
+  }: { top: number; bottom: number; left: number; right: number; nodePadding: number },
 ): FixedSankeyGeometry {
   const nodes = new Map<string, FixedSankeyNodeGeometry>();
   const nodesByColumn = new Map<string, SankeyChartNode[]>();
@@ -211,7 +218,8 @@ export function buildFixedSankeyGeometry(
     nodesByColumn.set(node.column.id, columnNodes);
   }
 
-  for (const columnNodes of nodesByColumn.values()) {
+  const columns = [...nodesByColumn.values()];
+  columns.forEach((columnNodes, columnIndex) => {
     const slotHeight = Math.max(
       0,
       (bottom - top - nodePadding * Math.max(0, columnNodes.length - 1)) / columnNodes.length,
@@ -220,14 +228,15 @@ export function buildFixedSankeyGeometry(
       1,
       ...columnNodes.map(node => node.displayValue ?? currentNodeWeights.get(node.id) ?? 0),
     );
+    const x = columns.length > 1 ? left + ((right - left) * columnIndex) / (columns.length - 1) : left;
 
     columnNodes.forEach((node, index) => {
       const value = node.displayValue ?? currentNodeWeights.get(node.id) ?? 0;
       const centerY = top + index * (slotHeight + nodePadding) + slotHeight / 2;
       const height = value > 0 ? Math.max(slotHeight * 0.08, slotHeight * 0.6 * (value / maximumValue)) : 0;
-      nodes.set(node.id, { centerY, y: centerY - height / 2, height });
+      nodes.set(node.id, { x, centerY, y: centerY - height / 2, height });
     });
-  }
+  });
 
   const links = new Map<string, FixedSankeyLinkGeometry>();
   const outgoingTotals = new Map<string, number>();

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -219,21 +219,23 @@ export function buildFixedSankeyGeometry(
   }
 
   const columns = [...nodesByColumn.values()];
+  const slotHeights = columns.map(columnNodes =>
+    Math.max(0, (bottom - top - nodePadding * Math.max(0, columnNodes.length - 1)) / columnNodes.length),
+  );
+  const maximumNodeHeight = Math.min(...slotHeights) * 0.6;
+
   columns.forEach((columnNodes, columnIndex) => {
-    const slotHeight = Math.max(
+    const slotHeight = slotHeights[columnIndex] ?? 0;
+    const columnTotal = columnNodes.reduce(
+      (total, node) => total + (node.displayValue ?? currentNodeWeights.get(node.id) ?? 0),
       0,
-      (bottom - top - nodePadding * Math.max(0, columnNodes.length - 1)) / columnNodes.length,
-    );
-    const maximumValue = Math.max(
-      1,
-      ...columnNodes.map(node => node.displayValue ?? currentNodeWeights.get(node.id) ?? 0),
     );
     const x = columns.length > 1 ? left + ((right - left) * columnIndex) / (columns.length - 1) : left;
 
     columnNodes.forEach((node, index) => {
       const value = node.displayValue ?? currentNodeWeights.get(node.id) ?? 0;
       const centerY = top + index * (slotHeight + nodePadding) + slotHeight / 2;
-      const height = value > 0 ? Math.max(slotHeight * 0.08, slotHeight * 0.6 * (value / maximumValue)) : 0;
+      const height = columnTotal > 0 ? maximumNodeHeight * (value / columnTotal) : 0;
       nodes.set(node.id, { x, centerY, y: centerY - height / 2, height });
     });
   });

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -126,8 +126,8 @@ export function buildSankeyChartGraph(
         : targetRecordValue;
       if (sourceValue === undefined || targetValue === undefined) continue;
 
-      const sourceLabel = getRecordNodeLabel?.(record, sourceColumn) ?? String(sourceValue);
-      const targetLabel = getRecordNodeLabel?.(record, targetColumn) ?? String(targetValue);
+      const sourceLabel = getRecordNodeLabel?.(record, sourceColumn) ?? String(sourceRecordValue);
+      const targetLabel = getRecordNodeLabel?.(record, targetColumn) ?? String(targetRecordValue);
       const source = getNode(sourceColumn, sourceValue, sourceLabel);
       const target = getNode(targetColumn, targetValue, targetLabel);
       const id = `${source.node.id}->${target.node.id}`;

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart-utils.ts
@@ -30,6 +30,24 @@ export type SankeyChartGraph = {
   links: Array<SankeyChartLink>;
 };
 
+export type FixedSankeyNodeGeometry = {
+  centerY: number;
+  y: number;
+  height: number;
+};
+
+export type FixedSankeyLinkGeometry = {
+  sourceY: number;
+  targetY: number;
+  sourceWidth: number;
+  targetWidth: number;
+};
+
+export type FixedSankeyGeometry = {
+  nodes: Map<string, FixedSankeyNodeGeometry>;
+  links: Map<string, FixedSankeyLinkGeometry>;
+};
+
 export type SankeyChartCurveSelection = {
   source: {
     column: SankeyChartColumn;
@@ -179,6 +197,71 @@ export function buildSankeyChartGraph(
   return { nodes, links: [...linksById.values()] };
 }
 
+export function buildFixedSankeyGeometry(
+  graph: SankeyChartGraph,
+  { top, bottom, nodePadding }: { top: number; bottom: number; nodePadding: number },
+): FixedSankeyGeometry {
+  const nodes = new Map<string, FixedSankeyNodeGeometry>();
+  const nodesByColumn = new Map<string, SankeyChartNode[]>();
+  const currentNodeWeights = getSankeyChartCurrentNodeWeights(graph);
+
+  for (const node of graph.nodes) {
+    const columnNodes = nodesByColumn.get(node.column.id) ?? [];
+    columnNodes.push(node);
+    nodesByColumn.set(node.column.id, columnNodes);
+  }
+
+  for (const columnNodes of nodesByColumn.values()) {
+    const slotHeight = Math.max(
+      0,
+      (bottom - top - nodePadding * Math.max(0, columnNodes.length - 1)) / columnNodes.length,
+    );
+    const maximumValue = Math.max(
+      1,
+      ...columnNodes.map(node => node.displayValue ?? currentNodeWeights.get(node.id) ?? 0),
+    );
+
+    columnNodes.forEach((node, index) => {
+      const value = node.displayValue ?? currentNodeWeights.get(node.id) ?? 0;
+      const centerY = top + index * (slotHeight + nodePadding) + slotHeight / 2;
+      const height = value > 0 ? Math.max(slotHeight * 0.1, slotHeight * 0.94 * (value / maximumValue)) : 0;
+      nodes.set(node.id, { centerY, y: centerY - height / 2, height });
+    });
+  }
+
+  const links = new Map<string, FixedSankeyLinkGeometry>();
+  const outgoingTotals = new Map<string, number>();
+  const incomingTotals = new Map<string, number>();
+  for (const link of graph.links) {
+    outgoingTotals.set(link.sourceNode.id, (outgoingTotals.get(link.sourceNode.id) ?? 0) + link.displayValue);
+    incomingTotals.set(link.targetNode.id, (incomingTotals.get(link.targetNode.id) ?? 0) + link.displayValue);
+  }
+  const sourceOffsets = new Map([...nodes].map(([id, geometry]) => [id, geometry.y]));
+  const targetOffsets = new Map([...nodes].map(([id, geometry]) => [id, geometry.y]));
+
+  for (const link of graph.links) {
+    const sourceGeometry = nodes.get(link.sourceNode.id);
+    const targetGeometry = nodes.get(link.targetNode.id);
+    if (!sourceGeometry || !targetGeometry) continue;
+    const sourceTotal = outgoingTotals.get(link.sourceNode.id) ?? 0;
+    const targetTotal = incomingTotals.get(link.targetNode.id) ?? 0;
+    const sourceWidth = sourceTotal > 0 ? sourceGeometry.height * (link.displayValue / sourceTotal) : 0;
+    const targetWidth = targetTotal > 0 ? targetGeometry.height * (link.displayValue / targetTotal) : 0;
+    const sourceOffset = sourceOffsets.get(link.sourceNode.id) ?? sourceGeometry.y;
+    const targetOffset = targetOffsets.get(link.targetNode.id) ?? targetGeometry.y;
+    links.set(link.id, {
+      sourceY: sourceOffset + sourceWidth / 2,
+      targetY: targetOffset + targetWidth / 2,
+      sourceWidth,
+      targetWidth,
+    });
+    sourceOffsets.set(link.sourceNode.id, sourceOffset + sourceWidth);
+    targetOffsets.set(link.targetNode.id, targetOffset + targetWidth);
+  }
+
+  return { nodes, links };
+}
+
 export function getSankeyChartNodeWeights(graph: SankeyChartGraph): Map<string, number> {
   const incomingWeights = new Map<string, number>();
   const outgoingWeights = new Map<string, number>();
@@ -186,6 +269,20 @@ export function getSankeyChartNodeWeights(graph: SankeyChartGraph): Map<string, 
   for (const link of graph.links) {
     outgoingWeights.set(link.sourceNode.id, (outgoingWeights.get(link.sourceNode.id) ?? 0) + link.value);
     incomingWeights.set(link.targetNode.id, (incomingWeights.get(link.targetNode.id) ?? 0) + link.value);
+  }
+
+  return new Map(
+    graph.nodes.map(node => [node.id, Math.max(incomingWeights.get(node.id) ?? 0, outgoingWeights.get(node.id) ?? 0)]),
+  );
+}
+
+function getSankeyChartCurrentNodeWeights(graph: SankeyChartGraph): Map<string, number> {
+  const incomingWeights = new Map<string, number>();
+  const outgoingWeights = new Map<string, number>();
+
+  for (const link of graph.links) {
+    outgoingWeights.set(link.sourceNode.id, (outgoingWeights.get(link.sourceNode.id) ?? 0) + link.displayValue);
+    incomingWeights.set(link.targetNode.id, (incomingWeights.get(link.targetNode.id) ?? 0) + link.displayValue);
   }
 
   return new Map(

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -127,8 +127,10 @@ describe('SankeyChart', () => {
   });
 
   describe('when a node label includes a description', () => {
-    const nodeLabel = 'Search. Looks up relevant knowledge before responding.: 1 trace (100%)';
-    const tooltipLabel = 'Search: Looks up relevant knowledge before responding.';
+    const description =
+      'Looks up relevant knowledge before responding, including all supporting context needed to explain a long theme description without clipping it.';
+    const nodeLabel = `Search. ${description}: 1 trace (100%)`;
+    const tooltipLabel = `Search: ${description}`;
 
     function renderDescribedNode() {
       return render(
@@ -136,7 +138,7 @@ describe('SankeyChart', () => {
           data={[
             {
               channel: 'channel-one',
-              channelLabel: 'Search\nLooks up relevant knowledge before responding.',
+              channelLabel: `Search\n${description}`,
               region: 'eu',
               regionLabel: 'Europe',
             },
@@ -164,6 +166,28 @@ describe('SankeyChart', () => {
       const node = await screen.findByLabelText(nodeLabel);
 
       fireEvent.mouseEnter(node);
+
+      expect(screen.getByRole('tooltip', { name: tooltipLabel }).textContent).toContain(description);
+    });
+
+    it('keeps the description visible when the pointer leaves a focused node', async () => {
+      renderDescribedNode();
+      const node = await screen.findByLabelText(nodeLabel);
+      fireEvent.focus(node);
+      fireEvent.mouseEnter(node);
+
+      fireEvent.mouseLeave(node);
+
+      expect(screen.getByRole('tooltip', { name: tooltipLabel })).not.toBeNull();
+    });
+
+    it('keeps the description visible when a hovered node loses focus', async () => {
+      renderDescribedNode();
+      const node = await screen.findByLabelText(nodeLabel);
+      fireEvent.mouseEnter(node);
+      fireEvent.focus(node);
+
+      fireEvent.blur(node);
 
       expect(screen.getByRole('tooltip', { name: tooltipLabel })).not.toBeNull();
     });

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -103,6 +103,26 @@ describe('SankeyChart', () => {
     expect(screen.queryByText('Select at least two columns with data to display a flow')).toBeNull();
   });
 
+  describe('when the caller separates node identity from its display label', () => {
+    it('renders equal labels as distinct nodes', async () => {
+      render(
+        <Sankey
+          data={[
+            { channel: 'channel-one', channelLabel: 'Shared channel', region: 'eu', regionLabel: 'Europe' },
+            { channel: 'channel-two', channelLabel: 'Shared channel', region: 'us', regionLabel: 'United States' },
+          ]}
+          columns={columns.slice(0, 2)}
+          getRecordNodeId={(record, column) => String(record[column.id])}
+          getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
+        >
+          <SankeyChart />
+        </Sankey>,
+      );
+
+      expect(await screen.findAllByText('Shared channel')).toHaveLength(2);
+    });
+  });
+
   it('labels each chart column above its nodes', async () => {
     const { container } = render(<Example />);
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -126,6 +126,28 @@ describe('SankeyChart', () => {
     });
   });
 
+  describe('when a node label includes a description', () => {
+    it('keeps the visible label concise and exposes the description on hover and focus', async () => {
+      const fullLabel = 'Search\nLooks up relevant knowledge before responding.';
+      const { container } = render(
+        <Sankey
+          data={[{ channel: 'channel-one', channelLabel: fullLabel, region: 'eu', regionLabel: 'Europe' }]}
+          columns={columns.slice(0, 2)}
+          getRecordNodeId={(record, column) => String(record[column.id])}
+          getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
+        >
+          <SankeyChart />
+        </Sankey>,
+      );
+
+      await screen.findByText('Search', { selector: 'text' });
+      expect(
+        screen.getByLabelText('Search. Looks up relevant knowledge before responding.: 1 trace (100%)'),
+      ).not.toBeNull();
+      expect([...container.querySelectorAll('svg title')].map(title => title.textContent)).toContain(fullLabel);
+    });
+  });
+
   describe('when a node has a long display label', () => {
     it('truncates the visible text and preserves the full accessible label', async () => {
       const longLabel = 'Adding a transcript to a workspace with a very descriptive name';

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -126,6 +126,39 @@ describe('SankeyChart', () => {
     });
   });
 
+  describe('when current values change within stable layout weights', () => {
+    it('changes bar height without moving its center', async () => {
+      const renderFrame = (count: number) => (
+        <Sankey
+          data={[{ channel: 'Search', channelCount: count, region: 'EU', regionCount: count, count, layoutCount: 10 }]}
+          columns={columns.slice(0, 2)}
+          getRecordWeight={record => Number(record.count)}
+          getRecordLayoutWeight={record => Number(record.layoutCount)}
+          getRecordNodeValue={(record, column) => Number(record[`${column.id}Count`])}
+        >
+          <SankeyChart />
+        </Sankey>
+      );
+      const { rerender } = render(renderFrame(2));
+      const getSearchRect = async () => {
+        const node = await screen.findByLabelText(/Search: 2 traces/);
+        return node.querySelector('rect');
+      };
+      const initialRect = await getSearchRect();
+      const initialHeight = Number(initialRect?.getAttribute('height'));
+      const initialCenter = Number(initialRect?.getAttribute('y')) + initialHeight / 2;
+
+      rerender(renderFrame(8));
+
+      const updatedNode = await screen.findByLabelText(/Search: 8 traces/);
+      const updatedRect = updatedNode.querySelector('rect');
+      const updatedHeight = Number(updatedRect?.getAttribute('height'));
+      const updatedCenter = Number(updatedRect?.getAttribute('y')) + updatedHeight / 2;
+      expect(updatedHeight).toBeGreaterThan(initialHeight);
+      expect(updatedCenter).toBe(initialCenter);
+    });
+  });
+
   describe('when a node label includes a description', () => {
     const description =
       'Looks up relevant knowledge before responding, including all supporting context needed to explain a long theme description without clipping it.';

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -130,7 +130,10 @@ describe('SankeyChart', () => {
     it('changes bar height without moving its center', async () => {
       const renderFrame = (count: number) => (
         <Sankey
-          data={[{ channel: 'Search', channelCount: count, region: 'EU', regionCount: count, count, layoutCount: 10 }]}
+          data={[
+            { channel: 'Search', channelCount: count, region: 'EU', regionCount: count, count, layoutCount: 10 },
+            { channel: 'Referral', channelCount: 8, region: 'US', regionCount: 8, count: 8, layoutCount: 10 },
+          ]}
           columns={columns.slice(0, 2)}
           getRecordWeight={record => Number(record.count)}
           getRecordLayoutWeight={record => Number(record.layoutCount)}

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -127,11 +127,20 @@ describe('SankeyChart', () => {
   });
 
   describe('when a node label includes a description', () => {
-    it('keeps the visible label concise and exposes the description on hover and focus', async () => {
-      const fullLabel = 'Search\nLooks up relevant knowledge before responding.';
-      const { container } = render(
+    const nodeLabel = 'Search. Looks up relevant knowledge before responding.: 1 trace (100%)';
+    const tooltipLabel = 'Search: Looks up relevant knowledge before responding.';
+
+    function renderDescribedNode() {
+      return render(
         <Sankey
-          data={[{ channel: 'channel-one', channelLabel: fullLabel, region: 'eu', regionLabel: 'Europe' }]}
+          data={[
+            {
+              channel: 'channel-one',
+              channelLabel: 'Search\nLooks up relevant knowledge before responding.',
+              region: 'eu',
+              regionLabel: 'Europe',
+            },
+          ]}
           columns={columns.slice(0, 2)}
           getRecordNodeId={(record, column) => String(record[column.id])}
           getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
@@ -139,12 +148,24 @@ describe('SankeyChart', () => {
           <SankeyChart />
         </Sankey>,
       );
+    }
 
-      await screen.findByText('Search', { selector: 'text' });
-      expect(
-        screen.getByLabelText('Search. Looks up relevant knowledge before responding.: 1 trace (100%)'),
-      ).not.toBeNull();
-      expect([...container.querySelectorAll('svg title')].map(title => title.textContent)).toContain(fullLabel);
+    it('shows the description when the node receives focus', async () => {
+      renderDescribedNode();
+      const node = await screen.findByLabelText(nodeLabel);
+
+      fireEvent.focus(node);
+
+      expect(screen.getByRole('tooltip', { name: tooltipLabel })).not.toBeNull();
+    });
+
+    it('shows the description when the node is hovered', async () => {
+      renderDescribedNode();
+      const node = await screen.findByLabelText(nodeLabel);
+
+      fireEvent.mouseEnter(node);
+
+      expect(screen.getByRole('tooltip', { name: tooltipLabel })).not.toBeNull();
     });
   });
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -105,7 +105,7 @@ describe('SankeyChart', () => {
 
   describe('when the caller separates node identity from its display label', () => {
     it('renders equal labels as distinct nodes', async () => {
-      render(
+      const { container } = render(
         <Sankey
           data={[
             { channel: 'channel-one', channelLabel: 'Shared channel', region: 'eu', regionLabel: 'Europe' },
@@ -119,14 +119,37 @@ describe('SankeyChart', () => {
         </Sankey>,
       );
 
-      expect(await screen.findAllByText('Shared channel')).toHaveLength(2);
+      await screen.findAllByText('Shared channel');
+      expect(
+        [...container.querySelectorAll('svg text')].filter(node => node.textContent === 'Shared channel'),
+      ).toHaveLength(2);
+    });
+  });
+
+  describe('when a node has a long display label', () => {
+    it('truncates the visible text and preserves the full accessible label', async () => {
+      const longLabel = 'Adding a transcript to a workspace with a very descriptive name';
+      const { container } = render(
+        <Sankey
+          data={[{ channel: 'channel-one', channelLabel: longLabel, region: 'eu', regionLabel: 'Europe' }]}
+          columns={columns.slice(0, 2)}
+          getRecordNodeId={(record, column) => String(record[column.id])}
+          getRecordNodeLabel={(record, column) => String(record[`${column.id}Label`])}
+        >
+          <SankeyChart />
+        </Sankey>,
+      );
+
+      await screen.findByText('Adding a transcript to…');
+      expect([...container.querySelectorAll('svg title')].map(title => title.textContent)).toContain(longLabel);
+      expect(screen.getByLabelText(`${longLabel}: 1 trace (100%)`)).not.toBeNull();
     });
   });
 
   it('labels each chart column above its nodes', async () => {
     const { container } = render(<Example />);
 
-    await screen.findByText('Search');
+    await screen.findByText('Search', { selector: 'text' });
     const chartLabels = [...container.querySelectorAll('svg text')].map(element => element.textContent);
 
     expect(chartLabels).toEqual(expect.arrayContaining(['Channel', 'Region', 'Outcome']));
@@ -179,7 +202,7 @@ describe('SankeyChart', () => {
         </Sankey>,
       );
 
-      await screen.findByText('Search');
+      await screen.findByText('Search', { selector: 'text' });
 
       expect(container.querySelector('svg rect[rx="3"]')?.getAttribute('x')).toBe('24');
     });
@@ -254,7 +277,7 @@ describe('SankeyChart', () => {
   it('keeps every connected ribbon bright while hovering a node label', async () => {
     render(<Example onCurveClick={() => {}} />);
     const curves = await screen.findAllByRole('button', { name: 'Select Sankey curve' });
-    const searchLabel = screen.getByText('Search');
+    const searchLabel = screen.getByText('Search', { selector: 'text' });
 
     fireEvent.mouseEnter(searchLabel);
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -126,6 +126,31 @@ describe('SankeyChart', () => {
     });
   });
 
+  describe('when first-column labels have different lengths', () => {
+    it('aligns short and truncated labels to the same column edge', async () => {
+      const { container } = render(
+        <Sankey
+          data={[
+            { channel: 'Short label', region: 'EU' },
+            { channel: 'A deliberately long channel label', region: 'US' },
+          ]}
+          columns={columns.slice(0, 2)}
+          getRecordLayoutWeight={() => 1}
+        >
+          <SankeyChart />
+        </Sankey>,
+      );
+      await screen.findAllByText('Short label');
+      const labels = [...container.querySelectorAll('svg text')];
+      const shortLabel = labels.find(node => node.textContent === 'Short label');
+      const longLabel = labels.find(node => node.textContent === 'A deliberately long ch…');
+
+      expect(shortLabel?.getAttribute('x')).toBe(longLabel?.getAttribute('x'));
+      expect(shortLabel?.getAttribute('text-anchor')).toBe('start');
+      expect(longLabel?.getAttribute('text-anchor')).toBe('start');
+    });
+  });
+
   describe('when current values change within stable layout weights', () => {
     it('changes bar height without moving its center', async () => {
       const renderFrame = (count: number) => (
@@ -276,18 +301,18 @@ describe('SankeyChart', () => {
     expect(channelLabel?.getAttribute('x')).toBe('163.5');
     const searchLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Search');
     expect(searchLabel?.getAttribute('font-size')).toBe('11');
-    expect(searchLabel?.getAttribute('text-anchor')).toBe('middle');
-    expect(searchLabel?.getAttribute('x')).toBe('163.5');
+    expect(searchLabel?.getAttribute('text-anchor')).toBe('start');
+    expect(searchLabel?.getAttribute('x')).toBe('160');
     expect(Number(searchLabel?.getAttribute('y'))).toBeGreaterThan(Number(channelLabel?.getAttribute('y')) + 16);
     expect(Number(searchLabel?.getAttribute('y'))).toBeLessThan(Number(node?.getAttribute('y')));
     expect(searchLabel?.getAttribute('style')).toBeNull();
     const searchDetails = [...container.querySelectorAll('svg text')].find(
-      element => element.textContent === '3 (75%)' && element.getAttribute('x') === '163.5',
+      element => element.textContent === '3 (75%)' && element.getAttribute('x') === '160',
     );
-    expect(searchDetails?.getAttribute('text-anchor')).toBe('middle');
+    expect(searchDetails?.getAttribute('text-anchor')).toBe('start');
     expect(Number(searchDetails?.getAttribute('y'))).toBeLessThan(Number(node?.getAttribute('y')) - 4);
     const lostLabel = [...container.querySelectorAll('svg text')].find(element => element.textContent === 'Lost');
-    expect(lostLabel?.getAttribute('text-anchor')).toBe('middle');
+    expect(lostLabel?.getAttribute('text-anchor')).toBe('end');
     expect(container.querySelector('svg text[font-size="9.5"]')).not.toBeNull();
   });
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -355,6 +355,21 @@ describe('SankeyChart', () => {
     expect(curves[2]?.getAttribute('fill-opacity')).toBe('0.32');
   });
 
+  it('restores the focused source after the pointer leaves another node', async () => {
+    render(<Example onCurveClick={() => {}} />);
+    const curves = await screen.findAllByRole('button', { name: 'Select Sankey curve' });
+    const searchNode = screen.getByLabelText('Search: 3 traces (75%)');
+    const referralNode = screen.getByLabelText('Referral: 1 trace (25%)');
+
+    fireEvent.focus(searchNode);
+    fireEvent.mouseEnter(referralNode);
+    fireEvent.mouseLeave(referralNode);
+
+    expect(curves[0]?.getAttribute('fill-opacity')).toBe('0.75');
+    expect(curves[1]?.getAttribute('fill-opacity')).toBe('0.75');
+    expect(curves[2]?.getAttribute('fill-opacity')).toBe('0.32');
+  });
+
   it('lets user-land controls toggle columns and recomputes the rendered flow', async () => {
     render(<Example />);
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.test.tsx
@@ -170,8 +170,8 @@ describe('SankeyChart', () => {
       expect(screen.getByRole('tooltip', { name: tooltipLabel }).textContent).toContain(description);
     });
 
-    it('keeps the description visible when the pointer leaves a focused node', async () => {
-      renderDescribedNode();
+    it('keeps the description and ribbons active when the pointer leaves a focused node', async () => {
+      const { container } = renderDescribedNode();
       const node = await screen.findByLabelText(nodeLabel);
       fireEvent.focus(node);
       fireEvent.mouseEnter(node);
@@ -179,10 +179,11 @@ describe('SankeyChart', () => {
       fireEvent.mouseLeave(node);
 
       expect(screen.getByRole('tooltip', { name: tooltipLabel })).not.toBeNull();
+      expect(container.querySelector('svg path[fill-opacity]')?.getAttribute('fill-opacity')).toBe('0.75');
     });
 
-    it('keeps the description visible when a hovered node loses focus', async () => {
-      renderDescribedNode();
+    it('keeps the description and ribbons active when a hovered node loses focus', async () => {
+      const { container } = renderDescribedNode();
       const node = await screen.findByLabelText(nodeLabel);
       fireEvent.mouseEnter(node);
       fireEvent.focus(node);
@@ -190,6 +191,7 @@ describe('SankeyChart', () => {
       fireEvent.blur(node);
 
       expect(screen.getByRole('tooltip', { name: tooltipLabel })).not.toBeNull();
+      expect(container.querySelector('svg path[fill-opacity]')?.getAttribute('fill-opacity')).toBe('0.75');
     });
   });
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -1,15 +1,12 @@
-import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useId, useState } from 'react';
 import type { ComponentProps, CSSProperties, KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { ResponsiveContainer, Sankey as RechartsSankey } from 'recharts';
-import {
-  buildFixedSankeyGeometry,
-  getSankeyChartCurveSelection,
-  getSankeyChartNodeWeights,
-} from './sankey-chart-utils';
+import { getSankeyChartCurveSelection, getSankeyChartNodeWeights } from './sankey-chart-utils';
 import type { SankeyChartCurveSelection } from './sankey-chart-utils';
 import { useSankeyRenderContext } from './sankey-context';
 import { nodeColor, nodeColorVivid } from './sankeyColor';
+import { useSankeyChartMeasurements } from './use-sankey-chart-measurements';
 import { Colors } from '@/ds/tokens';
 import { cn } from '@/lib/utils';
 
@@ -27,9 +24,12 @@ export function SankeyChart({
   onCurveClick,
 }: SankeyChartProps) {
   const { graph, enabledColumns, hueMap, usesFixedGeometry } = useSankeyRenderContext();
-  const chartContainerRef = useRef<HTMLDivElement>(null);
-  const [measuredHeight, setMeasuredHeight] = useState(typeof height === 'number' ? height : 320);
-  const [measuredWidth, setMeasuredWidth] = useState(800);
+  const { chartContainerRef, fixedGeometry } = useSankeyChartMeasurements({
+    graph,
+    height,
+    margin,
+    usesFixedGeometry,
+  });
   const [hoveredSourceName, setHoveredSourceName] = useState<string>();
   const [focusedSourceName, setFocusedSourceName] = useState<string>();
   const activeSourceName = hoveredSourceName ?? focusedSourceName;
@@ -40,32 +40,6 @@ export function SankeyChart({
     (sum, node) =>
       node.column.id === firstColumnId ? sum + (node.displayValue ?? nodeWeights.get(node.id) ?? 0) : sum,
     0,
-  );
-  useEffect(() => {
-    const element = chartContainerRef.current;
-    if (!element) return;
-    const updateDimensions = () => {
-      if (element.offsetHeight > 0) setMeasuredHeight(element.offsetHeight);
-      if (element.offsetWidth > 0) setMeasuredWidth(element.offsetWidth);
-    };
-    updateDimensions();
-    if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(updateDimensions);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [height]);
-  const fixedGeometry = useMemo(
-    () =>
-      usesFixedGeometry
-        ? buildFixedSankeyGeometry(graph, {
-            top: Number(margin?.top ?? 64),
-            bottom: measuredHeight - Number(margin?.bottom ?? 12),
-            left: Number(margin?.left ?? 160),
-            right: measuredWidth - Number(margin?.right ?? 160) - 7,
-            nodePadding: 8,
-          })
-        : undefined,
-    [graph, margin?.bottom, margin?.left, margin?.right, margin?.top, measuredHeight, measuredWidth, usesFixedGeometry],
   );
 
   return (

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -142,9 +142,12 @@ function SankeyNode({
 }: SankeyNodeProps) {
   const name = typeof payload.name === 'string' || typeof payload.name === 'number' ? String(payload.name) : '';
   const displayLabel = label ?? name;
-  const visibleDisplayLabel = displayLabel.split('\n', 1)[0] ?? displayLabel;
+  const descriptionIndex = displayLabel.indexOf('\n');
+  const visibleDisplayLabel = descriptionIndex >= 0 ? displayLabel.slice(0, descriptionIndex) : displayLabel;
+  const description = descriptionIndex >= 0 ? displayLabel.slice(descriptionIndex + 1) : undefined;
   const accessibleLabel = displayLabel.replaceAll('\n', '. ');
   const visibleLabel = truncateNodeLabel(visibleDisplayLabel);
+  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
   const numericValue = typeof payload.value === 'number' ? payload.value : Number(payload.value);
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
@@ -153,15 +156,30 @@ function SankeyNode({
   const labelX = isTruncated && isFirstColumn ? x : isTruncated && isLastColumn ? x + width : x + width / 2;
   const columnLabelX = x + width / 2;
   const hue = hueMap[name] ?? 0;
+  const tooltipWidth = 240;
+  const tooltipX = isFirstColumn ? x : isLastColumn ? x + width - tooltipWidth : x + width / 2 - tooltipWidth / 2;
+  const tooltipY = y > 84 ? y - 76 : y + height + 8;
 
   return (
     <g
       aria-label={`${accessibleLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
       className="outline-none focus-visible:[&>rect]:stroke-neutral6 focus-visible:[&>rect]:stroke-2"
-      onFocus={() => onHoverChange(name)}
-      onBlur={() => onHoverChange(undefined)}
-      onMouseEnter={() => onHoverChange(name)}
-      onMouseLeave={() => onHoverChange(undefined)}
+      onFocus={() => {
+        onHoverChange(name);
+        setIsTooltipVisible(true);
+      }}
+      onBlur={() => {
+        onHoverChange(undefined);
+        setIsTooltipVisible(false);
+      }}
+      onMouseEnter={() => {
+        onHoverChange(name);
+        setIsTooltipVisible(true);
+      }}
+      onMouseLeave={() => {
+        onHoverChange(undefined);
+        setIsTooltipVisible(false);
+      }}
       tabIndex={0}
     >
       <title>{displayLabel}</title>
@@ -184,6 +202,22 @@ function SankeyNode({
       <text x={labelX} y={y - 8} textAnchor={textAnchor} fill={Colors.neutral3} fontSize={9.5}>
         {value} ({percentage}%)
       </text>
+      {description && isTooltipVisible ? (
+        <foreignObject
+          aria-label={`${visibleDisplayLabel}: ${description}`}
+          height={68}
+          pointerEvents="none"
+          role="tooltip"
+          width={tooltipWidth}
+          x={tooltipX}
+          y={tooltipY}
+        >
+          <div className="rounded-md border border-border1 bg-surface5 p-2 text-xs leading-4 text-neutral6 shadow-elevated">
+            <div className="font-medium">{visibleDisplayLabel}</div>
+            <div className="text-neutral4">{description}</div>
+          </div>
+        </foreignObject>
+      ) : null}
     </g>
   );
 }

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -1,8 +1,12 @@
-import { useId, useState } from 'react';
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
 import type { ComponentProps, CSSProperties, KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { ResponsiveContainer, Sankey as RechartsSankey } from 'recharts';
-import { getSankeyChartCurveSelection, getSankeyChartNodeWeights } from './sankey-chart-utils';
+import {
+  buildFixedSankeyGeometry,
+  getSankeyChartCurveSelection,
+  getSankeyChartNodeWeights,
+} from './sankey-chart-utils';
 import type { SankeyChartCurveSelection } from './sankey-chart-utils';
 import { useSankeyRenderContext } from './sankey-context';
 import { nodeColor, nodeColorVivid } from './sankeyColor';
@@ -22,7 +26,9 @@ export function SankeyChart({
   margin = { top: 64, right: 160, bottom: 12, left: 160 },
   onCurveClick,
 }: SankeyChartProps) {
-  const { graph, enabledColumns, hueMap } = useSankeyRenderContext();
+  const { graph, enabledColumns, hueMap, usesFixedGeometry } = useSankeyRenderContext();
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const [measuredHeight, setMeasuredHeight] = useState(typeof height === 'number' ? height : 320);
   const [hoveredSourceName, setHoveredSourceName] = useState<string>();
   const [focusedSourceName, setFocusedSourceName] = useState<string>();
   const activeSourceName = hoveredSourceName ?? focusedSourceName;
@@ -33,6 +39,29 @@ export function SankeyChart({
     (sum, node) =>
       node.column.id === firstColumnId ? sum + (node.displayValue ?? nodeWeights.get(node.id) ?? 0) : sum,
     0,
+  );
+  useEffect(() => {
+    const element = chartContainerRef.current;
+    if (!element) return;
+    const updateHeight = () => {
+      if (element.offsetHeight > 0) setMeasuredHeight(element.offsetHeight);
+    };
+    updateHeight();
+    if (typeof ResizeObserver === 'undefined') return;
+    const observer = new ResizeObserver(updateHeight);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [height]);
+  const fixedGeometry = useMemo(
+    () =>
+      usesFixedGeometry
+        ? buildFixedSankeyGeometry(graph, {
+            top: Number(margin?.top ?? 64),
+            bottom: measuredHeight - Number(margin?.bottom ?? 12),
+            nodePadding: 8,
+          })
+        : undefined,
+    [graph, margin?.bottom, margin?.top, measuredHeight, usesFixedGeometry],
   );
 
   return (
@@ -45,7 +74,7 @@ export function SankeyChart({
           Select at least two columns with data to display a flow
         </div>
       ) : (
-        <div style={{ height }}>
+        <div ref={chartContainerRef} style={{ height }}>
           <ResponsiveContainer
             width="100%"
             height="100%"
@@ -61,14 +90,17 @@ export function SankeyChart({
                 const showColumnLabel = node
                   ? graph.nodes.findIndex(candidate => candidate.column.id === node.column.id) === props.index
                   : false;
+                const nodeGeometry = node ? fixedGeometry?.nodes.get(node.id) : undefined;
                 return (
                   <SankeyNode
                     {...props}
+                    y={nodeGeometry?.y ?? props.y}
+                    height={nodeGeometry?.height ?? props.height}
                     hueMap={hueMap}
                     columnLabel={node?.column.label}
                     label={node?.label}
                     nodeValue={node?.displayValue}
-                    layoutValue={node ? nodeWeights.get(node.id) : undefined}
+                    layoutValue={nodeGeometry ? undefined : node ? nodeWeights.get(node.id) : undefined}
                     total={total}
                     showColumnLabel={showColumnLabel}
                     isFirstColumn={node?.column.id === firstColumnId}
@@ -80,9 +112,14 @@ export function SankeyChart({
               }}
               link={(props: SankeyLinkRendererProps) => {
                 const link = graph.links[props.index];
+                const linkGeometry = link ? fixedGeometry?.links.get(link.id) : undefined;
                 return (
                   <SankeyLink
                     {...props}
+                    sourceY={linkGeometry?.sourceY ?? props.sourceY}
+                    targetY={linkGeometry?.targetY ?? props.targetY}
+                    sourceWidth={linkGeometry?.sourceWidth}
+                    targetWidth={linkGeometry?.targetWidth}
                     hueMap={hueMap}
                     highlighted={String(props.payload.source.name ?? '') === activeSourceName}
                     displayValue={link?.displayValue}
@@ -280,6 +317,8 @@ type SankeyLinkProps = SankeyLinkRendererProps & {
   highlighted: boolean;
   displayValue?: number;
   layoutValue?: number;
+  sourceWidth?: number;
+  targetWidth?: number;
   clickable: boolean;
   onHoverChange: (sourceName: string | undefined) => void;
   onSelect: () => void;
@@ -299,17 +338,20 @@ function SankeyLink({
   highlighted,
   displayValue,
   layoutValue,
+  sourceWidth,
+  targetWidth,
   clickable,
   onHoverChange,
   onSelect,
 }: SankeyLinkProps) {
   const visibleWidth = scaleSankeyDimension(linkWidth, displayValue, layoutValue);
-  const halfWidth = Math.max(0, visibleWidth) / 2;
+  const sourceHalfWidth = Math.max(0, sourceWidth ?? visibleWidth) / 2;
+  const targetHalfWidth = Math.max(0, targetWidth ?? visibleWidth) / 2;
   const path = [
-    `M${sourceX},${sourceY - halfWidth}`,
-    `C${sourceControlX},${sourceY - halfWidth} ${targetControlX},${targetY - halfWidth} ${targetX},${targetY - halfWidth}`,
-    `L${targetX},${targetY + halfWidth}`,
-    `C${targetControlX},${targetY + halfWidth} ${sourceControlX},${sourceY + halfWidth} ${sourceX},${sourceY + halfWidth}`,
+    `M${sourceX},${sourceY - sourceHalfWidth}`,
+    `C${sourceControlX},${sourceY - sourceHalfWidth} ${targetControlX},${targetY - targetHalfWidth} ${targetX},${targetY - targetHalfWidth}`,
+    `L${targetX},${targetY + targetHalfWidth}`,
+    `C${targetControlX},${targetY + targetHalfWidth} ${sourceControlX},${sourceY + sourceHalfWidth} ${sourceX},${sourceY + sourceHalfWidth}`,
     'Z',
   ].join(' ');
   const sourceName = String(payload.source.name ?? '');

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -60,6 +60,7 @@ export function SankeyChart({
                     {...props}
                     hueMap={hueMap}
                     columnLabel={node?.column.label}
+                    label={node?.label}
                     total={total}
                     showColumnLabel={showColumnLabel}
                     onHoverChange={setHoveredSourceName}
@@ -113,6 +114,7 @@ type SankeyLinkRendererProps = {
 type SankeyNodeProps = SankeyNodeRendererProps & {
   hueMap: Record<string, number>;
   columnLabel?: string;
+  label?: string;
   total: number;
   showColumnLabel: boolean;
   onHoverChange: (sourceName: string | undefined) => void;
@@ -126,11 +128,13 @@ function SankeyNode({
   payload,
   hueMap,
   columnLabel,
+  label,
   total,
   showColumnLabel,
   onHoverChange,
 }: SankeyNodeProps) {
   const name = typeof payload.name === 'string' || typeof payload.name === 'number' ? String(payload.name) : '';
+  const displayLabel = label ?? name;
   const numericValue = typeof payload.value === 'number' ? payload.value : Number(payload.value);
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
@@ -154,7 +158,7 @@ function SankeyNode({
         fontSize={11}
         fontFamily="var(--font-mono)"
       >
-        {name}
+        {displayLabel}
       </text>
       <text x={labelX} y={y - 8} textAnchor="middle" fill={Colors.neutral3} fontSize={9.5}>
         {value} ({percentage}%)

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -155,6 +155,7 @@ function SankeyNode({
   return (
     <g
       aria-label={`${displayLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
+      className="outline-none focus-visible:[&>rect]:stroke-neutral6 focus-visible:[&>rect]:stroke-2"
       onFocus={() => onHoverChange(name)}
       onBlur={() => onHoverChange(undefined)}
       onMouseEnter={() => onHoverChange(name)}

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -24,6 +24,8 @@ export function SankeyChart({
 }: SankeyChartProps) {
   const { graph, enabledColumns, hueMap } = useSankeyRenderContext();
   const [hoveredSourceName, setHoveredSourceName] = useState<string>();
+  const [focusedSourceName, setFocusedSourceName] = useState<string>();
+  const activeSourceName = hoveredSourceName ?? focusedSourceName;
   const firstColumnId = enabledColumns[0]?.id;
   const lastColumnId = enabledColumns.at(-1)?.id;
   const total = graph.links.reduce(
@@ -67,6 +69,7 @@ export function SankeyChart({
                     showColumnLabel={showColumnLabel}
                     isFirstColumn={node?.column.id === firstColumnId}
                     isLastColumn={node?.column.id === lastColumnId}
+                    onFocusChange={setFocusedSourceName}
                     onHoverChange={setHoveredSourceName}
                   />
                 );
@@ -77,7 +80,7 @@ export function SankeyChart({
                   <SankeyLink
                     {...props}
                     hueMap={hueMap}
-                    highlighted={String(props.payload.source.name ?? '') === hoveredSourceName}
+                    highlighted={String(props.payload.source.name ?? '') === activeSourceName}
                     onHoverChange={setHoveredSourceName}
                     clickable={onCurveClick !== undefined}
                     onSelect={() => {
@@ -123,6 +126,7 @@ type SankeyNodeProps = SankeyNodeRendererProps & {
   showColumnLabel: boolean;
   isFirstColumn: boolean;
   isLastColumn: boolean;
+  onFocusChange: (sourceName: string | undefined) => void;
   onHoverChange: (sourceName: string | undefined) => void;
 };
 
@@ -139,6 +143,7 @@ function SankeyNode({
   showColumnLabel,
   isFirstColumn,
   isLastColumn,
+  onFocusChange,
   onHoverChange,
 }: SankeyNodeProps) {
   const name = typeof payload.name === 'string' || typeof payload.name === 'number' ? String(payload.name) : '';
@@ -182,12 +187,12 @@ function SankeyNode({
         aria-label={`${accessibleLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
         className="outline-none focus-visible:[&>rect]:stroke-neutral6 focus-visible:[&>rect]:stroke-2"
         onFocus={event => {
-          onHoverChange(name);
+          onFocusChange(name);
           setIsFocused(true);
           showTooltipAt(event.currentTarget);
         }}
         onBlur={() => {
-          if (!isHovered) onHoverChange(undefined);
+          onFocusChange(undefined);
           setIsFocused(false);
         }}
         onMouseEnter={event => {
@@ -196,7 +201,7 @@ function SankeyNode({
           showTooltipAt(event.currentTarget);
         }}
         onMouseLeave={() => {
-          if (!isFocused) onHoverChange(undefined);
+          onHoverChange(undefined);
           setIsHovered(false);
         }}
         tabIndex={0}

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -187,7 +187,7 @@ function SankeyNode({
           showTooltipAt(event.currentTarget);
         }}
         onBlur={() => {
-          onHoverChange(undefined);
+          if (!isHovered) onHoverChange(undefined);
           setIsFocused(false);
         }}
         onMouseEnter={event => {
@@ -196,7 +196,7 @@ function SankeyNode({
           showTooltipAt(event.currentTarget);
         }}
         onMouseLeave={() => {
-          onHoverChange(undefined);
+          if (!isFocused) onHoverChange(undefined);
           setIsHovered(false);
         }}
         tabIndex={0}

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -24,6 +24,7 @@ export function SankeyChart({
   const { graph, enabledColumns, hueMap } = useSankeyRenderContext();
   const [hoveredSourceName, setHoveredSourceName] = useState<string>();
   const firstColumnId = enabledColumns[0]?.id;
+  const lastColumnId = enabledColumns.at(-1)?.id;
   const total = graph.links.reduce(
     (sum, link) => (link.sourceNode.column.id === firstColumnId ? sum + link.value : sum),
     0,
@@ -63,6 +64,8 @@ export function SankeyChart({
                     label={node?.label}
                     total={total}
                     showColumnLabel={showColumnLabel}
+                    isFirstColumn={node?.column.id === firstColumnId}
+                    isLastColumn={node?.column.id === lastColumnId}
                     onHoverChange={setHoveredSourceName}
                   />
                 );
@@ -117,6 +120,8 @@ type SankeyNodeProps = SankeyNodeRendererProps & {
   label?: string;
   total: number;
   showColumnLabel: boolean;
+  isFirstColumn: boolean;
+  isLastColumn: boolean;
   onHoverChange: (sourceName: string | undefined) => void;
 };
 
@@ -131,19 +136,32 @@ function SankeyNode({
   label,
   total,
   showColumnLabel,
+  isFirstColumn,
+  isLastColumn,
   onHoverChange,
 }: SankeyNodeProps) {
   const name = typeof payload.name === 'string' || typeof payload.name === 'number' ? String(payload.name) : '';
   const displayLabel = label ?? name;
+  const visibleLabel = truncateNodeLabel(displayLabel);
   const numericValue = typeof payload.value === 'number' ? payload.value : Number(payload.value);
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
-  const labelX = x + width / 2;
+  const isTruncated = visibleLabel !== displayLabel;
+  const textAnchor = isTruncated && isFirstColumn ? 'start' : isTruncated && isLastColumn ? 'end' : 'middle';
+  const labelX = isTruncated && isFirstColumn ? x : isTruncated && isLastColumn ? x + width : x + width / 2;
   const columnLabelX = x + width / 2;
   const hue = hueMap[name] ?? 0;
 
   return (
-    <g onMouseEnter={() => onHoverChange(name)} onMouseLeave={() => onHoverChange(undefined)}>
+    <g
+      aria-label={`${displayLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
+      onFocus={() => onHoverChange(name)}
+      onBlur={() => onHoverChange(undefined)}
+      onMouseEnter={() => onHoverChange(name)}
+      onMouseLeave={() => onHoverChange(undefined)}
+      tabIndex={0}
+    >
+      <title>{displayLabel}</title>
       {showColumnLabel && columnLabel ? (
         <text x={columnLabelX} y={18} textAnchor="middle" fill={nodeColor(hue)} fontSize={12} fontWeight={600}>
           {columnLabel}
@@ -153,18 +171,24 @@ function SankeyNode({
       <text
         x={labelX}
         y={y - 24}
-        textAnchor="middle"
+        textAnchor={textAnchor}
         fill={Colors.neutral5}
         fontSize={11}
         fontFamily="var(--font-mono)"
       >
-        {displayLabel}
+        {visibleLabel}
       </text>
-      <text x={labelX} y={y - 8} textAnchor="middle" fill={Colors.neutral3} fontSize={9.5}>
+      <text x={labelX} y={y - 8} textAnchor={textAnchor} fill={Colors.neutral3} fontSize={9.5}>
         {value} ({percentage}%)
       </text>
     </g>
   );
+}
+
+function truncateNodeLabel(label: string) {
+  const maximumLength = 23;
+  if (label.length <= maximumLength) return label;
+  return `${label.slice(0, maximumLength - 1).trimEnd()}…`;
 }
 
 type SankeyLinkProps = SankeyLinkRendererProps & {

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -142,11 +142,13 @@ function SankeyNode({
 }: SankeyNodeProps) {
   const name = typeof payload.name === 'string' || typeof payload.name === 'number' ? String(payload.name) : '';
   const displayLabel = label ?? name;
-  const visibleLabel = truncateNodeLabel(displayLabel);
+  const visibleDisplayLabel = displayLabel.split('\n', 1)[0] ?? displayLabel;
+  const accessibleLabel = displayLabel.replaceAll('\n', '. ');
+  const visibleLabel = truncateNodeLabel(visibleDisplayLabel);
   const numericValue = typeof payload.value === 'number' ? payload.value : Number(payload.value);
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
-  const isTruncated = visibleLabel !== displayLabel;
+  const isTruncated = visibleLabel !== visibleDisplayLabel;
   const textAnchor = isTruncated && isFirstColumn ? 'start' : isTruncated && isLastColumn ? 'end' : 'middle';
   const labelX = isTruncated && isFirstColumn ? x : isTruncated && isLastColumn ? x + width : x + width / 2;
   const columnLabelX = x + width / 2;
@@ -154,7 +156,7 @@ function SankeyNode({
 
   return (
     <g
-      aria-label={`${displayLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
+      aria-label={`${accessibleLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
       className="outline-none focus-visible:[&>rect]:stroke-neutral6 focus-visible:[&>rect]:stroke-2"
       onFocus={() => onHoverChange(name)}
       onBlur={() => onHoverChange(undefined)}

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -68,6 +68,7 @@ export function SankeyChart({
                     columnLabel={node?.column.label}
                     label={node?.label}
                     nodeValue={node?.displayValue}
+                    layoutValue={node ? nodeWeights.get(node.id) : undefined}
                     total={total}
                     showColumnLabel={showColumnLabel}
                     isFirstColumn={node?.column.id === firstColumnId}
@@ -84,6 +85,8 @@ export function SankeyChart({
                     {...props}
                     hueMap={hueMap}
                     highlighted={String(props.payload.source.name ?? '') === activeSourceName}
+                    displayValue={link?.displayValue}
+                    layoutValue={link?.value}
                     onHoverChange={setHoveredSourceName}
                     clickable={onCurveClick !== undefined}
                     onSelect={() => {
@@ -126,6 +129,7 @@ type SankeyNodeProps = SankeyNodeRendererProps & {
   columnLabel?: string;
   label?: string;
   nodeValue?: number;
+  layoutValue?: number;
   total: number;
   showColumnLabel: boolean;
   isFirstColumn: boolean;
@@ -144,6 +148,7 @@ function SankeyNode({
   columnLabel,
   label,
   nodeValue,
+  layoutValue,
   total,
   showColumnLabel,
   isFirstColumn,
@@ -169,6 +174,8 @@ function SankeyNode({
   const numericValue = nodeValue ?? (typeof payload.value === 'number' ? payload.value : Number(payload.value));
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
+  const visibleHeight = scaleSankeyDimension(height, numericValue, layoutValue);
+  const visibleY = y + (height - visibleHeight) / 2;
   const isTruncated = visibleLabel !== visibleDisplayLabel;
   const textAnchor = isTruncated && isFirstColumn ? 'start' : isTruncated && isLastColumn ? 'end' : 'middle';
   const labelX = isTruncated && isFirstColumn ? x : isTruncated && isLastColumn ? x + width : x + width / 2;
@@ -217,7 +224,7 @@ function SankeyNode({
             {columnLabel}
           </text>
         ) : null}
-        <rect x={x} y={y} width={width} height={height} rx={3} fill={nodeColor(hue)} />
+        <rect x={x} y={visibleY} width={width} height={visibleHeight} rx={3} fill={nodeColor(hue)} />
         <text
           x={labelX}
           y={y - 24}
@@ -257,6 +264,11 @@ function SankeyNode({
   );
 }
 
+function scaleSankeyDimension(size: number, displayValue: number | undefined, layoutValue: number | undefined) {
+  if (displayValue === undefined || layoutValue === undefined || layoutValue <= 0) return size;
+  return size * Math.min(Math.max(displayValue / layoutValue, 0), 1);
+}
+
 function truncateNodeLabel(label: string) {
   const maximumLength = 23;
   if (label.length <= maximumLength) return label;
@@ -266,6 +278,8 @@ function truncateNodeLabel(label: string) {
 type SankeyLinkProps = SankeyLinkRendererProps & {
   hueMap: Record<string, number>;
   highlighted: boolean;
+  displayValue?: number;
+  layoutValue?: number;
   clickable: boolean;
   onHoverChange: (sourceName: string | undefined) => void;
   onSelect: () => void;
@@ -283,11 +297,14 @@ function SankeyLink({
   payload,
   hueMap,
   highlighted,
+  displayValue,
+  layoutValue,
   clickable,
   onHoverChange,
   onSelect,
 }: SankeyLinkProps) {
-  const halfWidth = Math.max(0, linkWidth) / 2;
+  const visibleWidth = scaleSankeyDimension(linkWidth, displayValue, layoutValue);
+  const halfWidth = Math.max(0, visibleWidth) / 2;
   const path = [
     `M${sourceX},${sourceY - halfWidth}`,
     `C${sourceControlX},${sourceY - halfWidth} ${targetControlX},${targetY - halfWidth} ${targetX},${targetY - halfWidth}`,

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -29,6 +29,7 @@ export function SankeyChart({
   const { graph, enabledColumns, hueMap, usesFixedGeometry } = useSankeyRenderContext();
   const chartContainerRef = useRef<HTMLDivElement>(null);
   const [measuredHeight, setMeasuredHeight] = useState(typeof height === 'number' ? height : 320);
+  const [measuredWidth, setMeasuredWidth] = useState(800);
   const [hoveredSourceName, setHoveredSourceName] = useState<string>();
   const [focusedSourceName, setFocusedSourceName] = useState<string>();
   const activeSourceName = hoveredSourceName ?? focusedSourceName;
@@ -43,12 +44,13 @@ export function SankeyChart({
   useEffect(() => {
     const element = chartContainerRef.current;
     if (!element) return;
-    const updateHeight = () => {
+    const updateDimensions = () => {
       if (element.offsetHeight > 0) setMeasuredHeight(element.offsetHeight);
+      if (element.offsetWidth > 0) setMeasuredWidth(element.offsetWidth);
     };
-    updateHeight();
+    updateDimensions();
     if (typeof ResizeObserver === 'undefined') return;
-    const observer = new ResizeObserver(updateHeight);
+    const observer = new ResizeObserver(updateDimensions);
     observer.observe(element);
     return () => observer.disconnect();
   }, [height]);
@@ -58,10 +60,12 @@ export function SankeyChart({
         ? buildFixedSankeyGeometry(graph, {
             top: Number(margin?.top ?? 64),
             bottom: measuredHeight - Number(margin?.bottom ?? 12),
+            left: Number(margin?.left ?? 160),
+            right: measuredWidth - Number(margin?.right ?? 160) - 7,
             nodePadding: 8,
           })
         : undefined,
-    [graph, margin?.bottom, margin?.top, measuredHeight, usesFixedGeometry],
+    [graph, margin?.bottom, margin?.left, margin?.right, margin?.top, measuredHeight, measuredWidth, usesFixedGeometry],
   );
 
   return (
@@ -94,6 +98,7 @@ export function SankeyChart({
                 return (
                   <SankeyNode
                     {...props}
+                    x={nodeGeometry?.x ?? props.x}
                     y={nodeGeometry?.y ?? props.y}
                     height={nodeGeometry?.height ?? props.height}
                     hueMap={hueMap}

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -2,7 +2,7 @@ import { useId, useState } from 'react';
 import type { ComponentProps, CSSProperties, KeyboardEvent } from 'react';
 import { createPortal } from 'react-dom';
 import { ResponsiveContainer, Sankey as RechartsSankey } from 'recharts';
-import { getSankeyChartCurveSelection } from './sankey-chart-utils';
+import { getSankeyChartCurveSelection, getSankeyChartNodeWeights } from './sankey-chart-utils';
 import type { SankeyChartCurveSelection } from './sankey-chart-utils';
 import { useSankeyRenderContext } from './sankey-context';
 import { nodeColor, nodeColorVivid } from './sankeyColor';
@@ -28,8 +28,10 @@ export function SankeyChart({
   const activeSourceName = hoveredSourceName ?? focusedSourceName;
   const firstColumnId = enabledColumns[0]?.id;
   const lastColumnId = enabledColumns.at(-1)?.id;
-  const total = graph.links.reduce(
-    (sum, link) => (link.sourceNode.column.id === firstColumnId ? sum + link.value : sum),
+  const nodeWeights = getSankeyChartNodeWeights(graph);
+  const total = graph.nodes.reduce(
+    (sum, node) =>
+      node.column.id === firstColumnId ? sum + (node.displayValue ?? nodeWeights.get(node.id) ?? 0) : sum,
     0,
   );
 
@@ -65,6 +67,7 @@ export function SankeyChart({
                     hueMap={hueMap}
                     columnLabel={node?.column.label}
                     label={node?.label}
+                    nodeValue={node?.displayValue}
                     total={total}
                     showColumnLabel={showColumnLabel}
                     isFirstColumn={node?.column.id === firstColumnId}
@@ -122,6 +125,7 @@ type SankeyNodeProps = SankeyNodeRendererProps & {
   hueMap: Record<string, number>;
   columnLabel?: string;
   label?: string;
+  nodeValue?: number;
   total: number;
   showColumnLabel: boolean;
   isFirstColumn: boolean;
@@ -139,6 +143,7 @@ function SankeyNode({
   hueMap,
   columnLabel,
   label,
+  nodeValue,
   total,
   showColumnLabel,
   isFirstColumn,
@@ -161,7 +166,7 @@ function SankeyNode({
     top: number;
     placement: 'above' | 'below';
   }>();
-  const numericValue = typeof payload.value === 'number' ? payload.value : Number(payload.value);
+  const numericValue = nodeValue ?? (typeof payload.value === 'number' ? payload.value : Number(payload.value));
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
   const isTruncated = visibleLabel !== visibleDisplayLabel;

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -218,9 +218,8 @@ function SankeyNode({
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
   const visibleHeight = scaleSankeyDimension(height, numericValue, layoutValue);
   const visibleY = y + (height - visibleHeight) / 2;
-  const isTruncated = visibleLabel !== visibleDisplayLabel;
-  const textAnchor = isTruncated && isFirstColumn ? 'start' : isTruncated && isLastColumn ? 'end' : 'middle';
-  const labelX = isTruncated && isFirstColumn ? x : isTruncated && isLastColumn ? x + width : x + width / 2;
+  const textAnchor = isFirstColumn ? 'start' : isLastColumn ? 'end' : 'middle';
+  const labelX = isFirstColumn ? x : isLastColumn ? x + width : x + width / 2;
   const columnLabelX = x + width / 2;
   const hue = hueMap[name] ?? 0;
   const isTooltipVisible = Boolean(description && tooltipPosition && (isHovered || isFocused));

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-chart.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import type { ComponentProps, CSSProperties, KeyboardEvent } from 'react';
+import { createPortal } from 'react-dom';
 import { ResponsiveContainer, Sankey as RechartsSankey } from 'recharts';
 import { getSankeyChartCurveSelection } from './sankey-chart-utils';
 import type { SankeyChartCurveSelection } from './sankey-chart-utils';
@@ -147,7 +148,14 @@ function SankeyNode({
   const description = descriptionIndex >= 0 ? displayLabel.slice(descriptionIndex + 1) : undefined;
   const accessibleLabel = displayLabel.replaceAll('\n', '. ');
   const visibleLabel = truncateNodeLabel(visibleDisplayLabel);
-  const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+  const tooltipId = useId();
+  const [isHovered, setIsHovered] = useState(false);
+  const [isFocused, setIsFocused] = useState(false);
+  const [tooltipPosition, setTooltipPosition] = useState<{
+    left: number;
+    top: number;
+    placement: 'above' | 'below';
+  }>();
   const numericValue = typeof payload.value === 'number' ? payload.value : Number(payload.value);
   const value = Number.isFinite(numericValue) ? String(numericValue) : '';
   const percentage = total > 0 && Number.isFinite(numericValue) ? Math.round((numericValue / total) * 100) : 0;
@@ -156,69 +164,86 @@ function SankeyNode({
   const labelX = isTruncated && isFirstColumn ? x : isTruncated && isLastColumn ? x + width : x + width / 2;
   const columnLabelX = x + width / 2;
   const hue = hueMap[name] ?? 0;
-  const tooltipWidth = 240;
-  const tooltipX = isFirstColumn ? x : isLastColumn ? x + width - tooltipWidth : x + width / 2 - tooltipWidth / 2;
-  const tooltipY = y > 84 ? y - 76 : y + height + 8;
+  const isTooltipVisible = Boolean(description && tooltipPosition && (isHovered || isFocused));
+  const showTooltipAt = (target: SVGGElement) => {
+    const rect = target.getBoundingClientRect();
+    const placement = rect.top < 120 ? 'below' : 'above';
+    setTooltipPosition({
+      left: Math.min(Math.max(rect.left, 16), Math.max(window.innerWidth - 336, 16)),
+      top: placement === 'above' ? rect.top - 8 : rect.bottom + 8,
+      placement,
+    });
+  };
 
   return (
-    <g
-      aria-label={`${accessibleLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
-      className="outline-none focus-visible:[&>rect]:stroke-neutral6 focus-visible:[&>rect]:stroke-2"
-      onFocus={() => {
-        onHoverChange(name);
-        setIsTooltipVisible(true);
-      }}
-      onBlur={() => {
-        onHoverChange(undefined);
-        setIsTooltipVisible(false);
-      }}
-      onMouseEnter={() => {
-        onHoverChange(name);
-        setIsTooltipVisible(true);
-      }}
-      onMouseLeave={() => {
-        onHoverChange(undefined);
-        setIsTooltipVisible(false);
-      }}
-      tabIndex={0}
-    >
-      <title>{displayLabel}</title>
-      {showColumnLabel && columnLabel ? (
-        <text x={columnLabelX} y={18} textAnchor="middle" fill={nodeColor(hue)} fontSize={12} fontWeight={600}>
-          {columnLabel}
-        </text>
-      ) : null}
-      <rect x={x} y={y} width={width} height={height} rx={3} fill={nodeColor(hue)} />
-      <text
-        x={labelX}
-        y={y - 24}
-        textAnchor={textAnchor}
-        fill={Colors.neutral5}
-        fontSize={11}
-        fontFamily="var(--font-mono)"
+    <>
+      <g
+        aria-describedby={description ? tooltipId : undefined}
+        aria-label={`${accessibleLabel}: ${value} ${numericValue === 1 ? 'trace' : 'traces'} (${percentage}%)`}
+        className="outline-none focus-visible:[&>rect]:stroke-neutral6 focus-visible:[&>rect]:stroke-2"
+        onFocus={event => {
+          onHoverChange(name);
+          setIsFocused(true);
+          showTooltipAt(event.currentTarget);
+        }}
+        onBlur={() => {
+          onHoverChange(undefined);
+          setIsFocused(false);
+        }}
+        onMouseEnter={event => {
+          onHoverChange(name);
+          setIsHovered(true);
+          showTooltipAt(event.currentTarget);
+        }}
+        onMouseLeave={() => {
+          onHoverChange(undefined);
+          setIsHovered(false);
+        }}
+        tabIndex={0}
       >
-        {visibleLabel}
-      </text>
-      <text x={labelX} y={y - 8} textAnchor={textAnchor} fill={Colors.neutral3} fontSize={9.5}>
-        {value} ({percentage}%)
-      </text>
-      {description && isTooltipVisible ? (
-        <foreignObject
-          aria-label={`${visibleDisplayLabel}: ${description}`}
-          height={68}
-          pointerEvents="none"
-          role="tooltip"
-          width={tooltipWidth}
-          x={tooltipX}
-          y={tooltipY}
+        <title>{displayLabel}</title>
+        {showColumnLabel && columnLabel ? (
+          <text x={columnLabelX} y={18} textAnchor="middle" fill={nodeColor(hue)} fontSize={12} fontWeight={600}>
+            {columnLabel}
+          </text>
+        ) : null}
+        <rect x={x} y={y} width={width} height={height} rx={3} fill={nodeColor(hue)} />
+        <text
+          x={labelX}
+          y={y - 24}
+          textAnchor={textAnchor}
+          fill={Colors.neutral5}
+          fontSize={11}
+          fontFamily="var(--font-mono)"
         >
-          <div className="rounded-md border border-border1 bg-surface5 p-2 text-xs leading-4 text-neutral6 shadow-elevated">
-            <div className="font-medium">{visibleDisplayLabel}</div>
-            <div className="text-neutral4">{description}</div>
-          </div>
-        </foreignObject>
-      ) : null}
-    </g>
+          {visibleLabel}
+        </text>
+        <text x={labelX} y={y - 8} textAnchor={textAnchor} fill={Colors.neutral3} fontSize={9.5}>
+          {value} ({percentage}%)
+        </text>
+      </g>
+      {description && isTooltipVisible && tooltipPosition
+        ? createPortal(
+            <div
+              aria-label={`${visibleDisplayLabel}: ${description}`}
+              className="pointer-events-none fixed z-50 rounded-md border border-border1 bg-surface5 p-2 text-xs leading-4 text-neutral6 shadow-elevated"
+              id={tooltipId}
+              role="tooltip"
+              style={{
+                left: tooltipPosition.left,
+                maxWidth: 'min(20rem, calc(100vw - 2rem))',
+                top: tooltipPosition.top,
+                transform: tooltipPosition.placement === 'above' ? 'translateY(-100%)' : undefined,
+                width: 'max-content',
+              }}
+            >
+              <div className="font-medium">{visibleDisplayLabel}</div>
+              <div className="whitespace-pre-wrap text-neutral4">{description}</div>
+            </div>,
+            document.body,
+          )
+        : null}
+    </>
   );
 }
 

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
@@ -34,6 +34,7 @@ type SankeyRenderContext = {
   graph: SankeyChartGraph;
   enabledColumns: Array<SankeyChartColumn>;
   hueMap: Record<string, number>;
+  usesFixedGeometry: boolean;
 };
 
 const SankeyControlsContext = createContext<SankeyControls | undefined>(undefined);
@@ -107,7 +108,11 @@ export function Sankey({
 
   return (
     <SankeyControlsContext.Provider value={{ columns: controlColumns, toggleColumn, reorderColumns }}>
-      <SankeyRenderContext.Provider value={{ graph, enabledColumns, hueMap }}>{children}</SankeyRenderContext.Provider>
+      <SankeyRenderContext.Provider
+        value={{ graph, enabledColumns, hueMap, usesFixedGeometry: getRecordLayoutWeight !== undefined }}
+      >
+        {children}
+      </SankeyRenderContext.Provider>
     </SankeyControlsContext.Provider>
   );
 }

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
@@ -15,6 +15,7 @@ export type SankeyProps = {
   getRecordWeight?: (record: SankeyChartRecord) => number;
   getRecordNodeId?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
   getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
+  getRecordNodeValue?: (record: SankeyChartRecord, column: SankeyChartColumn) => number;
   getColumnHue?: (column: SankeyChartColumn) => number;
 };
 
@@ -48,6 +49,7 @@ export function Sankey({
   getRecordWeight,
   getRecordNodeId,
   getRecordNodeLabel,
+  getRecordNodeValue,
   getColumnHue,
 }: SankeyProps) {
   const columnIds = columns.map(column => column.id);
@@ -56,7 +58,14 @@ export function Sankey({
   const orderedColumns = orderColumns(columns, columnOrder ?? internalOrder);
   const visibleIds = new Set(visibleColumnIds ?? internalVisibleIds);
   const enabledColumns = orderedColumns.filter(column => visibleIds.has(column.id));
-  const graph = buildSankeyChartGraph(data, enabledColumns, getRecordWeight, getRecordNodeId, getRecordNodeLabel);
+  const graph = buildSankeyChartGraph(
+    data,
+    enabledColumns,
+    getRecordWeight,
+    getRecordNodeId,
+    getRecordNodeLabel,
+    getRecordNodeValue,
+  );
   const defaultHueMap = buildSankeyHueMap(graph.nodes.map(node => String(node.value)));
   const hueMap = Object.fromEntries(
     graph.nodes.map(node => [

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
@@ -13,6 +13,7 @@ export type SankeyProps = {
   visibleColumnIds?: Array<string>;
   onVisibleColumnIdsChange?: (columnIds: Array<string>) => void;
   getRecordWeight?: (record: SankeyChartRecord) => number;
+  getRecordLayoutWeight?: (record: SankeyChartRecord) => number;
   getRecordNodeId?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
   getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
   getRecordNodeValue?: (record: SankeyChartRecord, column: SankeyChartColumn) => number;
@@ -47,6 +48,7 @@ export function Sankey({
   visibleColumnIds,
   onVisibleColumnIdsChange,
   getRecordWeight,
+  getRecordLayoutWeight,
   getRecordNodeId,
   getRecordNodeLabel,
   getRecordNodeValue,
@@ -65,6 +67,7 @@ export function Sankey({
     getRecordNodeId,
     getRecordNodeLabel,
     getRecordNodeValue,
+    getRecordLayoutWeight,
   );
   const defaultHueMap = buildSankeyHueMap(graph.nodes.map(node => String(node.value)));
   const hueMap = Object.fromEntries(

--- a/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
+++ b/packages/playground-ui/src/ds/components/SankeyChart/sankey-context.tsx
@@ -13,6 +13,8 @@ export type SankeyProps = {
   visibleColumnIds?: Array<string>;
   onVisibleColumnIdsChange?: (columnIds: Array<string>) => void;
   getRecordWeight?: (record: SankeyChartRecord) => number;
+  getRecordNodeId?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
+  getRecordNodeLabel?: (record: SankeyChartRecord, column: SankeyChartColumn) => string;
   getColumnHue?: (column: SankeyChartColumn) => number;
 };
 
@@ -44,6 +46,8 @@ export function Sankey({
   visibleColumnIds,
   onVisibleColumnIdsChange,
   getRecordWeight,
+  getRecordNodeId,
+  getRecordNodeLabel,
   getColumnHue,
 }: SankeyProps) {
   const columnIds = columns.map(column => column.id);
@@ -52,7 +56,7 @@ export function Sankey({
   const orderedColumns = orderColumns(columns, columnOrder ?? internalOrder);
   const visibleIds = new Set(visibleColumnIds ?? internalVisibleIds);
   const enabledColumns = orderedColumns.filter(column => visibleIds.has(column.id));
-  const graph = buildSankeyChartGraph(data, enabledColumns, getRecordWeight);
+  const graph = buildSankeyChartGraph(data, enabledColumns, getRecordWeight, getRecordNodeId, getRecordNodeLabel);
   const defaultHueMap = buildSankeyHueMap(graph.nodes.map(node => String(node.value)));
   const hueMap = Object.fromEntries(
     graph.nodes.map(node => [

--- a/packages/playground-ui/src/ds/components/SankeyChart/use-sankey-chart-measurements.ts
+++ b/packages/playground-ui/src/ds/components/SankeyChart/use-sankey-chart-measurements.ts
@@ -1,0 +1,57 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { ComponentProps, CSSProperties } from 'react';
+import type { Sankey as RechartsSankey } from 'recharts';
+
+import { buildFixedSankeyGeometry } from './sankey-chart-utils';
+import type { SankeyChartGraph } from './sankey-chart-utils';
+
+type SankeyChartMeasurementsOptions = {
+  graph: SankeyChartGraph;
+  height: CSSProperties['height'];
+  margin: ComponentProps<typeof RechartsSankey>['margin'];
+  usesFixedGeometry: boolean;
+};
+
+export function useSankeyChartMeasurements({
+  graph,
+  height,
+  margin,
+  usesFixedGeometry,
+}: SankeyChartMeasurementsOptions) {
+  const chartContainerRef = useRef<HTMLDivElement>(null);
+  const [measuredHeight, setMeasuredHeight] = useState(typeof height === 'number' ? height : 320);
+  const [measuredWidth, setMeasuredWidth] = useState(800);
+
+  useEffect(() => {
+    const element = chartContainerRef.current;
+    if (!element) return;
+
+    const updateDimensions = () => {
+      if (element.offsetHeight > 0) setMeasuredHeight(element.offsetHeight);
+      if (element.offsetWidth > 0) setMeasuredWidth(element.offsetWidth);
+    };
+
+    updateDimensions();
+    if (typeof ResizeObserver === 'undefined') return;
+
+    const observer = new ResizeObserver(updateDimensions);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [height]);
+
+  const fixedGeometry = useMemo(
+    () =>
+      usesFixedGeometry
+        ? buildFixedSankeyGeometry(graph, {
+            top: Number(margin?.top ?? 64),
+            bottom: measuredHeight - Number(margin?.bottom ?? 12),
+            left: Number(margin?.left ?? 160),
+            right: measuredWidth - Number(margin?.right ?? 160) - 7,
+            nodePadding: 8,
+          })
+        : undefined,
+    [graph, margin?.bottom, margin?.left, margin?.right, margin?.top, measuredHeight, measuredWidth, usesFixedGeometry],
+  );
+
+  return { chartContainerRef, fixedGeometry };
+}

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -31,6 +31,36 @@ export const multiAgentThemeEntitiesResponse: ThemeEntitiesResponse = {
   ],
 };
 
+export const lowSignalFirstThemeEntitiesResponse: ThemeEntitiesResponse = {
+  entities: [
+    {
+      entityId: 'triage-agent',
+      entityType: 'agent',
+      availableSignals: ['goal'],
+      latestWindow: {
+        startedAt: '2026-07-01T00:00:00.000Z',
+        endedAt: '2026-07-08T00:00:00.000Z',
+      },
+    },
+    ...populatedThemeEntitiesResponse.entities,
+  ],
+};
+
+export const multiEligibleThemeEntitiesResponse: ThemeEntitiesResponse = {
+  entities: [
+    ...populatedThemeEntitiesResponse.entities,
+    {
+      entityId: 'billing-agent',
+      entityType: 'agent',
+      availableSignals: ['goal', 'outcome'],
+      latestWindow: {
+        startedAt: '2026-07-08T00:00:00.000Z',
+        endedAt: '2026-07-15T00:00:00.000Z',
+      },
+    },
+  ],
+};
+
 export const themeSnapshotsResponse: ThemeSnapshotsResponse = {
   snapshots: [
     {
@@ -40,6 +70,29 @@ export const themeSnapshotsResponse: ThemeSnapshotsResponse = {
       startedAt: '2026-07-01T00:00:00.000Z',
       endedAt: '2026-07-08T00:00:00.000Z',
       traceCount: 50,
+      availableSignals: ['goal', 'outcome'],
+    },
+  ],
+};
+
+export const billingThemeSnapshotsResponse: ThemeSnapshotsResponse = {
+  snapshots: [
+    {
+      snapshotId: 'billing-snapshot-1',
+      ordinal: 1,
+      total: 2,
+      startedAt: '2026-07-01T00:00:00.000Z',
+      endedAt: '2026-07-08T00:00:00.000Z',
+      traceCount: 20,
+      availableSignals: ['goal', 'outcome'],
+    },
+    {
+      snapshotId: 'billing-snapshot-2',
+      ordinal: 2,
+      total: 2,
+      startedAt: '2026-07-08T00:00:00.000Z',
+      endedAt: '2026-07-15T00:00:00.000Z',
+      traceCount: 30,
       availableSignals: ['goal', 'outcome'],
     },
   ],
@@ -68,7 +121,7 @@ export const multiThemeSnapshotsResponse: ThemeSnapshotsResponse = {
       startedAt: '2026-06-24T00:00:00.000Z',
       endedAt: '2026-07-01T00:00:00.000Z',
       traceCount: 40,
-      availableSignals: ['goal', 'outcome'],
+      availableSignals: ['goal', 'outcome', 'behavior', 'sentiment'],
     },
     ...themeSnapshotsResponse.snapshots,
   ],

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -1,4 +1,4 @@
-import type { ThemeEntitiesResponse, ThemeFlowResponse, ThemeSnapshotsResponse } from '@mastra/client-js';
+import type { ThemeEntitiesResponse, ThemeFlowResponse, ThemeNode, ThemeSnapshotsResponse } from '@mastra/client-js';
 
 export const emptyThemeEntitiesResponse: ThemeEntitiesResponse = { entities: [] };
 
@@ -77,8 +77,12 @@ export const themeFlowResponse: ThemeFlowResponse = {
 
 export const fourStageThemeFlowResponse: ThemeFlowResponse = {
   snapshot: {
-    ...themeSnapshotsResponse.snapshots[0],
-    availableSignals: ['goal', 'outcome', 'behavior', 'sentiment'],
+    snapshotId: 'snapshot-4',
+    ordinal: 4,
+    total: 4,
+    startedAt: '2026-07-01T00:00:00.000Z',
+    endedAt: '2026-07-08T00:00:00.000Z',
+    traceCount: 50,
   },
   stages: [
     {
@@ -280,6 +284,15 @@ export const fourStageThemeFlowResponse: ThemeFlowResponse = {
   ],
 };
 
+const metadataOnlyGoalNode: ThemeNode = {
+  nodeId: 'goal-disconnected',
+  kind: 'theme',
+  themeId: 'theme-goal-disconnected',
+  label: 'Metadata only goal',
+  traceCount: 99,
+  stageShare: 0.99,
+};
+
 export const inconsistentTraceCountThemeFlowResponse: ThemeFlowResponse = {
   ...fourStageThemeFlowResponse,
   snapshot: {
@@ -295,20 +308,67 @@ export const inconsistentTraceCountThemeFlowResponse: ThemeFlowResponse = {
         traceCount: node.traceCount + 20 + nodeIndex,
         stageShare: 0.9 - nodeIndex * 0.1,
       })),
-      ...(stage.signalName === 'goal'
-        ? [
-            {
-              nodeId: 'goal-disconnected',
-              kind: 'theme',
-              themeId: 'theme-goal-disconnected',
-              label: 'Metadata only goal',
-              traceCount: 99,
-              stageShare: 0.99,
-            },
-          ]
-        : []),
+      ...(stage.signalName === 'goal' ? [metadataOnlyGoalNode] : []),
     ],
   })),
+};
+
+export const duplicateLabelThemeFlowResponse: ThemeFlowResponse = {
+  snapshot: themeFlowResponse.snapshot,
+  stages: [
+    {
+      signalName: 'goal',
+      traceCount: 50,
+      nodes: [
+        {
+          nodeId: 'goal-theme-one',
+          kind: 'theme',
+          themeId: 'theme-one',
+          label: 'Shared theme label',
+          traceCount: 20,
+          stageShare: 0.4,
+        },
+        {
+          nodeId: 'goal-theme-two',
+          kind: 'theme',
+          themeId: 'theme-two',
+          label: 'Shared theme label',
+          traceCount: 30,
+          stageShare: 0.6,
+        },
+      ],
+    },
+    {
+      signalName: 'outcome',
+      traceCount: 50,
+      nodes: [
+        {
+          nodeId: 'outcome-theme',
+          kind: 'theme',
+          themeId: 'outcome-theme',
+          label: 'Resolved outcome',
+          traceCount: 50,
+          stageShare: 1,
+        },
+      ],
+    },
+  ],
+  links: [
+    {
+      sourceNodeId: 'goal-theme-one',
+      targetNodeId: 'outcome-theme',
+      traceCount: 20,
+      sourceShare: 1,
+      targetShare: 0.4,
+    },
+    {
+      sourceNodeId: 'goal-theme-two',
+      targetNodeId: 'outcome-theme',
+      traceCount: 30,
+      sourceShare: 1,
+      targetShare: 0.6,
+    },
+  ],
 };
 
 export const singleStageThemeFlowResponse: ThemeFlowResponse = {

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -45,6 +45,20 @@ export const themeSnapshotsResponse: ThemeSnapshotsResponse = {
   ],
 };
 
+export const sameDayThemeSnapshotsResponse: ThemeSnapshotsResponse = {
+  snapshots: [
+    {
+      snapshotId: 'snapshot-same-day',
+      ordinal: 4,
+      total: 4,
+      startedAt: '2026-07-15T08:00:00.000Z',
+      endedAt: '2026-07-15T09:00:00.000Z',
+      traceCount: 50,
+      availableSignals: ['goal', 'outcome'],
+    },
+  ],
+};
+
 export const multiThemeSnapshotsResponse: ThemeSnapshotsResponse = {
   snapshots: [
     {

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -16,6 +16,21 @@ export const populatedThemeEntitiesResponse: ThemeEntitiesResponse = {
   ],
 };
 
+export const multiAgentThemeEntitiesResponse: ThemeEntitiesResponse = {
+  entities: [
+    ...populatedThemeEntitiesResponse.entities,
+    {
+      entityId: 'triage-agent',
+      entityType: 'agent',
+      availableSignals: ['goal'],
+      latestWindow: {
+        startedAt: '2026-07-01T00:00:00.000Z',
+        endedAt: '2026-07-08T00:00:00.000Z',
+      },
+    },
+  ],
+};
+
 export const themeSnapshotsResponse: ThemeSnapshotsResponse = {
   snapshots: [
     {
@@ -27,6 +42,21 @@ export const themeSnapshotsResponse: ThemeSnapshotsResponse = {
       traceCount: 50,
       availableSignals: ['goal', 'outcome'],
     },
+  ],
+};
+
+export const multiThemeSnapshotsResponse: ThemeSnapshotsResponse = {
+  snapshots: [
+    {
+      snapshotId: 'snapshot-3',
+      ordinal: 3,
+      total: 4,
+      startedAt: '2026-06-24T00:00:00.000Z',
+      endedAt: '2026-07-01T00:00:00.000Z',
+      traceCount: 40,
+      availableSignals: ['goal', 'outcome'],
+    },
+    ...themeSnapshotsResponse.snapshots,
   ],
 };
 

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -1,4 +1,4 @@
-import type { ThemeEntitiesResponse, ThemeFlowResponse, ThemeSnapshotsResponse } from '../../types';
+import type { ThemeEntitiesResponse, ThemeFlowResponse, ThemeSnapshotsResponse } from '@mastra/client-js';
 
 export const emptyThemeEntitiesResponse: ThemeEntitiesResponse = { entities: [] };
 

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -474,3 +474,36 @@ export const singleStageThemeFlowResponse: ThemeFlowResponse = {
   stages: themeFlowResponse.stages.slice(0, 1),
   links: [],
 };
+
+export const earlierThemeFlowResponse: ThemeFlowResponse = {
+  ...fourStageThemeFlowResponse,
+  snapshot: multiThemeSnapshotsResponse.snapshots[0],
+  stages: fourStageThemeFlowResponse.stages.map(stage =>
+    stage.signalName === 'goal'
+      ? {
+          ...stage,
+          nodes: [
+            ...stage.nodes,
+            {
+              nodeId: 'goal-legacy',
+              kind: 'theme',
+              themeId: 'theme-goal-legacy',
+              label: 'Legacy support request',
+              traceCount: 4,
+              stageShare: 0.1,
+            },
+          ],
+        }
+      : stage,
+  ),
+  links: [
+    ...fourStageThemeFlowResponse.links,
+    {
+      sourceNodeId: 'goal-legacy',
+      targetNodeId: 'outcome-resolved',
+      traceCount: 4,
+      sourceShare: 1,
+      targetShare: 0.1,
+    },
+  ],
+};

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -191,6 +191,7 @@ export const fourStageThemeFlowResponse: ThemeFlowResponse = {
           kind: 'theme',
           themeId: 'theme-goal-support',
           label: 'Resolve support request',
+          description: 'The user wants help resolving a support issue.',
           traceCount: 22,
           stageShare: 0.44,
         },

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -7,8 +7,11 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import SignalsOverviewPage from '..';
 import {
+  billingThemeSnapshotsResponse,
   emptyThemeEntitiesResponse,
+  lowSignalFirstThemeEntitiesResponse,
   multiAgentThemeEntitiesResponse,
+  multiEligibleThemeEntitiesResponse,
   populatedThemeEntitiesResponse,
   themeFlowResponse,
   themeSnapshotsResponse,
@@ -126,6 +129,31 @@ describe('Signals page', () => {
 
       expect(await screen.findByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
     });
+
+    it('keeps the single agent visible in the selector', async () => {
+      renderSignalsPage();
+
+      expect((await screen.findByRole('combobox', { name: 'Agent' })).textContent).toContain('support-agent');
+    });
+  });
+
+  describe('when a low-signal agent is returned before an eligible agent', () => {
+    it('defaults to the first agent that can render a flow', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(lowSignalFirstThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(themeFlowResponse),
+        ),
+      );
+
+      renderSignalsPage();
+
+      expect((await screen.findByRole('combobox', { name: 'Agent' })).textContent).toContain('support-agent');
+      expect(screen.queryByText('Not enough signal data yet')).toBeNull();
+    });
   });
 
   describe('when multiple agents have different signal coverage', () => {
@@ -162,6 +190,40 @@ describe('Signals page', () => {
       expect(await screen.findByText('Not enough signal data yet')).not.toBeNull();
       expect(screen.getByText('Available signals: Goal')).not.toBeNull();
       expect(screen.getByRole('combobox', { name: 'Agent' })).not.toBeNull();
+    });
+  });
+
+  describe('when switching between eligible agents', () => {
+    it("loads the selected agent's latest snapshot", async () => {
+      let billingFlowSnapshotId: string | null = null;
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(multiEligibleThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(themeFlowResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/billing-agent/theme-snapshots`, () =>
+          HttpResponse.json(billingThemeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/billing-agent/theme-flow`, ({ request }) => {
+          billingFlowSnapshotId = new URL(request.url).searchParams.get('snapshotId');
+          return HttpResponse.json({
+            ...themeFlowResponse,
+            snapshot: billingThemeSnapshotsResponse.snapshots[1],
+          });
+        }),
+      );
+      renderSignalsPage();
+      fireEvent.click(await screen.findByRole('combobox', { name: 'Agent' }));
+      const billingAgent = await screen.findByRole('option', { name: 'billing-agent' });
+
+      fireEvent.pointerDown(billingAgent, { pointerType: 'mouse' });
+      fireEvent.click(billingAgent, { detail: 1 });
+
+      expect(await screen.findByText('Snapshot 2/2 · Jul 8–15, 2026 · 30 traces')).not.toBeNull();
+      expect(billingFlowSnapshotId).toBe('billing-snapshot-2');
     });
   });
 

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import SignalsOverviewPage from '..';
+import { mainNav } from '../../../lib/nav/nav-items';
 import {
   billingThemeSnapshotsResponse,
   emptyThemeEntitiesResponse,
@@ -128,6 +129,18 @@ describe('Signals page', () => {
       renderSignalsPage();
 
       expect(await screen.findByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
+    });
+
+    it('keeps exactly one Signals documentation action across the shell and page', async () => {
+      renderSignalsPage();
+      await screen.findByRole('region', { name: 'Signal theme flow' });
+      const shellDocumentationLinks = mainNav
+        .flatMap(section => section.items)
+        .filter(item => item.url === '/signals' && item.docs?.label === 'Signals documentation');
+
+      expect(
+        shellDocumentationLinks.length + screen.queryAllByRole('link', { name: 'Signals documentation' }).length,
+      ).toBe(1);
     });
 
     it('keeps the single agent visible in the selector', async () => {

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import SignalsOverviewPage from '..';
 import {
   emptyThemeEntitiesResponse,
+  multiAgentThemeEntitiesResponse,
   populatedThemeEntitiesResponse,
   themeFlowResponse,
   themeSnapshotsResponse,
@@ -96,6 +97,43 @@ describe('Signals page', () => {
       renderSignalsPage();
 
       expect(await screen.findByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
+    });
+  });
+
+  describe('when multiple agents have different signal coverage', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(multiAgentThemeEntitiesResponse)),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(themeFlowResponse),
+        ),
+      );
+    });
+
+    it('lists every agent in the always-visible selector', async () => {
+      renderSignalsPage();
+
+      const selector = await screen.findByRole('combobox', { name: 'Agent' });
+      fireEvent.click(selector);
+
+      expect(await screen.findByRole('option', { name: 'support-agent' })).not.toBeNull();
+      expect(screen.getByRole('option', { name: 'triage-agent' })).not.toBeNull();
+    });
+
+    it('explains why the selected agent cannot render a flow', async () => {
+      renderSignalsPage();
+
+      fireEvent.click(await screen.findByRole('combobox', { name: 'Agent' }));
+      const triageAgent = await screen.findByRole('option', { name: 'triage-agent' });
+      fireEvent.pointerDown(triageAgent, { pointerType: 'mouse' });
+      fireEvent.click(triageAgent, { detail: 1 });
+
+      expect(await screen.findByText('Not enough signal data yet')).not.toBeNull();
+      expect(screen.getByText('Available signals: Goal')).not.toBeNull();
+      expect(screen.getByRole('combobox', { name: 'Agent' })).not.toBeNull();
     });
   });
 

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -62,6 +62,34 @@ describe('Signals page', () => {
     });
   });
 
+  describe('when the entities request fails once', () => {
+    it('retries the failed request and renders the page', async () => {
+      let attempts = 0;
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities`, () => {
+          attempts += 1;
+          return attempts === 1
+            ? HttpResponse.json({ error: 'Unable to load entities' }, { status: 500 })
+            : HttpResponse.json(populatedThemeEntitiesResponse);
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(themeFlowResponse),
+        ),
+      );
+
+      renderSignalsPage();
+
+      expect(await screen.findByText('Unable to load signal entities.')).not.toBeNull();
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+      expect(await screen.findByRole('combobox', { name: 'Agent' })).not.toBeNull();
+      expect(attempts).toBe(2);
+    });
+  });
+
   describe('when no Agent Learning entities exist', () => {
     it('shows that the analysis is waiting for traces', async () => {
       server.use(http.get(`${BASE_URL}/api/learning/entities`, () => HttpResponse.json(emptyThemeEntitiesResponse)));

--- a/packages/playground/src/ee/signals/__tests__/index.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/index.test.tsx
@@ -2,11 +2,12 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
-import { MemoryRouter } from 'react-router';
+import { createMemoryRouter, MemoryRouter, RouterProvider } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import SignalsOverviewPage from '..';
-import { mainNav } from '../../../lib/nav/nav-items';
+import { navHandle } from '../../../lib/nav';
+import { RouteHeader } from '../../../lib/route-header/route-header';
 import {
   billingThemeSnapshotsResponse,
   emptyThemeEntitiesResponse,
@@ -30,6 +31,26 @@ function renderSignalsPage() {
       </QueryClientProvider>
     </MemoryRouter>,
   );
+}
+
+function renderSignalsPageWithShell() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const router = createMemoryRouter(
+    [
+      {
+        path: '/signals',
+        handle: navHandle('/signals'),
+        element: (
+          <QueryClientProvider client={queryClient}>
+            <RouteHeader />
+            <SignalsOverviewPage />
+          </QueryClientProvider>
+        ),
+      },
+    ],
+    { initialEntries: ['/signals'] },
+  );
+  return render(<RouterProvider router={router} />);
 }
 
 afterEach(() => {
@@ -132,15 +153,10 @@ describe('Signals page', () => {
     });
 
     it('keeps exactly one Signals documentation action across the shell and page', async () => {
-      renderSignalsPage();
+      renderSignalsPageWithShell();
       await screen.findByRole('region', { name: 'Signal theme flow' });
-      const shellDocumentationLinks = mainNav
-        .flatMap(section => section.items)
-        .filter(item => item.url === '/signals' && item.docs?.label === 'Signals documentation');
 
-      expect(
-        shellDocumentationLinks.length + screen.queryAllByRole('link', { name: 'Signals documentation' }).length,
-      ).toBe(1);
+      expect(screen.getAllByRole('link', { name: 'Signals documentation' })).toHaveLength(1);
     });
 
     it('keeps the single agent visible in the selector', async () => {

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -74,7 +74,7 @@ afterEach(() => {
 
 describe('stabilizeThemeFlow', () => {
   describe('when snapshot counts change within one timeline window', () => {
-    it('keeps link layout weights and node ordering fixed while retaining current node counts', () => {
+    it('keeps link layout weights and node ordering fixed while current link and node counts change', () => {
       const lowerVolumeFlow = {
         ...fourStageThemeFlowResponse,
         snapshot: earlierThemeFlowResponse.snapshot,
@@ -99,12 +99,13 @@ describe('stabilizeThemeFlow', () => {
       const higherFrame = stabilizeThemeFlow(fourStageThemeFlowResponse, windowFlows);
 
       const getLayoutLinks = (frame: typeof lowerFrame) =>
-        frame.links.map(link => [link.sourceNodeId, link.targetNodeId, link.traceCount]);
+        frame.links.map(link => [link.sourceNodeId, link.targetNodeId, link.layoutTraceCount]);
 
       expect(getLayoutLinks(lowerFrame)).toEqual(getLayoutLinks(higherFrame));
       expect(lowerFrame.stages.map(stage => stage.nodes.map(node => node.nodeId))).toEqual(
         higherFrame.stages.map(stage => stage.nodes.map(node => node.nodeId)),
       );
+      expect(lowerFrame.links.map(link => link.traceCount)).not.toEqual(higherFrame.links.map(link => link.traceCount));
       expect(lowerFrame.stages[0]?.nodes[0]?.traceCount).not.toBe(higherFrame.stages[0]?.nodes[0]?.traceCount);
     });
   });

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -13,6 +13,7 @@ import {
   stabilizeThemeFlow,
   themeFlowToSankeyData,
 } from '../sankey-signals-data';
+import type { ThemeFlowResponse } from '../types';
 import {
   duplicateLabelThemeFlowResponse,
   earlierThemeFlowResponse,
@@ -80,33 +81,52 @@ describe('stabilizeThemeFlow', () => {
         snapshot: earlierThemeFlowResponse.snapshot,
         stages: fourStageThemeFlowResponse.stages.map(stage => ({
           ...stage,
-          nodes: stage.nodes.map(node => ({
-            ...node,
-            traceCount: Math.max(1, Math.floor(node.traceCount / 2)),
-            stageShare: node.stageShare / 2,
-          })),
+          nodes: stage.nodes
+            .map(node => ({
+              ...node,
+              traceCount: Math.max(1, Math.floor(node.traceCount / 2)),
+              stageShare: node.stageShare / 2,
+            }))
+            .reverse(),
         })),
-        links: fourStageThemeFlowResponse.links.map(link => ({
-          ...link,
-          traceCount: Math.max(1, Math.floor(link.traceCount / 2)),
-          sourceShare: link.sourceShare / 2,
-          targetShare: link.targetShare / 2,
-        })),
+        links: fourStageThemeFlowResponse.links
+          .map(link => ({
+            ...link,
+            traceCount: Math.max(1, Math.floor(link.traceCount / 2)),
+            sourceShare: link.sourceShare / 2,
+            targetShare: link.targetShare / 2,
+          }))
+          .reverse(),
       };
       const windowFlows = [lowerVolumeFlow, fourStageThemeFlowResponse];
 
       const lowerFrame = stabilizeThemeFlow(lowerVolumeFlow, windowFlows);
       const higherFrame = stabilizeThemeFlow(fourStageThemeFlowResponse, windowFlows);
 
+      const getNodeOrder = (frame: typeof lowerFrame) =>
+        frame.stages.map(stage => stage.nodes.map(node => node.nodeId));
+      const getNodeCounts = (frame: Pick<ThemeFlowResponse, 'stages'>) =>
+        frame.stages.map(stage => Object.fromEntries(stage.nodes.map(node => [node.nodeId, node.traceCount])));
+      const getLinkCounts = (frame: Pick<ThemeFlowResponse, 'links'>) =>
+        Object.fromEntries(frame.links.map(link => [`${link.sourceNodeId}:${link.targetNodeId}`, link.traceCount]));
       const getLayoutLinks = (frame: typeof lowerFrame) =>
         frame.links.map(link => [link.sourceNodeId, link.targetNodeId, link.layoutTraceCount]);
+      const expectedNodeOrder = lowerVolumeFlow.stages.map(stage => stage.nodes.map(node => node.nodeId));
+      const expectedLayoutLinks = lowerVolumeFlow.links.map(link => {
+        const higherLink = fourStageThemeFlowResponse.links.find(
+          candidate => candidate.sourceNodeId === link.sourceNodeId && candidate.targetNodeId === link.targetNodeId,
+        );
+        return [link.sourceNodeId, link.targetNodeId, higherLink?.traceCount];
+      });
 
-      expect(getLayoutLinks(lowerFrame)).toEqual(getLayoutLinks(higherFrame));
-      expect(lowerFrame.stages.map(stage => stage.nodes.map(node => node.nodeId))).toEqual(
-        higherFrame.stages.map(stage => stage.nodes.map(node => node.nodeId)),
-      );
-      expect(lowerFrame.links.map(link => link.traceCount)).not.toEqual(higherFrame.links.map(link => link.traceCount));
-      expect(lowerFrame.stages[0]?.nodes[0]?.traceCount).not.toBe(higherFrame.stages[0]?.nodes[0]?.traceCount);
+      expect(getNodeOrder(lowerFrame)).toEqual(expectedNodeOrder);
+      expect(getNodeOrder(higherFrame)).toEqual(expectedNodeOrder);
+      expect(getLayoutLinks(lowerFrame)).toEqual(expectedLayoutLinks);
+      expect(getLayoutLinks(higherFrame)).toEqual(expectedLayoutLinks);
+      expect(getNodeCounts(lowerFrame)).toEqual(getNodeCounts(lowerVolumeFlow));
+      expect(getNodeCounts(higherFrame)).toEqual(getNodeCounts(fourStageThemeFlowResponse));
+      expect(getLinkCounts(lowerFrame)).toEqual(getLinkCounts(lowerVolumeFlow));
+      expect(getLinkCounts(higherFrame)).toEqual(getLinkCounts(fourStageThemeFlowResponse));
     });
   });
 });

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -14,6 +14,7 @@ import {
   fourStageThemeFlowResponse,
   inconsistentTraceCountThemeFlowResponse,
   multiThemeSnapshotsResponse,
+  sameDayThemeSnapshotsResponse,
   singleStageThemeFlowResponse,
   themeFlowResponse,
   themeSnapshotsResponse,
@@ -96,6 +97,32 @@ describe('SankeySignals', () => {
       renderSankeySignals();
 
       expect(await screen.findByRole('status', { name: 'Loading signal analysis' })).not.toBeNull();
+      expect(screen.getByTestId('signals-loading-skeleton')).not.toBeNull();
+    });
+  });
+
+  describe('when the flow request fails once', () => {
+    it('retries the failed request and renders the analysis', async () => {
+      let attempts = 0;
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () => {
+          attempts += 1;
+          return attempts === 1
+            ? HttpResponse.json({ error: 'Flow unavailable' }, { status: 500 })
+            : HttpResponse.json(themeFlowResponse);
+        }),
+      );
+
+      renderSankeySignals();
+
+      expect(await screen.findByText('Unable to load signal flow.')).not.toBeNull();
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+      expect(await screen.findByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
+      expect(attempts).toBe(2);
     });
   });
 
@@ -160,15 +187,13 @@ describe('SankeySignals', () => {
       );
     });
 
-    it('renders the reference page identity and detached documentation action', async () => {
+    it('renders the page identity without duplicating the shell documentation action', async () => {
       renderSankeySignals();
 
       expect(await screen.findByText('SIGNALS')).not.toBeNull();
       expect(screen.getByRole('heading', { name: 'Understand what drives every agent interaction' })).not.toBeNull();
       expect(screen.getByText(/Signals group recurring patterns across traces/)).not.toBeNull();
-      expect(screen.getByRole('link', { name: 'Signals documentation' }).getAttribute('href')).toBe(
-        'https://mastra.ai/en/docs/observability/tracing/overview',
-      );
+      expect(screen.queryByRole('link', { name: 'Signals documentation' })).toBeNull();
     });
 
     it('shows exactly three metrics derived from the loaded flow', async () => {
@@ -213,6 +238,15 @@ describe('SankeySignals', () => {
       ).toEqual(['Goal', 'Outcome', 'Behavior', 'Sentiment']);
     });
 
+    it('renders signal distributions before the flow chart', async () => {
+      renderSankeySignals();
+
+      const distributions = await screen.findByRole('region', { name: 'Signal distributions' });
+      const flow = screen.getByRole('region', { name: 'Signal theme flow' });
+
+      expect(distributions.compareDocumentPosition(flow) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+    });
+
     it('summarizes each signal with one stacked bar and compact theme rows', async () => {
       renderSankeySignals();
 
@@ -235,13 +269,29 @@ describe('SankeySignals', () => {
       expect(within(sentiment).getByText('29 · 58%')).not.toBeNull();
     });
 
-    it('scopes horizontal overflow to the analytical region', async () => {
+    it('does not force the analysis into a separate horizontal scroll region', async () => {
       renderSankeySignals();
 
-      const analysis = await screen.findByTestId('signals-analysis-scroll');
-      expect(analysis.getAttribute('data-scroll-container')).toBe('horizontal');
-      expect(within(analysis).getByTestId('signals-analysis-canvas').getAttribute('data-min-width')).toBe('920');
-      expect(screen.getByTestId('signals-page-header').closest('[data-scroll-container]')).toBeNull();
+      await screen.findByTestId('signals-page-header');
+      expect(screen.queryByTestId('signals-analysis-scroll')).toBeNull();
+      expect(screen.queryByTestId('signals-analysis-canvas')).toBeNull();
+    });
+  });
+
+  describe('when a snapshot starts and ends on the same day', () => {
+    it('shows the calendar date once', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(sameDayThemeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json({ ...themeFlowResponse, snapshot: sameDayThemeSnapshotsResponse.snapshots[0] }),
+        ),
+      );
+
+      renderSankeySignals();
+
+      expect(await screen.findByText('Snapshot 4/4 · Jul 15, 2026 · 50 traces')).not.toBeNull();
     });
   });
 
@@ -377,7 +427,7 @@ describe('SankeySignals', () => {
       renderSankeySignals();
 
       const chart = await screen.findByRole('region', { name: 'Signal theme flow' });
-      expect(within(chart).getAllByText('Shared theme label')).toHaveLength(2);
+      expect(within(chart).getAllByText('Shared theme label', { selector: 'text' })).toHaveLength(2);
       expect(within(chart).getByText('20 (40%)')).not.toBeNull();
       expect(within(chart).getByText('30 (60%)')).not.toBeNull();
     });

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -361,6 +361,29 @@ describe('SankeySignals', () => {
       expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
     });
 
+    it('stops scheduling snapshots after a playback request fails', async () => {
+      const flowRequests: Array<string> = [];
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const snapshotId = new URL(request.url).searchParams.get('snapshotId');
+          if (!snapshotId) return HttpResponse.json({ error: 'Missing snapshot' }, { status: 400 });
+          flowRequests.push(snapshotId);
+          if (snapshotId === 'snapshot-3') return HttpResponse.json({ error: 'Flow failed' }, { status: 500 });
+          const snapshot = multiThemeSnapshotsResponse.snapshots.find(item => item.snapshotId === snapshotId);
+          if (!snapshot) return HttpResponse.json({ error: 'Unknown snapshot' }, { status: 400 });
+          return HttpResponse.json({ ...fourStageThemeFlowResponse, snapshot });
+        }),
+      );
+      renderSankeySignals();
+      await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Play snapshots' }));
+      await screen.findByRole('button', { name: 'Retry' }, { timeout: 2000 });
+      await new Promise(resolve => window.setTimeout(resolve, 1100));
+
+      expect(flowRequests).toEqual(['snapshot-1', 'snapshot-3']);
+    });
+
     it('keeps the pause control available while the next flow is loading', async () => {
       let releasePendingFlow: (() => void) | undefined;
       const pendingFlow = new Promise<void>(resolve => {

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -7,7 +7,12 @@ import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SankeySignals } from '../sankey-signals';
-import { getSignalRecordNodeId, getSignalRecordNodeLabel, themeFlowToSankeyData } from '../sankey-signals-data';
+import {
+  getSignalRecordNodeId,
+  getSignalRecordNodeLabel,
+  stabilizeThemeFlow,
+  themeFlowToSankeyData,
+} from '../sankey-signals-data';
 import {
   duplicateLabelThemeFlowResponse,
   earlierThemeFlowResponse,
@@ -65,6 +70,44 @@ afterEach(() => {
   cleanup();
   vi.useRealTimers();
   vi.restoreAllMocks();
+});
+
+describe('stabilizeThemeFlow', () => {
+  describe('when snapshot counts change within one timeline window', () => {
+    it('keeps link layout weights and node ordering fixed while retaining current node counts', () => {
+      const lowerVolumeFlow = {
+        ...fourStageThemeFlowResponse,
+        snapshot: earlierThemeFlowResponse.snapshot,
+        stages: fourStageThemeFlowResponse.stages.map(stage => ({
+          ...stage,
+          nodes: stage.nodes.map(node => ({
+            ...node,
+            traceCount: Math.max(1, Math.floor(node.traceCount / 2)),
+            stageShare: node.stageShare / 2,
+          })),
+        })),
+        links: fourStageThemeFlowResponse.links.map(link => ({
+          ...link,
+          traceCount: Math.max(1, Math.floor(link.traceCount / 2)),
+          sourceShare: link.sourceShare / 2,
+          targetShare: link.targetShare / 2,
+        })),
+      };
+      const windowFlows = [lowerVolumeFlow, fourStageThemeFlowResponse];
+
+      const lowerFrame = stabilizeThemeFlow(lowerVolumeFlow, windowFlows);
+      const higherFrame = stabilizeThemeFlow(fourStageThemeFlowResponse, windowFlows);
+
+      const getLayoutLinks = (frame: typeof lowerFrame) =>
+        frame.links.map(link => [link.sourceNodeId, link.targetNodeId, link.traceCount]);
+
+      expect(getLayoutLinks(lowerFrame)).toEqual(getLayoutLinks(higherFrame));
+      expect(lowerFrame.stages.map(stage => stage.nodes.map(node => node.nodeId))).toEqual(
+        higherFrame.stages.map(stage => stage.nodes.map(node => node.nodeId)),
+      );
+      expect(lowerFrame.stages[0]?.nodes[0]?.traceCount).not.toBe(higherFrame.stages[0]?.nodes[0]?.traceCount);
+    });
+  });
 });
 
 describe('SankeySignals', () => {

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { buildSankeyChartGraph } from '@mastra/playground-ui/components/SankeyChart';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,6 +13,7 @@ import {
   emptyThemeSnapshotsResponse,
   fourStageThemeFlowResponse,
   inconsistentTraceCountThemeFlowResponse,
+  multiThemeSnapshotsResponse,
   singleStageThemeFlowResponse,
   themeFlowResponse,
   themeSnapshotsResponse,
@@ -60,6 +61,7 @@ beforeEach(() => {
 
 afterEach(() => {
   cleanup();
+  vi.useRealTimers();
   vi.restoreAllMocks();
 });
 
@@ -175,18 +177,16 @@ describe('SankeySignals', () => {
       const metrics = await screen.findByRole('list', { name: 'Signal analysis metrics' });
       expect(within(metrics).getAllByRole('listitem')).toHaveLength(3);
       expect(within(metrics).getByText('50 traces analyzed')).not.toBeNull();
-      expect(within(metrics).getByText('9 clusters')).not.toBeNull();
+      expect(within(metrics).getByText('9 themes')).not.toBeNull();
       expect(within(metrics).getByText('4 signal types')).not.toBeNull();
     });
 
-    it('omits date, period, agent, and processing controls', async () => {
+    it('shows the selected snapshot context and timeline controls', async () => {
       renderSankeySignals();
 
-      await screen.findByRole('region', { name: 'Signal theme flow' });
-      expect(screen.queryByText('Jul 1–8, 2026')).toBeNull();
-      expect(screen.queryByText(/Snapshot 4 of 4/)).toBeNull();
-      expect(screen.queryByText(/All agents/)).toBeNull();
-      expect(screen.queryByRole('status', { name: 'Signal processing status' })).toBeNull();
+      expect(await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces')).not.toBeNull();
+      expect(screen.getByRole('group', { name: 'Snapshot' })).not.toBeNull();
+      expect(screen.getByRole('button', { name: 'Play snapshots' })).not.toBeNull();
     });
 
     it('delegates the signal column headings to the Sankey chart', async () => {
@@ -245,6 +245,52 @@ describe('SankeySignals', () => {
     });
   });
 
+  describe('when multiple snapshots are available', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(multiThemeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const snapshotId = new URL(request.url).searchParams.get('snapshotId');
+          const snapshot = multiThemeSnapshotsResponse.snapshots.find(item => item.snapshotId === snapshotId);
+          return HttpResponse.json({ ...fourStageThemeFlowResponse, snapshot: snapshot! });
+        }),
+      );
+    });
+
+    it('selects the latest ordinal and labels it without parsing its cursor', async () => {
+      renderSankeySignals();
+
+      expect(await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces')).not.toBeNull();
+      expect(screen.getByRole('group', { name: 'Snapshot' })).not.toBeNull();
+    });
+
+    it('scrubs to an earlier snapshot', async () => {
+      const { container } = renderSankeySignals();
+
+      await screen.findByRole('group', { name: 'Snapshot' });
+      const sliderInput = container.querySelector('input[type="range"]');
+      if (!sliderInput) throw new Error('Snapshot slider input was not rendered');
+      fireEvent.change(sliderInput, { target: { value: '0' } });
+
+      expect(await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces')).not.toBeNull();
+    });
+
+    it('plays forward through snapshots', async () => {
+      renderSankeySignals();
+      await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Play snapshots' }));
+      expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
+
+      expect(
+        await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces', undefined, { timeout: 2000 }),
+      ).not.toBeNull();
+      expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
+    });
+  });
+
   describe('when API count metadata disagrees with the weighted graph', () => {
     beforeEach(() => {
       server.use(
@@ -257,21 +303,22 @@ describe('SankeySignals', () => {
       );
     });
 
-    it('uses the entry-stage graph total in the header badge', async () => {
+    it('uses the authoritative snapshot total in the header badge', async () => {
       renderSankeySignals();
 
       const metrics = await screen.findByRole('list', { name: 'Signal analysis metrics' });
-      expect(within(metrics).getByText('50 traces analyzed')).not.toBeNull();
-      expect(within(metrics).queryByText('80 traces analyzed')).toBeNull();
+      expect(within(metrics).getByText('80 traces analyzed')).not.toBeNull();
+      expect(within(metrics).queryByText('50 traces analyzed')).toBeNull();
     });
 
-    it('uses graph-derived totals for every distribution', async () => {
+    it('uses authoritative stage totals for every distribution', async () => {
       renderSankeySignals();
 
       const distributions = await screen.findByRole('region', { name: 'Signal distributions' });
-      for (const signalName of ['Goal', 'Outcome', 'Behavior', 'Sentiment']) {
+      const expectedTotals = { Goal: 70, Outcome: 80, Behavior: 90, Sentiment: 100 };
+      for (const [signalName, traceCount] of Object.entries(expectedTotals)) {
         const distribution = within(distributions).getByRole('article', { name: `${signalName} distribution` });
-        expect(within(distribution).getByText('50 traces')).not.toBeNull();
+        expect(within(distribution).getByText(`${traceCount} traces`)).not.toBeNull();
       }
     });
 
@@ -337,7 +384,7 @@ describe('SankeySignals', () => {
   });
 
   describe('when a theme snapshot has weighted links', () => {
-    it('renders the flow with the signal and theme labels', async () => {
+    beforeEach(() => {
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
           HttpResponse.json(themeSnapshotsResponse),
@@ -346,10 +393,23 @@ describe('SankeySignals', () => {
           HttpResponse.json(themeFlowResponse),
         ),
       );
+    });
 
+    it('renders the flow with the signal and theme labels', async () => {
       renderSankeySignals();
 
       expect(await screen.findByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
+    });
+
+    it('limits the legend to stages returned by the flow', async () => {
+      renderSankeySignals();
+
+      const legend = await screen.findByRole('list', { name: 'Signal stage legend' });
+      expect(
+        within(legend)
+          .getAllByRole('listitem')
+          .map(item => item.textContent),
+      ).toEqual(['Goal', 'Outcome']);
     });
 
     it('preserves the API-defined signal order', () => {

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -206,12 +206,12 @@ describe('SankeySignals', () => {
       expect(within(metrics).getByText('4 signal types')).not.toBeNull();
     });
 
-    it('shows the selected snapshot context and timeline controls', async () => {
+    it('shows the selected snapshot context without controls for a single snapshot', async () => {
       renderSankeySignals();
 
       expect(await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces')).not.toBeNull();
-      expect(screen.getByRole('group', { name: 'Snapshot' })).not.toBeNull();
-      expect(screen.getByRole('button', { name: 'Play snapshots' })).not.toBeNull();
+      expect(screen.queryByRole('group', { name: 'Snapshot' })).toBeNull();
+      expect(screen.queryByRole('button', { name: 'Play snapshots' })).toBeNull();
     });
 
     it('delegates the signal column headings to the Sankey chart', async () => {
@@ -304,7 +304,8 @@ describe('SankeySignals', () => {
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
           const snapshotId = new URL(request.url).searchParams.get('snapshotId');
           const snapshot = multiThemeSnapshotsResponse.snapshots.find(item => item.snapshotId === snapshotId);
-          return HttpResponse.json({ ...fourStageThemeFlowResponse, snapshot: snapshot! });
+          if (!snapshot) return HttpResponse.json({ error: 'Unknown snapshot' }, { status: 400 });
+          return HttpResponse.json({ ...fourStageThemeFlowResponse, snapshot });
         }),
       );
     });
@@ -339,6 +340,32 @@ describe('SankeySignals', () => {
       ).not.toBeNull();
       expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
     });
+
+    it('keeps the pause control available while the next flow is loading', async () => {
+      let releasePendingFlow: (() => void) | undefined;
+      const pendingFlow = new Promise<void>(resolve => {
+        releasePendingFlow = resolve;
+      });
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, async ({ request }) => {
+          const snapshotId = new URL(request.url).searchParams.get('snapshotId');
+          const snapshot = multiThemeSnapshotsResponse.snapshots.find(item => item.snapshotId === snapshotId);
+          if (snapshotId === 'snapshot-3') await pendingFlow;
+          return HttpResponse.json({ ...fourStageThemeFlowResponse, snapshot });
+        }),
+      );
+      renderSankeySignals();
+      await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Play snapshots' }));
+
+      expect(
+        await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces', undefined, { timeout: 2000 }),
+      ).not.toBeNull();
+      expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
+      expect(screen.getByRole('status', { name: 'Loading snapshot flow' })).not.toBeNull();
+      releasePendingFlow?.();
+    });
   });
 
   describe('when API count metadata disagrees with the weighted graph', () => {
@@ -372,22 +399,22 @@ describe('SankeySignals', () => {
       }
     });
 
-    it('uses graph-derived node counts and percentages in every distribution row', async () => {
+    it('uses authoritative API node counts and shares in every distribution row', async () => {
       renderSankeySignals();
 
       const distributions = await screen.findByRole('region', { name: 'Signal distributions' });
       const expectedRows = {
-        Goal: ['22 · 44%', '17 · 34%', '11 · 22%'],
-        Outcome: ['31 · 62%', '19 · 38%'],
-        Behavior: ['34 · 68%', '16 · 32%'],
-        Sentiment: ['29 · 58%', '21 · 42%'],
+        Goal: ['42 · 90%', '38 · 80%', '33 · 70%', '99 · 99%'],
+        Outcome: ['51 · 90%', '40 · 80%'],
+        Behavior: ['54 · 90%', '37 · 80%'],
+        Sentiment: ['49 · 90%', '42 · 80%'],
       };
 
       for (const [signalName, rows] of Object.entries(expectedRows)) {
         const distribution = within(distributions).getByRole('article', { name: `${signalName} distribution` });
         for (const row of rows) expect(within(distribution).getByText(row)).not.toBeNull();
       }
-      expect(within(distributions).queryByText('Metadata only goal')).toBeNull();
+      expect(within(distributions).getByText('Metadata only goal')).not.toBeNull();
     });
 
     it('shows the same graph-derived counts and percentages on chart nodes', async () => {

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -196,6 +196,13 @@ describe('SankeySignals', () => {
       expect(screen.queryByRole('link', { name: 'Signals documentation' })).toBeNull();
     });
 
+    it('shows entity, snapshot ordinal, and window in the analysis header', async () => {
+      renderSankeySignals();
+
+      const header = await screen.findByTestId('signals-page-header');
+      expect(within(header).getByText('support-agent · Snapshot 4 of 4 · Jul 1–8, 2026')).not.toBeNull();
+    });
+
     it('shows exactly three metrics derived from the loaded flow', async () => {
       renderSankeySignals();
 
@@ -212,6 +219,19 @@ describe('SankeySignals', () => {
       expect(await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces')).not.toBeNull();
       expect(screen.queryByRole('group', { name: 'Snapshot' })).toBeNull();
       expect(screen.queryByRole('button', { name: 'Play snapshots' })).toBeNull();
+    });
+
+    it('carries a theme description into the chart node label', () => {
+      const { columns, records } = themeFlowToSankeyData(fourStageThemeFlowResponse);
+
+      const record = records[0];
+      const column = columns[0];
+      expect(record).toBeDefined();
+      expect(column).toBeDefined();
+      if (!record || !column) throw new Error('Expected a signal flow record and column');
+      expect(getSignalRecordNodeLabel(record, column)).toBe(
+        'Resolve support request\nThe user wants help resolving a support issue.',
+      );
     });
 
     it('delegates the signal column headings to the Sankey chart', async () => {

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -7,8 +7,9 @@ import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { SankeySignals } from '../sankey-signals';
-import { themeFlowToSankeyData } from '../sankey-signals-data';
+import { getSignalRecordNodeId, getSignalRecordNodeLabel, themeFlowToSankeyData } from '../sankey-signals-data';
 import {
+  duplicateLabelThemeFlowResponse,
   emptyThemeSnapshotsResponse,
   fourStageThemeFlowResponse,
   inconsistentTraceCountThemeFlowResponse,
@@ -313,6 +314,28 @@ describe('SankeySignals', () => {
     });
   });
 
+  describe('when themes in one signal stage share a display label', () => {
+    beforeEach(() => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, () =>
+          HttpResponse.json(themeSnapshotsResponse),
+        ),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, () =>
+          HttpResponse.json(duplicateLabelThemeFlowResponse),
+        ),
+      );
+    });
+
+    it('renders each API node with its own trace count', async () => {
+      renderSankeySignals();
+
+      const chart = await screen.findByRole('region', { name: 'Signal theme flow' });
+      expect(within(chart).getAllByText('Shared theme label')).toHaveLength(2);
+      expect(within(chart).getByText('20 (40%)')).not.toBeNull();
+      expect(within(chart).getByText('30 (60%)')).not.toBeNull();
+    });
+  });
+
   describe('when a theme snapshot has weighted links', () => {
     it('renders the flow with the signal and theme labels', async () => {
       server.use(
@@ -340,9 +363,9 @@ describe('SankeySignals', () => {
 
     it('preserves the API-defined theme labels', () => {
       const { columns, records } = themeFlowToSankeyData(themeFlowResponse);
-      const graph = buildSankeyChartGraph(records, columns);
+      const graph = buildSankeyChartGraph(records, columns, undefined, getSignalRecordNodeId, getSignalRecordNodeLabel);
 
-      expect(graph.nodes.map(node => node.name)).toEqual(['Resolve support request', 'Request resolved']);
+      expect(graph.nodes.map(node => node.label)).toEqual(['Resolve support request', 'Request resolved']);
     });
 
     it('preserves each API link as one chart record', () => {
@@ -353,7 +376,13 @@ describe('SankeySignals', () => {
 
     it('preserves the API link weight in the playground-ui chart graph', () => {
       const { columns, records } = themeFlowToSankeyData(themeFlowResponse);
-      const graph = buildSankeyChartGraph(records, columns, record => Number(record.traceCount));
+      const graph = buildSankeyChartGraph(
+        records,
+        columns,
+        record => Number(record.traceCount),
+        getSignalRecordNodeId,
+        getSignalRecordNodeLabel,
+      );
 
       expect(graph.links[0]?.value).toBe(3);
     });

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -10,6 +10,7 @@ import { SankeySignals } from '../sankey-signals';
 import { getSignalRecordNodeId, getSignalRecordNodeLabel, themeFlowToSankeyData } from '../sankey-signals-data';
 import {
   duplicateLabelThemeFlowResponse,
+  earlierThemeFlowResponse,
   emptyThemeSnapshotsResponse,
   fourStageThemeFlowResponse,
   inconsistentTraceCountThemeFlowResponse,
@@ -239,6 +240,8 @@ describe('SankeySignals', () => {
 
       const chart = await screen.findByRole('region', { name: 'Signal theme flow' });
       expect(within(chart).queryByTestId('signal-column-heading')).toBeNull();
+      expect(within(chart).getByText('GOAL')).not.toBeNull();
+      expect(within(chart).queryByText(/GOAL \d+ themes?/)).toBeNull();
       expect(within(chart).getByText('RIBBON WIDTH = TRACE COUNT')).not.toBeNull();
       expect(within(chart).getByText('HOVER OR FOCUS TO ISOLATE FLOW')).not.toBeNull();
     });
@@ -258,13 +261,15 @@ describe('SankeySignals', () => {
       ).toEqual(['Goal', 'Outcome', 'Behavior', 'Sentiment']);
     });
 
-    it('renders signal distributions before the flow chart', async () => {
+    it('renders the flow before the timeline and distributions', async () => {
       renderSankeySignals();
 
-      const distributions = await screen.findByRole('region', { name: 'Signal distributions' });
-      const flow = screen.getByRole('region', { name: 'Signal theme flow' });
+      const flow = await screen.findByRole('region', { name: 'Signal theme flow' });
+      const timeline = screen.getByRole('region', { name: 'Snapshot timeline' });
+      const distributions = screen.getByRole('region', { name: 'Signal distributions' });
 
-      expect(distributions.compareDocumentPosition(flow) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+      expect(flow.compareDocumentPosition(timeline) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
+      expect(timeline.compareDocumentPosition(distributions) & Node.DOCUMENT_POSITION_FOLLOWING).not.toBe(0);
     });
 
     it('summarizes each signal with one stacked bar and compact theme rows', async () => {
@@ -325,9 +330,34 @@ describe('SankeySignals', () => {
           const snapshotId = new URL(request.url).searchParams.get('snapshotId');
           const snapshot = multiThemeSnapshotsResponse.snapshots.find(item => item.snapshotId === snapshotId);
           if (!snapshot) return HttpResponse.json({ error: 'Unknown snapshot' }, { status: 400 });
-          return HttpResponse.json({ ...fourStageThemeFlowResponse, snapshot });
+          return HttpResponse.json(snapshotId === 'snapshot-3' ? earlierThemeFlowResponse : fourStageThemeFlowResponse);
         }),
       );
+    });
+
+    it('keeps themes from every timeline snapshot visible in the latest Sankey frame', async () => {
+      renderSankeySignals();
+
+      const chart = await screen.findByRole('region', { name: 'Signal theme flow' });
+      expect(within(chart).getByLabelText('Legacy support request: 0 traces (0%)')).not.toBeNull();
+    });
+
+    it('keeps the rendered frame visible while playback advances', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, async ({ request }) => {
+          const snapshotId = new URL(request.url).searchParams.get('snapshotId');
+          if (snapshotId === 'snapshot-3') await new Promise(resolve => window.setTimeout(resolve, 100));
+          return HttpResponse.json(snapshotId === 'snapshot-3' ? earlierThemeFlowResponse : fourStageThemeFlowResponse);
+        }),
+      );
+      renderSankeySignals();
+      await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Play snapshots' }));
+
+      await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces', undefined, { timeout: 2000 });
+      expect(screen.queryByRole('status', { name: 'Loading snapshot flow' })).toBeNull();
+      expect(screen.getByRole('region', { name: 'Signal theme flow' })).not.toBeNull();
     });
 
     it('selects the latest ordinal and labels it without parsing its cursor', async () => {
@@ -361,7 +391,7 @@ describe('SankeySignals', () => {
       expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
     });
 
-    it('stops scheduling snapshots after a playback request fails', async () => {
+    it('does not expose playback when a timeline flow fails to preload', async () => {
       const flowRequests: Array<string> = [];
       server.use(
         http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
@@ -375,16 +405,13 @@ describe('SankeySignals', () => {
         }),
       );
       renderSankeySignals();
-      await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces');
 
-      fireEvent.click(screen.getByRole('button', { name: 'Play snapshots' }));
-      await screen.findByRole('button', { name: 'Retry' }, { timeout: 2000 });
-      await new Promise(resolve => window.setTimeout(resolve, 1100));
-
-      expect(flowRequests).toEqual(['snapshot-1', 'snapshot-3']);
+      expect(await screen.findByRole('button', { name: 'Retry' })).not.toBeNull();
+      expect(screen.queryByRole('button', { name: 'Play snapshots' })).toBeNull();
+      expect([...flowRequests].sort()).toEqual(['snapshot-1', 'snapshot-3']);
     });
 
-    it('keeps the pause control available while the next flow is loading', async () => {
+    it('waits for every timeline flow before exposing playback', async () => {
       let releasePendingFlow: (() => void) | undefined;
       const pendingFlow = new Promise<void>(resolve => {
         releasePendingFlow = resolve;
@@ -398,16 +425,11 @@ describe('SankeySignals', () => {
         }),
       );
       renderSankeySignals();
-      await screen.findByText('Snapshot 4/4 · Jul 1–8, 2026 · 50 traces');
 
-      fireEvent.click(screen.getByRole('button', { name: 'Play snapshots' }));
-
-      expect(
-        await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces', undefined, { timeout: 2000 }),
-      ).not.toBeNull();
-      expect(screen.getByRole('button', { name: 'Pause snapshots' })).not.toBeNull();
-      expect(screen.getByRole('status', { name: 'Loading snapshot flow' })).not.toBeNull();
+      expect(await screen.findByRole('status', { name: 'Loading signal analysis' })).not.toBeNull();
+      expect(screen.queryByRole('button', { name: 'Play snapshots' })).toBeNull();
       releasePendingFlow?.();
+      expect(await screen.findByRole('button', { name: 'Play snapshots' })).not.toBeNull();
     });
   });
 
@@ -460,22 +482,22 @@ describe('SankeySignals', () => {
       expect(within(distributions).getByText('Metadata only goal')).not.toBeNull();
     });
 
-    it('shows the same graph-derived counts and percentages on chart nodes', async () => {
+    it('shows authoritative node counts on chart nodes independently of layout weights', async () => {
       renderSankeySignals();
 
       const chart = await screen.findByRole('region', { name: 'Signal theme flow' });
       for (const label of [
-        '22 (44%)',
-        '17 (34%)',
-        '11 (22%)',
-        '31 (62%)',
-        '19 (38%)',
-        '34 (68%)',
-        '16 (32%)',
-        '29 (58%)',
-        '21 (42%)',
+        '42 (37%)',
+        '38 (34%)',
+        '33 (29%)',
+        '51 (45%)',
+        '40 (35%)',
+        '54 (48%)',
+        '37 (33%)',
+        '49 (43%)',
+        '42 (37%)',
       ]) {
-        expect(await within(chart).findByText(label)).not.toBeNull();
+        expect(within(chart).getAllByText(label).length).toBeGreaterThan(0);
       }
       expect(within(chart).queryByText('Metadata only goal')).toBeNull();
     });

--- a/packages/playground/src/ee/signals/hooks/use-snapshot-playback.test.ts
+++ b/packages/playground/src/ee/signals/hooks/use-snapshot-playback.test.ts
@@ -1,0 +1,42 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { multiThemeSnapshotsResponse } from '../__tests__/fixtures/theme-flow';
+import { useSnapshotPlayback } from './use-snapshot-playback';
+
+describe('useSnapshotPlayback', () => {
+  afterEach(() => vi.useRealTimers());
+
+  it('starts from the latest snapshot and advances while playing', () => {
+    vi.useFakeTimers();
+    const snapshots = multiThemeSnapshotsResponse.snapshots;
+    const { result } = renderHook(() => useSnapshotPlayback(snapshots, false));
+
+    expect(result.current.selectedSnapshotIndex).toBe(snapshots.length - 1);
+
+    act(() => result.current.setIsPlaying(true));
+    act(() => vi.advanceTimersByTime(900));
+
+    expect(result.current.selectedSnapshotIndex).toBe(0);
+  });
+
+  it('does not advance while playback is blocked', () => {
+    vi.useFakeTimers();
+    const snapshots = multiThemeSnapshotsResponse.snapshots;
+    const { result } = renderHook(() => useSnapshotPlayback(snapshots, true));
+
+    act(() => result.current.setIsPlaying(true));
+    act(() => vi.advanceTimersByTime(900));
+
+    expect(result.current.selectedSnapshotIndex).toBe(snapshots.length - 1);
+  });
+
+  it('selects a snapshot directly', () => {
+    const snapshots = multiThemeSnapshotsResponse.snapshots;
+    const { result } = renderHook(() => useSnapshotPlayback(snapshots, false));
+
+    act(() => result.current.selectSnapshot(0));
+
+    expect(result.current.snapshot?.snapshotId).toBe(snapshots[0]?.snapshotId);
+  });
+});

--- a/packages/playground/src/ee/signals/hooks/use-snapshot-playback.test.ts
+++ b/packages/playground/src/ee/signals/hooks/use-snapshot-playback.test.ts
@@ -1,42 +1,62 @@
-import { act, renderHook } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { multiThemeSnapshotsResponse } from '../__tests__/fixtures/theme-flow';
 import { useSnapshotPlayback } from './use-snapshot-playback';
 
 describe('useSnapshotPlayback', () => {
   afterEach(() => vi.useRealTimers());
 
-  it('starts from the latest snapshot and advances while playing', () => {
+  it('advances after the playback interval', () => {
     vi.useFakeTimers();
-    const snapshots = multiThemeSnapshotsResponse.snapshots;
-    const { result } = renderHook(() => useSnapshotPlayback(snapshots, false));
+    const onAdvance = vi.fn();
 
-    expect(result.current.selectedSnapshotIndex).toBe(snapshots.length - 1);
+    renderHook(() =>
+      useSnapshotPlayback({
+        isPlaying: true,
+        isPlaybackBlocked: false,
+        nextSnapshot: 'snapshot-2',
+        onAdvance,
+        snapshotCount: 2,
+      }),
+    );
+    vi.advanceTimersByTime(900);
 
-    act(() => result.current.setIsPlaying(true));
-    act(() => vi.advanceTimersByTime(900));
-
-    expect(result.current.selectedSnapshotIndex).toBe(0);
+    expect(onAdvance).toHaveBeenCalledWith('snapshot-2');
   });
 
   it('does not advance while playback is blocked', () => {
     vi.useFakeTimers();
-    const snapshots = multiThemeSnapshotsResponse.snapshots;
-    const { result } = renderHook(() => useSnapshotPlayback(snapshots, true));
+    const onAdvance = vi.fn();
 
-    act(() => result.current.setIsPlaying(true));
-    act(() => vi.advanceTimersByTime(900));
+    renderHook(() =>
+      useSnapshotPlayback({
+        isPlaying: true,
+        isPlaybackBlocked: true,
+        nextSnapshot: 'snapshot-2',
+        onAdvance,
+        snapshotCount: 2,
+      }),
+    );
+    vi.advanceTimersByTime(900);
 
-    expect(result.current.selectedSnapshotIndex).toBe(snapshots.length - 1);
+    expect(onAdvance).not.toHaveBeenCalled();
   });
 
-  it('selects a snapshot directly', () => {
-    const snapshots = multiThemeSnapshotsResponse.snapshots;
-    const { result } = renderHook(() => useSnapshotPlayback(snapshots, false));
+  it('does not advance a single-snapshot timeline', () => {
+    vi.useFakeTimers();
+    const onAdvance = vi.fn();
 
-    act(() => result.current.selectSnapshot(0));
+    renderHook(() =>
+      useSnapshotPlayback({
+        isPlaying: true,
+        isPlaybackBlocked: false,
+        nextSnapshot: 'snapshot-1',
+        onAdvance,
+        snapshotCount: 1,
+      }),
+    );
+    vi.advanceTimersByTime(900);
 
-    expect(result.current.snapshot?.snapshotId).toBe(snapshots[0]?.snapshotId);
+    expect(onAdvance).not.toHaveBeenCalled();
   });
 });

--- a/packages/playground/src/ee/signals/hooks/use-snapshot-playback.ts
+++ b/packages/playground/src/ee/signals/hooks/use-snapshot-playback.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import type { ThemeSnapshot } from '../types';
+
+export function useSnapshotPlayback(snapshots: ThemeSnapshot[], isPlaybackBlocked: boolean) {
+  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
+  const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
+  const snapshot = snapshots[selectedSnapshotIndex];
+  const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
+
+  useEffect(() => {
+    if (!isPlaying || snapshots.length < 2 || isPlaybackBlocked) return;
+
+    const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
+    return () => window.clearTimeout(timer);
+  }, [isPlaybackBlocked, isPlaying, nextSnapshotId, snapshots.length]);
+
+  return {
+    isPlaying,
+    selectedSnapshotIndex,
+    setIsPlaying,
+    snapshot,
+    selectSnapshot: (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId),
+  };
+}

--- a/packages/playground/src/ee/signals/hooks/use-snapshot-playback.ts
+++ b/packages/playground/src/ee/signals/hooks/use-snapshot-playback.ts
@@ -1,27 +1,24 @@
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
-import type { ThemeSnapshot } from '../types';
+type SnapshotPlaybackOptions<SnapshotCursor> = {
+  isPlaying: boolean;
+  isPlaybackBlocked: boolean;
+  nextSnapshot: SnapshotCursor | undefined;
+  onAdvance: (snapshot: SnapshotCursor | undefined) => void;
+  snapshotCount: number;
+};
 
-export function useSnapshotPlayback(snapshots: ThemeSnapshot[], isPlaybackBlocked: boolean) {
-  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
-  const [isPlaying, setIsPlaying] = useState(false);
-  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
-  const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
-  const snapshot = snapshots[selectedSnapshotIndex];
-  const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
-
+export function useSnapshotPlayback<SnapshotCursor>({
+  isPlaying,
+  isPlaybackBlocked,
+  nextSnapshot,
+  onAdvance,
+  snapshotCount,
+}: SnapshotPlaybackOptions<SnapshotCursor>) {
   useEffect(() => {
-    if (!isPlaying || snapshots.length < 2 || isPlaybackBlocked) return;
+    if (!isPlaying || snapshotCount < 2 || isPlaybackBlocked) return;
 
-    const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
+    const timer = window.setTimeout(() => onAdvance(nextSnapshot), 900);
     return () => window.clearTimeout(timer);
-  }, [isPlaybackBlocked, isPlaying, nextSnapshotId, snapshots.length]);
-
-  return {
-    isPlaying,
-    selectedSnapshotIndex,
-    setIsPlaying,
-    snapshot,
-    selectSnapshot: (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId),
-  };
+  }, [isPlaybackBlocked, isPlaying, nextSnapshot, onAdvance, snapshotCount]);
 }

--- a/packages/playground/src/ee/signals/hooks/use-theme-flows.ts
+++ b/packages/playground/src/ee/signals/hooks/use-theme-flows.ts
@@ -1,0 +1,19 @@
+import { useQueries } from '@tanstack/react-query';
+
+import { fetchThemeFlow } from '../entity-learning-api';
+import type { TraceSignalName } from '../types';
+
+export function useThemeFlows(
+  entityId: string,
+  entityType: string,
+  signalNames: TraceSignalName[],
+  snapshotIds: string[],
+) {
+  return useQueries({
+    queries: snapshotIds.map(snapshotId => ({
+      queryKey: ['entity-learning', entityType, entityId, 'theme-flow', signalNames, snapshotId],
+      queryFn: () => fetchThemeFlow(entityId, entityType, signalNames, snapshotId),
+      enabled: signalNames.length >= 2,
+    })),
+  });
+}

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -4,6 +4,9 @@ import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
 
 const MINIMUM_LAYOUT_WEIGHT = 0.01;
 
+type StableThemeFlowLink = ThemeFlowResponse['links'][number] & { layoutTraceCount: number };
+type StableThemeFlowResponse = Omit<ThemeFlowResponse, 'links'> & { links: StableThemeFlowLink[] };
+
 export function getSignalRecordNodeId(record: SankeyChartRecord, column: SankeyChartColumn) {
   return String(record[column.id]);
 }
@@ -48,6 +51,7 @@ export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
       [`${target.signalName}Description`]: target.node.description,
       [`${target.signalName}TraceCount`]: target.node.traceCount,
       traceCount: link.traceCount,
+      layoutTraceCount: 'layoutTraceCount' in link ? link.layoutTraceCount : link.traceCount,
     });
   }
 
@@ -61,7 +65,7 @@ export function buildSignalGraphSummary(flow: ThemeFlowResponse): {
   return themeFlowToSankeyData(flow);
 }
 
-export function stabilizeThemeFlow(flow: ThemeFlowResponse, windowFlows: ThemeFlowResponse[]): ThemeFlowResponse {
+export function stabilizeThemeFlow(flow: ThemeFlowResponse, windowFlows: ThemeFlowResponse[]): StableThemeFlowResponse {
   const stages = flow.stages.map(stage => {
     const nodes = new Map<string, ThemeNode>();
 
@@ -76,22 +80,27 @@ export function stabilizeThemeFlow(flow: ThemeFlowResponse, windowFlows: ThemeFl
     return { ...stage, nodes: [...nodes.values()] };
   });
 
-  const links = new Map<string, Map<string, ThemeFlowResponse['links'][number]>>();
+  const layoutLinks = new Map<string, ThemeFlowResponse['links'][number]>();
   for (const windowFlow of windowFlows) {
     for (const link of windowFlow.links) {
-      const targets = links.get(link.sourceNodeId) ?? new Map();
-      const existing = targets.get(link.targetNodeId);
-      if (!existing || link.traceCount > existing.traceCount) {
-        targets.set(link.targetNodeId, {
-          ...link,
-          traceCount: Math.max(MINIMUM_LAYOUT_WEIGHT, link.traceCount),
-        });
-      }
-      links.set(link.sourceNodeId, targets);
+      const key = `${link.sourceNodeId}\u0000${link.targetNodeId}`;
+      const existing = layoutLinks.get(key);
+      if (!existing || link.traceCount > existing.traceCount) layoutLinks.set(key, link);
     }
   }
+  const currentLinks = new Map(flow.links.map(link => [`${link.sourceNodeId}\u0000${link.targetNodeId}`, link]));
+  const stableLinks = [...layoutLinks.entries()].map(([key, layoutLink]): StableThemeFlowLink => {
+    const currentLink = currentLinks.get(key);
+    return {
+      ...(currentLink ?? layoutLink),
+      traceCount: currentLink?.traceCount ?? 0,
+      sourceShare: currentLink?.sourceShare ?? 0,
+      targetShare: currentLink?.targetShare ?? 0,
+      layoutTraceCount: Math.max(MINIMUM_LAYOUT_WEIGHT, layoutLink.traceCount),
+    };
+  });
 
-  return { ...flow, stages, links: [...links.values()].flatMap(targets => [...targets.values()]) };
+  return { ...flow, stages, links: stableLinks };
 }
 
 function formatSignalName(signalName: TraceSignalName) {

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -16,6 +16,14 @@ export interface SignalGraphStageSummary {
   nodes: SignalGraphNodeSummary[];
 }
 
+export function getSignalRecordNodeId(record: SankeyChartRecord, column: SankeyChartColumn) {
+  return String(record[column.id]);
+}
+
+export function getSignalRecordNodeLabel(record: SankeyChartRecord, column: SankeyChartColumn) {
+  return String(record[`${column.id}Label`]);
+}
+
 export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
   columns: SankeyChartColumn[];
   records: SankeyChartRecord[];
@@ -37,8 +45,10 @@ export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
     if (!source || !target) continue;
 
     records.push({
-      [source.signalName]: source.node.label,
-      [target.signalName]: target.node.label,
+      [source.signalName]: source.node.nodeId,
+      [`${source.signalName}Label`]: source.node.label,
+      [target.signalName]: target.node.nodeId,
+      [`${target.signalName}Label`]: target.node.label,
       traceCount: link.traceCount,
     });
   }
@@ -53,7 +63,13 @@ export function buildSignalGraphSummary(flow: ThemeFlowResponse): {
   stages: SignalGraphStageSummary[];
 } {
   const { columns, records } = themeFlowToSankeyData(flow);
-  const graph = buildSankeyChartGraph(records, columns, record => Number(record.traceCount));
+  const graph = buildSankeyChartGraph(
+    records,
+    columns,
+    record => Number(record.traceCount),
+    getSignalRecordNodeId,
+    getSignalRecordNodeLabel,
+  );
   const nodeWeights = getSankeyChartNodeWeights(graph);
   const firstColumnId = columns[0]?.id;
   const analyzedTraceCount = graph.nodes.reduce(
@@ -67,13 +83,13 @@ export function buildSignalGraphSummary(flow: ThemeFlowResponse): {
     );
     const seenNodeIds = new Set<string>();
     const nodes = stage.nodes.flatMap(node => {
-      const graphNode = graphNodes.get(node.label);
+      const graphNode = graphNodes.get(node.nodeId);
       if (!graphNode || seenNodeIds.has(graphNode.id)) return [];
       seenNodeIds.add(graphNode.id);
       const traceCount = nodeWeights.get(graphNode.id) ?? 0;
       return [
         {
-          nodeId: graphNode.id,
+          nodeId: node.nodeId,
           label: node.label,
           traceCount,
           stageShare: analyzedTraceCount > 0 ? traceCount / analyzedTraceCount : 0,

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -1,21 +1,6 @@
-import { buildSankeyChartGraph, getSankeyChartNodeWeights } from '@mastra/playground-ui/components/SankeyChart';
 import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui/components/SankeyChart';
 
 import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
-
-export interface SignalGraphNodeSummary {
-  nodeId: string;
-  label: string;
-  description?: string;
-  traceCount: number;
-  stageShare: number;
-}
-
-export interface SignalGraphStageSummary {
-  signalName: TraceSignalName;
-  traceCount: number;
-  nodes: SignalGraphNodeSummary[];
-}
 
 export function getSignalRecordNodeId(record: SankeyChartRecord, column: SankeyChartColumn) {
   return String(record[column.id]);
@@ -60,53 +45,8 @@ export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
 export function buildSignalGraphSummary(flow: ThemeFlowResponse): {
   columns: SankeyChartColumn[];
   records: SankeyChartRecord[];
-  analyzedTraceCount: number;
-  stages: SignalGraphStageSummary[];
 } {
-  const { columns, records } = themeFlowToSankeyData(flow);
-  const graph = buildSankeyChartGraph(
-    records,
-    columns,
-    record => Number(record.traceCount),
-    getSignalRecordNodeId,
-    getSignalRecordNodeLabel,
-  );
-  const nodeWeights = getSankeyChartNodeWeights(graph);
-  const firstColumnId = columns[0]?.id;
-  const analyzedTraceCount = graph.nodes.reduce(
-    (total, node) => (node.column.id === firstColumnId ? total + (nodeWeights.get(node.id) ?? 0) : total),
-    0,
-  );
-
-  const stages = flow.stages.map(stage => {
-    const graphNodes = new Map(
-      graph.nodes.filter(node => node.column.id === stage.signalName).map(node => [String(node.value), node]),
-    );
-    const seenNodeIds = new Set<string>();
-    const nodes = stage.nodes.flatMap(node => {
-      const graphNode = graphNodes.get(node.nodeId);
-      if (!graphNode || seenNodeIds.has(graphNode.id)) return [];
-      seenNodeIds.add(graphNode.id);
-      const traceCount = nodeWeights.get(graphNode.id) ?? 0;
-      return [
-        {
-          nodeId: node.nodeId,
-          label: node.label,
-          description: node.description,
-          traceCount,
-          stageShare: analyzedTraceCount > 0 ? traceCount / analyzedTraceCount : 0,
-        },
-      ];
-    });
-
-    return {
-      signalName: stage.signalName,
-      traceCount: nodes.reduce((total, node) => total + node.traceCount, 0),
-      nodes,
-    };
-  });
-
-  return { columns, records, analyzedTraceCount, stages };
+  return themeFlowToSankeyData(flow);
 }
 
 function formatSignalName(signalName: TraceSignalName) {

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -80,21 +80,15 @@ export function stabilizeThemeFlow(flow: ThemeFlowResponse, windowFlows: ThemeFl
   for (const windowFlow of windowFlows) {
     for (const link of windowFlow.links) {
       const targets = links.get(link.sourceNodeId) ?? new Map();
-      if (!targets.has(link.targetNodeId)) {
+      const existing = targets.get(link.targetNodeId);
+      if (!existing || link.traceCount > existing.traceCount) {
         targets.set(link.targetNodeId, {
           ...link,
-          traceCount: MINIMUM_LAYOUT_WEIGHT,
-          sourceShare: 0,
-          targetShare: 0,
+          traceCount: Math.max(MINIMUM_LAYOUT_WEIGHT, link.traceCount),
         });
       }
       links.set(link.sourceNodeId, targets);
     }
-  }
-  for (const link of flow.links) {
-    const targets = links.get(link.sourceNodeId) ?? new Map();
-    targets.set(link.targetNodeId, link);
-    links.set(link.sourceNodeId, targets);
   }
 
   return { ...flow, stages, links: [...links.values()].flatMap(targets => [...targets.values()]) };

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -2,6 +2,8 @@ import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui
 
 import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
 
+const MINIMUM_LAYOUT_WEIGHT = 0.01;
+
 export function getSignalRecordNodeId(record: SankeyChartRecord, column: SankeyChartColumn) {
   return String(record[column.id]);
 }
@@ -10,6 +12,10 @@ export function getSignalRecordNodeLabel(record: SankeyChartRecord, column: Sank
   const label = String(record[`${column.id}Label`]);
   const description = record[`${column.id}Description`];
   return typeof description === 'string' && description.trim() ? `${label}\n${description}` : label;
+}
+
+export function getSignalRecordNodeValue(record: SankeyChartRecord, column: SankeyChartColumn) {
+  return Number(record[`${column.id}TraceCount`]);
 }
 
 export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
@@ -36,9 +42,11 @@ export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
       [source.signalName]: source.node.nodeId,
       [`${source.signalName}Label`]: source.node.label,
       [`${source.signalName}Description`]: source.node.description,
+      [`${source.signalName}TraceCount`]: source.node.traceCount,
       [target.signalName]: target.node.nodeId,
       [`${target.signalName}Label`]: target.node.label,
       [`${target.signalName}Description`]: target.node.description,
+      [`${target.signalName}TraceCount`]: target.node.traceCount,
       traceCount: link.traceCount,
     });
   }
@@ -51,6 +59,45 @@ export function buildSignalGraphSummary(flow: ThemeFlowResponse): {
   records: SankeyChartRecord[];
 } {
   return themeFlowToSankeyData(flow);
+}
+
+export function stabilizeThemeFlow(flow: ThemeFlowResponse, windowFlows: ThemeFlowResponse[]): ThemeFlowResponse {
+  const stages = flow.stages.map(stage => {
+    const nodes = new Map<string, ThemeNode>();
+
+    for (const windowFlow of windowFlows) {
+      const windowStage = windowFlow.stages.find(candidate => candidate.signalName === stage.signalName);
+      for (const node of windowStage?.nodes ?? []) {
+        nodes.set(node.nodeId, { ...node, traceCount: 0, stageShare: 0 });
+      }
+    }
+    for (const node of stage.nodes) nodes.set(node.nodeId, node);
+
+    return { ...stage, nodes: [...nodes.values()] };
+  });
+
+  const links = new Map<string, Map<string, ThemeFlowResponse['links'][number]>>();
+  for (const windowFlow of windowFlows) {
+    for (const link of windowFlow.links) {
+      const targets = links.get(link.sourceNodeId) ?? new Map();
+      if (!targets.has(link.targetNodeId)) {
+        targets.set(link.targetNodeId, {
+          ...link,
+          traceCount: MINIMUM_LAYOUT_WEIGHT,
+          sourceShare: 0,
+          targetShare: 0,
+        });
+      }
+      links.set(link.sourceNodeId, targets);
+    }
+  }
+  for (const link of flow.links) {
+    const targets = links.get(link.sourceNodeId) ?? new Map();
+    targets.set(link.targetNodeId, link);
+    links.set(link.sourceNodeId, targets);
+  }
+
+  return { ...flow, stages, links: [...links.values()].flatMap(targets => [...targets.values()]) };
 }
 
 function formatSignalName(signalName: TraceSignalName) {

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -7,7 +7,9 @@ export function getSignalRecordNodeId(record: SankeyChartRecord, column: SankeyC
 }
 
 export function getSignalRecordNodeLabel(record: SankeyChartRecord, column: SankeyChartColumn) {
-  return String(record[`${column.id}Label`]);
+  const label = String(record[`${column.id}Label`]);
+  const description = record[`${column.id}Description`];
+  return typeof description === 'string' && description.trim() ? `${label}\n${description}` : label;
 }
 
 export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
@@ -33,8 +35,10 @@ export function themeFlowToSankeyData(flow: ThemeFlowResponse): {
     records.push({
       [source.signalName]: source.node.nodeId,
       [`${source.signalName}Label`]: source.node.label,
+      [`${source.signalName}Description`]: source.node.description,
       [target.signalName]: target.node.nodeId,
       [`${target.signalName}Label`]: target.node.label,
+      [`${target.signalName}Description`]: target.node.description,
       traceCount: link.traceCount,
     });
   }

--- a/packages/playground/src/ee/signals/sankey-signals-data.ts
+++ b/packages/playground/src/ee/signals/sankey-signals-data.ts
@@ -6,6 +6,7 @@ import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
 export interface SignalGraphNodeSummary {
   nodeId: string;
   label: string;
+  description?: string;
   traceCount: number;
   stageShare: number;
 }
@@ -91,6 +92,7 @@ export function buildSignalGraphSummary(flow: ThemeFlowResponse): {
         {
           nodeId: node.nodeId,
           label: node.label,
+          description: node.description,
           traceCount,
           stageShare: analyzedTraceCount > 0 ? traceCount / analyzedTraceCount : 0,
         },

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -266,10 +266,10 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
 
   useEffect(() => {
-    if (!isPlaying || snapshots.length < 2 || flowQuery.isFetching) return;
+    if (!isPlaying || snapshots.length < 2 || flowQuery.isFetching || flowQuery.isError) return;
     const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
     return () => window.clearTimeout(timer);
-  }, [flowQuery.isFetching, isPlaying, nextSnapshotId, snapshots.length]);
+  }, [flowQuery.isError, flowQuery.isFetching, isPlaying, nextSnapshotId, snapshots.length]);
 
   if (snapshotsQuery.isPending) return <SignalsLoadingSkeleton />;
 
@@ -277,7 +277,10 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
     return (
       <SignalsErrorState
         message="Unable to load signal flow."
-        onRetry={() => void Promise.all([snapshotsQuery.refetch(), flowQuery.refetch()])}
+        onRetry={() => {
+          setIsPlaying(false);
+          void Promise.all([snapshotsQuery.refetch(), flowQuery.refetch()]);
+        }}
       />
     );
   }

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -4,18 +4,17 @@ import { nodeColor, Sankey, SankeyChart } from '@mastra/playground-ui/components
 import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui/components/SankeyChart';
 import { Slider } from '@mastra/playground-ui/components/Slider';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
-import { ExternalLink, Pause, Play } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Pause, Play } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import { useThemeFlow } from './hooks/use-theme-flow';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
 import { buildSignalGraphSummary, getSignalRecordNodeId, getSignalRecordNodeLabel } from './sankey-signals-data';
 import type { SignalGraphNodeSummary, SignalGraphStageSummary } from './sankey-signals-data';
+import { SignalsErrorState } from './signals-error-state';
+import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
 import type { ThemeSnapshot, TraceSignalName } from './types';
 import { Link } from '@/lib/link';
-
-const SIGNAL_ORDER: TraceSignalName[] = ['goal', 'outcome', 'behavior', 'sentiment'];
-const SIGNAL_DOCS_URL = 'https://mastra.ai/en/docs/observability/tracing/overview';
 
 export interface SankeySignalsProps {
   entityId: string;
@@ -40,7 +39,9 @@ function formatSnapshotWindow(startedAt: string, endedAt: string) {
   const year = new Intl.DateTimeFormat('en-US', { year: 'numeric', timeZone: 'UTC' });
   const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
   const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
+  const sameDay = sameMonth && start.getUTCDate() === end.getUTCDate();
 
+  if (sameDay) return `${monthDay.format(start)}, ${year.format(start)}`;
   if (sameMonth) return `${monthDay.format(start)}–${day.format(end)}, ${year.format(end)}`;
   if (sameYear) return `${monthDay.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
   return `${monthDay.format(start)}, ${year.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
@@ -66,7 +67,7 @@ function SnapshotTimeline({
   return (
     <section
       aria-label="Snapshot timeline"
-      className="flex items-center gap-3 rounded-lg border border-border1 bg-surface2 px-4 py-3"
+      className="flex flex-wrap items-center gap-3 rounded-lg border border-border1 bg-surface2 px-3 py-2.5 sm:px-4"
     >
       <Button
         aria-label={isPlaying ? 'Pause snapshots' : 'Play snapshots'}
@@ -89,7 +90,7 @@ function SnapshotTimeline({
         step={1}
         value={[selectedIndex]}
       />
-      <p className="min-w-72 text-right font-mono text-xs tabular-nums text-neutral4">
+      <p className="w-full text-left font-mono text-xs tabular-nums text-neutral4 md:w-auto md:min-w-72 md:text-right">
         Snapshot {snapshot.ordinal}/{snapshot.total} · {formatSnapshotWindow(snapshot.startedAt, snapshot.endedAt)} ·{' '}
         {traceLabel(snapshot.traceCount)}
       </p>
@@ -139,7 +140,13 @@ function SignalDistribution({
         <ul className="space-y-2.5">
           {nodes.length > 0 ? (
             nodes.map((node, index) => (
-              <li key={node.nodeId} className="flex min-w-0 items-center justify-between gap-3 text-xs">
+              <li
+                key={node.nodeId}
+                aria-label={node.description ? `${node.label}. ${node.description}` : node.label}
+                className="flex min-w-0 items-center justify-between gap-3 rounded-xs text-xs focus-visible:outline-2 focus-visible:outline-offset-2"
+                tabIndex={0}
+                title={node.description ? `${node.label}\n${node.description}` : node.label}
+              >
                 <span className="flex min-w-0 items-center gap-2 text-neutral5">
                   <span
                     aria-hidden="true"
@@ -166,18 +173,15 @@ function SignalDistribution({
 
 function SignalDistributions({ stages }: { stages: SignalGraphStageSummary[] }) {
   return (
-    <section aria-label="Signal distributions" className="grid grid-cols-4 gap-3">
-      {SIGNAL_ORDER.map(signalName => {
-        const stage = stages.find(currentStage => currentStage.signalName === signalName);
-        return (
-          <SignalDistribution
-            key={signalName}
-            signalName={signalName}
-            traceCount={stage?.traceCount ?? 0}
-            nodes={stage?.nodes ?? []}
-          />
-        );
-      })}
+    <section aria-label="Signal distributions" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {stages.map(stage => (
+        <SignalDistribution
+          key={stage.signalName}
+          signalName={stage.signalName}
+          traceCount={stage.traceCount}
+          nodes={stage.nodes}
+        />
+      ))}
     </section>
   );
 }
@@ -203,8 +207,8 @@ function FlowCard({
   });
 
   return (
-    <Card aria-label="Signal theme flow" as="section" className="overflow-hidden" elevation="elevated">
-      <CardContent className="px-0 py-4">
+    <Card aria-label="Signal theme flow" as="section" className="min-w-0 overflow-hidden" elevation="elevated">
+      <CardContent className="px-0 py-2 sm:py-3">
         <Sankey
           data={records}
           columns={chartColumns}
@@ -213,17 +217,20 @@ function FlowCard({
           getRecordNodeLabel={getSignalRecordNodeLabel}
           getRecordWeight={record => Number(record.traceCount)}
         >
-          <SankeyChart height={height ?? 680} margin={{ top: 64, right: 160, bottom: 48, left: 160 }} />
+          <SankeyChart
+            height={height ?? 'clamp(340px, 42vw, 460px)'}
+            margin={{ top: 64, right: 32, bottom: 24, left: 32 }}
+          />
         </Sankey>
       </CardContent>
-      <CardFooter className="flex justify-between gap-6 border-t border-border1 bg-surface2 px-4 py-3">
+      <CardFooter className="flex flex-wrap justify-between gap-3 border-t border-border1 bg-surface2 px-4 py-3">
         <div className="flex flex-wrap items-center gap-x-5 gap-y-1 font-mono text-[10px] tracking-wider text-neutral3">
           <span>RIBBON WIDTH = TRACE COUNT</span>
           <span>HOVER OR FOCUS TO ISOLATE FLOW</span>
         </div>
         <ul
           aria-label="Signal stage legend"
-          className="flex shrink-0 items-center gap-4 text-xs text-neutral3"
+          className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-neutral3"
           data-alignment="right"
         >
           {stages.map(stage => (
@@ -245,42 +252,35 @@ function FlowCard({
 
 export function SankeySignals({ entityId, entityType = 'agent', signalNames, height }: SankeySignalsProps) {
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
-  const snapshots = useMemo(
-    () => [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal),
-    [snapshotsQuery.data?.snapshots],
-  );
+  const snapshots = [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal);
   const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
   const [isPlaying, setIsPlaying] = useState(false);
   const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
   const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
   const snapshot = snapshots[selectedSnapshotIndex];
-  const selectSnapshot = useCallback(
-    (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId),
-    [snapshots],
-  );
+  const selectSnapshot = (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId);
+
+  const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
 
   useEffect(() => {
     if (!isPlaying || snapshots.length < 2) return;
-    const timer = window.setInterval(() => selectSnapshot((selectedSnapshotIndex + 1) % snapshots.length), 900);
+    const timer = window.setInterval(() => setSelectedSnapshotId(nextSnapshotId), 900);
     return () => window.clearInterval(timer);
-  }, [isPlaying, selectSnapshot, selectedSnapshotIndex, snapshots.length]);
+  }, [isPlaying, nextSnapshotId, snapshots.length]);
 
   const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
 
   if (snapshotsQuery.isPending || (snapshot && flowQuery.isPending)) {
-    return (
-      <section
-        aria-label="Loading signal analysis"
-        className="flex h-[640px] items-center justify-center"
-        role="status"
-      >
-        <div className="size-8 animate-spin rounded-full border-2 border-border1 border-t-accent1" />
-      </section>
-    );
+    return <SignalsLoadingSkeleton />;
   }
 
   if (snapshotsQuery.isError || flowQuery.isError) {
-    return <div className="p-6 text-sm text-red-500">Unable to load signal flow.</div>;
+    return (
+      <SignalsErrorState
+        message="Unable to load signal flow."
+        onRetry={() => void Promise.all([snapshotsQuery.refetch(), flowQuery.refetch()])}
+      />
+    );
   }
 
   const flow = flowQuery.data;
@@ -299,39 +299,30 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   const themeCount = stages.reduce((total, stage) => total + stage.nodes.length, 0);
 
   return (
-    <main className="space-y-7 p-6">
-      <header className="flex items-start justify-between gap-8" data-testid="signals-page-header">
-        <div className="max-w-2xl">
-          <div className="flex items-center gap-2 font-mono text-xs font-semibold tracking-widest text-neutral4">
-            <span aria-hidden="true" className="size-2 rounded-full bg-accent1" />
-            SIGNALS
-          </div>
-          <h1 className="mt-3 text-2xl font-semibold text-neutral6">Understand what drives every agent interaction</h1>
-          <p className="mt-2 text-sm leading-6 text-neutral3">
-            Signals group recurring patterns across traces so you can see how goals, outcomes, behaviors, and sentiment
-            connect.
-          </p>
-          <ul aria-label="Signal analysis metrics" className="mt-5 flex flex-wrap gap-2">
-            <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
-              {traceLabel(flow.snapshot.traceCount)} analyzed
-            </li>
-            <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
-              {themeCount} themes
-            </li>
-            <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
-              {flow.stages.length} signal types
-            </li>
-          </ul>
+    <main className="min-w-0 space-y-5 p-4 lg:p-6">
+      <header className="max-w-3xl" data-testid="signals-page-header">
+        <div className="flex items-center gap-2 font-mono text-xs font-semibold tracking-widest text-neutral4">
+          <span aria-hidden="true" className="size-2 rounded-full bg-accent1" />
+          SIGNALS
         </div>
-        <a
-          className="flex shrink-0 items-center gap-1.5 text-xs text-neutral4 transition-colors hover:text-neutral6 focus-visible:outline-2 focus-visible:outline-offset-2"
-          href={SIGNAL_DOCS_URL}
-          rel="noreferrer"
-          target="_blank"
-        >
-          Signals documentation
-          <ExternalLink aria-hidden="true" className="size-3.5" />
-        </a>
+        <h1 className="mt-2 text-xl font-semibold text-neutral6 sm:text-2xl">
+          Understand what drives every agent interaction
+        </h1>
+        <p className="mt-1.5 text-sm leading-5 text-neutral3">
+          Signals group recurring patterns across traces so you can see how goals, outcomes, behaviors, and sentiment
+          connect.
+        </p>
+        <ul aria-label="Signal analysis metrics" className="mt-3 flex flex-wrap gap-2">
+          <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
+            {traceLabel(flow.snapshot.traceCount)} analyzed
+          </li>
+          <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
+            {themeCount} themes
+          </li>
+          <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
+            {flow.stages.length} signal types
+          </li>
+        </ul>
       </header>
       <SnapshotTimeline
         snapshots={snapshots}
@@ -340,12 +331,8 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
         onPlayingChange={setIsPlaying}
         onSnapshotChange={selectSnapshot}
       />
-      <div className="overflow-x-auto" data-scroll-container="horizontal" data-testid="signals-analysis-scroll">
-        <div className="min-w-[920px] space-y-4" data-min-width="920" data-testid="signals-analysis-canvas">
-          <FlowCard columns={graphSummary.columns} records={graphSummary.records} stages={stages} height={height} />
-          <SignalDistributions stages={stages} />
-        </div>
-      </div>
+      <SignalDistributions stages={stages} />
+      <FlowCard columns={graphSummary.columns} records={graphSummary.records} stages={stages} height={height} />
     </main>
   );
 }

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -2,7 +2,7 @@ import { Card, CardContent, CardFooter, CardHeader } from '@mastra/playground-ui
 import { nodeColor, Sankey, SankeyChart } from '@mastra/playground-ui/components/SankeyChart';
 import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui/components/SankeyChart';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useSnapshotPlayback } from './hooks/use-snapshot-playback';
 import { useThemeFlows } from './hooks/use-theme-flows';
@@ -176,6 +176,13 @@ function FlowCard({
 export function SankeySignals({ entityId, entityType = 'agent', signalNames, height }: SankeySignalsProps) {
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
   const snapshots = [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal);
+  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
+  const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
+  const snapshot = snapshots[selectedSnapshotIndex];
+  const selectSnapshot = (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId);
+  const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
   const flowQueries = useThemeFlows(
     entityId,
     entityType,
@@ -184,10 +191,13 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   );
   const isFlowPending = flowQueries.some(query => query.isPending);
   const hasFlowError = flowQueries.some(query => query.isError);
-  const { isPlaying, selectedSnapshotIndex, selectSnapshot, setIsPlaying, snapshot } = useSnapshotPlayback(
-    snapshots,
-    isFlowPending || hasFlowError,
-  );
+  useSnapshotPlayback({
+    isPlaying,
+    isPlaybackBlocked: isFlowPending || hasFlowError,
+    nextSnapshot: nextSnapshotId,
+    onAdvance: setSelectedSnapshotId,
+    snapshotCount: snapshots.length,
+  });
   const flow = flowQueries[selectedSnapshotIndex]?.data;
   const windowFlows = useMemo(() => flowQueries.flatMap(query => (query.data ? [query.data] : [])), [flowQueries]);
   const graphSummary = useMemo(

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -7,11 +7,17 @@ import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/
 import { Pause, Play } from 'lucide-react';
 import { useEffect, useState } from 'react';
 
-import { useThemeFlow } from './hooks/use-theme-flow';
+import { useThemeFlows } from './hooks/use-theme-flows';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
-import { buildSignalGraphSummary, getSignalRecordNodeId, getSignalRecordNodeLabel } from './sankey-signals-data';
+import {
+  buildSignalGraphSummary,
+  getSignalRecordNodeId,
+  getSignalRecordNodeLabel,
+  getSignalRecordNodeValue,
+  stabilizeThemeFlow,
+} from './sankey-signals-data';
 import { SignalsErrorState } from './signals-error-state';
-import { SignalsFrameLoadingSkeleton, SignalsLoadingSkeleton } from './signals-loading-skeleton';
+import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
 import type { ThemeFlowResponse, ThemeNode, ThemeSnapshot, TraceSignalName } from './types';
 import { Link } from '@/lib/link';
 
@@ -199,14 +205,7 @@ function FlowCard({
   stages: ThemeFlowResponse['stages'];
   height?: number;
 }) {
-  const chartColumns = columns.map(column => {
-    const stage = stages.find(currentStage => currentStage.signalName === column.id);
-    const themeCount = stage?.nodes.length ?? 0;
-    return {
-      ...column,
-      label: `${column.label.toUpperCase()} ${themeCount} ${themeCount === 1 ? 'theme' : 'themes'}`,
-    };
-  });
+  const chartColumns = columns.map(column => ({ ...column, label: column.label.toUpperCase() }));
 
   return (
     <Card aria-label="Signal theme flow" as="section" className="min-w-0 overflow-hidden" elevation="elevated">
@@ -217,6 +216,7 @@ function FlowCard({
           getColumnHue={column => getSignalHue(column.id)}
           getRecordNodeId={getSignalRecordNodeId}
           getRecordNodeLabel={getSignalRecordNodeLabel}
+          getRecordNodeValue={getSignalRecordNodeValue}
           getRecordWeight={record => Number(record.traceCount)}
         >
           <SankeyChart
@@ -263,23 +263,31 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   const selectSnapshot = (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId);
 
   const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
-  const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
+  const flowQueries = useThemeFlows(
+    entityId,
+    entityType,
+    signalNames,
+    snapshots.map(candidate => candidate.snapshotId),
+  );
+  const flowQuery = flowQueries[selectedSnapshotIndex];
+  const isFlowPending = flowQueries.some(query => query.isPending);
+  const hasFlowError = flowQueries.some(query => query.isError);
 
   useEffect(() => {
-    if (!isPlaying || snapshots.length < 2 || flowQuery.isFetching || flowQuery.isError) return;
+    if (!isPlaying || snapshots.length < 2 || isFlowPending || hasFlowError) return;
     const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
     return () => window.clearTimeout(timer);
-  }, [flowQuery.isError, flowQuery.isFetching, isPlaying, nextSnapshotId, snapshots.length]);
+  }, [hasFlowError, isFlowPending, isPlaying, nextSnapshotId, snapshots.length]);
 
   if (snapshotsQuery.isPending) return <SignalsLoadingSkeleton />;
 
-  if (snapshotsQuery.isError || flowQuery.isError) {
+  if (snapshotsQuery.isError || hasFlowError) {
     return (
       <SignalsErrorState
         message="Unable to load signal flow."
         onRetry={() => {
           setIsPlaying(false);
-          void Promise.all([snapshotsQuery.refetch(), flowQuery.refetch()]);
+          void Promise.all([snapshotsQuery.refetch(), ...flowQueries.map(query => query.refetch())]);
         }}
       />
     );
@@ -287,27 +295,15 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
 
   if (!snapshot) return <SignalsEmptyState LinkComponent={Link} />;
 
-  if (flowQuery.isPending) {
-    return (
-      <main className="min-w-0 space-y-5 p-4 lg:p-6">
-        <SnapshotTimeline
-          snapshots={snapshots}
-          selectedIndex={selectedSnapshotIndex}
-          isPlaying={isPlaying}
-          onPlayingChange={setIsPlaying}
-          onSnapshotChange={selectSnapshot}
-        />
-        <SignalsFrameLoadingSkeleton />
-      </main>
-    );
-  }
+  if (isFlowPending) return <SignalsLoadingSkeleton />;
 
-  const flow = flowQuery.data;
+  const flow = flowQuery?.data;
   const populatedStageCount = flow?.stages.filter(stage => stage.nodes.length > 0).length ?? 0;
 
   if (!flow || populatedStageCount < 2) return <SignalsEmptyState LinkComponent={Link} />;
 
-  const graphSummary = buildSignalGraphSummary(flow);
+  const windowFlows = flowQueries.flatMap(query => (query.data ? [query.data] : []));
+  const graphSummary = buildSignalGraphSummary(stabilizeThemeFlow(flow, windowFlows));
   const stages = flow.stages;
   const themeCount = stages.reduce(
     (total, stage) => total + stage.nodes.filter(node => node.kind === 'theme').length,
@@ -344,6 +340,7 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
           </li>
         </ul>
       </header>
+      <FlowCard columns={graphSummary.columns} records={graphSummary.records} stages={stages} height={height} />
       <SnapshotTimeline
         snapshots={snapshots}
         selectedIndex={selectedSnapshotIndex}
@@ -352,7 +349,6 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
         onSnapshotChange={selectSnapshot}
       />
       <SignalDistributions stages={stages} />
-      <FlowCard columns={graphSummary.columns} records={graphSummary.records} stages={stages} height={height} />
     </main>
   );
 }

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -263,14 +263,13 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   const selectSnapshot = (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId);
 
   const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
+  const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
 
   useEffect(() => {
-    if (!isPlaying || snapshots.length < 2) return;
-    const timer = window.setInterval(() => setSelectedSnapshotId(nextSnapshotId), 900);
-    return () => window.clearInterval(timer);
-  }, [isPlaying, nextSnapshotId, snapshots.length]);
-
-  const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
+    if (!isPlaying || snapshots.length < 2 || flowQuery.isFetching) return;
+    const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
+    return () => window.clearTimeout(timer);
+  }, [flowQuery.isFetching, isPlaying, nextSnapshotId, snapshots.length]);
 
   if (snapshotsQuery.isPending) return <SignalsLoadingSkeleton />;
 
@@ -325,6 +324,10 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
         <p className="mt-1.5 text-sm leading-5 text-neutral3">
           Signals group recurring patterns across traces so you can see how goals, outcomes, behaviors, and sentiment
           connect.
+        </p>
+        <p className="mt-2 font-mono text-xs text-neutral4">
+          {entityId} · Snapshot {flow.snapshot.ordinal} of {flow.snapshot.total} ·{' '}
+          {formatSnapshotWindow(flow.snapshot.startedAt, flow.snapshot.endedAt)}
         </p>
         <ul aria-label="Signal analysis metrics" className="mt-3 flex flex-wrap gap-2">
           <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -1,12 +1,10 @@
-import { Button } from '@mastra/playground-ui/components/Button';
 import { Card, CardContent, CardFooter, CardHeader } from '@mastra/playground-ui/components/Card';
 import { nodeColor, Sankey, SankeyChart } from '@mastra/playground-ui/components/SankeyChart';
 import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui/components/SankeyChart';
-import { Slider } from '@mastra/playground-ui/components/Slider';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
-import { Pause, Play } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
+import { useSnapshotPlayback } from './hooks/use-snapshot-playback';
 import { useThemeFlows } from './hooks/use-theme-flows';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
 import {
@@ -16,9 +14,11 @@ import {
   getSignalRecordNodeValue,
   stabilizeThemeFlow,
 } from './sankey-signals-data';
+import { formatSignalName, formatSnapshotWindow, traceLabel } from './signal-formatting';
 import { SignalsErrorState } from './signals-error-state';
 import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
-import type { ThemeFlowResponse, ThemeNode, ThemeSnapshot, TraceSignalName } from './types';
+import { SnapshotTimeline } from './snapshot-timeline';
+import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
 import { Link } from '@/lib/link';
 
 export interface SankeySignalsProps {
@@ -26,86 +26,6 @@ export interface SankeySignalsProps {
   entityType?: string;
   signalNames: TraceSignalName[];
   height?: number;
-}
-
-function formatSignalName(signalName: TraceSignalName) {
-  return signalName.charAt(0).toUpperCase() + signalName.slice(1);
-}
-
-function traceLabel(count: number) {
-  return `${count} ${count === 1 ? 'trace' : 'traces'}`;
-}
-
-function formatSnapshotWindow(startedAt: string, endedAt: string) {
-  const start = new Date(startedAt);
-  const end = new Date(endedAt);
-  const monthDay = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
-  const day = new Intl.DateTimeFormat('en-US', { day: 'numeric', timeZone: 'UTC' });
-  const year = new Intl.DateTimeFormat('en-US', { year: 'numeric', timeZone: 'UTC' });
-  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
-  const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
-  const sameDay = sameMonth && start.getUTCDate() === end.getUTCDate();
-
-  if (sameDay) return `${monthDay.format(start)}, ${year.format(start)}`;
-  if (sameMonth) return `${monthDay.format(start)}–${day.format(end)}, ${year.format(end)}`;
-  if (sameYear) return `${monthDay.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
-  return `${monthDay.format(start)}, ${year.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
-}
-
-function SnapshotTimeline({
-  snapshots,
-  selectedIndex,
-  isPlaying,
-  onPlayingChange,
-  onSnapshotChange,
-}: {
-  snapshots: ThemeSnapshot[];
-  selectedIndex: number;
-  isPlaying: boolean;
-  onPlayingChange: (isPlaying: boolean) => void;
-  onSnapshotChange: (index: number) => void;
-}) {
-  const snapshot = snapshots[selectedIndex];
-
-  if (!snapshot) return null;
-
-  return (
-    <section
-      aria-label="Snapshot timeline"
-      className="flex flex-wrap items-center gap-3 rounded-lg border border-border1 bg-surface2 px-3 py-2.5 sm:px-4"
-    >
-      {snapshots.length > 1 ? (
-        <>
-          <Button
-            aria-label={isPlaying ? 'Pause snapshots' : 'Play snapshots'}
-            onClick={() => onPlayingChange(!isPlaying)}
-            size="sm"
-            type="button"
-            variant="outline"
-          >
-            {isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
-            {isPlaying ? 'Pause' : 'Play'}
-          </Button>
-          <Slider
-            aria-label="Snapshot"
-            className="min-w-32 flex-1"
-            max={snapshots.length - 1}
-            min={0}
-            onValueChange={value => onSnapshotChange(value[0] ?? 0)}
-            step={1}
-            value={[selectedIndex]}
-          />
-        </>
-      ) : null}
-      <p
-        aria-live="polite"
-        className="w-full text-left font-mono text-xs tabular-nums text-neutral4 md:ml-auto md:w-auto md:min-w-72 md:text-right"
-      >
-        Snapshot {snapshot.ordinal}/{snapshot.total} · {formatSnapshotWindow(snapshot.startedAt, snapshot.endedAt)} ·{' '}
-        {traceLabel(snapshot.traceCount)}
-      </p>
-    </section>
-  );
 }
 
 function SignalDistribution({
@@ -256,35 +176,24 @@ function FlowCard({
 export function SankeySignals({ entityId, entityType = 'agent', signalNames, height }: SankeySignalsProps) {
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
   const snapshots = [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal);
-  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
-  const [isPlaying, setIsPlaying] = useState(false);
-  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
-  const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
-  const snapshot = snapshots[selectedSnapshotIndex];
-  const selectSnapshot = (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId);
-
-  const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
   const flowQueries = useThemeFlows(
     entityId,
     entityType,
     signalNames,
     snapshots.map(candidate => candidate.snapshotId),
   );
-  const flowQuery = flowQueries[selectedSnapshotIndex];
   const isFlowPending = flowQueries.some(query => query.isPending);
   const hasFlowError = flowQueries.some(query => query.isError);
-  const flow = flowQuery?.data;
+  const { isPlaying, selectedSnapshotIndex, selectSnapshot, setIsPlaying, snapshot } = useSnapshotPlayback(
+    snapshots,
+    isFlowPending || hasFlowError,
+  );
+  const flow = flowQueries[selectedSnapshotIndex]?.data;
   const windowFlows = useMemo(() => flowQueries.flatMap(query => (query.data ? [query.data] : [])), [flowQueries]);
   const graphSummary = useMemo(
     () => (flow ? buildSignalGraphSummary(stabilizeThemeFlow(flow, windowFlows)) : undefined),
     [flow, windowFlows],
   );
-
-  useEffect(() => {
-    if (!isPlaying || snapshots.length < 2 || isFlowPending || hasFlowError) return;
-    const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
-    return () => window.clearTimeout(timer);
-  }, [hasFlowError, isFlowPending, isPlaying, nextSnapshotId, snapshots.length]);
 
   if (snapshotsQuery.isPending) return <SignalsLoadingSkeleton />;
 

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -5,7 +5,7 @@ import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui
 import { Slider } from '@mastra/playground-ui/components/Slider';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
 import { Pause, Play } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { useThemeFlows } from './hooks/use-theme-flows';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
@@ -272,6 +272,12 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   const flowQuery = flowQueries[selectedSnapshotIndex];
   const isFlowPending = flowQueries.some(query => query.isPending);
   const hasFlowError = flowQueries.some(query => query.isError);
+  const flow = flowQuery?.data;
+  const windowFlows = useMemo(() => flowQueries.flatMap(query => (query.data ? [query.data] : [])), [flowQueries]);
+  const graphSummary = useMemo(
+    () => (flow ? buildSignalGraphSummary(stabilizeThemeFlow(flow, windowFlows)) : undefined),
+    [flow, windowFlows],
+  );
 
   useEffect(() => {
     if (!isPlaying || snapshots.length < 2 || isFlowPending || hasFlowError) return;
@@ -297,13 +303,10 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
 
   if (isFlowPending) return <SignalsLoadingSkeleton />;
 
-  const flow = flowQuery?.data;
   const populatedStageCount = flow?.stages.filter(stage => stage.nodes.length > 0).length ?? 0;
 
-  if (!flow || populatedStageCount < 2) return <SignalsEmptyState LinkComponent={Link} />;
+  if (!flow || !graphSummary || populatedStageCount < 2) return <SignalsEmptyState LinkComponent={Link} />;
 
-  const windowFlows = flowQueries.flatMap(query => (query.data ? [query.data] : []));
-  const graphSummary = buildSignalGraphSummary(stabilizeThemeFlow(flow, windowFlows));
   const stages = flow.stages;
   const themeCount = stages.reduce(
     (total, stage) => total + stage.nodes.filter(node => node.kind === 'theme').length,

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -6,7 +6,7 @@ import { ExternalLink } from 'lucide-react';
 
 import { useThemeFlow } from './hooks/use-theme-flow';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
-import { buildSignalGraphSummary } from './sankey-signals-data';
+import { buildSignalGraphSummary, getSignalRecordNodeId, getSignalRecordNodeLabel } from './sankey-signals-data';
 import type { SignalGraphNodeSummary, SignalGraphStageSummary } from './sankey-signals-data';
 import type { TraceSignalName } from './types';
 import { Link } from '@/lib/link';
@@ -141,6 +141,8 @@ function FlowCard({
           data={records}
           columns={chartColumns}
           getColumnHue={column => getSignalHue(column.id)}
+          getRecordNodeId={getSignalRecordNodeId}
+          getRecordNodeLabel={getSignalRecordNodeLabel}
           getRecordWeight={record => Number(record.traceCount)}
         >
           <SankeyChart height={height ?? 680} margin={{ top: 64, right: 160, bottom: 48, left: 160 }} />

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -10,10 +10,9 @@ import { useEffect, useState } from 'react';
 import { useThemeFlow } from './hooks/use-theme-flow';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
 import { buildSignalGraphSummary, getSignalRecordNodeId, getSignalRecordNodeLabel } from './sankey-signals-data';
-import type { SignalGraphNodeSummary, SignalGraphStageSummary } from './sankey-signals-data';
 import { SignalsErrorState } from './signals-error-state';
-import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
-import type { ThemeSnapshot, TraceSignalName } from './types';
+import { SignalsFrameLoadingSkeleton, SignalsLoadingSkeleton } from './signals-loading-skeleton';
+import type { ThemeFlowResponse, ThemeNode, ThemeSnapshot, TraceSignalName } from './types';
 import { Link } from '@/lib/link';
 
 export interface SankeySignalsProps {
@@ -69,28 +68,33 @@ function SnapshotTimeline({
       aria-label="Snapshot timeline"
       className="flex flex-wrap items-center gap-3 rounded-lg border border-border1 bg-surface2 px-3 py-2.5 sm:px-4"
     >
-      <Button
-        aria-label={isPlaying ? 'Pause snapshots' : 'Play snapshots'}
-        disabled={snapshots.length < 2}
-        onClick={() => onPlayingChange(!isPlaying)}
-        size="sm"
-        type="button"
-        variant="outline"
+      {snapshots.length > 1 ? (
+        <>
+          <Button
+            aria-label={isPlaying ? 'Pause snapshots' : 'Play snapshots'}
+            onClick={() => onPlayingChange(!isPlaying)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
+            {isPlaying ? 'Pause' : 'Play'}
+          </Button>
+          <Slider
+            aria-label="Snapshot"
+            className="min-w-32 flex-1"
+            max={snapshots.length - 1}
+            min={0}
+            onValueChange={value => onSnapshotChange(value[0] ?? 0)}
+            step={1}
+            value={[selectedIndex]}
+          />
+        </>
+      ) : null}
+      <p
+        aria-live="polite"
+        className="w-full text-left font-mono text-xs tabular-nums text-neutral4 md:ml-auto md:w-auto md:min-w-72 md:text-right"
       >
-        {isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
-        {isPlaying ? 'Pause' : 'Play'}
-      </Button>
-      <Slider
-        aria-label="Snapshot"
-        className="min-w-32 flex-1"
-        disabled={snapshots.length < 2}
-        max={Math.max(snapshots.length - 1, 1)}
-        min={0}
-        onValueChange={value => onSnapshotChange(value[0] ?? 0)}
-        step={1}
-        value={[selectedIndex]}
-      />
-      <p className="w-full text-left font-mono text-xs tabular-nums text-neutral4 md:w-auto md:min-w-72 md:text-right">
         Snapshot {snapshot.ordinal}/{snapshot.total} · {formatSnapshotWindow(snapshot.startedAt, snapshot.endedAt)} ·{' '}
         {traceLabel(snapshot.traceCount)}
       </p>
@@ -105,7 +109,7 @@ function SignalDistribution({
 }: {
   signalName: TraceSignalName;
   traceCount: number;
-  nodes: SignalGraphNodeSummary[];
+  nodes: ThemeNode[];
 }) {
   const label = formatSignalName(signalName);
   const color = nodeColor(getSignalHue(signalName));
@@ -142,9 +146,7 @@ function SignalDistribution({
             nodes.map((node, index) => (
               <li
                 key={node.nodeId}
-                aria-label={node.description ? `${node.label}. ${node.description}` : node.label}
-                className="flex min-w-0 items-center justify-between gap-3 rounded-xs text-xs focus-visible:outline-2 focus-visible:outline-offset-2"
-                tabIndex={0}
+                className="flex min-w-0 items-center justify-between gap-3 text-xs"
                 title={node.description ? `${node.label}\n${node.description}` : node.label}
               >
                 <span className="flex min-w-0 items-center gap-2 text-neutral5">
@@ -171,7 +173,7 @@ function SignalDistribution({
   );
 }
 
-function SignalDistributions({ stages }: { stages: SignalGraphStageSummary[] }) {
+function SignalDistributions({ stages }: { stages: ThemeFlowResponse['stages'] }) {
   return (
     <section aria-label="Signal distributions" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
       {stages.map(stage => (
@@ -194,7 +196,7 @@ function FlowCard({
 }: {
   columns: SankeyChartColumn[];
   records: SankeyChartRecord[];
-  stages: SignalGraphStageSummary[];
+  stages: ThemeFlowResponse['stages'];
   height?: number;
 }) {
   const chartColumns = columns.map(column => {
@@ -270,9 +272,7 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
 
   const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
 
-  if (snapshotsQuery.isPending || (snapshot && flowQuery.isPending)) {
-    return <SignalsLoadingSkeleton />;
-  }
+  if (snapshotsQuery.isPending) return <SignalsLoadingSkeleton />;
 
   if (snapshotsQuery.isError || flowQuery.isError) {
     return (
@@ -283,20 +283,34 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
     );
   }
 
+  if (!snapshot) return <SignalsEmptyState LinkComponent={Link} />;
+
+  if (flowQuery.isPending) {
+    return (
+      <main className="min-w-0 space-y-5 p-4 lg:p-6">
+        <SnapshotTimeline
+          snapshots={snapshots}
+          selectedIndex={selectedSnapshotIndex}
+          isPlaying={isPlaying}
+          onPlayingChange={setIsPlaying}
+          onSnapshotChange={selectSnapshot}
+        />
+        <SignalsFrameLoadingSkeleton />
+      </main>
+    );
+  }
+
   const flow = flowQuery.data;
   const populatedStageCount = flow?.stages.filter(stage => stage.nodes.length > 0).length ?? 0;
 
-  if (!snapshot || !flow || populatedStageCount < 2) {
-    return <SignalsEmptyState LinkComponent={Link} />;
-  }
+  if (!flow || populatedStageCount < 2) return <SignalsEmptyState LinkComponent={Link} />;
 
   const graphSummary = buildSignalGraphSummary(flow);
-  const stages = graphSummary.stages.map(stage => ({
-    ...stage,
-    traceCount:
-      flow.stages.find(flowStage => flowStage.signalName === stage.signalName)?.traceCount ?? stage.traceCount,
-  }));
-  const themeCount = stages.reduce((total, stage) => total + stage.nodes.length, 0);
+  const stages = flow.stages;
+  const themeCount = stages.reduce(
+    (total, stage) => total + stage.nodes.filter(node => node.kind === 'theme').length,
+    0,
+  );
 
   return (
     <main className="min-w-0 space-y-5 p-4 lg:p-6">

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -1,14 +1,17 @@
+import { Button } from '@mastra/playground-ui/components/Button';
 import { Card, CardContent, CardFooter, CardHeader } from '@mastra/playground-ui/components/Card';
 import { nodeColor, Sankey, SankeyChart } from '@mastra/playground-ui/components/SankeyChart';
 import type { SankeyChartColumn, SankeyChartRecord } from '@mastra/playground-ui/components/SankeyChart';
+import { Slider } from '@mastra/playground-ui/components/Slider';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
-import { ExternalLink } from 'lucide-react';
+import { ExternalLink, Pause, Play } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useThemeFlow } from './hooks/use-theme-flow';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
 import { buildSignalGraphSummary, getSignalRecordNodeId, getSignalRecordNodeLabel } from './sankey-signals-data';
 import type { SignalGraphNodeSummary, SignalGraphStageSummary } from './sankey-signals-data';
-import type { TraceSignalName } from './types';
+import type { ThemeSnapshot, TraceSignalName } from './types';
 import { Link } from '@/lib/link';
 
 const SIGNAL_ORDER: TraceSignalName[] = ['goal', 'outcome', 'behavior', 'sentiment'];
@@ -27,6 +30,71 @@ function formatSignalName(signalName: TraceSignalName) {
 
 function traceLabel(count: number) {
   return `${count} ${count === 1 ? 'trace' : 'traces'}`;
+}
+
+function formatSnapshotWindow(startedAt: string, endedAt: string) {
+  const start = new Date(startedAt);
+  const end = new Date(endedAt);
+  const monthDay = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  const day = new Intl.DateTimeFormat('en-US', { day: 'numeric', timeZone: 'UTC' });
+  const year = new Intl.DateTimeFormat('en-US', { year: 'numeric', timeZone: 'UTC' });
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
+  const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
+
+  if (sameMonth) return `${monthDay.format(start)}–${day.format(end)}, ${year.format(end)}`;
+  if (sameYear) return `${monthDay.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
+  return `${monthDay.format(start)}, ${year.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
+}
+
+function SnapshotTimeline({
+  snapshots,
+  selectedIndex,
+  isPlaying,
+  onPlayingChange,
+  onSnapshotChange,
+}: {
+  snapshots: ThemeSnapshot[];
+  selectedIndex: number;
+  isPlaying: boolean;
+  onPlayingChange: (isPlaying: boolean) => void;
+  onSnapshotChange: (index: number) => void;
+}) {
+  const snapshot = snapshots[selectedIndex];
+
+  if (!snapshot) return null;
+
+  return (
+    <section
+      aria-label="Snapshot timeline"
+      className="flex items-center gap-3 rounded-lg border border-border1 bg-surface2 px-4 py-3"
+    >
+      <Button
+        aria-label={isPlaying ? 'Pause snapshots' : 'Play snapshots'}
+        disabled={snapshots.length < 2}
+        onClick={() => onPlayingChange(!isPlaying)}
+        size="sm"
+        type="button"
+        variant="outline"
+      >
+        {isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
+        {isPlaying ? 'Pause' : 'Play'}
+      </Button>
+      <Slider
+        aria-label="Snapshot"
+        className="min-w-32 flex-1"
+        disabled={snapshots.length < 2}
+        max={Math.max(snapshots.length - 1, 1)}
+        min={0}
+        onValueChange={value => onSnapshotChange(value[0] ?? 0)}
+        step={1}
+        value={[selectedIndex]}
+      />
+      <p className="min-w-72 text-right font-mono text-xs tabular-nums text-neutral4">
+        Snapshot {snapshot.ordinal}/{snapshot.total} · {formatSnapshotWindow(snapshot.startedAt, snapshot.endedAt)} ·{' '}
+        {traceLabel(snapshot.traceCount)}
+      </p>
+    </section>
+  );
 }
 
 function SignalDistribution({
@@ -127,10 +195,10 @@ function FlowCard({
 }) {
   const chartColumns = columns.map(column => {
     const stage = stages.find(currentStage => currentStage.signalName === column.id);
-    const clusterCount = stage?.nodes.length ?? 0;
+    const themeCount = stage?.nodes.length ?? 0;
     return {
       ...column,
-      label: `${column.label.toUpperCase()} ${clusterCount} ${clusterCount === 1 ? 'cluster' : 'clusters'}`,
+      label: `${column.label.toUpperCase()} ${themeCount} ${themeCount === 1 ? 'theme' : 'themes'}`,
     };
   });
 
@@ -158,15 +226,15 @@ function FlowCard({
           className="flex shrink-0 items-center gap-4 text-xs text-neutral3"
           data-alignment="right"
         >
-          {SIGNAL_ORDER.map(signalName => (
-            <li key={signalName} className="flex items-center gap-1.5">
+          {stages.map(stage => (
+            <li key={stage.signalName} className="flex items-center gap-1.5">
               <span
                 aria-hidden="true"
                 className="size-2 rounded-[2px]"
                 data-testid="signal-legend-swatch"
-                style={{ backgroundColor: nodeColor(getSignalHue(signalName)) }}
+                style={{ backgroundColor: nodeColor(getSignalHue(stage.signalName)) }}
               />
-              {formatSignalName(signalName)}
+              {formatSignalName(stage.signalName)}
             </li>
           ))}
         </ul>
@@ -177,7 +245,26 @@ function FlowCard({
 
 export function SankeySignals({ entityId, entityType = 'agent', signalNames, height }: SankeySignalsProps) {
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
-  const snapshot = snapshotsQuery.data?.snapshots[0];
+  const snapshots = useMemo(
+    () => [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal),
+    [snapshotsQuery.data?.snapshots],
+  );
+  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
+  const [isPlaying, setIsPlaying] = useState(false);
+  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
+  const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
+  const snapshot = snapshots[selectedSnapshotIndex];
+  const selectSnapshot = useCallback(
+    (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId),
+    [snapshots],
+  );
+
+  useEffect(() => {
+    if (!isPlaying || snapshots.length < 2) return;
+    const timer = window.setInterval(() => selectSnapshot((selectedSnapshotIndex + 1) % snapshots.length), 900);
+    return () => window.clearInterval(timer);
+  }, [isPlaying, selectSnapshot, selectedSnapshotIndex, snapshots.length]);
+
   const flowQuery = useThemeFlow(entityId, entityType, signalNames, snapshot?.snapshotId);
 
   if (snapshotsQuery.isPending || (snapshot && flowQuery.isPending)) {
@@ -204,7 +291,12 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   }
 
   const graphSummary = buildSignalGraphSummary(flow);
-  const clusterCount = graphSummary.stages.reduce((total, stage) => total + stage.nodes.length, 0);
+  const stages = graphSummary.stages.map(stage => ({
+    ...stage,
+    traceCount:
+      flow.stages.find(flowStage => flowStage.signalName === stage.signalName)?.traceCount ?? stage.traceCount,
+  }));
+  const themeCount = stages.reduce((total, stage) => total + stage.nodes.length, 0);
 
   return (
     <main className="space-y-7 p-6">
@@ -221,10 +313,10 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
           </p>
           <ul aria-label="Signal analysis metrics" className="mt-5 flex flex-wrap gap-2">
             <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
-              {traceLabel(graphSummary.analyzedTraceCount)} analyzed
+              {traceLabel(flow.snapshot.traceCount)} analyzed
             </li>
             <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
-              {clusterCount} clusters
+              {themeCount} themes
             </li>
             <li className="rounded-md border border-border1 bg-surface2 px-3 py-1.5 text-xs text-neutral4">
               {flow.stages.length} signal types
@@ -241,15 +333,17 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
           <ExternalLink aria-hidden="true" className="size-3.5" />
         </a>
       </header>
+      <SnapshotTimeline
+        snapshots={snapshots}
+        selectedIndex={selectedSnapshotIndex}
+        isPlaying={isPlaying}
+        onPlayingChange={setIsPlaying}
+        onSnapshotChange={selectSnapshot}
+      />
       <div className="overflow-x-auto" data-scroll-container="horizontal" data-testid="signals-analysis-scroll">
         <div className="min-w-[920px] space-y-4" data-min-width="920" data-testid="signals-analysis-canvas">
-          <FlowCard
-            columns={graphSummary.columns}
-            records={graphSummary.records}
-            stages={graphSummary.stages}
-            height={height}
-          />
-          <SignalDistributions stages={graphSummary.stages} />
+          <FlowCard columns={graphSummary.columns} records={graphSummary.records} stages={stages} height={height} />
+          <SignalDistributions stages={stages} />
         </div>
       </div>
     </main>

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -218,6 +218,7 @@ function FlowCard({
           getRecordNodeLabel={getSignalRecordNodeLabel}
           getRecordNodeValue={getSignalRecordNodeValue}
           getRecordWeight={record => Number(record.traceCount)}
+          getRecordLayoutWeight={record => Number(record.layoutTraceCount)}
         >
           <SankeyChart
             height={height ?? 'clamp(340px, 42vw, 460px)'}

--- a/packages/playground/src/ee/signals/signal-formatting.ts
+++ b/packages/playground/src/ee/signals/signal-formatting.ts
@@ -1,0 +1,25 @@
+import type { TraceSignalName } from './types';
+
+export function formatSignalName(signalName: TraceSignalName) {
+  return signalName.charAt(0).toUpperCase() + signalName.slice(1);
+}
+
+export function traceLabel(count: number) {
+  return `${count} ${count === 1 ? 'trace' : 'traces'}`;
+}
+
+export function formatSnapshotWindow(startedAt: string, endedAt: string) {
+  const start = new Date(startedAt);
+  const end = new Date(endedAt);
+  const monthDay = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  const day = new Intl.DateTimeFormat('en-US', { day: 'numeric', timeZone: 'UTC' });
+  const year = new Intl.DateTimeFormat('en-US', { year: 'numeric', timeZone: 'UTC' });
+  const sameYear = start.getUTCFullYear() === end.getUTCFullYear();
+  const sameMonth = sameYear && start.getUTCMonth() === end.getUTCMonth();
+  const sameDay = sameMonth && start.getUTCDate() === end.getUTCDate();
+
+  if (sameDay) return `${monthDay.format(start)}, ${year.format(start)}`;
+  if (sameMonth) return `${monthDay.format(start)}–${day.format(end)}, ${year.format(end)}`;
+  if (sameYear) return `${monthDay.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
+  return `${monthDay.format(start)}, ${year.format(start)}–${monthDay.format(end)}, ${year.format(end)}`;
+}

--- a/packages/playground/src/ee/signals/signals-error-state.tsx
+++ b/packages/playground/src/ee/signals/signals-error-state.tsx
@@ -1,0 +1,19 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { TriangleAlert } from 'lucide-react';
+
+export function SignalsErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <section className="m-4 rounded-lg border border-border1 bg-surface2 p-6 lg:m-6" role="alert">
+      <div className="flex items-start gap-3">
+        <TriangleAlert aria-hidden="true" className="mt-0.5 size-5 shrink-0 text-red-500" />
+        <div>
+          <h1 className="text-sm font-semibold text-neutral6">{message}</h1>
+          <p className="mt-1 text-xs text-neutral3">Check the connection and try again.</p>
+          <Button className="mt-4" onClick={onRetry} size="sm" type="button" variant="outline">
+            Retry
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/playground/src/ee/signals/signals-loading-skeleton.tsx
+++ b/packages/playground/src/ee/signals/signals-loading-skeleton.tsx
@@ -11,6 +11,29 @@ function DistributionSkeleton() {
   );
 }
 
+function AnalysisSkeletons() {
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <DistributionSkeleton />
+        <DistributionSkeleton />
+        <DistributionSkeleton />
+        <DistributionSkeleton />
+      </div>
+      <Skeleton className="h-80 w-full" />
+    </>
+  );
+}
+
+export function SignalsFrameLoadingSkeleton() {
+  return (
+    <section aria-label="Loading snapshot flow" className="space-y-5" role="status">
+      <span className="sr-only">Loading snapshot flow</span>
+      <AnalysisSkeletons />
+    </section>
+  );
+}
+
 export function SignalsLoadingSkeleton() {
   return (
     <div
@@ -26,13 +49,7 @@ export function SignalsLoadingSkeleton() {
         <Skeleton className="h-4 w-xl max-w-full" />
       </div>
       <Skeleton className="h-14 w-full" />
-      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-        <DistributionSkeleton />
-        <DistributionSkeleton />
-        <DistributionSkeleton />
-        <DistributionSkeleton />
-      </div>
-      <Skeleton className="h-80 w-full" />
+      <AnalysisSkeletons />
     </div>
   );
 }

--- a/packages/playground/src/ee/signals/signals-loading-skeleton.tsx
+++ b/packages/playground/src/ee/signals/signals-loading-skeleton.tsx
@@ -1,22 +1,38 @@
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 
+function DistributionSkeleton() {
+  return (
+    <div className="space-y-3 rounded-lg border border-border1 bg-surface2 p-4">
+      <Skeleton className="h-3 w-20" />
+      <Skeleton className="h-2 w-full" />
+      <Skeleton className="h-3 w-4/5" />
+      <Skeleton className="h-3 w-3/5" />
+    </div>
+  );
+}
+
 export function SignalsLoadingSkeleton() {
   return (
     <div
-      role="status"
       aria-label="Loading signal analysis"
-      className="flex h-full min-h-0 flex-col gap-6 overflow-hidden p-6"
+      className="space-y-5 p-4 lg:p-6"
+      data-testid="signals-loading-skeleton"
+      role="status"
     >
       <span className="sr-only">Loading signal analysis</span>
       <div className="space-y-3">
-        <Skeleton className="h-7 w-48" />
-        <Skeleton className="h-4 w-80 max-w-full" />
+        <Skeleton className="h-5 w-24" />
+        <Skeleton className="h-7 w-96 max-w-full" />
+        <Skeleton className="h-4 w-xl max-w-full" />
       </div>
-      <div className="flex gap-2">
-        <Skeleton className="h-9 w-36" />
-        <Skeleton className="h-9 w-36" />
+      <Skeleton className="h-14 w-full" />
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <DistributionSkeleton />
+        <DistributionSkeleton />
+        <DistributionSkeleton />
+        <DistributionSkeleton />
       </div>
-      <Skeleton className="min-h-80 flex-1" />
+      <Skeleton className="h-80 w-full" />
     </div>
   );
 }

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -1,15 +1,52 @@
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@mastra/playground-ui/components/Select';
 import { SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
+import { useState } from 'react';
 
 import { Link } from '../../lib/link';
 import { useThemeEntities } from './hooks';
 import { SankeySignals } from './sankey-signals';
 import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
-import type { TraceSignalName } from './types';
+import type { ThemeLearningEntity, TraceSignalName } from './types';
 
 const SIGNAL_ORDER: TraceSignalName[] = ['goal', 'outcome', 'behavior', 'sentiment'];
 
+function formatSignalName(signalName: TraceSignalName) {
+  return signalName.charAt(0).toUpperCase() + signalName.slice(1);
+}
+
+function AgentSelector({
+  entities,
+  selectedEntityId,
+  onEntityChange,
+}: {
+  entities: ThemeLearningEntity[];
+  selectedEntityId: string;
+  onEntityChange: (entityId: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 px-6 pt-6">
+      <label className="text-xs font-medium text-neutral4" htmlFor="signals-agent-selector">
+        Agent
+      </label>
+      <Select value={selectedEntityId} onValueChange={onEntityChange}>
+        <SelectTrigger className="w-64" id="signals-agent-selector" size="sm">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {entities.map(entity => (
+            <SelectItem key={entity.entityId} value={entity.entityId}>
+              {entity.entityId}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
 export function SignalsOverviewPage() {
   const entitiesQuery = useThemeEntities('agent');
+  const [selectedEntityId, setSelectedEntityId] = useState<string>();
 
   if (entitiesQuery.isPending) {
     return <SignalsLoadingSkeleton />;
@@ -19,7 +56,8 @@ export function SignalsOverviewPage() {
     return <p>Unable to load signal entities.</p>;
   }
 
-  const entity = entitiesQuery.data?.entities.find(currentEntity => currentEntity.availableSignals.length >= 2);
+  const entities = entitiesQuery.data?.entities ?? [];
+  const entity = entities.find(currentEntity => currentEntity.entityId === selectedEntityId) ?? entities[0];
 
   if (!entity) {
     return <SignalsEmptyState LinkComponent={Link} />;
@@ -27,9 +65,27 @@ export function SignalsOverviewPage() {
 
   const signalNames = SIGNAL_ORDER.filter(signalName => entity.availableSignals.includes(signalName));
 
-  if (signalNames.length < 2) {
-    return <SignalsEmptyState LinkComponent={Link} />;
-  }
-
-  return <SankeySignals entityId={entity.entityId} entityType="agent" signalNames={signalNames} />;
+  return (
+    <>
+      <AgentSelector entities={entities} selectedEntityId={entity.entityId} onEntityChange={setSelectedEntityId} />
+      {signalNames.length >= 2 ? (
+        <SankeySignals key={entity.entityId} entityId={entity.entityId} entityType="agent" signalNames={signalNames} />
+      ) : (
+        <section
+          className="m-6 rounded-lg border border-border1 bg-surface2 p-6"
+          aria-labelledby="signals-data-heading"
+        >
+          <h1 className="text-lg font-semibold text-neutral6" id="signals-data-heading">
+            Not enough signal data yet
+          </h1>
+          <p className="mt-2 text-sm text-neutral3">
+            At least two signal types are needed to show how themes connect across traces.
+          </p>
+          <p className="mt-4 text-xs text-neutral4">
+            Available signals: {signalNames.length > 0 ? signalNames.map(formatSignalName).join(', ') : 'None'}
+          </p>
+        </section>
+      )}
+    </>
+  );
 }

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -58,7 +58,10 @@ export function SignalsOverviewPage() {
   }
 
   const entities = entitiesQuery.data?.entities ?? [];
-  const entity = entities.find(currentEntity => currentEntity.entityId === selectedEntityId) ?? entities[0];
+  const entity =
+    entities.find(currentEntity => currentEntity.entityId === selectedEntityId) ??
+    entities.find(currentEntity => currentEntity.availableSignals.length >= 2) ??
+    entities[0];
 
   if (!entity) {
     return <SignalsEmptyState LinkComponent={Link} />;

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -25,12 +25,12 @@ function AgentSelector({
   onEntityChange: (entityId: string) => void;
 }) {
   return (
-    <div className="flex items-center gap-3 px-4 pt-4 lg:px-6 lg:pt-6">
+    <div className="flex min-w-0 flex-wrap items-center gap-3 px-4 pt-4 lg:px-6 lg:pt-6">
       <label className="text-xs font-medium text-neutral4" htmlFor="signals-agent-selector">
         Agent
       </label>
       <Select value={selectedEntityId} onValueChange={onEntityChange}>
-        <SelectTrigger className="w-64" id="signals-agent-selector" size="sm">
+        <SelectTrigger className="min-w-0 flex-1 sm:w-64 sm:flex-none" id="signals-agent-selector" size="sm">
           <SelectValue />
         </SelectTrigger>
         <SelectContent>

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { Link } from '../../lib/link';
 import { useThemeEntities } from './hooks';
 import { SankeySignals } from './sankey-signals';
+import { SignalsErrorState } from './signals-error-state';
 import { SignalsLoadingSkeleton } from './signals-loading-skeleton';
 import type { ThemeLearningEntity, TraceSignalName } from './types';
 
@@ -24,7 +25,7 @@ function AgentSelector({
   onEntityChange: (entityId: string) => void;
 }) {
   return (
-    <div className="flex items-center gap-3 px-6 pt-6">
+    <div className="flex items-center gap-3 px-4 pt-4 lg:px-6 lg:pt-6">
       <label className="text-xs font-medium text-neutral4" htmlFor="signals-agent-selector">
         Agent
       </label>
@@ -53,7 +54,7 @@ export function SignalsOverviewPage() {
   }
 
   if (entitiesQuery.isError) {
-    return <p>Unable to load signal entities.</p>;
+    return <SignalsErrorState message="Unable to load signal entities." onRetry={() => void entitiesQuery.refetch()} />;
   }
 
   const entities = entitiesQuery.data?.entities ?? [];
@@ -72,7 +73,7 @@ export function SignalsOverviewPage() {
         <SankeySignals key={entity.entityId} entityId={entity.entityId} entityType="agent" signalNames={signalNames} />
       ) : (
         <section
-          className="m-6 rounded-lg border border-border1 bg-surface2 p-6"
+          className="m-4 rounded-lg border border-border1 bg-surface2 p-6 lg:m-6"
           aria-labelledby="signals-data-heading"
         >
           <h1 className="text-lg font-semibold text-neutral6" id="signals-data-heading">

--- a/packages/playground/src/ee/signals/snapshot-timeline.tsx
+++ b/packages/playground/src/ee/signals/snapshot-timeline.tsx
@@ -1,0 +1,62 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Slider } from '@mastra/playground-ui/components/Slider';
+import { Pause, Play } from 'lucide-react';
+
+import { formatSnapshotWindow, traceLabel } from './signal-formatting';
+import type { ThemeSnapshot } from './types';
+
+export function SnapshotTimeline({
+  snapshots,
+  selectedIndex,
+  isPlaying,
+  onPlayingChange,
+  onSnapshotChange,
+}: {
+  snapshots: ThemeSnapshot[];
+  selectedIndex: number;
+  isPlaying: boolean;
+  onPlayingChange: (isPlaying: boolean) => void;
+  onSnapshotChange: (index: number) => void;
+}) {
+  const snapshot = snapshots[selectedIndex];
+
+  if (!snapshot) return null;
+
+  return (
+    <section
+      aria-label="Snapshot timeline"
+      className="flex flex-wrap items-center gap-3 rounded-lg border border-border1 bg-surface2 px-3 py-2.5 sm:px-4"
+    >
+      {snapshots.length > 1 ? (
+        <>
+          <Button
+            aria-label={isPlaying ? 'Pause snapshots' : 'Play snapshots'}
+            onClick={() => onPlayingChange(!isPlaying)}
+            size="sm"
+            type="button"
+            variant="outline"
+          >
+            {isPlaying ? <Pause aria-hidden="true" /> : <Play aria-hidden="true" />}
+            {isPlaying ? 'Pause' : 'Play'}
+          </Button>
+          <Slider
+            aria-label="Snapshot"
+            className="min-w-32 flex-1"
+            max={snapshots.length - 1}
+            min={0}
+            onValueChange={(value: number[]) => onSnapshotChange(value[0] ?? 0)}
+            step={1}
+            value={[selectedIndex]}
+          />
+        </>
+      ) : null}
+      <p
+        aria-live="polite"
+        className="w-full text-left font-mono text-xs tabular-nums text-neutral4 md:ml-auto md:w-auto md:min-w-72 md:text-right"
+      >
+        Snapshot {snapshot.ordinal}/{snapshot.total} · {formatSnapshotWindow(snapshot.startedAt, snapshot.endedAt)} ·{' '}
+        {traceLabel(snapshot.traceCount)}
+      </p>
+    </section>
+  );
+}

--- a/packages/playground/src/ee/signals/types.ts
+++ b/packages/playground/src/ee/signals/types.ts
@@ -1,49 +1,9 @@
-export type TraceSignalName = 'goal' | 'sentiment' | 'behavior' | 'outcome';
-
-export interface ThemeLearningEntity {
-  entityId: string;
-  entityType: string;
-  availableSignals: TraceSignalName[];
-  latestWindow?: { startedAt: string; endedAt: string };
-}
-
-export interface ThemeSnapshot {
-  snapshotId: string;
-  ordinal: number;
-  total: number;
-  startedAt: string;
-  endedAt: string;
-  traceCount: number;
-  availableSignals?: string[];
-}
-
-export interface ThemeNode {
-  nodeId: string;
-  kind: 'theme' | 'noise' | 'other';
-  themeId?: string;
-  label: string;
-  description?: string;
-  traceCount: number;
-  stageShare: number;
-}
-
-export interface ThemeFlowResponse {
-  snapshot: ThemeSnapshot;
-  stages: Array<{ signalName: TraceSignalName; traceCount: number; nodes: ThemeNode[] }>;
-  links: Array<{
-    sourceNodeId: string;
-    targetNodeId: string;
-    traceCount: number;
-    sourceShare: number;
-    targetShare: number;
-  }>;
-}
-
-export interface ThemeSnapshotsResponse {
-  snapshots: ThemeSnapshot[];
-  nextCursor?: string;
-}
-
-export interface ThemeEntitiesResponse {
-  entities: ThemeLearningEntity[];
-}
+export type {
+  ThemeEntitiesResponse,
+  ThemeFlowResponse,
+  ThemeLearningEntity,
+  ThemeNode,
+  ThemeSnapshot,
+  ThemeSnapshotsResponse,
+  TraceSignalName,
+} from '@mastra/client-js';


### PR DESCRIPTION
## Summary

- export Agent Learning response types from `@mastra/client-js` and consume them in Playground fixtures
- preserve API node IDs as Sankey identity while rendering labels separately, including duplicate-label themes
- add an always-visible agent selector and an ordinal snapshot timeline with scrub/play controls
- use authoritative snapshot and stage metrics, returned-stage legends, and complete API stage distributions
- make the Signals page scannable at 1280×720 with distributions first, responsive flow sizing, constrained labels with descriptions, skeleton loading, and retryable errors

## Test plan

- `cd packages/playground && pnpm vitest run --reporter=dot` — 225 files, 1544 passed, 2 skipped
- `cd packages/playground-ui && pnpm test` — 95 files, 641 passed
- `cd packages/playground && pnpm typecheck`
- `cd packages/playground-ui && pnpm typecheck`
- `cd client-sdks/client-js && pnpm build:lib`
- focused ESLint and Prettier checks for all changed source files
- local browser proof at 1280×720 against the seeded 50-trace dataset: no page overflow, no clipped/overlapping labels, distributions above the flow, distinct near-duplicate themes, one documentation link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR makes the “Agent Learning Signals” page nicer to use: you can pick an agent, then scrub or play through snapshot time. It also improves the Sankey chart so node “identity” stays consistent while the visuals resize smoothly, with clearer labels and better loading/retry handling.

## What changed
- **SDK / fixtures**
  - Added **and re-exported “Agent Learning” response types** from `@mastra/client-js`, then updated Playground fixtures to use the exact API shapes.
  - Expanded Signals fixtures to cover **multi-agent selection**, **multi/low-signal cases**, and **duplicate-label themes**.

- **Sankey chart stability + identity/label/value separation**
  - Updated Sankey to use separate per-record extractors:
    - **Node identity** (`getRecordNodeId`) vs **display label** (`getRecordNodeLabel`) vs **display value** (`getRecordNodeValue`)
    - Added optional **layout weight** (`getRecordLayoutWeight`) so link thickness can be based on different weighting than what’s shown.
  - Preserves API node IDs as stable identities while still allowing **duplicate labels** to render as distinct nodes with **truncated labels** (full text available via hover/tooltips).
  - Keeps geometry stable during snapshot playback: **theme/node positions stay fixed** while **trace counts resize bars/ribbons**.
  - Improved chart rendering details (focus/hover behavior, tooltip/ARIA wiring, label truncation rules).

- **Signals page UX: agent selector + snapshot timeline**
  - Added an **always-visible agent selector** with fallback selection logic.
  - Refactored the page into an ordinal **snapshot timeline** with **scrub + play/pause**, driven by a `selectedSnapshotId`.
  - Data/loading behavior:
    - Shows skeleton **immediately**
    - **Retries** via a dedicated `SignalsErrorState`
    - Uses an empty/“not enough signal data yet” state when the selected agent/snapshot doesn’t meet readiness thresholds (including requiring enough signal types for the Sankey view)
    - Per-snapshot flow queries are **gated** until requirements are met (e.g., enough signal types).

- **Authoritative metrics + richer distributions**
  - Updated metrics/distributions to use **authoritative API snapshot totals/counts** (not Sankey-derived weights).
  - Enhanced distributions UI:
    - Returned-stage legends
    - Complete **stage distributions**
    - Label/tooling improvements (e.g., including `node.description` in distribution tooltips/titles)

- **Tests**
  - Strengthened Sankey unit tests for identity vs label/value/link weighting behavior (including duplicate-label scenarios).
  - Expanded Signals UI tests for timeline ordering, playback/scrubbing, loading/skeleton IDs, retry flow, and metric/distribution correctness against API metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->