### PR TITLE
feat(factory): add shared supervisor workspace

### DIFF
--- a/.changeset/hungry-flies-heal.md
+++ b/.changeset/hungry-flies-heal.md
@@ -1,0 +1,11 @@
+---
+'create-factory': patch
+'@mastra/client-js': patch
+'@mastra/factory': patch
+'@mastra/server': patch
+'@mastra/code-sdk': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Added Factory supervisor identity fields to Mastra Code session state.

--- a/.changeset/jolly-bats-push.md
+++ b/.changeset/jolly-bats-push.md
@@ -1,0 +1,11 @@
+---
+'@mastra/factory': minor
+'create-factory': patch
+'@mastra/client-js': patch
+'@mastra/server': patch
+'@mastra/code-sdk': patch
+'@mastra/core': patch
+'mastra': patch
+---
+
+Added a shared Factory supervisor session with tenant-scoped state, work-item signaling, approval tools, and durable lifecycle notifications.

--- a/.changeset/olive-pugs-shake.md
+++ b/.changeset/olive-pugs-shake.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': minor
+'@mastra/code-sdk': patch
+---
+
+Wake the Factory supervisor after a server restart when work is still open. A restart kills in-flight runs without emitting a run-completion event, so idle worker observation cannot see them and the affected work items stall silently. Factory now enqueues one durable supervisor notification per tenant that still has a work item outside the `done` and `canceled` stages, asking the supervisor to find stalled work and resolve it one item at a time. Repeated restarts inside a 15-minute window collapse into a single wake, and delivery is exactly-once across replicas. Opt out with `supervisor.checkInOnBoot: false` in the Factory rules.

--- a/.changeset/quiet-moons-repeat.md
+++ b/.changeset/quiet-moons-repeat.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'@mastra/code-sdk': patch
+---
+
+Give the Factory supervisor its tools on server-initiated runs. The supervisor resolved its tenant identity from the authenticated user on the request context, but runs the server starts itself — boot check-ins, idle worker observations, and approval notifications — build a fresh request context that carries no user. Those runs therefore woke the supervisor with none of its Factory tools registered, leaving it unable to query state or act on the very event that woke it. Tenant identity now comes from the supervisor session's own state, which is durable and pinned to the session's canonical resource and thread. A request user, when present, must still belong to the session's tenant and is used to attribute the resulting audit entries.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -41,7 +41,7 @@ Resolver and tenant identity always come from server authentication, not request
 
 ## Supervisor state and lifecycle signals
 
-Opening the canonical supervisor session emits a full `factory-state` snapshot. The snapshot is bounded to board and stage counts plus at most 50 pending approvals with work-item title, role, requested stage, revision, reason, summary, and age. It never includes credentials, storage handles, repository paths, or raw integration payloads. A stable cache key suppresses unchanged snapshots.
+Opening the canonical supervisor session emits a full `factory-state` snapshot. The snapshot is bounded to board and stage counts, at most 50 pending approvals with work-item title, role, requested stage, revision, reason, summary, and age, and live worker activity per active run binding — `running` (a run is in flight), `idle` (the bound session is live between runs), or `offline` (no in-process session owns the binding). It never includes credentials, storage handles, repository paths, or raw integration payloads. A stable cache key suppresses unchanged snapshots.
 
 Approval requests and terminal approval results (`approved`, `rejected`, or `stale`) are written to a tenant-scoped durable outbox in the same transaction as the approval state change. The Factory dispatcher retries delivery to the singleton supervisor conversation and refreshes its state snapshot. Idle-without-transition notifications use the live observer described below and refresh the same state snapshot, but remain advisory rather than durable.
 

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -39,6 +39,12 @@ Authenticated clients can list and resolve approvals through the tenant-scoped r
 
 Resolver and tenant identity always come from server authentication, not request-body fields.
 
+## Supervisor state and lifecycle signals
+
+Opening the canonical supervisor session emits a full `factory-state` snapshot. The snapshot is bounded to board and stage counts plus at most 50 pending approvals with work-item title, role, requested stage, revision, reason, summary, and age. It never includes credentials, storage handles, repository paths, or raw integration payloads. A stable cache key suppresses unchanged snapshots.
+
+Approval requests and terminal approval results (`approved`, `rejected`, or `stale`) are written to a tenant-scoped durable outbox in the same transaction as the approval state change. The Factory dispatcher retries delivery to the singleton supervisor conversation and refreshes its state snapshot. Idle-without-transition notifications use the live observer described below and refresh the same state snapshot, but remain advisory rather than durable.
+
 ## Idle worker observation
 
 Factory observes live work-item sessions for runs that finish normally without changing the item's stage or revision and without leaving a transition approval pending. The observer reconciles final persisted tool results before comparing state, records a bounded `factory.run.idle_without_transition` audit event, and provides the lifecycle callback used by the Factory supervisor.

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -41,7 +41,7 @@ Resolver and tenant identity always come from server authentication, not request
 
 ## Supervisor state and lifecycle signals
 
-Opening the canonical supervisor session emits a full `factory-state` snapshot. The snapshot is bounded to board and stage counts, at most 50 pending approvals with work-item title, role, requested stage, revision, reason, summary, and age, and live worker activity per active run binding — `running` (a run is in flight), `idle` (the bound session is live between runs), or `offline` (no in-process session owns the binding). It never includes credentials, storage handles, repository paths, or raw integration payloads. A stable cache key suppresses unchanged snapshots.
+Opening the canonical supervisor session emits a full `factory-state` snapshot. The snapshot is bounded to board and stage counts, at most 50 pending approvals with work-item title, role, requested stage, revision, reason, summary, and age, and live worker activity per active run binding — `running` (a run is in flight) or `idle` (no run in flight). It never includes credentials, storage handles, repository paths, or raw integration payloads. A stable cache key suppresses unchanged snapshots.
 
 Approval requests and terminal approval results (`approved`, `rejected`, or `stale`) are written to a tenant-scoped durable outbox in the same transaction as the approval state change. The Factory dispatcher retries delivery to the singleton supervisor conversation and refreshes its state snapshot. Idle-without-transition notifications use the live observer described below and refresh the same state snapshot, but remain advisory rather than durable.
 

--- a/mastracode/factory/README.md
+++ b/mastracode/factory/README.md
@@ -62,6 +62,25 @@ const rules = defaultFactoryRules({
 
 This is an advisory live lifecycle signal, not durable Factory state. Each qualifying `agent_end` triggers it directly; there is no persisted completion cursor or polling deduplication, so a process crash at the completion boundary may lose the notification. Aborted, errored, suspended, transitioned, approval-pending, unbound, and opted-out runs do not emit it.
 
+## Boot check-in
+
+A server restart kills in-flight runs without an `agent_end`, so idle worker observation cannot see them and the affected work stalls silently. On boot, Factory enqueues one supervisor wake per tenant that still has a work item outside the `done` and `canceled` stages, asking the supervisor to find stalled work and resolve it one item at a time.
+
+The wake is a durable row in the same supervisor notification outbox approvals use, so the dispatcher delivers it exactly once even when several replicas boot together. Enqueue happens before the dispatcher starts and never fails the boot: a tenant that cannot be enqueued is logged and skipped.
+
+Repeated restarts inside a 15-minute window collapse into a single wake, which keeps a file-watching dev server from spending a supervisor turn on every save. Tenants whose work is entirely `done` or `canceled` are skipped.
+
+Boot check-in is enabled by default. A Factory can opt out through its rules configuration:
+
+```ts
+const rules = defaultFactoryRules({
+  version: 'factory-rules-v1',
+  overrides: {
+    supervisor: { checkInOnBoot: false },
+  },
+});
+```
+
 ## Development (monorepo)
 
 This package lives in the `mastra-ai/mastra` monorepo at `mastracode/factory`.

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -50,6 +50,7 @@ import {
   primeTenantCredentials,
   registerTenantCredentialResolver,
 } from './routes/tenant-credentials.js';
+import { FactoryTransitionApprovalService } from './rules/approval-service.js';
 import { builtInFactoryRules } from './rules/defaults.js';
 import { FactoryDecisionDispatcher } from './rules/dispatcher.js';
 import { FactoryPhaseStateProcessor } from './rules/processor.js';
@@ -76,6 +77,8 @@ import { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import { QueueHealthStorage } from './storage/domains/queue-health/base.js';
 import { SourceControlStorage } from './storage/domains/source-control/base.js';
 import { WorkItemsStorage } from './storage/domains/work-items/base.js';
+import { FactorySupervisorService } from './supervisor/service.js';
+import { createFactorySupervisorTools } from './supervisor/tools.js';
 import { createWorkspaceFactory } from './workspace.js';
 
 type BuildApiRoutesDeps = Pick<FactoryApiRoutesDeps, 'controller' | 'authStorage'>;
@@ -500,6 +503,10 @@ export class MastraFactory {
     const transitionService = workItemsReady
       ? new FactoryTransitionService({ rules, storage: workItemsStorage })
       : undefined;
+    const approvalService = workItemsReady
+      ? new FactoryTransitionApprovalService({ storage: workItemsStorage })
+      : undefined;
+    let supervisorService: FactorySupervisorService | undefined;
     const factoryProcessor = workItemsReady
       ? new FactoryPhaseStateProcessor({
           rules,
@@ -609,6 +616,16 @@ export class MastraFactory {
                   await createFactoryTransitionTools({ requestContext, storage: workItemsStorage, transitionService }),
                 );
               }
+              if (supervisorService) {
+                mergeTools(
+                  'factory-supervisor',
+                  await createFactorySupervisorTools({
+                    requestContext,
+                    service: supervisorService,
+                    audit: auditDomain,
+                  }),
+                );
+              }
               for (const { integration, ready, ensureReady } of toolIntegrations) {
                 if (!ready && ensureReady) {
                   try {
@@ -648,46 +665,58 @@ export class MastraFactory {
         );
       },
       ...(pubsub ? { pubsub, crossProcessPubSub: true } : {}),
-      buildApiRoutes: ({ controller, authStorage }: BuildApiRoutesDeps) => [
-        // Public `/auth/*` routes (login/callback/logout/me). Folded in as
-        // `apiRoutes` (not plain Hono routes) because the entry can't touch the
-        // Hono app the deployer generates. `requiresAuth: false`; the gate
-        // skips `/auth/*`.
-        ...(auth ? buildAuthRoutes(auth, { publicUrl: publicOrigin }) : []),
-        // Custom `/web/*` routes (fs / config / integrations / factory / audit).
-        ...assembleFactoryApiRoutes({
-          controllerId: CONTROLLER_ID,
-          controller,
-          auth: routeAuth,
-          authStorage,
-          audit: auditDomain,
-          publicOrigin,
-          stateSigner,
-          fleet,
-          factoryStorage: storage,
-          integrationStorage,
-          sourceControlStorage,
-          domains,
-          integrations: integrationRegistrations,
-          intakeReady,
-          factoryReady,
-          rules,
-          factoryTransitionService: transitionService,
-          runLifecycleObserver,
-          onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
-            this.#dispatcher ??= new FactoryDecisionDispatcher({
-              controller,
-              transitionService: runtimeTransitionService,
-              storage: storage.getDomain<WorkItemsStorage>('work-items'),
-              reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
-              prepareBinding,
-              primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
-            });
-          },
-        }),
-        ...projectRoutes.routes(),
-        ...auditDomain.routes(),
-      ],
+      buildApiRoutes: ({ controller, authStorage }: BuildApiRoutesDeps) => {
+        if (approvalService) {
+          supervisorService ??= new FactorySupervisorService({
+            controller,
+            projects: factoryProjectsStorage,
+            workItems: workItemsStorage,
+            approvals: approvalService,
+            primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+          });
+        }
+        return [
+          // Public `/auth/*` routes (login/callback/logout/me). Folded in as
+          // `apiRoutes` (not plain Hono routes) because the entry can't touch the
+          // Hono app the deployer generates. `requiresAuth: false`; the gate
+          // skips `/auth/*`.
+          ...(auth ? buildAuthRoutes(auth, { publicUrl: publicOrigin }) : []),
+          // Custom `/web/*` routes (fs / config / integrations / factory / audit).
+          ...assembleFactoryApiRoutes({
+            controllerId: CONTROLLER_ID,
+            controller,
+            auth: routeAuth,
+            authStorage,
+            audit: auditDomain,
+            publicOrigin,
+            stateSigner,
+            fleet,
+            factoryStorage: storage,
+            integrationStorage,
+            sourceControlStorage,
+            domains,
+            integrations: integrationRegistrations,
+            intakeReady,
+            factoryReady,
+            rules,
+            factoryTransitionService: transitionService,
+            runLifecycleObserver,
+            supervisorService,
+            onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
+              this.#dispatcher ??= new FactoryDecisionDispatcher({
+                controller,
+                transitionService: runtimeTransitionService,
+                storage: storage.getDomain<WorkItemsStorage>('work-items'),
+                reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
+                prepareBinding,
+                primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+              });
+            },
+          }),
+          ...projectRoutes.routes(),
+          ...auditDomain.routes(),
+        ];
+      },
       buildServerConfig: () => {
         const cors = allowedOrigins.length ? { cors: { origin: allowedOrigins, credentials: true } } : {};
         // Log route errors with method/path/stack and answer with structured

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -78,6 +78,7 @@ import { QueueHealthStorage } from './storage/domains/queue-health/base.js';
 import { SourceControlStorage } from './storage/domains/source-control/base.js';
 import { WorkItemsStorage } from './storage/domains/work-items/base.js';
 import { FactorySupervisorService } from './supervisor/service.js';
+import { FactorySupervisorSignalService } from './supervisor/signal-service.js';
 import { createFactorySupervisorTools } from './supervisor/tools.js';
 import { createWorkspaceFactory } from './workspace.js';
 
@@ -500,13 +501,32 @@ export class MastraFactory {
       | GithubIntegration
       | undefined;
     const workItemsReady = storage.isDomainReady('work-items');
+    let supervisorService: FactorySupervisorService | undefined;
+    let supervisorSignals: FactorySupervisorSignalService | undefined;
     const transitionService = workItemsReady
-      ? new FactoryTransitionService({ rules, storage: workItemsStorage })
+      ? new FactoryTransitionService({
+          rules,
+          storage: workItemsStorage,
+          onCommitted: async input => {
+            if (!supervisorSignals || input.result.status === 'rejected') return;
+            const item = await workItemsStorage.getForProject(input.orgId, input.factoryProjectId, input.workItemId);
+            const userId =
+              (input.actor.type === 'human' ? input.actor.id : undefined) ??
+              (input.actor.type === 'agent' ? item?.sessions[input.actor.role]?.startedBy : undefined) ??
+              Object.values(item?.sessions ?? {}).find(session => session.startedBy)?.startedBy;
+            if (userId) {
+              await supervisorSignals.refresh({
+                orgId: input.orgId,
+                userId,
+                factoryProjectId: input.factoryProjectId,
+              });
+            }
+          },
+        })
       : undefined;
     const approvalService = workItemsReady
       ? new FactoryTransitionApprovalService({ storage: workItemsStorage })
       : undefined;
-    let supervisorService: FactorySupervisorService | undefined;
     const factoryProcessor = workItemsReady
       ? new FactoryPhaseStateProcessor({
           rules,
@@ -674,6 +694,11 @@ export class MastraFactory {
             approvals: approvalService,
             primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
           });
+          if (!supervisorSignals) {
+            const signals = new FactorySupervisorSignalService(supervisorService);
+            supervisorSignals = signals;
+            runLifecycleObserver?.subscribeIdle(event => signals.notifyIdle(event));
+          }
         }
         return [
           // Public `/auth/*` routes (login/callback/logout/me). Folded in as
@@ -702,6 +727,7 @@ export class MastraFactory {
             factoryTransitionService: transitionService,
             runLifecycleObserver,
             supervisorService,
+            supervisorSignals,
             onFactoryRuntime: ({ transitionService: runtimeTransitionService, prepareBinding }) => {
               this.#dispatcher ??= new FactoryDecisionDispatcher({
                 controller,
@@ -710,6 +736,10 @@ export class MastraFactory {
                 reconcileToolResults: () => factoryProcessor?.reconcileAllBoundThreads() ?? Promise.resolve(),
                 prepareBinding,
                 primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+                dispatchSupervisorNotification: record => {
+                  if (!supervisorSignals) throw new Error('Factory supervisor signals are unavailable.');
+                  return supervisorSignals.notifyApproval(record);
+                },
               });
             },
           }),

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -693,6 +693,7 @@ export class MastraFactory {
             workItems: workItemsStorage,
             approvals: approvalService,
             primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
+            storedSessions: sourceControlStorage.forIntegration('github').sessions,
           });
           if (!supervisorSignals) {
             const signals = new FactorySupervisorSignalService(supervisorService);

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -77,6 +77,7 @@ import { FactoryProjectsStorage } from './storage/domains/projects/base.js';
 import { QueueHealthStorage } from './storage/domains/queue-health/base.js';
 import { SourceControlStorage } from './storage/domains/source-control/base.js';
 import { WorkItemsStorage } from './storage/domains/work-items/base.js';
+import { FactoryBootCheckIn } from './supervisor/boot-check-in.js';
 import { FactorySupervisorService } from './supervisor/service.js';
 import { FactorySupervisorSignalService } from './supervisor/signal-service.js';
 import { createFactorySupervisorTools } from './supervisor/tools.js';
@@ -278,6 +279,7 @@ export class MastraFactory {
   #prepared: Awaited<ReturnType<typeof prepareAgentControllerMount>> | undefined;
   #dispatcher: FactoryDecisionDispatcher | undefined;
   #factoryProcessor: FactoryPhaseStateProcessor | undefined;
+  #bootCheckIn: FactoryBootCheckIn | undefined;
   #preparing = false;
 
   constructor(config: MastraFactoryConfig) {
@@ -699,6 +701,12 @@ export class MastraFactory {
             const signals = new FactorySupervisorSignalService(supervisorService);
             supervisorSignals = signals;
             runLifecycleObserver?.subscribeIdle(event => signals.notifyIdle(event));
+            this.#bootCheckIn ??= new FactoryBootCheckIn({
+              storage: workItemsStorage,
+              audit: auditStorage,
+              rules,
+              onError: error => console.warn('[factory] Supervisor boot check-in failed:', error),
+            });
           }
         }
         return [
@@ -739,7 +747,7 @@ export class MastraFactory {
                 primeCredentials: tenant => primeTenantCredentials({ tenant, credentials: modelCredentialsStorage }),
                 dispatchSupervisorNotification: record => {
                   if (!supervisorSignals) throw new Error('Factory supervisor signals are unavailable.');
-                  return supervisorSignals.notifyApproval(record);
+                  return supervisorSignals.notify(record);
                 },
               });
             },
@@ -852,6 +860,8 @@ export class MastraFactory {
     }
     await this.#prepared.finalize();
     await this.#factoryProcessor?.reconcileAllBoundThreads();
+    // Enqueue before the dispatcher starts so the first tick delivers it.
+    await this.#bootCheckIn?.run();
     this.#dispatcher?.start();
   }
 

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -1,7 +1,11 @@
 export { MastraFactory } from './factory.js';
 export type { MastraArgs, MastraFactoryConfig } from './factory.js';
 export { defaultFactoryRules, requireSupervisorApproval } from './rules/defaults.js';
-export { FactorySupervisorService, factorySupervisorThreadId } from './supervisor/service.js';
+export {
+  FactorySupervisorService,
+  factorySupervisorResourceId,
+  factorySupervisorThreadId,
+} from './supervisor/service.js';
 export { FactorySupervisorSignalService } from './supervisor/signal-service.js';
 export { createFactorySupervisorTools } from './supervisor/tools.js';
 export type { FactorySupervisorState } from './supervisor/state.js';

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -1,3 +1,6 @@
 export { MastraFactory } from './factory.js';
 export type { MastraArgs, MastraFactoryConfig } from './factory.js';
 export { defaultFactoryRules, requireSupervisorApproval } from './rules/defaults.js';
+export { FactorySupervisorService, factorySupervisorThreadId } from './supervisor/service.js';
+export { createFactorySupervisorTools } from './supervisor/tools.js';
+export type { FactorySupervisorState } from './supervisor/state.js';

--- a/mastracode/factory/src/index.ts
+++ b/mastracode/factory/src/index.ts
@@ -2,5 +2,6 @@ export { MastraFactory } from './factory.js';
 export type { MastraArgs, MastraFactoryConfig } from './factory.js';
 export { defaultFactoryRules, requireSupervisorApproval } from './rules/defaults.js';
 export { FactorySupervisorService, factorySupervisorThreadId } from './supervisor/service.js';
+export { FactorySupervisorSignalService } from './supervisor/signal-service.js';
 export { createFactorySupervisorTools } from './supervisor/tools.js';
 export type { FactorySupervisorState } from './supervisor/state.js';

