### PR TITLE
fix(server): tolerate unresolved dynamic agent models

### DIFF
--- a/packages/server/src/server/handlers/agents.test.ts
+++ b/packages/server/src/server/handlers/agents.test.ts
@@ -674,6 +674,39 @@ describe('Agent Routes Authorization', () => {
     });
   });
 
+  describe('agent model serialization', () => {
+    it('lists an agent whose dynamic model is not selected without logging a warning', async () => {
+      mockAgent = new Agent({
+        id: 'dynamic-model-agent',
+        name: 'dynamic-model-agent',
+        instructions: 'test-instructions',
+        model: () => {
+          throw new Error('No model selected. Use /models to select a model first.');
+        },
+      });
+
+      mastra = new Mastra({
+        agents: { 'dynamic-model-agent': mockAgent },
+        logger: false,
+      });
+      const warn = vi.fn();
+      vi.spyOn(mastra, 'getLogger').mockReturnValue({ warn, error: vi.fn() } as any);
+
+      const result = await LIST_AGENTS_ROUTE.handler({
+        mastra,
+        requestContext: new RequestContext(),
+      } as any);
+
+      expect(result['dynamic-model-agent']).toMatchObject({
+        id: 'dynamic-model-agent',
+        name: 'dynamic-model-agent',
+      });
+      expect(result['dynamic-model-agent']?.provider).toBeUndefined();
+      expect(result['dynamic-model-agent']?.modelId).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('GENERATE_AGENT_ROUTE', () => {
     it('should return 403 when memory option specifies thread owned by different resource', async () => {
       // Create a thread owned by user-b

--- a/packages/server/src/server/handlers/agents.ts
+++ b/packages/server/src/server/handlers/agents.ts
@@ -685,11 +685,16 @@ async function formatAgentList({
     logger.warn('Error listing tools for agent', { agentName: agent.name, error });
   }
 
+  const hasDynamicModel = typeof agent.model === 'function';
   let llm: Awaited<ReturnType<Agent['getLLM']>> | undefined;
   try {
     llm = await agent.getLLM({ requestContext });
   } catch (error) {
-    logger.warn('Error getting LLM for agent', { agentName: agent.name, error });
+    // Dynamic models can be intentionally unresolved until session context
+    // selects one. Agent listing should omit model metadata without warning.
+    if (!hasDynamicModel) {
+      logger.warn('Error getting LLM for agent', { agentName: agent.name, error });
+    }
   }
 
   let defaultGenerateOptionsLegacy: Awaited<ReturnType<Agent['getDefaultGenerateOptionsLegacy']>> | undefined;
@@ -778,7 +783,9 @@ async function formatAgentList({
   try {
     models = await agent.getModelList(requestContext);
   } catch (error) {
-    logger.warn('Error getting model list for agent', { agentName: agent.name, error });
+    if (!hasDynamicModel) {
+      logger.warn('Error getting model list for agent', { agentName: agent.name, error });
+    }
   }
   const modelList = models?.map(md => ({
     ...md,


### PR DESCRIPTION
## Summary

Allow agent listing before session context selects a dynamic model without emitting misleading server warnings.

## Changes

- omit provider, model ID, and model-list metadata when a dynamic model cannot yet resolve
- suppress expected resolution warnings only for function-backed dynamic models
- preserve warnings for static model failures
- add regression coverage for listing an agent before model selection

## Test plan

- `pnpm exec vitest run src/server/handlers/agents.test.ts --reporter=dot --bail 1`
- `pnpm lint` in `packages/server`
- `pnpm build:server`
