### PR TITLE
feat(factory): user GitHub authorship for factory-originated issues/PRs (acting-user plumbing)

### DIFF
--- a/mastracode/factory/src/capabilities/intake.ts
+++ b/mastracode/factory/src/capabilities/intake.ts
@@ -89,6 +89,8 @@ export interface GetIntakeIssueInput {
 
 export interface CreateIntakeCommentInput extends GetIntakeIssueInput {
   body: string;
+  /** End user the comment should be attributed to, when the provider supports acting on a user's behalf. */
+  actingUserId?: string;
 }
 
 export interface CreatedIntakeComment {

--- a/mastracode/factory/src/capabilities/version-control.ts
+++ b/mastracode/factory/src/capabilities/version-control.ts
@@ -52,6 +52,8 @@ export interface PullRequestRef {
   connection: IntegrationConnection;
   sourceId: string;
   pullRequestId: string;
+  /** End user the write should be attributed to, when the provider supports acting on a user's behalf. */
+  actingUserId?: string;
 }
 
 export interface ListPullRequestsInput {
@@ -70,6 +72,8 @@ export interface CreatePullRequestInput {
   baseBranch: string;
   headBranch: string;
   draft?: boolean;
+  /** End user the write should be attributed to, when the provider supports acting on a user's behalf. */
+  actingUserId?: string;
 }
 
 export interface UpdatePullRequestInput extends PullRequestRef {
@@ -118,12 +122,14 @@ export interface UpdatePullRequestCommentInput {
   sourceId: string;
   commentId: string;
   body: string;
+  actingUserId?: string;
 }
 
 export interface DeletePullRequestCommentInput {
   connection: IntegrationConnection;
   sourceId: string;
   commentId: string;
+  actingUserId?: string;
 }
 
 export type ReviewState = 'pending' | 'commented' | 'approved' | 'changes-requested' | 'dismissed';

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -1723,6 +1723,7 @@ describe('pr route', () => {
       headBranch: 'feat/x',
       title: 'My PR',
       body: 'Adds a thing',
+      actingUserId: 'u1',
     });
   });
 

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -1419,6 +1419,7 @@ function buildProjectGitRoutes({
                 headBranch: head,
                 title,
                 body: prBody,
+                actingUserId: userId,
               });
               await emitAudit?.({
                 context: loose(c),

--- a/mastracode/factory/src/integrations/platform/api-client.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.ts
@@ -44,7 +44,12 @@ export class PlatformApiClient {
     this.#fetch = config.fetchImpl ?? globalThis.fetch;
   }
 
-  async request<T>(method: string, path: string, body?: unknown, options?: { signal?: AbortSignal }): Promise<T> {
+  async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    options?: { signal?: AbortSignal; actingUserId?: string },
+  ): Promise<T> {
     const response = await this.#send(method, path, body, options);
     if (!response.ok) {
       const message = redact(await extractError(response), this.#accessToken);
@@ -88,13 +93,19 @@ export class PlatformApiClient {
     method: string,
     path: string,
     body?: unknown,
-    options?: { signal?: AbortSignal },
+    options?: { signal?: AbortSignal; actingUserId?: string },
     redirect?: RequestInit['redirect'],
   ): Promise<Response> {
     const headers: Record<string, string> = {
       accept: 'application/json',
       authorization: `Bearer ${this.#accessToken}`,
     };
+    // Acting end-user for platform GitHub writes: the platform resolves this
+    // user's GitHub OAuth connection (org-scoped) so issues/PRs are authored
+    // by the human instead of the App bot. Ignored by older platforms.
+    if (options?.actingUserId) {
+      headers['x-acting-user-id'] = options.actingUserId;
+    }
     const timeoutSignal = AbortSignal.timeout(15_000);
     const init: RequestInit = {
       method,

--- a/mastracode/factory/src/integrations/platform/api-client.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.ts
@@ -163,11 +163,15 @@ export function logPlatformInfo(message: string, fields?: Record<string, unknown
   writePlatformLog('info', message, fields);
 }
 
+export function logPlatformWarn(message: string, fields?: Record<string, unknown>): void {
+  writePlatformLog('warn', message, fields);
+}
+
 export function logPlatformError(message: string, fields?: Record<string, unknown>): void {
   writePlatformLog('error', message, fields);
 }
 
-function writePlatformLog(level: 'info' | 'error', message: string, fields?: Record<string, unknown>): void {
+function writePlatformLog(level: 'info' | 'warn' | 'error', message: string, fields?: Record<string, unknown>): void {
   const metadata = fields ? ` ${JSON.stringify(stripUndefined(fields))}` : '';
   process.stderr.write(`[MastraCode Web] ${level.toUpperCase()} ${message}${metadata}\n`);
 }

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -641,6 +641,59 @@ describe('PlatformGithubIntegration', () => {
     );
   });
 
+  it('logs the user-connection verification failure reason', async () => {
+    const warningLog = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    const seed = await createPlatformStorageForTests();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes('/github-app/installations')) {
+        return json({ installations: [], pendingRequests: [] });
+      }
+      if (url.includes('/github-app/user-connection')) {
+        return json({
+          connected: false,
+          githubUsername: 'ada',
+          reason: 'missing-permissions',
+        });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    const integration = createIntegration(fetchImpl);
+    const context = {
+      auth: fakeAuth(),
+      fleet: { enabled: true },
+      storage: {
+        generic: seed.integrations.forIntegration('github'),
+        sourceControl: seed.sourceControl.forIntegration('github'),
+        projects: seed.projects,
+        intake: seed.intake,
+      },
+      controller: {},
+      stateSigner: {},
+      baseUrl: 'https://factory.example',
+    } as unknown as IntegrationContext;
+    integration.initialize?.({ storage: context.storage.generic, projects: context.storage.projects });
+    integration.versionControl.initialize({ storage: context.storage.sourceControl });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('webAuthUser' as never, { workosId: 'user-1', organizationId: 'org-1' } as never);
+      await next();
+    });
+    mountApiRoutes(app as never, integration.routes(context));
+
+    const status = await app.request('/web/github/status');
+
+    await expect(status.json()).resolves.toMatchObject({
+      userConnected: false,
+      userGithubUsername: 'ada',
+    });
+    const logged = warningLog.mock.calls.map(call => String(call[0])).join('\n');
+    expect(logged).toContain('[MastraCode Web] WARN Platform GitHub user connection verification failed');
+    expect(logged).toContain('"userId":"user-1"');
+    expect(logged).toContain('"reason":"missing-permissions"');
+    warningLog.mockRestore();
+  });
+
   it('reports userConnected false when the platform lacks the user-connection endpoint', async () => {
     const seed = await createPlatformStorageForTests();
     const fetchImpl = vi.fn<typeof fetch>(async input => {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -297,6 +297,47 @@ describe('PlatformGithubIntegration', () => {
     ]);
     expect(JSON.parse(String((fetchImpl.mock.calls[1]?.[1] as RequestInit).body))).toMatchObject({ event: 'APPROVE' });
     expect(JSON.parse(String((fetchImpl.mock.calls[2]?.[1] as RequestInit).body))).toMatchObject({ side: 'RIGHT' });
+    for (const call of fetchImpl.mock.calls) {
+      expect((call[1] as RequestInit).headers).not.toHaveProperty('x-acting-user-id');
+    }
+  });
+
+  it('sends the acting user header on writes when actingUserId is provided', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(json(pullRequest))
+      .mockResolvedValueOnce(
+        json({
+          id: 91,
+          body: 'Done',
+          htmlUrl: 'https://github.com/acme/app/issues/12#issuecomment-91',
+          user: actor,
+          createdAt: '2026-07-03T00:00:00Z',
+          updatedAt: '2026-07-03T00:00:00Z',
+        }),
+      );
+    const integration = createIntegration(fetchImpl);
+    const connection = { type: 'app-installation' as const, installationId: 7 };
+
+    await integration.versionControl.createPullRequest({
+      connection,
+      sourceId: 'acme/app',
+      title: 'Ship intake',
+      baseBranch: 'main',
+      headBranch: 'feat/intake',
+      actingUserId: 'user-42',
+    });
+    await integration.intake.createComment({
+      connection,
+      sourceId: 'acme/app',
+      issueId: '12',
+      body: 'Done',
+      actingUserId: 'user-42',
+    });
+
+    for (const call of fetchImpl.mock.calls) {
+      expect((call[1] as RequestInit).headers).toMatchObject({ 'x-acting-user-id': 'user-42' });
+    }
   });
 
   it('maps every version-control operation to its platform endpoint', async () => {
@@ -512,10 +553,10 @@ describe('PlatformGithubIntegration', () => {
 
   it('uses platform installations for status and platform install URL for connect redirects', async () => {
     const seed = await createPlatformStorageForTests();
-    const fetchImpl = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce(
-        json({
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes('/github-app/installations')) {
+        return json({
           installations: [
             {
               installationId: 7,
@@ -526,9 +567,19 @@ describe('PlatformGithubIntegration', () => {
             },
           ],
           pendingRequests: [],
-        }),
-      )
-      .mockResolvedValueOnce(json({ url: 'https://github.com/apps/mastra/installations/new?state=platform-state' }));
+        });
+      }
+      if (url.includes('/github-app/user-connection')) {
+        return json({ connected: true, githubUsername: 'ada' });
+      }
+      if (url.includes('/github-app/install-url')) {
+        return json({ url: 'https://github.com/apps/mastra/installations/new?state=platform-state' });
+      }
+      if (url.includes('/github-app/authenticate')) {
+        return json({ url: 'https://github.com/login/oauth/authorize?client_id=abc&state=platform-state' });
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
     const integration = createIntegration(fetchImpl);
     const context = {
       auth: fakeAuth(),
@@ -557,8 +608,14 @@ describe('PlatformGithubIntegration', () => {
       enabled: true,
       connected: true,
       installations: [{ installationId: 7, accountLogin: 'acme', accountType: 'Organization' }],
+      userConnected: true,
+      userGithubUsername: 'ada',
       reason: 'ready',
     });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://platform.example.com/v1/server/github-app/user-connection?userId=user-1',
+      expect.anything(),
+    );
     await expect(context.storage.sourceControl.installations.list({ orgId: 'org-1' })).resolves.toEqual([
       expect.objectContaining({ externalId: '7', accountName: 'acme' }),
     ]);
@@ -568,11 +625,65 @@ describe('PlatformGithubIntegration', () => {
     expect(connect.headers.get('location')).toBe(
       'https://github.com/apps/mastra/installations/new?state=platform-state',
     );
-    expect(fetchImpl).toHaveBeenNthCalledWith(
-      2,
+    expect(fetchImpl).toHaveBeenCalledWith(
       'https://platform.example.com/v1/server/github-app/install-url?action=install&redirectTo=%2F&originator=https%3A%2F%2Ffactory.example',
       expect.anything(),
     );
+
+    const connectUser = await app.request('/auth/github/connect-user');
+    expect(connectUser.status).toBe(302);
+    expect(connectUser.headers.get('location')).toBe(
+      'https://github.com/login/oauth/authorize?client_id=abc&state=platform-state',
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'https://platform.example.com/v1/server/github-app/authenticate?userId=user-1&redirectTo=%2F&originator=https%3A%2F%2Ffactory.example',
+      expect.anything(),
+    );
+  });
+
+  it('reports userConnected false when the platform lacks the user-connection endpoint', async () => {
+    const seed = await createPlatformStorageForTests();
+    const fetchImpl = vi.fn<typeof fetch>(async input => {
+      const url = String(input);
+      if (url.includes('/github-app/installations')) {
+        return json({ installations: [], pendingRequests: [] });
+      }
+      if (url.includes('/github-app/user-connection')) {
+        return json({ error: 'Not found' }, 404);
+      }
+      throw new Error(`Unexpected fetch: ${url}`);
+    });
+    const integration = createIntegration(fetchImpl);
+    const context = {
+      auth: fakeAuth(),
+      fleet: { enabled: true },
+      storage: {
+        generic: seed.integrations.forIntegration('github'),
+        sourceControl: seed.sourceControl.forIntegration('github'),
+        projects: seed.projects,
+        intake: seed.intake,
+      },
+      controller: {},
+      stateSigner: {},
+      baseUrl: 'https://factory.example',
+    } as unknown as IntegrationContext;
+    integration.initialize?.({ storage: context.storage.generic, projects: context.storage.projects });
+    integration.versionControl.initialize({ storage: context.storage.sourceControl });
+    const app = new Hono();
+    app.use('*', async (c, next) => {
+      c.set('webAuthUser' as never, { workosId: 'user-1', organizationId: 'org-1' } as never);
+      await next();
+    });
+    mountApiRoutes(app as never, integration.routes(context));
+
+    const status = await app.request('/web/github/status');
+    await expect(status.json()).resolves.toMatchObject({
+      enabled: true,
+      connected: false,
+      userConnected: false,
+      userGithubUsername: null,
+      reason: 'not_connected',
+    });
   });
 
   it('defaults the Platform base URL and requires MASTRA_PLATFORM_SECRET_KEY', () => {

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -44,7 +44,13 @@ import {
   subscribeCurrentSessionToPullRequest,
 } from '../../github/session-subscriptions.js';
 import type { GithubSubscriptionStorage } from '../../github/subscriptions.js';
-import { logPlatformInfo, PlatformApiClient, PlatformApiError, platformApiClientConfigFromEnv } from '../api-client.js';
+import {
+  logPlatformInfo,
+  logPlatformWarn,
+  PlatformApiClient,
+  PlatformApiError,
+  platformApiClientConfigFromEnv,
+} from '../api-client.js';
 import { PlatformGithubEventWorker } from './event-worker.js';
 import type { PlatformGithubEventStorage } from './event-worker.js';
 
@@ -56,6 +62,12 @@ type PlatformGithubInstallation = {
   accountType: string;
   suspendedAt: string | null;
   usable: boolean;
+};
+
+type PlatformGithubUserConnection = {
+  connected: boolean;
+  githubUsername: string | null;
+  reason?: 'token-invalid' | 'no-accessible-installation' | 'missing-permissions' | 'verification-unavailable' | null;
 };
 
 type GithubIssue = {
@@ -490,12 +502,19 @@ export class PlatformGithubIntegration implements FactoryIntegration {
    * Personal GitHub connection status for the acting user. Returns
    * not-connected when the platform predates the user-connection endpoint.
    */
-  async #fetchUserConnection(userId: string): Promise<{ connected: boolean; githubUsername: string | null }> {
+  async #fetchUserConnection(userId: string): Promise<PlatformGithubUserConnection> {
     try {
-      return await this.#client.request<{ connected: boolean; githubUsername: string | null }>(
+      const connection = await this.#client.request<PlatformGithubUserConnection>(
         'GET',
         `${API_PREFIX}/github-app/user-connection?${new URLSearchParams({ userId })}`,
       );
+      if (!connection.connected && connection.reason) {
+        logPlatformWarn('Platform GitHub user connection verification failed', {
+          userId,
+          reason: connection.reason,
+        });
+      }
+      return connection;
     } catch {
       return { connected: false, githubUsername: null };
     }

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -4,7 +4,7 @@ import { registerApiRoute } from '@mastra/core/server';
 import type { Context } from 'hono';
 
 import type { IntegrationConnection } from '../../../capabilities/connection.js';
-import type { Intake, IntakeIssue, IntakeIssueDetail } from '../../../capabilities/intake.js';
+import type { CreateIntakeCommentInput, Intake, IntakeIssue, IntakeIssueDetail } from '../../../capabilities/intake.js';
 import type {
   CreatePullRequestCommentInput,
   CreatePullRequestInput,
@@ -250,7 +250,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       return this.#listIssues(input.connection, sourceId, parsePositiveCursor(input.cursor), input.labels);
     },
     getIssue: input => this.#getIssue(input.connection, input.sourceId, input.issueId),
-    createComment: input => this.#createIssueComment(input.connection, input.sourceId, input.issueId, input.body),
+    createComment: input => this.#createIssueComment(input),
   };
 
   readonly versionControl: VersionControl = {
@@ -362,6 +362,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     return [
       this.#statusRoute(ctx),
       this.#connectRoute(ctx),
+      this.#connectUserRoute(ctx),
       ...buildGithubRoutes({
         auth: ctx.auth,
         fleet: ctx.fleet,
@@ -396,12 +397,17 @@ export class PlatformGithubIntegration implements FactoryIntegration {
             organizationRequired: true,
             connected: false,
             installations: [],
+            userConnected: false,
+            userGithubUsername: null,
             reason: 'organization_required',
             diagnostics: this.diagnostics(),
           });
         }
 
-        const installations = await this.#syncInstallations(tenant.orgId, tenant.userId);
+        const [installations, userConnection] = await Promise.all([
+          this.#syncInstallations(tenant.orgId, tenant.userId),
+          this.#fetchUserConnection(tenant.userId),
+        ]);
         return c.json({
           enabled: true,
           sandboxEnabled: ctx.fleet.enabled,
@@ -411,6 +417,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
             accountLogin: installation.accountName,
             accountType: installation.accountType,
           })),
+          userConnected: userConnection.connected,
+          userGithubUsername: userConnection.githubUsername,
           reason: installations.length > 0 ? 'ready' : 'not_connected',
           diagnostics: this.diagnostics(),
         });
@@ -446,6 +454,51 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         return c.redirect(url);
       },
     });
+  }
+
+  #connectUserRoute(ctx: IntegrationContext): ApiRoute {
+    return registerApiRoute('/auth/github/connect-user', {
+      method: 'GET',
+      requiresAuth: false,
+      handler: async c => {
+        await ctx.auth.ensureUser(loose(c));
+        const tenant = ctx.auth.tenant(loose(c));
+        if (!tenant?.orgId) return c.json({ error: 'unauthorized' }, 401);
+
+        const redirectTo = c.req.query('redirectTo') || c.req.query('return_to') || '/';
+        const originator = routeBaseUrl(ctx, c.req.url);
+        logPlatformInfo('Starting Platform GitHub user authorization flow', {
+          orgId: tenant.orgId,
+          redirectTo,
+          originator,
+        });
+        const query = new URLSearchParams({
+          userId: tenant.userId,
+          redirectTo,
+          originator,
+        });
+        const { url } = await this.#client.request<{ url: string }>(
+          'GET',
+          `${API_PREFIX}/github-app/authenticate?${query}`,
+        );
+        return c.redirect(url);
+      },
+    });
+  }
+
+  /**
+   * Personal GitHub connection status for the acting user. Returns
+   * not-connected when the platform predates the user-connection endpoint.
+   */
+  async #fetchUserConnection(userId: string): Promise<{ connected: boolean; githubUsername: string | null }> {
+    try {
+      return await this.#client.request<{ connected: boolean; githubUsername: string | null }>(
+        'GET',
+        `${API_PREFIX}/github-app/user-connection?${new URLSearchParams({ userId })}`,
+      );
+    } catch {
+      return { connected: false, githubUsername: null };
+    }
   }
 
   async #syncInstallations(orgId: string, userId: string): Promise<SourceControlInstallation[]> {
@@ -628,20 +681,16 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     }
   }
 
-  async #createIssueComment(
-    connection: IntegrationConnection,
-    sourceId: string | undefined,
-    issueId: string,
-    body: string,
-  ) {
-    requireGithubConnection(connection);
-    const repository = requireSource(sourceId, 'GitHub Intake requires a repository source.');
-    const issueNumber = requirePositiveId(issueId, 'issue');
+  async #createIssueComment(input: CreateIntakeCommentInput) {
+    requireGithubConnection(input.connection);
+    const repository = requireSource(input.sourceId, 'GitHub Intake requires a repository source.');
+    const issueNumber = requirePositiveId(input.issueId, 'issue');
     try {
       const comment = await this.#client.request<GithubComment>(
         'POST',
         repositoryPath(repository, `issues/${issueNumber}/comments`),
-        { body },
+        { body: input.body },
+        { actingUserId: input.actingUserId },
       );
       return { id: String(comment.id), url: comment.htmlUrl };
     } catch (error) {
@@ -683,23 +732,33 @@ export class PlatformGithubIntegration implements FactoryIntegration {
 
   async #createPullRequest(input: CreatePullRequestInput) {
     requireGithubConnection(input.connection);
-    const result = await this.#client.request<GithubPullRequest>('POST', repositoryPath(input.sourceId, 'pulls'), {
-      head: input.headBranch,
-      base: input.baseBranch,
-      title: input.title,
-      body: input.body,
-      draft: input.draft,
-    });
+    const result = await this.#client.request<GithubPullRequest>(
+      'POST',
+      repositoryPath(input.sourceId, 'pulls'),
+      {
+        head: input.headBranch,
+        base: input.baseBranch,
+        title: input.title,
+        body: input.body,
+        draft: input.draft,
+      },
+      { actingUserId: input.actingUserId },
+    );
     return parsePullRequest(result);
   }
 
   async #updatePullRequest(input: UpdatePullRequestInput) {
-    const result = await this.#client.request<GithubPullRequest>('PATCH', pullRequestPath(input, input.pullRequestId), {
-      title: input.title,
-      body: input.body === null ? '' : input.body,
-      base: input.baseBranch,
-      state: input.state,
-    });
+    const result = await this.#client.request<GithubPullRequest>(
+      'PATCH',
+      pullRequestPath(input, input.pullRequestId),
+      {
+        title: input.title,
+        body: input.body === null ? '' : input.body,
+        base: input.baseBranch,
+        state: input.state,
+      },
+      { actingUserId: input.actingUserId },
+    );
     return parsePullRequest(result);
   }
 
@@ -708,6 +767,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'PUT',
       `${pullRequestPath(input, input.pullRequestId)}/merge`,
       { commitTitle: input.commitTitle, commitMessage: input.commitMessage, method: input.method },
+      { actingUserId: input.actingUserId },
     );
   }
 