--- a/mastracode/factory/src/routes/supervisor.test.ts
+++ b/mastracode/factory/src/routes/supervisor.test.ts
@@ -44,7 +44,7 @@ describe('Factory supervisor routes', () => {
   it('ensures and returns the canonical session using authenticated identity', async () => {
     const ensureSession = vi.fn(async (input: Record<string, unknown>) => ({
       factoryProjectId: input.factoryProjectId,
-      resourceId: input.factoryProjectId,
+      resourceId: `${input.factoryProjectId}-supervisor`,
       sessionId: `${input.factoryProjectId}-supervisor`,
       threadId: `${input.factoryProjectId}-supervisor`,
     }));
@@ -56,7 +56,7 @@ describe('Factory supervisor routes', () => {
     await expect(response.json()).resolves.toEqual({
       session: {
         factoryProjectId: projectId,
-        resourceId: projectId,
+        resourceId: `${projectId}-supervisor`,
         sessionId: `${projectId}-supervisor`,
         threadId: `${projectId}-supervisor`,
       },

--- a/mastracode/factory/src/routes/supervisor.test.ts
+++ b/mastracode/factory/src/routes/supervisor.test.ts
@@ -16,7 +16,11 @@ beforeEach(async () => {
   projectId = (await seed.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory project' } })).id;
 });
 
-function appFor(authUser: typeof user | null, service: { ensureSession: Function; getState: Function }) {
+function appFor(
+  authUser: typeof user | null,
+  service: { ensureSession: Function; getState: Function },
+  signals?: { refresh: Function },
+) {
   const app = new Hono();
   const requestContext = new RequestContext();
   app.use('*', async (context, next) => {
@@ -26,7 +30,12 @@ function appFor(authUser: typeof user | null, service: { ensureSession: Function
   });
   mountApiRoutes(
     app as never,
-    new SupervisorRoutes({ auth: fakeRouteAuth(), projects: seed.projects, service: service as never }).routes(),
+    new SupervisorRoutes({
+      auth: fakeRouteAuth(),
+      projects: seed.projects,
+      service: service as never,
+      signals: signals as never,
+    }).routes(),
   );
   return { app, requestContext };
 }
@@ -39,7 +48,8 @@ describe('Factory supervisor routes', () => {
       sessionId: `${input.factoryProjectId}-supervisor`,
       threadId: `${input.factoryProjectId}-supervisor`,
     }));
-    const { app, requestContext } = appFor(user, { ensureSession, getState: vi.fn() });
+    const refresh = vi.fn(async () => {});
+    const { app, requestContext } = appFor(user, { ensureSession, getState: vi.fn() }, { refresh });
     const response = await app.request(`/web/factory/projects/${projectId}/supervisor/session`, { method: 'POST' });
 
     expect(response.status).toBe(200);
@@ -57,6 +67,7 @@ describe('Factory supervisor routes', () => {
       factoryProjectId: projectId,
       requestContext,
     });
+    expect(refresh).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1', factoryProjectId: projectId });
   });
 
   it('returns the bounded state summary', async () => {

--- a/mastracode/factory/src/routes/supervisor.test.ts
+++ b/mastracode/factory/src/routes/supervisor.test.ts
@@ -1,0 +1,104 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import type { FactoryStorageTestSeed } from '../storage/test-utils.js';
+import { SupervisorRoutes } from './supervisor.js';
+import { fakeRouteAuth, mountApiRoutes } from './test-utils.js';
+
+const user = { workosId: 'user-1', organizationId: 'org-1' };
+let seed: FactoryStorageTestSeed;
+let projectId: string;
+
+beforeEach(async () => {
+  seed = await createFactoryStorageForTests();
+  projectId = (await seed.projects.create({ orgId: 'org-1', userId: 'user-1', input: { name: 'Factory project' } })).id;
+});
+
+function appFor(authUser: typeof user | null, service: { ensureSession: Function; getState: Function }) {
+  const app = new Hono();
+  const requestContext = new RequestContext();
+  app.use('*', async (context, next) => {
+    if (authUser) context.set('factoryAuthUser' as never, authUser as never);
+    context.set('requestContext' as never, requestContext as never);
+    await next();
+  });
+  mountApiRoutes(
+    app as never,
+    new SupervisorRoutes({ auth: fakeRouteAuth(), projects: seed.projects, service: service as never }).routes(),
+  );
+  return { app, requestContext };
+}
+
+describe('Factory supervisor routes', () => {
+  it('ensures and returns the canonical session using authenticated identity', async () => {
+    const ensureSession = vi.fn(async (input: Record<string, unknown>) => ({
+      factoryProjectId: input.factoryProjectId,
+      resourceId: input.factoryProjectId,
+      sessionId: `${input.factoryProjectId}-supervisor`,
+      threadId: `${input.factoryProjectId}-supervisor`,
+    }));
+    const { app, requestContext } = appFor(user, { ensureSession, getState: vi.fn() });
+    const response = await app.request(`/web/factory/projects/${projectId}/supervisor/session`, { method: 'POST' });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      session: {
+        factoryProjectId: projectId,
+        resourceId: projectId,
+        sessionId: `${projectId}-supervisor`,
+        threadId: `${projectId}-supervisor`,
+      },
+    });
+    expect(ensureSession).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: projectId,
+      requestContext,
+    });
+  });
+
+  it('returns the bounded state summary', async () => {
+    const getState = vi.fn(async () => ({
+      factoryProjectId: projectId,
+      totalItems: 2,
+      counts: { byBoard: { work: 2 }, byStage: { execute: 1, intake: 1 } },
+      pendingApprovals: [],
+    }));
+    const { app } = appFor(user, { ensureSession: vi.fn(), getState });
+    const response = await app.request(`/web/factory/projects/${projectId}/supervisor/state`);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({ state: { totalItems: 2, pendingApprovals: [] } });
+    expect(getState).toHaveBeenCalledWith({ orgId: 'org-1', userId: 'user-1', factoryProjectId: projectId });
+  });
+
+  it('returns 404 across tenant boundaries and 401 without authentication', async () => {
+    const service = { ensureSession: vi.fn(), getState: vi.fn() };
+    const other = appFor({ workosId: 'user-2', organizationId: 'org-2' }, service);
+    const crossTenant = await other.app.request(`/web/factory/projects/${projectId}/supervisor/session`, {
+      method: 'POST',
+    });
+    expect(crossTenant.status).toBe(404);
+    expect(service.ensureSession).not.toHaveBeenCalled();
+
+    const anonymous = appFor(null, service);
+    const unauthorized = await anonymous.app.request(`/web/factory/projects/${projectId}/supervisor/state`);
+    expect(unauthorized.status).toBe(401);
+  });
+
+  it('maps canonical-session conflicts to a bounded 409 response', async () => {
+    const { app } = appFor(user, {
+      ensureSession: vi.fn(async () => {
+        throw new Error('Factory supervisor resource is already bound to a non-canonical session.');
+      }),
+      getState: vi.fn(),
+    });
+    const response = await app.request(`/web/factory/projects/${projectId}/supervisor/session`, { method: 'POST' });
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'supervisor_session_unavailable',
+      message: 'Factory supervisor resource is already bound to a non-canonical session.',
+    });
+  });
+});

--- a/mastracode/factory/src/routes/supervisor.ts
+++ b/mastracode/factory/src/routes/supervisor.ts
@@ -5,6 +5,7 @@ import type { Context } from 'hono';
 
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
 import type { FactorySupervisorService } from '../supervisor/service.js';
+import type { FactorySupervisorSignalService } from '../supervisor/signal-service.js';
 import type { RouteAuth } from './route.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -13,6 +14,7 @@ export interface SupervisorRoutesOptions {
   auth: RouteAuth;
   projects: FactoryProjectsStorage;
   service: FactorySupervisorService;
+  signals?: Pick<FactorySupervisorSignalService, 'refresh'>;
 }
 
 function loose(value: unknown): Context {
@@ -23,11 +25,13 @@ export class SupervisorRoutes {
   readonly #auth: RouteAuth;
   readonly #projects: FactoryProjectsStorage;
   readonly #service: FactorySupervisorService;
+  readonly #signals?: Pick<FactorySupervisorSignalService, 'refresh'>;
 
   constructor(options: SupervisorRoutesOptions) {
     this.#auth = options.auth;
     this.#projects = options.projects;
     this.#service = options.service;
+    this.#signals = options.signals;
   }
 
   async #resolveProject(
@@ -68,6 +72,7 @@ export class SupervisorRoutes {
               ...resolved,
               requestContext: context.get('requestContext') as RequestContext | undefined,
             });
+            await this.#signals?.refresh(resolved);
             return c.json({ session });
           } catch (error) {
             return c.json(

--- a/mastracode/factory/src/routes/supervisor.ts
+++ b/mastracode/factory/src/routes/supervisor.ts
@@ -1,0 +1,94 @@
+import type { RequestContext } from '@mastra/core/request-context';
+import type { ApiRoute } from '@mastra/core/server';
+import { registerApiRoute } from '@mastra/core/server';
+import type { Context } from 'hono';
+
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
+import type { FactorySupervisorService } from '../supervisor/service.js';
+import type { RouteAuth } from './route.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export interface SupervisorRoutesOptions {
+  auth: RouteAuth;
+  projects: FactoryProjectsStorage;
+  service: FactorySupervisorService;
+}
+
+function loose(value: unknown): Context {
+  return value as Context;
+}
+
+export class SupervisorRoutes {
+  readonly #auth: RouteAuth;
+  readonly #projects: FactoryProjectsStorage;
+  readonly #service: FactorySupervisorService;
+
+  constructor(options: SupervisorRoutesOptions) {
+    this.#auth = options.auth;
+    this.#projects = options.projects;
+    this.#service = options.service;
+  }
+
+  async #resolveProject(
+    context: Context,
+  ): Promise<{ orgId: string; userId: string; factoryProjectId: string } | { response: Response }> {
+    await this.#auth.ensureUser(context);
+    const tenant = this.#auth.tenant(context);
+    if (!tenant) return { response: context.json({ error: 'unauthorized' }, 401) };
+    if (!tenant.orgId) {
+      return {
+        response: context.json(
+          { error: 'organization_required', message: 'The Factory supervisor requires an organization.' },
+          403,
+        ),
+      };
+    }
+    const factoryProjectId = context.req.param('id');
+    if (!factoryProjectId || !UUID_RE.test(factoryProjectId)) {
+      return { response: context.json({ error: 'Project not found' }, 404) };
+    }
+    await this.#projects.ensureReady();
+    const project = await this.#projects.get({ orgId: tenant.orgId, id: factoryProjectId });
+    if (!project) return { response: context.json({ error: 'Project not found' }, 404) };
+    return { orgId: tenant.orgId, userId: tenant.userId, factoryProjectId };
+  }
+
+  routes(): ApiRoute[] {
+    return [
+      registerApiRoute('/web/factory/projects/:id/supervisor/session', {
+        method: 'POST',
+        requiresAuth: false,
+        handler: async c => {
+          const context = loose(c);
+          const resolved = await this.#resolveProject(context);
+          if ('response' in resolved) return resolved.response;
+          try {
+            const session = await this.#service.ensureSession({
+              ...resolved,
+              requestContext: context.get('requestContext') as RequestContext | undefined,
+            });
+            return c.json({ session });
+          } catch (error) {
+            return c.json(
+              {
+                error: 'supervisor_session_unavailable',
+                message: error instanceof Error ? error.message : 'Factory supervisor session is unavailable.',
+              },
+              409,
+            );
+          }
+        },
+      }),
+      registerApiRoute('/web/factory/projects/:id/supervisor/state', {
+        method: 'GET',
+        requiresAuth: false,
+        handler: async c => {
+          const resolved = await this.#resolveProject(loose(c));
+          if ('response' in resolved) return resolved.response;
+          return c.json({ state: await this.#service.getState(resolved) });
+        },
+      }),
+    ];
+  }
+}

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -30,6 +30,7 @@ import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js
 import type { QueueHealthStorage } from '../storage/domains/queue-health/base.js';
 import type { SourceControlStorage } from '../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { FactorySupervisorService } from '../supervisor/service.js';
 import { ConfigRoutes } from './config.js';
 import { invalidateCustomProvidersSnapshots } from './custom-provider-source.js';
 import { buildFsRoutes } from './fs.js';
@@ -37,6 +38,7 @@ import { IntakeRoutes } from './intake.js';
 import { OAuthRoutes } from './oauth.js';
 import type { RouteAuth } from './route.js';
 import { SkillRoutes } from './skills.js';
+import { SupervisorRoutes } from './supervisor.js';
 import { invalidateTenantCredentialSnapshots } from './tenant-credentials.js';
 import { WorkItemRoutes } from './work-items.js';
 
@@ -80,6 +82,7 @@ export interface FactoryApiRoutesDeps {
   rules: FactoryRules;
   factoryTransitionService?: FactoryTransitionService;
   runLifecycleObserver?: Pick<FactoryRunLifecycleObserver, 'observe' | 'subscribeIdle'>;
+  supervisorService?: FactorySupervisorService;
   onFactoryRuntime?: (runtime: {
     transitionService: FactoryTransitionService;
     prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -408,6 +411,13 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           integrations: (deps.integrations ?? []).flatMap(({ integration }) =>
             integration.intake ? [{ id: integration.id, intake: integration.intake }] : [],
           ),
+        }).routes()
+      : []),
+    ...(deps.factoryReady && deps.supervisorService
+      ? new SupervisorRoutes({
+          auth: deps.auth,
+          projects: deps.domains.projects,
+          service: deps.supervisorService,
         }).routes()
       : []),
     ...(deps.factoryReady

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -31,6 +31,7 @@ import type { QueueHealthStorage } from '../storage/domains/queue-health/base.js
 import type { SourceControlStorage } from '../storage/domains/source-control/base.js';
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import type { FactorySupervisorService } from '../supervisor/service.js';
+import type { FactorySupervisorSignalService } from '../supervisor/signal-service.js';
 import { ConfigRoutes } from './config.js';
 import { invalidateCustomProvidersSnapshots } from './custom-provider-source.js';
 import { buildFsRoutes } from './fs.js';
@@ -83,6 +84,7 @@ export interface FactoryApiRoutesDeps {
   factoryTransitionService?: FactoryTransitionService;
   runLifecycleObserver?: Pick<FactoryRunLifecycleObserver, 'observe' | 'subscribeIdle'>;
   supervisorService?: FactorySupervisorService;
+  supervisorSignals?: Pick<FactorySupervisorSignalService, 'refresh'>;
   onFactoryRuntime?: (runtime: {
     transitionService: FactoryTransitionService;
     prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
@@ -418,6 +420,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           auth: deps.auth,
           projects: deps.domains.projects,
           service: deps.supervisorService,
+          signals: deps.supervisorSignals,
         }).routes()
       : []),
     ...(deps.factoryReady
@@ -430,6 +433,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
           approvalService: approvalService!,
           transitionService,
           startCoordinator,
+          onFactoryStateChanged: deps.supervisorSignals ? input => deps.supervisorSignals!.refresh(input) : undefined,
         }).routes()
       : []),
   ];

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -57,6 +57,7 @@ export interface WorkItemRoutesDeps extends RouteDependencies {
   approvalService: Pick<FactoryTransitionApprovalService, 'list' | 'resolve'>;
   /** Coordinator that binds a Factory run before dispatching its kickoff. */
   startCoordinator?: Pick<FactoryStartCoordinator, 'prepare'>;
+  onFactoryStateChanged?: (input: { orgId: string; userId: string; factoryProjectId: string }) => Promise<unknown>;
 }
 
 function loose(c: unknown): Context {
@@ -440,6 +441,14 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
     return { ...tenant, factoryProjectId: projectId, defaultModelId: project.defaultModelId };
   }
 
+  async #notifyFactoryStateChanged(input: { orgId: string; userId: string; factoryProjectId: string }): Promise<void> {
+    try {
+      await this.deps.onFactoryStateChanged?.(input);
+    } catch (error) {
+      console.warn('[factory] Supervisor state refresh failed after work-item mutation:', error);
+    }
+  }
+
   /**
    * Emit the audit events a successful work-item PATCH implies: always
    * `updated`, plus `stage_moved` when the stages actually changed and one
@@ -732,6 +741,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
                 patch: boundedPatch as unknown as Record<string, unknown>,
               });
             }
+            await this.#notifyFactoryStateChanged(resolved);
             return c.json({ workItem: item });
           } catch (error) {
             if (error instanceof WorkItemRelationError) {
@@ -791,6 +801,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
               },
             },
           });
+          if (result.status !== 'rejected') await this.#notifyFactoryStateChanged(resolved);
           if (result.status === 'accepted') return c.json({ result });
           if (result.status === 'pending_approval') return c.json({ result }, 202);
           return c.json({ result }, result.code === 'stale' ? 409 : 422);
@@ -846,6 +857,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
               },
             },
           });
+          await this.#notifyFactoryStateChanged(resolved);
           return c.json({ prepared }, 202);
         },
       }),
@@ -882,6 +894,10 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
               previous: updated.previous,
               patch: patch as Record<string, unknown>,
             });
+            await this.#notifyFactoryStateChanged({
+              ...tenant,
+              factoryProjectId: updated.item.factoryProjectId,
+            });
             return c.json({ workItem: updated.item });
           } catch (error) {
             if (error instanceof WorkItemRelationError) {
@@ -913,6 +929,10 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
               factoryProjectId: deleted.factoryProjectId,
               targets: [{ type: 'work_item', id: deleted.id, name: deleted.title }],
             },
+          });
+          await this.#notifyFactoryStateChanged({
+            ...tenant,
+            factoryProjectId: deleted.factoryProjectId,
           });
           return c.json({ ok: true });
         },

--- a/mastracode/factory/src/rules/approval-service.test.ts
+++ b/mastracode/factory/src/rules/approval-service.test.ts
@@ -18,7 +18,9 @@ async function createPendingApproval(storage: WorkItemsStorage) {
         externalSource: { integrationId: 'github', type: 'issue', externalId: '1' },
         title: 'Fix the bug',
         stages: ['intake'],
-        sessions: {},
+        sessions: {
+          work: { sessionId: 'session-1', branch: 'factory/fix-bug', threadId: 'thread-1' },
+        },
         metadata: {},
       },
     })
@@ -102,6 +104,9 @@ describe('FactoryTransitionApprovalService', () => {
     expect(
       (await seed.audit.list({ orgId: 'org-1', factoryProjectId: PROJECT_ID })).events.map(event => event.action),
     ).toEqual(['factory.approval.approved', 'factory.approval.requested']);
+    const supervisorNotifications = await seed.workItems.listSupervisorNotifications('org-1', PROJECT_ID);
+    expect(supervisorNotifications.map(record => record.event)).toEqual(['approval_requested', 'approval_approved']);
+    expect(supervisorNotifications.every(record => record.supervisorUserId === 'user-1')).toBe(true);
   });
 
   it('rejects without moving the item and persists one worker notification', async () => {
@@ -124,6 +129,9 @@ describe('FactoryTransitionApprovalService', () => {
     expect(
       (await seed.workItems.listDeferredDecisions('org-1', PROJECT_ID)).map(record => record.idempotencyKey),
     ).toEqual([`${approvalId}:resolution:rejected`]);
+    expect(
+      (await seed.workItems.listSupervisorNotifications('org-1', PROJECT_ID)).map(record => record.event).sort(),
+    ).toEqual(['approval_rejected', 'approval_requested']);
   });
 
   it('marks an approval stale without moving or dispatching captured effects when the revision changes', async () => {
@@ -146,6 +154,9 @@ describe('FactoryTransitionApprovalService', () => {
     expect(
       (await seed.workItems.listDeferredDecisions('org-1', PROJECT_ID)).map(record => record.idempotencyKey),
     ).toEqual([`${approvalId}:resolution:stale`]);
+    expect(
+      (await seed.workItems.listSupervisorNotifications('org-1', PROJECT_ID)).map(record => record.event).sort(),
+    ).toEqual(['approval_requested', 'approval_stale']);
   });
 
   it('marks an approval stale when the captured item was deleted', async () => {
@@ -163,6 +174,9 @@ describe('FactoryTransitionApprovalService', () => {
     });
 
     expect(result).toMatchObject({ status: 'stale', replayed: false, item: null });
+    expect(await seed.workItems.listSupervisorNotifications('org-1', PROJECT_ID)).toEqual(
+      expect.arrayContaining([expect.objectContaining({ event: 'approval_stale', supervisorUserId: 'user-1' })]),
+    );
   });
 
   it('does not expose or resolve approvals across tenants or projects', async () => {

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -313,6 +313,7 @@ export function mergeFactoryRuleOverrides(
     supervisor: {
       observeIdleWithoutTransition:
         overrides.supervisor?.observeIdleWithoutTransition ?? base.supervisor?.observeIdleWithoutTransition ?? true,
+      checkInOnBoot: overrides.supervisor?.checkInOnBoot ?? base.supervisor?.checkInOnBoot ?? true,
     },
   };
 }

--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import type { FactorySupervisorNotificationRecord, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
 import { FactoryTransitionApprovalService } from './approval-service.js';
 import { defaultFactoryRules, requireSupervisorApproval } from './defaults.js';
@@ -118,6 +118,111 @@ describe('FactoryDecisionDispatcher', () => {
     await dispatcher.runOnce();
 
     expect(reconcileToolResults).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries durable supervisor approval notifications and marks them succeeded after delivery', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const rules = defaultFactoryRules({
+      version: 'rules-v1',
+      overrides: {
+        work: {
+          intake: {
+            issue: {
+              onExit: context => requireSupervisorApproval(context, { reason: 'Supervisor approval required.' }),
+            },
+          },
+        },
+      },
+    });
+    const transitionService = new FactoryTransitionService({ storage, rules });
+    const result = await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: item.revision,
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'work' },
+      ingress: { type: 'agent', identity: 'tool:approval-1' },
+      cause: 'test',
+    });
+    expect(result.status).toBe('pending_approval');
+
+    const dispatchSupervisorNotification = vi
+      .fn<(record: FactorySupervisorNotificationRecord) => Promise<void>>()
+      .mockRejectedValueOnce(new Error('temporary delivery failure'))
+      .mockResolvedValue(undefined);
+    const { controller } = createSession();
+    const dispatcher = new FactoryDecisionDispatcher({
+      controller: controller as never,
+      transitionService,
+      storage,
+      ownerId: 'dispatcher-1',
+      dispatchSupervisorNotification,
+    });
+    const firstNow = new Date('2030-01-01T00:00:00.000Z');
+
+    await dispatcher.runOnce(firstNow);
+    expect(await storage.listSupervisorNotifications('org-1', PROJECT_ID)).toEqual([
+      expect.objectContaining({ status: 'retry', attempts: 1, lastError: 'temporary delivery failure' }),
+    ]);
+
+    await dispatcher.runOnce(new Date(firstNow.getTime() + 2_000));
+    expect(dispatchSupervisorNotification).toHaveBeenCalledTimes(2);
+    expect(await storage.listSupervisorNotifications('org-1', PROJECT_ID)).toEqual([
+      expect.objectContaining({ status: 'succeeded', attempts: 2, completedAt: expect.any(Date) }),
+    ]);
+  });
+
+  it('allows only one concurrent poller to claim a supervisor notification', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const transitionService = new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({
+        version: 'rules-v1',
+        overrides: {
+          work: {
+            intake: {
+              issue: {
+                onExit: context => requireSupervisorApproval(context, { reason: 'Supervisor approval required.' }),
+              },
+            },
+          },
+        },
+      }),
+    });
+    await transitionService.transition({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: item.revision,
+      actor: { type: 'agent', bindingId: 'binding-1', role: 'work' },
+      ingress: { type: 'agent', identity: 'tool:approval-lease' },
+      cause: 'test',
+    });
+    const now = new Date('2030-01-01T00:00:00.000Z');
+    const claim = (ownerId: string) =>
+      storage.claimSupervisorNotifications({
+        ownerId,
+        now,
+        leaseExpiresAt: new Date(now.getTime() + 30_000),
+        limit: 1,
+      });
+
+    const [left, right] = await Promise.all([claim('left'), claim('right')]);
+    expect(left.length + right.length).toBe(1);
+    const [claimed] = left.length ? left : right;
+    const staleOwner = left.length ? 'right' : 'left';
+    await expect(
+      storage.completeSupervisorNotification(
+        { id: claimed!.id, orgId: 'org-1', factoryProjectId: PROJECT_ID, ownerId: staleOwner },
+        now,
+      ),
+    ).resolves.toBeNull();
   });
 
   it('allows only one concurrent lease owner to claim a decision', async () => {
@@ -357,11 +462,16 @@ describe('FactoryDecisionDispatcher', () => {
       expect(resolution.status).toBe(terminalStatus);
 
       const { controller, delivered } = createSession();
+      const supervisorEvents: string[] = [];
+      const dispatchSupervisorNotification = vi.fn(async (record: FactorySupervisorNotificationRecord) => {
+        supervisorEvents.push(record.event);
+      });
       const firstDispatcher = new FactoryDecisionDispatcher({
         controller: controller as never,
         transitionService,
         storage,
         ownerId: 'before-restart',
+        dispatchSupervisorNotification,
       });
       await firstDispatcher.runOnce(new Date('2030-01-01T00:00:00Z'));
       const secondDispatcher = new FactoryDecisionDispatcher({
@@ -369,6 +479,7 @@ describe('FactoryDecisionDispatcher', () => {
         transitionService,
         storage,
         ownerId: 'after-restart',
+        dispatchSupervisorNotification,
       });
       await secondDispatcher.runOnce(new Date('2030-01-01T00:01:00Z'));
       await secondDispatcher.runOnce(new Date('2030-01-01T00:02:00Z'));
@@ -380,6 +491,11 @@ describe('FactoryDecisionDispatcher', () => {
       );
       expect(
         (await storage.listDeferredDecisions('org-1', PROJECT_ID)).every(record => record.status === 'succeeded'),
+      ).toBe(true);
+      expect(supervisorEvents.sort()).toEqual([`approval_${terminalStatus}`, 'approval_requested'].sort());
+      expect(dispatchSupervisorNotification).toHaveBeenCalledTimes(2);
+      expect(
+        (await storage.listSupervisorNotifications('org-1', PROJECT_ID)).every(record => record.status === 'succeeded'),
       ).toBe(true);
     },
   );

--- a/mastracode/factory/src/rules/dispatcher.ts
+++ b/mastracode/factory/src/rules/dispatcher.ts
@@ -10,6 +10,7 @@ import type {
   FactoryDeferredDecisionRecord,
   FactoryPendingStartRecord,
   FactoryRunBindingRecord,
+  FactorySupervisorNotificationRecord,
   WorkItemRow,
   WorkItemsStorage,
 } from '../storage/domains/work-items/base.js';
@@ -52,6 +53,7 @@ export interface FactoryDecisionDispatcherOptions {
   reconcileToolResults?: () => Promise<void>;
   prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
   primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
+  dispatchSupervisorNotification?: (record: FactorySupervisorNotificationRecord) => Promise<void>;
 }
 
 function sanitizeDispatchError(error: unknown): string {
@@ -96,7 +98,10 @@ function deferredActor(record: FactoryDeferredDecisionRecord): FactoryRuleActor 
 }
 
 function leaseIdentity(
-  record: Pick<FactoryDeferredDecisionRecord | FactoryPendingStartRecord, 'id' | 'orgId' | 'factoryProjectId'>,
+  record: Pick<
+    FactoryDeferredDecisionRecord | FactoryPendingStartRecord | FactorySupervisorNotificationRecord,
+    'id' | 'orgId' | 'factoryProjectId'
+  >,
   ownerId: string,
 ) {
   return { id: record.id, orgId: record.orgId, factoryProjectId: record.factoryProjectId, ownerId };
@@ -130,6 +135,7 @@ export class FactoryDecisionDispatcher {
   readonly #reconcileToolResults?: () => Promise<void>;
   readonly #prepareBinding?: (input: FactoryBindingPreparationInput) => Promise<void>;
   readonly #primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
+  readonly #dispatchSupervisorNotification?: (record: FactorySupervisorNotificationRecord) => Promise<void>;
   #timer?: ReturnType<typeof setInterval>;
   #activeRun?: Promise<void>;
 
@@ -141,6 +147,7 @@ export class FactoryDecisionDispatcher {
     this.#reconcileToolResults = options.reconcileToolResults;
     this.#prepareBinding = options.prepareBinding;
     this.#primeCredentials = options.primeCredentials;
+    this.#dispatchSupervisorNotification = options.dispatchSupervisorNotification;
   }
 
   start(): void {
@@ -173,9 +180,18 @@ export class FactoryDecisionDispatcher {
         limit: BATCH_SIZE,
       }),
     ]);
+    const supervisorNotifications = this.#dispatchSupervisorNotification
+      ? await this.#storage.claimSupervisorNotifications({
+          ownerId: this.#ownerId,
+          now,
+          leaseExpiresAt,
+          limit: BATCH_SIZE,
+        })
+      : [];
     await Promise.all([
       ...decisions.map(decision => this.#dispatchDecision(decision, now)),
       ...starts.map(start => this.#dispatchPendingStart(start, now)),
+      ...supervisorNotifications.map(notification => this.#dispatchSupervisorEvent(notification, now)),
     ]);
   }
 
@@ -188,6 +204,29 @@ export class FactoryDecisionDispatcher {
       await this.#activeRun;
     } finally {
       this.#activeRun = undefined;
+    }
+  }
+
+  async #dispatchSupervisorEvent(record: FactorySupervisorNotificationRecord, now: Date): Promise<void> {
+    try {
+      await this.#withLease(
+        async leaseExpiresAt =>
+          this.#storage.renewSupervisorNotificationLease(leaseIdentity(record, this.#ownerId), leaseExpiresAt),
+        async () => this.#dispatchSupervisorNotification?.(record),
+      );
+      const completed = await this.#storage.completeSupervisorNotification(
+        leaseIdentity(record, this.#ownerId),
+        new Date(),
+      );
+      if (!completed) throw new Error('Factory supervisor notification lease was lost before completion.');
+    } catch (error) {
+      await this.#storage.failSupervisorNotification({
+        ...leaseIdentity(record, this.#ownerId),
+        now: new Date(),
+        availableAt: retryAt(now, record.attempts),
+        lastError: sanitizeDispatchError(error),
+        terminal: record.attempts >= MAX_ATTEMPTS,
+      });
     }
   }
 

--- a/mastracode/factory/src/rules/transition-service.test.ts
+++ b/mastracode/factory/src/rules/transition-service.test.ts
@@ -146,9 +146,18 @@ describe('FactoryTransitionService', () => {
       },
     });
 
-    const result = await new FactoryTransitionService({ rules, storage }).transition(request(item));
+    const onCommitted = vi.fn(async () => {});
+    const transitionRequest = request(item);
+    const result = await new FactoryTransitionService({ rules, storage, onCommitted }).transition(transitionRequest);
 
     expect(order).toEqual(['exit', 'enter']);
+    expect(onCommitted).toHaveBeenCalledWith({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      workItemId: item.id,
+      actor: transitionRequest.actor,
+      result,
+    });
     expect(result).toMatchObject({ status: 'accepted', revision: 2, stage: 'execute' });
     expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stageHistory.map(entry => entry.stage)).toEqual([
       'intake',
@@ -158,6 +167,28 @@ describe('FactoryTransitionService', () => {
       'notify-exit',
       'message-enter',
     ]);
+  });
+
+  it('does not roll back a committed transition when the state-refresh callback fails', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const item = await createItem(storage);
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = await new FactoryTransitionService({
+      storage,
+      rules: defaultFactoryRules({ version: 'rules-v1' }),
+      onCommitted: async () => {
+        throw new Error('state delivery failed');
+      },
+    }).transition(request(item));
+
+    expect(result.status).toBe('accepted');
+    expect((await storage.get({ orgId: 'org-1', id: item.id }))?.stages).toEqual(['execute']);
+    expect(warn).toHaveBeenCalledWith(
+      '[factory] Supervisor state refresh failed after transition:',
+      expect.objectContaining({ message: 'state delivery failed' }),
+    );
+    warn.mockRestore();
   });
 
   it('creates one pending approval for agent transitions without moving or dispatching effects', async () => {

--- a/mastracode/factory/src/rules/transition-service.ts
+++ b/mastracode/factory/src/rules/transition-service.ts
@@ -43,6 +43,13 @@ export interface FactoryTransitionServiceOptions {
   rules: FactoryRules;
   storage: WorkItemsStorage;
   timeoutMs?: number;
+  onCommitted?: (input: {
+    orgId: string;
+    factoryProjectId: string;
+    workItemId: string;
+    actor: FactoryRuleActor;
+    result: FactoryTransitionResult;
+  }) => Promise<void>;
 }
 
 function rejection(
@@ -112,11 +119,13 @@ export class FactoryTransitionService {
   readonly #rules: FactoryRules;
   readonly #storage: WorkItemsStorage;
   readonly #timeoutMs: number;
+  readonly #onCommitted?: FactoryTransitionServiceOptions['onCommitted'];
 
   constructor(options: FactoryTransitionServiceOptions) {
     this.#rules = options.rules;
     this.#storage = options.storage;
     this.#timeoutMs = options.timeoutMs ?? RULE_TIMEOUT_MS;
+    this.#onCommitted = options.onCommitted;
   }
 
   get ruleSetVersion(): string {
@@ -336,6 +345,18 @@ export class FactoryTransitionService {
     if (committed.status === 'missing') {
       return rejection(transitionId, request.workItemId, 'invalid_transition', 'Work item not found.');
     }
-    return committed.result as unknown as FactoryTransitionResult;
+    const result = committed.result as unknown as FactoryTransitionResult;
+    try {
+      await this.#onCommitted?.({
+        orgId: request.orgId,
+        factoryProjectId: request.factoryProjectId,
+        workItemId: request.workItemId,
+        actor: request.actor,
+        result,
+      });
+    } catch (error) {
+      console.warn('[factory] Supervisor state refresh failed after transition:', error);
+    }
+    return result;
   }
 }

--- a/mastracode/factory/src/rules/types.ts
+++ b/mastracode/factory/src/rules/types.ts
@@ -157,6 +157,13 @@ export type FactoryBoardRules = Partial<
 
 export interface FactorySupervisorRules {
   observeIdleWithoutTransition?: boolean;
+  /**
+   * Wake the supervisor once after a server boot when the project still has
+   * non-terminal work. A restart kills in-flight runs without emitting an
+   * `agent_end`, so the idle observer never sees them — this is the only
+   * signal that surfaces work stranded by the restart itself.
+   */
+  checkInOnBoot?: boolean;
 }
 
 export interface FactoryRules {

--- a/mastracode/factory/src/rules/validation.ts
+++ b/mastracode/factory/src/rules/validation.ts
@@ -199,12 +199,15 @@ export function assertFactoryRules(rules: unknown): asserts rules is FactoryRule
     if (!isPlainObject(rules.supervisor)) {
       throw new FactoryRuleValidationError('Factory rules.supervisor must be an object.');
     }
-    assertExactKeys(rules.supervisor, ['observeIdleWithoutTransition'], 'Factory rules.supervisor');
+    assertExactKeys(rules.supervisor, ['observeIdleWithoutTransition', 'checkInOnBoot'], 'Factory rules.supervisor');
     if (
       rules.supervisor.observeIdleWithoutTransition !== undefined &&
       typeof rules.supervisor.observeIdleWithoutTransition !== 'boolean'
     ) {
       throw new FactoryRuleValidationError('Factory rules.supervisor.observeIdleWithoutTransition must be a boolean.');
+    }
+    if (rules.supervisor.checkInOnBoot !== undefined && typeof rules.supervisor.checkInOnBoot !== 'boolean') {
+      throw new FactoryRuleValidationError('Factory rules.supervisor.checkInOnBoot must be a boolean.');
     }
   }
 }

--- a/mastracode/factory/src/storage/domains/work-items/base.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.test.ts
@@ -304,6 +304,16 @@ describe('WorkItemsStorage', () => {
       }),
     ]);
     expect(await storage.listApprovals('other-org', 'p1')).toEqual([]);
+    expect(await storage.listSupervisorNotifications('org1', 'p1')).toEqual([
+      expect.objectContaining({
+        approvalId: (committed.result as { approvalId: string }).approvalId,
+        event: 'approval_requested',
+        requestingBindingId: 'binding-1',
+        requestingRole: 'work',
+        status: 'pending',
+      }),
+    ]);
+    expect(await storage.listSupervisorNotifications('other-org', 'p1')).toEqual([]);
   });
 
   it('serializes relationship writes and deletion on the project lock', async () => {

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -230,6 +230,36 @@ export interface FactoryDeferredDecisionRecord {
   updatedAt: Date;
 }
 
+export type FactorySupervisorNotificationEvent =
+  'approval_requested' | 'approval_approved' | 'approval_rejected' | 'approval_stale';
+
+export interface FactorySupervisorNotificationRecord {
+  id: string;
+  orgId: string;
+  factoryProjectId: string;
+  approvalId: string;
+  workItemId: string;
+  event: FactorySupervisorNotificationEvent;
+  approvalStatus: FactoryApprovalStatus;
+  requestedStage: string;
+  expectedRevision: number;
+  requestingBindingId: string | null;
+  requestingRole: string | null;
+  supervisorUserId: string | null;
+  reason: string;
+  summary: string | null;
+  idempotencyKey: string;
+  status: FactoryDispatchStatus;
+  attempts: number;
+  availableAt: Date;
+  leaseOwner: string | null;
+  leaseExpiresAt: Date | null;
+  lastError: string | null;
+  completedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
 export interface FactoryRunBindingSessionAddress {
   factoryProjectId: string;
   threadId: string;
@@ -684,6 +714,41 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
     ],
   },
   {
+    name: 'factory_supervisor_notifications',
+    columns: {
+      id: { type: 'uuid-pk' },
+      org_id: { type: 'text' },
+      factory_project_id: { type: 'text' },
+      approval_id: { type: 'text' },
+      work_item_id: { type: 'text' },
+      event_type: { type: 'text' },
+      approval_status: { type: 'text' },
+      requested_stage: { type: 'text' },
+      expected_revision: { type: 'integer' },
+      requesting_binding_id: { type: 'text', nullable: true },
+      requesting_role: { type: 'text', nullable: true },
+      supervisor_user_id: { type: 'text', nullable: true },
+      reason: { type: 'text' },
+      summary: { type: 'text', nullable: true },
+      idempotency_key: { type: 'text' },
+      status: { type: 'text' },
+      attempts: { type: 'integer' },
+      available_at: { type: 'timestamp' },
+      lease_owner: { type: 'text', nullable: true },
+      lease_expires_at: { type: 'timestamp', nullable: true },
+      last_error: { type: 'text', nullable: true },
+      completed_at: { type: 'timestamp', nullable: true },
+      created_at: { type: 'timestamp' },
+      updated_at: { type: 'timestamp' },
+    },
+    uniqueIndexes: [
+      {
+        name: 'factory_supervisor_notifications_tenant_key_unique',
+        columns: ['org_id', 'factory_project_id', 'idempotency_key'],
+      },
+    ],
+  },
+  {
     name: 'factory_deferred_decisions',
     columns: {
       id: { type: 'uuid-pk' },
@@ -846,6 +911,80 @@ function toDeferredDecision(row: GovernanceDbRow): FactoryDeferredDecisionRecord
     updatedAt: row.updated_at as Date,
   };
 }
+function toSupervisorNotification(row: GovernanceDbRow): FactorySupervisorNotificationRecord {
+  return {
+    id: row.id,
+    orgId: row.org_id,
+    factoryProjectId: String(row.factory_project_id),
+    approvalId: String(row.approval_id),
+    workItemId: String(row.work_item_id),
+    event: row.event_type as FactorySupervisorNotificationEvent,
+    approvalStatus: row.approval_status as FactoryApprovalStatus,
+    requestedStage: String(row.requested_stage),
+    expectedRevision: Number(row.expected_revision),
+    requestingBindingId: (row.requesting_binding_id as string | null) ?? null,
+    requestingRole: (row.requesting_role as string | null) ?? null,
+    supervisorUserId: (row.supervisor_user_id as string | null) ?? null,
+    reason: String(row.reason),
+    summary: (row.summary as string | null) ?? null,
+    idempotencyKey: String(row.idempotency_key),
+    status: row.status as FactoryDispatchStatus,
+    attempts: Number(row.attempts),
+    availableAt: row.available_at as Date,
+    leaseOwner: (row.lease_owner as string | null) ?? null,
+    leaseExpiresAt: (row.lease_expires_at as Date | null) ?? null,
+    lastError: (row.last_error as string | null) ?? null,
+    completedAt: (row.completed_at as Date | null) ?? null,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at as Date,
+  };
+}
+
+async function insertSupervisorNotification(
+  ops: FactoryStorageOps,
+  approval: FactoryApprovalRecord,
+  event: FactorySupervisorNotificationEvent,
+  now: Date,
+  supervisorUserId?: string | null,
+): Promise<void> {
+  const actor = approval.requestingActor;
+  const status = event === 'approval_requested' ? 'pending' : approval.status;
+  const requestNotification =
+    event === 'approval_requested'
+      ? null
+      : await ops.findOne<GovernanceDbRow>('factory_supervisor_notifications', {
+          org_id: approval.orgId,
+          factory_project_id: approval.factoryProjectId,
+          approval_id: approval.id,
+          event_type: 'approval_requested',
+        });
+  await ops.insertOne('factory_supervisor_notifications', {
+    org_id: approval.orgId,
+    factory_project_id: approval.factoryProjectId,
+    approval_id: approval.id,
+    work_item_id: approval.workItemId,
+    event_type: event,
+    approval_status: status,
+    requested_stage: approval.requestedStage,
+    expected_revision: approval.expectedRevision,
+    requesting_binding_id: actor.type === 'agent' && typeof actor.bindingId === 'string' ? actor.bindingId : null,
+    requesting_role: actor.type === 'agent' && typeof actor.role === 'string' ? actor.role : null,
+    supervisor_user_id: supervisorUserId ?? (requestNotification?.supervisor_user_id as string | null) ?? null,
+    reason: approval.reason.slice(0, 1_000),
+    summary: approval.summary?.slice(0, 1_000) ?? null,
+    idempotency_key: `${approval.id}:${event}`,
+    status: 'pending',
+    attempts: 0,
+    available_at: now,
+    lease_owner: null,
+    lease_expires_at: null,
+    last_error: null,
+    completed_at: null,
+    created_at: now,
+    updated_at: now,
+  });
+}
+
 async function insertApprovalAudit(
   ops: FactoryStorageOps,
   approval: {
@@ -985,7 +1124,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async #claimLeases<T>(
-    table: 'factory_deferred_decisions' | 'factory_pending_starts',
+    table: 'factory_deferred_decisions' | 'factory_pending_starts' | 'factory_supervisor_notifications',
     input: FactoryLeaseClaimInput,
     map: (row: GovernanceDbRow) => T,
   ): Promise<T[]> {
@@ -1032,7 +1171,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async #renewLease(
-    table: 'factory_deferred_decisions' | 'factory_pending_starts',
+    table: 'factory_deferred_decisions' | 'factory_pending_starts' | 'factory_supervisor_notifications',
     identity: FactoryLeaseIdentity,
     leaseExpiresAt: Date,
   ): Promise<boolean> {
@@ -1050,7 +1189,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async #completeLease(
-    table: 'factory_deferred_decisions' | 'factory_pending_starts',
+    table: 'factory_deferred_decisions' | 'factory_pending_starts' | 'factory_supervisor_notifications',
     identity: FactoryLeaseIdentity,
     now: Date,
   ): Promise<GovernanceDbRow | null> {
@@ -1074,7 +1213,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   }
 
   async #failLease(
-    table: 'factory_deferred_decisions' | 'factory_pending_starts',
+    table: 'factory_deferred_decisions' | 'factory_pending_starts' | 'factory_supervisor_notifications',
     input: FactoryDispatchFailureInput,
   ): Promise<GovernanceDbRow | null> {
     let failed = false;
@@ -1341,6 +1480,16 @@ export class WorkItemsStorage extends FactoryStorageDomain {
             occurredAt: input.now,
           },
         );
+        await insertSupervisorNotification(
+          ops,
+          approval,
+          terminalStatus === 'approved'
+            ? 'approval_approved'
+            : terminalStatus === 'rejected'
+              ? 'approval_rejected'
+              : 'approval_stale',
+          input.now,
+        );
         return { status: 'resolved', approval, item };
       });
     return this.#withProjectRelationLock(input.orgId, input.factoryProjectId, resolve);
