### PR TITLE
fix(deployer): support workspace subpath exports and transitive subpath imports under externals: true

### DIFF
--- a/.changeset/monorepo-flexibility-subpath-exports.md
+++ b/.changeset/monorepo-flexibility-subpath-exports.md
@@ -2,4 +2,8 @@
 '@mastra/deployer': patch
 ---
 
-Fix `mastra build`/`mastra dev` crashing with `Missing "." specifier in "<pkg>" package` for monorepos that contain workspace packages declaring only subpath exports (no `.` entry), when building with `bundler.externals: true` (or in dev). The transitive-dependency walk no longer fabricates a synthetic root `export * from '<pkg>'` for a workspace package that cannot be imported at its root; the subpaths that are actually imported are unaffected. The `resolve.exports` lookup for a root specifier is now guarded so it falls back to `main`/`index` instead of throwing. Purely additive: builds that already succeed are unchanged.
+Fix two monorepo bundling defects for workspace packages under `bundler.externals: true` (and dev). Purely additive: builds that already succeed are unchanged.
+
+1. Fix `mastra build`/`mastra dev` crashing with `Missing "." specifier in "<pkg>" package` when a workspace package declares only subpath exports (no `.` entry). The transitive-dependency walk no longer fabricates a synthetic root `export * from '<pkg>'` for a package that cannot be imported at its root, and the `resolve.exports` root lookup is guarded so it falls back to `main`/`index` instead of throwing.
+
+2. Fix workspace subpath imports leaking out of the bundle. A subpath imported transitively (by another workspace package, e.g. `@scope/a` importing `@scope/b/sub`) could be emitted as an unresolved bare specifier that is not registered in the generated `package.json`, causing `ERR_MODULE_NOT_FOUND` at runtime. Such subpaths are now resolved to their source and compiled inline.

--- a/.changeset/monorepo-flexibility-subpath-exports.md
+++ b/.changeset/monorepo-flexibility-subpath-exports.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fix `mastra build`/`mastra dev` crashing with `Missing "." specifier in "<pkg>" package` for monorepos that contain workspace packages declaring only subpath exports (no `.` entry), when building with `bundler.externals: true` (or in dev). The transitive-dependency walk no longer fabricates a synthetic root `export * from '<pkg>'` for a workspace package that cannot be imported at its root; the subpaths that are actually imported are unaffected. The `resolve.exports` lookup for a root specifier is now guarded so it falls back to `main`/`index` instead of throwing. Purely additive: builds that already succeed are unchanged.

--- a/packages/deployer/src/build/analyze/analyzeEntry.test.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.test.ts
@@ -1,9 +1,10 @@
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { noopLogger } from '@mastra/core/logger';
-import { readFile } from 'fs-extra';
+import { ensureDir, readFile, remove, writeFile } from 'fs-extra';
 import { rollup } from 'rollup';
 import type * as RollupModule from 'rollup';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { WorkspacePackageInfo } from '../../bundler/workspaceDependencies';
 import { analyzeEntry } from './analyzeEntry';
 
