### PR TITLE
fix(core): resolve unpinned caller-supplied tools

### DIFF
--- a/.changeset/crisp-bears-love.md
+++ b/.changeset/crisp-bears-love.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed caller-supplied tool providers so selected connectionless tools can initialize and manage user connections.

--- a/packages/core/src/tool-provider/runtime.test.ts
+++ b/packages/core/src/tool-provider/runtime.test.ts
@@ -96,6 +96,104 @@ describe('resolveStoredToolProviders — resolveConnectionAuthorId branches', ()
   });
 });
 
+describe('resolveStoredToolProviders — connectionless caller-supplied tools', () => {
+  it('materializes selected tools without a pinned connection', async () => {
+    const managementToolId = 'COMPOSIO_MANAGE_CONNECTIONS';
+    const resolveToolsVNext = vi.fn(async (_opts: ResolveToolsOpts) => ({
+      [managementToolId]: {
+        id: 'provider-internal-id',
+        description: 'Create or manage connections to user apps',
+        execute: async () => ({ success: true }),
+      },
+    }));
+    const provider: ToolProvider = {
+      ...makeStubProvider().provider,
+      defaultScope: 'caller-supplied',
+      resolveToolsVNext,
+    };
+    const toolProviders: ToolProviders = {
+      composio: {
+        tools: {
+          [managementToolId]: { toolkit: 'composio' },
+        },
+        connections: {},
+      },
+    };
+
+    const resolved = await resolveStoredToolProviders(toolProviders, () => provider, {
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant-user-1' },
+      authorId: 'agent-author',
+    });
+
+    expect(resolved[managementToolId]).toBeDefined();
+    expect(resolved[managementToolId]?.id).toBe(managementToolId);
+    expect(resolveToolsVNext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolSlugs: [managementToolId],
+        connectionId: 'tenant-user-1',
+        authorId: 'tenant-user-1',
+        scope: 'caller-supplied',
+        requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant-user-1' },
+      }),
+    );
+  });
+
+  it('derives the toolkit from legacy dot-prefixed tool slugs', async () => {
+    const legacyToolId = 'composio.manage_connections';
+    const resolveToolsVNext = vi.fn(async (_opts: ResolveToolsOpts) => ({
+      [legacyToolId]: {
+        id: legacyToolId,
+        description: 'Create or manage connections to user apps',
+        execute: async () => ({ success: true }),
+      },
+    }));
+    const provider: ToolProvider = {
+      ...makeStubProvider().provider,
+      defaultScope: 'caller-supplied',
+      resolveToolsVNext,
+    };
+    const toolProviders: ToolProviders = {
+      composio: {
+        tools: {
+          [legacyToolId]: {},
+        },
+        connections: {},
+      },
+    };
+
+    const resolved = await resolveStoredToolProviders(toolProviders, () => provider, {
+      requestContext: { [MASTRA_RESOURCE_ID_KEY]: 'tenant-user-1' },
+    });
+
+    expect(resolved[legacyToolId]).toBeDefined();
+    expect(resolveToolsVNext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        toolSlugs: [legacyToolId],
+        scope: 'caller-supplied',
+      }),
+    );
+  });
+
+  it('keeps requiring a pinned connection for providers without caller-supplied scope', async () => {
+    const { provider, resolveToolsVNext } = makeStubProvider();
+    const toolProviders: ToolProviders = {
+      composio: {
+        tools: {
+          'gmail.fetch_emails': { toolkit: 'gmail' },
+        },
+        connections: {},
+      },
+    };
+
+    const resolved = await resolveStoredToolProviders(toolProviders, () => provider, {
+      authorId: 'agent-author',
+    });
+
+    expect(resolved).toEqual({});
+    expect(resolveToolsVNext).not.toHaveBeenCalled();
+  });
+});
+
 describe('buildConnectionSuffix', () => {
   it('uppercases a plain alphanumeric label', () => {
     const used = new Set<string>();

--- a/packages/core/src/tool-provider/runtime.ts
+++ b/packages/core/src/tool-provider/runtime.ts
@@ -67,10 +67,15 @@ export function buildConnectionSuffix(label: string | undefined, usedSuffixes: S
  * Provider-agnostic runtime fan-out.
  *
  * For every stored `toolProviders[providerId].connections[toolkit]`
- * entry, calls `provider.resolveToolsVNext` once per connection, then renames
- * the resulting tools with a `__<LABEL>` suffix when more than one
- * connection is bound to the same toolkit. Single-connection toolkits keep
- * the natural slug.
+ * entry, calls `provider.resolveToolsVNext` once per connection. A provider
+ * whose default scope is `caller-supplied` is also called once for each
+ * selected toolkit without a pinned connection, using the request resource id
+ * as its dynamic connection bucket. This lets connection-management and other
+ * connectionless tools bootstrap a caller's first OAuth connection.
+ *
+ * Tools resolved through multiple pinned connections are renamed with a
+ * `__<LABEL>` suffix. Single-connection and unpinned caller-supplied toolkits
+ * keep the natural slug.
  *
  * Each renamed tool also gets a routing hint appended to its description so
  * the LLM can disambiguate between connections.
@@ -110,6 +115,53 @@ export async function resolveStoredToolProviders(
 
     const tools = cfg.tools ?? {};
     const connectionsByToolkit = cfg.connections ?? {};
+
+    // `caller-supplied` providers resolve within the current request's user
+    // bucket, so they do not need a persisted account pin to materialise a
+    // selected toolkit. This is required for bootstrap tools such as
+    // COMPOSIO_MANAGE_CONNECTIONS, whose own toolkit intentionally has no
+    // OAuth connection.
+    if (provider.defaultScope === 'caller-supplied') {
+      const unpinnedSlugsByToolkit = new Map<string, string[]>();
+      for (const [slug, meta] of Object.entries(tools)) {
+        const separatorIndex = slug.indexOf('.');
+        const toolkit = meta?.toolkit ?? (separatorIndex > 0 ? slug.slice(0, separatorIndex) : undefined);
+        if (!toolkit || connectionsByToolkit[toolkit]?.length) continue;
+        const slugs = unpinnedSlugsByToolkit.get(toolkit) ?? [];
+        slugs.push(slug);
+        unpinnedSlugsByToolkit.set(toolkit, slugs);
+      }
+
+      if (unpinnedSlugsByToolkit.size > 0) {
+        const resolvedAuthorId = resolveCallerSuppliedAuthorId(requestContext, logger);
+        for (const [toolkit, toolSlugs] of unpinnedSlugsByToolkit) {
+          logger?.debug(
+            `[resolveStoredToolProviders] resolving unpinned caller-supplied tools for ${providerId}/${toolkit}`,
+            { slugs: toolSlugs },
+          );
+
+          try {
+            const resolved = await provider.resolveToolsVNext({
+              toolSlugs,
+              toolMeta: tools,
+              connectionId: resolvedAuthorId,
+              authorId: resolvedAuthorId,
+              scope: 'caller-supplied',
+              requestContext,
+            });
+
+            for (const [slug, tool] of Object.entries(resolved)) {
+              out[slug] = { ...tool, id: slug } as ToolAction<any, any, any>;
+            }
+          } catch (error) {
+            logger?.warn(
+              `[resolveStoredToolProviders] Failed to resolve unpinned caller-supplied tools for ${providerId}/${toolkit}`,
+              { error },
+            );
+          }
+        }
+      }
+    }
 
     for (const [toolkit, connections] of Object.entries(connectionsByToolkit)) {
       if (!connections || connections.length === 0) {
@@ -224,17 +276,24 @@ function resolveConnectionAuthorId(
   if (connection.kind !== 'author') return undefined;
   if (connection.scope === 'shared') return SHARED_BUCKET_ID;
   if (connection.scope === 'caller-supplied') {
-    const resourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY];
-    if (typeof resourceId === 'string' && resourceId.length > 0) return resourceId;
-    // Match legacy ComposioToolProvider behavior: when the host app has not
-    // wired requestContext[MASTRA_RESOURCE_ID_KEY] (e.g. via
-    // authConfig.mapUserToResourceId), fall back to a shared 'default' bucket
-    // so tools still resolve. Multi-tenant deployments must wire the resource
-    // id explicitly to avoid cross-user bucket sharing.
-    warnDefaultBucketFallback(logger);
-    return 'default';
+    return resolveCallerSuppliedAuthorId(requestContext, logger);
   }
   return callerAuthorId;
+}
+
+function resolveCallerSuppliedAuthorId(
+  requestContext: Record<string, unknown> | undefined,
+  logger: IMastraLogger | undefined,
+): string {
+  const resourceId = requestContext?.[MASTRA_RESOURCE_ID_KEY];
+  if (typeof resourceId === 'string' && resourceId.length > 0) return resourceId;
+  // Match legacy ComposioToolProvider behavior: when the host app has not
+  // wired requestContext[MASTRA_RESOURCE_ID_KEY] (e.g. via
+  // authConfig.mapUserToResourceId), fall back to a shared 'default' bucket
+  // so tools still resolve. Multi-tenant deployments must wire the resource
+  // id explicitly to avoid cross-user bucket sharing.
+  warnDefaultBucketFallback(logger);
+  return 'default';
 }
 
 function appendRoutingHint(description: string, connection: ToolProviderConnection): string {


### PR DESCRIPTION
## Description

<!-- Provide a brief description of the changes in this PR -->

**ELI5:** Composio's connection-management tool creates an agent's first connection, but Mastra previously refused to load it until a connection already existed—like requiring a key to reach the key-cutting machine.

**Why this is needed:** Agent Builder can select `COMPOSIO_MANAGE_CONNECTIONS` for providers configured with `defaultScope: 'caller-supplied'`, but stored-agent hydration only iterated pinned connections, so the selected tool disappeared at runtime and users could not bootstrap OAuth.

**What changed:** Caller-supplied providers now resolve each selected toolkit without a stored pin once, using the request's resource ID as the dynamic user bucket; pinned toolkits and all other scopes retain their existing behavior, and legacy `toolkit.tool` slugs remain supported.

Regression tests cover connectionless resolution, resource ID forwarding, tool ID normalization, legacy slug inference, and preservation of the pin requirement for non-caller-supplied providers.

## Related Issue(s)

<!-- Link to the issue(s) this PR addresses, using hashtag notation: Fixes #123 -->

Fixes #19845

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Agents can now load selected tools that help users connect their accounts, even when no connection exists yet. This lets users start authentication and create new OAuth connections at runtime.

## Summary

- Updated stored-agent hydration for `caller-supplied` tool providers.
- Resolves unpinned tools using the request resource ID as the user bucket.
- Preserves existing behavior for pinned toolkits and other provider scopes.
- Continues supporting legacy `toolkit.tool` slugs.
- Added regression tests for connectionless resolution, resource ID forwarding, slug normalization, legacy slugs, and pin requirements.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->