### PR TITLE
feat(sandbox): preserve provider-specific workspace state

### DIFF
--- a/.changeset/petite-regions-work.md
+++ b/.changeset/petite-regions-work.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added a working directory override when deriving local sandboxes so callers can isolate each derived checkout.

--- a/.changeset/railway-session-checkpoints-core.md
+++ b/.changeset/railway-session-checkpoints-core.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Added `checkpointName` to sandbox derive options so providers can attach durable checkpoint identities to derived sandboxes.

--- a/.changeset/railway-session-checkpoints-railway.md
+++ b/.changeset/railway-session-checkpoints-railway.md
@@ -1,0 +1,5 @@
+---
+'@mastra/railway': patch
+---
+
+Allowed derived Railway sandboxes to override the checkpoint name used for checkpoint-backed creation and refresh.

--- a/docs/src/content/en/reference/workspace/railway-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/railway-sandbox.mdx
@@ -10,7 +10,7 @@ import TabItem from "@theme/TabItem";
 
 # RailwaySandbox
 
-Executes commands in ephemeral, isolated [Railway](https://docs.railway.com/sandboxes) sandboxes. Each sandbox is an isolated Debian Linux VM provisioned on demand through the Railway TypeScript SDK. Supports command execution with streaming output, command timeouts, configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base images via the Railway template builder, forking a running sandbox, and reattaching to an existing sandbox by ID. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
+Executes commands in ephemeral, isolated [Railway](https://docs.railway.com/sandboxes) sandboxes. Each sandbox is an isolated Debian Linux VM provisioned on demand through the Railway TypeScript SDK. Supports command execution with streaming output, command timeouts, configurable idle timeout, `ISOLATED`/`PRIVATE` network isolation, custom base images via the Railway template builder, checkpoint-backed recovery, forking a running sandbox, and reattaching to an existing sandbox by ID. For interface details, see [WorkspaceSandbox interface](/reference/workspace/sandbox).
 
 ## Installation
 
@@ -118,6 +118,38 @@ console.log(result.stdout)
 
 The forked sandbox inherits the parent's credentials and defaults unless overridden via the `fork()` options.
 
+### Checkpoint recovery
+
+Set `checkpointName` to preserve a sandbox filesystem across Railway sandbox replacement. On `start()`, `RailwaySandbox` first tries to create the sandbox from the named checkpoint. If the checkpoint is missing, it creates a sandbox from the configured template or default image, then captures the checkpoint.
+
+```typescript
+const sandbox = new RailwaySandbox({
+  checkpointName: 'project-session-42',
+  idleTimeoutMinutes: 30,
+})
+```
+
+`RailwaySandbox` refreshes the checkpoint shortly before the idle timeout. Recovery restores the latest successful checkpoint. It doesn't restore running processes or filesystem writes made after the last checkpoint.
+
+Use one stable checkpoint name for each independent filesystem. Do not share a checkpoint name across unrelated sessions or projects.
+
+### Derived sandbox checkpoints
+
+Use `derive({ checkpointName })` when a configured `RailwaySandbox` acts as the template for a sandbox fleet:
+
+```typescript
+const template = new RailwaySandbox({ idleTimeoutMinutes: 30 })
+
+const sessionSandbox = template.derive({
+  id: 'session-42',
+  checkpointName: 'project-session-42',
+})
+
+await sessionSandbox.start()
+```
+
+A derived sandbox uses the checkpoint passed to `derive()`. If no override is passed, it inherits the template sandbox's `checkpointName`.
+
 ### Streaming output
 
 Stream command output in real time via `onStdout` and `onStderr` callbacks:
@@ -170,6 +202,13 @@ const result = await sandbox.executeCommand('cat', ['/tmp/state.txt'])
     type: 'string',
     description:
       'Reattach to an existing Railway sandbox by its Railway ID instead of creating a new one. When set, start() calls Sandbox.connect().',
+    isOptional: true,
+  },
+  {
+    name: 'checkpointName',
+    type: 'string',
+    description:
+      'Named Railway checkpoint used to seed new sandboxes and preserve the filesystem before idle teardown. Use a unique stable name for each independent filesystem.',
     isOptional: true,
   },
   {
@@ -266,6 +305,12 @@ const result = await sandbox.executeCommand('cat', ['/tmp/state.txt'])
     type: '(options?) => Promise<RailwaySandbox>',
     description:
       'Clone this running sandbox into a new, independent RailwaySandbox. The returned sandbox is already started and reattached to the forked Railway sandbox. Accepts optional id, idleTimeoutMinutes, networkIsolation, and env overrides. Throws SandboxNotReadyError if this sandbox has not been started.',
+  },
+  {
+    name: 'derive',
+    type: '(options?) => RailwaySandbox',
+    description:
+      'Construct an unstarted sibling sandbox that inherits credentials and defaults. Accepts optional id, sandboxId, env, idleTimeoutMinutes, and checkpointName overrides. The derived sandbox uses options.checkpointName when set, otherwise it inherits the template checkpointName.',
   },
 ]}
 />

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -84,6 +84,16 @@ describe('LocalSandbox', () => {
       expect(child.isolation).toBe(template.isolation);
     });
 
