### PR TITLE
fix(create-factory): serve generated projects from one server

### DIFF
--- a/.changeset/shaky-poets-join.md
+++ b/.changeset/shaky-poets-join.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Fixed generated Factory projects to serve the UI and API from a single Mastra development server.

--- a/.github/workflows/sync-softwarefactory-template.yml
+++ b/.github/workflows/sync-softwarefactory-template.yml
@@ -62,27 +62,11 @@ jobs:
         working-directory: ${{ runner.temp }}/template-out
         env:
           MASTRA_TELEMETRY_DISABLED: '1'
-          NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
         run: |
           set -euo pipefail
-          ls -lah
-          if ! npm install --no-audit --no-fund --loglevel verbose; then
-            echo '::group::npm debug logs'
-            find "$NPM_CONFIG_CACHE/_logs" -maxdepth 1 -type f -print -exec cat {} \; || true
-            echo '::endgroup::'
-            exit 1
-          fi
+          npm install --no-audit --no-fund
           npm run check
           npm run build
-
-      - name: Upload npm debug logs
-        if: failure()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: softwarefactory-template-npm-logs
-          path: ${{ runner.temp }}/npm-cache/_logs
-          if-no-files-found: ignore
-          retention-days: 7
 
       - name: Checkout template repository
         uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
@@ -103,13 +87,8 @@ jobs:
 
       - name: Commit and push template
         working-directory: softwarefactory-template
-        env:
-          USERNAME: '${{ steps.app-auth.outputs.app-slug }}[bot]'
-          EMAIL: '${{ steps.app-auth.outputs.user-id }}+${{ steps.app-auth.outputs.app-slug }}[bot]@users.noreply.github.com'
         run: |
           set -euo pipefail
-          git config user.name "$USERNAME"
-          git config user.email "$EMAIL"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to sync"

--- a/.github/workflows/sync-softwarefactory-template.yml
+++ b/.github/workflows/sync-softwarefactory-template.yml
@@ -62,27 +62,54 @@ jobs:
         working-directory: ${{ runner.temp }}/template-out
         env:
           MASTRA_TELEMETRY_DISABLED: '1'
+          NPM_CONFIG_CACHE: ${{ runner.temp }}/npm-cache
         run: |
           set -euo pipefail
-          npm install --no-audit --no-fund
+          ls -lah
+          if ! npm install --no-audit --no-fund --loglevel verbose; then
+            echo '::group::npm debug logs'
+            find "$NPM_CONFIG_CACHE/_logs" -maxdepth 1 -type f -print -exec cat {} \; || true
+            echo '::endgroup::'
+            exit 1
+          fi
           npm run check
           npm run build
 
-      - name: Push to template repository
-        env:
-          GITHUB_TOKEN: ${{ steps.app-auth.outputs.token }}
-          USERNAME: '${{ steps.app-auth.outputs.app-slug }}[bot]'
-          EMAIL: '${{ steps.app-auth.outputs.user-id }}+${{ steps.app-auth.outputs.app-slug }}[bot]@users.noreply.github.com'
+      - name: Upload npm debug logs
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: softwarefactory-template-npm-logs
+          path: ${{ runner.temp }}/npm-cache/_logs
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Checkout template repository
+        uses: actions/checkout@e8d4307400f9427dba7cb98e488d6ab85f1cec5f
+        with:
+          repository: mastra-ai/softwarefactory-template
+          token: ${{ steps.app-auth.outputs.token }}
+          ref: main
+          path: softwarefactory-template
+
+      - name: Sync generated template
+        working-directory: softwarefactory-template
         run: |
           set -euo pipefail
-          git config --global user.name "$USERNAME"
-          git config --global user.email "$EMAIL"
-          git clone "https://x-access-token:${GITHUB_TOKEN}@github.com/mastra-ai/softwarefactory-template.git" "$RUNNER_TEMP/template-repo"
-          cd "$RUNNER_TEMP/template-repo"
           # One-way overwrite: remove everything except .git, then copy the
           # generated tree in. Downstream commits are intentionally clobbered.
           find . -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
           cp -R "$RUNNER_TEMP/template-out/." .
