### PR TITLE
Grant Factory GitHub CLI issue and PR write access

### DIFF
--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -451,7 +451,34 @@ describe('PlatformGithubIntegration', () => {
     });
     expect(JSON.parse(String((fetchImpl.mock.calls[0]?.[1] as RequestInit).body))).toEqual({
       repositories: ['app'],
-      permissions: { contents: 'write' },
+      permissions: { contents: 'write', issues: 'write', pull_requests: 'write' },
+    });
+  });
+
+  it('requests all write permissions when minting an installation token', async () => {
+    const fetchImpl = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        json({
+          repositories: [
+            {
+              id: 101,
+              owner: 'acme',
+              name: 'app',
+              fullName: 'acme/app',
+              private: true,
+              defaultBranch: 'main',
+            },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(json({ token: 'ghs_installation', expiresAt: '2026-07-21T18:00:00Z' }));
+    const integration = createIntegration(fetchImpl);
+
+    await expect(integration.mintInstallationToken(7)).resolves.toBe('ghs_installation');
+    expect(JSON.parse(String((fetchImpl.mock.calls[1]?.[1] as RequestInit).body))).toEqual({
+      repositories: ['app'],
+      permissions: { contents: 'write', issues: 'write', pull_requests: 'write' },
     });
   });
 

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -117,6 +117,11 @@ type GithubReviewComment = GithubComment & {
 
 const PAGE_SIZE = 30;
 const API_PREFIX = '/v1/server';
+const REPOSITORY_TOKEN_PERMISSIONS = {
+  contents: 'write',
+  issues: 'write',
+  pull_requests: 'write',
+} as const;
 
 function loose(c: unknown): Context {
   return c as Context;
@@ -292,7 +297,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
       const token = await this.#client.request<{ token: string }>(
         'POST',
         `${API_PREFIX}/github-app/installations/${installationId}/token`,
-        { repositories: [repositoryName], permissions: { contents: 'write' } },
+        { repositories: [repositoryName], permissions: REPOSITORY_TOKEN_PERMISSIONS },
       );
       return {
         cloneUrl: `https://github.com/${repository.slug}.git`,
@@ -565,7 +570,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     const result = await this.#client.request<{ token: string }>(
       'POST',
       `${API_PREFIX}/github-app/installations/${installationId}/token`,
-      { repositories: repositories.map(repository => repository.name), permissions: { contents: 'write' } },
+      { repositories: repositories.map(repository => repository.name), permissions: REPOSITORY_TOKEN_PERMISSIONS },
     );
     return result.token;
   }


### PR DESCRIPTION
## Summary

- Request `issues: write` and `pull_requests: write` alongside `contents: write` when minting repository-scoped GitHub App installation tokens.
- Use one shared permission set for both repository-access and installation-token minting paths.
- Add regression coverage for both request paths.

These tokens are injected into Factory sandboxes as `GH_TOKEN`. The additional permissions allow authenticated GitHub CLI sessions to create and update issues and pull requests instead of being limited to repository contents.

## Test plan

- [x] `pnpm build:mastracode`
- [x] `pnpm --filter ./mastracode/factory exec vitest run src/integrations/platform/github/integration.test.ts --reporter=dot --bail 1`
- [x] `pnpm --filter ./mastracode/factory test --reporter=dot` — 69 files, 949 tests
- [x] `pnpm --filter ./mastracode/factory check`
- [x] `pnpm --filter ./mastracode/factory lint`
- [x] `pnpm --filter ./mastracode/factory build:lib`
- [x] Prettier check on changed files
