### PR TITLE
fix(mcp): recover from failed reconnects

### DIFF
--- a/.changeset/happy-dingos-pump.md
+++ b/.changeset/happy-dingos-pump.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Fixed MCP clients getting permanently stuck after a failed reconnect to a streamable-HTTP-only server. A stale transport left attached to the underlying MCP SDK client is now detached before every connect attempt, so `listTools()`, `callTool()`, and `forceReconnect()` recover as soon as the server is reachable again instead of failing forever with "Already connected to a transport" or silently returning an empty toolset. Fixes https://github.com/mastra-ai/mastra/issues/19862

--- a/.changeset/happy-dingos-pump.md
+++ b/.changeset/happy-dingos-pump.md
@@ -2,4 +2,4 @@
 '@mastra/mcp': patch
 ---
 
-Fixed MCP clients getting permanently stuck after a failed reconnect to a streamable-HTTP-only server. A stale transport left attached to the underlying MCP SDK client is now detached before every connect attempt, so `listTools()`, `callTool()`, and `forceReconnect()` recover as soon as the server is reachable again instead of failing forever with "Already connected to a transport" or silently returning an empty toolset. Fixes https://github.com/mastra-ai/mastra/issues/19862
+Fixed MCP clients getting stuck after a failed reconnect to streamable-HTTP-only servers. `listTools()`, `callTool()`, and `forceReconnect()` now work once the server is reachable again. Fixes https://github.com/mastra-ai/mastra/issues/19862

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3621,6 +3621,46 @@ describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', 
     await new Promise<void>(resolve => httpServer.close(() => resolve()));
   });
 
+  it('clears the SDK client transport when severing the attached transport', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'wedge-sdk-transport-match',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+
+    const attachedTransport = (client as any).client.transport;
+    expect(attachedTransport).toBeDefined();
+
+    (client as any).severClientTransportLink(attachedTransport);
+
+    expect((client as any).client.transport).toBeUndefined();
+    expect(attachedTransport.onclose).toBeUndefined();
+    expect(attachedTransport.onerror).toBeUndefined();
+    expect(attachedTransport.onmessage).toBeUndefined();
+  });
+
+  it('keeps the SDK client transport when severing a different transport', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'wedge-sdk-transport-mismatch',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+
+    const attachedTransport = (client as any).client.transport;
+    const unrelatedTransport = {
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+      onmessage: vi.fn(),
+    };
+
+    (client as any).severClientTransportLink(unrelatedTransport);
+
+    expect((client as any).client.transport).toBe(attachedTransport);
+    expect(unrelatedTransport.onclose).toBeUndefined();
+    expect(unrelatedTransport.onerror).toBeUndefined();
+    expect(unrelatedTransport.onmessage).toBeUndefined();
+  });
+
   it('connect() succeeds after an earlier connect attempt failed during the SSE fallback', async () => {
     // First-ever connect during the outage: streamable init POST gets 404, the
     // SSE fallback GET gets 405 so SSEClientTransport.start() throws. The SDK

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3556,3 +3556,157 @@ describe('InternalMastraMCPClient - transport cleanup on close (issue #16693)', 
     await new Promise(resolve => setTimeout(resolve, 0));
   });
 });
