### PR TITLE
feat(mastracode-web): improve factory entry experience

### DIFF
--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -26,6 +26,7 @@
   "author": "",
   "license": "Apache-2.0",
   "dependencies": {
+    "@fontsource-variable/mona-sans": "5.3.0",
     "@mastra/auth-better-auth": "link:../../auth/better-auth",
     "@mastra/auth-workos": "link:../../auth/workos",
     "@mastra/client-js": "link:../../client-sdks/client-js",

--- a/mastracode/web/pnpm-lock.yaml
+++ b/mastracode/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@fontsource-variable/mona-sans':
+        specifier: 5.3.0
+        version: 5.3.0
       '@mastra/auth-better-auth':
         specifier: link:../../auth/better-auth
         version: link:../../auth/better-auth
@@ -629,6 +632,9 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
+
+  '@fontsource-variable/mona-sans@5.3.0':
+    resolution: {integrity: sha512-PkxRB3KI4z9Gjpk7vVqgO3GMSyQuOIIj4TaRDbvbcDj8SzWwI38jvLTQxJM/cTRorhcT7h8qjcllR+qjRtM/Fg==}
 
   '@inquirer/ansi@2.0.7':
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
@@ -2806,6 +2812,8 @@ snapshots:
 
   '@esbuild/win32-x64@0.28.1':
     optional: true
+
+  '@fontsource-variable/mona-sans@5.3.0': {}
 
   '@inquirer/ansi@2.0.7': {}
 

--- a/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
@@ -276,14 +276,14 @@ describe('MastraCode web routing', () => {
 
     await expectPathname(router, '/signin');
     expect(router.state.location.search).toBe('?returnTo=%2Fnew');
-    expect(await screen.findByRole('button', { name: /sign in/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Continue with GitHub' })).toBeInTheDocument();
     expect(screen.queryByText('What do you want to work on?')).not.toBeInTheDocument();
   });
 
   it('given an unauthenticated user on /signin with a returnTo, when they click Sign in, then they are sent to the hosted login with that returnTo', async () => {
     renderRoutes('/signin?returnTo=%2Fchat', UNAUTHENTICATED);
 
-    await userEvent.click(await screen.findByRole('button', { name: /sign in/i }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Continue with GitHub' }));
 
     expect(redirectToLogin).toHaveBeenCalledWith(TEST_BASE_URL, '/chat');
     expect(loginUrl(TEST_BASE_URL, '/chat')).toBe(`${TEST_BASE_URL}/auth/login?returnTo=%2Fchat`);
@@ -292,7 +292,7 @@ describe('MastraCode web routing', () => {
   it('given an unauthenticated user on /signin with an unsafe returnTo, when they click Sign in, then it falls back to the app root', async () => {
     renderRoutes('/signin?returnTo=https%3A%2F%2Fevil.example', UNAUTHENTICATED);
 
-    await userEvent.click(await screen.findByRole('button', { name: /sign in/i }));
+    await userEvent.click(await screen.findByRole('button', { name: 'Continue with GitHub' }));
 
     expect(redirectToLogin).toHaveBeenCalledWith(TEST_BASE_URL, '/');
   });

--- a/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/SignInPage.tsx
@@ -1,13 +1,14 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Input } from '@mastra/playground-ui/components/Input';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { GithubIcon } from '@mastra/playground-ui/icons/GithubIcon';
 import { useState } from 'react';
 import type { FormEvent } from 'react';
 import { useSearchParams } from 'react-router';
 
 import { useApiConfig } from '../../../../../shared/api/config';
 import { useWebAuth } from '../../../../../shared/hooks/useWebAuth';
-import { Wordmark } from '../../../ui';
 import { navigateAfterSignIn, redirectToLogin, signInWithPassword, signUpWithPassword } from '../services/auth';
 
 /**
@@ -59,52 +60,59 @@ function CredentialSignInForm({ returnTo, signUpDisabled }: { returnTo: string; 
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex w-64 flex-col gap-3">
+    <form onSubmit={handleSubmit} className="flex w-full flex-col gap-5">
       {mode === 'sign-up' ? (
-        <Input
-          type="text"
-          size="sm"
-          placeholder="Name"
-          aria-label="Name"
-          autoComplete="name"
-          required
-          value={name}
-          onChange={e => setName(e.target.value)}
-        />
+        <label className="flex flex-col gap-2 text-sm font-medium text-neutral5">
+          Name
+          <Input
+            type="text"
+            size="lg"
+            placeholder="Ada Lovelace"
+            autoComplete="name"
+            required
+            value={name}
+            onChange={e => setName(e.target.value)}
+          />
+        </label>
       ) : null}
-      <Input
-        type="email"
-        size="sm"
-        placeholder="Email"
-        aria-label="Email"
-        autoComplete="email"
-        required
-        value={email}
-        onChange={e => setEmail(e.target.value)}
-      />
-      <Input
-        type="password"
-        size="sm"
-        placeholder="Password"
-        aria-label="Password"
-        autoComplete={mode === 'sign-up' ? 'new-password' : 'current-password'}
-        required
-        value={password}
-        onChange={e => setPassword(e.target.value)}
-      />
+      <label className="flex flex-col gap-2 text-sm font-medium text-neutral5">
+        Email
+        <Input
+          type="email"
+          size="lg"
+          placeholder="you@company.com"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={e => setEmail(e.target.value)}
+        />
+      </label>
+      <label className="flex flex-col gap-2 text-sm font-medium text-neutral5">
+        Password
+        <Input
+          type="password"
+          size="lg"
+          placeholder="Enter your password"
+          autoComplete={mode === 'sign-up' ? 'new-password' : 'current-password'}
+          required
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+        />
+      </label>
       {error ? (
         <Txt as="p" variant="ui-sm" role="alert" className="text-accent2">
           {error}
         </Txt>
       ) : null}
-      <Button type="submit" variant="default" size="sm" disabled={pending}>
-        {mode === 'sign-up' ? 'Sign up' : 'Sign in'}
+      <Button type="submit" variant="primary" size="lg" className="w-full" disabled={pending}>
+        {pending ? 'Please wait…' : mode === 'sign-up' ? 'Create account' : 'Sign in'}
       </Button>
       {!signUpDisabled ? (
         <Button
           type="button"
           variant="ghost"
           size="sm"
+          className="self-center"
           onClick={() => {
             setError(null);
             setMode(mode === 'sign-up' ? 'sign-in' : 'sign-up');
@@ -112,7 +120,11 @@ function CredentialSignInForm({ returnTo, signUpDisabled }: { returnTo: string; 
         >
           {mode === 'sign-up' ? 'Have an account? Sign in' : 'New here? Sign up'}
         </Button>
-      ) : null}
+      ) : (
+        <Txt as="p" variant="ui-sm" className="text-center text-neutral3">
+          Account creation is managed by your administrator.
+        </Txt>
+      )}
     </form>
   );
 }
@@ -127,23 +139,64 @@ export function SignInPage() {
   const { baseUrl } = useApiConfig();
   const auth = useWebAuth();
   const [searchParams] = useSearchParams();
+  const [redirecting, setRedirecting] = useState(false);
   const returnTo = safeReturnTo(searchParams.get('returnTo')?.toString());
   const credentialForm = auth.data?.provider === 'better-auth';
 
   return (
-    <main className="grid h-dvh place-items-center">
-      <div className="flex flex-col items-center gap-6">
-        <Wordmark brand="factory" />
-        <Txt as="p" variant="ui-sm" className="text-icon3">
-          Sign in to continue
-        </Txt>
-        {credentialForm ? (
-          <CredentialSignInForm returnTo={returnTo} signUpDisabled={auth.data?.signUpDisabled === true} />
-        ) : (
-          <Button variant="ghost" size="sm" onClick={() => redirectToLogin(baseUrl, returnTo)}>
-            Sign in
-          </Button>
-        )}
+    <main className="relative min-h-dvh overflow-hidden bg-surface1 text-neutral6">
+      <div className="pointer-events-none absolute inset-0" aria-hidden="true">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_12%,color-mix(in_oklab,var(--accent1)_15%,transparent),transparent_32%),radial-gradient(circle_at_85%_80%,color-mix(in_oklab,var(--accent3)_12%,transparent),transparent_34%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(to_right,var(--border1)_1px,transparent_1px),linear-gradient(to_bottom,var(--border1)_1px,transparent_1px)] bg-[size:56px_56px] [mask-image:linear-gradient(to_bottom,black,transparent_85%)]" />
+        <div className="absolute top-[-12rem] left-1/2 h-[28rem] w-[42rem] -translate-x-1/2 rounded-full bg-accent1/5 blur-3xl" />
+      </div>
+
+      <div className="relative mx-auto flex min-h-dvh w-full max-w-7xl items-center px-6 py-10 sm:px-10 lg:px-16 lg:py-16">
+        <section className="flex w-full max-w-4xl flex-col items-start">
+          <div className="mb-12 flex items-center gap-3" aria-label="Mastra Factory">
+            <LogoWithoutText className="w-9 text-accent1" aria-hidden="true" />
+            <span className="font-mona-sans text-lg font-semibold tracking-tight">Mastra Factory</span>
+          </div>
+
+          <Txt as="p" variant="ui-md" className="mb-5 font-medium tracking-wide text-accent1 uppercase">
+            From backlog to production
+          </Txt>
+          <h1 className="max-w-3xl font-mona-sans text-4xl leading-[1.02] font-semibold tracking-[-0.04em] text-balance sm:text-5xl lg:text-6xl">
+            Turn issues into production-ready code.
+          </h1>
+          <Txt as="p" variant="ui-lg" className="mt-7 max-w-2xl leading-7 text-neutral3 sm:text-lg">
+            Mastra Factory turns work from GitHub Issues, Linear, and other trackers into reviewed pull requests that
+            are ready to merge and ship.
+          </Txt>
+
+          <section aria-label="Authentication" className="mt-10 w-full max-w-md">
+            {credentialForm ? (
+              <>
+                <div className="mb-7">
+                  <h2 className="font-display text-2xl font-semibold tracking-tight">Welcome back</h2>
+                  <Txt as="p" variant="ui-md" className="mt-2 leading-6 text-neutral3">
+                    Sign in to continue building with your team.
+                  </Txt>
+                </div>
+                <CredentialSignInForm returnTo={returnTo} signUpDisabled={auth.data?.signUpDisabled === true} />
+              </>
+            ) : (
+              <Button
+                variant="primary"
+                size="lg"
+                className="min-h-14 w-fit text-base"
+                disabled={redirecting || auth.isPending}
+                onClick={() => {
+                  setRedirecting(true);
+                  redirectToLogin(baseUrl, returnTo);
+                }}
+              >
+                <GithubIcon aria-hidden="true" />
+                {redirecting ? 'Opening GitHub…' : 'Continue with GitHub'}
+              </Button>
+            )}
+          </section>
+        </section>
       </div>
     </main>
   );

--- a/mastracode/web/src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx
@@ -45,24 +45,27 @@ function renderSignIn(initialEntry = '/signin') {
 }
 
 describe('SignInPage', () => {
-  it('renders the Mastra Factory wordmark', async () => {
+  it('renders the Mastra Factory brand and product message', async () => {
     stubAuthMe({ provider: 'workos' });
     renderSignIn();
 
-    const wordmark = await screen.findByLabelText('Mastra Factory');
-    expect(wordmark.textContent).toContain('█▀▀ ▄▀█ █▀▀ ▀█▀ █▀█ █▀█ █▄█');
+    expect(await screen.findByLabelText('Mastra Factory')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Turn issues into production-ready code.' })).toBeInTheDocument();
+    expect(screen.getByText(/GitHub Issues, Linear, and other trackers/)).toBeInTheDocument();
     expect(screen.queryByLabelText('Mastra Code')).not.toBeInTheDocument();
   });
 
   describe('given a WorkOS (hosted-login) deploy', () => {
-    it('renders the hosted sign-in button and redirects to the login route', async () => {
+    it('renders the GitHub sign-in action and redirects to the login route', async () => {
       stubAuthMe({ provider: 'workos' });
       renderSignIn('/signin?returnTo=%2Ffactory%2Fboard');
 
-      const button = await screen.findByRole('button', { name: 'Sign in' });
+      const button = await screen.findByRole('button', { name: 'Continue with GitHub' });
       expect(screen.queryByLabelText('Email')).not.toBeInTheDocument();
 
       await userEvent.click(button);
+      expect(button).toBeDisabled();
+      expect(button).toHaveTextContent('Opening GitHub…');
       expect(redirectToLogin).toHaveBeenCalledWith(TEST_BASE_URL, '/factory/board');
     });
   });
@@ -129,7 +132,7 @@ describe('SignInPage', () => {
       await userEvent.type(screen.getByLabelText('Name'), 'Ada Lovelace');
       await userEvent.type(screen.getByLabelText('Email'), 'ada@example.com');
       await userEvent.type(screen.getByLabelText('Password'), 'hunter22!');
-      await userEvent.click(screen.getByRole('button', { name: 'Sign up' }));
+      await userEvent.click(screen.getByRole('button', { name: 'Create account' }));
 
       await waitFor(() => expect(navigateAfterSignIn).toHaveBeenCalledWith('/'));
       expect(posted).toHaveBeenCalledWith({ name: 'Ada Lovelace', email: 'ada@example.com', password: 'hunter22!' });

--- a/mastracode/web/src/web/ui/domains/chat/NewPage.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/NewPage.tsx
@@ -21,17 +21,17 @@ export function NewPage() {
   const overlays = useOverlays();
   const { activeFactory } = useActiveFactoryContext();
 
+  if (!activeFactory) {
+    return <EmptyFactoryState onOpenFactories={() => overlays.open('factories')} />;
+  }
+
   return (
     <ChatLayout
       sidebar={<Sidebar />}
       header={<ChatHeader />}
       main={
         <ChatSessionBoundary>
-          {activeFactory ? (
-            <NewPageContent activeFactory={activeFactory} />
-          ) : (
-            <EmptyFactoryState onOpenFactories={() => overlays.open('factories')} />
-          )}
+          <NewPageContent activeFactory={activeFactory} />
         </ChatSessionBoundary>
       }
     />

--- a/mastracode/web/src/web/ui/domains/chat/ThreadPage.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/ThreadPage.tsx
@@ -37,6 +37,10 @@ export function ThreadPage() {
     ? activeWorkspacePath(workspaceFactory, activeUserSessionMatch?.worktree)
     : undefined;
 
+  if (!activeFactory) {
+    return <EmptyFactoryState onOpenFactories={() => overlays.open('factories')} />;
+  }
+
   return (
     <ChatLayout
       sidebar={<Sidebar />}
@@ -58,11 +62,7 @@ export function ThreadPage() {
       }
       main={
         <ChatSessionBoundary threadId={threadId}>
-          {activeFactory ? (
-            <ThreadPageMain />
-          ) : (
-            <EmptyFactoryState onOpenFactories={() => overlays.open('factories')} />
-          )}
+          <ThreadPageMain />
         </ChatSessionBoundary>
       }
     />

--- a/mastracode/web/src/web/ui/domains/factory/components/FactoryPageShell.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactoryPageShell.tsx
@@ -35,6 +35,10 @@ export function FactoryPageShell({ title, description, children }: FactoryPageSh
   const { activeFactory } = useActiveFactoryContext();
   const serverFactory = activeFactory && isServerFactory(activeFactory) ? activeFactory : undefined;
 
+  if (!activeFactory) {
+    return <EmptyFactoryState onOpenFactories={() => overlays.open('factories')} />;
+  }
+
   return (
     <PageLayout
       sidebar={<Sidebar />}
@@ -43,17 +47,13 @@ export function FactoryPageShell({ title, description, children }: FactoryPageSh
       description={activeFactory ? description : undefined}
       actions={serverFactory ? <RepositoryPicker factory={serverFactory} /> : undefined}
     >
-      {activeFactory ? (
-        serverFactory ? (
-          children(serverFactory)
-        ) : (
-          <Notice variant="info">
-            Board, metrics, and audit are available for server-backed Factories. This factory is bound to a local folder
-            — create a Factory from the switcher to use the Board.
-          </Notice>
-        )
+      {serverFactory ? (
+        children(serverFactory)
       ) : (
-        <EmptyFactoryState onOpenFactories={() => overlays.open('factories')} />
+        <Notice variant="info">
+          Board, metrics, and audit are available for server-backed Factories. This factory is bound to a local folder —
+          create a Factory from the switcher to use the Board.
+        </Notice>
       )}
     </PageLayout>
   );

--- a/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
@@ -4,7 +4,7 @@ import { Txt } from '@mastra/playground-ui/components/Txt';
 /** Factory onboarding shown when no factory is active yet. */
 export function EmptyFactoryState({ onOpenFactories }: { onOpenFactories: () => void }) {
   return (
-    <div className="m-auto flex max-w-md flex-col items-center gap-3 px-6 text-center">
+    <div className="m-auto flex max-w-md flex-col items-center gap-3 px-6 text-center h-screen justify-center">
       <Txt as="h2" variant="header-md" className="text-icon6">
         Welcome to MastraCode
       </Txt>

--- a/mastracode/web/src/web/ui/main.tsx
+++ b/mastracode/web/src/web/ui/main.tsx
@@ -8,6 +8,7 @@ import { RouterProvider } from 'react-router/dom';
 import { ApiConfigProvider } from '../../shared/api/config';
 import { createQueryClient } from '../../shared/query-client';
 import { createAppRouter } from './router';
+import '@fontsource-variable/mona-sans';
 import '@mastra/playground-ui/style.css';
 import './tailwind.css';
 import { ToastProvider } from './ui';

--- a/mastracode/web/src/web/ui/tailwind.css
+++ b/mastracode/web/src/web/ui/tailwind.css
@@ -20,6 +20,8 @@
  * `inline` so the utilities resolve `var(--neutral*)` at the class site and
  * keep flipping with the light/dark theme. */
 @theme inline {
+  --font-mona-sans: 'Mona Sans Variable', ui-sans-serif, sans-serif;
+
   --color-icon1: var(--neutral1);
   --color-icon2: var(--neutral2);
   --color-icon3: var(--neutral3);


### PR DESCRIPTION
## Summary

- redesign the sign-in page as a focused Mastra Factory landing experience with Mona Sans branding and a GitHub CTA
- preserve hosted and credential authentication behavior while updating accessible test coverage
- show factory onboarding without unnecessary app chrome and keep the empty state vertically centered

## Test plan

- `pnpm exec vitest run --config e2e/web-ui/vitest.config.ts src/web/ui/domains/auth/components/__tests__/SignInPage.msw.test.tsx --reporter=dot`
- `pnpm check:ui`
- `pnpm exec vite --config src/web/vite.config.ts build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives the Factory sign-in page a cleaner, more welcoming design with new branding and a GitHub sign-in option. It also makes the empty Factory screen appear without unnecessary page elements and keeps its message centered.

## Changes

- Redesigned the sign-in experience with Mona Sans branding, responsive marketing copy, and GitHub authentication feedback.
- Preserved hosted and credential-based authentication behavior, including safe `returnTo` handling.
- Updated accessibility-focused routing and sign-in tests for the new labels and states.
- Rendered the empty Factory state without chat or Factory page chrome.
- Vertically centered the empty Factory onboarding prompt.
- Added Mona Sans as a web font dependency and Tailwind font token.
- Validated with targeted Vitest tests, UI checks, a production build, and `git diff --check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->