### PR TITLE
feat(create-factory): add --skip-verify and --local-workspace to sync-template

### DIFF
--- a/.changeset/factory-sync-template-local-flags.md
+++ b/.changeset/factory-sync-template-local-flags.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Add `--skip-verify` and `--local-workspace` flags to `sync-template.mjs` for local template iteration when a linked dependency has not yet been published to npm. `--skip-verify` bypasses the publish check (caret ranges still written from local monorepo versions). `--local-workspace` implies `--skip-verify` and additionally rewrites any unpublished dep to a `file:` path anchored on the monorepo package so the generated template installs and runs without needing an npm publish first. Default and CI behavior is unchanged: the publish check still runs and still fails loudly when a dep is missing on npm, and error messages now point users to the new flags.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -22,6 +22,27 @@
  *
  * Usage:
  *   node scripts/sync-template.mjs [--out <dir>] [--tag latest]
+ *                                  [--skip-verify] [--local-workspace]
+ *
+ * Flags:
+ *   --out <dir>          Where to write the generated template
+ *                        (default: `template-out/` next to this package).
+ *   --tag <name>         Pin caret ranges to that dist-tag on npm instead of
+ *                        the local monorepo versions.
+ *   --skip-verify        Skip the `npm view` publish check. Caret ranges are
+ *                        still written from the local monorepo versions, so
+ *                        `npm install` inside the template will fail if any
+ *                        dep is not yet on npm. Intended for local iteration
+ *                        on the sync script itself, not for publishing.
+ *   --local-workspace    Implies `--skip-verify`. For any dep whose local
+ *                        monorepo version is not yet on npm, write a `file:`
+ *                        spec pointing at the monorepo package instead of a
+ *                        caret range. The resulting template installs and
+ *                        runs against the local package set — useful for
+ *                        smoke-testing an unreleased template end-to-end.
+ *                        NEVER use this for a template that will be pushed
+ *                        to the softwarefactory-template repo: `file:` paths
+ *                        only resolve inside this monorepo.
  *
  * Output defaults to `template-out/` next to this package (gitignored).
  * Publish flow: automated — the sync-softwarefactory-template workflow runs
