### PR TITLE
feat(integrations): add @mastra/you-search — zero-config You.com web search tool

### DIFF
--- a/.changeset/tidy-planes-search.md
+++ b/.changeset/tidy-planes-search.md
@@ -1,0 +1,5 @@
+---
+'@mastra/you-search': minor
+---
+
+Add `@mastra/you-search` — You.com web search tool for Mastra agents. Works with zero configuration via You.com's keyless free tier and upgrades to the keyed Search API when `YDC_API_KEY` is set.

--- a/docs/src/content/en/reference/sidebars.js
+++ b/docs/src/content/en/reference/sidebars.js
@@ -725,6 +725,7 @@ const sidebars = {
         { type: 'doc', id: 'tools/submit-plan-tool', label: 'submitPlanTool' },
         { type: 'doc', id: 'tools/task-tools', label: 'Task tools' },
         { type: 'doc', id: 'tools/tavily', label: 'Tavily Tools' },
+        { type: 'doc', id: 'tools/you-search', label: 'You.com Tools' },
       ],
     },
     {

--- a/docs/src/content/en/reference/tools/you-search.mdx
+++ b/docs/src/content/en/reference/tools/you-search.mdx
@@ -1,0 +1,164 @@
+---
+title: "Reference: You.com tools | Tools and MCP"
+description: "API reference for @mastra/you-search, which provides a You.com web search tool for Mastra agents with a zero-configuration keyless free tier."
+packages:
+  - "@mastra/you-search"
+---
+
+# You.com tools
+
+The `@mastra/you-search` package wraps the [You.com Search API](https://you.com/docs/api-reference/search/v1-search) as a Mastra-compatible tool. It exposes a factory function that returns a tool created with [`createTool()`](./create-tool) and full Zod input/output schemas.
+
+The tool works with **zero configuration**: without an API key, searches use You.com's keyless free tier (rate limited per IP). Set the `YDC_API_KEY` environment variable or pass `{ apiKey }` explicitly to use the keyed API with higher limits.
+
+## Installation
+
+Install the package alongside Zod:
+
+```sh npm2yarn
+npm install @mastra/you-search zod
+```
+
+## Usage example
+
+The following example creates the search tool with the default configuration — no API key required:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createYouSearchTool } from '@mastra/you-search'
+
+const searchTool = createYouSearchTool()
+```
+
+To pass an API key explicitly:
+
+```typescript title="src/mastra/tools/index.ts"
+import { createYouSearchTool } from '@mastra/you-search'
+
+const searchTool = createYouSearchTool({ apiKey: process.env.YDC_API_KEY })
+```
+
+## Configuration
+
+All factory functions accept a `YouClientOptions` object:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'apiKey',
+    type: 'string',
+    description:
+      'You.com API key. Falls back to the `YDC_API_KEY` environment variable. When neither is set, requests use the keyless free tier (rate limited per IP).',
+    isOptional: true,
+  },
+  {
+    name: 'baseUrl',
+    type: 'string',
+    description: 'Override the API base URL.',
+    isOptional: true,
+    defaultValue: "'https://ydc-index.io' (keyed) or 'https://api.you.com' (keyless)",
+  },
+  {
+    name: 'fetch',
+    type: 'typeof fetch',
+    description: 'Custom `fetch` implementation. Useful for tests, retries, or instrumentation.',
+    isOptional: true,
+  },
+]}
+/>
+
+## Methods
+
+### Factory functions
+
+#### `createYouTools(config?)`
+
+Returns an object containing all You.com tools that share the supplied configuration.
+
+```typescript
+import { createYouTools } from '@mastra/you-search'
+
+const tools = createYouTools()
+// { youSearch: Tool }
+```
+
+#### `createYouSearchTool(config?)`
+
+Returns the `you-search` tool. It searches the web via the You.com Search API and returns LLM-ready web and news results.
+
+Input schema:
+
+<PropertiesTable
+  content={[
+  {
+    name: 'query',
+    type: 'string',
+    description: 'The search query.',
+    isOptional: false,
+  },
+  {
+    name: 'count',
+    type: 'number',
+    description: 'Maximum number of results per section (web, news), 1-100.',
+    isOptional: true,
+    defaultValue: '10',
+  },
+  {
+    name: 'freshness',
+    type: 'string',
+    description:
+      'Only return results from within the given window: `day`, `week`, `month`, `year`, or a date range in the format `YYYY-MM-DDtoYYYY-MM-DD`.',
+    isOptional: true,
+  },
+  {
+    name: 'country',
+    type: 'string',
+    description: 'Two-letter country code determining the geographical focus of web results (e.g. `US`, `DE`, `JP`).',
+    isOptional: true,
+  },
+  {
+    name: 'language',
+    type: 'string',
+    description: 'Language of the returned web results in BCP 47 format (e.g. `EN`, `FR`, `PT-BR`).',
+    isOptional: true,
+    defaultValue: "'EN'",
+  },
+  {
+    name: 'safesearch',
+    type: "'off' | 'moderate' | 'strict'",
+    description: 'Content moderation level for the results.',
+    isOptional: true,
+  },
+  {
+    name: 'includeDomains',
+    type: 'string[]',
+    description: 'Restrict results to these domains only (strict allowlist). Cannot be combined with `excludeDomains`.',
+    isOptional: true,
+  },
+  {
+    name: 'excludeDomains',
+    type: 'string[]',
+    description: 'Exclude results from these domains. Cannot be combined with `includeDomains`.',
+    isOptional: true,
+  },
+]}
+/>
+
+Output shape:
+
+```typescript
+{
+  query: string
+  results: Array<{
+    title: string
+    url: string
+    description: string
+    snippets?: string[]      // web results only
+    publishedDate?: string   // ISO timestamp when available
+    source: 'web' | 'news'
+  }>
+}
+```
+
+## Rate limits
+
+Without an API key, requests use the keyless free tier, which is rate limited per IP (currently 100 searches/day) and does not support livecrawl. Over-limit requests cause the tool to throw an error with upgrade guidance. Get a free API key with higher limits at [you.com/platform](https://you.com/platform).

--- a/integrations/you-search/README.md
+++ b/integrations/you-search/README.md
@@ -1,0 +1,74 @@
+# @mastra/you-search
+
+[You.com](https://you.com) web search tool for [Mastra](https://mastra.ai) agents.
+
+Works with **zero configuration**: without an API key, searches use You.com's keyless free tier (rate limited per IP), so `npm install` + import yields working results immediately. Set the `YDC_API_KEY` environment variable (or pass `{ apiKey }`) to use the keyed [You.com Search API](https://you.com/docs/api-reference/search/v1-search) with higher limits.
+
+## Installation
+
+```bash
+npm install @mastra/you-search zod
+```
+
+## Quick Start
+
+```typescript
+import { Agent } from '@mastra/core/agent';
+import { createYouTools } from '@mastra/you-search';
+
+const agent = new Agent({
+  id: 'research-agent',
+  name: 'Research Agent',
+  instructions: 'You are a research assistant with access to web search.',
+  model: 'anthropic/claude-sonnet-4-6',
+  tools: createYouTools(),
+});
+```
+
+Or create the search tool individually:
+
+```typescript
+import { createYouSearchTool } from '@mastra/you-search';
+
+const searchTool = createYouSearchTool();
+
+// With an API key for higher limits:
+const keyedSearchTool = createYouSearchTool({ apiKey: process.env.YDC_API_KEY });
+```
+
+## Tools
+
+### `you-search`
+
+Searches the web via the You.com Search API and returns LLM-ready web and news results with titles, URLs, descriptions, and text snippets.
+
+Input parameters:
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `query` | `string` | The search query (required). |
+| `count` | `number` | Max results per section (web, news), 1–100. Default 10. |
+| `freshness` | `string` | `day`, `week`, `month`, `year`, or `YYYY-MM-DDtoYYYY-MM-DD`. |
+| `country` | `string` | Two-letter country code for geographic focus (e.g. `US`). |
+| `language` | `string` | Result language, BCP 47 (e.g. `EN`, `PT-BR`). |
+| `safesearch` | `'off' \| 'moderate' \| 'strict'` | Content moderation level. |
+| `includeDomains` | `string[]` | Strict domain allowlist. Cannot combine with `excludeDomains`. |
+| `excludeDomains` | `string[]` | Domain denylist. Cannot combine with `includeDomains`. |
+
+## Configuration
+
+All factory functions accept a `YouClientOptions` object:
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `apiKey` | `string` | `process.env.YDC_API_KEY` | You.com API key. When absent, the keyless free tier is used. |
+| `baseUrl` | `string` | keyed: `https://ydc-index.io`, keyless: `https://api.you.com` | Override the API base URL. |
+| `fetch` | `typeof fetch` | global `fetch` | Custom fetch implementation for tests, retries, or instrumentation. |
+
+## Free tier and rate limits
+
+Without an API key, requests go to You.com's keyless endpoint, which is rate limited per IP (currently 100 searches/day) and does not support livecrawl. When the limit is reached, the tool throws an error explaining how to upgrade. Get a free API key with higher limits at [you.com/platform](https://you.com/platform).
+
+## License
+
+Apache-2.0

--- a/integrations/you-search/eslint.config.js
+++ b/integrations/you-search/eslint.config.js
@@ -1,0 +1,6 @@
+import { createConfig } from '@internal/lint/eslint';
+
+const config = await createConfig();
+
+/** @type {import("eslint").Linter.Config[]} */
+export default [...config];

--- a/integrations/you-search/lint-staged.config.js
+++ b/integrations/you-search/lint-staged.config.js
@@ -1,0 +1,5 @@
+export default {
+  '*.{ts,tsx}': ['eslint --fix --max-warnings=0', 'prettier --write'],
+  '*.{js,jsx}': ['prettier --write'],
+  '*.{json,md,yml,yaml}': ['prettier --write'],
+};

--- a/integrations/you-search/package.json
+++ b/integrations/you-search/package.json
@@ -1,0 +1,64 @@
+{
+  "name": "@mastra/you-search",
+  "version": "0.1.0",
+  "description": "You.com web search tool for Mastra agents — works with zero configuration via the keyless free tier",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build:lib": "tsup --silent --config tsup.config.ts",
+    "build:watch": "pnpm build:lib --watch",
+    "lint": "eslint .",
+    "test": "vitest run"
+  },
+  "keywords": [
+    "mastra",
+    "you.com",
+    "web-search",
+    "tools",
+    "ai-agent"
+  ],
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mastra-ai/mastra.git",
+    "directory": "integrations/you-search"
+  },
+  "bugs": {
+    "url": "https://github.com/mastra-ai/mastra/issues"
+  },
+  "homepage": "https://mastra.ai",
+  "engines": {
+    "node": ">=22.13.0"
+  },
+  "peerDependencies": {
+    "@mastra/core": ">=1.0.0-0 <2.0.0-0",
+    "zod": ">=3.0.0 || >=4.0.0"
+  },
+  "devDependencies": {
+    "@internal/lint": "workspace:*",
+    "@internal/types-builder": "workspace:*",
+    "@mastra/core": "workspace:*",
+    "tsup": "^8.5.1",
+    "typescript": "catalog:",
+    "vitest": "catalog:",
+    "zod": "catalog:"
+  }
+}