@@ -381,5 +382,101 @@ describe('analyzeEntry', () => {
     // Virtual files have no stable path — each call creates a new Rollup instance
     expect(rollup).toHaveBeenCalledTimes(2);
     expect(analyzeCache.size).toBe(0);
+  });
+
+  // The transitive walk registers every transitive workspace dep as a root `export * from`
+  // virtual module. For a package that only declares subpath exports (no "."), that root cannot
+  // be resolved and the deployer's alias-optimized-deps plugin throws `Missing "." specifier`
+  // under `externals: true` / dev. The walk now skips fabricating a root for such packages.
+  describe('subpath-only transitive workspace packages', () => {
+    let tmpRoot: string;
+    let counter = 0;
+
+    beforeEach(() => {
+      tmpRoot = join(tmpdir(), `analyzeEntry-subpath-${Date.now()}-${counter++}`);
+    });
+
+    afterEach(async () => {
+      await remove(tmpRoot);
+    });
+
+    async function writePkg(dir: string, pkg: Record<string, unknown>) {
+      await ensureDir(dir);
+      await writeFile(join(dir, 'package.json'), JSON.stringify(pkg));
+    }
+
+    function makeWorkspaceMap(parentDir: string, leafDir: string) {
+      return new Map<string, WorkspacePackageInfo>([
+        ['@scope/parent', { location: parentDir, dependencies: { '@scope/leaf': 'workspace:*' }, version: '1.0.0' }],
+        ['@scope/leaf', { location: leafDir, dependencies: {}, version: '1.0.0' }],
+      ]);
+    }
+
+    const entry = `import { thing } from '@scope/parent'; export const x = thing;`;
+
+    it('skips the synthetic root for a subpath-only leaf that nothing imports at its root', async () => {
+      const parentDir = join(tmpRoot, 'packages', 'parent');
+      const leafDir = join(tmpRoot, 'packages', 'leaf');
+      await writePkg(parentDir, { name: '@scope/parent', version: '1.0.0', type: 'module', main: 'src/index.ts' });
+      await writePkg(leafDir, {
+        name: '@scope/leaf',
+        version: '1.0.0',
+        type: 'module',
+        // Only subpath exports, no "." — cannot be imported at its root.
+        exports: { './sub/*': './src/*.ts' },
+      });
+
+      const result = await analyzeEntry({ entry, isVirtualFile: true }, '', {
+        shouldCheckTransitiveDependencies: true,
+        logger: noopLogger,
+        sourcemapEnabled: false,
+        workspaceMap: makeWorkspaceMap(parentDir, leafDir),
+        projectRoot: tmpRoot,
+      });
+
+      // The parent is imported at its root and tracked as a workspace dep...
+      expect(result.dependencies.get('@scope/parent')?.isWorkspace).toBe(true);
+      // ...but the subpath-only leaf's fabricated root is skipped.
+      expect(result.dependencies.has('@scope/leaf')).toBe(false);
+    });
+
+    it('still registers the transitive root when the leaf has a "." export', async () => {
+      const parentDir = join(tmpRoot, 'packages', 'parent');
+      const leafDir = join(tmpRoot, 'packages', 'leaf');
+      await writePkg(parentDir, { name: '@scope/parent', version: '1.0.0', type: 'module', main: 'src/index.ts' });
+      await writePkg(leafDir, {
+        name: '@scope/leaf',
+        version: '1.0.0',
+        type: 'module',
+        exports: { '.': './src/index.ts', './sub/*': './src/*.ts' },
+      });
+
+      const result = await analyzeEntry({ entry, isVirtualFile: true }, '', {
+        shouldCheckTransitiveDependencies: true,
+        logger: noopLogger,
+        sourcemapEnabled: false,
+        workspaceMap: makeWorkspaceMap(parentDir, leafDir),
+        projectRoot: tmpRoot,
+      });
+
+      expect(result.dependencies.get('@scope/leaf')?.exports).toEqual(['*']);
+    });
+
+    it('still registers the transitive root when the leaf has no exports map (main/index fallback)', async () => {
+      const parentDir = join(tmpRoot, 'packages', 'parent');
+      const leafDir = join(tmpRoot, 'packages', 'leaf');
+      await writePkg(parentDir, { name: '@scope/parent', version: '1.0.0', type: 'module', main: 'src/index.ts' });
+      await writePkg(leafDir, { name: '@scope/leaf', version: '1.0.0', type: 'module', main: 'src/index.ts' });
+
+      const result = await analyzeEntry({ entry, isVirtualFile: true }, '', {
+        shouldCheckTransitiveDependencies: true,
+        logger: noopLogger,
+        sourcemapEnabled: false,
+        workspaceMap: makeWorkspaceMap(parentDir, leafDir),
+        projectRoot: tmpRoot,
+      });
+
+      expect(result.dependencies.get('@scope/leaf')?.exports).toEqual(['*']);
+    });
   });
 });

