### PR TITLE
Rename platform integration auth env var to MASTRA_PLATFORM_SECRET_KEY

### DIFF
--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -62,13 +62,15 @@ MASTRA_COOKIE_DOMAIN=
 # ---------------------------------------------------------------------------
 # Mastra Platform integrations and sandbox
 # PlatformGithubIntegration and PlatformLinearIntegration are zero-argument
-# integrations. They use MASTRA_SHARED_API_URL and this Platform API token.
-# PlatformSandbox is selected automatically only when MASTRA_PLATFORM_ACCESS_TOKEN,
+# integrations. They use MASTRA_SHARED_API_URL and this Platform secret key.
+# PlatformSandbox is selected automatically only when MASTRA_PLATFORM_SECRET_KEY,
 # MASTRA_PROJECT_ID, and MASTRA_ENVIRONMENT_ID are all set.
 # ---------------------------------------------------------------------------
 
 # Required when a Platform integration is instantiated or when PlatformSandbox
 # is selected.
+MASTRA_PLATFORM_SECRET_KEY=
+# Deprecated alias for MASTRA_PLATFORM_SECRET_KEY.
 MASTRA_PLATFORM_ACCESS_TOKEN=
 # Required for PlatformSandbox auto-selection.
 # @public

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -118,22 +118,21 @@ function localSandboxEnv(): Record<string, string> {
   return env;
 }
 
-const PLATFORM_SANDBOX_ENV_KEYS = [
-  'MASTRA_PLATFORM_ACCESS_TOKEN',
-  'MASTRA_PROJECT_ID',
-  'MASTRA_ENVIRONMENT_ID',
-] as const;
+const PLATFORM_SANDBOX_ENV_KEYS = ['MASTRA_PROJECT_ID', 'MASTRA_ENVIRONMENT_ID'] as const;
+
+function hasPlatformSecretKey(): boolean {
+  // MASTRA_PLATFORM_ACCESS_TOKEN is a deprecated alias for
+  // MASTRA_PLATFORM_SECRET_KEY.
+  return Boolean(process.env.MASTRA_PLATFORM_SECRET_KEY?.trim() || process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim());
+}
 
 function hasPlatformSandboxEnv(): boolean {
-  return PLATFORM_SANDBOX_ENV_KEYS.every(key => Boolean(process.env[key]?.trim()));
+  return hasPlatformSecretKey() && PLATFORM_SANDBOX_ENV_KEYS.every(key => Boolean(process.env[key]?.trim()));
 }
 
 function missingPlatformSandboxEnv(): string[] {
-  return PLATFORM_SANDBOX_ENV_KEYS.filter(key => !process.env[key]?.trim());
-}
-
-function hasPlatformAccessToken(): boolean {
-  return Boolean(process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim());
+  const missing: string[] = hasPlatformSecretKey() ? [] : ['MASTRA_PLATFORM_SECRET_KEY'];
+  return [...missing, ...PLATFORM_SANDBOX_ENV_KEYS.filter(key => !process.env[key]?.trim())];
 }
 
 // Sandbox machine, by env precedence (any `WorkspaceSandbox` implementing
@@ -142,8 +141,9 @@ function hasPlatformAccessToken(): boolean {
 //   1. MASTRACODE_SANDBOX_PROVIDER=platform|railway|local — explicit selection.
 //      Platform/Railway selected without their required env is a hard
 //      misconfiguration error.
-//   2. PlatformSandbox when MASTRA_PLATFORM_ACCESS_TOKEN, MASTRA_PROJECT_ID,
-//      and MASTRA_ENVIRONMENT_ID are all set.
+//   2. PlatformSandbox when MASTRA_PLATFORM_SECRET_KEY (or the deprecated
+//      MASTRA_PLATFORM_ACCESS_TOKEN alias), MASTRA_PROJECT_ID, and
+//      MASTRA_ENVIRONMENT_ID are all set.
 //   3. RAILWAY_API_TOKEN set → RailwaySandbox (isolated cloud VMs,
 //      multi-tenant safe).
 //   4. Neither → LocalSandbox, so repos can always be opened with no extra
@@ -239,7 +239,7 @@ const github = githubEnv
       slug: githubEnv.GITHUB_APP_SLUG,
       webhookSecret: process.env.GITHUB_APP_WEBHOOK_SECRET,
     })
-  : hasPlatformAccessToken()
+  : hasPlatformSecretKey()
     ? new PlatformGithubIntegration()
     : undefined;
 
@@ -253,7 +253,7 @@ const linearEnv = envGroup(
 );
 const linear = linearEnv
   ? new LinearIntegration({ clientId: linearEnv.LINEAR_CLIENT_ID, clientSecret: linearEnv.LINEAR_CLIENT_SECRET })
-  : hasPlatformAccessToken()
+  : hasPlatformSecretKey()
     ? new PlatformLinearIntegration()
     : undefined;
 