--- a/integrations/you-search/src/__tests__/client.test.ts
+++ b/integrations/you-search/src/__tests__/client.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { youSearchRequest, INTEGRATION_USER_AGENT } from '../client.js';
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+const EMPTY_RESULTS = { results: { web: [], news: [] } };
+
+describe('youSearchRequest', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.YDC_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('uses the keyless endpoint with no API key header when no key is configured', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest({ query: 'hello' }, { fetch: fetchMock });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://api.you.com/v1/agents/search?query=hello');
+    expect((init as RequestInit).headers).not.toHaveProperty('X-API-Key');
+  });
+
+  it('uses the keyed endpoint with the X-API-Key header when a key is passed explicitly', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest({ query: 'hello' }, { apiKey: 'explicit-key', fetch: fetchMock });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toBe('https://ydc-index.io/v1/search?query=hello');
+    expect((init as RequestInit).headers).toMatchObject({ 'X-API-Key': 'explicit-key' });
+  });
+
+  it('falls back to the YDC_API_KEY environment variable', async () => {
+    process.env.YDC_API_KEY = 'env-key';
+
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest({ query: 'hello' }, { fetch: fetchMock });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(String(url)).toContain('https://ydc-index.io/v1/search');
+    expect((init as RequestInit).headers).toMatchObject({ 'X-API-Key': 'env-key' });
+  });
+
+  it('explicit apiKey overrides the environment variable', async () => {
+    process.env.YDC_API_KEY = 'env-key';
+
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest({ query: 'q' }, { apiKey: 'explicit-key', fetch: fetchMock });
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect((init as RequestInit).headers).toMatchObject({ 'X-API-Key': 'explicit-key' });
+  });
+
+  it('always sends the integration User-Agent on both tiers', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest({ query: 'q' }, { fetch: fetchMock });
+    await youSearchRequest({ query: 'q' }, { apiKey: 'k', fetch: fetchMock });
+
+    for (const call of fetchMock.mock.calls) {
+      expect((call[1] as RequestInit).headers).toMatchObject({
+        'User-Agent': INTEGRATION_USER_AGENT,
+      });
+    }
+  });
+
+  it('serializes request parameters as query string values', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest(
+      {
+        query: 'mastra agent framework',
+        count: 7,
+        freshness: 'week',
+        country: 'US',
+        language: 'EN',
+        safesearch: 'moderate',
+        include_domains: ['mastra.ai', 'docs.mastra.ai'],
+      },
+      { apiKey: 'k', fetch: fetchMock, baseUrl: 'https://example.test/' },
+    );
+
+    const [url] = fetchMock.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect(parsed.origin + parsed.pathname).toBe('https://example.test/v1/search');
+    expect(parsed.searchParams.get('query')).toBe('mastra agent framework');
+    expect(parsed.searchParams.get('count')).toBe('7');
+    expect(parsed.searchParams.get('freshness')).toBe('week');
+    expect(parsed.searchParams.get('country')).toBe('US');
+    expect(parsed.searchParams.get('language')).toBe('EN');
+    expect(parsed.searchParams.get('safesearch')).toBe('moderate');
+    expect(parsed.searchParams.get('include_domains')).toBe('mastra.ai,docs.mastra.ai');
+    expect(parsed.searchParams.get('exclude_domains')).toBeNull();
+  });
+
+  it('omits unset parameters from the query string', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(EMPTY_RESULTS));
+
+    await youSearchRequest({ query: 'q' }, { apiKey: 'k', fetch: fetchMock });
+
+    const [url] = fetchMock.mock.calls[0]!;
+    const parsed = new URL(String(url));
+    expect([...parsed.searchParams.keys()]).toEqual(['query']);
+  });
+
+  it('throws a rate-limit error with upgrade guidance on keyless 402/429 responses', async () => {
+    for (const status of [402, 429]) {
+      const fetchMock = vi.fn(async () =>
+        new Response(JSON.stringify({ error: 'rate_limit_exceeded' }), { status }),
+      );
+
+      await expect(youSearchRequest({ query: 'q' }, { fetch: fetchMock })).rejects.toThrow(
+        /rate limit reached.*YDC_API_KEY.*you\.com\/platform/s,
+      );
+    }
+  });
+
+  it('throws a descriptive error on keyed non-2xx responses', async () => {
+    const fetchMock = vi.fn(async () => new Response('invalid key', { status: 401 }));
+
+    await expect(
+      youSearchRequest({ query: 'q' }, { apiKey: 'k', fetch: fetchMock }),
+    ).rejects.toThrow(/401.*invalid key/);
+  });
+
+  it('truncates long error response bodies to 1000 chars', async () => {
+    const huge = 'x'.repeat(5000);
+    const fetchMock = vi.fn(async () => new Response(huge, { status: 500 }));
+
+    await expect(
+      youSearchRequest({ query: 'q' }, { apiKey: 'k', fetch: fetchMock }),
+    ).rejects.toThrow(new RegExp(`status 500: x{1000}…$`));
+  });
+
+  it('normalizes missing result sections to empty arrays', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ metadata: { query: 'q' } }));
+
+    const out = await youSearchRequest({ query: 'q' }, { apiKey: 'k', fetch: fetchMock });
+
+    expect(out.results).toEqual({ web: [], news: [] });
+    expect(out.metadata).toEqual({ query: 'q' });
+  });
+});

