### PR TITLE
feat(cli): add mastra factory dev command using shared dev runtime

### DIFF
--- a/.changeset/cute-tables-hunt.md
+++ b/.changeset/cute-tables-hunt.md
@@ -1,0 +1,5 @@
+---
+'mastra': minor
+---
+
+Added the `mastra factory dev` command to start a local development server for Agent Builder development. It uses the same dev runtime and flags as `mastra dev` and shares the same `.mastra` output directory and dev lock, so the two commands cannot run at the same time in the same project.

--- a/docs/src/content/en/docs/agent-builder/overview.mdx
+++ b/docs/src/content/en/docs/agent-builder/overview.mdx
@@ -81,6 +81,8 @@ Start Mastra's development server:
 npx mastra dev
 ```
 
+For Agent Builder development, you can also use `mastra factory dev`, which uses the same dev runtime and flags as `mastra dev` and writes to the same `.mastra/output` directory. Both commands share a dev lock and can't run simultaneously in the same project. See the [CLI reference](/reference/cli/mastra#mastra-factory-dev) for details.
+
 The Agent Builder is mounted at `http://localhost:4111/agent-builder`.
 
 ## Disabling the Builder

--- a/docs/src/content/en/reference/cli/mastra.mdx
+++ b/docs/src/content/en/reference/cli/mastra.mdx
@@ -107,6 +107,18 @@ mastra dev
 These are forwarded to the Mastra model router and will work with any `"openai/..."`
 or `"anthropic/..."` model selections.
 
+## `mastra factory dev`
+
+Starts a development server for [Agent Builder](/docs/agent-builder/overview) development. It uses the same dev runtime and flags as [`mastra dev`](#mastra-dev) and writes to the same `.mastra/output` directory.
+
+```bash
+npx mastra factory dev
+```
+
+Both commands share the same dev lock, so `mastra dev` and `mastra factory dev` can't run simultaneously in the same project. If one is already running, the other exits with a duplicate development server error.
+
+Use `mastra factory dev` when developing Agent Builder features. It accepts the same flags as [`mastra dev`](#mastra-dev), including `--https`, `--inspect`, `--inspect-brk`, `--custom-args`, and `--request-context-presets`.
+
 ## `mastra build`
 
 The `mastra build` command bundles your Mastra project into a production-ready Hono server. [Hono](https://hono.dev/) is a lightweight, type-safe web framework that makes it straightforward to deploy Mastra agents as HTTP endpoints with middleware support.

--- a/packages/cli/src/commands/actions/start-dev-server.test.ts
+++ b/packages/cli/src/commands/actions/start-dev-server.test.ts
@@ -147,4 +147,58 @@ describe('startDevServer - inspect flag integration', () => {
       );
     });
   });
+
+  describe('factory mode', () => {
+    it('should pass factory: true to dev when factory is set', async () => {
+      const { startDevServer } = await import('./start-dev-server');
+
+      await startDevServer({
+        inspect: false,
+        inspectBrk: false,
+        debug: false,
+        factory: true,
+      });
+
+      expect(devMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          factory: true,
+        }),
+      );
+    });
+
+    it('should track factory dev analytics command when factory is set', async () => {
+      const { analytics } = await import('../..');
+      const { startDevServer } = await import('./start-dev-server');
+
+      await startDevServer({
+        inspect: false,
+        inspectBrk: false,
+        debug: false,
+        factory: true,
+      });
+
+      expect(analytics.trackCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'factory dev',
+        }),
+      );
+    });
+
+    it('should track dev analytics command when factory is not set', async () => {
+      const { analytics } = await import('../..');
+      const { startDevServer } = await import('./start-dev-server');
+
+      await startDevServer({
+        inspect: false,
+        inspectBrk: false,
+        debug: false,
+      });
+
+      expect(analytics.trackCommand).toHaveBeenCalledWith(
+        expect.objectContaining({
+          command: 'dev',
+        }),
+      );
+    });
+  });
 });

--- a/packages/cli/src/commands/actions/start-dev-server.ts
+++ b/packages/cli/src/commands/actions/start-dev-server.ts
@@ -13,11 +13,12 @@ interface DevArgs {
   https?: boolean;
   requestContextPresets?: string;
   debug: boolean;
+  factory?: boolean;
 }
 
 export const startDevServer = async (args: DevArgs) => {
   analytics.trackCommand({
-    command: 'dev',
+    command: args.factory ? 'factory dev' : 'dev',
     origin,
   });
 
@@ -32,6 +33,7 @@ export const startDevServer = async (args: DevArgs) => {
     https: args?.https,
     requestContextPresets: args?.requestContextPresets,
     debug: args.debug,
+    factory: args.factory,
   }).catch(err => {
     logger.error(err.message);
   });

