### PR TITLE
perf(mcp): list resources and prompts from all MCP servers concurrently

### DIFF
--- a/.changeset/mcp-parallel-resource-prompt-discovery.md
+++ b/.changeset/mcp-parallel-resource-prompt-discovery.md
@@ -1,0 +1,7 @@
+---
+'@mastra/mcp': patch
+---
+
+List resources and prompts from all MCP servers concurrently in `MCPClient.resources.list()`, `resources.templates()`, and `prompts.list()`.
+
+These methods previously queried each configured server one at a time in a serial loop, so a slow or unresponsive server delayed the aggregate result for every server behind it. They now fan out with `Promise.all`, matching the tool-discovery methods and the parallel teardown in `disconnect()`. Results are keyed by server and assembled in configuration order, and per-server failures are still logged and skipped, so behavior is otherwise unchanged.

--- a/packages/mcp/src/client/configuration.ts
+++ b/packages/mcp/src/client/configuration.ts
@@ -322,24 +322,35 @@ To fix this you have three different options:
        */
       list: async (): Promise<Record<string, Resource[]>> => {
         const allResources: Record<string, Resource[]> = {};
-        for (const serverName of Object.keys(this.serverConfigs)) {
-          try {
-            const internalClient = await this.getConnectedClientForServer(serverName);
-            allResources[serverName] = await internalClient.resources.list();
-          } catch (error) {
-            const mastraError = new MastraError(
-              {
-                id: 'MCP_CLIENT_LIST_RESOURCES_FAILED',
-                domain: ErrorDomain.MCP,
-                category: ErrorCategory.THIRD_PARTY,
-                details: {
-                  serverName,
+        // Query every server concurrently (see listToolsWithErrors) so a slow
+        // server does not delay the others; fold back in configuration order.
+        const serverNames = Object.keys(this.serverConfigs);
+        const settled = await Promise.all(
+          serverNames.map(async serverName => {
+            try {
+              const internalClient = await this.getConnectedClientForServer(serverName);
+              return { serverName, resources: await internalClient.resources.list() };
+            } catch (error) {
+              const mastraError = new MastraError(
+                {
+                  id: 'MCP_CLIENT_LIST_RESOURCES_FAILED',
+                  domain: ErrorDomain.MCP,
+                  category: ErrorCategory.THIRD_PARTY,
+                  details: {
+                    serverName,
+                  },
                 },
-              },
-              error,
-            );
-            this.logger.trackException(mastraError);
-            this.logger.error('Failed to list resources from server:', { error: mastraError.toString() });
+                error,
+              );
+              this.logger.trackException(mastraError);
+              this.logger.error('Failed to list resources from server:', { error: mastraError.toString() });
+              return { serverName, resources: undefined };
+            }
+          }),
+        );
+        for (const { serverName, resources } of settled) {
+          if (resources) {
+            allResources[serverName] = resources;
           }
         }
         return allResources;
@@ -360,24 +371,35 @@ To fix this you have three different options:
        */
       templates: async (): Promise<Record<string, ResourceTemplate[]>> => {
         const allTemplates: Record<string, ResourceTemplate[]> = {};
-        for (const serverName of Object.keys(this.serverConfigs)) {
-          try {
-            const internalClient = await this.getConnectedClientForServer(serverName);
-            allTemplates[serverName] = await internalClient.resources.templates();
-          } catch (error) {
-            const mastraError = new MastraError(
-              {
-                id: 'MCP_CLIENT_LIST_RESOURCE_TEMPLATES_FAILED',
-                domain: ErrorDomain.MCP,
-                category: ErrorCategory.THIRD_PARTY,
-                details: {
-                  serverName,
+        // Query every server concurrently (see listToolsWithErrors) so a slow
+        // server does not delay the others; fold back in configuration order.
+        const serverNames = Object.keys(this.serverConfigs);
+        const settled = await Promise.all(
+          serverNames.map(async serverName => {
+            try {
+              const internalClient = await this.getConnectedClientForServer(serverName);
+              return { serverName, templates: await internalClient.resources.templates() };
+            } catch (error) {
+              const mastraError = new MastraError(
+                {
+                  id: 'MCP_CLIENT_LIST_RESOURCE_TEMPLATES_FAILED',
+                  domain: ErrorDomain.MCP,
+                  category: ErrorCategory.THIRD_PARTY,
+                  details: {
+                    serverName,
+                  },
                 },
-              },
-              error,
-            );
-            this.logger.trackException(mastraError);
-            this.logger.error('Failed to list resource templates from server:', { error: mastraError.toString() });
+                error,
+              );
+              this.logger.trackException(mastraError);
+              this.logger.error('Failed to list resource templates from server:', { error: mastraError.toString() });
+              return { serverName, templates: undefined };
+            }
+          }),
+        );
+        for (const { serverName, templates } of settled) {
+          if (templates) {
+            allTemplates[serverName] = templates;
           }
         }
         return allTemplates;
@@ -591,24 +613,35 @@ To fix this you have three different options:
        */
       list: async (): Promise<Record<string, Prompt[]>> => {
         const allPrompts: Record<string, Prompt[]> = {};
-        for (const serverName of Object.keys(this.serverConfigs)) {
-          try {
-            const internalClient = await this.getConnectedClientForServer(serverName);
-            allPrompts[serverName] = await internalClient.prompts.list();
-          } catch (error) {
-            const mastraError = new MastraError(
-              {
-                id: 'MCP_CLIENT_LIST_PROMPTS_FAILED',
-                domain: ErrorDomain.MCP,
-                category: ErrorCategory.THIRD_PARTY,
-                details: {
-                  serverName,
+        // Query every server concurrently (see listToolsWithErrors) so a slow
+        // server does not delay the others; fold back in configuration order.
+        const serverNames = Object.keys(this.serverConfigs);
+        const settled = await Promise.all(
+          serverNames.map(async serverName => {
+            try {
+              const internalClient = await this.getConnectedClientForServer(serverName);
+              return { serverName, prompts: await internalClient.prompts.list() };
+            } catch (error) {
+              const mastraError = new MastraError(
+                {
+                  id: 'MCP_CLIENT_LIST_PROMPTS_FAILED',
+                  domain: ErrorDomain.MCP,
+                  category: ErrorCategory.THIRD_PARTY,
+                  details: {
+                    serverName,
+                  },
                 },
-              },
-              error,
-            );
-            this.logger.trackException(mastraError);
-            this.logger.error('Failed to list prompts from server:', { error: mastraError.toString() });
+                error,
+              );
+              this.logger.trackException(mastraError);
+              this.logger.error('Failed to list prompts from server:', { error: mastraError.toString() });
+              return { serverName, prompts: undefined };
+            }
+          }),
+        );
+        for (const { serverName, prompts } of settled) {
+          if (prompts) {
+            allPrompts[serverName] = prompts;
           }
         }
         return allPrompts;


### PR DESCRIPTION
## Description

Follow-up to the tool-discovery parallelization (#19919), completing the pattern class. The same serial `for … await` loop exists in the other multi-server aggregation methods on `MCPClient`:

- `resources.list()`
- `resources.templates()`
- `prompts.list()`

Each connects to every configured server one at a time, so the same additive-latency and head-of-line-blocking behavior applies — a slow server delays the aggregate for every server behind it. This PR converts them to concurrent `Promise.all` fan-out, identical in shape to the tool-discovery change and to the parallel teardown `disconnect()` already uses.

Behavior is unchanged: results are keyed by server and folded back in configuration order, and per-server failures are still logged and skipped (these methods return only the servers that succeeded and never throw for a single server's failure).

Left intentionally untouched:

- `disconnect()` — already parallel via `Promise.allSettled`.
- `getServerInstructions()`, `sessionIds`, `toMCPServerProxies()` — synchronous reads of already-connected client state (no per-server I/O).
- Single-server methods (`resources.read/subscribe/...`, `prompts.get`, `elicitation.onRequest`, `progress.onUpdate`) — no multi-server iteration.

## Related issue(s)

Relates to #19918

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement

## Checklist

- [x] I have linked the related issue(s) in the description above
- [x] I have made corresponding changes to the documentation (if applicable) — n/a, no API change
- [x] I have added tests that prove my fix is effective or that my feature works — covered by the existing resource/prompt suite; the concurrency pattern itself is proven by the tests in #19919
- [ ] I have addressed all Coderabbit comments on this PR

## Notes for reviewers

- Independent of #19919 in intent, but both edit `packages/mcp/src/client/configuration.ts`, so whichever merges second will need a trivial rebase.
- Split out from the tool-discovery PR to keep each change small and focused: that PR targets the measured hot path (`listTools` / `listToolsets`, called on every agent construction) and carries the concurrency-proof tests; resources/prompts listing is lower-traffic and mechanically identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Instead of asking each MCP server one at a time, the client now asks all servers at once, making resource and prompt discovery faster. Results stay organized in configuration order, and failed servers are still skipped without stopping everything.

## Changes

- Parallelized:
  - `resources.list()`
  - `resources.templates()`
  - `prompts.list()`
- Preserved per-server error logging and failure handling.
- Added a patch changeset for `@mastra/mcp`.
- Left single-server operations, `disconnect()`, and synchronous client-state methods unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->