### PR TITLE
feat(playground): configure dataset item timeouts

### DIFF
--- a/.changeset/studio-dataset-item-timeouts.md
+++ b/.changeset/studio-dataset-item-timeouts.md
@@ -1,0 +1,5 @@
+---
+'@internal/playground': patch
+---
+
+Studio now lets you configure a per-item execution timeout on dataset items. Set an optional timeout when creating an item, edit it later from the item detail panel or the item versions page, and see the saved override in the item details. Timeouts are whole milliseconds from 1 to 1,800,000 (30 minutes) and override the experiment-level fallback for that item.

--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -152,4 +152,35 @@ test.describe('Dataset items list', () => {
       await expect(page.getByRole('checkbox')).toHaveCount(0);
     });
   });
+
+  test.describe('when an item has a persisted timeout override', () => {
+    test('updates the override through the detail panel and retains it after reload', async ({ page, request }) => {
+      const seededDataset = await seedDatasetWithItems(1);
+      const itemId = seededDataset.itemIds[0];
+      const response = await request.patch(`/api/datasets/${seededDataset.id}/items/${itemId}`, {
+        data: { timeout: 15_000 },
+      });
+      expect(response.ok()).toBe(true);
+
+      await page.goto(`/datasets/${seededDataset.id}`);
+      await page.getByText('Test input 1', { exact: true }).click();
+
+      const detailPanel = page.locator('section').filter({
+        has: page.getByRole('heading', { name: new RegExp(itemId.slice(0, 12)) }),
+      });
+      await expect(detailPanel.getByText('15,000 ms')).toBeVisible();
+
+      await detailPanel.getByRole('button', { name: 'Actions menu' }).click();
+      await page.getByRole('menuitem', { name: 'Edit' }).click();
+      const timeoutInput = detailPanel.getByRole('spinbutton', { name: /item timeout/i });
+      await expect(timeoutInput).toHaveValue('15000');
+      await timeoutInput.fill('30000');
+      await detailPanel.getByRole('button', { name: 'Save Changes' }).click();
+      await expect(detailPanel.getByText('30,000 ms')).toBeVisible();
+
+      await page.reload();
+      await page.getByRole('button', { name: /Test input 1/ }).click();
+      await expect(detailPanel.getByText('30,000 ms')).toBeVisible();
+    });
+  });
 });

--- a/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
+++ b/packages/playground/e2e/tests/datasets/dataset-items-list.spec.ts
@@ -154,7 +154,7 @@ test.describe('Dataset items list', () => {
   });
 
   test.describe('when an item has a persisted timeout override', () => {
-    test('updates the override through the detail panel and retains it after reload', async ({ page, request }) => {
+    test('updates the override through both edit surfaces and retains it after reload', async ({ page, request }) => {
       const seededDataset = await seedDatasetWithItems(1);
       const itemId = seededDataset.itemIds[0];
       const response = await request.patch(`/api/datasets/${seededDataset.id}/items/${itemId}`, {
@@ -181,6 +181,19 @@ test.describe('Dataset items list', () => {
       await page.reload();
       await page.getByRole('button', { name: /Test input 1/ }).click();
       await expect(detailPanel.getByText('30,000 ms')).toBeVisible();
+
+      await detailPanel.getByRole('link', { name: 'Go to item versions history' }).click();
+      await expect(page).toHaveURL(new RegExp(`/datasets/${seededDataset.id}/items/${itemId}$`));
+      await page.getByRole('button', { name: 'Edit', exact: true }).click();
+      const historyPageTimeoutInput = page.getByRole('spinbutton', { name: /item timeout/i });
+      await expect(historyPageTimeoutInput).toHaveValue('30000');
+      await historyPageTimeoutInput.fill('45000');
+      await page.getByRole('button', { name: 'Save Changes' }).click();
+      await expect(historyPageTimeoutInput).not.toBeVisible();
+
+      await page.reload();
+      await page.getByRole('button', { name: 'Edit', exact: true }).click();
+      await expect(page.getByRole('spinbutton', { name: /item timeout/i })).toHaveValue('45000');
     });
   });
 });

--- a/packages/playground/src/domains/datasets/components/__tests__/add-item-dialog.test.tsx
+++ b/packages/playground/src/domains/datasets/components/__tests__/add-item-dialog.test.tsx
@@ -8,7 +8,7 @@ import type { ChangeEvent, PropsWithChildren } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { AddItemDialog } from '../add-item-dialog';
-import { createdDatasetItem, createdDatasetItemWithoutMocks } from './fixtures/add-item';
+import { createdDatasetItem, createdDatasetItemWithoutMocks, createdDatasetItemWithTimeout } from './fixtures/add-item';
 import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
@@ -60,101 +60,178 @@ function renderDialog() {
 
 /** The form has a known order of CodeEditors: input, groundTruth, expectedTrajectory, toolMocks, requestContext. */
 function getEditors() {
-  return screen.getAllByRole('textbox') as HTMLTextAreaElement[];
+  return screen.getAllByRole<HTMLTextAreaElement>('textbox');
+}
+
+function submitDialog() {
+  const form = screen.getByRole('button', { name: /add item/i }).closest('form');
+  if (!form) throw new Error('Add item form not found');
+  fireEvent.submit(form);
 }
 
 describe('AddItemDialog', () => {
-  it('posts parsed Tool Mocks JSON when creating a dataset item', async () => {
-    const capture = vi.fn();
-    server.use(
-      http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
-        capture(await request.json());
-        return HttpResponse.json(createdDatasetItem);
-      }),
-    );
+  describe('when valid Tool Mocks JSON is provided', () => {
+    it('posts the parsed mocks when creating a dataset item', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(createdDatasetItem);
+        }),
+      );
 
-    renderDialog();
+      renderDialog();
 
-    const [input, , , toolMocks] = getEditors();
-    fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
-    fireEvent.change(toolMocks, {
-      target: {
-        value: JSON.stringify([{ toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } }]),
-      },
+      const [input, , , toolMocks] = getEditors();
+      fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
+      fireEvent.change(toolMocks, {
+        target: {
+          value: JSON.stringify([{ toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } }]),
+        },
+      });
+
+      submitDialog();
+
+      await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+      expect(capture).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { city: 'Seattle' },
+          toolMocks: [{ toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } }],
+        }),
+      );
     });
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+  describe('when Tool Mocks is left empty', () => {
+    it('omits toolMocks from the request', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(createdDatasetItemWithoutMocks);
+        }),
+      );
 
-    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
-    expect(capture.mock.calls[0][0]).toMatchObject({
-      input: { city: 'Seattle' },
-      toolMocks: [{ toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } }],
+      renderDialog();
+
+      const [input] = getEditors();
+      fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
+
+      submitDialog();
+
+      await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+      expect(capture).toHaveBeenCalledWith(expect.not.objectContaining({ toolMocks: expect.anything() }));
     });
   });
 
-  it('omits toolMocks when the field is left empty', async () => {
-    const capture = vi.fn();
-    server.use(
-      http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
-        capture(await request.json());
-        return HttpResponse.json(createdDatasetItemWithoutMocks);
-      }),
-    );
+  describe('when Tool Mocks JSON is not an array', () => {
+    it('rejects the value before making a request', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(createdDatasetItem);
+        }),
+      );
 
-    renderDialog();
+      renderDialog();
 
-    const [input] = getEditors();
-    fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
+      const [input, , , toolMocks] = getEditors();
+      fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
+      fireEvent.change(toolMocks, { target: { value: '{"toolName":"getWeather"}' } });
 
-    fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+      submitDialog();
 
-    await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
-    expect(capture.mock.calls[0][0].toolMocks).toBeUndefined();
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Tool Mocks must be a JSON array'));
+      expect(capture).not.toHaveBeenCalled();
+    });
   });
 
