### PR TITLE
fix(core): preserve observational memory when cloning session threads

### DIFF
--- a/.changeset/silver-banks-report.md
+++ b/.changeset/silver-banks-report.md
@@ -1,0 +1,5 @@
+---
+'@mastra/core': patch
+---
+
+Fixed thread cloning to preserve configured memory state, including observational memory progress.

--- a/mastracode/tui/e2e/tui/resourceid-drift-prompt-accept.ts
+++ b/mastracode/tui/e2e/tui/resourceid-drift-prompt-accept.ts
@@ -7,6 +7,13 @@ import type { McE2eScenario } from './types.js';
 const OLD_RESOURCE_ID = 'mc-e2e-old-dirname-resource';
 const THREAD_ID = 'thread-resource-drift-prompt-accept';
 const TITLE = 'Thread from before resource drift';
+const USER_MESSAGE_ID = 'msg-drift-accept-user';
+const ASSISTANT_MESSAGE_ID = 'msg-drift-accept-assistant';
+const SOURCE_OBSERVATIONS = 'Observed that the source thread retains important project context.';
+const SOURCE_GENERATION = 7;
+const SOURCE_ORIGIN = 'reflection';
+const SOURCE_LAST_OBSERVED_AT = '2099-01-01T00:00:02.000Z';
+const SOURCE_OBSERVED_MESSAGE_IDS = [USER_MESSAGE_ID, ASSISTANT_MESSAGE_ID];
 
 let scenarioDbPath = '';
 let currentResourceId = '';
