### PR TITLE
Rename workspace provider auth env var to MASTRA_PLATFORM_SECRET_KEY

### DIFF
--- a/.changeset/chilly-cloths-camp.md
+++ b/.changeset/chilly-cloths-camp.md
@@ -1,0 +1,5 @@
+---
+'@mastra/platform-workspace': minor
+---
+
+Renamed the environment variable read by PlatformSandbox and PlatformFilesystem for platform authentication from MASTRA_PLATFORM_ACCESS_TOKEN to MASTRA_PLATFORM_SECRET_KEY. The old variable still works as a deprecated fallback.

--- a/docs/src/content/en/docs/mastra-platform/workspace.mdx
+++ b/docs/src/content/en/docs/mastra-platform/workspace.mdx
@@ -57,7 +57,7 @@ Every deploy that runs on a platform environment with a workspace receives these
 
 | Variable | Contents |
 | - | - |
-| `MASTRA_PLATFORM_ACCESS_TOKEN` | Access token scoped to the deploy. Used by the workspace providers to authenticate. |
+| `MASTRA_PLATFORM_SECRET_KEY` | Secret key scoped to the deploy. Used by the workspace providers to authenticate. `MASTRA_PLATFORM_ACCESS_TOKEN` is also injected as a deprecated alias. |
 | `MASTRA_PROJECT_ID` | Project the deploy belongs to. |
 | `MASTRA_ENVIRONMENT_ID` | Environment the deploy belongs to. Selects which sandbox pool the platform uses. |
 | `MASTRA_PLATFORM_BUCKET_NAME` | Bucket name attached to the environment. Selects which bucket `PlatformFilesystem` reads and writes. |
@@ -69,7 +69,7 @@ These names are reserved. If your project sets any of them explicitly, the platf
 Reuse the same providers locally by putting the four variables in your `.env` file. Get the values from your project's Workspaces tab:
 
 ```bash title=".env"
-MASTRA_PLATFORM_ACCESS_TOKEN=your-access-token
+MASTRA_PLATFORM_SECRET_KEY=your-secret-key
 MASTRA_PROJECT_ID=your-project-id
 MASTRA_ENVIRONMENT_ID=your-environment-id
 MASTRA_PLATFORM_BUCKET_NAME=your-bucket-name

--- a/docs/src/content/en/reference/workspace/platform-filesystem.mdx
+++ b/docs/src/content/en/reference/workspace/platform-filesystem.mdx
@@ -31,7 +31,7 @@ Configure the platform credentials. The access token, project ID, and bucket nam
 <Tabs>
   <TabItem value="env-file" label=".env file">
     ```bash
-    MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
+    MASTRA_PLATFORM_SECRET_KEY=your-platform-secret-key
     MASTRA_PROJECT_ID=your-project-id
     MASTRA_PLATFORM_BUCKET_NAME=your-bucket-name
     ```
@@ -115,7 +115,8 @@ await fs.writeFile('/analyses/repo.md', 'x') // throws WorkspaceReadOnlyError
   {
     name: 'accessToken',
     type: 'string',
-    description: 'Platform access token. Falls back to the MASTRA_PLATFORM_ACCESS_TOKEN environment variable.',
+    description:
+      'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable (MASTRA_PLATFORM_ACCESS_TOKEN is a deprecated fallback).',
     isOptional: true,
   },
   {

--- a/docs/src/content/en/reference/workspace/platform-sandbox.mdx
+++ b/docs/src/content/en/reference/workspace/platform-sandbox.mdx
@@ -31,7 +31,7 @@ Configure the platform credentials. The access token, project ID, and environmen
 <Tabs>
   <TabItem value="env-file" label=".env file">
     ```bash
-    MASTRA_PLATFORM_ACCESS_TOKEN=your-platform-access-token
+    MASTRA_PLATFORM_SECRET_KEY=your-platform-secret-key
     MASTRA_PROJECT_ID=your-project-id
     MASTRA_ENVIRONMENT_ID=your-environment-id
     ```
@@ -138,7 +138,8 @@ The `command` argument is a shell string and is concatenated verbatim into the r
   {
     name: 'accessToken',
     type: 'string',
-    description: 'Platform access token. Falls back to the MASTRA_PLATFORM_ACCESS_TOKEN environment variable.',
+    description:
+      'Platform secret key. Falls back to the MASTRA_PLATFORM_SECRET_KEY environment variable (MASTRA_PLATFORM_ACCESS_TOKEN is a deprecated fallback).',
     isOptional: true,
   },
   {

--- a/workspaces/platform-workspace/README.md
+++ b/workspaces/platform-workspace/README.md
@@ -14,10 +14,12 @@ All options can be passed to the constructor or read from environment variables:
 
 | Option          | Env var                        | Required         |
 | --------------- | ------------------------------ | ---------------- |
-| `accessToken`   | `MASTRA_PLATFORM_ACCESS_TOKEN` | Yes              |
+| `accessToken`   | `MASTRA_PLATFORM_SECRET_KEY`   | Yes              |
 | `projectId`     | `MASTRA_PROJECT_ID`            | Yes              |
 | `environmentId` | `MASTRA_ENVIRONMENT_ID`        | Yes (sandbox)    |
 | `bucketName`    | `MASTRA_PLATFORM_BUCKET_NAME`  | Yes (filesystem) |
+
+`MASTRA_PLATFORM_ACCESS_TOKEN` is still read as a deprecated fallback for `accessToken`.
 
 The proxy URL defaults to `https://workspaces.mastra.ai` and can be overridden with the `MASTRA_WORKSPACE_PROXY_URL` env var (useful for staging).
 

