### PR TITLE
fix: explain locked Mastra Code storage startup

### DIFF
--- a/.changeset/lemon-news-matter.md
+++ b/.changeset/lemon-news-matter.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Show actionable recovery instructions when another Mastra Code process blocks the local storage safety transition.

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -414,6 +414,47 @@ describe('createMastraCode', () => {
     expect(closeVector).toHaveBeenCalledOnce();
   }, 10_000);
 
+  it('explains how to recover when another process locks local storage during startup', async () => {
+    const startupError = Object.assign(new Error('database is locked'), { code: 'SQLITE_BUSY' });
+    createStorageMock.mockReturnValue({ storage: { close: vi.fn(async () => undefined) }, backend: 'memory' });
+    createOwnedVectorStoreMock.mockReturnValue({ vector: {}, close: vi.fn(async () => undefined) });
+    controllerInitMock.mockRejectedValueOnce(startupError);
+    const { createMastraCode } = await import('../index.js');
+
+    await expect(createMastraCode()).rejects.toThrow(
+      'Close all running Mastra Code sessions once, then restart Mastra Code.',
+    );
+  }, 10_000);
+
+  it('detects a local storage lock wrapped by failed startup cleanup', async () => {
+    const startupError = new Error('storage init failed');
+    const lockError = Object.assign(new Error('database is locked'), { code: 'SQLITE_LOCKED_SHAREDCACHE' });
+    const closeStorage = vi.fn(async () => {
+      throw new AggregateError([lockError], 'Failed to close storage');
+    });
+    createStorageMock.mockReturnValue({ storage: { close: closeStorage }, backend: 'memory' });
+    createOwnedVectorStoreMock.mockReturnValue({ vector: {}, close: vi.fn(async () => undefined) });
+    controllerInitMock.mockRejectedValueOnce(startupError);
+    const { createMastraCode } = await import('../index.js');
+
+    await expect(createMastraCode()).rejects.toThrow(
+      'Close all running Mastra Code sessions once, then restart Mastra Code.',
+    );
+  }, 10_000);
+
+  it('preserves the aggregate error for unrelated startup cleanup failures', async () => {
+    const startupError = new Error('storage init failed');
+    const closeStorage = vi.fn(async () => {
+      throw new Error('close failed');
+    });
+    createStorageMock.mockReturnValue({ storage: { close: closeStorage }, backend: 'memory' });
+    createOwnedVectorStoreMock.mockReturnValue({ vector: {}, close: vi.fn(async () => undefined) });
+    controllerInitMock.mockRejectedValueOnce(startupError);
+    const { createMastraCode } = await import('../index.js');
+
+    await expect(createMastraCode()).rejects.toThrow('Mastra Code startup and storage cleanup failed');
+  }, 10_000);
+
   it('registers the MastraCode gateway and app-provided model hooks on AgentController', async () => {
     const { createMastraCode } = await import('../index.js');
     const subagent = { id: 'review', name: 'Review', instructions: 'Review changes' };

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -1002,6 +1002,24 @@ export async function wireSessionConcerns(
   });
 }
 
+function isSqliteDatabaseLockedError(error: unknown, depth = 0): boolean {
+  if (!error || depth > 5) return false;
+  const candidate = error as { code?: unknown; message?: unknown; cause?: unknown; errors?: unknown };
+  if (typeof candidate.code === 'string' && /^(SQLITE_BUSY|SQLITE_LOCKED)/.test(candidate.code)) return true;
+  if (
+    typeof candidate.message === 'string' &&
+    /(SQLITE_BUSY|SQLITE_LOCKED|database is locked)/i.test(candidate.message)
+  )
+    return true;
+  if (candidate.cause && isSqliteDatabaseLockedError(candidate.cause, depth + 1)) return true;
+  if (
+    Array.isArray(candidate.errors) &&
+    candidate.errors.some((nested: unknown) => isSqliteDatabaseLockedError(nested, depth + 1))
+  )
+    return true;
+  return false;
+}
+
 /**
  * Case 3 (AgentController local + TUI/headless): build the controller, let it stand up its
  * own internal Mastra via `init()`, and mint the single eager session that all
@@ -1026,12 +1044,19 @@ export async function bootLocalAgentController(config?: MastraCodeConfig) {
       () => (base.signalsPubSub as { close?: () => Promise<void> | void } | undefined)?.close?.(),
     ];
     await Promise.allSettled(stopWork.map(stop => Promise.resolve().then(stop)));
+    let startupFailure = error;
     try {
       await base.storageMaintenance.closeStorage?.();
     } catch (closeError) {
-      throw new AggregateError([error, closeError], 'Mastra Code startup and storage cleanup failed');
+      startupFailure = new AggregateError([error, closeError], 'Mastra Code startup and storage cleanup failed');
     }
-    throw error;
+    if (isSqliteDatabaseLockedError(startupFailure)) {
+      throw new Error(
+        'Mastra Code could not switch local storage to safe journaling because another process still has the database open. Close all running Mastra Code sessions once, then restart Mastra Code.',
+        { cause: startupFailure },
+      );
+    }
+    throw startupFailure;
   }
 }
 


### PR DESCRIPTION
## Summary

- detect SQLite lock errors hidden inside startup and cleanup failures
- preserve the fail-closed journal transition
- tell users to close all running Mastra Code sessions once and restart
- preserve existing behavior for unrelated startup and cleanup errors

## Test plan

- `pnpm --filter ./mastracode/sdk exec vitest run src/__tests__/index.test.ts --reporter=dot --bail 1`
- `pnpm --filter ./mastracode/sdk check`
- `pnpm --filter ./mastracode/sdk lint`
- `pnpm build:mastracode`
- isolated live CLI startup against a temporary WAL database held by a separate process

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Mastra Code now recognizes when another session is using its local database during startup. It gives users clear instructions to close other sessions and restart, while preserving the existing handling for unrelated errors.

## What changed

- Added SQLite busy/locked error detection, including nested causes and errors.
- Improved startup cleanup failure handling by preserving both startup and cleanup failures.
- Added recovery guidance for local storage journaling failures caused by another process.
- Added tests for locked, busy, nested, and unrelated cleanup failures.
- Added a patch changeset for `@mastra/code-sdk`.

## Validation

- SDK tests
- Type checking
- Linting
- Mastra Code build
- Isolated CLI startup test using a temporary WAL database held by another process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->