### PR TITLE
feat(factory): add supervisor approval foundations

### DIFF
--- a/.changeset/fast-animals-unite.md
+++ b/.changeset/fast-animals-unite.md
@@ -2,7 +2,6 @@
 '@mastra/core': minor
 '@mastra/client-js': minor
 '@mastra/server': minor
-'@mastra/factory': patch
 ---
 
 Added bounded message attributes to AgentController messages, steering, and queued follow-ups. Server routes replace user attribution with authenticated identity before messages reach the model.

--- a/.changeset/fast-animals-unite.md
+++ b/.changeset/fast-animals-unite.md
@@ -1,0 +1,8 @@
+---
+'@mastra/core': minor
+'@mastra/client-js': minor
+'@mastra/server': minor
+'@mastra/factory': patch
+---
+
+Added bounded message attributes to AgentController messages, steering, and queued follow-ups. Server routes replace user attribution with authenticated identity before messages reach the model.

--- a/.changeset/humble-rivers-wear.md
+++ b/.changeset/humble-rivers-wear.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added durable supervisor approvals for agent stage transitions and default-on observation when work-item agents finish without moving their item. Approvals automatically apply only while the captured item revision is current, and Factory rules can disable idle observation.

--- a/client-sdks/client-js/src/resources/agent-controller.test.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.test.ts
@@ -97,6 +97,23 @@ describe('AgentController Resource', () => {
     expect(JSON.parse(init.body as string)).toEqual({ message: 'see attached', files });
   });
 