--- a/workspaces/platform-workspace/src/client.test.ts
+++ b/workspaces/platform-workspace/src/client.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { PlatformApiError } from './client.js';
-import { PlatformClient } from './client.js';
+import { PlatformClient, resolvePlatformOptions } from './client.js';
 
 function response(body: string, init?: ResponseInit) {
   return new Response(body, init);
@@ -27,6 +27,28 @@ describe('PlatformClient', () => {
     expect(String(url)).toBe('https://proxy.test/v1/projects/proj_123/sandbox?dryRun=true');
     expect((init.headers as Headers).get('authorization')).toBe('Bearer sk_test');
     expect(init.method).toBe('POST');
+  });
+
+  it('reads the access token from MASTRA_PLATFORM_SECRET_KEY', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
+    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+
+    expect(resolvePlatformOptions({}).accessToken).toBe('sk_secret');
+  });
+
+  it('prefers MASTRA_PLATFORM_SECRET_KEY over the deprecated MASTRA_PLATFORM_ACCESS_TOKEN', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'sk_secret');
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'sk_legacy');
+    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+
+    expect(resolvePlatformOptions({}).accessToken).toBe('sk_secret');
+  });
+
+  it('falls back to the deprecated MASTRA_PLATFORM_ACCESS_TOKEN', () => {
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'sk_legacy');
+    vi.stubEnv('MASTRA_PROJECT_ID', 'proj_env');
+
+    expect(resolvePlatformOptions({}).accessToken).toBe('sk_legacy');
   });
 
   it('throws PlatformApiError for non-2xx responses', async () => {

--- a/workspaces/platform-workspace/src/client.ts
+++ b/workspaces/platform-workspace/src/client.ts
@@ -24,7 +24,13 @@ export function requireOption(value: string | undefined, name: string): string {
 
 export function resolvePlatformOptions(options: PlatformClientOptions) {
   return {
-    accessToken: requireOption(options.accessToken ?? process.env.MASTRA_PLATFORM_ACCESS_TOKEN, 'accessToken'),
+    accessToken: requireOption(
+      options.accessToken ??
+        process.env.MASTRA_PLATFORM_SECRET_KEY ??
+        // Deprecated alias — prefer MASTRA_PLATFORM_SECRET_KEY.
+        process.env.MASTRA_PLATFORM_ACCESS_TOKEN,
+      'accessToken',
+    ),
     projectId: requireOption(options.projectId ?? process.env.MASTRA_PROJECT_ID, 'projectId'),
     proxyUrl: (process.env.MASTRA_WORKSPACE_PROXY_URL ?? DEFAULT_PROXY_URL).replace(/\/$/, ''),
     fetch: options.fetch ?? fetch,

--- a/workspaces/platform-workspace/src/provider.ts
+++ b/workspaces/platform-workspace/src/provider.ts
@@ -13,7 +13,7 @@ export const platformSandboxProvider: SandboxProvider<PlatformSandboxOptions> = 
     properties: {
       accessToken: {
         type: 'string',
-        description: 'Mastra Platform access token (falls back to MASTRA_PLATFORM_ACCESS_TOKEN)',
+        description: 'Mastra Platform secret key (falls back to MASTRA_PLATFORM_SECRET_KEY)',
       },
       projectId: { type: 'string', description: 'Platform project ID (falls back to MASTRA_PROJECT_ID)' },
       environmentId: { type: 'string', description: 'Platform environment ID (falls back to MASTRA_ENVIRONMENT_ID)' },
@@ -41,7 +41,7 @@ export const platformFilesystemProvider: FilesystemProvider<PlatformFilesystemOp
     properties: {
       accessToken: {
         type: 'string',
-        description: 'Mastra Platform access token (falls back to MASTRA_PLATFORM_ACCESS_TOKEN)',
+        description: 'Mastra Platform secret key (falls back to MASTRA_PLATFORM_SECRET_KEY)',
       },
       projectId: { type: 'string', description: 'Platform project ID (falls back to MASTRA_PROJECT_ID)' },
       bucketName: {


### PR DESCRIPTION
## Summary

Renames the environment variable that `PlatformSandbox` and `PlatformFilesystem` read for platform authentication from `MASTRA_PLATFORM_ACCESS_TOKEN` to `MASTRA_PLATFORM_SECRET_KEY`.

- `MASTRA_PLATFORM_SECRET_KEY` is now the primary variable for the workspace providers' `accessToken` option.
- `MASTRA_PLATFORM_ACCESS_TOKEN` still works as a deprecated fallback, so existing deployments (where the platform injects the old name) keep working until the platform injects the new name.
- Updated the `@mastra/platform-workspace` README, provider config schema descriptions, and the workspace docs (`platform-sandbox`, `platform-filesystem`, `mastra-platform/workspace`).

The observability token (`MASTRA_PLATFORM_ACCESS_TOKEN` as read by `MastraPlatformExporter`, the CLI, etc.) is intentionally unchanged — this rename only applies to the workspace providers.

## Test plan

- [x] `pnpm --filter @mastra/platform-workspace test` — 3 files / 25 tests, including new regressions for the primary read, precedence over the deprecated alias, and the fallback.
- [x] `pnpm --filter @mastra/platform-workspace build`
