### PR TITLE
feat(mastracode): notify session when GitHub plugins auto-update

### DIFF
--- a/.changeset/old-eagles-float.md
+++ b/.changeset/old-eagles-float.md
@@ -1,0 +1,6 @@
+---
+'@mastra/code-sdk': patch
+'mastracode': patch
+---
+
+Added a session notification when a GitHub plugin is automatically updated to its latest version

--- a/.changeset/old-eagles-float.md
+++ b/.changeset/old-eagles-float.md
@@ -4,3 +4,12 @@
 ---
 
 Added a session notification when a GitHub plugin is automatically updated to its latest version
+
+```ts
+const unsubscribe = pluginManager.onGithubPluginsUpdated(pluginNames => {
+  console.log(`Updated plugins: ${pluginNames.join(', ')}`);
+});
+
+// Call during shutdown.
+unsubscribe();
+```

--- a/mastracode/sdk/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/manager.test.ts
@@ -194,12 +194,16 @@ describe('PluginManager', () => {
 
     const manager = new PluginManager({ projectRoot, homeDir });
     const pluginTools = manager.getPluginTools();
+    const updateListener = vi.fn();
+    manager.onGithubPluginsUpdated(updateListener);
     await manager.reload();
     expect(pluginTools.github_tool?.description).toBe('first');
 
     await expect(manager.pollGithubSourcesForUpdates()).resolves.toBe(true);
 
     expect(pluginTools.github_tool?.description).toBe('second');
+    expect(updateListener).toHaveBeenCalledTimes(1);
+    expect(updateListener).toHaveBeenCalledWith(['acme.github']);
     expect(execaMock).toHaveBeenCalledWith(
       'git',
       ['fetch', 'origin'],
@@ -317,11 +321,14 @@ describe('PluginManager', () => {
     });
 
     const manager = new PluginManager({ projectRoot, homeDir });
+    const updateListener = vi.fn();
+    manager.onGithubPluginsUpdated(updateListener);
     await manager.reload();
 
     await expect(manager.pollGithubSourcesForUpdates()).resolves.toBe(false);
 
     expect(execaMock.mock.calls.some(call => call[0] === 'corepack' && call[1][0]?.startsWith('pnpm@'))).toBe(false);
+    expect(updateListener).not.toHaveBeenCalled();
   });
 
   it('backs up divergent GitHub plugin checkouts before forcing them to origin', async () => {

--- a/mastracode/sdk/src/plugins/__tests__/manager.test.ts
+++ b/mastracode/sdk/src/plugins/__tests__/manager.test.ts
@@ -25,10 +25,14 @@ afterEach(() => {
 });
 
 function writePlugin(pluginDir: string, id: string, toolName: string, description = 'tool'): void {
-  fs.mkdirSync(path.join(pluginDir, 'src'), { recursive: true });
+  writePluginSource(path.join(pluginDir, 'src/index.ts'), id, id, toolName, description);
+}
+
+function writePluginSource(entryPath: string, id: string, name: string, toolName: string, description = 'tool'): void {
+  fs.mkdirSync(path.dirname(entryPath), { recursive: true });
   fs.writeFileSync(
-    path.join(pluginDir, 'src/index.ts'),
-    `export default { id: '${id}', name: '${id}', tools: { ${toolName}: { tool: { id: '${toolName}', description: '${description}' } } } };`,
+    entryPath,
+    `export default { id: '${id}', name: '${name}', tools: { ${toolName}: { tool: { id: '${toolName}', description: '${description}' } } } };`,
   );
 }
 
@@ -222,6 +226,113 @@ describe('PluginManager', () => {
     expect(fs.realpathSync(path.join(checkoutDir, 'node_modules', 'mastracode'))).toBe(
       fs.realpathSync(mastracodePackageRoot),
     );
+  });
+
+  it('reports post-reload display names when an update renames a plugin', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-manager-'));
+    const projectRoot = path.join(tempDir, 'project');
+    const homeDir = path.join(tempDir, 'home');
+    const checkoutDir = path.join(projectRoot, '.mastracode/plugins/sources/github/acme-plugin');
+    writePluginSource(path.join(checkoutDir, 'src/index.ts'), 'acme.github', 'Acme Old', 'github_tool');
+    fs.mkdirSync(path.join(checkoutDir, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.mastracode/plugins'), { recursive: true });
+    fs.writeFileSync(
+      path.join(projectRoot, '.mastracode/plugins/plugins.json'),
+      JSON.stringify({
+        plugins: {
+          'acme.github': {
+            enabled: true,
+            source: 'github',
+            specifier: 'https://github.com/acme/plugin',
+            path: 'sources/github/acme-plugin',
+            entry: 'src/index.ts',
+          },
+        },
+      }),
+    );
+    execaMock.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return {
+          stdout:
+            execaMock.mock.calls.filter(call => call[1][0] === 'rev-parse' && call[1][1] === 'HEAD').length === 1
+              ? 'old'
+              : 'new',
+        };
+      }
+      if (args[0] === 'rev-parse') return { stdout: 'origin/main' };
+      if (args[0] === 'rev-list') return { stdout: '0\t1' };
+      if (args[0] === 'status') return { stdout: '' };
+      if (args[0] === 'reset') {
+        writePluginSource(path.join(checkoutDir, 'src/index.ts'), 'acme.github', 'Acme New', 'github_tool');
+      }
+      return { stdout: '' };
+    });
+
+    const manager = new PluginManager({ projectRoot, homeDir });
+    const updateListener = vi.fn();
+    manager.onGithubPluginsUpdated(updateListener);
+    await manager.reload();
+
+    await expect(manager.pollGithubSourcesForUpdates()).resolves.toBe(true);
+
+    expect(updateListener).toHaveBeenCalledTimes(1);
+    expect(updateListener).toHaveBeenCalledWith(['Acme New']);
+  });
+
+  it('reports every plugin sharing an updated checkout', async () => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mc-plugin-manager-'));
+    const projectRoot = path.join(tempDir, 'project');
+    const homeDir = path.join(tempDir, 'home');
+    const checkoutDir = path.join(projectRoot, '.mastracode/plugins/sources/github/acme-suite');
+    writePluginSource(path.join(checkoutDir, 'src/one.ts'), 'acme.one', 'acme.one', 'one_tool', 'first');
+    writePluginSource(path.join(checkoutDir, 'src/two.ts'), 'acme.two', 'acme.two', 'two_tool', 'first');
+    fs.mkdirSync(path.join(checkoutDir, '.git'), { recursive: true });
+    fs.mkdirSync(path.join(projectRoot, '.mastracode/plugins'), { recursive: true });
+    const sharedSource = {
+      enabled: true,
+      source: 'github',
+      specifier: 'https://github.com/acme/suite',
+      path: 'sources/github/acme-suite',
+    };
+    fs.writeFileSync(
+      path.join(projectRoot, '.mastracode/plugins/plugins.json'),
+      JSON.stringify({
+        plugins: {
+          'acme.one': { ...sharedSource, entry: 'src/one.ts' },
+          'acme.two': { ...sharedSource, entry: 'src/two.ts' },
+        },
+      }),
+    );
+    execaMock.mockImplementation(async (_cmd: string, args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+        return {
+          stdout:
+            execaMock.mock.calls.filter(call => call[1][0] === 'rev-parse' && call[1][1] === 'HEAD').length === 1
+              ? 'old'
+              : 'new',
+        };
+      }
+      if (args[0] === 'rev-parse') return { stdout: 'origin/main' };
+      if (args[0] === 'rev-list') return { stdout: '0\t1' };
+      if (args[0] === 'status') return { stdout: '' };
+      if (args[0] === 'reset') {
+        writePluginSource(path.join(checkoutDir, 'src/one.ts'), 'acme.one', 'acme.one', 'one_tool', 'second');
+        writePluginSource(path.join(checkoutDir, 'src/two.ts'), 'acme.two', 'acme.two', 'two_tool', 'second');
+      }
+      return { stdout: '' };
+    });
+
+    const manager = new PluginManager({ projectRoot, homeDir });
+    const updateListener = vi.fn();
+    manager.onGithubPluginsUpdated(updateListener);
+    await manager.reload();
+
+    await expect(manager.pollGithubSourcesForUpdates()).resolves.toBe(true);
+
+    // One checkout fetch despite two plugins, one notification naming both.
+    expect(execaMock.mock.calls.filter(call => call[1][0] === 'fetch')).toHaveLength(1);
+    expect(updateListener).toHaveBeenCalledTimes(1);
+    expect(updateListener).toHaveBeenCalledWith(['acme.one', 'acme.two']);
   });
 
   it('installs dependencies for nested GitHub entry package roots during updates', async () => {

--- a/mastracode/sdk/src/plugins/manager.ts
+++ b/mastracode/sdk/src/plugins/manager.ts
@@ -248,6 +248,8 @@ export class PluginManager {
 
     if (changedCheckouts.size === 0) return false;
 
+    await this.reload();
+    // Derive names from the reloaded state so a manifest display-name change reports the new name.
     // Multiple plugins can share one checkout — report every plugin whose source changed.
     const updatedPluginNames = this.loadedPlugins
       .filter(
@@ -258,7 +260,6 @@ export class PluginManager {
           changedCheckouts.has(this.resolvePluginSourcePath(plugin)),
       )
       .map(plugin => plugin.name ?? plugin.id);
-    await this.reload();
     await this.notifyGithubUpdateListeners(updatedPluginNames);
     return true;
   }

--- a/mastracode/sdk/src/plugins/manager.ts
+++ b/mastracode/sdk/src/plugins/manager.ts
@@ -40,12 +40,19 @@ export class PluginManager {
   private githubPollInFlight: Promise<boolean> | undefined;
   private reloadInFlight: Promise<LoadedPlugin[]> | undefined;
   private readonly reloadListeners = new Set<(plugins: LoadedPlugin[]) => void | Promise<void>>();
+  private readonly githubUpdateListeners = new Set<(pluginNames: string[]) => void | Promise<void>>();
 
   constructor(private readonly options: PluginManagerOptions) {}
 
   onReload(listener: (plugins: LoadedPlugin[]) => void | Promise<void>): () => void {
     this.reloadListeners.add(listener);
     return () => this.reloadListeners.delete(listener);
+  }
+
+  /** Notified with the display names of GitHub plugins that were updated by the background poll. */
+  onGithubPluginsUpdated(listener: (pluginNames: string[]) => void | Promise<void>): () => void {
+    this.githubUpdateListeners.add(listener);
+    return () => this.githubUpdateListeners.delete(listener);
   }
 
   async reload(): Promise<LoadedPlugin[]> {
@@ -225,7 +232,7 @@ export class PluginManager {
   }
 
   private async pollGithubSourcesForUpdatesOnce(): Promise<boolean> {
-    let changed = false;
+    const changedCheckouts = new Set<string>();
     const seen = new Set<string>();
     for (const plugin of this.loadedPlugins) {
       if (plugin.source !== 'github' || plugin.status === 'inactive' || plugin.status === 'blocked') continue;
@@ -236,13 +243,28 @@ export class PluginManager {
       const before = await this.readGitHead(checkoutPath);
       const checkoutChanged = await this.refreshGithubCheckout(plugin, checkoutPath, before);
       const after = await this.readGitHead(checkoutPath);
-      if (checkoutChanged || before !== after) changed = true;
+      if (checkoutChanged || before !== after) changedCheckouts.add(checkoutPath);
     }
 
-    if (changed) {
-      await this.reload();
-    }
-    return changed;
+    if (changedCheckouts.size === 0) return false;
+
+    // Multiple plugins can share one checkout — report every plugin whose source changed.
+    const updatedPluginNames = this.loadedPlugins
+      .filter(
+        plugin =>
+          plugin.source === 'github' &&
+          plugin.status !== 'inactive' &&
+          plugin.status !== 'blocked' &&
+          changedCheckouts.has(this.resolvePluginSourcePath(plugin)),
+      )
+      .map(plugin => plugin.name ?? plugin.id);
+    await this.reload();
+    await this.notifyGithubUpdateListeners(updatedPluginNames);
+    return true;
+  }
+
+  private async notifyGithubUpdateListeners(pluginNames: string[]): Promise<void> {
+    await Promise.all([...this.githubUpdateListeners].map(listener => Promise.resolve(listener(pluginNames))));
   }
 
   private async refreshGithubCheckout(

--- a/mastracode/tui/e2e/tui/plugins.ts
+++ b/mastracode/tui/e2e/tui/plugins.ts
@@ -820,6 +820,8 @@ export const pluginsGithubPollUpdateScenario: McE2eScenario = {
     const changed = await githubPollManager.pollGithubSourcesForUpdates();
     if (!changed) throw new Error('Expected GitHub plugin poll to detect an update');
 
+    await runtime.waitForScreenText(/Plugin updated to the latest version: E2E Local Plugin/i, terminal, 10_000);
+
     terminal.submit('Call the GitHub plugin after update.');
     await runtime.waitForScreenText(/version-two/i, terminal, 10_000);
 

--- a/mastracode/tui/src/tui/mastra-tui.ts
+++ b/mastracode/tui/src/tui/mastra-tui.ts
@@ -160,6 +160,7 @@ export class MastraTUI {
   private caffeinateProcess: ChildProcess | null = null;
   private cleanupKeyHandlers?: () => void;
   private cleanupPluginReloadListener?: () => void;
+  private cleanupPluginUpdateListener?: () => void;
   private lastStreamError: string | null = null;
 
   private static readonly DOUBLE_CTRL_C_MS = 500;
@@ -561,6 +562,11 @@ export class MastraTUI {
       this.cleanupPluginReloadListener = undefined;
     }
 
+    if (this.cleanupPluginUpdateListener) {
+      this.cleanupPluginUpdateListener();
+      this.cleanupPluginUpdateListener = undefined;
+    }
+
     if (this.state.unsubscribe) {
       this.state.unsubscribe();
     }
@@ -597,6 +603,14 @@ export class MastraTUI {
           process.stderr.write(`[plugin runtime refresh] ${msg}\n`);
         }),
       );
+    }
+
+    if (this.state.pluginManager && !this.cleanupPluginUpdateListener) {
+      this.cleanupPluginUpdateListener = this.state.pluginManager.onGithubPluginsUpdated(pluginNames => {
+        if (pluginNames.length === 0) return;
+        const label = pluginNames.length === 1 ? 'Plugin' : 'Plugins';
+        showInfo(this.state, `${label} updated to the latest version: ${pluginNames.join(', ')}`);
+      });
     }
 
     // Load custom slash commands


### PR DESCRIPTION
GitHub-sourced plugins are polled and auto-updated in the background every ~60s, but nothing told the user when that happened — a plugin's tools, skills, or commands could silently change mid-session.

Now the `PluginManager` reports which GitHub plugins actually changed after a poll, and the TUI surfaces it as an info line in the session:

```
Plugin updated to the latest version: plan
```

SDK side: new `PluginManager.onGithubPluginsUpdated(listener)` that fires with the display names of the plugins whose checkouts changed (local plugin hot-reloads from the user's own edits don't notify). TUI side: subscribes during init alongside the existing reload listener and cleans up on stop.

Test plan: extended the SDK poll tests — the listener fires once with the changed plugin's name when a checkout updates, and never fires when the checkout is unchanged. `tsc --noEmit` and eslint clean on sdk + tui.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
When a plugin you installed from GitHub updates itself in the background, the app now shows a small message telling you which plugin(s) were updated. If you change a local plugin yourself, it still hot-reloads—but it won’t pop that “GitHub updated” notification.

## What changed
- Added `PluginManager.onGithubPluginsUpdated(listener)` so consumers can subscribe to “GitHub poll detected an update” events.
- When the GitHub poll finds updated checkouts, the manager reloads plugins and then notifies listeners with the *post-reload* plugin display names (so renames/manifest display-name changes are reflected), including updates for multiple plugins that share one checkout.
- GitHub polling now tracks which checkout paths changed and only reloads/notifies when there’s a real change (unchanged checkouts do not trigger any notification).
- The TUI subscribes during initialization to show an info line like: `Plugin updated to the latest version: plan` (or multiple names), and unsubscribes during shutdown/`stop()` to prevent stale notifications.
- SDK tests were expanded for changed vs unchanged checkouts, renamed plugin manifests during reload, and multiple plugins sharing one checkout (ensuring a single notification includes all affected plugin names).
- TUI E2E coverage was added/updated to assert the notification appears in the UI at the right time during the GitHub poll update flow.
- Added a changeset bumping `@mastra/code-sdk` and `mastracode` to ship the new notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->