--- a/mastracode/web/src/web/platform/api-client.test.ts
+++ b/mastracode/web/src/web/platform/api-client.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 describe('PlatformApiClient', () => {
   it('resolves config from MASTRA_SHARED_API_URL and normalizes the /v1 root', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1/');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', accessToken);
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
 
     expect(platformApiClientConfigFromEnv()).toEqual({
       baseUrl: 'https://platform.example.com',
@@ -25,13 +25,26 @@ describe('PlatformApiClient', () => {
     });
   });
 
-  it('defaults shared API config to platform.mastra.ai and requires an access token', () => {
+  it('defaults shared API config to platform.mastra.ai and requires a secret key', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
-    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', accessToken);
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
     expect(platformApiClientConfigFromEnv()).toMatchObject({ baseUrl: 'https://platform.mastra.ai' });
 
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
-    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
+    expect(() => platformApiClientConfigFromEnv()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
+  });
+
+  it('prefers MASTRA_PLATFORM_SECRET_KEY over the deprecated MASTRA_PLATFORM_ACCESS_TOKEN', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', accessToken);
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
+    expect(platformApiClientConfigFromEnv()).toMatchObject({ accessToken });
+  });
+
+  it('falls back to the deprecated MASTRA_PLATFORM_ACCESS_TOKEN', () => {
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
+    vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'legacy-token');
+    expect(platformApiClientConfigFromEnv()).toMatchObject({ accessToken: 'legacy-token' });
   });
 
   it('uses bearer authentication without ambient cookie credentials', async () => {

--- a/mastracode/web/src/web/platform/api-client.ts
+++ b/mastracode/web/src/web/platform/api-client.ts
@@ -6,9 +6,12 @@ export interface PlatformApiClientConfig {
 
 export function platformApiClientConfigFromEnv(): PlatformApiClientConfig {
   const sharedApiUrl = process.env.MASTRA_SHARED_API_URL?.trim() || 'https://platform.mastra.ai/v1';
-  const accessToken = process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim();
+  const accessToken =
+    process.env.MASTRA_PLATFORM_SECRET_KEY?.trim() ||
+    // Deprecated alias — prefer MASTRA_PLATFORM_SECRET_KEY.
+    process.env.MASTRA_PLATFORM_ACCESS_TOKEN?.trim();
   if (!accessToken) {
-    throw new Error('Platform integration: missing required environment variable MASTRA_PLATFORM_ACCESS_TOKEN.');
+    throw new Error('Platform integration: missing required environment variable MASTRA_PLATFORM_SECRET_KEY.');
   }
   return { baseUrl: normalizeSharedApiUrl(sharedApiUrl), accessToken };
 }

--- a/mastracode/web/src/web/platform/github/event-worker.lifecycle.test.ts
+++ b/mastracode/web/src/web/platform/github/event-worker.lifecycle.test.ts
@@ -68,7 +68,7 @@ function json(data: unknown): Response {
 beforeEach(() => {
   vi.useFakeTimers();
   vi.stubEnv('MASTRA_SHARED_API_URL', 'https://platform.example.com/v1');
-  vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', 'platform-token');
+  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', 'platform-token');
   vi.stubEnv('MASTRA_PLATFORM_GITHUB_POLLING_INTERVAL_MS', '60000');
   harness.reset();
   __resetRuntimeConfigForTests();

--- a/mastracode/web/src/web/platform/github/integration.test.ts
+++ b/mastracode/web/src/web/platform/github/integration.test.ts
@@ -62,7 +62,7 @@ function json(data: unknown, status = 200): Response {
 
 beforeEach(() => {
   vi.stubEnv('MASTRA_SHARED_API_URL', config.baseUrl);
-  vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', config.accessToken);
+  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', config.accessToken);
 });
 
 afterEach(() => {
@@ -588,8 +588,9 @@ describe('PlatformGithubIntegration', () => {
     vi.stubEnv('MASTRA_SHARED_API_URL', '');
     expect(new PlatformGithubIntegration().diagnostics()).toMatchObject({ endpointHost: 'platform.mastra.ai' });
 
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
-    expect(() => new PlatformGithubIntegration()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
+    expect(() => new PlatformGithubIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
   });
 
   it('can disable polling and resolves collaborator permissions through the platform API', async () => {

--- a/mastracode/web/src/web/platform/linear/integration.test.ts
+++ b/mastracode/web/src/web/platform/linear/integration.test.ts
@@ -70,7 +70,7 @@ function json(data: unknown, status = 200): Response {
 
 beforeEach(() => {
   vi.stubEnv('MASTRA_SHARED_API_URL', config.baseUrl);
-  vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', config.accessToken);
+  vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', config.accessToken);
 });
 
 afterEach(() => {
@@ -355,7 +355,8 @@ describe('PlatformLinearIntegration', () => {
       endpointHost: 'platform.mastra.ai',
     });
 
+    vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
     vi.stubEnv('MASTRA_PLATFORM_ACCESS_TOKEN', '');
-    expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_ACCESS_TOKEN/);
+    expect(() => new PlatformLinearIntegration()).toThrow(/MASTRA_PLATFORM_SECRET_KEY/);
   });
 });


### PR DESCRIPTION
## Summary

Renames the environment variable the platform-backed MastraCode integrations read for Platform API authentication from `MASTRA_PLATFORM_ACCESS_TOKEN` to `MASTRA_PLATFORM_SECRET_KEY`.

- `PlatformGithubIntegration` and `PlatformLinearIntegration` (via the shared `PlatformApiClient`) now read `MASTRA_PLATFORM_SECRET_KEY` first, with `MASTRA_PLATFORM_ACCESS_TOKEN` kept as a deprecated fallback so existing deployments (where the platform still injects the old name) keep working.
- The `PlatformSandbox` auto-selection and platform integration gating in the web entry (`src/mastra/index.ts`) accept either variable, and the misconfiguration error names `MASTRA_PLATFORM_SECRET_KEY`.
- `.env.schema` documents the new variable and marks the old one deprecated.

Stacked on #19879 (`feat/platform-integrations`) — the platform adapters only exist on that branch. The companion rename for `@mastra/platform-workspace` is #19932; a companion platform PR updates the setup instructions and env injection.

## Test plan

- [x] `pnpm exec vitest run src/web/platform src/mastra/index.test.ts src/mastra/env-schema.test.ts` — 7 files / 40 tests, including new precedence and deprecated-fallback regressions for `platformApiClientConfigFromEnv()`.
- [x] `pnpm check` in `mastracode/web`
- [x] Prettier + `git diff --check`