@@ -728,6 +788,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'POST',
       repositoryPath(input.sourceId, `issues/${requirePositiveId(input.pullRequestId, 'pull request')}/comments`),
       { body: input.body },
+      { actingUserId: input.actingUserId },
     );
     return parseComment(comment);
   }
@@ -738,6 +799,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'PATCH',
       repositoryPath(input.sourceId, `issues/comments/${requirePositiveId(input.commentId, 'comment')}`),
       { body: input.body },
+      { actingUserId: input.actingUserId },
     );
     return parseComment(comment);
   }
@@ -747,6 +809,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     await this.#client.request<void>(
       'DELETE',
       repositoryPath(input.sourceId, `issues/comments/${requirePositiveId(input.commentId, 'comment')}`),
+      undefined,
+      { actingUserId: input.actingUserId },
     );
   }
 
@@ -781,6 +845,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'POST',
       `${pullRequestPath(input, input.pullRequestId)}/reviews`,
       { body: input.body, commitId: input.commitId, event: input.event ? reviewEvent(input.event) : undefined },
+      { actingUserId: input.actingUserId },
     );
     return parseReview(review);
   }
@@ -790,6 +855,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'PUT',
       `${pullRequestPath(input, input.pullRequestId)}/reviews/${requirePositiveId(input.reviewId, 'review')}`,
       { body: input.body },
