### PR TITLE
fix(mastracode-web): open local factory creation

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
@@ -8,7 +8,7 @@
  */
 import type { AgentControllerSessionState } from '@mastra/client-js';
 import { QueryClient } from '@tanstack/react-query';
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { delay, http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
@@ -167,6 +167,17 @@ describe('MastraCode web routing', () => {
 
     expect(await screen.findByRole('heading', { name: 'Welcome to MastraCode' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Create factory from local folder' })).toBeInTheDocument();
+  });
+
+  it('given no factory, when local factory creation is opened, then the creation panel replaces the welcome screen', async () => {
+    const user = userEvent.setup();
+    renderRoutes('/new', AUTH_DISABLED, { withFactory: false });
+
+    await user.click(await screen.findByRole('button', { name: 'Create factory from local folder' }));
+
+    const creationPanel = await screen.findByRole('region', { name: 'Create Factory' });
+    expect(within(creationPanel).getByRole('button', { name: 'Bind a local folder instead' })).toBeInTheDocument();
+    expect(screen.queryByText('Welcome to MastraCode')).not.toBeInTheDocument();
   });
 
   it('given auth is disabled, when visiting /, then the user is redirected to /new', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/Chat.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/Chat.tsx
@@ -50,10 +50,10 @@ function ChatSessionRouteProvider({ children }: { children: ReactNode }) {
 
 function ChatShell() {
   const overlays = useOverlays();
-  const { factories, factoriesPending } = useActiveFactoryContext();
+  const { activeFactory, factories, factoriesPending } = useActiveFactoryContext();
   const { isMobile } = useMainSidebar();
   const factorySetupRequired = factories.length === 0 && !factoriesPending;
-  const factoriesOpen = overlays.isOpen('factories') || factorySetupRequired;
+  const factoriesOpen = overlays.isOpen('factories');
 
   const closeFactories = () => {
     overlays.close('factories');
@@ -69,9 +69,13 @@ function ChatShell() {
 
   return (
     <>
-      <PageLayoutMainViewProvider view={mainView}>
-        <Outlet />
-      </PageLayoutMainViewProvider>
+      {!activeFactory && mainView !== undefined ? (
+        <main className="flex h-screen min-h-0 flex-col overflow-hidden bg-surface2">{mainView}</main>
+      ) : (
+        <PageLayoutMainViewProvider view={mainView}>
+          <Outlet />
+        </PageLayoutMainViewProvider>
+      )}
       <ChatOverlays />
     </>
   );


### PR DESCRIPTION
When no Factory was active, clicking “Create factory from local folder” only changed overlay state while the creation panel stayed hidden.

Before: `click → empty state remains`

After: `click → Factory creation panel opens`

This renders Factory creation directly in the empty-state route and adds routing coverage for first-time setup and factories without an active selection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When you have no factory selected, the app now takes you straight to the “Create Factory” panel instead of showing the welcome screen first. This makes it easier to start factory setup from a local folder on your very first visit.

## Summary
- Updated the “Create factory from local folder” flow so, with no active factory, it opens the factory creation panel (replacing the welcome/empty-state UI) and exposes the “Bind a local folder instead” control.
- Adjusted `ChatShell` so it can render settings/factory views directly when there’s no `activeFactory`, bypassing the usual `Outlet`/provider path.
- Refined factories panel behavior: `factoriesOpen` is no longer derived from “factory setup required”; the “setup required” flag is only used to decide whether the factories panel can be closed.
- Expanded routing test coverage for first-time/no-factory scenarios and updated test utilities (`within`) used to assert the new UI state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->