+
+      - name: Commit and push template
+        working-directory: softwarefactory-template
+        env:
+          USERNAME: '${{ steps.app-auth.outputs.app-slug }}[bot]'
+          EMAIL: '${{ steps.app-auth.outputs.user-id }}+${{ steps.app-auth.outputs.app-slug }}[bot]@users.noreply.github.com'
+        run: |
+          set -euo pipefail
+          git config user.name "$USERNAME"
+          git config user.email "$EMAIL"
           git add -A
           if git diff --cached --quiet; then
             echo "No changes to sync"

--- a/e2e-tests/softwarefactory/softwarefactory.test.ts
+++ b/e2e-tests/softwarefactory/softwarefactory.test.ts
@@ -50,8 +50,16 @@ describe('softwarefactory template', () => {
       env: { ...process.env, ...registryEnv },
     });
 
-    // Scaffold a project with the CLI's --default path (installs via npm).
-    await execa('node', [join(cliRoot, 'bin', 'cli.mjs'), 'factory', '--default', '--template-dir', templateDir], {
+    // The CLI accepts a Git template source, so make the generated directory
+    // cloneable and scaffold it through the built create-factory entrypoint.
+    await execa('git', ['init', '-q', '-b', 'main'], { cwd: templateDir });
+    await execa('git', ['add', '-A'], { cwd: templateDir });
+    await execa(
+      'git',
+      ['-c', 'user.name=Software Factory E2E', '-c', 'user.email=e2e@mastra.ai', 'commit', '-q', '-m', 'Template'],
+      { cwd: templateDir },
+    );
+    await execa('node', [join(cliRoot, 'dist', 'index.js'), 'factory', '--no-platform', '--template', templateDir], {
       cwd: workDir,
       stdio: 'inherit',
       env: { ...process.env, ...registryEnv, MASTRA_TELEMETRY_DISABLED: '1' },
@@ -84,19 +92,15 @@ describe('softwarefactory template', () => {
     });
   });
 
-  it('boots the dev servers and serves UI/API/proxied routes', async () => {
-    const apiPort = await getPort();
-    const uiPort = await getPort();
+  it('boots the dev server and serves UI and API routes', async () => {
+    const port = await getPort();
 
     const dev = execa('npm', ['run', 'dev'], {
       cwd: scaffoldDir,
       env: {
         ...process.env,
         ...registryEnv,
-        PORT: String(apiPort),
-        MASTRACODE_UI_PORT: String(uiPort),
-        // The Vite proxy targets :4111 by default; follow the API port.
-        MASTRACODE_API_TARGET: `http://localhost:${apiPort}`,
+        PORT: String(port),
       },
       detached: true,
       stdout: 'pipe',
@@ -120,7 +124,7 @@ describe('softwarefactory template', () => {
     };
 
     try {
-      // The dev servers bind `localhost`, which lands on ::1 or 127.0.0.1
+      // The dev server binds `localhost`, which lands on ::1 or 127.0.0.1
       // depending on the OS/Node resolver — accept whichever loopback answers.
       const probe = async (port: number, path: string) => {
         for (const host of ['localhost', '127.0.0.1', '[::1]']) {
@@ -137,7 +141,7 @@ describe('softwarefactory template', () => {
       const deadline = Date.now() + 5 * 60 * 1000;
       let ready = false;
       while (Date.now() < deadline && !devExited) {
-        const [ui, api] = await Promise.all([probe(uiPort, '/'), probe(apiPort, '/api')]);
+        const [ui, api] = await Promise.all([probe(port, '/'), probe(port, '/api')]);
         if (ui && api) {
           ready = true;
           break;
@@ -149,11 +153,10 @@ describe('softwarefactory template', () => {
         // Kill first so awaiting the (reject: false) result yields output.
         killDev();
         const result = await dev;
-        throw new Error(`Dev server did not become ready on ui:${uiPort} api:${apiPort}.\n${result.all ?? ''}`);
+        throw new Error(`Dev server did not become ready on port ${port}.\n${result.all ?? ''}`);
       }
 
-      // Web-surface route proxied through the Vite dev server.
-      const providers = await probe(uiPort, '/web/config/providers');
+      const providers = await probe(port, '/web/config/providers');
       expect(providers?.status).toBe(200);
     } finally {
       killDev();

--- a/e2e-tests/softwarefactory/softwarefactory.test.ts
+++ b/e2e-tests/softwarefactory/softwarefactory.test.ts
@@ -37,7 +37,12 @@ describe('softwarefactory template', () => {
     const templateDir = join(workDir, 'template');
     scaffoldDir = join(workDir, 'factory');
 
-    // The CLI bin runs from dist; build it (cheap, tsup).
+    // The create-factory bundle externalizes its `mastra/internal/auth`
+    // dependency, so both package dist directories must exist before it runs.
+    await execa('pnpm', ['--filter', './packages/cli', 'build:lib'], {
+      cwd: rootDir,
+      stdio: 'inherit',
+    });
     await execa('pnpm', ['--filter', './mastracode/mastra-factory', 'build'], {
       cwd: rootDir,
       stdio: 'inherit',

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -160,19 +160,16 @@ function transformPackageJson() {
   manifest.private = true;
   manifest.license = 'Apache-2.0';
 
-  // Direct mapping of the web project's own scripts (web:dev / web:build /
-  // web:start), minus monorepo-only bits (prebuild, monorepo-deps.mjs).
+  // Use the Factory server's integrated UI instead of running a separate
+  // Vite process. Keep standalone validation and lifecycle scripts.
   manifest.scripts = {
-    dev: 'concurrently --kill-others-on-fail --names server,ui "MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra" "vite --config src/web/vite.config.ts"',
-    'dev:prod':
-      'npm run build:ui && PORT=5173 MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra',
+    dev: 'mastra factory dev --dir src/mastra',
     'db:up': 'docker compose up -d --wait',
     'db:down': 'docker compose down',
-    build: 'mastra build --dir src/mastra',
-    'build:ui': 'vite --config src/web/vite.config.ts build',
-    start: 'varlock run -- mastra start',
-    deploy: 'npm run build && node scripts/validate-output.mjs && mastra deploy --skip-build',
     check: 'tsc --noEmit && tsc --noEmit -p src/web/ui/tsconfig.json',
+    build: 'mastra build --dir src/mastra',
+    start: 'varlock run -- mastra start',
+    deploy: 'mastra deploy',
   };
 
   // Every `link:` dep becomes `"alpha"`. The Mastra Factory sources are built
@@ -223,6 +220,9 @@ function transformPackageJson() {
   // `typescript-paths` (or whatever @mastra/deployer uses) supports tsgo.
   if (manifest.devDependencies?.typescript) {
     manifest.devDependencies.typescript = '^5.9.2';
+  }
+  if (manifest.devDependencies?.concurrently) {
+    delete manifest.devDependencies.concurrently;
   }
 
   fs.writeFileSync(path.join(outDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -153,8 +153,11 @@ describe('create --no-platform', () => {
     expect(cliAuth.getToken).not.toHaveBeenCalled();
     expect(platform.createServerProject).not.toHaveBeenCalled();
 
-    // Next steps shown.
+    // Next steps show the integrated Factory UI on the Mastra server port.
     expect(clack.note).toHaveBeenCalledWith(expect.stringContaining('Your Mastra Factory is ready!'), 'Next steps');
+    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining('http://localhost:4111'), 'Next steps');
+    expect(clack.note).not.toHaveBeenCalledWith(expect.stringContaining('http://localhost:5173'), 'Next steps');
+    expect(clack.note).not.toHaveBeenCalledWith(expect.stringContaining('Mastra Studio'), 'Next steps');
   });
 
   it('fails the run when the template clone fails, without a success outro', async () => {

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -179,8 +179,7 @@ export async function create(args: CreateArgs): Promise<void> {
     `${color.cyan('cd')} ${projectName}`,
     color.cyan(`${packageManager} run dev`),
     '',
-    `Factory UI     ${color.underline('http://localhost:5173')}`,
-    `Mastra Studio  ${color.underline('http://localhost:4111')}`,
+    `Factory UI     ${color.underline('http://localhost:4111')}`,
     '',
   ];
   if (platformResult) {

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -117,20 +117,17 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     expect(fs.existsSync(path.join(outDir, 'src/web/test-utils.ts'))).toBe(false);
     expect(fs.existsSync(path.join(outDir, 'src/web/storage/test-utils.ts'))).toBe(false);
 
-    // Scripts map the web project's own flow, minus monorepo-only bits.
-    expect(pkg.scripts.dev).toContain('concurrently');
-    expect(pkg.scripts.dev).toContain('mastra factory dev');
-    expect(pkg.scripts.dev).toContain('vite');
-    expect(pkg.scripts['dev:prod']).toBe(
-      'npm run build:ui && PORT=5173 MASTRA_SKIP_PEERDEP_CHECK=1 varlock run -- mastra factory dev --dir src/mastra',
-    );
-    expect(pkg.scripts['dev:prod']).not.toContain('concurrently');
+    // The Factory server serves the UI and API through one process.
+    expect(pkg.scripts.dev).toBe('mastra factory dev --dir src/mastra');
+    expect(pkg.scripts['dev:prod']).toBeUndefined();
     expect(pkg.scripts.prebuild).toBeUndefined();
     expect(JSON.stringify(pkg.scripts)).not.toContain('monorepo-deps');
-    // Production builds use the prebuilt Factory UI bundled with the Mastra CLI.
+    expect(pkg.scripts.check).toBe('tsc --noEmit && tsc --noEmit -p src/web/ui/tsconfig.json');
     expect(pkg.scripts.build).toBe('mastra build --dir src/mastra');
-    expect(pkg.scripts['build:ui']).toBe('vite --config src/web/vite.config.ts build');
+    expect(pkg.scripts['build:ui']).toBeUndefined();
     expect(pkg.scripts['build:server']).toBeUndefined();
+    expect(pkg.scripts.deploy).toBe('mastra deploy');
+    expect(pkg.devDependencies.concurrently).toBeUndefined();
     // The generated .gitignore ignores the Vite output directory.
     const gitignore = fs.readFileSync(path.join(outDir, '.gitignore'), 'utf8');
     expect(gitignore).toContain('src/mastra/public/factory/');


### PR DESCRIPTION
Generated Factory projects currently start separate Mastra and Vite development servers:

```json
"dev": "concurrently ... mastra factory dev ... vite ..."
```

This switches the template to the Factory server’s integrated UI and API:

```json
"dev": "mastra factory dev --dir src/mastra"
```

The scaffolded next steps now point to `http://localhost:4111`, deployment uses `mastra deploy`, and the template sync workflow keeps validation diagnostics while using a normal authenticated checkout and push flow. The generated-script tests and Software Factory E2E flow were updated for the single-port setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR updates generated “Factory” projects so they run both the website (UI) and backend (API) from a single built-in Mastra server. That removes the need to juggle multiple dev servers, making setup and testing/publishing simpler and more consistent.

## What changed

- Updated generated Factory projects to use one integrated dev server:
  - Dev now runs `mastra factory dev --dir src/mastra` and serves everything from a single port (`http://localhost:4111`) instead of separate Mastra + Vite setups.
  - The “Next steps” messaging was updated to point to `http://localhost:4111` and to remove the extra “Mastra Studio” line.

- Updated generated template scripts and synchronization behavior:
  - Template `package.json` scripts were changed to align with the single-server flow (notably `dev: mastra factory dev --dir src/mastra` and `deploy: mastra deploy`), removing the previous web/Vite-style script variants and cleaning up related dependency handling.

- Updated deployment to use Mastra Factory’s deploy:
  - Deployment now uses `mastra deploy`.

- Improved template sync to use authenticated checkout + safe overwrite:
  - The Software Factory template sync workflow was refactored to use an authenticated checkout into a fixed path, then overwrite the destination via a controlled “sync” step (instead of doing an inline clone/copy approach), while keeping CI validation diagnostics intact.

- Updated tests and the Software Factory E2E flow for the single-port setup:
  - E2E now builds the create-factory CLI library first, scaffolds via the built CLI entrypoint, and probes both `/` (UI) and `/api` (API) on the same dynamically chosen port.
  - Unit tests were updated to assert the new single-port “Next steps” output and the exact generated `package.json` script expectations (including `dev` and `deploy` commands).
  
- Added a changeset:
  - Included a patch-level changeset under the `create-factory` package describing the single-server fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->