+
+describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', () => {
+  // Minimal streamable-HTTP-only server: GET (legacy SSE) always returns 405.
+  // While `failing` is true, POSTs return 404 — like a load balancer with no
+  // healthy backend during a redeploy.
+  let httpServer: HttpServer;
+  let baseUrl: URL;
+  let failing = false;
+  let client: InternalMastraMCPClient;
+
+  beforeEach(async () => {
+    failing = false;
+    httpServer = createServer(async (req, res) => {
+      if (failing || req.method === 'GET') {
+        res.writeHead(req.method === 'GET' ? 405 : 404).end();
+        return;
+      }
+      if (req.method === 'DELETE') {
+        res.writeHead(200).end();
+        return;
+      }
+      const chunks: Buffer[] = [];
+      for await (const chunk of req) chunks.push(chunk as Buffer);
+      let body: any;
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+      } catch {
+        res.writeHead(400).end();
+        return;
+      }
+      const reply = (result: unknown) => {
+        res
+          .writeHead(200, { 'content-type': 'application/json' })
+          .end(JSON.stringify({ jsonrpc: '2.0', id: body.id, result }));
+      };
+      if (body?.method === 'initialize') {
+        reply({
+          protocolVersion: body.params?.protocolVersion ?? '2025-03-26',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'wedge-repro-server', version: '0.0.1' },
+        });
+      } else if (body?.id === undefined) {
+        res.writeHead(202).end();
+      } else if (body.method === 'tools/list') {
+        reply({ tools: [{ name: 'ping', description: 'ping', inputSchema: { type: 'object', properties: {} } }] });
+      } else if (body.method === 'tools/call') {
+        reply({ content: [{ type: 'text', text: 'pong' }] });
+      } else {
+        reply({});
+      }
+    });
+    baseUrl = await new Promise<URL>(resolve => {
+      httpServer.listen(0, '127.0.0.1', () => {
+        const addr = httpServer.address() as AddressInfo;
+        resolve(new URL(`http://127.0.0.1:${addr.port}/mcp`));
+      });
+    });
+  });
+
+  afterEach(async () => {
+    await client?.disconnect().catch(() => {});
+    httpServer.closeAllConnections();
+    await new Promise<void>(resolve => httpServer.close(() => resolve()));
+  });
+
+  it('connect() succeeds after an earlier connect attempt failed during the SSE fallback', async () => {
+    // First-ever connect during the outage: streamable init POST gets 404, the
+    // SSE fallback GET gets 405 so SSEClientTransport.start() throws. The SDK
+    // leaves that never-started transport attached to its Client.
+    failing = true;
+    client = new InternalMastraMCPClient({
+      name: 'wedge-fresh-connect',
+      server: { url: baseUrl },
+    });
+    await expect(client.connect()).rejects.toThrow();
+
+    // Server healthy again. Before the fix this threw "Already connected to a
+    // transport" (surfaced as "Could not connect to server with any available
+    // HTTP transport") forever.
+    failing = false;
+    await client.connect();
+    const tools = await client.tools();
+    expect(Object.keys(tools)).toContain('ping');
+  }, 20000);
+
+  it('forceReconnect() recovers once the server is healthy after a failed reconnect', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'wedge-force-reconnect',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+    expect(Object.keys(await client.tools())).toContain('ping');
+
+    // Reconnect attempt during the outage fails and used to poison the SDK client.
+    failing = true;
+    httpServer.closeAllConnections();
+    await expect(client.forceReconnect()).rejects.toThrow();
+
+    failing = false;
+    await client.forceReconnect();
+    expect(Object.keys(await client.tools())).toContain('ping');
+  }, 20000);
+
+  it('prevents a closed transport from clearing a replacement connection', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'wedge-stale-onclose',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+
+    const staleTransport = (client as any).transport;
+    const staleConnectionOnClose = (client as any).client.onclose;
+
+    await client.forceReconnect();
+
+    const replacementTransport = (client as any).transport;
+    const replacementConnection = (client as any).isConnected;
+    expect(replacementTransport).not.toBe(staleTransport);
+    expect(staleTransport.onclose).toBeUndefined();
+    expect(staleTransport.onerror).toBeUndefined();
+    expect(staleTransport.onmessage).toBeUndefined();
+
+    // A previously installed Mastra close wrapper may still be referenced by
+    // caller code. It must not reset state belonging to the replacement.
+    staleConnectionOnClose();
+    expect((client as any).transport).toBe(replacementTransport);
+    expect((client as any).isConnected).toBe(replacementConnection);
+  });
+
+  it('a tool instance handed out before the outage works again after the server heals', async () => {
+    client = new InternalMastraMCPClient({
+      name: 'wedge-old-tool',
+      server: { url: baseUrl },
+    });
+    await client.connect();
+    const tools = await client.tools();
+    expect(await tools['ping'].execute!({ context: {} })).toMatchObject({
+      content: [{ type: 'text', text: 'pong' }],
+    });
+
+    // Outage drops the connection mid-flight; the tool wrapper's retry calls
+    // forceReconnect, which fails while the server is still down.
+    failing = true;
+    httpServer.closeAllConnections();
+    await expect(tools['ping'].execute!({ context: {} })).rejects.toThrow();
+
+    // Once healthy, the same tool instance must recover on its retry path
+    // instead of failing with "Not connected" forever.
+    failing = false;
+    expect(await tools['ping'].execute!({ context: {} })).toMatchObject({
+      content: [{ type: 'text', text: 'pong' }],
+    });
+  }, 20000);
+});

