### PR TITLE
fix(create-factory): keep lockfiles and pnpm workspace files out of the template

### DIFF
--- a/.changeset/shiny-locks-vanish.md
+++ b/.changeset/shiny-locks-vanish.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Stop shipping `pnpm-workspace.yaml` and `package-lock.json` in projects scaffolded by `npm create factory`. The template generator now excludes the web project's pnpm workspace marker and lockfiles, and the sync workflow validates the template in a throwaway copy so `npm install` artifacts can no longer leak into the published template repository.

--- a/.github/workflows/sync-softwarefactory-template.yml
+++ b/.github/workflows/sync-softwarefactory-template.yml
@@ -58,12 +58,17 @@ jobs:
       # (workflow_dispatch) after the next release train catches up.
       # PR-time validation against the LOCAL package set lives in the
       # e2e-softwarefactory job of e2e-tests.yml.
+      # Runs in a throwaway copy: `npm install`/`npm run build` write
+      # package-lock.json, node_modules and .mastra into the working tree, and
+      # the sync step below copies template-out verbatim — validating in-place
+      # previously leaked package-lock.json into the template repo.
       - name: Validate template against published packages
-        working-directory: ${{ runner.temp }}/template-out
         env:
           MASTRA_TELEMETRY_DISABLED: '1'
         run: |
           set -euo pipefail
+          cp -R "$RUNNER_TEMP/template-out" "$RUNNER_TEMP/template-validate"
+          cd "$RUNNER_TEMP/template-validate"
           npm install --no-audit --no-fund
           npm run check
           npm run build

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -97,7 +97,12 @@ const EXCLUDE_TOP_LEVEL = new Set([
   'node_modules',
   '.mastra',
   'e2e',
+  // The web project is its own pnpm workspace root wired to the monorepo via
+  // `link:` deps — none of that applies to the standalone template, and npm
+  // scaffolds must not ship pnpm workspace/lock files (or a stale npm lock).
   'pnpm-lock.yaml',
+  'pnpm-workspace.yaml',
+  'package-lock.json',
   'vitest.config.ts',
   // Replaced with template-specific versions:
   'README.md',

--- a/mastracode/mastra-factory/src/sync-template.test.ts
+++ b/mastracode/mastra-factory/src/sync-template.test.ts
@@ -109,6 +109,13 @@ describe.skipIf(process.platform === 'win32')('sync-template.mjs', () => {
     // expose. Remove once the deployer supports tsgo.
     expect(pkg.devDependencies.typescript).toMatch(/^\^5\./);
 
+    // Package-manager coupling never ships: the web project's pnpm workspace
+    // marker and lockfiles stay behind (a stale npm lock would pin the
+    // floating `alpha` dist-tag at sync time).
+    expect(fs.existsSync(path.join(outDir, 'pnpm-workspace.yaml'))).toBe(false);
+    expect(fs.existsSync(path.join(outDir, 'pnpm-lock.yaml'))).toBe(false);
+    expect(fs.existsSync(path.join(outDir, 'package-lock.json'))).toBe(false);
+
     // Tests and their dependencies are stripped.
     expect(allDeps.vitest).toBeUndefined();
     expect(fs.existsSync(path.join(outDir, 'e2e'))).toBe(false);


### PR DESCRIPTION
## Summary

Projects scaffolded by `npm create factory` came with a `pnpm-workspace.yaml` and a `package-lock.json` they should never have — visible in the [softwarefactory-template](https://github.com/mastra-ai/softwarefactory-template) repo today. Two separate leaks:

1. **`pnpm-workspace.yaml`** — `sync-template.mjs` copied it straight from `mastracode/web`, where it exists purely for monorepo coupling (standalone pnpm root, `link:` deps). `EXCLUDE_TOP_LEVEL` only excluded `pnpm-lock.yaml`.
2. **`package-lock.json`** — the sync workflow's "validate against published packages" step ran `npm install` **inside** `$RUNNER_TEMP/template-out`, and the sync step then copied that mutated tree verbatim into the template repo. Besides being noise, a committed npm lock pins the floating `alpha` dist-tag at whatever versions the last sync resolved.

## Changes

- `sync-template.mjs`: exclude `pnpm-workspace.yaml` and `package-lock.json` (defensive) from the generated tree.
- `sync-softwarefactory-template.yml`: validation now runs in a throwaway copy (`template-validate`), so install/build artifacts (`package-lock.json`, `node_modules`, `.mastra`) never touch the tree that gets pushed.
- Test asserts none of `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `package-lock.json` ship.

The template repo cleans itself up on the next sync — the workflow does a one-way overwrite, and the pristine tree no longer contains either file.

## Test plan

- `vitest run src/sync-template.test.ts` — 4 passed (includes new assertions)
- Ran `sync-template.mjs` locally: output tree contains no `pnpm-workspace.yaml` or lockfiles
- `prettier --check` clean on all touched files
