### PR TITLE
feat(mastracode-web): redesign rules page decision list

### DIFF
--- a/.changeset/slick-feet-type.md
+++ b/.changeset/slick-feet-type.md
@@ -1,0 +1,9 @@
+---
+'@mastra/playground-ui': minor
+---
+
+Added a `revealScrollbarOnHover` prop to `ScrollArea`. Set it to `false` to keep the overlay scrollbar hidden until the user actively scrolls, instead of also revealing it when the pointer hovers the area. Defaults to `true`, so existing usage is unchanged.
+
+```tsx
+<ScrollArea revealScrollbarOnHover={false}>{content}</ScrollArea>
+```

--- a/mastracode/web/src/web/ui/pages/RulesPage.tsx
+++ b/mastracode/web/src/web/ui/pages/RulesPage.tsx
@@ -5,7 +5,17 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { Check, CircleCheck, CircleDashed, CircleX, Clock, ListFilter, RefreshCw, Repeat, type LucideIcon } from 'lucide-react';
+import {
+  Check,
+  CircleCheck,
+  CircleDashed,
+  CircleX,
+  Clock,
+  ListFilter,
+  RefreshCw,
+  Repeat,
+  type LucideIcon,
+} from 'lucide-react';
 import { Fragment, useState } from 'react';
 
 import { useFactoryDecisionHistory, useRetryFactoryDecision } from '../../../shared/hooks/useFactoryDecisions';

--- a/mastracode/web/src/web/ui/pages/RulesPage.tsx
+++ b/mastracode/web/src/web/ui/pages/RulesPage.tsx
@@ -5,8 +5,8 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { cn } from '@mastra/playground-ui/utils/cn';
-import { CircleCheck, CircleDashed, CircleX, ListFilter, type LucideIcon } from 'lucide-react';
-import { useState } from 'react';
+import { Check, CircleCheck, CircleDashed, CircleX, Clock, ListFilter, RefreshCw, Repeat, type LucideIcon } from 'lucide-react';
+import { Fragment, useState } from 'react';
 
 import { useFactoryDecisionHistory, useRetryFactoryDecision } from '../../../shared/hooks/useFactoryDecisions';
 import { relativeTime } from '../../../shared/lib/date/relativeTime';
@@ -25,6 +25,14 @@ const DECISION_GROUPS: ReadonlyArray<{
   { key: 'failed', label: 'Failed', icon: CircleX, statuses: ['failed'] },
   { key: 'succeeded', label: 'Succeeded', icon: CircleCheck, statuses: ['succeeded'] },
 ];