--- a/packages/mcp/src/client/client.test.ts
+++ b/packages/mcp/src/client/client.test.ts
@@ -3704,23 +3704,31 @@ describe('InternalMastraMCPClient - stale SDK transport detach (issue #19862)', 
       name: 'wedge-stale-onclose',
       server: { url: baseUrl },
     });
+    const baseOnClose = vi.fn();
+    (client as any).client.onclose = baseOnClose;
     await client.connect();
 
     const staleTransport = (client as any).transport;
     const staleConnectionOnClose = (client as any).client.onclose;
 
     await client.forceReconnect();
+    await client.forceReconnect();
 
     const replacementTransport = (client as any).transport;
     const replacementConnection = (client as any).isConnected;
+    expect((client as any).clientBaseOnClose).toBe(baseOnClose);
+    expect((client as any).client.onclose).not.toBe(staleConnectionOnClose);
     expect(replacementTransport).not.toBe(staleTransport);
     expect(staleTransport.onclose).toBeUndefined();
     expect(staleTransport.onerror).toBeUndefined();
     expect(staleTransport.onmessage).toBeUndefined();
 
     // A previously installed Mastra close wrapper may still be referenced by
-    // caller code. It must not reset state belonging to the replacement.
+    // caller code. It must not reset state belonging to the replacement or
+    // delegate through wrappers from every prior connection.
+    baseOnClose.mockClear();
     staleConnectionOnClose();
