### PR TITLE
fix(inngest): restore requestContext and tracingContext on durable resume

### DIFF
--- a/.changeset/inngest-resume-context.md
+++ b/.changeset/inngest-resume-context.md
@@ -1,0 +1,11 @@
+---
+'@mastra/inngest': patch
+---
+
+Fixed the Inngest durable engine losing `requestContext` and `tracingContext` when a suspended run is resumed. Core's engine persists both into the suspend snapshot (`persistStepUpdate`) and restores them on resume; the Inngest engine's snapshot writer omitted both, and its resume-event builder read `requestContext` from the snapshot only (ignoring any caller-provided context) and never carried `tracingContext` at all.
+
+The effect was that any tool scoping its work by a `requestContext` value survived the initial run but broke after a tool approval — e.g. a workspace/filesystem tool keyed on `team_id`/`thread_id` wrote to an `anon` fallback once resumed — and the resumed turn started a fresh root span in a new trace instead of continuing the original.
+
+`InngestWorkflow` now persists `requestContext` and `tracingContext` into the suspended snapshot, and `InngestAgent.resume()` merges caller-provided context over the snapshot (caller wins, matching core) and forwards the persisted `tracingContext` as `tracingOptions` so the resumed workflow span continues the original trace. `InngestAgentResumeOptions` gains a `requestContext` field for parity with core's `DurableAgent.resume()`.
+
+Adds a cross-process regression test (real connect() worker) asserting the resumed tool sees the original `requestContext` and that the resumed turn stays in the original trace.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8529,6 +8529,9 @@ importers:
       '@mastra/libsql':
         specifier: workspace:*
         version: link:../../stores/libsql
+      '@mastra/memory':
+        specifier: workspace:*
+        version: link:../../packages/memory
       '@mastra/observability':
         specifier: workspace:*
         version: link:../../observability/mastra

--- a/workflows/inngest/package.json
+++ b/workflows/inngest/package.json
@@ -57,6 +57,7 @@
     "@mastra/core": "workspace:*",
     "@mastra/deployer": "workspace:*",
     "@mastra/libsql": "workspace:*",
+    "@mastra/memory": "workspace:*",
     "@mastra/observability": "workspace:*",
     "@types/express": "^5.0.6",
     "@types/koa": "^3.0.1",

