### PR TITLE
fix: prevent local libSQL WAL corruption in Mastra Code

### DIFF
--- a/.changeset/blue-teams-exist.md
+++ b/.changeset/blue-teams-exist.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Improved local database safety by using rollback journals and closing storage during shutdown.

--- a/.changeset/chilly-taxis-slide.md
+++ b/.changeset/chilly-taxis-slide.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Fixed local database cleanup across interactive, ACP, and headless exits.

--- a/.changeset/large-shrimps-run.md
+++ b/.changeset/large-shrimps-run.md
@@ -1,0 +1,5 @@
+---
+'@mastra/libsql': minor
+---
+
+Added configurable local journal modes while preserving WAL as the default.

--- a/.changeset/large-shrimps-run.md
+++ b/.changeset/large-shrimps-run.md
@@ -3,3 +3,11 @@
 ---
 
 Added configurable local journal modes while preserving WAL as the default.
+
+```ts
+const storage = new LibSQLStore({
+  id: 'local-storage',
+  url: 'file:./mastra.db',
+  journalMode: 'delete',
+});
+```

--- a/docs/src/content/en/reference/storage/libsql.mdx
+++ b/docs/src/content/en/reference/storage/libsql.mdx
@@ -97,8 +97,36 @@ In-memory storage resets when the process changes. Only suitable for development
     description: 'Authentication token for remote libSQL databases.',
     isOptional: true,
   },
+  {
+    name: 'journalMode',
+    type: "'wal' | 'delete'",
+    description:
+      'Journal mode for local file databases. `wal` uses a write-ahead log. `delete` uses a rollback journal and removes it after each transaction.',
+    isOptional: true,
+    defaultValue: "'wal'",
+  },
 ]}
 />
+
+## Local journal modes
+
+`journalMode` applies only to local file databases. Remote and in-memory databases use their existing connection behavior.
+
+The default `wal` mode supports more concurrent read and write activity. Set `journalMode: 'delete'` when you need rollback journaling without persistent write-ahead log (WAL) sidecar files:
+
+```typescript
+const storage = new LibSQLStore({
+  id: 'libsql-storage',
+  url: 'file:./storage.db',
+  journalMode: 'delete',
+})
+
+await storage.init()
+```
+
+DELETE mode allows one writer at a time, so write-heavy workloads may have lower throughput. Mastra establishes the selected mode before creating tables. Initialization fails if SQLite can't switch a local file to DELETE mode, for example when another process holds an incompatible lock.
+
+Call `close()` when you use the store directly. Closing a local WAL store checkpoints its pending writes and transitions the file to DELETE mode before releasing the client. A store configured for DELETE mode closes the client without running a WAL checkpoint. Repeated `close()` calls are safe.
 
 ## Managed tables
 

--- a/docs/src/content/en/reference/vectors/libsql.mdx
+++ b/docs/src/content/en/reference/vectors/libsql.mdx
@@ -88,14 +88,40 @@ const results = await store.query({
     isOptional: true,
     description: 'Interval in milliseconds for database sync (Turso specific)',
   },
+  {
+    name: 'journalMode',
+    type: "'wal' | 'delete'",
+    isOptional: true,
+    defaultValue: "'wal'",
+    description:
+      'Journal mode for local file databases. `wal` uses a write-ahead log. `delete` uses a rollback journal and removes it after each transaction.',
+  },
 ]}
 />
+
+## Local journal modes
+
+`journalMode` applies only to local file databases. Remote and in-memory databases use their existing connection behavior.
+
+The default `wal` mode supports more concurrent read and write activity. Set `journalMode: 'delete'` when you need rollback journaling without persistent write-ahead log (WAL) sidecar files:
+
+```typescript
+const store = new LibSQLVector({
+  id: 'libsql-vector',
+  url: 'file:./vectors.db',
+  journalMode: 'delete',
+})
+```
+
+DELETE mode allows one writer at a time, so write-heavy workloads may have lower throughput. The selected mode is established before vector operations run. An operation fails if SQLite can't switch a local file to DELETE mode, for example when another process holds an incompatible lock.
+
+Call `close()` when the vector store is no longer needed. Closing a local WAL store checkpoints its pending writes and transitions the file to DELETE mode before releasing the client. A vector store configured for DELETE mode closes the client without running a WAL checkpoint. Repeated `close()` calls are safe.
 
 ## Methods
 
 ### `createIndex()`
 
