### PR TITLE
fix(core): stop llmPrompt clobbering tool-result output with a nullish stored modelOutput

### DIFF
--- a/.changeset/tool-result-output-nullish-clobber.md
+++ b/.changeset/tool-result-output-nullish-clobber.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed durable Agent prompt build clobbering a valid tool-result `output` with `undefined`. `MessageList`'s `llmPrompt()` restores stored tool outputs by keying off `'modelOutput' in providerMetadata.mastra` (key presence) and then unconditionally overwriting the already-converted `output`. When a tool's `toModelOutput` returns `undefined` (e.g. a text-only result), the durable llm-mapping step still persists `mastra: { modelOutput: undefined }`, so the override replaced the correct output with `undefined` — producing a tool-result whose `output` is missing. Providers that read `output.type` (e.g. `@openrouter/ai-sdk-provider`) then threw `Cannot read properties of undefined (reading 'type')`, aborting the request and poisoning the thread on every subsequent turn. The override now only applies when the stored `modelOutput` is non-nullish.

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -578,7 +578,16 @@ export class MessageList {
               part.toolInvocation?.state === 'result' &&
               part.providerMetadata?.mastra &&
               typeof part.providerMetadata.mastra === 'object' &&
-              'modelOutput' in (part.providerMetadata.mastra as Record<string, unknown>)
+              'modelOutput' in (part.providerMetadata.mastra as Record<string, unknown>) &&
+              // Only override with a real stored output. A tool's `toModelOutput` can
+              // return `undefined` (e.g. a text-only result), which the durable
+              // llm-mapping step still persists as `mastra: { modelOutput: undefined }`
+              // (key present, value nullish). Without this guard the override below
+              // clobbers the already-correct converted `output` with `undefined`,
+              // producing a tool-result whose `output` is missing — which then throws
+              // in providers that read `output.type` (e.g. @openrouter/ai-sdk-provider)
+              // and aborts the whole request.
+              (part.providerMetadata.mastra as Record<string, unknown>).modelOutput != null
             ) {
               storedModelOutputs.set(
                 part.toolInvocation.toolCallId,

--- a/packages/core/src/agent/message-list/tests/tool-result-output-undefined.test.ts
+++ b/packages/core/src/agent/message-list/tests/tool-result-output-undefined.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+import { MessageList } from '../index';
+
+/**
+ * Repro for a production crash in the durable Agent's OUTBOUND prompt build.
+ *
+ * When the durable Agent builds the next model request from thread history via
+ * `messageList.get.all.aiV6.llmPrompt()` (or the underlying `aiV5.llmPrompt()`),
+ * a stored, well-formed tool-result is converted into a `tool` ModelMessage whose
+ * tool-result part has `output: undefined`. Handed to `@openrouter/ai-sdk-provider`,
+ * whose `getToolResultContent(i){ return i.output.type === 'text' ? ... }` reads
+ * `.type` on undefined, this throws
+ * "Cannot read properties of undefined (reading 'type')" and permanently poisons
+ * the thread.
+ *
+ * Root cause: `llmPrompt()`'s `storedModelOutputs` override (message-list.ts,
+ * ~L571-605) keys off `'modelOutput' in providerMetadata.mastra` (key presence)
+ * and then unconditionally overwrites the already-correct converted `output` with
+ * `mastra.modelOutput`. When that stored value is `undefined`/`null`, it clobbers
+ * the valid output. The `.prompt()`/`.model()` accessors do NOT have this override,
+ * which is why the crash only shows up on the durable `llmPrompt` path.
+ *
+ * The tool-invocation part below carries `providerMetadata.mastra.modelOutput`
+ * present-but-undefined (JSON serialization drops the key, so a plain DB dump
+ * shows `mastra: {}` — the value only survives in-memory within a run, which is
+ * exactly when the durable workflow builds the next request).
+ */
+const TOOL_CALL_ID = 'call_a6vmNvERgEs7d6sv720R3G2z';
+const TOOL_NAME = 'mastra_workspace_read_file';
+const ARGS = {
+  path: '/output/openbayes-usage/whoami.json',
+  offset: 1,
+  limit: 220,
+  showLineNumbers: true,
+  encoding: 'utf-8',
+} as const;
+const RESULT =
+  '/output/openbayes-usage/whoami.json (lines 1-220 of 335, 6930 bytes)\n' +
+  '     1→{\n     2→  "me": { ... a long string ... }';
+
+const REASONING_DETAILS = [
+  {
+    type: 'reasoning.encrypted',
+    data: 'ZW5jcnlwdGVkLWJhc2U2NC1ibG9iLXBsYWNlaG9sZGVy',
+    id: 'rs_02ae0000',
+    format: 'openai-responses-v1',
+    index: 0,
+  },
+];
+
+function poisonedMessage() {
+  return {
+    id: 'mem-assistant-poisoned',
+    role: 'assistant' as const,
+    content: {
+      format: 2 as const,
+      parts: [
+        {
+          type: 'reasoning' as const,
+          reasoning: '',
+          details: [],
+          providerMetadata: { openrouter: { reasoning_details: REASONING_DETAILS } },
+        },
+        {
+          type: 'tool-invocation' as const,
+          toolInvocation: {
+            state: 'result' as const,
+            toolCallId: TOOL_CALL_ID,
+            toolName: TOOL_NAME,
+            args: { ...ARGS },
+            result: RESULT,
+          },
+          providerMetadata: {
+            openrouter: { reasoning_details: REASONING_DETAILS },
+            // The load-bearing poison: the key exists but the value is undefined.
+            mastra: { modelOutput: undefined },
+          },
+        },
+      ],
+      metadata: {
+        modelId: 'openai/gpt-5.4',
+        provider: 'openrouter',
+        mastra: { responseBoundary: true },
+      },
+    },
+    createdAt: new Date('2024-01-01T00:00:01Z'),
+    threadId: 'thread-1',
+  };
+}
+
+describe('outbound tool-result conversion — output must survive (prod crash repro)', () => {
+  it('preserves output and input on the durable v6 llmPrompt tool ModelMessage', async () => {
+    const list = new MessageList();
+
+    list.add(
+      {
+        id: 'mem-user1',
+        role: 'user',
+        content: { format: 2, parts: [{ type: 'text', text: 'Read whoami.json' }] },
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        threadId: 'thread-1',
+      },
+      'memory',
+    );
+
+    list.add(poisonedMessage(), 'memory');
+
+    // New user turn — the durable Agent builds the next model request from history.
+    list.add({ role: 'user', content: 'What is my username?' }, 'input');
+
+    // This is the exact accessor the durable Agent uses for v6/"responses" providers
+    // (packages/core/src/agent/durable/workflows/steps/llm-execution.ts).
+    const prompt = await list.get.all.aiV6.llmPrompt();
+
+    const toolMsg = prompt.find(m => m.role === 'tool');
+    expect(toolMsg, 'expected a role:"tool" model message').toBeDefined();
+    expect(Array.isArray(toolMsg!.content)).toBe(true);
+
+    const toolResult = (toolMsg!.content as any[]).find(p => p.type === 'tool-result' && p.toolCallId === TOOL_CALL_ID);
+    expect(toolResult, 'expected a tool-result part for the toolCallId').toBeDefined();
+
+    // The crash driver: output must NOT be undefined. `@openrouter/ai-sdk-provider`
+    // reads `output.type`, so an undefined output throws and aborts the stream.
+    expect(toolResult.output, 'tool-result.output must be defined').toBeDefined();
+
+    // And it must carry the actual tool result text.
+    expect(JSON.stringify(toolResult.output)).toContain('whoami.json');
+
+    // input must equal the original args (not {}).
+    expect(toolResult.input).toEqual(ARGS);
+  });
+});


### PR DESCRIPTION
## Summary

A durable Agent using an OpenRouter v6 (`@openrouter/ai-sdk-provider`) model hard-crashes the model request whenever thread history contains a text-only tool result, with:

```
Error processing LLM stream { error: Cannot read properties of undefined (reading 'type') }
   at getToolResultContent (@openrouter/ai-sdk-provider … input.output.type)
   at convertToOpenRouterChatMessages
   at OpenRouterChatLanguageModel.getArgs / doStream
```

The provider reads `output.type` on a `tool-result` whose `output` is `undefined`. The bad `output` is produced by `@mastra/core` itself while building the prompt — the stored DB message is well-formed — so once a thread holds such a message, **every subsequent turn crashes and the thread is permanently poisoned**.

## Root cause

`MessageList`'s `get.all.aiV5.llmPrompt()` (used by the durable agent via `get.all.aiV6.llmPrompt()` — see `agent/durable/workflows/steps/llm-execution.ts`) has a `storedModelOutputs` pass that restores a tool's rich model output onto the converted model message:

```ts
// message-list.ts
if (
  part.type === 'tool-invocation' &&
  part.toolInvocation?.state === 'result' &&
  part.providerMetadata?.mastra &&
  typeof part.providerMetadata.mastra === 'object' &&
  'modelOutput' in part.providerMetadata.mastra          // <-- key presence only
) {
  storedModelOutputs.set(part.toolInvocation.toolCallId, part.providerMetadata.mastra.modelOutput);
}
// ...later, unconditionally:
modelMsg.content[i] = { ...part, output: storedModelOutputs.get(part.toolCallId) };
```

The durable llm-mapping step persists that metadata from the tool's `toModelOutput`:

```ts
// agent/durable/workflows/steps/llm-mapping.ts
let modelOutput = await tool.toModelOutput(toolResult.result);
modelOutput = normalizeModelOutput(modelOutput);
// ...
mastra: { ...existingMastra, modelOutput },
```

When `toModelOutput` returns `undefined` (the common case for a **text-only** tool result — e.g. a workspace file read whose `toModelOutput` only maps media), this persists `mastra: { modelOutput: undefined }` — the **key is present but the value is nullish**. (A JSON dump of the DB row shows `mastra: {}` because `JSON.stringify` drops undefined-valued keys, but the key still exists in-memory within a running workflow, which is exactly when `llmPrompt` builds the next request.)

The guard keys off `'modelOutput' in mastra`, so it collects the `undefined`, and the override then **clobbers the already-correct converted `output` with `undefined`**. `aiV5PromptToAIV6Prompt` passes it through, and the provider throws on `output.type`.

This override exists **only** on the `llmPrompt` path — not `.prompt()` / `.model()` — which is why the crash is specific to the durable prompt build.

## Fix

Only override when the stored `modelOutput` is non-nullish. One-line guard addition; a nullish `modelOutput` now leaves the correctly-converted `output` intact.

## Test

Adds `packages/core/src/agent/message-list/tests/tool-result-output-undefined.test.ts`, which reproduces the crash by adding a faithful poisoned assistant message and asserting the `role:"tool"` model message from `get.all.aiV6.llmPrompt()` has a defined `output` carrying the result text. It fails on `main` (`output` is `undefined`) and passes with this change. Full `message-list` suite (42 files / 525 tests) stays green.

## Related

Same "tool-result loses its content on outbound conversion" family as #16017 (fabricated `args: {}` on stand-alone tool-results) and #17798 (background sub-agent placeholder → `null` tool content → provider 500); this is the `output`-side sibling, and the first that produces a hard `reading 'type'` crash rather than a validation/500.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

A saved tool result was sometimes replaced with an empty value, causing agents to crash later. This change keeps the correct result and adds a regression test.

## What changed

- Restore durable tool output only when the stored value is non-nullish.
- Preserve converted tool-result output when `modelOutput` is `undefined`.
- Add a regression test covering text-only tool results through `aiV6.llmPrompt()`.
- Add a changeset patch note.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->