### PR TITLE
fix(mastracode-web): use local auth.json credentials when web auth is disabled

### DIFF
--- a/mastracode/web/src/web/factory-entry.test.ts
+++ b/mastracode/web/src/web/factory-entry.test.ts
@@ -44,6 +44,16 @@ vi.mock('@mastra/code-sdk', () => ({
   prepareAgentControllerMount: (config: Record<string, unknown>) => prepareMock(config),
 }));
 
+// Keep the real tenant-credentials module but spy on the registration so tests
+// can assert whether the factory registers the per-tenant resolver. Registering
+// in local/auth-disabled mode would force model calls through an empty tenant
+// store and break chat with "Not logged in", so the factory must gate it.
+const registerTenantCredentialResolverMock = vi.fn();
+vi.mock('./tenant-credentials.js', async importOriginal => {
+  const actual = await importOriginal<typeof import('./tenant-credentials.js')>();
+  return { ...actual, registerTenantCredentialResolver: () => registerTenantCredentialResolverMock() };
+});
+
 /** An SSO-shaped fake provider: gets the hosted-login `/auth/*` routes. */
 function fakeProvider(
   overrides: Record<string, unknown> = {},
@@ -268,6 +278,23 @@ describe('MastraFactory.prepare', () => {
     const gatedConfig = await prepareFactory({ storage: fakeStorage(), auth: fakeProvider() });
     const gatedMiddleware = (gatedConfig.buildServerConfig as () => { middleware?: unknown[] })().middleware ?? [];
     expect(gatedMiddleware).toHaveLength(openMiddleware.length + 2);
+  });
+
+  it('registers the per-tenant credential resolver when auth is configured', async () => {
+    registerTenantCredentialResolverMock.mockClear();
+    await prepareFactory({ storage: fakeStorage(), auth: fakeProvider() });
+    expect(registerTenantCredentialResolverMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips the per-tenant credential resolver when auth is disabled (auth: null)', async () => {
+    // With no auth adapter there is no authenticated tenant. Registering the
+    // resolver would route every model call through an empty tenant store
+    // (fail-closed, no env fallback) and break local chat with "Not logged in".
+    // Leaving it unregistered lets the SDK fall back to the file-backed
+    // AuthStorage (auth.json) — the store the local /login + Settings use.
+    registerTenantCredentialResolverMock.mockClear();
+    await prepareFactory({ storage: fakeStorage(), auth: null });
+    expect(registerTenantCredentialResolverMock).not.toHaveBeenCalled();
   });
 
   it('defaults to MastraAuthStudio when no auth is configured', async () => {

--- a/mastracode/web/src/web/factory-entry.ts
+++ b/mastracode/web/src/web/factory-entry.ts
@@ -29,7 +29,7 @@ import { hasAuthInit } from '@mastra/core/server';
 import type { IMastraAuthProvider } from '@mastra/core/server';
 import { observeAgentGitAction } from './audit/agent-audit.js';
 import { AuditDomain } from './audit/domain.js';
-import { buildAuthRoutes, createWebAuthGate } from './auth.js';
+import { buildAuthRoutes, createWebAuthGate, isWebAuthEnabled } from './auth.js';
 import type { FactoryIntegration, IntegrationPostToolContext, IntegrationTools } from './factory-integration.js';
 import { getFactoryWorkspace } from './factory/workspace.js';
 import { ProjectDomain } from './projects/domain.js';
@@ -369,7 +369,16 @@ export class MastraFactory {
     // Per-tenant model credentials: once the credentials domain is up, model
     // resolution goes through the caller's own store and the SDK stops
     // mirroring stored API keys into process.env.
-    registerTenantCredentialResolver();
+    //
+    // Only register when a real auth adapter gates callers. In local /
+    // auth-disabled mode there is no authenticated tenant, so registering would
+    // force every model call through an empty tenant store (fail-closed, no env
+    // fallback) and break chat with "Not logged in". Leaving it unregistered
+    // lets the SDK fall back to the file-backed AuthStorage (auth.json) — the
+    // same store the local /login and Settings pages read and write.
+    if (isWebAuthEnabled()) {
+      registerTenantCredentialResolver();
+    }
 
     for (const integration of integrations) {
       if (integration.versionControl) {


### PR DESCRIPTION
## Summary

In local / auth-disabled mode (`MASTRACODE_AUTH_DISABLED=1`), starting a chat failed with **"Not logged in to Anthropic. Run /login first."** even though the Settings → API Keys page showed the provider as logged in.

### Root cause

The web factory called `registerTenantCredentialResolver()` unconditionally at boot. That installs a global SDK credential resolver which routes **every** model call through a per-tenant, DB-backed credential store. In auth-disabled mode there is no authenticated tenant, so the resolver returned an empty, fail-closed store (`allowEnvironmentFallback: false`) → the model call found no credential → "Not logged in".

Meanwhile the Settings page and `/login` resolve credentials through a separate local path that falls back to the file-backed `AuthStorage` (`auth.json`), which *did* contain a valid credential — hence the confusing mismatch (UI: logged in, run: not logged in).

### Fix

Gate the registration on `isWebAuthEnabled()`:

- **Auth disabled (local):** resolver stays unregistered → the SDK falls back to the file-backed `AuthStorage` (`auth.json`), the same store the local `/login` and Settings pages read and write. Credentials now resolve consistently across the UI and model runs.
- **Auth enabled (deployed):** unchanged — the per-tenant resolver registers and tenant isolation is preserved.

This matches the documented intent in `credential-resolver.ts`: *"When no provider is registered (TUI, local web), everything falls through to the existing global behavior."*

## Test plan

- Added `factory-entry.test.ts` coverage:
  - registers the resolver when auth is configured
  - **skips** the resolver when auth is disabled (`auth: null`)
- Verified non-vacuous: un-gating the call makes the auth-disabled test fail; restoring the gate makes it pass.
- `factory-entry.test.ts`: 50 passed. Web server typecheck + prettier clean.
- Manually verified locally: with `MASTRACODE_AUTH_DISABLED=1`, chat now streams using the `auth.json` Claude Max credential.

No changeset — `mastracode-web` is private.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When local web login is turned off, MastraCode now correctly uses credentials saved on your computer instead of looking in an empty account-specific store.

## What changed

- Register tenant credential resolution only when web authentication is enabled.
- Preserve tenant isolation for authenticated deployments.
- Add tests covering both enabled and disabled authentication modes.
- Verified tests, typechecking, formatting, and local chat streaming with `auth.json` credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->