@@ -1487,7 +1636,7 @@ export class WorkItemsStorage extends FactoryStorageDomain {
           });
           if (outcome === 'pending_approval' && input.evaluation.outcome === 'pending_approval' && !existingApproval) {
             const approval = input.evaluation.approval;
-            await ops.insertOne<GovernanceDbRow>('factory_approvals', {
+            const approvalRow = await ops.insertOne<GovernanceDbRow>('factory_approvals', {
               id: approvalId!,
               org_id: input.orgId,
               factory_project_id: input.factoryProjectId,
@@ -1532,6 +1681,18 @@ export class WorkItemsStorage extends FactoryStorageDomain {
                 status: 'pending',
                 occurredAt: now,
               },
+            );
+            const requestingRole =
+              approval.actor.type === 'agent' && typeof approval.actor.role === 'string' ? approval.actor.role : null;
+            const supervisorUserId = requestingRole
+              ? item.sessions[requestingRole]?.startedBy
+              : Object.values(item.sessions).find(session => session.startedBy)?.startedBy;
+            await insertSupervisorNotification(
+              ops,
+              toApproval(approvalRow),
+              'approval_requested',
+              now,
+              supervisorUserId,
             );
           }
           if (outcome === 'accepted' && input.evaluation.outcome === 'accepted') {
@@ -1773,6 +1934,42 @@ export class WorkItemsStorage extends FactoryStorageDomain {
   async failDeferredDecision(input: FactoryDispatchFailureInput): Promise<FactoryDeferredDecisionRecord | null> {
     const row = await this.#failLease('factory_deferred_decisions', input);
     return row ? toDeferredDecision(row) : null;
+  }
+
+  async listSupervisorNotifications(
+    orgId: string,
+    factoryProjectId: string,
+  ): Promise<FactorySupervisorNotificationRecord[]> {
+    return (
+      await this.#db.findMany<GovernanceDbRow>(
+        'factory_supervisor_notifications',
+        { org_id: orgId, factory_project_id: factoryProjectId },
+        { orderBy: [['created_at', 'asc']] },
+      )
+    ).map(toSupervisorNotification);
+  }
+
+  async claimSupervisorNotifications(input: FactoryLeaseClaimInput): Promise<FactorySupervisorNotificationRecord[]> {
+    return this.#claimLeases('factory_supervisor_notifications', input, toSupervisorNotification);
+  }
+
+  async renewSupervisorNotificationLease(identity: FactoryLeaseIdentity, leaseExpiresAt: Date): Promise<boolean> {
+    return this.#renewLease('factory_supervisor_notifications', identity, leaseExpiresAt);
+  }
+
+  async completeSupervisorNotification(
+    identity: FactoryLeaseIdentity,
+    now: Date,
+  ): Promise<FactorySupervisorNotificationRecord | null> {
+    const row = await this.#completeLease('factory_supervisor_notifications', identity, now);
+    return row ? toSupervisorNotification(row) : null;
+  }
+
+  async failSupervisorNotification(
+    input: FactoryDispatchFailureInput,
+  ): Promise<FactorySupervisorNotificationRecord | null> {
+    const row = await this.#failLease('factory_supervisor_notifications', input);
+    return row ? toSupervisorNotification(row) : null;
   }
 
   /** Requeue the same idempotent terminal effect; non-failed decisions are never rerun. */

--- a/mastracode/factory/src/storage/domains/work-items/base.ts
+++ b/mastracode/factory/src/storage/domains/work-items/base.ts
@@ -231,18 +231,23 @@ export interface FactoryDeferredDecisionRecord {
 }
 
 export type FactorySupervisorNotificationEvent =
-  'approval_requested' | 'approval_approved' | 'approval_rejected' | 'approval_stale';
+  'approval_requested' | 'approval_approved' | 'approval_rejected' | 'approval_stale' | 'boot_check_in';
 
+/**
+ * A durable supervisor wake event. Approval events carry the approval columns;
+ * project-scoped events (`boot_check_in`) leave them null — the row exists to
+ * get exactly-one delivery per tenant out of the dispatcher's lease loop.
+ */
 export interface FactorySupervisorNotificationRecord {
   id: string;
   orgId: string;
   factoryProjectId: string;
-  approvalId: string;
-  workItemId: string;
+  approvalId: string | null;
+  workItemId: string | null;
   event: FactorySupervisorNotificationEvent;
-  approvalStatus: FactoryApprovalStatus;
-  requestedStage: string;
-  expectedRevision: number;
+  approvalStatus: FactoryApprovalStatus | null;
+  requestedStage: string | null;
+  expectedRevision: number | null;
   requestingBindingId: string | null;
   requestingRole: string | null;
   supervisorUserId: string | null;
@@ -719,12 +724,12 @@ const FACTORY_GOVERNANCE_SCHEMAS: CollectionSchema[] = [
       id: { type: 'uuid-pk' },
       org_id: { type: 'text' },
       factory_project_id: { type: 'text' },
-      approval_id: { type: 'text' },
-      work_item_id: { type: 'text' },
+      approval_id: { type: 'text', nullable: true },
+      work_item_id: { type: 'text', nullable: true },
       event_type: { type: 'text' },
-      approval_status: { type: 'text' },
-      requested_stage: { type: 'text' },
-      expected_revision: { type: 'integer' },
+      approval_status: { type: 'text', nullable: true },
+      requested_stage: { type: 'text', nullable: true },
+      expected_revision: { type: 'integer', nullable: true },
       requesting_binding_id: { type: 'text', nullable: true },
       requesting_role: { type: 'text', nullable: true },
       supervisor_user_id: { type: 'text', nullable: true },
@@ -916,12 +921,12 @@ function toSupervisorNotification(row: GovernanceDbRow): FactorySupervisorNotifi
     id: row.id,
     orgId: row.org_id,
     factoryProjectId: String(row.factory_project_id),
-    approvalId: String(row.approval_id),
-    workItemId: String(row.work_item_id),
+    approvalId: row.approval_id == null ? null : String(row.approval_id),
+    workItemId: row.work_item_id == null ? null : String(row.work_item_id),
     event: row.event_type as FactorySupervisorNotificationEvent,
-    approvalStatus: row.approval_status as FactoryApprovalStatus,
-    requestedStage: String(row.requested_stage),
-    expectedRevision: Number(row.expected_revision),
+    approvalStatus: (row.approval_status as FactoryApprovalStatus | null) ?? null,
+    requestedStage: row.requested_stage == null ? null : String(row.requested_stage),
+    expectedRevision: row.expected_revision == null ? null : Number(row.expected_revision),
     requestingBindingId: (row.requesting_binding_id as string | null) ?? null,
     requestingRole: (row.requesting_role as string | null) ?? null,
     supervisorUserId: (row.supervisor_user_id as string | null) ?? null,
@@ -1951,6 +1956,89 @@ export class WorkItemsStorage extends FactoryStorageDomain {
 
   async claimSupervisorNotifications(input: FactoryLeaseClaimInput): Promise<FactorySupervisorNotificationRecord[]> {
     return this.#claimLeases('factory_supervisor_notifications', input, toSupervisorNotification);
+  }
+
+  /**
+   * Every tenant that still has non-terminal work, for the boot check-in. Reads
+   * across tenants because it runs before any request establishes one, and the
+   * `done`/`canceled` filter is applied in memory — the storage seam only
+   * supports equality filters and an item's stage list is a JSON column.
+   */
+  async listTenantsWithOpenWorkItems(): Promise<
+    Array<{ orgId: string; factoryProjectId: string; openItemCount: number; supervisorUserId: string | null }>
+  > {
+    const rows = await this.#db.findMany<WorkItemDbRow>('work_items', {});
+    const tenants = new Map<
+      string,
+      { orgId: string; factoryProjectId: string; openItemCount: number; supervisorUserId: string | null }
+    >();
+    for (const row of rows) {
+      const item = toWorkItem(row);
+      if (!item.stages.some(stage => stage !== 'done' && stage !== 'canceled')) continue;
+      const key = `${item.orgId}\u0000${item.factoryProjectId}`;
+      const tenant = tenants.get(key) ?? {
+        orgId: item.orgId,
+        factoryProjectId: item.factoryProjectId,
+        openItemCount: 0,
+        supervisorUserId: null,
+      };
+      tenant.openItemCount += 1;
+      // Notification delivery needs a user to resolve tenant credentials with;
+      // prefer whoever started a run, falling back to the item's creator.
+      tenant.supervisorUserId ??=
+        Object.values(item.sessions).find(session => session.startedBy)?.startedBy ?? item.createdBy ?? null;
+      tenants.set(key, tenant);
+    }
+    return [...tenants.values()];
+  }
+
+  /**
+   * Enqueue one boot check-in per tenant, deduped by `bucketKey` so a restart
+   * storm (or several replicas booting together) produces a single wake — the
+   * tenant-unique index on `idempotency_key` is what makes that safe.
+   */
+  async createBootCheckInNotification(input: {
+    orgId: string;
+    factoryProjectId: string;
+    supervisorUserId: string | null;
+    bucketKey: string;
+    reason: string;
+    summary: string;
+    now: Date;
+  }): Promise<FactorySupervisorNotificationRecord | null> {
+    const idempotencyKey = `boot_check_in:${input.bucketKey}`;
+    const existing = await this.#db.findOne<GovernanceDbRow>('factory_supervisor_notifications', {
+      org_id: input.orgId,
+      factory_project_id: input.factoryProjectId,
+      idempotency_key: idempotencyKey,
+    });
+    if (existing) return null;
+    const row = await this.ops.insertOne<GovernanceDbRow>('factory_supervisor_notifications', {
+      org_id: input.orgId,
+      factory_project_id: input.factoryProjectId,
+      approval_id: null,
+      work_item_id: null,
+      event_type: 'boot_check_in',
+      approval_status: null,
+      requested_stage: null,
+      expected_revision: null,
+      requesting_binding_id: null,
+      requesting_role: null,
+      supervisor_user_id: input.supervisorUserId,
+      reason: input.reason.slice(0, 1_000),
+      summary: input.summary.slice(0, 1_000),
+      idempotency_key: idempotencyKey,
+      status: 'pending',
+      attempts: 0,
+      available_at: input.now,
+      lease_owner: null,
+      lease_expires_at: null,
+      last_error: null,
+      completed_at: null,
+      created_at: input.now,
+      updated_at: input.now,
+    });
+    return toSupervisorNotification(row);
   }
 
   async renewSupervisorNotificationLease(identity: FactoryLeaseIdentity, leaseExpiresAt: Date): Promise<boolean> {

--- a/mastracode/factory/src/storage/domains/work-items/boot-check-in.test.ts
+++ b/mastracode/factory/src/storage/domains/work-items/boot-check-in.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import { createFactoryStorageForTests } from '../../test-utils.js';
+import type { WorkItemStage, WorkItemsStorage } from './base.js';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const OTHER_PROJECT_ID = '99999999-2222-4333-8444-555555555555';
+
+async function seedItem(
+  storage: WorkItemsStorage,
+  input: {
+    title: string;
+    stages: WorkItemStage[];
+    externalId: string;
+    orgId?: string;
+    factoryProjectId?: string;
+    sessions?: Record<string, { sessionId: string; branch: string; threadId: string }>;
+  },
+) {
+  return (
+    await storage.upsert({
+      orgId: input.orgId ?? 'org-1',
+      userId: 'user-1',
+      factoryProjectId: input.factoryProjectId ?? PROJECT_ID,
+      input: {
+        externalSource: { integrationId: 'github', type: 'issue', externalId: input.externalId },
+        title: input.title,
+        stages: input.stages,
+        ...(input.sessions ? { sessions: input.sessions } : {}),
+        metadata: {},
+      },
+    })
+  ).item;
+}
+
+describe('WorkItemsStorage boot check-in', () => {
+  it('reports only tenants that still have non-terminal work', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seedItem(seed.workItems, { title: 'Open', stages: ['execute'], externalId: '1' });
+    await seedItem(seed.workItems, { title: 'Shipped', stages: ['done'], externalId: '2' });
+    await seedItem(seed.workItems, { title: 'Dropped', stages: ['canceled'], externalId: '3' });
+    await seedItem(seed.workItems, {
+      title: 'Another org',
+      stages: ['review'],
+      externalId: '4',
+      orgId: 'org-2',
+      factoryProjectId: OTHER_PROJECT_ID,
+    });
+
+    const tenants = await seed.workItems.listTenantsWithOpenWorkItems();
+
+    expect(tenants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ orgId: 'org-1', factoryProjectId: PROJECT_ID, openItemCount: 1 }),
+        expect.objectContaining({ orgId: 'org-2', factoryProjectId: OTHER_PROJECT_ID, openItemCount: 1 }),
+      ]),
+    );
+    expect(tenants).toHaveLength(2);
+  });
+
+  it('reports nothing once every item reached a terminal stage', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seedItem(seed.workItems, { title: 'Shipped', stages: ['done'], externalId: '1' });
+    await seedItem(seed.workItems, { title: 'Dropped', stages: ['canceled'], externalId: '2' });
+
+    await expect(seed.workItems.listTenantsWithOpenWorkItems()).resolves.toEqual([]);
+  });
+
+  it('resolves a supervisor user from the run owner, falling back to the item creator', async () => {
+    const seed = await createFactoryStorageForTests();
+    await seedItem(seed.workItems, { title: 'No sessions', stages: ['intake'], externalId: '1' });
+    await seedItem(seed.workItems, {
+      title: 'Bound',
+      stages: ['execute'],
+      externalId: '2',
+      orgId: 'org-2',
+      factoryProjectId: OTHER_PROJECT_ID,
+      sessions: { work: { sessionId: 'session-1', branch: 'factory/bound', threadId: 'thread-1' } },
+    });
+
+    const tenants = await seed.workItems.listTenantsWithOpenWorkItems();
+
+    expect(tenants.every(tenant => tenant.supervisorUserId === 'user-1')).toBe(true);
+  });
+
+  it('accepts one boot check-in per bucket and rejects the rest of the storm', async () => {
+    const seed = await createFactoryStorageForTests();
+    const input = {
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      supervisorUserId: 'user-1',
+      reason: 'restarted',
+      summary: 'The Factory server restarted.',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    };
+
+    const first = await seed.workItems.createBootCheckInNotification({ ...input, bucketKey: 'bucket-1' });
+    const replay = await seed.workItems.createBootCheckInNotification({ ...input, bucketKey: 'bucket-1' });
+    const nextWindow = await seed.workItems.createBootCheckInNotification({ ...input, bucketKey: 'bucket-2' });
+
+    expect(first).toMatchObject({
+      event: 'boot_check_in',
+      status: 'pending',
+      supervisorUserId: 'user-1',
+      idempotencyKey: 'boot_check_in:bucket-1',
+      approvalId: null,
+      workItemId: null,
+      requestedStage: null,
+      expectedRevision: null,
+      approvalStatus: null,
+    });
+    expect(replay).toBeNull();
+    expect(nextWindow).not.toBeNull();
+    expect((await seed.workItems.listSupervisorNotifications('org-1', PROJECT_ID)).map(r => r.idempotencyKey)).toEqual([
+      'boot_check_in:bucket-1',
+      'boot_check_in:bucket-2',
+    ]);
+  });
+
+  it('scopes the boot check-in dedupe per tenant', async () => {
+    const seed = await createFactoryStorageForTests();
+    const input = {
+      supervisorUserId: 'user-1',
+      bucketKey: 'bucket-1',
+      reason: 'restarted',
+      summary: 'The Factory server restarted.',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    };
+
+    const first = await seed.workItems.createBootCheckInNotification({
+      ...input,
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+    });
+    const otherTenant = await seed.workItems.createBootCheckInNotification({
+      ...input,
+      orgId: 'org-2',
+      factoryProjectId: OTHER_PROJECT_ID,
+    });
+
+    expect(first).not.toBeNull();
+    expect(otherTenant).not.toBeNull();
+    expect(await seed.workItems.listSupervisorNotifications('org-2', PROJECT_ID)).toEqual([]);
+  });
+
+  it('hands the boot check-in to the dispatcher lease loop like any other notification', async () => {
+    const seed = await createFactoryStorageForTests();
+    const created = await seed.workItems.createBootCheckInNotification({
+      orgId: 'org-1',
+      factoryProjectId: PROJECT_ID,
+      supervisorUserId: 'user-1',
+      bucketKey: 'bucket-1',
+      reason: 'restarted',
+      summary: 'The Factory server restarted.',
+      now: new Date('2030-01-01T00:00:00.000Z'),
+    });
+
+    const claimed = await seed.workItems.claimSupervisorNotifications({
+      ownerId: 'dispatcher-1',
+      limit: 10,
+      now: new Date('2030-01-01T00:00:01.000Z'),
+      leaseExpiresAt: new Date('2030-01-01T00:05:00.000Z'),
+    });
+
+    expect(claimed.map(record => record.id)).toEqual([created!.id]);
+    expect(claimed[0]).toMatchObject({ event: 'boot_check_in', status: 'leased' });
+  });
+});

--- a/mastracode/factory/src/supervisor/boot-check-in.test.ts
+++ b/mastracode/factory/src/supervisor/boot-check-in.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { builtInFactoryRules } from '../rules/defaults.js';
+import type { FactoryRules } from '../rules/types.js';
+import { FACTORY_BOOT_CHECK_IN_COOLDOWN_MS, FactoryBootCheckIn } from './boot-check-in.js';
+
+function fixture(options: { rules?: FactoryRules; tenants?: unknown[] } = {}) {
+  const created: Array<Record<string, unknown>> = [];
+  const storage = {
+    listTenantsWithOpenWorkItems: vi
+      .fn()
+      .mockResolvedValue(
+        options.tenants ?? [
+          { orgId: 'org-1', factoryProjectId: 'project-1', openItemCount: 3, supervisorUserId: 'user-1' },
+        ],
+      ),
+    // Mirror the tenant-unique index on `idempotency_key`: a repeat insert for
+    // the same bucket returns null instead of a second row.
+    createBootCheckInNotification: vi.fn().mockImplementation(async (input: Record<string, unknown>) => {
+      const key = `${input.orgId}\u0000${input.factoryProjectId}\u0000${input.bucketKey}`;
+      if (created.some(row => row.key === key)) return null;
+      const record = { key, id: `notification-${created.length + 1}`, ...input };
+      created.push(record);
+      return record;
+    }),
+  };
+  const audit = { record: vi.fn().mockResolvedValue(undefined) };
+  const rules = options.rules ?? builtInFactoryRules();
+  return { storage, audit, rules, created };
+}
+
+describe('FactoryBootCheckIn', () => {
+  it('enqueues one wake per tenant that still has open work', async () => {
+    const { storage, audit, rules } = fixture();
+
+    const result = await new FactoryBootCheckIn({ storage, audit, rules }).run();
+
+    expect(result).toEqual({ enqueued: 1, skipped: 0 });
+    expect(storage.createBootCheckInNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ orgId: 'org-1', factoryProjectId: 'project-1', supervisorUserId: 'user-1' }),
+    );
+    expect(storage.createBootCheckInNotification.mock.calls[0]![0].summary).toContain('3 work item(s) are still open');
+    expect(audit.record).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'factory.supervisor.boot_check_in',
+        metadata: expect.objectContaining({ openItemCount: 3 }),
+      }),
+    );
+  });
+
+  it('collapses a restart storm inside the cooldown window into a single wake', async () => {
+    const { storage, audit, rules } = fixture();
+    let clock = new Date('2030-01-01T00:00:00.000Z').getTime();
+    const boot = () => new FactoryBootCheckIn({ storage, audit, rules, now: () => new Date(clock) }).run();
+
+    const first = await boot();
+    clock += 30_000;
+    const second = await boot();
+    clock += 60_000;
+    const third = await boot();
+
+    expect(first).toEqual({ enqueued: 1, skipped: 0 });
+    expect(second).toEqual({ enqueued: 0, skipped: 1 });
+    expect(third).toEqual({ enqueued: 0, skipped: 1 });
+    expect(audit.record).toHaveBeenCalledOnce();
+  });
+
+  it('wakes again once the cooldown window elapses', async () => {
+    const { storage, audit, rules } = fixture();
+    let clock = new Date('2030-01-01T00:00:00.000Z').getTime();
+    const boot = () => new FactoryBootCheckIn({ storage, audit, rules, now: () => new Date(clock) }).run();
+
+    await boot();
+    clock += FACTORY_BOOT_CHECK_IN_COOLDOWN_MS;
+
+    await expect(boot()).resolves.toEqual({ enqueued: 1, skipped: 0 });
+  });
+
+  it('stays silent when no tenant has open work', async () => {
+    const { storage, audit, rules } = fixture({ tenants: [] });
+
+    await expect(new FactoryBootCheckIn({ storage, audit, rules }).run()).resolves.toEqual({
+      enqueued: 0,
+      skipped: 0,
+    });
+    expect(storage.createBootCheckInNotification).not.toHaveBeenCalled();
+  });
+
+  it('stays silent when the Factory opts out', async () => {
+    const rules = { ...builtInFactoryRules(), supervisor: { checkInOnBoot: false } } as FactoryRules;
+    const { storage, audit } = fixture();
+
+    await expect(new FactoryBootCheckIn({ storage, audit, rules }).run()).resolves.toEqual({
+      enqueued: 0,
+      skipped: 0,
+    });
+    expect(storage.listTenantsWithOpenWorkItems).not.toHaveBeenCalled();
+  });
+
+  it('never lets one tenant failure block another tenant or the boot itself', async () => {
+    const { storage, audit, rules } = fixture({
+      tenants: [
+        { orgId: 'org-1', factoryProjectId: 'project-1', openItemCount: 1, supervisorUserId: 'user-1' },
+        { orgId: 'org-2', factoryProjectId: 'project-2', openItemCount: 2, supervisorUserId: 'user-2' },
+      ],
+    });
+    storage.createBootCheckInNotification.mockRejectedValueOnce(new Error('storage unavailable'));
+    const onError = vi.fn();
+
+    const result = await new FactoryBootCheckIn({ storage, audit, rules, onError }).run();
+
+    expect(result).toEqual({ enqueued: 1, skipped: 0 });
+    expect(onError).toHaveBeenCalledOnce();
+    expect(storage.createBootCheckInNotification).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mastracode/factory/src/supervisor/boot-check-in.ts
+++ b/mastracode/factory/src/supervisor/boot-check-in.ts
@@ -1,0 +1,91 @@
+import type { FactoryRules } from '../rules/types.js';
+import type { AuditStorage } from '../storage/domains/audit/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+
+/**
+ * How long one enqueued check-in suppresses the next. `mastra dev` restarts on
+ * every file save, so without this the supervisor would burn a model turn per
+ * keystroke-save; the window also collapses a fleet-wide rolling restart into a
+ * single wake.
+ */
+export const FACTORY_BOOT_CHECK_IN_COOLDOWN_MS = 15 * 60 * 1_000;
+
+export interface FactoryBootCheckInOptions {
+  storage: Pick<WorkItemsStorage, 'listTenantsWithOpenWorkItems' | 'createBootCheckInNotification'>;
+  audit: Pick<AuditStorage, 'record'>;
+  rules: FactoryRules;
+  cooldownMs?: number;
+  now?(): Date;
+  onError?(error: unknown): void;
+}
+
+export interface FactoryBootCheckInResult {
+  enqueued: number;
+  skipped: number;
+}
+
+/**
+ * Enqueue a durable "the server just restarted, check on ongoing work" wake for
+ * every tenant that still has non-terminal work.
+ *
+ * This is the only signal that covers runs killed by the restart: they never
+ * emit an `agent_end`, so `FactoryRunLifecycleObserver` cannot observe them.
+ * The rows land in the same table the dispatcher already leases, which is what
+ * makes delivery exactly-once across replicas.
+ */
+export class FactoryBootCheckIn {
+  readonly #options: FactoryBootCheckInOptions;
+
+  constructor(options: FactoryBootCheckInOptions) {
+    this.#options = options;
+  }
+
+  async run(): Promise<FactoryBootCheckInResult> {
+    if (this.#options.rules.supervisor?.checkInOnBoot === false) return { enqueued: 0, skipped: 0 };
+
+    const now = this.#options.now?.() ?? new Date();
+    const cooldownMs = this.#options.cooldownMs ?? FACTORY_BOOT_CHECK_IN_COOLDOWN_MS;
+    // Bucketing the key (rather than reading the last check-in) keeps the
+    // dedupe decision in the unique index, so concurrently booting replicas
+    // cannot both win.
+    const bucketKey = String(Math.floor(now.getTime() / cooldownMs));
+
+    const tenants = await this.#options.storage.listTenantsWithOpenWorkItems();
+    let enqueued = 0;
+    let skipped = 0;
+    for (const tenant of tenants) {
+      try {
+        const record = await this.#options.storage.createBootCheckInNotification({
+          orgId: tenant.orgId,
+          factoryProjectId: tenant.factoryProjectId,
+          supervisorUserId: tenant.supervisorUserId,
+          bucketKey,
+          reason: 'The Factory server restarted while work was open.',
+          summary:
+            `The Factory server restarted. ${tenant.openItemCount} work item(s) are still open, and any runs that ` +
+            `were in flight were killed without finishing. Check which items are stalled and nudge, cancel, or ` +
+            `escalate them one at a time.`,
+          now,
+        });
+        if (!record) {
+          skipped += 1;
+          continue;
+        }
+        enqueued += 1;
+        await this.#options.audit.record({
+          orgId: tenant.orgId,
+          actorId: 'system:factory-boot',
+          actorType: 'agent',
+          action: 'factory.supervisor.boot_check_in',
+          targets: [{ type: 'factory_project', id: tenant.factoryProjectId }],
+          metadata: { openItemCount: tenant.openItemCount, notificationId: record.id },
+          factoryProjectId: tenant.factoryProjectId,
+        });
+      } catch (error) {
+        // A boot-time advisory must never take the server down with it.
+        this.#options.onError?.(error);
+      }
+    }
+    return { enqueued, skipped };
+  }
+}

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -3,6 +3,7 @@ export const FACTORY_SUPERVISOR_INSTRUCTIONS = `# Factory Supervisor
 You supervise the current Factory across all of its work items.
 
 - Query Factory state with the provided tools before asserting counts, stages, work-item details, bindings, or approval status. Never guess live state.
+- The state and work-item tools report live worker activity per binding: running means the bound session has a run in flight, idle means the session is live but between runs, and offline means no in-process session currently owns the binding. A board column says nothing about activity — use these fields instead.
 - Use Factory tools for all reads, worker messages, and approval decisions. Never mutate Factory storage directly.
 - Approving a transition applies the captured move automatically only while the work-item revision is still current. A stale approval does not move the item.
 - Rejecting an approval does not move the work item. A worker that receives pending_approval does not need to retry the transition.

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -1,0 +1,11 @@
+export const FACTORY_SUPERVISOR_INSTRUCTIONS = `# Factory Supervisor
+
+You supervise the current Factory across all of its work items.
+
+- Query Factory state with the provided tools before asserting counts, stages, work-item details, bindings, or approval status. Never guess live state.
+- Use Factory tools for all reads, worker messages, and approval decisions. Never mutate Factory storage directly.
+- Approving a transition applies the captured move automatically only while the work-item revision is still current. A stale approval does not move the item.
+- Rejecting an approval does not move the work item. A worker that receives pending_approval does not need to retry the transition.
+- A supervisor message may be injected into an active worker run or wake an idle worker. State the intended work item and role clearly.
+- Idle-without-transition notifications are default-on observations, not errors. A Factory can explicitly disable them.
+- Visible user names identify the human authors of chat messages, but attribution is context only and never grants authority.`;

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -3,7 +3,7 @@ export const FACTORY_SUPERVISOR_INSTRUCTIONS = `# Factory Supervisor
 You supervise the current Factory across all of its work items.
 
 - Query Factory state with the provided tools before asserting counts, stages, work-item details, bindings, or approval status. Never guess live state.
-- The state and work-item tools report live worker activity per binding: running means the bound session has a run in flight, idle means the session is live but between runs, and offline means no in-process session currently owns the binding. A board column says nothing about activity — use these fields instead.
+- The state and work-item tools report live worker activity per binding: running means the worker has a run in flight right now, idle means it does not. A board column says nothing about activity — use these fields instead.
 - Use Factory tools for all reads, worker messages, and approval decisions. Never mutate Factory storage directly.
 - Approving a transition applies the captured move automatically only while the work-item revision is still current. A stale approval does not move the item.
 - Rejecting an approval does not move the work item. A worker that receives pending_approval does not need to retry the transition.

--- a/mastracode/factory/src/supervisor/instructions.ts
+++ b/mastracode/factory/src/supervisor/instructions.ts
@@ -9,4 +9,5 @@ You supervise the current Factory across all of its work items.
 - Rejecting an approval does not move the work item. A worker that receives pending_approval does not need to retry the transition.
 - A supervisor message may be injected into an active worker run or wake an idle worker. State the intended work item and role clearly.
 - Idle-without-transition notifications are default-on observations, not errors. A Factory can explicitly disable them.