+    it('applies a derived working directory override', () => {
+      const template = new LocalSandbox({ workingDirectory: tempDir });
+      const childWorkdir = path.join(tempDir, 'child');
+
+      const child = template.clone({ workingDirectory: childWorkdir });
+
+      expect(child.workingDirectory).toBe(childWorkdir);
+      expect(template.workingDirectory).toBe(tempDir);
+    });
+
     it('applies env overrides and can execute commands after start', async () => {
       const template = new LocalSandbox({ workingDirectory: tempDir, env: { PATH: process.env.PATH } });
 

--- a/packages/core/src/workspace/sandbox/local-sandbox.test.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.test.ts
@@ -258,7 +258,7 @@ describe('LocalSandbox', () => {
       expect(result.success).toBe(true);
       expect(result.stdout.trim()).toBe('Hello, World!');
       expect(result.exitCode).toBe(0);
-      expect(result.executionTimeMs).toBeGreaterThan(0);
+      expect(result.executionTimeMs).toBeGreaterThanOrEqual(0);
     });
 
     it('should handle command failure', async () => {

--- a/packages/core/src/workspace/sandbox/local-sandbox.ts
+++ b/packages/core/src/workspace/sandbox/local-sandbox.ts
@@ -211,8 +211,8 @@ export class LocalSandbox extends MastraSandbox {
 
   /**
    * Construct a sibling `LocalSandbox` that inherits this sandbox's
-   * configuration (working directory, isolation, native sandbox config,
-   * instructions) with per-instance overrides.
+   * configuration (isolation, native sandbox config, instructions) with
+   * per-instance overrides.
    *
    * Performs no I/O — the sandbox clone creates its working directory on its
    * own `start()`. `sandboxId` and `idleTimeoutMinutes` have no local
@@ -222,7 +222,7 @@ export class LocalSandbox extends MastraSandbox {
   clone(options: SandboxCloneOptions = {}): LocalSandbox {
     return new LocalSandbox({
       ...(options.id !== undefined && { id: options.id }),
-      workingDirectory: this.workingDirectory,
+      workingDirectory: options.workingDirectory ?? this.workingDirectory,
       env: options.env ?? this.env,
       isolation: this.isolation,
       nativeSandbox: {

--- a/packages/core/src/workspace/sandbox/sandbox.ts
+++ b/packages/core/src/workspace/sandbox/sandbox.ts
@@ -97,8 +97,15 @@ export interface SandboxCloneOptions {
   sandboxId?: string;
   /** Environment variables baked into the sandbox clone. */
   env?: Record<string, string>;
+  /** Provider working directory for the sandbox clone. */
+  workingDirectory?: string;
   /** Idle teardown window (minutes) for the sandbox clone. */
   idleTimeoutMinutes?: number;
+  /**
+   * Provider checkpoint used to seed and preserve the sandbox clone.
+   * Providers without checkpoint support may ignore this option.
+   */
+  checkpointName?: string;
 }
 
 // =============================================================================

--- a/workspaces/railway/src/sandbox/index.test.ts
+++ b/workspaces/railway/src/sandbox/index.test.ts
@@ -456,6 +456,48 @@ describe('RailwaySandbox', () => {
         expect.objectContaining({ token: 'tok', idleTimeoutMinutes: 45, env: { BASE: '1' } }),
       );
     });
+
+    it('inherits the template checkpoint name when no override is passed', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('checkpoint not found')).mockResolvedValueOnce(mockSandbox);
+      const template = new RailwaySandbox({ token: 'tok', checkpointName: 'root-checkpoint' });
+
+      const child = template.clone({ id: 'mc-project-1' });
+      await child._start();
+
+      expect(mockCreate).toHaveBeenNthCalledWith(1, 'root-checkpoint', expect.objectContaining({ token: 'tok' }));
+      expect(mockSandbox.checkpoint).toHaveBeenCalledWith('root-checkpoint');
+    });
+
+    it('uses a derived checkpoint override when restoring an existing checkpoint', async () => {
+      mockCheckpoints.mockResolvedValueOnce([
+        { id: 'checkpoint-id', key: 'session-checkpoint', environmentId: 'env-1' },
+      ]);
+      const template = new RailwaySandbox({ token: 'tok', checkpointName: 'root-checkpoint' });
+
+      const child = template.clone({ id: 'mc-project-1', checkpointName: 'session-checkpoint' });
+      await child._start();
+
+      expect(mockCreate).toHaveBeenCalledWith('session-checkpoint', expect.objectContaining({ token: 'tok' }));
+      expect(mockCreate).not.toHaveBeenCalledWith('root-checkpoint', expect.anything());
+      expect(mockSandbox.checkpoint).not.toHaveBeenCalled();
+    });
+
+    it('uses a derived checkpoint override when capturing a missing checkpoint', async () => {
+      mockCreate.mockRejectedValueOnce(new Error('checkpoint not found')).mockResolvedValueOnce(mockSandbox);
+      const template = new RailwaySandbox({
+        token: 'tok',
+        checkpointName: 'root-checkpoint',
+        template: t => t.run('npm i -g pnpm'),
+      });
+
+      const child = template.clone({ id: 'mc-project-1', checkpointName: 'session-checkpoint' });
+      await child._start();
+
+      expect(mockCreate).toHaveBeenNthCalledWith(1, 'session-checkpoint', expect.objectContaining({ token: 'tok' }));
+      expect(mockCreate).toHaveBeenNthCalledWith(2, mockTemplate, expect.objectContaining({ token: 'tok' }));
+      expect(mockSandbox.checkpoint).toHaveBeenCalledWith('session-checkpoint');
+      expect(mockSandbox.checkpoint).not.toHaveBeenCalledWith('root-checkpoint');
+    });
   });
 
   describe('executeCommand', () => {

--- a/workspaces/railway/src/sandbox/index.ts
+++ b/workspaces/railway/src/sandbox/index.ts
@@ -604,7 +604,9 @@ export class RailwaySandbox extends MastraSandbox {
       ...(this._token !== undefined && { token: this._token }),
       ...(this._environmentId !== undefined && { environmentId: this._environmentId }),
       ...(options.sandboxId !== undefined && { sandboxId: options.sandboxId }),
-      ...(this._checkpointName !== undefined && { checkpointName: this._checkpointName }),
+      ...((options.checkpointName ?? this._checkpointName) !== undefined && {
+        checkpointName: options.checkpointName ?? this._checkpointName,
+      }),
       idleTimeoutMinutes: options.idleTimeoutMinutes ?? this._idleTimeoutMinutes,
       ...(this._networkIsolation !== undefined && { networkIsolation: this._networkIsolation }),
       env: options.env ?? this._env,


### PR DESCRIPTION
This is PR 3 in the Factory session stack. The prerequisite AgentController changes in #19758 and #19902 have already merged.

## Summary

- Add `workingDirectory` and `checkpointName` overrides to `SandboxCloneOptions`.
- Allow `LocalSandbox.clone()` to create a sibling sandbox with a session-specific working directory.
- Allow `RailwaySandbox.clone()` to override or inherit its source checkpoint.
- Document how Railway sandbox clones inherit and override checkpoints.

These changes provide the provider-level primitives needed to give each Factory session an isolated workspace while retaining the configuration of a shared sandbox template.

## Test plan

- Core sandbox tests and typecheck passed: 153 tests passed, 2 skipped.
- Railway sandbox tests passed: 43 tests passed.
- Documentation validation passed: 577 files checked.

## Stack

- #19758 — exact thread bindings in AgentController (merged)
- #19902 — server and JavaScript client transport (merged)
- **#19907 — sandbox clone workspace state (this PR)**
- #19908 — Factory session workspace provisioning


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When the system makes a “copy” (clone) of a sandbox workspace, it can now remember or customize two key things: **where that copy stores its files** and **which saved checkpoint it should restart from**. This lets different sessions stay isolated while still recovering the right saved state.

## What changed

- Added provider-specific clone options to `SandboxCloneOptions`:
  - `workingDirectory?: string` (where the clone runs / stores files)
  - `checkpointName?: string` (which saved checkpoint identity to use)
- Updated `LocalSandbox.clone()` to honor `SandboxCloneOptions.workingDirectory` so derived sandboxes can use sibling-isolated working directories.
- Updated `RailwaySandbox.clone()` so `checkpointName` can be inherited or overridden when creating/restoring derived sandboxes.
- Expanded docs for Railway sandbox clone checkpoint behavior (including derived sandbox checkpoints and a new `derive` method).
- Added/updated tests for:
  - Local sandbox working-directory override behavior
  - Railway checkpoint inheritance vs override behavior
  - A small timing assertion relaxation for local command execution rounding edge cases
- Added patch changesets for `@mastra/core` and `@mastra/railway` describing the new clone option behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->