### PR TITLE
feat(posthog): export feedback as native $ai_feedback events

### DIFF
--- a/.changeset/ninety-carrots-spend.md
+++ b/.changeset/ninety-carrots-spend.md
@@ -1,0 +1,17 @@
+---
+'@mastra/posthog': minor
+---
+
+Added feedback export to the PostHog observability exporter. Feedback recorded with `addFeedback()` now flows to PostHog as native `$ai_feedback` events and appears as "User feedback" on the linked trace, alongside the traces the exporter already sends. No configuration changes are needed.
+
+```typescript
+const trace = await mastra.observability.getRecordedTrace({ traceId });
+await trace.addFeedback({
+  feedbackType: 'thumbs',
+  value: 'down',
+  comment: 'Wrong answer',
+});
+// The PostHog exporter now forwards this as a $ai_feedback event
+```
+
+Fixes https://github.com/mastra-ai/mastra/issues/19893

--- a/docs/src/content/en/docs/observability/feedback.mdx
+++ b/docs/src/content/en/docs/observability/feedback.mdx
@@ -133,6 +133,10 @@ const ratingsOverTime = await observability!.getFeedbackTimeSeries({
 
 See the [feedback reference](/reference/observability/feedback) for all fields, filters, return types, and percentile query parameters.
 
+## Export feedback to external platforms
+
+Feedback flows through the observability event bus, so exporters that support feedback forward it automatically. The [PostHog exporter](/reference/observability/tracing/exporters/posthog#feedback-export) sends feedback as native `$ai_feedback` events that appear on the linked trace in PostHog.
+
 ## Related
 
 - [Observability overview](/docs/observability/overview)

--- a/docs/src/content/en/reference/observability/tracing/exporters/posthog.mdx
+++ b/docs/src/content/en/reference/observability/tracing/exporters/posthog.mdx
@@ -99,6 +99,14 @@ async exportTracingEvent(event: TracingEvent): Promise<void>
 
 Exports a tracing event to PostHog.
 
+### `onFeedbackEvent`
+
+```typescript prettier:false
+async onFeedbackEvent(event: FeedbackEvent): Promise<void>
+```
+
+Exports a feedback event to PostHog. See [Feedback export](#feedback-export).
+
 ### flush
 
 ```typescript prettier:false
@@ -153,3 +161,33 @@ const exporter = new PosthogExporter({
 | `WORKFLOW_RUN` | `$ai_span` |
 | All other workflows | `$ai_span` |
 | `GENERIC` | `$ai_span` |
+
+## Feedback export
+
+Feedback recorded with [`addFeedback()`](/docs/observability/feedback) is exported to PostHog as a native `$ai_feedback` event. PostHog shows it as **User feedback** on the linked trace. No extra configuration is needed.
+
+```typescript
+const trace = await mastra.observability.getRecordedTrace({ traceId })
+await trace.addFeedback({
+  feedbackType: 'thumbs',
+  value: 'down',
+  comment: 'Wrong answer',
+})
+```
+
+Feedback events map to these PostHog properties:
+
+| Mastra feedback field | PostHog property |
+| - | - |
+| `traceId` | `$ai_trace_id` |
+| `comment` (or `value` when no comment) | `$ai_feedback_text` |
+| `feedbackId` | `feedback_id` |
+| `feedbackType` | `feedback_type` |
+| `value` | `feedback_value` |
+| `feedbackSource` | `feedback_source` |
+| `spanId` | `span_id` |
+| `sourceId` | `source_id` |
+| `metadata.sessionId` | `$ai_session_id` |
+| `metadata` (other keys) | custom properties |
+
+Feedback without a `traceId` is dropped because PostHog anchors feedback to a trace through `$ai_trace_id`. The event's distinct ID resolves from `feedbackUserId`, then `metadata.userId`, then `defaultDistinctId`, then `anonymous`.

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -1,4 +1,4 @@
-import type { AnyExportedSpan } from '@mastra/core/observability';
+import type { AnyExportedSpan, ExportedFeedback, FeedbackEvent } from '@mastra/core/observability';
 import { SpanType, TracingEventType } from '@mastra/core/observability';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
@@ -1144,6 +1144,121 @@ describe('PosthogExporter', () => {
       expect(mockCapture.mock.calls[0][0]).not.toHaveProperty('groups');
     });
   });
+
+  describe('Feedback Events', () => {
+    beforeEach(() => {
+      exporter = new TestPosthogExporter(validConfig);
+    });
+
+    it('should emit $ai_feedback with full property mapping', async () => {
+      await exporter.onFeedbackEvent(
+        createFeedbackEvent({
+          traceId: 'trace-1',
+          spanId: 'span-1',
+          comment: 'wrong answer',
+          feedbackSource: 'user',
+          feedbackUserId: 'user-1',
+          sourceId: 'message-1',
+          metadata: { userId: 'meta-user', sessionId: 'session-1', environment: 'prod' },
+        }),
+      );
+
+      expect(mockCapture).toHaveBeenCalledWith({
+        distinctId: 'user-1',
+        event: '$ai_feedback',
+        properties: {
+          $ai_trace_id: 'trace-1',
+          $ai_feedback_text: 'wrong answer',
+          feedback_id: 'feedback-1',
+          feedback_type: 'thumbs',
+          feedback_value: 'down',
+          feedback_source: 'user',
+          span_id: 'span-1',
+          source_id: 'message-1',
+          $ai_session_id: 'session-1',
+          environment: 'prod',
+        },
+        timestamp: expect.any(Date),
+      });
+    });
+
+    it('should fall back to the stringified value when comment is absent', async () => {
+      await exporter.onFeedbackEvent(createFeedbackEvent({ feedbackType: 'rating', value: 4 }));
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({ $ai_feedback_text: '4', feedback_value: 4 }),
+        }),
+      );
+    });
+
+    it('should drop feedback with no traceId', async () => {
+      await exporter.onFeedbackEvent(createFeedbackEvent({ traceId: undefined }));
+
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it('should resolve distinctId with feedbackUserId > userId > metadata.userId > defaultDistinctId > anonymous', async () => {
+      await exporter.onFeedbackEvent(
+        createFeedbackEvent({ feedbackUserId: 'primary', userId: 'legacy', metadata: { userId: 'meta' } }),
+      );
+      expect(mockCapture).toHaveBeenLastCalledWith(expect.objectContaining({ distinctId: 'primary' }));
+
+      await exporter.onFeedbackEvent(createFeedbackEvent({ userId: 'legacy', metadata: { userId: 'meta' } }));
+      expect(mockCapture).toHaveBeenLastCalledWith(expect.objectContaining({ distinctId: 'legacy' }));
+
+      await exporter.onFeedbackEvent(createFeedbackEvent({ metadata: { userId: 'meta' } }));
+      expect(mockCapture).toHaveBeenLastCalledWith(expect.objectContaining({ distinctId: 'meta' }));
+
+      await exporter.onFeedbackEvent(createFeedbackEvent());
+      expect(mockCapture).toHaveBeenLastCalledWith(expect.objectContaining({ distinctId: 'anonymous' }));
+    });
+
+    it('should use defaultDistinctId when feedback has no user', async () => {
+      exporter = new TestPosthogExporter({ ...validConfig, defaultDistinctId: 'default-user' });
+
+      await exporter.onFeedbackEvent(createFeedbackEvent());
+
+      expect(mockCapture).toHaveBeenCalledWith(expect.objectContaining({ distinctId: 'default-user' }));
+    });
+
+    it('should not capture when the exporter is disabled', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      exporter = new TestPosthogExporter({ apiKey: '' });
+      consoleSpy.mockRestore();
+
+      await exporter.onFeedbackEvent(createFeedbackEvent());
+
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it('should convert a serialized string timestamp to a Date', async () => {
+      await exporter.onFeedbackEvent(createFeedbackEvent({ timestamp: '2026-07-22T10:00:00.000Z' as unknown as Date }));
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        expect.objectContaining({ timestamp: new Date('2026-07-22T10:00:00.000Z') }),
+      );
+    });
+
+    it('should mirror metadata.$groups to top-level groups', async () => {
+      await exporter.onFeedbackEvent(createFeedbackEvent({ metadata: { $groups: { publication: 'publication-1' } } }));
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          groups: { publication: 'publication-1' },
+          properties: expect.objectContaining({ $groups: { publication: 'publication-1' } }),
+        }),
+      );
+    });
+
+    it('should log instead of throwing when capture fails', async () => {
+      mockCapture.mockImplementationOnce(() => {
+        throw new Error('capture failed');
+      });
+
+      await expect(exporter.onFeedbackEvent(createFeedbackEvent())).resolves.toBeUndefined();
+    });
+  });
 });
 
 // --- Test Helper Functions ---
@@ -1168,6 +1283,23 @@ function createSpan(overrides: Partial<AnyExportedSpan> = {}): AnyExportedSpan {
     attributes: {},
     metadata: {},
     ...overrides,
+  };
+}
+
+/**
+ * Helper to create feedback events with defaults
+ */
+function createFeedbackEvent(overrides: Partial<ExportedFeedback> = {}): FeedbackEvent {
+  return {
+    type: 'feedback',
+    feedback: {
+      feedbackId: 'feedback-1',
+      timestamp: new Date(),
+      traceId: 'trace-1',
+      feedbackType: 'thumbs',
+      value: 'down',
+      ...overrides,
+    },
   };
 }
 

--- a/observability/posthog/src/tracing.test.ts
+++ b/observability/posthog/src/tracing.test.ts
@@ -1251,12 +1251,36 @@ describe('PosthogExporter', () => {
       );
     });
 
+    it('should not let custom metadata overwrite natively mapped properties', async () => {
+      await exporter.onFeedbackEvent(
+        createFeedbackEvent({
+          traceId: 'trace-1',
+          metadata: { $ai_trace_id: 'spoofed-trace', feedback_type: 'spoofed-type', environment: 'prod' },
+        }),
+      );
+
+      expect(mockCapture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          properties: expect.objectContaining({
+            $ai_trace_id: 'trace-1',
+            feedback_type: 'thumbs',
+            environment: 'prod',
+          }),
+        }),
+      );
+    });
+
     it('should log instead of throwing when capture fails', async () => {
+      const errorSpy = vi.spyOn(exporter['logger'], 'error');
       mockCapture.mockImplementationOnce(() => {
         throw new Error('capture failed');
       });
 
       await expect(exporter.onFeedbackEvent(createFeedbackEvent())).resolves.toBeUndefined();
+      expect(errorSpy).toHaveBeenCalledWith(
+        'PostHog exporter: failed to submit feedback',
+        expect.objectContaining({ error: expect.any(Error), feedbackId: 'feedback-1' }),
+      );
     });
   });
 });

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -1,4 +1,11 @@
-import type { AnyExportedSpan, ModelGenerationAttributes, SpanErrorInfo, UsageStats } from '@mastra/core/observability';
+import type {
+  AnyExportedSpan,
+  ExportedFeedback,
+  FeedbackEvent,
+  ModelGenerationAttributes,
+  SpanErrorInfo,
+  UsageStats,
+} from '@mastra/core/observability';
 import { SpanType } from '@mastra/core/observability';
 import type { TraceData, TrackingExporterConfig } from '@mastra/observability';
 import { TrackingExporter } from '@mastra/observability';
@@ -233,6 +240,65 @@ export class PosthogExporter extends TrackingExporter<
   }
 
   /**
+   * Forward feedback recorded via `addFeedback()` to PostHog as a native
+   * `$ai_feedback` event, shown as "User feedback" on the linked trace in
+   * PostHog's AI observability UI.
+   */
+  async onFeedbackEvent(event: FeedbackEvent): Promise<void> {
+    if (!this.#client) return;
+
+    const { feedback } = event;
+    if (!feedback.traceId) {
+      this.logger.debug('PostHog exporter: dropping feedback with no traceId; PostHog requires $ai_trace_id', {
+        feedbackId: feedback.feedbackId,
+      });
+      return;
+    }
+
+    const properties: Record<string, any> = {
+      $ai_trace_id: feedback.traceId,
+      // PostHog's trace UI only displays feedback events that carry $ai_feedback_text
+      $ai_feedback_text: feedback.comment ?? String(feedback.value),
+      feedback_id: feedback.feedbackId,
+      feedback_type: feedback.feedbackType,
+      feedback_value: feedback.value,
+    };
+
+    const feedbackSource = feedback.feedbackSource ?? feedback.source;
+    if (feedbackSource) properties.feedback_source = feedbackSource;
+    if (feedback.spanId) properties.span_id = feedback.spanId;
+    if (feedback.sourceId) properties.source_id = feedback.sourceId;
+    if (feedback.metadata?.sessionId) properties.$ai_session_id = feedback.metadata.sessionId;
+
+    Object.assign(properties, this.extractCustomMetadata(feedback.metadata));
+
+    try {
+      this.#client.capture(
+        this.withGroups({
+          distinctId: this.getFeedbackDistinctId(feedback),
+          event: '$ai_feedback',
+          properties,
+          timestamp: new Date(feedback.timestamp),
+        }),
+      );
+    } catch (err) {
+      this.logger.error('PostHog exporter: failed to submit feedback', {
+        error: err,
+        traceId: feedback.traceId,
+        feedbackId: feedback.feedbackId,
+      });
+    }
+  }
+
+  private getFeedbackDistinctId(feedback: ExportedFeedback): string {
+    const userId = feedback.feedbackUserId ?? feedback.userId ?? feedback.metadata?.userId;
+    if (userId) {
+      return String(userId);
+    }
+    return this.config.defaultDistinctId ?? 'anonymous';
+  }
+
+  /**
    * PostHog group analytics are keyed off the top-level `groups` field on the
    * capture call. The Node SDK derives the event's `$groups` from that field and
    * overwrites any property-level `$groups`, so group metadata carried in
@@ -447,8 +513,8 @@ export class PosthogExporter extends TrackingExporter<
     return props;
   }
 
-  private extractCustomMetadata(span: AnyExportedSpan): Record<string, any> {
-    const { userId, sessionId, ...customMetadata } = span.metadata ?? {};
+  private extractCustomMetadata(metadata?: Record<string, unknown>): Record<string, any> {
+    const { userId, sessionId, ...customMetadata } = metadata ?? {};
     return customMetadata;
   }
 
@@ -471,7 +537,7 @@ export class PosthogExporter extends TrackingExporter<
     }
     if (attrs.streaming !== undefined) props.$ai_stream = attrs.streaming;
 
-    return { ...props, ...this.extractErrorProperties(span.errorInfo), ...this.extractCustomMetadata(span) };
+    return { ...props, ...this.extractErrorProperties(span.errorInfo), ...this.extractCustomMetadata(span.metadata) };
   }
 
   private buildSpanProperties(span: AnyExportedSpan): Record<string, any> {
@@ -490,7 +556,7 @@ export class PosthogExporter extends TrackingExporter<
       Object.assign(props, span.attributes);
     }
 
-    return { ...props, ...this.extractErrorProperties(span.errorInfo), ...this.extractCustomMetadata(span) };
+    return { ...props, ...this.extractErrorProperties(span.errorInfo), ...this.extractCustomMetadata(span.metadata) };
   }
 
   private formatMessages(data: SpanData, defaultRole: 'user' | 'assistant' = 'user'): PostHogMessage[] {

--- a/observability/posthog/src/tracing.ts
+++ b/observability/posthog/src/tracing.ts
@@ -256,6 +256,8 @@ export class PosthogExporter extends TrackingExporter<
     }
 
     const properties: Record<string, any> = {
+      // Custom metadata goes first so it cannot overwrite the natively mapped fields below
+      ...this.extractCustomMetadata(feedback.metadata),
       $ai_trace_id: feedback.traceId,
       // PostHog's trace UI only displays feedback events that carry $ai_feedback_text
       $ai_feedback_text: feedback.comment ?? String(feedback.value),
@@ -269,8 +271,6 @@ export class PosthogExporter extends TrackingExporter<
     if (feedback.spanId) properties.span_id = feedback.spanId;
     if (feedback.sourceId) properties.source_id = feedback.sourceId;
     if (feedback.metadata?.sessionId) properties.$ai_session_id = feedback.metadata.sessionId;
-
-    Object.assign(properties, this.extractCustomMetadata(feedback.metadata));
 
     try {
       this.#client.capture(


### PR DESCRIPTION
## Description

Adds feedback support to the PostHog observability exporter. Feedback recorded with `addFeedback()` already flows through the observability event bus, but the PostHog exporter had no handler for it, so feedback was silently dropped. It is now forwarded as PostHog's native `$ai_feedback` event and appears as "User feedback" on the linked trace in PostHog's AI observability UI, with no configuration changes needed.

<img width="1518" height="724" alt="image" src="https://github.com/user-attachments/assets/45235a61-496f-4d05-906d-0a11da666a71" />

## Related Issue(s)

Fixes #19893

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [x] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

When someone leaves feedback while a trace is happening, the exporter now sends that feedback to PostHog automatically. PostHog then shows it right on the related trace as “User feedback,” so you can analyze it without extra setup.

## What changed

- Exported Mastra `addFeedback()` results as native PostHog `$ai_feedback` events.
- Linked feedback to the trace using `$ai_trace_id`.
- Mapped feedback fields (text/value/type/id) plus related context (source, trace/span IDs, session ID, and other observability metadata) into PostHog event properties.
- Ensured distinct ID resolution follows precedence: `feedbackUserId → userId → metadata.userId → defaultDistinctId → anonymous`.
- Dropped feedback events that don’t include a `traceId`.
- Prevented custom metadata from spoofing natively mapped feedback properties (natively mapped fields take precedence).
- Generalized metadata extraction for use across different span event types.
- Added handling for timestamps, missing comments, exporter disabled behavior, and capture failures (logs without throwing).
- Added comprehensive unit tests and updated documentation for PostHog feedback export behavior and field mappings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->