### PR TITLE
fix(mastracode-web): chat threads fail to load with "Thread not found"

### DIFF
--- a/.changeset/mastracode-web-thread-addressing.md
+++ b/.changeset/mastracode-web-thread-addressing.md
@@ -1,0 +1,4 @@
+---
+---
+
+Fixed chat threads failing to load with "Thread not found" in MastraCode web. Factory-created work item threads and manually created user sessions now open their transcripts, and live factory runs stream into the thread page being viewed.

--- a/.changeset/mastracode-web-thread-addressing.md
+++ b/.changeset/mastracode-web-thread-addressing.md
@@ -1,4 +1,0 @@
----
----
-
-Fixed chat threads failing to load with "Thread not found" in MastraCode web. Factory-created work item threads and manually created user sessions now open their transcripts, and live factory runs stream into the thread page being viewed.

--- a/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
+++ b/mastracode/web/src/web/ui/domains/chat/context/ChatSessionProvider.tsx
@@ -9,8 +9,6 @@ import { useAgentControllerThreadMessages } from '../../../../../shared/hooks/us
 import { useFactoryQuery } from '../../../../../shared/hooks/useFactories';
 import { useEnsureMaterializedSandbox } from '../../../../../shared/hooks/useEnsureMaterializedSandbox';
 import { useUserSessionQuery } from '../../../../../shared/hooks/useWorkspaces';
-import { useFactoryAuth } from '../../../../../shared/hooks/useFactoryAuth';
-import { userSessionResourceId } from '../../auth/services/auth';
 import type { LinkedRepositoryPayload } from '../../workspaces/services/github';
 import { AGENT_CONTROLLER_ID } from '../services/constants';
 import { ChatCommandsProvider } from './ChatCommandsProvider';
@@ -42,7 +40,6 @@ export function ChatSessionConfigProvider({
   const { baseUrl } = useApiConfig();
   const factoryQuery = useFactoryQuery(factoryId);
   const sessionQuery = useUserSessionQuery(userScoped ? threadId : sessionId);
-  const authQuery = useFactoryAuth();
   const factory = factoryQuery.data;
   const storedSession = sessionQuery.data;
   const repository = storedSession
@@ -52,12 +49,16 @@ export function ChatSessionConfigProvider({
     : factory?.repositories[0];
   const ensureQuery = useEnsureMaterializedSandbox(repository?.projectRepositoryId);
   const resolvingSession = Boolean(userScoped ? threadId : sessionId) && sessionQuery.isPending;
-  const resourceId =
-    userScoped && authQuery.data ? userSessionResourceId(authQuery.data) : ensureQuery.data?.resourceId;
-  const projectPath = userScoped ? undefined : storedSession?.sessionId;
+  // Sessions and their threads are provisioned with the session's own id as the
+  // memory resourceId and no scope (see FactoryStartCoordinator.prepare and
+  // UserSessionsSection), so the chat surface must address the same
+  // (resourceId, no scope) session to read threads and share the live run.
+  // On user routes the :threadId param IS the sessionId.
+  const resourceId = userScoped ? threadId : (storedSession?.sessionId ?? sessionId);
+  const projectPath = undefined;
   const sessionEnabled = userScoped
     ? Boolean(storedSession) && !resolvingSession
-    : ensureQuery.isSuccess && Boolean(projectPath);
+    : ensureQuery.isSuccess && Boolean(storedSession) && !resolvingSession;
   const value = {
     resourceId: resourceId ?? '',
     sessionEnabled,

--- a/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/WorkspacesSection.tsx
@@ -102,29 +102,26 @@ export function WorkspacesSection() {
   const openWorkspaceThread = async (workspace: FactoryUserSession) => {
     clearAttention(workspace.sessionId);
     try {
+      // Workspace sessions (and their threads) live under the session's own id
+      // as the memory resourceId with no scope — see FactoryStartCoordinator.
       const { session: targetSession } = createAgentControllerClient({
         agentControllerId: AGENT_CONTROLLER_ID,
-        resourceId,
-        scope: workspace.sessionId,
+        resourceId: workspace.sessionId,
         baseUrl,
         enabled: sessionEnabled,
       });
       const chatSession = requireAgentControllerSession(targetSession);
-      await chatSession.create({ tags: { projectPath: workspace.sessionId } });
-      const threadsKey = queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, resourceId, workspace.sessionId);
+      await chatSession.create({});
+      const threadsKey = queryKeys.agentControllerThreads(AGENT_CONTROLLER_ID, workspace.sessionId, undefined);
       const threads = await queryClient.fetchQuery({
         queryKey: threadsKey,
-        queryFn: () =>
-          chatSession.listThreads({
-            limit: AGENT_CONTROLLER_THREAD_PAGE_SIZE,
-            tags: { projectPath: workspace.sessionId },
-          }),
+        queryFn: () => chatSession.listThreads({ limit: AGENT_CONTROLLER_THREAD_PAGE_SIZE }),
       });
       const thread = conversationThread(threads)?.id;
       if (thread) {
         const messagesKey = queryKeys.agentControllerThreadMessages(
           AGENT_CONTROLLER_ID,
-          resourceId,
+          workspace.sessionId,
           thread,
           INITIAL_THREAD_MESSAGE_LIMIT,
         );


### PR DESCRIPTION
## Summary

Every newly created chat thread in MastraCode web — whether created by the Factory when an issue is ingested, or manually via "New session" — failed to load with `Thread not found: <id>` (a 500 from the thread-messages route) as soon as the page tried to render the transcript.

Since Factory workspaces became session-provisioned (#19908), sessions and their threads are created with the session's own id as the memory `resourceId` and no session scope: `FactoryStartCoordinator.prepare`, the rule dispatcher (`getSessionByResource(binding.resourceId)`), and `UserSessionsSection` all address `(resourceId = sessionId)`. The chat read surface was never updated — `ChatSessionConfigProvider` still resolved `resourceId` to the factory project id for workspace threads and to the signed-in user id for user threads. Core's thread-ownership check (`SessionThread.#requireOwnedThread`) treats threads owned by another resource as missing, so every read 404'd.

## Changes

- `ChatSessionConfigProvider` now derives `resourceId` from the route's session id (the `:sessionId` param on workspace thread routes; on user routes the `:threadId` param *is* the session id) and drops the per-worktree session scope. Addressing the same `(resourceId, no scope)` session the coordinator bound also means live factory runs stream into the page the user is viewing instead of a parallel scoped session.
- The workspace sidebar's thread-opening flow addresses each workspace's own session directly instead of listing threads under the shared factory resource with `projectPath` tags.

## Test plan

- `vitest --config e2e/web-ui/vitest.config.ts`: 40 files, 216 tests pass
- `tsc --noEmit` and prettier clean in `mastracode/web`
- Manually verified locally: creating a GitHub issue produces a work item whose thread page loads and streams; manually created user sessions open their transcript after refresh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Chat sessions were looking for conversations in the wrong place. This change makes each session use its own ID consistently, so chat threads load correctly.

## What changed

- Updated chat session configuration to derive the memory resource ID from route parameters and stored sessions.
- Removed unnecessary session scoping and project-path tagging.
- Updated the workspace sidebar to open and query threads directly by workspace session ID.
- Maintained session-loading safeguards while simplifying thread addressing.

## Validation

- 216 tests passing across 40 files.
- TypeScript and formatting checks passed.
- Manually verified GitHub issue-created work items and user session transcript loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->