### PR TITLE
feat(mastracode-web): tune sidebar spacing and factory switcher style

### DIFF
--- a/mastracode/web/src/web/ui/Sidebar.tsx
+++ b/mastracode/web/src/web/ui/Sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar() {
   return (
     <MainSidebar className="h-full">
       <MainSidebar.Nav aria-label={settingsOpen ? 'Settings sections' : 'Main'}>
-        <div className="mt-2 mb-2 flex items-center justify-between gap-2 px-3 pt-1">
+        <div className="mt-1 mb-2 flex items-center justify-between gap-2 px-3 pt-1">
           <LogoWithoutText aria-label="Mastra" role="img" className="h-4 w-auto text-icon6" />
           <AlphaBadge />
         </div>

--- a/mastracode/web/src/web/ui/Sidebar.tsx
+++ b/mastracode/web/src/web/ui/Sidebar.tsx
@@ -61,7 +61,7 @@ export function Sidebar() {
   return (
     <MainSidebar className="h-full">
       <MainSidebar.Nav aria-label={settingsOpen ? 'Settings sections' : 'Main'}>
-        <div className="mb-2 flex items-center justify-between gap-2 px-3 pt-1">
+        <div className="mt-2 mb-2 flex items-center justify-between gap-2 px-3 pt-1">
           <LogoWithoutText aria-label="Mastra" role="img" className="h-4 w-auto text-icon6" />
           <AlphaBadge />
         </div>

--- a/mastracode/web/src/web/ui/domains/workspaces/components/FactorySwitcher.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/FactorySwitcher.tsx
@@ -29,7 +29,7 @@ export function FactorySwitcher() {
         id="factory-switcher-trigger"
         type="button"
         aria-label="Select factory"
-        className={cn(buttonVariants({ variant: 'ghost' }), 'w-full justify-start gap-2 px-2.5 text-left [&>svg]:mx-0')}
+        className={cn(buttonVariants({ variant: 'default' }), 'mt-1 w-full justify-start gap-2 px-2.5 text-left [&>svg]:mx-0')}
       >
         <FactoryIcon size={16} className="shrink-0 text-icon3" />
         <Txt as="span" variant="ui-sm" className="min-w-0 flex-1 truncate text-icon6">

--- a/mastracode/web/src/web/ui/domains/workspaces/components/FactorySwitcher.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/FactorySwitcher.tsx
@@ -29,7 +29,10 @@ export function FactorySwitcher() {
         id="factory-switcher-trigger"
         type="button"
         aria-label="Select factory"
-        className={cn(buttonVariants({ variant: 'default' }), 'mt-1 w-full justify-start gap-2 px-2.5 text-left [&>svg]:mx-0')}
+        className={cn(
+          buttonVariants({ variant: 'default' }),
+          'mt-1 w-full justify-start gap-2 px-2.5 text-left [&>svg]:mx-0',
+        )}
       >
         <FactoryIcon size={16} className="shrink-0 text-icon3" />
         <Txt as="span" variant="ui-sm" className="min-w-0 flex-1 truncate text-icon6">


### PR DESCRIPTION
Follow-up to #20027.

## What

- **Sidebar brand header** — add `mt-2` so the logo/badge row sits lower from the top edge.
- **Factory switcher trigger** — add `mt-1` and switch the button from the `ghost` to the `default` variant, giving it a filled resting state.

## Notes

- `mastracode-web` is a private package, so no changeset is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The sidebar just got a little more breathing room, and the “factory switcher” button now looks solid (not transparent). This helps it stand out and makes the sidebar easier to scan.

## Changes

- Added `mt-2` spacing to the sidebar brand header.
- Added `mt-1` spacing to the factory switcher trigger.
- Changed the factory switcher button variant from `ghost` to `default` to get a filled resting state.
- No changeset was included because the package is private.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->