### PR TITLE
fix(deployer): declare @hono/node-server as runtime dependency

### DIFF
--- a/.changeset/stale-actors-reply.md
+++ b/.changeset/stale-actors-reply.md
@@ -1,0 +1,5 @@
+---
+'@mastra/deployer': patch
+---
+
+Fixed `mastra build` failing with "Cannot find package '@hono/node-server'" in projects installed with pnpm. The deployer now declares @hono/node-server as a runtime dependency and falls back to project-level resolution when a hono package cannot be resolved from the deployer itself.

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -97,6 +97,7 @@
     "@babel/core": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
     "@babel/traverse": "^8.0.4",
+    "@hono/node-server": "^1.19.14",
     "@hono/node-ws": "^1.3.0",
     "@mastra/server": "workspace:*",
     "@optimize-lodash/rollup-plugin": "^5.1.0",
@@ -123,7 +124,6 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
-    "@hono/node-server": "^1.19.14",
     "@hono/standard-validator": "^0.3.0",
     "@hono/swagger-ui": "^0.5.3",
     "@internal/lint": "workspace:*",

--- a/packages/deployer/src/build/plugins/hono-alias.ts
+++ b/packages/deployer/src/build/plugins/hono-alias.ts
@@ -10,8 +10,14 @@ export function aliasHono(): Plugin {
         return;
       }
 
-      const path = import.meta.resolve(id);
-      return fileURLToPath(path);
+      try {
+        const path = import.meta.resolve(id);
+        return fileURLToPath(path);
+      } catch {
+        // Not resolvable from deployer (e.g. undeclared transitive dep under
+        // pnpm's strict isolation) — fall back to default resolution.
+        return;
+      }
     },
   } satisfies Plugin;
 }

--- a/packages/deployer/tsup.config.ts
+++ b/packages/deployer/tsup.config.ts
@@ -23,6 +23,6 @@ export default defineConfig({
   sourcemap: true,
   publicDir: true,
   onSuccess: async () => {
-    await generateTypes(process.cwd(), new Set(['@hono/node-server', '@mastra/hono']));
+    await generateTypes(process.cwd(), new Set(['@mastra/hono']));
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4529,6 +4529,9 @@ importers:
       '@babel/traverse':
         specifier: ^8.0.4
         version: 8.0.4
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.30)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.30))(bufferutil@4.1.0)(hono@4.12.30)
@@ -4602,9 +4605,6 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0(bufferutil@4.1.0)
     devDependencies:
-      '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.30)
       '@hono/standard-validator':
         specifier: ^0.3.0
         version: 0.3.0(@standard-schema/spec@1.1.0)(hono@4.12.30)


### PR DESCRIPTION
The analyzer's hono-alias rollup plugin resolves all @hono/* imports from the deployer's own location via import.meta.resolve. Under pnpm's strict node_modules isolation this fails for @hono/node-server because it was only a devDependency (bundled into dist at publish time), making `mastra build` fail with "Cannot find package '@hono/node-server'" in pnpm projects. npm's flat hoisting masked the bug.

- Move @hono/node-server from devDependencies to dependencies so it is always resolvable from the published package (and externalized by tsup instead of bundled).
- Make aliasHono fall back to default project-root resolution when a hono package cannot be resolved from the deployer, instead of crashing the whole analysis.
- Drop @hono/node-server from the type-bundling set since its types no longer need embedding.

## Description

<!-- Required: Provide a brief description of the changes in this PR. -->

## Related issue(s)

<!-- Required: Link to the issue(s) this PR addresses, e.g. with: Fixes #123. PRs without linked issues may be closed. -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have linked the related issue(s) in the description above
- [ ] I have made corresponding changes to the documentation (if applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The deployer can now find Hono packages reliably, even when pnpm keeps dependencies strictly separated. This prevents `mastra build` from failing because `@hono/node-server` cannot be found.

## Changes

- Moved `@hono/node-server` to runtime `dependencies`.
- Added a project-root resolution fallback for Hono packages.
- Removed `@hono/node-server` from type bundling.
- Added a patch changeset for `@mastra/deployer`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->