### PR TITLE
chore: apply prettier formatting to env.test.ts (fix main lint:format)

### DIFF
--- a/.changeset/env-test-prettier-fix.md
+++ b/.changeset/env-test-prettier-fix.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Apply prettier formatting to env.test.ts (post-merge follow-up)

--- a/mastracode/mastra-factory/src/env.test.ts
+++ b/mastracode/mastra-factory/src/env.test.ts
@@ -73,18 +73,15 @@ describe('upsertEnvFile', () => {
     expect(twice).toBe(once);
   });
 
-  it.runIf(process.platform !== 'win32')(
-    'tightens .env perms to 0600 so secrets are not world-readable',
-    () => {
-      const envPath = path.join(workDir, '.env');
-      // Start with the loose default that fs.copyFileSync leaves behind
-      // (0644-ish, depending on umask).
-      fs.writeFileSync(envPath, 'EXISTING=1\n', { mode: 0o644 });
+  it.runIf(process.platform !== 'win32')('tightens .env perms to 0600 so secrets are not world-readable', () => {
+    const envPath = path.join(workDir, '.env');
+    // Start with the loose default that fs.copyFileSync leaves behind
+    // (0644-ish, depending on umask).
+    fs.writeFileSync(envPath, 'EXISTING=1\n', { mode: 0o644 });
 
-      upsertEnvFile(envPath, { MASTRA_PLATFORM_SECRET_KEY: 'sk_secret' });
+    upsertEnvFile(envPath, { MASTRA_PLATFORM_SECRET_KEY: 'sk_secret' });
 
-      const mode = fs.statSync(envPath).mode & 0o777;
-      expect(mode).toBe(0o600);
-    },
-  );
+    const mode = fs.statSync(envPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
 });


### PR DESCRIPTION
## What

Runs `prettier --write` on `mastracode/mastra-factory/src/env.test.ts`. The whole file is whitespace-only churn: prettier prefers the single-line `it.runIf(process.platform !== 'win32')('…', () => { … })` signature over the multi-line form used in the file today.

## Why

The perms-check test added in #19945 slipped through without a `lint:format` pass, so `main` is now red:

```
[warn] mastracode/mastra-factory/src/env.test.ts
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
```

Run: https://github.com/mastra-ai/mastra/actions/runs/29932275522/job/88965549496

## Test plan

- `pnpm prettier --check mastracode/mastra-factory/**/*.ts` — all files use Prettier code style.
- `pnpm --filter ./mastracode/mastra-factory exec vitest run src/env.test.ts` — 7/7 pass.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>