### PR TITLE
feat(create-factory): add project region selection

### DIFF
--- a/.changeset/flat-cloths-act.md
+++ b/.changeset/flat-cloths-act.md
@@ -1,0 +1,5 @@
+---
+'create-factory': minor
+---
+
+Added EU and US region selection when creating Factory platform projects, with a --region flag for non-interactive setup.

--- a/mastracode/mastra-factory/README.md
+++ b/mastracode/mastra-factory/README.md
@@ -22,7 +22,7 @@ Options:
   --template <template-name>  Create a project from a template (public GitHub URL) (default: "https://github.com/mastra-ai/softwarefactory-template")
   --no-platform               Skip Mastra platform sign-in, project, and Neon provisioning
   --org <org>                 Mastra organization id or name — skips the interactive org picker
-  --region <region>           Neon region id (passed to the platform verbatim)
+  --region <region>           Platform project region (eu or us); prompts when omitted
   -v, --version               output the version number
   -h, --help                  display help for command
 ```

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -86,6 +86,7 @@ beforeEach(() => {
     { id: 'org_123', name: 'Acme', role: 'admin', isCurrent: true },
     { id: 'org_456', name: 'Beta', role: 'member', isCurrent: false },
   ]);
+  clack.select.mockResolvedValue('eu');
   platform.createServerProject.mockResolvedValue({ id: 'proj_abc', slug: 'my-factory', name: 'my-factory' });
   platform.mintOrgApiKey.mockResolvedValue('sk_live_test');
   platform.attachNeonDatabase.mockResolvedValue({ id: 'db_1', status: 'provisioning', error: null });
@@ -231,22 +232,31 @@ describe('create (platform provisioning)', () => {
     // Platform pipeline hit in order.
     expect(cliAuth.getToken).toHaveBeenCalledTimes(1);
     expect(cliAuth.resolveCurrentOrg).toHaveBeenCalledWith('wos-token', { forcePrompt: true });
+    expect(clack.select).toHaveBeenCalledWith({
+      message: 'Where should your Factory project run?',
+      options: [
+        { value: 'eu', label: '🇪🇺 eu' },
+        { value: 'us', label: '🇺🇸 us' },
+      ],
+    });
     expect(platform.createServerProject).toHaveBeenCalledWith({
       token: 'wos-token',
       orgId: 'org_123',
       name: 'my-factory',
+      region: 'eu',
     });
     expect(platform.mintOrgApiKey).toHaveBeenCalledWith({
       token: 'wos-token',
       orgId: 'org_123',
       keyName: 'create-factory: my-factory',
     });
-    expect(platform.attachNeonDatabase).toHaveBeenCalledWith(
-      expect.objectContaining({
-        projectId: 'proj_abc',
-        name: 'my-factory',
-      }),
-    );
+    expect(platform.attachNeonDatabase).toHaveBeenCalledWith({
+      token: 'wos-token',
+      orgId: 'org_123',
+      projectId: 'proj_abc',
+      name: 'my-factory',
+      regionId: 'aws-eu-central-1',
+    });
 
     // Success outro summarizes the provisioned infra so the user isn't
     // surprised by what now exists in their platform org.
@@ -300,15 +310,37 @@ describe('create (platform provisioning)', () => {
     expect(note).toContain('still provisioning');
   });
 
-  it('passes --region through to the Neon attach', async () => {
+  it('passes --region to project creation and skips the region picker', async () => {
     await create({
       projectName: 'my-factory',
       template: TEMPLATE_REPO,
-      region: 'aws-us-east-2',
+      region: 'us',
       analytics,
     });
 
-    expect(platform.attachNeonDatabase).toHaveBeenCalledWith(expect.objectContaining({ regionId: 'aws-us-east-2' }));
+    expect(clack.select).not.toHaveBeenCalled();
+    expect(platform.createServerProject).toHaveBeenCalledWith(expect.objectContaining({ region: 'us' }));
+    expect(platform.attachNeonDatabase).toHaveBeenCalledWith({
+      token: 'wos-token',
+      orgId: 'org_123',
+      projectId: 'proj_abc',
+      name: 'my-factory',
+      regionId: 'aws-us-west-2',
+    });
+  });
+
+  it('rejects unsupported --region values before scaffolding', async () => {
+    await expect(
+      create({
+        projectName: 'my-factory',
+        template: TEMPLATE_REPO,
+        region: 'aws-us-east-2',
+        analytics,
+      }),
+    ).rejects.toThrow('Invalid --region "aws-us-east-2". Expected one of: eu, us.');
+
+    expect(tinyexec.x).not.toHaveBeenCalled();
+    expect(platform.createServerProject).not.toHaveBeenCalled();
   });
 
   it('--org <name> skips the interactive picker and resolves via fetchOrgs', async () => {

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -10,7 +10,7 @@ import { x } from 'tinyexec';
 
 import type { Analytics } from './analytics.js';
 import { upsertEnvFile } from './env.js';
-import type { PlatformProject } from './platform.js';
+import type { PlatformProject, ProjectRegion } from './platform.js';
 import {
   attachNeonDatabase,
   createServerProject,
@@ -31,7 +31,7 @@ export interface CreateArgs {
    * `.env.example`.
    */
   noPlatform?: boolean;
-  /** Optional Neon region id (passed to the attach endpoint verbatim). */
+  /** Optional platform project region. Accepted values are `eu` and `us`. */
   region?: string;
   /**
    * Optional org identifier (id or name) to skip the interactive org picker.
@@ -50,9 +50,25 @@ interface PlatformProvisionResult {
   databaseUrl: string;
 }
 
+const PROJECT_REGION_OPTIONS = [
+  { value: 'eu', label: '🇪🇺 eu' },
+  { value: 'us', label: '🇺🇸 us' },
+] as const satisfies ReadonlyArray<{ value: ProjectRegion; label: string }>;
+
+const NEON_REGION_BY_PROJECT_REGION = {
+  eu: 'aws-eu-central-1',
+  us: 'aws-us-west-2',
+} as const satisfies Record<ProjectRegion, string>;
+
+function parseProjectRegion(region: string): ProjectRegion {
+  if (region === 'eu' || region === 'us') return region;
+  throw new Error(`Invalid --region "${region}". Expected one of: eu, us.`);
+}
+
 export async function create(args: CreateArgs): Promise<void> {
   p.intro(color.inverse(' Mastra Factory '));
 
+  const requestedRegion = args.region ? parseProjectRegion(args.region) : undefined;
   const projectName =
     args.projectName ??
     (await p.text({
@@ -125,7 +141,7 @@ export async function create(args: CreateArgs): Promise<void> {
       platformResult = await runPlatformProvisioning({
         projectName,
         projectPath,
-        region: args.region,
+        region: requestedRegion,
         org: args.org,
       });
     } catch (err) {
@@ -214,7 +230,7 @@ async function runPlatformProvisioning({
 }: {
   projectName: string;
   projectPath: string;
-  region?: string;
+  region?: ProjectRegion;
   org?: string;
 }): Promise<PlatformProvisionResult> {
   // Accumulator: whatever we successfully mint gets flushed to .env in a
@@ -256,12 +272,23 @@ async function runPlatformProvisioning({
     p.log.info(`Using organization ${color.cyan(orgName)}.`);
     envAccumulator.MASTRA_ORGANIZATION_ID = orgId;
 
+    const projectRegion =
+      region ??
+      (await p.select({
+        message: 'Where should your Factory project run?',
+        options: [...PROJECT_REGION_OPTIONS],
+      }));
+    if (p.isCancel(projectRegion)) {
+      p.cancel('Operation cancelled');
+      process.exit(0);
+    }
+
     // 3. Project — session-auth POST /v1/server/projects.
     const projectSpinner = p.spinner();
     projectSpinner.start(`Creating platform project "${projectName}"…`);
     let project: PlatformProject;
     try {
-      project = await createServerProject({ token, orgId, name: projectName });
+      project = await createServerProject({ token, orgId, name: projectName, region: projectRegion });
       projectSpinner.stop(`Created platform project ${color.cyan(project.slug)}.`);
     } catch (err) {
       projectSpinner.stop('Project creation failed.');
@@ -298,7 +325,7 @@ async function runPlatformProvisioning({
         orgId,
         projectId: project.id,
         name: sanitizeDatabaseName(projectName),
-        regionId: region,
+        regionId: NEON_REGION_BY_PROJECT_REGION[projectRegion],
       });
       const ready = await waitForDatabaseReady({
         token,

--- a/mastracode/mastra-factory/src/index.ts
+++ b/mastracode/mastra-factory/src/index.ts
@@ -29,7 +29,7 @@ program
   .option('--template <template-name>', 'Create a project from a template (public GitHub URL)', DEFAULT_TEMPLATE_REPO)
   .option('--no-platform', 'Skip Mastra platform sign-in, project, and Neon provisioning')
   .option('--org <org>', 'Mastra organization id or name — skips the interactive org picker')
-  .option('--region <region>', 'Neon region id (passed to the platform verbatim)')
+  .option('--region <region>', 'Platform project region (eu or us); prompts when omitted')
   .version(pkg.version, '-v, --version')
   .action(async (projectNameArg: string | undefined, args: CreateArgs) => {
     await create({

--- a/mastracode/mastra-factory/src/platform.test.ts
+++ b/mastracode/mastra-factory/src/platform.test.ts
@@ -54,25 +54,56 @@ describe('createServerProject', () => {
         }),
     );
 
-    await createServerProject({ token: 'wos-token', orgId: 'org_123', name: 'My Factory' });
+    await createServerProject({ token: 'wos-token', orgId: 'org_123', name: 'My Factory', region: 'eu' });
 
     expect(cliAuth.platformFetch).toHaveBeenCalledWith(
       'https://platform.example.test/v1/server/projects',
       expect.objectContaining({
-        body: JSON.stringify({ name: 'My Factory', factoryEnabled: true }),
+        body: JSON.stringify({ name: 'My Factory', region: 'eu', factoryEnabled: true }),
       }),
     );
   });
 });
 
 describe('attachNeonDatabase', () => {
+  it('passes the selected Neon region to the database endpoint', async () => {
+    cliAuth.platformFetch.mockImplementationOnce(
+      async () =>
+        new Response(JSON.stringify({ database: { id: 'db_1', status: 'provisioning' } }), {
+          status: 201,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    );
+
+    await attachNeonDatabase({
+      token: 'wos-token',
+      orgId: 'org_123',
+      projectId: 'proj_1',
+      name: 'my-factory',
+      regionId: 'aws-eu-central-1',
+    });
+
+    expect(cliAuth.platformFetch).toHaveBeenCalledWith(
+      'https://platform.example.test/v1/server/projects/proj_1/databases',
+      expect.objectContaining({
+        body: JSON.stringify({ kind: 'neon', name: 'my-factory', regionId: 'aws-eu-central-1' }),
+      }),
+    );
+  });
+
   it('surfaces the admin-role hint when the platform returns 403', async () => {
     cliAuth.platformFetch.mockImplementationOnce(
       async () => new Response(JSON.stringify({ detail: 'forbidden' }), { status: 403 }),
     );
 
     await expect(
-      attachNeonDatabase({ token: 'wos-token', orgId: 'org_123', projectId: 'proj_1', name: 'my-factory' }),
+      attachNeonDatabase({
+        token: 'wos-token',
+        orgId: 'org_123',
+        projectId: 'proj_1',
+        name: 'my-factory',
+        regionId: 'aws-us-west-2',
+      }),
     ).rejects.toMatchObject({
       status: 403,
       message: expect.stringContaining('admin role'),

--- a/mastracode/mastra-factory/src/platform.ts
+++ b/mastracode/mastra-factory/src/platform.ts
@@ -1,5 +1,7 @@
 import { MASTRA_PLATFORM_API_URL, authHeaders, extractApiErrorDetail, platformFetch } from 'mastra/internal/auth';
 
+export type ProjectRegion = 'eu' | 'us';
+
 export interface PlatformProject {
   id: string;
   slug: string;
@@ -66,15 +68,17 @@ export async function createServerProject({
   token,
   orgId,
   name,
+  region,
 }: {
   token: string;
   orgId: string;
   name: string;
+  region: ProjectRegion;
 }): Promise<PlatformProject> {
   const res = await platformFetch(`${MASTRA_PLATFORM_API_URL}/v1/server/projects`, {
     method: 'POST',
     headers: { ...authHeaders(token, orgId), 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name, factoryEnabled: true }),
+    body: JSON.stringify({ name, region, factoryEnabled: true }),
   });
   if (!res.ok) {
     throw new PlatformApiError(res.status, `Failed to create project — ${await extractError(res)}`);
@@ -126,14 +130,14 @@ export async function attachNeonDatabase({
   orgId: string;
   projectId: string;
   name: string;
-  regionId?: string;
+  regionId: string;
 }): Promise<AttachedDatabase> {
   const res = await platformFetch(
     `${MASTRA_PLATFORM_API_URL}/v1/server/projects/${encodeURIComponent(projectId)}/databases`,
     {
       method: 'POST',
       headers: { ...authHeaders(token, orgId), 'Content-Type': 'application/json' },
-      body: JSON.stringify({ kind: 'neon', name, ...(regionId ? { regionId } : {}) }),
+      body: JSON.stringify({ kind: 'neon', name, regionId }),
     },
   );
   if (!res.ok) {


### PR DESCRIPTION
## Summary
- add an interactive `eu`/`us` project-region picker with flag labels
- validate `--region` for non-interactive Factory creation
- send the selected region to Platform project creation
- place Neon in `aws-eu-central-1` or `aws-us-west-2` to match the project

Depends on https://github.com/mastra-ai/platform/pull/1736.

## Test plan
- `pnpm --filter ./mastracode/mastra-factory test`
- `pnpm --filter ./mastracode/mastra-factory build`
- `pnpm --filter ./mastracode/mastra-factory check`
- `pnpm --filter ./mastracode/mastra-factory lint`
- `pnpm build:cli`
- `pnpm test:cli`
- `pnpm --filter ./packages/cli typecheck`