### PR TITLE
fix(create-factory): downgrade template's typescript from tsgo to classic v5

### DIFF
--- a/.changeset/factory-sync-template-alpha.md
+++ b/.changeset/factory-sync-template-alpha.md
@@ -2,4 +2,10 @@
 'create-factory': patch
 ---
 
-The Software Factory template now pins every Mastra dep to `"alpha"` instead of a caret range anchored on the current monorepo version. The Mastra Factory sources on `main` are built against the alpha release train — the previous default (`"latest"`) picked up whatever was on the `latest` dist-tag for each package independently, which broke for `@mastra/factory` (still pre-1.0) and produced mismatched trains for the others. `sync-template.mjs` no longer shells out to `npm view` and no longer needs the `--tag` flag. The emitted template ships `.npmrc` with `legacy-peer-deps=true` so npm accepts the internally-consistent prerelease peer graph; both can be flipped back to `"latest"` (and the `.npmrc` deleted) once the packages ship stable releases.
+Make the Software Factory template installable and buildable against published packages so the sync-softwarefactory-template workflow can push it again. Three changes to the generation step:
+
+- Pin every synced Mastra dep to `"alpha"` instead of `"latest"` — the Mastra Factory sources on `main` are built against the alpha release train, and the previous `"latest"` default mixed release trains (worse, `@mastra/factory@latest` is currently an empty stub).
+- Emit `.npmrc` with `legacy-peer-deps=true` so npm accepts the internally-consistent prerelease peer graph (the same relaxation pnpm applies automatically inside the monorepo).
+- Downgrade `typescript` from tsgo (v7) to the classic compiler (`^5.9.2`) in the emitted template. The sources happily typecheck under tsgo, but `mastra build` transitively loads TypeScript via `typescript-paths`, which needs the classic `ts.sys` API tsgo doesn't expose. In the monorepo pnpm hoists classic TypeScript from another workspace package, hiding the problem; the standalone template has no hoist.
+
+All three are annotated as temporary in the script and README — remove once the packages ship stable releases and the deployer supports tsgo.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -211,6 +211,20 @@ function transformPackageJson() {
   manifest.dependencies['@mastra/memory'] = 'alpha'; // peer of @mastra/playground-ui
   manifest.dependencies['react-is'] = '^19.0.0'; // peer of recharts (via @mastra/playground-ui)
 
+  // Downgrade `typescript` from tsgo (v7) to classic (v5). The Mastra Factory
+  // sources happily typecheck under tsgo, but `mastra build` transitively
+  // loads the classic TypeScript API via `typescript-paths` — tsgo's ESM
+  // package doesn't expose `ts.sys`, so `require('typescript')` returns an
+  // almost-empty module and analyzeBundle crashes with
+  //   TypeError: Cannot read properties of undefined (reading 'readFile')
+  // In the monorepo pnpm hoists classic TypeScript from another workspace
+  // package, hiding the problem. In the standalone template there is no
+  // hoist, so we pin the classic compiler here. Remove once
+  // `typescript-paths` (or whatever @mastra/deployer uses) supports tsgo.
+  if (manifest.devDependencies?.typescript) {
+    manifest.devDependencies.typescript = '^5.9.2';
+  }
+
   fs.writeFileSync(path.join(outDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
 }
 

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -103,6 +103,12 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     const npmrc = fs.readFileSync(path.join(outDir, '.npmrc'), 'utf8');
     expect(npmrc).toMatch(/^legacy-peer-deps\s*=\s*true\s*$/m);
 
+    // `typescript` is downgraded from tsgo (v7) to the classic compiler (v5)
+    // because `mastra build` transitively loads TypeScript via
+    // `typescript-paths`, which needs the classic `ts.sys` API tsgo does not
+    // expose. Remove once the deployer supports tsgo.
+    expect(pkg.devDependencies.typescript).toMatch(/^\^5\./);
+
     // Tests and their dependencies are stripped.
     expect(allDeps.vitest).toBeUndefined();
     expect(fs.existsSync(path.join(outDir, 'e2e'))).toBe(false);


### PR DESCRIPTION
## Summary

Follow-up to #20001. That PR fixed the `npm install` and `npm run check` phases of the sync-softwarefactory-template validation. The **`npm run build`** phase still crashed with:

```
TypeError: Cannot read properties of undefined (reading 'readFile')
    at getTsConfig (typescript-paths/lib/index.js:117:44)
```

## Diagnosis

`mastra build` (in `@mastra/deployer`'s bundle-analyze step) transitively loads TypeScript via `typescript-paths`. That module does `ts.readConfigFile(tsConfigPath, host.readFile)` where `host` defaults to `ts.sys`.

The Mastra Factory sources pin `typescript: ^7.0.2` — that's **tsgo**, the new Go-based TypeScript compiler. tsgo ships as `"type": "module"` with no CommonJS entry, so `require('typescript')` returns an almost-empty module:

```
$ node -e "const ts = require('typescript'); console.log('has sys:', !!ts.sys)"
has sys: false
```

→ `host.readFile` is undefined → crash.

Inside the monorepo, pnpm hoists classic TypeScript (v5) from another workspace package, hiding the problem. The standalone template has no hoist.

## Change

`sync-template.mjs` now downgrades `typescript` from `^7.0.2` to `^5.9.2` in the emitted template. The Mastra Factory sources typecheck happily under both compilers, so `npm run check` is unaffected.

## Verification

Ran the sync workflow's exact chain locally against the newly-emitted template:

```
node mastracode/mastra-factory/scripts/sync-template.mjs --out /tmp/sf-template
cd /tmp/sf-template
npm install --no-audit --no-fund   # ✅ 1404 packages
npm run check                       # ✅ tsc clean
npm run build                       # ✅ Build successful — .mastra/output written
```

## Test plan

- [x] Emitted `package.json` has `"typescript": "^5.9.2"` in devDependencies
- [x] `npm install` succeeds
- [x] `npm run check` succeeds
- [x] `npm run build` succeeds end-to-end (both `build:ui` and `build:server`)
- [x] Vitest: 31/31 pass (includes new assertion on typescript version)
- [x] Prettier + lint clean

Both this override and the `.npmrc` / `alpha` pinning from #20001 are annotated as temporary in the script — remove once the deployer supports tsgo.

Co-Authored-By: Mastra Code (anthropic/claude-opus-4-7) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

New Software Factory templates now use the regular TypeScript compiler instead of an experimental replacement, preventing builds from crashing. The generated templates are also configured for the prerelease dependency setup and verified with tests.

## Summary

- Pin generated templates to the Mastra `alpha` dependency train.
- Add `.npmrc` with `legacy-peer-deps=true`.
- Emit `typescript: ^5.9.2` instead of `tsgo`.
- Add test coverage for the TypeScript version.
- Verify installation, type checking, building, and all 31 Vitest tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->