### PR TITLE
fix(factory): harden deployment detection and packaging

### DIFF
--- a/.changeset/factory-detection-deployer.md
+++ b/.changeset/factory-detection-deployer.md
@@ -2,4 +2,12 @@
 '@mastra/deployer': minor
 ---
 
-Added automatic detection of Software Factory projects from the Mastra entry's imports. When a Factory entry is detected, the bundler writes a `mastra-project.json` manifest to `.mastra/output/` identifying the project type and UI asset location. Also exposed an `analyzeEntryProjectType` helper for pre-build classification.
+Added automatic detection of Software Factory projects when the Mastra entry imports and constructs a `MastraFactory` binding. Detected projects receive a `mastra-project.json` manifest in `.mastra/output/` identifying the project type and UI asset location.
+
+Use the lightweight public helper when project-type detection is needed before a full bundle:
+
+```ts
+import { analyzeEntryProjectType } from '@mastra/deployer/build';
+
+const projectType = await analyzeEntryProjectType('./src/mastra/index.ts');
+```

--- a/.changeset/factory-template-dir.md
+++ b/.changeset/factory-template-dir.md
@@ -2,4 +2,18 @@
 'create-factory': minor
 ---
 
-Standardized the Vite SPA output directory to `src/mastra/public/factory/`. The template's `build` script delegates SPA building to `mastra build` (which calls `build:ui` automatically) instead of chaining it separately.
+Standardized the Factory SPA directory and simplified the generated build script because `mastra build` now packages the prebuilt UI automatically.
+
+Before:
+
+```json
+{ "build": "npm run build:ui && mastra build --dir src/mastra" }
+```
+
+After:
+
+```json
+{ "build": "mastra build --dir src/mastra" }
+```
+
+Factory assets now land in `src/mastra/public/factory/` during the build and `.mastra/output/factory/` in the deployable output, replacing the previous `ui/` path.

--- a/.changeset/factory-ui-build-cli.md
+++ b/.changeset/factory-ui-build-cli.md
@@ -2,4 +2,10 @@
 'mastra': minor
 ---
 
-Added automatic Factory UI building to `mastra build` and `mastra deploy`. When a Software Factory project is detected, the project's `build:ui` script runs before bundling, and the SPA is copied to `.mastra/output/factory/`. Build staleness checks now include Factory UI source files so UI-only edits trigger rebuilds.
+Added automatic Factory UI packaging to `mastra build` and `mastra deploy`. When a Software Factory project is detected, the CLI copies its prebuilt Factory SPA into `.mastra/output/factory/`; projects no longer need to build the SPA separately.
+
+```sh
+npx mastra build --dir src/mastra
+```
+
+The resulting deployment contains `.mastra/output/factory/index.html`.

--- a/mastracode/factory/scripts/rewrite-specifiers.mjs
+++ b/mastracode/factory/scripts/rewrite-specifiers.mjs
@@ -1,5 +1,6 @@
 import { existsSync, statSync } from 'node:fs';
 import { resolve } from 'node:path';
