### PR TITLE
fix(mastracode): align composer status line

### DIFF
--- a/mastracode/web/src/web/ui/domains/chat/components/Composer.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/Composer.tsx
@@ -368,9 +368,9 @@ export function Composer({ variant = 'inline' }: ComposerProps) {
           className="hidden"
           aria-label="Attach images"
         />
-        <ComposerActions className="static w-full justify-between px-3 pb-2">
+        <ComposerActions className="static w-full flex-wrap items-end justify-between px-3 pb-3">
           <StatusLine />
-          <ButtonsGroup spacing="close" aria-label="Composer actions">
+          <ButtonsGroup className="ml-auto" spacing="close" aria-label="Composer actions">
             <Button
               type="button"
               variant="outline"

--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/PullRequestLinks.tsx
@@ -129,7 +129,7 @@ export function PullRequestLinks({
   if (links.length === 0) return null;
 
   return (
-    <div className="flex items-center gap-2">
+    <div className="ml-auto flex items-center gap-2">
       {links.map(subscription => (
         <a
           key={subscription.id}

--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/StatusLine.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/StatusLine.tsx
@@ -29,7 +29,7 @@ export function StatusLine() {
   return (
     <div
       aria-label="Session status line"
-      className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 py-2 text-ui-sm text-icon3"
+      className="flex h-fit shrink-0 flex-wrap items-center gap-x-3 gap-y-1 text-ui-sm text-icon3"
     >
       <ModesSelection />
       <ActiveModel />
@@ -38,7 +38,6 @@ export function StatusLine() {
       <ConnectionActivity />
       <QueuedFollowUps />
       <GoalStatus />
-      <span className="flex-1" />
       <PullRequestLinks
         baseUrl={baseUrl}
         resourceId={resourceId}


### PR DESCRIPTION
The composer status row could leave uneven bottom and right spacing, especially when controls wrapped.

Before, the action row inherited reverse wrapping and the status line added nested vertical padding. After, the row wraps normally with equal 12px insets, while the status content keeps its natural height and centered items.

Verified in desktop and 390px browser layouts and with `pnpm check:ui`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The composer’s buttons now stay neatly spaced when they move onto a new line, so the layout looks consistent on both large and small screens.

## Changes

- Updated composer actions to wrap naturally with consistent 12px insets and right-aligned controls.
- Preserved natural status-row height and centered its contents.
- Right-aligned pull request links.
- Verified desktop and 390px layouts with `pnpm check:ui`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->