@@ -47,8 +54,23 @@ insert into mastra_threads (id, resourceId, title, metadata, createdAt, updatedA
 values (${quoteSql(THREAD_ID)}, ${quoteSql(OLD_RESOURCE_ID)}, ${quoteSql(TITLE)}, ${quoteSql(metadata)}, ${quoteSql(now.toISOString())}, ${quoteSql(now.toISOString())});
 insert into mastra_messages (id, thread_id, content, role, type, createdAt, resourceId)
 values
-  ('msg-drift-accept-user', ${quoteSql(THREAD_ID)}, ${quoteSql(userContent)}, 'user', 'v2', ${quoteSql(now.toISOString())}, ${quoteSql(OLD_RESOURCE_ID)}),
-  ('msg-drift-accept-assistant', ${quoteSql(THREAD_ID)}, ${quoteSql(assistantContent)}, 'assistant', 'v2', ${quoteSql(new Date(now.getTime() + 1000).toISOString())}, ${quoteSql(OLD_RESOURCE_ID)});
+  (${quoteSql(USER_MESSAGE_ID)}, ${quoteSql(THREAD_ID)}, ${quoteSql(userContent)}, 'user', 'v2', ${quoteSql(now.toISOString())}, ${quoteSql(OLD_RESOURCE_ID)}),
+  (${quoteSql(ASSISTANT_MESSAGE_ID)}, ${quoteSql(THREAD_ID)}, ${quoteSql(assistantContent)}, 'assistant', 'v2', ${quoteSql(new Date(now.getTime() + 1000).toISOString())}, ${quoteSql(OLD_RESOURCE_ID)});
+insert into mastra_observational_memory (
+  id, lookupKey, scope, resourceId, threadId, activeObservations,
+  activeObservationsPendingUpdate, originType, config, generationCount,
+  lastObservedAt, pendingMessageTokens, totalTokensObserved, observationTokenCount,
+  isObserving, isReflecting, observedMessageIds, isBufferingObservation,
+  isBufferingReflection, lastBufferedAtTokens, createdAt, updatedAt
+)
+values (
+  'om-resource-drift-source', ${quoteSql(`thread:${THREAD_ID}`)}, 'thread',
+  ${quoteSql(OLD_RESOURCE_ID)}, ${quoteSql(THREAD_ID)}, ${quoteSql(SOURCE_OBSERVATIONS)},
+  0, ${quoteSql(SOURCE_ORIGIN)}, ${quoteSql(JSON.stringify({ scope: 'thread' }))}, ${SOURCE_GENERATION},
+  ${quoteSql(SOURCE_LAST_OBSERVED_AT)}, 0, 42, 42, 0, 0,
+  ${quoteSql(JSON.stringify(SOURCE_OBSERVED_MESSAGE_IDS))}, 0, 0, 0,
+  ${quoteSql(now.toISOString())}, ${quoteSql(SOURCE_LAST_OBSERVED_AT)}
+);
 `;
   execFileSync('sqlite3', [dbPath], { input: sql });
 }
@@ -115,6 +137,104 @@ export const resourceidDriftPromptAcceptScenario: McE2eScenario = {
     );
     if (clonedMessageResourceIds !== currentResourceId) {
       throw new Error(`Expected cloned message resourceIds ${currentResourceId}, got ${clonedMessageResourceIds}`);
+    }
+
+    const clonedMessageIds = queryValue(
+      scenarioDbPath,
+      `select id from mastra_messages where thread_id = ${quoteSql(clonedThreadId)} order by createdAt asc;`,
+    )
+      .split('\n')
+      .filter(Boolean);
+    const clonedOmWhere = `threadId = ${quoteSql(clonedThreadId)} order by generationCount desc limit 1`;
+    const clonedActiveObservations = queryValue(
+      scenarioDbPath,
+      `select activeObservations from mastra_observational_memory where ${clonedOmWhere};`,
+    );
+    const clonedGeneration = queryValue(
+      scenarioDbPath,
+      `select generationCount from mastra_observational_memory where ${clonedOmWhere};`,
+    );
+    const clonedOrigin = queryValue(
+      scenarioDbPath,
+      `select originType from mastra_observational_memory where ${clonedOmWhere};`,
+    );
+    const clonedLastObservedAt = queryValue(
+      scenarioDbPath,
+      `select lastObservedAt from mastra_observational_memory where ${clonedOmWhere};`,
+    );
+    const clonedObservedMessageIdsRaw = queryValue(
+      scenarioDbPath,
+      `select observedMessageIds from mastra_observational_memory where ${clonedOmWhere};`,
+    );
+    let clonedObservedMessageIds: unknown = null;
+    try {
+      clonedObservedMessageIds = JSON.parse(clonedObservedMessageIdsRaw);
+    } catch {
+      // Report the raw value in the aggregate mismatch below.
+    }
+
+    const mismatches: string[] = [];
+    if (clonedActiveObservations !== SOURCE_OBSERVATIONS) {
+      mismatches.push(
+        `activeObservations: expected ${JSON.stringify(SOURCE_OBSERVATIONS)}, got ${JSON.stringify(clonedActiveObservations)}`,
+      );
+    }
+    if (clonedGeneration !== String(SOURCE_GENERATION) || clonedOrigin !== SOURCE_ORIGIN) {
+      mismatches.push(
+        `generation/origin: expected ${SOURCE_GENERATION}/${SOURCE_ORIGIN}, got ${clonedGeneration || '<missing>'}/${clonedOrigin || '<missing>'}`,
+      );
+    }
+    if (clonedLastObservedAt !== SOURCE_LAST_OBSERVED_AT) {
+      mismatches.push(
+        `lastObservedAt: expected ${SOURCE_LAST_OBSERVED_AT}, got ${clonedLastObservedAt || '<missing>'}`,
+      );
+    }
+    if (
+      JSON.stringify(clonedObservedMessageIds) !== JSON.stringify(clonedMessageIds) ||
+      SOURCE_OBSERVED_MESSAGE_IDS.some(
+        id => Array.isArray(clonedObservedMessageIds) && clonedObservedMessageIds.includes(id),
+      )
+    ) {
+      mismatches.push(
+        `observedMessageIds: expected cloned IDs ${JSON.stringify(clonedMessageIds)} with no source IDs, got ${clonedObservedMessageIdsRaw || '<missing>'}`,
+      );
+    }
+
+    const sourceOmWhere = `id = 'om-resource-drift-source'`;
+    const sourceActiveObservations = queryValue(
+      scenarioDbPath,
+      `select activeObservations from mastra_observational_memory where ${sourceOmWhere};`,
+    );
+    const sourceGeneration = queryValue(
+      scenarioDbPath,
+      `select generationCount from mastra_observational_memory where ${sourceOmWhere};`,
+    );
+    const sourceOrigin = queryValue(
+      scenarioDbPath,
+      `select originType from mastra_observational_memory where ${sourceOmWhere};`,
+    );
+    const sourceLastObservedAt = queryValue(
+      scenarioDbPath,
+      `select lastObservedAt from mastra_observational_memory where ${sourceOmWhere};`,
+    );
+    const sourceObservedMessageIds = queryValue(
+      scenarioDbPath,
+      `select observedMessageIds from mastra_observational_memory where ${sourceOmWhere};`,
+    );
+    if (sourceActiveObservations !== SOURCE_OBSERVATIONS) {
+      mismatches.push(`source activeObservations: source OM changed unexpectedly`);
+    }
+    if (sourceGeneration !== String(SOURCE_GENERATION) || sourceOrigin !== SOURCE_ORIGIN) {
+      mismatches.push(`source generation/origin: source OM changed unexpectedly`);
+    }
+    if (sourceLastObservedAt !== SOURCE_LAST_OBSERVED_AT) {
+      mismatches.push(`source lastObservedAt: source OM changed unexpectedly`);
+    }
+    if (sourceObservedMessageIds !== JSON.stringify(SOURCE_OBSERVED_MESSAGE_IDS)) {
+      mismatches.push(`source observedMessageIds: source OM changed unexpectedly`);
+    }
+    if (mismatches.length > 0) {
+      throw new Error(`Cloned observational memory mismatch:\n${mismatches.map(line => `- ${line}`).join('\n')}`);
     }
 
     terminal.keyCtrlC();

--- a/packages/core/src/agent-controller/agent-controller.ts
+++ b/packages/core/src/agent-controller/agent-controller.ts
@@ -282,7 +282,7 @@ export class AgentController<TState = {}> {
       setState: updates => void session.state.set(updates as Partial<TState>),
       setSetting: ({ key, value }) => session.thread.setSetting({ key, value }),
     });
-    session.thread.connect(this.createThreadDataStore(), session as Session);
+    session.thread.connect(this.createThreadDataStore(session), session as Session);
     session.setMachinery({
       getAgent: () => this.getCurrentAgent(session),
       subscribeToThread: ({ resourceId, threadId }) =>
@@ -658,22 +658,6 @@ export class AgentController<TState = {}> {
     return this.#externalMastra?.getStorage() ?? this.config.storage;
   }
 
-  private async resolveConfiguredMemory(): Promise<MastraMemory | undefined> {
-    const configuredMemory = this.config.memory;
-    if (!configuredMemory) return undefined;
-
-    const memory =
-      typeof configuredMemory === 'function'
-        ? await configuredMemory({ requestContext: new RequestContext(), mastra: this.getMastra() })
-        : configuredMemory;
-
-    if (!memory) {
-      throw new Error('Dynamic memory factory returned empty value');
-    }
-
-    return memory;
-  }
-
   /**
    * Sets or updates the harness-level browser and propagates it to mode agents.
    */
@@ -793,10 +777,11 @@ export class AgentController<TState = {}> {
 
   /**
    * The shared-host storage gateway the Session's thread domain reads/writes
-   * through. The Session owns the thread-domain logic; this adapter just maps
-   * raw storage rows to AgentController types — it does not call back into Session.
+   * through. The Session owns the thread-domain logic; this adapter maps raw
+   * storage rows to AgentController types and uses the active session only when
+   * resolving configured memory for a clone.
    */
-  private createThreadDataStore(): ThreadDataStore {
+  private createThreadDataStore(session: Session<TState>): ThreadDataStore {
     return {
       listThreads: ({ resourceId, includeForkedSubagents, metadata }) =>
         this.queryThreads({ resourceId, includeForkedSubagents, metadata }),
@@ -810,7 +795,7 @@ export class AgentController<TState = {}> {
       saveThread: ({ thread }) => this.persistThreadRow(thread),
       deleteThread: ({ threadId }) => this.deleteThreadRow(threadId),
       cloneThread: ({ sourceThreadId, resourceId, title, metadata }) =>
-        this.cloneThreadRow({ sourceThreadId, resourceId, title, metadata }),
+        this.cloneThreadRow({ session, sourceThreadId, resourceId, title, metadata }),
       acquireLock: threadId => this.config.threadLock?.acquire(threadId) ?? Promise.resolve(),
       releaseLock: threadId => this.config.threadLock?.release(threadId) ?? Promise.resolve(),
       getModeIds: () => this.config.modes.map(m => m.id),
@@ -842,18 +827,24 @@ export class AgentController<TState = {}> {
 
   /** Clone a thread (and messages) via the host's memory (gateway primitive for the Session thread domain). */
   private async cloneThreadRow({
+    session,
     sourceThreadId,
     resourceId,
     title,
     metadata,
   }: {
+    session: Session<TState>;
     sourceThreadId: string;
     resourceId: string;
     title?: string;
     metadata?: Record<string, unknown>;
   }): Promise<AgentControllerThread> {
     const storage = this.#resolveStorage();
-    const memory = storage ? await storage.getStore('memory') : await this.resolveConfiguredMemory();
+    const memory = this.config.memory
+      ? await this.resolveMemory(session)
+      : storage
+        ? await storage.getStore('memory')
+        : undefined;
     if (!memory) {
       throw new Error(
         storage ? 'Storage does not have a memory domain configured' : 'Memory is not configured on this Harness',

--- a/packages/core/src/agent-controller/clone-thread.test.ts
+++ b/packages/core/src/agent-controller/clone-thread.test.ts
@@ -1,31 +1,37 @@
 import { describe, expect, it, vi } from 'vitest';
 import { Agent } from '../agent';
+import { InMemoryStore } from '../storage/mock';
 import { AgentController } from './agent-controller';
 import { createMockWorkspace } from './test-utils';
 
 describe('AgentController cloneThread', () => {
-  it('resolves dynamic memory factory before cloning', async () => {
+  it('prefers session-aware dynamic memory over configured storage when cloning', async () => {
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    const storage = new InMemoryStore();
     const cloneThread = vi.fn().mockResolvedValue({
       thread: {
         id: 'cloned-thread-id',
         resourceId: 'target-resource',
         title: 'Cloned title',
-        createdAt: new Date('2026-01-01T00:00:00.000Z'),
-        updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+        createdAt: now,
+        updatedAt: now,
         metadata: {},
       },
       clonedMessages: [],
       messageIdMap: {},
     });
-
-    const memoryFactory = vi.fn().mockResolvedValue({
-      cloneThread,
+    let resolvedControllerContext: any;
+    const memoryFactory = vi.fn().mockImplementation(({ requestContext }) => {
+      resolvedControllerContext = requestContext.get('controller');
+      return { cloneThread };
     });
 
     const controller = new AgentController({
       workspace: createMockWorkspace(),
       id: 'test-controller',
       resourceId: 'controller-resource',
+      storage,
+      initialState: { memoryProfile: 'session-profile' },
       memory: memoryFactory as any,
       modes: [
         {
@@ -42,6 +48,18 @@ describe('AgentController cloneThread', () => {
     });
 
     await controller.init();
+    const memoryStore = await storage.getStore('memory');
+    await memoryStore.saveThread({
+      thread: {
+        id: 'source-thread-id',
+        resourceId: 'controller-resource',
+        title: 'Source title',
+        createdAt: now,
+        updatedAt: now,
+        metadata: {},
+      },
+    });
+    const storageCloneThread = vi.spyOn(memoryStore, 'cloneThread');
     const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
 
     const cloned = await session.thread.clone({
@@ -51,13 +69,72 @@ describe('AgentController cloneThread', () => {
     });
 
     expect(memoryFactory).toHaveBeenCalledTimes(1);
+    expect(resolvedControllerContext).toMatchObject({
+      controllerId: 'test-controller',
+      state: { memoryProfile: 'session-profile' },
+      session: { id: 'test-session', ownerId: 'test-owner' },
+    });
     expect(cloneThread).toHaveBeenCalledWith({
       sourceThreadId: 'source-thread-id',
       resourceId: 'target-resource',
       title: 'New title',
     });
+    expect(storageCloneThread).not.toHaveBeenCalled();
     expect(cloned.id).toBe('cloned-thread-id');
     expect(cloned.resourceId).toBe('target-resource');
+  });
+
+  it('uses the raw memory storage clone when configured memory is absent', async () => {
+    const now = new Date('2026-01-01T00:00:00.000Z');
+    const storage = new InMemoryStore();
+    const controller = new AgentController({
+      workspace: createMockWorkspace(),
+      id: 'test-controller',
+      resourceId: 'controller-resource',
+      storage,
+      modes: [
+        {
+          id: 'default',
+          name: 'Default',
+          default: true,
+          agent: new Agent({
+            name: 'test-agent',
+            instructions: 'You are a test agent.',
+            model: { provider: 'openai', name: 'gpt-4o', toolChoice: 'auto' },
+          }),
+        },
+      ],
+    });
+
+    await controller.init();
+    const memoryStore = await storage.getStore('memory');
+    await memoryStore.saveThread({
+      thread: {
+        id: 'source-thread-id',
+        resourceId: 'controller-resource',
+        title: 'Source title',
+        createdAt: now,
+        updatedAt: now,
+        metadata: {},
+      },
+    });
+    const storageCloneThread = vi.spyOn(memoryStore, 'cloneThread');
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    const cloned = await session.thread.clone({
+      sourceThreadId: 'source-thread-id',
+      title: 'Storage clone',
+      resourceId: 'target-resource',
+    });
+
+    expect(storageCloneThread).toHaveBeenCalledWith({
+      sourceThreadId: 'source-thread-id',
+      resourceId: 'target-resource',
+      title: 'Storage clone',
+    });
+    expect(cloned.id).not.toBe('source-thread-id');
+    expect(cloned.resourceId).toBe('target-resource');
+    expect(cloned.title).toBe('Storage clone');
   });
 
   it('throws when dynamic memory factory returns empty value', async () => {


### PR DESCRIPTION
Thread clones through `AgentController` preferred raw storage whenever storage existed. That copied thread and message rows, but skipped configured `Memory.cloneThread()` behavior such as preserving observational memory state and remapping its message cursor.

Before:
```ts
const memory = storage
  ? await storage.getStore('memory')
  : await this.resolveConfiguredMemory();
```

After:
```ts
const memory = this.config.memory
  ? await this.resolveMemory(session)
  : storage
    ? await storage.getStore('memory')
    : undefined;
```

Configured memory now resolves with the active session request context, while controllers with storage only keep the raw clone fallback. The focused core tests cover both routes, and the Mastra Code resource-drift scenario verifies that active observations, generation metadata, `lastObservedAt`, and remapped observed message IDs survive a real session clone.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a conversation is copied, it now remembers what the system had already noticed and learned. This keeps copied threads consistent while still supporting older storage-only setups.

## What changed

- Thread cloning now resolves configured memory using the active session context.
- Observational memory, generation metadata, timestamps, and observed message IDs are preserved and remapped correctly.
- Storage-only controllers retain the raw storage clone fallback.
- Added focused core tests for dynamic memory precedence and fallback behavior.
- Expanded Mastra Code drift coverage with database-level validation of cloned and source observational memory.
- Added a patch changeset for `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->