### PR TITLE
feat(mastracode-web): add brand logo and Alpha badge to sidebar nav

### DIFF
--- a/mastracode/web/src/web/ui/Sidebar.tsx
+++ b/mastracode/web/src/web/ui/Sidebar.tsx
@@ -1,4 +1,3 @@
-import { Badge } from '@mastra/playground-ui/components/Badge';
 import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
@@ -20,6 +19,38 @@ function useSettingsOpen() {
 }
 
 /**
+ * Alpha status tag rendered as a dashed-outline chip (Clerk-style), so it reads
+ * as a subtle stage marker rather than a solid pill competing with the nav items.
+ */
+function AlphaBadge() {
+  return (
+    <span className="relative bg-blue-50 px-[0.1875rem] font-medium text-[0.625rem]/[0.875rem] text-blue-500 uppercase tracking-wide dark:bg-blue-950">
+      Alpha
+      <span className="-top-px absolute inset-x-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+        <svg aria-hidden="true" height="1" stroke="currentColor" strokeDasharray="3.3 1" width="100%">
+          <line x1="0" x2="100%" y1="0.5" y2="0.5" />
+        </svg>
+      </span>
+      <span className="-bottom-px absolute inset-x-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+        <svg aria-hidden="true" height="1" stroke="currentColor" strokeDasharray="3.3 1" width="100%">
+          <line x1="0" x2="100%" y1="0.5" y2="0.5" />
+        </svg>
+      </span>
+      <span className="-left-px absolute inset-y-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+        <svg aria-hidden="true" height="100%" stroke="currentColor" strokeDasharray="3.3 1" width="1">
+          <line x1="0.5" x2="0.5" y1="0" y2="100%" />
+        </svg>
+      </span>
+      <span className="-right-px absolute inset-y-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+        <svg aria-hidden="true" height="100%" stroke="currentColor" strokeDasharray="3.3 1" width="1">
+          <line x1="0.5" x2="0.5" y1="0" y2="100%" />
+        </svg>
+      </span>
+    </span>
+  );
+}
+
+/**
  * Composition shell: each section owns its data through local query hooks,
  * focused chat hooks, or the router location, so nothing is wired through props here.
  */
@@ -31,9 +62,7 @@ export function Sidebar() {
       <MainSidebar.Nav aria-label={settingsOpen ? 'Settings sections' : 'Main'}>
         <div className="mb-2 flex items-center justify-between gap-2 px-3 pt-1">
           <LogoWithoutText aria-label="Mastra" role="img" className="h-4 w-auto text-icon6" />
-          <Badge variant="default" size="xs" className="uppercase tracking-wide">
-            Alpha
-          </Badge>
+          <AlphaBadge />
         </div>
         {settingsOpen ? (
           <SettingsNavigation />

--- a/mastracode/web/src/web/ui/Sidebar.tsx
+++ b/mastracode/web/src/web/ui/Sidebar.tsx
@@ -21,27 +21,28 @@ function useSettingsOpen() {
 /**
  * Alpha status tag rendered as a dashed-outline chip (Clerk-style), so it reads
  * as a subtle stage marker rather than a solid pill competing with the nav items.
+ * Tinted with the Mastra brand green (#7aff78, `--color-ds-green` on the website).
  */
 function AlphaBadge() {
   return (
-    <span className="relative bg-blue-50 px-[0.1875rem] font-medium text-[0.625rem]/[0.875rem] text-blue-500 uppercase tracking-wide dark:bg-blue-950">
+    <span className="relative bg-[#7aff78]/10 px-[0.1875rem] font-medium text-[0.625rem]/[0.875rem] text-[#7aff78] uppercase tracking-wide">
       Alpha
-      <span className="-top-px absolute inset-x-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+      <span className="-top-px absolute inset-x-[-0.1875rem] block transform-gpu text-[#7aff78]/40">
         <svg aria-hidden="true" height="1" stroke="currentColor" strokeDasharray="3.3 1" width="100%">
           <line x1="0" x2="100%" y1="0.5" y2="0.5" />
         </svg>
       </span>
-      <span className="-bottom-px absolute inset-x-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+      <span className="-bottom-px absolute inset-x-[-0.1875rem] block transform-gpu text-[#7aff78]/40">
         <svg aria-hidden="true" height="1" stroke="currentColor" strokeDasharray="3.3 1" width="100%">
           <line x1="0" x2="100%" y1="0.5" y2="0.5" />
         </svg>
       </span>
-      <span className="-left-px absolute inset-y-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+      <span className="-left-px absolute inset-y-[-0.1875rem] block transform-gpu text-[#7aff78]/40">
         <svg aria-hidden="true" height="100%" stroke="currentColor" strokeDasharray="3.3 1" width="1">
           <line x1="0.5" x2="0.5" y1="0" y2="100%" />
         </svg>
       </span>
-      <span className="-right-px absolute inset-y-[-0.1875rem] block transform-gpu text-blue-200 dark:text-blue-900">
+      <span className="-right-px absolute inset-y-[-0.1875rem] block transform-gpu text-[#7aff78]/40">
         <svg aria-hidden="true" height="100%" stroke="currentColor" strokeDasharray="3.3 1" width="1">
           <line x1="0.5" x2="0.5" y1="0" y2="100%" />
         </svg>

--- a/mastracode/web/src/web/ui/Sidebar.tsx
+++ b/mastracode/web/src/web/ui/Sidebar.tsx
@@ -1,3 +1,5 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { LogoWithoutText } from '@mastra/playground-ui/components/Logo';
 import { MainSidebar } from '@mastra/playground-ui/components/MainSidebar';
 import { Skeleton } from '@mastra/playground-ui/components/Skeleton';
 import { CircleUserRound, Settings } from 'lucide-react';
@@ -27,6 +29,12 @@ export function Sidebar() {
   return (
     <MainSidebar className="h-full">
       <MainSidebar.Nav aria-label={settingsOpen ? 'Settings sections' : 'Main'}>
+        <div className="mb-2 flex items-center justify-between gap-2 px-3 pt-1">
+          <LogoWithoutText aria-label="Mastra" role="img" className="h-4 w-auto text-icon6" />
+          <Badge variant="default" size="xs" className="uppercase tracking-wide">
+            Alpha
+          </Badge>
+        </div>
         {settingsOpen ? (
           <SettingsNavigation />
         ) : (


### PR DESCRIPTION
## What

Adds a brand header row to the top of the mastracode-web sidebar navigation: the Mastra logo (`LogoWithoutText`) on the left and an **Alpha** `Badge` on the right.

```tsx
<div className="mb-2 flex items-center justify-between gap-2 px-3 pt-1">
  <LogoWithoutText aria-label="Mastra" role="img" className="h-4 w-auto text-icon6" />
  <Badge variant="default" size="xs" className="uppercase tracking-wide">
    Alpha
  </Badge>
</div>
```

## Why

Gives the sidebar a clear product identity and signals the app's Alpha status directly in the nav chrome.

## Notes

- Both `LogoWithoutText` and `Badge` come from the `@mastra/playground-ui` design system.
- `mastracode-web` is a private package, so no changeset is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The sidebar now has a Mastra logo and an “Alpha” label at the top, making it clearer which product users are viewing and that it is still in an early stage.

## Changes

- Added a branded header row to the `mastracode-web` sidebar.
- Displayed the Mastra logo alongside an Alpha badge.
- Styled the badge with a dashed outline and Mastra brand-green tinting.
- No changeset required because `mastracode-web` is a private package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->