### PR TITLE
fix(mastracode): injected storage crashes when dependency graph has duplicate @mastra/core copies

### DIFF
--- a/.changeset/tiny-falcons-live.md
+++ b/.changeset/tiny-falcons-live.md
@@ -1,0 +1,5 @@
+---
+'@mastra/code-sdk': patch
+---
+
+Fixed a crash (`TypeError: Cannot read properties of undefined (reading 'includes')`) when a Mastra store instance is injected into the SDK from a project whose dependency graph contains duplicate copies of @mastra/core. Injected stores are now detected structurally instead of with `instanceof`, so stores built against a different core copy are recognized correctly instead of being mistaken for a storage config.

--- a/.changeset/witty-badgers-wave.md
+++ b/.changeset/witty-badgers-wave.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed a server startup crash when the factory's storage backend could not be recognized by the SDK. The factory now tells the SDK explicitly whether its Mastra store is Postgres or LibSQL, so agent state wiring works even when the project's dependency graph contains duplicate copies of Mastra packages.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -285,6 +285,18 @@ describe('MastraFactory.prepare', () => {
     expect(config.vector).toBe(vector);
   });
 
+  it('tells the SDK which backend the Mastra store uses (instanceof breaks across duplicate package copies)', async () => {
+    const config = await prepareFactory({ storage: fakeStorage() });
+    expect(config.storageBackend).toBe('libsql');
+  });
+
+  it('resolves the pg backend from the FactoryStorage class name', async () => {
+    class PgFactoryStorage extends LibSQLFactoryStorage {}
+    const storage = new PgFactoryStorage({ url: ':memory:', id: 'factory-test-pg-named' });
+    const config = await prepareFactory({ storage });
+    expect(config.storageBackend).toBe('pg');
+  });
+
   it('installs a Web Factory session workspace resolver instead of changing the SDK default', async () => {
     const config = await prepareFactory({ storage: fakeStorage() });
     expect(config.workspace).toEqual(expect.any(Function));

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -535,6 +535,19 @@ export class MastraFactory {
       }
     }
 
+    // The SDK needs to know which backend the injected Mastra store uses
+    // (its own `instanceof` detection breaks when the dependency graph holds
+    // duplicate package copies). Resolve it by walking the FactoryStorage
+    // prototype chain by class name — the factory can't import the concrete
+    // classes since '@mastra/pg' / '@mastra/libsql' are the user's choice.
+    const mastraStorageBackend = (() => {
+      for (let proto = Object.getPrototypeOf(storage); proto; proto = Object.getPrototypeOf(proto)) {
+        if (proto.constructor?.name === 'PgFactoryStorage') return 'pg' as const;
+        if (proto.constructor?.name === 'LibSQLFactoryStorage') return 'libsql' as const;
+      }
+      return undefined;
+    })();
+
     // Integrations contributing tools to agent sessions: org-scoped
     // `agentTools` (resolved per request) + session-scoped `sessionTools`.
     const toolIntegrations = integrationRegistrations.filter(
@@ -557,6 +570,7 @@ export class MastraFactory {
       // org/user), so the host machine's TUI settings.json must not seed them.
       disableSettingsOmSeed: true,
       storage: storage.getMastraStorage(),
+      ...(mastraStorageBackend ? { storageBackend: mastraStorageBackend } : {}),
       ...(factoryProcessor ? { inputProcessors: [factoryProcessor] } : {}),
       ...(vector ? { vector } : {}),
       ...(toolIntegrations.length > 0 || (workItemsStorage && transitionService)

--- a/mastracode/sdk/src/__tests__/index.test.ts
+++ b/mastracode/sdk/src/__tests__/index.test.ts
@@ -471,6 +471,56 @@ describe('createMastraCode', () => {
     expect(createStorageMock).not.toHaveBeenCalled();
   });
 
+  // Simulates a duplicated-dependency graph: the injected store was built
+  // against a different copy of @mastra/core, so `instanceof
+  // MastraCompositeStore` (and `instanceof LibSQLStore`/`PostgresStore`) fail
+  // even though the instance is a real store. Detection must be structural.
+  describe('injected storage from a foreign @mastra/core copy', () => {
+    class ForeignCompositeStore {
+      stores = {};
+      async init() {}
+      __registerMastra() {}
+    }
+
+    it('detects a foreign LibSQLStore instance and resolves the libsql backend', async () => {
+      class LibSQLStore extends ForeignCompositeStore {}
+      const { createMastraCode } = await import('../index.js');
+
+      await createMastraCode({ storage: new LibSQLStore() as any });
+
+      expect(createStorageMock).not.toHaveBeenCalled();
+    });
+
+    it('detects a foreign PostgresStore subclass and resolves the pg backend', async () => {
+      class PostgresStore extends ForeignCompositeStore {}
+      class CustomPgStore extends PostgresStore {}
+      const { createMastraCode } = await import('../index.js');
+
+      await createMastraCode({ storage: new CustomPgStore() as any });
+
+      expect(createStorageMock).not.toHaveBeenCalled();
+    });
+
+    it('accepts an unrecognized foreign store when storageBackend is configured', async () => {
+      class SomeOtherStore extends ForeignCompositeStore {}
+      const { createMastraCode } = await import('../index.js');
+
+      await createMastraCode({ storage: new SomeOtherStore() as any, storageBackend: 'pg' });
+
+      expect(createStorageMock).not.toHaveBeenCalled();
+    });
+
+    it('still requires an explicit backend for unrecognized foreign stores', async () => {
+      class SomeOtherStore extends ForeignCompositeStore {}
+      const { createMastraCode } = await import('../index.js');
+
+      await expect(createMastraCode({ storage: new SomeOtherStore() as any })).rejects.toThrow(
+        'storageBackend is required when injecting a custom storage instance.',
+      );
+      expect(createStorageMock).not.toHaveBeenCalled();
+    });
+  });
+
   it('uses caller memory while applying configDir to startup services and state', async () => {
     const projectPath = '/tmp/mastracode-project';
     const customMemory = { id: 'custom-memory' };

--- a/mastracode/sdk/src/index.ts
+++ b/mastracode/sdk/src/index.ts
@@ -297,13 +297,40 @@ function resolveCloudObservabilityConfig(
  *
  * See {@link bootLocalAgentController} (Case 3) and `mountAgentControllerOnMastra` (Cases 1 & 2).
  */
+/**
+ * `instanceof` checks against Mastra classes are unreliable here: published
+ * packages pin exact `@mastra/core` versions, so a user's dependency graph can
+ * contain multiple copies of core (and peer-keyed copies of `@mastra/libsql` /
+ * `@mastra/pg`). A store built against one copy fails `instanceof` against
+ * another — the injected instance then silently fell through to the
+ * StorageConfig path and crashed on `config.url`. These structural checks work
+ * across duplicated copies.
+ */
+function isInjectedStorageInstance(storage: MastraCodeConfig['storage']): storage is MastraCompositeStore {
+  if (!storage) return false;
+  if (storage instanceof MastraCompositeStore) return true;
+  // A StorageConfig is a plain data object with a string `backend`
+  // discriminant; a store instance carries the MastraCompositeStore method
+  // surface.
+  const candidate = storage as Partial<MastraCompositeStore>;
+  return typeof candidate.init === 'function' && typeof candidate.__registerMastra === 'function';
+}
+
+/** Cross-copy-safe class check: walks the prototype chain by constructor name. */
+function hasAncestorClassNamed(value: object, className: string): boolean {
+  for (let proto = Object.getPrototypeOf(value); proto; proto = Object.getPrototypeOf(proto)) {
+    if (proto.constructor?.name === className) return true;
+  }
+  return false;
+}
+
 function resolveInjectedStorageBackend(
   storage: MastraCompositeStore,
   configuredBackend?: 'libsql' | 'pg',
 ): 'libsql' | 'pg' {
   if (configuredBackend) return configuredBackend;
-  if (storage instanceof LibSQLStore) return 'libsql';
-  if (storage instanceof PostgresStore) return 'pg';
+  if (storage instanceof LibSQLStore || hasAncestorClassNamed(storage, 'LibSQLStore')) return 'libsql';
+  if (storage instanceof PostgresStore || hasAncestorClassNamed(storage, 'PostgresStore')) return 'pg';
   throw new Error('storageBackend is required when injecting a custom storage instance.');
 }
 
@@ -410,7 +437,7 @@ export async function createMastraCodeAgentController(config?: MastraCodeConfig)
 
   // Storage. An injected instance is used as-is — no connection test, no
   // LibSQL fallback: if the injected store fails, that's a hard error.
-  const injectedStorage = config?.storage instanceof MastraCompositeStore ? config.storage : undefined;
+  const injectedStorage = isInjectedStorageInstance(config?.storage) ? config.storage : undefined;
   const storageConfig = injectedStorage
     ? undefined
     : ((config?.storage as StorageConfig | undefined) ??


### PR DESCRIPTION
## Summary

Fixes a startup crash (`TypeError: Cannot read properties of undefined (reading 'includes')` at `new LibSQLStore`) hit when running a Mastra Factory app against published packages.

**Root cause:** `@mastra/code-sdk` pins an exact `@mastra/core` version, so a consumer's dependency graph can contain multiple copies of core (and peer-keyed copies of `@mastra/libsql` / `@mastra/pg`). When the factory injects its store into `prepareAgentControllerMount`, the SDK's `config.storage instanceof MastraCompositeStore` check fails across copies. The store instance then falls through to the `StorageConfig` path, where `buildLibSQLStore` reads `config.url` (undefined) and crashes.

**Fix (defense in depth):**
- `@mastra/code-sdk`: injected stores are now detected structurally (the `MastraCompositeStore` method surface) with `instanceof` kept as the fast path, and the backend is resolved by walking the prototype chain by class name (`LibSQLStore` / `PostgresStore`) so it works across duplicated package copies.
- `@mastra/factory`: the factory now passes `storageBackend` explicitly to the SDK mount, resolved from the `FactoryStorage` class name (`PgFactoryStorage` → `pg`, `LibSQLFactoryStorage` → `libsql`), so backend resolution never depends on cross-copy `instanceof` checks.

Unknown injected stores without an explicit `storageBackend` still fail loudly with the existing error.

## Test plan

- New SDK tests simulating a foreign-core-copy store (duck-typed, not `instanceof`): detection as an instance, backend resolution for LibSQL/Postgres subclasses, explicit-backend acceptance, and the loud failure for unrecognized stores.
- New factory tests asserting `storageBackend` is forwarded to the SDK mount (`libsql` for `LibSQLFactoryStorage`, `pg` via class-name resolution).
- `pnpm --filter ./mastracode/sdk test` (1055 passed), `pnpm --filter ./mastracode/factory test` (954 passed), `tsc --noEmit` clean in both packages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Some apps crashed because they had two copies of the same storage code, so the app could not recognize its own storage. This change identifies storage by its shape and class name instead, and tells the factory which database it uses.

## Changes

- Detects injected stores across duplicate `@mastra/core` copies without relying solely on `instanceof`.
- Resolves LibSQL and Postgres backends by walking the prototype chain.
- Passes the resolved `storageBackend` from `@mastra/factory` to the SDK.
- Preserves explicit backend configuration and existing errors for unknown stores.
- Adds SDK and factory tests covering cross-copy stores, backend resolution, and failure cases.
- Adds patch changesets for `@mastra/code-sdk` and `@mastra/factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->