### PR TITLE
feat(mastracode-web): direct GitHub App fallback

### DIFF
--- a/mastracode/web/src/mastra/index.test.ts
+++ b/mastracode/web/src/mastra/index.test.ts
@@ -74,6 +74,28 @@ describe('platform entry (src/mastra/index.ts)', () => {
     );
 
     it(
+      'registers the direct GitHub App integration when the full group is configured',
+      { timeout: 60_000 },
+      async () => {
+        vi.resetModules();
+        // No platform identity in this env, so the only source of a GitHub
+        // connection is the direct GITHUB_APP_* group wired in the entry.
+        vi.stubEnv('MASTRA_PLATFORM_SECRET_KEY', '');
+        vi.stubEnv('GITHUB_APP_ID', '12345');
+        vi.stubEnv('GITHUB_APP_PRIVATE_KEY', 'test-private-key');
+        vi.stubEnv('GITHUB_APP_CLIENT_ID', 'Iv1.client');
+        vi.stubEnv('GITHUB_APP_CLIENT_SECRET', 'client-secret');
+        vi.stubEnv('GITHUB_APP_SLUG', 'test-app');
+        vi.stubEnv('GITHUB_APP_WEBHOOK_SECRET', 'webhook-secret');
+        const mod = await import('./index.js');
+        const paths = mod.mastra.getServer()?.apiRoutes?.map(route => route.path) ?? [];
+        // The connect route is registered only by the GithubIntegration, so its
+        // presence proves the direct fallback wired the integration onto the factory.
+        expect(paths).toContain('/auth/github/connect');
+      },
+    );
+
+    it(
       'boots when the Linear group is partially configured so diagnostics can report the missing setup',
       { timeout: 60_000 },
       async () => {

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -28,6 +28,7 @@ import { RedisStreamsPubSub } from '@mastra/redis-streams';
 import { getDatabasePath } from '@mastra/code-sdk/utils/project';
 import { DEFAULT_RETENTION } from '@mastra/code-sdk/utils/storage-maintenance';
 import { MastraFactory } from '@mastra/factory';
+import { GithubIntegration } from '@mastra/factory/integrations/github/integration';
 import type { IMastraAuthProvider } from '@mastra/core/server';
 
 /**
@@ -71,6 +72,28 @@ let auth: IMastraAuthProvider | null | undefined;
 if (authDisabled) {
   auth = null;
 }
+
+// Direct GitHub App fallback: when the platform-backed integration isn't in
+// play (self-hosted / local deploys), a complete GITHUB_APP_* env group wires
+// a GithubIntegration so the app still gets a real GitHub connection — Connect
+// GitHub in onboarding, the repo picker, and webhooks. A partial group stays
+// disabled so the status route can report exactly what's missing.
+const githubAppId = process.env.GITHUB_APP_ID?.trim();
+const githubPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY?.trim();
+const githubClientId = process.env.GITHUB_APP_CLIENT_ID?.trim();
+const githubClientSecret = process.env.GITHUB_APP_CLIENT_SECRET?.trim();
+const githubAppSlug = process.env.GITHUB_APP_SLUG?.trim();
+const github =
+  githubAppId && githubPrivateKey && githubClientId && githubClientSecret && githubAppSlug
+    ? new GithubIntegration({
+        appId: githubAppId,
+        privateKey: githubPrivateKey,
+        clientId: githubClientId,
+        clientSecret: githubClientSecret,
+        slug: githubAppSlug,
+        webhookSecret: process.env.GITHUB_APP_WEBHOOK_SECRET?.trim() || undefined,
+      })
+    : undefined;
 
 // Host env exposed to local sandboxes: an allow-list only, so app secrets
 // (GITHUB_APP_PRIVATE_KEY, WORKOS_API_KEY, DATABASE_URL, …) never leak into
@@ -151,6 +174,7 @@ const vector = databaseUrl ? new PgVector({ id: 'mastra-code-vectors', connectio
 
 export const factory = new MastraFactory({
   auth,
+  integrations: github ? [github] : undefined,
   sandbox: {
     machine: sandbox,
     // Remote checkout base (nested `owner/name` per repo). LocalSandbox ignores


### PR DESCRIPTION
## What

When the platform-backed GitHub integration isn't in play (self-hosted or local deployments), wire a `GithubIntegration` from a complete `GITHUB_APP_*` env group so the app still gets a real GitHub connection — "Connect GitHub" in onboarding, the repository picker, and webhooks.

## Why

On `main`, the `mastracode-web` entry only gets GitHub through the platform-backed default. A self-hosted or local deployment that already has a GitHub App configured via env (`GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_CLIENT_SECRET`, `GITHUB_APP_SLUG`) still shows **"GitHub is not configured for this deployment"** in onboarding and can't create a first factory. This falls back to a directly-configured `GithubIntegration` built from that env group.

## Behavior

- **Complete `GITHUB_APP_*` group** → integration active: Connect GitHub, repo picker, webhooks.
- **Partial group** → stays disabled, so the status route reports exactly what's missing (matches the existing "boots when partially configured" behavior).
- **Auth wiring is unchanged** — this only adds to the `integrations` slot of `MastraFactory`.

## Test

Added a colocated case in `src/mastra/index.test.ts` asserting the entry registers `/auth/github/connect` — a route only the `GithubIntegration` adds — when the full group is configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Self-hosted deployments can now connect to GitHub directly when the platform connection is unavailable, as long as all required GitHub App settings are provided. Incomplete settings remain disabled and report what is missing.

## Changes

- Added a direct `GithubIntegration` fallback using `GITHUB_APP_*` environment variables.
- Supports GitHub connections, repository selection, and webhooks.
- Preserves existing authentication wiring and partial-configuration behavior.
- Added a test confirming `/auth/github/connect` is registered with complete configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->