+import ts from 'typescript';
 
 /**
  * Rewrites a single relative specifier to its emitted Node ESM path.
@@ -36,27 +37,43 @@ export function rewriteSpecifier(specifier, resolveSuffix) {
  * @returns {string} Rewritten source
  */
 export function rewriteRelativeSpecifiers(source, resolveSuffix) {
-  let result = source;
+  const sourceFile = ts.createSourceFile('source.ts', source, ts.ScriptTarget.Latest, true, ts.ScriptKind.TS);
+  const replacements = [];
 
-  // from '...' or from "..." (static import/export with from keyword)
-  result = result.replace(/\bfrom\s*(['"])(\.\.?\/[^'"]+)\1/g, (match, quote, specifier) => {
-    const rewritten = rewriteSpecifier(specifier, resolveSuffix);
-    return rewritten ? `from ${quote}${rewritten}${quote}` : match;
-  });
+  const addReplacement = node => {
+    if (!ts.isStringLiteralLike(node) || (!node.text.startsWith('./') && !node.text.startsWith('../'))) {
+      return;
+    }
 
-  // import('...') or import("...") (dynamic import)
-  result = result.replace(/\bimport\s*\(\s*(['"])(\.\.?\/[^'"]+)\1/g, (match, quote, specifier) => {
-    const rewritten = rewriteSpecifier(specifier, resolveSuffix);
-    return rewritten ? `import(${quote}${rewritten}${quote}` : match;
-  });
+    const rewritten = rewriteSpecifier(node.text, resolveSuffix);
+    if (rewritten) {
+      replacements.push({ start: node.getStart(sourceFile) + 1, end: node.getEnd() - 1, text: rewritten });
+    }
+  };
 
-  // import '...' or import "..." (side-effect import)
-  result = result.replace(/\bimport\s+(['"])(\.\.?\/[^'"]+)\1/g, (match, quote, specifier) => {
-    const rewritten = rewriteSpecifier(specifier, resolveSuffix);
-    return rewritten ? `import ${quote}${rewritten}${quote}` : match;
-  });
+  const visit = node => {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      if (node.moduleSpecifier) {
+        addReplacement(node.moduleSpecifier);
+      }
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length > 0
+    ) {
+      addReplacement(node.arguments[0]);
+    }
 
-  return result;
+    ts.forEachChild(node, visit);
+  };
+
+  visit(sourceFile);
+
+  return replacements
+    .sort((a, b) => b.start - a.start)
+    .reduce((result, replacement) => {
+      return result.slice(0, replacement.start) + replacement.text + result.slice(replacement.end);
+    }, source);
 }
 
 /**

--- a/mastracode/factory/src/build/rewrite-specifiers.test.ts
+++ b/mastracode/factory/src/build/rewrite-specifiers.test.ts
@@ -137,10 +137,20 @@ import { c } from '@mastra/core';`;
     expect(rewriteRelativeSpecifiers(src, resolveSuffix)).toBe(`import { foo } from "./foo.js";`);
   });
 
-  // Regex-based rewriting may match import-like syntax inside strings/template
-  // literals. This is harmless: the filesystem resolver only rewrites when the
-  // target file actually exists, and such patterns are vanishingly rare in
-  // real TypeScript source.
+  it('does not rewrite import-like text inside strings, templates, or comments', () => {
+    const src = `const stringValue = "import('./dyn')";
+const templateValue = \`export { foo } from './foo'\`;
+// import './bar'
+/* import('./dyn') */
+const mod = await import('./dyn');`;
+    const expected = `const stringValue = "import('./dyn')";
+const templateValue = \`export { foo } from './foo'\`;
+// import './bar'
+/* import('./dyn') */
+const mod = await import('./dyn.js');`;
+    expect(rewriteRelativeSpecifiers(src, resolveSuffix)).toBe(expected);
+  });
+
   it('leaves source unchanged when no resolvable relative specifiers present', () => {
     const src = `import { foo } from '@mastra/core';
 const x = 1;`;

--- a/mastracode/web/scripts/validate-output.mjs
+++ b/mastracode/web/scripts/validate-output.mjs
@@ -33,7 +33,7 @@ function ok(msg) {
 // 1. Server entry
 const indexMjs = path.join(outputDir, 'index.mjs');
 if (!fs.existsSync(indexMjs)) {
-  fail('.mastra/output/index.mjs not found — run `pnpm web:build` first');
+  fail('.mastra/output/index.mjs not found — run `npm run build` first');
 } else {
   ok('server entry (.mastra/output/index.mjs)');
 }
@@ -41,7 +41,7 @@ if (!fs.existsSync(indexMjs)) {
 // 2. Deploy manifest
 const outputPkgPath = path.join(outputDir, 'package.json');
 if (!fs.existsSync(outputPkgPath)) {
-  fail('.mastra/output/package.json not found — run `pnpm web:build` first');
+  fail('.mastra/output/package.json not found — run `npm run build` first');
 } else {
   const pkg = JSON.parse(fs.readFileSync(outputPkgPath, 'utf8'));
   const deps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
@@ -60,7 +60,7 @@ if (!fs.existsSync(outputPkgPath)) {
 // 3. SPA
 const spaPath = path.join(outputDir, 'factory', 'index.html');
 if (!fs.existsSync(spaPath)) {
-  fail('SPA index.html not found in .mastra/output/factory/ — run `pnpm web:build` (includes vite build)');
+  fail('SPA index.html not found in .mastra/output/factory/ — run `npm run build` first');
 } else {
   ok(`SPA (${path.relative(outputDir, spaPath)})`);
 }

--- a/packages/cli/src/commands/dev/dev.test.ts
+++ b/packages/cli/src/commands/dev/dev.test.ts
@@ -559,7 +559,7 @@ describe('dev command - factory mode environment', () => {
 
     expect(devBundlerConstructorSpy).toHaveBeenCalled();
     const lastCall = devBundlerConstructorSpy.mock.calls[devBundlerConstructorSpy.mock.calls.length - 1];
-    expect(lastCall[1]).not.toBe(true);
+    expect(lastCall[1]).toBeUndefined();
   });
 
   it('should not set MASTRA_FACTORY_DEV in spawned env when factory is not set', async () => {

--- a/packages/deployer/src/build/analyze.test.ts
+++ b/packages/deployer/src/build/analyze.test.ts
@@ -416,3 +416,67 @@ describe('npm alias dependencies', () => {
     });
   }, 15000);
 });
+
+describe('Software Factory project type detection', () => {
+  it('classifies a MastraFactory entry as factory', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'factory-analyze-'));
+    tempDirs.push(tempDir);
+
+    const mastraDir = join(tempDir, 'src', 'mastra');
+    const entryFile = join(mastraDir, 'index.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(mastraDir, { recursive: true });
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test', version: '1.0.0', type: 'module' }));
+    await writeFile(join(mastraDir, 'factory.ts'), `export class MastraFactory { prepare() { return {}; } }\n`);
+    await writeFile(
+      entryFile,
+      `import { MastraFactory } from './factory';\n` +
+        `const factory = new MastraFactory();\n` +
+        `export const mastra = factory.prepare();\n`,
+    );
+
+    const result = await analyzeBundle(
+      [entryFile],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: { externals: [], enableSourcemap: false },
+      },
+      noopLogger,
+    );
+
+    expect(result.projectType).toBe('factory');
+  });
+
+  it('classifies an ordinary Mastra entry as undefined projectType', async () => {
+    await mkdir(tempRoot, { recursive: true });
+    const tempDir = await mkdtemp(join(tempRoot, 'factory-analyze-'));
+    tempDirs.push(tempDir);
+
+    const mastraDir = join(tempDir, 'src', 'mastra');
+    const entryFile = join(mastraDir, 'index.ts');
+    const outputDir = join(tempDir, '.mastra', '.build');
+    await mkdir(outputDir, { recursive: true });
+    await mkdir(mastraDir, { recursive: true });
+    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test', version: '1.0.0', type: 'module' }));
+    await writeFile(entryFile, `export const mastra = new Mastra({});\n`);
+
+    const result = await analyzeBundle(
+      [entryFile],
+      entryFile,
+      {
+        outputDir,
+        projectRoot: tempDir,
+        platform: 'node',
+        bundlerOptions: { externals: [], enableSourcemap: false },
+      },
+      noopLogger,
+    );
+
+    expect(result.projectType).toBeUndefined();
+  });
+});

--- a/packages/deployer/src/build/babel/check-config-export.test.ts
+++ b/packages/deployer/src/build/babel/check-config-export.test.ts
@@ -133,6 +133,21 @@ describe('checkConfigExport Babel plugin', () => {
     expect(runPlugin(code).projectType).toBeUndefined();
   });
 
+  it('does not detect factory when a local parameter shadows the imported binding', () => {
+    const code = `
+      import { MastraFactory } from './factory';
+      function create(MastraFactory: new () => unknown) {
+        return new MastraFactory();
+      }
+    `;
+    expect(runPlugin(code).projectType).toBeUndefined();
+  });
+
+  it('detects factory when the import declaration appears after construction', () => {
+    const code = `const f = new MastraFactory(); import { MastraFactory } from './factory'`;
+    expect(runPlugin(code).projectType).toBe('factory');
+  });
+
   it('does not detect factory for non-constructor usage of imported MastraFactory', () => {
     const code = `import { MastraFactory } from './factory'; const f = MastraFactory()`;
     expect(runPlugin(code).projectType).toBeUndefined();

--- a/packages/deployer/src/build/babel/check-config-export.ts
+++ b/packages/deployer/src/build/babel/check-config-export.ts
@@ -4,27 +4,19 @@ import type { PluginObject } from '@babel/core';
 export function checkConfigExport(result: { hasValidConfig: boolean; projectType?: string }): PluginObject {
   // Track which local variable names are assigned to `new Mastra()`
   const mastraVars = new Set<string>();
-  // Track local bindings imported as the named `MastraFactory` export (including aliases).
-  // Detection is based on the imported name, not the module source, so it works with
-  // both relative imports and a future package export.
-  const factoryBindings = new Set<string>();
 
   return {
     visitor: {
-      ImportDeclaration(path) {
-        for (const spec of path.node.specifiers) {
-          if (
-            t.isImportSpecifier(spec) &&
-            t.isIdentifier(spec.imported, { name: 'MastraFactory' }) &&
-            t.isIdentifier(spec.local)
-          ) {
-            factoryBindings.add(spec.local.name);
-          }
-        }
-      },
       NewExpression(path) {
-        // Detect `new MastraFactory(...)` using the tracked import binding.
-        if (t.isIdentifier(path.node.callee) && factoryBindings.has(path.node.callee.name)) {
+        if (!t.isIdentifier(path.node.callee)) {
+          return;
+        }
+
+        const binding = path.scope.getBinding(path.node.callee.name);
+        if (
+          binding?.path.isImportSpecifier() &&
+          t.isIdentifier(binding.path.node.imported, { name: 'MastraFactory' })
+        ) {
           result.projectType = 'factory';
         }
       },

--- a/packages/deployer/src/bundler/factory-marker.test.ts
+++ b/packages/deployer/src/bundler/factory-marker.test.ts
@@ -3,9 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { MastraError } from '@mastra/core/error';
-import { noopLogger } from '@mastra/core/logger';
 import { afterEach, describe, expect, it } from 'vitest';
-import { analyzeBundle } from '../build/analyze';
 import { Bundler } from './index';
 
 const tempDirs: string[] = [];
@@ -21,73 +19,6 @@ class TestBundler extends Bundler {
     return Promise.resolve([]);
   }
 }
-
-describe('Software Factory project type detection in analyzeBundle', () => {
-  it('classifies a MastraFactory entry as factory', async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), 'factory-analyze-'));
-    tempDirs.push(tempDir);
-
-    const mastraDir = join(tempDir, 'src', 'mastra');
-    const entryFile = join(mastraDir, 'index.ts');
-    const outputDir = join(tempDir, '.mastra', '.build');
-    await mkdir(outputDir, { recursive: true });
-    await mkdir(mastraDir, { recursive: true });
-    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test', version: '1.0.0', type: 'module' }));
-
-    // A Factory-style entry that imports MastraFactory and constructs it,
-    // then exports a Mastra instance (so hasValidConfig is also true).
-    // Create the imported module so Rollup can resolve it.
-    await writeFile(join(mastraDir, 'factory.ts'), `export class MastraFactory { prepare() { return {}; } }\n`);
-    await writeFile(
-      entryFile,
-      `import { MastraFactory } from './factory';\n` +
-        `const factory = new MastraFactory();\n` +
-        `export const mastra = factory.prepare();\n`,
-    );
-
-    const result = await analyzeBundle(
-      [entryFile],
-      entryFile,
-      {
-        outputDir,
-        projectRoot: tempDir,
-        platform: 'node',
-        bundlerOptions: { externals: [], enableSourcemap: false },
-      },
-      noopLogger,
-    );
-
-    expect(result.projectType).toBe('factory');
-  });
-
-  it('classifies an ordinary Mastra entry as undefined projectType', async () => {
-    const tempDir = await mkdtemp(join(tmpdir(), 'factory-analyze-'));
-    tempDirs.push(tempDir);
-
-    const mastraDir = join(tempDir, 'src', 'mastra');
-    const entryFile = join(mastraDir, 'index.ts');
-    const outputDir = join(tempDir, '.mastra', '.build');
-    await mkdir(outputDir, { recursive: true });
-    await mkdir(mastraDir, { recursive: true });
-    await writeFile(join(tempDir, 'package.json'), JSON.stringify({ name: 'test', version: '1.0.0', type: 'module' }));
-
-    await writeFile(entryFile, `export const mastra = new Mastra({});\n`);
-
-    const result = await analyzeBundle(
-      [entryFile],
-      entryFile,
-      {
-        outputDir,
-        projectRoot: tempDir,
-        platform: 'node',
-        bundlerOptions: { externals: [], enableSourcemap: false },
-      },
-      noopLogger,
-    );
-
-    expect(result.projectType).toBeUndefined();
-  });
-});
 
 describe('Bundler.writeFactoryMarker', () => {
   it('writes mastra-project.json with the agreed schema when factory/index.html exists', async () => {

--- a/packages/deployer/src/bundler/factory-marker.test.ts
+++ b/packages/deployer/src/bundler/factory-marker.test.ts
@@ -18,6 +18,9 @@ class TestBundler extends Bundler {
   getEnvFiles(): Promise<string[]> {
     return Promise.resolve([]);
   }
+  writeFactoryMarkerForTest(outputDirectory: string): Promise<void> {
+    return this.writeFactoryMarker(outputDirectory);
+  }
 }
 
 describe('Bundler.writeFactoryMarker', () => {
@@ -31,7 +34,7 @@ describe('Bundler.writeFactoryMarker', () => {
     await writeFile(join(outputDir, 'factory', 'index.html'), '<html></html>');
 
     const bundler = new TestBundler('Test');
-    await (bundler as any).writeFactoryMarker(tempDir);
+    await bundler.writeFactoryMarkerForTest(tempDir);
 
     const markerPath = join(outputDir, 'mastra-project.json');
     expect(existsSync(markerPath)).toBe(true);
@@ -54,7 +57,7 @@ describe('Bundler.writeFactoryMarker', () => {
 
     const bundler = new TestBundler('Test');
 
-    const error = await (bundler as any).writeFactoryMarker(tempDir).catch((error: unknown) => error);
+    const error = await bundler.writeFactoryMarkerForTest(tempDir).catch((error: unknown) => error);
     expect(error).toBeInstanceOf(MastraError);
     expect(error).toMatchObject({ id: 'DEPLOYER_BUNDLER_FACTORY_UI_MISSING' });
     expect((error as Error).message).toMatch(/factory\/index\.html.*not found/);

--- a/packages/deployer/src/bundler/factory-marker.test.ts
+++ b/packages/deployer/src/bundler/factory-marker.test.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { MastraError } from '@mastra/core/error';
 import { noopLogger } from '@mastra/core/logger';
 import { afterEach, describe, expect, it } from 'vitest';
 import { analyzeBundle } from '../build/analyze';
@@ -122,7 +123,10 @@ describe('Bundler.writeFactoryMarker', () => {
 
     const bundler = new TestBundler('Test');
 
-    await expect((bundler as any).writeFactoryMarker(tempDir)).rejects.toThrow(/factory\/index\.html.*not found/);
+    const error = await (bundler as any).writeFactoryMarker(tempDir).catch((error: unknown) => error);
+    expect(error).toBeInstanceOf(MastraError);
+    expect(error).toMatchObject({ id: 'DEPLOYER_BUNDLER_FACTORY_UI_MISSING' });
+    expect((error as Error).message).toMatch(/factory\/index\.html.*not found/);
 
     // Marker should not have been written
     expect(existsSync(join(outputDir, 'mastra-project.json'))).toBe(false);

--- a/packages/deployer/src/bundler/index.ts
+++ b/packages/deployer/src/bundler/index.ts
@@ -465,6 +465,10 @@ export const tools = [${toolsExports.join(', ')}]`,
       await this.generateNpmLockfile(join(outputDirectory, this.outputDir));
       this.logger.info('Done generating package-lock.json');
     } catch (error) {
+      if (error instanceof MastraError && error.id === 'DEPLOYER_BUNDLER_FACTORY_UI_MISSING') {
+        throw error;
+      }
+
       const message = error instanceof Error ? error.message : String(error);
       throw new MastraError(
         {


### PR DESCRIPTION
This follows #19948 with the review-driven hardening that landed after the original PR merged. Factory detection now follows the imported `MastraFactory` binding, specifier rewriting only changes actual module specifiers, and missing Factory UI errors keep their specific error code.

It also corrects the generated build guidance and tightens the related test coverage and changeset examples. For example, string contents such as `"import(\'./unchanged\')"` remain untouched while real `import("./module")` specifiers are rewritten.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR helps Mastra recognize Factory projects more reliably, package their UI correctly, and provide clearer build errors. It also ensures code comments and strings are not accidentally modified during module rewriting.

## What changed

- Detects Factory projects by verifying the imported `MastraFactory` binding, including protection against shadowed names.
- Rewrites only actual relative module specifiers in imports and dynamic imports.
- Preserves Factory-specific errors when UI assets are missing.
- Updates build guidance to use `npm run build`.
- Expands coverage for Factory detection, deployment markers, CLI behavior, and specifier rewriting.
- Documents Factory detection requirements, UI output paths, automatic packaging, and build migration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->