--- a/workflows/inngest/src/__tests__/durable-resume-context.test.ts
+++ b/workflows/inngest/src/__tests__/durable-resume-context.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Regression test for issue #19873: a resumed durable run must restore the `requestContext` and
+ * `tracingContext` it suspended with.
+ *
+ * Two things break without the fix, both because the Inngest engine's suspend snapshot never
+ * persists these fields (core's `persistStepUpdate` does):
+ *
+ *  1. requestContext — a tool that scopes its work by a context value (here: `tenant`) sees an empty
+ *     context on resume and falls back to `anon`. We assert the resumed tool wrote under `team-42`.
+ *  2. tracingContext — the resumed run mints a fresh root span in a NEW trace instead of continuing
+ *     the original. We assert the resumed run's root-span traceId equals the one captured at suspend.
+ *
+ * Why a separate connect() worker: the durable loop (and the tool call) run on the worker, whose
+ * globalRunRegistry is empty. Only what the resume event carries survives — so an in-process
+ * (serve-mode) test can't reproduce this.
+ */
+import { spawn } from 'node:child_process';
+import type { ChildProcess } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { RequestContext } from '@mastra/core/request-context';
+import { DefaultStorage } from '@mastra/libsql';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.setConfig({ testTimeout: 180_000, hookTimeout: 120_000 });
+
+const INNGEST_PORT = 4100;
+const AGENT_ID = 'resume-ctx-agent';
+const DB_PATH = `/tmp/mastra-resume-ctx-${Date.now()}.db`;
+const DB_URL = `file:${DB_PATH}`;
+const OUT_DIR = mkdtempSync(path.join(tmpdir(), 'resume-ctx-out-'));
+const LOOP_WORKFLOW = 'inngest:durable-agentic-loop';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const WORKER = path.join(here, 'fixtures', 'resume-context-worker.ts');
+
+let worker: ChildProcess | undefined;
+
+function startWorker(): Promise<ChildProcess> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('npx', ['tsx', WORKER, DB_URL, AGENT_ID, String(INNGEST_PORT), OUT_DIR], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, INNGEST_DEV: '1', INNGEST_BASE_URL: `http://localhost:${INNGEST_PORT}` },
+    });
+    const timer = setTimeout(() => reject(new Error('worker did not become ready in 90s')), 90_000);
+    const onData = (buf: Buffer) => {
+      const out = buf.toString();
+      if (process.env.MASTRA_DBG_CTX) process.stderr.write(`[worker-out] ${out}`);
+      if (out.includes('[worker] ready')) {
+        clearTimeout(timer);
+        resolve(proc);
+      }
+    };
+    proc.stdout?.on('data', onData);
+    proc.stderr?.on('data', onData);
+    proc.on('exit', code => {
+      clearTimeout(timer);
+      reject(new Error(`worker exited early with code ${code}`));
+    });
+  });
+}
+
+describe('durable agent resume restores requestContext + tracingContext (cross-process worker)', () => {
+  beforeAll(async () => {
+    worker = await startWorker();
+    await new Promise(r => setTimeout(r, 3000)); // let Inngest register the worker's functions
+  });
+
+  afterAll(async () => {
+    worker?.kill('SIGTERM');
+    await new Promise(r => setTimeout(r, 500));
+    if (worker && !worker.killed) worker.kill('SIGKILL');
+    rmSync(OUT_DIR, { recursive: true, force: true });
+  });
+
+  it('resumed tool sees the original requestContext and stays in the original trace', async () => {
+    const threadId = `thread-${Date.now()}`;
+    const resourceId = `resource-${Date.now()}`;
+
+    const { buildResumeContextAgent } = await import('./fixtures/resume-context-agent');
+    const { durableAgent } = buildResumeContextAgent({
+      dbUrl: DB_URL,
+      agentId: AGENT_ID,
+      inngestPort: INNGEST_PORT,
+      outDir: OUT_DIR,
+    });
+
+    // Initial run — requestContext carries the tenant. The mock model calls save_note, which suspends.
+    const requestContext = new RequestContext([['tenant', 'team-42']]);
+    const res = await durableAgent.stream([{ role: 'user', content: 'Please save a note.' }], {
+      memory: { thread: threadId, resource: resourceId },
+      requestContext,
+    });
+    const runId = res.runId;
+    void (async () => {
+      try {
+        for await (const _ of res.output.fullStream) {
+          /* consume until suspend tears the stream down */
+        }
+      } catch {
+        /* expected at suspend */
+      } finally {
+        res.cleanup?.();
+      }
+    })();
+
+    // Wait until the loop snapshot is suspended, then capture the traceId it was persisted with.
+    const wf = await new DefaultStorage({ id: 'resume-ctx-reader', url: DB_URL }).getStore('workflows');
+    let suspendSnapshot: any;
+    for (let i = 0; i < 60 && suspendSnapshot?.status !== 'suspended'; i++) {
+      suspendSnapshot = await wf.loadWorkflowSnapshot({ workflowName: LOOP_WORKFLOW, runId }).catch(() => undefined);
+      if (suspendSnapshot?.status !== 'suspended') await new Promise(r => setTimeout(r, 1000));
+    }
+    expect(suspendSnapshot?.status).toBe('suspended');
+
+    // The fix persists tracingContext into the suspend snapshot; without it this is undefined.
+    const suspendTraceId = suspendSnapshot?.tracingContext?.traceId;
+    expect(suspendTraceId, 'suspend snapshot must persist tracingContext.traceId').toBeTruthy();
+
+    // Resume with approval — the exact HITL approve. Pass only threadId/resourceId, so requestContext
+    // must come from the snapshot (the contract the app relies on).
+    const r2 = await durableAgent.resume(runId, { approved: true }, { threadId, resourceId });
+    try {
+      for await (const _ of r2.output.fullStream) {
+        /* consume to completion */
+      }
+    } catch {
+      /* ignore */
+    }
+
+    // Assertion 1 (requestContext): the resumed tool must have written under team-42, not anon.
+    await vi.waitFor(
+      () => {
+        expect(existsSync(path.join(OUT_DIR, 'team-42', 'note.txt')), 'note written under team-42').toBe(true);
+      },
+      { timeout: 30_000, interval: 500 },
+    );
+    expect(existsSync(path.join(OUT_DIR, 'anon', 'note.txt')), 'note must NOT fall back to anon').toBe(false);
+
+    // Assertion 2 (tracingContext continuity): the traceId persisted at suspend must reappear as a
+    // root trace once the run resumes, i.e. the resumed turn continues the original trace rather than
+    // living only in a brand-new one. (We don't assert a single root here: unrelated open span-
+    // parenting issues on the Inngest path can emit extra orphan roots; this check is scoped to the
+    // resume behaviour this fix owns — that the suspended trace is the one the run continues in.)
+    const obs = await new DefaultStorage({ id: 'resume-ctx-span-reader', url: DB_URL }).getStore('observability');
+    await vi.waitFor(
+      async () => {
+        const { spans } = (await obs.listTraces({ pagination: { page: 0, perPage: 50 } } as never)) as any;
+        const traceIds = (spans ?? []).map((s: any) => s.traceId);
+        if (process.env.MASTRA_DBG_CTX) console.error('[test] root traceIds:', traceIds, 'suspend:', suspendTraceId);
+        expect(traceIds, 'resumed run continues the trace it suspended in').toContain(suspendTraceId);
+      },
+      { timeout: 30_000, interval: 1000 },
+    );
+  });
+});