--- a/integrations/you-search/src/__tests__/search.test.ts
+++ b/integrations/you-search/src/__tests__/search.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createYouSearchTool } from '../search.js';
+import { createYouTools } from '../tools.js';
+
+const ORIGINAL_ENV = { ...process.env };
+
+beforeEach(() => {
+  delete process.env.YDC_API_KEY;
+});
+
+afterEach(() => {
+  process.env = { ...ORIGINAL_ENV };
+  vi.restoreAllMocks();
+});
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('createYouSearchTool', () => {
+  it('exposes the expected tool id, description, and schemas', () => {
+    const tool = createYouSearchTool();
+
+    expect(tool.id).toBe('you-search');
+    expect(tool.description).toContain('You.com Search API');
+    expect(tool.inputSchema).toBeDefined();
+    expect(tool.outputSchema).toBeDefined();
+  });
+
+  it('executes without any configuration via the keyless tier', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ results: { web: [], news: [] } }));
+    const tool = createYouSearchTool({ fetch: fetchMock });
+
+    const out = (await tool.execute!({ query: 'q' }, {} as any)) as { results: unknown[] };
+
+    expect(out.results).toEqual([]);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain('https://api.you.com/v1/agents/search');
+  });
+
+  it('maps camelCase input to API query parameters', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({ results: { web: [], news: [] } }));
+    const tool = createYouSearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    await tool.execute!(
+      {
+        query: 'agent frameworks',
+        count: 5,
+        freshness: 'month',
+        country: 'US',
+        includeDomains: ['mastra.ai'],
+      },
+      {} as any,
+    );
+
+    const parsed = new URL(String(fetchMock.mock.calls[0]![0]));
+    expect(parsed.searchParams.get('query')).toBe('agent frameworks');
+    expect(parsed.searchParams.get('count')).toBe('5');
+    expect(parsed.searchParams.get('freshness')).toBe('month');
+    expect(parsed.searchParams.get('country')).toBe('US');
+    expect(parsed.searchParams.get('include_domains')).toBe('mastra.ai');
+  });
+
+  it('flattens web and news sections into a single results list with source tags', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({
+        results: {
+          web: [
+            {
+              title: 'Web A',
+              url: 'https://a.test',
+              description: 'desc a',
+              snippets: ['snippet one'],
+              page_age: '2026-01-01T00:00:00',
+            },
+          ],
+          news: [
+            {
+              title: 'News B',
+              url: 'https://b.test',
+              description: 'desc b',
+              page_age: '2026-02-02T00:00:00',
+            },
+          ],
+        },
+      }),
+    );
+    const tool = createYouSearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    const out = await tool.execute!({ query: 'q' }, {} as any);
+
+    expect(out).toEqual({
+      query: 'q',
+      results: [
+        {
+          title: 'Web A',
+          url: 'https://a.test',
+          description: 'desc a',
+          snippets: ['snippet one'],
+          publishedDate: '2026-01-01T00:00:00',
+          source: 'web',
+        },
+        {
+          title: 'News B',
+          url: 'https://b.test',
+          description: 'desc b',
+          publishedDate: '2026-02-02T00:00:00',
+          source: 'news',
+        },
+      ],
+    });
+  });
+
+  it('defaults missing result fields to empty strings', async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ results: { web: [{ url: 'https://a.test' }], news: [] } }),
+    );
+    const tool = createYouSearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    const out = (await tool.execute!({ query: 'q' }, {} as any)) as {
+      results: Array<{ title: string; description: string }>;
+    };
+
+    expect(out.results[0]).toMatchObject({ title: '', description: '', url: 'https://a.test' });
+  });
+
+  it('lets API errors propagate to the caller', async () => {
+    const fetchMock = vi.fn(async () => new Response('forbidden', { status: 403 }));
+    const tool = createYouSearchTool({ apiKey: 'k', fetch: fetchMock });
+
+    await expect(tool.execute!({ query: 'q' }, {} as any)).rejects.toThrow(/403/);
+  });
+
+  it('rejects input combining includeDomains and excludeDomains', () => {
+    const tool = createYouSearchTool();
+
+    const parsed = tool.inputSchema!.safeParse({
+      query: 'q',
+      includeDomains: ['a.com'],
+      excludeDomains: ['b.com'],
+    });
+    expect(parsed.success).toBe(false);
+    if (!parsed.success) {
+      expect(parsed.error.issues[0]!.message).toMatch(/cannot be combined/i);
+    }
+  });
+
+  it('accepts includeDomains or excludeDomains on their own', () => {
+    const tool = createYouSearchTool();
+
+    expect(tool.inputSchema!.safeParse({ query: 'q', includeDomains: ['a.com'] }).success).toBe(true);
+    expect(tool.inputSchema!.safeParse({ query: 'q', excludeDomains: ['b.com'] }).success).toBe(true);
+  });
+});
+
+describe('createYouTools', () => {
+  it('returns the search tool under the youSearch key', () => {
+    const tools = createYouTools();
+    expect(Object.keys(tools)).toEqual(['youSearch']);
+    expect(tools.youSearch.id).toBe('you-search');
+  });
+});