--- a/packages/cli/src/commands/dev/DevBundler.test.ts
+++ b/packages/cli/src/commands/dev/DevBundler.test.ts
@@ -67,6 +67,8 @@ vi.mock('fs-extra', () => {
   return {
     pathExists: vi.fn().mockResolvedValue(false),
     copy: vi.fn().mockResolvedValue(undefined),
+    emptyDir: vi.fn().mockResolvedValue(undefined),
+    ensureDir: vi.fn().mockResolvedValue(undefined),
   };
 });
 
@@ -85,6 +87,45 @@ describe('DevBundler', () => {
   afterEach(() => {
     process.env.NODE_ENV = originalEnv;
     process.exit = originalExit;
+  });
+
+  describe('prepare', () => {
+    it('preserves dev.lock across emptyDir', async () => {
+      const { writeFile, readFile, mkdir, rm } = await import('node:fs/promises');
+      const { join } = await import('node:path');
+
+      const tmpDir = '.test-tmp-prepare-dev';
+      const lockPath = join(tmpDir, 'dev.lock');
+      const lockData = JSON.stringify({ pid: 12345, host: 'localhost', port: 4111 });
+
+      try {
+        await mkdir(tmpDir, { recursive: true });
+        await writeFile(lockPath, lockData, 'utf-8');
+
+        const devBundler = new DevBundler();
+        await devBundler.prepare(tmpDir);
+
+        // The lock file still exists with the same contents after prepare()
+        const restored = await readFile(lockPath, 'utf-8');
+        expect(restored).toBe(lockData);
+      } finally {
+        await rm(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('works when no dev.lock exists', async () => {
+      const { rm } = await import('node:fs/promises');
+      const devBundler = new DevBundler();
+      const tmpDir = '.test-tmp-prepare-nolock-dev';
+
+      try {
+        await devBundler.prepare(tmpDir);
+        // Should not throw even without a lock file
+        expect(true).toBe(true);
+      } finally {
+        await rm(tmpDir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('watch', () => {

--- a/packages/cli/src/commands/dev/DevBundler.ts
+++ b/packages/cli/src/commands/dev/DevBundler.ts
@@ -1,4 +1,4 @@
-import { writeFile } from 'node:fs/promises';
+import { readFile, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { FileService } from '@mastra/deployer';
@@ -65,7 +65,24 @@ export class DevBundler extends Bundler {
   }
 
   async prepare(outputDirectory: string): Promise<void> {
+    // Preserve the dev lock across super.prepare(), which calls emptyDir()
+    const lockPath = join(outputDirectory, 'dev.lock');
+    let lockContents: string | null = null;
+    try {
+      lockContents = await readFile(lockPath, 'utf-8');
+    } catch {
+      // No lock file — nothing to preserve
+    }
+
     await super.prepare(outputDirectory);
+
+    if (lockContents) {
+      try {
+        await writeFile(lockPath, lockContents, 'utf-8');
+      } catch {
+        // Best-effort — don't block dev startup
+      }
+    }
 
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = dirname(__filename);

--- a/packages/cli/src/commands/dev/dev-lock.ts
+++ b/packages/cli/src/commands/dev/dev-lock.ts
@@ -50,7 +50,7 @@ function parseLockContents(contents: string): LockData | null {
 function printDuplicateError(lock: LockData): never {
   console.error('');
   console.error(
-    pc.red('  ✗ ') + pc.bold(pc.red('Another instance of `mastra dev` is already running in this directory')),
+    pc.red('  ✗ ') + pc.bold(pc.red('Another development server instance is already running in this directory')),
   );
   console.error('');
   console.error(`  ${pc.red('│')} PID ${pc.bold(String(lock.pid))} is still active.`);
@@ -62,7 +62,7 @@ function printDuplicateError(lock: LockData): never {
   console.error(`  ${pc.red('│')} (e.g. database locks, port collisions).`);
   console.error('');
   console.error(`  ${pc.dim('To fix this:')}`);
-  console.error(`  ${pc.dim('•')} Stop the other \`mastra dev\` process (PID ${lock.pid}), or`);
+  console.error(`  ${pc.dim('•')} Stop the other development server process (PID ${lock.pid}), or`);
   console.error(`  ${pc.dim('•')} If that process is stuck, run: ${pc.cyan(`kill ${lock.pid}`)}`);
   console.error('');
   process.exit(1);
@@ -87,7 +87,7 @@ async function checkAndRemoveStaleLock(lockPath: string): Promise<void> {
 }
 
 /**
- * Attempt to acquire the dev lock. If another `mastra dev` instance is
+ * Attempt to acquire the dev lock. If another development server instance is
  * already running against the same `.mastra` directory, print a
  * user-friendly error and exit instead of letting resources fail with
  * confusing lock errors.

--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -470,3 +470,113 @@ describe('dev command - inspect flag behavior', () => {
     });
   });
 });
+
+describe('dev command - factory mode environment', () => {
+  let execaMock: any;
+  let mockChildProcess: MockChildProcess;
+
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+
+    mockChildProcess = new MockChildProcess();
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('server unavailable')));
+
+    const { execa } = await import('execa');
+    execaMock = vi.mocked(execa);
+    execaMock.mockReturnValue(mockChildProcess as unknown as ChildProcess);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('should set MASTRA_FACTORY_DEV=true in spawned env when factory is true', async () => {
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: false,
+      debug: false,
+      factory: true,
+    });
+
+    expect(execaMock).toHaveBeenCalled();
+    const callOptions = execaMock.mock.calls[0][2] as { env: Record<string, string> };
+    expect(callOptions.env.MASTRA_FACTORY_DEV).toBe('true');
+    expect(callOptions.env.MASTRA_TELEMETRY_COMMAND).toBe('factory dev');
+  });
+
+  it('should not set MASTRA_FACTORY_DEV in spawned env when factory is not set', async () => {
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: false,
+      debug: false,
+    });
+
+    expect(execaMock).toHaveBeenCalled();
+    const callOptions = execaMock.mock.calls[0][2] as { env: Record<string, string> };
+    expect(callOptions.env.MASTRA_FACTORY_DEV).toBeUndefined();
+    expect(callOptions.env.MASTRA_TELEMETRY_COMMAND).toBe('dev');
+  });
+
+  it('should retain MASTRA_FACTORY_DEV=true across a hot-reload restart', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ disabled: false }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const { dev } = await import('./dev');
+
+    await dev({
+      dir: undefined,
+      root: process.cwd(),
+      tools: undefined,
+      env: undefined,
+      inspect: false,
+      inspectBrk: false,
+      customArgs: undefined,
+      https: false,
+      debug: false,
+      factory: true,
+    });
+
+    // Initial start should have MASTRA_FACTORY_DEV=true
+    expect(execaMock).toHaveBeenCalledTimes(1);
+    const initialEnv = execaMock.mock.calls[0][2].env as Record<string, string>;
+    expect(initialEnv.MASTRA_FACTORY_DEV).toBe('true');
+
+    // Trigger a BUNDLE_END event to cause a hot-reload restart
+    const watcherOnCall = mockWatcher.on.mock.calls.find((call: any[]) => call[0] === 'event');
+    expect(watcherOnCall).toBeDefined();
+    const eventCallback = watcherOnCall![1];
+
+    eventCallback({ code: 'BUNDLE_END' });
+
+    // Wait for the restart to call execa again
+    await vi.waitFor(() => {
+      expect(execaMock).toHaveBeenCalledTimes(2);
+    });
+
+    const restartEnv = execaMock.mock.calls[1][2].env as Record<string, string>;
+    expect(restartEnv.MASTRA_FACTORY_DEV).toBe('true');
+    expect(restartEnv.MASTRA_TELEMETRY_COMMAND).toBe('factory dev');
+  });
+});

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -69,6 +69,7 @@ interface StartOptions {
   https?: HTTPSOptions;
   mastraPackages?: MastraPackageInfo[];
   peerDepMismatches?: PeerDepMismatch[];
+  factory?: boolean;
 }
 
 type ProcessOptions = {
@@ -149,7 +150,7 @@ const startServer = async (
         MASTRA_DEV: 'true',
         PORT: port.toString(),
         MASTRA_PACKAGES_FILE: packagesFilePath,
-        MASTRA_TELEMETRY_COMMAND: 'dev',
+        MASTRA_TELEMETRY_COMMAND: startOptions.factory ? 'factory dev' : 'dev',
         MASTRA_PROJECT_ROOT: resolve(dotMastraPath, '..'),
         ...(getAnalytics()?.getDistinctId() ? { MASTRA_CLI_DISTINCT_ID: getAnalytics()!.getDistinctId() } : {}),
         ...(startOptions?.https
@@ -158,6 +159,7 @@ const startServer = async (
               MASTRA_HTTPS_CERT: startOptions.https.cert.toString('base64'),
             }
           : {}),
+        ...(startOptions.factory ? { MASTRA_FACTORY_DEV: 'true' } : {}),
       },
       stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
       reject: false,
@@ -423,6 +425,7 @@ export async function dev({
   https,
   requestContextPresets,
   debug,
+  factory,
 }: {
   dir?: string;
   root?: string;
@@ -434,6 +437,7 @@ export async function dev({
   https?: boolean;
   requestContextPresets?: string;
   debug: boolean;
+  factory?: boolean;
 }) {
   const rootDir = root || process.cwd();
   const mastraDir = dir ? (dir.startsWith('/') ? dir : join(process.cwd(), dir)) : join(process.cwd(), 'src', 'mastra');
@@ -533,9 +537,14 @@ export async function dev({
     https: httpsOptions,
     mastraPackages,
     peerDepMismatches,
+    factory,
   };
 
   await bundler.prepare(dotMastraPath);
+
+  // Re-assert the lock after prepare() emptied the directory.
+  // The bundler preserves the lock, but this ensures the data is current.
+  await updateDevLock(dotMastraPath, hostToUse, Number(portToUse));
 
   // Write the generated fs-routed agents wrapper entry. Runs after `prepare()`
   // empties the output directory so the wrapper is not wiped before the watcher

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -173,6 +173,32 @@ program
   .option('--debug', 'Enable debug logs', false)
   .action(startDevServer);
 
+const factoryCommand = program.command('factory').description('Manage Mastra Factory');
+
+factoryCommand
+  .command('dev')
+  .description('Start mastra server')
+  .option('-d, --dir <dir>', 'Path to your mastra folder')
+  .option('-r, --root <root>', 'Path to your root folder')
+  .option('-t, --tools <toolsDirs>', 'Comma-separated list of paths to tool files to include')
+  .option('-e, --env <env>', 'Custom env file to include in the dev server')
+  .option(
+    '-i, --inspect [host:port]',
+    'Start the dev server in inspect mode (optional: [host:]port, e.g., 0.0.0.0:9229)',
+  )
+  .option(
+    '-b, --inspect-brk [host:port]',
+    'Start the dev server in inspect mode and break at the beginning of the script (optional: [host:]port)',
+  )
+  .option(
+    '-c, --custom-args <args>',
+    'Comma-separated list of custom arguments to pass to the dev server. IE: --experimental-transform-types',
+  )
+  .option('-s, --https', 'Enable local HTTPS')
+  .option('--request-context-presets <file>', 'Path to request context presets JSON file')
+  .option('--debug', 'Enable debug logs', false)
+  .action(args => startDevServer({ ...args, factory: true }));
+
 program
   .command('build')
   .description('Build your Mastra project')


### PR DESCRIPTION
Adds `mastra factory dev` as a nested CLI command that routes through the same `startDevServer` action and `dev()` runtime as `mastra dev`. An explicit `factory` boolean propagates through the action and `StartOptions`, setting `MASTRA_FACTORY_DEV=true` and the matching telemetry command only in the spawned bundled server process. This lets `dev.entry.js` switch Factory-specific routes later without duplicating the runtime, bundler, lock, or entry template.

`mastra factory dev` has full flag parity with `mastra dev`:

```sh
mastra factory dev --dir src/mastra --port 4112 --https
```

Both commands share the same `.mastra` output directory and dev lock, so they can't run at the same time in the same project. The error message is command-neutral either way.

Also fixes a shared lock lifecycle bug where `DevBundler.prepare()` called `emptyDir` on `.mastra`, deleting the active `dev.lock`. The lock is now preserved across `prepare()` so concurrent dev servers correctly conflict in both directions.

Co-Authored-By: Mastra Code (alibaba-token-plan/glm-5.2) <noreply@mastra.ai>