### PR TITLE
feat(factory): pass resolved auth provider to server.auth and studio.auth

### DIFF
--- a/.changeset/fine-bobcats-knock.md
+++ b/.changeset/fine-bobcats-knock.md
@@ -2,4 +2,4 @@
 '@mastra/factory': patch
 ---
 
-Deployed factories now configure the resolved auth provider on both server.auth and studio.auth. Plain API callers and Studio requests (routed via the x-mastra-client-type: studio header) authenticate through the same provider, so a deployed Software Factory accepts Studio sessions without extra configuration.
+Deployed factories now authenticate API and Studio requests with the same provider, so Studio sessions work without extra configuration.

--- a/.changeset/fine-bobcats-knock.md
+++ b/.changeset/fine-bobcats-knock.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Deployed factories now configure the resolved auth provider on both server.auth and studio.auth. Plain API callers and Studio requests (routed via the x-mastra-client-type: studio header) authenticate through the same provider, so a deployed Software Factory accepts Studio sessions without extra configuration.

--- a/.changeset/real-lions-lie.md
+++ b/.changeset/real-lions-lie.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'@mastra/code-sdk': patch
+---
+
+Fixed cloned session threads reading from a previous storage instance. The dynamic memory cache now invalidates when the storage or vector instance changes, so thread cloning always uses the current database.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -389,6 +389,29 @@ describe('MastraFactory.prepare', () => {
     expect(gatedMiddleware).toHaveLength(openMiddleware.length + 2);
   });
 
+  it('passes the resolved auth provider to both server.auth and studio.auth', async () => {
+    // Deploys must authenticate BOTH plain API callers (server.auth) and
+    // Studio requests routed via `x-mastra-client-type: studio` (studio.auth).
+    const provider = fakeProvider();
+    const factory = new MastraFactory({ storage: fakeStorage(), auth: provider });
+    const args = (await factory.prepare()) as { studio?: { auth?: unknown } };
+    expect(args.studio?.auth).toBe(provider);
+
+    const config = prepareMock.mock.calls[0]![0];
+    const serverConfig = (config.buildServerConfig as () => { auth?: unknown })();
+    expect(serverConfig.auth).toBe(provider);
+  });
+
+  it('omits server.auth and studio.auth when auth is explicitly disabled (auth: null)', async () => {
+    const factory = new MastraFactory({ storage: fakeStorage(), auth: null });
+    const args = (await factory.prepare()) as { studio?: unknown };
+    expect(args.studio).toBeUndefined();
+
+    const config = prepareMock.mock.calls[0]![0];
+    const serverConfig = (config.buildServerConfig as () => { auth?: unknown })();
+    expect(serverConfig.auth).toBeUndefined();
+  });
+
   it('registers the per-tenant credential resolver when auth is configured', async () => {
     registerTenantCredentialResolverMock.mockClear();
     await prepareFactory({ storage: fakeStorage(), auth: fakeProvider() });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -651,7 +651,11 @@ export class MastraFactory {
         //   2. primer — hydrates the caller's model-credential snapshot so the
         //               request's first model call resolves tenant credentials.
         //   3. spa    — serves the built UI for everything the server doesn't own.
+        // `auth` also lands on `server.auth` so the core auth middleware (and
+        // Studio's dual-auth routing — see `studio.auth` on the returned args)
+        // authenticates core `/api/*` routes with the same provider.
         return {
+          auth,
           middleware: [
             createFactoryAuthGate(auth),
             createTenantCredentialPrimer({ auth: routeAuth, credentials: modelCredentialsStorage }),
@@ -695,6 +699,10 @@ export class MastraFactory {
 
     return {
       ...prepared.mastraArgs,
+      // Same provider on `studio.auth` as on `server.auth` (buildServerConfig):
+      // deployed factories must authenticate BOTH plain API callers and Studio
+      // requests (`x-mastra-client-type: studio` routes to `studio.auth`).
+      ...(auth ? { studio: { auth } } : {}),
       ...(integrationWorkers.length > 0 ? { workers: integrationWorkers } : {}),
     };
   }

--- a/mastracode/sdk/src/agents/memory.ts
+++ b/mastracode/sdk/src/agents/memory.ts
@@ -11,6 +11,8 @@ import { resolveModel } from './model.js';
 
 let cachedMemory: Memory | null = null;
 let cachedMemoryKey: string | null = null;
+let cachedStorage: MastraCompositeStore | null = null;
+let cachedVector: MastraVector | undefined;
 
 /**
  * Read controller state from requestContext.
@@ -89,7 +91,10 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
     const observerPreviousObservationTokens = 1000;
     const observeAttachments = state?.observeAttachments;
     const cacheKey = `${obsThreshold}:${refThreshold}:${omScope}:${observerPreviousObservationTokens}:${caveman ? 1 : 0}:${observeAttachments}`;
-    if (cachedMemory && cachedMemoryKey === cacheKey) {
+    // The cache key must also pin the storage/vector instances: the module-level
+    // cache outlives a single controller in-process (e.g. sequential e2e runs),
+    // and a Memory bound to a previous run's storage would read the wrong DB.
+    if (cachedMemory && cachedMemoryKey === cacheKey && cachedStorage === storage && cachedVector === vector) {
       return cachedMemory;
     }
 
@@ -135,6 +140,8 @@ export function getDynamicMemory(storage: MastraCompositeStore, vector?: MastraV
       },
     });
     cachedMemoryKey = cacheKey;
+    cachedStorage = storage;
+    cachedVector = vector;
 
     return cachedMemory;
   };


### PR DESCRIPTION
Deployed factories previously relied only on the factory's own auth gate middleware — the core server auth path was never configured, so Studio requests (`x-mastra-client-type: studio`) and plain API callers weren't authenticated through the standard auth middleware.

`MastraFactory.prepare()` now wires the resolved auth provider into both surfaces: `server.auth` via `buildServerConfig` and `studio.auth` on the returned Mastra args. Both are omitted when auth is explicitly disabled (`auth: null`), so local-dev open mode is unchanged.

```ts
const prepared = await factory.prepare();
// prepared now includes:
// server: { auth: <provider>, middleware: [...] }
// studio: { auth: <provider> }
export const mastra = new Mastra(prepared);
```

Cookie sessions still work: `coreAuthMiddleware` passes the full request to `authenticateToken`, and `MastraAuthStudio` reads the sealed session cookie before falling back to Bearer tokens. Added tests for both the enabled and disabled cases (860 factory tests passing).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Deployed factories now use the same authentication setup for both the Studio app and the factory’s API. That way, when Studio signs in, its requests are accepted by the same auth system as the API.

## Summary

- Updates `MastraFactory.prepare()` to pass the resolved auth provider into both `server.auth` and `studio.auth`.
- Ensures Studio requests authenticate the same way as normal API callers (including behavior keyed for Studio requests).
- When auth is explicitly disabled with `auth: null`, both `server.auth` and `studio.auth` remain omitted, preserving local “open” development mode.
- Keeps cookie-based sessions working alongside Bearer tokens.
- Adds tests for both enabled-auth and disabled-auth scenarios.
- Adds a changeset for `@mastra/factory` documenting the deployed-factory authentication behavior update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->