+  it('sends attributes for user-authored session messages', async () => {
+    const session = client.getAgentController('code').session('user-1');
+    const attributes = { userId: 'user-1', name: 'Ada Lovelace' };
+
+    mockJson({ ok: true });
+    await session.sendMessage('hello', { attributes });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'hello', attributes });
+
+    mockJson({ ok: true });
+    await session.steer('focus', { attributes });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'focus', attributes });
+
+    mockJson({ ok: true });
+    await session.followUp('later', { attributes });
+    expect(JSON.parse(lastCall()[1].body as string)).toEqual({ message: 'later', attributes });
+  });
+
   it('sends requestContext in the body for run-triggering methods', async () => {
     const session = client.getAgentController('code').session('user-1');
     const requestContext = { userId: 'u-42', tier: 'pro' };

--- a/client-sdks/client-js/src/resources/agent-controller.ts
+++ b/client-sdks/client-js/src/resources/agent-controller.ts
@@ -324,6 +324,11 @@ export interface AgentControllerRequestOptions {
   requestContext?: RequestContext | Record<string, any>;
 }
 
+/** Options for user-authored session messages. */
+export interface AgentControllerMessageOptions extends AgentControllerRequestOptions {
+  attributes?: Record<string, string | number | boolean | null | undefined>;
+}
+
 /** Options for subscribing to an agent controller session's event stream. */
 export interface SubscribeAgentControllerSessionOptions {
   /** Called for each event received over the stream. */
@@ -640,7 +645,7 @@ export class AgentControllerSession extends BaseResource {
    */
   async sendMessage(
     message: string | { content: string; files?: Array<{ data: string; mediaType: string; filename?: string }> },
-    options?: AgentControllerRequestOptions,
+    options?: AgentControllerMessageOptions,
   ): Promise<void> {
     const { content, files } = typeof message === 'string' ? { content: message, files: undefined } : message;
     const requestContext = parseClientRequestContext(options?.requestContext);
@@ -649,6 +654,7 @@ export class AgentControllerSession extends BaseResource {
       body: {
         message: content,
         ...(files?.length ? { files } : {}),
+        ...(options?.attributes ? { attributes: options.attributes } : {}),
         ...(requestContext ? { requestContext } : {}),
       },
     });
@@ -686,11 +692,15 @@ export class AgentControllerSession extends BaseResource {
   }
 
   /** Inject a message into the in-flight run without starting a new turn. */
-  async steer(message: string, options?: AgentControllerRequestOptions): Promise<void> {
+  async steer(message: string, options?: AgentControllerMessageOptions): Promise<void> {
     const requestContext = parseClientRequestContext(options?.requestContext);
     await this.request(this.url(`${this.base()}/steer`), {
       method: 'POST',
-      body: { message, ...(requestContext ? { requestContext } : {}) },
+      body: {
+        message,
+        ...(options?.attributes ? { attributes: options.attributes } : {}),
+        ...(requestContext ? { requestContext } : {}),
+      },
     });
   }
 
@@ -787,11 +797,15 @@ export class AgentControllerSession extends BaseResource {
    * Queue a follow-up message. If the session is idle it sends immediately;
    * if a run is active it queues for after completion.
    */
-  async followUp(message: string, options?: AgentControllerRequestOptions): Promise<void> {
+  async followUp(message: string, options?: AgentControllerMessageOptions): Promise<void> {
     const requestContext = parseClientRequestContext(options?.requestContext);
     await this.request(this.url(`${this.base()}/follow-up`), {
       method: 'POST',
-      body: { message, ...(requestContext ? { requestContext } : {}) },
+      body: {
+        message,
+        ...(options?.attributes ? { attributes: options.attributes } : {}),
+        ...(requestContext ? { requestContext } : {}),
+      },
     });
   }
 

--- a/client-sdks/client-js/src/route-types.generated.ts
+++ b/client-sdks/client-js/src/route-types.generated.ts
@@ -19815,6 +19815,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdMessages_QueryParam
 
 export type PostAgentControllerControllerIdSessionsResourceIdMessages_Body = {
   message: string;
+  attributes?:
+    | {
+        [key: string]: string | number | boolean | null | undefined;
+      }
+    | undefined;
   requestContext?:
     | {
         [key: string]: unknown;
@@ -19868,6 +19873,11 @@ export type PostAgentControllerControllerIdSessionsResourceIdSteer_QueryParams =
 
 export type PostAgentControllerControllerIdSessionsResourceIdSteer_Body = {
   message: string;
+  attributes?:
+    | {
+        [key: string]: string | number | boolean | null | undefined;
+      }
+    | undefined;
   requestContext?:
     | {
         [key: string]: unknown;

--- a/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
+++ b/docs/src/content/en/reference/agent-controller/agent-controller-class.mdx
@@ -688,13 +688,20 @@ const session = await agentController.getSession()
 
 ### Messages
 
-#### `sendMessage({ content, files?, requestContext? })`
+#### `sendMessage({ content, files?, attributes?, requestContext? })`
 
 Send a message to the current agent. Creates a thread if none exists, builds a `RequestContext` and toolsets, and streams the agent's response. Handles tool calls, approvals, and errors automatically. If you provide `requestContext`, the agentController forwards it to tools and subagents during the run.
 
+Use `attributes` for bounded display or prompt context. Signal rendering escapes the values and includes them on the user XML element. For example, the following message reaches the model as `<user name="Ada Lovelace">Explain the authentication flow</user>`:
+
 ```typescript
-await agentController.sendMessage({ content: 'Explain the authentication flow' })
+await agentController.sendMessage({
+  content: 'Explain the authentication flow',
+  attributes: { name: 'Ada Lovelace' },
+})
 ```
+
+Treat attributes as context, not authorization claims. At an HTTP boundary, replace identity attributes with values from the authenticated server session before forwarding the message.
 
 Reading messages is owned by [`session.thread`](/reference/agent-controller/session#thread): use `listActiveMessages()` for the active thread, `listMessages({ threadId })` for a specific thread, and `firstUserMessage({ threadId })` / `firstUserMessages({ threadIds })` for thread previews.
 
@@ -720,20 +727,26 @@ Abort any in-progress generation.
 agentController.abort()
 ```
 
-#### `steer({ content, requestContext? })`
+#### `steer({ content, attributes?, requestContext? })`
 
-Steer the agent mid-stream by injecting an instruction into the current generation.
+Steer the agent mid-stream by injecting an instruction into the current generation. Attributes are preserved on the injected user signal.
 
 ```typescript
-agentController.steer({ content: 'Focus on security implications' })
+agentController.steer({
+  content: 'Focus on security implications',
+  attributes: { name: 'Ada Lovelace' },
+})
 ```
 
-#### `followUp({ content, requestContext? })`
+#### `followUp({ content, attributes?, requestContext? })`
 
-Queue a follow-up message to be sent after the current generation completes. If no operation is running, sends the message immediately.
+Queue a follow-up message to be sent after the current generation completes. If no operation is running, sends the message immediately. Attributes remain attached while a follow-up waits in the queue.
 
 ```typescript
-agentController.followUp({ content: 'Now apply those changes' })
+agentController.followUp({
+  content: 'Now apply those changes',
+  attributes: { name: 'Ada Lovelace' },
+})
 ```
 
 ### Tool approvals

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -39,6 +39,23 @@ Authenticated clients can list and resolve approvals through the tenant-scoped r
 
 Resolver and tenant identity always come from server authentication, not request-body fields.
 
+## Idle worker observation
+
+Factory observes live work-item sessions for runs that finish normally without changing the item's stage or revision and without leaving a transition approval pending. The observer reconciles final persisted tool results before comparing state, records a bounded `factory.run.idle_without_transition` audit event, and provides the lifecycle callback used by the Factory supervisor.
+
+Observation is enabled by default. A Factory can opt out through its rules configuration:
+
+```ts
+const rules = defaultFactoryRules({
+  version: 'factory-rules-v1',
+  overrides: {
+    supervisor: { observeIdleWithoutTransition: false },
+  },
+});
+```
+
+This is an advisory live lifecycle signal, not durable Factory state. Each qualifying `agent_end` triggers it directly; there is no persisted completion cursor or polling deduplication, so a process crash at the completion boundary may lose the notification. Aborted, errored, suspended, transitioned, approval-pending, unbound, and opted-out runs do not emit it.
+
 ## Development (monorepo)
 
 This package lives in the `mastra-ai/mastra` monorepo at `mastracode/factory`.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -4,6 +4,41 @@ The Mastra Software Factory module: the server core behind the Mastra Software F
 
 Like `@mastra/code-sdk`, this package ships an unbundled ESM build that preserves the `src/` module structure, so every module is importable via the `@mastra/factory/*` wildcard export.
 
+## Governed transition approvals
+
+Factory rules can require supervisor approval for an agent-initiated stage transition with `requireSupervisorApproval`:
+
+```ts
+import { defaultFactoryRules, requireSupervisorApproval } from '@mastra/factory';
+
+const rules = defaultFactoryRules({
+  overrides: {
+    work: {
+      execute: {
+        issue: {
+          onEnter: context =>
+            requireSupervisorApproval(context, {
+              reason: 'Approve execution after reviewing the plan.',
+              summary: 'Move this work item to execution',
+            }),
+        },
+      },
+    },
+  },
+});
+```
+
+The helper only creates approvals for transitions whose actor is an agent. Human transitions through the Factory HTTP API bypass the approval helper.
+
+When approval is required, `factory_transition_work_item` returns `status: 'pending_approval'` immediately. It does not suspend the worker or require the worker to retry. The approval captures the item revision, destination stage, and validated rule effects. Approving it atomically moves the item and enqueues those effects only if the captured revision is still current. Rejecting it does not move the item. If the item changed first, resolution marks the approval `stale` without applying the transition.
+
+Authenticated clients can list and resolve approvals through the tenant-scoped routes:
+
+- `GET /web/factory/projects/:factoryProjectId/approvals?status=pending`
+- `POST /web/factory/projects/:factoryProjectId/approvals/:approvalId/resolve` with `{ "decision": "approve" }` or `{ "decision": "reject" }`
+
+Resolver and tenant identity always come from server authentication, not request-body fields.
+
 ## Development (monorepo)
 
 This package lives in the `mastra-ai/mastra` monorepo at `mastracode/factory`.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -53,6 +53,7 @@ import {
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
+import { FactoryRunLifecycleObserver } from './rules/run-lifecycle-observer.js';
 import { createFactoryTransitionTools } from './rules/tools.js';
 import { FactoryTransitionService } from './rules/transition-service.js';
 import type { FactoryRules } from './rules/types.js';
@@ -523,6 +524,15 @@ export class MastraFactory {
           },
         })
       : undefined;
+    const runLifecycleObserver = factoryProcessor
+      ? new FactoryRunLifecycleObserver({
+          storage: workItemsStorage,
+          audit: auditStorage,
+          rules,
+          reconcileBinding: binding => factoryProcessor.reconcileBinding(binding),
+          onError: error => console.warn('[factory] Run lifecycle observer failed:', error),
+        })
+      : undefined;
 
     // Boot assertion: an active integration that signs OAuth `state` needs a
     // replica-stable signer — a per-process random secret silently breaks the
@@ -663,6 +673,7 @@ export class MastraFactory {
           factoryReady,
           rules,
           factoryTransitionService: transitionService,
+          runLifecycleObserver,
           onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
             this.#dispatcher ??= new FactoryDecisionDispatcher({
               controller,

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -1,2 +1,3 @@
 export { MastraFactory } from './factory.js';
 export type { MastraArgs, MastraFactoryConfig } from './factory.js';
+export { defaultFactoryRules, requireSupervisorApproval } from './rules/defaults.js';

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -9,6 +9,7 @@ import type { FactoryIntegration, IntegrationContext } from '../integrations/bas
 import { getGithubFeatureDiagnostics } from '../integrations/github/config.js';
 import { ensureFactoryRuleSession } from '../integrations/github/factory-session.js';
 import type { GithubIntegration } from '../integrations/github/integration.js';
+import { FactoryTransitionApprovalService } from '../rules/approval-service.js';
 import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
 import { FactoryGithubEventService } from '../rules/github-service.js';
 import { FactoryLinearIssueService } from '../rules/linear-service.js';
@@ -337,6 +338,9 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
     ? (deps.factoryTransitionService ??
       new FactoryTransitionService({ rules: deps.rules, storage: deps.domains.workItems }))
     : undefined;
+  const approvalService = deps.factoryReady
+    ? new FactoryTransitionApprovalService({ storage: deps.domains.workItems })
+    : undefined;
   const startCoordinator = transitionService
     ? new FactoryStartCoordinator(
         deps.controller,
@@ -410,6 +414,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           projects: deps.domains.projects,
           workItems: deps.domains.workItems,
           queueHealth: deps.domains.queueHealth,
+          approvalService: approvalService!,
           transitionService,
           startCoordinator,
         }).routes()

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -13,6 +13,7 @@ import { FactoryTransitionApprovalService } from '../rules/approval-service.js';
 import type { FactoryBindingPreparationInput } from '../rules/dispatcher.js';
 import { FactoryGithubEventService } from '../rules/github-service.js';
 import { FactoryLinearIssueService } from '../rules/linear-service.js';
+import type { FactoryRunLifecycleObserver } from '../rules/run-lifecycle-observer.js';
 import { FactoryStartCoordinator } from '../rules/start-coordinator.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
 import type { FactoryRules } from '../rules/types.js';
@@ -78,6 +79,7 @@ export interface FactoryApiRoutesDeps {
   /** Resolved Factory rule set, threaded from the host (no service locator). */
   rules: FactoryRules;
   factoryTransitionService?: FactoryTransitionService;
+  runLifecycleObserver?: Pick<FactoryRunLifecycleObserver, 'observe' | 'subscribeIdle'>;
   onFactoryRuntime?: (runtime: {
     transitionService: FactoryTransitionService;
     prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -348,6 +350,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
         transitionService,
         githubIntegration?.sourceControlStorage,
         deps.domains.memorySettings,
+        deps.runLifecycleObserver,
       )
     : undefined;
   if (transitionService && startCoordinator) {

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
+import { FactoryTransitionApprovalService } from '../rules/approval-service.js';
 import { builtInFactoryRules } from '../rules/defaults.js';
 import { FactoryTransitionService } from '../rules/transition-service.js';
 import type { AuditEmitter } from '../storage/domains/audit/domain.js';
@@ -59,6 +60,7 @@ function buildApp(
       projects: seed.projects,
       workItems: seed.workItems,
       queueHealth: seed.queueHealth,
+      approvalService: new FactoryTransitionApprovalService({ storage: seed.workItems }),
       transitionService: new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems }),
       startCoordinator,
     }).routes(),
@@ -101,11 +103,57 @@ const createBody = (overrides: Record<string, unknown> = {}) => ({
 });
 
 let seed: FactoryStorageTestSeed;
+let approvalSequence = 0;
+
+async function createPendingApprovalForRoutes() {
+  approvalSequence += 1;
+  const item = (
+    await seed.workItems.upsert({
+      orgId: 'org1',
+      userId: 'u1',
+      factoryProjectId: PROJECT_ID,
+      input: createBody({
+        externalSource: { ...createBody().externalSource, externalId: `approval-${approvalSequence}` },
+      }),
+    })
+  ).item;
+  const committed = await seed.workItems.commitTransition({
+    orgId: 'org1',
+    factoryProjectId: PROJECT_ID,
+    workItemId: item.id,
+    expectedRevision: item.revision,
+    destinationStage: 'execute',
+    actorId: 'agent:binding-1',
+    ingress: {
+      identity: `tool:call-${approvalSequence}`,
+      triggerType: 'agent',
+      transitionId: `transition-${approvalSequence}`,
+    },
+    ruleSetVersion: 'rules-v1',
+    causalChain: [],
+    evaluation: {
+      outcome: 'pending_approval',
+      approval: {
+        idempotencyKey: `tool:call-${approvalSequence}:approval`,
+        board: 'work',
+        actor: { type: 'agent', bindingId: 'binding-1', role: 'work' },
+        ingress: { type: 'agent', identity: `tool:call-${approvalSequence}` },
+        cause: 'agent_tool',
+        reason: 'Supervisor approval required.',
+        summary: 'Move Fix the login flow to execute',
+        decisions: [],
+      },
+    },
+  });
+  if (committed.status !== 'committed') throw new Error('Expected approval commit.');
+  return { item, approvalId: (committed.result as { approvalId: string }).approvalId };
+}
 
 beforeEach(async () => {
   seed = await createFactoryStorageForTests();
   auditRecorded = [];
   auditFailure = undefined;
+  approvalSequence = 0;
   await seedProject();
 });
 
@@ -144,6 +192,93 @@ describe('auth and scoping', () => {
     const body = await res.json();
     expect(body.workItems).toHaveLength(1);
     expect(body.workItems[0].createdBy).toBe('u1');
+  });
+});
+
+describe('Factory transition approval routes', () => {
+  it('lists pending approvals with bounded metadata and resolves with the authenticated user', async () => {
+    const { item, approvalId } = await createPendingApprovalForRoutes();
+
+    const listed = await json('GET', `/web/factory/projects/${PROJECT_ID}/approvals?status=pending`);
+    expect(listed.status).toBe(200);
+    await expect(listed.json()).resolves.toEqual({
+      approvals: [
+        expect.objectContaining({
+          id: approvalId,
+          workItemId: item.id,
+          stage: 'execute',
+          expectedRevision: item.revision,
+          requestingRole: 'work',
+          status: 'pending',
+        }),
+      ],
+    });
+
+    const resolved = await json('POST', `/web/factory/projects/${PROJECT_ID}/approvals/${approvalId}/resolve`, {
+      decision: 'approve',
+    });
+    expect(resolved.status).toBe(200);
+    await expect(resolved.json()).resolves.toEqual({
+      result: expect.objectContaining({
+        status: 'approved',
+        replayed: false,
+        approval: expect.objectContaining({ id: approvalId, resolvedBy: 'u1', status: 'approved' }),
+        item: expect.objectContaining({ id: item.id, stages: ['execute'], revision: item.revision + 1 }),
+      }),
+    });
+    expect((await seed.audit.list({ orgId: 'org1', factoryProjectId: PROJECT_ID })).events[0]).toMatchObject({
+      action: 'factory.approval.approved',
+      actorId: 'u1',
+      actorType: 'human',
+    });
+  });
+
+  it('returns rejected and stale terminal outcomes without moving the item', async () => {
+    const rejected = await createPendingApprovalForRoutes();
+    const rejectedResponse = await json(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/approvals/${rejected.approvalId}/resolve`,
+      { decision: 'reject' },
+    );
+    expect(rejectedResponse.status).toBe(200);
+    expect((await rejectedResponse.json()).result.status).toBe('rejected');
+    expect((await seed.workItems.get({ orgId: 'org1', id: rejected.item.id }))?.stages).toEqual(['intake']);
+
+    const stale = await createPendingApprovalForRoutes();
+    await seed.workItems.update({ orgId: 'org1', id: stale.item.id, userId: 'u1', patch: { title: 'Changed' } });
+    const staleResponse = await json(
+      'POST',
+      `/web/factory/projects/${PROJECT_ID}/approvals/${stale.approvalId}/resolve`,
+      { decision: 'approve' },
+    );
+    expect(staleResponse.status).toBe(200);
+    expect((await staleResponse.json()).result.status).toBe('stale');
+    expect((await seed.workItems.get({ orgId: 'org1', id: stale.item.id }))?.stages).toEqual(['intake']);
+  });
+
+  it('rejects malformed requests and hides approvals across tenant boundaries', async () => {
+    const { approvalId } = await createPendingApprovalForRoutes();
+    expect((await json('GET', `/web/factory/projects/${PROJECT_ID}/approvals?status=unknown`)).status).toBe(400);
+    expect(
+      (
+        await json('POST', `/web/factory/projects/${PROJECT_ID}/approvals/${approvalId}/resolve`, {
+          decision: 'approve',
+          userId: 'spoofed',
+        })
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await buildApp({ workosId: 'other', organizationId: 'other-org' }).request(
+          `/web/factory/projects/${PROJECT_ID}/approvals/${approvalId}/resolve`,
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ decision: 'approve' }),
+          },
+        )
+      ).status,
+    ).toBe(404);
   });
 });
 
@@ -334,14 +469,6 @@ describe('POST /web/factory/projects/:id/work-items/:workItemId/transition', () 
         metadata: expect.objectContaining({ ingressType: 'human', ruleSetVersion: 'factory-default-v1' }),
       }),
     );
-  });
-
-  it('accepts a human cancel over HTTP', async () => {
-    const item = await createItem();
-    const res = await transition(item, { stage: 'canceled' });
-    expect(res.status).toBe(200);
-    expect((await res.json()).result).toMatchObject({ status: 'accepted', stage: 'canceled' });
-    expect((await listItems())[0]?.stages).toEqual(['canceled']);
   });
 
   it('returns typed stale without overwriting the winner', async () => {
@@ -675,54 +802,6 @@ describe('GET /web/factory/projects/:id/metrics', () => {
     expect(metrics.cycleTime).toEqual({ medianMs: null, p90Ms: null, samples: 0 });
     expect(metrics.wip).toEqual([]);
     expect(metrics.agingWip).toEqual([]);
-    expect(metrics.stageAutomation).toEqual([]);
-  });
-
-  it('serves per-stage automation: automated triage pass vs human-approved planning', async () => {
-    // Human files the card, the rules engine runs triage (intake → triage →
-    // planning) through the governed path, then a human approves planning into done.
-    const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
-    const { workItem } = await created.json();
-    const service = new FactoryTransitionService({ rules: builtInFactoryRules(), storage: seed.workItems });
-    const autoMove = (stage: 'triage' | 'planning', expectedRevision: number, identity: string) =>
-      service.transition({
-        orgId: 'org1',
-        factoryProjectId: PROJECT_ID,
-        workItemId: workItem.id,
-        board: 'work',
-        stage,
-        expectedRevision,
-        actor: { type: 'system', id: 'factory-rule-dispatcher' },
-        ingress: { type: 'rule', identity },
-        cause: 'auto_triage',
-      });
-    const triaged = await autoMove('triage', workItem.revision, 'auto-1');
-    expect(triaged.status).toBe('accepted');
-    const planned = await autoMove('planning', (triaged as { revision: number }).revision, 'auto-2');
-    expect(planned.status).toBe('accepted');
-    const approved = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items/${workItem.id}/transition`, {
-      board: 'work',
-      stage: 'done',
-      expectedRevision: (planned as { revision: number }).revision,
-      requestId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaa7',
-      cause: 'board_drag',
-    });
-    expect(approved.status).toBe(200);
-
-    const res = await json('GET', `/web/factory/projects/${PROJECT_ID}/metrics?days=7`);
-    expect(res.status).toBe(200);
-    const { metrics } = await res.json();
-
-    expect(metrics.stageAutomation).toEqual([
-      // Human-entered (creation), automation-exited → not automated.
-      { stage: 'intake', exits: 1, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
-      // Automation-entered and -exited, first visit → clean automated pass, item is done.
-      { stage: 'triage', exits: 1, automated: 1, outcomes: { done: 1, canceled: 0, reworked: 0, inFlight: 0 } },
-      // Automation-entered, human-exited → not automated.
-      { stage: 'planning', exits: 1, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
-    ]);
-    // Global split matches: 4 entered stages, 2 by automation.
-    expect(metrics.transitions).toEqual({ human: 2, total: 4 });
   });
 });
 

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -11,6 +11,7 @@ import type { ApiRoute } from '@mastra/core/server';
 import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
+import type { FactoryTransitionApprovalService } from '../rules/approval-service';
 import type {
   FactoryStartCoordinator,
   FactoryStartPreparedResult,
@@ -27,6 +28,8 @@ import { thresholdsOrDefault } from '../storage/domains/queue-health/base.js';
 import type {
   CreateWorkItemInput,
   ExternalWorkItemSource,
+  FactoryApprovalRecord,
+  FactoryApprovalStatus,
   FactoryDeferredDecisionRecord,
   FactoryDispatchStatus,
   UpdateWorkItemInput,
@@ -51,6 +54,7 @@ export interface WorkItemRoutesDeps extends RouteDependencies {
   queueHealth: QueueHealthStorage;
   /** Governed stage-transition service. Stage moves 503 when absent. */
   transitionService?: Pick<FactoryTransitionService, 'transition' | 'ruleSetVersion'>;
+  approvalService: Pick<FactoryTransitionApprovalService, 'list' | 'resolve'>;
   /** Coordinator that binds a Factory run before dispatching its kickoff. */
   startCoordinator?: Pick<FactoryStartCoordinator, 'prepare'>;
 }
@@ -356,6 +360,43 @@ function decisionSummary(decision: FactoryDeferredDecisionRecord) {
   };
 }
 
+const APPROVAL_STATUSES = new Set<FactoryApprovalStatus>(['pending', 'approved', 'rejected', 'stale']);
+
+function parseApprovalStatuses(raw: string | undefined): FactoryApprovalStatus[] | null {
+  if (!raw) return ['pending'];
+  const statuses = [...new Set(raw.split(',').map(status => status.trim()))];
+  if (statuses.length === 0 || statuses.some(status => !APPROVAL_STATUSES.has(status as FactoryApprovalStatus))) {
+    return null;
+  }
+  return statuses as FactoryApprovalStatus[];
+}
+
+function parseApprovalResolution(body: unknown): { decision: 'approve' | 'reject' } | null {
+  if (!isRecord(body) || Object.keys(body).some(key => key !== 'decision')) return null;
+  return body.decision === 'approve' || body.decision === 'reject' ? { decision: body.decision } : null;
+}
+
+function approvalSummary(approval: FactoryApprovalRecord) {
+  return {
+    id: approval.id,
+    workItemId: approval.workItemId,
+    transitionId: approval.transitionId,
+    board: approval.requestedBoard,
+    stage: approval.requestedStage,
+    expectedRevision: approval.expectedRevision,
+    requestingRole:
+      typeof approval.requestingActor.role === 'string' ? approval.requestingActor.role.slice(0, 64) : null,
+    reason: approval.reason,
+    summary: approval.summary,
+    status: approval.status,
+    resolvedBy: approval.resolvedBy,
+    resolutionReason: approval.resolutionReason,
+    resolvedAt: approval.resolvedAt?.toISOString() ?? null,
+    createdAt: approval.createdAt.toISOString(),
+    updatedAt: approval.updatedAt.toISOString(),
+  };
+}
+
 export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
   /** Resolve the `(orgId, userId)` tenant or a ready-to-return error response. */
   async #resolveTenant(c: Context): Promise<{ orgId: string; userId: string } | { response: Response }> {
@@ -464,7 +505,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
 
   /** Build the Factory work-item routes as Mastra `apiRoutes`. */
   routes(): ApiRoute[] {
-    const { audit, workItems, queueHealth, transitionService, startCoordinator } = this.deps;
+    const { audit, workItems, queueHealth, transitionService, approvalService, startCoordinator } = this.deps;
     return [
       // ── List the org's work items for a project ─────────────────────────────
       registerApiRoute('/web/factory/projects/:id/work-items', {
@@ -479,6 +520,57 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
             factoryProjectId: resolved.factoryProjectId,
           });
           return c.json({ workItems: items });
+        },
+      }),
+
+      registerApiRoute('/web/factory/projects/:id/approvals', {
+        method: 'GET',
+        requiresAuth: false,
+        handler: async c => {
+          const context = loose(c);
+          const resolved = await this.#resolveProject(context);
+          if ('response' in resolved) return resolved.response;
+          const statuses = parseApprovalStatuses(context.req.query('status'));
+          if (!statuses) return c.json({ error: 'invalid_approval_status' }, 400);
+          await workItems.ensureReady();
+          const approvals = await approvalService.list({
+            orgId: resolved.orgId,
+            factoryProjectId: resolved.factoryProjectId,
+            statuses,
+          });
+          return c.json({ approvals: approvals.map(approvalSummary) });
+        },
+      }),
+
+      registerApiRoute('/web/factory/projects/:id/approvals/:approvalId/resolve', {
+        method: 'POST',
+        requiresAuth: false,
+        handler: async c => {
+          const context = loose(c);
+          const resolved = await this.#resolveProject(context);
+          if ('response' in resolved) return resolved.response;
+          const approvalId = context.req.param('approvalId');
+          if (!approvalId || !UUID_RE.test(approvalId)) return c.json({ error: 'Approval not found' }, 404);
+          const body = parseApprovalResolution(await readJson(context));
+          if (!body) return c.json({ error: 'invalid_approval_resolution' }, 400);
+          await workItems.ensureReady();
+          const result = await approvalService.resolve({
+            orgId: resolved.orgId,
+            factoryProjectId: resolved.factoryProjectId,
+            approvalId,
+            decision: body.decision,
+            resolvedBy: resolved.userId,
+            resolverType: 'human',
+          });
+          if (result.status === 'missing') return c.json({ error: 'Approval not found' }, 404);
+          return c.json({
+            result: {
+              status: result.status,
+              replayed: result.replayed,
+              approval: approvalSummary(result.approval),
+              item: result.item,
+            },
+          });
         },
       }),
 
@@ -682,7 +774,9 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
               action:
                 result.status === 'accepted'
                   ? 'factory.work_item.stage_moved'
-                  : 'factory.work_item.transition_rejected',
+                  : result.status === 'pending_approval'
+                    ? 'factory.work_item.transition_approval_requested'
+                    : 'factory.work_item.transition_rejected',
               factoryProjectId: resolved.factoryProjectId,
               targets: [{ type: 'work_item', id: workItemId }],
               metadata: {
@@ -691,11 +785,14 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
                 ruleSetVersion: transitionService.ruleSetVersion,
                 ...(result.status === 'accepted'
                   ? { to: result.stage, revision: result.revision }
-                  : { code: result.code, reason: result.reason }),
+                  : result.status === 'pending_approval'
+                    ? { approvalId: result.approvalId, to: result.stage, revision: result.revision }
+                    : { code: result.code, reason: result.reason }),
               },
             },
           });
           if (result.status === 'accepted') return c.json({ result });
+          if (result.status === 'pending_approval') return c.json({ result }, 202);
           return c.json({ result }, result.code === 'stale' ? 409 : 422);
         },
       }),

--- a/mastracode/factory/src/rules/approval-service.test.ts
+++ b/mastracode/factory/src/rules/approval-service.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { FactoryTransitionApprovalService } from './approval-service.js';
+import { defaultFactoryRules, requireSupervisorApproval } from './defaults.js';
+import { FactoryTransitionService } from './transition-service.js';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+
+async function createPendingApproval(storage: WorkItemsStorage) {
+  const item = (
+    await storage.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: PROJECT_ID,
+      input: {
+        externalSource: { integrationId: 'github', type: 'issue', externalId: '1' },
+        title: 'Fix the bug',
+        stages: ['intake'],
+        sessions: {},
+        metadata: {},
+      },
+    })
+  ).item;
+  const rules = defaultFactoryRules({
+    version: 'rules-v1',
+    overrides: {
+      work: {
+        intake: {
+          issue: {
+            onExit: context =>
+              requireSupervisorApproval(context, {
+                reason: 'Supervisor approval required.',
+                summary: 'Move Fix the bug to execute',
+              }),
+          },
+        },
+        execute: {
+          issue: {
+            onEnter: () => ({ type: 'notify', idempotencyKey: 'approved-effect', title: 'Execution approved' }),
+          },
+        },
+      },
+    },
+  });
+  const result = await new FactoryTransitionService({ rules, storage }).transition({
+    orgId: 'org-1',
+    factoryProjectId: PROJECT_ID,
+    workItemId: item.id,
+    board: 'work',
+    stage: 'execute',
+    expectedRevision: item.revision,
+    actor: { type: 'agent', bindingId: 'binding-1', role: 'work' },
+    ingress: { type: 'agent', identity: 'tool:call-1' },
+    cause: 'agent_tool',
+  });
+  if (result.status !== 'pending_approval') throw new Error('Expected pending approval.');
+  return { item, approvalId: result.approvalId };
+}
+
+describe('FactoryTransitionApprovalService', () => {
+  it('atomically approves the captured revision, effects, notifications, and audit once', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item, approvalId } = await createPendingApproval(seed.workItems);
+    const service = new FactoryTransitionApprovalService({ storage: seed.workItems });
+    const now = new Date('2030-01-01T00:00:00.000Z');
+
+    const [first, second] = await Promise.all([
+      service.resolve({
+        orgId: 'org-1',
+        factoryProjectId: PROJECT_ID,
+        approvalId,
+        decision: 'approve',
+        resolvedBy: 'supervisor-1',
+        resolverType: 'agent',
+        now,
+      }),
+      service.resolve({
+        orgId: 'org-1',
+        factoryProjectId: PROJECT_ID,
+        approvalId,
+        decision: 'approve',
+        resolvedBy: 'supervisor-1',
+        resolverType: 'agent',
+        now,
+      }),
+    ]);
+
+    expect([first, second].map(result => result.status)).toEqual(['approved', 'approved']);
+    expect([first, second].filter(result => result.status !== 'missing' && result.replayed)).toHaveLength(1);
+    expect((await seed.workItems.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['execute']);
+    expect((await seed.workItems.get({ orgId: 'org-1', id: item.id }))?.revision).toBe(item.revision + 1);
+    const deferred = await seed.workItems.listDeferredDecisions('org-1', PROJECT_ID);
+    expect(deferred.map(record => record.idempotencyKey)).toEqual([
+      'approved-effect',
+      `${approvalId}:stage-changed`,
+      `${approvalId}:resolution:approved`,
+    ]);
+    expect(deferred.every(record => record.causalChain.at(-1)?.decisionType === 'requestApproval')).toBe(true);
+    expect(deferred.every(record => record.causalChain.at(-1)?.ingressId === approvalId)).toBe(true);
+    expect(
+      (await seed.audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).events.map(event => event.action),
+    ).toEqual(['factory.approval.approved', 'factory.approval.requested']);
+  });
+
+  it('rejects without moving the item and persists one worker notification', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item, approvalId } = await createPendingApproval(seed.workItems);
+    const service = new FactoryTransitionApprovalService({ storage: seed.workItems });
+
+    const result = await service.resolve({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      approvalId,
+      decision: 'reject',
+      resolvedBy: 'supervisor-1',
+      resolverType: 'agent',
+      resolutionReason: 'Needs more evidence.',
+    });
+
+    expect(result).toMatchObject({ status: 'rejected', replayed: false });
+    expect((await seed.workItems.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+    expect(
+      (await seed.workItems.listDeferredDecisions('org-1', PROJECT_ID)).map(record => record.idempotencyKey),
+    ).toEqual([`${approvalId}:resolution:rejected`]);
+  });
+
+  it('marks an approval stale without moving or dispatching captured effects when the revision changes', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item, approvalId } = await createPendingApproval(seed.workItems);
+    await seed.workItems.update({ orgId: 'org-1', id: item.id, userId: 'user-2', patch: { title: 'Updated title' } });
+    const service = new FactoryTransitionApprovalService({ storage: seed.workItems });
+
+    const result = await service.resolve({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      approvalId,
+      decision: 'approve',
+      resolvedBy: 'supervisor-1',
+      resolverType: 'agent',
+    });
+
+    expect(result).toMatchObject({ status: 'stale', replayed: false });
+    expect((await seed.workItems.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+    expect(
+      (await seed.workItems.listDeferredDecisions('org-1', PROJECT_ID)).map(record => record.idempotencyKey),
+    ).toEqual([`${approvalId}:resolution:stale`]);
+  });
+
+  it('marks an approval stale when the captured item was deleted', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { item, approvalId } = await createPendingApproval(seed.workItems);
+    await seed.workItems.delete({ orgId: 'org-1', id: item.id });
+
+    const result = await new FactoryTransitionApprovalService({ storage: seed.workItems }).resolve({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      approvalId,
+      decision: 'approve',
+      resolvedBy: 'supervisor-1',
+      resolverType: 'agent',
+    });
+
+    expect(result).toMatchObject({ status: 'stale', replayed: false, item: null });
+  });
+
+  it('does not expose or resolve approvals across tenants or projects', async () => {
+    const seed = await createFactoryStorageForTests();
+    const { approvalId } = await createPendingApproval(seed.workItems);
+    const service = new FactoryTransitionApprovalService({ storage: seed.workItems });
+
+    await expect(
+      service.resolve({
+        orgId: 'other-org',
+        factoryProjectId: PROJECT_ID,
+        approvalId,
+        decision: 'approve',
+        resolvedBy: 'supervisor-1',
+        resolverType: 'agent',
+      }),
+    ).resolves.toEqual({ status: 'missing' });
+    await expect(service.get({ orgId: 'org-1', factoryProjectId: 'other-project', approvalId })).resolves.toBeNull();
+  });
+});

