### PR TITLE
chore(web): fix prettier formatting failing Lint on main

### DIFF
--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -56,25 +56,33 @@ describe('platform entry (src/mastra/index.ts)', () => {
       vi.resetModules();
     });
 
-    it('boots when the GitHub group is partially configured so diagnostics can report the missing setup', { timeout: 60_000 }, async () => {
-      vi.resetModules();
-      // The test env may carry a full GitHub config — blank everything but the
-      // app id to force the partial state.
-      vi.stubEnv('GITHUB_APP_ID', '12345');
-      vi.stubEnv('GITHUB_APP_PRIVATE_KEY', '');
-      vi.stubEnv('GITHUB_APP_CLIENT_ID', '');
-      vi.stubEnv('GITHUB_APP_CLIENT_SECRET', '');
-      vi.stubEnv('GITHUB_APP_SLUG', '');
-      const mod = await import('./index.js');
-      expect(mod.mastra).toBeDefined();
-    });
+    it(
+      'boots when the GitHub group is partially configured so diagnostics can report the missing setup',
+      { timeout: 60_000 },
+      async () => {
+        vi.resetModules();
+        // The test env may carry a full GitHub config — blank everything but the
+        // app id to force the partial state.
+        vi.stubEnv('GITHUB_APP_ID', '12345');
+        vi.stubEnv('GITHUB_APP_PRIVATE_KEY', '');
+        vi.stubEnv('GITHUB_APP_CLIENT_ID', '');
+        vi.stubEnv('GITHUB_APP_CLIENT_SECRET', '');
+        vi.stubEnv('GITHUB_APP_SLUG', '');
+        const mod = await import('./index.js');
+        expect(mod.mastra).toBeDefined();
+      },
+    );
 
-    it('boots when the Linear group is partially configured so diagnostics can report the missing setup', { timeout: 60_000 }, async () => {
-      vi.resetModules();
-      vi.stubEnv('LINEAR_CLIENT_ID', 'lin_client');
-      vi.stubEnv('LINEAR_CLIENT_SECRET', '');
-      const mod = await import('./index.js');
-      expect(mod.mastra).toBeDefined();
-    });
+    it(
+      'boots when the Linear group is partially configured so diagnostics can report the missing setup',
+      { timeout: 60_000 },
+      async () => {
+        vi.resetModules();
+        vi.stubEnv('LINEAR_CLIENT_ID', 'lin_client');
+        vi.stubEnv('LINEAR_CLIENT_SECRET', '');
+        const mod = await import('./index.js');
+        expect(mod.mastra).toBeDefined();
+      },
+    );
   });
 });

--- a/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
+++ b/mastracode/web/src/shared/hooks/useStartFactoryRun.ts
@@ -119,7 +119,10 @@ export function useStartFactoryRun() {
   });
 
   const pendingRuns = useMutationState({
-    filters: { mutationKey: factoryRunMutationKey(repository?.projectRepositoryId ?? '', factoryId), status: 'pending' },
+    filters: {
+      mutationKey: factoryRunMutationKey(repository?.projectRepositoryId ?? '', factoryId),
+      status: 'pending',
+    },
     select: pending => toPendingFactoryRun(pending.state.variables),
   }).filter(run => run !== undefined);
 

