### PR TITLE
fix template

### DIFF
--- a/.changeset/stale-actors-reply.md
+++ b/.changeset/stale-actors-reply.md
@@ -1,5 +1,0 @@
----
-'@mastra/deployer': patch
----
-
-Fixed `mastra build` failing with "Cannot find package '@hono/node-server'" in projects installed with pnpm. The deployer now declares @hono/node-server as a runtime dependency and falls back to project-level resolution when a hono package cannot be resolved from the deployer itself.

--- a/mastracode/web/src/mastra/index.ts
+++ b/mastracode/web/src/mastra/index.ts
@@ -189,10 +189,6 @@ export const factory = new MastraFactory({
 const prepared = await factory.prepare();
 export const mastra = new Mastra({
   ...prepared,
-  bundler: {
-    externals: ['@anush008/tokenizers', '@duckdb/node-bindings', '@node-rs/xxhash', 'supports-color'],
-    transpilePackages: ['@mastra/factory'],
-  },
 });
 
 // Post-construct boot: initialize the controller (which now inherits this

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -97,7 +97,6 @@
     "@babel/core": "^8.0.1",
     "@babel/preset-typescript": "^8.0.1",
     "@babel/traverse": "^8.0.4",
-    "@hono/node-server": "^1.19.14",
     "@hono/node-ws": "^1.3.0",
     "@mastra/server": "workspace:*",
     "@optimize-lodash/rollup-plugin": "^5.1.0",
@@ -124,6 +123,7 @@
     "ws": "^8.21.0"
   },
   "devDependencies": {
+    "@hono/node-server": "^1.19.14",
     "@hono/standard-validator": "^0.3.0",
     "@hono/swagger-ui": "^0.5.3",
     "@internal/lint": "workspace:*",

--- a/packages/deployer/src/build/plugins/hono-alias.ts
+++ b/packages/deployer/src/build/plugins/hono-alias.ts
@@ -10,14 +10,8 @@ export function aliasHono(): Plugin {
         return;
       }
 
-      try {
-        const path = import.meta.resolve(id);
-        return fileURLToPath(path);
-      } catch {
-        // Not resolvable from deployer (e.g. undeclared transitive dep under
-        // pnpm's strict isolation) — fall back to default resolution.
-        return;
-      }
+      const path = import.meta.resolve(id);
+      return fileURLToPath(path);
     },
   } satisfies Plugin;
 }

--- a/packages/deployer/tsup.config.ts
+++ b/packages/deployer/tsup.config.ts
@@ -23,6 +23,6 @@ export default defineConfig({
   sourcemap: true,
   publicDir: true,
   onSuccess: async () => {
-    await generateTypes(process.cwd(), new Set(['@mastra/hono']));
+    await generateTypes(process.cwd(), new Set(['@hono/node-server', '@mastra/hono']));
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4529,9 +4529,6 @@ importers:
       '@babel/traverse':
         specifier: ^8.0.4
         version: 8.0.4
-      '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.30)
       '@hono/node-ws':
         specifier: ^1.3.0
         version: 1.3.1(@hono/node-server@1.19.14(hono@4.12.30))(bufferutil@4.1.0)(hono@4.12.30)
@@ -4605,6 +4602,9 @@ importers:
         specifier: ^8.21.0
         version: 8.21.0(bufferutil@4.1.0)
     devDependencies:
+      '@hono/node-server':
+        specifier: ^1.19.14
+        version: 1.19.14(hono@4.12.30)
       '@hono/standard-validator':
         specifier: ^0.3.0
         version: 0.3.0(@standard-schema/spec@1.1.0)(hono@4.12.30)


### PR DESCRIPTION
- **fix bundler config**
- **Revert "fix(deployer): declare @hono/node-server as runtime dependency (#20049)"**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR makes generated Mastra projects easier to build by using the project’s Hono packages correctly and removing unnecessary bundler settings. It also keeps `@hono/node-server` as a development-only dependency for the deployer.

## What changed

- Removed explicit bundler configuration from the example Mastra setup.
- Updated Hono module resolution to resolve packages directly from the target project.
- Moved `@hono/node-server` from runtime dependencies to development dependencies.
- Included `@hono/node-server` in generated type processing alongside `@mastra/hono`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->