-  it('rejects non-array Tool Mocks JSON before making a request', async () => {
-    const capture = vi.fn();
-    server.use(
-      http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
-        capture(await request.json());
-        return HttpResponse.json(createdDatasetItem);
-      }),
-    );
-
-    renderDialog();
-
-    const [input, , , toolMocks] = getEditors();
-    fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
-    fireEvent.change(toolMocks, { target: { value: '{"toolName":"getWeather"}' } });
-
-    fireEvent.click(screen.getByRole('button', { name: /add item/i }));
-
-    // The non-array guard surfaces an error toast and short-circuits before any request.
-    await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Tool Mocks must be a JSON array'));
-    expect(capture).not.toHaveBeenCalled();
-  });
-
-  it('renders server-side Tool Mocks validation errors inline', async () => {
-    server.use(
-      http.post(`${BASE_URL}/api/datasets/dataset-1/items`, () =>
-        HttpResponse.json(
-          { error: 'Validation failed', field: 'toolMocks', errors: [{ path: '0.output', message: 'Required' }] },
-          { status: 400 },
+  describe('when the server rejects Tool Mocks', () => {
+    it('renders the field validation error', async () => {
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, () =>
+          HttpResponse.json(
+            { error: 'Validation failed', field: 'toolMocks', errors: [{ path: '0.output', message: 'Required' }] },
+            { status: 400 },
+          ),
         ),
-      ),
-    );
+      );
 
-    renderDialog();
+      renderDialog();
 
-    const [input, , , toolMocks] = getEditors();
-    fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
-    fireEvent.change(toolMocks, {
-      target: { value: JSON.stringify([{ toolName: 'getWeather', args: {} }]) },
+      const [input, , , toolMocks] = getEditors();
+      fireEvent.change(input, { target: { value: '{"city":"Seattle"}' } });
+      fireEvent.change(toolMocks, {
+        target: { value: JSON.stringify([{ toolName: 'getWeather', args: {} }]) },
+      });
+
+      submitDialog();
+
+      expect(await screen.findByText(/0\.output/)).not.toBeNull();
+      expect(screen.getByText(/Required/)).not.toBeNull();
     });
+  });
 
-    fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+  describe('when a valid item timeout is provided', () => {
+    it('posts the timeout in milliseconds', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(createdDatasetItemWithTimeout);
+        }),
+      );
 
-    expect(await screen.findByText(/0\.output/)).not.toBeNull();
-    expect(screen.getByText(/Required/)).not.toBeNull();
+      renderDialog();
+
+      fireEvent.change(screen.getByRole<HTMLInputElement>('spinbutton', { name: /item timeout/i }), {
+        target: { value: '15000' },
+      });
+      submitDialog();
+
+      await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 15_000 }));
+    });
+  });
+
+  describe('when the item timeout is left empty', () => {
+    it('omits timeout from the request', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(createdDatasetItemWithoutMocks);
+        }),
+      );
+
+      renderDialog();
+      submitDialog();
+
+      await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+      expect(capture).toHaveBeenCalledWith(expect.not.objectContaining({ timeout: expect.anything() }));
+    });
+  });
+
+  describe('when the item timeout is not a positive whole number', () => {
+    it.each(['0', '-1', '1.5'])('rejects %s before making a request', async timeout => {
+      const capture = vi.fn();
+      server.use(
+        http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(createdDatasetItem);
+        }),
+      );
+
+      renderDialog();
+
+      fireEvent.change(screen.getByRole<HTMLInputElement>('spinbutton', { name: /item timeout/i }), {
+        target: { value: timeout },
+      });
+      submitDialog();
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Item timeout must be a positive whole number'));
+      expect(capture).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/playground/src/domains/datasets/components/__tests__/add-item-dialog.test.tsx
+++ b/packages/playground/src/domains/datasets/components/__tests__/add-item-dialog.test.tsx
@@ -186,12 +186,12 @@ describe('AddItemDialog', () => {
       renderDialog();
 
       fireEvent.change(screen.getByRole<HTMLInputElement>('spinbutton', { name: /item timeout/i }), {
-        target: { value: '15000' },
+        target: { value: '1800000' },
       });
       submitDialog();
 
       await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
-      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 15_000 }));
+      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 1_800_000 }));
     });
   });
 
@@ -213,8 +213,8 @@ describe('AddItemDialog', () => {
     });
   });
 
-  describe('when the item timeout is not a positive whole number', () => {
-    it.each(['0', '-1', '1.5'])('rejects %s before making a request', async timeout => {
+  describe('when the item timeout is outside the supported range', () => {
+    it.each(['0', '-1', '1.5', '1800001'])('rejects %s before making a request', async timeout => {
       const capture = vi.fn();
       server.use(
         http.post(`${BASE_URL}/api/datasets/dataset-1/items`, async ({ request }) => {
@@ -230,7 +230,11 @@ describe('AddItemDialog', () => {
       });
       submitDialog();
 
-      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Item timeout must be a positive whole number'));
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          'Item timeout must be a positive integer no greater than 1,800,000 milliseconds (30 minutes)',
+        ),
+      );
       expect(capture).not.toHaveBeenCalled();
     });
   });

--- a/packages/playground/src/domains/datasets/components/__tests__/fixtures/add-item.ts
+++ b/packages/playground/src/domains/datasets/components/__tests__/fixtures/add-item.ts
@@ -1,6 +1,6 @@
 import type { DatasetItem } from '@mastra/client-js';
 
-export const createdDatasetItem: DatasetItem = {
+export const createdDatasetItem = {
   id: 'item-1',
   datasetId: 'dataset-1',
   datasetVersion: 1,
@@ -8,9 +8,14 @@ export const createdDatasetItem: DatasetItem = {
   toolMocks: [{ toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } }],
   createdAt: '2026-06-16T10:00:00.000Z',
   updatedAt: '2026-06-16T10:00:00.000Z',
-};
+} satisfies DatasetItem;
 
-export const createdDatasetItemWithoutMocks: DatasetItem = {
+export const createdDatasetItemWithoutMocks = {
   ...createdDatasetItem,
   toolMocks: undefined,
-};
+} satisfies DatasetItem;
+
+export const createdDatasetItemWithTimeout = {
+  ...createdDatasetItem,
+  timeout: 15_000,
+} satisfies DatasetItem;

--- a/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
@@ -4,6 +4,7 @@ import type { DatasetItemToolMock } from '@mastra/client-js';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogBody } from '@mastra/playground-ui/components/Dialog';
+import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useState } from 'react';
@@ -65,6 +66,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
   const [groundTruth, setGroundTruth] = useState('');
   const [expectedTrajectory, setExpectedTrajectory] = useState('');
   const [toolMocks, setToolMocks] = useState('');
+  const [timeout, setTimeout] = useState('');
   const [requestContext, setRequestContext] = useState('');
   const [validationErrors, setValidationErrors] = useState<SchemaValidationError | null>(null);
   const { addItem } = useDatasetMutations();
@@ -118,6 +120,16 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
       }
     }
 
+    let parsedTimeout: number | undefined;
+    if (timeout.trim()) {
+      const timeoutValue = Number(timeout);
+      if (!Number.isFinite(timeoutValue) || !Number.isInteger(timeoutValue) || timeoutValue <= 0) {
+        toast.error('Item timeout must be a positive whole number');
+        return;
+      }
+      parsedTimeout = timeoutValue;
+    }
+
     // Parse requestContext if provided
     let parsedRequestContext: Record<string, unknown> | undefined;
     if (requestContext.trim()) {
@@ -136,6 +148,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
         groundTruth: parsedGroundTruth,
         expectedTrajectory: parsedTrajectory,
         toolMocks: parsedToolMocks,
+        timeout: parsedTimeout,
         requestContext: parsedRequestContext,
       });
 
@@ -147,6 +160,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
       setGroundTruth('');
       setExpectedTrajectory('');
       setToolMocks('');
+      setTimeout('');
       setRequestContext('');
       onOpenChange(false);
 
@@ -191,6 +205,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
     setGroundTruth('');
     setExpectedTrajectory('');
     setToolMocks('');
+    setTimeout('');
     setRequestContext('');
     setValidationErrors(null);
     onOpenChange(false);
@@ -246,6 +261,21 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
               {validationErrors?.field === 'toolMocks' && (
                 <ValidationErrors field="toolMocks" errors={validationErrors.errors} />
               )}
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="item-timeout">Item timeout (ms, optional)</Label>
+              <p className="text-xs text-muted-foreground">
+                Overrides the experiment-level item timeout. Enter a positive whole number of milliseconds.
+              </p>
+              <Input
+                id="item-timeout"
+                type="number"
+                min={1}
+                step={1}
+                value={timeout}
+                onChange={event => setTimeout(event.target.value)}
+              />
             </div>
 
             <div className="space-y-2">

--- a/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
+++ b/packages/playground/src/domains/datasets/components/add-item-dialog.tsx
@@ -8,6 +8,7 @@ import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
 import { toast } from '@mastra/playground-ui/utils/toast';
 import { useState } from 'react';
+import { MAX_EXPERIMENT_ITEM_TIMEOUT_MS } from '../constants';
 import { useDatasetMutations } from '../hooks/use-dataset-mutations';
 
 /** Schema validation error from API */
@@ -66,7 +67,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
   const [groundTruth, setGroundTruth] = useState('');
   const [expectedTrajectory, setExpectedTrajectory] = useState('');
   const [toolMocks, setToolMocks] = useState('');
-  const [timeout, setTimeout] = useState('');
+  const [timeoutValue, setTimeoutValue] = useState('');
   const [requestContext, setRequestContext] = useState('');
   const [validationErrors, setValidationErrors] = useState<SchemaValidationError | null>(null);
   const { addItem } = useDatasetMutations();
@@ -113,7 +114,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
           toast.error('Tool Mocks must be a JSON array');
           return;
         }