-Creates a new vector collection. The index name must start with a letter or underscore and can only contain letters, numbers, and underscores. The dimension must be a positive integer.
+Creates a new vector collection. The index name must start with a letter or underscore and can only contain letters, numbers, and underscore characters. The dimension must be a positive integer.
 
 <PropertiesTable
   content={[

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -41,6 +41,8 @@ vi.mock('@mastra/core/coding-agent', () => ({
 const agentConstructorMock = vi.fn();
 
 const controllerConstructorMock = vi.fn();
+const controllerInitMock = vi.fn(async () => undefined);
+const controllerStopIntervalsMock = vi.fn(async () => undefined);
 const loadSettingsMock = vi.fn();
 const getAvailableModePacksMock = vi.fn(() => []);
 const getAvailableOmPacksMock = vi.fn(() => []);
@@ -120,7 +122,12 @@ vi.mock('@mastra/core/agent-controller', () => ({
     constructor(config: unknown) {
       controllerConstructorMock(config);
     }
-    async init() {}
+    init() {
+      return controllerInitMock();
+    }
+    stopIntervals() {
+      return controllerStopIntervalsMock();
+    }
     getMastra() {
       return undefined;
     }
@@ -316,11 +323,11 @@ vi.mock('../utils/project.js', () => ({
 }));
 
 const createStorageMock = vi.fn((): { storage: unknown; backend?: string } => ({ storage: {} }));
-const createVectorStoreMock = vi.fn(() => ({}));
+const createOwnedVectorStoreMock = vi.fn((): { vector: unknown; close?: () => Promise<void> } => ({ vector: {} }));
 
 vi.mock('../utils/storage-factory.js', () => ({
   createStorage: createStorageMock,
-  createVectorStore: createVectorStoreMock,
+  createOwnedVectorStore: createOwnedVectorStoreMock,
 }));
 
 vi.mock('../utils/thread-lock.js', () => ({
@@ -341,8 +348,8 @@ describe('createMastraCode', () => {
     mastraCodeGatewayMock.resolveLanguageModel.mockClear();
     createStorageMock.mockReset();
     createStorageMock.mockReturnValue({ storage: {}, backend: 'memory' });
-    createVectorStoreMock.mockReset();
-    createVectorStoreMock.mockReturnValue({});
+    createOwnedVectorStoreMock.mockReset();
+    createOwnedVectorStoreMock.mockReturnValue({ vector: {} });
     getDynamicMemoryMock.mockReset();
     getDynamicMemoryMock.mockReturnValue(() => undefined);
     controllerSubscribeMock.mockReset();
@@ -375,6 +382,10 @@ describe('createMastraCode', () => {
     loadSettingsMock.mockReturnValue(createMockSettings());
     agentConstructorMock.mockReset();
     controllerConstructorMock.mockReset();
+    controllerInitMock.mockReset();
+    controllerInitMock.mockResolvedValue(undefined);
+    controllerStopIntervalsMock.mockReset();
+    controllerStopIntervalsMock.mockResolvedValue(undefined);
     streamErrorRetryProcessorConstructorMock.mockReset();
     getAvailableModePacksMock.mockClear();
     getAvailableOmPacksMock.mockClear();
@@ -386,6 +397,22 @@ describe('createMastraCode', () => {
     delete process.env.MASTRA_GATEWAY_API_KEY;
     delete process.env.MASTRA_GATEWAY_URL;
   });
+
+  it('closes owned storage when local controller startup fails', async () => {
+    const startupError = new Error('storage init failed');
+    const closeStorage = vi.fn(async () => undefined);
+    const closeVector = vi.fn(async () => undefined);
+    createStorageMock.mockReturnValue({ storage: { close: closeStorage }, backend: 'memory' });
+    createOwnedVectorStoreMock.mockReturnValue({ vector: {}, close: closeVector });
+    controllerInitMock.mockRejectedValueOnce(startupError);
+    const { createMastraCode } = await import('../index.js');
+
+    await expect(createMastraCode()).rejects.toBe(startupError);
+
+    expect(controllerStopIntervalsMock).toHaveBeenCalledOnce();
+    expect(closeStorage).toHaveBeenCalledOnce();
+    expect(closeVector).toHaveBeenCalledOnce();
+  }, 10_000);
 
   it('registers the MastraCode gateway and app-provided model hooks on AgentController', async () => {
     const { createMastraCode } = await import('../index.js');
@@ -457,7 +484,7 @@ describe('createMastraCode', () => {
     await createMastraCode({ vector: vector as any });
 
     expect(getDynamicMemoryMock).toHaveBeenCalledWith(expect.anything(), vector);
-    expect(createVectorStoreMock).not.toHaveBeenCalled();
+    expect(createOwnedVectorStoreMock).not.toHaveBeenCalled();
   });
 
   it('requires an explicit backend for unknown injected storage implementations', async () => {

--- a/mastracode/sdk/src/acp/__tests__/index.test.ts
+++ b/mastracode/sdk/src/acp/__tests__/index.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createAcpCleanup } from '../index.js';
+
+describe('ACP cleanup', () => {
+  it('stops work before closing storage and runs only once', async () => {
+    const events: string[] = [];
+    const closeStorage = vi.fn(async () => {
+      events.push('storage');
+    });
+    const releaseLocks = vi.fn(() => events.push('locks'));
+    const restoreConsole = vi.fn(() => events.push('console'));
+    const cleanup = createAcpCleanup({
+      stopWork: [
+        async () => {
+          events.push('stop');
+        },
+      ],
+      closeStorage,
+      releaseLocks,
+      restoreConsole,
+    });
+
+    await Promise.all([cleanup(), cleanup()]);
+
+    expect(events).toEqual(['stop', 'storage', 'locks', 'console']);
+    expect(closeStorage).toHaveBeenCalledOnce();
+  });
+
+  it('releases process resources when storage close fails', async () => {
+    const error = new Error('close failed');
+    const releaseLocks = vi.fn();
+    const restoreConsole = vi.fn();
+    const cleanup = createAcpCleanup({
+      stopWork: [vi.fn().mockRejectedValue(new Error('stop failed'))],
+      closeStorage: vi.fn().mockRejectedValue(error),
+      releaseLocks,
+      restoreConsole,
+    });
+
+    await expect(cleanup()).rejects.toBe(error);
+    expect(releaseLocks).toHaveBeenCalledOnce();
+    expect(restoreConsole).toHaveBeenCalledOnce();
+  });
+});

--- a/mastracode/sdk/src/acp/index.ts
+++ b/mastracode/sdk/src/acp/index.ts
@@ -51,7 +51,7 @@ export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Pro
       disableHooks: false,
     });
 
-    const { controller, mcpManager, signalsPubSub, storageMaintenance } = result;
+    const { controller, githubSignals, mcpManager, signalsPubSub, storageMaintenance } = result;
 
     // Default modes (same as createMastraCode defaults)
     const modes: AgentControllerMode[] = [
@@ -66,6 +66,7 @@ export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Pro
         () => mcpManager?.disconnect(),
         () => controller?.getMastra()?.stopWorkers(),
         () => controller?.stopIntervals(),
+        () => githubSignals?.stopAllPolling(),
         () => (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
       ],
       closeStorage: () => storageMaintenance.closeStorage?.(),

--- a/mastracode/sdk/src/acp/index.ts
+++ b/mastracode/sdk/src/acp/index.ts
@@ -5,6 +5,27 @@ import { releaseAllThreadLocks } from '../utils/thread-lock.js';
 import { setAutoApprove } from './event-mapper.js';
 import { runAcpServer } from './server.js';
 
+export function createAcpCleanup(options: {
+  stopWork: Array<() => Promise<unknown> | unknown>;
+  closeStorage: () => Promise<void> | void;
+  releaseLocks: () => void;
+  restoreConsole: () => void;
+}): () => Promise<void> {
+  let cleanupPromise: Promise<void> | undefined;
+  return () => {
+    cleanupPromise ??= (async () => {
+      try {
+        await Promise.allSettled(options.stopWork.map(stop => Promise.resolve().then(stop)));
+        await options.closeStorage();
+      } finally {
+        options.releaseLocks();
+        options.restoreConsole();
+      }
+    })();
+    return cleanupPromise;
+  };
+}
+
 /**
  * Entry point for ACP server mode.
  * Initializes mastracode and runs the ACP protocol over stdio.
@@ -30,7 +51,7 @@ export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Pro
       disableHooks: false,
     });
 
-    const { controller, mcpManager, signalsPubSub } = result;
+    const { controller, mcpManager, signalsPubSub, storageMaintenance } = result;
 
     // Default modes (same as createMastraCode defaults)
     const modes: AgentControllerMode[] = [
@@ -40,25 +61,30 @@ export async function acpMain(options?: { dangerousAutoApprove?: boolean }): Pro
     ];
 
     // Cleanup function (mirrors main.ts asyncCleanup)
-    const cleanup = async () => {
-      releaseAllThreadLocks();
-      const closeSignalsPubSub = (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
-      await Promise.allSettled([
-        mcpManager?.disconnect(),
-        controller?.getMastra()?.stopWorkers(),
-        controller?.stopIntervals(),
-        closeSignalsPubSub?.(),
-      ]);
-
-      // Restore console.log
-      // eslint-disable-next-line no-console
-      console.log = originalConsoleLog;
-    };
+    const cleanup = createAcpCleanup({
+      stopWork: [
+        () => mcpManager?.disconnect(),
+        () => controller?.getMastra()?.stopWorkers(),
+        () => controller?.stopIntervals(),
+        () => (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
+      ],
+      closeStorage: () => storageMaintenance.closeStorage?.(),
+      releaseLocks: releaseAllThreadLocks,
+      restoreConsole: () => {
+        // eslint-disable-next-line no-console
+        console.log = originalConsoleLog;
+      },
+    });
 
     // Handle signals
     const handleSignal = async () => {
-      await cleanup();
-      process.exit(0);
+      try {
+        await cleanup();
+        process.exit(0);
+      } catch (error) {
+        process.stderr.write(`[acp] Storage cleanup failed: ${error}\n`);
+        process.exit(1);
+      }
     };
 
     process.on('SIGINT', handleSignal);

--- a/mastracode/sdk/src/headless/cli.test.ts
+++ b/mastracode/sdk/src/headless/cli.test.ts
@@ -1,11 +1,65 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 
-import { hasHeadlessFlag, parseHeadlessArgs } from './cli.js';
+import { cleanupHeadless, hasHeadlessFlag, parseHeadlessArgs } from './cli.js';
 import { buildParseArgsOptions, FLAGS, renderFlagUsage } from './flags.js';
 
 function argv(...rest: string[]): string[] {
   return ['node', 'main.js', ...rest];
 }
+
+describe('cleanupHeadless', () => {
+  it('stops work before closing storage and preserves a successful exit', async () => {
+    const events: string[] = [];
+    const closeStorage = vi.fn(async () => {
+      events.push('storage');
+    });
+    const releaseLocks = vi.fn(() => {
+      events.push('locks');
+    });
+
+    const exitCode = await cleanupHeadless({
+      stopWork: [
+        async () => {
+          events.push('stop');
+        },
+      ],
+      closeStorage,
+      releaseLocks,
+      exitCode: 0,
+      onStorageError: vi.fn(),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(events).toEqual(['stop', 'storage', 'locks']);
+    expect(closeStorage).toHaveBeenCalledOnce();
+  });
+
+  it('reports storage failure without masking an earlier nonzero exit', async () => {
+    const error = new Error('close failed');
+    const onStorageError = vi.fn();
+    const releaseLocks = vi.fn();
+
+    const failedSuccess = await cleanupHeadless({
+      stopWork: [vi.fn().mockRejectedValue(new Error('stop failed'))],
+      closeStorage: vi.fn().mockRejectedValue(error),
+      releaseLocks,
+      exitCode: 0,
+      onStorageError,
+    });
+    const existingFailure = await cleanupHeadless({
+      stopWork: [],
+      closeStorage: vi.fn().mockRejectedValue(error),
+      releaseLocks,
+      exitCode: 2,
+      onStorageError,
+    });
+
+    expect(failedSuccess).toBe(1);
+    expect(existingFailure).toBe(2);
+    expect(onStorageError).toHaveBeenCalledWith(error);
+    expect(releaseLocks).toHaveBeenCalledTimes(2);
+  });
+});
 
 describe('hasHeadlessFlag', () => {
   it('detects --prompt', () => {

--- a/mastracode/sdk/src/headless/cli.ts
+++ b/mastracode/sdk/src/headless/cli.ts
@@ -207,7 +207,7 @@ export async function runMCCli(predrainedInput?: string | null): Promise<never> 
   }
 
   const boot = await createMastraCode({ settingsPath: args.settings });
-  const { controller, session, mcpManager, effectiveDefaults, storageMaintenance } = boot;
+  const { controller, session, githubSignals, mcpManager, effectiveDefaults, storageMaintenance } = boot;
 
   if (mcpManager?.hasServers()) {
     try {
@@ -275,6 +275,7 @@ export async function runMCCli(predrainedInput?: string | null): Promise<never> 
         () => mcpManager?.disconnect(),
         () => controller.getMastra()?.stopWorkers(),
         () => controller?.stopIntervals(),
+        () => githubSignals?.stopAllPolling(),
         () => (boot.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
       ],
       closeStorage: () => storageMaintenance.closeStorage?.(),

--- a/mastracode/sdk/src/headless/cli.ts
+++ b/mastracode/sdk/src/headless/cli.ts
@@ -144,6 +144,28 @@ Examples:
 `);
 }
 
+export async function cleanupHeadless(options: {
+  stopWork: Array<() => Promise<unknown> | unknown>;
+  closeStorage: () => Promise<void> | void;
+  releaseLocks: () => void;
+  exitCode: number;
+  onStorageError: (error: unknown) => void;
+}): Promise<number> {
+  let exitCode = options.exitCode;
+  try {
+    await Promise.allSettled(options.stopWork.map(stop => Promise.resolve().then(stop)));
+    try {
+      await options.closeStorage();
+    } catch (error) {
+      options.onStorageError(error);
+      if (exitCode === 0) exitCode = 1;
+    }
+  } finally {
+    options.releaseLocks();
+  }
+  return exitCode;
+}
+
 /**
  * Headless CLI entry point: parse arguments, read stdin, initialize MastraCode,
  * run via `runMC`, render output, and exit with the mapped code.
@@ -185,7 +207,7 @@ export async function runMCCli(predrainedInput?: string | null): Promise<never> 
   }
 
   const boot = await createMastraCode({ settingsPath: args.settings });
-  const { controller, session, mcpManager, effectiveDefaults } = boot;
+  const { controller, session, mcpManager, effectiveDefaults, storageMaintenance } = boot;
 
   if (mcpManager?.hasServers()) {
     try {
@@ -248,14 +270,20 @@ export async function runMCCli(predrainedInput?: string | null): Promise<never> 
     exitCode = 1;
   } finally {
     // --- Teardown (always runs, even on a thrown error) ---
-    releaseAllThreadLocks();
-    const closeSignalsPubSub = (boot.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
-    await Promise.allSettled([
-      mcpManager?.disconnect(),
-      controller.getMastra()?.stopWorkers(),
-      controller?.stopIntervals(),
-      closeSignalsPubSub?.(),
-    ]);
+    exitCode = await cleanupHeadless({
+      stopWork: [
+        () => mcpManager?.disconnect(),
+        () => controller.getMastra()?.stopWorkers(),
+        () => controller?.stopIntervals(),
+        () => (boot.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
+      ],
+      closeStorage: () => storageMaintenance.closeStorage?.(),
+      releaseLocks: releaseAllThreadLocks,
+      exitCode,
+      onStorageError: error => {
+        process.stderr.write(`Storage cleanup failed: ${(error as Error).message ?? error}\n`);
+      },
+    });
   }
 
   process.exit(exitCode);

--- a/mastracode/sdk/src/index.test.ts
+++ b/mastracode/sdk/src/index.test.ts
@@ -181,6 +181,7 @@ vi.mock('./utils/project.js', () => ({
 
 vi.mock('./utils/storage-factory.js', () => ({
   createStorage: vi.fn(() => ({ storage: {}, backend: 'memory' })),
+  createOwnedVectorStore: vi.fn(() => ({ vector: {}, close: vi.fn() })),
   createVectorStore: vi.fn(() => ({})),
 }));
 

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -35,7 +35,7 @@ import type { MastraVector } from '@mastra/core/vector';
 import { DuckDBStore } from '@mastra/duckdb';
 
 import { GithubSignals } from '@mastra/github-signals';
-import { LibSQLStore, LibSQLVector } from '@mastra/libsql';
+import { LibSQLStore } from '@mastra/libsql';
 import {
   Observability,
   MastraStorageExporter,
@@ -98,7 +98,7 @@ import {
 } from './utils/project.js';
 import type { StorageConfig } from './utils/project.js';
 import { createSignalsPubSub } from './utils/signals-pubsub.js';
-import { createStorage, createVectorStore } from './utils/storage-factory.js';
+import { createOwnedVectorStore, createStorage } from './utils/storage-factory.js';
 import type { StorageResult } from './utils/storage-factory.js';
 import { createStorageMaintenance, DEFAULT_RETENTION, resolveLocalDbFiles } from './utils/storage-maintenance.js';
 import type { StorageMaintenance } from './utils/storage-maintenance.js';
@@ -505,20 +505,20 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
   // Vector store for recall search (separate DB file to avoid bloating main
   // storage). An injected instance is used as-is; with an injected storage
   // instance and no injected vector, recall search stays vector-less.
-  const vector =
-    config?.vector ?? (storageConfig ? await createVectorStore(storageConfig, storageResult.backend) : undefined);
+  const ownedVector =
+    config?.vector || !storageConfig ? undefined : await createOwnedVectorStore(storageConfig, storageResult.backend);
+  const vector = config?.vector ?? ownedVector?.vector;
 
-  // Maintenance handle for /prune: prunes via the inner store (whose retention
-  // config covers every domain, including legacy libsql observability spans)
-  // and can compact local libsql files to reclaim disk. The vector store's
-  // connection must close alongside storage — the compaction's file swap
-  // refuses to run while any connection is open.
+  // Maintenance handle for /prune and shutdown: prunes via the inner store
+  // (whose retention config covers every domain, including legacy libsql
+  // observability spans) and closes only vector stores created here. Injected
+  // vectors remain owned by their caller.
   const storageMaintenance: StorageMaintenance = createStorageMaintenance({
     storage: storageResult.storage,
     backend: storageResult.backend,
     retention: DEFAULT_RETENTION,
     localDbFiles: storageConfig ? resolveLocalDbFiles(storageConfig, storageResult.backend) : [],
-    closeVector: vector instanceof LibSQLVector ? () => vector.close() : undefined,
+    closeVector: ownedVector?.close,
   });
 
   const memory = config?.memory === false ? undefined : (config?.memory ?? getDynamicMemory(storage, vector));

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -983,7 +983,7 @@ export async function wireSessionConcerns(
       if (event.type === 'thread_changed') void startGithubPollingForCurrentThread(event.threadId);
       else if (event.type === 'thread_created') void startGithubPollingForCurrentThread(event.thread.id);
     });
-    void startGithubPollingForCurrentThread(session.thread.getId());
+    await startGithubPollingForCurrentThread(session.thread.getId());
   }
 
   // Persist MastraCode-owned /om settings per-thread (mastracode-only concern;

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -1004,12 +1004,28 @@ export async function bootLocalAgentController(config?: MastraCodeConfig) {
   const base = await createMastraCodeAgentController(config);
   const { controller, sessionId, ownerId } = base;
 
-  await controller.init();
-  await controller.getMastra()?.startWorkers();
-  const session = await controller.createSession({ id: sessionId, ownerId });
-  await wireSessionConcerns(base, session);
+  try {
+    await controller.init();
+    await controller.getMastra()?.startWorkers();
+    const session = await controller.createSession({ id: sessionId, ownerId });
+    await wireSessionConcerns(base, session);
 
-  return { ...base, session };
+    return { ...base, session };
+  } catch (error) {
+    const stopWork: Array<() => Promise<unknown> | unknown> = [
+      () => controller.getMastra()?.stopWorkers(),
+      () => controller.stopIntervals(),
+      () => base.mcpManager?.disconnect(),
+      () => (base.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
+    ];
+    await Promise.allSettled(stopWork.map(stop => Promise.resolve().then(stop)));
+    try {
+      await base.storageMaintenance.closeStorage?.();
+    } catch (closeError) {
+      throw new AggregateError([error, closeError], 'Mastra Code startup and storage cleanup failed');
+    }
+    throw error;
+  }
 }
 
 /** Result of {@link mountAgentControllerOnMastra}: shared handles plus the owning Mastra. */

--- a/mastracode/sdk/src/utils/__tests__/storage-config.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-config.test.ts
@@ -3,7 +3,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 import { createClient } from '@libsql/client';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { PgVector } from '@mastra/pg';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 describe('getStorageConfig', () => {
   const originalEnv = { ...process.env };
@@ -192,6 +193,22 @@ describe('createStorage', () => {
       await result.storage.close?.();
       await (vector as { close?: () => Promise<void> })?.close?.();
       rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('closes the owned PostgreSQL vector pool', async () => {
+    const disconnect = vi.spyOn(PgVector.prototype, 'disconnect').mockResolvedValue();
+    const { createOwnedVectorStore } = await import('../storage-factory.js');
+    const ownedVector = await createOwnedVectorStore({
+      backend: 'pg',
+      connectionString: 'postgresql://user:pass@localhost:5432/testdb',
+    });
+
+    try {
+      await ownedVector?.close?.();
+      expect(disconnect).toHaveBeenCalledOnce();
+    } finally {
+      disconnect.mockRestore();
     }
   });
 

--- a/mastracode/sdk/src/utils/__tests__/storage-config.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-config.test.ts
@@ -1,9 +1,17 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { createClient } from '@libsql/client';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 
 describe('getStorageConfig', () => {
   const originalEnv = { ...process.env };
+  let appDataDir: string;
 
   beforeEach(() => {
+    appDataDir = mkdtempSync(join(tmpdir(), 'mastracode-storage-config-'));
+    process.env.MASTRA_APP_DATA_DIR = appDataDir;
     // Clear storage-related env vars
     delete process.env.MASTRA_STORAGE_BACKEND;
     delete process.env.MASTRA_DB_URL;
@@ -18,6 +26,7 @@ describe('getStorageConfig', () => {
   });
 
   afterEach(() => {
+    rmSync(appDataDir, { recursive: true, force: true });
     process.env = { ...originalEnv };
   });
 
@@ -133,6 +142,18 @@ describe('getStorageConfig', () => {
 });
 
 describe('createStorage', () => {
+  let appDataDir: string;
+
+  beforeEach(() => {
+    appDataDir = mkdtempSync(join(tmpdir(), 'mastracode-create-storage-'));
+    process.env.MASTRA_APP_DATA_DIR = appDataDir;
+  });
+
+  afterEach(() => {
+    rmSync(appDataDir, { recursive: true, force: true });
+    delete process.env.MASTRA_APP_DATA_DIR;
+  });
+
   it('creates LibSQLStore for libsql backend', async () => {
     const { createStorage } = await import('../storage-factory.js');
     const result = await createStorage({
@@ -144,6 +165,34 @@ describe('createStorage', () => {
     expect(result.storage.constructor.name).toBe('LibSQLStore');
     expect(result.backend).toBe('libsql');
     expect(result.warning).toBeUndefined();
+  });
+
+  it('uses DELETE journals for local main and vector databases', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'mastracode-storage-'));
+    const mainUrl = `file:${join(dir, 'main.db')}`;
+    const vectorUrl = `file:${join(dir, 'vectors.db')}`;
+    const { createStorage, createVectorStore } = await import('../storage-factory.js');
+    const result = await createStorage({ backend: 'libsql', url: mainUrl, vectorUrl, isRemote: false });
+    const vector = await createVectorStore({ backend: 'libsql', url: mainUrl, vectorUrl, isRemote: false });
+
+    try {
+      await result.storage.init();
+      await vector!.listIndexes();
+
+      for (const url of [mainUrl, vectorUrl]) {
+        const client = createClient({ url });
+        try {
+          const journal = await client.execute('PRAGMA journal_mode');
+          expect(String(journal.rows[0]?.journal_mode).toLowerCase()).toBe('delete');
+        } finally {
+          client.close();
+        }
+      }
+    } finally {
+      await result.storage.close?.();
+      await (vector as { close?: () => Promise<void> })?.close?.();
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('falls back to LibSQL with warning when pg has no connection info', async () => {

--- a/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
+++ b/mastracode/sdk/src/utils/__tests__/storage-maintenance.test.ts
@@ -94,7 +94,7 @@ describe('createStorageMaintenance', () => {
       localDbFiles: [],
       closeVector,
     });
-    await withClose.closeStorage!();
+    await Promise.all([withClose.closeStorage!(), withClose.closeStorage!()]);
     expect(close).toHaveBeenCalledOnce();
     expect(closeVector).toHaveBeenCalledOnce();
 
@@ -105,6 +105,27 @@ describe('createStorageMaintenance', () => {
       localDbFiles: [],
     });
     await expect(withoutClose.closeStorage!()).resolves.toBeUndefined();
+  });
+
+  it('attempts both closes and propagates their failures', async () => {
+    const storageError = new Error('storage close failed');
+    const vectorError = new Error('vector close failed');
+    const close = vi.fn().mockRejectedValue(storageError);
+    const closeVector = vi.fn().mockRejectedValue(vectorError);
+    const maintenance = createStorageMaintenance({
+      storage: { prune: vi.fn(), close } as any,
+      backend: 'libsql',
+      retention: DEFAULT_RETENTION,
+      localDbFiles: [],
+      closeVector,
+    });
+
+    const error = await maintenance.closeStorage!().catch(error => error);
+
+    expect(close).toHaveBeenCalledOnce();
+    expect(closeVector).toHaveBeenCalledOnce();
+    expect(error).toBeInstanceOf(AggregateError);
+    expect((error as AggregateError).errors).toEqual([storageError, vectorError]);
   });
 });
 

--- a/mastracode/sdk/src/utils/storage-factory.ts
+++ b/mastracode/sdk/src/utils/storage-factory.ts
@@ -19,6 +19,10 @@ export const MASTRA_CODE_LOCAL_PRAGMAS = {
   mmapSize: 536870912,
 };
 
+function isLocalFileUrl(url: string): boolean {
+  return url.startsWith('file:') && !url.includes(':memory:');
+}
+
 /**
  * Construct a LibSQL store for an arbitrary url/authToken, applying the same
  * local pragmas the default factory uses.
@@ -28,22 +32,24 @@ export function buildLibSQLStore(opts: {
   url: string;
   authToken?: string;
   retention?: RetentionConfig;
-}): MastraCompositeStore {
+}): LibSQLStore {
   return new LibSQLStore({
     id: opts.id ?? 'mastra-code-storage',
     url: opts.url,
     ...(opts.authToken ? { authToken: opts.authToken } : {}),
     ...(opts.retention ? { retention: opts.retention } : {}),
+    ...(isLocalFileUrl(opts.url) ? { journalMode: 'delete' } : {}),
     localPragmas: MASTRA_CODE_LOCAL_PRAGMAS,
   });
 }
 
 /** Construct a LibSQL vector store for an arbitrary url/authToken. */
-export function buildLibSQLVector(opts: { id?: string; url: string; authToken?: string }): MastraVector {
+export function buildLibSQLVector(opts: { id?: string; url: string; authToken?: string }): LibSQLVector {
   return new LibSQLVector({
     id: opts.id ?? 'mastra-code-vectors',
     url: opts.url,
     ...(opts.authToken ? { authToken: opts.authToken } : {}),
+    ...(isLocalFileUrl(opts.url) ? { journalMode: 'delete' } : {}),
   });
 }
 
@@ -137,30 +143,45 @@ async function createPgStorage(config: PgStorageConfig): Promise<StorageResult> 
  * Uses a separate LibSQL file to avoid bloating the main storage DB with embedding data.
  * For PG backends, reuses the same connection (PG handles the extra tables fine).
  */
-export async function createVectorStore(
+export interface OwnedVectorStore {
+  vector: MastraVector;
+  close?: () => Promise<void>;
+}
+
+export async function createOwnedVectorStore(
   config: StorageConfig,
   effectiveBackend: 'libsql' | 'pg' = config.backend,
-): Promise<MastraVector | undefined> {
+): Promise<OwnedVectorStore | undefined> {
   if (effectiveBackend === 'pg') {
     // PG can handle vector tables in the same database
     const pgConfig = config as PgStorageConfig;
     if (!pgConfig.connectionString && !pgConfig.host) return undefined;
 
     const { PgVector } = await import('@mastra/pg');
-    return new PgVector({
-      id: 'mastra-code-vectors',
-      connectionString:
-        pgConfig.connectionString ??
-        `postgresql://${pgConfig.user}:${pgConfig.password}@${pgConfig.host}:${pgConfig.port ?? 5432}/${pgConfig.database}`,
-    });
+    return {
+      vector: new PgVector({
+        id: 'mastra-code-vectors',
+        connectionString:
+          pgConfig.connectionString ??
+          `postgresql://${pgConfig.user}:${pgConfig.password}@${pgConfig.host}:${pgConfig.port ?? 5432}/${pgConfig.database}`,
+      }),
+    };
   }
 
   // LibSQL: separate file for vectors. Per-tenant configs supply an explicit
   // vectorUrl so each tenant's recall vectors are isolated; otherwise use the
   // shared default file.
   const libsqlConfig = config as { vectorUrl?: string; vectorAuthToken?: string };
-  return buildLibSQLVector({
+  const vector = buildLibSQLVector({
     url: libsqlConfig.vectorUrl ?? `file:${getVectorDatabasePath()}`,
     authToken: libsqlConfig.vectorAuthToken,
   });
+  return { vector, close: () => vector.close() };
+}
+
+export async function createVectorStore(
+  config: StorageConfig,
+  effectiveBackend: 'libsql' | 'pg' = config.backend,
+): Promise<MastraVector | undefined> {
+  return (await createOwnedVectorStore(config, effectiveBackend))?.vector;
 }

--- a/mastracode/sdk/src/utils/storage-factory.ts
+++ b/mastracode/sdk/src/utils/storage-factory.ts
@@ -158,14 +158,13 @@ export async function createOwnedVectorStore(
     if (!pgConfig.connectionString && !pgConfig.host) return undefined;
 
     const { PgVector } = await import('@mastra/pg');
-    return {
-      vector: new PgVector({
-        id: 'mastra-code-vectors',
-        connectionString:
-          pgConfig.connectionString ??
-          `postgresql://${pgConfig.user}:${pgConfig.password}@${pgConfig.host}:${pgConfig.port ?? 5432}/${pgConfig.database}`,
-      }),
-    };
+    const vector = new PgVector({
+      id: 'mastra-code-vectors',
+      connectionString:
+        pgConfig.connectionString ??
+        `postgresql://${pgConfig.user}:${pgConfig.password}@${pgConfig.host}:${pgConfig.port ?? 5432}/${pgConfig.database}`,
+    });
+    return { vector, close: () => vector.disconnect() };
   }
 
   // LibSQL: separate file for vectors. Per-tenant configs supply an explicit

--- a/mastracode/sdk/src/utils/storage-maintenance.ts
+++ b/mastracode/sdk/src/utils/storage-maintenance.ts
@@ -286,13 +286,24 @@ export function createStorageMaintenance(opts: {
   closeVector?: () => Promise<void>;
 }): StorageMaintenance {
   const { storage, backend, retention, localDbFiles, closeVector } = opts;
+  let closePromise: Promise<void> | undefined;
   return {
     backend,
     retention,
     prune: options => storage.prune(options),
-    closeStorage: async () => {
-      await storage.close?.();
-      await closeVector?.();
+    closeStorage: () => {
+      closePromise ??= (async () => {
+        const results = await Promise.allSettled([
+          Promise.resolve().then(() => storage.close?.()),
+          Promise.resolve().then(() => closeVector?.()),
+        ]);
+        const errors = results
+          .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+          .map(result => result.reason);
+        if (errors.length === 1) throw errors[0];
+        if (errors.length > 1) throw new AggregateError(errors, 'Failed to close Mastra Code storage');
+      })();
+      return closePromise;
     },
     ...(backend === 'libsql' && localDbFiles.length > 0
       ? {

--- a/mastracode/tui/e2e/terminal-backend-vitest-shared.ts
+++ b/mastracode/tui/e2e/terminal-backend-vitest-shared.ts
@@ -17,6 +17,10 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const mastracodeDir = resolve(scriptDir, '../..');
 const fixturesDir = join(scriptDir, 'fixtures');
 const tmpRootDir = join(mastracodeDir, '.tmp-mc-e2e-vitest');
+// The in-process runner shares event infrastructure across scenarios. Keep each
+// DELETE-journal database alive until the shard finishes so stale handles never
+// observe a removed database while the next scenario starts.
+const completedRunRoots = new Set<string>();
 const defaultScenarioNames = [
   'startup',
   'automated-chat',
@@ -247,18 +251,19 @@ async function runScenarioInProcess(scenario: McE2eScenario): Promise<void> {
 
   const runRoot = join(tmpRootDir, `${Date.now()}-${process.pid}`, scenario.name);
   const { aimock, config } = await prepareTerminalRun(scenario, runRoot);
-  let status = 1;
+  let passed = false;
   try {
-    status = await runTerminalBackend(config);
+    const status = await runTerminalBackend(config);
     if (status !== 0) throw new Error(`${scenario.name} exited with status ${status}`);
     if (aimock) {
       const requestCount = aimock.requestCount();
       if (requestCount === 0) throw new Error(`${scenario.name} expected at least one AIMock request but saw none`);
       scenario.verifyAimockRequests?.(aimock.requests());
     }
+    passed = true;
   } finally {
     await aimock?.stop();
-    if (status === 0) rmSync(runRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    if (passed) completedRunRoots.add(runRoot);
   }
 }
 
@@ -268,6 +273,10 @@ export function defineTerminalBackendVitestTests(options: { shardIndex?: number;
   const scenarioNames = selectScenarioNames(shardIndex, shardTotal);
 
   afterAll(() => {
+    for (const runRoot of completedRunRoots) {
+      rmSync(runRoot, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    }
+    completedRunRoots.clear();
     try {
       if (readdirSync(tmpRootDir).length === 0) rmdirSync(tmpRootDir);
     } catch {

--- a/mastracode/tui/e2e/terminal-backend-vitest-shared.ts
+++ b/mastracode/tui/e2e/terminal-backend-vitest-shared.ts
@@ -262,8 +262,8 @@ async function runScenarioInProcess(scenario: McE2eScenario): Promise<void> {
     }
     passed = true;
   } finally {
-    await aimock?.stop();
     if (passed) completedRunRoots.add(runRoot);
+    await aimock?.stop();
   }
 }
 

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -407,6 +407,7 @@ async function startMastraCodeApp(
         result.mcpManager?.disconnect(),
         result.controller.getMastra()?.stopWorkers(),
         result.controller.stopIntervals(),
+        result.githubSignals?.stopAllPolling(),
         closeSignalsPubSub?.(),
       ]);
       await result.storageMaintenance.closeStorage?.();

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -401,6 +401,7 @@ async function startMastraCodeApp(
 
   return {
     async stop() {
+      result.session.thread.detachFromCurrent();
       tui.stop();
       const closeSignalsPubSub = (result.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
       await Promise.allSettled([
@@ -410,7 +411,6 @@ async function startMastraCodeApp(
         result.githubSignals?.stopAllPolling(),
         closeSignalsPubSub?.(),
       ]);
-      await result.storageMaintenance.closeStorage?.();
     },
   };
 }

--- a/mastracode/tui/e2e/terminal-backend.ts
+++ b/mastracode/tui/e2e/terminal-backend.ts
@@ -409,6 +409,7 @@ async function startMastraCodeApp(
         result.controller.stopIntervals(),
         closeSignalsPubSub?.(),
       ]);
+      await result.storageMaintenance.closeStorage?.();
     },
   };
 }

--- a/mastracode/tui/e2e/tui/index.ts
+++ b/mastracode/tui/e2e/tui/index.ts
@@ -123,6 +123,7 @@ import { stateCommandsScenario } from './state-commands.js';
 import { stateSignalBrowserProcessorScenario } from './state-signal-browser-processor.js';
 import { stateSignalReloadScenario } from './state-signal-reload.js';
 import { stateSignalRenderingScenario } from './state-signal-rendering.js';
+import { storageDeleteModeScenario } from './storage-delete-mode.js';
 import { storageFallbackHistoryReloadScenario } from './storage-fallback-history-reload.js';
 import { storageSettingsScenario } from './storage-settings.js';
 import { storageStartupPgFallbackScenario } from './storage-startup-pg-fallback.js';
@@ -278,6 +279,7 @@ export const scenarios: Record<ScenarioName, McE2eScenario> = {
   'shell-passthrough-nonpersistent': shellPassthroughNonpersistentScenario,
   'skills-command-activation': skillsCommandActivationScenario,
   'skills-symlink-dedupe': skillsSymlinkDedupeScenario,
+  'storage-delete-mode': storageDeleteModeScenario,
   'storage-fallback-history-reload': storageFallbackHistoryReloadScenario,
   'storage-settings': storageSettingsScenario,
   'storage-startup-pg-fallback': storageStartupPgFallbackScenario,

--- a/mastracode/tui/e2e/tui/storage-delete-mode.ts
+++ b/mastracode/tui/e2e/tui/storage-delete-mode.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { McE2eScenario } from './types.js';
@@ -32,11 +32,22 @@ export const storageDeleteModeScenario: McE2eScenario = {
     const { DatabaseSync } = await import('node:sqlite');
     for (const file of [dbPath, vectorPath]) {
       const database = new DatabaseSync(file);
-      database.exec('PRAGMA journal_mode=WAL; CREATE TABLE seed (id INTEGER PRIMARY KEY);');
-      // Preserve the WAL header to model a database left by an older Mastra Code
-      // process. The product path under test owns the safe transition to DELETE.
-      database.close();
-      if (readJournalHeader(file) !== 'wal') throw new Error(`Failed to seed WAL database: ${file}`);
+      let wal: Buffer;
+      let shm: Buffer;
+      try {
+        database.exec('PRAGMA journal_mode=WAL; CREATE TABLE seed (id INTEGER PRIMARY KEY);');
+        wal = readFileSync(`${file}-wal`);
+        shm = readFileSync(`${file}-shm`);
+      } finally {
+        database.close();
+      }
+      // Restore the valid sidecars removed by the clean seed shutdown to model
+      // the files an older WAL-mode process can leave behind.
+      writeFileSync(`${file}-wal`, wal);
+      writeFileSync(`${file}-shm`, shm);
+      if (readJournalHeader(file) !== 'wal' || !existsSync(`${file}-wal`) || !existsSync(`${file}-shm`)) {
+        throw new Error(`Failed to seed WAL database with sidecars: ${file}`);
+      }
     }
   },
   inProcessApp: ({ appDataDir, dbPath, startMastraCodeApp, terminal }) => {

--- a/mastracode/tui/e2e/tui/storage-delete-mode.ts
+++ b/mastracode/tui/e2e/tui/storage-delete-mode.ts
@@ -1,17 +1,20 @@
-import { readFileSync, statSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import type { McE2eScenario } from './types.js';
+
+function readJournalHeader(file: string): 'delete' | 'wal' | 'unknown' {
+  if (statSync(file).size < 100) return 'unknown';
+  const header = readFileSync(file).subarray(18, 20);
+  return header[0] === 1 && header[1] === 1 ? 'delete' : header[0] === 2 && header[1] === 2 ? 'wal' : 'unknown';
+}
 
 async function waitForDeleteHeader(file: string): Promise<'delete' | 'wal' | 'unknown'> {
   let mode: 'delete' | 'wal' | 'unknown' = 'unknown';
   for (let attempt = 0; attempt < 100; attempt++) {
     try {
-      if (statSync(file).size >= 100) {
-        const header = readFileSync(file).subarray(18, 20);
-        mode = header[0] === 1 && header[1] === 1 ? 'delete' : header[0] === 2 && header[1] === 2 ? 'wal' : 'unknown';
-        if (mode === 'delete') return mode;
-      }
+      mode = readJournalHeader(file);
+      if (mode === 'delete') return mode;
     } catch {
       // The database may still be initializing during application setup.
     }
@@ -24,12 +27,20 @@ export const storageDeleteModeScenario: McE2eScenario = {
   name: 'storage-delete-mode',
   description: 'Starts real Mastra Code storage and verifies local main and vector databases use rollback journals.',
   testName: 'uses DELETE journal mode for local main and vector databases',
-  async prepare({ appDataDir }) {
+  async prepare({ appDataDir, dbPath }) {
     const vectorPath = join(appDataDir, 'mastra-vectors.db');
-    const { createStorage } = await import('@mastra/code-sdk/utils/storage-factory');
-    const seeded = await createStorage({ backend: 'libsql', url: `file:${vectorPath}`, isRemote: false });
-    await seeded.storage.init();
-    await seeded.storage.close?.();
+    const { LibSQLStore } = await import('@mastra/libsql');
+    for (const [id, file] of [
+      ['seed-main', dbPath],
+      ['seed-vector', vectorPath],
+    ] as const) {
+      const store = new LibSQLStore({ id, url: `file:${file}` });
+      await store.init();
+      // Preserve the WAL header to model a database left by an older Mastra Code
+      // process. The product path under test owns the safe transition to DELETE.
+      (store as unknown as { client: { close: () => void } }).client.close();
+      if (readJournalHeader(file) !== 'wal') throw new Error(`Failed to seed WAL database: ${file}`);
+    }
   },
   inProcessApp: ({ appDataDir, dbPath, startMastraCodeApp, terminal }) => {
     const vectorPath = join(appDataDir, 'mastra-vectors.db');
@@ -47,6 +58,8 @@ export const storageDeleteModeScenario: McE2eScenario = {
         const vectorMode = await waitForDeleteHeader(vectorPath);
         terminal.write(`STORAGE_JOURNAL_MAIN=${mainMode}\r\n`);
         terminal.write(`STORAGE_JOURNAL_VECTOR=${vectorMode}\r\n`);
+        terminal.write(`STORAGE_WAL_MAIN=${existsSync(`${dbPath}-wal`) || existsSync(`${dbPath}-shm`)}\r\n`);
+        terminal.write(`STORAGE_WAL_VECTOR=${existsSync(`${vectorPath}-wal`) || existsSync(`${vectorPath}-shm`)}\r\n`);
       },
     });
   },
@@ -54,5 +67,7 @@ export const storageDeleteModeScenario: McE2eScenario = {
     runtime.startLiveOutput(terminal);
     await runtime.waitForOutputText(/STORAGE_JOURNAL_MAIN=delete/i, terminal);
     await runtime.waitForOutputText(/STORAGE_JOURNAL_VECTOR=delete/i, terminal);
+    await runtime.waitForOutputText(/STORAGE_WAL_MAIN=false/i, terminal);
+    await runtime.waitForOutputText(/STORAGE_WAL_VECTOR=false/i, terminal);
   },
 };

--- a/mastracode/tui/e2e/tui/storage-delete-mode.ts
+++ b/mastracode/tui/e2e/tui/storage-delete-mode.ts
@@ -29,16 +29,13 @@ export const storageDeleteModeScenario: McE2eScenario = {
   testName: 'uses DELETE journal mode for local main and vector databases',
   async prepare({ appDataDir, dbPath }) {
     const vectorPath = join(appDataDir, 'mastra-vectors.db');
-    const { LibSQLStore } = await import('@mastra/libsql');
-    for (const [id, file] of [
-      ['seed-main', dbPath],
-      ['seed-vector', vectorPath],
-    ] as const) {
-      const store = new LibSQLStore({ id, url: `file:${file}` });
-      await store.init();
+    const { DatabaseSync } = await import('node:sqlite');
+    for (const file of [dbPath, vectorPath]) {
+      const database = new DatabaseSync(file);
+      database.exec('PRAGMA journal_mode=WAL; CREATE TABLE seed (id INTEGER PRIMARY KEY);');
       // Preserve the WAL header to model a database left by an older Mastra Code
       // process. The product path under test owns the safe transition to DELETE.
-      (store as unknown as { client: { close: () => void } }).client.close();
+      database.close();
       if (readJournalHeader(file) !== 'wal') throw new Error(`Failed to seed WAL database: ${file}`);
     }
   },

--- a/mastracode/tui/e2e/tui/storage-delete-mode.ts
+++ b/mastracode/tui/e2e/tui/storage-delete-mode.ts
@@ -1,0 +1,58 @@
+import { readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { McE2eScenario } from './types.js';
+
+async function waitForDeleteHeader(file: string): Promise<'delete' | 'wal' | 'unknown'> {
+  let mode: 'delete' | 'wal' | 'unknown' = 'unknown';
+  for (let attempt = 0; attempt < 100; attempt++) {
+    try {
+      if (statSync(file).size >= 100) {
+        const header = readFileSync(file).subarray(18, 20);
+        mode = header[0] === 1 && header[1] === 1 ? 'delete' : header[0] === 2 && header[1] === 2 ? 'wal' : 'unknown';
+        if (mode === 'delete') return mode;
+      }
+    } catch {
+      // The database may still be initializing during application setup.
+    }
+    await new Promise(resolve => setTimeout(resolve, 20));
+  }
+  return mode;
+}
+
+export const storageDeleteModeScenario: McE2eScenario = {
+  name: 'storage-delete-mode',
+  description: 'Starts real Mastra Code storage and verifies local main and vector databases use rollback journals.',
+  testName: 'uses DELETE journal mode for local main and vector databases',
+  async prepare({ appDataDir }) {
+    const vectorPath = join(appDataDir, 'mastra-vectors.db');
+    const { createStorage } = await import('@mastra/code-sdk/utils/storage-factory');
+    const seeded = await createStorage({ backend: 'libsql', url: `file:${vectorPath}`, isRemote: false });
+    await seeded.storage.init();
+    await seeded.storage.close?.();
+  },
+  inProcessApp: ({ appDataDir, dbPath, startMastraCodeApp, terminal }) => {
+    const vectorPath = join(appDataDir, 'mastra-vectors.db');
+    return startMastraCodeApp({
+      config: {
+        storage: {
+          backend: 'libsql',
+          url: `file:${dbPath}`,
+          vectorUrl: `file:${vectorPath}`,
+          isRemote: false,
+        },
+      },
+      onCreated: async () => {
+        const mainMode = await waitForDeleteHeader(dbPath);
+        const vectorMode = await waitForDeleteHeader(vectorPath);
+        terminal.write(`STORAGE_JOURNAL_MAIN=${mainMode}\r\n`);
+        terminal.write(`STORAGE_JOURNAL_VECTOR=${vectorMode}\r\n`);
+      },
+    });
+  },
+  async run({ terminal, runtime }) {
+    runtime.startLiveOutput(terminal);
+    await runtime.waitForOutputText(/STORAGE_JOURNAL_MAIN=delete/i, terminal);
+    await runtime.waitForOutputText(/STORAGE_JOURNAL_VECTOR=delete/i, terminal);
+  },
+};

--- a/mastracode/tui/e2e/tui/types.ts
+++ b/mastracode/tui/e2e/tui/types.ts
@@ -125,6 +125,7 @@ export type ScenarioName =
   | 'shell-passthrough-nonpersistent'
   | 'skills-command-activation'
   | 'skills-symlink-dedupe'
+  | 'storage-delete-mode'
   | 'storage-fallback-history-reload'
   | 'storage-settings'
   | 'storage-startup-pg-fallback'

--- a/mastracode/tui/src/__tests__/main.test.ts
+++ b/mastracode/tui/src/__tests__/main.test.ts
@@ -40,4 +40,22 @@ describe('Mastra Code TUI cleanup', () => {
     expect(shutdownAnalytics).toHaveBeenCalledOnce();
     expect(releaseLocks).toHaveBeenCalledOnce();
   });
+
+  it('reports both storage and analytics shutdown failures', async () => {
+    const storageError = new Error('close failed');
+    const analyticsError = new Error('analytics failed');
+    const releaseLocks = vi.fn();
+    const cleanup = createTuiCleanup({
+      stopWork: [],
+      closeStorage: vi.fn().mockRejectedValue(storageError),
+      shutdownAnalytics: vi.fn().mockRejectedValue(analyticsError),
+      releaseLocks,
+    });
+
+    const error = await cleanup().catch(error => error);
+
+    expect(error).toBeInstanceOf(AggregateError);
+    expect(error.errors).toEqual([storageError, analyticsError]);
+    expect(releaseLocks).toHaveBeenCalledOnce();
+  });
 });

--- a/mastracode/tui/src/__tests__/main.test.ts
+++ b/mastracode/tui/src/__tests__/main.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createTuiCleanup } from '../main-cleanup.js';
+
+describe('Mastra Code TUI cleanup', () => {
+  it('stops work before closing storage and is single-flight across exit paths', async () => {
+    const events: string[] = [];
+    const stopWork = vi.fn(async () => {
+      events.push('stop');
+    });
+    const closeStorage = vi.fn(async () => {
+      events.push('storage');
+    });
+    const shutdownAnalytics = vi.fn(async () => {
+      events.push('analytics');
+    });
+    const releaseLocks = vi.fn(() => {
+      events.push('locks');
+    });
+    const cleanup = createTuiCleanup({ stopWork: [stopWork], closeStorage, shutdownAnalytics, releaseLocks });
+
+    await Promise.all([cleanup(), cleanup(), cleanup()]);
+
+    expect(events).toEqual(['stop', 'storage', 'analytics', 'locks']);
+    expect(closeStorage).toHaveBeenCalledOnce();
+  });
+
+  it('continues teardown while propagating a storage close failure', async () => {
+    const error = new Error('close failed');
+    const shutdownAnalytics = vi.fn();
+    const releaseLocks = vi.fn();
+    const cleanup = createTuiCleanup({
+      stopWork: [vi.fn().mockRejectedValue(new Error('producer failed'))],
+      closeStorage: vi.fn().mockRejectedValue(error),
+      shutdownAnalytics,
+      releaseLocks,
+    });
+
+    await expect(cleanup()).rejects.toBe(error);
+    expect(shutdownAnalytics).toHaveBeenCalledOnce();
+    expect(releaseLocks).toHaveBeenCalledOnce();
+  });
+});

--- a/mastracode/tui/src/main-cleanup.ts
+++ b/mastracode/tui/src/main-cleanup.ts
@@ -7,16 +7,22 @@ export function createTuiCleanup(options: {
   let cleanupPromise: Promise<void> | undefined;
   return () => {
     cleanupPromise ??= (async () => {
+      await Promise.allSettled(options.stopWork.map(stop => Promise.resolve().then(stop)));
+      const errors: unknown[] = [];
       try {
-        await Promise.allSettled(options.stopWork.map(stop => Promise.resolve().then(stop)));
         await options.closeStorage();
-      } finally {
-        try {
-          await options.shutdownAnalytics();
-        } finally {
-          options.releaseLocks();
-        }
+      } catch (error) {
+        errors.push(error);
       }
+      try {
+        await options.shutdownAnalytics();
+      } catch (error) {
+        errors.push(error);
+      } finally {
+        options.releaseLocks();
+      }
+      if (errors.length === 1) throw errors[0];
+      if (errors.length > 1) throw new AggregateError(errors, 'TUI cleanup failed');
     })();
     return cleanupPromise;
   };

--- a/mastracode/tui/src/main-cleanup.ts
+++ b/mastracode/tui/src/main-cleanup.ts
@@ -1,0 +1,23 @@
+export function createTuiCleanup(options: {
+  stopWork: Array<() => Promise<unknown> | unknown>;
+  closeStorage: () => Promise<void> | void;
+  shutdownAnalytics: () => Promise<unknown> | unknown;
+  releaseLocks: () => void;
+}): () => Promise<void> {
+  let cleanupPromise: Promise<void> | undefined;
+  return () => {
+    cleanupPromise ??= (async () => {
+      try {
+        await Promise.allSettled(options.stopWork.map(stop => Promise.resolve().then(stop)));
+        await options.closeStorage();
+      } finally {
+        try {
+          await options.shutdownAnalytics();
+        } finally {
+          options.releaseLocks();
+        }
+      }
+    })();
+    return cleanupPromise;
+  };
+}

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -136,9 +136,7 @@ async function tuiMain(pipedInput?: string | null) {
     githubSignals: result.githubSignals,
     ...(pipedInput ? { initialMessage: `The following was piped via stdin:\n\n${pipedInput}` } : {}),
   });
-  tui.run().catch(error => {
-    handleFatalError(error);
-  });
+  const tuiRun = tui.run();
 
   if (settings.browser.enabled) {
     void loadBrowser()
@@ -149,6 +147,9 @@ async function tuiMain(pipedInput?: string | null) {
       })
       .catch(() => {});
   }
+
+  await tuiRun;
+  await asyncCleanup();
 }
 
 export const asyncCleanup = createTuiCleanup({

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -24,6 +24,7 @@ let mcpManager: Awaited<ReturnType<typeof createMastraCode>>['mcpManager'];
 let hookManager: Awaited<ReturnType<typeof createMastraCode>>['hookManager'];
 let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 let signalsPubSub: Awaited<ReturnType<typeof createMastraCode>>['signalsPubSub'];
+let githubSignals: Awaited<ReturnType<typeof createMastraCode>>['githubSignals'];
 let storageMaintenance: Awaited<ReturnType<typeof createMastraCode>>['storageMaintenance'];
 let analytics: ReturnType<typeof createMastraCodeAnalytics> | undefined;
 let tui: MastraTUI | undefined;
@@ -73,6 +74,7 @@ async function tuiMain(pipedInput?: string | null) {
   hookManager = result.hookManager;
   authStorage = result.authStorage;
   signalsPubSub = result.signalsPubSub;
+  githubSignals = result.githubSignals;
   storageMaintenance = result.storageMaintenance;
 
   if (result.storageWarning) {
@@ -157,6 +159,7 @@ export const asyncCleanup = createTuiCleanup({
     () => mcpManager?.disconnect(),
     () => controller?.getMastra()?.stopWorkers(),
     () => controller?.stopIntervals(),
+    () => githubSignals?.stopAllPolling(),
     () => (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
   ],
   closeStorage: () => storageMaintenance?.closeStorage?.(),

--- a/mastracode/tui/src/main.ts
+++ b/mastracode/tui/src/main.ts
@@ -13,6 +13,7 @@ import { formatScaffoldSuccess, scaffoldPlugin } from '@mastra/code-sdk/plugins/
 import { setupDebugLogging } from '@mastra/code-sdk/utils/debug-log';
 import { drainPipedStdin, reopenStdinFromTTY } from '@mastra/code-sdk/utils/stdin-pipe';
 import { releaseAllThreadLocks } from '@mastra/code-sdk/utils/thread-lock';
+import { createTuiCleanup } from './main-cleanup.js';
 import { detectTerminalTheme } from './tui/detect-theme.js';
 import { MastraTUI } from './tui/index.js';
 import { applyThemeMode, restoreTerminalForeground } from './tui/theme.js';
@@ -23,6 +24,7 @@ let mcpManager: Awaited<ReturnType<typeof createMastraCode>>['mcpManager'];
 let hookManager: Awaited<ReturnType<typeof createMastraCode>>['hookManager'];
 let authStorage: Awaited<ReturnType<typeof createMastraCode>>['authStorage'];
 let signalsPubSub: Awaited<ReturnType<typeof createMastraCode>>['signalsPubSub'];
+let storageMaintenance: Awaited<ReturnType<typeof createMastraCode>>['storageMaintenance'];
 let analytics: ReturnType<typeof createMastraCodeAnalytics> | undefined;
 let tui: MastraTUI | undefined;
 
@@ -71,6 +73,7 @@ async function tuiMain(pipedInput?: string | null) {
   hookManager = result.hookManager;
   authStorage = result.authStorage;
   signalsPubSub = result.signalsPubSub;
+  storageMaintenance = result.storageMaintenance;
 
   if (result.storageWarning) {
     console.info(`⚠ ${result.storageWarning}`);
@@ -148,20 +151,22 @@ async function tuiMain(pipedInput?: string | null) {
   }
 }
 
-const asyncCleanup = async () => {
-  releaseAllThreadLocks();
-  const closeSignalsPubSub = (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close;
-  await Promise.allSettled([
-    mcpManager?.disconnect(),
-    controller?.getMastra()?.stopWorkers(),
-    controller?.stopIntervals(),
-    closeSignalsPubSub?.(),
-    analytics?.shutdown(),
-  ]);
-};
+export const asyncCleanup = createTuiCleanup({
+  stopWork: [
+    () => mcpManager?.disconnect(),
+    () => controller?.getMastra()?.stopWorkers(),
+    () => controller?.stopIntervals(),
+    () => (signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
+  ],
+  closeStorage: () => storageMaintenance?.closeStorage?.(),
+  shutdownAnalytics: () => analytics?.shutdown(),
+  releaseLocks: releaseAllThreadLocks,
+});
 
 process.on('beforeExit', () => {
-  void asyncCleanup();
+  void asyncCleanup().catch(error => {
+    process.stderr.write(`Storage cleanup failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  });
 });
 process.on('exit', () => {
   // Ensure terminal protocols (kitty keyboard, modifyOtherKeys, bracketed paste,
@@ -206,7 +211,13 @@ const handleTermSignal = () => {
   } catch {
     // ignored — exit handler has failsafe reset
   }
-  void asyncCleanup().finally(() => process.exit(0));
+  void asyncCleanup().then(
+    () => process.exit(0),
+    error => {
+      process.stderr.write(`Storage cleanup failed: ${error instanceof Error ? error.message : String(error)}\n`);
+      process.exit(1);
+    },
+  );
 };
 process.on('SIGINT', handleTermSignal);
 process.on('SIGTERM', handleTermSignal);
@@ -250,7 +261,7 @@ function readFlag(args: string[], flag: string): string | undefined {
   return value;
 }
 
-function handleFatalError(error: unknown): never {
+function handleFatalError(error: unknown): void {
   // Always write to real stderr, even if console.error was overridden
   const write = (msg: string) => process.stderr.write(msg + '\n');
 
@@ -264,7 +275,12 @@ function handleFatalError(error: unknown): never {
         `\n\nTo switch back to LibSQL:` +
         `\n  Set MASTRA_STORAGE_BACKEND=libsql or change the backend in /settings\n`,
     );
-    process.exit(1);
+    void asyncCleanup()
+      .catch(cleanupError => {
+        write(`Storage cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+      })
+      .finally(() => process.exit(1));
+    return;
   }
 
   const msg = `Fatal error: ${error instanceof Error ? error.message : String(error)}`;
@@ -277,7 +293,11 @@ function handleFatalError(error: unknown): never {
   if (error instanceof Error && error.stack) {
     write(error.stack);
   }
-  process.exit(1);
+  void asyncCleanup()
+    .catch(cleanupError => {
+      write(`Storage cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`);
+    })
+    .finally(() => process.exit(1));
 }
 
 async function main() {

--- a/stores/libsql/src/storage/__fixtures__/delete-mode-worker.mjs
+++ b/stores/libsql/src/storage/__fixtures__/delete-mode-worker.mjs
@@ -1,0 +1,37 @@
+import { createClient } from '@libsql/client';
+
+const [dbPath, workerId, writeCountArg] = process.argv.slice(2);
+const writeCount = Number(writeCountArg);
+const client = createClient({ url: `file:${dbPath}`, timeout: 5000 });
+
+async function executeWithRetry(statement) {
+  let delay = 20;
+  for (let attempt = 1; attempt <= 10; attempt++) {
+    try {
+      return await client.execute(statement);
+    } catch (error) {
+      const isBusy = error?.code === 'SQLITE_BUSY' || error?.code === 'SQLITE_LOCKED';
+      if (!isBusy || attempt === 10) {
+        throw error;
+      }
+      await new Promise(resolve => setTimeout(resolve, delay));
+      delay *= 2;
+    }
+  }
+}
+
+try {
+  const mode = await executeWithRetry('PRAGMA journal_mode=DELETE;');
+  if (Object.values(mode.rows[0] ?? {})[0] !== 'delete') {
+    throw new Error(`SQLite did not enter DELETE mode: ${JSON.stringify(mode.rows)}`);
+  }
+
+  for (let index = 0; index < writeCount; index++) {
+    await executeWithRetry({
+      sql: 'INSERT INTO stress_writes (id, worker_id, write_index) VALUES (?, ?, ?)',
+      args: [`${workerId}-${index}`, workerId, index],
+    });
+  }
+} finally {
+  client.close();
+}

--- a/stores/libsql/src/storage/__fixtures__/delete-mode-worker.mjs
+++ b/stores/libsql/src/storage/__fixtures__/delete-mode-worker.mjs
@@ -2,6 +2,9 @@ import { createClient } from '@libsql/client';
 
 const [dbPath, workerId, writeCountArg] = process.argv.slice(2);
 const writeCount = Number(writeCountArg);
+if (!dbPath || !workerId || !Number.isSafeInteger(writeCount) || writeCount < 1) {
+  throw new Error('Expected a database path, worker ID, and positive integer write count');
+}
 const client = createClient({ url: `file:${dbPath}`, timeout: 5000 });
 
 async function executeWithRetry(statement) {

--- a/stores/libsql/src/storage/close.test.ts
+++ b/stores/libsql/src/storage/close.test.ts
@@ -45,6 +45,36 @@ describe('LibSQLStore.close()', () => {
     expect(client.closed).toBe(true);
   });
 
+  it('skips WAL cleanup when DELETE mode was selected', async () => {
+    const dbPath = path.join(tmpDir, 'delete.db');
+    const store = new LibSQLStore({ id: 'close-delete', url: `file:${dbPath}`, journalMode: 'delete' });
+    await store.init();
+
+    const client = getClient(store);
+    const executeSpy = vi.spyOn(client, 'execute');
+    const closeSpy = vi.spyOn(client, 'close');
+
+    await store.close();
+
+    const executedSql = executedSqlFrom(executeSpy);
+    expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
+    expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces overlapping close calls', async () => {
+    const dbPath = path.join(tmpDir, 'overlapping.db');
+    const store = new LibSQLStore({ id: 'close-overlapping', url: `file:${dbPath}` });
+    await store.init();
+
+    const client = getClient(store);
+    const closeSpy = vi.spyOn(client, 'close');
+
+    await Promise.all([store.close(), store.close(), store.close()]);
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('is idempotent — a second close() is a no-op', async () => {
     const dbPath = path.join(tmpDir, 'mastra.db');
     const store = new LibSQLStore({ id: 'close-idempotent', url: `file:${dbPath}` });
@@ -97,6 +127,22 @@ describe('LibSQLStore.close()', () => {
     expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
     expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
     expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the client while propagating a readiness failure', async () => {
+    const dbPath = path.join(tmpDir, 'readiness-fail.db');
+    const store = new LibSQLStore({ id: 'close-readiness-fail', url: `file:${dbPath}` });
+    await store.init();
+
+    const client = getClient(store);
+    const closeSpy = vi.spyOn(client, 'close');
+    (store as unknown as { pragmasReady: Promise<void> }).pragmasReady = Promise.reject(
+      new Error('journal transition failed'),
+    );
+
+    await expect(store.close()).rejects.toThrow('journal transition failed');
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    expect(client.closed).toBe(true);
   });
 
   it('still closes the client and warns when WAL checkpoint fails', async () => {

--- a/stores/libsql/src/storage/delete-mode-concurrency.test.ts
+++ b/stores/libsql/src/storage/delete-mode-concurrency.test.ts
@@ -1,0 +1,72 @@
+import { spawn } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { createClient } from '@libsql/client';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const workerPath = fileURLToPath(new URL('./__fixtures__/delete-mode-worker.mjs', import.meta.url));
+
+function runWorker(dbPath: string, workerId: number, writeCount: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [workerPath, dbPath, String(workerId), String(writeCount)], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stderr = '';
+    child.stderr.setEncoding('utf8');
+    child.stderr.on('data', chunk => {
+      stderr += chunk;
+    });
+    child.on('error', reject);
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`DELETE-mode worker ${workerId} exited with ${code}: ${stderr}`));
+      }
+    });
+  });
+}
+
+describe('local DELETE journal concurrency', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves all writes across processes without WAL sidecars', async () => {
+    const workerCount = 6;
+    const writesPerWorker = 30;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-delete-concurrency-'));
+    tempDirs.push(tempDir);
+    const dbPath = path.join(tempDir, 'stress.db');
+
+    const setupClient = createClient({ url: `file:${dbPath}`, timeout: 5000 });
+    await setupClient.execute('PRAGMA journal_mode=DELETE;');
+    await setupClient.execute(
+      'CREATE TABLE stress_writes (id TEXT PRIMARY KEY, worker_id INTEGER NOT NULL, write_index INTEGER NOT NULL);',
+    );
+    setupClient.close();
+
+    await Promise.all(
+      Array.from({ length: workerCount }, (_, workerId) => runWorker(dbPath, workerId, writesPerWorker)),
+    );
+
+    const verifyClient = createClient({ url: `file:${dbPath}` });
+    const count = await verifyClient.execute('SELECT COUNT(*) AS count FROM stress_writes;');
+    const integrity = await verifyClient.execute('PRAGMA quick_check;');
+    const mode = await verifyClient.execute('PRAGMA journal_mode;');
+    verifyClient.close();
+
+    expect(count.rows[0]?.count).toBe(workerCount * writesPerWorker);
+    expect(Object.values(integrity.rows[0] ?? {})[0]).toBe('ok');
+    expect(Object.values(mode.rows[0] ?? {})[0]).toBe('delete');
+    expect(fs.existsSync(`${dbPath}-wal`)).toBe(false);
+    expect(fs.existsSync(`${dbPath}-shm`)).toBe(false);
+  });
+});

--- a/stores/libsql/src/storage/domains/workflows/index.test.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.test.ts
@@ -1,22 +1,34 @@
 import { createClient } from '@libsql/client';
 import { TABLE_WORKFLOW_SNAPSHOT, TABLE_SCHEMAS } from '@mastra/core/storage';
 import type { WorkflowRunState } from '@mastra/core/workflows';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { LibSQLDB } from '../../db';
 import { WorkflowsLibSQL } from './index';
 
 describe('WorkflowsLibSQL — snapshot serialization', () => {
   let workflows: WorkflowsLibSQL;
+  let client: ReturnType<typeof createClient>;
 
   beforeEach(async () => {
-    const client = createClient({ url: ':memory:' });
+    client = createClient({ url: ':memory:' });
     const db = new LibSQLDB({ client, maxRetries: 1, initialBackoffMs: 10 });
     await db.createTable({
       tableName: TABLE_WORKFLOW_SNAPSHOT,
       schema: TABLE_SCHEMAS[TABLE_WORKFLOW_SNAPSHOT],
     });
     workflows = new WorkflowsLibSQL({ client });
+  });
+
+  it('does not mutate connection-wide PRAGMA policy', () => {
+    const executeSpy = vi.spyOn(client, 'execute');
+
+    new WorkflowsLibSQL({ client });
+
+    const sql = (executeSpy.mock.calls as unknown as Array<[string | { sql: string }]>).map(([statement]) =>
+      typeof statement === 'string' ? statement : statement.sql,
+    );
+    expect(sql.some(statement => /^PRAGMA\b/i.test(statement.trim()))).toBe(false);
   });
 
   // Regression test: the default workflow executor builds the success snapshot

--- a/stores/libsql/src/storage/domains/workflows/index.ts
+++ b/stores/libsql/src/storage/domains/workflows/index.ts
@@ -51,12 +51,6 @@ export class WorkflowsLibSQL extends WorkflowsStorage {
       maxRetries,
       initialBackoffMs,
     });
-
-    // Set PRAGMA settings to help with database locks
-    // Note: This is async but we can't await in constructor, so we'll handle it as a fire-and-forget
-    this.setupPragmaSettings().catch(err =>
-      this.logger.warn('LibSQL Workflows: Failed to setup PRAGMA settings.', err),
-    );
   }
 
   supportsConcurrentUpdates(): boolean {
@@ -105,32 +99,6 @@ export class WorkflowsLibSQL extends WorkflowsStorage {
       order: ['workflowSnapshot'],
     });
     return runPrune({ db: this.#db, domain: 'workflows', targets, options, logger: this.logger });
-  }
-
-  private async setupPragmaSettings() {
-    try {
-      // Set busy timeout to wait longer before returning busy errors
-      await this.#client.execute('PRAGMA busy_timeout = 10000;');
-      this.logger.debug('LibSQL Workflows: PRAGMA busy_timeout=10000 set.');
-
-      // Enable WAL mode for better concurrency (if supported)
-      try {
-        await this.#client.execute('PRAGMA journal_mode = WAL;');
-        this.logger.debug('LibSQL Workflows: PRAGMA journal_mode=WAL set.');
-      } catch {
-        this.logger.debug('LibSQL Workflows: WAL mode not supported, using default journal mode.');
-      }
-
-      // Set synchronous mode for better durability vs performance trade-off
-      try {
-        await this.#client.execute('PRAGMA synchronous = NORMAL;');
-        this.logger.debug('LibSQL Workflows: PRAGMA synchronous=NORMAL set.');
-      } catch {
-        this.logger.debug('LibSQL Workflows: Failed to set synchronous mode.');
-      }
-    } catch (err) {
-      this.logger.warn('LibSQL Workflows: Failed to set PRAGMA settings.', err);
-    }
   }
 
   async updateWorkflowResults({

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -3,6 +3,7 @@ import type { Client } from '@libsql/client';
 import type { RetentionConfig, StorageDomains } from '@mastra/core/storage';
 import { MastraCompositeStore } from '@mastra/core/storage';
 
+import type { LibSQLLocalJournalMode } from '../types';
 import { DEFAULT_CONNECTION_TIMEOUT_MS } from './db';
 import { AgentsLibSQL } from './domains/agents';
 import { BackgroundTasksLibSQL } from './domains/background-tasks';
@@ -52,6 +53,7 @@ export {
   WorkflowsLibSQL,
   WorkspacesLibSQL,
 };
+export type { LibSQLLocalJournalMode } from '../types';
 export type { LibSQLDomainConfig } from './db';
 export { LibSQLFactoryStorage, type LibSQLFactoryStorageConfig } from './factory-storage';
 
@@ -103,6 +105,12 @@ export type LibSQLBaseConfig = {
    * @default 5000
    */
   connectionTimeoutMs?: number;
+  /**
+   * SQLite journal mode for local file databases. Remote and in-memory databases
+   * keep their existing behavior.
+   * @default 'wal'
+   */
+  journalMode?: LibSQLLocalJournalMode;
   /**
    * Overrides local SQLite PRAGMA values used for startup/read performance.
    * Only applies to local file and in-memory databases.
@@ -171,7 +179,10 @@ export class LibSQLStore extends MastraCompositeStore {
   private readonly connectionTimeoutMs: number;
   private readonly pragmasReady: Promise<void>;
   private readonly isLocalDb: boolean;
+  private readonly isLocalFileDb: boolean;
+  private readonly journalMode: LibSQLLocalJournalMode;
   private readonly localPragmas: Required<LibSQLLocalPragmaOptions>;
+  private closePromise?: Promise<void>;
 
   stores: StorageDomains;
 
@@ -179,11 +190,15 @@ export class LibSQLStore extends MastraCompositeStore {
     if (!config.id || typeof config.id !== 'string' || config.id.trim() === '') {
       throw new Error('LibSQLStore: id must be provided and cannot be empty.');
     }
+    if (config.journalMode !== undefined && config.journalMode !== 'wal' && config.journalMode !== 'delete') {
+      throw new Error("LibSQLStore: journalMode must be either 'wal' or 'delete'.");
+    }
     super({ id: config.id, name: `LibSQLStore`, disableInit: config.disableInit, retention: config.retention });
 
     this.maxRetries = config.maxRetries ?? 5;
     this.initialBackoffMs = config.initialBackoffMs ?? 100;
     this.connectionTimeoutMs = config.connectionTimeoutMs ?? DEFAULT_CONNECTION_TIMEOUT_MS;
+    this.journalMode = config.journalMode ?? 'wal';
     this.localPragmas = {
       cacheSize: config.localPragmas?.cacheSize ?? DEFAULT_LOCAL_CACHE_SIZE,
       mmapSize: config.localPragmas?.mmapSize ?? DEFAULT_LOCAL_MMAP_SIZE,
@@ -196,6 +211,7 @@ export class LibSQLStore extends MastraCompositeStore {
       }
 
       this.isLocalDb = config.url.startsWith('file:') || config.url.includes(':memory:');
+      this.isLocalFileDb = config.url.startsWith('file:') && !config.url.includes(':memory:');
 
       this.client = createClient({
         url: config.url,
@@ -208,6 +224,7 @@ export class LibSQLStore extends MastraCompositeStore {
     } else {
       this.client = config.client;
       this.isLocalDb = false;
+      this.isLocalFileDb = false;
       this.pragmasReady = Promise.resolve();
     }
 
@@ -267,8 +284,27 @@ export class LibSQLStore extends MastraCompositeStore {
   }
 
   private async applyLocalPragmas(): Promise<void> {
+    const journalMode = this.journalMode.toUpperCase();
+    try {
+      const result = await this.client.execute(`PRAGMA journal_mode=${journalMode};`);
+
+      if (this.isLocalFileDb && this.journalMode === 'delete') {
+        const appliedMode = Object.values(result.rows[0] ?? {})[0];
+        if (typeof appliedMode !== 'string' || appliedMode.toLowerCase() !== 'delete') {
+          throw new Error(
+            `LibSQLStore: Failed to set PRAGMA journal_mode=DELETE; SQLite reported ${String(appliedMode)}.`,
+          );
+        }
+      }
+      this.logger.debug(`LibSQLStore: PRAGMA journal_mode=${journalMode} set.`);
+    } catch (err) {
+      if (this.isLocalFileDb && this.journalMode === 'delete') {
+        throw err;
+      }
+      this.logger.warn(`LibSQLStore: Failed to set PRAGMA journal_mode=${journalMode}.`, err);
+    }
+
     const pragmas = [
-      ['journal_mode=WAL', 'PRAGMA journal_mode=WAL;'],
       // Keep in sync with the connection-level `timeout` passed to createClient
       // so a custom connectionTimeoutMs isn't clobbered back to a hardcoded value.
       [`busy_timeout=${this.connectionTimeoutMs}`, `PRAGMA busy_timeout=${this.connectionTimeoutMs};`],
@@ -341,27 +377,39 @@ export class LibSQLStore extends MastraCompositeStore {
   /**
    * Closes the underlying libsql client, releasing all OS file handles.
    *
-   * For local file databases, first runs PRAGMA wal_checkpoint(TRUNCATE) and
-   * switches back to journal_mode=DELETE so that Windows releases the -wal
-   * and -shm sidecar files promptly. Without this, the handles stay open
-   * until process exit, causing EBUSY errors when callers try to fs.rm the
-   * storage directory after Mastra.shutdown().
+   * Local file databases configured for WAL are checkpointed and switched to
+   * journal_mode=DELETE so that Windows releases the -wal and -shm sidecar
+   * files promptly. Databases already configured for DELETE skip that work.
    *
    * Remote (Turso) databases skip the WAL pragmas and just close the client.
    *
    * Safe to call more than once; subsequent calls are no-ops.
    */
-  async close(): Promise<void> {
+  close(): Promise<void> {
+    if (!this.closePromise) {
+      this.closePromise = this.closeClient();
+    }
+    return this.closePromise;
+  }
+
+  private async closeClient(): Promise<void> {
     if (this.client.closed) {
       return;
     }
 
-    // A store built from an injected client may still point at a local file even
-    // though `isLocalDb` (derived from the url config) is false, so also trust the
-    // client's own protocol to decide whether WAL cleanup is needed.
-    const isLocalFileDb = this.isLocalDb || this.client.protocol === 'file';
+    let readinessError: unknown;
+    try {
+      await this.pragmasReady;
+    } catch (err) {
+      readinessError = err;
+    }
 
-    if (isLocalFileDb) {
+    // A store built from an injected client may still point at a local file even
+    // though its journal mode is unknown, so preserve the WAL cleanup behavior.
+    const needsWalCleanup =
+      (this.isLocalFileDb && this.journalMode === 'wal') || (!this.isLocalDb && this.client.protocol === 'file');
+
+    if (!readinessError && needsWalCleanup) {
       try {
         await this.client.execute('PRAGMA wal_checkpoint(TRUNCATE);');
         await this.client.execute('PRAGMA journal_mode=DELETE;');
@@ -371,6 +419,10 @@ export class LibSQLStore extends MastraCompositeStore {
     }
 
     this.client.close();
+
+    if (readinessError) {
+      throw readinessError;
+    }
   }
 }
 

--- a/stores/libsql/src/storage/index.ts
+++ b/stores/libsql/src/storage/index.ts
@@ -221,6 +221,9 @@ export class LibSQLStore extends MastraCompositeStore {
         ...(this.isLocalDb ? { timeout: this.connectionTimeoutMs } : {}),
       });
       this.pragmasReady = this.isLocalDb ? this.applyLocalPragmas() : Promise.resolve();
+      // init() and close() await the original promise. Attach a handler now so a
+      // fast local PRAGMA failure isn't reported as unhandled before either runs.
+      void this.pragmasReady.catch(() => undefined);
     } else {
       this.client = config.client;
       this.isLocalDb = false;

--- a/stores/libsql/src/storage/local-performance.test.ts
+++ b/stores/libsql/src/storage/local-performance.test.ts
@@ -18,6 +18,10 @@ function createMockClient() {
       const sql = typeof statement === 'string' ? statement : statement.sql;
       statements.push({ sql, kind: 'execute' });
 
+      const journalMode = sql.match(/PRAGMA\s+journal_mode\s*=\s*(\w+)/i)?.[1];
+      if (journalMode) {
+        return { rows: [{ journal_mode: journalMode.toLowerCase() }], rowsAffected: 0 };
+      }
       if (/PRAGMA\s+table_info/i.test(sql)) {
         return { rows: [], rowsAffected: 0 };
       }
@@ -58,6 +62,12 @@ beforeEach(() => {
 });
 
 describe('LibSQLStore local performance initialization', () => {
+  it('rejects invalid journal modes at runtime', () => {
+    expect(
+      () => new LibSQLStore({ id: 'invalid-mode', url: 'file:invalid.db', journalMode: 'truncate' as 'wal' }),
+    ).toThrow("journalMode must be either 'wal' or 'delete'");
+  });
+
   it('applies safe local PRAGMAs before local file DB schema initialization', async () => {
     const { client, statements } = createMockClient();
     mockCreateClient.mockReturnValueOnce(client as any);
@@ -84,6 +94,57 @@ describe('LibSQLStore local performance initialization', () => {
       expect(index, `${pragma} should execute before DDL`).toBeLessThan(firstCreateTable);
     }
     expect(executedSql).not.toContain('PRAGMA synchronous=OFF;');
+  });
+
+  it('applies and validates explicit DELETE mode before local file DB schema initialization', async () => {
+    const { client, statements } = createMockClient();
+    mockCreateClient.mockReturnValueOnce(client as any);
+
+    const store = new LibSQLStore({
+      id: 'local-file-delete',
+      url: 'file:local-performance-delete.db',
+      journalMode: 'delete',
+    });
+    await store.init();
+
+    const executedSql = sqls(statements);
+    const journalMode = executedSql.indexOf('PRAGMA journal_mode=DELETE;');
+    const firstCreateTable = executedSql.findIndex(sql => /^CREATE TABLE/i.test(sql));
+    expect(journalMode).toBeGreaterThan(-1);
+    expect(journalMode).toBeLessThan(firstCreateTable);
+    expect(executedSql).not.toContain('PRAGMA journal_mode=WAL;');
+  });
+
+  it('fails before DDL when SQLite does not confirm explicit DELETE mode', async () => {
+    const { client, statements } = createMockClient();
+    client.execute.mockImplementationOnce(async () => ({
+      rows: [{ journal_mode: 'wal' }],
+      rowsAffected: 0,
+    }));
+    mockCreateClient.mockReturnValueOnce(client as any);
+
+    const store = new LibSQLStore({
+      id: 'local-file-delete-rejected',
+      url: 'file:local-performance-delete-rejected.db',
+      journalMode: 'delete',
+    });
+
+    await expect(store.init()).rejects.toThrow('SQLite reported wal');
+    expect(sqls(statements).some(sql => /^CREATE TABLE/i.test(sql))).toBe(false);
+  });
+
+  it('does not apply explicit local journal mode for remote URLs', () => {
+    const { client, statements } = createMockClient();
+    mockCreateClient.mockReturnValueOnce(client as any);
+
+    new LibSQLStore({
+      id: 'remote-delete',
+      url: 'libsql://example.turso.io',
+      authToken: 'test-token',
+      journalMode: 'delete',
+    });
+
+    expect(sqls(statements)).not.toContain('PRAGMA journal_mode=DELETE;');
   });
 
   it('does not apply store-level local PRAGMAs for remote URLs', () => {

--- a/stores/libsql/src/types.ts
+++ b/stores/libsql/src/types.ts
@@ -1,0 +1,1 @@
+export type LibSQLLocalJournalMode = 'wal' | 'delete';

--- a/stores/libsql/src/vector/close.test.ts
+++ b/stores/libsql/src/vector/close.test.ts
@@ -45,6 +45,36 @@ describe('LibSQLVector.close()', () => {
     expect(client.closed).toBe(true);
   });
 
+  it('skips WAL cleanup when DELETE mode was selected', async () => {
+    const dbPath = path.join(tmpDir, 'vectors-delete.db');
+    const vector = new LibSQLVector({ id: 'close-delete', url: `file:${dbPath}`, journalMode: 'delete' });
+    await vector.createIndex({ indexName: 'close_test', dimension: 4 });
+
+    const client = getClient(vector);
+    const executeSpy = vi.spyOn(client, 'execute');
+    const closeSpy = vi.spyOn(client, 'close');
+
+    await vector.close();
+
+    const executedSql = executedSqlFrom(executeSpy);
+    expect(executedSql).not.toContain('PRAGMA wal_checkpoint(TRUNCATE);');
+    expect(executedSql).not.toContain('PRAGMA journal_mode=DELETE;');
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces overlapping close calls', async () => {
+    const dbPath = path.join(tmpDir, 'vectors-overlapping.db');
+    const vector = new LibSQLVector({ id: 'close-overlapping', url: `file:${dbPath}` });
+    await vector.createIndex({ indexName: 'close_test', dimension: 4 });
+
+    const client = getClient(vector);
+    const closeSpy = vi.spyOn(client, 'close');
+
+    await Promise.all([vector.close(), vector.close(), vector.close()]);
+
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+  });
+
   it('is idempotent — a second close() is a no-op', async () => {
     const dbPath = path.join(tmpDir, 'vectors.db');
     const vector = new LibSQLVector({ id: 'close-idempotent', url: `file:${dbPath}` });

--- a/stores/libsql/src/vector/index.test.ts
+++ b/stores/libsql/src/vector/index.test.ts
@@ -3,6 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 
 import { createVectorTestSuite } from '@internal/storage-test-utils';
+import { createClient } from '@libsql/client';
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 
 import { LibSQLVector } from './index.js';
@@ -267,5 +268,58 @@ describe('LibSQLVector - Store Specific', () => {
 
       expect(results.length).toBe(0);
     });
+  });
+});
+
+describe('LibSQLVector local journal mode readiness', () => {
+  it('rejects invalid journal modes at runtime', () => {
+    expect(
+      () => new LibSQLVector({ id: 'invalid-mode', url: 'file:invalid.db', journalMode: 'truncate' as 'wal' }),
+    ).toThrow("journalMode must be either 'wal' or 'delete'");
+  });
+
+  it('establishes DELETE mode before the first vector operation', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-vector-delete-mode-'));
+    const dbPath = path.join(tmpDir, 'vectors.db');
+    const vector = new LibSQLVector({ id: 'delete-mode', url: `file:${dbPath}`, journalMode: 'delete' });
+
+    try {
+      await vector.createIndex({ indexName: 'ready_test', dimension: 4 });
+      const client = (vector as unknown as { turso: ReturnType<typeof createClient> }).turso;
+      const result = await client.execute('PRAGMA journal_mode;');
+
+      expect(Object.values(result.rows[0] ?? {})[0]).toBe('delete');
+      expect(fs.existsSync(`${dbPath}-wal`)).toBe(false);
+      expect(fs.existsSync(`${dbPath}-shm`)).toBe(false);
+    } finally {
+      await vector.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('propagates a failed DELETE transition before vector access and close', async () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'libsql-vector-delete-locked-'));
+    const dbPath = path.join(tmpDir, 'vectors.db');
+    const blocker = createClient({ url: `file:${dbPath}` });
+    await blocker.execute('PRAGMA journal_mode=WAL;');
+    await blocker.execute('CREATE TABLE blocker (id INTEGER PRIMARY KEY);');
+    const tx = await blocker.transaction('write');
+    await tx.execute('INSERT INTO blocker (id) VALUES (1);');
+
+    const vector = new LibSQLVector({ id: 'delete-mode-locked', url: `file:${dbPath}`, journalMode: 'delete' });
+    const vectorClient = (vector as unknown as { turso: ReturnType<typeof createClient> }).turso;
+
+    try {
+      await expect(vector.listIndexes()).rejects.toThrow();
+      await tx.rollback();
+      await expect(vector.close()).rejects.toThrow();
+      expect(vectorClient.closed).toBe(true);
+    } finally {
+      if (!tx.closed) {
+        await tx.rollback();
+      }
+      blocker.close();
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/stores/libsql/src/vector/index.ts
+++ b/stores/libsql/src/vector/index.ts
@@ -17,6 +17,7 @@ import type {
   UpdateVectorParams,
   DeleteVectorsParams,
 } from '@mastra/core/vector';
+import type { LibSQLLocalJournalMode } from '../types';
 import type { LibSQLVectorFilter } from './filter';
 import { LibSQLFilterTranslator } from './filter';
 import { buildFilterQuery } from './sql-builder';
@@ -46,6 +47,12 @@ export interface LibSQLVectorConfig {
    */
   initialBackoffMs?: number;
   /**
+   * SQLite journal mode for local file databases. Remote and in-memory databases
+   * keep their existing behavior.
+   * @default 'wal'
+   */
+  journalMode?: LibSQLLocalJournalMode;
+  /**
    * Over-fetch multiplier for vector_top_k queries when metadata filters are present.
    * Since vector_top_k doesn't support inline WHERE clauses, we fetch topK * this multiplier
    * candidates and post-filter. Higher values improve recall at the cost of more data scanned.
@@ -60,7 +67,11 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   private readonly initialBackoffMs: number;
   private readonly overFetchMultiplier: number;
   private readonly isMemoryDb: boolean;
+  private readonly isLocalFileDb: boolean;
+  private readonly journalMode: LibSQLLocalJournalMode;
+  private readonly pragmasReady: Promise<void>;
   private vectorIndexes: Promise<Set<string>>;
+  private closePromise?: Promise<void>;
 
   constructor({
     url,
@@ -69,10 +80,15 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     syncInterval,
     maxRetries = 5,
     initialBackoffMs = 100,
+    journalMode = 'wal',
     vectorTopKOverFetchMultiplier = 10,
     id,
   }: LibSQLVectorConfig & { id: string }) {
     super({ id });
+
+    if (journalMode !== 'wal' && journalMode !== 'delete') {
+      throw new Error("LibSQLVector: journalMode must be either 'wal' or 'delete'.");
+    }
 
     this.turso = createClient({
       url,
@@ -87,38 +103,77 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     }
     this.overFetchMultiplier = vectorTopKOverFetchMultiplier;
     this.isMemoryDb = url.includes(':memory:');
+    this.isLocalFileDb = url.startsWith('file:') && !this.isMemoryDb;
+    this.journalMode = journalMode;
+    this.pragmasReady = this.isLocalFileDb || this.isMemoryDb ? this.applyLocalPragmas() : Promise.resolve();
+    this.vectorIndexes = this.pragmasReady.then(() =>
+      this.isMemoryDb ? new Set<string>() : this.discoverVectorIndexes(),
+    );
+    // Public operations await pragmasReady directly. Mark this dependent promise
+    // handled so a rejected journal transition is not reported twice.
+    void this.vectorIndexes.catch(() => undefined);
+  }
 
-    if (url.includes(`file:`) || this.isMemoryDb) {
-      this.turso
-        .execute('PRAGMA journal_mode=WAL;')
-        .then(() => this.logger.debug('LibSQLStore: PRAGMA journal_mode=WAL set.'))
-        .catch(err => this.logger.warn('LibSQLStore: Failed to set PRAGMA journal_mode=WAL.', err));
-      this.turso
-        .execute('PRAGMA busy_timeout = 5000;')
-        .then(() => this.logger.debug('LibSQLStore: PRAGMA busy_timeout=5000 set.'))
-        .catch(err => this.logger.warn('LibSQLStore: Failed to set PRAGMA busy_timeout=5000.', err));
+  private async applyLocalPragmas(): Promise<void> {
+    const journalMode = this.journalMode.toUpperCase();
+    try {
+      const result = await this.turso.execute(`PRAGMA journal_mode=${journalMode};`);
+
+      if (this.isLocalFileDb && this.journalMode === 'delete') {
+        const appliedMode = Object.values(result.rows[0] ?? {})[0];
+        if (typeof appliedMode !== 'string' || appliedMode.toLowerCase() !== 'delete') {
+          throw new Error(
+            `LibSQLVector: Failed to set PRAGMA journal_mode=DELETE; SQLite reported ${String(appliedMode)}.`,
+          );
+        }
+      }
+      this.logger.debug(`LibSQLVector: PRAGMA journal_mode=${journalMode} set.`);
+    } catch (err) {
+      if (this.isLocalFileDb && this.journalMode === 'delete') {
+        throw err;
+      }
+      this.logger.warn(`LibSQLVector: Failed to set PRAGMA journal_mode=${journalMode}.`, err);
     }
 
-    this.vectorIndexes = this.isMemoryDb ? Promise.resolve(new Set<string>()) : this.discoverVectorIndexes();
+    try {
+      await this.turso.execute('PRAGMA busy_timeout=5000;');
+      this.logger.debug('LibSQLVector: PRAGMA busy_timeout=5000 set.');
+    } catch (err) {
+      this.logger.warn('LibSQLVector: Failed to set PRAGMA busy_timeout=5000.', err);
+    }
   }
 
   /**
    * Closes the underlying libsql client, releasing all OS file handles.
    *
-   * For local file databases, first runs PRAGMA wal_checkpoint(TRUNCATE) and
-   * switches back to journal_mode=DELETE so the -wal and -shm sidecar files
-   * are released promptly (mirrors LibSQLStore.close()).
+   * Local file databases configured for WAL are checkpointed and switched to
+   * journal_mode=DELETE so the -wal and -shm sidecar files are released
+   * promptly (mirrors LibSQLStore.close()). DELETE mode skips that work.
    *
    * Remote (Turso) databases skip the WAL pragmas and just close the client.
    *
    * Safe to call more than once; subsequent calls are no-ops.
    */
-  async close(): Promise<void> {
+  close(): Promise<void> {
+    if (!this.closePromise) {
+      this.closePromise = this.closeClient();
+    }
+    return this.closePromise;
+  }
+
+  private async closeClient(): Promise<void> {
     if (this.turso.closed) {
       return;
     }
 
-    if (this.turso.protocol === 'file' && !this.isMemoryDb) {
+    let readinessError: unknown;
+    try {
+      await this.pragmasReady;
+    } catch (err) {
+      readinessError = err;
+    }
+
+    if (!readinessError && this.isLocalFileDb && this.journalMode === 'wal') {
       try {
         await this.turso.execute('PRAGMA wal_checkpoint(TRUNCATE);');
         await this.turso.execute('PRAGMA journal_mode=DELETE;');
@@ -128,6 +183,10 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     }
 
     this.turso.close();
+
+    if (readinessError) {
+      throw readinessError;
+    }
   }
 
   private async discoverVectorIndexes(): Promise<Set<string>> {
@@ -237,6 +296,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
     includeVector = false,
     minScore = -1, // Default to -1 to include all results (cosine similarity ranges from -1 to 1)
   }: LibSQLQueryVectorParams): Promise<QueryResult[]> {
+    await this.pragmasReady;
     // Validate topK parameter - throws MastraError directly
     validateTopK('LIBSQL', topK);
 
@@ -342,6 +402,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async doUpsert({ indexName, vectors, metadata, ids }: UpsertVectorParams): Promise<string[]> {
+    await this.pragmasReady;
     // Validate input parameters
     validateUpsertInput('LIBSQL', vectors, metadata, ids);
 
@@ -404,6 +465,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async doCreateIndex({ indexName, dimension }: CreateIndexParams): Promise<void> {
+    await this.pragmasReady;
     if (!Number.isInteger(dimension) || dimension <= 0) {
       throw new Error('Dimension must be a positive integer');
     }
@@ -446,6 +508,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async doDeleteIndex({ indexName }: DeleteIndexParams): Promise<void> {
+    await this.pragmasReady;
     const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
     await this.turso.execute({
       sql: `DROP TABLE IF EXISTS ${parsedIndexName}`,
@@ -455,6 +518,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   async listIndexes(): Promise<string[]> {
+    await this.pragmasReady;
     try {
       const vectorTablesQuery = `
         SELECT name FROM sqlite_master 
@@ -485,6 +549,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
    * @returns A promise that resolves to the index statistics including dimension, count and metric
    */
   async describeIndex({ indexName }: DescribeIndexParams): Promise<IndexStats> {
+    await this.pragmasReady;
     try {
       const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
       // Get table info including column info
@@ -553,6 +618,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async doUpdateVector(params: UpdateVectorParams<LibSQLVectorFilter>): Promise<void> {
+    await this.pragmasReady;
     const { indexName, update } = params;
     const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
 
@@ -721,6 +787,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async doDeleteVector({ indexName, id }: DeleteVectorParams): Promise<void> {
+    await this.pragmasReady;
     const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
     await this.turso.execute({
       sql: `DELETE FROM ${parsedIndexName} WHERE vector_id = ?`,
@@ -733,6 +800,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async doDeleteVectors({ indexName, filter, ids }: DeleteVectorsParams<LibSQLVectorFilter>): Promise<void> {
+    await this.pragmasReady;
     const parsedIndexName = parseSqlIdentifier(indexName, 'index name');
 
     // Validate that exactly one of filter or ids is provided
@@ -862,6 +930,7 @@ export class LibSQLVector extends MastraVector<LibSQLVectorFilter> {
   }
 
   private async _doTruncateIndex({ indexName }: DeleteIndexParams): Promise<void> {
+    await this.pragmasReady;
     await this.turso.execute({
       sql: `DELETE FROM ${parseSqlIdentifier(indexName, 'index name')}`,
       args: [],


### PR DESCRIPTION
## Summary

- add deterministic local `journalMode` support to `@mastra/libsql` while preserving WAL as the general default
- run Mastra Code-owned main and vector databases in DELETE journal mode to avoid the vulnerable SQLite 3.45.1 WAL-reset path
- close owned main/vector storage from TUI, ACP, headless, startup-failure, and E2E shutdown paths
- document the journal-mode option and cover legacy WAL transitions, sidecar cleanup, concurrent writers, and cleanup ordering

## Test plan

- `pnpm build:mastracode` — 29/29 tasks passed
- full `@mastra/libsql` suite — 905 passed, 19 skipped
- focused Code SDK/TUI suites — 103 passed
- `prune-command` + `storage-delete-mode` E2E — 2 passed
- Mastra Code E2E smoke — 3 passed, 1 skipped
- package typechecks, lint, docs validation, Remark, and Vale — passed
- six-process DELETE stress proof — 1,800/1,800 writes, `quick_check=ok`, no WAL/SHM sidecars
- `pnpm test:mastracode` — SDK passes; TUI retains the same four pre-existing baseline failures in `shell-output.test.ts` and `transcribe.test.ts`, with no storage or cleanup failures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
Mastra can now tell its local SQLite databases to use a safer “DELETE” mode instead of always using WAL. It also makes shutdown more predictable, so Mastra Code reliably stops background work and closes the databases (and related locks) even when startup or cleanup fails.

## Summary
- Added configurable local `journalMode` support (`wal` or `delete`) to `@mastra/libsql` storage and vector, keeping `wal` as the default.
- Updated Mastra Code’s owned local main + vector databases to use `journalMode: 'delete'` to avoid a known SQLite WAL-reset safety issue.
- Implemented deterministic, single-flight teardown ordering across TUI, ACP, headless, startup-failure, and E2E shutdown paths:
  - Stop work first, then close storage/vector, then release locks / restore console (and restore shutdown analytics where applicable).
  - Memoized close logic so `close()`/cleanup runs only once, with correct error propagation (including `AggregateError` when multiple closes fail).
  - Ensured signal polling is stopped before storage close (and improved console/error handling when cleanup fails).
- Ensured journal-mode correctness and safety in the LibSQL implementation:
  - Validated `journalMode` inputs; added readiness gating so pragma failures surface at the right time.
  - Implemented and tested WAL→DELETE behavior and sidecar (`-wal`/`-shm`) handling for local file DBs.
  - Added concurrency stress coverage for DELETE journal mode with multi-process writers.
- Removed unintended workflow-level PRAGMA mutations to avoid connection-wide side effects.
- Added/updated tests, including:
  - Unit tests for memoized/coalesced `close()` behavior and readiness/pragma failure paths (storage + vector).
  - ACP/TUI/headless cleanup ordering and concurrency tests.
  - New TUI E2E scenario validating local databases switch to DELETE mode and don’t leave WAL sidecars.
  - E2E cleanup adjustment to keep in-process scenario DBs alive until shard completion, while still performing explicit storage shutdown for real CLI entry points.
- Updated docs for the new “Local journal modes” option and how it affects initialization and `close()` for local file databases.
- Ran the described build/package/focused-suite/E2E/validation and multi-process DELETE stress tests successfully; TUI retained only the same pre-existing baseline failures with no new storage/cleanup failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->