### PR TITLE
fix(lance): skip rebuilding matching vector indexes

### DIFF
--- a/.changeset/fluffy-clowns-deny.md
+++ b/.changeset/fluffy-clowns-deny.md
@@ -1,0 +1,5 @@
+---
+'@mastra/lance': patch
+---
+
+Fixed Lance vector indexes being rebuilt when the matching index already exists.

--- a/stores/lance/src/vector/index.test.ts
+++ b/stores/lance/src/vector/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { LanceVectorStore } from './index';
 
 describe('Lance vector store tests', () => {
@@ -76,6 +76,31 @@ describe('Lance vector store tests', () => {
         const stats = await vectorDB.describeIndex({ indexName: indexOnColumn + '_idx' });
 
         expect(stats?.metric).toBe('euclidean');
+      });
+
+      it('does not rebuild an existing index', async () => {
+        const createIndexParams = {
+          indexConfig: { type: 'hnsw' as const },
+          indexName: indexOnColumn,
+          dimension: 3,
+          metric: 'euclidean' as const,
+          tableName: testTableName,
+        };
+        await vectorDB.createIndex(createIndexParams);
+
+        const lanceClient = (
+          vectorDB as unknown as {
+            lanceClient: { openTable: (name: string) => Promise<{ createIndex: (...args: never[]) => Promise<void> }> };
+          }
+        ).lanceClient;
+        const table = await lanceClient.openTable(testTableName);
+        const createIndex = vi.spyOn(table, 'createIndex');
+        const openTable = vi.spyOn(lanceClient, 'openTable').mockResolvedValue(table);
+
+        await vectorDB.createIndex(createIndexParams);
+
+        expect(createIndex).not.toHaveBeenCalled();
+        openTable.mockRestore();
       });
 
       it('should default tableName to indexName when tableName is not provided', async () => {

--- a/stores/lance/src/vector/index.ts
+++ b/stores/lance/src/vector/index.ts
@@ -736,6 +736,20 @@ export class LanceVectorStore extends MastraVector<LanceVectorFilter> {
         return;
       }
 
+      const expectedIndexType = indexConfig.type === 'ivfflat' ? 'IvfPq' : 'IvfHnswPq';
+      const existingIndex = (await table.listIndices()).find(
+        index => index.columns.includes(columnToIndex) && index.indexType === expectedIndexType,
+      );
+      if (existingIndex) {
+        const existingStats = await table.indexStats(existingIndex.name);
+        if (existingStats && this.lanceMetricToMastra(existingStats.distanceType) === metric) {
+          this.logger.debug(
+            `Vector index ${existingIndex.name} already exists on ${resolvedTableName}.${columnToIndex}; skipping rebuild.`,
+          );
+          return;
+        }
+      }
+
       if (indexConfig.type === 'ivfflat') {
         await table.createIndex(columnToIndex, {
           config: Index.ivfPq({


### PR DESCRIPTION
## Summary
- avoid retraining an existing Lance vector index when its column, type, and metric already match
- preserve rebuilds when the requested type or distance metric changes
- add a regression test for repeated `createIndex()` calls

## Testing
- `DB_URL=$(mktemp -d) pnpm exec vitest run src/vector/index.test.ts`
- `pnpm run build:lib`
- `pnpm exec tsc --noEmit -p tsconfig.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

If the right vector index already exists, Lance now reuses it instead of rebuilding it. It still rebuilds the index when its type or distance metric changes.

## Changes

- Added matching checks for the indexed column, index type, and distance metric.
- Added a regression test for repeated `createIndex()` calls.
- Added a patch Changesets entry for `@mastra/lance`.

## Testing

- Vector index test suite
- Library build
- TypeScript type checking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->