### PR TITLE
feat(playground): reorder Signals perspectives

### DIFF
--- a/.changeset/salty-bees-wonder.md
+++ b/.changeset/salty-bees-wonder.md
@@ -3,7 +3,7 @@
 '@mastra/playground-ui': minor
 ---
 
-Added trace-level Agent Learning theme drill-in with theme details, examples, history, and per-signal Noise summaries.
+Added trace-level Agent Learning theme drill-in with theme details, examples, history, per-signal Noise summaries, and drag-and-drop signal column reordering.
 
 Added optional Sankey node activation with mouse and keyboard support, including per-node eligibility.
 

--- a/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
+++ b/packages/playground/src/ee/signals/__tests__/fixtures/theme-flow.ts
@@ -127,6 +127,14 @@ export const multiThemeSnapshotsResponse: ThemeSnapshotsResponse = {
   ],
 };
 
+export const reorderedMultiThemeSnapshotsResponse: ThemeSnapshotsResponse = {
+  snapshots: multiThemeSnapshotsResponse.snapshots.map(snapshot => ({
+    ...snapshot,
+    snapshotId: `reordered-${snapshot.snapshotId}`,
+    availableSignals: ['goal', 'behavior', 'outcome', 'sentiment'],
+  })),
+};
+
 export const emptyThemeSnapshotsResponse: ThemeSnapshotsResponse = { snapshots: [] };
 
 export const themeFlowResponse: ThemeFlowResponse = {
@@ -377,6 +385,116 @@ export const fourStageThemeFlowResponse: ThemeFlowResponse = {
       targetNodeId: 'sentiment-neutral',
       traceCount: 8,
       sourceShare: 0.5,
+      targetShare: 8 / 21,
+    },
+  ],
+};
+
+export const reorderedFourStageThemeFlowResponse: ThemeFlowResponse = {
+  ...fourStageThemeFlowResponse,
+  stages: [
+    fourStageThemeFlowResponse.stages[0],
+    fourStageThemeFlowResponse.stages[2],
+    fourStageThemeFlowResponse.stages[1],
+    fourStageThemeFlowResponse.stages[3],
+  ],
+  links: [
+    {
+      sourceNodeId: 'goal-support',
+      targetNodeId: 'behavior-search',
+      traceCount: 15,
+      sourceShare: 15 / 22,
+      targetShare: 15 / 34,
+    },
+    {
+      sourceNodeId: 'goal-support',
+      targetNodeId: 'behavior-escalate',
+      traceCount: 7,
+      sourceShare: 7 / 22,
+      targetShare: 7 / 16,
+    },
+    {
+      sourceNodeId: 'goal-billing',
+      targetNodeId: 'behavior-search',
+      traceCount: 12,
+      sourceShare: 12 / 17,
+      targetShare: 12 / 34,
+    },
+    {
+      sourceNodeId: 'goal-billing',
+      targetNodeId: 'behavior-escalate',
+      traceCount: 5,
+      sourceShare: 5 / 17,
+      targetShare: 5 / 16,
+    },
+    {
+      sourceNodeId: 'goal-account',
+      targetNodeId: 'behavior-search',
+      traceCount: 7,
+      sourceShare: 7 / 11,
+      targetShare: 7 / 34,
+    },
+    {
+      sourceNodeId: 'goal-account',
+      targetNodeId: 'behavior-escalate',
+      traceCount: 4,
+      sourceShare: 4 / 11,
+      targetShare: 4 / 16,
+    },
+    {
+      sourceNodeId: 'behavior-search',
+      targetNodeId: 'outcome-resolved',
+      traceCount: 23,
+      sourceShare: 23 / 34,
+      targetShare: 23 / 31,
+    },
+    {
+      sourceNodeId: 'behavior-search',
+      targetNodeId: 'outcome-follow-up',
+      traceCount: 11,
+      sourceShare: 11 / 34,
+      targetShare: 11 / 19,
+    },
+    {
+      sourceNodeId: 'behavior-escalate',
+      targetNodeId: 'outcome-resolved',
+      traceCount: 8,
+      sourceShare: 8 / 16,
+      targetShare: 8 / 31,
+    },
+    {
+      sourceNodeId: 'behavior-escalate',
+      targetNodeId: 'outcome-follow-up',
+      traceCount: 8,
+      sourceShare: 8 / 16,
+      targetShare: 8 / 19,
+    },
+    {
+      sourceNodeId: 'outcome-resolved',
+      targetNodeId: 'sentiment-frustrated',
+      traceCount: 18,
+      sourceShare: 18 / 31,
+      targetShare: 18 / 29,
+    },
+    {
+      sourceNodeId: 'outcome-resolved',
+      targetNodeId: 'sentiment-neutral',
+      traceCount: 13,
+      sourceShare: 13 / 31,
+      targetShare: 13 / 21,
+    },
+    {
+      sourceNodeId: 'outcome-follow-up',
+      targetNodeId: 'sentiment-frustrated',
+      traceCount: 11,
+      sourceShare: 11 / 19,
+      targetShare: 11 / 29,
+    },
+    {
+      sourceNodeId: 'outcome-follow-up',
+      targetNodeId: 'sentiment-neutral',
+      traceCount: 8,
+      sourceShare: 8 / 19,
       targetShare: 8 / 21,
     },
   ],

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -62,23 +62,43 @@ function renderSankeySignals() {
   );
 }
 