--- a/integrations/you-search/src/client.ts
+++ b/integrations/you-search/src/client.ts
@@ -1,0 +1,149 @@
+/**
+ * Base URL for the keyless free tier. No API key required — rate limited per IP
+ * (currently 100 searches/day). Livecrawl is not available on this tier.
+ */
+export const KEYLESS_BASE_URL = 'https://api.you.com';
+
+/**
+ * Base URL for the keyed You.com Search API, used when an API key is configured.
+ */
+export const KEYED_BASE_URL = 'https://ydc-index.io';
+
+const KEYLESS_SEARCH_PATH = '/v1/agents/search';
+const KEYED_SEARCH_PATH = '/v1/search';
+
+/**
+ * Product token identifying this integration to You.com, per the You.com
+ * integration attribution convention. On the keyless tier there is no API key,
+ * so the User-Agent is the primary attribution signal.
+ */
+export const INTEGRATION_USER_AGENT = 'youdotcom-integration/mastra-ai-mastra';
+
+export type YouClientOptions = {
+  /**
+   * You.com API key. Falls back to the `YDC_API_KEY` environment variable.
+   * When neither is set, requests use the keyless free tier
+   * (rate limited per IP) — no configuration is required to get started.
+   * Get a key with higher limits at https://you.com/platform.
+   */
+  apiKey?: string;
+  /**
+   * Override the API base URL. Defaults to `https://ydc-index.io` when an API
+   * key is configured, or `https://api.you.com` (keyless free tier) otherwise.
+   */
+  baseUrl?: string;
+  /**
+   * Optional `fetch` implementation. Useful for tests, retries, or instrumentation.
+   * Defaults to the global `fetch`.
+   */
+  fetch?: typeof fetch;
+};
+
+export type YouWebResult = {
+  url?: string;
+  title?: string;
+  description?: string;
+  snippets?: string[];
+  page_age?: string;
+  thumbnail_url?: string;
+  favicon_url?: string;
+  authors?: string[];
+};
+
+export type YouNewsResult = {
+  url?: string;
+  title?: string;
+  description?: string;
+  page_age?: string;
+  thumbnail_url?: string;
+};
+
+export type YouSearchResponse = {
+  results: {
+    web: YouWebResult[];
+    news: YouNewsResult[];
+  };
+  metadata?: {
+    search_uuid?: string;
+    query?: string;
+    latency?: number;
+  };
+};
+
+export type YouSearchRequest = {
+  query: string;
+  count?: number;
+  freshness?: string;
+  country?: string;
+  language?: string;
+  safesearch?: 'off' | 'moderate' | 'strict';
+  include_domains?: string[];
+  exclude_domains?: string[];
+};
+
+function resolveApiKey(explicit?: string): string | undefined {
+  return explicit ?? process.env.YDC_API_KEY;
+}
+
+/**
+ * Performs a search against the You.com Search API.
+ *
+ * Uses the keyed endpoint when an API key is available (via `options.apiKey`
+ * or the `YDC_API_KEY` environment variable) and transparently falls back to
+ * the keyless free tier otherwise, so it works with zero configuration.
+ */
+export async function youSearchRequest(
+  request: YouSearchRequest,
+  options?: YouClientOptions,
+): Promise<YouSearchResponse> {
+  const apiKey = resolveApiKey(options?.apiKey);
+  const baseUrl = (options?.baseUrl ?? (apiKey ? KEYED_BASE_URL : KEYLESS_BASE_URL)).replace(/\/$/, '');
+  const path = apiKey ? KEYED_SEARCH_PATH : KEYLESS_SEARCH_PATH;
+  const fetchImpl = options?.fetch ?? fetch;
+
+  const params = new URLSearchParams({ query: request.query });
+  if (request.count !== undefined) params.set('count', String(request.count));
+  if (request.freshness !== undefined) params.set('freshness', request.freshness);
+  if (request.country !== undefined) params.set('country', request.country);
+  if (request.language !== undefined) params.set('language', request.language);
+  if (request.safesearch !== undefined) params.set('safesearch', request.safesearch);
+  if (request.include_domains?.length) params.set('include_domains', request.include_domains.join(','));
+  if (request.exclude_domains?.length) params.set('exclude_domains', request.exclude_domains.join(','));
+
+  const headers: Record<string, string> = {
+    'User-Agent': INTEGRATION_USER_AGENT,
+  };
+  if (apiKey) {
+    headers['X-API-Key'] = apiKey;
+  }
+
+  const response = await fetchImpl(`${baseUrl}${path}?${params.toString()}`, {
+    method: 'GET',
+    headers,
+  });
+
+  if (!response.ok) {
+    const rawText = await response.text().catch(() => '');
+    const MAX_ERROR_BODY = 1000;
+    const text = rawText.length > MAX_ERROR_BODY ? `${rawText.slice(0, MAX_ERROR_BODY)}…` : rawText;
+    if (!apiKey && (response.status === 402 || response.status === 429)) {
+      throw new Error(
+        `You.com keyless search rate limit reached (status ${response.status}). ` +
+          'Set the YDC_API_KEY environment variable (or pass { apiKey }) for higher limits — ' +
+          `get a free key at https://you.com/platform.${text ? ` Response: ${text}` : ''}`,
+      );
+    }
+    throw new Error(
+      `You.com search request failed with status ${response.status}${text ? `: ${text}` : ''}`,
+    );
+  }
+
+  const json = (await response.json()) as Partial<YouSearchResponse>;
+  return {
+    results: {
+      web: Array.isArray(json.results?.web) ? json.results.web : [],
+      news: Array.isArray(json.results?.news) ? json.results.news : [],
+    },
+    metadata: json.metadata,
+  };
+}

