### PR TITLE
fix(cli): serve the Factory UI during `mastra factory dev`

### DIFF
--- a/.changeset/factory-dev-serves-ui.md
+++ b/.changeset/factory-dev-serves-ui.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Serve the Factory UI during `mastra factory dev`. The prebuilt SPA bundled with the CLI was only copied into `public/factory` by `mastra build`, so in dev the SPA middleware never mounted and the browser fell back to the default Mastra Server page. Dev now points the server at the CLI-bundled UI via `MASTRACODE_UI_DIST`, unless the user set an explicit override or has a locally built UI at `public/factory`.

--- a/packages/cli/src/commands/build/factory-ui-build.test.ts
+++ b/packages/cli/src/commands/build/factory-ui-build.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { PinoLogger } from '@mastra/loggers';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { buildFactoryUI } from './factory-ui-build';
+import { buildFactoryUI, resolveFactoryUIDevDist } from './factory-ui-build';
 
 const logger = new PinoLogger({ name: 'test', level: 'silent' });
 
@@ -52,5 +52,41 @@ describe('buildFactoryUI', () => {
 
   it('throws when the prebuilt Factory UI is missing', async () => {
     await expect(buildFactoryUI(mastraDir, logger, factoryUISource)).rejects.toThrow(/Prebuilt Factory UI not found/);
+  });
+});
+
+describe('resolveFactoryUIDevDist', () => {
+  let tmpDir: string;
+  let publicDir: string;
+  let factoryUISource: string;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'factory-ui-dev-dist-test-'));
+    publicDir = join(tmpDir, 'project', 'src', 'mastra', 'public');
+    factoryUISource = join(tmpDir, 'cli-dist-factory');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('falls back to the CLI-bundled SPA when no local UI build exists', async () => {
+    await mkdir(factoryUISource, { recursive: true });
+    await writeFile(join(factoryUISource, 'index.html'), '<html>bundled</html>');
+
+    expect(resolveFactoryUIDevDist(publicDir, factoryUISource)).toBe(factoryUISource);
+  });
+
+  it('prefers a locally built UI at public/factory by returning undefined', async () => {
+    await mkdir(factoryUISource, { recursive: true });
+    await writeFile(join(factoryUISource, 'index.html'), '<html>bundled</html>');
+    await mkdir(join(publicDir, 'factory'), { recursive: true });
+    await writeFile(join(publicDir, 'factory', 'index.html'), '<html>local</html>');
+
+    expect(resolveFactoryUIDevDist(publicDir, factoryUISource)).toBeUndefined();
+  });
+
+  it('returns undefined when no prebuilt UI exists anywhere', () => {
+    expect(resolveFactoryUIDevDist(publicDir, factoryUISource)).toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/build/factory-ui-build.ts
+++ b/packages/cli/src/commands/build/factory-ui-build.ts
@@ -12,6 +12,22 @@ function resolveFactoryUISource(): string {
 }
 
 /**
+ * Resolve the Factory SPA dir the dev server should serve (via `MASTRACODE_UI_DIST`).
+ *
+ * Prefers a locally built UI at `<publicDir>/factory` (e.g. `build:ui` output) by
+ * returning `undefined` — the server already picks that up as `cwd/factory`.
+ * Otherwise falls back to the SPA bundled with the CLI, or `undefined` when no
+ * prebuilt UI exists (behavior unchanged: no SPA middleware is mounted).
+ */
+export function resolveFactoryUIDevDist(
+  publicDir: string,
+  factoryUISource = resolveFactoryUISource(),
+): string | undefined {
+  if (existsSync(join(publicDir, 'factory', 'index.html'))) return undefined;
+  return existsSync(join(factoryUISource, 'index.html')) ? factoryUISource : undefined;
+}
+
+/**
  * Copies the Factory SPA bundled with the CLI into the project's public directory
  * so the bundler's `copyPublic()` can include it in the deployment output.
  */

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -22,6 +22,7 @@ import { createLogger } from '../../utils/logger.js';
 import type { MastraPackageInfo } from '../../utils/mastra-packages.js';
 import { getMastraPackages } from '../../utils/mastra-packages.js';
 import { loadAndValidatePresets } from '../../utils/validate-presets.js';
+import { resolveFactoryUIDevDist } from '../build/factory-ui-build.js';
 
 import { acquireDevLock, releaseDevLock, updateDevLock } from './dev-lock';
 import { DevBundler } from './DevBundler';
@@ -142,6 +143,15 @@ const startServer = async (
     }
 
     await mkdir(publicDir, { recursive: true });
+
+    // Factory dev: the SPA is not copied into public/ (that only happens during
+    // `mastra build`), so point the server at the UI bundled with the CLI unless
+    // the user has an explicit override or a locally built UI at public/factory.
+    const factoryUiDist =
+      startOptions.factory && !process.env.MASTRACODE_UI_DIST && !env.has('MASTRACODE_UI_DIST')
+        ? resolveFactoryUIDevDist(publicDir)
+        : undefined;
+
     currentServerProcess = execa(process.execPath, commands, {
       cwd: publicDir,
       env: {
@@ -160,6 +170,7 @@ const startServer = async (
             }
           : {}),
         ...(startOptions.factory ? { MASTRA_FACTORY_DEV: 'true' } : {}),
+        ...(factoryUiDist ? { MASTRACODE_UI_DIST: factoryUiDist } : {}),
       },
       stdio: ['inherit', 'pipe', 'pipe', 'ipc'],
       reject: false,


### PR DESCRIPTION
## Summary

Running `mastra factory dev` in a generated factory project showed the default "Mastra Server" landing page instead of the Factory UI.

The prebuilt Factory SPA that ships with the CLI (`dist/factory`) was only copied into the project's `public/factory` directory by `mastra build` — nothing exposed it in dev. The server's SPA middleware (`resolveUiDistDir`) found no `factory/index.html` in any of its candidate locations, never mounted, and every navigation fell through to the default server homepage.

Dev now passes `MASTRACODE_UI_DIST` (pointing at the CLI-bundled SPA) to the dev server process in factory mode, so the SPA middleware mounts without copying anything into the user's source tree. The fallback is skipped when:
- the user set `MASTRACODE_UI_DIST` explicitly (shell or env file), or
- a locally built UI exists at `public/factory` (e.g. the monorepo `web:dev:prod` flow), which the server already picks up as `cwd/factory`.

## Test plan

- New unit tests for `resolveFactoryUIDevDist` (fallback, local-build preference, missing-UI no-op)
- `dev`, `DevBundler`, and `factory-ui-build` suites pass (33 tests)
- CLI typecheck clean, `pnpm build:cli` green
- Manually verified against a generated pnpm factory project: `GET /signin` now serves the Factory SPA (`Mastra Factory` index.html), hashed assets return 200, and the sign-in page renders in the browser

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When developing a Factory project, the CLI now shows the Factory UI instead of the generic Mastra page. It uses a bundled UI when no local UI build or explicit override is available.

## Changes

- Added Factory UI distribution resolution for development.
- Preserves explicit `MASTRACODE_UI_DIST` configuration.
- Prefers locally built `public/factory` UI assets.
- Falls back to the CLI-bundled Factory SPA when needed.
- Handles missing UI assets without mounting UI middleware.
- Added tests covering fallback, local-build preference, and missing UI behavior.
- Added a changeset for the updated `mastra factory dev` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->