### PR TITLE
fix(factory): default publicUrl to the single-server origin (localhost:4111)

### DIFF
--- a/.changeset/crisp-owls-doubt.md
+++ b/.changeset/crisp-owls-doubt.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+The Factory's default `publicUrl` is now `http://localhost:4111` (the Factory server, which serves both the UI and the API) instead of `http://localhost:5173`. Generated Factory projects now run from a single server, so OAuth callback URLs and auth redirects derived from `publicUrl` point at the right origin out of the box. If you serve the SPA from a separate origin (for example a Vite dev server on :5173), set `publicUrl` (or `MASTRACODE_PUBLIC_URL`) explicitly.

--- a/.changeset/eighty-owls-travel.md
+++ b/.changeset/eighty-owls-travel.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Updated the generated project README for the single-server setup: the Factory UI and API are both served from `http://localhost:4111`, OAuth callback instructions use the server origin, and the removed `dev:prod` / `build:ui` scripts are no longer documented.

--- a/mastracode/factory/src/factory.test.ts
+++ b/mastracode/factory/src/factory.test.ts
@@ -331,13 +331,13 @@ describe('MastraFactory.prepare', () => {
     } satisfies AuthInitContext);
   });
 
-  it('defaults publicUrl to the local Factory UI origin', async () => {
+  it('defaults publicUrl to the local Factory server origin (single server serves UI and API)', async () => {
     const auth = fakeProvider();
     const storage = fakeStorage();
     await prepareFactory({ auth, storage });
     expect(auth.init).toHaveBeenCalledExactlyOnceWith({
       database: storage.authDatabase(),
-      publicUrl: 'http://localhost:5173',
+      publicUrl: 'http://localhost:4111',
       allowedOrigins: [],
     } satisfies AuthInitContext);
   });

--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -125,7 +125,8 @@ export interface MastraFactoryConfig {
    * Browser-facing origin used to build integration OAuth/install callback
    * URLs and to derive the auth redirect URI. On the platform the SPA is
    * hosted separately, so this MUST be the public API origin.
-   * Default: `http://localhost:5173` (the local Factory UI origin).
+   * Default: `http://localhost:4111` (the local Factory server, which also
+   * serves the UI).
    */
   publicUrl?: string;
   /**
@@ -297,7 +298,7 @@ export class MastraFactory {
     if (this.#preparing) throw new Error('MastraFactory.prepare() called twice');
     this.#preparing = true;
 
-    const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:5173').replace(/\/+$/, '');
+    const publicOrigin = (this.#config.publicUrl ?? 'http://localhost:4111').replace(/\/+$/, '');
     const allowedOrigins = (this.#config.allowedOrigins ?? []).map(o => o.replace(/\/+$/, '')).filter(Boolean);
     const storage = this.#config.storage;
     const vector = this.#config.vector;

--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -15,16 +15,16 @@ npm run db:up
 npm run dev
 ```
 
-- **Factory UI** → http://localhost:5173
+- **Factory UI** → http://localhost:4111
 - **API** → http://localhost:4111/api
 
-For a production-like, same-origin server without UI live reload, run `npm run dev:prod` and open http://localhost:5173.
+One server serves both the UI and the API.
 
 With zero configuration the app runs in local, auth-less mode (agents + local storage, no integrations). Open the Factory UI to finish setup — model provider keys are added there (Settings › Models). Deployment-level features enable themselves as you add environment variables — see below.
 
 ### Ports
 
-The UI port is **strict**: if 5173 is taken, `npm run dev` fails instead of moving to a free port, because OAuth callback URLs (WorkOS/GitHub/Linear) are registered against the configured origin and would silently break. To run on a different port, change both together — run with `MASTRACODE_UI_PORT=<port>` and set `MASTRACODE_PUBLIC_URL=http://localhost:<port>` in `.env` (then update the callback URLs on your OAuth apps). The API server port is overridable with `PORT`.
+The server port is overridable with `PORT`. OAuth callback URLs (WorkOS/GitHub/Linear) are registered against the configured origin, so if you change the port, also set `MASTRACODE_PUBLIC_URL=http://localhost:<port>` in `.env` (then update the callback URLs on your OAuth apps).
 
 ## Configuration
 
@@ -53,7 +53,7 @@ Without `APP_DATABASE_URL`, agent state falls back to a local libSQL file and in
 Integrations are per-organization, so they require sign-in, powered by [WorkOS](https://workos.com) (free tier is fine):
 
 1. Create a WorkOS project → copy the **API key** and **Client ID** into `.env`.
-2. In WorkOS → Redirects, add `http://localhost:5173/auth/callback`.
+2. In WorkOS → Redirects, add `http://localhost:4111/auth/callback`.
 3. Set `WORKOS_COOKIE_PASSWORD` to a random 32+ character string.
 
 ### GitHub
@@ -72,15 +72,14 @@ Create a Linear OAuth app (Linear → Settings → API → OAuth applications �
 
 | Script                      | What it does                                                                                   |
 | --------------------------- | ---------------------------------------------------------------------------------------------- |
-| `npm run dev`               | API server (:4111) + Factory UI (:5173) with live reload                                       |
-| `npm run dev:prod`          | Build the UI once and serve it from the Factory server (:5173)                                 |
+| `npm run dev`               | Factory server (:4111) serving the UI and the API                                              |
 | `npm run db:up` / `db:down` | Start/stop local Postgres + Redis (Docker)                                                     |
-| `npm run build`             | Build the SPA (`build:ui`) and bundle the server to `.mastra/output`                           |
+| `npm run build`             | Build the SPA and bundle the server to `.mastra/output`                                        |
 | `npm run start`             | Run the production build                                                                       |
-| `npm run deploy`            | Build, validate, and deploy to [Mastra Cloud](https://mastra.ai/docs/mastra-platform/overview) |
+| `npm run deploy`            | Build and deploy to [Mastra Cloud](https://mastra.ai/docs/mastra-platform/overview)            |
 | `npm run check`             | Typecheck server and UI                                                                        |
 
-`mastra build` and `mastra deploy` detect the Factory entry automatically and run `build:ui` (Vite) before bundling. The SPA is copied to `.mastra/output/factory/` and a `mastra-project.json` manifest is emitted alongside it.
+`mastra build` and `mastra deploy` detect the Factory entry automatically and build the SPA (Vite) before bundling. The SPA is copied to `.mastra/output/factory/` and a `mastra-project.json` manifest is emitted alongside it.
 
 ## Requirements
 

--- a/mastracode/web/.env.schema
+++ b/mastracode/web/.env.schema
@@ -14,10 +14,11 @@
 #   - WorkOS:  <MASTRACODE_PUBLIC_URL>/auth/callback
 #   - GitHub:  <MASTRACODE_PUBLIC_URL>/auth/github/callback
 #   - Linear:  <MASTRACODE_PUBLIC_URL>/auth/linear/callback
-# In dev the SPA is served by Vite on :5173 and proxies to the server (:4111),
-# so set this to the SPA origin (http://localhost:5173). Falls back to the
-# server bind when unset. Restart `web:dev` after changing this — varlock
-# re-reads .env on each start.
+# Defaults to http://localhost:4111 (the Factory server, which also serves
+# the UI) when unset. When developing with a separate Vite dev server (:5173
+# proxying to the API on :4111), set this to the SPA origin
+# (http://localhost:5173). Restart the dev server after changing this —
+# varlock re-reads .env on each start.
 # @public @type=url
 MASTRACODE_PUBLIC_URL=
 # Comma-separated origins allowed for credentialed cross-origin requests; only


### PR DESCRIPTION
## Summary

Follow-up to #20019, which made `create-factory` projects serve the Factory UI and API from a single `mastra factory dev` server on port 4111 (no separate Vite process).

The Factory's default `publicUrl` was still `http://localhost:5173` (the old standalone Vite origin), so out of the box, OAuth callback URLs (WorkOS/GitHub/Linear) and auth redirect URIs derived from `publicUrl` pointed at an origin nothing is listening on.

**Changes:**
- `@mastra/factory`: `publicUrl` now defaults to `http://localhost:4111` — the Factory server origin, which also serves the UI. Deployments and split-origin dev setups keep working by setting `publicUrl` / `MASTRACODE_PUBLIC_URL` explicitly, exactly as before.
- `create-factory` template README: updated for the single-server layout — UI and API both on :4111, WorkOS redirect instructions use the server origin, the port section describes `PORT` + `MASTRACODE_PUBLIC_URL` instead of the removed strict UI port, and the dropped `dev:prod` / `build:ui` scripts are no longer documented.
- `mastracode/web/.env.schema` comment: documents the new 4111 fallback and when to point `MASTRACODE_PUBLIC_URL` at a separate SPA origin (monorepo Vite dev on :5173).

## Test plan

- Updated the factory default-`publicUrl` test to expect `http://localhost:4111`.
- `pnpm --filter ./mastracode/factory test` (955 passed) and `tsc --noEmit` clean.
- `pnpm --filter ./mastracode/mastra-factory test` (34 passed) — covers template sync and the "Next steps show :4111, not :5173" assertions from #20019.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory now uses one local server on port 4111 for both the UI and API, so login redirects work without extra setup. Documentation and tests were updated, with guidance for setups that use a separate UI origin.

## Changes

- Changed Factory’s default `publicUrl` from `http://localhost:5173` to `http://localhost:4111`.
- Updated generated `create-factory` README instructions for the single-server setup and WorkOS redirects.
- Documented `MASTRACODE_PUBLIC_URL` for separate SPA origins.
- Updated environment schema documentation and default URL expectations in tests.
- Added changeset entries for the Factory and `create-factory` updates.
- Verified template synchronization and reported passing Factory, `mastra-factory`, and TypeScript checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->