### PR TITLE
fix(create-factory): pin template deps to "alpha" and restore legacy-peer-deps npmrc

### DIFF
--- a/.changeset/factory-sync-template-alpha.md
+++ b/.changeset/factory-sync-template-alpha.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+The Software Factory template now pins every Mastra dep to `"alpha"` instead of a caret range anchored on the current monorepo version. The Mastra Factory sources on `main` are built against the alpha release train — the previous default (`"latest"`) picked up whatever was on the `latest` dist-tag for each package independently, which broke for `@mastra/factory` (still pre-1.0) and produced mismatched trains for the others. `sync-template.mjs` no longer shells out to `npm view` and no longer needs the `--tag` flag. The emitted template ships `.npmrc` with `legacy-peer-deps=true` so npm accepts the internally-consistent prerelease peer graph; both can be flipped back to `"latest"` (and the `.npmrc` deleted) once the packages ship stable releases.

--- a/.changeset/factory-sync-template-latest.md
+++ b/.changeset/factory-sync-template-latest.md
@@ -1,5 +1,0 @@
----
-'create-factory': patch
----
-
-The Software Factory template now pins every Mastra dep to `"latest"` instead of a caret range anchored on the current monorepo version, matching how every other create-mastra template ships. `sync-template.mjs` no longer shells out to `npm view` and no longer needs the `--tag` flag or the `legacy-peer-deps=true` `.npmrc` (which only existed to work around prerelease pins). The sync workflow no longer breaks whenever a linked package sits mid-alpha between publishes.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -3,19 +3,20 @@
  * Produces the Mastra Factory template tree from `mastracode/web`.
  *
  * The template is the web project minus monorepo coupling:
