### PR TITLE
docs: add Vercel sandbox providers to supported providers list

### DIFF
--- a/docs/src/content/en/docs/workspace/sandbox.mdx
+++ b/docs/src/content/en/docs/workspace/sandbox.mdx
@@ -37,6 +37,8 @@ Watch [Mastra remote sandboxes overview](https://www.youtube.com/watch?v=Ix2X-sj
 - [`ModalSandbox`](/reference/workspace/modal-sandbox): Executes commands in isolated Modal cloud sandboxes
 - [`PlatformSandbox`](/reference/workspace/platform-sandbox): Executes commands in a sandbox tied to a Mastra Platform environment
 - [`RailwaySandbox`](/reference/workspace/railway-sandbox): Executes commands in ephemeral, isolated Railway cloud sandboxes
+- [`VercelSandbox`](/reference/workspace/vercel-sandbox): Executes commands in an ephemeral Vercel Sandbox Firecracker MicroVM
+- [`VercelServerlessSandbox`](/reference/workspace/vercel-serverless): Executes commands as stateless Vercel serverless functions
 
 ## Basic usage
 
@@ -252,5 +254,6 @@ For the full `SandboxProcessManager` API (spawning processes programmatically, r
 - [`E2BSandbox` reference](/reference/workspace/e2b-sandbox)
 - [`LocalSandbox` reference](/reference/workspace/local-sandbox)
 - [`ModalSandbox` reference](/reference/workspace/modal-sandbox)
+- [`VercelSandbox` reference](/reference/workspace/vercel-sandbox)
 - [Workspace overview](/docs/workspace/overview)
 - [Filesystem](/docs/workspace/filesystem)


### PR DESCRIPTION
The workspace sandbox page lists supported providers but is missing both Vercel ones, even though they ship in `@mastra/vercel` and already have reference pages. This adds `VercelSandbox` (the Firecracker MicroVM backed by Vercel Sandbox) and `VercelServerlessSandbox` (stateless Vercel Functions) to the list, and adds `VercelSandbox` to the Related section next to the other cloud providers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The sandbox documentation now tells users that two Vercel sandbox options are available. It also links to VercelSandbox alongside other related cloud providers.

## Changes

- Added `VercelSandbox` and `VercelServerlessSandbox` to the supported providers list.
- Added `VercelSandbox` to the Related section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->