### PR TITLE
fix: activity provider wrapping the app (factory)

### DIFF
--- a/mastracode/web/src/web/ui/main.tsx
+++ b/mastracode/web/src/web/ui/main.tsx
@@ -11,6 +11,7 @@ import { createQueryClient } from '../../shared/query-client';
 import { createAppRouter } from './router';
 import '@mastra/playground-ui/style.css';
 import './tailwind.css';
+import { ActiveFactoryProvider } from './domains/workspaces';
 
 // The web app talks to the Mastra server same-origin (`baseUrl=""`): in prod
 // the server serves this build itself, and in dev Vite proxies `/api` + `/auth`
@@ -32,8 +33,10 @@ createRoot(document.getElementById('root')!).render(
       <TooltipProvider delayDuration={0}>
         <QueryClientProvider client={queryClient}>
           <ApiConfigProvider baseUrl="">
-            <RouterProvider router={router} />
-            <Toaster position="bottom-right" />
+            <ActiveFactoryProvider>
+              <RouterProvider router={router} />
+              <Toaster position="bottom-right" />
+            </ActiveFactoryProvider>
           </ApiConfigProvider>
         </QueryClientProvider>
       </TooltipProvider>


### PR DESCRIPTION
## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The app now wraps its main screens with the activity factory provider, so activity-related features can work throughout the application.

## Changes

- Added `ActiveFactoryProvider` around the router and notifications.
- Kept the existing provider structure unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->