- *   - `link:` deps           -> `"latest"` (matches the templates/* pattern)
+ *   - `link:` deps           -> `"alpha"` (Mastra packages ship as a set)
  *   - monorepo tsconfig      -> standalone tsconfig
  *   - contributor README     -> checked-in template/README.md
  *   - e2e/tests/test deps    -> stripped
  *   - monorepo-only scripts  -> user-facing scripts (dev/build/start/deploy)
  *   - .env.schema            -> also emitted as .env.example (decorators stripped)
  *
- * Versions: every `link:` dep becomes `"latest"`, matching the monorepo's
- * other templates (templates/*). We do not pin the current monorepo version
- * because pinning a mid-train alpha would make the template uninstallable
- * whenever the alpha has not been published yet, and it forces peer-range
- * relaxation for prereleases. `"latest"` floats to whatever is currently on
- * the `latest` dist-tag, which is exactly what create-mastra scaffolds do.
+ * Versions: every `link:` dep becomes `"alpha"`. The Mastra Factory sources on
+ * `main` are built against the alpha release train, not the stable `latest`
+ * tag — several packages the template needs (notably `@mastra/factory`) only
+ * exist as prereleases today, and pinning individual packages to `latest`
+ * while the rest are alphas breaks peer resolution. Floating to the `alpha`
+ * dist-tag keeps the whole install internally consistent; once the packages
+ * cut stable releases we can switch this back to `"latest"`.
  *
  * Usage:
  *   node scripts/sync-template.mjs [--out <dir>]
@@ -139,7 +140,7 @@ function copyTree(srcDir, destDir, relBase = '') {
 /**
  * Verify the linked package exists in the monorepo and its manifest name
  * matches the dependency key. This is a source-of-truth check only — no
- * version is read from it; the template pins `"latest"` from npm.
+ * version is read from it; the template pins `"alpha"` from npm.
  */
 function assertLinkedPackage(name, relPath) {
   const pkgJsonPath = path.join(monorepoRoot, relPath, 'package.json');
@@ -173,18 +174,20 @@ function transformPackageJson() {
     check: 'tsc --noEmit && tsc --noEmit -p src/web/ui/tsconfig.json',
   };
 
-  // Every `link:` dep becomes `"latest"`, matching the monorepo's other
-  // templates (templates/*). We still resolve the link target so an invalid
-  // `link:` spec (typo, deleted package) fails the sync loudly.
-  console.log('sync-template: rewriting link: deps to "latest"...');
+  // Every `link:` dep becomes `"alpha"`. The Mastra Factory sources are built
+  // against the alpha release train, so the template floats to the same
+  // dist-tag rather than mixing `latest` and `alpha` across the Mastra set.
+  // We still resolve the link target so an invalid `link:` spec (typo,
+  // deleted package) fails the sync loudly.
+  console.log('sync-template: rewriting link: deps to "alpha"...');
   for (const section of ['dependencies', 'devDependencies']) {
     const deps = manifest[section];
     if (!deps) continue;
     for (const [name, spec] of Object.entries(deps)) {
       if (!spec.startsWith('link:')) continue;
       assertLinkedPackage(name, linkSpecToRelPath(spec));
-      deps[name] = 'latest';
-      console.log(`  ✓ ${name}@latest`);
+      deps[name] = 'alpha';
+      console.log(`  ✓ ${name}@alpha`);
     }
   }
 
@@ -204,7 +207,7 @@ function transformPackageJson() {
   // Transitive runtime peers that must be declared as direct deps so npm
   // resolves them without needing pnpm's auto-install-peers behavior.
   // (In the monorepo dev setup pnpm provides them automatically.)
-  manifest.dependencies['@mastra/memory'] = 'latest'; // peer of @mastra/playground-ui
+  manifest.dependencies['@mastra/memory'] = 'alpha'; // peer of @mastra/playground-ui
   manifest.dependencies['react-is'] = '^19.0.0'; // peer of recharts (via @mastra/playground-ui)
 
   fs.writeFileSync(path.join(outDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
@@ -303,6 +306,23 @@ src/mastra/public/ui/
   );
 }
 
+/**
+ * Emit `.npmrc` with `legacy-peer-deps=true`.
+ *
+ * The Mastra packages ship as an internally-consistent alpha release train:
+ * peer-dependency *ranges* are correctly stated across the set, but npm 7+
+ * enforces peer resolution strictly and rejects prerelease versions that
+ * satisfy a peer range but not a concrete peer pin. In the monorepo pnpm
+ * relaxes this automatically; downstream `npm install` needs the equivalent
+ * knob or every scaffolded template fails on install.
+ *
+ * When the packages cut stable releases and the template pins `"latest"`
+ * again, this file can be removed.
+ */
+function writeNpmrc() {
+  fs.writeFileSync(path.join(outDir, '.npmrc'), 'legacy-peer-deps=true\n');
+}
+
 /** Copy the checked-in user-facing README verbatim. */
 function writeReadme() {
   const source = path.join(pkgRoot, 'template', 'README.md');
@@ -335,6 +355,7 @@ writeTsconfig();
 stripTestingTypesFromUiTsconfig();
 writeEnvExample();
 writeGitignore();
+writeNpmrc();
 writeReadme();
 
 console.log(`sync-template: done. Template written to ${outDir}`);

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -86,18 +86,22 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     const envExample = fs.readFileSync(path.join(outDir, '.env.example'), 'utf8');
     expect(envExample).not.toMatch(/^[A-Z][A-Z0-9_]*=\s*$/m);
 
-    // package.json: monorepo coupling removed; every Mastra dep pins `latest`.
+    // package.json: monorepo coupling removed; every Mastra dep pins `alpha`.
     const pkg = JSON.parse(fs.readFileSync(path.join(outDir, 'package.json'), 'utf8'));
     const allDeps: Record<string, string> = { ...pkg.dependencies, ...pkg.devDependencies };
     for (const [name, spec] of Object.entries(allDeps)) {
       expect(spec, `${name} must not use a link:/workspace: spec`).not.toMatch(/^(link|workspace|catalog|file):/);
       if (name === 'mastra' || name.startsWith('@mastra/')) {
-        expect(spec, `${name} must be pinned to "latest"`).toBe('latest');
+        expect(spec, `${name} must be pinned to "alpha"`).toBe('alpha');
       }
     }
-    expect(pkg.dependencies['@mastra/memory']).toBe('latest');
-    // Legacy artifact from the caret-pinning era must not appear anymore.
-    expect(fs.existsSync(path.join(outDir, '.npmrc'))).toBe(false);
+    expect(pkg.dependencies['@mastra/memory']).toBe('alpha');
+    // While the Mastra deps float on `alpha`, `.npmrc` needs
+    // `legacy-peer-deps=true` so npm accepts the internally-consistent
+    // prerelease peer graph. Remove once the packages ship stable versions
+    // and the template pins `"latest"` again.
+    const npmrc = fs.readFileSync(path.join(outDir, '.npmrc'), 'utf8');
+    expect(npmrc).toMatch(/^legacy-peer-deps\s*=\s*true\s*$/m);
 
     // Tests and their dependencies are stripped.
     expect(allDeps.vitest).toBeUndefined();

--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -86,7 +86,9 @@ Create a Linear OAuth app (Linear → Settings → API → OAuth applications �
 
 ## Versions
 
-The Mastra packages are pinned to `latest`, so `npm install` pulls the current published release. Upgrade them together by re-running `npm install` (or by rescaffolding).
+The Mastra packages are pinned to `alpha`, so `npm install` pulls the current published prerelease. Upgrade them together by re-running `npm install` (or by rescaffolding).
+
+The included `.npmrc` sets `legacy-peer-deps=true` so npm accepts the internally-consistent prerelease peer graph; you can delete it once the packages ship stable releases.
 
 ## License
 


### PR DESCRIPTION
## Summary

Follow-up to #19989. The `"latest"` fix landed but the sync workflow still can't produce an installable template because:

1. **`@mastra/factory@latest === 0.0.0`** — a stub with unresolved `workspace:*` deps. `npm install` crashes silently on the malformed manifest.
2. Even with that fixed, the Mastra Factory sources on `main` are built against the **alpha release train**, not stable. Pinning individual packages to `latest` while the rest are alphas would mix release trains and break peer resolution.

## Change

- `sync-template.mjs` emits every `link:` Mastra dep as `"alpha"` (was `"latest"`).
- Emitted template now ships `.npmrc` with `legacy-peer-deps=true`. The alpha train's peer *ranges* are correct but npm 7+ rejects prereleases whose concrete version doesn't match a peer's concrete pin — the same relaxation pnpm applies automatically in the monorepo.
- Both flagged as temporary in comments/README — swap `"alpha"` back to `"latest"` and delete the `.npmrc` once the packages ship stable releases.

## Verification

Ran the sync workflow's exact steps locally:

```
node mastracode/mastra-factory/scripts/sync-template.mjs --out /tmp/sf-template
cd /tmp/sf-template
npm install --no-audit --no-fund   # ✅ 1405 packages, exit 0
npm run check                       # ✅ tsc clean, exit 0
```

Unit tests updated: 31 passed (was asserting no `.npmrc`; now asserts `legacy-peer-deps=true`).

## Test plan

- [x] `sync-template.mjs` emits `"alpha"` for every Mastra dep
- [x] Emitted `.npmrc` contains `legacy-peer-deps=true`
- [x] `npm install` succeeds on the emitted template
- [x] `npm run check` succeeds on the emitted template
- [x] Vitest: 31/31 pass
- [x] Prettier + lint clean

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The template now consistently uses Mastra’s alpha versions so its packages work together, instead of accidentally mixing incompatible releases. It also adds an npm setting that helps install these prerelease packages successfully.

## Changes

- Updated `sync-template.mjs` to pin `link:` Mastra dependencies and `@mastra/memory` to the `alpha` dist-tag.
- Added generated `.npmrc` with `legacy-peer-deps=true`.
- Updated tests and README documentation, including temporary-workaround notes.
- Removed the obsolete “latest” changeset.
- Verified with 31 passing tests, `npm install`, and `npm run check`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->