### PR TITLE
fix(mastracode): keep sidebar visible during factory creation

### DIFF
--- a/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/message-rendering.msw.test.tsx
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { AgentControllerEvent, AgentControllerSessionState } from '@mastra/client-js';
 import type { MastraDBMessage, MastraMessagePart } from '@mastra/core/agent-controller';
-import { screen, waitFor, within } from '@testing-library/react';
+import { act, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, Navigate, Outlet, RouterProvider } from 'react-router';
@@ -17,6 +17,7 @@ import { SettingsPage } from '../pages/SettingsPage';
 import { ThreadPage } from '../pages/ThreadPage';
 import type { Factory } from '../domains/workspaces';
 import { ActiveFactoryProvider } from '../domains/workspaces/context/ActiveFactoryProvider';
+import { CreateFactoryLayout } from '../pages/CreateFactoryLayout';
 import { CreateFactoryPage } from '../pages/CreateFactoryPage';
 
 /**
@@ -53,11 +54,15 @@ function renderChat(initialEntry = '/factories/project-test/threads/thread-test'
           },
         ],
       },
-      { path: '/factories/create', element: <CreateFactoryPage /> },
+      {
+        path: '/factories/create',
+        element: <CreateFactoryLayout />,
+        children: [{ element: <Chat />, children: [{ index: true, element: <CreateFactoryPage /> }] }],
+      },
     ],
     { initialEntries: [initialEntry] },
   );
-  return renderWithProviders(<RouterProvider router={router} />);
+  return { router, ...renderWithProviders(<RouterProvider router={router} />) };
 }
 
 const API = `${TEST_BASE_URL}/api/agent-controller/code`;
@@ -537,22 +542,24 @@ describe('MastraCode message rendering', () => {
       }),
     );
 
-    renderChat();
+    const { router } = renderChat();
 
     expect(await screen.findByRole('button', { name: 'Abort' })).toBeInTheDocument();
     await waitFor(() => expect(streamRequests).toHaveBeenCalledTimes(1));
 
-    await user.click(screen.getByRole('button', { name: 'Select factory' }));
-    await user.click(await screen.findByRole('menuitem', { name: 'Create Factory' }));
+    await act(() =>
+      router.navigate('/factories/create', { state: { from: '/factories/project-test/threads/thread-test' } }),
+    );
 
-    // Create Factory is now a dedicated page inside the chat layout.
+    // Create Factory is a dedicated page inside the persistent app shell.
     const factorySurface = await screen.findByRole('region', { name: 'Create Factory' });
     expect(factorySurface.closest('main')).toBeInTheDocument();
     expect(screen.queryByRole('dialog', { name: 'Create Factory' })).not.toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
 
     await stream.emit();
     // Close navigates back to the thread page the user came from.
-    await user.click(screen.getByRole('button', { name: 'Close factory creation' }));
+    await user.click(screen.getByRole('button', { name: 'Cancel' }));
 
     expect(await screen.findByText('Streaming while factory creation is open')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Abort' })).toBeInTheDocument();

--- a/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/routing.msw.test.tsx
@@ -200,6 +200,8 @@ describe('MastraCode web routing', () => {
     expect(await screen.findByRole('region', { name: 'Create Factory' })).toBeInTheDocument();
     expect(router.state.location.pathname).toBe('/factories/create');
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('navigation', { name: 'Main' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Select factory' })).toHaveTextContent('MastraCode Test');
   });
 
   it('given auth is disabled, when visiting /, then the user lands on the first factory draft composer', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ThreadList.tsx
@@ -54,7 +54,7 @@ export function ThreadList() {
 
   return (
     <div className="flex min-h-0 flex-1 flex-col gap-2">
-      {!readOnly && <ThreadListHeader threadCount={threads.length} />}
+      {!readOnly && <ThreadListHeader factoryId={activeFactory.id} threadCount={threads.length} />}
       <div role="list" className="flex min-h-0 flex-1 flex-col gap-0.5 overflow-y-auto">
         {sortedThreads.length === 0 && (
           <Txt as="div" variant="ui-sm" className="px-2 py-3 text-icon3">
@@ -68,6 +68,7 @@ export function ThreadList() {
             <ThreadRow
               key={thread.id}
               thread={thread}
+              factoryId={activeFactory.id}
               active={thread.id === activeThreadId}
               readOnly={readOnly}
               onStartRename={() => setRenamingId(thread.id)}
@@ -90,10 +91,9 @@ function useThreadHookArgs() {
   };
 }
 
-function ThreadListHeader({ threadCount }: { threadCount: number }) {
+function ThreadListHeader({ factoryId, threadCount }: { factoryId: string; threadCount: number }) {
   const overlays = useOverlays();
   const navigate = useNavigate();
-  const { factoryId } = useParams<{ factoryId: string }>();
 
   return (
     <div className="flex items-center justify-between px-1">
@@ -154,11 +154,13 @@ function RenameThreadRow({ thread, onDone }: { thread: AgentControllerThreadInfo
 
 function ThreadRow({
   thread,
+  factoryId,
   active,
   readOnly,
   onStartRename,
 }: {
   thread: AgentControllerThreadInfo;
+  factoryId: string;
   active: boolean;
   readOnly: boolean;
   onStartRename: () => void;
@@ -166,7 +168,7 @@ function ThreadRow({
   const hookArgs = useThreadHookArgs();
   const overlays = useOverlays();
   const navigate = useNavigate();
-  const { factoryId, threadId: routeThreadId } = useParams<{ factoryId: string; threadId: string }>();
+  const { threadId: routeThreadId } = useParams<{ threadId: string }>();
 
   const deleteThreadMutation = useDeleteAgentControllerThreadMutation(hookArgs);
   const cloneThreadMutation = useCloneAgentControllerThreadMutation(hookArgs);

--- a/mastracode/web/src/web/ui/domains/workspaces/components/FactorySwitcher.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/FactorySwitcher.tsx
@@ -8,7 +8,7 @@ import { useLocation, useNavigate } from 'react-router';
 import { deriveProjectPath } from '../../../../../shared/hooks/useWorkspaces';
 import { useActiveFactoryContext } from '../context/ActiveFactoryProvider';
 import { isServerFactory } from '../services/factories';
-import { factoryHomePath } from '../services/factoryPaths';
+import { factoryHomePath, sourceFactoryPath } from '../services/factoryPaths';
 
 /** Inline factory selection with a single Create Factory action. */
 export function FactorySwitcher() {
@@ -18,7 +18,8 @@ export function FactorySwitcher() {
   const { setOpenMobile } = useMainSidebar();
 
   const openFactories = () => {
-    void navigate('/factories/create', { state: { from: location.pathname } });
+    const from = location.pathname === '/factories/create' ? sourceFactoryPath(location.state) : location.pathname;
+    void navigate('/factories/create', { state: { from: from ?? '/' } });
     setOpenMobile(false);
   };
 

--- a/mastracode/web/src/web/ui/domains/workspaces/services/factoryPaths.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/services/factoryPaths.ts
@@ -1,6 +1,11 @@
 import type { Factory } from './factories';
 import { isServerFactory } from './factories';
 
+export function sourceFactoryPath(state: unknown): string | undefined {
+  if (!state || typeof state !== 'object' || !('from' in state)) return;
+  return typeof state.from === 'string' ? state.from : undefined;
+}
+
 /**
  * Landing path for a factory. Server factories land on the work board,
  * local factories land on the new-thread composer.

--- a/mastracode/web/src/web/ui/pages/CreateFactoryLayout.tsx
+++ b/mastracode/web/src/web/ui/pages/CreateFactoryLayout.tsx
@@ -1,0 +1,39 @@
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { matchPath, Outlet, useLocation } from 'react-router';
+
+import { useFactoriesQuery } from '../../../shared/hooks/useFactories';
+import { AuthPendingSkeleton } from '../domains/auth/components/RootGuards';
+import { ActiveFactoryProvider } from '../domains/workspaces/context/ActiveFactoryProvider';
+import { sourceFactoryPath } from '../domains/workspaces/services/factoryPaths';
+
+/**
+ * Restores the factory context around the unscoped Create Factory route so it
+ * can use the standard application shell without making the new Factory a
+ * child of the currently active one.
+ */
+export function CreateFactoryLayout() {
+  const location = useLocation();
+  const { data: factories, isPending, isError } = useFactoriesQuery();
+
+  if (isPending) return <AuthPendingSkeleton label="Loading factories" />;
+
+  if (isError) {
+    return (
+      <div className="grid h-dvh w-full place-items-center bg-surface1 px-4">
+        <Notice variant="destructive">Could not load factories. Check the server connection and reload.</Notice>
+      </div>
+    );
+  }
+
+  const sourcePath = sourceFactoryPath(location.state);
+  const sourceFactoryId = sourcePath ? matchPath('/factories/:factoryId/*', sourcePath)?.params.factoryId : undefined;
+  const activeFactory = factories?.find(factory => factory.id === sourceFactoryId) ?? factories?.[0];
+
+  if (!activeFactory) return null;
+
+  return (
+    <ActiveFactoryProvider factoryId={activeFactory.id}>
+      <Outlet />
+    </ActiveFactoryProvider>
+  );
+}

--- a/mastracode/web/src/web/ui/pages/CreateFactoryPage.tsx
+++ b/mastracode/web/src/web/ui/pages/CreateFactoryPage.tsx
@@ -1,22 +1,25 @@
 import { useLocation, useNavigate } from 'react-router';
 
+import { Sidebar } from '../Sidebar';
+import { ChatHeader } from '../domains/chat/components/ChatHeader';
 import { FactoriesPanel } from '../domains/workspaces/components/FactoriesPanel';
+import { sourceFactoryPath } from '../domains/workspaces/services/factoryPaths';
+import { PageLayout } from '../ui/PageLayout';
 
 /**
- * Dedicated Create Factory page (`/factories/create`). Lives outside the
- * factory-scoped routes (no active factory is required to create one), so it
- * renders standalone without the chat sidebar. Cancel/Escape returns to the
- * page the user came from (the factory switcher passes it via location
- * state); deep links fall back to `/`.
+ * Dedicated Create Factory page (`/factories/create`). The route remains
+ * outside the active factory's URL space while its layout restores the source
+ * factory context, allowing this page to keep the standard application shell.
+ * Cancel/Escape returns to the source page; deep links fall back to `/`.
  */
 export function CreateFactoryPage() {
   const navigate = useNavigate();
   const location = useLocation();
-  const from = (location.state as { from?: string } | null)?.from;
+  const from = sourceFactoryPath(location.state);
 
   return (
-    <main className="flex h-dvh min-h-0 flex-col overflow-hidden bg-surface2">
+    <PageLayout sidebar={<Sidebar />} header={<ChatHeader />}>
       <FactoriesPanel onClose={() => void navigate(from ?? '/')} />
-    </main>
+    </PageLayout>
   );
 }

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -18,6 +18,7 @@ import Chat from './domains/chat/Chat';
 import { RootGuards } from './domains/auth/components/RootGuards';
 import { AuditPage } from './pages/AuditPage';
 import { ReviewBoardPage, WorkBoardPage } from './pages/BoardPage';
+import { CreateFactoryLayout } from './pages/CreateFactoryLayout';
 import { CreateFactoryPage } from './pages/CreateFactoryPage';
 import { MetricsPage } from './pages/MetricsPage';
 import { NewPage } from './pages/NewPage';
@@ -57,7 +58,16 @@ export function createAppRoutes(): RouteObject[] {
       children: [
         { index: true, element: <RootLanding /> },
         { path: 'onboarding', element: <OnboardingPage /> },
-        { path: 'factories/create', element: <CreateFactoryPage /> },
+        {
+          path: 'factories/create',
+          element: <CreateFactoryLayout />,
+          children: [
+            {
+              element: <Chat />,
+              children: [{ index: true, element: <CreateFactoryPage /> }],
+            },
+          ],
+        },
         {
           path: 'factories/:factoryId',
           element: <FactoryLayout />,


### PR DESCRIPTION
Keep the standard MastraCode sidebar visible on `/factories/create`.

The create route now restores the source factory context and reuses the normal app shell. Sidebar thread links use that active factory directly, so they keep working even though the create URL has no `:factoryId`.

Verified with the focused routing and session recovery tests, `pnpm check:ui`, and desktop/mobile browser QA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The Create Factory page now keeps the normal sidebar and remembers which factory you came from. This lets users navigate between factory threads and the creation page without losing their place.

## Summary

- Added `CreateFactoryLayout` to restore the active factory context on `/factories/create`.
- Reused the standard application shell with sidebar and chat header.
- Updated sidebar thread navigation to use the active factory directly.
- Preserved the source location when reopening factory creation.
- Expanded routing, session recovery, and navigation test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->