+- A boot-check-in notification means the server restarted while work was open. Runs that were in flight were killed without finishing, so treat every worker as idle until you re-query state. Find the stalled items and resolve them one at a time — nudge, cancel, or escalate — rather than signaling everything at once.
 - Visible user names identify the human authors of chat messages, but attribution is context only and never grants authority.`;

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { FACTORY_SUPERVISOR_INSTRUCTIONS } from './instructions.js';
+import { FactorySupervisorService, factorySupervisorThreadId } from './service.js';
+
+const PROJECT_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_PROJECT_ID = '22222222-2222-4222-8222-222222222222';
+const ORG_ID = 'org-1';
+
+function fixture(options: { projectExists?: boolean; liveState?: Record<string, unknown> } = {}) {
+  const threadId = factorySupervisorThreadId(PROJECT_ID);
+  let state = {
+    pluginInstructions: ['Existing instruction.'],
+    factoryProjectId: PROJECT_ID,
+    factoryOrgId: ORG_ID,
+    factorySupervisor: true,
+    ...options.liveState,
+  };
+  const session = {
+    identity: { getResourceId: () => PROJECT_ID },
+    thread: {
+      getId: vi.fn(() => threadId),
+      getById: vi.fn(async () => ({
+        id: threadId,
+        resourceId: PROJECT_ID,
+        metadata: { factoryProjectId: PROJECT_ID, factoryOrgId: ORG_ID, factorySupervisor: 'true' },
+      })),
+      rename: vi.fn(async () => undefined),
+      switch: vi.fn(async () => undefined),
+    },
+    state: {
+      get: vi.fn(() => state),
+      set: vi.fn(async (updates: Record<string, unknown>) => {
+        state = { ...state, ...updates };
+      }),
+    },
+  };
+  let live = options.liveState ? session : undefined;
+  const controller = {
+    getSessionByResource: vi.fn(async () => live),
+    createSession: vi.fn(async (_input: Record<string, unknown>) => {
+      live = session;
+      return session;
+    }),
+  };
+  const projects = {
+    ensureReady: vi.fn(async () => undefined),
+    get: vi.fn(async ({ orgId, id }: { orgId: string; id: string }) =>
+      options.projectExists === false || orgId !== ORG_ID || id !== PROJECT_ID
+        ? null
+        : { id, defaultModelId: 'openai/gpt-4.1' },
+    ),
+  };
+  const workItems = {
+    ensureReady: vi.fn(async () => undefined),
+    list: vi.fn(async () => []),
+  };
+  const approvals = { list: vi.fn(async () => []), get: vi.fn(), resolve: vi.fn() };
+  const primeCredentials = vi.fn(async () => undefined);
+  const service = new FactorySupervisorService({
+    controller: controller as never,
+    projects: projects as never,
+    workItems: workItems as never,
+    approvals,
+    primeCredentials,
+  });
+  return { service, controller, projects, session, primeCredentials, getState: () => state };
+}
+
+describe('FactorySupervisorService', () => {
+  it('creates the deterministic repo-less singleton and installs supervisor instructions', async () => {
+    const { service, controller, session, primeCredentials, getState } = fixture();
+    const address = await service.ensureSession({ orgId: ORG_ID, userId: 'user-1', factoryProjectId: PROJECT_ID });
+
+    expect(address).toEqual({
+      factoryProjectId: PROJECT_ID,
+      resourceId: PROJECT_ID,
+      sessionId: `${PROJECT_ID}-supervisor`,
+      threadId: `${PROJECT_ID}-supervisor`,
+    });
+    expect(controller.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: `${PROJECT_ID}-supervisor`,
+        ownerId: `factory:${ORG_ID}`,
+        resourceId: PROJECT_ID,
+        threadId: `${PROJECT_ID}-supervisor`,
+        tags: {
+          factoryProjectId: PROJECT_ID,
+          factoryOrgId: ORG_ID,
+          factorySupervisor: 'true',
+          currentModelId: 'openai/gpt-4.1',
+        },
+      }),
+    );
+    expect(controller.createSession.mock.calls[0]?.[0]).not.toHaveProperty('scope');
+    expect(controller.createSession.mock.calls[0]?.[0]).not.toHaveProperty('workspace');
+    expect(primeCredentials).toHaveBeenCalledWith({ orgId: ORG_ID, userId: 'user-1' });
+    expect(session.thread.rename).toHaveBeenCalledWith({ title: 'Factory Supervisor' });
+    expect(getState()).toMatchObject({
+      factoryProjectId: PROJECT_ID,
+      factoryOrgId: ORG_ID,
+      factorySupervisor: true,
+      projectPath: undefined,
+      projectRepositoryId: undefined,
+      worktreePath: undefined,
+    });
+    expect(getState().pluginInstructions).toContain(FACTORY_SUPERVISOR_INSTRUCTIONS);
+  });
+
+  it('coalesces concurrent creation and reuses the transcript across users', async () => {
+    const { service, controller, primeCredentials } = fixture();
+    const [first, second] = await Promise.all([
+      service.ensureSession({ orgId: ORG_ID, userId: 'user-1', factoryProjectId: PROJECT_ID }),
+      service.ensureSession({ orgId: ORG_ID, userId: 'user-2', factoryProjectId: PROJECT_ID }),
+    ]);
+    const third = await service.ensureSession({ orgId: ORG_ID, userId: 'user-2', factoryProjectId: PROJECT_ID });
+
+    expect(first).toEqual(second);
+    expect(third.threadId).toBe(first.threadId);
+    expect(controller.createSession).toHaveBeenCalledOnce();
+    expect(primeCredentials).toHaveBeenCalledWith({ orgId: ORG_ID, userId: 'user-1' });
+    expect(primeCredentials).toHaveBeenCalledWith({ orgId: ORG_ID, userId: 'user-2' });
+  });
+
+  it('fails closed for another tenant or a mismatched live resource', async () => {
+    const missing = fixture({ projectExists: false });
+    await expect(
+      missing.service.ensureSession({ orgId: ORG_ID, userId: 'user-1', factoryProjectId: OTHER_PROJECT_ID }),
+    ).rejects.toThrow('Factory project not found');
+
+    const mismatched = fixture({ liveState: { factoryOrgId: 'org-other' } });
+    await expect(
+      mismatched.service.ensureSession({ orgId: ORG_ID, userId: 'user-1', factoryProjectId: PROJECT_ID }),
+    ).rejects.toThrow('non-canonical session');
+    expect(mismatched.controller.createSession).not.toHaveBeenCalled();
+  });
+
+  it('returns bounded Factory state scoped through tenant-aware storage calls', async () => {
+    const { service } = fixture();
+    const state = await service.getState({ orgId: ORG_ID, factoryProjectId: PROJECT_ID });
+    expect(state).toEqual({
+      factoryProjectId: PROJECT_ID,
+      totalItems: 0,
+      counts: { byBoard: {}, byStage: {} },
+      pendingApprovals: [],
+    });
+  });
+});

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -17,12 +17,12 @@ function fixture(options: { projectExists?: boolean; liveState?: Record<string, 
     ...options.liveState,
   };
   const session = {
-    identity: { getResourceId: () => PROJECT_ID },
+    identity: { getResourceId: () => `${PROJECT_ID}-supervisor` },
     thread: {
       getId: vi.fn(() => threadId),
       getById: vi.fn(async () => ({
         id: threadId,
-        resourceId: PROJECT_ID,
+        resourceId: `${PROJECT_ID}-supervisor`,
         metadata: { factoryProjectId: PROJECT_ID, factoryOrgId: ORG_ID, factorySupervisor: 'true' },
       })),
       rename: vi.fn(async () => undefined),
@@ -36,8 +36,13 @@ function fixture(options: { projectExists?: boolean; liveState?: Record<string, 
     },
   };
   let live = options.liveState ? session : undefined;
+  // A factory-level (non-supervisor) session always occupies the bare factory
+  // id in practice — the supervisor must never resolve or collide with it.
+  const factoryLevelSession = { state: { get: vi.fn(() => ({})) } };
   const controller = {
-    getSessionByResource: vi.fn(async () => live),
+    getSessionByResource: vi.fn(async (resourceId: string) =>
+      resourceId === `${PROJECT_ID}-supervisor` ? live : resourceId === PROJECT_ID ? factoryLevelSession : undefined,
+    ),
     createSession: vi.fn(async (_input: Record<string, unknown>) => {
       live = session;
       return session;
@@ -74,7 +79,7 @@ describe('FactorySupervisorService', () => {
 
     expect(address).toEqual({
       factoryProjectId: PROJECT_ID,
-      resourceId: PROJECT_ID,
+      resourceId: `${PROJECT_ID}-supervisor`,
       sessionId: `${PROJECT_ID}-supervisor`,
       threadId: `${PROJECT_ID}-supervisor`,
     });
@@ -82,7 +87,7 @@ describe('FactorySupervisorService', () => {
       expect.objectContaining({
         id: `${PROJECT_ID}-supervisor`,
         ownerId: `factory:${ORG_ID}`,
-        resourceId: PROJECT_ID,
+        resourceId: `${PROJECT_ID}-supervisor`,
         threadId: `${PROJECT_ID}-supervisor`,
         tags: {
           factoryProjectId: PROJECT_ID,
@@ -94,6 +99,10 @@ describe('FactorySupervisorService', () => {
     );
     expect(controller.createSession.mock.calls[0]?.[0]).not.toHaveProperty('scope');
     expect(controller.createSession.mock.calls[0]?.[0]).not.toHaveProperty('workspace');
+    // Regression: the bare factory id belongs to the factory-level session
+    // provisioned by /ensure; the supervisor must address its own resource.
+    expect(controller.getSessionByResource).toHaveBeenCalledWith(`${PROJECT_ID}-supervisor`);
+    expect(controller.getSessionByResource).not.toHaveBeenCalledWith(PROJECT_ID);
     expect(primeCredentials).toHaveBeenCalledWith({ orgId: ORG_ID, userId: 'user-1' });
     expect(session.thread.rename).toHaveBeenCalledWith({ title: 'Factory Supervisor' });
     expect(getState()).toMatchObject({

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -171,8 +171,7 @@ describe('FactorySupervisorService', () => {
       pendingApprovals: [],
       workers: {
         running: 1,
-        idle: 1,
-        offline: 1,
+        idle: 2,
         bindings: [
           {
             workItemId: 'item-1',
@@ -194,7 +193,7 @@ describe('FactorySupervisorService', () => {
             workItemId: 'item-3',
             role: 'review',
             bindingId: 'binding-3',
-            activity: 'offline',
+            activity: 'idle',
             workItemTitle: null,
             stage: null,
           },

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -41,7 +41,15 @@ function fixture(options: { projectExists?: boolean; liveState?: Record<string, 
   const factoryLevelSession = { state: { get: vi.fn(() => ({})) } };
   const controller = {
     getSessionByResource: vi.fn(async (resourceId: string) =>
-      resourceId === `${PROJECT_ID}-supervisor` ? live : resourceId === PROJECT_ID ? factoryLevelSession : undefined,
+      resourceId === `${PROJECT_ID}-supervisor`
+        ? live
+        : resourceId === PROJECT_ID
+          ? factoryLevelSession
+          : resourceId === 'worker-running'
+            ? runningWorkerSession
+            : resourceId === 'worker-idle'
+              ? idleWorkerSession
+              : undefined,
     ),
     createSession: vi.fn(async (_input: Record<string, unknown>) => {
       live = session;
@@ -56,9 +64,17 @@ function fixture(options: { projectExists?: boolean; liveState?: Record<string, 
         : { id, defaultModelId: 'openai/gpt-4.1' },
     ),
   };
+  const runningWorkerSession = { run: { isRunning: () => true } };
+  const idleWorkerSession = { run: { isRunning: () => false } };
   const workItems = {
     ensureReady: vi.fn(async () => undefined),
     list: vi.fn(async () => []),
+    listRunBindings: vi.fn(async () => [
+      { id: 'binding-1', workItemId: 'item-1', role: 'work', resourceId: 'worker-running', status: 'active' },
+      { id: 'binding-2', workItemId: 'item-2', role: 'work', resourceId: 'worker-idle', status: 'active' },
+      { id: 'binding-3', workItemId: 'item-3', role: 'review', resourceId: 'worker-gone', status: 'active' },
+      { id: 'binding-4', workItemId: 'item-4', role: 'work', resourceId: 'worker-revoked', status: 'revoked' },
+    ]),
   };
   const approvals = { list: vi.fn(async () => []), get: vi.fn(), resolve: vi.fn() };
   const primeCredentials = vi.fn(async () => undefined);
@@ -153,6 +169,37 @@ describe('FactorySupervisorService', () => {
       counts: { byBoard: {}, byStage: {} },
       pendingApprovalCount: 0,
       pendingApprovals: [],
+      workers: {
+        running: 1,
+        idle: 1,
+        offline: 1,
+        bindings: [
+          {
+            workItemId: 'item-1',
+            role: 'work',
+            bindingId: 'binding-1',
+            activity: 'running',
+            workItemTitle: null,
+            stage: null,
+          },
+          {
+            workItemId: 'item-2',
+            role: 'work',
+            bindingId: 'binding-2',
+            activity: 'idle',
+            workItemTitle: null,
+            stage: null,
+          },
+          {
+            workItemId: 'item-3',
+            role: 'review',
+            bindingId: 'binding-3',
+            activity: 'offline',
+            workItemTitle: null,
+            stage: null,
+          },
+        ],
+      },
       snapshotAt: expect.any(String),
     });
   });

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -7,7 +7,18 @@ const PROJECT_ID = '11111111-1111-4111-8111-111111111111';
 const OTHER_PROJECT_ID = '22222222-2222-4222-8222-222222222222';
 const ORG_ID = 'org-1';
 
-function fixture(options: { projectExists?: boolean; liveState?: Record<string, unknown> } = {}) {
+function fixture(
+  options: {
+    projectExists?: boolean;
+    liveState?: Record<string, unknown>;
+    storedWorkerSession?: {
+      orgId: string;
+      projectRepositoryId: string;
+      sandboxId: string | null;
+      sandboxWorkdir: string | null;
+    };
+  } = {},
+) {
   const threadId = factorySupervisorThreadId(PROJECT_ID);
   let state = {
     pluginInstructions: ['Existing instruction.'],
@@ -64,8 +75,14 @@ function fixture(options: { projectExists?: boolean; liveState?: Record<string, 
         : { id, defaultModelId: 'openai/gpt-4.1' },
     ),
   };
-  const runningWorkerSession = { run: { isRunning: () => true } };
-  const idleWorkerSession = { run: { isRunning: () => false } };
+  const runningWorkerSession = {
+    run: { isRunning: () => true },
+    thread: { getId: vi.fn(() => 'worker-thread'), switch: vi.fn(async () => undefined) },
+  };
+  const idleWorkerSession = {
+    run: { isRunning: () => false },
+    thread: { getId: vi.fn(() => 'worker-thread'), switch: vi.fn(async () => undefined) },
+  };
   const workItems = {
     ensureReady: vi.fn(async () => undefined),
     list: vi.fn(async () => []),
@@ -78,14 +95,27 @@ function fixture(options: { projectExists?: boolean; liveState?: Record<string, 
   };
   const approvals = { list: vi.fn(async () => []), get: vi.fn(), resolve: vi.fn() };
   const primeCredentials = vi.fn(async () => undefined);
+  const storedSessions = {
+    getBySessionId: vi.fn(async (_sessionId: string) => options.storedWorkerSession ?? null),
+  };
   const service = new FactorySupervisorService({
     controller: controller as never,
     projects: projects as never,
     workItems: workItems as never,
     approvals,
     primeCredentials,
+    storedSessions,
   });
-  return { service, controller, projects, session, primeCredentials, getState: () => state };
+  return {
+    service,
+    controller,
+    projects,
+    session,
+    primeCredentials,
+    storedSessions,
+    runningWorkerSession,
+    getState: () => state,
+  };
 }
 
 describe('FactorySupervisorService', () => {
@@ -201,5 +231,66 @@ describe('FactorySupervisorService', () => {
       },
       snapshotAt: expect.any(String),
     });
+  });
+
+  it('reuses a live worker session and rebinds it to the binding thread', async () => {
+    const { service, controller, runningWorkerSession } = fixture();
+    const resolved = await service.resolveWorkerSession({
+      orgId: ORG_ID,
+      factoryProjectId: PROJECT_ID,
+      binding: { resourceId: 'worker-running', threadId: 'other-thread' },
+    });
+    expect(resolved).toBe(runningWorkerSession);
+    expect(runningWorkerSession.thread.switch).toHaveBeenCalledWith({ threadId: 'other-thread', emitEvent: false });
+    expect(controller.createSession).not.toHaveBeenCalled();
+  });
+
+  it('reopens a worker session from its stored workspace coordinates when none is live', async () => {
+    const { service, controller, session, storedSessions } = fixture({
+      storedWorkerSession: {
+        orgId: ORG_ID,
+        projectRepositoryId: 'repo-1',
+        sandboxId: 'sandbox-1',
+        sandboxWorkdir: '/workspaces/app',
+      },
+    });
+    const resolved = await service.resolveWorkerSession({
+      orgId: ORG_ID,
+      factoryProjectId: PROJECT_ID,
+      binding: { resourceId: 'worker-gone', threadId: 'worker-gone-thread' },
+    });
+    expect(resolved).toBe(session);
+    expect(storedSessions.getBySessionId).toHaveBeenCalledWith('worker-gone');
+    expect(controller.createSession).toHaveBeenCalledWith(
+      expect.objectContaining({ resourceId: 'worker-gone', threadId: 'worker-gone-thread' }),
+    );
+    expect(session.state.set).toHaveBeenCalledWith({
+      factoryProjectId: PROJECT_ID,
+      projectRepositoryId: 'repo-1',
+      sandboxId: 'sandbox-1',
+      sandboxWorkdir: '/workspaces/app',
+    });
+  });
+
+  it('reopens without workspace state when no stored record exists and fails closed across tenants', async () => {
+    const bare = fixture();
+    await bare.service.resolveWorkerSession({
+      orgId: ORG_ID,
+      factoryProjectId: PROJECT_ID,
+      binding: { resourceId: 'worker-gone', threadId: 'worker-gone-thread' },
+    });
+    expect(bare.session.state.set).toHaveBeenCalledWith({ factoryProjectId: PROJECT_ID });
+
+    const foreign = fixture({
+      storedWorkerSession: { orgId: 'org-other', projectRepositoryId: 'repo-1', sandboxId: null, sandboxWorkdir: null },
+    });
+    await expect(
+      foreign.service.resolveWorkerSession({
+        orgId: ORG_ID,
+        factoryProjectId: PROJECT_ID,
+        binding: { resourceId: 'worker-gone', threadId: 'worker-gone-thread' },
+      }),
+    ).rejects.toThrow('not available to this tenant');
+    expect(foreign.controller.createSession).not.toHaveBeenCalled();
   });
 });

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -142,7 +142,9 @@ describe('FactorySupervisorService', () => {
       factoryProjectId: PROJECT_ID,
       totalItems: 0,
       counts: { byBoard: {}, byStage: {} },
+      pendingApprovalCount: 0,
       pendingApprovals: [],
+      snapshotAt: expect.any(String),
     });
   });
 });

--- a/mastracode/factory/src/supervisor/service.test.ts
+++ b/mastracode/factory/src/supervisor/service.test.ts
@@ -139,6 +139,8 @@ describe('FactorySupervisorService', () => {
           factoryProjectId: PROJECT_ID,
           factoryOrgId: ORG_ID,
           factorySupervisor: 'true',
+          // Server-initiated runs resolve tenant identity from session state.
+          factorySupervisorUserId: 'user-1',
           currentModelId: 'openai/gpt-4.1',
         },
       }),

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -1,6 +1,6 @@
 import type { MastraCodeState } from '@mastra/code-sdk/schema';
 import type { AgentController } from '@mastra/core/agent-controller';
-import type { RequestContext } from '@mastra/core/request-context';
+import { RequestContext } from '@mastra/core/request-context';
 
 import type { FactoryTransitionApprovalService } from '../rules/approval-service.js';
 import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
@@ -24,6 +24,19 @@ export function factorySupervisorThreadId(factoryProjectId: string): string {
  */
 export function factorySupervisorResourceId(factoryProjectId: string): string {
   return `${factoryProjectId}${FACTORY_SUPERVISOR_SESSION_SUFFIX}`;
+}
+
+/**
+ * Build a fresh request context for acting on a worker session, carrying only
+ * the caller's `user` identity. The controller mutates the context it's given
+ * (it writes the target session's `controller` entry into it), so worker
+ * operations must never share the supervisor's live run context.
+ */
+export function isolatedWorkerRequestContext(source: RequestContext | undefined): RequestContext {
+  const context = new RequestContext();
+  const user = source?.get('user');
+  if (user) context.set('user', user);
+  return context;
 }
 
 export interface FactorySupervisorAddress {
@@ -218,6 +231,12 @@ export class FactorySupervisorService {
    * (repository, sandbox) into session state. A binding with no stored
    * session record simply reopens without workspace state, exactly like a
    * user opening a session with no repository.
+   *
+   * `requestContext` here must be an isolated worker context (see
+   * {@link isolatedWorkerRequestContext}) — the controller writes the target
+   * session's identity into the context it's given, so passing the
+   * supervisor's live run context would clobber the supervisor's own
+   * `controller` key and de-canonicalize its session mid-run.
    */
   async resolveWorkerSession(input: {
     orgId: string;

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -200,9 +200,9 @@ export class FactorySupervisorService {
 
   /**
    * Live activity for each active run binding. A binding whose bound session
-   * has a run in flight is `running`; a live session between runs is `idle`;
-   * a binding with no in-process session (e.g. right after a server restart)
-   * is `offline`. Pure in-memory registry lookups — never creates sessions.
+   * has a run in flight is `running`; everything else is `idle` — whether an
+   * in-process session exists is a server detail the supervisor doesn't need.
+   * Pure in-memory registry lookups — never creates sessions.
    */
   async describeWorkerBindings(input: {
     orgId: string;
@@ -215,7 +215,7 @@ export class FactorySupervisorService {
         .filter(binding => binding.status === 'active')
         .map(async binding => {
           const session = await this.#controller.getSessionByResource(binding.resourceId);
-          const activity = !session ? 'offline' : session.run.isRunning() ? 'running' : 'idle';
+          const activity = session?.run.isRunning() ? 'running' : 'idle';
           return { workItemId: binding.workItemId, role: binding.role, bindingId: binding.id, activity } as const;
         }),
     );

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -15,6 +15,17 @@ export function factorySupervisorThreadId(factoryProjectId: string): string {
   return `${factoryProjectId}${FACTORY_SUPERVISOR_SESSION_SUFFIX}`;
 }
 
+/**
+ * The supervisor owns a dedicated controller resource. The bare factory id is
+ * already claimed by the factory-level session that `/ensure` provisions for
+ * settings/permissions surfaces, and the controller registry allows only one
+ * live session per (resourceId, scope) — sharing that resource made every
+ * supervisor open collide with an existing non-supervisor session.
+ */
+export function factorySupervisorResourceId(factoryProjectId: string): string {
+  return `${factoryProjectId}${FACTORY_SUPERVISOR_SESSION_SUFFIX}`;
+}
+
 export interface FactorySupervisorAddress {
   factoryProjectId: string;
   resourceId: string;
@@ -99,7 +110,8 @@ export class FactorySupervisorService {
     defaultModelId?: string,
   ): Promise<FactorySupervisorAddress> {
     const threadId = factorySupervisorThreadId(input.factoryProjectId);
-    const live = await this.#controller.getSessionByResource(input.factoryProjectId);
+    const resourceId = factorySupervisorResourceId(input.factoryProjectId);
+    const live = await this.#controller.getSessionByResource(resourceId);
     if (live) {
       const state = live.state.get();
       if (
@@ -113,7 +125,7 @@ export class FactorySupervisorService {
       await this.#configureSession(live, input.orgId, input.factoryProjectId, threadId);
       return {
         factoryProjectId: input.factoryProjectId,
-        resourceId: input.factoryProjectId,
+        resourceId,
         sessionId: threadId,
         threadId,
       };
@@ -122,7 +134,7 @@ export class FactorySupervisorService {
     const session = await this.#controller.createSession({
       id: threadId,
       ownerId: `factory:${input.orgId}`,
-      resourceId: input.factoryProjectId,
+      resourceId,
       threadId,
       tags: {
         factoryProjectId: input.factoryProjectId,
@@ -135,7 +147,7 @@ export class FactorySupervisorService {
     await this.#configureSession(session, input.orgId, input.factoryProjectId, threadId);
     return {
       factoryProjectId: input.factoryProjectId,
-      resourceId: input.factoryProjectId,
+      resourceId,
       sessionId: threadId,
       threadId,
     };
@@ -151,7 +163,7 @@ export class FactorySupervisorService {
     const metadata = thread?.metadata as Record<string, unknown> | undefined;
     if (
       !thread ||
-      thread.resourceId !== factoryProjectId ||
+      thread.resourceId !== factorySupervisorResourceId(factoryProjectId) ||
       metadata?.factoryProjectId !== factoryProjectId ||
       metadata?.factoryOrgId !== orgId ||
       metadata?.factorySupervisor !== 'true'

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -33,12 +33,22 @@ export interface FactorySupervisorAddress {
   threadId: string;
 }
 
+/** The stored workspace coordinates a session record re-supplies on reopen. */
+export interface FactoryStoredWorkerSession {
+  orgId: string;
+  projectRepositoryId: string;
+  sandboxId: string | null;
+  sandboxWorkdir: string | null;
+}
+
 export interface FactorySupervisorServiceOptions {
   controller: AgentController<MastraCodeState>;
   projects: FactoryProjectsStorage;
   workItems: WorkItemsStorage;
   approvals: Pick<FactoryTransitionApprovalService, 'list' | 'get' | 'resolve'>;
   primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
+  /** Stored session lookup used to restore worker workspace state on reopen. */
+  storedSessions?: { getBySessionId(sessionId: string): Promise<FactoryStoredWorkerSession | null> };
 }
 
 export class FactorySupervisorService {
@@ -47,6 +57,7 @@ export class FactorySupervisorService {
   readonly #workItems: WorkItemsStorage;
   readonly #approvals: Pick<FactoryTransitionApprovalService, 'list' | 'get' | 'resolve'>;
   readonly #primeCredentials?: FactorySupervisorServiceOptions['primeCredentials'];
+  readonly #storedSessions?: FactorySupervisorServiceOptions['storedSessions'];
   readonly #pending = new Map<string, Promise<FactorySupervisorAddress>>();
 
   constructor(options: FactorySupervisorServiceOptions) {
@@ -55,6 +66,7 @@ export class FactorySupervisorService {
     this.#workItems = options.workItems;
     this.#approvals = options.approvals;
     this.#primeCredentials = options.primeCredentials;
+    this.#storedSessions = options.storedSessions;
   }
 
   get controller(): AgentController<MastraCodeState> {
@@ -196,6 +208,46 @@ export class FactorySupervisorService {
       this.describeWorkerBindings(input),
     ]);
     return buildFactorySupervisorState(input.factoryProjectId, items, approvals, workers);
+  }
+
+  /**
+   * Resolve the controller session for a worker binding, reopening it when no
+   * in-process session exists — the same recipe the browser uses to reopen a
+   * stored session after a server restart: get-or-create by resourceId, bind
+   * the binding's thread, then re-supply the stored workspace coordinates
+   * (repository, sandbox) into session state. A binding with no stored
+   * session record simply reopens without workspace state, exactly like a
+   * user opening a session with no repository.
+   */
+  async resolveWorkerSession(input: {
+    orgId: string;
+    factoryProjectId: string;
+    binding: { resourceId: string; threadId: string };
+    requestContext?: RequestContext;
+  }) {
+    const live = await this.#controller.getSessionByResource(input.binding.resourceId);
+    if (live) {
+      if (live.thread.getId() !== input.binding.threadId) {
+        await live.thread.switch({ threadId: input.binding.threadId, emitEvent: false });
+      }
+      return live;
+    }
+    const stored = await this.#storedSessions?.getBySessionId(input.binding.resourceId);
+    if (stored && stored.orgId !== input.orgId) {
+      throw new Error('Factory session is not available to this tenant.');
+    }
+    const session = await this.#controller.createSession({
+      resourceId: input.binding.resourceId,
+      threadId: input.binding.threadId,
+      requestContext: input.requestContext,
+    });
+    await session.state.set({
+      factoryProjectId: input.factoryProjectId,
+      ...(stored?.projectRepositoryId ? { projectRepositoryId: stored.projectRepositoryId } : {}),
+      ...(stored?.sandboxId ? { sandboxId: stored.sandboxId } : {}),
+      ...(stored?.sandboxWorkdir ? { sandboxWorkdir: stored.sandboxWorkdir } : {}),
+    });
+    return session;
   }
 
   /**

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -1,0 +1,187 @@
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+import type { AgentController } from '@mastra/core/agent-controller';
+import type { RequestContext } from '@mastra/core/request-context';
+
+import type { FactoryTransitionApprovalService } from '../rules/approval-service.js';
+import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js';
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { FACTORY_SUPERVISOR_INSTRUCTIONS } from './instructions.js';
+import { buildFactorySupervisorState } from './state.js';
+import type { FactorySupervisorState } from './state.js';
+
+export const FACTORY_SUPERVISOR_SESSION_SUFFIX = '-supervisor';
+
+export function factorySupervisorThreadId(factoryProjectId: string): string {
+  return `${factoryProjectId}${FACTORY_SUPERVISOR_SESSION_SUFFIX}`;
+}
+
+export interface FactorySupervisorAddress {
+  factoryProjectId: string;
+  resourceId: string;
+  sessionId: string;
+  threadId: string;
+}
+
+export interface FactorySupervisorServiceOptions {
+  controller: AgentController<MastraCodeState>;
+  projects: FactoryProjectsStorage;
+  workItems: WorkItemsStorage;
+  approvals: Pick<FactoryTransitionApprovalService, 'list' | 'get' | 'resolve'>;
+  primeCredentials?: (tenant: { orgId: string; userId: string }) => Promise<void>;
+}
+
+export class FactorySupervisorService {
+  readonly #controller: AgentController<MastraCodeState>;
+  readonly #projects: FactoryProjectsStorage;
+  readonly #workItems: WorkItemsStorage;
+  readonly #approvals: Pick<FactoryTransitionApprovalService, 'list' | 'get' | 'resolve'>;
+  readonly #primeCredentials?: FactorySupervisorServiceOptions['primeCredentials'];
+  readonly #pending = new Map<string, Promise<FactorySupervisorAddress>>();
+
+  constructor(options: FactorySupervisorServiceOptions) {
+    this.#controller = options.controller;
+    this.#projects = options.projects;
+    this.#workItems = options.workItems;
+    this.#approvals = options.approvals;
+    this.#primeCredentials = options.primeCredentials;
+  }
+
+  get controller(): AgentController<MastraCodeState> {
+    return this.#controller;
+  }
+
+  get workItems(): WorkItemsStorage {
+    return this.#workItems;
+  }
+
+  get approvals(): Pick<FactoryTransitionApprovalService, 'list' | 'get' | 'resolve'> {
+    return this.#approvals;
+  }
+
+  async #getProject(input: { orgId: string; factoryProjectId: string }) {
+    await this.#projects.ensureReady();
+    const project = await this.#projects.get({ orgId: input.orgId, id: input.factoryProjectId });
+    if (!project) throw new Error('Factory project not found.');
+    return project;
+  }
+
+  async requireProject(input: { orgId: string; factoryProjectId: string }): Promise<void> {
+    await this.#getProject(input);
+  }
+
+  async ensureSession(input: {
+    orgId: string;
+    userId: string;
+    factoryProjectId: string;
+    requestContext?: RequestContext;
+  }): Promise<FactorySupervisorAddress> {
+    const project = await this.#getProject(input);
+    await this.#primeCredentials?.({ orgId: input.orgId, userId: input.userId });
+
+    const key = `${input.orgId}\u0000${input.factoryProjectId}`;
+    const existing = this.#pending.get(key);
+    if (existing) return existing;
+
+    const creation = this.#ensureCanonicalSession(input, project.defaultModelId ?? undefined).finally(() => {
+      if (this.#pending.get(key) === creation) this.#pending.delete(key);
+    });
+    this.#pending.set(key, creation);
+    return creation;
+  }
+
+  async #ensureCanonicalSession(
+    input: {
+      orgId: string;
+      userId: string;
+      factoryProjectId: string;
+      requestContext?: RequestContext;
+    },
+    defaultModelId?: string,
+  ): Promise<FactorySupervisorAddress> {
+    const threadId = factorySupervisorThreadId(input.factoryProjectId);
+    const live = await this.#controller.getSessionByResource(input.factoryProjectId);
+    if (live) {
+      const state = live.state.get();
+      if (
+        state.factoryProjectId !== input.factoryProjectId ||
+        state.factoryOrgId !== input.orgId ||
+        (state.factorySupervisor !== true && state.factorySupervisor !== 'true')
+      ) {
+        throw new Error('Factory supervisor resource is already bound to a non-canonical session.');
+      }
+      if (live.thread.getId() !== threadId) await live.thread.switch({ threadId, emitEvent: false });
+      await this.#configureSession(live, input.orgId, input.factoryProjectId, threadId);
+      return {
+        factoryProjectId: input.factoryProjectId,
+        resourceId: input.factoryProjectId,
+        sessionId: threadId,
+        threadId,
+      };
+    }
+
+    const session = await this.#controller.createSession({
+      id: threadId,
+      ownerId: `factory:${input.orgId}`,
+      resourceId: input.factoryProjectId,
+      threadId,
+      tags: {
+        factoryProjectId: input.factoryProjectId,
+        factoryOrgId: input.orgId,
+        factorySupervisor: 'true',
+        ...(defaultModelId ? { currentModelId: defaultModelId } : {}),
+      },
+      requestContext: input.requestContext,
+    });
+    await this.#configureSession(session, input.orgId, input.factoryProjectId, threadId);
+    return {
+      factoryProjectId: input.factoryProjectId,
+      resourceId: input.factoryProjectId,
+      sessionId: threadId,
+      threadId,
+    };
+  }
+
+  async #configureSession(
+    session: Awaited<ReturnType<AgentController<MastraCodeState>['createSession']>>,
+    orgId: string,
+    factoryProjectId: string,
+    threadId: string,
+  ): Promise<void> {
+    const thread = await session.thread.getById({ threadId });
+    const metadata = thread?.metadata as Record<string, unknown> | undefined;
+    if (
+      !thread ||
+      thread.resourceId !== factoryProjectId ||
+      metadata?.factoryProjectId !== factoryProjectId ||
+      metadata?.factoryOrgId !== orgId ||
+      metadata?.factorySupervisor !== 'true'
+    ) {
+      throw new Error('Factory supervisor thread identity does not match the requested tenant and project.');
+    }
+    await session.thread.rename({ title: 'Factory Supervisor' });
+    const current = session.state.get();
+    const pluginInstructions = current.pluginInstructions.includes(FACTORY_SUPERVISOR_INSTRUCTIONS)
+      ? current.pluginInstructions
+      : [...current.pluginInstructions, FACTORY_SUPERVISOR_INSTRUCTIONS];
+    await session.state.set({
+      factoryProjectId,
+      factoryOrgId: orgId,
+      factorySupervisor: true,
+      pluginInstructions,
+      projectPath: undefined,
+      projectRepositoryId: undefined,
+      worktreePath: undefined,
+      branch: undefined,
+    });
+  }
+
+  async getState(input: { orgId: string; factoryProjectId: string }): Promise<FactorySupervisorState> {
+    await this.requireProject(input);
+    await this.#workItems.ensureReady();
+    const [items, approvals] = await Promise.all([
+      this.#workItems.list(input),
+      this.#approvals.list({ ...input, statuses: ['pending'] }),
+    ]);
+    return buildFactorySupervisorState(input.factoryProjectId, items, approvals);
+  }
+}

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -7,7 +7,7 @@ import type { FactoryProjectsStorage } from '../storage/domains/projects/base.js
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { FACTORY_SUPERVISOR_INSTRUCTIONS } from './instructions.js';
 import { buildFactorySupervisorState } from './state.js';
-import type { FactorySupervisorState } from './state.js';
+import type { FactorySupervisorState, FactorySupervisorWorkerBinding } from './state.js';
 
 export const FACTORY_SUPERVISOR_SESSION_SUFFIX = '-supervisor';
 
@@ -190,10 +190,34 @@ export class FactorySupervisorService {
   async getState(input: { orgId: string; factoryProjectId: string }): Promise<FactorySupervisorState> {
     await this.requireProject(input);
     await this.#workItems.ensureReady();
-    const [items, approvals] = await Promise.all([
+    const [items, approvals, workers] = await Promise.all([
       this.#workItems.list(input),
       this.#approvals.list({ ...input, statuses: ['pending'] }),
+      this.describeWorkerBindings(input),
     ]);
-    return buildFactorySupervisorState(input.factoryProjectId, items, approvals);
+    return buildFactorySupervisorState(input.factoryProjectId, items, approvals, workers);
+  }
+
+  /**
+   * Live activity for each active run binding. A binding whose bound session
+   * has a run in flight is `running`; a live session between runs is `idle`;
+   * a binding with no in-process session (e.g. right after a server restart)
+   * is `offline`. Pure in-memory registry lookups — never creates sessions.
+   */
+  async describeWorkerBindings(input: {
+    orgId: string;
+    factoryProjectId: string;
+    workItemId?: string;
+  }): Promise<FactorySupervisorWorkerBinding[]> {
+    const bindings = await this.#workItems.listRunBindings(input.orgId, input.factoryProjectId, input.workItemId);
+    return Promise.all(
+      bindings
+        .filter(binding => binding.status === 'active')
+        .map(async binding => {
+          const session = await this.#controller.getSessionByResource(binding.resourceId);
+          const activity = !session ? 'offline' : session.run.isRunning() ? 'running' : 'idle';
+          return { workItemId: binding.workItemId, role: binding.role, bindingId: binding.id, activity } as const;
+        }),
+    );
   }
 }

--- a/mastracode/factory/src/supervisor/service.ts
+++ b/mastracode/factory/src/supervisor/service.ts
@@ -146,6 +146,10 @@ export class FactorySupervisorService {
       ) {
         throw new Error('Factory supervisor resource is already bound to a non-canonical session.');
       }
+      // Sessions created before this field existed (or by a caller acting as a
+      // different member of the same org) still need an owning user on state so
+      // server-initiated runs can resolve tenant identity without a request user.
+      if (!state.factorySupervisorUserId) live.state.set({ factorySupervisorUserId: input.userId });
       if (live.thread.getId() !== threadId) await live.thread.switch({ threadId, emitEvent: false });
       await this.#configureSession(live, input.orgId, input.factoryProjectId, threadId);
       return {
@@ -165,6 +169,7 @@ export class FactorySupervisorService {
         factoryProjectId: input.factoryProjectId,
         factoryOrgId: input.orgId,
         factorySupervisor: 'true',
+        factorySupervisorUserId: input.userId,
         ...(defaultModelId ? { currentModelId: defaultModelId } : {}),
       },
       requestContext: input.requestContext,

--- a/mastracode/factory/src/supervisor/signal-service.test.ts
+++ b/mastracode/factory/src/supervisor/signal-service.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { FactoryIdleWithoutTransitionEvent } from '../rules/run-lifecycle-observer.js';
+import type { FactorySupervisorNotificationRecord } from '../storage/domains/work-items/base.js';
+import type { FactorySupervisorService } from './service.js';
+import { FactorySupervisorSignalService } from './signal-service.js';
+
+function fixture() {
+  const sendStateSignal = vi.fn().mockResolvedValue({ skipped: false });
+  const sendNotificationSignal = vi.fn().mockResolvedValue({
+    persisted: Promise.resolve({ id: 'notification-1' }),
+    accepted: Promise.resolve({ status: 'accepted' }),
+  });
+  const session = { sendNotificationSignal };
+  const getForProject = vi.fn().mockResolvedValue({
+    id: 'item-1',
+    title: 'Fix login',
+    sessions: { work: { startedBy: 'user-1' } },
+  });
+  const state = {
+    factoryProjectId: 'project-1',
+    totalItems: 2,
+    counts: { byBoard: { work: 2 }, byStage: { intake: 1, execute: 1 } },
+    pendingApprovalCount: 1,
+    pendingApprovals: [
+      {
+        id: 'approval-1',
+        workItemId: 'item-1',
+        board: 'work',
+        stage: 'execute',
+        expectedRevision: 2,
+        requestingRole: 'work',
+        workItemTitle: 'Fix login',
+        reason: 'Approval required',
+        summary: null,
+        createdAt: '2030-01-01T00:00:00.000Z',
+        ageSeconds: 10,
+      },
+    ],
+    snapshotAt: '2030-01-01T00:00:10.000Z',
+  };
+  const service = {
+    ensureSession: vi.fn().mockResolvedValue({
+      resourceId: 'project-1-supervisor',
+      threadId: 'project-1-supervisor',
+    }),
+    getState: vi.fn().mockImplementation(async () => structuredClone(state)),
+    controller: {
+      getSessionByResource: vi.fn().mockResolvedValue(session),
+      getCurrentAgent: vi.fn().mockReturnValue({ sendStateSignal }),
+    },
+    workItems: { getForProject },
+  };
+  return {
+    service: service as unknown as FactorySupervisorService,
+    state,
+    sendStateSignal,
+    sendNotificationSignal,
+    getForProject,
+  };
+}
+
+function approvalNotification(): FactorySupervisorNotificationRecord {
+  return {
+    id: 'event-1',
+    orgId: 'org-1',
+    factoryProjectId: 'project-1',
+    approvalId: 'approval-1',
+    workItemId: 'item-1',
+    event: 'approval_requested',
+    approvalStatus: 'pending',
+    requestedStage: 'execute',
+    expectedRevision: 2,
+    requestingBindingId: 'binding-1',
+    requestingRole: 'work',
+    supervisorUserId: 'user-1',
+    reason: 'Approval required',
+    summary: null,
+    idempotencyKey: 'approval-1:approval_requested',
+    status: 'leased',
+    attempts: 1,
+    availableAt: new Date(),
+    leaseOwner: 'dispatcher',
+    leaseExpiresAt: new Date(),
+    lastError: null,
+    completedAt: null,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+}
+
+describe('FactorySupervisorSignalService', () => {
+  it('emits a bounded snapshot with a stable cache key', async () => {
+    const { service, state, sendStateSignal } = fixture();
+    const signals = new FactorySupervisorSignalService(service);
+
+    await signals.refresh({ orgId: 'org-1', userId: 'user-1', factoryProjectId: 'project-1' });
+    state.snapshotAt = '2030-01-01T00:00:11.000Z';
+    state.pendingApprovals[0]!.ageSeconds = 11;
+    await signals.refresh({ orgId: 'org-1', userId: 'user-1', factoryProjectId: 'project-1' });
+    state.totalItems = 3;
+    await signals.refresh({ orgId: 'org-1', userId: 'user-1', factoryProjectId: 'project-1' });
+
+    expect(sendStateSignal).toHaveBeenCalledTimes(3);
+    const [firstSignal, options] = sendStateSignal.mock.calls[0]!;
+    const [secondSignal] = sendStateSignal.mock.calls[1]!;
+    const [changedSignal] = sendStateSignal.mock.calls[2]!;
+    expect(firstSignal).toMatchObject({
+      id: 'factory-state',
+      mode: 'snapshot',
+      tagName: 'factory-state',
+      attributes: { factoryProjectId: 'project-1', pendingApprovalCount: 1, totalItems: 2 },
+    });
+    expect(firstSignal.cacheKey).toBe(secondSignal.cacheKey);
+    expect(changedSignal.cacheKey).not.toBe(firstSignal.cacheKey);
+    expect(firstSignal.value.pendingApprovals).toHaveLength(1);
+    expect(firstSignal.value.pendingApprovals[0]).toMatchObject({ workItemTitle: 'Fix login', ageSeconds: 10 });
+    expect(options).toEqual({
+      resourceId: 'project-1-supervisor',
+      threadId: 'project-1-supervisor',
+      ifActive: { behavior: 'deliver' },
+      ifIdle: { behavior: 'persist' },
+    });
+  });
+
+  it('refreshes state and wakes the shared supervisor for approval lifecycle events', async () => {
+    const { service, sendStateSignal, sendNotificationSignal, getForProject } = fixture();
+    getForProject.mockResolvedValueOnce(null);
+    await new FactorySupervisorSignalService(service).notifyApproval(approvalNotification());
+
+    expect(sendStateSignal).toHaveBeenCalledOnce();
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'approval_requested',
+        sourceId: 'event-1',
+        dedupeKey: 'approval-1:approval_requested',
+        payload: expect.objectContaining({ approvalId: 'approval-1', workItemId: 'item-1' }),
+      }),
+      { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+    );
+  });
+
+  it('emits idle-without-transition events only for the captured session owner', async () => {
+    const { service, sendStateSignal, sendNotificationSignal } = fixture();
+    const event: FactoryIdleWithoutTransitionEvent = {
+      orgId: 'org-1',
+      factoryProjectId: 'project-1',
+      workItemId: 'item-1',
+      bindingId: 'binding-1',
+      threadId: 'thread-1',
+      resourceId: 'resource-1',
+      sessionId: 'session-1',
+      role: 'work',
+      stage: 'execute',
+      revision: 2,
+    };
+
+    await new FactorySupervisorSignalService(service).notifyIdle(event);
+
+    expect(sendStateSignal).toHaveBeenCalledOnce();
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'idle-without-transition',
+        payload: {
+          workItemId: 'item-1',
+          bindingId: 'binding-1',
+          role: 'work',
+          stage: 'execute',
+          revision: 2,
+        },
+      }),
+      { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+    );
+  });
+});

--- a/mastracode/factory/src/supervisor/signal-service.test.ts
+++ b/mastracode/factory/src/supervisor/signal-service.test.ts
@@ -126,7 +126,7 @@ describe('FactorySupervisorSignalService', () => {
   it('refreshes state and wakes the shared supervisor for approval lifecycle events', async () => {
     const { service, sendStateSignal, sendNotificationSignal, getForProject } = fixture();
     getForProject.mockResolvedValueOnce(null);
-    await new FactorySupervisorSignalService(service).notifyApproval(approvalNotification());
+    await new FactorySupervisorSignalService(service).notify(approvalNotification());
 
     expect(sendStateSignal).toHaveBeenCalledOnce();
     expect(sendNotificationSignal).toHaveBeenCalledWith(
@@ -137,6 +137,51 @@ describe('FactorySupervisorSignalService', () => {
         payload: expect.objectContaining({ approvalId: 'approval-1', workItemId: 'item-1' }),
       }),
       { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+    );
+  });
+
+  it('wakes the supervisor for a boot check-in without touching approval fields', async () => {
+    const { service, sendStateSignal, sendNotificationSignal, getForProject } = fixture();
+    const record: FactorySupervisorNotificationRecord = {
+      ...approvalNotification(),
+      event: 'boot_check_in',
+      approvalId: null,
+      workItemId: null,
+      approvalStatus: null,
+      requestedStage: null,
+      expectedRevision: null,
+      requestingBindingId: null,
+      requestingRole: null,
+      reason: 'The Factory server restarted while work was open.',
+      summary: 'The Factory server restarted. 3 work item(s) are still open.',
+      idempotencyKey: 'boot_check_in:1',
+    };
+
+    await new FactorySupervisorSignalService(service).notify(record);
+
+    // The boot path must never look up a work item — there isn't one.
+    expect(getForProject).not.toHaveBeenCalled();
+    expect(sendStateSignal).toHaveBeenCalledOnce();
+    expect(sendNotificationSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: 'boot-check-in',
+        summary: 'The Factory server restarted. 3 work item(s) are still open.',
+        dedupeKey: 'boot_check_in:1',
+      }),
+      { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+    );
+  });
+
+  it('refuses to deliver a boot check-in with no resolvable session owner', async () => {
+    const { service } = fixture();
+    const record: FactorySupervisorNotificationRecord = {
+      ...approvalNotification(),
+      event: 'boot_check_in',
+      supervisorUserId: null,
+    };
+
+    await expect(new FactorySupervisorSignalService(service).notify(record)).rejects.toThrow(
+      /no authenticated session owner/,
     );
   });
 

--- a/mastracode/factory/src/supervisor/signal-service.ts
+++ b/mastracode/factory/src/supervisor/signal-service.ts
@@ -1,0 +1,148 @@
+import { createHash } from 'node:crypto';
+
+import type { FactoryIdleWithoutTransitionEvent } from '../rules/run-lifecycle-observer.js';
+import type { FactorySupervisorNotificationRecord } from '../storage/domains/work-items/base.js';
+import type { FactorySupervisorService } from './service.js';
+
+const STATE_SIGNAL_ID = 'factory-state';
+
+function cacheKey(value: unknown): string {
+  return createHash('sha256').update(JSON.stringify(value)).digest('hex');
+}
+
+function notificationSummary(record: FactorySupervisorNotificationRecord): string {
+  switch (record.event) {
+    case 'approval_requested':
+      return `Transition approval requested for ${record.requestedStage}.`;
+    case 'approval_approved':
+      return `Transition to ${record.requestedStage} was approved.`;
+    case 'approval_rejected':
+      return `Transition to ${record.requestedStage} was rejected.`;
+    case 'approval_stale':
+      return `Transition approval for ${record.requestedStage} became stale.`;
+  }
+}
+
+export class FactorySupervisorSignalService {
+  readonly #supervisor: FactorySupervisorService;
+
+  constructor(supervisor: FactorySupervisorService) {
+    this.#supervisor = supervisor;
+  }
+
+  async refresh(input: { orgId: string; userId: string; factoryProjectId: string }) {
+    const address = await this.#supervisor.ensureSession(input);
+    const state = await this.#supervisor.getState(input);
+    const stableState = {
+      factoryProjectId: state.factoryProjectId,
+      totalItems: state.totalItems,
+      counts: state.counts,
+      pendingApprovalCount: state.pendingApprovalCount,
+      pendingApprovals: state.pendingApprovals.map(({ ageSeconds: _ageSeconds, ...approval }) => approval),
+    };
+    const stateCacheKey = cacheKey(stableState);
+    const snapshot = { ...state, snapshotVersion: stateCacheKey };
+    const session = await this.#supervisor.controller.getSessionByResource(address.resourceId);
+    if (!session) throw new Error('Factory supervisor session is unavailable.');
+    const agent = this.#supervisor.controller.getCurrentAgent(session);
+    return agent.sendStateSignal(
+      {
+        id: STATE_SIGNAL_ID,
+        cacheKey: stateCacheKey,
+        mode: 'snapshot',
+        tagName: 'factory-state',
+        contents: `Factory state snapshot:\n${JSON.stringify(snapshot)}`,
+        value: snapshot,
+        attributes: {
+          factoryProjectId: input.factoryProjectId,
+          pendingApprovalCount: state.pendingApprovalCount,
+          totalItems: state.totalItems,
+        },
+        metadata: { source: 'factory-supervisor', snapshotVersion: stateCacheKey },
+      },
+      {
+        resourceId: address.resourceId,
+        threadId: address.threadId,
+        ifActive: { behavior: 'deliver' },
+        ifIdle: { behavior: 'persist' },
+      },
+    );
+  }
+
+  async notifyApproval(record: FactorySupervisorNotificationRecord): Promise<void> {
+    const item = await this.#supervisor.workItems.getForProject(
+      record.orgId,
+      record.factoryProjectId,
+      record.workItemId,
+    );
+    const userId =
+      record.supervisorUserId ??
+      (record.requestingRole ? item?.sessions[record.requestingRole]?.startedBy : undefined) ??
+      Object.values(item?.sessions ?? {}).find(session => session.startedBy)?.startedBy;
+    if (!userId) throw new Error('Factory approval has no authenticated session owner.');
+
+    const address = await this.#supervisor.ensureSession({
+      orgId: record.orgId,
+      userId,
+      factoryProjectId: record.factoryProjectId,
+    });
+    await this.refresh({ orgId: record.orgId, userId, factoryProjectId: record.factoryProjectId });
+    const session = await this.#supervisor.controller.getSessionByResource(address.resourceId);
+    if (!session) throw new Error('Factory supervisor session is unavailable.');
+    const result = await session.sendNotificationSignal(
+      {
+        source: 'factory',
+        kind: record.event,
+        summary: notificationSummary(record),
+        priority: record.event === 'approval_requested' ? 'high' : 'medium',
+        payload: {
+          approvalId: record.approvalId,
+          workItemId: record.workItemId,
+          status: record.approvalStatus,
+          requestedStage: record.requestedStage,
+          expectedRevision: record.expectedRevision,
+          reason: record.reason,
+          summary: record.summary,
+        },
+        sourceId: record.id,
+        dedupeKey: record.idempotencyKey,
+      },
+      { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+    );
+    await result.persisted;
+    if (!result.accepted) throw new Error('Factory supervisor notification was not accepted for delivery.');
+    await result.accepted;
+  }
+
+  async notifyIdle(event: FactoryIdleWithoutTransitionEvent): Promise<void> {
+    const item = await this.#supervisor.workItems.getForProject(event.orgId, event.factoryProjectId, event.workItemId);
+    const userId = item?.sessions[event.role]?.startedBy;
+    if (!item || !userId) return;
+    const address = await this.#supervisor.ensureSession({
+      orgId: event.orgId,
+      userId,
+      factoryProjectId: event.factoryProjectId,
+    });
+    await this.refresh({ orgId: event.orgId, userId, factoryProjectId: event.factoryProjectId });
+    const session = await this.#supervisor.controller.getSessionByResource(address.resourceId);
+    if (!session) throw new Error('Factory supervisor session is unavailable.');
+    const result = await session.sendNotificationSignal(
+      {
+        source: 'factory',
+        kind: 'idle-without-transition',
+        summary: `Work-item agent finished without moving ${item.title}.`,
+        priority: 'medium',
+        payload: {
+          workItemId: event.workItemId,
+          bindingId: event.bindingId,
+          role: event.role,
+          stage: event.stage,
+          revision: event.revision,
+        },
+      },
+      { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
+    );
+    await result.persisted;
+    await result.accepted;
+  }
+}

--- a/mastracode/factory/src/supervisor/signal-service.ts
+++ b/mastracode/factory/src/supervisor/signal-service.ts
@@ -39,6 +39,7 @@ export class FactorySupervisorSignalService {
       counts: state.counts,
       pendingApprovalCount: state.pendingApprovalCount,
       pendingApprovals: state.pendingApprovals.map(({ ageSeconds: _ageSeconds, ...approval }) => approval),
+      workers: state.workers,
     };
     const stateCacheKey = cacheKey(stableState);
     const snapshot = { ...state, snapshotVersion: stateCacheKey };

--- a/mastracode/factory/src/supervisor/signal-service.ts
+++ b/mastracode/factory/src/supervisor/signal-service.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto';
 
 import type { FactoryIdleWithoutTransitionEvent } from '../rules/run-lifecycle-observer.js';
-import type { FactorySupervisorNotificationRecord } from '../storage/domains/work-items/base.js';
+import type {
+  FactorySupervisorNotificationEvent,
+  FactorySupervisorNotificationRecord,
+} from '../storage/domains/work-items/base.js';
 import type { FactorySupervisorService } from './service.js';
 
 const STATE_SIGNAL_ID = 'factory-state';
@@ -10,7 +13,20 @@ function cacheKey(value: unknown): string {
   return createHash('sha256').update(JSON.stringify(value)).digest('hex');
 }
 
-function notificationSummary(record: FactorySupervisorNotificationRecord): string {
+type FactoryApprovalNotificationRecord = Omit<FactorySupervisorNotificationRecord, 'event'> & {
+  event: Exclude<FactorySupervisorNotificationEvent, 'boot_check_in'>;
+  approvalId: string;
+  workItemId: string;
+  requestedStage: string;
+};
+
+function isApprovalNotification(
+  record: FactorySupervisorNotificationRecord,
+): record is FactoryApprovalNotificationRecord {
+  return record.event !== 'boot_check_in';
+}
+
+function approvalSummary(record: FactoryApprovalNotificationRecord): string {
   switch (record.event) {
     case 'approval_requested':
       return `Transition approval requested for ${record.requestedStage}.`;
@@ -70,7 +86,12 @@ export class FactorySupervisorSignalService {
     );
   }
 
-  async notifyApproval(record: FactorySupervisorNotificationRecord): Promise<void> {
+  /** Deliver one durable supervisor notification, whatever kind it is. */
+  async notify(record: FactorySupervisorNotificationRecord): Promise<void> {
+    return isApprovalNotification(record) ? this.notifyApproval(record) : this.notifyBootCheckIn(record);
+  }
+
+  async notifyApproval(record: FactoryApprovalNotificationRecord): Promise<void> {
     const item = await this.#supervisor.workItems.getForProject(
       record.orgId,
       record.factoryProjectId,
@@ -82,6 +103,42 @@ export class FactorySupervisorSignalService {
       Object.values(item?.sessions ?? {}).find(session => session.startedBy)?.startedBy;
     if (!userId) throw new Error('Factory approval has no authenticated session owner.');
 
+    await this.#deliver(record, userId, {
+      kind: record.event,
+      summary: approvalSummary(record),
+      priority: record.event === 'approval_requested' ? 'high' : 'medium',
+      payload: {
+        approvalId: record.approvalId,
+        workItemId: record.workItemId,
+        status: record.approvalStatus,
+        requestedStage: record.requestedStage,
+        expectedRevision: record.expectedRevision,
+        reason: record.reason,
+        summary: record.summary,
+      },
+    });
+  }
+
+  /**
+   * Wake the supervisor after a restart. Runs killed mid-flight never emit an
+   * `agent_end`, so the idle observer cannot see them — this is the only
+   * signal that surfaces work stranded by the restart itself.
+   */
+  async notifyBootCheckIn(record: FactorySupervisorNotificationRecord): Promise<void> {
+    if (!record.supervisorUserId) throw new Error('Factory boot check-in has no authenticated session owner.');
+    await this.#deliver(record, record.supervisorUserId, {
+      kind: 'boot-check-in',
+      summary: record.summary ?? 'The Factory server restarted.',
+      priority: 'medium',
+      payload: { reason: record.reason, summary: record.summary },
+    });
+  }
+
+  async #deliver(
+    record: FactorySupervisorNotificationRecord,
+    userId: string,
+    notification: { kind: string; summary: string; priority: 'medium' | 'high'; payload: Record<string, unknown> },
+  ): Promise<void> {
     const address = await this.#supervisor.ensureSession({
       orgId: record.orgId,
       userId,
@@ -91,23 +148,7 @@ export class FactorySupervisorSignalService {
     const session = await this.#supervisor.controller.getSessionByResource(address.resourceId);
     if (!session) throw new Error('Factory supervisor session is unavailable.');
     const result = await session.sendNotificationSignal(
-      {
-        source: 'factory',
-        kind: record.event,
-        summary: notificationSummary(record),
-        priority: record.event === 'approval_requested' ? 'high' : 'medium',
-        payload: {
-          approvalId: record.approvalId,
-          workItemId: record.workItemId,
-          status: record.approvalStatus,
-          requestedStage: record.requestedStage,
-          expectedRevision: record.expectedRevision,
-          reason: record.reason,
-          summary: record.summary,
-        },
-        sourceId: record.id,
-        dedupeKey: record.idempotencyKey,
-      },
+      { source: 'factory', ...notification, sourceId: record.id, dedupeKey: record.idempotencyKey },
       { ifActive: { behavior: 'deliver' }, ifIdle: { behavior: 'wake' } },
     );
     await result.persisted;

--- a/mastracode/factory/src/supervisor/state.test.ts
+++ b/mastracode/factory/src/supervisor/state.test.ts
@@ -5,7 +5,7 @@ import { FACTORY_SUPERVISOR_INSTRUCTIONS } from './instructions.js';
 import { buildFactorySupervisorState } from './state.js';
 
 function item(id: string, stages: string[], type: 'issue' | 'pull-request' = 'issue'): WorkItemRow {
-  return { id, stages, externalSource: { type } } as WorkItemRow;
+  return { id, title: `Title ${id}`, stages, externalSource: { type } } as WorkItemRow;
 }
 
 function approval(index: number): FactoryApprovalRecord {
@@ -35,11 +35,12 @@ describe('Factory supervisor contract', () => {
     const state = buildFactorySupervisorState(
       'project-1',
       [
-        item('one', ['intake', 'planning']),
+        item('item-0', ['intake', 'planning']),
         item('two', ['intake']),
         item('three', ['intake', 'review'], 'pull-request'),
       ],
       Array.from({ length: 60 }, (_, index) => approval(index)),
+      new Date('2026-07-22T00:01:00.000Z'),
     );
 
     expect(state).toMatchObject({
@@ -50,6 +51,12 @@ describe('Factory supervisor contract', () => {
         byStage: { planning: 1, intake: 1, review: 1 },
       },
     });
+    expect(state.pendingApprovalCount).toBe(60);
     expect(state.pendingApprovals).toHaveLength(50);
+    expect(state.pendingApprovals[0]).toMatchObject({
+      workItemTitle: 'Title item-0',
+      ageSeconds: 60,
+    });
+    expect(state.snapshotAt).toBe('2026-07-22T00:01:00.000Z');
   });
 });

--- a/mastracode/factory/src/supervisor/state.test.ts
+++ b/mastracode/factory/src/supervisor/state.test.ts
@@ -43,7 +43,7 @@ describe('Factory supervisor contract', () => {
       [
         { workItemId: 'item-0', role: 'work', bindingId: 'binding-a', activity: 'running' },
         { workItemId: 'two', role: 'work', bindingId: 'binding-b', activity: 'idle' },
-        { workItemId: 'missing', role: 'review', bindingId: 'binding-c', activity: 'offline' },
+        { workItemId: 'missing', role: 'review', bindingId: 'binding-c', activity: 'idle' },
       ],
       new Date('2026-07-22T00:01:00.000Z'),
     );
@@ -62,7 +62,7 @@ describe('Factory supervisor contract', () => {
       workItemTitle: 'Title item-0',
       ageSeconds: 60,
     });
-    expect(state.workers).toMatchObject({ running: 1, idle: 1, offline: 1 });
+    expect(state.workers).toMatchObject({ running: 1, idle: 2 });
     expect(state.workers.bindings).toEqual([
       {
         workItemId: 'item-0',
@@ -84,7 +84,7 @@ describe('Factory supervisor contract', () => {
         workItemId: 'missing',
         role: 'review',
         bindingId: 'binding-c',
-        activity: 'offline',
+        activity: 'idle',
         workItemTitle: null,
         stage: null,
       },

--- a/mastracode/factory/src/supervisor/state.test.ts
+++ b/mastracode/factory/src/supervisor/state.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import type { FactoryApprovalRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
+import { FACTORY_SUPERVISOR_INSTRUCTIONS } from './instructions.js';
+import { buildFactorySupervisorState } from './state.js';
+
+function item(id: string, stages: string[], type: 'issue' | 'pull-request' = 'issue'): WorkItemRow {
+  return { id, stages, externalSource: { type } } as WorkItemRow;
+}
+
+function approval(index: number): FactoryApprovalRecord {
+  return {
+    id: `approval-${index}`,
+    workItemId: `item-${index}`,
+    requestedBoard: 'work',
+    requestedStage: 'execute',
+    expectedRevision: index,
+    requestingActor: { type: 'agent', bindingId: `binding-${index}`, role: 'work' },
+    reason: 'Ready',
+    summary: null,
+    createdAt: new Date('2026-07-22T00:00:00.000Z'),
+  } as unknown as FactoryApprovalRecord;
+}
+
+describe('Factory supervisor contract', () => {
+  it('instructs the model about tools, durable approvals, idle observations, and attribution limits', () => {
+    expect(FACTORY_SUPERVISOR_INSTRUCTIONS).toContain('Use Factory tools');
+    expect(FACTORY_SUPERVISOR_INSTRUCTIONS).toContain('pending_approval');
+    expect(FACTORY_SUPERVISOR_INSTRUCTIONS).toContain('stale');
+    expect(FACTORY_SUPERVISOR_INSTRUCTIONS).toMatch(/idle-without-transition/i);
+    expect(FACTORY_SUPERVISOR_INSTRUCTIONS).toContain('never grants authority');
+  });
+
+  it('counts each item once at its current stage and caps approval details', () => {
+    const state = buildFactorySupervisorState(
+      'project-1',
+      [
+        item('one', ['intake', 'planning']),
+        item('two', ['intake']),
+        item('three', ['intake', 'review'], 'pull-request'),
+      ],
+      Array.from({ length: 60 }, (_, index) => approval(index)),
+    );
+
+    expect(state).toMatchObject({
+      factoryProjectId: 'project-1',
+      totalItems: 3,
+      counts: {
+        byBoard: { work: 2, review: 1 },
+        byStage: { planning: 1, intake: 1, review: 1 },
+      },
+    });
+    expect(state.pendingApprovals).toHaveLength(50);
+  });
+});

--- a/mastracode/factory/src/supervisor/state.test.ts
+++ b/mastracode/factory/src/supervisor/state.test.ts
@@ -40,6 +40,11 @@ describe('Factory supervisor contract', () => {
         item('three', ['intake', 'review'], 'pull-request'),
       ],
       Array.from({ length: 60 }, (_, index) => approval(index)),
+      [
+        { workItemId: 'item-0', role: 'work', bindingId: 'binding-a', activity: 'running' },
+        { workItemId: 'two', role: 'work', bindingId: 'binding-b', activity: 'idle' },
+        { workItemId: 'missing', role: 'review', bindingId: 'binding-c', activity: 'offline' },
+      ],
       new Date('2026-07-22T00:01:00.000Z'),
     );
 
@@ -57,6 +62,33 @@ describe('Factory supervisor contract', () => {
       workItemTitle: 'Title item-0',
       ageSeconds: 60,
     });
+    expect(state.workers).toMatchObject({ running: 1, idle: 1, offline: 1 });
+    expect(state.workers.bindings).toEqual([
+      {
+        workItemId: 'item-0',
+        role: 'work',
+        bindingId: 'binding-a',
+        activity: 'running',
+        workItemTitle: 'Title item-0',
+        stage: 'planning',
+      },
+      {
+        workItemId: 'two',
+        role: 'work',
+        bindingId: 'binding-b',
+        activity: 'idle',
+        workItemTitle: 'Title two',
+        stage: 'intake',
+      },
+      {
+        workItemId: 'missing',
+        role: 'review',
+        bindingId: 'binding-c',
+        activity: 'offline',
+        workItemTitle: null,
+        stage: null,
+      },
+    ]);
     expect(state.snapshotAt).toBe('2026-07-22T00:01:00.000Z');
   });
 });

--- a/mastracode/factory/src/supervisor/state.ts
+++ b/mastracode/factory/src/supervisor/state.ts
@@ -9,9 +9,11 @@ export interface FactorySupervisorApprovalSummary {
   stage: string;
   expectedRevision: number;
   requestingRole: string | null;
+  workItemTitle: string | null;
   reason: string;
   summary: string | null;
   createdAt: string;
+  ageSeconds: number;
 }
 
 export interface FactorySupervisorState {
@@ -21,10 +23,16 @@ export interface FactorySupervisorState {
     byBoard: Record<string, number>;
     byStage: Record<string, number>;
   };
+  pendingApprovalCount: number;
   pendingApprovals: FactorySupervisorApprovalSummary[];
+  snapshotAt: string;
 }
 
-export function supervisorApprovalSummary(approval: FactoryApprovalRecord): FactorySupervisorApprovalSummary {
+export function supervisorApprovalSummary(
+  approval: FactoryApprovalRecord,
+  workItemTitle: string | null = null,
+  now: Date = new Date(),
+): FactorySupervisorApprovalSummary {
   return {
     id: approval.id,
     workItemId: approval.workItemId,
@@ -33,9 +41,11 @@ export function supervisorApprovalSummary(approval: FactoryApprovalRecord): Fact
     expectedRevision: approval.expectedRevision,
     requestingRole:
       typeof approval.requestingActor.role === 'string' ? approval.requestingActor.role.slice(0, 64) : null,
+    workItemTitle,
     reason: approval.reason.slice(0, 1_000),
     summary: approval.summary?.slice(0, 1_000) ?? null,
     createdAt: approval.createdAt.toISOString(),
+    ageSeconds: Math.max(0, Math.floor((now.getTime() - approval.createdAt.getTime()) / 1_000)),
   };
 }
 
@@ -43,9 +53,11 @@ export function buildFactorySupervisorState(
   factoryProjectId: string,
   items: WorkItemRow[],
   pendingApprovals: FactoryApprovalRecord[],
+  now: Date = new Date(),
 ): FactorySupervisorState {
   const byBoard: Record<string, number> = {};
   const byStage: Record<string, number> = {};
+  const itemTitles = new Map(items.map(item => [item.id, item.title]));
   for (const item of items) {
     const board = item.externalSource?.type === 'pull-request' ? 'review' : 'work';
     byBoard[board] = (byBoard[board] ?? 0) + 1;
@@ -56,6 +68,10 @@ export function buildFactorySupervisorState(
     factoryProjectId,
     totalItems: items.length,
     counts: { byBoard, byStage },
-    pendingApprovals: pendingApprovals.slice(0, MAX_PENDING_APPROVALS).map(supervisorApprovalSummary),
+    pendingApprovalCount: pendingApprovals.length,
+    pendingApprovals: pendingApprovals
+      .slice(0, MAX_PENDING_APPROVALS)
+      .map(approval => supervisorApprovalSummary(approval, itemTitles.get(approval.workItemId) ?? null, now)),
+    snapshotAt: now.toISOString(),
   };
 }

--- a/mastracode/factory/src/supervisor/state.ts
+++ b/mastracode/factory/src/supervisor/state.ts
@@ -5,11 +5,12 @@ const MAX_WORKERS = 100;
 
 /**
  * Live activity of one active run binding: `running` means the bound session
- * has a run in flight right now, `idle` means the session is live but between
- * runs, and `offline` means no in-process session currently owns the binding
- * (e.g. after a server restart, before reconciliation).
+ * has a run in flight right now; `idle` means it does not — whether the
+ * session is loaded between runs or has to be rehydrated on the next signal
+ * is a server implementation detail the supervisor never needs to reason
+ * about, so both report as `idle`.
  */
-export type FactorySupervisorWorkerActivity = 'running' | 'idle' | 'offline';
+export type FactorySupervisorWorkerActivity = 'running' | 'idle';
 
 export interface FactorySupervisorWorkerBinding {
   workItemId: string;
@@ -49,7 +50,6 @@ export interface FactorySupervisorState {
   workers: {
     running: number;
     idle: number;
-    offline: number;
     bindings: FactorySupervisorWorkerSummary[];
   };
   snapshotAt: string;
@@ -96,7 +96,6 @@ export function buildFactorySupervisorState(
   const workers = {
     running: workerBindings.filter(worker => worker.activity === 'running').length,
     idle: workerBindings.filter(worker => worker.activity === 'idle').length,
-    offline: workerBindings.filter(worker => worker.activity === 'offline').length,
     bindings: workerBindings.slice(0, MAX_WORKERS).map(worker => ({
       ...worker,
       workItemTitle: itemsById.get(worker.workItemId)?.title ?? null,

--- a/mastracode/factory/src/supervisor/state.ts
+++ b/mastracode/factory/src/supervisor/state.ts
@@ -1,6 +1,27 @@
 import type { FactoryApprovalRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
 
 const MAX_PENDING_APPROVALS = 50;
+const MAX_WORKERS = 100;
+
+/**
+ * Live activity of one active run binding: `running` means the bound session
+ * has a run in flight right now, `idle` means the session is live but between
+ * runs, and `offline` means no in-process session currently owns the binding
+ * (e.g. after a server restart, before reconciliation).
+ */
+export type FactorySupervisorWorkerActivity = 'running' | 'idle' | 'offline';
+
+export interface FactorySupervisorWorkerBinding {
+  workItemId: string;
+  role: string;
+  bindingId: string;
+  activity: FactorySupervisorWorkerActivity;
+}
+
+export interface FactorySupervisorWorkerSummary extends FactorySupervisorWorkerBinding {
+  workItemTitle: string | null;
+  stage: string | null;
+}
 
 export interface FactorySupervisorApprovalSummary {
   id: string;
@@ -25,6 +46,12 @@ export interface FactorySupervisorState {
   };
   pendingApprovalCount: number;
   pendingApprovals: FactorySupervisorApprovalSummary[];
+  workers: {
+    running: number;
+    idle: number;
+    offline: number;
+    bindings: FactorySupervisorWorkerSummary[];
+  };
   snapshotAt: string;
 }
 
@@ -53,10 +80,12 @@ export function buildFactorySupervisorState(
   factoryProjectId: string,
   items: WorkItemRow[],
   pendingApprovals: FactoryApprovalRecord[],
+  workerBindings: FactorySupervisorWorkerBinding[] = [],
   now: Date = new Date(),
 ): FactorySupervisorState {
   const byBoard: Record<string, number> = {};
   const byStage: Record<string, number> = {};
+  const itemsById = new Map(items.map(item => [item.id, item]));
   const itemTitles = new Map(items.map(item => [item.id, item.title]));
   for (const item of items) {
     const board = item.externalSource?.type === 'pull-request' ? 'review' : 'work';
@@ -64,6 +93,16 @@ export function buildFactorySupervisorState(
     const stage = item.stages.at(-1);
     if (stage) byStage[stage] = (byStage[stage] ?? 0) + 1;
   }
+  const workers = {
+    running: workerBindings.filter(worker => worker.activity === 'running').length,
+    idle: workerBindings.filter(worker => worker.activity === 'idle').length,
+    offline: workerBindings.filter(worker => worker.activity === 'offline').length,
+    bindings: workerBindings.slice(0, MAX_WORKERS).map(worker => ({
+      ...worker,
+      workItemTitle: itemsById.get(worker.workItemId)?.title ?? null,
+      stage: itemsById.get(worker.workItemId)?.stages.at(-1) ?? null,
+    })),
+  };
   return {
     factoryProjectId,
     totalItems: items.length,
@@ -72,6 +111,7 @@ export function buildFactorySupervisorState(
     pendingApprovals: pendingApprovals
       .slice(0, MAX_PENDING_APPROVALS)
       .map(approval => supervisorApprovalSummary(approval, itemTitles.get(approval.workItemId) ?? null, now)),
+    workers,
     snapshotAt: now.toISOString(),
   };
 }

--- a/mastracode/factory/src/supervisor/state.ts
+++ b/mastracode/factory/src/supervisor/state.ts
@@ -1,0 +1,61 @@
+import type { FactoryApprovalRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
+
+const MAX_PENDING_APPROVALS = 50;
+
+export interface FactorySupervisorApprovalSummary {
+  id: string;
+  workItemId: string;
+  board: string;
+  stage: string;
+  expectedRevision: number;
+  requestingRole: string | null;
+  reason: string;
+  summary: string | null;
+  createdAt: string;
+}
+
+export interface FactorySupervisorState {
+  factoryProjectId: string;
+  totalItems: number;
+  counts: {
+    byBoard: Record<string, number>;
+    byStage: Record<string, number>;
+  };
+  pendingApprovals: FactorySupervisorApprovalSummary[];
+}
+
+export function supervisorApprovalSummary(approval: FactoryApprovalRecord): FactorySupervisorApprovalSummary {
+  return {
+    id: approval.id,
+    workItemId: approval.workItemId,
+    board: approval.requestedBoard,
+    stage: approval.requestedStage,
+    expectedRevision: approval.expectedRevision,
+    requestingRole:
+      typeof approval.requestingActor.role === 'string' ? approval.requestingActor.role.slice(0, 64) : null,
+    reason: approval.reason.slice(0, 1_000),
+    summary: approval.summary?.slice(0, 1_000) ?? null,
+    createdAt: approval.createdAt.toISOString(),
+  };
+}
+
+export function buildFactorySupervisorState(
+  factoryProjectId: string,
+  items: WorkItemRow[],
+  pendingApprovals: FactoryApprovalRecord[],
+): FactorySupervisorState {
+  const byBoard: Record<string, number> = {};
+  const byStage: Record<string, number> = {};
+  for (const item of items) {
+    const board = item.externalSource?.type === 'pull-request' ? 'review' : 'work';
+    byBoard[board] = (byBoard[board] ?? 0) + 1;
+    const stage = item.stages.at(-1);
+    if (stage) byStage[stage] = (byStage[stage] ?? 0) + 1;
+  }
+  return {
+    factoryProjectId,
+    totalItems: items.length,
+    counts: { byBoard, byStage },
+    pendingApprovals: pendingApprovals.slice(0, MAX_PENDING_APPROVALS).map(supervisorApprovalSummary),
+  };
+}

--- a/mastracode/factory/src/supervisor/tools.test.ts
+++ b/mastracode/factory/src/supervisor/tools.test.ts
@@ -1,0 +1,210 @@
+import { RequestContext } from '@mastra/core/request-context';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
+import { createFactoryStorageForTests } from '../storage/test-utils.js';
+import { factorySupervisorThreadId } from './service.js';
+import { createFactorySupervisorTools } from './tools.js';
+
+const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
+const ORG_ID = 'org-1';
+
+type ExecutableTool = { execute: (input: unknown, context: unknown) => Promise<unknown> };
+
+function supervisorContext(overrides: Partial<{ orgId: string; projectId: string; threadId: string }> = {}) {
+  const orgId = overrides.orgId ?? ORG_ID;
+  const factoryProjectId = overrides.projectId ?? PROJECT_ID;
+  const context = new RequestContext();
+  context.set('user', { workosId: 'user-1', organizationId: orgId, name: 'Ada Lovelace' });
+  context.set('controller', {
+    resourceId: factoryProjectId,
+    threadId: overrides.threadId ?? factorySupervisorThreadId(factoryProjectId),
+    getState: () => ({
+      factoryProjectId,
+      factoryOrgId: orgId,
+      factorySupervisor: true,
+    }),
+  });
+  return context;
+}
+
+async function prepareBoundItem(storage: WorkItemsStorage) {
+  return storage.prepareRunStart({
+    orgId: ORG_ID,
+    userId: 'worker-1',
+    factoryProjectId: PROJECT_ID,
+    workItem: {
+      input: {
+        externalSource: { integrationId: 'github', type: 'issue', externalId: 'issue:1' },
+        title: 'Investigate flaky build',
+        stages: ['intake'],
+      },
+    },
+    role: 'work',
+    session: { sessionId: 'worker-resource', branch: 'factory/work', threadId: 'worker-thread' },
+    resourceId: 'worker-resource',
+    kickoffKey: 'kickoff-1',
+    kickoffMessage: null,
+  });
+}
+
+async function fixture() {
+  const storage = (await createFactoryStorageForTests()).workItems;
+  const prepared = await prepareBoundItem(storage);
+  const accepted = Promise.resolve({ accepted: true as const, runId: 'run-1' });
+  const workerSession = {
+    thread: {
+      getId: vi.fn(() => 'worker-thread'),
+      switch: vi.fn(async () => undefined),
+    },
+    sendSignal: vi.fn(() => ({ accepted })),
+  };
+  const controller = { getSessionByResource: vi.fn(async () => workerSession) };
+  const approvals = {
+    list: vi.fn(async () => []),
+    get: vi.fn(async () => null),
+    resolve: vi.fn(),
+  };
+  const getState = vi.fn(async () => ({
+    factoryProjectId: PROJECT_ID,
+    totalItems: 1,
+    counts: { byBoard: { work: 1 }, byStage: { intake: 1 } },
+    pendingApprovals: [],
+  }));
+  const service = {
+    requireProject: vi.fn(async ({ orgId }: { orgId: string }) => {
+      if (orgId !== ORG_ID) throw new Error('Factory project not found.');
+    }),
+    getState,
+    workItems: storage,
+    approvals,
+    controller,
+  };
+  const audit = { emitAgent: vi.fn(async (_input: Record<string, unknown>) => undefined) };
+  return { storage, prepared, workerSession, controller, approvals, service, audit };
+}
+
+async function toolsFor(context: RequestContext, built: Awaited<ReturnType<typeof fixture>>) {
+  return createFactorySupervisorTools({ requestContext: context, service: built.service as never, audit: built.audit });
+}
+
+function execute(tool: ExecutableTool, context: RequestContext, input: unknown) {
+  return tool.execute(input, { requestContext: context, agent: { toolCallId: 'tool-1' } });
+}
+
+describe('Factory supervisor tools', () => {
+  it('exposes tools only in the exact canonical tenant-scoped supervisor session', async () => {
+    const built = await fixture();
+    const tools = await toolsFor(supervisorContext(), built);
+    expect(Object.keys(tools).sort()).toEqual([
+      'factory_get_state',
+      'factory_get_work_item',
+      'factory_list_pending_approvals',
+      'factory_resolve_transition_approval',
+      'factory_signal_work_item',
+    ]);
+    await expect(toolsFor(supervisorContext({ threadId: 'other-thread' }), built)).resolves.toEqual({});
+    await expect(toolsFor(supervisorContext({ orgId: 'org-other' }), built)).rejects.toThrow(
+      'Factory project not found',
+    );
+  });
+
+  it('queries bounded state and tenant-scoped work-item details', async () => {
+    const built = await fixture();
+    const context = supervisorContext();
+    const tools = await toolsFor(context, built);
+
+    await expect(execute(tools.factory_get_state as ExecutableTool, context, {})).resolves.toMatchObject({
+      totalItems: 1,
+      pendingApprovals: [],
+    });
+    await expect(
+      execute(tools.factory_get_work_item as ExecutableTool, context, { workItemId: built.prepared.item.id }),
+    ).resolves.toMatchObject({
+      id: built.prepared.item.id,
+      title: 'Investigate flaky build',
+      sessionRoles: ['work'],
+    });
+    await expect(
+      execute(tools.factory_get_work_item as ExecutableTool, context, {
+        workItemId: '22222222-2222-4222-8222-222222222222',
+      }),
+    ).rejects.toThrow('work item not found');
+  });
+
+  it('signals only an active binding and records bounded audit metadata without the message body', async () => {
+    const built = await fixture();
+    const context = supervisorContext();
+    const tools = await toolsFor(context, built);
+    const result = await execute(tools.factory_signal_work_item as ExecutableTool, context, {
+      workItemId: built.prepared.item.id,
+      role: 'work',
+      message: 'Please summarize the failing checks.',
+    });
+
+    expect(result).toMatchObject({ status: 'accepted', role: 'work', runId: 'run-1' });
+    expect(built.workerSession.sendSignal).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'user',
+        tagName: 'factory-supervisor-message',
+        contents: 'Please summarize the failing checks.',
+        attributes: expect.objectContaining({ name: 'Ada Lovelace', workItemId: built.prepared.item.id }),
+        ifActive: { attributes: { delivery: 'while-active' } },
+        ifIdle: { attributes: { delivery: 'message' } },
+      }),
+      { requestContext: context },
+    );
+    const auditInput = built.audit.emitAgent.mock.calls[0]?.[0];
+    expect(auditInput?.input).toMatchObject({
+      action: 'factory.supervisor.message_sent',
+      metadata: { bindingId: built.prepared.binding.id, role: 'work', runId: 'run-1' },
+    });
+    expect(JSON.stringify(auditInput)).not.toContain('Please summarize');
+  });
+
+  it('resolves only pending approvals through the approval service', async () => {
+    const built = await fixture();
+    const approval = {
+      id: '33333333-3333-4333-8333-333333333333',
+      orgId: ORG_ID,
+      factoryProjectId: PROJECT_ID,
+      workItemId: built.prepared.item.id,
+      requestedStage: 'planning',
+      status: 'pending',
+    };
+    built.approvals.get.mockResolvedValue(approval as never);
+    built.approvals.resolve.mockResolvedValue({
+      status: 'approved',
+      replayed: false,
+      approval,
+      item: { ...built.prepared.item, revision: 2 },
+    } as never);
+    const context = supervisorContext();
+    const tools = await toolsFor(context, built);
+
+    await expect(
+      execute(tools.factory_resolve_transition_approval as ExecutableTool, context, {
+        approvalId: approval.id,
+        decision: 'approve',
+        reason: 'Scope is ready.',
+      }),
+    ).resolves.toMatchObject({ status: 'approved', workItemId: built.prepared.item.id, revision: 2 });
+    expect(built.approvals.resolve).toHaveBeenCalledWith({
+      orgId: ORG_ID,
+      factoryProjectId: PROJECT_ID,
+      approvalId: approval.id,
+      decision: 'approve',
+      resolvedBy: 'user-1',
+      resolverType: 'agent',
+      resolutionReason: 'Scope is ready.',
+    });
+
+    built.approvals.get.mockResolvedValue({ ...approval, status: 'stale' } as never);
+    await expect(
+      execute(tools.factory_resolve_transition_approval as ExecutableTool, context, {
+        approvalId: approval.id,
+        decision: 'approve',
+      }),
+    ).rejects.toThrow('already stale');
+  });
+});

--- a/mastracode/factory/src/supervisor/tools.test.ts
+++ b/mastracode/factory/src/supervisor/tools.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import { createFactoryStorageForTests } from '../storage/test-utils.js';
-import { factorySupervisorThreadId } from './service.js';
+import { factorySupervisorResourceId, factorySupervisorThreadId } from './service.js';
 import { createFactorySupervisorTools } from './tools.js';
 
 const PROJECT_ID = '11111111-2222-4333-8444-555555555555';
@@ -17,7 +17,7 @@ function supervisorContext(overrides: Partial<{ orgId: string; projectId: string
   const context = new RequestContext();
   context.set('user', { workosId: 'user-1', organizationId: orgId, name: 'Ada Lovelace' });
   context.set('controller', {
-    resourceId: factoryProjectId,
+    resourceId: factorySupervisorResourceId(factoryProjectId),
     threadId: overrides.threadId ?? factorySupervisorThreadId(factoryProjectId),
     getState: () => ({
       factoryProjectId,

--- a/mastracode/factory/src/supervisor/tools.test.ts
+++ b/mastracode/factory/src/supervisor/tools.test.ts
@@ -57,7 +57,7 @@ async function fixture() {
       getId: vi.fn(() => 'worker-thread'),
       switch: vi.fn(async () => undefined),
     },
-    sendSignal: vi.fn(() => ({ accepted })),
+    sendSignal: vi.fn((_signal: unknown, _options: { requestContext?: RequestContext }) => ({ accepted })),
   };
   const controller = { getSessionByResource: vi.fn(async (_resourceId: string) => workerSession) };
   const approvals = {
@@ -74,11 +74,17 @@ async function fixture() {
   const describeWorkerBindings = vi.fn(async () => [
     { workItemId: prepared.item.id, role: 'work', bindingId: prepared.binding.id, activity: 'idle' as const },
   ]);
-  const resolveWorkerSession = vi.fn(async (input: { binding: { resourceId: string } }) => {
-    const session = await controller.getSessionByResource(input.binding.resourceId);
-    if (!session) throw new Error('Bound Factory session is unavailable.');
-    return session;
-  });
+  const resolveWorkerSession = vi.fn(
+    async (input: { binding: { resourceId: string }; requestContext?: RequestContext }) => {
+      const session = await controller.getSessionByResource(input.binding.resourceId);
+      if (!session) throw new Error('Bound Factory session is unavailable.');
+      // The real controller writes the target session's identity into the
+      // context it's handed — simulate that so the regression test below can
+      // prove the supervisor's own context is never the one being written to.
+      input.requestContext?.set('controller', { resourceId: input.binding.resourceId, threadId: 'worker-thread' });
+      return session;
+    },
+  );
   const service = {
     requireProject: vi.fn(async ({ orgId }: { orgId: string }) => {
       if (orgId !== ORG_ID) throw new Error('Factory project not found.');
@@ -165,14 +171,47 @@ describe('Factory supervisor tools', () => {
         ifActive: { attributes: { delivery: 'while-active' } },
         ifIdle: { attributes: { delivery: 'message' } },
       }),
-      { requestContext: context },
+      { requestContext: expect.any(RequestContext) },
     );
+    // Worker operations must never share the supervisor's live run context —
+    // the controller writes the target session's identity into it.
+    const signalContext = built.workerSession.sendSignal.mock.calls[0]?.[1]?.requestContext as RequestContext;
+    expect(signalContext).not.toBe(context);
+    expect(signalContext.get('user')).toEqual(context.get('user'));
+    // The worker identity lands on the isolated context, not the supervisor's.
+    expect(signalContext.get('controller')).toMatchObject({ resourceId: 'worker-resource' });
+    expect((context.get('controller') as { resourceId: string }).resourceId).toBe(
+      factorySupervisorResourceId(PROJECT_ID),
+    );
+    const resolveContext = built.service.resolveWorkerSession.mock.calls[0]?.[0]?.requestContext;
+    expect(resolveContext).toBe(signalContext);
     const auditInput = built.audit.emitAgent.mock.calls[0]?.[0];
     expect(auditInput?.input).toMatchObject({
       action: 'factory.supervisor.message_sent',
       metadata: { bindingId: built.prepared.binding.id, role: 'work', runId: 'run-1' },
     });
     expect(JSON.stringify(auditInput)).not.toContain('Please summarize');
+  });
+
+  it('stays canonical after signaling: reopening a worker never clobbers the supervisor context', async () => {
+    const built = await fixture();
+    const context = supervisorContext();
+    const tools = await toolsFor(context, built);
+    const controllerEntry = context.get('controller');
+
+    await execute(tools.factory_signal_work_item as ExecutableTool, context, {
+      workItemId: built.prepared.item.id,
+      role: 'work',
+      message: 'Status check.',
+    });
+
+    // The fixture's resolveWorkerSession writes the worker identity into the
+    // context it receives (like the real controller). The supervisor's own
+    // context must be untouched, and follow-up tools must still resolve.
+    expect(context.get('controller')).toBe(controllerEntry);
+    await expect(execute(tools.factory_get_state as ExecutableTool, context, {})).resolves.toMatchObject({
+      factoryProjectId: PROJECT_ID,
+    });
   });
 
   it('resolves only pending approvals through the approval service', async () => {

--- a/mastracode/factory/src/supervisor/tools.test.ts
+++ b/mastracode/factory/src/supervisor/tools.test.ts
@@ -59,7 +59,7 @@ async function fixture() {
     },
     sendSignal: vi.fn(() => ({ accepted })),
   };
-  const controller = { getSessionByResource: vi.fn(async () => workerSession) };
+  const controller = { getSessionByResource: vi.fn(async (_resourceId: string) => workerSession) };
   const approvals = {
     list: vi.fn(async () => []),
     get: vi.fn(async () => null),
@@ -74,12 +74,18 @@ async function fixture() {
   const describeWorkerBindings = vi.fn(async () => [
     { workItemId: prepared.item.id, role: 'work', bindingId: prepared.binding.id, activity: 'idle' as const },
   ]);
+  const resolveWorkerSession = vi.fn(async (input: { binding: { resourceId: string } }) => {
+    const session = await controller.getSessionByResource(input.binding.resourceId);
+    if (!session) throw new Error('Bound Factory session is unavailable.');
+    return session;
+  });
   const service = {
     requireProject: vi.fn(async ({ orgId }: { orgId: string }) => {
       if (orgId !== ORG_ID) throw new Error('Factory project not found.');
     }),
     getState,
     describeWorkerBindings,
+    resolveWorkerSession,
     workItems: storage,
     approvals,
     controller,

--- a/mastracode/factory/src/supervisor/tools.test.ts
+++ b/mastracode/factory/src/supervisor/tools.test.ts
@@ -71,11 +71,15 @@ async function fixture() {
     counts: { byBoard: { work: 1 }, byStage: { intake: 1 } },
     pendingApprovals: [],
   }));
+  const describeWorkerBindings = vi.fn(async () => [
+    { workItemId: prepared.item.id, role: 'work', bindingId: prepared.binding.id, activity: 'idle' as const },
+  ]);
   const service = {
     requireProject: vi.fn(async ({ orgId }: { orgId: string }) => {
       if (orgId !== ORG_ID) throw new Error('Factory project not found.');
     }),
     getState,
+    describeWorkerBindings,
     workItems: storage,
     approvals,
     controller,
@@ -124,6 +128,9 @@ describe('Factory supervisor tools', () => {
       id: built.prepared.item.id,
       title: 'Investigate flaky build',
       sessionRoles: ['work'],
+      workers: [
+        { workItemId: built.prepared.item.id, role: 'work', bindingId: built.prepared.binding.id, activity: 'idle' },
+      ],
     });
     await expect(
       execute(tools.factory_get_work_item as ExecutableTool, context, {

--- a/mastracode/factory/src/supervisor/tools.test.ts
+++ b/mastracode/factory/src/supervisor/tools.test.ts
@@ -11,11 +11,17 @@ const ORG_ID = 'org-1';
 
 type ExecutableTool = { execute: (input: unknown, context: unknown) => Promise<unknown> };
 
-function supervisorContext(overrides: Partial<{ orgId: string; projectId: string; threadId: string }> = {}) {
+function supervisorContext(
+  overrides: Partial<{ orgId: string; projectId: string; threadId: string; user: unknown }> = {},
+) {
   const orgId = overrides.orgId ?? ORG_ID;
   const factoryProjectId = overrides.projectId ?? PROJECT_ID;
   const context = new RequestContext();
-  context.set('user', { workosId: 'user-1', organizationId: orgId, name: 'Ada Lovelace' });
+  // `user` is absent on server-initiated runs — the controller builds a fresh
+  // request context per run that carries only `controller`.
+  const user =
+    'user' in overrides ? overrides.user : { workosId: 'user-1', organizationId: orgId, name: 'Ada Lovelace' };
+  if (user) context.set('user', user);
   context.set('controller', {
     resourceId: factorySupervisorResourceId(factoryProjectId),
     threadId: overrides.threadId ?? factorySupervisorThreadId(factoryProjectId),
@@ -23,6 +29,7 @@ function supervisorContext(overrides: Partial<{ orgId: string; projectId: string
       factoryProjectId,
       factoryOrgId: orgId,
       factorySupervisor: true,
+      factorySupervisorUserId: 'user-1',
     }),
   });
   return context;
@@ -123,6 +130,26 @@ describe('Factory supervisor tools', () => {
     await expect(toolsFor(supervisorContext({ orgId: 'org-other' }), built)).rejects.toThrow(
       'Factory project not found',
     );
+  });
+
+  it('exposes tools on server-initiated runs that carry no authenticated request user', async () => {
+    const built = await fixture();
+    // Boot check-ins, idle observations, and approval notifications start a run
+    // from the server: the controller builds a fresh request context holding
+    // only `controller`, so identity has to come off the session's own state.
+    const context = supervisorContext({ user: null });
+    const tools = await toolsFor(context, built);
+    expect(Object.keys(tools)).toContain('factory_get_state');
+
+    await expect(execute(tools.factory_get_state as ExecutableTool, context, {})).resolves.toMatchObject({
+      totalItems: 1,
+    });
+  });
+
+  it('withholds tools from a request user outside the session tenant', async () => {
+    const built = await fixture();
+    const context = supervisorContext({ user: { workosId: 'intruder', organizationId: 'org-other' } });
+    await expect(toolsFor(context, built)).resolves.toEqual({});
   });
 
   it('queries bounded state and tenant-scoped work-item details', async () => {

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -81,7 +81,7 @@ function itemSummary(item: WorkItemRow, approvals: Awaited<ReturnType<FactorySup
     revision: item.revision,
     parentWorkItemId: item.parentWorkItemId,
     sessionRoles: Object.keys(item.sessions).sort(),
-    approvals: approvals.map(supervisorApprovalSummary),
+    approvals: approvals.map(approval => supervisorApprovalSummary(approval)),
     createdAt: item.createdAt.toISOString(),
     updatedAt: item.updatedAt.toISOString(),
   };
@@ -146,7 +146,7 @@ export async function createFactorySupervisorTools(options: {
           factoryProjectId: current.factoryProjectId,
           statuses: ['pending'],
         });
-        return { approvals: approvals.slice(0, limit).map(supervisorApprovalSummary) };
+        return { approvals: approvals.slice(0, limit).map(approval => supervisorApprovalSummary(approval)) };
       },
     }),
     factory_signal_work_item: createTool({

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -71,7 +71,11 @@ function resolveSupervisorContext(requestContext: RequestContext | undefined): S
   };
 }
 
-function itemSummary(item: WorkItemRow, approvals: Awaited<ReturnType<FactorySupervisorService['approvals']['list']>>) {
+function itemSummary(
+  item: WorkItemRow,
+  approvals: Awaited<ReturnType<FactorySupervisorService['approvals']['list']>>,
+  workers: Awaited<ReturnType<FactorySupervisorService['describeWorkerBindings']>>,
+) {
   return {
     id: item.id,
     title: item.title,
@@ -81,6 +85,7 @@ function itemSummary(item: WorkItemRow, approvals: Awaited<ReturnType<FactorySup
     revision: item.revision,
     parentWorkItemId: item.parentWorkItemId,
     sessionRoles: Object.keys(item.sessions).sort(),
+    workers,
     approvals: approvals.map(approval => supervisorApprovalSummary(approval)),
     createdAt: item.createdAt.toISOString(),
     updatedAt: item.updatedAt.toISOString(),
@@ -104,7 +109,8 @@ export async function createFactorySupervisorTools(options: {
   return {
     factory_get_state: createTool({
       id: 'factory_get_state',
-      description: 'Get bounded live counts by board and stage plus pending transition approvals for this Factory.',
+      description:
+        'Get bounded live counts by board and stage, per-binding worker activity (running/idle/offline), and pending transition approvals for this Factory.',
       inputSchema: z.object({}).strict(),
       execute: async (_input, execution) => {
         const current = resolveSupervisorContext(execution.requestContext);
@@ -125,11 +131,18 @@ export async function createFactorySupervisorTools(options: {
         }
         const item = await options.service.workItems.getForProject(current.orgId, current.factoryProjectId, workItemId);
         if (!item) throw new Error('Factory work item not found.');
-        const approvals = await options.service.approvals.list({
-          orgId: current.orgId,
-          factoryProjectId: current.factoryProjectId,
-        });
-        return itemSummary(item, approvals.filter(approval => approval.workItemId === item.id).slice(0, 50));
+        const [approvals, workers] = await Promise.all([
+          options.service.approvals.list({
+            orgId: current.orgId,
+            factoryProjectId: current.factoryProjectId,
+          }),
+          options.service.describeWorkerBindings({
+            orgId: current.orgId,
+            factoryProjectId: current.factoryProjectId,
+            workItemId,
+          }),
+        ]);
+        return itemSummary(item, approvals.filter(approval => approval.workItemId === item.id).slice(0, 50), workers);
       },
     }),
     factory_list_pending_approvals: createTool({

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -11,7 +11,7 @@ import { getFactoryAuthOrgId, getFactoryAuthUserId } from '../auth.js';
 import type { IntegrationTools } from '../integrations/base.js';
 import type { AuditAgentEmitter } from '../storage/domains/audit/domain.js';
 import type { FactoryRunBindingRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
-import { factorySupervisorThreadId } from './service.js';
+import { factorySupervisorResourceId, factorySupervisorThreadId } from './service.js';
 import type { FactorySupervisorService } from './service.js';
 import { supervisorApprovalSummary } from './state.js';
 
@@ -57,7 +57,7 @@ function resolveSupervisorContext(requestContext: RequestContext | undefined): S
     !factoryProjectId ||
     state.factoryOrgId !== orgId ||
     (state.factorySupervisor !== true && state.factorySupervisor !== 'true') ||
-    controller.resourceId !== factoryProjectId ||
+    controller.resourceId !== factorySupervisorResourceId(factoryProjectId) ||
     controller.threadId !== factorySupervisorThreadId(factoryProjectId)
   ) {
     return null;

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -11,7 +11,7 @@ import { getFactoryAuthOrgId, getFactoryAuthUserId } from '../auth.js';
 import type { IntegrationTools } from '../integrations/base.js';
 import type { AuditAgentEmitter } from '../storage/domains/audit/domain.js';
 import type { FactoryRunBindingRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
-import { factorySupervisorResourceId, factorySupervisorThreadId } from './service.js';
+import { factorySupervisorResourceId, factorySupervisorThreadId, isolatedWorkerRequestContext } from './service.js';
 import type { FactorySupervisorService } from './service.js';
 import { supervisorApprovalSummary } from './state.js';
 
@@ -180,11 +180,16 @@ export async function createFactorySupervisorTools(options: {
         );
         if (!binding)
           throw new Error(role ? `No active Factory binding for role '${role}'.` : 'No active Factory binding found.');
+        // The controller writes the target session's identity into the request
+        // context it's handed — worker operations must run on an isolated
+        // context or they clobber the supervisor's own `controller` entry and
+        // de-canonicalize this session mid-run.
+        const workerContext = isolatedWorkerRequestContext(execution.requestContext);
         const session = await options.service.resolveWorkerSession({
           orgId: current.orgId,
           factoryProjectId: current.factoryProjectId,
           binding: { resourceId: binding.resourceId, threadId: binding.threadId },
-          requestContext: execution.requestContext,
+          requestContext: workerContext,
         });
         const signalId = randomUUID();
         const accepted = await session.sendSignal(
@@ -204,7 +209,7 @@ export async function createFactorySupervisorTools(options: {
             ifActive: { attributes: { delivery: 'while-active' } },
             ifIdle: { attributes: { delivery: 'message' } },
           },
-          { requestContext: execution.requestContext },
+          { requestContext: workerContext },
         ).accepted;
         await options.audit.emitAgent({
           requestContext: execution.requestContext,

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -1,0 +1,251 @@
+import { randomUUID } from 'node:crypto';
+
+import type { MastraCodeState } from '@mastra/code-sdk/schema';
+import type { AgentControllerRequestContext } from '@mastra/core/agent-controller';
+import type { RequestContext } from '@mastra/core/request-context';
+import { createTool } from '@mastra/core/tools';
+import { z } from 'zod';
+
+import type { FactoryAuthUser } from '../auth.js';
+import { getFactoryAuthOrgId, getFactoryAuthUserId } from '../auth.js';
+import type { IntegrationTools } from '../integrations/base.js';
+import type { AuditAgentEmitter } from '../storage/domains/audit/domain.js';
+import type { FactoryRunBindingRecord, WorkItemRow } from '../storage/domains/work-items/base.js';
+import { factorySupervisorThreadId } from './service.js';
+import type { FactorySupervisorService } from './service.js';
+import { supervisorApprovalSummary } from './state.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const uuidSchema = z.string().regex(UUID_RE);
+const workItemInputSchema = z.object({ workItemId: uuidSchema }).strict();
+const pendingApprovalInputSchema = z.object({ limit: z.number().int().min(1).max(50).default(20) }).strict();
+const signalInputSchema = z
+  .object({
+    workItemId: uuidSchema,
+    role: z.string().trim().min(1).max(64).optional(),
+    message: z.string().trim().min(1).max(4_000),
+  })
+  .strict();
+const resolveApprovalInputSchema = z
+  .object({
+    approvalId: uuidSchema,
+    decision: z.enum(['approve', 'reject']),
+    reason: z.string().trim().min(1).max(1_000).optional(),
+  })
+  .strict();
+
+interface SupervisorContext {
+  orgId: string;
+  userId: string;
+  userName?: string;
+  factoryProjectId: string;
+  threadId: string;
+}
+
+function resolveSupervisorContext(requestContext: RequestContext | undefined): SupervisorContext | null {
+  if (!requestContext || typeof requestContext.get !== 'function') return null;
+  const controller = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
+  const user = requestContext.get('user') as FactoryAuthUser | undefined;
+  const state = controller?.getState();
+  const orgId = getFactoryAuthOrgId(user);
+  const userId = getFactoryAuthUserId(user);
+  const factoryProjectId = state?.factoryProjectId;
+  if (
+    !controller?.threadId ||
+    !orgId ||
+    !userId ||
+    !factoryProjectId ||
+    state.factoryOrgId !== orgId ||
+    (state.factorySupervisor !== true && state.factorySupervisor !== 'true') ||
+    controller.resourceId !== factoryProjectId ||
+    controller.threadId !== factorySupervisorThreadId(factoryProjectId)
+  ) {
+    return null;
+  }
+  return {
+    orgId,
+    userId,
+    ...(typeof user?.name === 'string' && user.name.trim() ? { userName: user.name.trim().slice(0, 128) } : {}),
+    factoryProjectId,
+    threadId: controller.threadId,
+  };
+}
+
+function itemSummary(item: WorkItemRow, approvals: Awaited<ReturnType<FactorySupervisorService['approvals']['list']>>) {
+  return {
+    id: item.id,
+    title: item.title,
+    board: item.externalSource?.type === 'pull-request' ? 'review' : 'work',
+    stages: item.stages,
+    stageHistory: item.stageHistory,
+    revision: item.revision,
+    parentWorkItemId: item.parentWorkItemId,
+    sessionRoles: Object.keys(item.sessions).sort(),
+    approvals: approvals.map(supervisorApprovalSummary),
+    createdAt: item.createdAt.toISOString(),
+    updatedAt: item.updatedAt.toISOString(),
+  };
+}
+
+function selectBinding(bindings: FactoryRunBindingRecord[], role: string | undefined): FactoryRunBindingRecord | null {
+  const eligible = bindings.filter(binding => binding.status === 'active' && (!role || binding.role === role));
+  return eligible.at(-1) ?? null;
+}
+
+export async function createFactorySupervisorTools(options: {
+  requestContext: RequestContext;
+  service: FactorySupervisorService;
+  audit: AuditAgentEmitter;
+}): Promise<IntegrationTools> {
+  const context = resolveSupervisorContext(options.requestContext);
+  if (!context) return {};
+  await options.service.requireProject(context);
+
+  return {
+    factory_get_state: createTool({
+      id: 'factory_get_state',
+      description: 'Get bounded live counts by board and stage plus pending transition approvals for this Factory.',
+      inputSchema: z.object({}).strict(),
+      execute: async (_input, execution) => {
+        const current = resolveSupervisorContext(execution.requestContext);
+        if (!current || current.factoryProjectId !== context.factoryProjectId) {
+          throw new Error('Factory supervisor session is no longer canonical.');
+        }
+        return options.service.getState(current);
+      },
+    }),
+    factory_get_work_item: createTool({
+      id: 'factory_get_work_item',
+      description: 'Get one work item in this Factory with bounded stage, history, session-role, and approval details.',
+      inputSchema: workItemInputSchema,
+      execute: async ({ workItemId }, execution) => {
+        const current = resolveSupervisorContext(execution.requestContext);
+        if (!current || current.factoryProjectId !== context.factoryProjectId) {
+          throw new Error('Factory supervisor session is no longer canonical.');
+        }
+        const item = await options.service.workItems.getForProject(current.orgId, current.factoryProjectId, workItemId);
+        if (!item) throw new Error('Factory work item not found.');
+        const approvals = await options.service.approvals.list({
+          orgId: current.orgId,
+          factoryProjectId: current.factoryProjectId,
+        });
+        return itemSummary(item, approvals.filter(approval => approval.workItemId === item.id).slice(0, 50));
+      },
+    }),
+    factory_list_pending_approvals: createTool({
+      id: 'factory_list_pending_approvals',
+      description: 'List pending governed transition approvals for this Factory.',
+      inputSchema: pendingApprovalInputSchema,
+      execute: async ({ limit }, execution) => {
+        const current = resolveSupervisorContext(execution.requestContext);
+        if (!current || current.factoryProjectId !== context.factoryProjectId) {
+          throw new Error('Factory supervisor session is no longer canonical.');
+        }
+        const approvals = await options.service.approvals.list({
+          orgId: current.orgId,
+          factoryProjectId: current.factoryProjectId,
+          statuses: ['pending'],
+        });
+        return { approvals: approvals.slice(0, limit).map(supervisorApprovalSummary) };
+      },
+    }),
+    factory_signal_work_item: createTool({
+      id: 'factory_signal_work_item',
+      description:
+        'Send a supervisor message to an active binding for one work item, injecting active work or waking idle work.',
+      inputSchema: signalInputSchema,
+      execute: async ({ workItemId, role, message }, execution) => {
+        const current = resolveSupervisorContext(execution.requestContext);
+        if (!current || current.factoryProjectId !== context.factoryProjectId) {
+          throw new Error('Factory supervisor session is no longer canonical.');
+        }
+        const item = await options.service.workItems.getForProject(current.orgId, current.factoryProjectId, workItemId);
+        if (!item) throw new Error('Factory work item not found.');
+        const binding = selectBinding(
+          await options.service.workItems.listRunBindings(current.orgId, current.factoryProjectId, workItemId),
+          role,
+        );
+        if (!binding)
+          throw new Error(role ? `No active Factory binding for role '${role}'.` : 'No active Factory binding found.');
+        const session = await options.service.controller.getSessionByResource(binding.resourceId);
+        if (!session) throw new Error('Bound Factory session is unavailable.');
+        if (session.thread.getId() !== binding.threadId) {
+          await session.thread.switch({ threadId: binding.threadId, emitEvent: false });
+        }
+        const signalId = randomUUID();
+        const accepted = await session.sendSignal(
+          {
+            id: signalId,
+            type: 'user',
+            tagName: 'factory-supervisor-message',
+            contents: message,
+            attributes: {
+              factoryProjectId: current.factoryProjectId,
+              workItemId,
+              role: binding.role,
+              supervisorThreadId: current.threadId,
+              userId: current.userId,
+              ...(current.userName ? { name: current.userName } : {}),
+            },
+            ifActive: { attributes: { delivery: 'while-active' } },
+            ifIdle: { attributes: { delivery: 'message' } },
+          },
+          { requestContext: execution.requestContext },
+        ).accepted;
+        await options.audit.emitAgent({
+          requestContext: execution.requestContext,
+          input: {
+            action: 'factory.supervisor.message_sent',
+            targets: [{ type: 'work_item', id: workItemId, name: item.title }],
+            metadata: { bindingId: binding.id, role: binding.role, signalId, runId: accepted.runId ?? null },
+          },
+        });
+        return {
+          status: 'accepted',
+          bindingId: binding.id,
+          role: binding.role,
+          signalId,
+          runId: accepted.runId ?? null,
+        };
+      },
+    }),
+    factory_resolve_transition_approval: createTool({
+      id: 'factory_resolve_transition_approval',
+      description:
+        'Approve or reject one pending transition approval. Approval applies the captured move only if its revision is current.',
+      inputSchema: resolveApprovalInputSchema,
+      execute: async ({ approvalId, decision, reason }, execution) => {
+        const current = resolveSupervisorContext(execution.requestContext);
+        if (!current || current.factoryProjectId !== context.factoryProjectId) {
+          throw new Error('Factory supervisor session is no longer canonical.');
+        }
+        const approval = await options.service.approvals.get({
+          orgId: current.orgId,
+          factoryProjectId: current.factoryProjectId,
+          approvalId,
+        });
+        if (!approval) throw new Error('Factory transition approval not found.');
+        if (approval.status !== 'pending')
+          throw new Error(`Factory transition approval is already ${approval.status}.`);
+        const result = await options.service.approvals.resolve({
+          orgId: current.orgId,
+          factoryProjectId: current.factoryProjectId,
+          approvalId,
+          decision,
+          resolvedBy: current.userId,
+          resolverType: 'agent',
+          ...(reason ? { resolutionReason: reason } : {}),
+        });
+        if (result.status === 'missing') throw new Error('Factory transition approval not found.');
+        return {
+          status: result.status,
+          replayed: result.replayed,
+          approvalId,
+          workItemId: result.approval.workItemId,
+          stage: result.approval.requestedStage,
+          revision: result.item?.revision ?? null,
+        };
+      },
+    }),
+  };
+}

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -110,7 +110,7 @@ export async function createFactorySupervisorTools(options: {
     factory_get_state: createTool({
       id: 'factory_get_state',
       description:
-        'Get bounded live counts by board and stage, per-binding worker activity (running/idle/offline), and pending transition approvals for this Factory.',
+        'Get bounded live counts by board and stage, per-binding worker activity (running/idle), and pending transition approvals for this Factory.',
       inputSchema: z.object({}).strict(),
       execute: async (_input, execution) => {
         const current = resolveSupervisorContext(execution.requestContext);

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -180,11 +180,12 @@ export async function createFactorySupervisorTools(options: {
         );
         if (!binding)
           throw new Error(role ? `No active Factory binding for role '${role}'.` : 'No active Factory binding found.');
-        const session = await options.service.controller.getSessionByResource(binding.resourceId);
-        if (!session) throw new Error('Bound Factory session is unavailable.');
-        if (session.thread.getId() !== binding.threadId) {
-          await session.thread.switch({ threadId: binding.threadId, emitEvent: false });
-        }
+        const session = await options.service.resolveWorkerSession({
+          orgId: current.orgId,
+          factoryProjectId: current.factoryProjectId,
+          binding: { resourceId: binding.resourceId, threadId: binding.threadId },
+          requestContext: execution.requestContext,
+        });
         const signalId = randomUUID();
         const accepted = await session.sendSignal(
           {

--- a/mastracode/factory/src/supervisor/tools.ts
+++ b/mastracode/factory/src/supervisor/tools.ts
@@ -47,24 +47,35 @@ function resolveSupervisorContext(requestContext: RequestContext | undefined): S
   const controller = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
   const user = requestContext.get('user') as FactoryAuthUser | undefined;
   const state = controller?.getState();
-  const orgId = getFactoryAuthOrgId(user);
-  const userId = getFactoryAuthUserId(user);
   const factoryProjectId = state?.factoryProjectId;
+  // Tenant identity comes from the supervisor session's own state, not the
+  // request context: server-initiated runs (boot check-ins, idle observations,
+  // approval notifications) build a fresh context that carries no `user`, and
+  // those runs still need the Factory tools. The session is only reachable at
+  // its canonical resource/thread pair, which is verified below.
+  const orgId = state?.factoryOrgId;
+  const userId = state?.factorySupervisorUserId;
   if (
     !controller?.threadId ||
     !orgId ||
     !userId ||
     !factoryProjectId ||
-    state.factoryOrgId !== orgId ||
     (state.factorySupervisor !== true && state.factorySupervisor !== 'true') ||
     controller.resourceId !== factorySupervisorResourceId(factoryProjectId) ||
     controller.threadId !== factorySupervisorThreadId(factoryProjectId)
   ) {
     return null;
   }
+  // When a request user is present (UI-driven turn) it must belong to the same
+  // tenant as the session — a cross-tenant caller never gets these tools.
+  const requestOrgId = getFactoryAuthOrgId(user);
+  if (requestOrgId && requestOrgId !== orgId) return null;
+  const requestUserId = requestOrgId ? getFactoryAuthUserId(user) : undefined;
   return {
     orgId,
-    userId,
+    // Attribute actions to the human driving the turn when there is one, so
+    // audit trails name the actual operator rather than the session owner.
+    userId: requestUserId ?? userId,
     ...(typeof user?.name === 'string' && user.name.trim() ? { userName: user.name.trim().slice(0, 128) } : {}),
     factoryProjectId,
     threadId: controller.threadId,

--- a/mastracode/sdk/src/agents/__tests__/workspace-env.test.ts
+++ b/mastracode/sdk/src/agents/__tests__/workspace-env.test.ts
@@ -50,6 +50,22 @@ afterEach(() => {
 });
 
 describe('mastracode workspace sandbox environment', () => {
+  it('provides an isolated workspace for Factory supervisor sessions without a project path', async () => {
+    const requestContext = new RequestContext();
+    const getState = () => ({ factorySupervisor: true });
+    requestContext.set('controller', {
+      modeId: 'build',
+      getState,
+      session: { state: { get: getState } },
+    });
+
+    const { getDynamicWorkspace } = await import('../workspace.js');
+    const workspace = await getDynamicWorkspace({ requestContext: requestContext as any });
+
+    expect(workspace.id).toBe('mastracode-factory-supervisor');
+    expect(workspace.sandbox).toBeUndefined();
+  });
+
   it('passes arbitrary parent environment variables to local subprocesses', async () => {
     const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mastracode-workspace-env-'));
 

--- a/mastracode/sdk/src/agents/workspace.ts
+++ b/mastracode/sdk/src/agents/workspace.ts
@@ -254,6 +254,25 @@ export async function getDynamicWorkspace({
   const ctx = requestContext.get('controller') as AgentControllerRequestContext<MastraCodeState> | undefined;
   const state = ctx?.getState();
 
+  if (state?.factorySupervisor === true || state?.factorySupervisor === 'true') {
+    const workspaceId = 'mastracode-factory-supervisor';
+    try {
+      const existing = mastra?.getWorkspaceById(workspaceId) as Workspace | undefined;
+      if (existing) return existing;
+    } catch {
+      // Not registered yet.
+    }
+
+    const basePath = path.join(os.tmpdir(), `mastracode-factory-supervisor-${process.pid}`);
+    fs.mkdirSync(basePath, { recursive: true });
+    return new Workspace({
+      id: workspaceId,
+      name: 'Factory Supervisor Workspace',
+      filesystem: new LocalFilesystem({ basePath, readOnly: true }),
+      tools: {},
+    });
+  }
+
   // Repository-backed project: the repo lives inside a remote sandbox, not on
   // the server host. Reattach to the already-provisioned + materialized sandbox
   // and build a sandbox-backed Workspace. Optional embedders may add read-only

--- a/mastracode/sdk/src/schema.ts
+++ b/mastracode/sdk/src/schema.ts
@@ -18,6 +18,10 @@ export interface MastraCodeState {
   projectName?: string;
   /** Factory project that owns this session. */
   factoryProjectId?: string;
+  /** Factory tenant that owns a server-managed global session. */
+  factoryOrgId?: string;
+  /** Marks the canonical Factory supervisor session (`'true'` is the persisted thread tag form). */
+  factorySupervisor?: boolean | 'true';
   /** Linked repository used by this session when source-control execution is required. */
   projectRepositoryId?: string;
   /** Persisted sandbox id for reattaching the project's cloud workspace. */
@@ -90,6 +94,8 @@ export const stateSchema = z.object({
   projectPath: z.string().optional(),
   projectName: z.string().optional(),
   factoryProjectId: z.string().optional(),
+  factoryOrgId: z.string().optional(),
+  factorySupervisor: z.union([z.boolean(), z.literal('true')]).optional(),
   projectRepositoryId: z.string().optional(),
   sandboxId: z.string().optional(),
   sandboxWorkdir: z.string().optional(),

--- a/mastracode/sdk/src/schema.ts
+++ b/mastracode/sdk/src/schema.ts
@@ -22,6 +22,13 @@ export interface MastraCodeState {
   factoryOrgId?: string;
   /** Marks the canonical Factory supervisor session (`'true'` is the persisted thread tag form). */
   factorySupervisor?: boolean | 'true';
+  /**
+   * Factory user the supervisor session acts as. Server-initiated runs (boot
+   * check-ins, idle observations, approval notifications) build a fresh request
+   * context that carries no authenticated `user`, so the supervisor's tools
+   * resolve their tenant identity from session state instead.
+   */
+  factorySupervisorUserId?: string;
   /** Linked repository used by this session when source-control execution is required. */
   projectRepositoryId?: string;
   /** Persisted sandbox id for reattaching the project's cloud workspace. */
@@ -96,6 +103,7 @@ export const stateSchema = z.object({
   factoryProjectId: z.string().optional(),
   factoryOrgId: z.string().optional(),
   factorySupervisor: z.union([z.boolean(), z.literal('true')]).optional(),
+  factorySupervisorUserId: z.string().optional(),
   projectRepositoryId: z.string().optional(),
   sandboxId: z.string().optional(),
   sandboxWorkdir: z.string().optional(),

--- a/mastracode/web/.gitignore
+++ b/mastracode/web/.gitignore
@@ -5,3 +5,6 @@ src/mastra/public/factory/
 # Factory skill assets — copied from @mastra/factory by
 # scripts/copy-factory-skills.mjs during web:ui:build.
 src/mastra/public/factory-skills/
+
+# Local dev/proof Vite build output.
+src/mastra/public/ui/

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -91,6 +91,12 @@ Open GitHub issues appear as **Work** intake candidates. Open pull requests appe
 
 When a Factory pull request branch matches a related work session branch, the Review item stores the Work item as its parent. The Work card links to the Review session, and the Review card links back to the Work session. The same reciprocal links appear in the session header. Links to a thread are shown only while its referenced worktree still exists; the related board item remains available after worktree deletion.
 
+## Factory supervisor
+
+The **Supervisor** page at `/factories/:factoryId/supervisor` gives each server-backed Factory one shared conversation. Its AgentController thread ID is always `${factoryProjectId}-supervisor`, so every authenticated member of the Factory sees the same history rather than receiving a personal, repository-specific, or browser-specific thread. The page shows a bounded Factory state summary and pending transition approvals beside the existing chat transcript and composer.
+
+Approval controls call the tenant-scoped Factory API and never move a card optimistically. Approving a request applies the captured transition automatically only when its work item revision is still current; otherwise the request becomes stale. Rejecting leaves the item unchanged. User messages use the authenticated display name for model context and transcript attribution, but authorization continues to come from the authenticated tenant and session.
+
 ## Workspace skill invocation
 
 The private Web API can activate a user-invocable skill on an existing scoped AgentController session with `POST /web/agent-controller/:controllerId/skills/invoke`. The Web Factory packages workflow skills such as `understand-issue` and `understand-pr` as ordinary, read-only `SKILL.md` files and adds them only to workspaces created by `MastraFactory`; the shared SDK and TUI workspace resolver do not load them. The route resolves every ID through the session workspace, uses the same `<skill name="…">` activation envelope as `/skill/<name>` in the TUI, and returns an error without dispatching when the skill is missing. Authenticated requests may target only the caller's personal session or a Factory worktree owned by that organization user.

--- a/mastracode/web/README.md
+++ b/mastracode/web/README.md
@@ -93,7 +93,7 @@ When a Factory pull request branch matches a related work session branch, the Re
 
 ## Factory supervisor
 
-The **Supervisor** page at `/factories/:factoryId/supervisor` gives each server-backed Factory one shared conversation. Its AgentController thread ID is always `${factoryProjectId}-supervisor`, so every authenticated member of the Factory sees the same history rather than receiving a personal, repository-specific, or browser-specific thread. The page shows a bounded Factory state summary and pending transition approvals beside the existing chat transcript and composer.
+The **Supervisor** page at `/factories/:factoryId/supervisor` gives each server-backed Factory one shared conversation. Its AgentController resource and thread IDs are both `${factoryProjectId}-supervisor` — a dedicated resource, because the bare factory ID is claimed by the factory-level session used for settings and permissions — so every authenticated member of the Factory sees the same history rather than receiving a personal, repository-specific, or browser-specific thread. The page shows a bounded Factory state summary and pending transition approvals beside the existing chat transcript and composer.
 
 Approval controls call the tenant-scoped Factory API and never move a card optimistically. Approving a request applies the captured transition automatically only when its work item revision is still current; otherwise the request becomes stale. Rejecting leaves the item unchanged. User messages use the authenticated display name for model context and transcript attribution, but authorization continues to come from the authenticated tenant and session.
 

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -36,6 +36,13 @@ export const queryKeys = {
     [...queryKeys.linearIssuesAll(), githubProjectId ?? null] as const,
   intakeConfig: () => ['intake', 'config'] as const,
   workItems: (factoryProjectId: string | undefined) => ['factory', 'work-items', factoryProjectId ?? null] as const,
+  factorySupervisorSession: (factoryProjectId: string | undefined) =>
+    ['factory', 'supervisor', factoryProjectId ?? null, 'session'] as const,
+  factorySupervisorState: (factoryProjectId: string | undefined) =>
+    ['factory', 'supervisor', factoryProjectId ?? null, 'state'] as const,
+  factorySupervisorApprovals: (factoryProjectId: string | undefined) =>
+    ['factory', 'supervisor', factoryProjectId ?? null, 'approvals'] as const,
+  factoryAuditAll: (factoryProjectId: string | undefined) => ['factory', 'audit', factoryProjectId ?? null] as const,
   factoryMetrics: (githubProjectId: string | undefined, from: string, to: string) =>
     ['factory', 'metrics', githubProjectId ?? null, from, to] as const,
   factoryHealthThresholds: (githubProjectId: string | undefined) =>

--- a/mastracode/web/src/shared/hooks/useFactorySupervisor.ts
+++ b/mastracode/web/src/shared/hooks/useFactorySupervisor.ts
@@ -1,0 +1,67 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  ensureFactorySupervisorSession,
+  getFactorySupervisorState,
+  listFactorySupervisorApprovals,
+  resolveFactorySupervisorApproval,
+} from '../../web/ui/domains/factory/services/supervisor';
+import { AGENT_CONTROLLER_ID } from '../../web/ui/domains/chat/services/constants';
+import { useApiConfig } from '../api/config';
+import { queryKeys } from '../api/keys';
+
+export function useFactorySupervisorSession(factoryProjectId: string | undefined) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.factorySupervisorSession(factoryProjectId),
+    queryFn: () => ensureFactorySupervisorSession(baseUrl, factoryProjectId!),
+    enabled: Boolean(factoryProjectId),
+    retry: false,
+    staleTime: Infinity,
+  });
+}
+
+export function useFactorySupervisorState(factoryProjectId: string | undefined) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.factorySupervisorState(factoryProjectId),
+    queryFn: () => getFactorySupervisorState(baseUrl, factoryProjectId!),
+    enabled: Boolean(factoryProjectId),
+    refetchInterval: 5_000,
+  });
+}
+
+export function useFactorySupervisorApprovals(factoryProjectId: string | undefined) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.factorySupervisorApprovals(factoryProjectId),
+    queryFn: () => listFactorySupervisorApprovals(baseUrl, factoryProjectId!),
+    enabled: Boolean(factoryProjectId),
+    refetchInterval: 5_000,
+  });
+}
+
+export function useResolveFactorySupervisorApproval(factoryProjectId: string | undefined) {
+  const { baseUrl } = useApiConfig();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ approvalId, decision }: { approvalId: string; decision: 'approve' | 'reject' }) =>
+      resolveFactorySupervisorApproval(baseUrl, factoryProjectId!, approvalId, decision),
+    onSuccess: async result => {
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: queryKeys.factorySupervisorState(factoryProjectId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.factorySupervisorApprovals(factoryProjectId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.workItems(factoryProjectId) }),
+        queryClient.invalidateQueries({ queryKey: queryKeys.factoryAuditAll(factoryProjectId) }),
+        queryClient.invalidateQueries({
+          queryKey: queryKeys.agentControllerThreadMessages(
+            AGENT_CONTROLLER_ID,
+            factoryProjectId,
+            `${factoryProjectId}-supervisor`,
+          ),
+        }),
+      ]);
+      return result;
+    },
+  });
+}

--- a/mastracode/web/src/web/ui/domains/chat/Chat.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/Chat.tsx
@@ -28,11 +28,15 @@ function ChatSessionRouteProvider({ children }: { children: ReactNode }) {
   // routes explicitly (params come back already decoded).
   const userThreadMatch = useMatch('/factories/:factoryId/user/threads/:threadId');
   const factoryThreadMatch = useMatch('/factories/:factoryId/workspaces/:sessionId/threads/:threadId');
+  // The supervisor page provides its own session context bound to the
+  // deterministic supervisor resource; disable the generic provider so it
+  // cannot claim that resource before the supervisor session is established.
+  const supervisorMatch = useMatch('/factories/:factoryId/supervisor');
   const userScoped = userThreadMatch !== null;
   const threadId = userThreadMatch?.params.threadId ?? factoryThreadMatch?.params.threadId;
 
   return (
-    <ChatSessionConfigProvider threadId={threadId} userScoped={userScoped}>
+    <ChatSessionConfigProvider threadId={threadId} userScoped={userScoped} disabled={supervisorMatch !== null}>
       <ChatPermissionsProvider>{children}</ChatPermissionsProvider>
     </ChatSessionConfigProvider>
   );

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -31,10 +31,12 @@ export function ChatSessionConfigProvider({
   children,
   threadId,
   userScoped = false,
+  disabled = false,
 }: {
   children: ReactNode;
   threadId?: string;
   userScoped?: boolean;
+  disabled?: boolean;
 }) {
   const { factoryId, sessionId } = useParams<{ factoryId: string; sessionId: string }>();
   const { baseUrl } = useApiConfig();
@@ -64,8 +66,8 @@ export function ChatSessionConfigProvider({
     : ensureQuery.isSuccess && Boolean(storedSession) && !resolvingSession;
   const value = {
     resourceId: resourceId ?? '',
-    sessionEnabled,
-    resourceEnabled: userScoped ? Boolean(resourceId) : ensureQuery.isSuccess,
+    sessionEnabled: disabled ? false : sessionEnabled,
+    resourceEnabled: disabled ? false : userScoped ? Boolean(resourceId) : ensureQuery.isSuccess,
     projectPath,
     factorySessionState:
       factory && repository

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
@@ -1,0 +1,302 @@
+/**
+ * Product coverage for the shared Factory supervisor page.
+ *
+ * The tests drive the real route, React Query hooks, AgentController chat
+ * providers, and approval mutations. Only HTTP is mocked through MSW.
+ */
+import { QueryClient } from '@tanstack/react-query';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { createMemoryRouter, RouterProvider } from 'react-router';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../../e2e/web-ui/render';
+import { createAppRoutes } from '../../../router';
+import type { FactorySupervisorApproval, FactorySupervisorState } from '../services/supervisor';
+
+const API = `${TEST_BASE_URL}/api/agent-controller/code`;
+const FACTORY_PROJECT_ID = '9f5345e2-c44d-4e4e-a063-c5590f27d344';
+const SUPERVISOR_THREAD_ID = `${FACTORY_PROJECT_ID}-supervisor`;
+const SUPERVISOR_RESOURCE_ID = FACTORY_PROJECT_ID;
+
+const pendingApproval: FactorySupervisorApproval = {
+  id: '1ed5b84f-f21e-47c6-a859-1bfbd4f44fe6',
+  workItemId: 'work-item-1',
+  transitionId: 'transition-1',
+  board: 'work',
+  stage: 'execute',
+  expectedRevision: 4,
+  requestingRole: 'plan',
+  reason: 'The plan agent requested execution.',
+  summary: 'Move approved plan to execution',
+  status: 'pending',
+  resolvedBy: null,
+  resolutionReason: null,
+  resolvedAt: null,
+  createdAt: '2026-07-22T18:00:00.000Z',
+  updatedAt: '2026-07-22T18:00:00.000Z',
+};
+
+const initialState: FactorySupervisorState = {
+  factoryProjectId: FACTORY_PROJECT_ID,
+  totalItems: 3,
+  counts: {
+    byBoard: { work: 3, review: 0 },
+    byStage: { intake: 1, plan: 1, execute: 1 },
+  },
+  pendingApprovals: [
+    {
+      id: '1ed5b84f-f21e-47c6-a859-1bfbd4f44fe6',
+      workItemId: 'work-item-1',
+      board: 'work',
+      stage: 'execute',
+      expectedRevision: 4,
+      requestingRole: 'plan',
+      workItemTitle: 'Approved plan',
+      reason: 'The plan agent requested execution.',
+      summary: 'Move approved plan to execution',
+      ageSeconds: 30,
+      createdAt: '2026-07-22T18:00:00.000Z',
+    },
+  ],
+  pendingApprovalCount: 1,
+  snapshotAt: '2026-07-22T18:00:30.000Z',
+};
+
+function emptySse(): Response {
+  return new Response(
+    new ReadableStream<Uint8Array>({
+      start() {},
+      cancel() {},
+    }),
+    { headers: { 'content-type': 'text/event-stream' } },
+  );
+}
+
+function useChatHandlers(options?: { user?: { userId: string; name?: string }; onMessage?: (body: unknown) => void }) {
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({
+        authenticated: true,
+        authEnabled: true,
+        user: options?.user ?? { userId: 'user-1' },
+      }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+      HttpResponse.json({ projects: [{ id: FACTORY_PROJECT_ID, name: 'Mastra Factory' }] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/source-control-connections`, () =>
+      HttpResponse.json({ connections: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/github/status`, () =>
+      HttpResponse.json({ enabled: true, connected: false, installations: [] }),
+    ),
+    http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/work-items`, () =>
+      HttpResponse.json({ workItems: [] }),
+    ),
+    http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/session`, () =>
+      HttpResponse.json({
+        session: {
+          sessionId: SUPERVISOR_RESOURCE_ID,
+          resourceId: SUPERVISOR_RESOURCE_ID,
+          threadId: SUPERVISOR_THREAD_ID,
+          factoryProjectId: FACTORY_PROJECT_ID,
+        },
+      }),
+    ),
+    http.post(`${API}/sessions`, () =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: SUPERVISOR_RESOURCE_ID,
+        threadId: SUPERVISOR_THREAD_ID,
+      }),
+    ),
+    http.get(`${API}/modes`, () => HttpResponse.json({ modes: [{ id: 'build', label: 'Build' }] })),
+    http.get(`${API}/models`, () => HttpResponse.json({ models: [] })),
+    http.get(`${API}/sessions/:resourceId`, ({ params }) =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: params.resourceId,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SUPERVISOR_THREAD_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.put(`${API}/sessions/:resourceId/state`, ({ params }) =>
+      HttpResponse.json({
+        controllerId: 'code',
+        resourceId: params.resourceId,
+        modeId: 'build',
+        modelId: 'openai/gpt-4o-mini',
+        threadId: SUPERVISOR_THREAD_ID,
+        settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+      }),
+    ),
+    http.get(`${API}/sessions/:resourceId/permissions`, () => HttpResponse.json({ categories: {}, tools: {} })),
+    http.get(`${API}/sessions/:resourceId/threads`, () =>
+      HttpResponse.json({
+        threads: [{ id: SUPERVISOR_THREAD_ID, resourceId: SUPERVISOR_RESOURCE_ID, title: 'Factory Supervisor' }],
+      }),
+    ),
+    http.get(`${API}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
+    http.get(`${API}/sessions/:resourceId/stream`, () => emptySse()),
+    http.post(`${API}/sessions/:resourceId/messages`, async ({ request }) => {
+      options?.onMessage?.(await request.json());
+      return HttpResponse.json({ ok: true });
+    }),
+  );
+}
+
+function renderSupervisor(options?: {
+  user?: { userId: string; name?: string };
+  onMessage?: (body: unknown) => void;
+  initialEntry?: string;
+}) {
+  useChatHandlers(options);
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false }, mutations: { retry: false } } });
+  const router = createMemoryRouter(createAppRoutes(), {
+    initialEntries: [options?.initialEntry ?? `/factories/${FACTORY_PROJECT_ID}/supervisor`],
+  });
+  renderWithProviders(<RouterProvider router={router} />, client);
+  return { client, router };
+}
+
+describe('Factory supervisor page', () => {
+  describe('when a Factory has a pending approval', () => {
+    it('shows the shared supervisor chat with bounded state and the approval', async () => {
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/state`, () =>
+          HttpResponse.json({ state: initialState }),
+        ),
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/approvals`, () =>
+          HttpResponse.json({ approvals: [pendingApproval] }),
+        ),
+      );
+
+      renderSupervisor();
+
+      expect(await screen.findByRole('heading', { name: 'Factory Supervisor' })).toBeInTheDocument();
+      expect(screen.getByRole('link', { name: 'Supervisor' })).toHaveAttribute(
+        'href',
+        `/factories/${FACTORY_PROJECT_ID}/supervisor`,
+      );
+      expect(screen.getByText('3 work items')).toBeInTheDocument();
+      expect(screen.getByText('1 pending approval')).toBeInTheDocument();
+      expect(screen.getByRole('heading', { name: 'Pending approvals' })).toBeInTheDocument();
+      expect(screen.getByText('Move approved plan to execution')).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
+    });
+  });
+
+  describe('when an authenticated user sends a supervisor message', () => {
+    it('sends attributed content through the deterministic supervisor session', async () => {
+      const sent: unknown[] = [];
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/state`, () =>
+          HttpResponse.json({ state: initialState }),
+        ),
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/approvals`, () =>
+          HttpResponse.json({ approvals: [pendingApproval] }),
+        ),
+      );
+
+      renderSupervisor({
+        user: { userId: 'user-ada', name: 'Ada Lovelace' },
+        onMessage: body => sent.push(body),
+      });
+      const input = await screen.findByRole('textbox');
+      await waitFor(() => expect(input).toBeEnabled());
+      await userEvent.type(input, 'Review current Factory state{Enter}');
+
+      await waitFor(() =>
+        expect(sent).toContainEqual({
+          message: 'Review current Factory state',
+          attributes: { name: 'Ada Lovelace', userId: 'user-ada' },
+        }),
+      );
+      expect((await screen.findAllByText('Ada Lovelace')).length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText('Review current Factory state')).toBeInTheDocument();
+    });
+  });
+
+  describe('when a pending transition is approved', () => {
+    it('resolves the approval and removes it after invalidation', async () => {
+      const user = userEvent.setup();
+      let approvals: FactorySupervisorApproval[] = [pendingApproval];
+      const decisions: string[] = [];
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/state`, () =>
+          HttpResponse.json({ state: { ...initialState, pendingApprovalCount: approvals.length } }),
+        ),
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/approvals`, () =>
+          HttpResponse.json({ approvals }),
+        ),
+        http.post(
+          `${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/approvals/:approvalId/resolve`,
+          async ({ request, params }) => {
+            const body = (await request.json()) as { decision: string };
+            decisions.push(body.decision);
+            approvals = approvals.filter(approval => approval.id !== params.approvalId);
+            return HttpResponse.json({
+              result: {
+                status: 'approved',
+                replayed: false,
+                approval: { ...pendingApproval, status: 'approved', resolvedBy: 'user-1' },
+                item: { id: 'work-item-1', revision: 5, stages: ['execute'] },
+              },
+            });
+          },
+        ),
+      );
+
+      renderSupervisor();
+      await user.click(await screen.findByRole('button', { name: 'Approve Move approved plan to execution' }));
+
+      await waitFor(() => expect(decisions).toEqual(['approve']));
+      expect(await screen.findByText('No pending approvals')).toBeInTheDocument();
+      expect(screen.queryByText('Move approved plan to execution')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the work item revision changed before approval', () => {
+    it('reports the stale result without moving state optimistically', async () => {
+      const user = userEvent.setup();
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/state`, () =>
+          HttpResponse.json({ state: initialState }),
+        ),
+        http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/approvals`, () =>
+          HttpResponse.json({ approvals: [pendingApproval] }),
+        ),
+        http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/approvals/:approvalId/resolve`, () =>
+          HttpResponse.json({
+            result: {
+              status: 'stale',
+              replayed: false,
+              approval: { ...pendingApproval, status: 'stale' },
+            },
+          }),
+        ),
+      );
+
+      renderSupervisor();
+      await user.click(await screen.findByRole('button', { name: 'Approve Move approved plan to execution' }));
+
+      expect(await screen.findByText(/work item changed before approval/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('when the URL names an unknown Factory', () => {
+    it('bounces to the landing route instead of rendering a supervisor', async () => {
+      const { router } = renderSupervisor({
+        initialEntry: '/factories/00000000-0000-4000-8000-00000000dead/supervisor',
+      });
+
+      await waitFor(() => expect(router.state.location.pathname).not.toContain('/supervisor'));
+      expect(screen.queryByRole('heading', { name: 'Factory Supervisor' })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
@@ -19,7 +19,7 @@ import type { FactorySupervisorApproval, FactorySupervisorState } from '../servi
 const API = `${TEST_BASE_URL}/api/agent-controller/code`;
 const FACTORY_PROJECT_ID = '9f5345e2-c44d-4e4e-a063-c5590f27d344';
 const SUPERVISOR_THREAD_ID = `${FACTORY_PROJECT_ID}-supervisor`;
-const SUPERVISOR_RESOURCE_ID = FACTORY_PROJECT_ID;
+const SUPERVISOR_RESOURCE_ID = `${FACTORY_PROJECT_ID}-supervisor`;
 
 const pendingApproval: FactorySupervisorApproval = {
   id: '1ed5b84f-f21e-47c6-a859-1bfbd4f44fe6',

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
@@ -65,7 +65,6 @@ const initialState: FactorySupervisorState = {
   workers: {
     running: 1,
     idle: 1,
-    offline: 0,
     bindings: [
       {
         workItemId: 'work-item-1',

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
@@ -75,7 +75,12 @@ function emptySse(): Response {
   );
 }
 
-function useChatHandlers(options?: { user?: { userId: string; name?: string }; onMessage?: (body: unknown) => void }) {
+function useChatHandlers(options?: {
+  user?: { userId: string; name?: string };
+  onMessage?: (body: unknown) => void;
+  onSessionRequest?: (kind: 'supervisor' | 'controller') => void;
+  supervisorGate?: Promise<void>;
+}) {
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
       HttpResponse.json({
@@ -96,35 +101,39 @@ function useChatHandlers(options?: { user?: { userId: string; name?: string }; o
     http.get(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/work-items`, () =>
       HttpResponse.json({ workItems: [] }),
     ),
-    http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/session`, () =>
-      HttpResponse.json({
+    http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_PROJECT_ID}/supervisor/session`, async () => {
+      options?.onSessionRequest?.('supervisor');
+      await options?.supervisorGate;
+      return HttpResponse.json({
         session: {
           sessionId: SUPERVISOR_RESOURCE_ID,
           resourceId: SUPERVISOR_RESOURCE_ID,
           threadId: SUPERVISOR_THREAD_ID,
           factoryProjectId: FACTORY_PROJECT_ID,
         },
-      }),
-    ),
-    http.post(`${API}/sessions`, () =>
-      HttpResponse.json({
+      });
+    }),
+    http.post(`${API}/sessions`, () => {
+      options?.onSessionRequest?.('controller');
+      return HttpResponse.json({
         controllerId: 'code',
         resourceId: SUPERVISOR_RESOURCE_ID,
         threadId: SUPERVISOR_THREAD_ID,
-      }),
-    ),
+      });
+    }),
     http.get(`${API}/modes`, () => HttpResponse.json({ modes: [{ id: 'build', label: 'Build' }] })),
     http.get(`${API}/models`, () => HttpResponse.json({ models: [] })),