--- a/workflows/inngest/src/__tests__/fixtures/resume-context-agent.ts
+++ b/workflows/inngest/src/__tests__/fixtures/resume-context-agent.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared agent for the resume-context regression test (issue #19873).
+ *
+ * A durable run that suspends for tool approval must, on resume, see the SAME `requestContext` it
+ * had on the initial run and continue the SAME trace. Both are lost today because the Inngest
+ * engine's suspend snapshot never persists `requestContext`/`tracingContext`.
+ *
+ * The tool records the `tenant` it observed from `requestContext` into a file under a per-run OUT
+ * dir, so the driver process (which can't see the worker's memory) can assert what the resumed tool
+ * saw. Observability is configured so the workflow root span gets a real traceId — the test compares
+ * the suspend snapshot's traceId with the resumed run's to prove the trace is continuous.
+ *
+ * Both the driver and the connect() worker build the SAME agent from this factory, mirroring
+ * production where a web replica and a worker pool each construct the agent from the same code but
+ * keep their own in-memory globalRunRegistry.
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import { createTool } from '@mastra/core/tools';
+import { DefaultStorage } from '@mastra/libsql';
+import { Memory } from '@mastra/memory';
+import { Observability, MastraStorageExporter } from '@mastra/observability';
+import { simulateReadableStream } from 'ai';
+import { Inngest } from 'inngest';
+import { z } from 'zod';
+
+import { createInngestAgent } from '../../durable-agent';
+import { createInngestDurableAgenticWorkflow } from '../../durable-agent/create-inngest-agentic-workflow';
+
+/** First turn calls the approval tool; a later turn answers with text. */
+function toolCallThenText(): any {
+  let call = 0;
+  return {
+    specificationVersion: 'v2',
+    provider: 'mock',
+    modelId: 'mock-model',
+    supportedUrls: {},
+    async doStream() {
+      call++;
+      const chunks =
+        call === 1
+          ? [
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-0', modelId: 'mock-model', timestamp: new Date(0) },
+              {
+                type: 'tool-call',
+                toolCallId: 'call-1',
+                toolName: 'save_note',
+                input: JSON.stringify({ text: 'note' }),
+                providerExecuted: false,
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 },
+              },
+            ]
+          : [
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'id-1', modelId: 'mock-model', timestamp: new Date(0) },
+              { type: 'text-start', id: 't1' },
+              { type: 'text-delta', id: 't1', delta: 'Done.' },
+              { type: 'text-end', id: 't1' },
+              { type: 'finish', finishReason: 'stop', usage: { inputTokens: 5, outputTokens: 5, totalTokens: 10 } },
+            ];
+      return {
+        stream: simulateReadableStream({ chunks: chunks as any }),
+        rawCall: { rawPrompt: null, rawSettings: {} },
+      };
+    },
+  };
+}
+
+export function buildResumeContextAgent({
+  dbUrl,
+  agentId,
+  inngestPort,
+  outDir,
+}: {
+  dbUrl: string;
+  agentId: string;
+  inngestPort: number;
+  outDir: string;
+}) {
+  const inngest = new Inngest({ id: 'resume-context-test', baseUrl: `http://localhost:${inngestPort}` });
+
+  // Suspends for approval; on approve, writes the tenant it read from requestContext into
+  // `${outDir}/<tenant>/note.txt`. Before the fix the resumed invocation reads an empty
+  // requestContext, so tenant falls back to 'anon' and the file lands in the wrong place.
+  const saveNote = createTool({
+    id: 'save_note',
+    description: 'Save a note after the user approves',
+    inputSchema: z.object({ text: z.string() }),
+    suspendSchema: z.object({ text: z.string() }),
+    resumeSchema: z.object({ approved: z.boolean() }),
+    execute: async (input: any, execCtx: any) => {
+      const agentCtx = execCtx?.agent ?? execCtx ?? {};
+      if (agentCtx.resumeData == null) {
+        await agentCtx.suspend?.({ text: input.text });
+        return { saved: false };
+      }
+      if (!agentCtx.resumeData.approved) return { saved: false };
+      const tenant = execCtx?.requestContext?.get?.('tenant') ?? 'anon';
+      const dir = `${outDir}/${tenant}`;
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(`${dir}/note.txt`, input.text);
+      return { saved: true, tenant };
+    },
+  });
+
+  const storage = new DefaultStorage({ id: `resume-ctx-${agentId}`, url: dbUrl });
+
+  const agent = new Agent({
+    id: agentId,
+    name: 'Resume Context Agent',
+    instructions: 'Call save_note, then confirm.',
+    model: toolCallThenText(),
+    tools: { save_note: saveNote },
+    memory: new Memory({ storage }),
+  });
+
+  const durableAgent = createInngestAgent({ agent, inngest });
+  const workflow = createInngestDurableAgenticWorkflow({ inngest });
+
+  const mastra = new Mastra({
+    storage,
+    agents: { [agentId]: durableAgent } as any,
+    workflows: { [workflow.id]: workflow } as any,
+    observability: new Observability({
+      configs: { default: { serviceName: 'resume-context-test', exporters: [new MastraStorageExporter()] } },
+    }),
+  });
+
+  return { inngest, mastra, durableAgent, storage };
+}

