### PR TITLE
fix(create-factory): mark platform projects as factory enabled

### DIFF
--- a/.changeset/free-schools-cheat.md
+++ b/.changeset/free-schools-cheat.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Marked projects created by create-factory as factory-enabled on the Mastra platform.

--- a/mastracode/mastra-factory/src/platform.test.ts
+++ b/mastracode/mastra-factory/src/platform.test.ts
@@ -22,7 +22,7 @@ const cliAuth = vi.hoisted(() => ({
 
 vi.mock('mastra/internal/auth', () => cliAuth);
 
-import { attachNeonDatabase, PlatformApiError, waitForDatabaseReady } from './platform.js';
+import { attachNeonDatabase, createServerProject, PlatformApiError, waitForDatabaseReady } from './platform.js';
 
 /**
  * Build a fresh Response every time — a `Response` body is single-use, and
@@ -42,6 +42,27 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+});
+
+describe('createServerProject', () => {
+  it('marks projects as factory-enabled', async () => {
+    cliAuth.platformFetch.mockImplementationOnce(
+      async () =>
+        new Response(JSON.stringify({ project: { id: 'proj_1', slug: 'my-factory', name: 'My Factory' } }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    await createServerProject({ token: 'wos-token', orgId: 'org_123', name: 'My Factory' });
+
+    expect(cliAuth.platformFetch).toHaveBeenCalledWith(
+      'https://platform.example.test/v1/server/projects',
+      expect.objectContaining({
+        body: JSON.stringify({ name: 'My Factory', factoryEnabled: true }),
+      }),
+    );
+  });
 });
 
 describe('attachNeonDatabase', () => {

--- a/mastracode/mastra-factory/src/platform.ts
+++ b/mastracode/mastra-factory/src/platform.ts
@@ -74,7 +74,7 @@ export async function createServerProject({
   const res = await platformFetch(`${MASTRA_PLATFORM_API_URL}/v1/server/projects`, {
     method: 'POST',
     headers: { ...authHeaders(token, orgId), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name }),
+    body: JSON.stringify({ name, factoryEnabled: true }),
   });
   if (!res.ok) {
     throw new PlatformApiError(res.status, `Failed to create project — ${await extractError(res)}`);


### PR DESCRIPTION
create-factory now sends `factoryEnabled: true` when creating a Platform project, allowing Platform to distinguish factory-created projects.

```ts
body: JSON.stringify({ name, factoryEnabled: true })
```

The focused platform client tests, package typecheck, lint, and build pass. The full package test suite retains an existing failure from PR #19973 in `create.test.ts` (`clack.outro` is not called in the `--no-platform` success test).