-    http.get(`${API}/sessions/:resourceId`, ({ params }) =>
-      HttpResponse.json({
+    http.get(`${API}/sessions/:resourceId`, ({ params }) => {
+      options?.onSessionRequest?.('controller');
+      return HttpResponse.json({
         controllerId: 'code',
         resourceId: params.resourceId,
         modeId: 'build',
         modelId: 'openai/gpt-4o-mini',
         threadId: SUPERVISOR_THREAD_ID,
         settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
-      }),
-    ),
+      });
+    }),
     http.put(`${API}/sessions/:resourceId/state`, ({ params }) =>
       HttpResponse.json({
         controllerId: 'code',
@@ -135,12 +144,16 @@ function useChatHandlers(options?: { user?: { userId: string; name?: string }; o
         settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
       }),
     ),
-    http.get(`${API}/sessions/:resourceId/permissions`, () => HttpResponse.json({ categories: {}, tools: {} })),
-    http.get(`${API}/sessions/:resourceId/threads`, () =>
-      HttpResponse.json({
+    http.get(`${API}/sessions/:resourceId/permissions`, () => {
+      options?.onSessionRequest?.('controller');
+      return HttpResponse.json({ categories: {}, tools: {} });
+    }),
+    http.get(`${API}/sessions/:resourceId/threads`, () => {
+      options?.onSessionRequest?.('controller');
+      return HttpResponse.json({
         threads: [{ id: SUPERVISOR_THREAD_ID, resourceId: SUPERVISOR_RESOURCE_ID, title: 'Factory Supervisor' }],
-      }),
-    ),
+      });
+    }),
     http.get(`${API}/sessions/:resourceId/threads/:threadId/messages`, () => HttpResponse.json({ messages: [] })),
     http.get(`${API}/sessions/:resourceId/stream`, () => emptySse()),
     http.post(`${API}/sessions/:resourceId/messages`, async ({ request }) => {
@@ -153,6 +166,8 @@ function useChatHandlers(options?: { user?: { userId: string; name?: string }; o
 function renderSupervisor(options?: {
   user?: { userId: string; name?: string };
   onMessage?: (body: unknown) => void;
+  onSessionRequest?: (kind: 'supervisor' | 'controller') => void;
+  supervisorGate?: Promise<void>;
   initialEntry?: string;
 }) {
   useChatHandlers(options);
@@ -176,8 +191,21 @@ describe('Factory supervisor page', () => {
         ),
       );
 
-      renderSupervisor();
+      const sessionRequests: Array<'supervisor' | 'controller'> = [];
+      let releaseSupervisor!: () => void;
+      const supervisorGate = new Promise<void>(resolve => {
+        releaseSupervisor = resolve;
+      });
+      renderSupervisor({
+        onSessionRequest: kind => sessionRequests.push(kind),
+        supervisorGate,
+      });
 
+      await waitFor(() => expect(sessionRequests).toContain('supervisor'));
+      await new Promise(resolve => setTimeout(resolve, 50));
+      const requestsBeforeSupervisorReady = [...sessionRequests];
+      releaseSupervisor();
+      expect(requestsBeforeSupervisorReady).toEqual(['supervisor']);
       expect(await screen.findByRole('heading', { name: 'Factory Supervisor' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'Supervisor' })).toHaveAttribute(
         'href',

--- a/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/__tests__/SupervisorPage.msw.test.tsx
@@ -62,6 +62,29 @@ const initialState: FactorySupervisorState = {
     },
   ],
   pendingApprovalCount: 1,
+  workers: {
+    running: 1,
+    idle: 1,
+    offline: 0,
+    bindings: [
+      {
+        workItemId: 'work-item-1',
+        workItemTitle: 'Approved plan',
+        stage: 'plan',
+        role: 'plan',
+        bindingId: 'binding-1',
+        activity: 'running',
+      },
+      {
+        workItemId: 'work-item-2',
+        workItemTitle: 'Idle item',
+        stage: 'execute',
+        role: 'work',
+        bindingId: 'binding-2',
+        activity: 'idle',
+      },
+    ],
+  },
   snapshotAt: '2026-07-22T18:00:30.000Z',
 };
 
@@ -213,6 +236,7 @@ describe('Factory supervisor page', () => {
       );
       expect(screen.getByText('3 work items')).toBeInTheDocument();
       expect(screen.getByText('1 pending approval')).toBeInTheDocument();
+      expect(screen.getByText('workers: 1 running · 1 idle')).toBeInTheDocument();
       expect(screen.getByRole('heading', { name: 'Pending approvals' })).toBeInTheDocument();
       expect(screen.getByText('Move approved plan to execution')).toBeInTheDocument();
       expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -284,7 +308,7 @@ describe('Factory supervisor page', () => {
       await user.click(await screen.findByRole('button', { name: 'Approve Move approved plan to execution' }));
 
       await waitFor(() => expect(decisions).toEqual(['approve']));
-      expect(await screen.findByText('No pending approvals')).toBeInTheDocument();
+      expect(await screen.findByText(/No pending approvals/)).toBeInTheDocument();
       expect(screen.queryByText('Move approved plan to execution')).not.toBeInTheDocument();
     });
   });

--- a/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactorySection.tsx
@@ -1,6 +1,6 @@
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { ChartLine, GitPullRequest, ListChecks, ScrollText, SquareKanban } from 'lucide-react';
+import { Bot, ChartLine, GitPullRequest, ListChecks, ScrollText, SquareKanban } from 'lucide-react';
 import type { ComponentType, ReactNode } from 'react';
 import { NavLink, useLocation, useParams } from 'react-router';
 
@@ -26,6 +26,7 @@ export function FactorySection({ children }: { children?: ReactNode }) {
         </Txt>
       </div>
       <MainSidebar.NavList>
+        <FactoryLink to={`/factories/${factoryId}/supervisor`} icon={Bot} label="Supervisor" />
         <FactoryLink to={`/factories/${factoryId}/work`} icon={SquareKanban} label="Work" />
         <FactoryLink to={`/factories/${factoryId}/review`} icon={GitPullRequest} label="Review" />
         <FactoryLink to={`/factories/${factoryId}/metrics`} icon={ChartLine} label="Metrics" />

--- a/mastracode/web/src/web/ui/domains/factory/services/supervisor.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/supervisor.ts
@@ -1,0 +1,117 @@
+export interface FactorySupervisorSession {
+  factoryProjectId: string;
+  resourceId: string;
+  sessionId: string;
+  threadId: string;
+}
+
+export interface FactorySupervisorApproval {
+  id: string;
+  workItemId: string;
+  transitionId: string;
+  board: string;
+  stage: string;
+  expectedRevision: number;
+  requestingRole: string | null;
+  reason: string;
+  summary: string | null;
+  status: 'pending' | 'approved' | 'rejected' | 'stale';
+  resolvedBy: string | null;
+  resolutionReason: string | null;
+  resolvedAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface FactorySupervisorApprovalState {
+  id: string;
+  workItemId: string;
+  board: string;
+  stage: string;
+  expectedRevision: number;
+  requestingRole: string | null;
+  workItemTitle: string | null;
+  reason: string;
+  summary: string | null;
+  createdAt: string;
+  ageSeconds: number;
+}
+
+export interface FactorySupervisorState {
+  factoryProjectId: string;
+  totalItems: number;
+  counts: {
+    byBoard: Record<string, number>;
+    byStage: Record<string, number>;
+  };
+  pendingApprovalCount: number;
+  pendingApprovals: FactorySupervisorApprovalState[];
+  snapshotAt: string;
+}
+
+export interface FactoryApprovalResolution {
+  status: 'approved' | 'rejected' | 'stale';
+  replayed: boolean;
+  approval: FactorySupervisorApproval;
+}
+
+async function requestJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(url, {
+    headers: { Accept: 'application/json', ...(init?.body ? { 'content-type': 'application/json' } : {}) },
+    credentials: 'include',
+    ...init,
+  });
+  const body = (await response.json()) as T & { error?: string; message?: string };
+  if (!response.ok) {
+    throw new Error(body.message ?? body.error ?? `Request failed (${response.status})`);
+  }
+  return body;
+}
+
+function projectUrl(baseUrl: string, factoryProjectId: string): string {
+  return `${baseUrl}/web/factory/projects/${encodeURIComponent(factoryProjectId)}`;
+}
+
+export async function ensureFactorySupervisorSession(
+  baseUrl: string,
+  factoryProjectId: string,
+): Promise<FactorySupervisorSession> {
+  const body = await requestJson<{ session: FactorySupervisorSession }>(
+    `${projectUrl(baseUrl, factoryProjectId)}/supervisor/session`,
+    { method: 'POST' },
+  );
+  return body.session;
+}
+
+export async function getFactorySupervisorState(
+  baseUrl: string,
+  factoryProjectId: string,
+): Promise<FactorySupervisorState> {
+  const body = await requestJson<{ state: FactorySupervisorState }>(
+    `${projectUrl(baseUrl, factoryProjectId)}/supervisor/state`,
+  );
+  return body.state;
+}
+
+export async function listFactorySupervisorApprovals(
+  baseUrl: string,
+  factoryProjectId: string,
+): Promise<FactorySupervisorApproval[]> {
+  const body = await requestJson<{ approvals: FactorySupervisorApproval[] }>(
+    `${projectUrl(baseUrl, factoryProjectId)}/approvals?status=pending`,
+  );
+  return body.approvals;
+}
+
+export async function resolveFactorySupervisorApproval(
+  baseUrl: string,
+  factoryProjectId: string,
+  approvalId: string,
+  decision: 'approve' | 'reject',
+): Promise<FactoryApprovalResolution> {
+  const body = await requestJson<{ result: FactoryApprovalResolution }>(
+    `${projectUrl(baseUrl, factoryProjectId)}/approvals/${encodeURIComponent(approvalId)}/resolve`,
+    { method: 'POST', body: JSON.stringify({ decision }) },
+  );
+  return body.result;
+}

--- a/mastracode/web/src/web/ui/domains/factory/services/supervisor.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/supervisor.ts
@@ -37,6 +37,15 @@ export interface FactorySupervisorApprovalState {
   ageSeconds: number;
 }
 
+export interface FactorySupervisorWorker {
+  workItemId: string;
+  workItemTitle: string | null;
+  stage: string | null;
+  role: string;
+  bindingId: string;
+  activity: 'running' | 'idle' | 'offline';
+}
+
 export interface FactorySupervisorState {
   factoryProjectId: string;
   totalItems: number;
@@ -46,6 +55,12 @@ export interface FactorySupervisorState {
   };
   pendingApprovalCount: number;
   pendingApprovals: FactorySupervisorApprovalState[];
+  workers: {
+    running: number;
+    idle: number;
+    offline: number;
+    bindings: FactorySupervisorWorker[];
+  };
   snapshotAt: string;
 }
 

--- a/mastracode/web/src/web/ui/domains/factory/services/supervisor.ts
+++ b/mastracode/web/src/web/ui/domains/factory/services/supervisor.ts
@@ -43,7 +43,7 @@ export interface FactorySupervisorWorker {
   stage: string | null;
   role: string;
   bindingId: string;
-  activity: 'running' | 'idle' | 'offline';
+  activity: 'running' | 'idle';
 }
 
 export interface FactorySupervisorState {
@@ -58,7 +58,6 @@ export interface FactorySupervisorState {
   workers: {
     running: number;
     idle: number;
-    offline: number;
     bindings: FactorySupervisorWorker[];
   };
   snapshotAt: string;

--- a/mastracode/web/src/web/ui/pages/SupervisorPage.tsx
+++ b/mastracode/web/src/web/ui/pages/SupervisorPage.tsx
@@ -175,9 +175,8 @@ function SupervisorStateSummary({
         {state.pendingApprovalCount} {state.pendingApprovalCount === 1 ? 'pending approval' : 'pending approvals'}
       </Badge>
       {state.workers ? (
-        <Badge size="sm" variant={state.workers.offline > 0 ? 'warning' : 'default'}>
+        <Badge size="sm" variant="default">
           workers: {state.workers.running} running · {state.workers.idle} idle
-          {state.workers.offline > 0 ? ` · ${state.workers.offline} offline` : ''}
         </Badge>
       ) : null}
       {stages.map(([stage, count]) => (

--- a/mastracode/web/src/web/ui/pages/SupervisorPage.tsx
+++ b/mastracode/web/src/web/ui/pages/SupervisorPage.tsx
@@ -1,0 +1,292 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@mastra/playground-ui/components/Card';
+import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
+import { Notice } from '@mastra/playground-ui/components/Notice';
+import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
+import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Bot, Check, X } from 'lucide-react';
+
+import { useParams } from 'react-router';
+
+import { useApiConfig } from '../../../shared/api/config';
+import { useFactoryQuery } from '../../../shared/hooks/useFactories';
+import {
+  useFactorySupervisorApprovals,
+  useFactorySupervisorSession,
+  useFactorySupervisorState,
+  useResolveFactorySupervisorApproval,
+} from '../../../shared/hooks/useFactorySupervisor';
+import { Sidebar } from '../Sidebar';
+import { ChatLayout } from '../layouts/ChatLayout';
+import { ChatHeader } from '../domains/chat/components/ChatHeader';
+import { ChatMessageList } from '../domains/chat/components/ChatMessageList';
+import { ComposerPanel } from '../domains/chat/components/ComposerPanel';
+import { TaskPanel } from '../domains/chat/components/TaskPanel';
+import { ChatPermissionsProvider } from '../domains/chat/context/ChatPermissionsProvider';
+import { ChatSessionContext } from '../domains/chat/context/ChatSessionContext';
+import { ChatMessageBoundary, ChatSessionBoundary } from '../domains/chat/context/ChatSessionProvider';
+import { useGlobalShortcuts } from '../domains/chat/hooks/useGlobalShortcuts';
+import type { FactorySupervisorApproval, FactorySupervisorState } from '../domains/factory/services/supervisor';
+
+export function SupervisorPage() {
+  const { factoryId } = useParams<{ factoryId: string }>();
+  const factoryQuery = useFactoryQuery(factoryId);
+
+  return (
+    <ChatLayout
+      sidebar={<Sidebar />}
+      header={<ChatHeader />}
+      main={
+        factoryQuery.isPending ? (
+          <div className="flex h-full items-center justify-center">
+            <Spinner />
+          </div>
+        ) : factoryQuery.data ? (
+          <SupervisorSession factoryProjectId={factoryQuery.data.id} />
+        ) : (
+          <div className="p-5">
+            <Notice variant="destructive">Factory not found.</Notice>
+          </div>
+        )
+      }
+    />
+  );
+}
+
+function SupervisorSession({ factoryProjectId }: { factoryProjectId: string }) {
+  const { baseUrl } = useApiConfig();
+  const session = useFactorySupervisorSession(factoryProjectId);
+
+  if (session.isPending) {
+    return <SupervisorLoading />;
+  }
+  if (session.error || !session.data) {
+    const message =
+      session.error instanceof Error ? session.error.message : 'Factory supervisor session is unavailable.';
+    return (
+      <div className="p-5">
+        <Notice variant="destructive">Failed to open the Factory supervisor: {message}</Notice>
+      </div>
+    );
+  }
+
+  const chatSession = {
+    resourceId: session.data.resourceId,
+    sessionEnabled: true,
+    resourceEnabled: true,
+    projectPath: undefined,
+    factorySessionState: { factoryProjectId },
+    baseUrl,
+    kind: 'factory' as const,
+  };
+  return (
+    <ChatSessionContext.Provider value={chatSession}>
+      <ChatPermissionsProvider>
+        <ChatSessionBoundary threadId={session.data.threadId} deferUntilMessagesReady>
+          <SupervisorWorkspace factoryProjectId={factoryProjectId} />
+        </ChatSessionBoundary>
+      </ChatPermissionsProvider>
+    </ChatSessionContext.Provider>
+  );
+}
+
+function SupervisorLoading() {
+  return (
+    <div
+      className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] gap-4 p-5"
+      aria-label="Loading Factory supervisor"
+    >
+      <Skeleton className="h-16 w-full" />
+      <div className="grid min-h-0 grid-cols-1 gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+        <Skeleton className="h-full min-h-80 w-full" />
+        <Skeleton className="hidden h-full min-h-80 w-full xl:block" />
+      </div>
+    </div>
+  );
+}
+
+function SupervisorWorkspace({ factoryProjectId }: { factoryProjectId: string }) {
+  useGlobalShortcuts();
+  const state = useFactorySupervisorState(factoryProjectId);
+  const approvals = useFactorySupervisorApprovals(factoryProjectId);
+
+  return (
+    <div className="grid h-full min-h-0 grid-cols-1 grid-rows-[minmax(0,1fr)_auto] xl:grid-cols-[minmax(0,1fr)_22rem] xl:grid-rows-1">
+      <div className="grid min-h-0 grid-rows-[auto_minmax(0,1fr)_auto_auto] overflow-hidden">
+        <SupervisorStateSummary state={state.data} pending={state.isPending} error={state.error} />
+        <ChatMessageBoundary>
+          <div className="min-h-0 overflow-hidden">
+            <ChatMessageList />
+          </div>
+        </ChatMessageBoundary>
+        <TaskPanel />
+        <div className="w-full p-3 md:p-5">
+          <div className="mx-auto w-full max-w-[80ch]" role="region" aria-label="Supervisor composer">
+            <ComposerPanel />
+          </div>
+        </div>
+      </div>
+      <PendingApprovals
+        factoryProjectId={factoryProjectId}
+        approvals={approvals.data}
+        pending={approvals.isPending}
+        error={approvals.error}
+      />
+    </div>
+  );
+}
+
+function SupervisorStateSummary({
+  state,
+  pending,
+  error,
+}: {
+  state: FactorySupervisorState | undefined;
+  pending: boolean;
+  error: unknown;
+}) {
+  if (pending) {
+    return (
+      <div className="flex gap-3 p-3 md:px-5">
+        <Skeleton className="h-8 w-24" />
+        <Skeleton className="h-8 w-32" />
+        <Skeleton className="h-8 w-28" />
+      </div>
+    );
+  }
+  if (error || !state) {
+    return (
+      <div className="p-3 md:px-5">
+        <Notice variant="destructive">Factory state is temporarily unavailable.</Notice>
+      </div>
+    );
+  }
+
+  const stages = Object.entries(state.counts.byStage);
+  return (
+    <section className="flex flex-wrap items-center gap-2 p-3 md:px-5" aria-label="Factory state summary">
+      <Txt as="h1" variant="ui-md" className="mr-2 text-neutral6">
+        Factory Supervisor
+      </Txt>
+      <Badge size="sm">{state.totalItems} work items</Badge>
+      <Badge size="sm" variant={state.pendingApprovalCount > 0 ? 'warning' : 'default'}>
+        {state.pendingApprovalCount} {state.pendingApprovalCount === 1 ? 'pending approval' : 'pending approvals'}
+      </Badge>
+      {stages.map(([stage, count]) => (
+        <Badge key={stage} size="sm">
+          {stage}: {count}
+        </Badge>
+      ))}
+    </section>
+  );
+}
+
+function PendingApprovals({
+  factoryProjectId,
+  approvals,
+  pending,
+  error,
+}: {
+  factoryProjectId: string;
+  approvals: FactorySupervisorApproval[] | undefined;
+  pending: boolean;
+  error: unknown;
+}) {
+  const resolution = useResolveFactorySupervisorApproval(factoryProjectId);
+  const resolvingId = resolution.isPending ? resolution.variables?.approvalId : undefined;
+
+  return (
+    <aside className="min-h-0 border-t border-border1 xl:border-l xl:border-t-0" aria-label="Pending approvals">
+      <ScrollArea className="h-full max-h-72 xl:max-h-none">
+        <div className="flex flex-col gap-3 p-3 md:p-5">
+          <div>
+            <Txt as="h2" variant="ui-md" className="text-neutral6">
+              Pending approvals
+            </Txt>
+            <Txt as="p" variant="ui-sm" className="text-neutral3">
+              Approved moves apply automatically when the captured revision is current.
+            </Txt>
+          </div>
+          {resolution.error ? (
+            <Notice variant="destructive">
+              {resolution.error instanceof Error ? resolution.error.message : 'Failed to resolve approval.'}
+            </Notice>
+          ) : null}
+          {resolution.data?.status === 'stale' ? (
+            <Notice variant="warning">The work item changed before approval. The request was marked stale.</Notice>
+          ) : null}
+          {pending ? <Skeleton className="h-28 w-full" /> : null}
+          {error ? <Notice variant="destructive">Failed to load pending approvals.</Notice> : null}
+          {!pending && !error && approvals?.length === 0 ? (
+            <EmptyState
+              iconSlot={<Bot />}
+              titleSlot="No pending approvals"
+              descriptionSlot="Agent transition requests that require supervision will appear here."
+            />
+          ) : null}
+          {approvals?.map(approval => (
+            <ApprovalCard
+              key={approval.id}
+              approval={approval}
+              resolving={resolvingId === approval.id}
+              onResolve={decision => resolution.mutate({ approvalId: approval.id, decision })}
+            />
+          ))}
+        </div>
+      </ScrollArea>
+    </aside>
+  );
+}
+
+function ApprovalCard({
+  approval,
+  resolving,
+  onResolve,
+}: {
+  approval: FactorySupervisorApproval;
+  resolving: boolean;
+  onResolve: (decision: 'approve' | 'reject') => void;
+}) {
+  const title = approval.summary ?? `Move work item to ${approval.stage}`;
+  return (
+    <Card as="article">
+      <CardHeader>
+        <div className="flex items-start justify-between gap-3">
+          <CardTitle>{title}</CardTitle>
+          <Badge size="xs" variant="warning">
+            {approval.stage}
+          </Badge>
+        </div>
+        <CardDescription>{approval.reason}</CardDescription>
+      </CardHeader>
+      <CardContent density="compact" className="flex flex-col gap-3">
+        <Txt as="p" variant="ui-xs" className="text-neutral3">
+          {approval.requestingRole ? `${approval.requestingRole} agent · ` : ''}revision {approval.expectedRevision}
+        </Txt>
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="primary"
+            disabled={resolving}
+            aria-label={`Approve ${title}`}
+            onClick={() => onResolve('approve')}
+          >
+            <Check /> Approve
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            disabled={resolving}
+            aria-label={`Reject ${title}`}
+            onClick={() => onResolve('reject')}
+          >
+            <X /> Reject
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/mastracode/web/src/web/ui/pages/SupervisorPage.tsx
+++ b/mastracode/web/src/web/ui/pages/SupervisorPage.tsx
@@ -1,13 +1,12 @@
 import { Badge } from '@mastra/playground-ui/components/Badge';
 import { Button } from '@mastra/playground-ui/components/Button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@mastra/playground-ui/components/Card';
-import { EmptyState } from '@mastra/playground-ui/components/EmptyState';
 import { Notice } from '@mastra/playground-ui/components/Notice';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Bot, Check, X } from 'lucide-react';
+import { Check, X } from 'lucide-react';
 
 import { useParams } from 'react-router';
 
@@ -175,6 +174,12 @@ function SupervisorStateSummary({
       <Badge size="sm" variant={state.pendingApprovalCount > 0 ? 'warning' : 'default'}>
         {state.pendingApprovalCount} {state.pendingApprovalCount === 1 ? 'pending approval' : 'pending approvals'}
       </Badge>
+      {state.workers ? (
+        <Badge size="sm" variant={state.workers.offline > 0 ? 'warning' : 'default'}>
+          workers: {state.workers.running} running · {state.workers.idle} idle
+          {state.workers.offline > 0 ? ` · ${state.workers.offline} offline` : ''}
+        </Badge>
+      ) : null}
       {stages.map(([stage, count]) => (
         <Badge key={stage} size="sm">
           {stage}: {count}
@@ -206,9 +211,11 @@ function PendingApprovals({
             <Txt as="h2" variant="ui-md" className="text-neutral6">
               Pending approvals
             </Txt>
-            <Txt as="p" variant="ui-sm" className="text-neutral3">
-              Approved moves apply automatically when the captured revision is current.
-            </Txt>
+            {approvals?.length ? (
+              <Txt as="p" variant="ui-sm" className="text-neutral3">
+                Approved moves apply automatically when the captured revision is current.
+              </Txt>
+            ) : null}
           </div>
           {resolution.error ? (
             <Notice variant="destructive">
@@ -221,11 +228,9 @@ function PendingApprovals({
           {pending ? <Skeleton className="h-28 w-full" /> : null}
           {error ? <Notice variant="destructive">Failed to load pending approvals.</Notice> : null}
           {!pending && !error && approvals?.length === 0 ? (
-            <EmptyState
-              iconSlot={<Bot />}
-              titleSlot="No pending approvals"
-              descriptionSlot="Agent transition requests that require supervision will appear here."
-            />
+            <Txt as="p" variant="ui-sm" className="text-neutral3">
+              No pending approvals. Agent transition requests that require supervision will appear here.
+            </Txt>
           ) : null}
           {approvals?.map(approval => (
             <ApprovalCard

--- a/mastracode/web/src/web/ui/router.tsx
+++ b/mastracode/web/src/web/ui/router.tsx
@@ -25,6 +25,7 @@ import { OnboardingPage } from './pages/OnboardingPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { RulesPage } from './pages/RulesPage';
 import { SignInPage } from './pages/SignInPage';
+import { SupervisorPage } from './pages/SupervisorPage';
 import { ThreadPage } from './pages/ThreadPage';
 
 import { useFactoriesQuery } from '../../shared/hooks/useFactories';
@@ -99,6 +100,7 @@ export function createAppRoutes(): RouteObject[] {
               element: <Chat />,
               children: [
                 { path: 'new', element: <NewPage /> },
+                { path: 'supervisor', element: <SupervisorPage /> },
                 { path: 'work', element: <WorkBoardPage /> },
                 { path: 'review', element: <ReviewBoardPage /> },
                 { path: 'metrics', element: <MetricsPage /> },


### PR DESCRIPTION
## Stack

Two-part stack — merge in order:

1. #19970 — supervisor approval foundations (base: `main`)
2. **#20005 — shared supervisor workspace** ← you are here (base: `feat/factory-supervisor-approvals`)

This PR builds on #19970 and **must not merge before it**. Its base is #19970's branch, so the diff shown here is only the supervisor half; GitHub will retarget this to `main` once #19970 merges, at which point it needs a rebase.

Reviewing this in isolation is fine — the approval primitives it consumes (durable approvals, `pending_approval`, attributed messages) all land in #19970.

## Summary

- add one tenant-scoped Factory supervisor session per project with deterministic `${factoryProjectId}-supervisor` thread identity
- add bounded Factory state, work-item inspection, worker signaling, and transition approval tools with durable lifecycle notifications
- add the `/factory/supervisor` workspace, shared attributed chat transcript, live state summary, and approve/reject controls
- isolate repository-free supervisor runs from project workspaces and prevent the generic chat shell from claiming the supervisor resource before canonical session setup

## Test plan

- `pnpm --filter @mastra/factory test -- --reporter=dot --bail 1`
- `pnpm --dir mastracode/sdk test -- --reporter=dot --bail 1`
- `pnpm --dir mastracode/web web:ui:test -- --reporter=dot --bail 1`
- `pnpm --dir mastracode/web web:build`
- live authenticated browser proof with a configured real model: query Factory state, verify attributed transcript, create an agent-only pending approval, approve it, and observe the automatic intake-to-execute move