--- a/integrations/you-search/src/index.ts
+++ b/integrations/you-search/src/index.ts
@@ -1,0 +1,13 @@
+export {
+  youSearchRequest,
+  KEYLESS_BASE_URL,
+  KEYED_BASE_URL,
+  INTEGRATION_USER_AGENT,
+  type YouClientOptions,
+  type YouSearchRequest,
+  type YouSearchResponse,
+  type YouWebResult,
+  type YouNewsResult,
+} from './client.js';
+export { createYouSearchTool } from './search.js';
+export { createYouTools } from './tools.js';

--- a/integrations/you-search/src/search.ts
+++ b/integrations/you-search/src/search.ts
@@ -1,0 +1,121 @@
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import { youSearchRequest } from './client.js';
+import type { YouClientOptions } from './client.js';
+
+const inputSchema = z
+  .object({
+    query: z.string().describe('The search query.'),
+    count: z
+      .number()
+      .int()
+      .min(1)
+      .max(100)
+      .optional()
+      .describe('Maximum number of results to return per section (web, news). Defaults to the API default of 10.'),
+    freshness: z
+      .string()
+      .optional()
+      .describe(
+        'Only return results from within the given window: `day`, `week`, `month`, `year`, or a date range in the format `YYYY-MM-DDtoYYYY-MM-DD`.',
+      ),
+    country: z
+      .string()
+      .optional()
+      .describe('Two-letter country code determining the geographical focus of web results (e.g. `US`, `DE`, `JP`).'),
+    language: z
+      .string()
+      .optional()
+      .describe('Language of the returned web results in BCP 47 format (e.g. `EN`, `FR`, `PT-BR`). Defaults to `EN`.'),
+    safesearch: z
+      .enum(['off', 'moderate', 'strict'])
+      .optional()
+      .describe('Content moderation level for the results.'),
+    includeDomains: z
+      .array(z.string())
+      .optional()
+      .describe(
+        'Restrict results to these domains only (strict allowlist, e.g. `["nytimes.com", "bbc.com"]`). Cannot be combined with excludeDomains.',
+      ),
+    excludeDomains: z
+      .array(z.string())
+      .optional()
+      .describe('Exclude results from these domains. Cannot be combined with includeDomains.'),
+  })
+  .refine(input => !(input.includeDomains?.length && input.excludeDomains?.length), {
+    message: 'includeDomains and excludeDomains cannot be combined in the same call.',
+  });
+
+const outputSchema = z.object({
+  query: z.string(),
+  results: z.array(
+    z.object({
+      title: z.string(),
+      url: z.string(),
+      description: z.string(),
+      snippets: z.array(z.string()).optional(),
+      publishedDate: z.string().optional(),
+      source: z.enum(['web', 'news']),
+    }),
+  ),
+});
+
+/**
+ * Creates a tool that searches the web using the You.com Search API.
+ *
+ * Returns LLM-ready web and news results with titles, URLs, descriptions, and
+ * text snippets. Supports filtering by freshness, country, language, safesearch
+ * level, and domain allow/deny lists.
+ *
+ * Works with zero configuration: without an API key, requests use the keyless
+ * You.com free tier (rate limited per IP). Set the `YDC_API_KEY` environment
+ * variable or pass `{ apiKey }` for higher limits.
+ *
+ * @see https://you.com/docs/api-reference/search/v1-search
+ */
+export function createYouSearchTool(config?: YouClientOptions) {
+  return createTool({
+    id: 'you-search',
+    description:
+      'Search the web for up-to-date information using the You.com Search API. Returns ranked web and news results with titles, URLs, descriptions, and text snippets. Supports filtering by freshness, country, language, and domain allow/deny lists.',
+    inputSchema,
+    outputSchema,
+    execute: async input => {
+      const response = await youSearchRequest(
+        {
+          query: input.query,
+          count: input.count,
+          freshness: input.freshness,
+          country: input.country,
+          language: input.language,
+          safesearch: input.safesearch,
+          include_domains: input.includeDomains,
+          exclude_domains: input.excludeDomains,
+        },
+        config,
+      );
+
+      return {
+        query: input.query,
+        results: [
+          ...response.results.web.map(r => ({
+            title: r.title ?? '',
+            url: r.url ?? '',
+            description: r.description ?? '',
+            snippets: r.snippets,
+            publishedDate: r.page_age,
+            source: 'web' as const,
+          })),
+          ...response.results.news.map(r => ({
+            title: r.title ?? '',
+            url: r.url ?? '',
+            description: r.description ?? '',
+            publishedDate: r.page_age,
+            source: 'news' as const,
+          })),
+        ],
+      };
+    },
+  });
+}

