### PR TITLE
perf(mcp): discover tools, resources, and prompts from all MCP servers concurrently

### DIFF
--- a/.changeset/mcp-parallel-tool-discovery.md
+++ b/.changeset/mcp-parallel-tool-discovery.md
@@ -1,0 +1,5 @@
+---
+'@mastra/mcp': patch
+---
+
+Speed up MCP discovery when an `MCPClient` is configured with multiple servers. `listTools()`, `listToolsets()`, `resources.list()`, `resources.templates()`, and `prompts.list()` now query all configured servers concurrently instead of one at a time, so total discovery time is roughly the slowest single server rather than the sum of all of them, and one slow or unresponsive server no longer stalls discovery for the rest. Tool, resource, and prompt ordering and per-server error reporting are unchanged.

--- a/packages/mcp/src/client/configuration.test.ts
+++ b/packages/mcp/src/client/configuration.test.ts
@@ -283,4 +283,97 @@ describe('MCPClient tool discovery retries', () => {
       empty: undefined,
     });
   });
+
+  const makeThreeServerClient = () => {
+    const client = new MCPClient({
+      id: `configuration-test-${++clientId}`,
+      servers: {
+        alpha: { url: new URL('http://localhost:1111/sse') },
+        bravo: { url: new URL('http://localhost:2222/sse') },
+        charlie: { url: new URL('http://localhost:3333/sse') },
+      },
+    });
+    clients.push(client);
+    return client;
+  };
+
+  // Spies getConnectedClientForServer so each server's discovery call awaits
+  // `gate(serverName)` before returning a probe result. `gate` is where each
+  // test injects its timing — a per-server delay, or a concurrency latch.
+  type Gate = (serverName: string) => Promise<void>;
+  const installToolsMock = (client: MCPClient, gate: Gate) =>
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockImplementation(async (serverName: string) => ({
+      tools: vi.fn().mockImplementation(async () => {
+        await gate(serverName);
+        return { probe: {} as any };
+      }),
+    }));
+  const installResourcesMock = (client: MCPClient, gate: Gate) =>
+    vi.spyOn(client as any, 'getConnectedClientForServer').mockImplementation(async (serverName: string) => ({
+      resources: {
+        list: vi.fn().mockImplementation(async () => {
+          await gate(serverName);
+          return [{ uri: `${serverName}://probe` } as any];
+        }),
+      },
+    }));
+
+  // Servers resolve in reverse configuration order; asserts the folded result
+  // still keys in configuration order (a completion-order fold would not).
+  const expectConfigOrder = async (
+    installMock: (client: MCPClient, gate: Gate) => void,
+    invoke: (client: MCPClient) => Promise<Record<string, unknown>>,
+    expectedKeys: string[],
+  ) => {
+    const client = makeThreeServerClient();
+    const delays: Record<string, number> = { alpha: 30, bravo: 15, charlie: 0 };
+    installMock(client, serverName => new Promise(resolve => setTimeout(resolve, delays[serverName])));
+    expect(Object.keys(await invoke(client))).toEqual(expectedKeys);
+  };
+
+  // Asserts every server's discovery is in flight at once; deadlocks against a
+  // serial implementation, where only the first server would ever start.
+  const expectConcurrentDiscovery = async (
+    installMock: (client: MCPClient, gate: Gate) => void,
+    invoke: (client: MCPClient) => Promise<unknown>,
+  ) => {
+    const client = makeThreeServerClient();
+    const serverCount = 3;
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const release: Array<() => void> = [];
+    const allStarted = new Promise<void>(resolveAllStarted => {
+      installMock(client, async () => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        if (inFlight === serverCount) resolveAllStarted();
+        await new Promise<void>(resolve => release.push(resolve));
+        inFlight--;
+      });
+    });
+
+    const pending = invoke(client);
+    await allStarted;
+    expect(maxInFlight).toBe(serverCount);
+    release.forEach(fn => fn());
+    await pending;
+  };
+
+  it('preserves configuration order in listToolsWithErrors even when servers resolve out of order', () =>
+    expectConfigOrder(installToolsMock, async client => (await client.listToolsWithErrors()).tools, [
+      'alpha_probe',
+      'bravo_probe',
+      'charlie_probe',
+    ]));
+
+  it('discovers tools from all servers concurrently rather than serially', () =>
+    expectConcurrentDiscovery(installToolsMock, client => client.listToolsWithErrors()));
+
+  // resources.list() shares the concurrent settle/fold path but is an
+  // independent code path from tool discovery, so cover it directly too.
+  it('preserves configuration order in resources.list even when servers resolve out of order', () =>
+    expectConfigOrder(installResourcesMock, client => client.resources.list(), ['alpha', 'bravo', 'charlie']));
+
+  it('lists resources from all servers concurrently rather than serially', () =>
+    expectConcurrentDiscovery(installResourcesMock, client => client.resources.list()));
 });

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -27,6 +27,14 @@ import { MCPClientServerProxy } from './server-proxy';
 const mcpClientInstances = new Map<string, InstanceType<typeof MCPClient>>();
 const TOOL_DISCOVERY_MAX_ATTEMPTS = 2;
 