--- a/workflows/inngest/src/__tests__/fixtures/resume-context-worker.ts
+++ b/workflows/inngest/src/__tests__/fixtures/resume-context-worker.ts
@@ -1,0 +1,29 @@
+/**
+ * Connect worker for the resume-context test — runs in a SEPARATE process.
+ *
+ * The durable loop (and its tool calls) execute here, not in the process that called stream()/
+ * resume(). This worker's globalRunRegistry starts empty, so any context the resume doesn't carry
+ * in its event is gone — the exact condition an in-process (serve-mode) test can't reproduce.
+ *
+ * Usage: tsx resume-context-worker.ts <dbUrl> <agentId> <inngestPort> <outDir>
+ */
+import { connect } from '../../connect';
+import { buildResumeContextAgent } from './resume-context-agent';
+
+const dbUrl = process.argv[2];
+const agentId = process.argv[3];
+const inngestPort = Number(process.argv[4] ?? 4100);
+const outDir = process.argv[5];
+
+if (!dbUrl || !agentId || !outDir) {
+  console.error('[worker] usage: worker.ts <dbUrl> <agentId> <inngestPort> <outDir>');
+  process.exit(1);
+}
+
+const { mastra, inngest } = buildResumeContextAgent({ dbUrl, agentId, inngestPort, outDir });
+
+await connect({ mastra, inngest });
+console.log('[worker] ready');
+
+process.on('SIGTERM', () => process.exit(0));
+process.on('SIGINT', () => process.exit(0));

