### PR TITLE
fix(web): stop disabling auth when MASTRA_FACTORY_DEV is set

### DIFF
--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -65,7 +65,7 @@ if (redisUrl) {
 
 // Factory dev is auth-less by default. Production can opt out explicitly;
 // otherwise MastraFactory installs its platform-backed auth provider.
-const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1' || process.env.MASTRA_FACTORY_DEV === 'true';
+const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1';
 let auth: IMastraAuthProvider | null | undefined;
 
 if (authDisabled) {


### PR DESCRIPTION
MASTRA_FACTORY_DEV=true was also switching the factory web app into auth-less mode, which meant dev-flagged deployments skipped the platform-backed auth provider entirely. Auth-less mode is now only enabled through the explicit MASTRACODE_AUTH_DISABLED=1 opt-out.

Before:

```ts
const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1' || process.env.MASTRA_FACTORY_DEV === 'true';
```

After:

```ts
const authDisabled = process.env.MASTRACODE_AUTH_DISABLED === '1';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Authentication stays on by default, even in factory development mode. It can now be turned off only by explicitly setting `MASTRACODE_AUTH_DISABLED=1`.

## Changes

- Updated `authDisabled` to depend solely on `MASTRACODE_AUTH_DISABLED === '1'`.
- Factory development environments now use the platform-backed authentication provider by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->