-function reorderOutcomeAfterBehavior(beforeDrop?: () => void) {
-  const outcomeHandle = screen.getByLabelText('Reorder Outcome');
-  const behaviorCard = screen.getByRole('article', { name: 'Behavior distribution' });
-  const behaviorDropTarget = behaviorCard.parentElement;
-  if (!behaviorDropTarget) throw new Error('Behavior drop target was not rendered');
-  const dataTransfer = {
-    dropEffect: 'none',
-    effectAllowed: 'none',
-    getData: vi.fn(),
-    setData: vi.fn(),
+function rectangle(left: number, width: number, height: number) {
+  return {
+    x: left,
+    y: 0,
+    top: 0,
+    right: left + width,
+    bottom: height,
+    left,
+    width,
+    height,
+    toJSON: () => ({}),
   };
-  fireEvent.dragStart(outcomeHandle, { dataTransfer });
-  fireEvent.dragEnter(behaviorDropTarget, { dataTransfer });
-  fireEvent.dragOver(behaviorDropTarget, { dataTransfer });
+}
+
+async function reorderOutcomeAfterBehavior(beforeDrop?: () => void) {
+  const distributionCards = within(screen.getByRole('region', { name: 'Signal distributions' })).getAllByRole(
+    'article',
+  );
+  distributionCards.forEach((card, index) => {
+    const draggable = card.parentElement;
+    if (!draggable) throw new Error('Signal distribution draggable was not rendered');
+    vi.spyOn(draggable, 'getBoundingClientRect').mockReturnValue(rectangle(index * 250, 240, 300));
+  });
+  vi.spyOn(screen.getByRole('region', { name: 'Signal distributions' }), 'getBoundingClientRect').mockReturnValue(
+    rectangle(0, 990, 300),
+  );
+  const outcomeCard = screen.getByRole('article', { name: 'Outcome distribution' });
+  const outcomeHandle = screen.getByLabelText('Reorder Outcome');
+  expect(outcomeCard.parentElement?.getAttribute('draggable')).not.toBe('true');
+  expect(outcomeHandle.getAttribute('draggable')).not.toBe('true');
+  fireEvent.mouseDown(outcomeHandle, { button: 0, buttons: 1, clientX: 375, clientY: 100 });
+  fireEvent.mouseMove(window, { buttons: 1, clientX: 390, clientY: 100 });
+  await waitFor(() => expect(outcomeCard.parentElement?.style.position).toBe('fixed'));
+  fireEvent.mouseMove(window, { buttons: 1, clientX: 650, clientY: 100 });
+  await waitFor(() => expect(outcomeCard.parentElement?.style.transform).not.toBe(''));
   beforeDrop?.();
-  fireEvent.drop(behaviorDropTarget, { dataTransfer });
-  fireEvent.dragEnd(outcomeHandle, { dataTransfer });
+  fireEvent.mouseUp(window, { button: 0, buttons: 0, clientX: 650, clientY: 100 });
 }
 
 beforeEach(() => {
@@ -407,12 +427,9 @@ describe('SankeySignals', () => {
 
       await screen.findByLabelText('Reorder Outcome');
       expect(snapshotOrders).toEqual(['goal,outcome,behavior,sentiment']);
-      reorderOutcomeAfterBehavior(() => {
+      await reorderOutcomeAfterBehavior(() => {
         expect(snapshotOrders).toEqual(['goal,outcome,behavior,sentiment']);
         expect(flowOrders).toEqual(['goal,outcome,behavior,sentiment']);
-        expect(screen.getByRole('article', { name: 'Behavior distribution' }).parentElement?.className).toContain(
-          'ring-accent1',
-        );
       });
 
       await waitFor(() =>
@@ -428,6 +445,13 @@ describe('SankeySignals', () => {
             .map(card => card.getAttribute('aria-label')),
         ).toEqual(['Goal distribution', 'Behavior distribution', 'Outcome distribution', 'Sentiment distribution']),
       );
+      const chart = within(screen.getByRole('region', { name: 'Signal theme flow' }));
+      expect(chart.getByText('GOAL')).not.toBeNull();
+      expect(chart.getByText('BEHAVIOR')).not.toBeNull();
+      expect(chart.getByText('OUTCOME')).not.toBeNull();
+      expect(chart.getByText('SENTIMENT')).not.toBeNull();
+      expect(chart.getByLabelText(/Resolve support request.*22 traces/)).not.toBeNull();
+      expect(chart.getByLabelText(/Frustrated.*29 traces/)).not.toBeNull();
     });
 
     it('keeps the current perspective visible while the new perspective loads', async () => {
@@ -461,15 +485,15 @@ describe('SankeySignals', () => {
       renderSankeySignals();
       await screen.findByLabelText('Reorder Outcome');
 
-      reorderOutcomeAfterBehavior();
+      await reorderOutcomeAfterBehavior();
 
-      expect(await screen.findByText('Updating signal perspective…')).not.toBeNull();
+      expect(await screen.findByText('Reloading snapshots for new signal perspective…')).not.toBeNull();
       expect(screen.queryByTestId('signals-loading-skeleton')).toBeNull();
       expect(
         within(screen.getByRole('region', { name: 'Signal distributions' }))
           .getAllByRole('article')
           .map(card => card.getAttribute('aria-label')),
-      ).toEqual(['Goal distribution', 'Outcome distribution', 'Behavior distribution', 'Sentiment distribution']);
+      ).toEqual(['Goal distribution', 'Behavior distribution', 'Outcome distribution', 'Sentiment distribution']);
 
       releaseReorderedSnapshots();
       await waitFor(() =>
@@ -519,7 +543,7 @@ describe('SankeySignals', () => {
       fireEvent.change(sliderInput, { target: { value: '0' } });
       await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces');
 
-      reorderOutcomeAfterBehavior();
+      await reorderOutcomeAfterBehavior();
 
       expect(await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces')).not.toBeNull();
       await waitFor(() => expect(reorderedFlowSnapshots).toContain('reordered-snapshot-3'));

--- a/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
+++ b/packages/playground/src/ee/signals/__tests__/sankey-signals.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { buildSankeyChartGraph } from '@mastra/playground-ui/components/SankeyChart';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 import { MemoryRouter } from 'react-router';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -20,6 +20,8 @@ import {
   fourStageThemeFlowResponse,
   inconsistentTraceCountThemeFlowResponse,
   multiThemeSnapshotsResponse,
+  reorderedFourStageThemeFlowResponse,
+  reorderedMultiThemeSnapshotsResponse,
   sameDayThemeSnapshotsResponse,
   singleStageThemeFlowResponse,
   themeFlowResponse,
@@ -58,6 +60,25 @@ function renderSankeySignals() {
       </QueryClientProvider>
     </MemoryRouter>,
   );
+}
+
+function reorderOutcomeAfterBehavior(beforeDrop?: () => void) {
+  const outcomeHandle = screen.getByLabelText('Reorder Outcome');
+  const behaviorCard = screen.getByRole('article', { name: 'Behavior distribution' });
+  const behaviorDropTarget = behaviorCard.parentElement;
+  if (!behaviorDropTarget) throw new Error('Behavior drop target was not rendered');
+  const dataTransfer = {
+    dropEffect: 'none',
+    effectAllowed: 'none',
+    getData: vi.fn(),
+    setData: vi.fn(),
+  };
+  fireEvent.dragStart(outcomeHandle, { dataTransfer });
+  fireEvent.dragEnter(behaviorDropTarget, { dataTransfer });
+  fireEvent.dragOver(behaviorDropTarget, { dataTransfer });
+  beforeDrop?.();
+  fireEvent.drop(behaviorDropTarget, { dataTransfer });
+  fireEvent.dragEnd(outcomeHandle, { dataTransfer });
 }
 
 beforeEach(() => {
@@ -344,6 +365,164 @@ describe('SankeySignals', () => {
       await screen.findByTestId('signals-page-header');
       expect(screen.queryByTestId('signals-analysis-scroll')).toBeNull();
       expect(screen.queryByTestId('signals-analysis-canvas')).toBeNull();
+    });
+  });
+
+  describe('when a signal distribution is reordered', () => {
+    it('requests the new perspective only after the column is dropped', async () => {
+      const snapshotOrders: string[] = [];
+      const flowOrders: string[] = [];
+      const reorderedSnapshot = {
+        ...themeSnapshotsResponse.snapshots[0],
+        snapshotId: 'reordered-snapshot',
+        availableSignals: ['goal', 'behavior', 'outcome', 'sentiment'],
+      };
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          const signalNames = new URL(request.url).searchParams.get('signalNames') ?? '';
+          snapshotOrders.push(signalNames);
+          return HttpResponse.json(
+            signalNames === 'goal,behavior,outcome,sentiment'
+              ? { snapshots: [reorderedSnapshot] }
+              : themeSnapshotsResponse,
+          );
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const signalNames = new URL(request.url).searchParams.get('signalNames') ?? '';
+          flowOrders.push(signalNames);
+          const flow =
+            signalNames === 'goal,behavior,outcome,sentiment'
+              ? reorderedFourStageThemeFlowResponse
+              : fourStageThemeFlowResponse;
+          return HttpResponse.json({
+            ...flow,
+            snapshot:
+              signalNames === 'goal,behavior,outcome,sentiment'
+                ? reorderedSnapshot
+                : themeSnapshotsResponse.snapshots[0],
+          });
+        }),
+      );
+      renderSankeySignals();
+
+      await screen.findByLabelText('Reorder Outcome');
+      expect(snapshotOrders).toEqual(['goal,outcome,behavior,sentiment']);
+      reorderOutcomeAfterBehavior(() => {
+        expect(snapshotOrders).toEqual(['goal,outcome,behavior,sentiment']);
+        expect(flowOrders).toEqual(['goal,outcome,behavior,sentiment']);
+        expect(screen.getByRole('article', { name: 'Behavior distribution' }).parentElement?.className).toContain(
+          'ring-accent1',
+        );
+      });
+
+      await waitFor(() =>
+        expect(snapshotOrders).toEqual(['goal,outcome,behavior,sentiment', 'goal,behavior,outcome,sentiment']),
+      );
+      await waitFor(() =>
+        expect(flowOrders).toEqual(['goal,outcome,behavior,sentiment', 'goal,behavior,outcome,sentiment']),
+      );
+      await waitFor(() =>
+        expect(
+          within(screen.getByRole('region', { name: 'Signal distributions' }))
+            .getAllByRole('article')
+            .map(card => card.getAttribute('aria-label')),
+        ).toEqual(['Goal distribution', 'Behavior distribution', 'Outcome distribution', 'Sentiment distribution']),
+      );
+    });
+
+    it('keeps the current perspective visible while the new perspective loads', async () => {
+      let releaseReorderedSnapshots = () => {};
+      const reorderedSnapshotsPending = new Promise<void>(resolve => {
+        releaseReorderedSnapshots = resolve;
+      });
+      const reorderedSnapshot = {
+        ...themeSnapshotsResponse.snapshots[0],
+        snapshotId: 'reordered-snapshot',
+        availableSignals: ['goal', 'behavior', 'outcome', 'sentiment'],
+      };
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, async ({ request }) => {
+          const signalNames = new URL(request.url).searchParams.get('signalNames');
+          if (signalNames !== 'goal,behavior,outcome,sentiment') {
+            return HttpResponse.json(themeSnapshotsResponse);
+          }
+          await reorderedSnapshotsPending;
+          return HttpResponse.json({ snapshots: [reorderedSnapshot] });
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const signalNames = new URL(request.url).searchParams.get('signalNames');
+          return HttpResponse.json(
+            signalNames === 'goal,behavior,outcome,sentiment'
+              ? { ...reorderedFourStageThemeFlowResponse, snapshot: reorderedSnapshot }
+              : fourStageThemeFlowResponse,
+          );
+        }),
+      );
+      renderSankeySignals();
+      await screen.findByLabelText('Reorder Outcome');
+
+      reorderOutcomeAfterBehavior();
+
+      expect(await screen.findByText('Updating signal perspective…')).not.toBeNull();
+      expect(screen.queryByTestId('signals-loading-skeleton')).toBeNull();
+      expect(
+        within(screen.getByRole('region', { name: 'Signal distributions' }))
+          .getAllByRole('article')
+          .map(card => card.getAttribute('aria-label')),
+      ).toEqual(['Goal distribution', 'Outcome distribution', 'Behavior distribution', 'Sentiment distribution']);
+
+      releaseReorderedSnapshots();
+      await waitFor(() =>
+        expect(
+          within(screen.getByRole('region', { name: 'Signal distributions' }))
+            .getAllByRole('article')
+            .map(card => card.getAttribute('aria-label')),
+        ).toEqual(['Goal distribution', 'Behavior distribution', 'Outcome distribution', 'Sentiment distribution']),
+      );
+    });
+
+    it('keeps the selected snapshot ordinal when the new perspective returns opaque cursors', async () => {
+      const reorderedFlowSnapshots: Array<string> = [];
+      server.use(
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-snapshots`, ({ request }) => {
+          const signalNames = new URL(request.url).searchParams.get('signalNames');
+          return HttpResponse.json(
+            signalNames === 'goal,behavior,outcome,sentiment'
+              ? reorderedMultiThemeSnapshotsResponse
+              : multiThemeSnapshotsResponse,
+          );
+        }),
+        http.get(`${BASE_URL}/api/learning/entities/support-agent/theme-flow`, ({ request }) => {
+          const url = new URL(request.url);
+          const signalNames = url.searchParams.get('signalNames')?.split(',') ?? [];
+          const snapshotId = url.searchParams.get('snapshotId');
+          if (!snapshotId) return HttpResponse.json({ error: 'Missing snapshot' }, { status: 400 });
+          const reordered = signalNames.join(',') === 'goal,behavior,outcome,sentiment';
+          const snapshots = reordered
+            ? reorderedMultiThemeSnapshotsResponse.snapshots
+            : multiThemeSnapshotsResponse.snapshots;
+          const snapshot = snapshots.find(candidate => candidate.snapshotId === snapshotId);
+          if (!snapshot) return HttpResponse.json({ error: 'Unknown snapshot' }, { status: 400 });
+          if (snapshotId.startsWith('reordered-')) reorderedFlowSnapshots.push(snapshotId);
+          const sourceFlow = reordered
+            ? reorderedFourStageThemeFlowResponse
+            : snapshot.ordinal === 3
+              ? earlierThemeFlowResponse
+              : fourStageThemeFlowResponse;
+          return HttpResponse.json({ ...sourceFlow, snapshot });
+        }),
+      );
+      const { container } = renderSankeySignals();
+      await screen.findByLabelText('Reorder Outcome');
+      const sliderInput = container.querySelector('input[type="range"]');
+      if (!sliderInput) throw new Error('Snapshot slider input was not rendered');
+      fireEvent.change(sliderInput, { target: { value: '0' } });
+      await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces');
+
+      reorderOutcomeAfterBehavior();
+
+      expect(await screen.findByText('Snapshot 3/4 · Jun 24–Jul 1, 2026 · 40 traces')).not.toBeNull();
+      await waitFor(() => expect(reorderedFlowSnapshots).toContain('reordered-snapshot-3'));
     });
   });
 

--- a/packages/playground/src/ee/signals/hooks/use-theme-flows.ts
+++ b/packages/playground/src/ee/signals/hooks/use-theme-flows.ts
@@ -14,6 +14,7 @@ export function useThemeFlows(
       queryKey: ['entity-learning', entityType, entityId, 'theme-flow', signalNames, snapshotId],
       queryFn: () => fetchThemeFlow(entityId, entityType, signalNames, snapshotId),
       enabled: signalNames.length >= 2,
+      staleTime: 30_000,
     })),
   });
 }

--- a/packages/playground/src/ee/signals/hooks/use-theme-paths.ts
+++ b/packages/playground/src/ee/signals/hooks/use-theme-paths.ts
@@ -15,5 +15,6 @@ export function useThemePaths(
     queryKey: ['entity-learning', entityType, entityId, 'theme-paths', signalNames, snapshotId],
     queryFn: () => fetchThemePaths(entityId, entityType, signalNames, requireSnapshotId(snapshotId)),
     enabled: snapshotId !== undefined && isNumericThemeId(themeId),
+    staleTime: 30_000,
   });
 }

--- a/packages/playground/src/ee/signals/hooks/use-theme-snapshots.ts
+++ b/packages/playground/src/ee/signals/hooks/use-theme-snapshots.ts
@@ -8,5 +8,6 @@ export function useThemeSnapshots(entityId: string, entityType: string, signalNa
     queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', signalNames],
     queryFn: () => fetchThemeSnapshots(entityId, entityType, signalNames),
     enabled: signalNames.length >= 2,
+    staleTime: 30_000,
   });
 }

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -8,7 +8,7 @@ import type {
 } from '@mastra/playground-ui/components/SankeyChart';
 import { Slider } from '@mastra/playground-ui/components/Slider';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
-import { useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Pause, Play } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
@@ -204,9 +204,6 @@ export function SankeySignals({
 }: SankeySignalsProps) {
   const queryClient = useQueryClient();
   const [signalNames, setSignalNames] = useState(() => initialSignalNames);
-  const [pendingSignalNames, setPendingSignalNames] = useState<TraceSignalName[]>();
-  const [isChangingPerspective, setIsChangingPerspective] = useState(false);
-  const [perspectiveError, setPerspectiveError] = useState<string>();
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
   const snapshots = [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal);
   const [selectedSnapshotOrdinal, setSelectedSnapshotOrdinal] = useState<number>();
@@ -258,6 +255,34 @@ export function SankeySignals({
     return () => window.clearTimeout(timer);
   }, [hasFlowError, isFlowPending, isPlaying, isPlaybackBlockedByDrillIn, nextSnapshotOrdinal, snapshots.length]);
 
+  const perspectiveMutation = useMutation({
+    mutationFn: async (nextSignalNames: TraceSignalName[]) => {
+      const nextSnapshots = await queryClient.fetchQuery({
+        queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', nextSignalNames],
+        queryFn: () => fetchThemeSnapshots(entityId, entityType, nextSignalNames),
+      });
+      await Promise.all(
+        nextSnapshots.snapshots.map(nextSnapshot =>
+          queryClient.fetchQuery({
+            queryKey: ['entity-learning', entityType, entityId, 'theme-flow', nextSignalNames, nextSnapshot.snapshotId],
+            queryFn: () => fetchThemeFlow(entityId, entityType, nextSignalNames, nextSnapshot.snapshotId),
+          }),
+        ),
+      );
+      const nextSnapshot =
+        nextSnapshots.snapshots.find(candidate => candidate.ordinal === snapshot?.ordinal) ??
+        nextSnapshots.snapshots.at(-1);
+      if (drillIn && nextSnapshot && nextSnapshot.traceCount <= DRILL_IN_TRACE_LIMIT) {
+        await queryClient.fetchQuery({
+          queryKey: ['entity-learning', entityType, entityId, 'theme-paths', nextSignalNames, nextSnapshot.snapshotId],
+          queryFn: () => fetchThemePaths(entityId, entityType, nextSignalNames, nextSnapshot.snapshotId),
+        });
+      }
+      return nextSignalNames;
+    },
+    onSuccess: setSignalNames,
+  });
+
   if (snapshotsQuery.isPending) return <SignalsLoadingSkeleton />;
 
   if (snapshotsQuery.isError || hasFlowError || pathsQuery.isError) {
@@ -299,7 +324,7 @@ export function SankeySignals({
   }
 
   const stages = flow.stages;
-  const distributionSignalNames = pendingSignalNames ?? signalNames;
+  const distributionSignalNames = perspectiveMutation.isPending ? perspectiveMutation.variables : signalNames;
   const distributionPositions = new Map(distributionSignalNames.map((signalName, index) => [signalName, index]));
   const distributionStages = [...stages].sort(
     (left, right) =>
@@ -324,44 +349,12 @@ export function SankeySignals({
     ? undefined
     : 'Drill-in is unavailable for snapshots with more than 2,000 traces.';
   const isDrilledEmpty = drillIn !== undefined && pathsQuery.data !== undefined && flow.snapshot.traceCount === 0;
-  const handleSignalOrderChange = async (nextSignalNames: TraceSignalName[]) => {
-    if (isChangingPerspective) return;
+  const handleSignalOrderChange = (nextSignalNames: TraceSignalName[]) => {
+    if (perspectiveMutation.isPending) return;
     setIsPlaying(false);
     setDetailSelection(undefined);
     setNoiseSignalName(undefined);
-    setPerspectiveError(undefined);
-    setPendingSignalNames(nextSignalNames);
-    setIsChangingPerspective(true);
-
-    try {
-      const nextSnapshots = await queryClient.fetchQuery({
-        queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', nextSignalNames],
-        queryFn: () => fetchThemeSnapshots(entityId, entityType, nextSignalNames),
-      });
-      await Promise.all(
-        nextSnapshots.snapshots.map(nextSnapshot =>
-          queryClient.fetchQuery({
-            queryKey: ['entity-learning', entityType, entityId, 'theme-flow', nextSignalNames, nextSnapshot.snapshotId],
-            queryFn: () => fetchThemeFlow(entityId, entityType, nextSignalNames, nextSnapshot.snapshotId),
-          }),
-        ),
-      );
-      const nextSnapshot =
-        nextSnapshots.snapshots.find(candidate => candidate.ordinal === snapshot.ordinal) ??
-        nextSnapshots.snapshots.at(-1);
-      if (drillIn && nextSnapshot && nextSnapshot.traceCount <= DRILL_IN_TRACE_LIMIT) {
-        await queryClient.fetchQuery({
-          queryKey: ['entity-learning', entityType, entityId, 'theme-paths', nextSignalNames, nextSnapshot.snapshotId],
-          queryFn: () => fetchThemePaths(entityId, entityType, nextSignalNames, nextSnapshot.snapshotId),
-        });
-      }
-      setSignalNames(nextSignalNames);
-    } catch {
-      setPerspectiveError('Unable to load that signal perspective. Try reordering the columns again.');
-    } finally {
-      setPendingSignalNames(undefined);
-      setIsChangingPerspective(false);
-    }
+    perspectiveMutation.mutate(nextSignalNames);
   };
 
   return (
@@ -446,18 +439,18 @@ export function SankeySignals({
       />
       {drillIn && (!drillInAvailable || pathsQuery.isPending || isDrilledEmpty) ? null : (
         <>
-          {isChangingPerspective ? (
+          {perspectiveMutation.isPending ? (
             <p className="font-mono text-xs text-neutral3" role="status">
               Reloading snapshots for new signal perspective…
             </p>
           ) : null}
-          {perspectiveError ? (
+          {perspectiveMutation.isError ? (
             <p className="text-xs text-red-500" role="alert">
-              {perspectiveError}
+              Unable to load that signal perspective. Try reordering the columns again.
             </p>
           ) : null}
           <SignalDistributions
-            disabled={isChangingPerspective}
+            disabled={perspectiveMutation.isPending}
             stages={distributionStages}
             onOrderChange={handleSignalOrderChange}
             onViewThemeDetails={selection => {

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -153,6 +153,7 @@ function FlowCard({
         <Sankey
           data={records}
           columns={chartColumns}
+          columnOrder={chartColumns.map(column => column.id)}
           getColumnHue={column => getSignalHue(column.id)}
           getRecordNodeId={getSignalRecordNodeId}
           getRecordNodeLabel={getSignalRecordNodeLabel}
@@ -203,6 +204,7 @@ export function SankeySignals({
 }: SankeySignalsProps) {
   const queryClient = useQueryClient();
   const [signalNames, setSignalNames] = useState(() => initialSignalNames);
+  const [pendingSignalNames, setPendingSignalNames] = useState<TraceSignalName[]>();
   const [isChangingPerspective, setIsChangingPerspective] = useState(false);
   const [perspectiveError, setPerspectiveError] = useState<string>();
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
@@ -306,6 +308,13 @@ export function SankeySignals({
   }
 
   const stages = flow.stages;
+  const distributionSignalNames = pendingSignalNames ?? signalNames;
+  const distributionPositions = new Map(distributionSignalNames.map((signalName, index) => [signalName, index]));
+  const distributionStages = [...stages].sort(
+    (left, right) =>
+      (distributionPositions.get(left.signalName) ?? stages.length) -
+      (distributionPositions.get(right.signalName) ?? stages.length),
+  );
   const themeCount = stages.reduce(
     (total, stage) => total + stage.nodes.filter(node => node.kind === 'theme').length,
     0,
@@ -330,6 +339,7 @@ export function SankeySignals({
     setDetailSelection(undefined);
     setNoiseSignalName(undefined);
     setPerspectiveError(undefined);
+    setPendingSignalNames(nextSignalNames);
     setIsChangingPerspective(true);
 
     try {
@@ -358,6 +368,7 @@ export function SankeySignals({
     } catch {
       setPerspectiveError('Unable to load that signal perspective. Try reordering the columns again.');
     } finally {
+      setPendingSignalNames(undefined);
       setIsChangingPerspective(false);
     }
   };
@@ -446,7 +457,7 @@ export function SankeySignals({
         <>
           {isChangingPerspective ? (
             <p className="font-mono text-xs text-neutral3" role="status">
-              Updating signal perspective…
+              Reloading snapshots for new signal perspective…
             </p>
           ) : null}
           {perspectiveError ? (
@@ -456,7 +467,7 @@ export function SankeySignals({
           ) : null}
           <SignalDistributions
             disabled={isChangingPerspective}
-            stages={stages}
+            stages={distributionStages}
             onOrderChange={handleSignalOrderChange}
             onViewThemeDetails={selection => {
               setNoiseSignalName(undefined);

--- a/packages/playground/src/ee/signals/sankey-signals.tsx
+++ b/packages/playground/src/ee/signals/sankey-signals.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@mastra/playground-ui/components/Button';
-import { Card, CardContent, CardFooter, CardHeader } from '@mastra/playground-ui/components/Card';
+import { Card, CardContent, CardFooter } from '@mastra/playground-ui/components/Card';
 import { nodeColor, Sankey, SankeyChart } from '@mastra/playground-ui/components/SankeyChart';
 import type {
   SankeyChartColumn,
@@ -8,9 +8,11 @@ import type {
 } from '@mastra/playground-ui/components/SankeyChart';
 import { Slider } from '@mastra/playground-ui/components/Slider';
 import { getSignalHue, SignalsOverviewPage as SignalsEmptyState } from '@mastra/playground-ui/ee/signals';
+import { useQueryClient } from '@tanstack/react-query';
 import { Pause, Play } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
+import { fetchThemeFlow, fetchThemePaths, fetchThemeSnapshots } from './entity-learning-api';
 import { useThemeFlows } from './hooks/use-theme-flows';
 import { useThemePaths } from './hooks/use-theme-paths';
 import { useThemeSnapshots } from './hooks/use-theme-snapshots';
@@ -22,12 +24,13 @@ import {
   getSignalRecordNodeValue,
   stabilizeThemeFlow,
 } from './sankey-signals-data';
+import { SignalDistributions } from './signal-distributions';
 import { SignalsErrorState } from './signals-error-state';
 import { SignalsFrameLoadingSkeleton, SignalsLoadingSkeleton } from './signals-loading-skeleton';
 import { ThemeDetailPanel } from './theme-detail-panel';
 import { buildDrilledThemeFlow, findThemeSelection } from './theme-drilldown-data';
 import type { ThemeSelection } from './theme-drilldown-data';
-import type { ThemeFlowResponse, ThemeNode, ThemeSnapshot, TraceSignalName } from './types';
+import type { ThemeFlowResponse, ThemeSnapshot, TraceSignalName } from './types';
 import { Link } from '@/lib/link';
 
 export interface SankeySignalsProps {
@@ -36,6 +39,8 @@ export interface SankeySignalsProps {
   signalNames: TraceSignalName[];
   height?: number;
 }
+
+const DRILL_IN_TRACE_LIMIT = 2000;
 
 function formatSignalName(signalName: TraceSignalName) {
   return signalName.charAt(0).toUpperCase() + signalName.slice(1);
@@ -117,192 +122,6 @@ function SnapshotTimeline({
   );
 }
 
-function SignalDistributionRow({
-  color,
-  index,
-  node,
-  onViewThemeDetails,
-  signalName,
-}: {
-  color: string;
-  index: number;
-  node: ThemeNode;
-  onViewThemeDetails: (selection: ThemeSelection) => void;
-  signalName: TraceSignalName;
-}) {
-  const content = (
-    <>
-      <span className="flex min-w-0 items-center gap-2 text-neutral5">
-        <span
-          aria-hidden="true"
-          className="size-2 shrink-0 rounded-[2px]"
-          style={{ backgroundColor: color, opacity: Math.max(0.35, 1 - index * 0.2) }}
-        />
-        <span className="truncate" title={node.label}>
-          {node.label}
-        </span>
-      </span>
-      <span className="shrink-0 font-mono text-neutral3">
-        {node.traceCount} · {Math.round(node.stageShare * 100)}%
-      </span>
-    </>
-  );
-
-  if (node.kind === 'theme' && node.themeId && /^\d+$/.test(node.themeId)) {
-    return (
-      <li title={node.description ? `${node.label}\n${node.description}` : node.label}>
-        <button
-          aria-label={`View theme details for ${node.label}`}
-          className="flex w-full min-w-0 items-center justify-between gap-3 rounded-sm text-left text-xs outline-hidden hover:bg-surface3 focus-visible:ring-1 focus-visible:ring-border2"
-          onClick={() => onViewThemeDetails({ signalName, themeId: node.themeId, label: node.label })}
-          type="button"
-        >
-          {content}
-        </button>
-      </li>
-    );
-  }
-
-  return <li className="flex min-w-0 items-center justify-between gap-3 text-xs">{content}</li>;
-}
-
-function NoiseDistributionRow({
-  color,
-  signalName,
-  traceCount,
-  stageShare,
-  onViewNoiseDetails,
-}: {
-  color: string;
-  signalName: TraceSignalName;
-  traceCount: number;
-  stageShare: number;
-  onViewNoiseDetails: (signalName: TraceSignalName) => void;
-}) {
-  const signalLabel = formatSignalName(signalName);
-
-  return (
-    <li>
-      <button
-        aria-label={`View Noise details for ${signalLabel}`}
-        className="flex w-full min-w-0 items-center justify-between gap-3 rounded-sm text-left text-xs outline-hidden hover:bg-surface3 focus-visible:ring-1 focus-visible:ring-border2"
-        onClick={() => onViewNoiseDetails(signalName)}
-        type="button"
-      >
-        <span className="flex min-w-0 items-center gap-2 text-neutral5">
-          <span
-            aria-hidden="true"
-            className="size-2 shrink-0 rounded-[2px]"
-            style={{ backgroundColor: color, opacity: 0.35 }}
-          />
-          <span>Noise</span>
-        </span>
-        <span className="shrink-0 font-mono text-neutral3">
-          {traceCount} · {Math.round(stageShare * 100)}%
-        </span>
-      </button>
-    </li>
-  );
-}
-
-function SignalDistribution({
-  signalName,
-  traceCount,
-  nodes,
-  onViewThemeDetails,
-  onViewNoiseDetails,
-}: {
-  signalName: TraceSignalName;
-  traceCount: number;
-  nodes: ThemeNode[];
-  onViewThemeDetails: (selection: ThemeSelection) => void;
-  onViewNoiseDetails: (signalName: TraceSignalName) => void;
-}) {
-  const label = formatSignalName(signalName);
-  const color = nodeColor(getSignalHue(signalName));
-  const displayNodes = nodes.filter(node => node.kind !== 'noise');
-  const noiseNode = nodes.find(node => node.kind === 'noise');
-
-  return (
-    <Card aria-label={`${label} distribution`} as="article" className="min-w-0" elevation="elevated">
-      <CardHeader className="border-b border-border1 px-4 py-3">
-        <h3 className="font-mono text-xs font-semibold tracking-wider" style={{ color }}>
-          {label.toUpperCase()}
-        </h3>
-      </CardHeader>
-      <CardContent className="space-y-4 p-4">
-        <p className="font-mono text-[10px] tracking-wider text-neutral3">{traceLabel(traceCount)}</p>
-        <div
-          aria-label={`${label} stacked distribution`}
-          className="flex h-1.5 overflow-hidden rounded-sm bg-surface4"
-          data-testid="distribution-stack"
-        >
-          {nodes.map((node, index) => (
-            <span
-              key={node.nodeId}
-              aria-hidden="true"
-              className="h-full"
-              style={{
-                backgroundColor: color,
-                opacity: Math.max(0.35, 1 - index * 0.2),
-                width: `${Math.min(node.stageShare * 100, 100)}%`,
-              }}
-            />
-          ))}
-        </div>
-        <ul className="space-y-2.5">
-          {displayNodes.length > 0 ? (
-            displayNodes.map((node, index) => (
-              <SignalDistributionRow
-                key={node.nodeId}
-                color={color}
-                index={index}
-                node={node}
-                onViewThemeDetails={onViewThemeDetails}
-                signalName={signalName}
-              />
-            ))
-          ) : (
-            <li className="text-xs text-neutral3">No themes detected</li>
-          )}
-          <NoiseDistributionRow
-            color={color}
-            signalName={signalName}
-            traceCount={noiseNode?.traceCount ?? 0}
-            stageShare={noiseNode?.stageShare ?? 0}
-            onViewNoiseDetails={onViewNoiseDetails}
-          />
-        </ul>
-      </CardContent>
-    </Card>
-  );
-}
-
-function SignalDistributions({
-  stages,
-  onViewThemeDetails,
-  onViewNoiseDetails,
-}: {
-  stages: ThemeFlowResponse['stages'];
-  onViewThemeDetails: (selection: ThemeSelection) => void;
-  onViewNoiseDetails: (signalName: TraceSignalName) => void;
-}) {
-  return (
-    <section aria-label="Signal distributions" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-      {stages.map(stage => (
-        <SignalDistribution
-          key={stage.signalName}
-          signalName={stage.signalName}
-          traceCount={stage.traceCount}
-          nodes={stage.nodes}
-          onViewThemeDetails={onViewThemeDetails}
-          onViewNoiseDetails={onViewNoiseDetails}
-        />
-      ))}
-    </section>
-  );
-}
-
 function FlowCard({
   columns,
   records,
@@ -376,20 +195,29 @@ function FlowCard({
   );
 }
 
-export function SankeySignals({ entityId, entityType = 'agent', signalNames, height }: SankeySignalsProps) {
+export function SankeySignals({
+  entityId,
+  entityType = 'agent',
+  signalNames: initialSignalNames,
+  height,
+}: SankeySignalsProps) {
+  const queryClient = useQueryClient();
+  const [signalNames, setSignalNames] = useState(() => initialSignalNames);
+  const [isChangingPerspective, setIsChangingPerspective] = useState(false);
+  const [perspectiveError, setPerspectiveError] = useState<string>();
   const snapshotsQuery = useThemeSnapshots(entityId, entityType, signalNames);
   const snapshots = [...(snapshotsQuery.data?.snapshots ?? [])].sort((left, right) => left.ordinal - right.ordinal);
-  const [selectedSnapshotId, setSelectedSnapshotId] = useState<string>();
+  const [selectedSnapshotOrdinal, setSelectedSnapshotOrdinal] = useState<number>();
   const [isPlaying, setIsPlaying] = useState(false);
   const [drillIn, setDrillIn] = useState<ThemeSelection>();
   const [detailSelection, setDetailSelection] = useState<ThemeSelection>();
   const [noiseSignalName, setNoiseSignalName] = useState<TraceSignalName>();
-  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.snapshotId === selectedSnapshotId);
+  const matchedSnapshotIndex = snapshots.findIndex(snapshot => snapshot.ordinal === selectedSnapshotOrdinal);
   const selectedSnapshotIndex = matchedSnapshotIndex >= 0 ? matchedSnapshotIndex : snapshots.length - 1;
   const snapshot = snapshots[selectedSnapshotIndex];
-  const selectSnapshot = (index: number) => setSelectedSnapshotId(snapshots[index]?.snapshotId);
+  const selectSnapshot = (index: number) => setSelectedSnapshotOrdinal(snapshots[index]?.ordinal);
 
-  const nextSnapshotId = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.snapshotId;
+  const nextSnapshotOrdinal = snapshots[(selectedSnapshotIndex + 1) % snapshots.length]?.ordinal;
   const flowQueries = useThemeFlows(
     entityId,
     entityType,
@@ -405,7 +233,7 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
     () => (currentFlow ? stabilizeThemeFlow(currentFlow, windowFlows) : undefined),
     [currentFlow, windowFlows],
   );
-  const drillInAvailable = Boolean(currentFlow && currentFlow.snapshot.traceCount <= 2000);
+  const drillInAvailable = Boolean(currentFlow && currentFlow.snapshot.traceCount <= DRILL_IN_TRACE_LIMIT);
   const pathsQuery = useThemePaths(
     entityId,
     entityType,
@@ -424,14 +252,14 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
   useEffect(() => {
     const drillInQueryBlocked = drillIn !== undefined && (pathsQuery.isFetching || pathsQuery.isError);
     if (!isPlaying || snapshots.length < 2 || isFlowPending || hasFlowError || drillInQueryBlocked) return;
-    const timer = window.setTimeout(() => setSelectedSnapshotId(nextSnapshotId), 900);
+    const timer = window.setTimeout(() => setSelectedSnapshotOrdinal(nextSnapshotOrdinal), 900);
     return () => window.clearTimeout(timer);
   }, [
     drillIn,
     hasFlowError,
     isFlowPending,
     isPlaying,
-    nextSnapshotId,
+    nextSnapshotOrdinal,
     pathsQuery.isError,
     pathsQuery.isFetching,
     snapshots.length,
@@ -496,6 +324,43 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
     ? undefined
     : 'Drill-in is unavailable for snapshots with more than 2,000 traces.';
   const isDrilledEmpty = drillIn !== undefined && pathsQuery.data !== undefined && flow.snapshot.traceCount === 0;
+  const handleSignalOrderChange = async (nextSignalNames: TraceSignalName[]) => {
+    if (isChangingPerspective) return;
+    setIsPlaying(false);
+    setDetailSelection(undefined);
+    setNoiseSignalName(undefined);
+    setPerspectiveError(undefined);
+    setIsChangingPerspective(true);
+
+    try {
+      const nextSnapshots = await queryClient.fetchQuery({
+        queryKey: ['entity-learning', entityType, entityId, 'theme-snapshots', nextSignalNames],
+        queryFn: () => fetchThemeSnapshots(entityId, entityType, nextSignalNames),
+      });
+      await Promise.all(
+        nextSnapshots.snapshots.map(nextSnapshot =>
+          queryClient.fetchQuery({
+            queryKey: ['entity-learning', entityType, entityId, 'theme-flow', nextSignalNames, nextSnapshot.snapshotId],
+            queryFn: () => fetchThemeFlow(entityId, entityType, nextSignalNames, nextSnapshot.snapshotId),
+          }),
+        ),
+      );
+      const nextSnapshot =
+        nextSnapshots.snapshots.find(candidate => candidate.ordinal === snapshot.ordinal) ??
+        nextSnapshots.snapshots.at(-1);
+      if (drillIn && nextSnapshot && nextSnapshot.traceCount <= DRILL_IN_TRACE_LIMIT) {
+        await queryClient.fetchQuery({
+          queryKey: ['entity-learning', entityType, entityId, 'theme-paths', nextSignalNames, nextSnapshot.snapshotId],
+          queryFn: () => fetchThemePaths(entityId, entityType, nextSignalNames, nextSnapshot.snapshotId),
+        });
+      }
+      setSignalNames(nextSignalNames);
+    } catch {
+      setPerspectiveError('Unable to load that signal perspective. Try reordering the columns again.');
+    } finally {
+      setIsChangingPerspective(false);
+    }
+  };
 
   return (
     <main className="min-w-0 space-y-5 p-4 lg:p-6">
@@ -578,17 +443,31 @@ export function SankeySignals({ entityId, entityType = 'agent', signalNames, hei
         onSnapshotChange={selectSnapshot}
       />
       {drillIn && (!drillInAvailable || pathsQuery.isPending || isDrilledEmpty) ? null : (
-        <SignalDistributions
-          stages={stages}
-          onViewThemeDetails={selection => {
-            setNoiseSignalName(undefined);
-            setDetailSelection(selection);
-          }}
-          onViewNoiseDetails={signalName => {
-            setDetailSelection(undefined);
-            setNoiseSignalName(signalName);
-          }}
-        />
+        <>
+          {isChangingPerspective ? (
+            <p className="font-mono text-xs text-neutral3" role="status">
+              Updating signal perspective…
+            </p>
+          ) : null}
+          {perspectiveError ? (
+            <p className="text-xs text-red-500" role="alert">
+              {perspectiveError}
+            </p>
+          ) : null}
+          <SignalDistributions
+            disabled={isChangingPerspective}
+            stages={stages}
+            onOrderChange={handleSignalOrderChange}
+            onViewThemeDetails={selection => {
+              setNoiseSignalName(undefined);
+              setDetailSelection(selection);
+            }}
+            onViewNoiseDetails={signalName => {
+              setDetailSelection(undefined);
+              setNoiseSignalName(signalName);
+            }}
+          />
+        </>
       )}
       <ThemeDetailPanel
         key={`${snapshot.snapshotId}:${detailSelection?.signalName ?? ''}:${detailSelection?.themeId ?? ''}`}

--- a/packages/playground/src/ee/signals/signal-distributions.tsx
+++ b/packages/playground/src/ee/signals/signal-distributions.tsx
@@ -1,9 +1,9 @@
+import type { DraggableProvidedDragHandleProps, DropResult, DroppableProvided } from '@hello-pangea/dnd';
+import { DragDropContext, Draggable, Droppable, useMouseSensor, useTouchSensor } from '@hello-pangea/dnd';
 import { Card, CardContent, CardHeader } from '@mastra/playground-ui/components/Card';
 import { nodeColor } from '@mastra/playground-ui/components/SankeyChart';
 import { getSignalHue } from '@mastra/playground-ui/ee/signals';
 import { GripVertical } from 'lucide-react';
-import type { DragEvent } from 'react';
-import { useState } from 'react';
 
 import type { ThemeSelection } from './theme-drilldown-data';
 import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
@@ -102,20 +102,20 @@ function NoiseDistributionRow({
 
 function SignalDistribution({
   disabled,
+  dragHandleProps,
+  isDragging,
   signalName,
   traceCount,
   nodes,
-  onDragStart,
-  onDragEnd,
   onViewThemeDetails,
   onViewNoiseDetails,
 }: {
   disabled: boolean;
+  dragHandleProps?: DraggableProvidedDragHandleProps;
+  isDragging: boolean;
   signalName: TraceSignalName;
   traceCount: number;
   nodes: ThemeNode[];
-  onDragStart: (event: DragEvent<HTMLDivElement>) => void;
-  onDragEnd: () => void;
   onViewThemeDetails: (selection: ThemeSelection) => void;
   onViewNoiseDetails: (signalName: TraceSignalName) => void;
 }) {
@@ -124,22 +124,24 @@ function SignalDistribution({
   const displayNodes = nodes.filter(node => node.kind !== 'noise');
   const noiseNode = nodes.find(node => node.kind === 'noise');
 
+  const cardClassName = isDragging ? 'min-w-0 shadow-lg ring-2 ring-accent1' : 'min-w-0 transition-shadow duration-150';
+
   return (
-    <Card aria-label={`${label} distribution`} as="article" className="min-w-0" elevation="elevated">
+    <Card aria-label={`${label} distribution`} as="article" className={cardClassName} elevation="elevated">
       <CardHeader className="flex flex-row items-center justify-between border-b border-border1 px-4 py-3">
         <h3 className="font-mono text-xs font-semibold tracking-wider" style={{ color }}>
           {label.toUpperCase()}
         </h3>
-        <div
-          aria-disabled={disabled}
-          aria-label={`Reorder ${label}`}
-          className="cursor-grab rounded-xs p-1 text-neutral3 hover:bg-surface3 hover:text-neutral5 active:cursor-grabbing aria-disabled:cursor-wait aria-disabled:opacity-50"
-          draggable={!disabled}
-          onDragEnd={onDragEnd}
-          onDragStart={onDragStart}
-          title={`Drag to reorder ${label}`}
-        >
-          <GripVertical aria-hidden="true" className="size-4" />
+        <div className="flex items-center gap-2">
+          <div
+            {...dragHandleProps}
+            aria-disabled={disabled}
+            aria-label={`Reorder ${label}`}
+            className="cursor-grab rounded-xs p-1 text-neutral3 group-hover:text-neutral5 active:cursor-grabbing aria-disabled:cursor-wait aria-disabled:opacity-50"
+            title={`Drag the ${label} card to reorder`}
+          >
+            <GripVertical aria-hidden="true" className="size-4" />
+          </div>
         </div>
       </CardHeader>
       <CardContent className="space-y-4 p-4">
@@ -203,72 +205,54 @@ export function SignalDistributions({
   onViewThemeDetails: (selection: ThemeSelection) => void;
   onViewNoiseDetails: (signalName: TraceSignalName) => void;
 }) {
-  const [draggedSignalName, setDraggedSignalName] = useState<TraceSignalName>();
-  const [dropTargetSignalName, setDropTargetSignalName] = useState<TraceSignalName>();
-  const clearDragState = () => {
-    setDraggedSignalName(undefined);
-    setDropTargetSignalName(undefined);
-  };
-  const handleDrop = (targetSignalName: TraceSignalName) => {
-    if (!draggedSignalName || draggedSignalName === targetSignalName) {
-      clearDragState();
-      return;
-    }
+  const handleDragEnd = (result: DropResult) => {
+    const destinationIndex = result.destination?.index;
+    if (destinationIndex === undefined || destinationIndex === result.source.index) return;
 
     const reorderedStages = [...stages];
-    const sourceIndex = reorderedStages.findIndex(stage => stage.signalName === draggedSignalName);
-    const targetIndex = reorderedStages.findIndex(stage => stage.signalName === targetSignalName);
-    if (sourceIndex < 0 || targetIndex < 0) {
-      clearDragState();
-      return;
-    }
-    const [movedStage] = reorderedStages.splice(sourceIndex, 1);
-    if (!movedStage) {
-      clearDragState();
-      return;
-    }
-    reorderedStages.splice(targetIndex, 0, movedStage);
-    clearDragState();
+    const [movedStage] = reorderedStages.splice(result.source.index, 1);
+    if (!movedStage) return;
+    reorderedStages.splice(destinationIndex, 0, movedStage);
     onOrderChange(reorderedStages.map(stage => stage.signalName));
   };
 
   return (
-    <section aria-label="Signal distributions" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-      {stages.map(stage => (
-        <div
-          key={stage.signalName}
-          className={dropTargetSignalName === stage.signalName ? 'rounded-lg ring-2 ring-accent1' : undefined}
-          onDragEnter={() => {
-            if (draggedSignalName && draggedSignalName !== stage.signalName) {
-              setDropTargetSignalName(stage.signalName);
-            }
-          }}
-          onDragOver={event => {
-            if (!draggedSignalName || draggedSignalName === stage.signalName) return;
-            event.preventDefault();
-            event.dataTransfer.dropEffect = 'move';
-          }}
-          onDrop={event => {
-            event.preventDefault();
-            handleDrop(stage.signalName);
-          }}
-        >
-          <SignalDistribution
-            disabled={disabled}
-            signalName={stage.signalName}
-            traceCount={stage.traceCount}
-            nodes={stage.nodes}
-            onDragStart={event => {
-              event.dataTransfer.effectAllowed = 'move';
-              event.dataTransfer.setData('text/plain', stage.signalName);
-              setDraggedSignalName(stage.signalName);
-            }}
-            onDragEnd={clearDragState}
-            onViewThemeDetails={onViewThemeDetails}
-            onViewNoiseDetails={onViewNoiseDetails}
-          />
-        </div>
-      ))}
-    </section>
+    <DragDropContext enableDefaultSensors={false} sensors={[useMouseSensor, useTouchSensor]} onDragEnd={handleDragEnd}>
+      <Droppable direction="horizontal" droppableId="signal-distributions">
+        {(provided: DroppableProvided) => (
+          <section
+            {...provided.droppableProps}
+            ref={provided.innerRef}
+            aria-label="Signal distributions"
+            className="flex gap-3 overflow-x-auto pb-1"
+          >
+            {stages.map((stage, index) => (
+              <Draggable key={stage.signalName} draggableId={stage.signalName} index={index} isDragDisabled={disabled}>
+                {(provided, snapshot) => (
+                  <div
+                    ref={provided.innerRef}
+                    {...provided.draggableProps}
+                    className="min-w-56 flex-1 basis-0"
+                    style={provided.draggableProps.style}
+                  >
+                    <SignalDistribution
+                      disabled={disabled}
+                      dragHandleProps={provided.dragHandleProps ?? undefined}
+                      isDragging={snapshot.isDragging}
+                      signalName={stage.signalName}
+                      traceCount={stage.traceCount}
+                      nodes={stage.nodes}
+                      onViewThemeDetails={onViewThemeDetails}
+                      onViewNoiseDetails={onViewNoiseDetails}
+                    />
+                  </div>
+                )}
+              </Draggable>
+            ))}
+            {provided.placeholder}
+          </section>
+        )}
+      </Droppable>
+    </DragDropContext>
   );
 }

--- a/packages/playground/src/ee/signals/signal-distributions.tsx
+++ b/packages/playground/src/ee/signals/signal-distributions.tsx
@@ -8,6 +8,8 @@ import { GripVertical } from 'lucide-react';
 import type { ThemeSelection } from './theme-drilldown-data';
 import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
 
+const DRAG_SENSORS = [useMouseSensor, useTouchSensor];
+
 function formatSignalName(signalName: TraceSignalName) {
   return signalName.charAt(0).toUpperCase() + signalName.slice(1);
 }
@@ -217,7 +219,7 @@ export function SignalDistributions({
   };
 
   return (
-    <DragDropContext enableDefaultSensors={false} sensors={[useMouseSensor, useTouchSensor]} onDragEnd={handleDragEnd}>
+    <DragDropContext enableDefaultSensors={false} sensors={DRAG_SENSORS} onDragEnd={handleDragEnd}>
       <Droppable direction="horizontal" droppableId="signal-distributions">
         {(provided: DroppableProvided) => (
           <section

--- a/packages/playground/src/ee/signals/signal-distributions.tsx
+++ b/packages/playground/src/ee/signals/signal-distributions.tsx
@@ -1,0 +1,274 @@
+import { Card, CardContent, CardHeader } from '@mastra/playground-ui/components/Card';
+import { nodeColor } from '@mastra/playground-ui/components/SankeyChart';
+import { getSignalHue } from '@mastra/playground-ui/ee/signals';
+import { GripVertical } from 'lucide-react';
+import type { DragEvent } from 'react';
+import { useState } from 'react';
+
+import type { ThemeSelection } from './theme-drilldown-data';
+import type { ThemeFlowResponse, ThemeNode, TraceSignalName } from './types';
+
+function formatSignalName(signalName: TraceSignalName) {
+  return signalName.charAt(0).toUpperCase() + signalName.slice(1);
+}
+
+function traceLabel(count: number) {
+  return `${count} ${count === 1 ? 'trace' : 'traces'}`;
+}
+
+function SignalDistributionRow({
+  color,
+  index,
+  node,
+  onViewThemeDetails,
+  signalName,
+}: {
+  color: string;
+  index: number;
+  node: ThemeNode;
+  onViewThemeDetails: (selection: ThemeSelection) => void;
+  signalName: TraceSignalName;
+}) {
+  const content = (
+    <>
+      <span className="flex min-w-0 items-center gap-2 text-neutral5">
+        <span
+          aria-hidden="true"
+          className="size-2 shrink-0 rounded-[2px]"
+          style={{ backgroundColor: color, opacity: Math.max(0.35, 1 - index * 0.2) }}
+        />
+        <span className="truncate" title={node.label}>
+          {node.label}
+        </span>
+      </span>
+      <span className="shrink-0 font-mono text-neutral3">
+        {node.traceCount} · {Math.round(node.stageShare * 100)}%
+      </span>
+    </>
+  );
+
+  if (node.kind === 'theme' && node.themeId && /^\d+$/.test(node.themeId)) {
+    return (
+      <li title={node.description ? `${node.label}\n${node.description}` : node.label}>
+        <button
+          aria-label={`View theme details for ${node.label}`}
+          className="flex w-full min-w-0 items-center justify-between gap-3 rounded-xs text-left text-xs outline-hidden hover:bg-surface3 focus-visible:ring-1 focus-visible:ring-border2"
+          onClick={() => onViewThemeDetails({ signalName, themeId: node.themeId, label: node.label })}
+          type="button"
+        >
+          {content}
+        </button>
+      </li>
+    );
+  }
+
+  return <li className="flex min-w-0 items-center justify-between gap-3 text-xs">{content}</li>;
+}
+
+function NoiseDistributionRow({
+  color,
+  signalName,
+  traceCount,
+  stageShare,
+  onViewNoiseDetails,
+}: {
+  color: string;
+  signalName: TraceSignalName;
+  traceCount: number;
+  stageShare: number;
+  onViewNoiseDetails: (signalName: TraceSignalName) => void;
+}) {
+  const signalLabel = formatSignalName(signalName);
+
+  return (
+    <li>
+      <button
+        aria-label={`View Noise details for ${signalLabel}`}
+        className="flex w-full min-w-0 items-center justify-between gap-3 rounded-xs text-left text-xs outline-hidden hover:bg-surface3 focus-visible:ring-1 focus-visible:ring-border2"
+        onClick={() => onViewNoiseDetails(signalName)}
+        type="button"
+      >
+        <span className="flex min-w-0 items-center gap-2 text-neutral5">
+          <span aria-hidden="true" className="size-2 shrink-0 rounded-[2px]" style={{ backgroundColor: color }} />
+          <span>Noise</span>
+        </span>
+        <span className="shrink-0 font-mono text-neutral3">
+          {traceCount} · {Math.round(stageShare * 100)}%
+        </span>
+      </button>
+    </li>
+  );
+}
+
+function SignalDistribution({
+  disabled,
+  signalName,
+  traceCount,
+  nodes,
+  onDragStart,
+  onDragEnd,
+  onViewThemeDetails,
+  onViewNoiseDetails,
+}: {
+  disabled: boolean;
+  signalName: TraceSignalName;
+  traceCount: number;
+  nodes: ThemeNode[];
+  onDragStart: (event: DragEvent<HTMLDivElement>) => void;
+  onDragEnd: () => void;
+  onViewThemeDetails: (selection: ThemeSelection) => void;
+  onViewNoiseDetails: (signalName: TraceSignalName) => void;
+}) {
+  const label = formatSignalName(signalName);
+  const color = nodeColor(getSignalHue(signalName));
+  const displayNodes = nodes.filter(node => node.kind !== 'noise');
+  const noiseNode = nodes.find(node => node.kind === 'noise');
+
+  return (
+    <Card aria-label={`${label} distribution`} as="article" className="min-w-0" elevation="elevated">
+      <CardHeader className="flex flex-row items-center justify-between border-b border-border1 px-4 py-3">
+        <h3 className="font-mono text-xs font-semibold tracking-wider" style={{ color }}>
+          {label.toUpperCase()}
+        </h3>
+        <div
+          aria-disabled={disabled}
+          aria-label={`Reorder ${label}`}
+          className="cursor-grab rounded-xs p-1 text-neutral3 hover:bg-surface3 hover:text-neutral5 active:cursor-grabbing aria-disabled:cursor-wait aria-disabled:opacity-50"
+          draggable={!disabled}
+          onDragEnd={onDragEnd}
+          onDragStart={onDragStart}
+          title={`Drag to reorder ${label}`}
+        >
+          <GripVertical aria-hidden="true" className="size-4" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4 p-4">
+        <p className="font-mono text-[10px] tracking-wider text-neutral3">{traceLabel(traceCount)}</p>
+        <div
+          aria-label={`${label} stacked distribution`}
+          className="flex h-1.5 overflow-hidden rounded-xs bg-surface4"
+          data-testid="distribution-stack"
+        >
+          {nodes.map((node, index) => (
+            <span
+              key={node.nodeId}
+              aria-hidden="true"
+              className="h-full"
+              style={{
+                backgroundColor: color,
+                opacity: Math.max(0.35, 1 - index * 0.2),
+                width: `${Math.min(node.stageShare * 100, 100)}%`,
+              }}
+            />
+          ))}
+        </div>
+        <ul className="space-y-2.5">
+          {displayNodes.length > 0 ? (
+            displayNodes.map((node, index) => (
+              <SignalDistributionRow
+                key={node.nodeId}
+                color={color}
+                index={index}
+                node={node}
+                onViewThemeDetails={onViewThemeDetails}
+                signalName={signalName}
+              />
+            ))
+          ) : (
+            <li className="text-xs text-neutral3">No themes detected</li>
+          )}
+          <NoiseDistributionRow
+            color={color}
+            signalName={signalName}
+            traceCount={noiseNode?.traceCount ?? 0}
+            stageShare={noiseNode?.stageShare ?? 0}
+            onViewNoiseDetails={onViewNoiseDetails}
+          />
+        </ul>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function SignalDistributions({
+  disabled = false,
+  stages,
+  onOrderChange,
+  onViewThemeDetails,
+  onViewNoiseDetails,
+}: {
+  disabled?: boolean;
+  stages: ThemeFlowResponse['stages'];
+  onOrderChange: (signalNames: TraceSignalName[]) => void;
+  onViewThemeDetails: (selection: ThemeSelection) => void;
+  onViewNoiseDetails: (signalName: TraceSignalName) => void;
+}) {
+  const [draggedSignalName, setDraggedSignalName] = useState<TraceSignalName>();
+  const [dropTargetSignalName, setDropTargetSignalName] = useState<TraceSignalName>();
+  const clearDragState = () => {
+    setDraggedSignalName(undefined);
+    setDropTargetSignalName(undefined);
+  };
+  const handleDrop = (targetSignalName: TraceSignalName) => {
+    if (!draggedSignalName || draggedSignalName === targetSignalName) {
+      clearDragState();
+      return;
+    }
+
+    const reorderedStages = [...stages];
+    const sourceIndex = reorderedStages.findIndex(stage => stage.signalName === draggedSignalName);
+    const targetIndex = reorderedStages.findIndex(stage => stage.signalName === targetSignalName);
+    if (sourceIndex < 0 || targetIndex < 0) {
+      clearDragState();
+      return;
+    }
+    const [movedStage] = reorderedStages.splice(sourceIndex, 1);
+    if (!movedStage) {
+      clearDragState();
+      return;
+    }
+    reorderedStages.splice(targetIndex, 0, movedStage);
+    clearDragState();
+    onOrderChange(reorderedStages.map(stage => stage.signalName));
+  };
+
+  return (
+    <section aria-label="Signal distributions" className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+      {stages.map(stage => (
+        <div
+          key={stage.signalName}
+          className={dropTargetSignalName === stage.signalName ? 'rounded-lg ring-2 ring-accent1' : undefined}
+          onDragEnter={() => {
+            if (draggedSignalName && draggedSignalName !== stage.signalName) {
+              setDropTargetSignalName(stage.signalName);
+            }
+          }}
+          onDragOver={event => {
+            if (!draggedSignalName || draggedSignalName === stage.signalName) return;
+            event.preventDefault();
+            event.dataTransfer.dropEffect = 'move';
+          }}
+          onDrop={event => {
+            event.preventDefault();
+            handleDrop(stage.signalName);
+          }}
+        >
+          <SignalDistribution
+            disabled={disabled}
+            signalName={stage.signalName}
+            traceCount={stage.traceCount}
+            nodes={stage.nodes}
+            onDragStart={event => {
+              event.dataTransfer.effectAllowed = 'move';
+              event.dataTransfer.setData('text/plain', stage.signalName);
+              setDraggedSignalName(stage.signalName);
+            }}
+            onDragEnd={clearDragState}
+            onViewThemeDetails={onViewThemeDetails}
+            onViewNoiseDetails={onViewNoiseDetails}
+          />
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/packages/playground/src/ee/signals/signals-overview-page.tsx
+++ b/packages/playground/src/ee/signals/signals-overview-page.tsx
@@ -73,7 +73,12 @@ export function SignalsOverviewPage() {
     <>
       <AgentSelector entities={entities} selectedEntityId={entity.entityId} onEntityChange={setSelectedEntityId} />
       {signalNames.length >= 2 ? (
-        <SankeySignals key={entity.entityId} entityId={entity.entityId} entityType="agent" signalNames={signalNames} />
+        <SankeySignals
+          key={`${entity.entityId}:${signalNames.join(',')}`}
+          entityId={entity.entityId}
+          entityType="agent"
+          signalNames={signalNames}
+        />
       ) : (
         <section
           className="m-4 rounded-lg border border-border1 bg-surface2 p-6 lg:m-6"


### PR DESCRIPTION
## Summary

- add drag-and-drop reordering for signal distribution columns
- recompute snapshot flows using the dropped signal order without issuing requests during hover
- preserve the selected snapshot ordinal across opaque reordered cursors
- keep the current chart visible while the next perspective preloads, preventing layout and loading-state flashes

## Test plan

- `cd packages/playground && pnpm vitest run src/ee/signals`
- `cd packages/playground && pnpm typecheck`
- focused ESLint and Prettier checks for changed Signals files
- Chromium drag proof at 1280×720: Outcome moved after Behavior, snapshot remained 4/4, and no full-page loading skeleton appeared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

You can now rearrange signal columns by dragging them into a new order. The chart updates after you drop, keeps your place in the snapshots, and stays visible while new data loads.

## What changed

- Added drag-and-drop reordering for Signals distribution columns.
- Reloads snapshots, theme flows, and relevant theme paths only after a drop—not during hover.
- Preserves the selected snapshot position even when snapshot IDs or cursors change.
- Keeps the current chart visible while the reordered perspective preloads.
- Added draggable distribution cards, theme/noise detail actions, and loading/error states.
- Added 30-second React Query freshness windows for theme data.
- Added regression fixtures and tests covering reorder behavior, snapshot preservation, and loading UI.
- Added a centralized trace drill-in eligibility limit.
- Added a composite key so the Signals view remounts when signal order changes.

## Testing

- Signals Vitest tests, including Chromium drag-and-drop coverage.
- Playground type checking.
- Focused linting and formatting checks.
- Verified reordered columns, preserved snapshot position, and absence of a full-page loading skeleton.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->