### PR TITLE
feat(agent-controller): expose exact thread bindings

### DIFF
--- a/.changeset/many-knives-occur.md
+++ b/.changeset/many-knives-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/client-js': minor
+---
+
+Added exact thread binding when creating AgentController sessions through the JavaScript client.

--- a/.changeset/tiny-lies-occur.md
+++ b/.changeset/tiny-lies-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/server': minor
+---
+
+Added exact thread binding to the AgentController session creation endpoint.

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -69,6 +69,16 @@ describe('AgentController Resource', () => {
     expect(JSON.parse(init.body as string)).toEqual({ resourceId: 'user-1' });
   });
 
+  it('requests an exact thread binding when creating a session', async () => {
+    mockJson({ controllerId: 'code', resourceId: 'factory-session-1', threadId: 'factory-session-1' });
+    await client.getAgentController('code').session('factory-session-1').create({ threadId: 'factory-session-1' });
+    const [, init] = lastCall();
+    expect(JSON.parse(init.body as string)).toEqual({
+      resourceId: 'factory-session-1',
+      threadId: 'factory-session-1',
+    });
+  });
+
   it('sends a message to the resource-scoped session', async () => {
     mockJson({ ok: true });
     await client.getAgentController('code').session('user-1').sendMessage('hello');

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -398,14 +398,21 @@ export class AgentControllerSession extends BaseResource {
   /**
    * Create or resume this session. Pass `tags` to scope initial thread
    * selection — a thread is a resume candidate only when its metadata matches
-   * every tag. Required when sessions share a resourceId (e.g. git worktrees
-   * using a `{ projectPath }` tag) so each resumes its own thread instead of the
-   * most recent thread across the whole resource.
+   * every tag. Pass `threadId` to bind the session to one exact thread,
+   * creating it with that id when it does not exist.
    */
-  create(options?: { tags?: Record<string, string> }): Promise<CreateAgentControllerSessionResponse> {
+  create(options?: {
+    tags?: Record<string, string>;
+    threadId?: string;
+  }): Promise<CreateAgentControllerSessionResponse> {
     return this.request(`/agent-controller/${encodeURIComponent(this.controllerId)}/sessions`, {
       method: 'POST',
-      body: { resourceId: this.resourceId, tags: options?.tags, sessionScope: this.scope },
+      body: {
+        resourceId: this.resourceId,
+        tags: options?.tags,
+        threadId: options?.threadId,
+        sessionScope: this.scope,
+      },
     });
   }
 

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -19390,6 +19390,7 @@ export type PostAgentControllerControllerIdSessions_Body = {
         [key: string]: string;
       }
     | undefined;
+  threadId?: string | undefined;
   sessionScope?: string | undefined;
 };
 

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -5857,7 +5857,8 @@ export const API_ROUTE_METADATA = {
     "bodyParams": [
       "resourceId",
       "sessionScope",
-      "tags"
+      "tags",
+      "threadId"
     ],
     "hasQuery": false,
     "hasBody": true,

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -94,6 +94,18 @@ describe('agent-controller routes', () => {
       expect(second.threadId).toBe(first.threadId);
     });
 
+    it('binds the session to an exact thread id when requested', async () => {
+      const res = (await CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-1',
+        threadId: 'factory-session-1',
+      } as any)) as { resourceId: string; threadId?: string };
+
+      expect(res.resourceId).toBe('user-1');
+      expect(res.threadId).toBe('factory-session-1');
+    });
+
     it('404s for an unknown agent controller id', async () => {
       await expect(
         CREATE_AGENT_CONTROLLER_SESSION_ROUTE.handler({ mastra, controllerId: 'nope', resourceId: 'user-1' } as any),

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -65,16 +65,17 @@ function getAgentControllerOrThrow(
 async function getSession(
   controller: AgentController<any>,
   resourceId: string,
-  options?: { tags?: Record<string, string>; scope?: string },
+  options?: { tags?: Record<string, string>; scope?: string; threadId?: string },
   requestContext?: RequestContext,
 ): Promise<Session<any>> {
   await controller.init();
-  const { tags, scope } = options ?? {};
+  const { tags, scope, threadId } = options ?? {};
   // Scoped sessions are independent sessions over the same resource (e.g. one
   // per git worktree), so qualify the stable session id with the scope to keep
-  // their identities distinct as well.
-  const id = scope ? `${resourceId}::${scope}` : resourceId;
-  return controller.createSession({ resourceId, id, ownerId: controller.id, tags, scope, requestContext });
+  // their identities distinct as well. An exact thread binding doubles as the
+  // stable session id when supplied.
+  const id = threadId ?? (scope ? `${resourceId}::${scope}` : resourceId);
+  return controller.createSession({ resourceId, id, ownerId: controller.id, tags, scope, threadId, requestContext });
 }
 
 // ---------------------------------------------------------------------------
@@ -94,6 +95,7 @@ const sessionScopeQuerySchema = z.object({ sessionScope: z.string().optional() }
 const createSessionBodySchema = z.object({
   resourceId: z.string(),
   tags: z.record(z.string(), z.string()).optional(),
+  threadId: z.string().optional(),
   sessionScope: z.string().optional(),
 });
 // Server-side attachment limits mirroring the web composer caps (10MB per
@@ -358,10 +360,10 @@ export const CREATE_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, sessionScope, tags, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, tags, threadId, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
-      const session = await getSession(controller, resourceId, { tags, scope: sessionScope }, requestContext);
+      const session = await getSession(controller, resourceId, { tags, scope: sessionScope, threadId }, requestContext);
       return {
         controllerId,
         resourceId,


### PR DESCRIPTION
This is PR 2 of 4, stacked on #19758. It exposes the core exact-thread session primitive through the AgentController server route and JavaScript client.\n\nCallers can pass  when creating a session, and the generated route types include the new optional field. Existing calls without  are unchanged.\n\nThe stack continues with:\n- #19907 — provider-specific sandbox workspace state\n- #19908 — Factory session workspace provisioning\n\nVerified with the focused server and client tests, the server build, and the client build and lint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now choose the exact conversation thread used when starting an AgentController session. This helps callers resume or bind sessions to a specific thread, while existing calls continue working as before.

## What changed

- Added optional `threadId` support to the AgentController server session route.
- Forwarded `threadId` through the JavaScript client.
- Bound sessions to the provided exact thread ID when creating or resuming them.
- Added focused server and client tests.
- Added minor release changesets for `@mastra/server` and `@mastra/client-js`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->