### PR TITLE
feat(mastracode/web): split-screen onboarding with side motion panel

### DIFF
--- a/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
@@ -18,6 +18,7 @@ import { InitialFactoryStep } from './InitialFactoryStep';
 import { ProjectManagementFactoryStep } from './ProjectManagementFactoryStep';
 import { VcsFactoryStep } from './VcsFactoryStep';
 import { useNavigate } from 'react-router';
+import '@fontsource-variable/mona-sans/standard.css';
 
 export type Step = 'initial' | 'vcs' | 'project-management';
 
@@ -134,36 +135,41 @@ export function EmptyFactoryState() {
     }
   };
 
+  const stepIndex = ['initial', 'vcs', 'project-management'].indexOf(step);
+
   return (
-    <main className="relative min-h-dvh overflow-hidden bg-surface1 text-neutral6">
-      <FactoryHalftoneField variant="backdrop" />
-      <div className="relative mx-auto flex min-h-dvh w-full max-w-7xl flex-col px-6 py-8 sm:px-10 lg:px-16">
-        <section className="mx-auto flex w-full max-w-3xl flex-1 flex-col text-center">
-          <div className="pt-2 sm:pt-4">
-            <ol className="mb-6 flex justify-center gap-2" aria-label="Factory setup progress">
+    <main className="factory-signin-theme min-h-dvh bg-surface1 font-mona-sans text-neutral6">
+      <div className="grid min-h-dvh w-full grid-cols-1 lg:grid-cols-[minmax(0,1fr)_minmax(480px,42%)]">
+        <section className="relative z-3 flex flex-col justify-center px-6 py-12 sm:px-10 lg:px-16 lg:py-17 xl:px-20">
+          <div className="w-full max-w-2xl">
+            <ol className="mb-9 flex gap-2" aria-label="Factory setup progress">
               {(['initial', 'vcs', 'project-management'] as const).map((item, index) => (
                 <li
                   key={item}
                   aria-current={step === item ? 'step' : undefined}
-                  className={`h-1 w-14 rounded-full ${index <= ['initial', 'vcs', 'project-management'].indexOf(step) ? 'bg-accent1' : 'bg-surface4'}`}
+                  className={`h-1 w-14 rounded-full transition-colors ${index <= stepIndex ? 'bg-accent1' : 'bg-surface4'}`}
                 >
                   <span className="sr-only">Step {index + 1}</span>
                 </li>
               ))}
             </ol>
-            <h1 className="mx-auto max-w-2xl text-3xl leading-tight font-semibold tracking-[-0.035em] text-balance sm:text-4xl lg:text-5xl">
+
+            <h1 className="max-w-xl text-[clamp(2rem,3.9vw,3.25rem)] leading-[1.1] font-[520] tracking-[0.01em] text-balance [font-stretch:112%]">
               {STEP_META[step].title}
             </h1>
             {STEP_META[step].description && (
-              <Txt as="p" variant="ui-lg" className="mx-auto mt-6 max-w-2xl leading-7 text-neutral3 sm:text-lg">
+              <Txt
+                as="p"
+                variant="ui-lg"
+                className="mt-6 max-w-lg text-[clamp(1rem,1.5vw,1.25rem)] leading-[1.4] tracking-[0.01em] text-neutral3"
+              >
                 {STEP_META[step].description}
               </Txt>
             )}
-          </div>
-          <div className="flex flex-1 items-start justify-center pt-16">
+
             <div
               key={step}
-              className="w-full animate-in fade-in slide-in-from-bottom-2 duration-300 motion-reduce:animate-none"
+              className="mt-11 w-full animate-in fade-in slide-in-from-bottom-2 duration-300 motion-reduce:animate-none"
             >
               {step === 'initial' && <InitialFactoryStep onContinue={() => goTo('vcs')} />}
               {step === 'vcs' && (
@@ -198,6 +204,10 @@ export function EmptyFactoryState() {
             </div>
           </div>
         </section>
+
+        <div className="hidden lg:grid">
+          <FactoryHalftoneField />
+        </div>
       </div>
     </main>
   );

--- a/mastracode/web/src/web/ui/domains/workspaces/components/InitialFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/InitialFactoryStep.tsx
@@ -7,7 +7,7 @@ export interface InitialFactoryStepProps {
 export function InitialFactoryStep({ onContinue }: InitialFactoryStepProps) {
   return (
     <>
-      <div className="mx-auto w-full max-w-2xl text-left" aria-hidden="true">
+      <div className="w-full max-w-2xl text-left" aria-hidden="true">
         <div className="grid grid-cols-3 gap-3">
           <div className="rounded-xl border border-border1 bg-surface2/80 p-3">
             <div className="mb-3 flex items-center gap-2 text-ui-xs font-medium text-icon3">

--- a/mastracode/web/src/web/ui/domains/workspaces/components/ProjectManagementFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/ProjectManagementFactoryStep.tsx
@@ -23,10 +23,7 @@ export function ProjectManagementFactoryStep({
   const linearStatus = useLinearStatusQuery();
 
   return (
-    <section
-      aria-label="Linear connection"
-      className="max-w-xl rounded-2xl border border-border1 bg-surface2/80 p-5"
-    >
+    <section aria-label="Linear connection" className="max-w-xl rounded-2xl border border-border1 bg-surface2/80 p-5">
       {linearStatus.isPending ? (
         <SkeletonRows label="Loading Linear status" rows={2} rowClassName="h-12 w-full rounded-xl" />
       ) : linearStatus.data?.connected ? (

--- a/mastracode/web/src/web/ui/domains/workspaces/components/ProjectManagementFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/ProjectManagementFactoryStep.tsx
@@ -25,7 +25,7 @@ export function ProjectManagementFactoryStep({
   return (
     <section
       aria-label="Linear connection"
-      className="mx-auto max-w-xl rounded-2xl border border-border1 bg-surface2/80 p-5"
+      className="max-w-xl rounded-2xl border border-border1 bg-surface2/80 p-5"
     >
       {linearStatus.isPending ? (
         <SkeletonRows label="Loading Linear status" rows={2} rowClassName="h-12 w-full rounded-xl" />

--- a/mastracode/web/src/web/ui/domains/workspaces/components/VcsFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/VcsFactoryStep.tsx
@@ -35,7 +35,7 @@ export function VcsFactoryStep({
   const repos = useGithubReposQuery(query || undefined, connected);
 
   return (
-    <section aria-label="GitHub repository" className="mx-auto max-w-2xl text-left">
+    <section aria-label="GitHub repository" className="max-w-2xl text-left">
       {githubStatus.isPending ? (
         <SkeletonRows label="Loading GitHub status" rows={3} rowClassName="h-12 w-full rounded-xl" />
       ) : !connected ? (


### PR DESCRIPTION
## What

Reworks the Factory onboarding (`/onboarding`) into a two-column brand layout that mirrors the sign-in screen, instead of the previous centered layout with the animated field used as a faded full-page backdrop.

- **Left column** — left-aligned progress bar, title, description and step content (no background), on the same dark `factory-signin-theme` + Mona Sans as sign-in for continuity.
- **Right column** — the animated Factory halftone panel (Intake → Build → Review → Ship), now the `panel` variant reused from the sign-in screen.

## Why

The onboarding felt inconsistent and "vibecoded" next to the sign-in screen. Splitting the screen — content left, motion right — matches the sign-in brand entry and reads more intentional.

## Responsive

- Full-bleed motion panel to the right edge; content hugs the left with responsive padding (`px-6 sm:px-10 lg:px-16 xl:px-20`) instead of a centered `max-w-7xl` gutter that pushed the text toward the middle.
- Motion panel hidden below the `lg` breakpoint (single-column, content only on mobile).

## Notes

- `mastracode-web` is a private app package — no changeset.
- Touches only the onboarding surface; the sign-in screen is unchanged.

## Testing

`pnpm --filter mastracode-web check:ui` passes. Visual verification pending (dev server not running locally at review time).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5
The Factory onboarding page now looks like the sign-in page: it has a clear “step-by-step” progress indicator, and on larger screens it shows an animated decorative panel to the right. On smaller screens, that animated panel is hidden so users focus on the onboarding content.

## Changes
- Reworked the `/onboarding` flow into a responsive two-column layout (left content + right panel).
- Applied the dark `factory-signin-theme` and Mona Sans styling to the onboarding screen.
- Updated the progress indicator styling to use a computed `stepIndex` to highlight the active/completed steps.
- Added the animated Factory halftone panel via `FactoryHalftoneField` inside a `hidden lg:grid` wrapper (so it’s not shown below `lg`).
- Updated onboarding typography, spacing/padding, and step alignment (including removing `mx-auto` from step section wrappers).
- Left the sign-in screen unchanged.
- `pnpm --filter mastracode-web check:ui` passes; visual verification is pending.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->