### PR TITLE
fix(create-factory): pin every synced template dep to "latest"

### DIFF
--- a/.changeset/factory-sync-template-latest.md
+++ b/.changeset/factory-sync-template-latest.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+The Software Factory template now pins every Mastra dep to `"latest"` instead of a caret range anchored on the current monorepo version, matching how every other create-mastra template ships. `sync-template.mjs` no longer shells out to `npm view` and no longer needs the `--tag` flag or the `legacy-peer-deps=true` `.npmrc` (which only existed to work around prerelease pins). The sync workflow no longer breaks whenever a linked package sits mid-alpha between publishes.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -3,34 +3,29 @@
  * Produces the Mastra Factory template tree from `mastracode/web`.
  *
  * The template is the web project minus monorepo coupling:
- *   - `link:` deps           -> caret ranges on published versions (verified on npm)
+ *   - `link:` deps           -> `"latest"` (matches the templates/* pattern)
  *   - monorepo tsconfig      -> standalone tsconfig
- *   - contributor README     -> checked-in template/README.md (version tokens filled)
+ *   - contributor README     -> checked-in template/README.md
  *   - e2e/tests/test deps    -> stripped
  *   - monorepo-only scripts  -> user-facing scripts (dev/build/start/deploy)
  *   - .env.schema            -> also emitted as .env.example (decorators stripped)
  *
- * Versions: Mastra deps become caret ranges (`^1.51.0` style), matching the
- * monorepo's other templates (templates/* float via `latest`/caret). By
- * default the range is anchored on the LOCAL monorepo version of each
- * package (verified to exist on npm); `--tag latest` anchors on the `latest`
- * dist-tags instead. Automated sync uses the default mode so the generated
- * template matches the coherent local package set. Because those anchors
- * may be prereleases, the template ships an `.npmrc`
- * with `legacy-peer-deps=true` — npm's strict resolver rejects prereleases
- * like `1.51.1-alpha.1` against peer ranges like `>=1.50.0-0`.
+ * Versions: every `link:` dep becomes `"latest"`, matching the monorepo's
+ * other templates (templates/*). We do not pin the current monorepo version
+ * because pinning a mid-train alpha would make the template uninstallable
+ * whenever the alpha has not been published yet, and it forces peer-range
+ * relaxation for prereleases. `"latest"` floats to whatever is currently on
+ * the `latest` dist-tag, which is exactly what create-mastra scaffolds do.
  *
  * Usage:
- *   node scripts/sync-template.mjs [--out <dir>] [--tag latest]
+ *   node scripts/sync-template.mjs [--out <dir>]
  *
  * Output defaults to `template-out/` next to this package (gitignored).
  * Publish flow: automated — the sync-softwarefactory-template workflow runs
- * this against published local monorepo versions on pushes to main touching
- * `mastracode/web`, then force-syncs the softwarefactory-template repository,
- * mirroring the templates/* sync process (one-way overwrite; the monorepo is
- * truth).
+ * this on pushes to main touching `mastracode/web`, then force-syncs the
+ * softwarefactory-template repository, mirroring the templates/* sync process
+ * (one-way overwrite; the monorepo is truth).
  */
-import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -47,7 +42,6 @@ function argValue(flag) {
 }
 const defaultOutDir = path.join(pkgRoot, 'template-out');
 const outDir = path.resolve(argValue('--out') ?? defaultOutDir);
-const pinTag = argValue('--tag'); // undefined = local monorepo versions
 
 /** True when `candidate` is `parent` or nested inside it. */
 function containsPath(parent, candidate) {
@@ -142,39 +136,17 @@ function copyTree(srcDir, destDir, relBase = '') {
   }
 }
 
-function monorepoVersion(name, relPath) {
+/**
+ * Verify the linked package exists in the monorepo and its manifest name
+ * matches the dependency key. This is a source-of-truth check only — no
+ * version is read from it; the template pins `"latest"` from npm.
+ */
+function assertLinkedPackage(name, relPath) {
   const pkgJsonPath = path.join(monorepoRoot, relPath, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
   if (pkg.name !== name) {
     throw new Error(`sync-template: ${pkgJsonPath} is named ${pkg.name}, expected ${name}`);
   }
-  return pkg.version;
-}
-
-/**
- * Resolve the version to pin: the local monorepo version (default, verified
- * published) or the requested dist-tag.
- */
-function resolvePinnedVersion(name, relPath) {
-  if (pinTag) {
-    try {
-      return execFileSync('npm', ['view', name, `dist-tags.${pinTag}`], { stdio: 'pipe' })
-        .toString()
-        .trim();
-    } catch {
-      throw new Error(`sync-template: could not resolve ${name}@${pinTag} on npm.`);
-    }
-  }
-  const version = monorepoVersion(name, relPath);
-  try {
-    execFileSync('npm', ['view', `${name}@${version}`, 'version'], { stdio: 'pipe' });
-  } catch {
-    throw new Error(
-      `sync-template: ${name}@${version} (local monorepo version) is not published on npm — ` +
-        `publish it (or wait for the release train), or sync with --tag latest.`,
-    );
-  }
-  return version;
 }
 
 function transformPackageJson() {
@@ -201,24 +173,18 @@ function transformPackageJson() {
     check: 'tsc --noEmit && tsc --noEmit -p src/web/ui/tsconfig.json',
   };
 
-  const pins = [];
-  console.log(
-    pinTag
-      ? `sync-template: pinning npm ${pinTag} dist-tags...`
-      : 'sync-template: pinning local monorepo versions (verified on npm)...',
-  );
+  // Every `link:` dep becomes `"latest"`, matching the monorepo's other
+  // templates (templates/*). We still resolve the link target so an invalid
+  // `link:` spec (typo, deleted package) fails the sync loudly.
+  console.log('sync-template: rewriting link: deps to "latest"...');
   for (const section of ['dependencies', 'devDependencies']) {
     const deps = manifest[section];
     if (!deps) continue;
     for (const [name, spec] of Object.entries(deps)) {
       if (!spec.startsWith('link:')) continue;
-      const version = resolvePinnedVersion(name, linkSpecToRelPath(spec));
-      // Caret ranges, matching the monorepo's other templates (templates/*):
-      // the scaffold floats to compatible releases instead of freezing the
-      // exact set that existed at sync time.
-      deps[name] = `^${version}`;
-      pins.push([name, version]);
-      console.log(`  ✓ ${name}@^${version}`);
+      assertLinkedPackage(name, linkSpecToRelPath(spec));
+      deps[name] = 'latest';
+      console.log(`  ✓ ${name}@latest`);
     }
   }
 
@@ -235,15 +201,13 @@ function transformPackageJson() {
     }
   }
 
-  // The template installs with `legacy-peer-deps=true` (see writeNpmrc), which
-  // skips automatic peer installation. Most peers are already direct deps;
-  // these transitive runtime peers are not, so declare them explicitly.
-  // (In the monorepo dev setup pnpm's auto-install-peers provides them.)
-  manifest.dependencies['@mastra/memory'] = manifest.dependencies['@mastra/core']; // peer of @mastra/playground-ui
+  // Transitive runtime peers that must be declared as direct deps so npm
+  // resolves them without needing pnpm's auto-install-peers behavior.
+  // (In the monorepo dev setup pnpm provides them automatically.)
+  manifest.dependencies['@mastra/memory'] = 'latest'; // peer of @mastra/playground-ui
   manifest.dependencies['react-is'] = '^19.0.0'; // peer of recharts (via @mastra/playground-ui)
 
   fs.writeFileSync(path.join(outDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
-  return pins;
 }
 
 function writeTsconfig() {
@@ -323,13 +287,6 @@ function writeEnvExample() {
   fs.writeFileSync(path.join(outDir, '.env.example'), `${header}${body}`);
 }
 
-function writeNpmrc() {
-  // Pins may be prerelease versions (mid-train alphas); npm's strict resolver
-  // rejects prereleases against peer ranges like `>=1.50.0-0`, so relax peer
-  // resolution. pnpm/yarn ignore this setting and handle peers leniently.
-  fs.writeFileSync(path.join(outDir, '.npmrc'), 'legacy-peer-deps=true\n');
-}
-
 function writeGitignore() {
   fs.writeFileSync(
     path.join(outDir, '.gitignore'),
@@ -346,21 +303,13 @@ src/mastra/public/ui/
   );
 }
 
-/**
- * Copy the checked-in user-facing README and fill `{{package-name}}` tokens
- * with the versions this sync run pinned. Tokens keep the markdown editable
- * as a normal file (create-mastra style) while still reflecting live pins.
- */
-function writeReadme(pins) {
+/** Copy the checked-in user-facing README verbatim. */
+function writeReadme() {
   const source = path.join(pkgRoot, 'template', 'README.md');
   if (!fs.existsSync(source)) {
     throw new Error(`sync-template: missing checked-in template README at ${source}`);
   }
-  const versions = Object.fromEntries(pins);
-  const readme = fs.readFileSync(source, 'utf8').replace(/\{\{([^}]+)\}\}/g, (match, name) => {
-    return Object.hasOwn(versions, name) ? versions[name] : match;
-  });
-  fs.writeFileSync(path.join(outDir, 'README.md'), readme);
+  fs.copyFileSync(source, path.join(outDir, 'README.md'));
 }
 
 // ── main ────────────────────────────────────────────────────────────────────
@@ -381,13 +330,12 @@ if (fs.existsSync(outDir)) {
   }
 }
 copyTree(webRoot, outDir);
-const pins = transformPackageJson();
+transformPackageJson();
 writeTsconfig();
 stripTestingTypesFromUiTsconfig();
 writeEnvExample();
-writeNpmrc();
 writeGitignore();
-writeReadme(pins);
+writeReadme();
 
 console.log(`sync-template: done. Template written to ${outDir}`);
 console.log('The sync-softwarefactory-template workflow pushes this to the template repo on main.');

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -7,8 +7,9 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 /**
  * Validates the output of scripts/sync-template.mjs — the artifact users
- * actually receive. Runs the real script offline: a fake `npm` on PATH
- * answers the version-verification calls so no network is needed.
+ * actually receive. Runs the real script with no network dependency: the
+ * script no longer shells out to npm, so the emitted template is entirely
+ * derived from local monorepo state.
  */
 
 const here = path.dirname(fileURLToPath(import.meta.url));
@@ -18,15 +19,11 @@ const script = path.join(pkgRoot, 'scripts', 'sync-template.mjs');
 
 let workDir: string;
 let outDir: string;
-let fakeBinDir: string;
 let sentinel: string;
 
 function runSync(args: string[]): { status: number; stderr: string } {
   try {
-    execFileSync(process.execPath, [script, ...args], {
-      stdio: 'pipe',
-      env: { ...process.env, PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH ?? ''}` },
-    });
+    execFileSync(process.execPath, [script, ...args], { stdio: 'pipe' });
     return { status: 0, stderr: '' };
   } catch (err) {
     const e = err as { status?: number; stderr?: Buffer };
@@ -37,11 +34,6 @@ function runSync(args: string[]): { status: number; stderr: string } {
 beforeAll(() => {
   workDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'sf-sync-test-')));
   outDir = path.join(workDir, 'out');
-
-  // Fake npm: satisfies `npm view <pkg>@<version> version` offline.
-  fakeBinDir = path.join(workDir, 'bin');
-  fs.mkdirSync(fakeBinDir);
-  fs.writeFileSync(path.join(fakeBinDir, 'npm'), '#!/bin/sh\necho "9.9.9"\n', { mode: 0o755 });
 
   // Sentinel env file in the source tree — must never reach the template.
   sentinel = path.join(webRoot, '.env.test-sentinel');
@@ -80,13 +72,11 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     expect(fs.existsSync(path.join(outDir, 'README.md'))).toBe(true);
     expect(fs.existsSync(path.join(outDir, 'tsconfig.json'))).toBe(true);
 
-    // README is the checked-in template with version tokens filled (no bare {{tokens}} left).
+    // README is the checked-in template copied verbatim (no build-time tokens).
     const readme = fs.readFileSync(path.join(outDir, 'README.md'), 'utf8');
     expect(readme).toContain('# Mastra Factory');
     expect(readme).toContain('npm create factory');
     expect(readme).not.toMatch(/\{\{[^}]+\}\}/);
-    expect(readme).toMatch(/@mastra\/core@\d/);
-    expect(readme).toMatch(/@mastra\/code-sdk@\d/);
 
     // The dev script is a direct mapping of the web project's own dev flow —
     // no generated wrapper script.
@@ -96,16 +86,18 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     const envExample = fs.readFileSync(path.join(outDir, '.env.example'), 'utf8');
     expect(envExample).not.toMatch(/^[A-Z][A-Z0-9_]*=\s*$/m);
 
-    // package.json: monorepo coupling removed, mastra deps float via caret.
+    // package.json: monorepo coupling removed; every Mastra dep pins `latest`.
     const pkg = JSON.parse(fs.readFileSync(path.join(outDir, 'package.json'), 'utf8'));
     const allDeps: Record<string, string> = { ...pkg.dependencies, ...pkg.devDependencies };
     for (const [name, spec] of Object.entries(allDeps)) {
-      expect(spec, `${name} must not use a link:/workspace: spec`).not.toMatch(/^(link|workspace|catalog):/);
+      expect(spec, `${name} must not use a link:/workspace: spec`).not.toMatch(/^(link|workspace|catalog|file):/);
       if (name === 'mastra' || name.startsWith('@mastra/')) {
-        expect(spec, `${name} must use a caret range`).toMatch(/^\^/);
+        expect(spec, `${name} must be pinned to "latest"`).toBe('latest');
       }
     }
-    expect(pkg.dependencies['@mastra/memory']).toMatch(/^\^/);
+    expect(pkg.dependencies['@mastra/memory']).toBe('latest');
+    // Legacy artifact from the caret-pinning era must not appear anymore.
+    expect(fs.existsSync(path.join(outDir, '.npmrc'))).toBe(false);
 
     // Tests and their dependencies are stripped.
     expect(allDeps.vitest).toBeUndefined();

--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -86,7 +86,7 @@ Create a Linear OAuth app (Linear → Settings → API → OAuth applications �
 
 ## Versions
 
-The Mastra packages use caret ranges (currently anchored on `@mastra/core@{{@mastra/core}}` and `@mastra/code-sdk@{{@mastra/code-sdk}}`). Upgrade them together when updating.
+The Mastra packages are pinned to `latest`, so `npm install` pulls the current published release. Upgrade them together by re-running `npm install` (or by rescaffolding).
 
 ## License
 


### PR DESCRIPTION
## Summary

The Software Factory template used to pin each linked Mastra dep to a caret range anchored on the *current* monorepo version (e.g. `"@mastra/core": "^1.51.0-alpha.12"`). That went through an `npm view` verification step which failed the whole `sync-softwarefactory-template.yml` workflow any time the local alpha wasn't on npm yet — which is exactly the situation whenever a brand-new package (like `@mastra/factory`) or a mid-train alpha bump lands on `main`.

Every other create-mastra template just pins `"latest"`:

```json
// templates/template-agent-builder/package.json
{
  "dependencies": {
    "@mastra/auth-workos": "latest",
    "@mastra/core": "latest",
    ...
  }
}
```

This PR makes the Factory template do the same. That's it.

## What changes

- Every `link:` spec in `mastracode/web/package.json` is rewritten to `"latest"` when the template is generated.
- `sync-template.mjs` no longer shells out to `npm view` (no `execFileSync`, no `--tag`, no dist-tag lookup, no publish-existence check).
- The peer alias for `@mastra/memory` becomes `"latest"` too, instead of copying `@mastra/core`'s spec.
- The template no longer emits `.npmrc` with `legacy-peer-deps=true`. That workaround only existed because caret ranges on prerelease pins don't resolve against normal peer specs. With `"latest"` we're on stable releases, so npm's default resolver handles peers fine.
- `template/README.md` drops its `{{@mastra/core}}` / `{{@mastra/code-sdk}}` tokens and its "pinned to caret ranges" line, so the doc is accurate. `writeReadme()` is now a plain file copy.

## Why this is the right fix

The previous design tried to keep the template locked to a "coherent snapshot" of the monorepo. In practice:

- Alpha bumps constantly desync the workflow from published npm state.
- Users running `npm create factory` want the current published Mastra release, not whatever version happened to be building on `main` when the workflow last ran.
- We ship `.npmrc` with `legacy-peer-deps=true` in production just to hide the fact we're pinning prereleases. That's papering over the real problem.
- The other 20+ Mastra templates already prove `"latest"` is the shipped pattern.

## Diff summary

```
mastracode/mastra-factory/scripts/sync-template.mjs  | 120 ++++++--------
mastracode/mastra-factory/src/sync-template.test.ts  |  30 +---
mastracode/mastra-factory/template/README.md         |   2 +-
.changeset/factory-sync-template-latest.md           |   5 +
4 files changed, 51 insertions(+), 106 deletions(-)
```

Net −55 lines. No new flags. No behavioral surface added.

## Test plan

- `pnpm --filter ./mastracode/mastra-factory exec vitest run` — 31/31 pass. The main sync-template test now asserts every Mastra dep is exactly `"latest"`, no `.npmrc` is emitted, and no bare `{{tokens}}` remain in the README.
- Lint clean, prettier clean.
- Live run: `node mastracode/mastra-factory/scripts/sync-template.mjs --out /tmp/sf-template` produces the manifest you'd expect (`"@mastra/core": "latest"` etc.), completes offline, and takes ~200ms end-to-end.

## Follow-ups

None required. Whenever `@mastra/factory` first hits the `latest` dist-tag, the sync workflow starts producing a fully installable template with zero further changes. Nothing about the CI wiring in `.github/workflows/sync-softwarefactory-template.yml` needs to change.
