### PR TITLE
fix(mastracode): align E2E tests with default models

### DIFF
--- a/mastracode/tui/e2e/tui/login-preserves-model-pack.ts
+++ b/mastracode/tui/e2e/tui/login-preserves-model-pack.ts
@@ -11,7 +11,7 @@ const packId = `custom:${packName}`;
 /**
  * The `/login` command must not change the active model or model pack — that
  * only belongs to the onboarding flow. This exercises logging in to Anthropic
- * (whose post-login default is anthropic/claude-opus-4-6) while a custom pack is
+ * (whose post-login default is anthropic/claude-fable-5) while a custom pack is
  * active, and asserts the session keeps its custom build model.
  */
 export const loginPreservesModelPackScenario = {
@@ -83,7 +83,7 @@ export const loginPreservesModelPackScenario = {
     // The active model pack must survive login: the status line still shows the
     // custom build model, and the login never switched to the provider default.
     await runtime.waitForScreenText(/▐build▌login-preserve-e2e\/build-model/i, terminal, 8_000);
-    await runtime.waitForScreenTextAbsent(/claude-opus-4-6/i, terminal, 4_000);
+    await runtime.waitForScreenTextAbsent(/claude-fable-5/i, terminal, 4_000);
     await runtime.waitForScreenTextAbsent(/switched to anthropic/i, terminal, 4_000);
 
     terminal.submit(

--- a/mastracode/tui/e2e/tui/om-pack-startup-restore.ts
+++ b/mastracode/tui/e2e/tui/om-pack-startup-restore.ts
@@ -40,8 +40,8 @@ export const omPackStartupRestoreScenario: McE2eScenario = {
 
     terminal.submit('/om');
     await runtime.waitForScreenText(/Observational Memory Settings/i, terminal, 8_000);
-    await runtime.waitForScreenText(/Observer model\s+gemini-2\.5-flash/i, terminal, 8_000);
-    await runtime.waitForScreenText(/Reflector model\s+gemini-2\.5-flash/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Observer model\s+gemini-3\.5-flash/i, terminal, 8_000);
+    await runtime.waitForScreenText(/Reflector model\s+gemini-3\.5-flash/i, terminal, 8_000);
     terminal.write('\x1b');
     await runtime.waitForScreenTextAbsent(/Observational Memory Settings/i, terminal, 8_000);
 

--- a/mastracode/tui/e2e/tui/setup-login-refresh.ts
+++ b/mastracode/tui/e2e/tui/setup-login-refresh.ts
@@ -72,7 +72,7 @@ export const setupLoginRefreshScenario = {
     terminal.write('\r');
 
     await runtime.waitForScreenText(/Project:\s+mastra/i, terminal, 8_000);
-    await runtime.waitForScreenText(/anthropic\/claude-opus-4-7/i, terminal, 8_000);
+    await runtime.waitForScreenText(/anthropic\/claude-fable-5/i, terminal, 8_000);
 
     terminal.submit(
       `!node -e 'const fs=require("fs"); const app=process.env.MASTRA_APP_DATA_DIR; const s=JSON.parse(fs.readFileSync(app+"/settings.json","utf8")); const a=JSON.parse(fs.readFileSync(app+"/auth.json","utf8")); console.log("SETUP_LOGIN_AUTH="+(a.anthropic?.type||"missing")+":"+(a.anthropic?.access||"missing")); console.log("SETUP_LOGIN_PACK="+s.models.activeModelPackId+":"+s.onboarding.modePackId+":"+s.onboarding.omPackId+":"+s.models.activeOmPackId); console.log("SETUP_LOGIN_BUILTIN_DEFAULTS="+Object.keys(s.models.modeDefaults||{}).length);'`,


### PR DESCRIPTION
The Mastra Code E2E suite still expected previous built-in model pack defaults after the Anthropic and Gemini defaults changed.

Before:
```ts
anthropic/claude-opus-4-7
google/gemini-2.5-flash
```

After:
```ts
anthropic/claude-fable-5
google/gemini-3.5-flash
```

This also updates the login model-pack preservation scenario so its negative assertion checks the current Anthropic default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The tests now expect the model names that Mastra actually uses today, so they won’t fail because they’re checking outdated defaults.

## Changes

- Updated Anthropic expectations to `anthropic/claude-fable-5`.
- Updated Google observer and reflector expectations to `gemini-3.5-flash`.
- Updated login model-pack preservation assertions to use the current Anthropic default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->