--- a/mastracode/factory/src/rules/approval-service.ts
+++ b/mastracode/factory/src/rules/approval-service.ts
@@ -1,0 +1,82 @@
+import type {
+  FactoryApprovalRecord,
+  FactoryApprovalStatus,
+  ResolveFactoryApprovalResult,
+  WorkItemRow,
+  WorkItemsStorage,
+} from '../storage/domains/work-items/base.js';
+
+export interface FactoryTransitionApprovalServiceOptions {
+  storage: WorkItemsStorage;
+}
+
+export interface ResolveFactoryTransitionApprovalInput {
+  orgId: string;
+  factoryProjectId: string;
+  approvalId: string;
+  decision: 'approve' | 'reject';
+  resolvedBy: string;
+  resolverType: 'human' | 'agent';
+  resolutionReason?: string;
+  now?: Date;
+}
+
+export type FactoryTransitionApprovalResolution =
+  | { status: 'missing' }
+  | {
+      status: Exclude<FactoryApprovalStatus, 'pending'>;
+      replayed: boolean;
+      approval: FactoryApprovalRecord;
+      item: WorkItemRow | null;
+    };
+
+function resolution(result: ResolveFactoryApprovalResult): FactoryTransitionApprovalResolution {
+  if (result.status === 'missing') return result;
+  if (result.approval.status === 'pending')
+    throw new Error('Factory approval resolution did not reach a terminal state.');
+  return {
+    status: result.approval.status,
+    replayed: result.status === 'replayed',
+    approval: result.approval,
+    item: result.item,
+  };
+}
+
+export class FactoryTransitionApprovalService {
+  readonly #storage: WorkItemsStorage;
+
+  constructor(options: FactoryTransitionApprovalServiceOptions) {
+    this.#storage = options.storage;
+  }
+
+  async list(input: {
+    orgId: string;
+    factoryProjectId: string;
+    statuses?: FactoryApprovalStatus[];
+  }): Promise<FactoryApprovalRecord[]> {
+    return this.#storage.listApprovals(input.orgId, input.factoryProjectId, input.statuses);
+  }
+
+  async get(input: {
+    orgId: string;
+    factoryProjectId: string;
+    approvalId: string;
+  }): Promise<FactoryApprovalRecord | null> {
+    return this.#storage.getApproval(input);
+  }
+
+  async resolve(input: ResolveFactoryTransitionApprovalInput): Promise<FactoryTransitionApprovalResolution> {
+    return resolution(
+      await this.#storage.resolveApproval({
+        orgId: input.orgId,
+        factoryProjectId: input.factoryProjectId,
+        approvalId: input.approvalId,
+        decision: input.decision,
+        resolvedBy: input.resolvedBy,
+        resolverType: input.resolverType,
+        ...(input.resolutionReason ? { resolutionReason: input.resolutionReason } : {}),
+        now: input.now ?? new Date(),
+      }),
+    );
+  }
+}

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -310,6 +310,10 @@ export function mergeFactoryRuleOverrides(
     tools: mergeToolRules(base.tools, overrides.tools),
     github: mergeGithubRules(base.github, overrides.github),
     linear: mergeLinearRules(base.linear, overrides.linear),
+    supervisor: {
+      observeIdleWithoutTransition:
+        overrides.supervisor?.observeIdleWithoutTransition ?? base.supervisor?.observeIdleWithoutTransition ?? true,
+    },
   };
 }
 

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -19,6 +19,19 @@ import { assertFactoryRules, FactoryRuleValidationError } from './validation.js'
 
 export const DEFAULT_FACTORY_RULE_VERSION = 'factory-default-v1';
 
+export function requireSupervisorApproval(
+  context: Pick<FactoryStageRuleContext, 'actor' | 'ingress'>,
+  options: { reason: string; summary?: string; idempotencyKey?: string },
+) {
+  if (context.actor.type !== 'agent') return;
+  return {
+    type: 'requestApproval',
+    idempotencyKey: options.idempotencyKey ?? `${context.ingress.id}:supervisor-approval`,
+    reason: options.reason,
+    ...(options.summary ? { summary: options.summary } : {}),
+  } as const;
+}
+
 function trustedGithubActor(context: Pick<FactoryStageRuleContext, 'actor'>): boolean {
   return context.actor.type === 'github' && context.actor.trusted;
 }

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { defaultFactoryRules } from './defaults.js';
+import { FactoryTransitionApprovalService } from './approval-service.js';
+import { defaultFactoryRules, requireSupervisorApproval } from './defaults.js';
 import { FactoryDecisionDispatcher } from './dispatcher.js';
 import { FactoryStartCoordinator } from './start-coordinator.js';
 import { FactoryTransitionService } from './transition-service.js';
@@ -288,6 +289,100 @@ describe('FactoryDecisionDispatcher', () => {
     expect(requestContext?.get('user')).toEqual({ workosId: 'user-1', organizationId: 'org-1' });
     expect(consumeStream).toHaveBeenCalledOnce();
   });