+      { actingUserId: input.actingUserId },
     );
     return parseReview(review);
   }
@@ -799,6 +865,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'POST',
       `${pullRequestPath(input, input.pullRequestId)}/reviews/${requirePositiveId(input.reviewId, 'review')}/events`,
       { body: input.body, event: reviewEvent(input.event) },
+      { actingUserId: input.actingUserId },
     );
     return parseReview(review);
   }
@@ -808,6 +875,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       'PUT',
       `${pullRequestPath(input, input.pullRequestId)}/reviews/${requirePositiveId(input.reviewId, 'review')}/dismissals`,
       { message: input.message },
+      { actingUserId: input.actingUserId },
     );
     return parseReview(review);
   }
@@ -816,6 +884,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     await this.#client.request<void>(
       'DELETE',
       `${pullRequestPath(input, input.pullRequestId)}/reviews/${requirePositiveId(input.reviewId, 'review')}`,
+      undefined,
+      { actingUserId: input.actingUserId },
     );
   }
 
@@ -854,6 +924,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         'POST',
         `${pullRequestPath(input, input.pullRequestId)}/comments`,
         body,
+        { actingUserId: input.actingUserId },
       ),
     );
   }
@@ -865,6 +936,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         'PATCH',
         repositoryPath(input.sourceId, `pulls/comments/${requirePositiveId(input.commentId, 'review comment')}`),
         { body: input.body },
