### PR TITLE
Factory bug bash: onboarding copy fixes, fold queue health into Metrics

### DIFF
--- a/mastracode/web/src/web/ui/domains/workspaces/components/InitialFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/InitialFactoryStep.tsx
@@ -12,8 +12,8 @@ export function InitialFactoryStep({ onContinue }: InitialFactoryStepProps) {
         Build software with a Factory that knows your work.
       </h1>
       <Txt as="p" variant="ui-lg" className="mx-auto mt-6 max-w-2xl leading-7 text-neutral3 sm:text-lg">
-        A Software Factory connects your code, project context, and coding sessions in one shared workspace. It keeps
-        every agent grounded in the repository and work that matter to your team.
+        Mastra Factory connects your code, project context, and coding sessions in one shared workspace. It keeps
+        every agent grounded in the repository and work that matters to your team.
       </Txt>
 
       <div className="mx-auto mt-8 w-full max-w-2xl text-left" aria-hidden="true">

--- a/mastracode/web/src/web/ui/domains/workspaces/components/VcsFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/VcsFactoryStep.tsx
@@ -40,7 +40,7 @@ export function VcsFactoryStep({
         Choose your codebase.
       </h1>
       <Txt as="p" variant="ui-lg" className="mx-auto mt-6 max-w-2xl leading-7 text-neutral3 sm:text-lg">
-        Connect GitHub, then select the repository that will become your first Factory.
+        Connect GitHub, then select the repository that will become your first factory.
       </Txt>
       <section
         aria-label="GitHub repository"


### PR DESCRIPTION
## Summary

Bug-bash fixes for the Mastra Factory web UI (`mastracode/web`):

**Onboarding copy**
- "A Software Factory connects..." → "Mastra Factory connects..."
- Grammar: "work that matter" → "work that matters"
- Lowercased "factory" in the GitHub connect step

**Overview page removed, queue health moved into Metrics**
- The Overview page's queue-health chart (per-stage bars segmented by work-item age, with active-agent overlay and click-to-filter drill-down) now lives on the Metrics page, replacing the Stages breakdown it overlapped with
- The section is labeled as live so it reads correctly next to the date-range-scoped metrics
- Overview route and sidebar link removed; factories land on the Work board (already the home path), and legacy `/overview` links fall through the catch-all back to the factory home

## Test plan

- `pnpm check` (server + UI tsconfigs) passes
- Overview MSW specs migrated to `QueueHealthSection.msw.test.tsx` driving the real route table at `/factories/:id/metrics` — chart buckets, drill-down filtering, and active-overlay specs all pass
- MetricsPage MSW specs updated for the new section; 4 pre-existing failures in that file reproduce identically at HEAD (verified via stash) and are unrelated
- Full web-ui suite matches the HEAD baseline (23 pre-existing failures, none introduced)