+
+const STATUS_ICON: Record<FactoryDecisionStatus, { icon: LucideIcon; className: string }> = {
+  pending: { icon: CircleDashed, className: 'text-accent1' },
+  leased: { icon: CircleDashed, className: 'text-accent1' },
+  retry: { icon: CircleDashed, className: 'text-accent1' },
+  succeeded: { icon: CircleCheck, className: 'text-green' },
+  failed: { icon: CircleX, className: 'text-red' },
+};
 
 /** Rule decisions and their durable queued effects for the active Factory. */
 export function RulesPage() {
@@ -98,16 +106,18 @@ function RulesContent({ factoryProjectId }: { factoryProjectId: string | undefin
           }
         />
       ) : (
-        <ScrollArea className="min-h-0 flex-1">
+        <ScrollArea className="min-h-0 flex-1" revealScrollbarOnHover={false}>
           <div className="flex flex-col gap-2 pr-1">
-            <ul className="m-0 flex list-none flex-col gap-1 p-0" aria-label="Rule decisions">
-              {decisions.map(decision => (
-                <DecisionRow
-                  key={decision.id}
-                  decision={decision}
-                  retrying={retryDecision.isPending && retryDecision.variables === decision.id}
-                  onRetry={() => retryDecision.mutate(decision.id)}
-                />
+            <ul className="m-0 flex list-none flex-col p-0" aria-label="Rule decisions">
+              {decisions.map((decision, index) => (
+                <Fragment key={decision.id}>
+                  {index > 0 ? <li role="separator" aria-hidden className="mx-3 my-px h-px bg-border1" /> : null}
+                  <DecisionRow
+                    decision={decision}
+                    retrying={retryDecision.isPending && retryDecision.variables === decision.id}
+                    onRetry={() => retryDecision.mutate(decision.id)}
+                  />
+                </Fragment>
               ))}
             </ul>
             {decisionsQuery.hasNextPage ? (
@@ -138,34 +148,43 @@ function DecisionRow({
   onRetry: () => void;
 }) {
   const active = decision.status === 'pending' || decision.status === 'leased' || decision.status === 'retry';
-  const detail = [
-    `attempts ${decision.attempts}`,
-    `created ${relativeTime(decision.createdAt)}`,
+  const { icon: StatusIcon, className: statusIconClass } = STATUS_ICON[decision.status];
+  const metrics: ReadonlyArray<{ icon: LucideIcon; label: string; value: string }> = [
+    { icon: Repeat, label: 'attempts', value: String(decision.attempts) },
+    { icon: Clock, label: 'created', value: relativeTime(decision.createdAt) },
     decision.completedAt
-      ? `completed ${relativeTime(decision.completedAt)}`
-      : `updated ${relativeTime(decision.updatedAt)}`,
-  ].join(' · ');
+      ? { icon: Check, label: 'completed', value: relativeTime(decision.completedAt) }
+      : { icon: RefreshCw, label: 'updated', value: relativeTime(decision.updatedAt) },
+  ];
 
   return (
-    <li className="rounded-lg border border-border1 bg-surface2 px-3 py-2">
-      <div className="flex items-baseline gap-3">
-        <span
-          className={cn(
-            'inline-flex w-fit rounded-md bg-surface4 px-1.5 py-0.5 text-ui-xs',
-            decision.status === 'failed' ? 'text-error' : active ? 'text-accent1' : 'text-icon5',
-          )}
-        >
-          {decision.status}
-        </span>
+    <li className="rounded-lg px-3 py-2 transition-colors hover:bg-neutral6/5">
+      <div className="flex items-start gap-3">
         <div className="flex min-w-0 flex-1 flex-col gap-0.5">
-          <Txt as="span" variant="ui-sm" className="text-icon6">
-            {decision.type}
-          </Txt>
-          <Txt as="span" variant="ui-xs" className="text-icon3">
-            {detail}
-          </Txt>
+          <div className="flex items-center gap-2">
+            <StatusIcon className={cn('size-3 shrink-0', statusIconClass)} aria-hidden />
+            <Txt as="span" variant="ui-sm" className="text-icon6">
+              {decision.type}
+            </Txt>
+            <span
+              className={cn(
+                'inline-flex w-fit rounded-md bg-surface4 px-1.5 py-0.5 text-ui-xs',
+                decision.status === 'failed' ? 'text-error' : active ? 'text-accent1' : 'text-icon5',
+              )}
+            >
+              {decision.status}
+            </span>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 text-ui-xs leading-ui-xs text-icon3">
+            {metrics.map(({ icon: MetricIcon, label, value }) => (
+              <span key={label} className="inline-flex items-center gap-1" title={`${label} ${value}`}>
+                <MetricIcon className="size-3 shrink-0" aria-hidden />
+                {value}
+              </span>
+            ))}
+          </div>
           {decision.lastError ? (
-            <Txt as="span" variant="ui-xs" className="break-words text-error">
+            <Txt as="span" variant="ui-xs" className="break-words text-icon3">
               {decision.lastError}
             </Txt>
           ) : null}

--- a/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
+++ b/packages/playground-ui/src/ds/components/ScrollArea/scroll-area.tsx
@@ -54,6 +54,11 @@ export type ScrollAreaProps = React.ComponentPropsWithoutRef<typeof ScrollAreaPr
   /** @deprecated Use `mask` instead. Retained for backward compatibility. */
   showMask?: boolean;
   /**
+   * Reveal the overlay scrollbar when the pointer hovers the area. When `false`,
+   * the scrollbar only appears while actively scrolling. Defaults to `true`.
+   */
+  revealScrollbarOnHover?: boolean;
+  /**
    * Ref to the scrolling viewport element. Use this as the scroll element for a
    * virtualizer (`getScrollElement: () => viewportRef.current`) so the list can
    * virtualize while still using the ScrollArea's overlay scrollbar + masks.
@@ -232,6 +237,7 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
       scrollButtons,
       mask,
       showMask,
+      revealScrollbarOnHover = true,
       viewportRef,
       ...props
     },
@@ -291,8 +297,12 @@ const ScrollArea = React.forwardRef<HTMLDivElement, ScrollAreaProps>(
         {scrollButtons && orientation !== 'vertical' && (
           <ScrollButtons areaRef={areaRef} scrollButtons={scrollButtons} />
         )}
-        {(orientation === 'vertical' || orientation === 'both') && <ScrollBar orientation="vertical" />}
-        {(orientation === 'horizontal' || orientation === 'both') && <ScrollBar orientation="horizontal" />}
+        {(orientation === 'vertical' || orientation === 'both') && (
+          <ScrollBar orientation="vertical" revealOnHover={revealScrollbarOnHover} />
+        )}
+        {(orientation === 'horizontal' || orientation === 'both') && (
+          <ScrollBar orientation="horizontal" revealOnHover={revealScrollbarOnHover} />
+        )}
         {orientation === 'both' && <ScrollAreaPrimitive.Corner />}
       </ScrollAreaPrimitive.Root>
     );
@@ -302,14 +312,15 @@ ScrollArea.displayName = 'ScrollArea';
 
 const ScrollBar = React.forwardRef<
   HTMLDivElement,
-  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar>
->(({ className, orientation = 'vertical', ...props }, ref) => (
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Scrollbar> & { revealOnHover?: boolean }
+>(({ className, orientation = 'vertical', revealOnHover = true, ...props }, ref) => (
   <ScrollAreaPrimitive.Scrollbar
     ref={ref}
     orientation={orientation}
     className={cn(
       'duration-normal flex touch-none transition-opacity ease-out-custom select-none',
-      'opacity-0 data-[hovering]:opacity-100 data-[scrolling]:opacity-100 data-[scrolling]:duration-0',
+      'opacity-0 data-[scrolling]:opacity-100 data-[scrolling]:duration-0',
+      revealOnHover && 'data-[hovering]:opacity-100',
       orientation === 'vertical' && 'h-full w-1.5 p-px',
       orientation === 'horizontal' && 'h-1.5 w-full flex-col p-px',
       className,


### PR DESCRIPTION
## What

Redesigns the mastracode-web **Rules** page decision list and adds the small design-system hook it needs.

### `RulesPage`
- Replaces the bordered, boxed decision cards with a lighter divided list (hairline separators, hover affordance).
- Adds a leading **status icon** per row (pending/leased/retry → dashed, succeeded → check, failed → x).
- Turns the `attempts · created · completed` text blob into inline **metric chips** with lucide icons.
- Keeps the retry action and error line intact.

### `@mastra/playground-ui` — `ScrollArea`
- Adds a `revealScrollbarOnHover` prop. When `false`, the overlay scrollbar only appears while actively scrolling instead of also on hover. Defaults to `true`, so existing usage is unchanged.
- The Rules list uses `revealScrollbarOnHover={false}` to avoid a scrollbar flashing in on hover.

```tsx
<ScrollArea revealScrollbarOnHover={false}>{content}</ScrollArea>
```

## Notes
- `mastracode-web` is private (no changeset); `@mastra/playground-ui` change ships as a **minor** (changeset included).

## Checks
- `eslint` clean on `scroll-area.tsx`
- `tsc --noEmit` clean on the mastracode-web UI project


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

The Rules page now shows decisions as a cleaner, easier-to-scan list with a clear status icon and quick timing info on each row. The scrollbar stays hidden until you actually scroll, so the list feels less cluttered.

## What changed

- Redesigned the Rules decision UI from bordered cards to a divided list with row separators and hover highlighting.
- Added per-decision status icons (pending/leased/retry, succeeded, failed).
- Replaced decision metadata text with inline metric chips (attempts, created time, and completed/last-updated time).
- Kept existing retry actions and continued showing `lastError` when present.
- Added `revealScrollbarOnHover` to `@mastra/playground-ui`’s `ScrollArea` (defaults to `true`).
- Updated the Rules list `ScrollArea` to set `revealScrollbarOnHover={false}` so the overlay scrollbar only appears during active scrolling.
- Included a minor changeset for `@mastra/playground-ui`.
- ESLint and TypeScript checks pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->