+        { actingUserId: input.actingUserId },
       ),
     );
   }
@@ -874,6 +946,8 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     await this.#client.request<void>(
       'DELETE',
       repositoryPath(input.sourceId, `pulls/comments/${requirePositiveId(input.commentId, 'review comment')}`),
+      undefined,
+      { actingUserId: input.actingUserId },
     );
   }
 
@@ -883,6 +957,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       method,
       `${pullRequestPath(input, input.pullRequestId)}/requested-reviewers`,
       method === 'GET' ? undefined : { users: input.users, teams: input.teams },
+      method === 'GET' ? undefined : { actingUserId: input.actingUserId },
     );
   }
 }


### PR DESCRIPTION
## Summary

When a factory user's org has the GitHub App installed but the user never personally authorized it, issues/PRs created through the factory are authored by the App bot. This PR is the factory half of the fix: it threads the acting end user through every platform GitHub write and adds the connect/status plumbing so users can link their own GitHub identity.

- `PlatformApiClient` accepts an optional `actingUserId` per request and sends it as an `x-acting-user-id` header. The platform (mastra-ai/platform#1734) resolves that user's org-scoped GitHub OAuth connection so writes are authored by the human instead of the bot.
- All `PlatformGithubIntegration` write methods (issue comments, PR create/update/merge, PR comments, reviews, review comments, reviewer requests) forward `actingUserId`; capability inputs in `version-control.ts`/`intake.ts` gained the optional field.
- `POST /web/github/projects/:id/pr` (the only production write producer) passes the tenant WorkOS user id as the acting user.
- `GET /web/github/status` now reports `userConnected` / `userGithubUsername` from the platform's `GET /github-app/user-connection` endpoint. When platform verification returns a failure reason (revoked token, inaccessible installation, missing permissions, or verification unavailable), the factory writes a structured WARN log with the acting user id and reason.
- New `GET /auth/github/connect-user` starts the GitHub App *user authorization* flow (no App install) via the platform's `GET /github-app/authenticate` endpoint and redirects the browser to GitHub.

### Identity mapping

The factory's tenant `userId` is the WorkOS user id (`FactoryAuthUser.workosId`, `getFactoryAuthUserId`), and the platform stores `github_connections.user_id` from the WorkOS session user id — same identifier space, verified in code on both sides. Final confirmation happens in the staging round trip below.

### Compatibility / deploy order

Depends on mastra-ai/platform#1734 being **deployed first**. All new behavior degrades gracefully against an older platform: unknown `x-acting-user-id` headers are ignored, and a 404 from `user-connection` yields `userConnected: false` without failing the status route — so this can merge before the platform deploy without breakage.

## Test plan

- `vitest` factory suites: platform integration tests assert the header is sent on writes (and absent without an acting user), the connect-user redirect, and the older-platform 404 fallback; `routes.test.ts` asserts the PR route passes the tenant user id.
- `tsc`/`eslint` clean on touched files (one pre-existing unrelated `metrics.ts` type error on main).
- After platform deploy: connect a user via settings, open a PR through the factory, confirm GitHub shows the human as author; confirm bot fallback for a non-connected user.
