### PR TITLE
feat(create-factory): announce auth flow and summarize provisioned infra

### DIFF
--- a/.changeset/huge-laws-make.md
+++ b/.changeset/huge-laws-make.md
@@ -1,0 +1,8 @@
+---
+'create-factory': patch
+---
+
+Improved the create-factory sign-in and success experience:
+
+- When no Mastra platform session exists, the CLI now pauses with "Mastra account is required, press enter to continue..." before opening the browser auth flow instead of opening it unannounced.
+- The success message now summarizes the infrastructure provisioned on Mastra platform (project, Postgres database, credentials in .env), notes that deployed code agent sessions run inside Mastra platform sandboxes, and links directly to the new project on https://projects.mastra.ai for managing project settings.

--- a/.changeset/huge-laws-make.md
+++ b/.changeset/huge-laws-make.md
@@ -5,4 +5,4 @@
 Improved the create-factory sign-in and success experience:
 
 - When no Mastra platform session exists, the CLI now pauses with "Mastra account is required, press enter to continue..." before opening the browser auth flow instead of opening it unannounced.
-- The success message now summarizes the infrastructure provisioned on Mastra platform (project, Postgres database, credentials in .env), notes that deployed code agent sessions run inside Mastra platform sandboxes, and links directly to the new project on https://projects.mastra.ai for managing project settings.
+- The success message now summarizes the infrastructure provisioned on Mastra platform (project, Postgres database, credentials in .env), notes that deployed code agent sessions run inside Mastra platform sandboxes, and links to https://projects.mastra.ai for managing the project.

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -253,7 +253,8 @@ describe('create (platform provisioning)', () => {
     expect(note).toContain('Acme');
     expect(note).toContain('Postgres database');
     expect(note).toContain('code agent sessions run inside Mastra platform sandboxes');
-    expect(note).toContain('https://projects.mastra.ai/orgs/org_123/projects/proj_abc');
+    expect(note).toContain('Manage your project at');
+    expect(note).toContain('https://projects.mastra.ai');
   });
 
   it('surfaces a Neon 403 as a "need admin role" hint without failing the run', async () => {

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -37,6 +37,7 @@ const platform = vi.hoisted(() => ({
 
 const cliAuth = vi.hoisted(() => ({
   getToken: vi.fn(),
+  loadCredentials: vi.fn(),
   resolveCurrentOrg: vi.fn(),
   fetchOrgs: vi.fn(),
   MASTRA_PLATFORM_API_URL: 'https://platform.example.test',
@@ -77,6 +78,8 @@ beforeEach(() => {
   vi.clearAllMocks();
 
   // Sensible default: platform provisioning succeeds. Tests can override.
+  // Cached credentials exist, so no "press enter to open auth flow" pause.
+  cliAuth.loadCredentials.mockResolvedValue({ token: 'cached' });
   cliAuth.getToken.mockResolvedValue('wos-token');
   cliAuth.resolveCurrentOrg.mockResolvedValue({ orgId: 'org_123', orgName: 'Acme' });
   cliAuth.fetchOrgs.mockResolvedValue([
@@ -242,11 +245,15 @@ describe('create (platform provisioning)', () => {
       }),
     );
 
-    // Success outro mentions the connected project.
+    // Success outro summarizes the provisioned infra so the user isn't
+    // surprised by what now exists in their platform org.
     const note = clack.note.mock.calls[0]![0] as string;
-    expect(note).toContain('Platform connected.');
+    expect(note).toContain('Provisioned on Mastra platform');
     expect(note).toContain('my-factory');
     expect(note).toContain('Acme');
+    expect(note).toContain('Postgres database');
+    expect(note).toContain('code agent sessions run inside Mastra platform sandboxes');
+    expect(note).toContain('https://projects.mastra.ai/orgs/org_123/projects/proj_abc');
   });
 
   it('surfaces a Neon 403 as a "need admin role" hint without failing the run', async () => {
@@ -311,6 +318,44 @@ describe('create (platform provisioning)', () => {
     expect(cliAuth.fetchOrgs).toHaveBeenCalledTimes(1);
     expect(cliAuth.resolveCurrentOrg).not.toHaveBeenCalled();
     expect(platform.createServerProject).toHaveBeenCalledWith(expect.objectContaining({ orgId: 'org_456' }));
+  });
+
+  it('pauses with a "press enter" prompt before opening the auth flow when not logged in', async () => {
+    vi.stubEnv('MASTRA_API_TOKEN', '');
+    cliAuth.loadCredentials.mockResolvedValue(null);
+    clack.text.mockResolvedValue('');
+
+    await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
+
+    expect(clack.text).toHaveBeenCalledWith({
+      message: 'Mastra account is required, press enter to continue...',
+      defaultValue: '',
+    });
+    // Prompt shown before the auth flow starts.
+    expect(clack.text.mock.invocationCallOrder[0]!).toBeLessThan(cliAuth.getToken.mock.invocationCallOrder[0]!);
+    expect(clack.note).toHaveBeenCalledWith(expect.stringContaining('Provisioned on Mastra platform'), 'Next steps');
+    vi.unstubAllEnvs();
+  });
+
+  it('skips the auth pause when cached credentials already exist', async () => {
+    await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
+
+    expect(clack.text).not.toHaveBeenCalled();
+    expect(cliAuth.getToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats cancelling the auth pause as a provisioning failure without opening the auth flow', async () => {
+    vi.stubEnv('MASTRA_API_TOKEN', '');
+    cliAuth.loadCredentials.mockResolvedValue(null);
+    clack.text.mockResolvedValue(Symbol.for('clack.cancel'));
+
+    await create({ projectName: 'my-factory', template: TEMPLATE_REPO, analytics });
+
+    expect(cliAuth.getToken).not.toHaveBeenCalled();
+    const note = clack.note.mock.calls[0]![0] as string;
+    expect(note).toContain('Platform provisioning failed');
+    expect(note).toContain('Sign-in cancelled.');
+    vi.unstubAllEnvs();
   });
 
   it('--org fails with a clear message when no org matches', async () => {

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -190,7 +190,7 @@ export async function create(args: CreateArgs): Promise<void> {
       `  - Postgres database (credentials written to ${color.cyan('.env')})`,
       '',
       'When deployed, code agent sessions run inside Mastra platform sandboxes.',
-      `Manage project settings at ${color.underline(`https://projects.mastra.ai/orgs/${platformResult.orgId}/projects/${platformResult.project.id}`)}`,
+      `Manage your project at ${color.underline('https://projects.mastra.ai')}`,
     );
   } else if (args.noPlatform) {
     lines.push(

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -4,7 +4,7 @@ import * as p from '@clack/prompts';
 // `mastra/internal/auth` is the CLI's internal barrel — drives the browser-auth
 // flow and reuses persisted credentials + org resolution rather than duplicating
 // them here.
-import { fetchOrgs, getToken, resolveCurrentOrg } from 'mastra/internal/auth';
+import { fetchOrgs, getToken, loadCredentials, resolveCurrentOrg } from 'mastra/internal/auth';
 import color from 'picocolors';
 import { x } from 'tinyexec';
 
@@ -185,8 +185,12 @@ export async function create(args: CreateArgs): Promise<void> {
   ];
   if (platformResult) {
     lines.push(
-      `${color.green('Platform connected.')} Project ${color.cyan(platformResult.project.name)} in ${color.cyan(platformResult.orgName)}.`,
-      `Wrote ${color.cyan('MASTRA_PROJECT_ID')}, ${color.cyan('MASTRA_PLATFORM_SECRET_KEY')}, and ${color.cyan('DATABASE_URL')} to ${color.cyan('.env')}.`,
+      `${color.green('Provisioned on Mastra platform')} in ${color.cyan(platformResult.orgName)}:`,
+      `  - Project ${color.cyan(platformResult.project.name)}`,
+      `  - Postgres database (credentials written to ${color.cyan('.env')})`,
+      '',
+      'When deployed, code agent sessions run inside Mastra platform sandboxes.',
+      `Manage project settings at ${color.underline(`https://projects.mastra.ai/orgs/${platformResult.orgId}/projects/${platformResult.project.id}`)}`,
     );
   } else if (args.noPlatform) {
     lines.push(
@@ -229,6 +233,18 @@ async function runPlatformProvisioning({
 
   try {
     // 1. Auth — triggers the browser-auth flow if no cached credential.
+    //    When that flow is about to open (no env token, no cached credential),
+    //    pause first so the browser doesn't pop open unannounced.
+    const willOpenAuthFlow = !process.env.MASTRA_API_TOKEN && !(await loadCredentials());
+    if (willOpenAuthFlow) {
+      const proceed = await p.text({
+        message: 'Mastra account is required, press enter to continue...',
+        defaultValue: '',
+      });
+      if (p.isCancel(proceed)) {
+        throw new Error('Sign-in cancelled.');
+      }
+    }
     p.log.info('Signing in to Mastra…');
     const token = await getToken();
 


### PR DESCRIPTION
Two small UX improvements to `npm create factory` platform provisioning.

Before, the browser auth window popped open with no warning the moment provisioning started. Now, if there's no cached session (and no `MASTRA_API_TOKEN`), the CLI pauses first:

```
Mastra account is required, press enter to continue...
```

Ctrl+C at the prompt aborts provisioning cleanly instead of opening the browser.

The success message also now explains what was actually created in your org instead of just "Platform connected":

```
Provisioned on Mastra platform in Acme:
  - Project my-factory
  - Postgres database (credentials written to .env)

When deployed, code agent sessions run inside Mastra platform sandboxes.
Manage project settings at https://projects.mastra.ai/orgs/<orgId>/projects/<projectId>
```

The settings link goes directly to the new project. Covered by unit tests (prompt shown / skipped when cached / cancel aborts, plus the new success note contents).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This makes setting up a new project easier by warning users before opening the sign-in page, letting them cancel, and clearly explaining what was created afterward.

## What changed

- Added an authentication prompt before browser sign-in when no token or cached session is available.
- Supports cancelling provisioning with Ctrl+C before authentication begins.
- Expanded the success message to include:
  - Provisioned project details
  - Postgres database and `.env` credentials
  - Mastra sandbox usage for deployed sessions
  - Project settings link
- Added tests for prompt behavior, cached credentials, cancellation, and success messaging.
- Added a patch changeset for `create-factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->