--- a/integrations/you-search/src/tools.ts
+++ b/integrations/you-search/src/tools.ts
@@ -1,0 +1,8 @@
+import type { YouClientOptions } from './client.js';
+import { createYouSearchTool } from './search.js';
+
+export function createYouTools(config?: YouClientOptions) {
+  return {
+    youSearch: createYouSearchTool(config),
+  };
+}

--- a/integrations/you-search/tsconfig.build.json
+++ b/integrations/you-search/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": ["./tsconfig.json", "../../tsconfig.build.json"],
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/you-search/tsconfig.json
+++ b/integrations/you-search/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../tsconfig.node.json",
+  "include": ["src/**/*", "tsup.config.ts"],
+  "exclude": ["node_modules", "**/*.test.ts"]
+}

--- a/integrations/you-search/tsup.config.ts
+++ b/integrations/you-search/tsup.config.ts
@@ -1,0 +1,17 @@
+import { generateTypes } from '@internal/types-builder';
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm', 'cjs'],
+  clean: true,
+  dts: false,
+  splitting: true,
+  treeshake: {
+    preset: 'smallest',
+  },
+  sourcemap: true,
+  onSuccess: async () => {
+    await generateTypes(process.cwd());
+  },
+});

--- a/integrations/you-search/turbo.json
+++ b/integrations/you-search/turbo.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://v2-9-16.turborepo.dev/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build:lib": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**",
+        "tsup.config.ts",
+        "tsconfig.json",
+        "tsconfig.build.json",
+        "package.json",
+        "!**/*.md",
+        "!**/*.test.ts",
+        "!**/*.spec.ts",
+        "!**/__tests__/**"
+      ],
+      "outputs": ["dist/**"]
+    },
+    "build": {
+      "dependsOn": ["build:lib"],
+      "inputs": ["package.json"]
+    }
+  }
+}