-        parsedToolMocks = parsed as DatasetItemToolMock[];
+        parsedToolMocks = parsed;
       } catch {
         toast.error('Tool Mocks must be valid JSON');
         return;
@@ -121,13 +122,18 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
     }
 
     let parsedTimeout: number | undefined;
-    if (timeout.trim()) {
-      const timeoutValue = Number(timeout);
-      if (!Number.isFinite(timeoutValue) || !Number.isInteger(timeoutValue) || timeoutValue <= 0) {
-        toast.error('Item timeout must be a positive whole number');
+    if (timeoutValue.trim()) {
+      const timeout = Number(timeoutValue);
+      if (
+        !Number.isFinite(timeout) ||
+        !Number.isInteger(timeout) ||
+        timeout <= 0 ||
+        timeout > MAX_EXPERIMENT_ITEM_TIMEOUT_MS
+      ) {
+        toast.error('Item timeout must be a positive integer no greater than 1,800,000 milliseconds (30 minutes)');
         return;
       }
-      parsedTimeout = timeoutValue;
+      parsedTimeout = timeout;
     }
 
     // Parse requestContext if provided
@@ -160,7 +166,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
       setGroundTruth('');
       setExpectedTrajectory('');
       setToolMocks('');
-      setTimeout('');
+      setTimeoutValue('');
       setRequestContext('');
       onOpenChange(false);
 
@@ -205,7 +211,7 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
     setGroundTruth('');
     setExpectedTrajectory('');
     setToolMocks('');
-    setTimeout('');
+    setTimeoutValue('');
     setRequestContext('');
     setValidationErrors(null);
     onOpenChange(false);
@@ -266,15 +272,17 @@ export function AddItemDialog({ datasetId, open, onOpenChange, onSuccess }: AddI
             <div className="space-y-2">
               <Label htmlFor="item-timeout">Item timeout (ms, optional)</Label>
               <p className="text-xs text-muted-foreground">
-                Overrides the experiment-level item timeout. Enter a positive whole number of milliseconds.
+                Overrides the experiment-level item timeout. Enter a positive integer from 1 to 1,800,000 milliseconds
+                (30 minutes).
               </p>
               <Input
                 id="item-timeout"
                 type="number"
                 min={1}
+                max={MAX_EXPERIMENT_ITEM_TIMEOUT_MS}
                 step={1}
-                value={timeout}
-                onChange={event => setTimeout(event.target.value)}
+                value={timeoutValue}
+                onChange={event => setTimeoutValue(event.target.value)}
               />
             </div>
 

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
@@ -1,17 +1,38 @@
 'use client';
 
+import type { DatasetItem, DatasetItemToolMock } from '@mastra/client-js';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { CodeEditor } from '@mastra/playground-ui/components/CodeEditor';
+import { Input } from '@mastra/playground-ui/components/Input';
 import { Label } from '@mastra/playground-ui/components/Label';
+import { toast } from '@mastra/playground-ui/utils/toast';
 import { Pencil } from 'lucide-react';
+import { useState } from 'react';
+import type { ReactNode } from 'react';
+import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
 
-/** Schema validation error from API */
-export interface SchemaValidationError {
+interface SchemaValidationError {
   field: 'input' | 'groundTruth' | 'toolMocks';
   errors: Array<{ path: string; message: string }>;
 }
 
-/** Displays field-level validation errors */
+function parseValidationError(error: unknown): SchemaValidationError | null {
+  if (!(error instanceof Error)) return null;
+
+  const match = error.message.match(/- ({.*})$/);
+  if (!match) return null;
+
+  try {
+    const parsed = JSON.parse(match[1]);
+    if (parsed.field && Array.isArray(parsed.errors)) {
+      return { field: parsed.field, errors: parsed.errors };
+    }
+  } catch {
+    // Not valid JSON
+  }
+  return null;
+}
+
 function ValidationErrors({ field, errors }: { field: string; errors: Array<{ path: string; message: string }> }) {
   if (!errors.length) return null;
 
@@ -30,9 +51,6 @@ function ValidationErrors({ field, errors }: { field: string; errors: Array<{ pa
   );
 }
 
-/**
- * Editable form view for updating dataset item
- */
 export interface EditModeContentProps {
   inputValue: string;
   setInputValue: (value: string) => void;
@@ -50,6 +68,7 @@ export interface EditModeContentProps {
   onSave: () => void;
   onCancel: () => void;
   isSaving: boolean;
+  children?: ReactNode;
 }
 
 export function EditModeContent({
@@ -69,6 +88,7 @@ export function EditModeContent({
   onSave,
   onCancel,
   isSaving,
+  children,
 }: EditModeContentProps) {
   return (
     <>
@@ -126,6 +146,8 @@ export function EditModeContent({
           )}
         </div>
 
+        {children}
+
         <div className="space-y-2">
           <Label>Request Context (JSON, optional)</Label>
           <CodeEditor
@@ -156,5 +178,189 @@ export function EditModeContent({
         </div>
       </div>
     </>
+  );
+}
+
+const formatOptionalJson = (value: unknown) => (value == null ? '' : JSON.stringify(value, null, 2));
+
+export interface DatasetItemEditFormProps {
+  item: DatasetItem;
+  onSuccess: () => void;
+  onCancel: () => void;
+}
+
+export function DatasetItemEditForm({ item, onSuccess, onCancel }: DatasetItemEditFormProps) {
+  const [inputValue, setInputValue] = useState(() => JSON.stringify(item.input, null, 2));
+  const [groundTruthValue, setGroundTruthValue] = useState(() => formatOptionalJson(item.groundTruth));
+  const [metadataValue, setMetadataValue] = useState(() => formatOptionalJson(item.metadata));
+  const [trajectoryValue, setTrajectoryValue] = useState(() => formatOptionalJson(item.expectedTrajectory));
+  const [toolMocksValue, setToolMocksValue] = useState(() =>
+    item.toolMocks?.length ? JSON.stringify(item.toolMocks, null, 2) : '',
+  );
+  const [timeoutValue, setTimeoutValue] = useState(() => item.timeout?.toString() ?? '');
+  const [requestContextValue, setRequestContextValue] = useState(() => formatOptionalJson(item.requestContext));
+  const [validationErrors, setValidationErrors] = useState<SchemaValidationError | null>(null);
+  const { updateItem } = useDatasetMutations();
+
+  const handleSave = async () => {
+    let parsedInput: unknown;
+    try {
+      parsedInput = JSON.parse(inputValue);
+    } catch {
+      toast.error('Input must be valid JSON');
+      return;
+    }
+
+    let parsedGroundTruth: unknown | undefined;
+    if (groundTruthValue.trim()) {
+      try {
+        parsedGroundTruth = JSON.parse(groundTruthValue);
+      } catch {
+        toast.error('Ground Truth must be valid JSON');
+        return;
+      }
+    }
+
+    let parsedMetadata: Record<string, unknown> | undefined;
+    if (metadataValue.trim()) {
+      try {
+        parsedMetadata = JSON.parse(metadataValue);
+      } catch {
+        toast.error('Metadata must be valid JSON');
+        return;
+      }
+    }
+
+    let parsedTrajectory: unknown | null = null;
+    if (trajectoryValue.trim()) {
+      try {
+        parsedTrajectory = JSON.parse(trajectoryValue);
+      } catch {
+        toast.error('Expected Trajectory must be valid JSON');
+        return;
+      }
+    }
+
+    let parsedToolMocks: DatasetItemToolMock[] | undefined;
+    if (toolMocksValue.trim()) {
+      try {
+        const parsed = JSON.parse(toolMocksValue);
+        if (!Array.isArray(parsed)) {
+          toast.error('Tool Mocks must be a JSON array');
+          return;
+        }
+        parsedToolMocks = parsed;
+      } catch {
+        toast.error('Tool Mocks must be valid JSON');
+        return;
+      }
+    } else {
+      parsedToolMocks = [];
+    }
+
+    let parsedTimeout: number | undefined;
+    if (timeoutValue.trim()) {
+      const timeout = Number(timeoutValue);
+      if (!Number.isFinite(timeout) || !Number.isInteger(timeout) || timeout <= 0) {
+        toast.error('Item timeout must be a positive whole number');
+        return;
+      }
+      parsedTimeout = timeout;
+    } else if (item.timeout !== undefined) {
+      toast.error('An existing item timeout cannot be cleared; enter a positive whole number');
+      return;
+    }
+
+    let parsedRequestContext: Record<string, unknown> | undefined;
+    if (requestContextValue.trim()) {
+      try {
+        parsedRequestContext = JSON.parse(requestContextValue);
+      } catch {
+        toast.error('Request Context must be valid JSON');
+        return;
+      }
+    }
+
+    try {
+      await updateItem.mutateAsync({
+        datasetId: item.datasetId,
+        itemId: item.id,
+        input: parsedInput,
+        groundTruth: parsedGroundTruth,
+        metadata: parsedMetadata,
+        expectedTrajectory: parsedTrajectory,
+        toolMocks: parsedToolMocks,
+        timeout: parsedTimeout,
+        requestContext: parsedRequestContext,
+      });
+
+      toast.success('Item updated successfully');
+      setValidationErrors(null);
+      onSuccess();
+    } catch (error) {
+      const schemaError = parseValidationError(error);
+      if (schemaError) {
+        setValidationErrors(schemaError);
+      } else {
+        toast.error(`Failed to update item: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      }
+    }
+  };
+
+  const handleInputValueChange = (value: string) => {
+    setInputValue(value);
+    if (validationErrors?.field === 'input') {
+      setValidationErrors(null);
+    }
+  };
+
+  const handleGroundTruthValueChange = (value: string) => {
+    setGroundTruthValue(value);
+    if (validationErrors?.field === 'groundTruth') {
+      setValidationErrors(null);
+    }
+  };
+
+  const handleToolMocksValueChange = (value: string) => {
+    setToolMocksValue(value);
+    if (validationErrors?.field === 'toolMocks') {
+      setValidationErrors(null);
+    }
+  };
+
+  return (
+    <EditModeContent
+      inputValue={inputValue}
+      setInputValue={handleInputValueChange}
+      groundTruthValue={groundTruthValue}
+      setGroundTruthValue={handleGroundTruthValueChange}
+      metadataValue={metadataValue}
+      setMetadataValue={setMetadataValue}
+      trajectoryValue={trajectoryValue}
+      setTrajectoryValue={setTrajectoryValue}
+      toolMocksValue={toolMocksValue}
+      setToolMocksValue={handleToolMocksValueChange}
+      requestContextValue={requestContextValue}
+      setRequestContextValue={setRequestContextValue}
+      validationErrors={validationErrors}
+      onSave={handleSave}
+      onCancel={onCancel}
+      isSaving={updateItem.isPending}
+    >
+      <div className="space-y-2">
+        <Label htmlFor="edit-item-timeout">Item timeout (ms, optional)</Label>
+        <p className="text-xs text-muted-foreground">
+          Overrides the experiment-level item timeout. Enter a positive whole number of milliseconds.
+        </p>
+        <Input
+          id="edit-item-timeout"
+          type="number"
+          min={1}
+          step={1}
+          value={timeoutValue}
+          onChange={event => setTimeoutValue(event.target.value)}
+        />
+      </div>
+    </EditModeContent>
   );
 }

--- a/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
+++ b/packages/playground/src/domains/datasets/components/dataset-detail/dataset-item-form.tsx
@@ -9,6 +9,7 @@ import { toast } from '@mastra/playground-ui/utils/toast';
 import { Pencil } from 'lucide-react';
 import { useState } from 'react';
 import type { ReactNode } from 'react';
+import { MAX_EXPERIMENT_ITEM_TIMEOUT_MS } from '../../constants';
 import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
 
 interface SchemaValidationError {
@@ -261,13 +262,18 @@ export function DatasetItemEditForm({ item, onSuccess, onCancel }: DatasetItemEd
     let parsedTimeout: number | undefined;
     if (timeoutValue.trim()) {
       const timeout = Number(timeoutValue);
-      if (!Number.isFinite(timeout) || !Number.isInteger(timeout) || timeout <= 0) {
-        toast.error('Item timeout must be a positive whole number');
+      if (
+        !Number.isFinite(timeout) ||
+        !Number.isInteger(timeout) ||
+        timeout <= 0 ||
+        timeout > MAX_EXPERIMENT_ITEM_TIMEOUT_MS
+      ) {
+        toast.error('Item timeout must be a positive integer no greater than 1,800,000 milliseconds (30 minutes)');
         return;
       }
       parsedTimeout = timeout;
     } else if (item.timeout !== undefined) {
-      toast.error('An existing item timeout cannot be cleared; enter a positive whole number');
+      toast.error('An existing item timeout cannot be cleared; enter a positive integer no greater than 30 minutes');
       return;
     }
 
@@ -350,12 +356,14 @@ export function DatasetItemEditForm({ item, onSuccess, onCancel }: DatasetItemEd
       <div className="space-y-2">
         <Label htmlFor="edit-item-timeout">Item timeout (ms, optional)</Label>
         <p className="text-xs text-muted-foreground">
-          Overrides the experiment-level item timeout. Enter a positive whole number of milliseconds.
+          Overrides the experiment-level item timeout. Enter a positive integer from 1 to 1,800,000 milliseconds (30
+          minutes).
         </p>
         <Input
           id="edit-item-timeout"
           type="number"
           min={1}
+          max={MAX_EXPERIMENT_ITEM_TIMEOUT_MS}
           step={1}
           value={timeoutValue}
           onChange={event => setTimeoutValue(event.target.value)}

--- a/packages/playground/src/domains/datasets/components/items/__tests__/dataset-item-panel.test.tsx
+++ b/packages/playground/src/domains/datasets/components/items/__tests__/dataset-item-panel.test.tsx
@@ -1,18 +1,37 @@
 // @vitest-environment jsdom
 import type { DatasetItem } from '@mastra/client-js';
+import { toast } from '@mastra/playground-ui/utils/toast';
 import { MastraReactProvider } from '@mastra/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { ChangeEvent } from 'react';
 import { MemoryRouter } from 'react-router';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { DatasetItemPanel } from '../dataset-item-panel';
-import { baseItem, itemWithMocks } from './fixtures/dataset-item-panel';
+import { baseItem, itemWithMocks, itemWithTimeout } from './fixtures/dataset-item-panel';
+import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
 
+vi.mock('@mastra/playground-ui/utils/toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@uiw/react-codemirror', () => ({
+  default: ({ value, onChange }: { value?: string; onChange?: (value: string) => void }) => (
+    <textarea
+      value={value ?? ''}
+      onChange={(event: ChangeEvent<HTMLTextAreaElement>) => onChange?.(event.target.value)}
+    />
+  ),
+}));
+
 const renderPanel = (item: DatasetItem) => {
-  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
   return render(
     <MastraReactProvider baseUrl={BASE_URL}>
       <QueryClientProvider client={queryClient}>
@@ -24,19 +43,132 @@ const renderPanel = (item: DatasetItem) => {
   );
 };
 
-afterEach(() => cleanup());
+async function openEditForm() {
+  fireEvent.click(screen.getByRole('button', { name: 'Actions menu' }));
+  fireEvent.click(await screen.findByRole('menuitem', { name: 'Edit' }));
+  return screen.findByRole<HTMLInputElement>('spinbutton', { name: /item timeout/i });
+}
 
-describe('DatasetItemPanel view mode', () => {
-  it('renders the Tool Mocks section in view mode when the item has mocks', () => {
-    renderPanel(itemWithMocks);
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
 
-    expect(screen.getByText('Tool Mocks')).not.toBeNull();
-    expect(screen.getByText(/getWeather/)).not.toBeNull();
+describe('DatasetItemPanel', () => {
+  describe('when the item has Tool Mocks', () => {
+    it('renders the mocks in view mode', () => {
+      renderPanel(itemWithMocks);
+
+      expect(screen.getByText('Tool Mocks')).not.toBeNull();
+      expect(screen.getByText(/getWeather/)).not.toBeNull();
+    });
   });
 
-  it('always renders the Tool Mocks section in view mode, even with no mocks', () => {
-    renderPanel(baseItem);
+  describe('when the item has no Tool Mocks', () => {
+    it('still renders the Tool Mocks section', () => {
+      renderPanel(baseItem);
 
-    expect(screen.getByText('Tool Mocks')).not.toBeNull();
+      expect(screen.getByText('Tool Mocks')).not.toBeNull();
+    });
+  });
+
+  describe('when the item inherits the experiment timeout', () => {
+    it('omits the item timeout metadata row', () => {
+      renderPanel(baseItem);
+
+      expect(screen.queryByText('Item timeout')).toBeNull();
+    });
+  });
+
+  describe('when the item has a timeout override', () => {
+    it('renders the formatted timeout in view mode', () => {
+      renderPanel(itemWithTimeout);
+
+      expect(screen.getByText('Item timeout')).not.toBeNull();
+      expect(screen.getByText('15,000 ms')).not.toBeNull();
+    });
+
+    it('prepopulates the timeout field in edit mode', async () => {
+      renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+
+      expect(timeout.value).toBe('15000');
+    });
+
+    it('posts a changed timeout through the real mutation', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.patch(`${BASE_URL}/api/datasets/ds-1/items/item-1`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json({ ...itemWithTimeout, timeout: 30_000 });
+        }),
+      );
+      renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+      fireEvent.change(timeout, { target: { value: '30000' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
+      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 30_000 }));
+    });
+  });
+
+  describe('when a timeout edit is cancelled', () => {
+    it('remounts the original timeout on the next edit', async () => {
+      renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+      fireEvent.change(timeout, { target: { value: '30000' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+      const reopenedTimeout = await openEditForm();
+
+      expect(reopenedTimeout.value).toBe('15000');
+    });
+  });
+
+  describe('when a persisted timeout is blanked', () => {
+    it('rejects the unsupported clear operation before making a request', async () => {
+      const capture = vi.fn();
+      server.use(
+        http.patch(`${BASE_URL}/api/datasets/ds-1/items/item-1`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(itemWithTimeout);
+        }),
+      );
+      renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+      fireEvent.change(timeout, { target: { value: '' } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          'An existing item timeout cannot be cleared; enter a positive whole number',
+        ),
+      );
+      expect(capture).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('when the edited timeout is not a positive whole number', () => {
+    it.each(['0', '-1', '1.5'])('rejects %s before making a request', async timeoutValue => {
+      const capture = vi.fn();
+      server.use(
+        http.patch(`${BASE_URL}/api/datasets/ds-1/items/item-1`, async ({ request }) => {
+          capture(await request.json());
+          return HttpResponse.json(itemWithTimeout);
+        }),
+      );
+      renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+      fireEvent.change(timeout, { target: { value: timeoutValue } });
+      fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
+
+      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Item timeout must be a positive whole number'));
+      expect(capture).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/playground/src/domains/datasets/components/items/__tests__/dataset-item-panel.test.tsx
+++ b/packages/playground/src/domains/datasets/components/items/__tests__/dataset-item-panel.test.tsx
@@ -101,17 +101,17 @@ describe('DatasetItemPanel', () => {
       server.use(
         http.patch(`${BASE_URL}/api/datasets/ds-1/items/item-1`, async ({ request }) => {
           capture(await request.json());
-          return HttpResponse.json({ ...itemWithTimeout, timeout: 30_000 });
+          return HttpResponse.json({ ...itemWithTimeout, timeout: 1_800_000 });
         }),
       );
       renderPanel(itemWithTimeout);
 
       const timeout = await openEditForm();
-      fireEvent.change(timeout, { target: { value: '30000' } });
+      fireEvent.change(timeout, { target: { value: '1800000' } });
       fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
 
       await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
-      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 30_000 }));
+      expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 1_800_000 }));
     });
   });
 
@@ -145,15 +145,15 @@ describe('DatasetItemPanel', () => {
 
       await waitFor(() =>
         expect(toast.error).toHaveBeenCalledWith(
-          'An existing item timeout cannot be cleared; enter a positive whole number',
+          'An existing item timeout cannot be cleared; enter a positive integer no greater than 30 minutes',
         ),
       );
       expect(capture).not.toHaveBeenCalled();
     });
   });
 
-  describe('when the edited timeout is not a positive whole number', () => {
-    it.each(['0', '-1', '1.5'])('rejects %s before making a request', async timeoutValue => {
+  describe('when the edited timeout is outside the supported range', () => {
+    it.each(['0', '-1', '1.5', '1800001'])('rejects %s before making a request', async timeoutValue => {
       const capture = vi.fn();
       server.use(
         http.patch(`${BASE_URL}/api/datasets/ds-1/items/item-1`, async ({ request }) => {
@@ -167,7 +167,11 @@ describe('DatasetItemPanel', () => {
       fireEvent.change(timeout, { target: { value: timeoutValue } });
       fireEvent.click(screen.getByRole('button', { name: 'Save Changes' }));
 
-      await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Item timeout must be a positive whole number'));
+      await waitFor(() =>
+        expect(toast.error).toHaveBeenCalledWith(
+          'Item timeout must be a positive integer no greater than 1,800,000 milliseconds (30 minutes)',
+        ),
+      );
       expect(capture).not.toHaveBeenCalled();
     });
   });

--- a/packages/playground/src/domains/datasets/components/items/__tests__/dataset-item-panel.test.tsx
+++ b/packages/playground/src/domains/datasets/components/items/__tests__/dataset-item-panel.test.tsx
@@ -15,6 +15,12 @@ import { server } from '@/test/msw-server';
 
 const BASE_URL = 'http://localhost:4111';
 
+const anotherItemWithTimeout = {
+  ...itemWithTimeout,
+  id: 'item-2',
+  timeout: 30_000,
+} satisfies DatasetItem;
+
 vi.mock('@mastra/playground-ui/utils/toast', () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
@@ -32,15 +38,27 @@ const renderPanel = (item: DatasetItem) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return render(
+  const renderPanelWithItem = (currentItem: DatasetItem) => (
     <MastraReactProvider baseUrl={BASE_URL}>
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <DatasetItemPanel datasetId="ds-1" item={item} items={[item]} onItemChange={() => {}} onClose={() => {}} />
+          <DatasetItemPanel
+            datasetId="ds-1"
+            item={currentItem}
+            items={[currentItem]}
+            onItemChange={() => {}}
+            onClose={() => {}}
+          />
         </MemoryRouter>
       </QueryClientProvider>
-    </MastraReactProvider>,
+    </MastraReactProvider>
   );
+  const rendered = render(renderPanelWithItem(item));
+
+  return {
+    ...rendered,
+    rerenderPanel: (nextItem: DatasetItem) => rendered.rerender(renderPanelWithItem(nextItem)),
+  };
 };
 
 async function openEditForm() {
@@ -112,6 +130,28 @@ describe('DatasetItemPanel', () => {
 
       await waitFor(() => expect(capture).toHaveBeenCalledTimes(1));
       expect(capture).toHaveBeenCalledWith(expect.objectContaining({ timeout: 1_800_000 }));
+    });
+  });
+
+  describe('when item data changes during editing', () => {
+    it('resets drafts when a different item is selected', async () => {
+      const { rerenderPanel } = renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+      fireEvent.change(timeout, { target: { value: '25000' } });
+      rerenderPanel(anotherItemWithTimeout);
+
+      expect(screen.getByRole<HTMLInputElement>('spinbutton', { name: /item timeout/i }).value).toBe('30000');
+    });
+
+    it('preserves drafts when the same item is refetched', async () => {
+      const { rerenderPanel } = renderPanel(itemWithTimeout);
+
+      const timeout = await openEditForm();
+      fireEvent.change(timeout, { target: { value: '25000' } });
+      rerenderPanel({ ...itemWithTimeout, metadata: { refetched: true } });
+
+      expect(screen.getByRole<HTMLInputElement>('spinbutton', { name: /item timeout/i }).value).toBe('25000');
     });
   });
 

--- a/packages/playground/src/domains/datasets/components/items/__tests__/fixtures/dataset-item-panel.ts
+++ b/packages/playground/src/domains/datasets/components/items/__tests__/fixtures/dataset-item-panel.ts
@@ -1,15 +1,20 @@
 import type { DatasetItem } from '@mastra/client-js';
 
-export const baseItem: DatasetItem = {
+export const baseItem = {
   id: 'item-1',
   datasetId: 'ds-1',
   datasetVersion: 1,
   input: { q: 'weather in Seattle?' },
   createdAt: '2026-01-01T00:00:00.000Z',
   updatedAt: '2026-01-01T00:00:00.000Z',
-};
+} satisfies DatasetItem;
 
-export const itemWithMocks: DatasetItem = {
+export const itemWithMocks = {
   ...baseItem,
   toolMocks: [{ toolName: 'getWeather', args: { city: 'Seattle' }, output: { temp: 52 } }],
-};
+} satisfies DatasetItem;
+
+export const itemWithTimeout = {
+  ...baseItem,
+  timeout: 15_000,
+} satisfies DatasetItem;

--- a/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import type { DatasetItem, DatasetItemToolMock } from '@mastra/client-js';
+import type { DatasetItem } from '@mastra/client-js';
 import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
@@ -21,35 +21,10 @@ import {
   Trash2,
   WrenchIcon,
 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useDatasetMutations } from '../../hooks/use-dataset-mutations';
-import { EditModeContent } from '../dataset-detail/dataset-item-form';
+import { DatasetItemEditForm } from '../dataset-detail/dataset-item-form';
 import { useLinkComponent } from '@/lib/framework';
-
-/** Schema validation error from API */
-interface SchemaValidationError {
-  field: 'input' | 'groundTruth' | 'toolMocks';
-  errors: Array<{ path: string; message: string }>;
-}
-
-/** Parses API error message to extract schema validation details */
-function parseValidationError(error: unknown): SchemaValidationError | null {
-  if (!(error instanceof Error)) return null;
-
-  // API error format: "HTTP error! status: 400 - {\"error\":\"...\",\"field\":\"...\",\"errors\":[...]}"
-  const match = error.message.match(/- ({.*})$/);
-  if (!match) return null;
-
-  try {
-    const parsed = JSON.parse(match[1]);
-    if (parsed.field && Array.isArray(parsed.errors)) {
-      return { field: parsed.field, errors: parsed.errors };
-    }
-  } catch {
-    // Not valid JSON
-  }
-  return null;
-}
 
 export interface DatasetItemPanelProps {
   datasetId: string;
@@ -65,171 +40,16 @@ export interface DatasetItemPanelProps {
  */
 export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose }: DatasetItemPanelProps) {
   const { Link } = useLinkComponent();
-  const { updateItem, deleteItem } = useDatasetMutations();
-
-  // Edit mode state
+  const { deleteItem } = useDatasetMutations();
   const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState('');
-  const [groundTruthValue, setGroundTruthValue] = useState('');
-  const [metadataValue, setMetadataValue] = useState('');
-  const [trajectoryValue, setTrajectoryValue] = useState('');
-  const [toolMocksValue, setToolMocksValue] = useState('');
-  const [requestContextValue, setRequestContextValue] = useState('');
-
-  // Validation error state
-  const [validationErrors, setValidationErrors] = useState<SchemaValidationError | null>(null);
-
-  // Delete confirmation state
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
-
-  // Reset form state when item changes (navigation or prop update)
-  useEffect(() => {
-    if (item) {
-      setInputValue(JSON.stringify(item.input, null, 2));
-      setGroundTruthValue(item.groundTruth ? JSON.stringify(item.groundTruth, null, 2) : '');
-      setMetadataValue(item.metadata ? JSON.stringify(item.metadata, null, 2) : '');
-      setTrajectoryValue(item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : '');
-      setToolMocksValue(item.toolMocks?.length ? JSON.stringify(item.toolMocks, null, 2) : '');
-      setRequestContextValue(item.requestContext ? JSON.stringify(item.requestContext, null, 2) : '');
-      setIsEditing(false); // Exit edit mode on item change
-      setShowDeleteConfirm(false); // Reset delete state on item change
-      setValidationErrors(null); // Reset validation errors on item change
-    }
-    // Intentionally depends on item.id only — re-running on every new `item` object
-    // reference would clobber in-progress edits whenever the parent refetches.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [item?.id]);
 
   const currentIndex = items.findIndex(i => i.id === item.id);
   const onPrevious = currentIndex > 0 ? () => onItemChange(items[currentIndex - 1].id) : undefined;
   const onNext =
     currentIndex >= 0 && currentIndex < items.length - 1 ? () => onItemChange(items[currentIndex + 1].id) : undefined;
 
-  // Form handlers
-  const handleSave = async () => {
-    // Validate input JSON
-    let parsedInput: unknown;
-    try {
-      parsedInput = JSON.parse(inputValue);
-    } catch {
-      toast.error('Input must be valid JSON');
-      return;
-    }
-
-    // Parse groundTruth if provided
-    let parsedGroundTruth: unknown | undefined;
-    if (groundTruthValue.trim()) {
-      try {
-        parsedGroundTruth = JSON.parse(groundTruthValue);
-      } catch {
-        toast.error('Ground Truth must be valid JSON');
-        return;
-      }
-    }
-
-    // Parse metadata if provided
-    let parsedMetadata: Record<string, unknown> | undefined;
-    if (metadataValue.trim()) {
-      try {
-        parsedMetadata = JSON.parse(metadataValue);
-      } catch {
-        toast.error('Metadata must be valid JSON');
-        return;
-      }
-    }
-
-    // Parse expectedTrajectory: empty string means explicitly clear (null), omitted means keep existing
-    let parsedTrajectory: unknown | null = null;
-    if (trajectoryValue.trim()) {
-      try {
-        parsedTrajectory = JSON.parse(trajectoryValue);
-      } catch {
-        toast.error('Expected Trajectory must be valid JSON');
-        return;
-      }
-    }
-
-    // Parse toolMocks: empty string means clear, otherwise must be a JSON array
-    let parsedToolMocks: DatasetItemToolMock[] | undefined;
-    if (toolMocksValue.trim()) {
-      try {
-        const parsed = JSON.parse(toolMocksValue);
-        if (!Array.isArray(parsed)) {
-          toast.error('Tool Mocks must be a JSON array');
-          return;
-        }
-        parsedToolMocks = parsed as DatasetItemToolMock[];
-      } catch {
-        toast.error('Tool Mocks must be valid JSON');
-        return;
-      }
-    } else {
-      parsedToolMocks = [];
-    }
-
-    // Parse requestContext if provided
-    let parsedRequestContext: Record<string, unknown> | undefined;
-    if (requestContextValue.trim()) {
-      try {
-        parsedRequestContext = JSON.parse(requestContextValue);
-      } catch {
-        toast.error('Request Context must be valid JSON');
-        return;
-      }
-    }
-
-    try {
-      await updateItem.mutateAsync({
-        datasetId,
-        itemId: item.id,
-        input: parsedInput,
-        groundTruth: parsedGroundTruth,
-        metadata: parsedMetadata,
-        expectedTrajectory: parsedTrajectory,
-        toolMocks: parsedToolMocks,
-        requestContext: parsedRequestContext,
-      });
-
-      toast.success('Item updated successfully');
-      setIsEditing(false);
-      setValidationErrors(null);
-    } catch (error) {
-      // Check for schema validation error from API
-      const schemaError = parseValidationError(error);
-      if (schemaError) {
-        setValidationErrors(schemaError);
-      } else {
-        toast.error(`Failed to update item: ${error instanceof Error ? error.message : 'Unknown error'}`);
-      }
-    }
-  };
-
-  const handleCancel = () => {
-    // Reset to original values
-    setInputValue(JSON.stringify(item.input, null, 2));
-    setGroundTruthValue(item.groundTruth ? JSON.stringify(item.groundTruth, null, 2) : '');
-    setMetadataValue(item.metadata ? JSON.stringify(item.metadata, null, 2) : '');
-    setTrajectoryValue(item.expectedTrajectory ? JSON.stringify(item.expectedTrajectory, null, 2) : '');
-    setToolMocksValue(item.toolMocks?.length ? JSON.stringify(item.toolMocks, null, 2) : '');
-    setRequestContextValue(item.requestContext ? JSON.stringify(item.requestContext, null, 2) : '');
-    setIsEditing(false);
-    setValidationErrors(null);
-  };
-
-  // Clear validation errors on field change
-  const handleInputValueChange = (value: string) => {
-    setInputValue(value);
-    if (validationErrors?.field === 'input') {
-      setValidationErrors(null);
-    }
-  };
-
-  const handleGroundTruthValueChange = (value: string) => {
-    setGroundTruthValue(value);
-    if (validationErrors?.field === 'groundTruth') {
-      setValidationErrors(null);
-    }
-  };
+  const closeEditor = () => setIsEditing(false);
 
   const handleDeleteConfirm = async () => {
     try {
@@ -296,24 +116,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
 
         <DataPanel.Content>
           {isEditing ? (
-            <EditModeContent
-              inputValue={inputValue}
-              setInputValue={handleInputValueChange}
-              groundTruthValue={groundTruthValue}
-              setGroundTruthValue={handleGroundTruthValueChange}
-              metadataValue={metadataValue}
-              setMetadataValue={setMetadataValue}
-              trajectoryValue={trajectoryValue}
-              setTrajectoryValue={setTrajectoryValue}
-              toolMocksValue={toolMocksValue}
-              setToolMocksValue={setToolMocksValue}
-              requestContextValue={requestContextValue}
-              setRequestContextValue={setRequestContextValue}
-              validationErrors={validationErrors}
-              onSave={handleSave}
-              onCancel={handleCancel}
-              isSaving={updateItem.isPending}
-            />
+            <DatasetItemEditForm item={item} onSuccess={closeEditor} onCancel={closeEditor} />
           ) : (
             <>
               <DataKeysAndValues>
@@ -326,6 +129,12 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
                 </DataKeysAndValues.ValueWithCopyBtn>
                 <DataKeysAndValues.Key>Version</DataKeysAndValues.Key>
                 <DataKeysAndValues.Value>v{item.datasetVersion}</DataKeysAndValues.Value>
+                {item.timeout !== undefined && (
+                  <>
+                    <DataKeysAndValues.Key>Item timeout</DataKeysAndValues.Key>
+                    <DataKeysAndValues.Value>{item.timeout.toLocaleString()} ms</DataKeysAndValues.Value>
+                  </>
+                )}
                 <DataKeysAndValues.Key>Created</DataKeysAndValues.Key>
                 <DataKeysAndValues.Value>
                   {format(new Date(item.createdAt), 'MMM d, yyyy h:mm aaa')}

--- a/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-item-panel.tsx
@@ -116,7 +116,7 @@ export function DatasetItemPanel({ datasetId, item, items, onItemChange, onClose
 
         <DataPanel.Content>
           {isEditing ? (
-            <DatasetItemEditForm item={item} onSuccess={closeEditor} onCancel={closeEditor} />
+            <DatasetItemEditForm key={item.id} item={item} onSuccess={closeEditor} onCancel={closeEditor} />
           ) : (
             <>
               <DataKeysAndValues>

--- a/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
+++ b/packages/playground/src/domains/datasets/components/items/dataset-items.tsx
@@ -231,6 +231,7 @@ export function DatasetItems({
 
   const detailPanelSlot = featuredItem ? (
     <DatasetItemPanel
+      key={featuredItem.id}
       datasetId={datasetId}
       item={featuredItem}
       items={items}

--- a/packages/playground/src/domains/datasets/constants.ts
+++ b/packages/playground/src/domains/datasets/constants.ts
@@ -1,0 +1,1 @@
+export const MAX_EXPERIMENT_ITEM_TIMEOUT_MS = 30 * 60 * 1000;

--- a/packages/playground/src/domains/datasets/hooks/__tests__/fixtures/dataset-item-history.ts
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/fixtures/dataset-item-history.ts
@@ -1,0 +1,18 @@
+import type { DatasetItemVersionResponse } from '@mastra/client-js';
+
+export const datasetItemHistoryResponse = {
+  history: [
+    {
+      id: 'item-1',
+      datasetId: 'dataset-1',
+      datasetVersion: 3,
+      input: { question: 'What is the weather?' },
+      timeout: 30_000,
+      metadata: { source: 'test' },
+      validTo: null,
+      isDeleted: false,
+      createdAt: '2026-07-28T00:00:00.000Z',
+      updatedAt: '2026-07-28T00:00:00.000Z',
+    },
+  ],
+} satisfies { history: DatasetItemVersionResponse[] };

--- a/packages/playground/src/domains/datasets/hooks/__tests__/use-dataset-item-versions.test.tsx
+++ b/packages/playground/src/domains/datasets/hooks/__tests__/use-dataset-item-versions.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { MastraReactProvider } from '@mastra/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { http, HttpResponse } from 'msw';
+import type { PropsWithChildren } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import { useDatasetItemVersions } from '../use-dataset-item-versions';
+import { datasetItemHistoryResponse } from './fixtures/dataset-item-history';
+import { server } from '@/test/msw-server';
+
+const BASE_URL = 'http://localhost:4111';
+
+function wrapper({ children }: PropsWithChildren) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return (
+    <MastraReactProvider baseUrl={BASE_URL}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </MastraReactProvider>
+  );
+}
+
+describe('useDatasetItemVersions', () => {
+  describe('when item history contains a timeout override', () => {
+    it('returns the timeout for the item edit form', async () => {
+      server.use(
+        http.get(`${BASE_URL}/api/datasets/dataset-1/items/item-1/history`, () =>
+          HttpResponse.json(datasetItemHistoryResponse),
+        ),
+      );
+
+      const { result } = renderHook(() => useDatasetItemVersions('dataset-1', 'item-1'), { wrapper });
+
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(result.current.data?.[0]).toMatchObject({ id: 'item-1', timeout: 30_000, isLatest: true });
+    });
+  });
+});

--- a/packages/playground/src/domains/datasets/hooks/use-dataset-item-versions.ts
+++ b/packages/playground/src/domains/datasets/hooks/use-dataset-item-versions.ts
@@ -10,6 +10,7 @@ export interface DatasetItemVersion {
   groundTruth?: unknown;
   expectedTrajectory?: unknown;
   toolMocks?: DatasetItemToolMock[];
+  timeout?: number;
   requestContext?: Record<string, unknown>;
   metadata?: Record<string, unknown>;
   validTo: number | null;
@@ -39,6 +40,7 @@ export const useDatasetItemVersions = (datasetId: string, itemId: string) => {
           groundTruth: version.groundTruth,
           expectedTrajectory: version.expectedTrajectory,
           toolMocks: version.toolMocks,
+          timeout: version.timeout,
           metadata: version.metadata,
           validTo: version.validTo,
           isDeleted: version.isDeleted,
@@ -76,6 +78,7 @@ export const useDatasetItemVersion = (
         groundTruth: v.groundTruth,
         expectedTrajectory: v.expectedTrajectory,
         toolMocks: v.toolMocks,
+        timeout: v.timeout,
         metadata: v.metadata,
         validTo: v.validTo ?? null,
         isDeleted: v.isDeleted ?? false,

--- a/packages/playground/src/domains/datasets/index.ts
+++ b/packages/playground/src/domains/datasets/index.ts
@@ -59,8 +59,8 @@ export { DatasetItemHeader } from './components/dataset-detail/dataset-item-head
 export type { DatasetItemHeaderProps } from './components/dataset-detail/dataset-item-header';
 export { DatasetItemContent } from './components/dataset-detail/dataset-item-content';
 export type { DatasetItemContentProps } from './components/dataset-detail/dataset-item-content';
-export { EditModeContent } from './components/dataset-detail/dataset-item-form';
-export type { EditModeContentProps } from './components/dataset-detail/dataset-item-form';
+export { DatasetItemEditForm, EditModeContent } from './components/dataset-detail/dataset-item-form';
+export type { DatasetItemEditFormProps, EditModeContentProps } from './components/dataset-detail/dataset-item-form';
 export { ItemPageToolbar } from './components/dataset-detail/item-page-toolbar';
 export type { ItemPageToolbarProps } from './components/dataset-detail/item-page-toolbar';
 

--- a/packages/playground/src/pages/datasets/dataset/item/index.tsx
+++ b/packages/playground/src/pages/datasets/dataset/item/index.tsx
@@ -1,4 +1,4 @@
-import type { DatasetItemToolMock } from '@mastra/client-js';
+import type { DatasetItem } from '@mastra/client-js';
 import { AlertDialog } from '@mastra/playground-ui/components/AlertDialog';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
@@ -22,14 +22,31 @@ import {
   HistoryIcon,
   Trash2Icon,
 } from 'lucide-react';
-import { useState, useMemo } from 'react';
+import { useState } from 'react';
 import { useParams, useNavigate } from 'react-router';
-import { DatasetItemContent, DatasetItemVersionsPanel, EditModeContent } from '@/domains/datasets';
+import { DatasetItemContent, DatasetItemEditForm, DatasetItemVersionsPanel } from '@/domains/datasets';
 import { useDatasetItemVersions } from '@/domains/datasets/hooks/use-dataset-item-versions';
 import type { DatasetItemVersion } from '@/domains/datasets/hooks/use-dataset-item-versions';
 import { useDatasetMutations } from '@/domains/datasets/hooks/use-dataset-mutations';
 import { useDataset } from '@/domains/datasets/hooks/use-datasets';
 import { useLinkComponent } from '@/lib/framework';
+
+function toDatasetItem(version: DatasetItemVersion, datasetId: string, itemId: string): DatasetItem {
+  return {
+    id: itemId,
+    datasetId,
+    datasetVersion: version.datasetVersion,
+    input: version.input,
+    groundTruth: version.groundTruth,
+    expectedTrajectory: version.expectedTrajectory,
+    toolMocks: version.toolMocks,
+    timeout: version.timeout,
+    requestContext: version.requestContext,
+    metadata: version.metadata,
+    createdAt: version.createdAt,
+    updatedAt: version.updatedAt,
+  };
+}
 
 function DatasetItemPage() {
   const { datasetId, itemId } = useParams<{ datasetId: string; itemId: string }>();
@@ -38,7 +55,7 @@ function DatasetItemPage() {
 
   // Use versions as single source of truth - works for both active and deleted items
   const { data: versions, isLoading: isVersionsLoading, error } = useDatasetItemVersions(datasetId ?? '', itemId ?? '');
-  const { updateItem, deleteItem } = useDatasetMutations();
+  const { deleteItem } = useDatasetMutations();
   const { data: dataset } = useDataset(datasetId ?? '');
 
   // Derive item state from versions
@@ -48,44 +65,7 @@ function DatasetItemPage() {
   // Version viewing state
   const [selectedVersion, setSelectedVersion] = useState<DatasetItemVersion | null>(null);
 
-  // Derive form defaults from latest version (recomputes when version changes)
-  const formDefaults = useMemo(() => {
-    if (!latestVersion || isDeleted)
-      return { input: '', groundTruth: '', metadata: '', trajectory: '', toolMocks: '', requestContext: '' };
-    return {
-      input: JSON.stringify(latestVersion.input, null, 2),
-      groundTruth: latestVersion.groundTruth ? JSON.stringify(latestVersion.groundTruth, null, 2) : '',
-      metadata: latestVersion.metadata ? JSON.stringify(latestVersion.metadata, null, 2) : '',
-      trajectory:
-        latestVersion.expectedTrajectory != null ? JSON.stringify(latestVersion.expectedTrajectory, null, 2) : '',
-      toolMocks: latestVersion.toolMocks?.length ? JSON.stringify(latestVersion.toolMocks, null, 2) : '',
-      requestContext: latestVersion.requestContext ? JSON.stringify(latestVersion.requestContext, null, 2) : '',
-    };
-  }, [latestVersion, isDeleted]);
-
-  // Use datasetVersion as key to reset form state when version changes
-  const versionKey = latestVersion?.datasetVersion ?? 0;
-
-  // Edit mode state
   const [isEditing, setIsEditing] = useState(false);
-  const [inputValue, setInputValue] = useState(formDefaults.input);
-  const [groundTruthValue, setGroundTruthValue] = useState(formDefaults.groundTruth);
-  const [metadataValue, setMetadataValue] = useState(formDefaults.metadata);
-  const [trajectoryValue, setTrajectoryValue] = useState(formDefaults.trajectory);
-  const [toolMocksValue, setToolMocksValue] = useState(formDefaults.toolMocks);
-  const [requestContextValue, setRequestContextValue] = useState(formDefaults.requestContext);
-
-  // Reset form values when version changes (key-based reset pattern)
-  const [prevVersionKey, setPrevVersionKey] = useState(versionKey);
-  if (versionKey !== prevVersionKey) {
-    setPrevVersionKey(versionKey);
-    setInputValue(formDefaults.input);
-    setGroundTruthValue(formDefaults.groundTruth);
-    setMetadataValue(formDefaults.metadata);
-    setTrajectoryValue(formDefaults.trajectory);
-    setToolMocksValue(formDefaults.toolMocks);
-    setRequestContextValue(formDefaults.requestContext);
-  }
 
   // Delete dialog state
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -119,111 +99,6 @@ function DatasetItemPage() {
     }
   };
 
-  const handleSave = async () => {
-    if (!datasetId || !itemId) return;
-
-    // Parse and validate input JSON
-    let parsedInput: unknown;
-    try {
-      parsedInput = JSON.parse(inputValue);
-    } catch {
-      toast.error('Input must be valid JSON');
-      return;
-    }
-
-    // Parse groundTruth if provided
-    let parsedGroundTruth: unknown | undefined;
-    if (groundTruthValue.trim()) {
-      try {
-        parsedGroundTruth = JSON.parse(groundTruthValue);
-      } catch {
-        toast.error('Ground Truth must be valid JSON');
-        return;
-      }
-    }
-
-    // Parse metadata if provided
-    let parsedMetadata: Record<string, unknown> | undefined;
-    if (metadataValue.trim()) {
-      try {
-        parsedMetadata = JSON.parse(metadataValue);
-      } catch {
-        toast.error('Metadata must be valid JSON');
-        return;
-      }
-    }
-
-    let parsedTrajectory: unknown | undefined;
-    const trajectoryChanged = trajectoryValue !== formDefaults.trajectory;
-    if (trajectoryChanged && trajectoryValue.trim()) {
-      try {
-        parsedTrajectory = JSON.parse(trajectoryValue);
-      } catch {
-        toast.error('Expected Trajectory must be valid JSON');
-        return;
-      }
-    }
-
-    let parsedToolMocks: DatasetItemToolMock[] | undefined;
-    const toolMocksChanged = toolMocksValue !== formDefaults.toolMocks;
-    if (toolMocksChanged && toolMocksValue.trim()) {
-      try {
-        const parsed = JSON.parse(toolMocksValue);
-        if (!Array.isArray(parsed)) {
-          toast.error('Tool Mocks must be a JSON array');
-          return;
-        }
-        parsedToolMocks = parsed as DatasetItemToolMock[];
-      } catch {
-        toast.error('Tool Mocks must be valid JSON');
-        return;
-      }
-    }
-
-    let parsedRequestContext: Record<string, unknown> | undefined;
-    const requestContextChanged = requestContextValue !== formDefaults.requestContext;
-    if (requestContextChanged && requestContextValue.trim()) {
-      try {
-        parsedRequestContext = JSON.parse(requestContextValue);
-      } catch {
-        toast.error('Request Context must be valid JSON');
-        return;
-      }
-    }
-
-    try {
-      await updateItem.mutateAsync({
-        datasetId,
-        itemId,
-        input: parsedInput,
-        groundTruth: parsedGroundTruth,
-        metadata: parsedMetadata,
-        ...(trajectoryChanged ? { expectedTrajectory: parsedTrajectory ?? null } : {}),
-        ...(toolMocksChanged ? { toolMocks: parsedToolMocks ?? [] } : {}),
-        ...(requestContextChanged ? { requestContext: parsedRequestContext } : {}),
-      });
-      toast.success('Item updated successfully');
-      setIsEditing(false);
-    } catch (error) {
-      toast.error(`Failed to update item: ${error instanceof Error ? error.message : 'Unknown error'}`);
-    }
-  };
-
-  const handleCancel = () => {
-    // Reset form values to latest version
-    if (latestVersion) {
-      setInputValue(JSON.stringify(latestVersion.input, null, 2));
-      setGroundTruthValue(latestVersion.groundTruth ? JSON.stringify(latestVersion.groundTruth, null, 2) : '');
-      setMetadataValue(latestVersion.metadata ? JSON.stringify(latestVersion.metadata, null, 2) : '');
-      setTrajectoryValue(
-        latestVersion.expectedTrajectory != null ? JSON.stringify(latestVersion.expectedTrajectory, null, 2) : '',
-      );
-      setToolMocksValue(latestVersion.toolMocks?.length ? JSON.stringify(latestVersion.toolMocks, null, 2) : '');
-      setRequestContextValue(latestVersion.requestContext ? JSON.stringify(latestVersion.requestContext, null, 2) : '');
-    }
-    setIsEditing(false);
-  };
-
   const handleDeleteConfirm = async () => {
     if (!datasetId || !itemId) return;
     try {
@@ -239,20 +114,9 @@ function DatasetItemPage() {
   // Determine which version to display
   const versionToDisplay = selectedVersion ?? latestVersion;
 
-  // Build display item from flat version data
-  const displayItem = versionToDisplay
-    ? {
-        id: itemId ?? '',
-        datasetId: datasetId ?? '',
-        datasetVersion: versionToDisplay.datasetVersion,
-        input: versionToDisplay.input,
-        groundTruth: versionToDisplay.groundTruth,
-        expectedTrajectory: versionToDisplay.expectedTrajectory,
-        metadata: versionToDisplay.metadata,
-        createdAt: versionToDisplay.createdAt,
-        updatedAt: versionToDisplay.updatedAt,
-      }
-    : null;
+  const displayItem =
+    versionToDisplay && datasetId && itemId ? toDatasetItem(versionToDisplay, datasetId, itemId) : null;
+  const editableItem = latestVersion && datasetId && itemId ? toDatasetItem(latestVersion, datasetId, itemId) : null;
 
   if (error && is401UnauthorizedError(error)) {
     return (
@@ -360,24 +224,12 @@ function DatasetItemPage() {
                   </Notice>
                 )}
 
-                {isEditing ? (
-                  <EditModeContent
-                    inputValue={inputValue}
-                    setInputValue={setInputValue}
-                    groundTruthValue={groundTruthValue}
-                    setGroundTruthValue={setGroundTruthValue}
-                    metadataValue={metadataValue}
-                    setMetadataValue={setMetadataValue}
-                    trajectoryValue={trajectoryValue}
-                    setTrajectoryValue={setTrajectoryValue}
-                    toolMocksValue={toolMocksValue}
-                    setToolMocksValue={setToolMocksValue}
-                    requestContextValue={requestContextValue}
-                    setRequestContextValue={setRequestContextValue}
-                    validationErrors={null}
-                    onSave={handleSave}
-                    onCancel={handleCancel}
-                    isSaving={updateItem.isPending}
+                {isEditing && editableItem ? (
+                  <DatasetItemEditForm
+                    key={editableItem.id}
+                    item={editableItem}
+                    onSuccess={() => setIsEditing(false)}
+                    onCancel={() => setIsEditing(false)}
                   />
                 ) : displayItem ? (
                   <DatasetItemContent item={displayItem} Link={FrameworkLink} />


### PR DESCRIPTION
PR 4 of 4 for [MASTRA-4509](https://linear.app/kepler-crm/issue/MASTRA-4509/oss-experiments-per-item-timeout-overrides), stacked on #20138.

Adds Studio controls for setting and editing per-item timeout overrides. Persisted values are displayed in the dataset item detail panel, and the shared form on both the detail panel and item-history page accepts only positive integer milliseconds up to `1_800_000` (30 minutes).

After this change, users can configure an override while creating an item, edit it from either supported surface, and confirm the persisted value after reloading. Because the update API does not currently support clearing a stored override, the form prevents an existing value from being replaced with a blank value.

The core, storage, and API behavior is implemented in #20136, #20137, and #20138.

Verified with 25 MSW tests, typecheck, lint, the CLI build, and the 8-test dataset Playwright suite.
