### PR TITLE
fix(memory): preserve OM continuation hints after buffered activation

### DIFF
--- a/.changeset/dry-carrots-occur.md
+++ b/.changeset/dry-carrots-occur.md
@@ -1,0 +1,5 @@
+---
+'@mastra/memory': patch
+---
+
+Fixed observational memory activation clearing thread continuation hints when buffered chunks have no hints (#19809)

--- a/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/observational-memory.test.ts
@@ -1,6 +1,7 @@
 import { MockLanguageModelV2, convertArrayToReadableStream } from '@internal/ai-sdk-v5/test';
 import type { MastraDBMessage, MastraMessageContentV2 } from '@mastra/core/agent';
 import { coreFeatures } from '@mastra/core/features';
+import { getThreadOMMetadata } from '@mastra/core/memory';
 import { MASTRA_THREAD_ID_KEY, RequestContext } from '@mastra/core/request-context';
 import { InMemoryMemory, InMemoryDB } from '@mastra/core/storage';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
@@ -9735,6 +9736,68 @@ describe('Async Buffering Processor Logic', () => {
       expect(result.activated).toBe(true);
       expect(result.record).toBeDefined();
       expect(result.record.activeObservations).toContain('Important observation');
+    });
+
+    it('should preserve existing continuation hints when activating buffered chunks without hints (#19809)', async () => {
+      const storage = createInMemoryStorage();
+      const threadId = 'thread-1';
+      const resourceId = 'resource-1';
+      const om = new ObservationalMemory({
+        storage,
+        scope: 'thread',
+        model: createStreamCapableMockModel({ defaultObjectGenerationMode: 'json' }),
+        observation: {
+          messageTokens: 50000,
+          bufferTokens: 10000,
+          bufferActivation: 1,
+        },
+        reflection: { observationTokens: 20000, bufferActivation: 0.5 },
+      });
+
+      await storage.saveThread({
+        thread: {
+          id: threadId,
+          resourceId,
+          title: 'Test Thread',
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          metadata: {
+            mastra: {
+              om: {
+                currentTask: 'Finalize regulatory advice',
+                suggestedResponse: 'Confirm the summary with the user.',
+              },
+            },
+          },
+        },
+      });
+
+      const record = await storage.initializeObservationalMemory({
+        threadId,
+        resourceId,
+        scope: 'thread',
+        config: {},
+      });
+
+      await storage.updateBufferedObservations({
+        id: record.id,
+        chunk: {
+          observations: '- Buffered observation without continuation hints',
+          tokenCount: 100,
+          messageIds: ['msg-1'],
+          messageTokens: 45000,
+          lastObservedAt: new Date('2026-02-05T10:00:00Z'),
+          cycleId: 'cycle-1',
+        },
+      });
+
+      const result = await om.activate({ threadId, resourceId });
+
+      expect(result.activated).toBe(true);
+      const updatedThread = await storage.getThreadById({ threadId });
+      const omMetadata = getThreadOMMetadata(updatedThread?.metadata);
+      expect(omMetadata?.currentTask).toBe('Finalize regulatory advice');
+      expect(omMetadata?.suggestedResponse).toBe('Confirm the summary with the user.');
     });
 
     it('should skip activation when pending tokens are below threshold (checkThreshold)', async () => {

--- a/packages/memory/src/processors/observational-memory/observational-memory.ts
+++ b/packages/memory/src/processors/observational-memory/observational-memory.ts
@@ -3349,10 +3349,11 @@ ${formattedMessages}
       const lastActivated = activatedChunks[activatedChunks.length - 1];
       if (lastActivated) {
         const chunkThreadTitle = lastActivated.threadTitle;
+        const previousOmMetadata = getThreadOMMetadata(thread.metadata);
         const newMetadata = setThreadOMMetadata(thread.metadata, {
-          suggestedResponse: lastActivated.suggestedContinuation,
-          currentTask: lastActivated.currentTask,
-          threadTitle: chunkThreadTitle,
+          suggestedResponse: lastActivated.suggestedContinuation ?? previousOmMetadata?.suggestedResponse,
+          currentTask: lastActivated.currentTask ?? previousOmMetadata?.currentTask,
+          threadTitle: chunkThreadTitle ?? previousOmMetadata?.threadTitle,
         });
         const oldTitle = thread.title?.trim();
         const newTitle = chunkThreadTitle?.trim();


### PR DESCRIPTION
## Description

Buffered observation chunks are observed with `skipContinuationHints: true`, so they do not carry `currentTask` or `suggestedResponse`. During activation, those missing fields were still written into thread metadata as `undefined`, which overwrote the persisted continuation hints used by:

- the next observer pass (`## Prior Thread Metadata`)
- the main agent context injection (`<current-task>` / `<suggested-response>`)

Activation now falls back to the existing thread OM metadata when an activated chunk does not provide new hint values.

## Related issue(s)

Fixes #19809

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [x] Test update

## Checklist

- [x] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When saved observation chunks are activated, they now keep the task and response guidance already stored for the conversation instead of accidentally erasing it. New guidance still replaces old guidance when provided.

## Changes

- Updated observational memory activation to fall back to existing OM metadata when buffered chunks omit continuation hints.
- Preserved `currentTask`, `suggestedResponse`, and `threadTitle` during activation when no new values are available.
- Added regression coverage for preserving continuation hints.
- Added a patch changeset for `@mastra/memory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->