+
+  it.each(['approved', 'rejected', 'stale'] as const)(
+    'delivers durable %s approval notifications exactly once after resolution',
+    async terminalStatus => {
+      const storage = (await createFactoryStorageForTests()).workItems;
+      const prepared = await storage.prepareRunStart({
+        orgId: 'org-1',
+        userId: 'user-1',
+        factoryProjectId: PROJECT_ID,
+        workItem: {
+          input: {
+            externalSource: { integrationId: 'github', type: 'issue', externalId: `approval-${terminalStatus}` },
+            title: 'Approval item',
+            stages: ['intake'],
+            sessions: {},
+            metadata: {},
+          },
+        },
+        role: 'work',
+        session: { sessionId: 'session-1', branch: 'factory/approval', threadId: 'thread-1' },
+        resourceId: PROJECT_ID,
+        kickoffKey: `kickoff-${terminalStatus}`,
+        kickoffMessage: null,
+      });
+      const rules = defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: {
+            execute: {
+              issue: {
+                onEnter: context => requireSupervisorApproval(context, { reason: 'Supervisor approval required.' }),
+              },
+            },
+          },
+        },
+      });
+      const transitionService = new FactoryTransitionService({ storage, rules });
+      const pending = await transitionService.transition({
+        orgId: 'org-1',
+        factoryProjectId: PROJECT_ID,
+        workItemId: prepared.item.id,
+        board: 'work',
+        stage: 'execute',
+        expectedRevision: prepared.item.revision,
+        actor: { type: 'agent', bindingId: prepared.binding.id, role: 'work' },
+        ingress: { type: 'agent', identity: `tool:${terminalStatus}` },
+        cause: 'test',
+      });
+      if (pending.status !== 'pending_approval') throw new Error('Expected pending approval.');
+      if (terminalStatus === 'stale') {
+        await storage.update({
+          orgId: 'org-1',
+          id: prepared.item.id,
+          userId: 'user-2',
+          patch: { title: 'Changed before resolution' },
+        });
+      }
+      const resolution = await new FactoryTransitionApprovalService({ storage }).resolve({
+        orgId: 'org-1',
+        factoryProjectId: PROJECT_ID,
+        approvalId: pending.approvalId,
+        decision: terminalStatus === 'rejected' ? 'reject' : 'approve',
+        resolvedBy: 'supervisor-1',
+        resolverType: 'agent',
+      });
+      expect(resolution.status).toBe(terminalStatus);
+
+      const { controller, delivered } = createSession();
+      const firstDispatcher = new FactoryDecisionDispatcher({
+        controller: controller as never,
+        transitionService,
+        storage,
+        ownerId: 'before-restart',
+      });
+      await firstDispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
+      const secondDispatcher = new FactoryDecisionDispatcher({
+        controller: controller as never,
+        transitionService,
+        storage,
+        ownerId: 'after-restart',
+      });
+      await secondDispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
+      await secondDispatcher.runOnce(new Date('2030-01-01T00:02:00Z'));
+
+      expect(delivered).toEqual(
+        terminalStatus === 'approved'
+          ? [`${pending.approvalId}:stage-changed`, `${pending.approvalId}:resolution:approved`]
+          : [`${pending.approvalId}:resolution:${terminalStatus}`],
+      );
+      expect(
+        (await storage.listDeferredDecisions('org-1', PROJECT_ID)).every(record => record.status === 'succeeded'),
+      ).toBe(true);
+    },
+  );
 
   it('renews the lease while an external delivery remains in flight', async () => {
     vi.useFakeTimers();

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -194,7 +194,9 @@ export class FactoryDecisionDispatcher {
   async #dispatchDecision(record: FactoryDeferredDecisionRecord, now: Date): Promise<void> {
     try {
       const decision = validateFactoryRuleDecision(record.decision, record.causalChain.length);
-      if (decision.type === 'reject') throw new Error('Deferred Factory decisions cannot reject.');
+      if (decision.type === 'reject' || decision.type === 'requestApproval') {
+        throw new Error('Deferred Factory decisions must contain an executable effect.');
+      }
       await this.#withLease(
         async leaseExpiresAt =>
           this.#storage.renewDeferredDecisionLease(leaseIdentity(record, this.#ownerId), leaseExpiresAt),

--- a/mastracode/factory/src/rules/index.ts
+++ b/mastracode/factory/src/rules/index.ts
@@ -56,6 +56,7 @@ export type {
   FactoryRuleStage,
   FactorySendMessageDecision,
   FactoryStageRuleContext,
+  FactorySupervisorRules,
   FactoryToolResultRuleContext,
   FactoryToolRuleLeaf,
   FactoryTransitionDecision,

--- a/mastracode/factory/src/rules/index.ts
+++ b/mastracode/factory/src/rules/index.ts
@@ -1,4 +1,15 @@
-export { builtInFactoryRules, defaultFactoryRules, DEFAULT_FACTORY_RULE_VERSION } from './defaults.js';
+export { FactoryTransitionApprovalService } from './approval-service.js';
+export type {
+  FactoryTransitionApprovalResolution,
+  FactoryTransitionApprovalServiceOptions,
+  ResolveFactoryTransitionApprovalInput,
+} from './approval-service.js';
+export {
+  builtInFactoryRules,
+  defaultFactoryRules,
+  DEFAULT_FACTORY_RULE_VERSION,
+  requireSupervisorApproval,
+} from './defaults.js';
 export {
   resolveFactoryGithubRule,
   resolveFactoryLinearRule,
@@ -38,6 +49,7 @@ export type {
   FactoryRuleJsonValue,
   FactoryRuleRejectionCode,
   FactoryRuleRejectDecision,
+  FactoryRequestApprovalDecision,
   FactoryRuleSource,
   FactoryRules,
   FactoryRulesOverrides,
@@ -49,6 +61,7 @@ export type {
   FactoryTransitionDecision,
   FactoryTransitionResult,
   FactoryTransitionResultAccepted,
+  FactoryTransitionResultPendingApproval,
   FactoryTransitionResultRejected,
   FactoryUpsertLinkedWorkItemDecision,
 } from './types.js';

--- a/mastracode/factory/src/rules/run-lifecycle-observer.test.ts
+++ b/mastracode/factory/src/rules/run-lifecycle-observer.test.ts
@@ -1,0 +1,218 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FactoryRunBindingRecord, WorkItemsStorage } from '../storage/domains/work-items/base';
+import { defaultFactoryRules } from './defaults';
+import { FactoryRunLifecycleObserver } from './run-lifecycle-observer';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const address = {
+  orgId: 'org-1',
+  factoryProjectId: PROJECT_ID,
+  threadId: 'thread-1',
+  resourceId: 'resource-1',
+  sessionId: 'session-1',
+};
+const binding: FactoryRunBindingRecord = {
+  id: 'binding-1',
+  orgId: address.orgId,
+  factoryProjectId: address.factoryProjectId,
+  workItemId: 'item-1',
+  role: 'work',
+  threadId: address.threadId,
+  resourceId: address.resourceId,
+  sessionId: address.sessionId,
+  branch: 'factory/issue-1',
+  status: 'active',
+  createdAt: new Date('2026-07-22T15:00:00Z'),
+  revokedAt: null,
+};
+
+function makeSession() {
+  const listeners = new Set<(event: AgentControllerEvent) => void>();
+  return {
+    session: {
+      subscribe: vi.fn((listener: (event: AgentControllerEvent) => void) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      }),
+    },
+    emit(event: AgentControllerEvent) {
+      for (const listener of listeners) listener(event);
+    },
+  };
+}
+
+function makeObserver(
+  options: {
+    enabled?: boolean;
+    itemAfterReconcile?: { stages: string[]; revision: number } | null;
+    approvals?: Array<{ workItemId: string }>;
+    bindingAfterReconcile?: FactoryRunBindingRecord | null;
+  } = {},
+) {
+  const startItem = { id: 'item-1', stages: ['planning'], revision: 4 };
+  const itemAfterReconcile = options.itemAfterReconcile === undefined ? startItem : options.itemAfterReconcile;
+  let itemReads = 0;
+  const storage = {
+    findActiveRunBinding: vi
+      .fn()
+      .mockResolvedValueOnce(binding)
+      .mockResolvedValue(options.bindingAfterReconcile === undefined ? binding : options.bindingAfterReconcile),
+    getForProject: vi.fn(async () => {
+      itemReads += 1;
+      return itemReads === 1 ? startItem : itemAfterReconcile;
+    }),
+    listApprovals: vi.fn(async () => options.approvals ?? []),
+  } as unknown as WorkItemsStorage;
+  const reconcileBinding = vi.fn(async () => {});
+  const onIdleWithoutTransition = vi.fn(async () => {});
+  const audit = { record: vi.fn(async () => ({ id: 'audit-1' })) };
+  const observer = new FactoryRunLifecycleObserver({
+    storage,
+    audit: audit as never,
+    rules: defaultFactoryRules({
+      version: 'idle-observer-v1',
+      ...(options.enabled === undefined
+        ? {}
+        : { overrides: { supervisor: { observeIdleWithoutTransition: options.enabled } } }),
+    }),
+    reconcileBinding,
+    onIdleWithoutTransition,
+  });
+  return { observer, storage, audit, reconcileBinding, onIdleWithoutTransition };
+}
+
+async function completeRun(observer: FactoryRunLifecycleObserver, session: ReturnType<typeof makeSession>) {
+  session.emit({ type: 'agent_start' });
+  session.emit({ type: 'agent_end', reason: 'complete' });
+  await observer.waitForSettled(session.session);
+}
+
+describe('FactoryRunLifecycleObserver', () => {
+  it('emits one bounded idle event after final reconciliation with the default-on setting', async () => {
+    const setup = makeObserver();
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+    setup.observer.observe(session.session, address);
+
+    await completeRun(setup.observer, session);
+
+    expect(session.session.subscribe).toHaveBeenCalledTimes(1);
+    expect(setup.reconcileBinding).toHaveBeenCalledWith(binding);
+    expect(setup.audit.record).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      actorId: 'agent:thread-1',
+      actorType: 'agent',
+      action: 'factory.run.idle_without_transition',
+      targets: [{ type: 'work_item', id: 'item-1' }],
+      metadata: { bindingId: 'binding-1', role: 'work', stage: 'planning', revision: 4 },
+      factoryProjectId: PROJECT_ID,
+    });
+    expect(setup.onIdleWithoutTransition).toHaveBeenCalledOnce();
+    expect(setup.onIdleWithoutTransition).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: 'item-1',
+      bindingId: 'binding-1',
+      role: 'work',
+      stage: 'planning',
+      revision: 4,
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      sessionId: 'session-1',
+    });
+    expect(setup.storage.findActiveRunBinding).toHaveBeenCalledWith(address);
+  });
+
+  it('exposes a live subscription seam for the supervisor notification service', async () => {
+    const setup = makeObserver();
+    const session = makeSession();
+    const supervisorListener = vi.fn(async () => {});
+    const unsubscribe = setup.observer.subscribeIdle(supervisorListener);
+    setup.observer.observe(session.session, address);
+
+    await completeRun(setup.observer, session);
+    expect(supervisorListener).toHaveBeenCalledOnce();
+
+    unsubscribe();
+    await completeRun(setup.observer, session);
+    expect(supervisorListener).toHaveBeenCalledOnce();
+  });
+
+  it('emits once for each qualifying agent_end without a persisted completion identity', async () => {
+    const setup = makeObserver();
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+
+    await completeRun(setup.observer, session);
+    await completeRun(setup.observer, session);
+
+    expect(setup.audit.record).toHaveBeenCalledTimes(2);
+    expect(setup.onIdleWithoutTransition).toHaveBeenCalledTimes(2);
+  });
+
+  it('emits when observation is explicitly enabled and suppresses an explicit opt-out', async () => {
+    const enabled = makeObserver({ enabled: true });
+    const enabledSession = makeSession();
+    enabled.observer.observe(enabledSession.session, address);
+    await completeRun(enabled.observer, enabledSession);
+    expect(enabled.onIdleWithoutTransition).toHaveBeenCalledOnce();
+
+    const disabled = makeObserver({ enabled: false });
+    const disabledSession = makeSession();
+    disabled.observer.observe(disabledSession.session, address);
+    await completeRun(disabled.observer, disabledSession);
+    expect(disabled.reconcileBinding).not.toHaveBeenCalled();
+    expect(disabled.audit.record).not.toHaveBeenCalled();
+    expect(disabled.onIdleWithoutTransition).not.toHaveBeenCalled();
+  });
+
+  it.each(['aborted', 'error', 'suspended'] as const)('ignores an agent_end with reason %s', async reason => {
+    const setup = makeObserver();
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+    session.emit({ type: 'agent_start' });
+    session.emit({ type: 'agent_end', reason });
+    await setup.observer.waitForSettled(session.session);
+    expect(setup.reconcileBinding).not.toHaveBeenCalled();
+    expect(setup.onIdleWithoutTransition).not.toHaveBeenCalled();
+  });
+
+  it('suppresses runs whose stage or revision changed during final reconciliation', async () => {
+    const setup = makeObserver({ itemAfterReconcile: { stages: ['execute'], revision: 5 } });
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+    await completeRun(setup.observer, session);
+    expect(setup.reconcileBinding).toHaveBeenCalledOnce();
+    expect(setup.onIdleWithoutTransition).not.toHaveBeenCalled();
+  });
+
+  it('suppresses runs with a pending transition approval for the bound item', async () => {
+    const setup = makeObserver({ approvals: [{ workItemId: 'item-1' }] });
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+    await completeRun(setup.observer, session);
+    expect(setup.audit.record).not.toHaveBeenCalled();
+    expect(setup.onIdleWithoutTransition).not.toHaveBeenCalled();
+  });
+
+  it('does not let another item or tenant-scoped binding suppress the observed worker', async () => {
+    const setup = makeObserver({ approvals: [{ workItemId: 'item-2' }] });
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+    await completeRun(setup.observer, session);
+    expect(setup.storage.listApprovals).toHaveBeenCalledWith('org-1', PROJECT_ID, ['pending']);
+    expect(setup.onIdleWithoutTransition).toHaveBeenCalledOnce();
+  });
+
+  it('suppresses completion when the exact tenant-scoped binding is no longer active', async () => {
+    const setup = makeObserver({ bindingAfterReconcile: null });
+    const session = makeSession();
+    setup.observer.observe(session.session, address);
+    await completeRun(setup.observer, session);
+    expect(setup.storage.findActiveRunBinding).toHaveBeenNthCalledWith(1, address);
+    expect(setup.storage.findActiveRunBinding).toHaveBeenNthCalledWith(2, address);
+    expect(setup.onIdleWithoutTransition).not.toHaveBeenCalled();
+  });
+});

--- a/mastracode/factory/src/rules/run-lifecycle-observer.ts
+++ b/mastracode/factory/src/rules/run-lifecycle-observer.ts
@@ -1,0 +1,149 @@
+import type { AgentControllerEvent } from '@mastra/core/agent-controller';
+
+import type { AuditStorage } from '../storage/domains/audit/base.js';
+import type {
+  FactoryRunBindingAddress,
+  FactoryRunBindingRecord,
+  WorkItemsStorage,
+} from '../storage/domains/work-items/base.js';
+import type { FactoryRules } from './types.js';
+
+export interface FactoryIdleWithoutTransitionEvent {
+  orgId: string;
+  factoryProjectId: string;
+  workItemId: string;
+  bindingId: string;
+  role: string;
+  stage: string;
+  revision: number;
+  threadId: string;
+  resourceId: string;
+  sessionId: string;
+}
+
+type ObservableFactorySession = {
+  subscribe(listener: (event: AgentControllerEvent) => void): () => void;
+};
+
+type RunStartSnapshot = {
+  binding: FactoryRunBindingRecord;
+  stage: string;
+  revision: number;
+};
+
+export interface FactoryRunLifecycleObserverOptions {
+  storage: WorkItemsStorage;
+  audit: Pick<AuditStorage, 'record'>;
+  rules: FactoryRules;
+  reconcileBinding(binding: FactoryRunBindingRecord): Promise<void>;
+  onIdleWithoutTransition?(event: FactoryIdleWithoutTransitionEvent): Promise<void>;
+  onError?(error: unknown): void;
+}
+
+export class FactoryRunLifecycleObserver {
+  readonly #observed = new WeakSet<ObservableFactorySession>();
+  readonly #lifecycles = new WeakMap<ObservableFactorySession, Promise<void>>();
+  readonly #idleListeners = new Set<(event: FactoryIdleWithoutTransitionEvent) => Promise<void>>();
+  readonly #options: FactoryRunLifecycleObserverOptions;
+
+  constructor(options: FactoryRunLifecycleObserverOptions) {
+    this.#options = options;
+    if (options.onIdleWithoutTransition) this.#idleListeners.add(options.onIdleWithoutTransition);
+  }
+
+  subscribeIdle(listener: (event: FactoryIdleWithoutTransitionEvent) => Promise<void>): () => void {
+    this.#idleListeners.add(listener);
+    return () => this.#idleListeners.delete(listener);
+  }
+
+  observe(session: ObservableFactorySession, address: FactoryRunBindingAddress): void {
+    if (this.#observed.has(session)) return;
+    this.#observed.add(session);
+
+    let snapshot: RunStartSnapshot | undefined;
+    let lifecycle = Promise.resolve();
+    session.subscribe(event => {
+      if (event.type !== 'agent_start' && event.type !== 'agent_end') return;
+      lifecycle = lifecycle
+        .then(async () => {
+          if (event.type === 'agent_start') {
+            snapshot = await this.#capture(address);
+            return;
+          }
+          const completedRun = snapshot;
+          snapshot = undefined;
+          if (event.reason !== 'complete' || !completedRun) return;
+          await this.#observeCompletion(address, completedRun);
+        })
+        .catch(error => {
+          snapshot = undefined;
+          this.#options.onError?.(error);
+        });
+      this.#lifecycles.set(session, lifecycle);
+    });
+  }
+
+  waitForSettled(session: ObservableFactorySession): Promise<void> {
+    return this.#lifecycles.get(session) ?? Promise.resolve();
+  }
+
+  async #capture(address: FactoryRunBindingAddress): Promise<RunStartSnapshot | undefined> {
+    const binding = await this.#options.storage.findActiveRunBinding(address);
+    if (!binding) return;
+    const item = await this.#options.storage.getForProject(binding.orgId, binding.factoryProjectId, binding.workItemId);
+    const stage = item?.stages.length === 1 ? item.stages[0] : undefined;
+    return item && stage ? { binding, stage, revision: item.revision } : undefined;
+  }
+
+  async #observeCompletion(address: FactoryRunBindingAddress, snapshot: RunStartSnapshot): Promise<void> {
+    if (this.#options.rules.supervisor?.observeIdleWithoutTransition === false) return;
+
+    await this.#options.reconcileBinding(snapshot.binding);
+    const binding = await this.#options.storage.findActiveRunBinding(address);
+    if (!binding || binding.id !== snapshot.binding.id || binding.workItemId !== snapshot.binding.workItemId) return;
+
+    const [item, pendingApprovals] = await Promise.all([
+      this.#options.storage.getForProject(binding.orgId, binding.factoryProjectId, binding.workItemId),
+      this.#options.storage.listApprovals(binding.orgId, binding.factoryProjectId, ['pending']),
+    ]);
+    if (
+      !item ||
+      item.stages.length !== 1 ||
+      item.stages[0] !== snapshot.stage ||
+      item.revision !== snapshot.revision ||
+      pendingApprovals.some(approval => approval.workItemId === item.id)
+    ) {
+      return;
+    }
+
+    const event: FactoryIdleWithoutTransitionEvent = {
+      orgId: binding.orgId,
+      factoryProjectId: binding.factoryProjectId,
+      workItemId: binding.workItemId,
+      bindingId: binding.id,
+      role: binding.role,
+      stage: snapshot.stage,
+      revision: snapshot.revision,
+      threadId: binding.threadId,
+      resourceId: binding.resourceId,
+      sessionId: binding.sessionId,
+    };
+    await Promise.all([
+      this.#options.audit.record({
+        orgId: event.orgId,
+        actorId: `agent:${event.threadId}`,
+        actorType: 'agent',
+        action: 'factory.run.idle_without_transition',
+        targets: [{ type: 'work_item', id: event.workItemId }],
+        metadata: {
+          bindingId: event.bindingId,
+          role: event.role,
+          stage: event.stage,
+          revision: event.revision,
+        },
+        factoryProjectId: event.factoryProjectId,
+      }),
+      ...[...this.#idleListeners].map(listener => listener(event)),
+    ]);
+  }
+}

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -128,6 +128,30 @@ function startRequest(
 }
 
 describe('FactoryStartCoordinator', () => {
+  it('attaches the live run observer to the exact prepared binding', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController();
+    const runLifecycleObserver = { observe: vi.fn() };
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      undefined,
+      makeSourceControl() as never,
+      undefined,
+      runLifecycleObserver as never,
+    );
+
+    const prepared = await coordinator.prepare(startRequest({ kickoffMessage: null }));
+
+    expect(runLifecycleObserver.observe).toHaveBeenCalledWith(session, {
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      threadId: prepared.threadId,
+      resourceId: prepared.resourceId,
+      sessionId: prepared.sessionId,
+    });
+  });
+
   it('commits the item session, exact binding, and durable pending start', async () => {
     const storage = (await createFactoryStorageForTests()).workItems;
     const { controller, sendMessage } = makeController();

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -6,6 +6,7 @@ import { formatSkillActivation } from '@mastra/core/workspace';
 import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlSession, SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { CreateWorkItemInput, WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { FactoryRunLifecycleObserver } from './run-lifecycle-observer.js';
 import type { FactoryTransitionService } from './transition-service.js';
 import type { FactoryRuleStage, FactoryTransitionResult } from './types.js';
 
@@ -121,6 +122,7 @@ export class FactoryStartCoordinator {
   readonly #transitionService?: Pick<FactoryTransitionService, 'transition'>;
   readonly #sourceControl?: SourceControlStorageHandle;
   readonly #memorySettings?: MemorySettingsStorage;
+  readonly #runLifecycleObserver?: Pick<FactoryRunLifecycleObserver, 'observe'>;
 
   constructor(
     controller: FactoryController,
@@ -128,12 +130,14 @@ export class FactoryStartCoordinator {
     transitionService?: Pick<FactoryTransitionService, 'transition'>,
     sourceControl?: SourceControlStorageHandle,
     memorySettings?: MemorySettingsStorage,
+    runLifecycleObserver?: Pick<FactoryRunLifecycleObserver, 'observe'>,
   ) {
     this.#controller = controller;
     this.#storage = storage;
     this.#transitionService = transitionService;
     this.#sourceControl = sourceControl;
     this.#memorySettings = memorySettings;
+    this.#runLifecycleObserver = runLifecycleObserver;
   }
 
   async prepare(request: FactoryStartRequest): Promise<FactoryStartPreparedResult> {
@@ -223,6 +227,14 @@ export class FactoryStartCoordinator {
       await storage.markPendingStart(prepared.binding.id, 'sent');
       prepared.pendingStart.status = 'sent';
     }
+
+    this.#runLifecycleObserver?.observe(session, {
+      orgId: prepared.binding.orgId,
+      factoryProjectId: prepared.binding.factoryProjectId,
+      threadId: prepared.binding.threadId,
+      resourceId: prepared.binding.resourceId,
+      sessionId: prepared.binding.sessionId,
+    });
 
     return {
       workItemId: prepared.item.id,

--- a/mastracode/factory/src/rules/tools.test.ts
+++ b/mastracode/factory/src/rules/tools.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { defaultFactoryRules } from './defaults.js';
+import { defaultFactoryRules, requireSupervisorApproval } from './defaults.js';
 import { createFactoryTransitionTools } from './tools.js';
 import { FactoryTransitionService } from './transition-service.js';
 
@@ -141,6 +141,43 @@ describe('factory_transition_work_item', () => {
       ingress: { type: 'agent', identity: `${prepared.binding.id}:tool-call-9` },
       cause: 'The investigation is complete.',
     });
+  });
+
+  it('returns pending_approval immediately without suspending or requiring a retry', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    await prepareBoundItem(storage);
+    const service = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: {
+            planning: {
+              issue: {
+                onEnter: context =>
+                  requireSupervisorApproval(context, { reason: 'Supervisor approval is required for planning.' }),
+              },
+            },
+          },
+        },
+      }),
+    });
+    const context = requestContext();
+    const tools = await createFactoryTransitionTools({ requestContext: context, storage, transitionService: service });
+
+    const result = await execute(tools.factory_transition_work_item as ExecutableTool, context, {
+      stage: 'planning',
+      expectedRevision: 1,
+      rationale: 'Investigation complete.',
+    });
+
+    expect(result).toMatchObject({
+      status: 'pending_approval',
+      approvalId: expect.any(String),
+      stage: 'planning',
+      revision: 1,
+    });
+    expect(await storage.listApprovals('org-1', PROJECT_ID, ['pending'])).toHaveLength(1);
   });
 
   it('rechecks authority at execution and rejects revoked or replaced bindings', async () => {

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { defaultFactoryRules } from './defaults.js';
+import { defaultFactoryRules, requireSupervisorApproval } from './defaults.js';
 import { FactoryTransitionService } from './transition-service.js';
-import type { FactoryRuleBoard, FactoryRuleStage } from './types.js';
+import type { FactoryRuleActor, FactoryRuleBoard, FactoryRuleStage } from './types.js';
 import { MAX_FACTORY_RULE_CAUSAL_DEPTH } from './validation.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
@@ -42,6 +42,7 @@ function request(
     stage: FactoryRuleStage;
     expectedRevision: number;
     identity: string;
+    actor: FactoryRuleActor;
     causalChain: Array<{ ingressId: string; decisionType: 'transition' }>;
   }> = {},
 ) {
@@ -52,8 +53,11 @@ function request(
     board: overrides.board ?? ('work' as const),
     stage: overrides.stage ?? ('execute' as const),
     expectedRevision: overrides.expectedRevision ?? item.revision,
-    actor: { type: 'human' as const, id: 'user-1' },
-    ingress: { type: 'human' as const, identity: overrides.identity ?? 'request-1' },
+    actor: overrides.actor ?? { type: 'human' as const, id: 'user-1' },
+    ingress: {
+      type: overrides.actor?.type === 'agent' ? ('agent' as const) : ('human' as const),
+      identity: overrides.identity ?? 'request-1',
+    },
     cause: 'test',
     causalChain: overrides.causalChain,
   };
@@ -154,6 +158,102 @@ describe('FactoryTransitionService', () => {
       'notify-exit',
       'message-enter',
     ]);
+  });
+
+  it('creates one pending approval for agent transitions without moving or dispatching effects', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          intake: {
+            issue: {
+              onExit: context =>
+                requireSupervisorApproval(context, {
+                  reason: 'A supervisor must approve execution.',
+                  summary: 'Move Fix the bug to execute',
+                }),
+            },
+          },
+          execute: {
+            issue: {
+              onEnter: () => ({ type: 'notify', idempotencyKey: 'ready-effect', title: 'Ready to execute' }),
+            },
+          },
+        },
+      },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage }).transition(
+      request(item, { actor: { type: 'agent', bindingId: 'binding-1', role: 'work' } }),
+    );
+
+    expect(result).toMatchObject({
+      status: 'pending_approval',
+      approvalId: expect.any(String),
+      revision: item.revision,
+      stage: 'execute',
+      reason: 'A supervisor must approve execution.',
+    });
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['intake']);
+    expect(await storage.listDeferredDecisions('org-1', PROJECT_ID)).toEqual([]);
+    expect(await storage.listApprovals('org-1', PROJECT_ID, ['pending'])).toEqual([
+      expect.objectContaining({
+        workItemId: item.id,
+        expectedRevision: item.revision,
+        decisions: [expect.objectContaining({ idempotencyKey: 'ready-effect' })],
+      }),
+    ]);
+  });
+
+  it('does not gate human transitions when a rule uses the supervisor approval helper', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          execute: {
+            issue: {
+              onEnter: context => requireSupervisorApproval(context, { reason: 'Supervisor approval required.' }),
+            },
+          },
+        },
+      },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage }).transition(request(item));
+
+    expect(result).toMatchObject({ status: 'accepted', stage: 'execute' });
+    expect(await storage.listApprovals('org-1', PROJECT_ID)).toEqual([]);
+  });
+
+  it('lets rejection win when another rule requests agent approval', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          intake: {
+            issue: {
+              onExit: context => requireSupervisorApproval(context, { reason: 'Supervisor approval required.' }),
+            },
+          },
+          execute: {
+            issue: { onEnter: () => ({ type: 'reject', code: 'forbidden', reason: 'Execution is frozen.' }) },
+          },
+        },
+      },
+    });
+
+    const result = await new FactoryTransitionService({ rules, storage }).transition(
+      request(item, { actor: { type: 'agent', bindingId: 'binding-1', role: 'work' } }),
+    );
+
+    expect(result).toMatchObject({ status: 'rejected', code: 'forbidden', reason: 'Execution is frozen.' });
+    expect(await storage.listApprovals('org-1', PROJECT_ID)).toEqual([]);
   });
 
   it('persists rule rejection without moving or queuing decisions', async () => {
@@ -317,24 +417,6 @@ describe('FactoryTransitionService', () => {
       status: 'rejected',
       code: 'invalid_transition',
     });
-  });
-
-  it('accepts a human cancel and can revive the item out of canceled', async () => {
-    const storage = (await createFactoryStorageForTests()).workItems;
-    const item = await createItem(storage, { stages: ['review'] });
-    const service = new FactoryTransitionService({ rules: defaultFactoryRules({ version: 'rules-v1' }), storage });
-
-    const discard = await service.transition(request(item, { stage: 'canceled', identity: 'discard-1' }));
-    expect(discard).toMatchObject({ status: 'accepted', stage: 'canceled' });
-    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['canceled']);
-
-    // An item sitting in canceled still has a canonical stage, so it can be
-    // pulled back onto the board.
-    const revive = await service.transition(
-      request({ id: item.id, revision: 2 }, { stage: 'triage', identity: 'revive-1' }),
-    );
-    expect(revive).toMatchObject({ status: 'accepted', stage: 'triage' });
-    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['triage']);
   });
 
   it('scopes ingress replay and deferred idempotency to the tenant', async () => {

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -7,6 +7,7 @@ import type {
   FactoryRuleActor,
   FactoryRuleBoard,
   FactoryRuleCausalEntry,
+  FactoryRequestApprovalDecision,
   FactoryRuleRejectionCode,
   FactoryRuleStage,
   FactoryRules,
@@ -131,9 +132,17 @@ export class FactoryTransitionService {
     if (replay) return replay as unknown as FactoryTransitionResult;
 
     const transitionId = request.ingress.transitionId ?? randomUUID();
-    const item = await this.#storage.get({ orgId: request.orgId, id: request.workItemId });
+    const item = await this.#storage.getForProject(request.orgId, request.factoryProjectId, request.workItemId);
     if (!item) {
       return this.#commitRejection(request, transitionId, 'invalid_transition', 'Work item not found.');
+    }
+    if (item.revision !== request.expectedRevision) {
+      return this.#commitRejection(
+        request,
+        transitionId,
+        'stale',
+        'The work item changed before this transition was evaluated.',
+      );
     }
 
     if (request.causalChain && request.causalChain.length > MAX_FACTORY_RULE_CAUSAL_DEPTH) {
@@ -191,11 +200,25 @@ export class FactoryTransitionService {
 
     let evaluation:
       | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
-      | { outcome: 'rejected'; code: string; reason: string };
+      | { outcome: 'rejected'; code: string; reason: string }
+      | {
+          outcome: 'pending_approval';
+          approval: {
+            idempotencyKey: string;
+            board: string;
+            actor: Record<string, unknown>;
+            ingress: Record<string, unknown>;
+            cause: string;
+            reason: string;
+            summary?: string;
+            decisions: Record<string, unknown>[];
+          };
+        };
     try {
       evaluation = await withRuleTimeout(
         (async () => {
           const decisions: FactoryCommitDecision[] = [];
+          let approval: FactoryRequestApprovalDecision | undefined;
           for (const rule of resolveFactoryStageRules(this.#rules, {
             board: request.board,
             source,
@@ -213,9 +236,28 @@ export class FactoryTransitionService {
             if (decision.type === 'reject') {
               return { outcome: 'rejected' as const, code: decision.code, reason: decision.reason };
             }
+            if (decision.type === 'requestApproval') {
+              if (request.actor.type === 'agent') approval ??= decision;
+              continue;
+            }
             decisions.push(decision);
           }
           const validated = validateFactoryRuleDecisions(decisions);
+          if (approval) {
+            return {
+              outcome: 'pending_approval' as const,
+              approval: {
+                idempotencyKey: approval.idempotencyKey,
+                board: request.board,
+                actor: request.actor,
+                ingress: request.ingress,
+                cause: request.cause,
+                reason: approval.reason,
+                ...(approval.summary ? { summary: approval.summary } : {}),
+                decisions: validated as unknown as Record<string, unknown>[],
+              },
+            };
+          }
           if (request.actor.type === 'human' && request.cause === 'board_drag' && fromStage !== request.stage) {
             const message = stageTransitionMessage(fromStage, request.stage);
             const skill = validated.find(decision => decision.type === 'invokeSkill');
@@ -264,7 +306,20 @@ export class FactoryTransitionService {
     transitionId: string,
     evaluation:
       | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
-      | { outcome: 'rejected'; code: string; reason: string },
+      | { outcome: 'rejected'; code: string; reason: string }
+      | {
+          outcome: 'pending_approval';
+          approval: {
+            idempotencyKey: string;
+            board: string;
+            actor: Record<string, unknown>;
+            ingress: Record<string, unknown>;
+            cause: string | null;
+            reason: string;
+            summary?: string;
+            decisions: Record<string, unknown>[];
+          };
+        },
   ): Promise<FactoryTransitionResult> {
     const committed = await this.#storage.commitTransition({
       orgId: request.orgId,

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -155,6 +155,10 @@ export type FactoryBoardRules = Partial<
   Record<FactoryRuleStage, Partial<Record<FactoryRuleSource, FactoryBoardRuleLeaf>>>
 >;
 
+export interface FactorySupervisorRules {
+  observeIdleWithoutTransition?: boolean;
+}
+
 export interface FactoryRules {
   version: string;
   work: FactoryBoardRules;
@@ -162,6 +166,7 @@ export interface FactoryRules {
   tools: Record<string, FactoryToolRuleLeaf>;
   github: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>>;
   linear: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>>;
+  supervisor?: FactorySupervisorRules;
 }
 
 export interface FactoryRulesOverrides {
@@ -170,6 +175,7 @@ export interface FactoryRulesOverrides {
   tools?: Record<string, FactoryToolRuleLeaf>;
   github?: Partial<Record<FactoryGithubEventName, FactoryGithubRuleLeaf>>;
   linear?: Partial<Record<FactoryLinearEventName, FactoryLinearRuleLeaf>>;
+  supervisor?: FactorySupervisorRules;
 }
 
 export type FactoryRuleRejectionCode =

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -188,6 +188,13 @@ export interface FactoryRuleRejectDecision {
   reason: string;
 }
 
+export interface FactoryRequestApprovalDecision {
+  type: 'requestApproval';
+  idempotencyKey: string;
+  reason: string;
+  summary?: string;
+}
+
 interface FactoryCommitDecisionBase {
   idempotencyKey: string;
 }
@@ -240,7 +247,7 @@ export type FactoryCommitDecision =
   | FactorySendMessageDecision
   | FactoryNotifyDecision;
 
-export type FactoryRuleDecision = FactoryRuleRejectDecision | FactoryCommitDecision;
+export type FactoryRuleDecision = FactoryRuleRejectDecision | FactoryRequestApprovalDecision | FactoryCommitDecision;
 
 export interface FactoryTransitionResultAccepted {
   status: 'accepted';
@@ -251,6 +258,16 @@ export interface FactoryTransitionResultAccepted {
   decisions: FactoryCommitDecision[];
 }
 
+export interface FactoryTransitionResultPendingApproval {
+  status: 'pending_approval';
+  transitionId: string;
+  approvalId: string;
+  itemId: string;
+  revision: number;
+  stage: FactoryRuleStage;
+  reason: string;
+}
+
 export interface FactoryTransitionResultRejected {
   status: 'rejected';
   transitionId: string;
@@ -259,7 +276,8 @@ export interface FactoryTransitionResultRejected {
   reason: string;
 }
 
-export type FactoryTransitionResult = FactoryTransitionResultAccepted | FactoryTransitionResultRejected;
+export type FactoryTransitionResult =
+  FactoryTransitionResultAccepted | FactoryTransitionResultPendingApproval | FactoryTransitionResultRejected;
 
 export function factoryRuleSourceForWorkItem(source: WorkItemSource): FactoryRuleSource {
   switch (source) {

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -283,7 +283,9 @@ export interface FactoryTransitionResultRejected {
 }
 
 export type FactoryTransitionResult =
-  FactoryTransitionResultAccepted | FactoryTransitionResultPendingApproval | FactoryTransitionResultRejected;
+  | FactoryTransitionResultAccepted
+  | FactoryTransitionResultPendingApproval
+  | FactoryTransitionResultRejected;
 
 export function factoryRuleSourceForWorkItem(source: WorkItemSource): FactoryRuleSource {
   switch (source) {

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -149,6 +149,20 @@ describe('Factory rule validation', () => {
     ).toThrow(/unique idempotency keys/i);
   });
 
+  it('defaults idle-without-transition observation on and preserves an explicit opt-out', () => {
+    expect(defaultFactoryRules({ version: 'validation-v1' }).supervisor?.observeIdleWithoutTransition).toBe(true);
+    expect(
+      defaultFactoryRules({
+        version: 'validation-v1',
+        overrides: { supervisor: { observeIdleWithoutTransition: false } },
+      }).supervisor?.observeIdleWithoutTransition,
+    ).toBe(false);
+
+    const legacyRules = defaultFactoryRules({ version: 'validation-v1' });
+    delete legacyRules.supervisor;
+    expect(() => assertFactoryRules(legacyRules)).not.toThrow();
+  });
+
   it('rejects unknown rule keys and non-handler leaves at boot', () => {
     const rules = defaultFactoryRules({ version: 'validation-v1' });
     expect(() => assertFactoryRules({ ...rules, actions: {} })).toThrow(/unsupported field/i);
@@ -170,5 +184,11 @@ describe('Factory rule validation', () => {
         linear: { madeUpEvent: { onEvent: () => undefined } },
       }),
     ).toThrow(/Linear event is invalid/i);
+    expect(() =>
+      assertFactoryRules({
+        ...rules,
+        supervisor: { observeIdleWithoutTransition: 'yes' },
+      }),
+    ).toThrow(/must be a boolean/i);
   });
 });

--- a/mastracode/factory/src/rules/validation.test.ts
+++ b/mastracode/factory/src/rules/validation.test.ts
@@ -55,6 +55,34 @@ describe('Factory rule validation', () => {
     ).toThrow(/rejection cannot be persisted/i);
   });
 
+  it('validates approval requests separately from deferred effects', () => {
+    expect(
+      validateFactoryRuleDecision({
+        type: 'requestApproval',
+        idempotencyKey: 'approval-1',
+        reason: 'Supervisor approval required.',
+        summary: 'Move item to execute',
+      }),
+    ).toEqual({
+      type: 'requestApproval',
+      idempotencyKey: 'approval-1',
+      reason: 'Supervisor approval required.',
+      summary: 'Move item to execute',
+    });
+    expect(() =>
+      validateFactoryRuleDecisions([
+        { type: 'requestApproval', idempotencyKey: 'approval-1', reason: 'Supervisor approval required.' },
+      ]),
+    ).toThrow(/approval request cannot be persisted/i);
+    expect(() =>
+      validateFactoryRuleDecision({
+        type: 'requestApproval',
+        idempotencyKey: 'approval-1',
+        reason: 'x'.repeat(513),
+      }),
+    ).toThrow(/approval reason is invalid/i);
+  });
+
   it('enforces bounds, serializability, and causal depth', () => {
     expect(() =>
       validateFactoryRuleDecision({

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -159,7 +159,7 @@ function validateBoardRules(rules: unknown, label: string): asserts rules is Fac
 
 export function assertFactoryRules(rules: unknown): asserts rules is FactoryRules {
   if (!isPlainObject(rules)) throw new FactoryRuleValidationError('Factory rules must be an object.');
-  assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'github', 'linear'], 'Factory rules');
+  assertExactKeys(rules, ['version', 'work', 'review', 'tools', 'github', 'linear', 'supervisor'], 'Factory rules');
   boundedString(rules.version, 'Factory rule version', MAX_VERSION_LENGTH);
   validateBoardRules(rules.work, 'Factory rules.work');
   validateBoardRules(rules.review, 'Factory rules.review');
@@ -192,6 +192,19 @@ export function assertFactoryRules(rules: unknown): asserts rules is FactoryRule
     assertExactKeys(leaf, ['onEvent'], `Factory rules.linear.${event}`);
     if (leaf.onEvent !== undefined && typeof leaf.onEvent !== 'function') {
       throw new FactoryRuleValidationError(`Factory rules.linear.${event}.onEvent must be a function.`);
+    }
+  }
+
+  if (rules.supervisor !== undefined) {
+    if (!isPlainObject(rules.supervisor)) {
+      throw new FactoryRuleValidationError('Factory rules.supervisor must be an object.');
+    }
+    assertExactKeys(rules.supervisor, ['observeIdleWithoutTransition'], 'Factory rules.supervisor');
+    if (
+      rules.supervisor.observeIdleWithoutTransition !== undefined &&
+      typeof rules.supervisor.observeIdleWithoutTransition !== 'boolean'
+    ) {
+      throw new FactoryRuleValidationError('Factory rules.supervisor.observeIdleWithoutTransition must be a boolean.');
     }
   }
 }

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -219,6 +219,16 @@ export function validateFactoryRuleDecision(value: unknown, causalDepth = 0): Fa
         reason: boundedString(value.reason, 'Factory rejection reason', MAX_REASON_LENGTH),
       };
     }
+    case 'requestApproval': {
+      assertExactKeys(value, ['type', 'idempotencyKey', 'reason', 'summary'], 'Factory approval decision');
+      const summary = optionalBoundedString(value.summary, 'Factory approval summary', MAX_TITLE_LENGTH);
+      return {
+        type,
+        ...commonCommitFields(value),
+        reason: boundedString(value.reason, 'Factory approval reason', MAX_REASON_LENGTH),
+        ...(summary ? { summary } : {}),
+      };
+    }
     case 'transition': {
       assertExactKeys(value, ['type', 'idempotencyKey', 'board', 'stage'], 'Factory transition decision');
       return {
@@ -328,6 +338,9 @@ export function validateFactoryRuleDecisions(values: readonly unknown[], causalD
     const decision = validateFactoryRuleDecision(value, causalDepth);
     if (decision.type === 'reject') {
       throw new FactoryRuleValidationError('A rejection cannot be persisted with commit decisions.');
+    }
+    if (decision.type === 'requestApproval') {
+      throw new FactoryRuleValidationError('An approval request cannot be persisted as a deferred effect.');
     }
     decisions.push(decision);
   }

--- a/mastracode/factory/src/storage/domains/audit/base.ts
+++ b/mastracode/factory/src/storage/domains/audit/base.ts
@@ -26,6 +26,7 @@
  *   - factory.git.push
  *   - factory.git.pr_opened
  *   - factory.intake.config_updated
+ *   - factory.run.idle_without_transition
  *
  * v1.1 adds agent-level actions (also register these in WorkOS):
  *   - factory.agent.commit

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -235,6 +235,77 @@ describe('WorkItemsStorage', () => {
     expect((await storage.get({ orgId: 'org1', id: child.item.id }))?.parentWorkItemId).toBeNull();
   });
 
+  it('persists pending transition approvals without mutating the work item', async () => {
+    const storage = await makeStorage();
+    const created = await storage.upsert({ orgId: 'org1', userId: 'agent', factoryProjectId: 'p1', input });
+    const transition = {
+      orgId: 'org1',
+      factoryProjectId: 'p1',
+      workItemId: created.item.id,
+      expectedRevision: created.item.revision,
+      destinationStage: 'execute',
+      actorId: 'agent:binding-1',
+      ingress: { identity: 'tool:call-1', triggerType: 'tool', transitionId: 'transition-1' },
+      ruleSetVersion: 'rules-v1',
+      causalChain: [],
+      evaluation: {
+        outcome: 'pending_approval' as const,
+        approval: {
+          idempotencyKey: 'tool:call-1:approval',
+          board: 'work',
+          actor: { type: 'agent', bindingId: 'binding-1', role: 'work' },
+          ingress: { type: 'tool', identity: 'tool:call-1' },
+          cause: 'agent_tool',
+          reason: 'Supervisor approval is required.',
+          summary: 'Move Fix login to execute',
+          decisions: [{ type: 'notify', idempotencyKey: 'notify-1', title: 'Ready' }],
+        },
+      },
+    };
+
+    const committed = await storage.commitTransition(transition);
+    const replayed = await storage.commitTransition(transition);
+    const coalesced = await storage.commitTransition({
+      ...transition,
+      ingress: { identity: 'tool:call-2', triggerType: 'tool', transitionId: 'transition-2' },
+      evaluation: {
+        ...transition.evaluation,
+        approval: {
+          ...transition.evaluation.approval,
+          idempotencyKey: 'tool:call-2:approval',
+          reason: 'A second rule evaluation reached the same pending transition.',
+        },
+      },
+    });
+    if (committed.status !== 'committed' || replayed.status !== 'replayed' || coalesced.status !== 'committed') {
+      throw new Error('Expected approval commit replay and coalescing.');
+    }
+
+    expect(committed.result).toMatchObject({
+      status: 'pending_approval',
+      approvalId: expect.any(String),
+      revision: created.item.revision,
+      stage: 'execute',
+    });
+    expect(replayed).toMatchObject({ status: 'replayed', result: committed.result });
+    expect(coalesced.result).toMatchObject({
+      status: 'pending_approval',
+      approvalId: (committed.result as { approvalId: string }).approvalId,
+      reason: 'Supervisor approval is required.',
+    });
+    expect((await storage.get({ orgId: 'org1', id: created.item.id }))?.stages).toEqual(['intake']);
+    expect(await storage.listApprovals('org1', 'p1', ['pending'])).toEqual([
+      expect.objectContaining({
+        id: (committed.result as { approvalId: string }).approvalId,
+        expectedRevision: created.item.revision,
+        requestedStage: 'execute',
+        requestingActor: { type: 'agent', bindingId: 'binding-1', role: 'work' },
+        status: 'pending',
+      }),
+    ]);
+    expect(await storage.listApprovals('other-org', 'p1')).toEqual([]);
+  });
+
   it('serializes relationship writes and deletion on the project lock', async () => {
     const backend = new LibSQLFactoryStorage({ id: 'work-items-lock-test', url: ':memory:' });
     const locks: string[] = [];

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -8,10 +8,12 @@
  * Factory transition path keeps one exclusive current stage per item.
  */
 
-import { createHash } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 
 import { FactoryStorageDomain, UniqueViolationError } from '@mastra/core/storage';
 import type { CollectionSchema, FactoryStorageOps } from '@mastra/core/storage';
+
+import { AUDIT_EVENTS_SCHEMA } from '../audit/base.js';
 
 export type WorkItemStage = string;
 
@@ -127,12 +129,68 @@ export interface FactoryRuleEvaluationRecord {
   workItemId: string | null;
   ruleSetVersion: string;
   expectedRevision: number | null;
-  outcome: 'accepted' | 'rejected';
+  outcome: 'accepted' | 'rejected' | 'pending_approval';
   code: string | null;
   reason: string | null;
   causalChain: Array<{ ingressId: string; decisionType: string }>;
   createdAt: Date;
 }
+
+export type FactoryApprovalStatus = 'pending' | 'approved' | 'rejected' | 'stale';
+
+export interface FactoryApprovalRecord {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  evaluationId: string;
+  workItemId: string;
+  transitionId: string;
+  idempotencyKey: string;
+  requestedBoard: string;
+  requestedStage: string;
+  expectedRevision: number;
+  requestingActor: Record<string, unknown>;
+  ingress: Record<string, unknown>;
+  cause: string | null;
+  causalChain: Array<{ ingressId: string; decisionType: string }>;
+  reason: string;
+  summary: string | null;
+  decisions: Record<string, unknown>[];
+  status: FactoryApprovalStatus;
+  resolvedBy: string | null;
+  resolutionReason: string | null;
+  resolvedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface FactoryApprovalPageInput {
+  orgId: string;
+  factoryProjectId: string;
+  statuses?: FactoryApprovalStatus[];
+  before?: { createdAt: Date; id: string };
+  limit: number;
+}
+
+export interface FactoryApprovalPage {
+  approvals: FactoryApprovalRecord[];
+  hasMore: boolean;
+}
+
+export interface ResolveFactoryApprovalInput {
+  orgId: string;
+  factoryProjectId: string;
+  approvalId: string;
+  decision: 'approve' | 'reject';
+  resolvedBy: string;
+  resolverType: 'human' | 'agent';
+  resolutionReason?: string;
+  now: Date;
+}
+
+export type ResolveFactoryApprovalResult =
+  | { status: 'missing' }
+  | { status: 'resolved' | 'replayed'; approval: FactoryApprovalRecord; item: WorkItemRow | null };
 
 export type FactoryDispatchStatus = 'pending' | 'leased' | 'retry' | 'succeeded' | 'failed';
 
@@ -256,7 +314,20 @@ export interface CommitFactoryTransitionInput {
   causalChain: Array<{ ingressId: string; decisionType: string }>;
   evaluation:
     | { outcome: 'accepted'; decisions: Record<string, unknown>[] }
-    | { outcome: 'rejected'; code: string; reason: string };
+    | { outcome: 'rejected'; code: string; reason: string }
+    | {
+        outcome: 'pending_approval';
+        approval: {
+          idempotencyKey: string;
+          board: string;
+          actor: Record<string, unknown>;
+          ingress: Record<string, unknown>;
+          cause: string | null;
+          reason: string;
+          summary?: string;
+          decisions: Record<string, unknown>[];
+        };
+      };
 }
 
 export type CommitFactoryTransitionResult =
@@ -579,6 +650,40 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
     },
   },
   {
+    name: 'factory_approvals',
+    columns: {
+      id: { type: 'uuid-pk' },
+      org_id: { type: 'text' },
+      factory_project_id: { type: 'text' },
+      evaluation_id: { type: 'text' },
+      work_item_id: { type: 'text' },
+      transition_id: { type: 'text' },
+      idempotency_key: { type: 'text' },
+      requested_board: { type: 'text' },
+      requested_stage: { type: 'text' },
+      expected_revision: { type: 'integer' },
+      requesting_actor: { type: 'json' },
+      ingress: { type: 'json' },
+      cause: { type: 'text', nullable: true },
+      causal_chain: { type: 'json' },
+      reason: { type: 'text' },
+      summary: { type: 'text', nullable: true },
+      decisions: { type: 'json' },
+      status: { type: 'text' },
+      resolved_by: { type: 'text', nullable: true },
+      resolution_reason: { type: 'text', nullable: true },
+      resolved_at: { type: 'timestamp', nullable: true },
+      created_at: { type: 'timestamp' },
+      updated_at: { type: 'timestamp' },
+    },
+    uniqueIndexes: [
+      {
+        name: 'factory_approvals_tenant_key_unique',
+        columns: ['org_id', 'factory_project_id', 'idempotency_key'],
+      },
+    ],
+  },
+  {
     name: 'factory_deferred_decisions',
     columns: {
       id: { type: 'uuid-pk' },
@@ -689,6 +794,34 @@ function toBinding(row: GovernanceDbRow): FactoryRunBindingRecord {
     revokedAt: (row.revoked_at as Date | null) ?? null,
   };
 }
+function toApproval(row: GovernanceDbRow): FactoryApprovalRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    factoryProjectId: String(row.factory_project_id),
+    evaluationId: String(row.evaluation_id),
+    workItemId: String(row.work_item_id),
+    transitionId: String(row.transition_id),
+    idempotencyKey: String(row.idempotency_key),
+    requestedBoard: String(row.requested_board),
+    requestedStage: String(row.requested_stage),
+    expectedRevision: Number(row.expected_revision),
+    requestingActor: row.requesting_actor as Record<string, unknown>,
+    ingress: row.ingress as Record<string, unknown>,
+    cause: (row.cause as string | null) ?? null,
+    causalChain: (row.causal_chain as FactoryApprovalRecord['causalChain']) ?? [],
+    reason: String(row.reason),
+    summary: (row.summary as string | null) ?? null,
+    decisions: (row.decisions as Record<string, unknown>[]) ?? [],
+    status: row.status as FactoryApprovalStatus,
+    resolvedBy: (row.resolved_by as string | null) ?? null,
+    resolutionReason: (row.resolution_reason as string | null) ?? null,
+    resolvedAt: (row.resolved_at as Date | null) ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at as Date,
+  };
+}
+
 function toDeferredDecision(row: GovernanceDbRow): FactoryDeferredDecisionRecord {
   return {
     id: row.id,
@@ -713,6 +846,84 @@ function toDeferredDecision(row: GovernanceDbRow): FactoryDeferredDecisionRecord
     updatedAt: row.updated_at as Date,
   };
 }
+async function insertApprovalAudit(
+  ops: FactoryStorageOps,
+  approval: {
+    id: string;
+    orgId: string;
+    factoryProjectId: string;
+    workItemId: string;
+    stage: string;
+    expectedRevision: number;
+  },
+  input: {
+    action: string;
+    actorId: string;
+    actorType: 'human' | 'agent';
+    status: FactoryApprovalStatus;
+    occurredAt: Date;
+  },
+): Promise<void> {
+  await ops.insertOne('audit_events', {
+    org_id: approval.orgId,
+    actor_id: input.actorId,
+    actor_type: input.actorType,
+    action: input.action,
+    targets: [
+      { type: 'approval', id: approval.id },
+      { type: 'work_item', id: approval.workItemId },
+    ],
+    metadata: {
+      approvalId: approval.id,
+      stage: approval.stage,
+      expectedRevision: approval.expectedRevision,
+      status: input.status,
+    },
+    factory_project_id: approval.factoryProjectId,
+    project_repository_id: null,
+    context: {},
+    occurred_at: input.occurredAt,
+  });
+}
+
+async function insertDeferredDecision(
+  ops: FactoryStorageOps,
+  input: {
+    orgId: string;
+    factoryProjectId: string;
+    evaluationId: string;
+    workItemId: string;
+    idempotencyKey: string;
+    ordinal: number;
+    causalChain: Array<{ ingressId: string; decisionType: string }>;
+    actor: Record<string, unknown> | null;
+    decision: Record<string, unknown>;
+    now: Date;
+  },
+): Promise<void> {
+  await ops.insertOne('factory_deferred_decisions', {
+    org_id: input.orgId,
+    factory_project_id: input.factoryProjectId,
+    evaluation_id: input.evaluationId,
+    work_item_id: input.workItemId,
+    idempotency_key: input.idempotencyKey,
+    effect_ordinal: input.ordinal,
+    effect_hash: factoryDecisionHash(input.decision),
+    causal_chain: input.causalChain,
+    actor: input.actor,
+    decision: input.decision,
+    status: 'pending',
+    attempts: 0,
+    available_at: input.now,
+    lease_owner: null,
+    lease_expires_at: null,
+    last_error: null,
+    completed_at: null,
+    created_at: new Date(input.now.getTime() + input.ordinal),
+    updated_at: input.now,
+  });
+}
+
 function toPendingStart(row: GovernanceDbRow): FactoryPendingStartRecord {
   return {
     id: row.id,
@@ -739,7 +950,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async init(): Promise<void> {
-    await this.ensureCollections([WORK_ITEMS_SCHEMA, ...FACTORY_GOVERNANCE_SCHEMAS]);
+    await this.ensureCollections([WORK_ITEMS_SCHEMA, AUDIT_EVENTS_SCHEMA, ...FACTORY_GOVERNANCE_SCHEMAS]);
   }
 
   async dangerouslyClearAll(): Promise<void> {
@@ -911,6 +1122,230 @@ export class WorkItemsStorage extends FactoryStorageDomain {
     return row ? toRow(row) : null;
   }
 
+  async getApproval({
+    orgId,
+    factoryProjectId,
+    approvalId,
+  }: {
+    orgId: string;
+    factoryProjectId: string;
+    approvalId: string;
+  }): Promise<FactoryApprovalRecord | null> {
+    const row = await this.#db.findOne<GovernanceDbRow>('factory_approvals', {
+      id: approvalId,
+      org_id: orgId,
+      factory_project_id: factoryProjectId,
+    });
+    return row ? toApproval(row) : null;
+  }
+
+  async listApprovalPage(input: FactoryApprovalPageInput): Promise<FactoryApprovalPage> {
+    const rows = await this.#db.findMany<GovernanceDbRow>(
+      'factory_approvals',
+      {
+        org_id: input.orgId,
+        factory_project_id: input.factoryProjectId,
+        ...(input.statuses?.length ? { status: { in: input.statuses } } : {}),
+      },
+      {
+        orderBy: [
+          ['created_at', 'desc'],
+          ['id', 'desc'],
+        ],
+        limit: input.limit + 1,
+        ...(input.before ? { cursor: { values: [input.before.createdAt, input.before.id] } } : {}),
+      },
+    );
+    return { approvals: rows.slice(0, input.limit).map(toApproval), hasMore: rows.length > input.limit };
+  }
+
+  async listApprovals(
+    orgId: string,
+    factoryProjectId: string,
+    statuses?: FactoryApprovalStatus[],
+  ): Promise<FactoryApprovalRecord[]> {
+    return (
+      await this.listApprovalPage({
+        orgId,
+        factoryProjectId,
+        ...(statuses ? { statuses } : {}),
+        limit: 100,
+      })
+    ).approvals;
+  }
+
+  async resolveApproval(input: ResolveFactoryApprovalInput): Promise<ResolveFactoryApprovalResult> {
+    const resolve = () =>
+      this.storage.withTransaction<ResolveFactoryApprovalResult>(async ops => {
+        const row = await ops.findOne<GovernanceDbRow>('factory_approvals', {
+          id: input.approvalId,
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+        });
+        if (!row) return { status: 'missing' };
+
+        const currentApproval = toApproval(row);
+        const currentItemRow = await ops.findOne<WorkItemDbRow>('work_items', {
+          id: currentApproval.workItemId,
+          org_id: input.orgId,
+          factory_project_id: input.factoryProjectId,
+        });
+        if (currentApproval.status !== 'pending') {
+          return {
+            status: 'replayed',
+            approval: currentApproval,
+            item: currentItemRow ? toRow(currentItemRow) : null,
+          };
+        }
+
+        let item = currentItemRow ? toRow(currentItemRow) : null;
+        let terminalStatus: Exclude<FactoryApprovalStatus, 'pending'>;
+        if (input.decision === 'reject') {
+          terminalStatus = 'rejected';
+        } else if (!item || item.revision !== currentApproval.expectedRevision) {
+          terminalStatus = 'stale';
+        } else {
+          terminalStatus = 'approved';
+          if (!(item.stages.length === 1 && item.stages[0] === currentApproval.requestedStage)) {
+            let revisionMatched = false;
+            const updated = await ops.updateAtomic<WorkItemDbRow>(
+              'work_items',
+              { id: item.id, org_id: input.orgId, factory_project_id: input.factoryProjectId },
+              current => {
+                const latest = toRow(current);
+                if (latest.revision !== currentApproval.expectedRevision) return null;
+                revisionMatched = true;
+                return patchColumns({
+                  stages: [currentApproval.requestedStage],
+                  stageHistory: applyStageTransition(
+                    latest.stageHistory,
+                    latest.stages,
+                    [currentApproval.requestedStage],
+                    input.resolvedBy,
+                    input.now,
+                  ),
+                  revision: latest.revision + 1,
+                  updatedAt: input.now,
+                });
+              },
+            );
+            if (!revisionMatched || !updated) {
+              terminalStatus = 'stale';
+              item = currentItemRow ? toRow(currentItemRow) : null;
+            } else {
+              item = toRow(updated);
+            }
+          }
+        }
+
+        let resolved = false;
+        const approvalRow = await ops.updateAtomic<GovernanceDbRow>(
+          'factory_approvals',
+          { id: input.approvalId, org_id: input.orgId, factory_project_id: input.factoryProjectId },
+          current => {
+            if (current.status !== 'pending') return null;
+            resolved = true;
+            return {
+              status: terminalStatus,
+              resolved_by: input.resolvedBy,
+              resolution_reason: input.resolutionReason ?? null,
+              resolved_at: input.now,
+              updated_at: input.now,
+            };
+          },
+        );
+        if (!resolved || !approvalRow) {
+          const replay = await ops.findOne<GovernanceDbRow>('factory_approvals', {
+            id: input.approvalId,
+            org_id: input.orgId,
+            factory_project_id: input.factoryProjectId,
+          });
+          if (!replay) return { status: 'missing' };
+          return { status: 'replayed', approval: toApproval(replay), item };
+        }
+
+        const approval = toApproval(approvalRow);
+        const role = typeof approval.requestingActor.role === 'string' ? approval.requestingActor.role : 'work';
+        let ordinal = 0;
+        if (terminalStatus === 'approved') {
+          for (const decision of approval.decisions) {
+            await insertDeferredDecision(ops, {
+              orgId: input.orgId,
+              factoryProjectId: input.factoryProjectId,
+              evaluationId: approval.evaluationId,
+              workItemId: approval.workItemId,
+              idempotencyKey: String(decision.idempotencyKey),
+              ordinal: ordinal++,
+              causalChain: approval.causalChain,
+              actor: approval.requestingActor,
+              decision,
+              now: input.now,
+            });
+          }
+          await insertDeferredDecision(ops, {
+            orgId: input.orgId,
+            factoryProjectId: input.factoryProjectId,
+            evaluationId: approval.evaluationId,
+            workItemId: approval.workItemId,
+            idempotencyKey: `${approval.id}:stage-changed`,
+            ordinal: ordinal++,
+            causalChain: approval.causalChain,
+            actor: approval.requestingActor,
+            decision: {
+              type: 'sendMessage',
+              idempotencyKey: `${approval.id}:stage-changed`,
+              role,
+              message: `Work item moved to ${approval.requestedStage} after supervisor approval.`,
+            },
+            now: input.now,
+          });
+        }
+        const resolutionMessage =
+          terminalStatus === 'approved'
+            ? `Supervisor approved transition to ${approval.requestedStage}.`
+            : terminalStatus === 'rejected'
+              ? `Supervisor rejected transition to ${approval.requestedStage}.`
+              : `Transition approval became stale because the work item changed.`;
+        await insertDeferredDecision(ops, {
+          orgId: input.orgId,
+          factoryProjectId: input.factoryProjectId,
+          evaluationId: approval.evaluationId,
+          workItemId: approval.workItemId,
+          idempotencyKey: `${approval.id}:resolution:${terminalStatus}`,
+          ordinal,
+          causalChain: approval.causalChain,
+          actor: approval.requestingActor,
+          decision: {
+            type: 'sendMessage',
+            idempotencyKey: `${approval.id}:resolution:${terminalStatus}`,
+            role,
+            message: resolutionMessage,
+          },
+          now: input.now,
+        });
+        await insertApprovalAudit(
+          ops,
+          {
+            id: approval.id,
+            orgId: approval.orgId,
+            factoryProjectId: approval.factoryProjectId,
+            workItemId: approval.workItemId,
+            stage: approval.requestedStage,
+            expectedRevision: approval.expectedRevision,
+          },
+          {
+            action: `factory.approval.${terminalStatus}`,
+            actorId: input.resolvedBy,
+            actorType: input.resolverType,
+            status: terminalStatus,
+            occurredAt: input.now,
+          },
+        );
+        return { status: 'resolved', approval, item };
+      });
+    return this.#withProjectRelationLock(input.orgId, input.factoryProjectId, resolve);
+  }
+
   async getTransitionResultByIngress(
     orgId: string,
     factoryProjectId: string,
@@ -940,6 +1375,18 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           };
 
         const now = new Date();
+        const existingApproval =
+          input.evaluation.outcome === 'pending_approval'
+            ? await ops.findOne<GovernanceDbRow>('factory_approvals', {
+                org_id: input.orgId,
+                factory_project_id: input.factoryProjectId,
+                work_item_id: input.workItemId,
+                expected_revision: input.expectedRevision,
+                requested_board: input.evaluation.approval.board,
+                requested_stage: input.destinationStage,
+                status: 'pending',
+              })
+            : null;
         let item: WorkItemRow | null = null;
         let code: string | null = null;
         let reason: string | null = null;
@@ -964,6 +1411,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
               reason = input.evaluation.reason;
               return null;
             }
+            if (input.evaluation.outcome === 'pending_approval') return null;
             if (existing.stages.length === 1 && existing.stages[0] === input.destinationStage) return null;
             return patchColumns({
               stages: [input.destinationStage],
@@ -984,8 +1432,9 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           code = input.evaluation.outcome === 'rejected' ? input.evaluation.code : 'invalid_transition';
           reason = input.evaluation.outcome === 'rejected' ? input.evaluation.reason : 'Work item not found.';
         }
-        const outcome: 'accepted' | 'rejected' =
-          item && code === null && input.evaluation.outcome === 'accepted' ? 'accepted' : 'rejected';
+        const outcome: 'accepted' | 'rejected' | 'pending_approval' =
+          item && code === null ? input.evaluation.outcome : 'rejected';
+        const approvalId = outcome === 'pending_approval' ? (existingApproval?.id ?? randomUUID()) : null;
         result =
           outcome === 'accepted'
             ? {
@@ -996,7 +1445,25 @@ export class WorkItemsStorage extends FactoryStorageDomain {
                 stage: input.destinationStage,
                 decisions: input.evaluation.outcome === 'accepted' ? input.evaluation.decisions : [],
               }
-            : { status: 'rejected', transitionId: input.ingress.transitionId, itemId: input.workItemId, code, reason };
+            : outcome === 'pending_approval'
+              ? {
+                  status: 'pending_approval',
+                  transitionId: input.ingress.transitionId,
+                  approvalId: approvalId!,
+                  itemId: item!.id,
+                  revision: item!.revision,
+                  stage: input.destinationStage,
+                  reason:
+                    existingApproval?.reason ??
+                    (input.evaluation.outcome === 'pending_approval' ? input.evaluation.approval.reason : ''),
+                }
+              : {
+                  status: 'rejected',
+                  transitionId: input.ingress.transitionId,
+                  itemId: input.workItemId,
+                  code,
+                  reason,
+                };
         const ingress = await ops.insertOne<GovernanceDbRow>('factory_rule_ingress', {
           org_id: input.orgId,
           factory_project_id: input.factoryProjectId,
@@ -1018,40 +1485,75 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             causal_chain: input.causalChain,
             created_at: now,
           });
+          if (outcome === 'pending_approval' && input.evaluation.outcome === 'pending_approval' && !existingApproval) {
+            const approval = input.evaluation.approval;
+            await ops.insertOne<GovernanceDbRow>('factory_approvals', {
+              id: approvalId!,
+              org_id: input.orgId,
+              factory_project_id: input.factoryProjectId,
+              evaluation_id: evaluation.id,
+              work_item_id: item.id,
+              transition_id: input.ingress.transitionId,
+              idempotency_key: approval.idempotencyKey,
+              requested_board: approval.board,
+              requested_stage: input.destinationStage,
+              expected_revision: input.expectedRevision,
+              requesting_actor: approval.actor,
+              ingress: approval.ingress,
+              cause: approval.cause,
+              causal_chain: [...input.causalChain, { ingressId: approvalId!, decisionType: 'requestApproval' }],
+              reason: approval.reason,
+              summary: approval.summary ?? null,
+              decisions: approval.decisions,
+              status: 'pending',
+              resolved_by: null,
+              resolution_reason: null,
+              resolved_at: null,
+              created_at: now,
+              updated_at: now,
+            });
+            await insertApprovalAudit(
+              ops,
+              {
+                id: approvalId!,
+                orgId: input.orgId,
+                factoryProjectId: input.factoryProjectId,
+                workItemId: item.id,
+                stage: input.destinationStage,
+                expectedRevision: input.expectedRevision,
+              },
+              {
+                action: 'factory.approval.requested',
+                actorId:
+                  approval.actor.type === 'agent' && typeof approval.actor.bindingId === 'string'
+                    ? `agent:${approval.actor.bindingId}`
+                    : 'factory-rule',
+                actorType: 'agent',
+                status: 'pending',
+                occurredAt: now,
+              },
+            );
+          }
           if (outcome === 'accepted' && input.evaluation.outcome === 'accepted') {
             for (const [index, decision] of input.evaluation.decisions.entries()) {
-              await ops.insertOne<GovernanceDbRow>('factory_deferred_decisions', {
-                org_id: input.orgId,
-                factory_project_id: input.factoryProjectId,
-                evaluation_id: evaluation.id,
-                work_item_id: item.id,
-                idempotency_key: String(decision.idempotencyKey),
-                effect_ordinal: index,
-                effect_hash: factoryDecisionHash(decision),
-                causal_chain: input.causalChain,
+              await insertDeferredDecision(ops, {
+                orgId: input.orgId,
+                factoryProjectId: input.factoryProjectId,
+                evaluationId: evaluation.id,
+                workItemId: item.id,
+                idempotencyKey: String(decision.idempotencyKey),
+                ordinal: index,
+                causalChain: input.causalChain,
                 actor: null,
                 decision,
-                status: 'pending',
-                attempts: 0,
-                available_at: now,
-                lease_owner: null,
-                lease_expires_at: null,
-                last_error: null,
-                completed_at: null,
-                created_at: new Date(now.getTime() + index),
-                updated_at: now,
+                now,
               });
             }
           }
         }
         return { status: 'committed', item, result };
       });
-    return this.storage.withDistributedLock
-      ? this.storage.withDistributedLock(
-          `factory-ingress:${input.orgId}:${input.factoryProjectId}:${input.ingress.identity}`,
-          commit,
-        )
-      : commit();
+    return this.#withProjectRelationLock(input.orgId, input.factoryProjectId, commit);
   }
 
   async commitRuleEvaluation(input: CommitFactoryRuleEvaluationInput): Promise<CommitFactoryRuleEvaluationResult> {

--- a/mastracode/web/package.json
+++ b/mastracode/web/package.json
@@ -48,7 +48,7 @@
     "@octokit/auth-app": "^8.0.0",
     "@octokit/rest": "^22.0.1",
     "@tanstack/react-query": "^5.90.21",
-    "@workos-inc/node": "8.8.0",
+    "@workos-inc/node": "8.13.0",
     "date-fns": "^4.4.0",
     "debug": "^4.4.3",
     "drizzle-orm": "^0.45.0",

--- a/mastracode/web/pnpm-lock.yaml
+++ b/mastracode/web/pnpm-lock.yaml
@@ -69,8 +69,8 @@ importers:
         specifier: ^5.90.21
         version: 5.101.3(react@19.2.7)
       '@workos-inc/node':
-        specifier: 8.8.0
-        version: 8.8.0
+        specifier: 8.13.0
+        version: 8.13.0
       date-fns:
         specifier: ^4.4.0
         version: 4.4.0
@@ -1364,8 +1364,8 @@ packages:
   '@vitest/utils@4.1.10':
     resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
 
-  '@workos-inc/node@8.8.0':
-    resolution: {integrity: sha512-niYqVLkrJCmDxY3FA372kZoiYruW6C2lRJVIMUZ42vcNLMpo5aAXTkmd39YSCXKmIYQEIa24wYwODv8xH5U3XA==}
+  '@workos-inc/node@8.13.0':
+    resolution: {integrity: sha512-NgQKHpwh8AbT4KvAsW91Y+4f4jja2IvFPQ5atcy5NUxUMVRgXzRFEee3erawfXrTmiCVqJjd9PljHySKBXmHKQ==}
     engines: {node: '>=20.15.0'}
 
   agent-base@7.1.4:
@@ -1673,6 +1673,9 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   eventsource-parser@3.1.0:
     resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
     engines: {node: '>=18.0.0'}
@@ -1767,9 +1770,6 @@ packages:
     resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
     engines: {node: '>=8'}
 
-  iron-webcrypto@2.0.0:
-    resolution: {integrity: sha512-rtffZKDUHciZElM8mjFCufBC7nVhCxHYyWHESqs89OioEDz4parOofd8/uhrejh/INhQFfYQfByS22LlezR9sQ==}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
@@ -1791,9 +1791,6 @@ packages:
   jiti@2.7.0:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
-
-  jose@6.1.3:
-    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2353,10 +2350,6 @@ packages:
     resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
     engines: {node: '>=16.20.0'}
     hasBin: true
-
-  uint8array-extras@1.5.0:
-    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
-    engines: {node: '>=18'}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -3523,10 +3516,9 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
-  '@workos-inc/node@8.8.0':
+  '@workos-inc/node@8.13.0':
     dependencies:
-      iron-webcrypto: 2.0.0
-      jose: 6.1.3
+      eventemitter3: 5.0.4
 
   agent-base@7.1.4: {}
 
@@ -3755,6 +3747,8 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.9
 
+  eventemitter3@5.0.4: {}
+
   eventsource-parser@3.1.0: {}
 
   expect-type@1.4.0: {}
@@ -3841,10 +3835,6 @@ snapshots:
 
   indent-string@4.0.0: {}
 
-  iron-webcrypto@2.0.0:
-    dependencies:
-      uint8array-extras: 1.5.0
-
   is-fullwidth-code-point@3.0.0: {}
 
   is-interactive@2.0.0: {}
@@ -3856,8 +3846,6 @@ snapshots:
   is-unicode-supported@2.1.0: {}
 
   jiti@2.7.0: {}
-
-  jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -4410,8 +4398,6 @@ snapshots:
       '@typescript/typescript-sunos-x64': 7.0.2
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
-
-  uint8array-extras@1.5.0: {}
 
   undici-types@6.21.0: {}
 

--- a/mastracode/web/src/shared/hooks/useAgentControllerRunMutations.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerRunMutations.ts
@@ -2,6 +2,8 @@ import type { PlanResume } from '@mastra/client-js';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { queryKeys } from '../api/keys';
+import { userMessageAttributes } from '../../web/ui/domains/auth/services/auth';
+import { useFactoryAuth } from './useFactoryAuth';
 import {
   createAgentControllerClient,
   requireAgentControllerSession,
@@ -33,13 +35,14 @@ export interface SendAgentControllerMessageInput {
 
 export function useSendAgentControllerMessageMutation(args: AgentControllerRunMutationArgs) {
   const { session } = createAgentControllerClient(args);
+  const auth = useFactoryAuth();
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
     mutationFn: (input: SendAgentControllerMessageInput | string) => {
       const { text, files } = typeof input === 'string' ? { text: input, files: undefined } : input;
-      return requireAgentControllerSession(session).sendMessage(
-        files?.length ? { content: text, files } : { content: text },
-      );
+      return requireAgentControllerSession(session).sendMessage(files?.length ? { content: text, files } : text, {
+        attributes: userMessageAttributes(auth.data),
+      });
     },
     onSuccess: invalidateSession,
   });
@@ -47,18 +50,22 @@ export function useSendAgentControllerMessageMutation(args: AgentControllerRunMu
 
 export function useSteerAgentControllerMutation(args: AgentControllerRunMutationArgs) {
   const { session } = createAgentControllerClient(args);
+  const auth = useFactoryAuth();
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
-    mutationFn: (text: string) => requireAgentControllerSession(session).steer(text),
+    mutationFn: (text: string) =>
+      requireAgentControllerSession(session).steer(text, { attributes: userMessageAttributes(auth.data) }),
     onSuccess: invalidateSession,
   });
 }
 
 export function useFollowUpAgentControllerMutation(args: AgentControllerRunMutationArgs) {
   const { session } = createAgentControllerClient(args);
+  const auth = useFactoryAuth();
   const invalidateSession = useSessionInvalidation(args);
   return useMutation({
-    mutationFn: (text: string) => requireAgentControllerSession(session).followUp(text),
+    mutationFn: (text: string) =>
+      requireAgentControllerSession(session).followUp(text, { attributes: userMessageAttributes(auth.data) }),
     onSuccess: invalidateSession,
   });
 }

--- a/mastracode/web/src/web/ui/domains/auth/services/auth.ts
+++ b/mastracode/web/src/web/ui/domains/auth/services/auth.ts
@@ -33,6 +33,15 @@ export function userSessionResourceId(state: FactoryAuthState | undefined): stri
   return userId;
 }
 
+export function userMessageAttributes(
+  state: FactoryAuthState | undefined,
+): { name: string; userId?: string } | undefined {
+  const name = state?.authenticated ? state.user?.name : undefined;
+  if (!name || name.length > 128) return undefined;
+  const userId = state?.user?.userId;
+  return userId && userId.length <= 128 ? { name, userId } : { name };
+}
+
 /**
  * Build the hosted-login URL. `returnTo` is where the server sends the user
  * after authenticating; it defaults to the current location so contexts that

--- a/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Transcript.tsx
@@ -856,7 +856,8 @@ function MessageBubble({
 
   const roles: MessageRoleRenderers = {
     User: ({ children }) => (
-      <div className="my-3 flex w-full flex-col items-end">
+      <div className="my-3 flex w-full flex-col items-end gap-1">
+        {entry.authorName && <div className="text-ui-xs text-icon3">{entry.authorName}</div>}
         <div
           className={`text-text1 max-w-[70%] rounded-xl px-4 py-2 break-words ${
             entry.steer ? 'bg-warning1/10' : 'bg-surface3'

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerTranscript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerTranscript.ts
@@ -1,6 +1,8 @@
 import type { AgentControllerEvent, AgentControllerOMProgress, MastraDBMessage } from '@mastra/client-js';
 import { useReducer, useRef } from 'react';
 
+import { useFactoryAuth } from '../../../../../shared/hooks/useFactoryAuth';
+import { userMessageAttributes } from '../../auth/services/auth';
 import { createInitialTranscript, transcriptReducer } from '../services/transcript';
 import type { OutgoingFile, TranscriptState, UsageSnapshot } from '../services/transcript';
 
@@ -18,6 +20,7 @@ export function useAgentControllerTranscript({
   initialMessages?: MastraDBMessage[];
   initialState?: SessionStateSnapshot;
 } = {}) {
+  const auth = useFactoryAuth();
   const [transcript, dispatch] = useReducer(transcriptReducer, undefined, () =>
     createInitialTranscript({
       messages: initialMessages,
@@ -43,7 +46,7 @@ export function useAgentControllerTranscript({
   };
 
   const localUser = (text: string, steer?: boolean, files?: OutgoingFile[]) => {
-    dispatch({ type: 'localUser', text, steer, files });
+    dispatch({ type: 'localUser', text, steer, files, authorName: userMessageAttributes(auth.data)?.name });
   };
 
   const resolvePrompt = (id: string) => {

--- a/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/__tests__/transcript.test.ts
@@ -147,6 +147,7 @@ describe('transcript reducer message entries', () => {
       type: 'user',
       tagName: 'user',
       text: 'sup',
+      attributes: { name: 'Ada Lovelace' },
     });
     const steered = signalMessage({
       id: 'user-signal-2',
@@ -171,6 +172,7 @@ describe('transcript reducer message entries', () => {
       id: persisted.id,
       message: { role: 'user', createdAt: persisted.createdAt, content: persisted.content },
       steer: false,
+      authorName: 'Ada Lovelace',
     });
     expect(reminderEntry).toMatchObject({
       kind: 'message',
@@ -192,6 +194,37 @@ describe('transcript reducer message entries', () => {
       steer: true,
     });
     expect(steered.role).toBe('signal');
+  });
+
+  it('keeps optimistic attribution aligned with hydration and ignores malformed names', () => {
+    const optimistic = transcriptReducer(initialTranscript, {
+      type: 'localUser',
+      text: 'Ship it',
+      authorName: 'Ada Lovelace',
+    });
+    expect(optimistic.entries[0]).toMatchObject({
+      kind: 'message',
+      message: { role: 'user' },
+      authorName: 'Ada Lovelace',
+    });
+
+    const malformed = signalMessage({
+      id: 'user-signal-malformed',
+      type: 'user',
+      tagName: 'user',
+      text: 'No trusted label',
+      attributes: { name: 42 },
+    });
+    const oversized = signalMessage({
+      id: 'user-signal-oversized',
+      type: 'user',
+      tagName: 'user',
+      text: 'No oversized label',
+      attributes: { name: 'a'.repeat(129) },
+    });
+    const hydrated = createInitialTranscript({ messages: [malformed, oversized] });
+    expect(hydrated.entries[0]).toMatchObject({ authorName: undefined });
+    expect(hydrated.entries[1]).toMatchObject({ authorName: undefined });
   });
 
   it('streams message updates without replacing non-message transcript state', () => {

--- a/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
+++ b/mastracode/web/src/web/ui/domains/chat/services/transcript.ts
@@ -49,6 +49,8 @@ export interface MessageEntry {
   streaming?: boolean;
   /** A steer (interjection) vs a normal message. */
   steer?: boolean;
+  /** Authenticated display name attached to a user-authored signal. */
+  authorName?: string;
 }
 
 export interface NoticeEntry {
@@ -199,7 +201,7 @@ export interface OutgoingFile {
 
 type Action =
   | { type: 'event'; event: AgentControllerEvent }
-  | { type: 'localUser'; text: string; steer?: boolean; files?: OutgoingFile[] }
+  | { type: 'localUser'; text: string; steer?: boolean; files?: OutgoingFile[]; authorName?: string }
   | { type: 'clearPending' }
   | { type: 'localNotice'; text: string; level: 'info' | 'error' }
   | { type: 'resolvePrompt'; id: string }
@@ -253,7 +255,7 @@ export function transcriptReducer(state: TranscriptState, action: Action): Trans
                 parts: [{ type: 'text', text: action.text }, ...(action.files ?? []).map(toOutgoingFilePart)],
               },
             },
-            { steer: action.steer },
+            { steer: action.steer, authorName: action.authorName },
           ),
         ],
       };
@@ -632,7 +634,7 @@ function prependOlderMessages(state: TranscriptState, messages: MastraDBMessage[
 
 function toMessageEntry(
   message: MastraDBMessage,
-  options: { streaming?: boolean; steer?: boolean; runtimeTools?: Record<string, ToolCall> } = {},
+  options: { streaming?: boolean; steer?: boolean; runtimeTools?: Record<string, ToolCall>; authorName?: string } = {},
 ): MessageEntry {
   const signalMetadata = message.role === 'signal' ? message.content.metadata?.signal : undefined;
   const signal =
@@ -645,6 +647,9 @@ function toMessageEntry(
       ? (signal.attributes as Record<string, unknown>)
       : undefined;
   const displayMessage = isUserSignal ? { ...message, role: 'user' as const } : message;
+  const attributedName = isUserSignal && typeof attributes?.name === 'string' ? attributes.name : undefined;
+  const candidateName = attributedName ?? options.authorName;
+  const authorName = candidateName && candidateName.length <= 128 ? candidateName : undefined;
 
   return {
     kind: 'message',
@@ -653,6 +658,7 @@ function toMessageEntry(
     runtimeTools: options.runtimeTools,
     streaming: options.streaming,
     steer: options.steer ?? (isUserSignal ? attributes?.delivery === 'while-active' : undefined),
+    authorName,
   };
 }
 

--- a/packages/cli/src/commands/api/route-metadata.generated.ts
+++ b/packages/cli/src/commands/api/route-metadata.generated.ts
@@ -6012,6 +6012,7 @@ export const API_ROUTE_METADATA = {
       "sessionScope"
     ],
     "bodyParams": [
+      "attributes",
       "files",
       "message",
       "requestContext"
@@ -6033,6 +6034,7 @@ export const API_ROUTE_METADATA = {
       "sessionScope"
     ],
     "bodyParams": [
+      "attributes",
       "message",
       "requestContext"
     ],
@@ -6053,6 +6055,7 @@ export const API_ROUTE_METADATA = {
       "sessionScope"
     ],
     "bodyParams": [
+      "attributes",
       "message",
       "requestContext"
     ],

--- a/packages/core/src/agent-controller/__tests__/signal-messages.test.ts
+++ b/packages/core/src/agent-controller/__tests__/signal-messages.test.ts
@@ -64,6 +64,68 @@ describe('AgentController signal messages', () => {
     );
   });
 
+  it('preserves attributed message attributes for active delivery, persistence, and model input', async () => {
+    const activeRunId = 'run-1';
+    const agent = createAgentMock(() => activeRunId);
+    const controller = new AgentController({
+      workspace: createMockWorkspace(),
+      id: 'controller-attributed-active',
+      resourceId: 'resource-1',
+      modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],
+    });
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+    const threadId = session.thread.getId()!;
+    const subscription = createSubscription(() => activeRunId);
+
+    session.run.ensureAbortController();
+    session.run.setRunId({ runId: activeRunId });
+    session.stream.attach({ subscription: subscription as any, key: `agent-1:resource-1:${threadId}` });
+
+    await session.sendMessage({
+      content: 'Use <safe> & sound output',
+      attributes: { userId: 'user-1', name: 'Ada Lovelace' },
+    });
+
+    const signal = agent.sendSignal.mock.calls[0]![0];
+    expect(signal.attributes).toEqual({ userId: 'user-1', name: 'Ada Lovelace' });
+    expect(signal.toDBMessage().content.metadata.signal.attributes).toEqual({
+      userId: 'user-1',
+      name: 'Ada Lovelace',
+    });
+    expect(signal.toLLMMessage()).toEqual({
+      role: 'user',
+      content: '<user userId="user-1" name="Ada Lovelace">Use &lt;safe&gt; &amp; sound output</user>',
+    });
+  });
+
+  it('preserves attributed message attributes when an idle signal wakes a run', async () => {
+    const agent = createAgentMock(() => null);
+    const controller = new AgentController({
+      workspace: createMockWorkspace(),
+      id: 'controller-attributed-idle',
+      resourceId: 'resource-1',
+      modes: [{ id: 'default', name: 'Default', default: true, agent: agent as any }],
+    });
+    await controller.init();
+    const session = await controller.createSession({ id: 'test-session', ownerId: 'test-owner' });
+
+    const result = session.sendSignal({
+      content: 'wake up',
+      attributes: { name: 'Ada Lovelace' },
+    });
+    await expect(result.accepted).resolves.toEqual({ accepted: true, runId: undefined });
+
+    expect(agent.sendSignal.mock.calls[0]![0]).toEqual(
+      expect.objectContaining({
+        type: 'user',
+        tagName: 'user',
+        contents: 'wake up',
+        attributes: { name: 'Ada Lovelace' },
+      }),
+    );
+  });
+
   it('declines an armed approval with interruption context before delivering a user signal', async () => {
     let activeRunId: string | null = 'run-1';
     const agent = createAgentMock(() => activeRunId);

--- a/packages/core/src/agent-controller/session.ts
+++ b/packages/core/src/agent-controller/session.ts
@@ -1100,6 +1100,8 @@ export class SessionSuspensions {
 export interface FollowUp {
   /** The message text to send. */
   content: string;
+  /** Optional signal attributes preserved when the queued message is sent. */
+  attributes?: AgentSignalAttributes;
   /** Optional request context to apply when the queued message is sent. */
   requestContext?: RequestContext;
 }
@@ -3009,6 +3011,7 @@ export class Session<TState = unknown> {
       | AgentSignalInput
       | {
           content: AgentSignalContents;
+          attributes?: AgentSignalAttributes;
           ifActive?: { attributes?: AgentSignalAttributes };
           ifIdle?: { attributes?: AgentSignalAttributes };
           tracingContext?: TracingContext;
@@ -3049,7 +3052,9 @@ export class Session<TState = unknown> {
     // run to fully idle before starting a new run.
     const submittedAbortRequested = this.run.isAbortRequested();
     const signal = createSignal(
-      'content' in input ? { type: 'user', tagName: 'user', contents: input.content } : input,
+      'content' in input
+        ? { type: 'user', tagName: 'user', contents: input.content, attributes: input.attributes }
+        : input,
     );
     const accepted = Promise.resolve().then(async () => {
       if (!this.thread.getId()) {
@@ -3164,12 +3169,14 @@ export class Session<TState = unknown> {
   async sendMessage({
     content,
     files,
+    attributes,
     tracingContext,
     tracingOptions,
     requestContext: requestContextInput,
   }: {
     content: string;
     files?: Array<{ data: string; mediaType: string; filename?: string }>;
+    attributes?: AgentSignalAttributes;
     tracingContext?: TracingContext;
     tracingOptions?: TracingOptions;
     requestContext?: RequestContext;
@@ -3190,6 +3197,7 @@ export class Session<TState = unknown> {
         });
     const signal = this.sendSignal({
       content: messageInput,
+      attributes,
       tracingContext,
       tracingOptions,
       requestContext: requestContextInput,
@@ -3213,23 +3221,39 @@ export class Session<TState = unknown> {
   /**
    * Steer the agent mid-stream: aborts the current run and sends a new message.
    */
-  async steer({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
+  async steer({
+    content,
+    attributes,
+    requestContext,
+  }: {
+    content: string;
+    attributes?: AgentSignalAttributes;
+    requestContext?: RequestContext;
+  }): Promise<void> {
     this.abort();
     this.followUps.clear();
     this.emit({ type: 'follow_up_queued', count: 0 });
-    await this.sendMessage({ content, requestContext });
+    await this.sendMessage({ content, attributes, requestContext });
   }
 
   /**
    * Queue a follow-up message to be processed after the current run completes,
    * or send it immediately when the session is idle.
    */
-  async followUp({ content, requestContext }: { content: string; requestContext?: RequestContext }): Promise<void> {
+  async followUp({
+    content,
+    attributes,
+    requestContext,
+  }: {
+    content: string;
+    attributes?: AgentSignalAttributes;
+    requestContext?: RequestContext;
+  }): Promise<void> {
     if (this.run.isRunning()) {
-      this.followUps.enqueue({ content, requestContext });
+      this.followUps.enqueue({ content, attributes, requestContext });
       this.emit({ type: 'follow_up_queued', count: this.followUps.count() });
     } else {
-      await this.sendMessage({ content, requestContext });
+      await this.sendMessage({ content, attributes, requestContext });
     }
   }
 
@@ -3253,11 +3277,15 @@ export class Session<TState = unknown> {
           tracingContext: options?.tracingContext,
           tracingOptions: options?.tracingOptions,
         });
-        const result = agent.queueMessage(this.createMessageInput({ content: next.content }), {
-          resourceId: this.identity.getResourceId(),
-          threadId,
-          ifIdle: { streamOptions: streamOptions as any },
-        });
+        const messageInput = this.createMessageInput({ content: next.content });
+        const result = agent.queueMessage(
+          next.attributes ? { contents: messageInput, attributes: next.attributes } : messageInput,
+          {
+            resourceId: this.identity.getResourceId(),
+            threadId,
+            ifIdle: { streamOptions: streamOptions as any },
+          },
+        );
         // Let a rejected `accepted` propagate: `next` is already dequeued, so a
         // setup/misconfig failure must reach the outer catch to requeue it
         // rather than being swallowed into a false success (the follow-up would
@@ -3269,6 +3297,7 @@ export class Session<TState = unknown> {
         this.emit({ type: 'follow_up_queued', count: this.followUps.count() });
         await this.sendMessage({
           content: next.content,
+          attributes: next.attributes,
           requestContext: next.requestContext,
           tracingContext: options?.tracingContext,
           tracingOptions: options?.tracingOptions,

--- a/packages/server/src/server/handlers/agent-controller.test.ts
+++ b/packages/server/src/server/handlers/agent-controller.test.ts
@@ -6,6 +6,7 @@ import { InMemoryStore } from '@mastra/core/storage';
 import { Workspace } from '@mastra/core/workspace';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 
+import { MASTRA_USER_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import {
   LIST_AGENT_CONTROLLERS_ROUTE,
@@ -265,6 +266,63 @@ describe('agent-controller routes', () => {
       } as any);
 
       expect(spy).toHaveBeenCalledWith({ content: 'hello', requestContext });
+    });
+
+    it('uses authenticated identity instead of caller-supplied message attribution', async () => {
+      const session = await getRouteSession('user-attributed');
+      const sendSpy = vi.spyOn(session, 'sendMessage').mockResolvedValue(undefined);
+      const steerSpy = vi.spyOn(session, 'steer').mockResolvedValue(undefined);
+      const followUpSpy = vi.spyOn(session, 'followUp').mockResolvedValue(undefined);
+      const requestContext = makeRequestContext();
+      requestContext.set(MASTRA_USER_KEY, { id: 'user-1', name: 'Ada Lovelace' });
+      const spoofed = { userId: 'other', name: 'Other User', source: 'web' };
+
+      await SEND_AGENT_CONTROLLER_MESSAGE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-attributed',
+        message: 'hello',
+        attributes: spoofed,
+        requestContext,
+      } as any);
+      await STEER_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-attributed',
+        message: 'focus',
+        attributes: spoofed,
+        requestContext,
+      } as any);
+      await FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'user-attributed',
+        message: 'later',
+        attributes: spoofed,
+        requestContext,
+      } as any);
+
+      const attributes = { source: 'web', userId: 'user-1', name: 'Ada Lovelace' };
+      expect(sendSpy).toHaveBeenCalledWith({ content: 'hello', attributes, requestContext });
+      expect(steerSpy).toHaveBeenCalledWith({ content: 'focus', attributes, requestContext });
+      expect(followUpSpy).toHaveBeenCalledWith({ content: 'later', attributes, requestContext });
+    });
+
+    it('removes caller-supplied identity when no authenticated identity exists', async () => {
+      const session = await getRouteSession('local-unattributed');
+      const spy = vi.spyOn(session, 'sendMessage').mockResolvedValue(undefined);
+      const requestContext = makeRequestContext();
+
+      await SEND_AGENT_CONTROLLER_MESSAGE_ROUTE.handler({
+        mastra,
+        controllerId: 'code',
+        resourceId: 'local-unattributed',
+        message: 'hello',
+        attributes: { userId: 'other', name: 'Other User', source: 'web' },
+        requestContext,
+      } as any);
+
+      expect(spy).toHaveBeenCalledWith({ content: 'hello', attributes: { source: 'web' }, requestContext });
     });
 
     it('forwards files to session.sendMessage', async () => {

--- a/packages/server/src/server/handlers/agent-controller.ts
+++ b/packages/server/src/server/handlers/agent-controller.ts
@@ -7,6 +7,7 @@ import type { RequestContext } from '@mastra/core/request-context';
 // value import.
 import { z } from 'zod/v4';
 
+import { MASTRA_USER_KEY } from '../constants';
 import { HTTPException } from '../http-exception';
 import { createRoute } from '../server-adapter/routes/route-builder';
 import { handleError } from './error';
@@ -109,9 +110,14 @@ const MAX_TOTAL_FILE_DATA_LENGTH = 28 * 1024 * 1024;
  * spec documents it.
  */
 const bodyRequestContextSchema = z.record(z.string(), z.unknown()).optional();
+const messageAttributesSchema = z
+  .record(z.string().max(64), z.union([z.string().max(1024), z.number(), z.boolean(), z.null(), z.undefined()]))
+  .refine(attributes => Object.keys(attributes).length <= 20, 'Message attributes may contain at most 20 entries')
+  .optional();
 
 const sendMessageBodySchema = z.object({
   message: z.string(),
+  attributes: messageAttributesSchema,
   requestContext: bodyRequestContextSchema,
   // Optional attachments (e.g. pasted images). `data` is base64-encoded.
   files: z
@@ -128,7 +134,11 @@ const sendMessageBodySchema = z.object({
     })
     .optional(),
 });
-const steerBodySchema = z.object({ message: z.string(), requestContext: bodyRequestContextSchema });
+const steerBodySchema = z.object({
+  message: z.string(),
+  attributes: messageAttributesSchema,
+  requestContext: bodyRequestContextSchema,
+});
 const toolApprovalBodySchema = z.object({
   toolCallId: z.string(),
   approved: z.boolean(),
@@ -177,7 +187,35 @@ const listThreadsQuerySchema = z.object({
     }, z.record(z.string(), z.string()).optional())
     .optional(),
 });
-const followUpBodySchema = z.object({ message: z.string(), requestContext: bodyRequestContextSchema });
+const followUpBodySchema = z.object({
+  message: z.string(),
+  attributes: messageAttributesSchema,
+  requestContext: bodyRequestContextSchema,
+});
+
+type MessageAttributes = Record<string, string | number | boolean | null | undefined>;
+
+function trustedUserAttributes(
+  requestContext: RequestContext | undefined,
+  attributes: MessageAttributes | undefined,
+): MessageAttributes | undefined {
+  const trusted = { ...attributes };
+  delete trusted.userId;
+  delete trusted.name;
+
+  const user = requestContext?.get(MASTRA_USER_KEY) ?? requestContext?.get('user');
+  if (user && typeof user === 'object' && !Array.isArray(user)) {
+    const record = user as Record<string, unknown>;
+    const bounded = (value: unknown) =>
+      typeof value === 'string' && value.length > 0 && value.length <= 128 ? value : undefined;
+    const userId = bounded(record.id) ?? bounded(record.userId) ?? bounded(record.workosId);
+    const name = bounded(record.name);
+    if (userId) trusted.userId = userId;
+    if (name) trusted.name = name;
+  }
+
+  return Object.keys(trusted).length > 0 ? trusted : undefined;
+}
 
 const sendNotificationBodySchema = z.object({
   source: z.string(),
@@ -494,14 +532,21 @@ export const SEND_AGENT_CONTROLLER_MESSAGE_ROUTE = createRoute({
   tags: ['AgentController', 'Streaming'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, files, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, files, attributes, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId, { scope: sessionScope }, requestContext);
       // Forward the server middleware's requestContext so identity injected in
       // `server.middleware` reaches dynamic instructions and tools (same as the
-      // plain agent message route).
-      void session.sendMessage({ content: message, files, requestContext });
+      // plain agent message route). Authenticated identity always wins over
+      // caller-supplied display attributes.
+      const messageAttributes = trustedUserAttributes(requestContext, attributes);
+      void session.sendMessage({
+        content: message,
+        files,
+        ...(messageAttributes ? { attributes: messageAttributes } : {}),
+        requestContext,
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error sending controller message');
@@ -602,11 +647,16 @@ export const STEER_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, attributes, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId, { scope: sessionScope }, requestContext);
-      void session.steer({ content: message, requestContext });
+      const messageAttributes = trustedUserAttributes(requestContext, attributes);
+      void session.steer({
+        content: message,
+        ...(messageAttributes ? { attributes: messageAttributes } : {}),
+        requestContext,
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error steering controller session');
@@ -1077,11 +1127,16 @@ export const FOLLOW_UP_AGENT_CONTROLLER_SESSION_ROUTE = createRoute({
   tags: ['AgentController'],
   requiresAuth: true,
   requiresPermission: 'agent-controller:execute',
-  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, requestContext }) => {
+  handler: async ({ mastra, controllerId, resourceId, sessionScope, message, attributes, requestContext }) => {
     try {
       const controller = getAgentControllerOrThrow(mastra, controllerId);
       const session = await getSession(controller, resourceId, { scope: sessionScope }, requestContext);
-      void session.followUp({ content: message, requestContext });
+      const messageAttributes = trustedUserAttributes(requestContext, attributes);
+      void session.followUp({
+        content: message,
+        ...(messageAttributes ? { attributes: messageAttributes } : {}),
+        requestContext,
+      });
       return { ok: true };
     } catch (error) {
       return handleError(error, 'error queuing controller follow-up');


### PR DESCRIPTION
## Stack

Two-part stack — merge in order:

1. **#19970 — supervisor approval foundations** ← you are here (base: `main`)
2. #20005 — shared supervisor workspace (base: `feat/factory-supervisor-approvals`)

This PR is the foundation half: it lands the durable approval storage, the `pending_approval` transition outcome, and the attributed-message plumbing. It stands on its own and is reviewable without #20005.

#20005 is branched off this one, so GitHub will retarget it to `main` automatically once this merges.

## Summary

- add bounded AgentController message attributes across core, server, client, and MastraCode chat, replacing identity fields at the authenticated server boundary and rendering the attributed user name in optimistic and hydrated transcripts
- add durable, tenant-scoped Factory transition approvals for agent-initiated moves, including revision-bound automatic application, stale/reject handling, notifications, audit records, and HTTP APIs
- observe normally completed work-item runs that remain idle without a transition, defaulting on with an explicit per-Factory rules opt-out
- align the standalone MastraCode Web WorkOS client with the extracted Factory package so its production build and typecheck use one compatible SDK version

## Test plan

- `pnpm build:core`
- `pnpm build:clients`
- `pnpm --filter @mastra/factory build:lib`
- `pnpm --filter @mastra/factory check`
- `pnpm --dir mastracode/web check`
- `pnpm --dir mastracode/web web:build`
- `pnpm --filter @mastra/core exec vitest run src/agent-controller/__tests__/signal-messages.test.ts --reporter=dot --bail 1`
- `pnpm --filter @mastra/client-js exec vitest run src/resources/agent-controller.test.ts --reporter=dot --bail 1`
- `pnpm --filter @mastra/factory exec vitest run src/rules/transition-service.test.ts src/rules/approval-service.test.ts src/rules/tools.test.ts src/rules/dispatcher.test.ts src/rules/run-lifecycle-observer.test.ts src/routes/work-items.test.ts --reporter=dot --bail 1`
- `pnpm --dir mastracode/web exec vitest run src/web/ui/domains/chat/services/__tests__/transcript.test.ts src/web/ui/__tests__/message-rendering.msw.test.tsx --reporter=dot --bail 1`
- `pnpm --dir docs lint:remark`
- `pnpm --dir docs validate`
- real Mastra server proof: authenticated user attribution overrides spoofed fields; agent tool returns `pending_approval`; approval resolution advances the captured revision (`PROOF: GREEN — attributed approval flow passed`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
This PR helps Factory handle “who approved what” more safely. It makes the system trust only the logged-in user on the server (not user-provided names/ids), adds a durable supervisor approval step when agents try to advance work, and records when agent runs finish without any transition.

## What changed

- **Bounded, attributed AgentController message attributes (client → core → server)**
  - Added optional `attributes` to user-authored `AgentController` flows (`sendMessage`, `steer`, `followUp`) and to queued follow-ups.
  - Updated client/core types and request bodies to include bounded `attributes`.
  - **Hardened server identity attribution**: server handlers validate `attributes`, strip any caller-supplied `userId`/`name`, and repopulate them from authenticated `requestContext` before forwarding to the agent session.

- **Transcript user-name hydration + optimistic consistency**
  - Extended chat transcript `MessageEntry` to support an optional `authorName`.
  - UI now renders `authorName` for user messages and ensures optimistic local attribution matches hydrated persisted attributes, while ignoring malformed/oversized names.

- **Durable, tenant-scoped supervisor approvals for agent transitions**
  - Introduced a `pending_approval` transition outcome driven by new `requestApproval` rule decisions.
  - Added `requireSupervisorApproval` + `defaultFactoryRules` updates, including **revision-bound** approval validity.
  - Implemented `FactoryTransitionApprovalService` to **list** and **resolve** approvals, with:
    - approve/reject behavior
    - stale detection when captured revisions change
    - tenant/project boundary enforcement
    - idempotent replay handling
    - audit/notification effects and deferred decision persistence.
  - Extended `WorkItemsStorage` with approval persistence and APIs to support the new approval lifecycle.

- **Observe “idle without transition” (default on, configurable)**
  - Added `FactoryRunLifecycleObserver` + wiring so completed work-item runs that don’t transition emit `factory.run.idle_without_transition` audit/notification events.
  - Added `observeIdleWithoutTransition` to supervisor rules, defaulting to enabled but disable-able per Factory rules.

- **HTTP route surface for approvals**
  - Added endpoints to list approvals and resolve approvals (approve/reject) with request validation and correct authenticated actor/audit behavior.
  - Updated/expanded route/unit tests for pending approvals, stale handling, and tenant boundary denial.

- **MastraCode Web compatibility**
  - Updated MastraCode Web’s WorkOS SDK dependency to align with the extracted Factory package.

- **Verification & maintenance**
  - Added/updated targeted unit tests, route tests, and documentation for the new attributes/transcript behavior and approval workflows.
  - Added changeset(s) for the relevant `@mastra` packages and updated formatting-related union types to keep formatting tooling/linting working.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->