--- a/workflows/inngest/src/durable-agent/create-inngest-agent.ts
+++ b/workflows/inngest/src/durable-agent/create-inngest-agent.ts
@@ -261,6 +261,12 @@ export interface InngestAgentStreamResult<OUTPUT = undefined> {
 export interface InngestAgentResumeOptions<OUTPUT = undefined> {
   threadId?: string;
   resourceId?: string;
+  /**
+   * Runtime context for the resumed segment. Merged over the persisted snapshot's requestContext
+   * (caller-provided values win), mirroring core's DurableAgent.resume(). Omit to restore the
+   * context the run suspended with.
+   */
+  requestContext?: AgentExecutionOptions<OUTPUT>['requestContext'];
   onChunk?: (chunk: ChunkType<OUTPUT>) => void | Promise<void>;
   onStepFinish?: (result: AgentStepFinishEventData) => void | Promise<void>;
   onFinish?: MastraOnFinishCallback<OUTPUT>;
@@ -982,6 +988,24 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
           const suspendedStepIds = snapshot?.suspendedPaths ? Object.keys(snapshot.suspendedPaths) : [];
           const steps = suspendedStepIds.length > 0 ? suspendedStepIds : [];
 
+          // Restore requestContext from the snapshot, letting any caller-provided context win
+          // (parity with core's resume, which merges caller over snapshot). Without this the
+          // resumed run rehydrates an empty context and context-scoped tools misbehave.
+          const callerRequestContext = resumeOptions?.requestContext;
+          const callerRequestContextObj =
+            callerRequestContext && typeof callerRequestContext.toJSON === 'function'
+              ? callerRequestContext.toJSON()
+              : {};
+
+          // Continue the original trace instead of minting a new root span: forward the persisted
+          // tracingContext as tracingOptions, which the workflow handler threads into its
+          // `span.start` step. traceId keeps the resumed turn in the same trace; parentSpanId nests
+          // it under the span the run suspended at.
+          const persistedTracingContext = snapshot?.tracingContext;
+          const resumeTracingOptions = persistedTracingContext?.traceId
+            ? { traceId: persistedTracingContext.traceId, parentSpanId: persistedTracingContext.spanId }
+            : undefined;
+
           await inngest.send({
             name: eventName,
             data: {
@@ -989,7 +1013,8 @@ export function createInngestAgent<TOutput = undefined>(options: CreateInngestAg
               initialState: snapshot?.value ?? {},
               runId,
               resourceId: resumeOptions?.resourceId,
-              requestContext: snapshot?.requestContext ?? {},
+              requestContext: { ...(snapshot?.requestContext ?? {}), ...callerRequestContextObj },
+              tracingOptions: resumeTracingOptions,
               stepResults: snapshot?.context,
               resume: {
                 steps,

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -509,6 +509,15 @@ export class InngestWorkflow<
                     serializedStepGraph: this.serializedStepGraph,
                     suspendedPaths: existingSnapshot?.suspendedPaths ?? {},
                     waitingPaths: {},
+                    // Persist requestContext and tracingContext so they can be restored on resume
+                    // (matches core's persistStepUpdate in workflows/handlers/entry.ts). Without
+                    // requestContext, resumed runs rehydrate an empty context; without
+                    // tracingContext, the resumed run mints a fresh root span in a new trace instead
+                    // of continuing the original.
+                    requestContext: requestContext.toJSON(),
+                    tracingContext: workflowSpanData
+                      ? { traceId: workflowSpanData.traceId, spanId: workflowSpanData.id }
+                      : undefined,
                     resumeLabels: existingSnapshot?.resumeLabels ?? result.resumeLabels ?? {},
                     result: result.status === 'success' ? toSnapshotResult(result.result) : undefined,
                     error: result.status === 'failed' ? result.error : undefined,


### PR DESCRIPTION
## Description

When a suspended durable run resumes on the Inngest engine, it comes back with an empty `requestContext` and starts a fresh trace. The core engine doesn't have either problem — its `persistStepUpdate` writes `requestContext` and `tracingContext` into the suspend snapshot and restores them on resume — but the Inngest engine's snapshot writer omitted both, and its resume-event builder read `requestContext` from the snapshot only (ignoring any caller-provided context) and never carried `tracingContext` at all.

The practical fallout is that any tool scoping its work by a `requestContext` value survives the initial run but breaks after a tool approval. In my case a workspace/filesystem tool keys its path prefix off `team_id`/`thread_id`; after resume that read is empty and every write lands under an `anon` fallback. Separately, the resumed turn shows up as its own disconnected trace instead of continuing the original.

The approval decision itself round-trips fine — approve/reject/edit all reach the shared `tool-call-step` and the tool executes on resume. It's only the ambient context that's lost, so all four suspend/resume variants are affected equally.

The fix mirrors core:

- `InngestWorkflow` now persists `requestContext` (via `RequestContext.toJSON()`) and `tracingContext` (`{ traceId, spanId }` from the workflow root span) into the suspended snapshot, matching `packages/core/src/workflows/handlers/entry.ts`.
- `InngestAgent.resume()` builds the resume event's `requestContext` by merging any caller-provided context over the snapshot (caller wins, like core), and forwards the persisted `tracingContext` as `tracingOptions`. The workflow handler already threads `event.data.tracingOptions` into its `span.start` step, so the resumed root span continues the original trace (`traceId`) as a child of the span the run suspended at (`parentSpanId`) — no new handler code needed.
- `InngestAgentResumeOptions` gains a `requestContext` field for parity with core's `DurableAgent.resume()`.

This is the Inngest-side sibling of the durable cold-resume work already merged for the core path (#18031, #19301).

I verified it with the regression test below (a real cross-process `connect()` worker, since an in-process run keeps the context in memory and hides the bug): with the fix the resumed tool reads `team-42` and writes to the right place and the suspended trace is the one the run continues in; reverting either half of the fix turns it red — the snapshot loses `tracingContext` and the write falls back to `anon`.

## Related issue(s)

Fixes #19873

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR
