### PR TITLE
fix(core): stop llmPrompt clobbering tool-result output with a nullish stored modelOutput

### DIFF
--- a/.changeset/tool-result-output-nullish-clobber.md
+++ b/.changeset/tool-result-output-nullish-clobber.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed the durable Agent prompt build (`MessageList.llmPrompt`) overwriting a valid tool-result `output` with `undefined` when a tool's `toModelOutput` returns nothing (e.g. a text-only result). The resulting tool message had a missing `output`, which crashed providers that read `output.type` (such as OpenRouter) and aborted the request. The stored model output now only overrides when it is non-nullish.

--- a/.changeset/tool-result-output-nullish-clobber.md
+++ b/.changeset/tool-result-output-nullish-clobber.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed the durable Agent prompt build (`MessageList.llmPrompt`) overwriting a valid tool-result `output` with `undefined` when a tool's `toModelOutput` returns nothing (e.g. a text-only result). The resulting tool message had a missing `output`, which crashed providers that read `output.type` (such as OpenRouter) and aborted the request. The stored model output now only overrides when it is non-nullish.
+Fixed durable Agent conversations crashing on a later turn after a tool returned a text-only result, which previously left the thread stuck and unable to continue.

--- a/.changeset/tool-result-output-nullish-clobber.md
+++ b/.changeset/tool-result-output-nullish-clobber.md
@@ -2,4 +2,4 @@
 '@mastra/core': patch
 ---
 
-Fixed durable Agent conversations crashing on a later turn after a tool returned a text-only result, which previously left the thread stuck and unable to continue.
+Fixed durable Agent conversations crashing on a later turn after a tool returned a text-only result, which previously left the thread stuck and unable to continue. Durable runs also no longer store the empty mapping result on the message, matching regular agents, so existing conversations recover and new ones stay clean.

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping-model-output.test.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping-model-output.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { MessageList } from '../../../message-list';
+import { globalRunRegistry } from '../../run-registry';
+import { createDurableLLMMappingStep } from './llm-mapping';
+
+// Write-side companion to the llmPrompt read-side guard (message-list.ts).
+//
+// A tool's `toModelOutput` can return `undefined` (e.g. a text-only result).
+// The durable llm-mapping step used to persist that as
+// `providerMetadata.mastra.modelOutput: undefined` — key present, value
+// nullish — poisoning the stored message so every later prompt build tripped
+// the stored-output override. The non-durable llm-mapping-step already skips
+// nullish values on write; this covers the durable step's parity.
+
+function buildInput(toModelOutput: (result: unknown) => unknown, runId: string) {
+  const toolCallId = 'call_1';
+  const list = new MessageList({ threadId: 'thread-1', resourceId: 'resource-1' });
+  list.add({ role: 'user', content: 'read whoami.json' }, 'input');
+  list.add(
+    {
+      id: 'assistant-1',
+      role: 'assistant',
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      threadId: 'thread-1',
+      content: {
+        format: 2,
+        parts: [
+          {
+            type: 'tool-invocation',
+            toolInvocation: { state: 'call', toolCallId, toolName: 'read_file', args: { path: 'whoami.json' } },
+          },
+        ],
+      },
+    },
+    'response',
+  );
+
+  globalRunRegistry.set(runId, { tools: { read_file: { toModelOutput } } } as any);
+
+  return {
+    inputData: {
+      llmOutput: {
+        messageListState: list.serialize(),
+        stepResult: { isContinued: false },
+        text: '',
+        toolCalls: [],
+      },
+      toolResults: [{ toolCallId, toolName: 'read_file', args: { path: 'whoami.json' }, result: '{ "id": 1 }' }],
+      runId,
+      agentId: 'agent-1',
+      messageId: 'assistant-1',
+      state: { threadId: 'thread-1', resourceId: 'resource-1', threadExists: false },
+    },
+    mastra: undefined,
+    requestContext: undefined,
+  };
+}
+
+function getToolInvocationPart(messageListState: unknown) {
+  const list = new MessageList({ threadId: 'thread-1', resourceId: 'resource-1' });
+  list.deserialize(messageListState as any);
+  for (const dbMsg of list.get.all.db()) {
+    if (dbMsg.content?.format !== 2 || !dbMsg.content.parts) continue;
+    for (const part of dbMsg.content.parts) {
+      if (part.type === 'tool-invocation') return part as any;
+    }
+  }
+  return undefined;
+}
+
+describe('durable llm-mapping toModelOutput persistence', () => {
+  it('does not persist a nullish modelOutput', async () => {
+    const runId = 'durable-model-output-nullish';
+    try {
+      const result = await (createDurableLLMMappingStep() as any).execute(buildInput(() => undefined, runId));
+
+      const part = getToolInvocationPart(result.messageListState);
+      expect(part, 'tool-invocation part should exist').toBeDefined();
+      const mastraMeta = part.providerMetadata?.mastra as Record<string, unknown> | undefined;
+      expect(
+        mastraMeta === undefined || !('modelOutput' in mastraMeta),
+        'a nullish modelOutput must not be persisted (poisons the stored message)',
+      ).toBe(true);
+    } finally {
+      globalRunRegistry.delete(runId);
+    }
+  });
+
+  it('still persists a real modelOutput', async () => {
+    const runId = 'durable-model-output-real';
+    try {
+      const result = await (createDurableLLMMappingStep() as any).execute(
+        buildInput(() => ({ type: 'text', value: 'mapped' }), runId),
+      );
+
+      const part = getToolInvocationPart(result.messageListState);
+      expect((part.providerMetadata?.mastra as any)?.modelOutput).toEqual({ type: 'text', value: 'mapped' });
+    } finally {
+      globalRunRegistry.delete(runId);
+    }
+  });
+});

--- a/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
+++ b/packages/core/src/agent/durable/workflows/steps/llm-mapping.ts
@@ -211,11 +211,16 @@ export function createDurableLLMMappingStep() {
                 modelOutput = normalizeModelOutput(modelOutput);
                 mappingSpan?.end({ output: modelOutput });
 
-                const existingMastra = (toolResult.providerMetadata as any)?.mastra;
-                providerMetadata = {
-                  ...toolResult.providerMetadata,
-                  mastra: { ...existingMastra, modelOutput },
-                };
+                // Skip nullish modelOutput (e.g. a text-only result): persisting
+                // `mastra: { modelOutput: undefined }` poisons the stored message.
+                // Mirrors the non-durable llm-mapping-step.
+                if (modelOutput != null) {
+                  const existingMastra = (toolResult.providerMetadata as any)?.mastra;
+                  providerMetadata = {
+                    ...toolResult.providerMetadata,
+                    mastra: { ...existingMastra, modelOutput },
+                  };
+                }
               } catch (err) {
                 mappingSpan?.error({ error: err as Error, endSpan: true });
                 // toModelOutput errors are non-fatal — the tool result is still usable

--- a/packages/core/src/agent/message-list/message-list.ts
+++ b/packages/core/src/agent/message-list/message-list.ts
@@ -574,17 +574,16 @@ export class MessageList {
           if (dbMsg.content?.format !== 2 || !dbMsg.content.parts) continue;
 
           for (const part of dbMsg.content.parts) {
-            if (
-              part.type === 'tool-invocation' &&
-              part.toolInvocation?.state === 'result' &&
-              part.providerMetadata?.mastra &&
-              typeof part.providerMetadata.mastra === 'object' &&
-              'modelOutput' in (part.providerMetadata.mastra as Record<string, unknown>)
-            ) {
-              storedModelOutputs.set(
-                part.toolInvocation.toolCallId,
-                (part.providerMetadata.mastra as Record<string, unknown>).modelOutput,
-              );
+            if (part.type !== 'tool-invocation' || part.toolInvocation?.state !== 'result') continue;
+
+            // A tool's `toModelOutput` can return `undefined` (e.g. a text-only result), which the
+            // durable llm-mapping step still persists as `mastra: { modelOutput: undefined }`. Skip
+            // nullish values: the override below would otherwise clobber the correctly-converted
+            // `output` with `undefined`, producing a tool-result whose `output` is missing — which
+            // then throws in providers that read `output.type` (e.g. @openrouter/ai-sdk-provider).
+            const mastra = part.providerMetadata?.mastra as Record<string, unknown> | undefined;
+            if (mastra?.modelOutput != null) {
+              storedModelOutputs.set(part.toolInvocation.toolCallId, mastra.modelOutput);
             }
           }
         }

--- a/packages/core/src/agent/message-list/tests/tool-result-output-undefined.test.ts
+++ b/packages/core/src/agent/message-list/tests/tool-result-output-undefined.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { MessageList } from '../index';
+
+// Regression for a durable-Agent prompt-build crash.
+//
+// A tool's `toModelOutput` can return `undefined` (e.g. a text-only result). The
+// durable llm-mapping step persists that as `mastra: { modelOutput: undefined }`
+// (key present, value nullish). `llmPrompt()`'s stored-output override used to
+// key off key-presence and clobber the correctly-converted tool-result `output`
+// with `undefined`. Providers that read `output.type` (e.g.
+// `@openrouter/ai-sdk-provider`) then throw `Cannot read properties of undefined
+// (reading 'type')` and abort the request.
+describe('MessageList llmPrompt tool-result output', () => {
+  it('does not clobber the converted output when the stored modelOutput is nullish', async () => {
+    const toolCallId = 'call_1';
+    const result = 'whoami.json (17 lines)\n{ "id": "aisensiy" }';
+
+    const list = new MessageList();
+    list.add({ role: 'user', content: 'read whoami.json' }, 'input');
+    list.add(
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        createdAt: new Date('2024-01-01T00:00:00Z'),
+        threadId: 'thread-1',
+        content: {
+          format: 2,
+          parts: [
+            {
+              type: 'tool-invocation',
+              toolInvocation: {
+                state: 'result',
+                toolCallId,
+                toolName: 'read_file',
+                args: { path: 'whoami.json' },
+                result,
+              },
+              // The poison: the key exists but its value is undefined.
+              providerMetadata: { mastra: { modelOutput: undefined } },
+            },
+          ],
+        },
+      },
+      'memory',
+    );
+
+    const prompt = await list.get.all.aiV6.llmPrompt();
+    const toolResult = prompt
+      .filter(m => m.role === 'tool')
+      .flatMap(m => (Array.isArray(m.content) ? m.content : []))
+      .find((p: any) => p.type === 'tool-result' && p.toolCallId === toolCallId) as any;
+
+    expect(toolResult?.output, 'tool-result output must not be clobbered to undefined').toBeDefined();
+    expect(JSON.stringify(toolResult.output)).toContain('whoami.json');
+  });
+});


### PR DESCRIPTION
Fixes #19915

`MessageList.llmPrompt()` restores stored tool outputs keyed off `'modelOutput' in providerMetadata.mastra` (key presence only) and then unconditionally overwrites the converted tool-result `output`. When a tool's `toModelOutput` returns `undefined` (e.g. a text-only result), the durable llm-mapping step persists `mastra: { modelOutput: undefined }`, so the override clobbers the correct `output` with `undefined` — crashing providers that read `output.type` (e.g. `@openrouter/ai-sdk-provider` → `Cannot read properties of undefined (reading 'type')`) and aborting the request. `.prompt()`/`.model()` lack this override, so it is specific to the durable `llmPrompt` path used by `get.all.aiV6.llmPrompt()`.

**Fix:** only override when the stored `modelOutput` is non-nullish.

**Test:** adds a regression test reproducing the crash via `get.all.aiV6.llmPrompt()` (fails on `main`, passes with this change). Full `message-list` suite (42 files / 525 tests) stays green.

See #19915 for the full root-cause writeup and reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When a tool returns real text for a conversation that’s saved for later (durable), the next prompt-building step sometimes accidentally replaces that tool’s answer with “nothing.” This PR fixes the prompt-builder so it only reuses saved tool outputs when they actually exist, preventing later crashes and keeping durable conversations working.

## What changed

- Updated `MessageList.llmPrompt()` durable prompt construction to **guard against nullish persisted `providerMetadata.mastra.modelOutput`** so saved tool-result output isn’t overwritten with `undefined`.
- Made durable extraction of `part.providerMetadata.mastra` more defensive (cast-based) before reading `modelOutput`.
- Added the corresponding **durable write-side guard** so durable logic **doesn’t persist nullish `modelOutput`** into tool-result metadata (avoiding “poisoned” durable entries).
- Added regression coverage for the durable `get.all.aiV6.llmPrompt()` path to ensure tool-result `output` remains populated when stored `modelOutput` is `undefined`.

## Testing

- Added `packages/core/src/agent/message-list/tests/tool-result-output-undefined.test.ts` regression test covering durable prompt conversion/model-output mapping (including expected `whoami.json` content preservation).
- Durable step tests passed locally after rebasing.
- Changeset added for `@mastra/core` as a patch release documenting the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->