### PR TITLE
chore: fix prettier formatting in create-factory template README

### DIFF
--- a/mastracode/mastra-factory/template/README.md
+++ b/mastracode/mastra-factory/template/README.md
@@ -70,14 +70,14 @@ Create a Linear OAuth app (Linear → Settings → API → OAuth applications �
 
 ## Scripts
 
-| Script                      | What it does                                                                                   |
-| --------------------------- | ---------------------------------------------------------------------------------------------- |
-| `npm run dev`               | Factory server (:4111) serving the UI and the API                                              |
-| `npm run db:up` / `db:down` | Start/stop local Postgres + Redis (Docker)                                                     |
-| `npm run build`             | Build the SPA and bundle the server to `.mastra/output`                                        |
-| `npm run start`             | Run the production build                                                                       |
-| `npm run deploy`            | Build and deploy to [Mastra Cloud](https://mastra.ai/docs/mastra-platform/overview)            |
-| `npm run check`             | Typecheck server and UI                                                                        |
+| Script                      | What it does                                                                        |
+| --------------------------- | ----------------------------------------------------------------------------------- |
+| `npm run dev`               | Factory server (:4111) serving the UI and the API                                   |
+| `npm run db:up` / `db:down` | Start/stop local Postgres + Redis (Docker)                                          |
+| `npm run build`             | Build the SPA and bundle the server to `.mastra/output`                             |
+| `npm run start`             | Run the production build                                                            |
+| `npm run deploy`            | Build and deploy to [Mastra Cloud](https://mastra.ai/docs/mastra-platform/overview) |
+| `npm run check`             | Typecheck server and UI                                                             |
 
 `mastra build` and `mastra deploy` detect the Factory entry automatically and build the SPA (Vite) before bundling. The SPA is copied to `.mastra/output/factory/` and a `mastra-project.json` manifest is emitted alongside it.
 


### PR DESCRIPTION
## Summary

`lint:format` (`prettier --check`) fails on `main` — and therefore on the release PR #20033 — because the scripts table in `mastracode/mastra-factory/template/README.md` was edited in #20036 without re-running prettier (column padding drifted).

This is the output of `prettier --write` on that file; whitespace-only, no content changes, no changeset.

## Test plan

- `pnpm exec prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'` now passes on the full repo (same invocation as the CI Lint job).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR fixes spacing in a README table so the formatting checker passes. It does not change the documented commands or their meanings.

## Changes

- Updated whitespace and alignment in the Scripts table in `mastracode/mastra-factory/template/README.md`.
- Formatting-only change; no public API or content changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->