--- a/integrations/you-search/vitest.config.ts
+++ b/integrations/you-search/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    name: 'unit:integrations/you-search',
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2194,6 +2194,30 @@ importers:
         specifier: 'catalog:'
         version: 4.4.3
 
+  integrations/you-search:
+    devDependencies:
+      '@internal/lint':
+        specifier: workspace:*
+        version: link:../../packages/_config
+      '@internal/types-builder':
+        specifier: workspace:*
+        version: link:../../packages/_types-builder
+      '@mastra/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(patch_hash=78092cc873f6c3c61ff4846b4b326faa7db54bb3c1506c510614d708601e2b7f)(@microsoft/api-extractor@7.58.12(@types/node@22.19.15))(@swc/core@1.15.7(@swc/helpers@0.5.17))(jiti@2.7.0)(postcss@8.5.16)(tsx@4.23.1)(typescript@6.0.3)(yaml@2.9.0)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@22.19.15)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(jsdom@27.4.0(@noble/hashes@2.2.0)(bufferutil@4.1.0))(msw@2.14.6(@types/node@22.19.15)(typescript@6.0.3))(vite@7.3.6(@types/node@22.19.15)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.44.1)(tsx@4.23.1)(yaml@2.9.0))
+      zod:
+        specifier: 'catalog:'
+        version: 4.4.3
+
   mastracode/factory:
     dependencies:
       '@mastra/auth-studio':