@@ -48,6 +69,14 @@ function argValue(flag) {
 const defaultOutDir = path.join(pkgRoot, 'template-out');
 const outDir = path.resolve(argValue('--out') ?? defaultOutDir);
 const pinTag = argValue('--tag'); // undefined = local monorepo versions
+// `--local-workspace` implies `--skip-verify`: with `file:` fallbacks the
+// npm publish check is meaningless for the unpublished deps we'd be swapping.
+const useLocalWorkspace = args.includes('--local-workspace');
+const skipVerify = useLocalWorkspace || args.includes('--skip-verify');
+if ((useLocalWorkspace || args.includes('--skip-verify')) && pinTag) {
+  console.error('sync-template: --skip-verify / --local-workspace cannot be combined with --tag');
+  process.exit(1);
+}
 
 /** True when `candidate` is `parent` or nested inside it. */
 function containsPath(parent, candidate) {
@@ -154,27 +183,46 @@ function monorepoVersion(name, relPath) {
 /**
  * Resolve the version to pin: the local monorepo version (default, verified
  * published) or the requested dist-tag.
+ *
+ * Returns `{ version, published }`. `published` is only meaningful when the
+ * caller passed `--skip-verify` or `--local-workspace` — in the default mode
+ * it is always `true` because we throw on unpublished versions.
  */
 function resolvePinnedVersion(name, relPath) {
   if (pinTag) {
     try {
-      return execFileSync('npm', ['view', name, `dist-tags.${pinTag}`], { stdio: 'pipe' })
+      const version = execFileSync('npm', ['view', name, `dist-tags.${pinTag}`], { stdio: 'pipe' })
         .toString()
         .trim();
+      return { version, published: true };
     } catch {
       throw new Error(`sync-template: could not resolve ${name}@${pinTag} on npm.`);
     }
   }
   const version = monorepoVersion(name, relPath);
+  if (skipVerify) {
+    // With --local-workspace we care whether the dep is on npm so we can
+    // fall back to `file:`. With bare --skip-verify we still probe (cheap)
+    // to let the caller see which deps would break, but never throw.
+    let published = false;
+    try {
+      execFileSync('npm', ['view', `${name}@${version}`, 'version'], { stdio: 'pipe' });
+      published = true;
+    } catch {
+      published = false;
+    }
+    return { version, published };
+  }
   try {
     execFileSync('npm', ['view', `${name}@${version}`, 'version'], { stdio: 'pipe' });
   } catch {
     throw new Error(
       `sync-template: ${name}@${version} (local monorepo version) is not published on npm — ` +
-        `publish it (or wait for the release train), or sync with --tag latest.`,
+        `publish it (or wait for the release train), or sync with --tag latest. ` +
+        `For local iteration, use --skip-verify or --local-workspace.`,
     );
   }
-  return version;
+  return { version, published: true };
 }
 
 function transformPackageJson() {
@@ -205,20 +253,36 @@ function transformPackageJson() {
   console.log(
     pinTag
       ? `sync-template: pinning npm ${pinTag} dist-tags...`
-      : 'sync-template: pinning local monorepo versions (verified on npm)...',
+      : skipVerify
+        ? useLocalWorkspace
+          ? 'sync-template: pinning local monorepo versions (unpublished deps get file: fallbacks)...'
+          : 'sync-template: pinning local monorepo versions (publish verification skipped)...'
+        : 'sync-template: pinning local monorepo versions (verified on npm)...',
   );
   for (const section of ['dependencies', 'devDependencies']) {
     const deps = manifest[section];
     if (!deps) continue;
     for (const [name, spec] of Object.entries(deps)) {
       if (!spec.startsWith('link:')) continue;
-      const version = resolvePinnedVersion(name, linkSpecToRelPath(spec));
+      const relPath = linkSpecToRelPath(spec);
+      const { version, published } = resolvePinnedVersion(name, relPath);
+      if (useLocalWorkspace && !published) {
+        // `file:` spec relative to the template's own package.json so npm
+        // links the local build. Only reachable via --local-workspace, which
+        // the docstring documents as monorepo-only (never published).
+        const fileSpec = `file:${path.relative(outDir, path.join(monorepoRoot, relPath))}`;
+        deps[name] = fileSpec;
+        pins.push([name, version]);
+        console.log(`  ! ${name}@${version} not on npm, using ${fileSpec}`);
+        continue;
+      }
       // Caret ranges, matching the monorepo's other templates (templates/*):
       // the scaffold floats to compatible releases instead of freezing the
       // exact set that existed at sync time.
       deps[name] = `^${version}`;
       pins.push([name, version]);
-      console.log(`  ✓ ${name}@^${version}`);
+      const suffix = skipVerify && !published ? ' (WARNING: not on npm)' : '';
+      console.log(`  ${skipVerify && !published ? '!' : '✓'} ${name}@^${version}${suffix}`);
     }
   }
 
@@ -227,9 +291,12 @@ function transformPackageJson() {
   }
 
   // npm cannot install monorepo-only protocols; nothing may slip through.
+  // `file:` is only permitted under --local-workspace (documented as
+  // monorepo-only, never pushed to the template repo).
+  const forbidden = useLocalWorkspace ? /^(link:|workspace:|catalog:)/ : /^(link:|workspace:|file:|catalog:)/;
   for (const section of ['dependencies', 'devDependencies']) {
     for (const [name, spec] of Object.entries(manifest[section] ?? {})) {
-      if (/^(link:|workspace:|file:|catalog:)/.test(spec)) {
+      if (forbidden.test(spec)) {
         throw new Error(`sync-template: unresolved monorepo spec in template: ${name}@${spec}`);
       }
     }
@@ -239,7 +306,22 @@ function transformPackageJson() {
   // skips automatic peer installation. Most peers are already direct deps;
   // these transitive runtime peers are not, so declare them explicitly.
   // (In the monorepo dev setup pnpm's auto-install-peers provides them.)
-  manifest.dependencies['@mastra/memory'] = manifest.dependencies['@mastra/core']; // peer of @mastra/playground-ui
+  //
+  // @mastra/memory tracks @mastra/core's version. Normally that's a caret
+  // range we can copy verbatim, but under --local-workspace core may resolve
+  // to a `file:` path pointing at packages/core — so give memory its own
+  // resolution against packages/memory instead of aliasing core's spec.
+  if (useLocalWorkspace && manifest.dependencies['@mastra/core']?.startsWith('file:')) {
+    const memoryRelPath = 'packages/memory';
+    const { version, published } = resolvePinnedVersion('@mastra/memory', memoryRelPath);
+    if (published) {
+      manifest.dependencies['@mastra/memory'] = `^${version}`;
+    } else {
+      manifest.dependencies['@mastra/memory'] = `file:${path.relative(outDir, path.join(monorepoRoot, memoryRelPath))}`;
+    }
+  } else {
+    manifest.dependencies['@mastra/memory'] = manifest.dependencies['@mastra/core']; // peer of @mastra/playground-ui
+  }
   manifest.dependencies['react-is'] = '^19.0.0'; // peer of recharts (via @mastra/playground-ui)
 
   fs.writeFileSync(path.join(outDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -19,13 +19,15 @@ const script = path.join(pkgRoot, 'scripts', 'sync-template.mjs');
 let workDir: string;
 let outDir: string;
 let fakeBinDir: string;
+let failingBinDir: string;
 let sentinel: string;
 
-function runSync(args: string[]): { status: number; stderr: string } {
+function runSync(args: string[], overrides: { binDir?: string } = {}): { status: number; stderr: string } {
+  const binDir = overrides.binDir ?? fakeBinDir;
   try {
     execFileSync(process.execPath, [script, ...args], {
       stdio: 'pipe',
-      env: { ...process.env, PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}` },
+      env: { ...process.env, PATH: `${binDir}${path.delimiter}${process.env.PATH ?? ''}` },
     });
     return { status: 0, stderr: '' };
   } catch (err) {
@@ -42,6 +44,12 @@ beforeAll(() => {
   fakeBinDir = path.join(workDir, 'bin');
   fs.mkdirSync(fakeBinDir);
   fs.writeFileSync(path.join(fakeBinDir, 'npm'), '#!/bin/sh\necho "9.9.9"\n', { mode: 0o755 });
+
+  // Failing fake npm: every `npm view` exits non-zero, simulating a package
+  // that is not yet published. Used to exercise --skip-verify / --local-workspace.
+  failingBinDir = path.join(workDir, 'bin-failing');
+  fs.mkdirSync(failingBinDir);
+  fs.writeFileSync(path.join(failingBinDir, 'npm'), '#!/bin/sh\necho "npm ERR! 404" >&2\nexit 1\n', { mode: 0o755 });
 
   // Sentinel env file in the source tree — must never reach the template.
   sentinel = path.join(webRoot, '.env.test-sentinel');
@@ -121,5 +129,54 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     expect(pkg.scripts.dev).toContain('vite');
     expect(pkg.scripts.prebuild).toBeUndefined();
     expect(JSON.stringify(pkg.scripts)).not.toContain('monorepo-deps');
+  });
+
+  it('default mode fails when a linked dep is not on npm', () => {
+    const failOut = path.join(workDir, 'out-fail');
+    const result = runSync(['--out', failOut], { binDir: failingBinDir });
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('not published on npm');
+    expect(result.stderr).toContain('--skip-verify');
+  });
+
+  it('--skip-verify writes caret ranges anyway when deps are not on npm', () => {
+    const skipOut = path.join(workDir, 'out-skip');
+    const result = runSync(['--out', skipOut, '--skip-verify'], { binDir: failingBinDir });
+    expect(result.status).toBe(0);
+    const pkg = JSON.parse(fs.readFileSync(path.join(skipOut, 'package.json'), 'utf8'));
+    const mastraCore = pkg.dependencies['@mastra/core'];
+    expect(mastraCore).toMatch(/^\^/);
+    // The peer alias falls back to the caret range too.
+    expect(pkg.dependencies['@mastra/memory']).toMatch(/^\^/);
+  });
+
+  it('--local-workspace rewrites unpublished deps to file: paths', () => {
+    const localOut = path.join(workDir, 'out-local');
+    const result = runSync(['--out', localOut, '--local-workspace'], { binDir: failingBinDir });
+    expect(result.status).toBe(0);
+    const pkg = JSON.parse(fs.readFileSync(path.join(localOut, 'package.json'), 'utf8'));
+    // Every mastra dep that came from `link:` should now be a `file:` spec
+    // pointing at a real directory inside the monorepo.
+    const monorepoRoot = path.resolve(pkgRoot, '../..');
+    for (const [name, spec] of Object.entries(pkg.dependencies) as Array<[string, string]>) {
+      if (name !== 'mastra' && !name.startsWith('@mastra/')) continue;
+      expect(spec, `${name} should be a file: spec under --local-workspace`).toMatch(/^file:/);
+      const resolved = path.resolve(localOut, spec.slice('file:'.length));
+      expect(fs.existsSync(path.join(resolved, 'package.json')), `${resolved} must exist`).toBe(true);
+      // The resolved path must live inside the monorepo — never escape it.
+      const rel = path.relative(monorepoRoot, resolved);
+      expect(rel.startsWith('..')).toBe(false);
+    }
+    // Peer alias must not reuse @mastra/core's file: path (which points at
+    // packages/core, not packages/memory).
+    expect(pkg.dependencies['@mastra/memory']).not.toBe(pkg.dependencies['@mastra/core']);
+    expect(pkg.dependencies['@mastra/memory']).toMatch(/^file:/);
+  });
+
+  it('rejects --skip-verify combined with --tag', () => {
+    const bogusOut = path.join(workDir, 'out-bogus');
+    const result = runSync(['--out', bogusOut, '--skip-verify', '--tag', 'latest']);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('cannot be combined with --tag');
   });
 });


### PR DESCRIPTION
## Summary

Adds two escape-hatch flags to `mastracode/mastra-factory/scripts/sync-template.mjs` so the Software Factory template can be generated locally when a linked dependency has not yet been published to npm.

Today, the sync script hard-fails at the `npm view <pkg>@<version> version` step if any linked dep is missing from npm. That's the right default for the CI-driven publish flow, but it makes local iteration impossible whenever a brand-new package (e.g. `@mastra/factory` before its first release-train publish) or an unreleased alpha bump lands in the monorepo. There was no way to say "I know it's not on npm yet, generate the template anyway so I can smoke-test it."

## New flags

| Flag | Behavior |
| --- | --- |
| `--skip-verify` | Bypasses only the `npm view` publish check. Caret ranges are still written from the local monorepo versions, so `npm install` inside the generated template will fail if a dep is truly missing from npm. The script now logs `! <pkg>@^<ver> (WARNING: not on npm)` for each affected dep so the caller can see exactly what will break. |
| `--local-workspace` | Implies `--skip-verify`. For every dep whose local monorepo version isn't on npm, writes a `file:` spec pointing at the monorepo package instead of a caret range. The resulting template installs and runs against the local package set — useful for smoke-testing a template end-to-end without waiting for a publish. Never valid for the softwarefactory-template repo (documented in the docstring): `file:` paths only resolve inside this monorepo. |

Default behavior is unchanged: the publish check still runs, still fails loudly, and the error message now points at the new flags:

```
Error: sync-template: @mastra/factory@0.1.0-alpha.1 (local monorepo version) is
not published on npm — publish it (or wait for the release train), or sync with
--tag latest. For local iteration, use --skip-verify or --local-workspace.
```

## CI safety

- The `sync-softwarefactory-template.yml` workflow keeps calling the script with **no new flags**, so it still requires every dep to be on npm before pushing to the template repo.
- The `--local-workspace` output emits `file:` specs, which are explicitly rejected by the existing "unresolved monorepo spec" guard for every other mode. That guard now only relaxes when `--local-workspace` is set, so a caller who wanted `--skip-verify` without `file:` fallback can never accidentally ship one.
- `--skip-verify` and `--tag` are mutually exclusive (the flags have opposite intents); combining them exits with a clear error.

## Latent bug caught by the new mode

The manifest transform aliases `@mastra/memory` to `@mastra/core`'s spec verbatim (memory tracks core's version and is used as a transitive peer). Under `--local-workspace` that would make memory resolve to `packages/core` when core became a `file:` path. The alias now resolves memory against `packages/memory` directly when core is a `file:` spec, using the same publish check the rest of the script uses. Behavior in the default (caret-range) path is unchanged.

## Tests

Adds four cases to `mastracode/mastra-factory/src/sync-template.test.ts` that install a fake `npm` on `$PATH` which returns 404 for every `npm view`:

- **default mode fails when a linked dep is not on npm** — asserts the error message calls out `--skip-verify` so users don't have to grep the source.
- **--skip-verify writes caret ranges anyway** — confirms the manifest still ends up with caret ranges and the peer alias still resolves.
- **--local-workspace rewrites unpublished deps to file: paths** — walks every mastra dep in the emitted manifest, confirms each `file:` spec resolves to a real `package.json` inside the monorepo, and asserts the memory peer alias no longer duplicates core's path.
- **rejects --skip-verify combined with --tag** — guards the mutual-exclusion check.

All 35 factory tests pass. Prettier and lint clean.

## Motivation

Unblocks local end-to-end validation of unreleased template changes — most immediately for `@mastra/factory`, which was added in #19945 but hasn't been through a release train yet, so the sync workflow currently can't run. Once the next release train publishes `@mastra/factory`, the automated workflow starts working again without any further change; this PR only adds a manual escape hatch for local iteration.

## Test plan

- `pnpm --filter ./mastracode/mastra-factory exec vitest run sync-template` — 8/8 pass
- `pnpm --filter ./mastracode/mastra-factory exec vitest run` — 35/35 pass
- `node mastracode/mastra-factory/scripts/sync-template.mjs --out /tmp/x` (default mode) — fails with the improved error message
- `node mastracode/mastra-factory/scripts/sync-template.mjs --out /tmp/x --skip-verify` — succeeds, warns for missing deps
- `node mastracode/mastra-factory/scripts/sync-template.mjs --out /tmp/x --local-workspace` — succeeds, writes `file:` specs for `@mastra/factory`, `@mastra/hono`, and `mastra`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This adds two ways to create the Software Factory template when some local packages are not published yet: skip checking npm, or link directly to local packages. Normal behavior and CI checks stay unchanged.

## What changed

- Added `--skip-verify` to bypass npm publication failures while retaining caret version ranges.
- Added `--local-workspace`, which implies `--skip-verify` and uses `file:` paths for unpublished local dependencies.
- Prevented `--skip-verify` and `--tag` from being used together.
- Improved warnings and error messages for unpublished dependencies.
- Fixed `@mastra/memory` to resolve to its own package path in local-workspace mode.
- Added four tests covering failure behavior, both new flags, and flag conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->