### PR TITLE
fix(factory): inclusive UTC calendar-day metrics window

### DIFF
--- a/.changeset/heavy-frogs-yawn.md
+++ b/.changeset/heavy-frogs-yawn.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed Factory metrics windowing to use inclusive UTC calendar days. Date-only `from`/`to` bounds now include both selected days, an item completing at the current instant is counted in today's throughput (previously it could be dropped on the window's exclusive edge), and `windowDays` reflects the number of gap-filled day buckets. Cards feed the source mix only when created inside the window.

--- a/.changeset/little-pans-shave.md
+++ b/.changeset/little-pans-shave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed duplicate repositories in Factory source control settings.

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -942,6 +942,19 @@ describe('repos route', () => {
     vi.mocked(listInstallationRepos).mockImplementation(defaultImpl);
   });
 
+  it('lists a repository once when multiple installations return it', async () => {
+    install(7, 'octo');
+    install(8, 'octo-duplicate');
+
+    const res = await buildApp({ workosId: 'u1' }).request('/web/github/repos');
+
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.repos).toHaveLength(1);
+    expect(json.repos[0].fullName).toBe('octo/hello');
+    expect(tables.repositories).toHaveLength(1);
+  });
+
   it('prunes installations GitHub no longer knows (404) and keeps listing the rest', async () => {
     install(7, 'octo');
     install(8, 'stale');

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -623,6 +623,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
 
         const query = (c.req.query('q') ?? '').toLowerCase();
         const repos = [];
+        const seenRepositoryIds = new Set<number>();
         for (const inst of installs) {
           let list;
           try {
@@ -640,6 +641,8 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
           }
           for (const repo of list) {
             if (query && !repo.fullName.toLowerCase().includes(query)) continue;
+            if (seenRepositoryIds.has(repo.id)) continue;
+            seenRepositoryIds.add(repo.id);
             const repository = await github.sourceControlStorage.repositories.upsert({
               orgId: resolved.tenant.orgId,
               input: {

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -612,10 +612,10 @@ describe('GET /web/factory/projects/:id/metrics', () => {
     // No params → default 30-day window.
     expect((await bodyFor('')).windowDays).toBe(30);
 
-    // Explicit 7-day window.
-    const to = new Date();
-    const from = new Date(to.getTime() - 7 * 86_400_000);
-    expect((await bodyFor(`?from=${from.toISOString()}&to=${to.toISOString()}`)).windowDays).toBe(7);
+    // Explicit inclusive 7-calendar-day window.
+    const to = new Date().toISOString().slice(0, 10);
+    const from = new Date(Date.parse(`${to}T00:00:00.000Z`) - 6 * 86_400_000).toISOString().slice(0, 10);
+    expect((await bodyFor(`?from=${from}&to=${to}`)).windowDays).toBe(7);
 
     // Malformed params fall back to the default.
     expect((await bodyFor('?from=evil&to=evil')).windowDays).toBe(30);
@@ -638,12 +638,9 @@ describe('GET /web/factory/projects/:id/metrics', () => {
       createBody({ externalSource: null, title: 'Manual card' }),
     );
 
-    const to = new Date();
-    const from = new Date(to.getTime() - 7 * 86_400_000);
-    const res = await json(
-      'GET',
-      `/web/factory/projects/${PROJECT_ID}/metrics?from=${from.toISOString()}&to=${to.toISOString()}`,
-    );
+    const to = new Date().toISOString().slice(0, 10);
+    const from = new Date(Date.parse(`${to}T00:00:00.000Z`) - 6 * 86_400_000).toISOString().slice(0, 10);
+    const res = await json('GET', `/web/factory/projects/${PROJECT_ID}/metrics?from=${from}&to=${to}`);
     expect(res.status).toBe(200);
     const { metrics } = await res.json();
 

--- a/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
@@ -5,13 +5,16 @@ import { computeFactoryMetrics, parseMetricsRange } from './metrics.js';
 
 /** Fixed "now" so every duration in the specs is deterministic. */
 const NOW = new Date('2026-07-15T12:00:00.000Z');
+/** Exclusive end of NOW's UTC day — the upper bound for open/future windows. */
+const END_OF_TODAY = Date.parse('2026-07-16T00:00:00.000Z');
 
 const HOUR = 3_600_000;
 const DAY = 24 * HOUR;
 
-/** A rolling window of `days` ending at NOW — the old `{ days }` shorthand. */
+/** A UTC calendar window of `days` ending at NOW. */
 function lastDays(days: number): { windowStart: number; windowEnd: number } {
-  return { windowStart: NOW.getTime() - days * DAY, windowEnd: NOW.getTime() };
+  const todayStart = Date.parse(`${NOW.toISOString().slice(0, 10)}T00:00:00.000Z`);
+  return { windowStart: todayStart - (days - 1) * DAY, windowEnd: NOW.getTime() };
 }
 
 /** ISO timestamp `hours` before NOW. */
@@ -55,8 +58,8 @@ function doneItem(id: string, createdHoursAgo: number, doneHoursAgo: number): Wo
 describe('parseMetricsRange', () => {
   it('defaults to the last 30 days when from/to are absent', () => {
     expect(parseMetricsRange(undefined, undefined, NOW)).toEqual({
-      windowStart: NOW.getTime() - 30 * DAY,
-      windowEnd: NOW.getTime(),
+      windowStart: Date.parse('2026-06-16T00:00:00.000Z'),
+      windowEnd: END_OF_TODAY,
     });
   });
 
@@ -69,9 +72,19 @@ describe('parseMetricsRange', () => {
     });
   });
 
-  it('clamps a future end to now', () => {
+  it('treats a date-only to bound as the end of that UTC calendar day', () => {
+    const range = parseMetricsRange('2026-07-01', '2026-07-10', NOW);
+
+    expect(range).toEqual({
+      windowStart: Date.parse('2026-07-01T00:00:00.000Z'),
+      windowEnd: Date.parse('2026-07-11T00:00:00.000Z'),
+    });
+    expect(computeFactoryMetrics([], range)).toMatchObject({ windowDays: 10 });
+  });
+
+  it('clamps a future end to the end of the current UTC day', () => {
     const future = new Date(NOW.getTime() + 5 * DAY).toISOString();
-    expect(parseMetricsRange(undefined, future, NOW).windowEnd).toBe(NOW.getTime());
+    expect(parseMetricsRange(undefined, future, NOW).windowEnd).toBe(END_OF_TODAY);
   });
 
   it('falls back to the default span when from is not before to', () => {
@@ -86,15 +99,15 @@ describe('parseMetricsRange', () => {
   it('caps the span at 366 days', () => {
     const from = new Date(NOW.getTime() - 500 * DAY).toISOString();
     expect(parseMetricsRange(from, undefined, NOW)).toEqual({
-      windowStart: NOW.getTime() - 366 * DAY,
-      windowEnd: NOW.getTime(),
+      windowStart: Date.parse('2025-07-15T00:00:00.000Z'),
+      windowEnd: END_OF_TODAY,
     });
   });
 
   it('treats malformed values as absent', () => {
     expect(parseMetricsRange('nonsense', '', NOW)).toEqual({
-      windowStart: NOW.getTime() - 30 * DAY,
-      windowEnd: NOW.getTime(),
+      windowStart: Date.parse('2026-06-16T00:00:00.000Z'),
+      windowEnd: END_OF_TODAY,
     });
   });
 });
@@ -242,18 +255,38 @@ describe('computeFactoryMetrics', () => {
       type: 'issue',
       externalId,
     });
+    const insideWindow = new Date(NOW.getTime() - 20 * DAY);
     const items = [
-      makeItem({ id: '00000000-0000-4000-8000-000000000001', externalSource: githubIssue('1') }),
-      makeItem({ id: '00000000-0000-4000-8000-000000000002', externalSource: githubIssue('2') }),
-      makeItem({ id: '00000000-0000-4000-8000-000000000003' }),
+      makeItem({
+        id: '00000000-0000-4000-8000-000000000001',
+        externalSource: githubIssue('1'),
+        createdAt: insideWindow,
+      }),
+      makeItem({
+        id: '00000000-0000-4000-8000-000000000002',
+        externalSource: githubIssue('2'),
+        createdAt: insideWindow,
+      }),
+      makeItem({
+        id: '00000000-0000-4000-8000-000000000003',
+        createdAt: insideWindow,
+      }),
       makeItem({
         id: '00000000-0000-4000-8000-000000000004',
         externalSource: { integrationId: 'linear', type: 'issue', externalId: 'LIN-1' },
         createdAt: new Date(NOW.getTime() - 40 * DAY),
       }),
+      makeItem({
+        id: '00000000-0000-4000-8000-000000000005',
+        externalSource: { integrationId: 'linear', type: 'issue', externalId: 'LIN-2' },
+        createdAt: new Date(NOW.getTime() - DAY),
+      }),
     ];
 
-    const metrics = computeFactoryMetrics(items, lastDays(30));
+    const metrics = computeFactoryMetrics(items, {
+      windowStart: NOW.getTime() - 30 * DAY,
+      windowEnd: NOW.getTime() - 10 * DAY,
+    });
 
     expect(metrics.sourceMix).toEqual([
       { source: 'github:issue', count: 2 },
@@ -271,7 +304,7 @@ describe('computeFactoryMetrics', () => {
       ],
     });
 
-    const metrics = computeFactoryMetrics({ items: [canceled], days: 7, now: NOW });
+    const metrics = computeFactoryMetrics([canceled], lastDays(7));
 
     // Not a completion: throughput and cycle time stay done-only.
     expect(metrics.throughput.every(point => point.count === 0)).toBe(true);
@@ -294,7 +327,7 @@ describe('computeFactoryMetrics', () => {
       ],
     });
 
-    const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+    const metrics = computeFactoryMetrics([item], lastDays(7));
 
     expect(metrics.stageDurations).toEqual([{ stage: 'triage', medianMs: 3 * HOUR, samples: 1 }]);
   });
@@ -308,7 +341,7 @@ describe('computeFactoryMetrics', () => {
       ],
     });
 
-    const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+    const metrics = computeFactoryMetrics([item], lastDays(7));
 
     expect(metrics.wipTotal).toBe(1);
     expect(metrics.agingWip).toHaveLength(1);
@@ -348,7 +381,7 @@ describe('computeFactoryMetrics', () => {
       ],
     });
 
-    const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+    const metrics = computeFactoryMetrics([item], lastDays(7));
 
     expect(metrics.transitions).toEqual({ human: 1, total: 3 });
     expect(metrics.stageAutomation).toEqual([
@@ -370,7 +403,7 @@ describe('computeFactoryMetrics', () => {
         ],
       });
 
-      const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+      const metrics = computeFactoryMetrics([item], lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([
         { stage: 'triage', exits: 1, automated: 1, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 1 } },
@@ -390,7 +423,7 @@ describe('computeFactoryMetrics', () => {
         ],
       });
 
-      const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+      const metrics = computeFactoryMetrics([item], lastDays(7));
 
       // Second visit is never automated even with automation actors on both ends.
       expect(metrics.stageAutomation).toEqual([
@@ -420,7 +453,7 @@ describe('computeFactoryMetrics', () => {
         }),
       ];
 
-      const metrics = computeFactoryMetrics({ items, days: 7, now: NOW });
+      const metrics = computeFactoryMetrics(items, lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([
         { stage: 'triage', exits: 2, automated: 0, outcomes: { done: 0, canceled: 0, reworked: 0, inFlight: 0 } },
@@ -455,7 +488,7 @@ describe('computeFactoryMetrics', () => {
         ),
       ];
 
-      const metrics = computeFactoryMetrics({ items, days: 7, now: NOW });
+      const metrics = computeFactoryMetrics(items, lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([
         { stage: 'triage', exits: 3, automated: 3, outcomes: { done: 1, canceled: 1, reworked: 0, inFlight: 1 } },
@@ -477,7 +510,7 @@ describe('computeFactoryMetrics', () => {
         ],
       });
 
-      const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+      const metrics = computeFactoryMetrics([item], lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([]);
     });
@@ -492,7 +525,7 @@ describe('computeFactoryMetrics', () => {
         ],
       });
 
-      const metrics = computeFactoryMetrics({ items: [item], days: 7, now: NOW });
+      const metrics = computeFactoryMetrics([item], lastDays(7));
 
       expect(metrics.stageAutomation).toEqual([]);
     });

--- a/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
@@ -5,7 +5,7 @@ import { computeFactoryMetrics, parseMetricsRange } from './metrics.js';
 
 /** Fixed "now" so every duration in the specs is deterministic. */
 const NOW = new Date('2026-07-15T12:00:00.000Z');
-/** Exclusive end of NOW's UTC day — the upper bound for open/future windows. */
+/** Exclusive end of NOW's UTC day. */
 const END_OF_TODAY = Date.parse('2026-07-16T00:00:00.000Z');
 
 const HOUR = 3_600_000;

--- a/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.test.ts
@@ -110,6 +110,18 @@ describe('parseMetricsRange', () => {
       windowEnd: END_OF_TODAY,
     });
   });
+
+  it('rejects timezone-less datetimes so the window is deployment-independent', () => {
+    // No Z/offset → Date.parse reads server-local; treated as absent (default window).
+    expect(parseMetricsRange('2026-07-01T10:00:00', '2026-07-05T10:00:00', NOW)).toEqual({
+      windowStart: Date.parse('2026-06-16T00:00:00.000Z'),
+      windowEnd: END_OF_TODAY,
+    });
+    // An explicit offset is honored.
+    expect(parseMetricsRange('2026-07-01T00:00:00+00:00', undefined, NOW).windowStart).toBe(
+      Date.parse('2026-07-01T00:00:00Z'),
+    );
+  });
 });
 
 describe('computeFactoryMetrics', () => {

--- a/mastracode/factory/src/storage/domains/work-items/metrics.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.ts
@@ -89,14 +89,10 @@ function utcDayStart(time: number): number {
 }
 
 /**
- * Resolve untrusted `from`/`to` query params into a bounded half-open UTC
- * window. Date-only bounds include both selected calendar days: `from` starts
- * at midnight and `to` resolves to the following midnight. Datetimes remain
- * exact instants. An open or future end resolves to the exclusive end of the
- * current UTC day (not `now`) so an event happening at this instant still falls
- * inside the half-open window instead of landing on its excluded upper edge.
- * The default and maximum spans are calendar-day based so the gap-filled
- * throughput series has a stable size.
+ * Resolve untrusted `from`/`to` into a bounded half-open UTC window. A date-only
+ * `to` covers the whole day; an open/future end resolves to the end of the
+ * current UTC day (not `now`) so an event at this instant stays inside the
+ * window instead of on its excluded edge.
  */
 export function parseMetricsRange(
   fromParam: unknown,

--- a/mastracode/factory/src/storage/domains/work-items/metrics.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.ts
@@ -75,18 +75,28 @@ export interface FactoryMetrics {
   }[];
 }
 
-/** Parse an untrusted `from`/`to` query param (ISO date or datetime) to epoch ms. */
-function parseRangeParam(value: unknown): number | undefined {
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+function parseRangeParam(value: unknown, boundary: 'from' | 'to'): number | undefined {
   if (typeof value !== 'string' || value.length === 0) return undefined;
   const time = Date.parse(value);
-  return Number.isNaN(time) ? undefined : time;
+  if (Number.isNaN(time)) return undefined;
+  return boundary === 'to' && DATE_ONLY_RE.test(value) ? time + DAY_MS : time;
+}
+
+function utcDayStart(time: number): number {
+  return Date.parse(`${utcDay(time)}T00:00:00Z`);
 }
 
 /**
- * Resolve untrusted `from`/`to` query params into a bounded epoch-ms window.
- * Defaults to the last {@link DEFAULT_METRICS_WINDOW} days, clamps the end to
- * `now`, falls back to the default span when the ordering is invalid, and caps
- * the span at {@link MAX_METRICS_WINDOW} days so the throughput array stays bounded.
+ * Resolve untrusted `from`/`to` query params into a bounded half-open UTC
+ * window. Date-only bounds include both selected calendar days: `from` starts
+ * at midnight and `to` resolves to the following midnight. Datetimes remain
+ * exact instants. An open or future end resolves to the exclusive end of the
+ * current UTC day (not `now`) so an event happening at this instant still falls
+ * inside the half-open window instead of landing on its excluded upper edge.
+ * The default and maximum spans are calendar-day based so the gap-filled
+ * throughput series has a stable size.
  */
 export function parseMetricsRange(
   fromParam: unknown,
@@ -94,11 +104,14 @@ export function parseMetricsRange(
   now: Date,
 ): { windowStart: number; windowEnd: number } {
   const nowMs = now.getTime();
-  const windowEnd = Math.min(parseRangeParam(toParam) ?? nowMs, nowMs);
-  const parsedFrom = parseRangeParam(fromParam);
-  const defaultStart = windowEnd - DEFAULT_METRICS_WINDOW * DAY_MS;
+  const endOfToday = utcDayStart(nowMs) + DAY_MS;
+  const requestedEnd = parseRangeParam(toParam, 'to') ?? endOfToday;
+  const windowEnd = Math.min(requestedEnd, endOfToday);
+  const lastIncludedDay = utcDayStart(windowEnd - 1);
+  const defaultStart = lastIncludedDay - (DEFAULT_METRICS_WINDOW - 1) * DAY_MS;
+  const parsedFrom = parseRangeParam(fromParam, 'from');
   let windowStart = parsedFrom !== undefined && parsedFrom < windowEnd ? parsedFrom : defaultStart;
-  const earliestStart = windowEnd - MAX_METRICS_WINDOW * DAY_MS;
+  const earliestStart = lastIncludedDay - (MAX_METRICS_WINDOW - 1) * DAY_MS;
   if (windowStart < earliestStart) windowStart = earliestStart;
   return { windowStart, windowEnd };
 }
@@ -154,19 +167,16 @@ export function computeFactoryMetrics(
   const earliestItemAt = Number.isFinite(earliest) ? new Date(earliest).toISOString() : null;
 
   // ── Throughput + cycle time (completed in window) ─────────────────────────
-  // Gap-fill one bucket per whole UTC day covered by the window. Start at the
-  // first midnight at or after `windowStart` so a rolling "last N days" yields N
-  // buckets (the partial opening day isn't a full day and is dropped).
+  // Gap-fill every UTC calendar date intersecting the half-open window.
   const throughputByDay = new Map<string, number>();
-  let firstDay = Date.parse(`${utcDay(windowStart)}T00:00:00Z`);
-  if (firstDay < windowStart) firstDay += DAY_MS;
-  for (let day = firstDay; day <= windowEnd; day += DAY_MS) {
+  const firstDay = utcDayStart(windowStart);
+  for (let day = firstDay; day < windowEnd; day += DAY_MS) {
     throughputByDay.set(utcDay(day), 0);
   }
   const cycleSamples: number[] = [];
   for (const item of items) {
     const doneAt = completedAt(item);
-    if (doneAt === undefined || doneAt < windowStart || doneAt > windowEnd) continue;
+    if (doneAt === undefined || doneAt < windowStart || doneAt >= windowEnd) continue;
     const day = utcDay(doneAt);
     throughputByDay.set(day, (throughputByDay.get(day) ?? 0) + 1);
     cycleSamples.push(Math.max(0, doneAt - item.createdAt.getTime()));
@@ -178,7 +188,7 @@ export function computeFactoryMetrics(
     for (const entry of item.stageHistory) {
       if (entry.exitedAt === undefined || TERMINAL_STAGES.has(entry.stage)) continue;
       const exited = parseTime(entry.exitedAt);
-      if (exited < windowStart || exited > windowEnd) continue;
+      if (exited < windowStart || exited >= windowEnd) continue;
       const duration = Math.max(0, exited - parseTime(entry.enteredAt));
       const samples = durationsByStage.get(entry.stage) ?? [];
       samples.push(duration);
@@ -220,7 +230,7 @@ export function computeFactoryMetrics(
   let transitionsTotal = 0;
   let transitionsHuman = 0;
   for (const item of items) {
-    if (item.createdAt.getTime() >= windowStart) {
+    if (item.createdAt.getTime() >= windowStart && item.createdAt.getTime() < windowEnd) {
       const source = item.externalSource
         ? `${item.externalSource.integrationId}:${item.externalSource.type}`
         : 'manual';
@@ -228,7 +238,7 @@ export function computeFactoryMetrics(
     }
     for (const entry of item.stageHistory) {
       const entered = parseTime(entry.enteredAt);
-      if (entered < windowStart || entered > windowEnd) continue;
+      if (entered < windowStart || entered >= windowEnd) continue;
       transitionsTotal += 1;
       if (!isAutomationActor(entry.by)) transitionsHuman += 1;
     }
@@ -245,7 +255,7 @@ export function computeFactoryMetrics(
       const entry = item.stageHistory[i]!;
       if (entry.exitedAt === undefined || TERMINAL_STAGES.has(entry.stage)) continue;
       const exited = parseTime(entry.exitedAt);
-      if (exited < windowStart || exited > nowMs) continue;
+      if (exited < windowStart || exited >= windowEnd) continue;
       let row = automationByStage.get(entry.stage);
       if (!row) {
         row = {
@@ -272,7 +282,7 @@ export function computeFactoryMetrics(
   }
 
   return {
-    windowDays: Math.round((windowEnd - windowStart) / DAY_MS),
+    windowDays: throughputByDay.size,
     earliestItemAt,
     throughput: [...throughputByDay.entries()]
       .map(([date, count]) => ({ date, count }))

--- a/mastracode/factory/src/storage/domains/work-items/metrics.ts
+++ b/mastracode/factory/src/storage/domains/work-items/metrics.ts
@@ -76,12 +76,18 @@ export interface FactoryMetrics {
 }
 
 const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+/** Datetime carrying an explicit `Z` or `±HH:MM` offset. */
+const ZONED_DATETIME_RE = /(?:[Zz]|[+-]\d{2}:?\d{2})$/;
 
 function parseRangeParam(value: unknown, boundary: 'from' | 'to'): number | undefined {
   if (typeof value !== 'string' || value.length === 0) return undefined;
+  const dateOnly = DATE_ONLY_RE.test(value);
+  // Timezone-less datetimes are parsed as server-local by Date.parse, so the
+  // window would shift by deployment region — reject them as invalid.
+  if (!dateOnly && !ZONED_DATETIME_RE.test(value)) return undefined;
   const time = Date.parse(value);
   if (Number.isNaN(time)) return undefined;
-  return boundary === 'to' && DATE_ONLY_RE.test(value) ? time + DAY_MS : time;
+  return boundary === 'to' && dateOnly ? time + DAY_MS : time;
 }
 
 function utcDayStart(time: number): number {

--- a/mastracode/web/src/shared/hooks/useFactoryMetrics.ts
+++ b/mastracode/web/src/shared/hooks/useFactoryMetrics.ts
@@ -13,5 +13,6 @@ export function useFactoryMetrics(factoryProjectId: string | undefined, range: F
     queryFn: () => fetchFactoryMetrics(baseUrl, factoryProjectId!, range),
     enabled: Boolean(factoryProjectId),
     staleTime: 30_000,
+    placeholderData: previousData => previousData,
   });
 }

--- a/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
@@ -215,7 +215,7 @@ function ThreadRow({
               </Button>
             }
           />
-          <DropdownMenu.Content align="end" className="min-w-28">
+          <DropdownMenu.Content align="end">
             <DropdownMenu.Item onClick={onStartRename}>
               <Pencil />
               Rename

--- a/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
@@ -5,7 +5,7 @@ import { toast } from '@mastra/playground-ui/components/Toaster';
 import { DropdownMenu } from '@mastra/playground-ui/components/DropdownMenu';
 import { Input } from '@mastra/playground-ui/components/Input';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { MoreHorizontal, Plus, Trash2 } from 'lucide-react';
+import { Copy, MoreHorizontal, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 
@@ -216,8 +216,14 @@ function ThreadRow({
             }
           />
           <DropdownMenu.Content align="end" className="min-w-28">
-            <DropdownMenu.Item onClick={onStartRename}>Rename</DropdownMenu.Item>
-            <DropdownMenu.Item onClick={() => void cloneThread()}>Clone</DropdownMenu.Item>
+            <DropdownMenu.Item onClick={onStartRename}>
+              <Pencil />
+              Rename
+            </DropdownMenu.Item>
+            <DropdownMenu.Item onClick={() => void cloneThread()}>
+              <Copy />
+              Clone
+            </DropdownMenu.Item>
             <DropdownMenu.Item variant="destructive" onClick={() => void deleteThread()}>
               <Trash2 />
               Delete

--- a/mastracode/web/src/web/ui/domains/factory/services/metrics.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/metrics.ts
@@ -43,7 +43,7 @@ export interface FactoryMetrics {
   }[];
 }
 
-/** Absolute window bounds (ISO 8601) for a metrics request. */
+/** Inclusive UTC calendar-date bounds (`yyyy-MM-dd`) for a metrics request. */
 export interface FactoryMetricsRange {
   from: string;
   to: string;

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -82,8 +82,7 @@ function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undef
   const metrics = metricsQuery.data;
   const windowDays = inclusiveRangeDays(range);
 
-  // Keep the current request inside the rendered domain. Once the user moves
-  // the range, the real creation date becomes the natural lower bound.
+  // Keep the selected range inside the domain until the board's earliest item is known.
   const earliestDay = metrics?.earliestItemAt
     ? metrics.earliestItemAt.slice(0, 10)
     : shiftUtcDay(today, -(EMPTY_BOARD_LOOKBACK_DAYS - 1));

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -1,14 +1,9 @@
-import {
-  DateRangeTimeline,
-  clampDateRangeToBounds,
-  getDateRangeBounds,
-} from '@mastra/playground-ui/components/DateRangeTimeline';
+import { DateRangeTimeline, getDateRangeBounds } from '@mastra/playground-ui/components/DateRangeTimeline';
 import type { DateRangeValue } from '@mastra/playground-ui/components/DateRangeTimeline';
 import { MetricsLineChart } from '@mastra/playground-ui/components/MetricsLineChart';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { format, subDays } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useApiConfig } from '../../../shared/api/config';
 import { useFactoryMetrics } from '../../../shared/hooks/useFactoryMetrics';
@@ -18,26 +13,37 @@ import { formatDuration, relativeTime } from '../../../shared/lib/date';
 import { AGENT_CONTROLLER_ID } from '../domains/chat/services/constants';
 import { isServerFactory, useActiveFactoryContext } from '../domains/workspaces';
 import { FactoryPageShell } from '../domains/factory/components/FactoryPageShell';
-import type { FactoryMetrics, FactoryMetricsRange } from '../domains/factory/services/metrics';
+import type { FactoryMetrics } from '../domains/factory/services/metrics';
 import { BOARD_STAGES, stageLabel, stageOrder } from '../domains/factory/stages';
 
-const API_DATE_FORMAT = 'yyyy-MM-dd';
-/** Domain lower bound when the board has no items yet — there's no real
- * creation date to anchor to, so offer a modest explorable window. */
+const DAY_MS = 86_400_000;
 const EMPTY_BOARD_LOOKBACK_DAYS = 90;
+/** Mirrors the server's bounded aggregation window. */
+const MAX_METRICS_WINDOW_DAYS = 366;
 
-/** Default window: the last 30 days, as `yyyy-MM-dd` bounds. */
-function defaultRange(): DateRangeValue {
-  const today = new Date();
-  return { from: format(subDays(today, 30), API_DATE_FORMAT), to: format(today, API_DATE_FORMAT) };
+function shiftUtcDay(day: string, offset: number): string {
+  return new Date(Date.parse(`${day}T00:00:00.000Z`) + offset * DAY_MS).toISOString().slice(0, 10);
+}
+
+function inclusiveRangeDays(range: DateRangeValue): number {
+  return Math.floor((Date.parse(`${range.to}T00:00:00.000Z`) - Date.parse(`${range.from}T00:00:00.000Z`)) / DAY_MS) + 1;
+}
+
+function clampRangeSpan(range: DateRangeValue, maximumDays: number): DateRangeValue {
+  if (inclusiveRangeDays(range) <= maximumDays) return range;
+  return { from: shiftUtcDay(range.to, -(maximumDays - 1)), to: range.to };
+}
+
+function defaultRange(today: string): DateRangeValue {
+  return { from: shiftUtcDay(today, -29), to: today };
 }
 
 const THROUGHPUT_SERIES = [{ dataKey: 'done', label: 'Done per day', color: '#34d399' }];
 
 const SOURCE_LABELS: Record<string, string> = {
-  'github-issue': 'GitHub issues',
-  'github-pr': 'GitHub PRs',
-  'linear-issue': 'Linear issues',
+  'github:issue': 'GitHub issues',
+  'github:pull-request': 'GitHub PRs',
+  'linear:issue': 'Linear issues',
   manual: 'Manual',
 };
 
@@ -64,48 +70,33 @@ export function MetricsPage() {
 }
 
 function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undefined }) {
-  const [today] = useState(() => format(new Date(), API_DATE_FORMAT));
-  const [range, setRange] = useState<DateRangeValue>(defaultRange);
-
-  // Expand the day-granular range to a precise instant window: full first day
-  // through end of the last day (the server clamps the end to `now`). Keyed on
-  // the day strings so the query key stays stable across renders.
-  const fetchRange = useMemo<FactoryMetricsRange>(
-    () => ({
-      from: new Date(`${range.from}T00:00:00.000Z`).toISOString(),
-      to: new Date(`${range.to}T23:59:59.999Z`).toISOString(),
-    }),
-    [range.from, range.to],
-  );
-  // Whole-day span of the selected window, for labels like "Automated moves (30d)".
-  const windowDays = Math.max(
-    1,
-    Math.round((Date.parse(`${range.to}T00:00:00.000Z`) - Date.parse(`${range.from}T00:00:00.000Z`)) / 86_400_000),
-  );
-  const metricsQuery = useFactoryMetrics(factoryProjectId, fetchRange);
+  const [today] = useState(() => new Date().toISOString().slice(0, 10));
+  const [range, setRange] = useState<DateRangeValue>(() => defaultRange(today));
+  const metricsQuery = useFactoryMetrics(factoryProjectId, range);
   const agentsRunning = useAgentsRunningCount();
 
   if (metricsQuery.isError) {
-    return <Notice variant="destructive">{(metricsQuery.error as Error).message}</Notice>;
+    const message = metricsQuery.error instanceof Error ? metricsQuery.error.message : 'Failed to load metrics';
+    return <Notice variant="destructive">{message}</Notice>;
   }
   const metrics = metricsQuery.data;
+  const windowDays = inclusiveRangeDays(range);
 
-  // Bounds: project's first work item (once metrics load) → today. Fall back to
-  // the max lookback until the earliest date is known.
+  // Keep the current request inside the rendered domain. Once the user moves
+  // the range, the real creation date becomes the natural lower bound.
   const earliestDay = metrics?.earliestItemAt
     ? metrics.earliestItemAt.slice(0, 10)
-    : format(subDays(new Date(`${today}T00:00:00.000Z`), EMPTY_BOARD_LOOKBACK_DAYS), API_DATE_FORMAT);
-  const bounds = getDateRangeBounds(earliestDay, today);
-  const selectedRange = clampDateRangeToBounds(range, bounds);
+    : shiftUtcDay(today, -(EMPTY_BOARD_LOOKBACK_DAYS - 1));
+  const bounds = getDateRangeBounds(earliestDay < range.from ? earliestDay : range.from, today);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto">
       <DateRangeTimeline
         key={`${bounds.min}:${bounds.max}`}
-        value={selectedRange}
+        value={range}
         min={bounds.min}
         max={bounds.max}
-        onCommit={setRange}
+        onCommit={value => setRange(clampRangeSpan(value, MAX_METRICS_WINDOW_DAYS))}
       />
 
       {!metrics ? null : (

--- a/mastracode/web/src/web/ui/pages/MetricsPage.tsx
+++ b/mastracode/web/src/web/ui/pages/MetricsPage.tsx
@@ -80,7 +80,9 @@ function MetricsContent({ factoryProjectId }: { factoryProjectId: string | undef
     return <Notice variant="destructive">{message}</Notice>;
   }
   const metrics = metricsQuery.data;
-  const windowDays = inclusiveRangeDays(range);
+  // Prefer the server's count so the label stays paired with the rendered data
+  // (placeholderData keeps the old range's metrics during a refetch).
+  const windowDays = metrics?.windowDays ?? inclusiveRangeDays(range);
 
   // Keep the selected range inside the domain until the board's earliest item is known.
   const earliestDay = metrics?.earliestItemAt

--- a/mastracode/web/src/web/ui/ui/PageLayout.tsx
+++ b/mastracode/web/src/web/ui/ui/PageLayout.tsx
@@ -16,7 +16,7 @@ export function PageLayout({ sidebar, header, title, description, actions, child
 
   return (
     <div className="relative z-1 flex h-screen overflow-hidden bg-surface1">
-      <aside className="h-full min-h-0 shrink-0 overflow-hidden py-5">{sidebar}</aside>
+      <aside className="h-full min-h-0 shrink-0 overflow-hidden py-2">{sidebar}</aside>
       <div className="relative z-1 flex min-w-0 flex-1 flex-col overflow-hidden border-l border-border1 bg-surface2">
         {header}
         <main className="flex min-h-0 flex-1 flex-col overflow-hidden">


### PR DESCRIPTION
Follow-up to #19959. Finalizes the Factory metrics window and fixes a boundary bug.

## `@mastra/factory`
- `parseMetricsRange` / `computeFactoryMetrics` resolve an inclusive UTC calendar-day window with a half-open `[start, end)` comparison. Date-only `from`/`to` cover both selected days.
- An open/future/today end resolves to the end of the current UTC day, not `now`. Previously `windowEnd === nowMs` with `exited >= windowEnd` dropped an item completing at the current instant from throughput and automation (intermittent `work-items.test.ts` failure).
- `windowDays` reports the gap-filled bucket count; `sourceMix` counts cards created inside the window.

## `mastracode-web` (private, no changeset)
- Drop `date-fns` for native UTC helpers; send date-only `yyyy-MM-dd` bounds. Local-timezone `format`/`subDays` produced off-by-one days near midnight — native `toISOString().slice(0, 10)` is UTC by construction and matches the server helpers.
- Fix source-mix labels to the server's `integrationId:type` keys (`github:issue`, `github:pull-request`, `linear:issue`); the old `github-issue` keys never matched.
- Keep previous data while a new range refetches (no flash on drag).
- Reduce sidebar vertical padding to `py-2`.

## Testing
`metrics.test.ts` and `work-items.test.ts` pass; eslint, `tsc --noEmit` (factory + web), and prettier are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5
Factory’s metrics now use “which UTC day did this happen on?” instead of “exact timestamp math,” so work that finishes at the current moment correctly counts as happening “today.” The Metrics page and backend now agree on the same UTC, inclusive date-range rules.

## What changed
- Reworked Factory metrics windowing to use half-open UTC calendar-day semantics (`[start, end)`): date-only `from`/`to` include both selected days.
- Fixed the current-day boundary bug so items completing at the current instant are included in today’s throughput/automation metrics.
- Reject timezone-less metrics range inputs (datetime bounds must be well-formed).
- Updated `windowDays` to match the actual gap-filled daily buckets (`throughputByDay.size`), not a rounded duration estimate.
- Aligned all metric calculations to the same half-open window rules (throughput, cycle times, stage durations/automation, demand-mix, transitions).
- Updated `sourceMix` so cards contribute only when created within the selected window.
- Kept previously fetched metrics visible during range refetches in the private Metrics page (React Query `placeholderData`).
- Refactored the Metrics page to use UTC day strings/helpers, send date-only bounds, and use source-mix keys that match the server response; removed client-side clamping/expansion logic in favor of UTC inclusive-day handling.
- Updated/added tests to cover the new UTC boundary behavior, including deterministic “end of today” handling and new `sourceMix` expectations.
- Included related fixes/UI changes:
  - GitHub repos route now deduplicates repositories across installations.
  - Small UI tweaks (thread actions/icons, sidebar padding) plus release notes/changesets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->