### PR TITLE
fix(auth-studio): default shared API URL to platform.mastra.ai

### DIFF
--- a/.changeset/wet-rooms-rule.md
+++ b/.changeset/wet-rooms-rule.md
@@ -1,0 +1,5 @@
+---
+'@mastra/auth-studio': patch
+---
+
+Changed the default shared API URL for Studio auth from http://localhost:3010/v1 to https://platform.mastra.ai/v1, so deployed instances work against the production platform without extra configuration. Set MASTRA_SHARED_API_URL or the sharedApiUrl option to point at a different environment. Production cookie settings (Secure + Domain=.mastra.ai) are now only auto-enabled when the shared API URL is explicitly configured on .mastra.ai, keeping local development cookies host-only.

--- a/auth/studio/src/index.test.ts
+++ b/auth/studio/src/index.test.ts
@@ -87,15 +87,26 @@ describe('MastraAuthStudio', () => {
       delete process.env.MASTRA_SHARED_API_URL;
     });
 
-    it('should fall back to localhost default when no config or env var', () => {
+    it('should fall back to the platform default when no config or env var', () => {
       delete process.env.MASTRA_SHARED_API_URL;
       const a = new MastraAuthStudio();
       const url = a.getLoginUrl('https://app.mastra.ai/callback', '');
-      expect(url).toContain('http://localhost:3010/v1/auth/login');
+      expect(url).toContain('https://platform.mastra.ai/v1/auth/login');
     });
 
     it('should set isMastraCloudAuth to true', () => {
       expect(auth.isMastraCloudAuth).toBe(true);
+    });
+
+    it('should not auto-detect a .mastra.ai cookie domain from the built-in default URL', () => {
+      // The platform.mastra.ai fallback must not flip on production cookies —
+      // a localhost studio using the default would mint Domain=.mastra.ai
+      // cookies the browser rejects.
+      delete process.env.MASTRA_SHARED_API_URL;
+      const a = new MastraAuthStudio();
+      const headers = a.getSessionHeaders({ id: 'sess', userId: 'u1' } as any);
+      expect(headers['Set-Cookie']).not.toContain('Domain=');
+      expect(headers['Set-Cookie']).not.toContain('Secure');
     });
   });
 

--- a/auth/studio/src/index.ts
+++ b/auth/studio/src/index.ts
@@ -98,7 +98,8 @@ export class MastraAuthStudio
 
   constructor(options?: MastraAuthStudioOptions) {
     super({ name: 'mastra-studio', ...options });
-    this.sharedApiUrl = options?.sharedApiUrl || process.env.MASTRA_SHARED_API_URL || 'http://localhost:3010/v1';
+    const explicitSharedApiUrl = options?.sharedApiUrl || process.env.MASTRA_SHARED_API_URL;
+    this.sharedApiUrl = explicitSharedApiUrl || 'https://platform.mastra.ai/v1';
     this.organizationId = options?.organizationId || process.env.MASTRA_ORGANIZATION_ID;
 
     // Strip trailing slash
@@ -111,14 +112,19 @@ export class MastraAuthStudio
 
     // Use production cookie settings (Secure + Domain) when:
     // 1. An explicit cookieDomain is configured, OR
-    // 2. The shared API is on .mastra.ai (auto-detect default domain)
+    // 2. The shared API is *explicitly* configured on .mastra.ai (auto-detect
+    //    default domain). The built-in platform.mastra.ai fallback doesn't
+    //    count — a localhost studio using the default would otherwise mint
+    //    Domain=.mastra.ai cookies the browser rejects.
     // Use hostname-based detection to avoid false positives (e.g., api.mastra.ai.evil.com)
     let autoDetectMastraAi = false;
-    try {
-      const hostname = new URL(this.sharedApiUrl).hostname.toLowerCase();
-      autoDetectMastraAi = hostname === 'mastra.ai' || hostname.endsWith('.mastra.ai');
-    } catch {
-      autoDetectMastraAi = false;
+    if (explicitSharedApiUrl) {
+      try {
+        const hostname = new URL(this.sharedApiUrl).hostname.toLowerCase();
+        autoDetectMastraAi = hostname === 'mastra.ai' || hostname.endsWith('.mastra.ai');
+      } catch {
+        autoDetectMastraAi = false;
+      }
     }
     this.useProductionCookies = !!this.cookieDomain || autoDetectMastraAi;
 


### PR DESCRIPTION
Studio auth previously defaulted its shared API URL to `http://localhost:3010/v1`, so any deployed instance without `MASTRA_SHARED_API_URL` set would silently point auth at localhost. The default is now `https://platform.mastra.ai/v1`, so deployed instances work against the production platform out of the box.

```ts
// before: unconfigured MastraAuthStudio → http://localhost:3010/v1
// after:
new MastraAuthStudio().getLoginUrl(...) // → https://platform.mastra.ai/v1/auth/login
```

One follow-on: production cookie settings (`Secure; Domain=.mastra.ai`) are now only auto-enabled when the shared API URL is explicitly configured on `.mastra.ai` — otherwise the new default would make an unconfigured localhost studio mint cookies the browser rejects.

Tests: auth-studio 98/98, factory cookie-derivation suite 52/52, tsc clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Deployed Studio instances now connect to Mastra’s production platform by default instead of a local computer. Production-only cookie settings are used only when a Mastra domain is explicitly configured.

## Changes

- Changed the default shared API URL to `https://platform.mastra.ai/v1`.
- Restricted automatic `Secure` and `.mastra.ai` cookie settings to explicitly configured Mastra API URLs.
- Updated tests and added a patch changeset.
- Verified auth-studio tests, cookie derivation tests, and TypeScript compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->