### PR TITLE
fix(deployer): resolve @hono/node-server failure during `mastra build` on pnpm projects

### DIFF
--- a/.changeset/stale-actors-reply.md
+++ b/.changeset/stale-actors-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` failing with "Cannot find package '@hono/node-server'" in projects installed with pnpm. The deployer now declares @hono/node-server as a runtime dependency and falls back to project-level resolution when a hono package cannot be resolved from the deployer itself.

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -97,6 +97,7 @@
     "@babel/core": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
     "@babel/traverse": "^8.0.4",
+    "@hono/node-server": "^1.19.14",
     "@hono/node-ws": "^1.3.0",
     "@mastra/server": "workspace:*",
     "@optimize-lodash/rollup-plugin": "^5.1.0",
@@ -123,7 +124,6 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
-    "@hono/node-server": "^1.19.14",
     "@hono/standard-validator": "^0.3.0",
     "@hono/swagger-ui": "^0.5.3",
     "@internal/lint": "workspace:*",

--- a/packages/deployer/src/build/plugins/hono-alias.ts
+++ b/packages/deployer/src/build/plugins/hono-alias.ts
@@ -10,8 +10,14 @@ export function aliasHono(): Plugin {
         return;
       }
 
-      const path = import.meta.resolve(id);
-      return fileURLToPath(path);
+      try {
+        const path = import.meta.resolve(id);
+        return fileURLToPath(path);
+      } catch {
+        // Not resolvable from deployer (e.g. undeclared transitive dep under
+        // pnpm's strict isolation) — fall back to default resolution.
+        return;
+      }
     },
   } satisfies Plugin;
 }

--- a/packages/deployer/tsup.config.ts
+++ b/packages/deployer/tsup.config.ts
@@ -23,6 +23,6 @@ export default defineConfig({
   sourcemap: true,
   publicDir: true,
   onSuccess: async () => {
-    await generateTypes(process.cwd(), new Set(['@hono/node-server', '@mastra/hono']));
+    await generateTypes(process.cwd(), new Set(['@mastra/hono']));
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4529,6 +4529,9 @@ importers:
       '@babel/traverse':
         specifier: ^8.0.4
         version: 8.0.4
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.30)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.30))(bufferutil@4.1.0)(hono@4.12.30)
@@ -4602,9 +4605,6 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0(bufferutil@4.1.0)
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.30)
       '@hono/standard-validator':
         specifier: ^0.3.0
         version: 0.3.0(@standard-schema/spec@1.1.0)(hono@4.12.30)


### PR DESCRIPTION
## Summary

`mastra build` fails in pnpm-managed projects with:

```
Failed to analyze Mastra application: Cannot find package '@hono/node-server'
imported from .../@mastra/deployer/dist/chunk-*.js
```

The analyzer's `hono-alias` rollup plugin resolves every `@hono/*` import from the deployer's own location via `import.meta.resolve`. `@hono/node-server` was only a **devDependency** of `@mastra/deployer` (bundled into dist at publish time), so it isn't installed alongside the published package. npm's flat hoisting masks this, but pnpm's strict `node_modules` isolation makes the resolution fail and the whole build aborts.

## Changes

- **`packages/deployer/package.json`**: move `@hono/node-server` from `devDependencies` to `dependencies` so it is always resolvable from the published package (tsup now externalizes it instead of bundling).
- **`packages/deployer/src/build/plugins/hono-alias.ts`**: wrap `import.meta.resolve` in try/catch and fall back to default project-root resolution instead of crashing analysis when a hono package can't be resolved from the deployer.
- **`packages/deployer/tsup.config.ts`**: drop `@hono/node-server` from the type-bundling set — as a runtime dependency its types no longer need embedding.
- Changeset: patch bump for `@mastra/deployer`.

## Test plan

- Reproduced the failure with the published `@mastra/deployer@1.52.0-alpha.13` in a pnpm factory project: `mastra build` fails with the exact error above, and `createRequire(<chunk path>).resolve('@hono/node-server')` fails with `MODULE_NOT_FOUND`.
- Confirmed that declaring `@hono/node-server` as a dependency of the deployer (via `pnpm.packageExtensions` in the repro project) removes the error and analysis proceeds.
- `pnpm turbo build --filter ./packages/deployer` — clean.
- `pnpm --filter ./packages/deployer test` — 554 tests pass.
- `tsc -p tsconfig.build.json --noEmit` — clean.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

`mastra build` could not find a Hono package in pnpm projects. This PR makes the package available at runtime and safely falls back to normal resolution when needed.

## Changes

- Moved `@hono/node-server` to `@mastra/deployer`’s runtime dependencies.
- Added a fallback for failed `import.meta.resolve` calls.
- Removed `@hono/node-server` from tsup type bundling.
- Added a patch changeset for `@mastra/deployer`.

## Validation

- Build, tests, and TypeScript checks pass.
- 554 deployer tests pass.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->