### PR TITLE
fix(factory): default public URL to local UI

### DIFF
--- a/.changeset/bold-papers-flow.md
+++ b/.changeset/bold-papers-flow.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed local Factory authentication by defaulting the public URL to the UI origin at http://localhost:5173.

--- a/.changeset/bold-papers-flow.md
+++ b/.changeset/bold-papers-flow.md
@@ -1,5 +1,0 @@
----
-'@mastra/factory': patch
----
-
-Fixed local Factory authentication by defaulting the public URL to the UI origin at http://localhost:5173.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -317,6 +317,17 @@ describe('MastraFactory.prepare', () => {
     } satisfies AuthInitContext);
   });
 
+  it('defaults publicUrl to the local Factory UI origin', async () => {
+    const auth = fakeProvider();
+    const storage = fakeStorage();
+    await prepareFactory({ auth, storage });
+    expect(auth.init).toHaveBeenCalledExactlyOnceWith({
+      database: storage.authDatabase(),
+      publicUrl: 'http://localhost:5173',
+      allowedOrigins: [],
+    } satisfies AuthInitContext);
+  });
+
   it('surfaces provider init failures at prepare()', async () => {
     const auth = fakeProvider({ init: vi.fn(async () => Promise.reject(new Error('provider misconfigured'))) });
     const factory = new MastraFactory({ storage: fakeStorage(), auth });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -122,7 +122,7 @@ export interface MastraFactoryConfig {
    * Browser-facing origin used to build integration OAuth/install callback
    * URLs and to derive the auth redirect URI. On the platform the SPA is
    * hosted separately, so this MUST be the public API origin.
-   * Default: `http://localhost:4111`.
+   * Default: `http://localhost:5173` (the local Factory UI origin).
    */
   publicUrl?: string;
   /**
@@ -294,7 +294,7 @@ export class MastraFactory {
     if (this.#preparing) throw new Error('MastraFactory.prepare() called twice');
     this.#preparing = true;
 
-    const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:4111').replace(/\/+$/, '');
+    const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:5173').replace(/\/+$/, '');
     const allowedOrigins = (this.#config.allowedOrigins ?? []).map(o => o.replace(/\/+$/, '')).filter(Boolean);
     const storage = this.#config.storage;
     const vector = this.#config.vector;

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -99,11 +99,7 @@ function localSandboxEnv(): Record<string, string> {
   return env;
 }
 
-const PLATFORM_SANDBOX_ENV_KEYS = [
-  'MASTRA_ENVIRONMENT_ID',
-  'MASTRA_PROJECT_ID',
-  'MASTRA_PLATFORM_SECRET_KEY',
-] as const;
+const PLATFORM_SANDBOX_ENV_KEYS = ['MASTRA_ENVIRONMENT_ID', 'MASTRA_PROJECT_ID', 'MASTRA_PLATFORM_SECRET_KEY'] as const;
 const hasPlatformSandboxEnv = PLATFORM_SANDBOX_ENV_KEYS.every(key => Boolean(process.env[key]?.trim()));
 
 // Use PlatformSandbox only when its complete identity is configured. Otherwise


### PR DESCRIPTION
MastraFactory now defaults its public URL to the local Factory UI origin when MASTRACODE_PUBLIC_URL is not set. This keeps local auth redirects and callbacks on the UI port.

Before: `http://localhost:4111`

After: `http://localhost:5173`

Regression coverage verifies the default passed to auth providers. Tests, type checking, and lint pass.