--- a/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/EmptyThreadState.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/ChatMessageList/EmptyThreadState.tsx
@@ -25,7 +25,9 @@ export function EmptyThreadState() {
   const { prefillComposer } = useChatCommands();
   if (!activeFactory) return null;
 
-  const repository = activeFactory.repositories.find(repo => repo.projectRepositoryId === factorySessionState?.projectRepositoryId);
+  const repository = activeFactory.repositories.find(
+    repo => repo.projectRepositoryId === factorySessionState?.projectRepositoryId,
+  );
   const gitBranch = repository?.gitBranch;
 
   return (

--- a/mastracode/web/src/web/ui/domains/chat/components/StatusLine/StatusLine.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/StatusLine/StatusLine.tsx
@@ -21,7 +21,9 @@ export function StatusLine() {
   const { baseUrl, resourceId, projectPath, factorySessionState } = useChatSessionContext();
   const { data: factory } = useFactoryQuery(factoryId);
   const { transcript, busy } = useChatTranscript();
-  const repository = factory?.repositories.find(repo => repo.projectRepositoryId === factorySessionState?.projectRepositoryId);
+  const repository = factory?.repositories.find(
+    repo => repo.projectRepositoryId === factorySessionState?.projectRepositoryId,
+  );
   const projectRepositoryId = repository?.projectRepositoryId;
   const factoryProjectId = factorySessionState?.factoryProjectId;
 

--- a/mastracode/web/src/web/ui/domains/chat/components/__tests__/overlay-test-utils.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/components/__tests__/overlay-test-utils.tsx
@@ -73,7 +73,11 @@ export function useOverlayControllerHandlers() {
       }),
     ),
     http.post(`${TEST_BASE_URL}/web/github/projects/:projectRepositoryId/ensure`, () =>
-      HttpResponse.json({ resourceId: 'test-resource', sandboxId: 'sandbox-overlay', sandboxWorkdir: '/workspace/overlay' }),
+      HttpResponse.json({
+        resourceId: 'test-resource',
+        sandboxId: 'sandbox-overlay',
+        sandboxWorkdir: '/workspace/overlay',
+      }),
     ),
     http.post(`${API}/sessions`, async ({ request }) => {
       const { resourceId } = (await request.json()) as { resourceId: string };
@@ -118,7 +122,9 @@ export function useOverlayControllerHandlers() {
 
 export function OverlayTestProviders({ children }: { children: ReactNode }) {
   return (
-    <MemoryRouter initialEntries={[`/factories/${OVERLAY_FACTORY_ID}/workspaces/${OVERLAY_SESSION_ID}/threads/thread-test`]}>
+    <MemoryRouter
+      initialEntries={[`/factories/${OVERLAY_FACTORY_ID}/workspaces/${OVERLAY_SESSION_ID}/threads/thread-test`]}
+    >
       <Routes>
         <Route
           path="/factories/:factoryId/workspaces/:sessionId/threads/:threadId"

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -46,13 +46,18 @@ export function ChatSessionConfigProvider({
   const factory = factoryQuery.data;
   const storedSession = sessionQuery.data;
   const repository = storedSession
-    ? factory?.repositories.find((repo: LinkedRepositoryPayload) => repo.projectRepositoryId === storedSession.projectRepositoryId)
+    ? factory?.repositories.find(
+        (repo: LinkedRepositoryPayload) => repo.projectRepositoryId === storedSession.projectRepositoryId,
+      )
     : factory?.repositories[0];
   const ensureQuery = useEnsureMaterializedSandbox(repository?.projectRepositoryId);
   const resolvingSession = Boolean(userScoped ? threadId : sessionId) && sessionQuery.isPending;
-  const resourceId = userScoped && authQuery.data ? userSessionResourceId(authQuery.data) : ensureQuery.data?.resourceId;
+  const resourceId =
+    userScoped && authQuery.data ? userSessionResourceId(authQuery.data) : ensureQuery.data?.resourceId;
   const projectPath = userScoped ? undefined : storedSession?.sessionId;
-  const sessionEnabled = userScoped ? Boolean(storedSession) && !resolvingSession : ensureQuery.isSuccess && Boolean(projectPath);
+  const sessionEnabled = userScoped
+    ? Boolean(storedSession) && !resolvingSession
+    : ensureQuery.isSuccess && Boolean(projectPath);
   const value = {
     resourceId: resourceId ?? '',
     sessionEnabled,
@@ -64,7 +69,8 @@ export function ChatSessionConfigProvider({
             factoryProjectId: factory.id,
             projectRepositoryId: repository.projectRepositoryId,
             sandboxId: storedSession?.sandboxId ?? ensureQuery.data?.sandboxId,
-            sandboxWorkdir: storedSession?.sandboxWorkdir ?? ensureQuery.data?.sandboxWorkdir ?? repository.sandboxWorkdir,
+            sandboxWorkdir:
+              storedSession?.sandboxWorkdir ?? ensureQuery.data?.sandboxWorkdir ?? repository.sandboxWorkdir,
           }
         : undefined,
     baseUrl,

--- a/mastracode/web/src/web/ui/domains/factory/components/FactoryPageShell.tsx
+++ b/mastracode/web/src/web/ui/domains/factory/components/FactoryPageShell.tsx
@@ -49,4 +49,3 @@ export function FactoryPageShell({ title, description, children }: FactoryPageSh
     </PageLayout>
   );
 }
-

--- a/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
@@ -3,7 +3,11 @@ import { useEffect, useState } from 'react';
 
 import { useApiConfig } from '../../../../../shared/api/config';
 import { queryKeys } from '../../../../../shared/api/keys';
-import { useCreateFactoryMutation, useFactoriesQuery, useLinkRepositoryMutation } from '../../../../../shared/hooks/useFactories';
+import {
+  useCreateFactoryMutation,
+  useFactoriesQuery,
+  useLinkRepositoryMutation,
+} from '../../../../../shared/hooks/useFactories';
 import { connectLinear } from '../../factory/services/linear';
 import type { FactoryProject, FactoryProjectPayload } from '../services/github';
 import { connectGithub, manageGithubConnection } from '../services/github';

--- a/mastracode/web/src/web/ui/domains/workspaces/components/FactoriesPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/FactoriesPanel.tsx
@@ -37,7 +37,6 @@ export function FactoriesPanel({ onClose }: { onClose: () => void }) {
     }
   };
 
-
   return (
     <section aria-labelledby="create-factory-title" className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-5">
@@ -84,7 +83,6 @@ export function FactoriesPanel({ onClose }: { onClose: () => void }) {
               </Button>
             </div>
           </form>
-
         </div>
       </div>
     </section>

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -56,7 +56,9 @@ export function WorkspacesSection() {
 
   const allWorkItems = workItems.data ?? [];
   const workItemByPath = new Map(
-    allWorkItems.flatMap(item => Object.values(item.sessions ?? {}).map(sessionRef => [sessionRef.sessionId, item] as const)),
+    allWorkItems.flatMap(item =>
+      Object.values(item.sessions ?? {}).map(sessionRef => [sessionRef.sessionId, item] as const),
+    ),
   );
   const rows = workspaceRows.flatMap(workspace => {
     const item = workItemByPath.get(workspace.sessionId);
@@ -77,7 +79,9 @@ export function WorkspacesSection() {
     ];
   });
   const latestRows = (review: boolean) => {
-    const sorted = [...rows.filter(row => row.review === review)].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+    const sorted = [...rows.filter(row => row.review === review)].sort((a, b) =>
+      b.updatedAt.localeCompare(a.updatedAt),
+    );
     const visible = sorted.slice(0, 5);
     for (const pinned of sorted.slice(5).filter(row => row.active || row.running || row.attention)) {
       let replaceIndex = visible.length - 1;
@@ -128,7 +132,9 @@ export function WorkspacesSection() {
           queryKey: messagesKey,
           queryFn: () => chatSession.listMessages(thread, INITIAL_THREAD_MESSAGE_LIMIT),
         });
-        void navigate(`/factories/${factoryId}/workspaces/${workspace.sessionId}/threads/${thread}`, { state: { from: location } });
+        void navigate(`/factories/${factoryId}/workspaces/${workspace.sessionId}/threads/${thread}`, {
+          state: { from: location },
+        });
       } else {
         void navigate(`/factories/${factoryId}/workspaces/${workspace.sessionId}`, { state: { from: location } });
       }
@@ -147,10 +153,22 @@ export function WorkspacesSection() {
   return (
     <section className="flex flex-col gap-4" aria-label="Factory sessions">
       {workRows.length > 0 && (
-        <WorkspaceGroup title="Work Sessions" rows={workRows} pending={pending} onSelect={openWorkspaceThread} onDelete={setConfirmDelete} />
+        <WorkspaceGroup
+          title="Work Sessions"
+          rows={workRows}
+          pending={pending}
+          onSelect={openWorkspaceThread}
+          onDelete={setConfirmDelete}
+        />
       )}
       {reviewRows.length > 0 && (
-        <WorkspaceGroup title="Review Sessions" rows={reviewRows} pending={pending} onSelect={openWorkspaceThread} onDelete={setConfirmDelete} />
+        <WorkspaceGroup
+          title="Review Sessions"
+          rows={reviewRows}
+          pending={pending}
+          onSelect={openWorkspaceThread}
+          onDelete={setConfirmDelete}
+        />
       )}
 
       {confirmDelete && (

--- a/mastracode/web/src/web/ui/pages/NewPage.tsx
+++ b/mastracode/web/src/web/ui/pages/NewPage.tsx
@@ -87,7 +87,9 @@ function BrandLockup() {
 function FactoryContext({ activeFactory }: { activeFactory: FactoryProject | undefined }) {
   const { sessionId } = useParams<{ sessionId: string }>();
   const sessionQuery = useUserSessionQuery(sessionId);
-  const repository = activeFactory?.repositories.find(repo => repo.projectRepositoryId === sessionQuery.data?.projectRepositoryId);
+  const repository = activeFactory?.repositories.find(
+    repo => repo.projectRepositoryId === sessionQuery.data?.projectRepositoryId,
+  );
   const projectPath = sessionQuery.data?.sessionId;
   const gitBranch = repository?.gitBranch;
   return (


### PR DESCRIPTION
## Summary

The Lint job is failing on every open PR (including the changeset release PR #19994) because 11 files in `mastracode/web` landed on `main` without prettier formatting. `pnpm lint:format` (`prettier --check`) rejects them.

This PR runs `prettier --write` on the affected files — formatting-only, no behavior changes:

- `src/mastra/index.test.ts`
- `src/shared/hooks/useStartFactoryRun.ts`
- `src/web/ui/domains/chat/components/__tests__/overlay-test-utils.tsx`
- `src/web/ui/domains/chat/components/ChatMessageList/EmptyThreadState.tsx`
- `src/web/ui/domains/chat/components/StatusLine/StatusLine.tsx`
- `src/web/ui/domains/chat/context/ChatSessionProvider.tsx`
- `src/web/ui/domains/factory/components/FactoryPageShell.tsx`
- `src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx`
- `src/web/ui/domains/workspaces/components/FactoriesPanel.tsx`
- `src/web/ui/domains/workspaces/components/WorkspacesSection.tsx`
- `src/web/ui/pages/NewPage.tsx`

## Test plan

- `pnpm exec prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'` passes locally (matching the CI `lint:format` invocation)
- Diff reviewed: whitespace/wrapping only


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR tidies up the formatting in 11 web files so the CI lint check passes. It only changes spacing and line breaks, not how the application works.

## Summary

- Applied Prettier formatting across tests, hooks, providers, and UI components in `mastracode/web`.
- Reformatted long imports, expressions, JSX props, callbacks, and test cases for readability.
- Preserved all existing behavior, logic, and public APIs.
- Confirmed the Prettier check passes locally using the CI invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->