### PR TITLE
fix(mastracode-web): GitHub issues never appear in the intake swimlane

### DIFF
--- a/mastracode/web/src/web/ui/domains/settings/components/IntakeSection.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/IntakeSection.tsx
@@ -160,14 +160,14 @@ export function IntakeSection() {
                 <SourceCheckbox
                   key={repository.projectRepositoryId}
                   label={repository.slug}
-                  checked={config.github.sourceIds?.includes(repository.projectRepositoryId) ?? false}
+                  checked={config.github.sourceIds?.includes(repository.slug) ?? false}
                   disabled={busy}
                   onChange={() =>
                     update({
                       ...config,
                       github: {
                         ...config.github,
-                        sourceIds: toggleId(config.github.sourceIds, repository.projectRepositoryId),
+                        sourceIds: toggleId(config.github.sourceIds, repository.slug),
                       },
                     })
                   }

--- a/mastracode/web/src/web/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/__tests__/IntakeSection.msw.test.tsx
@@ -160,7 +160,8 @@ describe('IntakeSection', () => {
       await userEvent.click(await screen.findByRole('checkbox', { name: 'mastra' }));
 
       await waitFor(() => expect(saved).toHaveLength(1));
-      expect(saved[0]!.github.sourceIds).toEqual(['ghp-1']);
+      // The board and intake integrations key GitHub sources by repo slug (owner/name).
+      expect(saved[0]!.github.sourceIds).toEqual(['mastra']);
       expect(saved[0]).not.toHaveProperty('github.repositoryIds');
     });
   });


### PR DESCRIPTION
## Summary

With GitHub intake connected and a repository selected in Settings, the board's intake swimlane stayed empty — no GitHub issues ever appeared.

Root cause: an identifier mismatch between where intake sources are saved and where they are read.

- **Settings → Intake** saved the project repository **UUID** (`repository.projectRepositoryId`) as the GitHub sourceId.
- **The board** decides whether GitHub intake is active by checking the stored sourceIds against the repository **slug** (e.g. `mastra-ai/mastra`) — the same identifier the platform GitHub integration uses in `listSources`/`listItems`.

The UUID never matched the slug, so `githubIntakeActive` was always false and issues were never fetched.

This changes the intake settings repository pills to save the slug, matching what the board and the platform integration expect.

## Test plan

- Updated `IntakeSection.msw.test.tsx`: picking a GitHub repository now persists the slug in `github.sourceIds`
- `IntakeSection` MSW suite: 10/10 pass
- Manually verified end-to-end: with a repository selected, the board activates GitHub intake and requests issues for the selected project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When you choose a GitHub repository, the app now saves the repository’s name instead of an unrelated internal ID, so issues can show up in the intake swimlane correctly.

## Changes

- Store GitHub repository slugs in intake settings.
- Update repository selection and checkbox state handling.
- Update MSW tests to expect slug-based source IDs.
- IntakeSection MSW suite passes 10/10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->