### PR DESCRIPTION
## Description

Closes #19984

Adds `@mastra/you-search` — a You.com web-search integration package, following the pattern of `@mastra/perplexity` (#15939), `@mastra/tavily` (#15448), and `@mastra/brightdata` (#16392).

What's different from the existing search tools: **it works with zero configuration.** You.com exposes a keyless free tier (`https://api.you.com/v1/agents/search`, IP-rate-limited at 100 searches/day), so `createYouSearchTool()` returns real results with no API key and no signup. When `YDC_API_KEY` (or an explicit `{ apiKey }`) is present, the client transparently switches to the keyed Search API (`https://ydc-index.io/v1/search`) with higher limits.

### Exports

- `createYouSearchTool(config?)` — `you-search` tool built with `createTool()`, full Zod input/output schemas
  - Inputs: `query`, `count`, `freshness`, `country`, `language`, `safesearch`, `includeDomains`/`excludeDomains` (mutually exclusive, enforced by schema refinement)
  - Output: flattened, LLM-ready list of web + news results (`title`, `url`, `description`, `snippets`, `publishedDate`, `source`)
- `createYouTools(config?)` — bundle factory (`{ youSearch }`)
- `youSearchRequest()` low-level client + types

### Implementation notes

- Raw `fetch` client, no vendor SDK dependency; injectable `fetch` for tests (mirrors `@mastra/perplexity`)
- Sends the `youdotcom-integration/mastra-ai-mastra` User-Agent on You.com calls for attribution, analogous to Tavily's `clientName: 'mastra'` (#19607)
- Keyless over-limit (402/429) responses throw a clear error with upgrade guidance; other errors surface status + body (truncated to 1000 chars)
- Naming: happy to rename to `@mastra/youdotcom` if the vendor-name convention is preferred

### Included

- `integrations/you-search` package (ESM/CJS via tsup, types via `@internal/types-builder`)
- 20 vitest unit tests with mocked fetch (endpoint selection, env-var fallback, param mapping, result flattening, error paths, schema validation)
- README, reference docs page (`docs/src/content/en/reference/tools/you-search.mdx`) + sidebar entry
- Changeset (minor)

### Disclosure

I work at You.com. This PR was developed with AI assistance (Claude Code) and human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR lets Mastra agents search the web using You.com. It works without setup through You.com’s free tier, or uses an API key for higher limits.

## What changed

- Added the new `@mastra/you-search` integration.
- Added:
  - `createYouSearchTool()`
  - `createYouTools()`
  - `youSearchRequest()`
- Supports keyless search and keyed requests via `YDC_API_KEY` or `apiKey`.
- Added configurable query options, including result count, freshness, location, language, safesearch, and domain filters.
- Normalizes web and news results into a flattened, LLM-ready format.
- Added injectable `fetch`, request validation, response normalization, and rate-limit/error handling.
- Added unit tests covering client routing, parameters, errors, schemas, and tool output.
- Added package configuration, README, reference documentation, sidebar navigation, and a minor changeset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->