+// Outcome of a single server's discovery within discoverAcrossServers(). An
+// explicit discriminated union (rather than `{ value?: T; error?: string }`) so
+// that narrowing on `error` also narrows `value` — Promise.all would otherwise
+// widen the two branches into independent optional props and break the fold.
+type ServerDiscoveryResult<T> =
+  | { serverName: string; value: T; error: undefined }
+  | { serverName: string; value: undefined; error: string };
+
 // Matches the entire 127.0.0.0/8 range in dotted-quad form. `URL` normalizes
 // IPv4 hosts to four octets (so `127.1` becomes `127.0.0.1`), so anchoring the
 // pattern is enough — and it rejects lookalikes like `127.evil.com` that a
@@ -322,24 +330,13 @@ To fix this you have three different options:
        */
       list: async (): Promise<Record<string, Resource[]>> => {
         const allResources: Record<string, Resource[]> = {};
-        for (const serverName of Object.keys(this.serverConfigs)) {
-          try {
-            const internalClient = await this.getConnectedClientForServer(serverName);
-            allResources[serverName] = await internalClient.resources.list();
-          } catch (error) {
-            const mastraError = new MastraError(
-              {
-                id: 'MCP_CLIENT_LIST_RESOURCES_FAILED',
-                domain: ErrorDomain.MCP,
-                category: ErrorCategory.THIRD_PARTY,
-                details: {
-                  serverName,
-                },
-              },
-              error,
-            );
-            this.logger.trackException(mastraError);
-            this.logger.error('Failed to list resources from server:', { error: mastraError.toString() });
+        const settled = await this.discoverAcrossServers(
+          async serverName => (await this.getConnectedClientForServer(serverName)).resources.list(),
+          { errorId: 'MCP_CLIENT_LIST_RESOURCES_FAILED', logMessage: 'Failed to list resources from server:' },
+        );
+        for (const { serverName, value, error } of settled) {
+          if (error === undefined) {
+            allResources[serverName] = value;
           }
         }
         return allResources;
@@ -360,24 +357,16 @@ To fix this you have three different options:
        */
       templates: async (): Promise<Record<string, ResourceTemplate[]>> => {
         const allTemplates: Record<string, ResourceTemplate[]> = {};
-        for (const serverName of Object.keys(this.serverConfigs)) {
-          try {
-            const internalClient = await this.getConnectedClientForServer(serverName);
-            allTemplates[serverName] = await internalClient.resources.templates();
-          } catch (error) {
-            const mastraError = new MastraError(
-              {
-                id: 'MCP_CLIENT_LIST_RESOURCE_TEMPLATES_FAILED',
-                domain: ErrorDomain.MCP,
-                category: ErrorCategory.THIRD_PARTY,
-                details: {
-                  serverName,
-                },
-              },
-              error,
-            );
-            this.logger.trackException(mastraError);
-            this.logger.error('Failed to list resource templates from server:', { error: mastraError.toString() });
+        const settled = await this.discoverAcrossServers(
+          async serverName => (await this.getConnectedClientForServer(serverName)).resources.templates(),
+          {
+            errorId: 'MCP_CLIENT_LIST_RESOURCE_TEMPLATES_FAILED',
+            logMessage: 'Failed to list resource templates from server:',
+          },
+        );
+        for (const { serverName, value, error } of settled) {
+          if (error === undefined) {
+            allTemplates[serverName] = value;
           }
         }
         return allTemplates;
@@ -591,24 +580,13 @@ To fix this you have three different options:
        */
       list: async (): Promise<Record<string, Prompt[]>> => {
         const allPrompts: Record<string, Prompt[]> = {};
-        for (const serverName of Object.keys(this.serverConfigs)) {
-          try {
-            const internalClient = await this.getConnectedClientForServer(serverName);
-            allPrompts[serverName] = await internalClient.prompts.list();
-          } catch (error) {
-            const mastraError = new MastraError(
-              {
-                id: 'MCP_CLIENT_LIST_PROMPTS_FAILED',
-                domain: ErrorDomain.MCP,
-                category: ErrorCategory.THIRD_PARTY,
-                details: {
-                  serverName,
-                },
-              },
-              error,
-            );
-            this.logger.trackException(mastraError);
-            this.logger.error('Failed to list prompts from server:', { error: mastraError.toString() });
+        const settled = await this.discoverAcrossServers(
+          async serverName => (await this.getConnectedClientForServer(serverName)).prompts.list(),
+          { errorId: 'MCP_CLIENT_LIST_PROMPTS_FAILED', logMessage: 'Failed to list prompts from server:' },
+        );
+        for (const { serverName, value, error } of settled) {
+          if (error === undefined) {
+            allPrompts[serverName] = value;
           }
         }
         return allPrompts;
@@ -1091,27 +1069,18 @@ To fix this you have three different options:
     const connectedTools: Record<string, Tool<any, any, any, any>> = {};
     const errors: Record<string, string> = {};
 
-    for (const serverName of Object.keys(this.serverConfigs)) {
-      try {
-        const tools = await this.getToolsForServer(serverName);
-        for (const [toolName, toolConfig] of Object.entries(tools)) {
-          connectedTools[`${serverName}_${toolName}`] = toolConfig;
-        }
-      } catch (error) {
-        const mastraError = new MastraError(
-          {
-            id: 'MCP_CLIENT_GET_TOOLS_FAILED',
-            domain: ErrorDomain.MCP,
-            category: ErrorCategory.THIRD_PARTY,
-            details: {
-              serverName,
-            },
-          },
-          error,
-        );
-        this.logger.trackException(mastraError);
-        this.logger.error('Failed to list tools from server:', { error: mastraError.toString() });
-        errors[serverName] = error instanceof Error ? error.message : String(error);
+    const settled = await this.discoverAcrossServers(serverName => this.getToolsForServer(serverName), {
+      errorId: 'MCP_CLIENT_GET_TOOLS_FAILED',
+      logMessage: 'Failed to list tools from server:',
+    });
+
+    for (const { serverName, value, error } of settled) {
+      if (error !== undefined) {
+        errors[serverName] = error;
+        continue;
+      }
+      for (const [toolName, toolConfig] of Object.entries(value)) {
+        connectedTools[`${serverName}_${toolName}`] = toolConfig;
       }
     }
 
@@ -1171,31 +1140,59 @@ To fix this you have three different options:
     const connectedToolsets: Record<string, Record<string, Tool<any, any, any, any>>> = {};
     const errors: Record<string, string> = {};
 
-    for (const serverName of Object.keys(this.serverConfigs)) {
-      try {
-        const tools = await this.getToolsForServer(serverName);
-        if (tools) {
-          connectedToolsets[serverName] = tools;
-        }
-      } catch (error) {
-        const mastraError = new MastraError(
-          {
-            id: 'MCP_CLIENT_GET_TOOLSETS_FAILED',
-            domain: ErrorDomain.MCP,
-            category: ErrorCategory.THIRD_PARTY,
-            details: {
-              serverName,
-            },
-          },
-          error,
-        );
-        this.logger.trackException(mastraError);
-        this.logger.error('Failed to list toolsets from server:', { error: mastraError.toString() });
-        errors[serverName] = error instanceof Error ? error.message : String(error);
+    const settled = await this.discoverAcrossServers(serverName => this.getToolsForServer(serverName), {
+      errorId: 'MCP_CLIENT_GET_TOOLSETS_FAILED',
+      logMessage: 'Failed to list toolsets from server:',
+    });
+
+    for (const { serverName, value, error } of settled) {
+      if (error !== undefined) {
+        errors[serverName] = error;
+        continue;
       }
+      connectedToolsets[serverName] = value;
     }
 
     return { toolsets: connectedToolsets, errors };
+  }
+
+  /**
+   * Runs a per-server discovery `operation` against every configured server
+   * concurrently, isolating and logging per-server failures. Results are
+   * returned in configuration order (`Object.keys(serverConfigs)`) so callers
+   * fold them back deterministically.
+   *
+   * Mirrors the parallel teardown in `disconnect()`: each server is bounded by
+   * its own request timeout, so total time is the slowest single server rather
+   * than the sum, and one slow or unresponsive server never stalls the others.
+   * Backs `listTools`/`listToolsets`, `resources.list`/`templates`, and
+   * `prompts.list`.
+   */
+  private async discoverAcrossServers<T>(
+    operation: (serverName: string) => Promise<T>,
+    onError: { errorId: Uppercase<string>; logMessage: string },
+  ): Promise<Array<ServerDiscoveryResult<T>>> {
+    const serverNames = Object.keys(this.serverConfigs);
+    return Promise.all(
+      serverNames.map(async (serverName): Promise<ServerDiscoveryResult<T>> => {
+        try {
+          return { serverName, value: await operation(serverName), error: undefined };
+        } catch (error) {
+          const mastraError = new MastraError(
+            {
+              id: onError.errorId,
+              domain: ErrorDomain.MCP,
+              category: ErrorCategory.THIRD_PARTY,
+              details: { serverName },
+            },
+            error,
+          );
+          this.logger.trackException(mastraError);
+          this.logger.error(onError.logMessage, { error: mastraError.toString() });
+          return { serverName, value: undefined, error: error instanceof Error ? error.message : String(error) };
+        }
+      }),
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

`MCPClient` aggregated across configured servers by connecting to each one and awaiting it inside a serial `for … await` loop. Five multi-server methods did this:

- `listTools()` / `listToolsWithErrors()`
- `listToolsets()` / `listToolsetsWithErrors()`
- `resources.list()`
- `resources.templates()`
- `prompts.list()`

With multiple servers this makes discovery additive — each server contributes its full connect + list latency (~500–600 ms each in production with real remote servers) to the total, and a single slow or unresponsive server blocks discovery for every server behind it. Because each server is bounded only by its own request timeout (`DEFAULT_REQUEST_TIMEOUT_MSEC`, 60 s by default), the worst case is roughly `timeout × serverCount` — one hung server can push total discovery toward 60 s even though the other servers would answer in milliseconds.

This change fans out the per-server work concurrently in all five methods, mirroring the parallel teardown that `disconnect()` already uses in the same file (via `Promise.allSettled`). Each server is still bounded by its own request timeout, so total time collapses from the sum of per-server times to roughly the slowest single server.

The shared scaffolding — concurrent fan-out, per-server error isolation/logging, and configuration-order folding — lives in one private `discoverAcrossServers()` helper that all five methods call, so the concurrency pattern is defined once rather than copied per method.

Behavior is otherwise unchanged:

- **Ordering preserved** — the concurrent results are folded back in the original `Object.keys(serverConfigs)` (configuration) order, so tool/resource/prompt ordering and `serverName_toolName` namespacing are identical.
- **Error semantics unchanged** — each server's `try/catch` stays per server (now inside the mapped async function), so per-server error reporting and isolation are the same and one server failing never rejects the whole call.
- **Reconnect retry preserved** — `getToolsForServer`'s transient-failure reconnect-and-retry is untouched.

No new public API, options, or configuration — purely an internal scheduling change. Per-server work is already bounded by the client's request timeout, so no per-server timeout option or per-server duration reporting is introduced.

### Scope note

This PR is the consolidation of two originally-separate PRs: this one (tools/toolsets, the measured hot path) and #19920 (resources/prompts). #19920 was auto-closed by the `needs-issue` bot because its `Relates to #19918` link isn't a recognized closing keyword. Since both edit the same file with a mechanically identical change, I've folded them into this single reviewable PR under one changeset. Happy to split resources/prompts back out into their own PR if you'd prefer to review them separately.

Left intentionally untouched:

- `disconnect()` — already parallel via `Promise.allSettled`.
- `getServerInstructions()`, `sessionIds`, `toMCPServerProxies()` — synchronous reads of already-connected client state (no per-server I/O).
- Single-server methods (`resources.read/subscribe/...`, `prompts.get`, `elicitation.onRequest`, `progress.onUpdate`) — no multi-server iteration.

## Related issue(s)

Fixes #19918

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — n/a, no API change
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have addressed all CodeRabbit comments on this PR

## Tests

Added to `packages/mcp/src/client/configuration.test.ts`:

- **Order preservation** — three servers whose `tools()` resolve in reverse configuration order; asserts `Object.keys(result.tools)` is still `[alpha_probe, bravo_probe, charlie_probe]`. A completion-order fold would fail this.
- **Concurrency proof** — three servers whose `tools()` block on a deferred; asserts all three are in flight simultaneously before any resolves. This test deadlocks against the previous serial implementation.

The same two shapes are also applied to `resources.list()`, since the resource/prompt methods are independent code paths (not just callers of `getToolsForServer`).

Existing tests (partial-failure error isolation, reconnect retry, duplicate-name namespacing) pass unchanged. Ran `pnpm --filter ./packages/mcp test:client` (168 passed) and `test:integration` (10 passed); `pnpm build:mcp` clean.

## Notes for reviewers

- Concurrency is safe: within a single call each `serverName` is distinct, so the parallel branches touch disjoint keys in `mcpClientsById` — no shared-state collision.
- The cache-then-connect path in `getConnectedClient` / `getOrCreateClient` has no per-server mutex, so two *separate* callers racing discovery on the *same* server could each create a client. That race is pre-existing and unaffected by this change (which only parallelizes across distinct servers within one call); happy to file it separately if you'd like.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Mastra can connect to multiple MCP servers. This PR makes it ask **all configured servers at the same time** to discover tools, toolsets, resources, and prompts, then merges the results in a consistent order—so discovery finishes in about as long as the **slowest single server**, instead of waiting server-by-server.

## Changes

- Updated multi-server MCP discovery to run **concurrently** across all configured servers (fan-out with `Promise.all`) instead of serial querying.
- Centralized the fan-out + deterministic merge logic in a shared internal helper (`discoverAcrossServers()`), used by:
  - `listToolsWithErrors()` / `listToolsetsWithErrors()`
  - `resources.list()` / `resources.templates()`
  - `prompts.list()`
- Preserved existing behavior where applicable:
  - deterministic output ordering based on the original server configuration order (`Object.keys(this.serverConfigs)`)
  - existing namespacing/keying of discovered items
  - unchanged reconnect retry behavior and request timeouts
  - per-server failure isolation with per-server error reporting (one slow/failed server doesn’t block others)
- Improved error folding to use the result `error` discriminant and skipped/returned only successful entries in the aggregated maps; tool-related variants still also return an errors map keyed by server name.
- Added/expanded tests to ensure:
  - **ordering stability** even when per-server discovery resolves out of order (notably for `listToolsWithErrors()` and `resources.list()`)
  - **true parallelism** (the max in-flight discovery count reaches the number of configured servers)
  - coverage for both tools and resources discovery concurrency/ordering guarantees.
- Added a patch Changeset for `@mastra/mcp` documenting the latency improvement: total discovery time is reduced to roughly the slowest single server while keeping ordering and per-server error semantics consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->