### PR TITLE
fix(web): simplify empty thread context

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/EmptyThreadState.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/EmptyThreadState.tsx
@@ -1,10 +1,7 @@
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Logo } from '@mastra/playground-ui/components/Logo';
-import { ChevronDown } from 'lucide-react';
-import { deriveProjectPath } from '../../../../../../shared/hooks/useWorkspaces';
 import { isLocalFactory, selectedRepository, useActiveFactoryContext } from '../../../workspaces';
 import { useChatCommands } from '../../context/ChatCommandsProvider';
-import { FactoryMetadata } from './FactoryMetadata';
 
 const emptyThreadClass =
   'flex w-full min-w-0 max-w-full flex-1 flex-col items-center justify-center px-6 py-12 text-center';
@@ -13,7 +10,6 @@ export function EmptyThreadState() {
   const { activeFactory } = useActiveFactoryContext();
   const { prefillComposer } = useChatCommands();
   if (!activeFactory) return null;
-  const workspace = deriveProjectPath(activeFactory);
   const gitBranch = isLocalFactory(activeFactory)
     ? activeFactory.binding.gitBranch
     : selectedRepository(activeFactory)?.gitBranch;
@@ -58,24 +54,15 @@ export function EmptyThreadState() {
         </Button>
       </div>
 
-      <details className="group mt-8 w-full min-w-0 max-w-lg text-ui-sm text-icon3">
-        <summary className="flex cursor-pointer list-none items-center justify-center gap-1.5 rounded-full px-3 py-2 transition-colors hover:text-icon5 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent1 [&::-webkit-details-marker]:hidden">
-          <span>
-            Working in <span className="font-medium text-icon5">{activeFactory.name}</span>
-          </span>
-          <ChevronDown
-            aria-hidden="true"
-            size={14}
-            className="transition-transform duration-200 group-open:rotate-180 motion-reduce:transition-none"
-          />
-        </summary>
-        <dl className="mx-auto mt-3 grid w-full min-w-0 gap-1 text-left font-mono leading-relaxed">
-          <FactoryMetadata label="Factory" value={activeFactory.name} />
-          {activeFactory.resourceId && <FactoryMetadata label="Resource ID" value={activeFactory.resourceId} />}
-          {gitBranch && <FactoryMetadata label="Branch" value={gitBranch} />}
-          {workspace && <FactoryMetadata label="Workspace" value={workspace} />}
-        </dl>
-      </details>
+      <p className="mt-8 text-ui-sm text-icon3">
+        Working in <span className="font-medium text-icon5">{activeFactory.name}</span>
+        {gitBranch && (
+          <>
+            <span aria-hidden="true"> · </span>
+            <span className="font-mono text-icon5">{gitBranch}</span>
+          </>
+        )}
+      </p>
     </section>
   );
 }

--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/FactoryMetadata.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/FactoryMetadata.tsx
@@ -1,8 +1,0 @@
-export function FactoryMetadata({ label, value }: { label: string; value: string | undefined }) {
-  return (
-    <div className="flex min-w-0 gap-2">
-      <dt className="min-w-24 shrink-0 text-icon2">{label}</dt>
-      <dd className="m-0 min-w-0 wrap-anywhere text-icon5">{value}</dd>
-    </div>
-  );
-}

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatMessageList.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/ChatMessageList.msw.test.tsx
@@ -108,8 +108,7 @@ function renderMessageList() {
 }
 
 describe('ChatMessageList', () => {
-  it('given an empty thread, then it shows conversation starters with optional project context', async () => {
-    const user = userEvent.setup();
+  it('given an empty thread, then it shows conversation starters with current project context', async () => {
     seedProject();
     useAgentControllerHandlers();
     renderMessageList();
@@ -123,15 +122,13 @@ describe('ChatMessageList', () => {
     expect(screen.getByRole('button', { name: 'Review recent changes' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Debug an issue' })).toBeInTheDocument();
 
-    await user.click(screen.getByText(/Working in/));
-    expect(screen.getByText('Factory')).toBeVisible();
-    expect(screen.getAllByText('MastraCode Test')).toHaveLength(2);
-    expect(screen.getByText('Resource ID')).toBeVisible();
-    expect(screen.getByText(RESOURCE_ID)).toBeVisible();
-    expect(screen.getByText('Branch')).toBeVisible();
+    expect(screen.getByText(/Working in/)).toBeVisible();
+    expect(screen.getByText('MastraCode Test')).toBeVisible();
     expect(screen.getByText('main')).toBeVisible();
-    expect(screen.getByText('Workspace')).toBeVisible();
-    expect(screen.getByText('/tmp/mastracode-test')).toBeVisible();
+    expect(screen.queryByText('Resource ID')).not.toBeInTheDocument();
+    expect(screen.queryByText(RESOURCE_ID)).not.toBeInTheDocument();
+    expect(screen.queryByText('Workspace')).not.toBeInTheDocument();
+    expect(screen.queryByText('/tmp/mastracode-test')).not.toBeInTheDocument();
   });
 
   it('given streamed assistant text, then it renders the transcript entry', async () => {


### PR DESCRIPTION
The empty thread state no longer hides technical factory metadata behind an expandable control. It now shows only a quiet `Working in {factory} · {branch}` line, keeping the first-run state focused on starting a conversation.

Before: expandable factory, resource, branch, and workspace details. After: static factory and branch context.

Verified with the focused ChatMessageList MSW suite, the web UI typecheck, React Doctor, and desktop and mobile browser checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The empty chat screen now shows only the project and branch you’re working in, instead of hiding extra details behind a button. This keeps the first-run experience simpler and focused on starting a conversation.

## Changes

- Replaced expandable factory, resource, branch, and workspace metadata with a static `Working in {factory} · {branch}` line.
- Removed the unused `FactoryMetadata` component and related workspace/path logic.
- Updated the ChatMessageList test to verify the simplified context display and hidden metadata.

## Verification

- Focused ChatMessageList MSW suite
- Web UI typecheck
- React Doctor
- Desktop and mobile browser checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->