### PR TITLE
fix(create-factory): stop writing MASTRA_SHARED_API_URL to scaffolded .env

### DIFF
--- a/.changeset/polite-cases-live.md
+++ b/.changeset/polite-cases-live.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Stopped writing MASTRA_SHARED_API_URL to the scaffolded project's .env during platform provisioning. Platform consumers now use their built-in default platform URL, so scaffolded factories no longer pin the API endpoint at create time.

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -210,8 +210,9 @@ describe('create (platform provisioning)', () => {
     const projectPath = path.join(workDir, 'my-factory');
     const env = fs.readFileSync(path.join(projectPath, '.env'), 'utf8');
 
-    // All five platform keys present with real values.
-    expect(env).toMatch(/^MASTRA_SHARED_API_URL=https:\/\/platform\.example\.test$/m);
+    // All four platform keys present with real values; the shared API URL is
+    // no longer written (consumers default to the production platform URL).
+    expect(env).not.toMatch(/^MASTRA_SHARED_API_URL=/m);
     expect(env).toMatch(/^MASTRA_ORGANIZATION_ID=org_123$/m);
     expect(env).toMatch(/^MASTRA_PROJECT_ID=proj_abc$/m);
     expect(env).toMatch(/^MASTRA_PLATFORM_SECRET_KEY=sk_live_test$/m);
@@ -277,7 +278,7 @@ describe('create (platform provisioning)', () => {
     await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
 
     const env = fs.readFileSync(path.join(workDir, 'my-factory', '.env'), 'utf8');
-    expect(env).toMatch(/^MASTRA_SHARED_API_URL=/m);
+    expect(env).not.toMatch(/^MASTRA_SHARED_API_URL=/m);
     expect(env).toMatch(/^MASTRA_ORGANIZATION_ID=org_123$/m);
     expect(env).toMatch(/^MASTRA_PROJECT_ID=proj_abc$/m);
     expect(env).toMatch(/^MASTRA_PLATFORM_SECRET_KEY=sk_live_test$/m);

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts';
 // `mastra/internal/auth` is the CLI's internal barrel — drives the browser-auth
 // flow and reuses persisted credentials + org resolution rather than duplicating
 // them here.
-import { fetchOrgs, getToken, MASTRA_PLATFORM_API_URL, resolveCurrentOrg } from 'mastra/internal/auth';
+import { fetchOrgs, getToken, resolveCurrentOrg } from 'mastra/internal/auth';
 import color from 'picocolors';
 import { x } from 'tinyexec';
 
@@ -239,7 +239,6 @@ async function runPlatformProvisioning({
       ? await resolveOrgFromFlag(token, org)
       : await resolveCurrentOrg(token, { forcePrompt: true });
     p.log.info(`Using organization ${color.cyan(orgName)}.`);
-    envAccumulator.MASTRA_SHARED_API_URL = MASTRA_PLATFORM_API_URL;
     envAccumulator.MASTRA_ORGANIZATION_ID = orgId;
 
     // 3. Project — session-auth POST /v1/server/projects.


### PR DESCRIPTION
## Summary

`npm create factory` wrote `MASTRA_SHARED_API_URL` (from the CLI's compile-time `MASTRA_PLATFORM_API_URL` constant) into every scaffolded project's `.env` during platform provisioning. This pinned new factories to whichever platform environment the CLI binary happened to be built against.

Platform consumers (`mastracode/factory` api-client) already fall back to the production platform URL when the env var is absent, so the write is unnecessary — and dropping it lets scaffolded projects follow the runtime default while still allowing users to set `MASTRA_SHARED_API_URL` manually to target another environment.

- Remove the `MASTRA_SHARED_API_URL` write from platform provisioning in `create.ts`
- Remove the now-unused `MASTRA_PLATFORM_API_URL` import
- Update `create.test.ts` to assert the key is no longer written
- Changeset: patch bump for `create-factory`

## Test plan

- `pnpm --filter ./mastracode/mastra-factory test` — 31/31 pass
- `pnpm --filter ./mastracode/mastra-factory check` — clean
- `pnpm --filter ./mastracode/mastra-factory lint` — clean
- `pnpm --filter ./mastracode/mastra-factory build` — clean


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

New projects created with `npm create factory` will no longer be locked to the platform URL used to build the CLI. They use the normal runtime default instead, while users can still set a custom URL themselves.

## Changes

- Stopped writing `MASTRA_SHARED_API_URL` to scaffolded `.env` files during platform provisioning.
- Removed the unused `MASTRA_PLATFORM_API_URL` import.
- Updated provisioning tests for successful and failed Neon setup.
- Added a patch changeset for `create-factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->