+    expect(baseOnClose).toHaveBeenCalledOnce();
     expect((client as any).transport).toBe(replacementTransport);
     expect((client as any).isConnected).toBe(replacementConnection);
   });

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -229,6 +229,8 @@ export class InternalMastraMCPClient extends MastraBase {
   private serverConfig: MastraMCPServerDefinition;
   private transport?: Transport;
   private pendingAuthTransport?: StreamableHTTPClientTransport | SSEClientTransport;
+  private clientBaseOnClose?: () => void;
+  private clientConnectionOnClose?: () => void;
   private _authState?: MCPServerAuthState;
   private operationContextStore = new AsyncLocalStorage<RequestContext | null>();
   private exitHookUnsubscribe?: () => void;
@@ -686,8 +688,10 @@ export class InternalMastraMCPClient extends MastraBase {
         // reconnects cannot clear the state of a replacement connection.
         const connectedTransport = this.transport;
         const connectionPromise = this.isConnected;
-        const originalOnClose = this.client.onclose;
-        this.client.onclose = () => {
+        if (this.client.onclose !== this.clientConnectionOnClose) {
+          this.clientBaseOnClose = this.client.onclose;
+        }
+        const connectionOnClose = () => {
           if (this.transport === connectedTransport) {
             this.log('debug', `MCP server connection closed`);
             // Close the stale transport before any reconnect so its EventSource/session
@@ -706,10 +710,10 @@ export class InternalMastraMCPClient extends MastraBase {
               void staleTransport.close().catch(() => {});
             }
           }
-          if (typeof originalOnClose === 'function') {
-            originalOnClose();
-          }
+          this.clientBaseOnClose?.();
         };
+        this.clientConnectionOnClose = connectionOnClose;
+        this.client.onclose = connectionOnClose;
       } catch (e) {
         this.isConnected = null;
         reject(e);

--- a/packages/mcp/src/client/client.ts
+++ b/packages/mcp/src/client/client.ts
@@ -130,8 +130,7 @@ function extractToolErrorText(content: unknown): string {
 
 function getDatadogScope(): DatadogScopeLike | null {
   const testTracer = (globalThis as Record<PropertyKey, unknown>)[DATADOG_TRACER_TEST_SYMBOL] as
-    | DatadogTracerLike
-    | undefined;
+    DatadogTracerLike | undefined;
   const tracer = testTracer ?? loadDatadogTracer();
 
   if (typeof tracer?.scope === 'function') {
@@ -488,6 +487,11 @@ export class InternalMastraMCPClient extends MastraBase {
     }
 
     if (shouldTrySSE) {
+      // The SDK's cleanup after a failed streamable initialize is fire-and-forget,
+      // so the streamable transport may still be attached; detach it or the SSE
+      // attempt is rejected with "Already connected to a transport".
+      await this.detachStaleClientTransport();
+
       this.log('debug', 'Falling back to deprecated HTTP+SSE transport...');
       // Fallback to SSE transport
       // The top-level fetch is used for POST requests, but eventSourceInit.fetch is needed for the SSE stream.
@@ -524,6 +528,59 @@ export class InternalMastraMCPClient extends MastraBase {
     this.closePendingAuthTransport();
     if (authProvider) {
       this._authState = 'authorized';
+    }
+  }
+
+  /**
+   * Detaches whatever transport is still attached to the underlying SDK Client.
+   *
+   * The SDK assigns its internal `_transport` before `transport.start()` and never
+   * clears it when `start()` throws, and its cleanup after a failed initialize is a
+   * fire-and-forget `void this.close()`. Either way a stale transport can remain
+   * attached, making every subsequent `client.connect()` throw "Already connected
+   * to a transport" and permanently wedging this client (issue #19862). Mastra's
+   * own `this.transport` is only assigned after a successful connect, so
+   * disconnect/forceReconnect never see the stale one. Calling this before every
+   * connect attempt restores the invariant that a connect starts from a detached
+   * SDK client.
+   */
+  private async detachStaleClientTransport(): Promise<void> {
+    const stale = this.client.transport;
+    if (!stale) {
+      return;
+    }
+    if (stale === this.pendingAuthTransport) {
+      // Keep the transport alive: finishAuth must complete the OAuth flow on it.
+      // Just sever its link to the SDK client so the next connect isn't rejected.
+      this.severClientTransportLink(stale);
+      return;
+    }
+    this.log('debug', 'Closing stale SDK client transport before connect attempt');
+    try {
+      // Close fires the SDK's onclose chain, which rejects in-flight requests and
+      // clears the SDK client's transport reference.
+      await stale.close();
+    } catch (e) {
+      this.log('debug', 'Error closing stale SDK client transport (ignored)', {
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
+    // Safety net in case close() did not fire the onclose chain.
+    this.severClientTransportLink(stale);
+  }
+
+  /**
+   * Severs the mutual references between the SDK client and a stale transport
+   * without closing it. Clearing the transport's callbacks ensures a later
+   * close() of the stale transport cannot reach into the SDK client and clear
+   * the state of a newer live connection.
+   */
+  private severClientTransportLink(stale: Transport): void {
+    stale.onclose = undefined;
+    stale.onerror = undefined;
+    stale.onmessage = undefined;
+    if (this.client.transport === stale) {
+      (this.client as unknown as { _transport?: Transport })._transport = undefined;
     }
   }
 
@@ -607,6 +664,10 @@ export class InternalMastraMCPClient extends MastraBase {
 
     this.isConnected = new Promise<boolean>(async (resolve, reject) => {
       try {
+        // A previous failed connect attempt can leave a stale transport attached
+        // to the SDK client; release it or every reconnect fails (issue #19862).
+        await this.detachStaleClientTransport();
+
         const { command, url } = this.serverConfig;
 
         if (command) {
@@ -621,19 +682,29 @@ export class InternalMastraMCPClient extends MastraBase {
 
         resolve(true);
 
-        // Set up disconnect handler to reset state.
+        // Scope the reset to this connection so an older handler retained across
+        // reconnects cannot clear the state of a replacement connection.
+        const connectedTransport = this.transport;
+        const connectionPromise = this.isConnected;
         const originalOnClose = this.client.onclose;
         this.client.onclose = () => {
-          this.log('debug', `MCP server connection closed`);
-          // Close the stale transport before any reconnect so its EventSource/session
-          // can't keep retrying and leak server-side sessions (issue #16693). Clear
-          // synchronously first so a concurrent connect() sees a clean slate.
-          const staleTransport = this.transport;
-          this.transport = undefined;
-          this.isConnected = null;
-          this.serverInstructions = undefined;
-          if (staleTransport) {
-            void staleTransport.close().catch(() => {});
+          if (this.transport === connectedTransport) {
+            this.log('debug', `MCP server connection closed`);
+            // Close the stale transport before any reconnect so its EventSource/session
+            // can't keep retrying and leak server-side sessions (issue #16693). Clear
+            // synchronously first so a concurrent connect() sees a clean slate.
+            const staleTransport = this.transport;
+            this.transport = undefined;
+            if (this.isConnected === connectionPromise) {
+              this.isConnected = null;
+            }
+            this.serverInstructions = undefined;
+            if (staleTransport) {
+              // Prevent a duplicate late close signal from this transport from
+              // reaching the SDK client after a replacement connection is attached.
+              this.severClientTransportLink(staleTransport);
+              void staleTransport.close().catch(() => {});
+            }
           }
           if (typeof originalOnClose === 'function') {
             originalOnClose();
@@ -721,12 +792,17 @@ export class InternalMastraMCPClient extends MastraBase {
     // even when there is no live transport to tear down.
     this.closePendingAuthTransport();
     if (!this.transport) {
+      // Even without a live transport, a failed connect attempt may have left a
+      // stale transport attached to the SDK client; release it so a future
+      // connect starts clean (issue #19862).
+      await this.detachStaleClientTransport();
       this.log('debug', 'Disconnect called but no transport was connected.');
       return;
     }
     this.log('debug', `Disconnecting from MCP server`);
+    const disconnectedTransport = this.transport;
     try {
-      await this.transport.close();
+      await disconnectedTransport.close();
       this.log('debug', 'Successfully disconnected from MCP server');
     } catch (e) {
       this.log('error', 'Error during MCP server disconnect', {
@@ -734,6 +810,7 @@ export class InternalMastraMCPClient extends MastraBase {
       });
       throw e;
     } finally {
+      this.severClientTransportLink(disconnectedTransport);
       this.transport = undefined;
       this.isConnected = null;
       this.serverInstructions = undefined;
@@ -773,14 +850,19 @@ export class InternalMastraMCPClient extends MastraBase {
     this.closePendingAuthTransport();
 
     // Disconnect current connection (ignore errors as connection may already be broken)
+    const disconnectedTransport = this.transport;
     try {
-      if (this.transport) {
-        await this.transport.close();
+      if (disconnectedTransport) {
+        await disconnectedTransport.close();
       }
     } catch (e) {
       this.log('debug', 'Error during force disconnect (ignored)', {
         error: e instanceof Error ? e.message : String(e),
       });
+    } finally {
+      if (disconnectedTransport) {
+        this.severClientTransportLink(disconnectedTransport);
+      }
     }
 
     // Reset connection state


### PR DESCRIPTION
Fixes MCP clients becoming stuck after a reconnect attempt fails while the server is temporarily unavailable. The underlying SDK can retain a failed transport, causing later calls to fail with `Already connected to a transport` or return an empty tool list.

Before:
```ts
await client.reconnectServer('server');
await client.listTools(); // {} after the server recovers
```

After:
```ts
await client.reconnectServer('server');
await client.listTools(); // tools are available once the server recovers
```

This detaches stale SDK transports before reconnecting and prevents delayed close handlers from clearing replacement connections. Regression coverage includes direct reconnects and previously returned tool instances. Fixes #19862.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the MCP server goes offline for a bit, the client can get “stuck” holding onto an old/broken network connection. This PR makes the client throw away that stale connection before retrying, so tools can be listed and called again after the server comes back.

## Summary

- Detaches stale MCP SDK transports before starting new `connect()`/`forceReconnect()` attempts, preventing wedged states like `Already connected to a transport` and empty `listTools()` results.
- Reworks cleanup to sever only the stale/old transport link (not a newer one), so late `onclose` events from an older connection can’t accidentally reset state for a replacement connection.
- Improves transport/SDK link handling across `connect()`, `disconnect()`, and `forceReconnect()` (including during SSE/Streamable-HTTP fallback) to ensure consistent recovery after outages.
- Adds regression tests using a minimal streamable-HTTP-only server harness to verify:
  - stale transport detachment targets only the currently attached transport,
  - reconnection succeeds after a failed connect during outage,
  - `forceReconnect()` recovers after outage failures,
  - stale/previous transports with delayed close handlers don’t break replacement connections,
  - previously created tool instances continue to work once the server is healthy.
- Adds a patch changeset for `@mastra/mcp` documenting the reconnect recovery fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->