### PR TITLE
fix(inngest): scope cancelOn to workflow runId

### DIFF
--- a/.changeset/inngest-cancelon-runid-scope.md
+++ b/.changeset/inngest-cancelon-runid-scope.md
@@ -1,0 +1,5 @@
+---
+'@mastra/inngest': patch
+---
+
+Scope Inngest `cancelOn` to the target workflow `runId` so one cancel no longer aborts every concurrent run of the shared function.

--- a/workflows/inngest/src/cancel-on-runid-scope.test.ts
+++ b/workflows/inngest/src/cancel-on-runid-scope.test.ts
@@ -1,0 +1,99 @@
+import { Mastra } from '@mastra/core/mastra';
+import { MockStore } from '@mastra/core/storage';
+import { Inngest } from 'inngest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { init } from './index';
+
+describe('InngestWorkflow cancelOn runId scope', () => {
+  let inngest: Inngest;
+  let createFunctionSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    inngest = new Inngest({ id: 'cancel-on-scope-test' });
+    createFunctionSpy = vi.spyOn(inngest, 'createFunction');
+  });
+
+  it('registers cancelOn with runId match for the workflow function', () => {
+    const { createWorkflow, createStep } = init(inngest);
+
+    const step1 = createStep({
+      id: 'step1',
+      execute: async () => ({ result: 'done' }),
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'scoped-cancel-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      steps: [step1],
+    });
+
+    workflow.then(step1).commit();
+
+    // Registering with Mastra is not required to inspect getFunction() config,
+    // but mirrors serve() registration.
+    new Mastra({
+      storage: new MockStore(),
+      workflows: {
+        'scoped-cancel-workflow': workflow,
+      },
+    });
+
+    workflow.getFunction();
+
+    expect(createFunctionSpy).toHaveBeenCalled();
+    const opts = createFunctionSpy.mock.calls.find(
+      ([config]) => (config as { id?: string }).id === 'workflow.scoped-cancel-workflow',
+    )?.[0] as {
+      cancelOn?: Array<{ event: string; if?: string }>;
+    };
+
+    expect(opts?.cancelOn).toEqual([
+      {
+        event: 'cancel.workflow.scoped-cancel-workflow',
+        if: 'async.data.runId == event.data.runId',
+      },
+    ]);
+  });
+
+  it('registers cancelOn with runId match for the cron function', () => {
+    const { createWorkflow, createStep } = init(inngest);
+
+    const step1 = createStep({
+      id: 'step1',
+      execute: async () => ({ result: 'done' }),
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+    });
+
+    const workflow = createWorkflow({
+      id: 'scoped-cancel-cron-workflow',
+      inputSchema: z.object({}),
+      outputSchema: z.object({ result: z.string() }),
+      steps: [step1],
+      cron: '0 * * * *',
+    });
+
+    workflow.then(step1).commit();
+
+    const functions = workflow.getFunctions();
+    expect(functions.length).toBeGreaterThanOrEqual(2);
+
+    const cronOpts = createFunctionSpy.mock.calls.find(
+      ([config]) => (config as { id?: string }).id === 'workflow.scoped-cancel-cron-workflow.cron',
+    )?.[0] as {
+      cancelOn?: Array<{ event: string; if?: string }>;
+    };
+
+    expect(cronOpts?.cancelOn).toEqual([
+      {
+        event: 'cancel.workflow.scoped-cancel-cron-workflow',
+        if: 'async.data.runId == event.data.runId',
+      },
+    ]);
+  });
+});

--- a/workflows/inngest/src/workflow.ts
+++ b/workflows/inngest/src/workflow.ts
@@ -264,7 +264,14 @@ export class InngestWorkflow<
       {
         id: `workflow.${this.id}.cron`,
         retries: 0,
-        cancelOn: [{ event: `cancel.workflow.${this.id}` }],
+        cancelOn: [
+          {
+            event: `cancel.workflow.${this.id}`,
+            // Scope cancel to one run. Unscoped cancel.workflow.* cancels every
+            // concurrent run of this function (Inngest match is per-function).
+            if: 'async.data.runId == event.data.runId',
+          },
+        ],
         triggers: { cron: this.cronConfig?.cron ?? '' },
         ...this.flowControlConfig,
       },
@@ -294,7 +301,14 @@ export class InngestWorkflow<
       {
         id: `workflow.${this.id}`,
         retries: 0,
-        cancelOn: [{ event: `cancel.workflow.${this.id}` }],
+        cancelOn: [
+          {
+            event: `cancel.workflow.${this.id}`,
+            // Scope cancel to one run. Unscoped cancel.workflow.* cancels every
+            // concurrent run of this function (Inngest match is per-function).
+            if: 'async.data.runId == event.data.runId',
+          },
+        ],
         triggers: { event: `workflow.${this.id}` },
         // Spread flow control configuration
         ...this.flowControlConfig,


### PR DESCRIPTION
## Description

`@mastra/inngest` registers:

```ts
cancelOn: [{ event: `cancel.workflow.${id}` }]
```

without an `if` / match expression. Inngest treats that as “cancel every in-flight run of this function,” so one `InngestRun.cancel()` (which already sends `{ runId }`) can kill all concurrent runs — including every durable agent sharing `inngest:durable-agentic-loop`.

This PR scopes cancellation with Inngest’s cancellation `if`:

```ts
if: 'async.data.runId == event.data.runId'
```

for both the workflow function and the cron function. `InngestRun.cancel()` already sends `data: { runId }`, so no cancel-path API change is required.

## Related issue(s)

Fixes #19883

Also related: #19869 (broader abort/cancel discussion; this PR addresses only the unscoped `cancelOn` blast radius).

Temporary-workaround context from Nomerra:

- Memory finish-time side effects: #19839 / #19855 — we currently carry a temporary `pnpm` patch for both the cancelOn scoping fix and a memory-flush workaround, and will drop the memory hunk when #19855 lands.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

## Test plan

- [x] Unit test spies `inngest.createFunction` and asserts both workflow + cron `cancelOn` include `if: 'async.data.runId == event.data.runId'`
- [ ] Optional: run the concurrent cancel blast-radius repro from #19869 and confirm bystander runs finish