--- a/packages/deployer/src/build/analyze/analyzeEntry.ts
+++ b/packages/deployer/src/build/analyze/analyzeEntry.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { IMastraLogger } from '@mastra/core/logger';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
@@ -14,6 +16,42 @@ import { tsConfigPaths } from '../plugins/tsconfig-paths';
 import type { DependencyMetadata } from '../types';
 import { getPackageName, isBareModuleSpecifier, slash } from '../utils';
 import { DEPS_TO_IGNORE } from './constants';
+
+const workspaceRootEntryCache = new Map<string, boolean>();
+
+/**
+ * True if a workspace package can be imported at its root (`import '<pkg>'`).
+ * A package with an `exports` map that declares only subpaths (no ".") cannot be imported at
+ * its root, so fabricating a synthetic `export * from '<pkg>'` for it makes the deployer's
+ * alias-optimized-deps resolver throw `Missing "." specifier`. Permissive by default: only
+ * returns false when we are certain there is no root entry.
+ */
+function workspacePackageHasRootEntry(location: string): boolean {
+  const cached = workspaceRootEntryCache.get(location);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  let hasRoot = true;
+  try {
+    const pkgJson = JSON.parse(readFileSync(join(location, 'package.json'), 'utf-8'));
+    const exp = pkgJson.exports;
+    // exp == null   -> no map, main/index fallback applies -> has root
+    // typeof string -> string sugar IS the root            -> has root
+    if (exp != null && typeof exp === 'object' && !Array.isArray(exp)) {
+      const keys = Object.keys(exp);
+      const hasSubpathKeys = keys.some(k => k.startsWith('./'));
+      // A conditions-only object (no "./..." keys) represents the root itself.
+      // Once there are subpath keys, the root resolves only if "." is present.
+      hasRoot = hasSubpathKeys ? keys.includes('.') : true;
+    }
+  } catch {
+    hasRoot = true;
+  }
+
+  workspaceRootEntryCache.set(location, hasRoot);
+  return hasRoot;
+}
 
 /**
  * Configures and returns the Rollup plugins needed for analyzing entry files.
@@ -164,6 +202,17 @@ async function captureDependenciesToOptimize(
             ...existingMeta,
             exports: existingMeta.exports.includes('*') ? existingMeta.exports : [...existingMeta.exports, '*'],
           });
+          continue;
+        }
+
+        if (!workspacePackageHasRootEntry(innerWorkspaceInfo.location)) {
+          // Subpath-only workspace package: it cannot be imported at its root, so a synthetic
+          // `export * from '<pkg>'` would make the resolver throw under `externals: true` / dev.
+          // The subpaths that ARE imported are captured independently from `output.importedBindings`,
+          // so skipping the fabricated root drops nothing.
+          logger.debug(
+            `Skipping synthetic root export for workspace package "${innerDep}" - it declares only subpath exports.`,
+          );
           continue;
         }
 

--- a/packages/deployer/src/build/analyze/bundleExternals.test.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.test.ts
@@ -1026,4 +1026,48 @@ describe('bundleExternals', () => {
       expect(dependencyValues).toContain('react');
     });
   });
+
+  describe('subpath-only workspace exports (regression: Missing "." specifier)', () => {
+    async function createSubpathOnlyWorkspacePackage(packagePath: string, packageName: string) {
+      await ensureDir(packagePath);
+      await writeFile(
+        join(packagePath, 'package.json'),
+        JSON.stringify({
+          name: packageName,
+          version: '1.0.0',
+          // Only subpath exports: no "." and no "main". resolve.exports(pkgJson, '.') throws here.
+          exports: { './sub/*': './src/*.js' },
+        }),
+      );
+    }
+
+    it('should not crash when a workspace package declares only subpath exports under externals: true', async () => {
+      const pkgPath = join(testDir, 'packages', 'leaf');
+      await createSubpathOnlyWorkspacePackage(pkgPath, '@workspace/leaf');
+
+      const workspaceMap = new Map<string, WorkspacePackageInfo>([
+        ['@workspace/leaf', { location: pkgPath, dependencies: {}, version: '1.0.0' }],
+      ]);
+
+      // `externals: true` -> externalsPreset -> noBundling, which activates the
+      // alias-optimized-deps plugin whose `resolve.exports(pkgJson, '.')` throws
+      // `Missing "." specifier` for subpath-only packages without the try/catch guard.
+      const depsToOptimize = new Map<string, DependencyMetadata>([
+        ['@workspace/leaf', { exports: ['*'], rootPath: pkgPath, isWorkspace: true }],
+      ]);
+
+      const result = await bundleExternals(depsToOptimize, testDir, {
+        workspaceRoot: testDir,
+        projectRoot: join(testDir, 'app'),
+        workspaceMap,
+        bundlerOptions: {
+          externals: true,
+        },
+      });
+
+      expect(result).toBeDefined();
+      // The package is still tracked (falls through to being externalized), not crashed on.
+      expect(Array.from(result.fileNameToDependencyMap.values())).toContain('@workspace/leaf');
+    });
+  });
 });

--- a/packages/deployer/src/build/analyze/bundleExternals.ts
+++ b/packages/deployer/src/build/analyze/bundleExternals.ts
@@ -221,12 +221,21 @@ async function getInputPlugins(
             }
 
             const pkgName = pkgJson.name || '';
-            let resolvedPath: string | undefined = resolve.exports(pkgJson, id.replace(pkgName, '.'))?.[0];
-            if (!resolvedPath) {
-              resolvedPath = pkgJson!.main ?? 'index.js';
-            }
+            const requestedSpecifier = id.replace(pkgName, '.');
 
-            const resolved = await this.resolve(path.posix.join(packageRootPath, resolvedPath!), importer, options);
+            let resolvedPath: string | undefined;
+            try {
+              // `resolve.exports` THROWS (it does not return undefined) when the package
+              // declares an `exports` map with no entry matching `requestedSpecifier` - e.g.
+              // a workspace package that only declares subpath exports has no "." entry.
+              // Fall through to the main/index fallback below in that case.
+              resolvedPath = resolve.exports(pkgJson, requestedSpecifier)?.[0];
+            } catch {
+              resolvedPath = undefined;
+            }
+            const entryPath = resolvedPath ?? (typeof pkgJson.main === 'string' ? pkgJson.main : 'index.js');
+
+            const resolved = await this.resolve(path.posix.join(packageRootPath, entryPath), importer, options);
             return resolved;
           },
         } satisfies Plugin)

--- a/packages/deployer/src/build/bundler.ts
+++ b/packages/deployer/src/build/bundler.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 import { optimizeLodashImports } from '@optimize-lodash/rollup-plugin';
@@ -5,8 +6,10 @@ import alias from '@rollup/plugin-alias';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';
 import nodeResolve from '@rollup/plugin-node-resolve';
+import * as resolve from 'resolve.exports';
 import { rollup } from 'rollup';
 import type { InputOptions, OutputOptions, Plugin } from 'rollup';
+import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
 import type { analyzeBundle } from './analyze';
 import { esbuild } from './plugins/esbuild';
 import { esmShim } from './plugins/esm-shim';
@@ -16,8 +19,49 @@ import { protocolExternalResolver } from './plugins/protocol-external-resolver';
 import { removeDeployer } from './plugins/remove-deployer';
 import { subpathExternalsResolver } from './plugins/subpath-externals-resolver';
 import { tsConfigPaths } from './plugins/tsconfig-paths';
-import { getNodeResolveOptions, slash } from './utils';
+import { getNodeResolveOptions, getPackageName, slash } from './utils';
 import type { BundlerPlatform } from './utils';
+
+/**
+ * Resolve a workspace package *subpath* specifier to the source file it points at, via the
+ * package's `exports` map. Used to compile a workspace subpath that escaped analyze capture
+ * inline, instead of letting it leak out of the bundle as an unresolved bare specifier.
+ * Returns null for non-subpath / non-workspace ids, or when it cannot be resolved.
+ * `resolve.exports` throws for a missing entry, so the lookup is guarded.
+ */
+export function resolveWorkspaceSubpathToSource(
+  id: string,
+  workspaceMap: Map<string, WorkspacePackageInfo>,
+): string | null {
+  const pkgName = getPackageName(id);
+  // Only subpaths — package roots are handled by the analyze dependency map.
+  if (!pkgName || id === pkgName) {
+    return null;
+  }
+  const info = workspaceMap.get(pkgName);
+  if (!info) {
+    return null;
+  }
+
+  let pkgJson;
+  try {
+    pkgJson = JSON.parse(readFileSync(join(info.location, 'package.json'), 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  let rel: string | undefined;
+  try {
+    rel = resolve.exports(pkgJson, `.${id.slice(pkgName.length)}`)?.[0];
+  } catch {
+    rel = undefined;
+  }
+  if (!rel) {
+    return null;
+  }
+
+  return join(info.location, rel);
+}
 
 export function mastraInternalAliasPlugin(entryFile: string): Plugin {
   const normalizedEntryFile = slash(entryFile);
@@ -96,6 +140,16 @@ export async function getInputOptions(
         name: 'alias-optimized-deps',
         resolveId(id: string) {
           if (!analyzedBundleInfo.dependencies.has(id)) {
+            // A workspace subpath imported transitively (by another workspace package) can escape
+            // analyze capture and would otherwise leak out of the bundle as an unresolved bare
+            // specifier - unregistered in the generated package.json, so ERR_MODULE_NOT_FOUND at
+            // runtime. Resolve it to its source so the bundler compiles it inline instead.
+            if (externalsPreset) {
+              const workspaceSource = resolveWorkspaceSubpathToSource(id, analyzedBundleInfo.workspaceMap);
+              if (workspaceSource) {
+                return { id: workspaceSource, external: false };
+              }
+            }
             return null;
           }
 

--- a/packages/deployer/src/build/bundler.workspace-subpath.test.ts
+++ b/packages/deployer/src/build/bundler.workspace-subpath.test.ts
@@ -1,0 +1,58 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ensureDir, remove, writeFile } from 'fs-extra';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import type { WorkspacePackageInfo } from '../bundler/workspaceDependencies';
+import { resolveWorkspaceSubpathToSource } from './bundler';
+
+describe('resolveWorkspaceSubpathToSource', () => {
+  let dir: string;
+  let counter = 0;
+
+  beforeEach(async () => {
+    dir = join(tmpdir(), `ws-subpath-${Date.now()}-${counter++}`);
+    await ensureDir(dir);
+  });
+
+  afterEach(async () => {
+    await remove(dir);
+  });
+
+  async function writePkg(exportsField: Record<string, string>) {
+    await writeFile(
+      join(dir, 'package.json'),
+      JSON.stringify({ name: '@scope/leaf', version: '1.0.0', exports: exportsField }),
+    );
+    return new Map<string, WorkspacePackageInfo>([
+      ['@scope/leaf', { location: dir, dependencies: {}, version: '1.0.0' }],
+    ]);
+  }
+
+  it('resolves a subpath via the exports map', async () => {
+    const workspaceMap = await writePkg({ './api': './src/api.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf/api', workspaceMap)).toBe(join(dir, 'src', 'api.ts'));
+  });
+
+  it('resolves a wildcard subpath', async () => {
+    const workspaceMap = await writePkg({ './dist/*': './src/*.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf/dist/lexorder', workspaceMap)).toBe(
+      join(dir, 'src', 'lexorder.ts'),
+    );
+  });
+
+  it('returns null for a bare root specifier (roots are handled elsewhere)', async () => {
+    const workspaceMap = await writePkg({ './api': './src/api.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf', workspaceMap)).toBeNull();
+  });
+
+  it('returns null for a package that is not in the workspace map', async () => {
+    const workspaceMap = await writePkg({ './api': './src/api.ts' });
+    expect(resolveWorkspaceSubpathToSource('@other/pkg/api', workspaceMap)).toBeNull();
+  });
+
+  it('returns null (guarded) when the exports map has no entry for the subpath', async () => {
+    // resolve.exports throws for a missing entry; the resolver must swallow it and return null.
+    const workspaceMap = await writePkg({ './api': './src/api.ts' });
+    expect(resolveWorkspaceSubpathToSource('@scope/leaf/does-not-exist', workspaceMap)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Two related, additive fixes to `@mastra/deployer` for pnpm/Nx monorepos built with `bundler: { externals: true }` (the mode required when a consumer has native `.node` bindings, e.g. LiveKit). Both are behavior-preserving: any build that already succeeds is unchanged.

- Fixes #19379 — `mastra build`/`mastra dev` crashed with `Missing "." specifier in "<pkg>" package` when a workspace package declares only subpath exports (no `.` entry).
- Fixes #19909 — a workspace subpath imported transitively (by another workspace package) leaked out of the bundle as an unresolved bare specifier, unregistered in the generated `package.json` → `ERR_MODULE_NOT_FOUND` at runtime.

## Changes

**1. Subpath-only workspace exports (#19379)** — `build/analyze/analyzeEntry.ts`, `build/analyze/bundleExternals.ts`

The transitive-dependency walk registered every transitive workspace package as a synthetic root `export * from '<pkg>'` module — even for packages that cannot be imported at their root. In `noBundling` mode (`externals: true` / dev), the `alias-optimized-deps` resolver then called `resolve.exports(pkgJson, '.')`, which throws for a subpath-only `exports` map.

- `analyzeEntry.ts`: skip the synthetic root registration for workspace packages with no root entry (no `.` export, no `exports` map, or string sugar). The subpaths actually imported are captured independently, so nothing previously bundled is dropped.
- `bundleExternals.ts`: guard the `resolve.exports` root lookup so it falls back to `main`/`index` instead of throwing.

**2. Transitive workspace subpath imports (#19909)** — `build/bundler.ts`

Transitive-dependency discovery is manifest-name-based: it registers workspace package *roots*, but never reads a workspace package's *source* to learn which *subpaths* it imports from other workspace packages. Such a subpath (`@scope/a` importing `@scope/b/sub`, app depends on `@scope/a` only) was never captured, fell through the resolver, and leaked as a bare specifier.

- `bundler.ts`: in the main bundle, resolve an uncaptured workspace subpath (recognized via `workspaceMap`) to its source through the package's `exports` map and return it non-external, so the bundler compiles it inline. No new analysis pass is added, so the existing manifest-based transitive-discovery behavior is preserved.

## Why additive

- #19379 fix: for packages with a root, the register branch is always taken and the `resolve.exports` `try` always succeeds — byte-identical behavior. The change only affects the case that currently crashes.
- #19909 fix: only engages for a workspace subpath that is otherwise unresolved (would leak); every already-resolvable import is untouched.

## Testing

- New unit tests: subpath-only root-entry detection + skip logic (`analyzeEntry.test.ts`), the `resolve.exports` guard (`bundleExternals.test.ts`), and the workspace-subpath resolver (`bundler.workspace-subpath.test.ts`).
- Full `packages/deployer` build suite green (`vitest run src/build`, 420 tests), `tsc --noEmit` clean, `eslint` clean.
- Verified end-to-end on a reproduction monorepo: unfixed → `Missing "." specifier` crash; with the fixes → `mastra build` exits 0, the transitive subpath is compiled inline, no bare workspace specifier leaks into the output, and the generated `package.json` is self-contained.

Changeset included (`@mastra/deployer` patch).
