### PR TITLE
feat(factory): GitHub PAT settings for sandbox gh CLI auth

### DIFF
--- a/mastracode/factory/src/factory.ts
+++ b/mastracode/factory/src/factory.ts
@@ -564,6 +564,7 @@ export class MastraFactory {
       workspace: createWorkspaceFactory({
         ...(this.#config.sandbox ? { sandbox: this.#config.sandbox } : {}),
         ...(githubIntegration ? { github: githubIntegration } : {}),
+        ...(workItemsStorage ? { workItems: workItemsStorage } : {}),
         fleet,
       }),
       disableGithubSignals: true,

--- a/mastracode/factory/src/integrations/github/pat.ts
+++ b/mastracode/factory/src/integrations/github/pat.ts
@@ -1,0 +1,98 @@
+/**
+ * Org-scoped GitHub Personal Access Token settings.
+ *
+ * GitHub App installation tokens are the wrong credential for the `gh` CLI —
+ * they hit "Resource not accessible by integration" on endpoints the CLI
+ * needs regardless of the minted permission set. When an org pastes a PAT in
+ * Settings, the sandbox `GH_TOKEN` injection sites and the
+ * `github_refresh_token` tool use it instead of a minted installation token.
+ * Tokens must be classic PATs whose account has access to the linked repos.
+ *
+ * Two kinds:
+ * - `default` — the worker token every sandbox gets.
+ * - `reviewer` — optional second token for review-board sessions, so PR
+ *   reviews come from a different account than the author. When it isn't
+ *   configured, review sessions fall back to the worker token.
+ *
+ * Both live in the generic `integration_settings` collection for the
+ * `github` integration under a sentinel user id (the settings are org-wide,
+ * but the schema keys settings per `(org, user)`). Tokens are never returned
+ * to the browser — the routes only report whether each is configured.
+ */
+
+import type { GithubSubscriptionStorage } from './subscriptions.js';
+
+/** Sentinel `user_id` for the org-wide settings row. */
+const PAT_SETTINGS_USER_ID = '__github_org_settings__';
+
+export type GithubPatKind = 'default' | 'reviewer';
+
+type GithubOrgSettings = { pat?: string; reviewerPat?: string };
+
+const FIELD_FOR_KIND: Record<GithubPatKind, keyof GithubOrgSettings> = {
+  default: 'pat',
+  reviewer: 'reviewerPat',
+};
+
+function asToken(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+/** The PAT to install for `kind`, or null. `reviewer` falls back to the
+ * worker token so review sessions still authenticate when no dedicated
+ * reviewer token is configured. Fail-soft: storage errors (e.g. integration
+ * storage not initialized in a partial test harness) read as "no PAT
+ * configured" so token minting still works. */
+export async function getGithubPat(
+  getStorage: () => GithubSubscriptionStorage,
+  orgId: string,
+  kind: GithubPatKind = 'default',
+): Promise<string | null> {
+  try {
+    const settings = (await getStorage().settings.get(orgId, PAT_SETTINGS_USER_ID)) as GithubOrgSettings | null;
+    if (!settings) return null;
+    if (kind === 'reviewer') return asToken(settings.reviewerPat) ?? asToken(settings.pat);
+    return asToken(settings.pat);
+  } catch {
+    return null;
+  }
+}
+
+/** Which tokens are configured, without fallback semantics — feeds the
+ * settings UI status badges. */
+export async function getGithubPatStatus(
+  getStorage: () => GithubSubscriptionStorage,
+  orgId: string,
+): Promise<{ configured: boolean; reviewerConfigured: boolean }> {
+  try {
+    const settings = (await getStorage().settings.get(orgId, PAT_SETTINGS_USER_ID)) as GithubOrgSettings | null;
+    return {
+      configured: asToken(settings?.pat) !== null,
+      reviewerConfigured: asToken(settings?.reviewerPat) !== null,
+    };
+  } catch {
+    return { configured: false, reviewerConfigured: false };
+  }
+}
+
+export async function setGithubPat(
+  storage: GithubSubscriptionStorage,
+  orgId: string,
+  pat: string,
+  kind: GithubPatKind = 'default',
+): Promise<void> {
+  const existing = ((await storage.settings.get(orgId, PAT_SETTINGS_USER_ID)) ?? {}) as GithubOrgSettings;
+  await storage.settings.save(orgId, PAT_SETTINGS_USER_ID, { ...existing, [FIELD_FOR_KIND[kind]]: pat });
+}
+
+export async function clearGithubPat(
+  storage: GithubSubscriptionStorage,
+  orgId: string,
+  kind: GithubPatKind = 'default',
+): Promise<void> {
+  const existing = (await storage.settings.get(orgId, PAT_SETTINGS_USER_ID)) as GithubOrgSettings | null;
+  const field = FIELD_FOR_KIND[kind];
+  if (!existing?.[field]) return;
+  const { [field]: _removed, ...rest } = existing;
+  await storage.settings.save(orgId, PAT_SETTINGS_USER_ID, rest);
+}

--- a/mastracode/factory/src/integrations/github/routes.test.ts
+++ b/mastracode/factory/src/integrations/github/routes.test.ts
@@ -142,7 +142,15 @@ function subscriptionRow(row: Record<string, any>) {
   };
 }
 
+const settingsRows = new Map<string, Record<string, any>>();
+
 const integrationStorage = {
+  settings: {
+    get: vi.fn(async (orgId: string, userId: string) => settingsRows.get(`${orgId}:${userId}`) ?? null),
+    save: vi.fn(async (orgId: string, userId: string, config: Record<string, any>) => {
+      settingsRows.set(`${orgId}:${userId}`, config);
+    }),
+  },
   subscriptions: {
     create: vi.fn(async (input: Record<string, any>) => {
       const row = subscriptionRow({
@@ -643,6 +651,7 @@ beforeEach(() => {
   featureEnabled = true;
   sandboxEnabled = true;
   cookieUser = null;
+  settingsRows.clear();
   auditRecorded = [];
   auditFailure = undefined;
   process.env.GITHUB_APP_WEBHOOK_SECRET = 'test-webhook-secret';
@@ -888,6 +897,81 @@ describe('status route', () => {
     expect(json.enabled).toBe(true);
     expect(json.connected).toBe(true);
     expect(json.installations[0].installationId).toBe(7);
+  });
+});
+
+describe('pat route', () => {
+  const jsonPost = (token: unknown, kind?: unknown) =>
+    new Request('http://localhost/web/github/pat', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(kind === undefined ? { token } : { token, kind }),
+    });
+  const del = (kind?: string) =>
+    new Request(`http://localhost/web/github/pat${kind ? `?kind=${kind}` : ''}`, { method: 'DELETE' });
+
+  it('requires an authenticated org tenant', async () => {
+    const res = await buildApp(null).request('/web/github/pat');
+    expect(res.status).toBe(401);
+  });
+
+  it('reports not configured by default', async () => {
+    const res = await buildApp({ workosId: 'u1' }).request('/web/github/pat');
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ configured: false, reviewerConfigured: false });
+  });
+
+  it('saves a pasted worker token and reports configured without ever returning it', async () => {
+    const app = buildApp({ workosId: 'u1' });
+    const saved = await app.request(jsonPost('ghp_secret123'));
+    expect(saved.status).toBe(200);
+    expect(await saved.json()).toEqual({ configured: true, reviewerConfigured: false });
+
+    const status = await app.request('/web/github/pat');
+    const body = await status.json();
+    expect(body).toEqual({ configured: true, reviewerConfigured: false });
+    expect(JSON.stringify(body)).not.toContain('ghp_secret123');
+  });
+
+  it('saves and removes a reviewer token independently of the worker token', async () => {
+    const app = buildApp({ workosId: 'u1' });
+    await app.request(jsonPost('ghp_worker', 'default'));
+    const saved = await app.request(jsonPost('ghp_reviewer', 'reviewer'));
+    expect(await saved.json()).toEqual({ configured: true, reviewerConfigured: true });
+
+    const removed = await app.request(del('reviewer'));
+    expect(await removed.json()).toEqual({ configured: true, reviewerConfigured: false });
+  });
+
+  it('rejects an unknown token kind', async () => {
+    const app = buildApp({ workosId: 'u1' });
+    expect((await app.request(jsonPost('ghp_x', 'author'))).status).toBe(400);
+    expect((await app.request(del('author'))).status).toBe(400);
+  });
+
+  it('rejects an empty or whitespace token', async () => {
+    const app = buildApp({ workosId: 'u1' });
+    expect((await app.request(jsonPost('   '))).status).toBe(400);
+    expect((await app.request(jsonPost('bad token'))).status).toBe(400);
+    expect((await app.request(jsonPost(42))).status).toBe(400);
+    const status = await app.request('/web/github/pat');
+    expect(await status.json()).toEqual({ configured: false, reviewerConfigured: false });
+  });
+
+  it('removes the configured worker token', async () => {
+    const app = buildApp({ workosId: 'u1' });
+    await app.request(jsonPost('ghp_secret123'));
+    const removed = await app.request(del());
+    expect(removed.status).toBe(200);
+    expect(await removed.json()).toEqual({ configured: false, reviewerConfigured: false });
+    const status = await app.request('/web/github/pat');
+    expect(await status.json()).toEqual({ configured: false, reviewerConfigured: false });
+  });
+
+  it('scopes the tokens per org', async () => {
+    await buildApp({ workosId: 'u1' }).request(jsonPost('ghp_org1'));
+    const other = await buildApp({ workosId: 'u2', organizationId: 'org2' }).request('/web/github/pat');
+    expect(await other.json()).toEqual({ configured: false, reviewerConfigured: false });
   });
 });
 

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -33,6 +33,8 @@ import type {
 } from '../../storage/domains/source-control/base.js';
 import { getGithubFeatureDiagnostics, isGithubFeatureEnabled } from './config.js';
 import type { GithubIntegration } from './integration.js';
+import { clearGithubPat, getGithubPat, getGithubPatStatus, setGithubPat } from './pat.js';
+import type { GithubPatKind } from './pat.js';
 import { withProjectLock } from './project-lock.js';
 
 import {
@@ -947,6 +949,66 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
     }),
   );
 
+  // ── Org GitHub PATs ──────────────────────────────────────────────────────
+  // Installation tokens are the wrong credential for the `gh` CLI (integration
+  // -restricted endpoints 403 regardless of permissions), so orgs paste
+  // classic PATs the sandboxes use instead: a `default` worker token, and an
+  // optional `reviewer` token that review-board sessions use so PR reviews
+  // come from a different account. Tokens are never sent back to the browser —
+  // only whether each is configured.
+  const parsePatKind = (value: unknown): GithubPatKind | null => {
+    if (value === undefined || value === null || value === 'default') return 'default';
+    if (value === 'reviewer') return 'reviewer';
+    return null;
+  };
+  routes.push(
+    registerApiRoute('/web/github/pat', {
+      method: 'GET',
+      requiresAuth: false,
+      handler: async c => {
+        const resolved = await resolveOrgTenant(loose(c), auth);
+        if ('response' in resolved) return resolved.response;
+        return c.json(await getGithubPatStatus(() => github.integrationStorage, resolved.tenant.orgId));
+      },
+    }),
+    registerApiRoute('/web/github/pat', {
+      method: 'POST',
+      requiresAuth: false,
+      handler: async c => {
+        const resolved = await resolveOrgTenant(loose(c), auth);
+        if ('response' in resolved) return resolved.response;
+
+        let body: { token?: unknown; kind?: unknown };
+        try {
+          body = await c.req.json();
+        } catch {
+          return c.json({ error: 'Invalid JSON body' }, 400);
+        }
+        const kind = parsePatKind(body.kind);
+        if (!kind) return c.json({ error: "kind must be 'default' or 'reviewer'" }, 400);
+        const token = typeof body.token === 'string' ? body.token.trim() : '';
+        if (!token) return c.json({ error: 'A token is required' }, 400);
+        if (token.length > 500) return c.json({ error: 'Token too long (max 500 characters)' }, 400);
+        if (/\s/.test(token)) return c.json({ error: 'Token must not contain whitespace' }, 400);
+
+        await setGithubPat(github.integrationStorage, resolved.tenant.orgId, token, kind);
+        return c.json(await getGithubPatStatus(() => github.integrationStorage, resolved.tenant.orgId));
+      },
+    }),
+    registerApiRoute('/web/github/pat', {
+      method: 'DELETE',
+      requiresAuth: false,
+      handler: async c => {
+        const resolved = await resolveOrgTenant(loose(c), auth);
+        if ('response' in resolved) return resolved.response;
+        const kind = parsePatKind(c.req.query('kind'));
+        if (!kind) return c.json({ error: "kind must be 'default' or 'reviewer'" }, 400);
+        await clearGithubPat(github.integrationStorage, resolved.tenant.orgId, kind);
+        return c.json(await getGithubPatStatus(() => github.integrationStorage, resolved.tenant.orgId));
+      },
+    }),
+  );
+
   // ── Sessions / commit / push / PR ────────────────────────────────────────
   routes.push(...buildProjectGitRoutes({ github, auth, fleet, storage, emitAudit }));
 
@@ -1045,11 +1107,15 @@ async function prepareProject(options: {
   if (!access.authorization) {
     throw new MaterializeError('Repository access did not include a bearer token.', 'clone-failed');
   }
+  // The sandbox env token feeds the `gh` CLI — a configured org PAT wins
+  // there. Git clone/pull below keep the minted installation token.
+  const ghCliToken =
+    (await getGithubPat(() => github.integrationStorage, project.installation.orgId)) ?? access.authorization.token;
   const sandbox = await ensureProjectSandbox({
     fleet,
     row: sandboxRow,
     storage: github.sourceControlStorage.sandboxes,
-    token: access.authorization.token,
+    token: ghCliToken,
     onProgress,
   });
   // Re-read the sandbox binding so we have the freshly persisted sandboxId.

--- a/mastracode/factory/src/integrations/github/session-subscriptions.test.ts
+++ b/mastracode/factory/src/integrations/github/session-subscriptions.test.ts
@@ -18,7 +18,7 @@ vi.mock('./subscriptions', () => ({
 }));
 
 // Stub integration: entry points consume the injected instance for PR verification and persistence.
-const integrationStorage = {};
+const integrationStorage: { settings?: { get: (orgId: string, userId: string) => Promise<unknown> } } = {};
 const githubStub = {
   integrationStorage,
   sourceControlStorage: {
@@ -61,7 +61,7 @@ import {
   subscribeCurrentSessionToPullRequest,
   unsubscribeCurrentSessionFromPullRequest,
 } from './session-subscriptions.js';
-import { registerGithubTokenInjector } from './token-refresh.js';
+import { registerGithubPatKind, registerGithubTokenInjector } from './token-refresh.js';
 
 function authenticatedRequestContext(scope = '/worktrees/a') {
   const requestContext = new RequestContext();
@@ -78,6 +78,7 @@ function authenticatedRequestContext(scope = '/worktrees/a') {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  delete integrationStorage.settings;
 });
 
 describe('parseCreatedPullRequest', () => {
@@ -143,6 +144,30 @@ describe('GitHub subscription entry points', () => {
 
     expect(mocks.getRepositoryAccess).toHaveBeenCalledWith({ orgId: 'org-1', repositoryId: 'repository-1' });
     expect(inject).toHaveBeenCalledWith('fresh-gh-token');
+  });
+
+  it('re-injects a configured org PAT instead of minting an installation token', async () => {
+    integrationStorage.settings = { get: vi.fn(async () => ({ pat: 'ghp_org_pat' })) };
+    const requestContext = authenticatedRequestContext();
+    const inject = vi.fn();
+    registerGithubTokenInjector(requestContext, inject);
+
+    await expect(refreshGithubToken(requestContext, githubStub)).resolves.toBeUndefined();
+
+    expect(inject).toHaveBeenCalledWith('ghp_org_pat');
+    expect(mocks.getRepositoryAccess).not.toHaveBeenCalled();
+  });
+
+  it('re-injects the reviewer PAT when the sandbox was provisioned as a reviewer', async () => {
+    integrationStorage.settings = { get: vi.fn(async () => ({ pat: 'ghp_worker', reviewerPat: 'ghp_reviewer' })) };
+    const requestContext = authenticatedRequestContext();
+    const inject = vi.fn();
+    registerGithubTokenInjector(requestContext, inject);
+    registerGithubPatKind(requestContext, 'reviewer');
+
+    await expect(refreshGithubToken(requestContext, githubStub)).resolves.toBeUndefined();
+
+    expect(inject).toHaveBeenCalledWith('ghp_reviewer');
   });
 
   it('silently skips auto-subscription outside repository sessions', async () => {

--- a/mastracode/factory/src/integrations/github/session-subscriptions.ts
+++ b/mastracode/factory/src/integrations/github/session-subscriptions.ts
@@ -9,8 +9,9 @@ import type {
   SourceControlRepository,
 } from '../../storage/domains/source-control/base.js';
 import type { GithubIntegration } from './integration.js';
+import { getGithubPat } from './pat.js';
 import { subscribeToPullRequest, unsubscribeFromPullRequest } from './subscriptions.js';
-import { injectGithubToken } from './token-refresh.js';
+import { getRegisteredGithubPatKind, injectGithubToken } from './token-refresh.js';
 
 type RepositorySessionState = { factoryProjectId?: string; projectRepositoryId?: string };
 
@@ -154,6 +155,19 @@ export async function unsubscribeCurrentSessionFromPullRequest(
 
 export async function refreshGithubToken(requestContext: RequestContext, github: GithubIntegration): Promise<void> {
   const target = await resolveSessionTarget(requestContext, github);
+  // `GH_TOKEN` feeds the `gh` CLI, so a configured org PAT wins over a minted
+  // installation token (which 403s on integration-restricted endpoints). The
+  // workspace records which PAT kind the sandbox was provisioned with, so a
+  // review-board sandbox keeps its reviewer token on refresh.
+  const pat = await getGithubPat(
+    () => github.integrationStorage,
+    target.orgId,
+    getRegisteredGithubPatKind(requestContext),
+  );
+  if (pat) {
+    injectGithubToken(requestContext, pat);
+    return;
+  }
   const access = await github.versionControl.getRepositoryAccess({
     orgId: target.orgId,
     repositoryId: target.repository.id,

--- a/mastracode/factory/src/integrations/github/token-refresh.ts
+++ b/mastracode/factory/src/integrations/github/token-refresh.ts
@@ -1,11 +1,26 @@
 import type { RequestContext } from '@mastra/core/request-context';
 
+import type { GithubPatKind } from './pat.js';
+
 const GITHUB_TOKEN_INJECTOR_CONTEXT_KEY = 'factoryGithubTokenInjector';
+const GITHUB_PAT_KIND_CONTEXT_KEY = 'factoryGithubPatKind';
 
 type GithubTokenInjector = (token: string) => void;
 
 export function registerGithubTokenInjector(requestContext: RequestContext, injector: GithubTokenInjector): void {
   requestContext.set(GITHUB_TOKEN_INJECTOR_CONTEXT_KEY, injector);
+}
+
+/** Record which PAT kind the active sandbox was provisioned with, so token
+ * refresh re-injects the same credential (review-board sandboxes keep the
+ * reviewer token instead of being clobbered with the worker token). */
+export function registerGithubPatKind(requestContext: RequestContext, kind: GithubPatKind): void {
+  requestContext.set(GITHUB_PAT_KIND_CONTEXT_KEY, kind);
+}
+
+export function getRegisteredGithubPatKind(requestContext: RequestContext): GithubPatKind {
+  const kind = requestContext.get(GITHUB_PAT_KIND_CONTEXT_KEY);
+  return kind === 'reviewer' ? 'reviewer' : 'default';
 }
 
 export function injectGithubToken(requestContext: RequestContext, token: string): void {

--- a/mastracode/factory/src/integrations/platform/github/integration.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.ts
@@ -301,6 +301,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
     getRepositoryAccess: async ({ orgId, repositoryId }) => {
       const repository = await this.storage.repositories.get({ orgId, id: repositoryId });
       if (!repository) throw new Error('Version-control repository not found.');
+      const cloneUrl = `https://github.com/${repository.slug}.git`;
       const installation = await this.storage.installations.get({ orgId, id: repository.installationId });
       if (!installation) throw new Error('Version-control installation not found.');
       const installationId = parsePositiveInteger(installation.externalId);
@@ -312,7 +313,7 @@ export class PlatformGithubIntegration implements FactoryIntegration {
         { repositories: [repositoryName], permissions: REPOSITORY_TOKEN_PERMISSIONS },
       );
       return {
-        cloneUrl: `https://github.com/${repository.slug}.git`,
+        cloneUrl,
         authorization: { scheme: 'bearer', token: token.token },
       };
     },

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -31,6 +31,14 @@ const mocks = vi.hoisted(() => ({
   })),
   mintInstallationToken: vi.fn(async () => 'gh-token'),
   setEnvironmentVariable: vi.fn(),
+  /** Org GitHub PATs surfaced via integration settings; null = not configured. */
+  githubPat: null as string | null,
+  githubReviewerPat: null as string | null,
+  /** Run-binding role resolved for the session; null = no binding found. */
+  runBindingRole: null as string | null,
+  findRunBindingBySession: vi.fn(async () =>
+    mocks.runBindingRole ? { role: mocks.runBindingRole, orgId: 'org-1' } : null,
+  ),
 }));
 
 vi.mock('./integrations/github/sandbox', () => ({
@@ -57,6 +65,10 @@ afterEach(async () => {
   mocks.getRepositoryAccess.mockClear();
   mocks.mintInstallationToken.mockClear();
   mocks.setEnvironmentVariable.mockClear();
+  mocks.githubPat = null;
+  mocks.githubReviewerPat = null;
+  mocks.runBindingRole = null;
+  mocks.findRunBindingBySession.mockClear();
 });
 
 function createRequestContext(projectPath: string) {
@@ -75,7 +87,7 @@ function createRequestContext(projectPath: string) {
 }
 
 function createGithubRequestContext(
-  _projectId: string,
+  projectId: string,
   sessionId: string,
   user: Record<string, unknown> = { organizationId: 'org-1', workosId: 'user-1' },
 ) {
@@ -83,6 +95,8 @@ function createGithubRequestContext(
   requestContext.set('controller', {
     modeId: 'build',
     resourceId: sessionId,
+    threadId: sessionId,
+    getState: () => ({ factoryProjectId: projectId }),
     session: { id: sessionId },
   });
   requestContext.set('user', user);
@@ -158,6 +172,18 @@ function fakeGithubIntegration() {
     },
     mintInstallationToken: (...args: unknown[]) => mocks.mintInstallationToken(...(args as [])),
     getInstallationOctokit: vi.fn(),
+    integrationStorage: {
+      settings: {
+        get: vi.fn(async () =>
+          mocks.githubPat || mocks.githubReviewerPat
+            ? {
+                ...(mocks.githubPat ? { pat: mocks.githubPat } : {}),
+                ...(mocks.githubReviewerPat ? { reviewerPat: mocks.githubReviewerPat } : {}),
+              }
+            : null,
+        ),
+      },
+    },
     sourceControlStorage: {
       sessions: {
         getBySessionId: vi.fn(async (id: string) => mocks.sessions.find(session => session.sessionId === id) ?? null),
@@ -267,6 +293,7 @@ describe('GitHub session workspace preparation', () => {
         sandbox: { machine, workdir: root },
         github: fakeGithubIntegration() as any,
         fleet,
+        workItems: { findRunBindingBySession: mocks.findRunBindingBySession } as any,
       }),
     };
   }
@@ -331,6 +358,78 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.getRepositoryAccess).toHaveBeenCalledWith({ orgId: 'org-1', repositoryId: 'repository-1' });
     expect(mocks.mintInstallationToken).not.toHaveBeenCalled();
     expect(mocks.materializeRepo).toHaveBeenCalledWith(expect.objectContaining({ token: 'repo-token-repository-1' }));
+  });
+
+  it('installs a configured org PAT as GH_TOKEN while git keeps the repository-scoped token', async () => {
+    mocks.githubPat = 'ghp_org_pat';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    // gh CLI env gets the PAT…
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_org_pat' },
+      undefined,
+      expect.any(Object),
+    );
+    // …but git materialization keeps the installation-scoped token.
+    expect(mocks.materializeRepo).toHaveBeenCalledWith(expect.objectContaining({ token: 'repo-token-repository-1' }));
+  });
+
+  it('installs the reviewer PAT for review-board sessions', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'review';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_reviewer' },
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to the worker PAT for review sessions without a reviewer token', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.runBindingRole = 'review';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_worker' },
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it('keeps the worker PAT for non-review sessions even when a reviewer token exists', async () => {
+    mocks.githubPat = 'ghp_worker';
+    mocks.githubReviewerPat = 'ghp_reviewer';
+    mocks.runBindingRole = 'triage';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+
+    expect(mocks.ensureSandbox).toHaveBeenCalledWith(
+      expect.any(Object),
+      { GH_TOKEN: 'ghp_worker' },
+      undefined,
+      expect.any(Object),
+    );
   });
 
   it('registers a runtime injector for refreshing GH_TOKEN in the active sandbox', async () => {

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -14,9 +14,13 @@ import { getFactoryAuthUserId } from './auth.js';
 import type { FactoryAuthUser } from './auth.js';
 import type { MastraFactorySandboxConfig } from './factory.js';
 import type { GithubIntegration } from './integrations/github/integration.js';
+import { getGithubPat } from './integrations/github/pat.js';
+import type { GithubPatKind } from './integrations/github/pat.js';
 import { checkoutSessionBranch, materializeRepo, runWorktreeSetup } from './integrations/github/sandbox.js';
-import { registerGithubTokenInjector } from './integrations/github/token-refresh.js';
+import { registerGithubPatKind, registerGithubTokenInjector } from './integrations/github/token-refresh.js';
+import { getFactorySessionAddress } from './rules/binding-context.js';
 import type { SandboxBindingStore, SandboxFleet } from './sandbox/fleet.js';
+import type { WorkItemsStorage } from './storage/domains/work-items/base.js';
 
 const WORKSPACE_ID_PREFIX = 'mfw';
 const SESSION_CHECKPOINT_PREFIX = 'mastracode-session';
@@ -111,12 +115,16 @@ export interface CreateWorkspaceFactoryOptions {
   github?: GithubIntegration;
   /** Fleet the per-session sandboxes are provisioned/reattached through. */
   fleet?: SandboxFleet;
+  /** Work-items storage used to resolve the session's run-binding role, so
+   * review-board sessions get the reviewer PAT as `GH_TOKEN`. Optional —
+   * without it every session uses the default (worker) PAT. */
+  workItems?: Pick<WorkItemsStorage, 'findRunBindingBySession'>;
 }
 
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
-  const { sandbox: sandboxConfig, github, fleet } = options;
+  const { sandbox: sandboxConfig, github, fleet, workItems } = options;
   const isLocalSandbox = sandboxConfig?.machine instanceof LocalSandbox;
-  const githubTokenInjectors = new Map<string, (token: string) => void>();
+  const githubTokenInjectors = new Map<string, { inject: (token: string) => void; patKind: GithubPatKind }>();
 
   return async ({ requestContext, mastra, skillExtension }: DynamicWorkspaceContext) => {
     const effectiveSkillExtension = skillExtension ?? factorySkillExtension;
@@ -177,8 +185,11 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       const existing = mastra?.getWorkspaceById(workspaceId) as Workspace | undefined;
       if (existing) {
         existing.setToolsConfig(MASTRACODE_WORKSPACE_TOOLS);
-        const injectGithubToken = githubTokenInjectors.get(workspaceId);
-        if (injectGithubToken) registerGithubTokenInjector(requestContext, injectGithubToken);
+        const registered = githubTokenInjectors.get(workspaceId);
+        if (registered) {
+          registerGithubTokenInjector(requestContext, registered.inject);
+          registerGithubPatKind(requestContext, registered.patKind);
+        }
         return existing;
       }
     } catch {
@@ -192,9 +203,27 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
     const token = access.authorization?.token;
     if (!token) throw new Error('Repository access did not include a bearer token for the Factory session');
 
+    // The `gh` CLI needs a PAT when the org configured one (installation
+    // tokens 403 on integration-restricted endpoints); git clone/checkout
+    // below keep using the minted installation token. Review-board sessions
+    // (run-binding role `review`) authenticate `gh` as the reviewer account
+    // when a reviewer token is configured; everything else — including
+    // sessions with no resolvable run binding — uses the worker token.
+    let patKind: GithubPatKind = 'default';
+    if (workItems) {
+      try {
+        const address = getFactorySessionAddress(requestContext);
+        const runBinding = address ? await workItems.findRunBindingBySession(address) : null;
+        if (runBinding?.role === 'review' && runBinding.orgId === session.orgId) patKind = 'reviewer';
+      } catch {
+        // No resolvable binding — worker token.
+      }
+    }
+    const ghCliToken = (await getGithubPat(() => github.integrationStorage, session.orgId, patKind)) ?? token;
+
     const sandbox = await fleet.ensureSandbox(
       binding,
-      { GH_TOKEN: token },
+      { GH_TOKEN: ghCliToken },
       undefined,
       isLocalSandbox ? { workingDirectory: workdir } : {},
     );
@@ -219,8 +248,9 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
       }
       sandbox.setEnvironmentVariable('GH_TOKEN', freshToken);
     };
-    githubTokenInjectors.set(workspaceId, injectGithubToken);
+    githubTokenInjectors.set(workspaceId, { inject: injectGithubToken, patKind });
     registerGithubTokenInjector(requestContext, injectGithubToken);
+    registerGithubPatKind(requestContext, patKind);
 
     const filesystem = new SandboxFilesystem({ sandbox, workdir });
     const projectSkillPaths = [path.join(configDir, 'skills'), '.claude/skills', '.agents/skills'];

--- a/mastracode/web/src/shared/api/keys.ts
+++ b/mastracode/web/src/shared/api/keys.ts
@@ -23,6 +23,7 @@ export const queryKeys = {
   factoryCreateFlow: () => ['factories', 'create-flow'] as const,
   factoryProject: (factoryProjectId: string | undefined) => ['factory', 'project', factoryProjectId ?? null] as const,
   githubStatus: () => ['github', 'status'] as const,
+  githubPat: () => ['github', 'pat'] as const,
   githubRepos: (query: string | undefined) => ['github', 'repos', query ?? null] as const,
   githubIssues: (githubProjectId: string | undefined, label?: string) =>
     ['github', 'issues', githubProjectId ?? null, label ?? null] as const,

--- a/mastracode/web/src/shared/hooks/useGithubPat.ts
+++ b/mastracode/web/src/shared/hooks/useGithubPat.ts
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { useApiConfig } from '../api/config';
+import { queryKeys } from '../api/keys';
+import {
+  deleteGithubPat,
+  fetchGithubPatStatus,
+  saveGithubPat,
+} from '../../web/ui/domains/workspaces/services/github';
+import type { GithubPatKind } from '../../web/ui/domains/workspaces/services/github';
+
+/**
+ * Which GitHub Personal Access Tokens the org has configured for `gh` CLI
+ * auth inside sandboxes (worker + optional reviewer). The tokens themselves
+ * never reach the browser — only these configured flags.
+ */
+export function useGithubPatStatusQuery(enabled: boolean = true) {
+  const { baseUrl } = useApiConfig();
+  return useQuery({
+    queryKey: queryKeys.githubPat(),
+    queryFn: () => fetchGithubPatStatus(baseUrl),
+    enabled,
+    retry: false,
+  });
+}
+
+export function useSaveGithubPatMutation(kind: GithubPatKind = 'default') {
+  const { baseUrl } = useApiConfig();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (token: string) => saveGithubPat(baseUrl, token, kind),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.githubPat() }),
+  });
+}
+
+export function useRemoveGithubPatMutation(kind: GithubPatKind = 'default') {
+  const { baseUrl } = useApiConfig();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => deleteGithubPat(baseUrl, kind),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: queryKeys.githubPat() }),
+  });
+}

--- a/mastracode/web/src/web/ui/domains/settings/components/GithubPatBlock.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/GithubPatBlock.tsx
@@ -1,0 +1,164 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Input } from '@mastra/playground-ui/components/Input';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { useState } from 'react';
+
+import {
+  useGithubPatStatusQuery,
+  useRemoveGithubPatMutation,
+  useSaveGithubPatMutation,
+} from '../../../../../shared/hooks/useGithubPat';
+import type { GithubPatKind } from '../../workspaces/services/github';
+
+/**
+ * Org-wide GitHub Personal Access Tokens used only for `gh` CLI auth inside
+ * Factory sandboxes. GitHub App installation tokens 403 on the endpoints the
+ * CLI needs ("Resource not accessible by integration"), so agents need PATs
+ * there; git clone/push and API access keep using the app installation.
+ *
+ * Two tokens: the worker token every sandbox gets, and an optional reviewer
+ * token used by review-board sessions so PR reviews come from a different
+ * account. Without a reviewer token, review sessions use the worker token.
+ */
+export function GithubPatBlock() {
+  const statusQuery = useGithubPatStatusQuery();
+
+  return (
+    <div className="flex flex-col gap-4 border-t border-border1 pt-4">
+      <div className="flex flex-col">
+        <Txt variant="ui-md" className="font-medium">
+          GitHub CLI tokens
+        </Txt>
+        <Txt variant="ui-xs">
+          Personal Access Tokens agents use for `gh` CLI commands in sandboxes. Tokens must be classic PATs, and the
+          token&apos;s account must have access to the linked repositories. Git and API access keep using the GitHub App
+          connection.
+        </Txt>
+      </div>
+
+      <TokenRow
+        kind="default"
+        title="Worker token"
+        description="Used by every sandbox for gh CLI commands (issues, PRs, comments)."
+        configured={statusQuery.data?.configured === true}
+      />
+      <TokenRow
+        kind="reviewer"
+        title="Reviewer token (optional)"
+        description="Used by review-board sessions so PR reviews come from a different account. Falls back to the worker token when not set."
+        configured={statusQuery.data?.reviewerConfigured === true}
+      />
+    </div>
+  );
+}
+
+function TokenRow({
+  kind,
+  title,
+  description,
+  configured,
+}: {
+  kind: GithubPatKind;
+  title: string;
+  description: string;
+  configured: boolean;
+}) {
+  const saveMutation = useSaveGithubPatMutation(kind);
+  const removeMutation = useRemoveGithubPatMutation(kind);
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  const busy = saveMutation.isPending || removeMutation.isPending;
+  const mutationError = saveMutation.error ?? removeMutation.error;
+  const error = mutationError instanceof Error ? mutationError.message : undefined;
+
+  const save = async () => {
+    const token = draft.trim();
+    if (!token) return;
+    try {
+      await saveMutation.mutateAsync(token);
+      setEditing(false);
+      setDraft('');
+    } catch {
+      // Mutation error is rendered below.
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between gap-4">
+        <div className="min-w-0 flex flex-col">
+          <div className="flex items-center gap-2">
+            <Txt variant="ui-sm" className="font-medium">
+              {title}
+            </Txt>
+            <Badge size="sm" variant={configured ? 'success' : 'default'}>
+              {configured ? 'Configured' : 'Not set'}
+            </Badge>
+          </div>
+          <Txt variant="ui-xs">{description}</Txt>
+        </div>
+        {!editing && (
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              size="sm"
+              disabled={busy}
+              onClick={() => {
+                setEditing(true);
+                setDraft('');
+              }}
+            >
+              {configured ? 'Update token' : 'Add token'}
+            </Button>
+            {configured && (
+              <Button variant="outline" size="sm" disabled={busy} onClick={() => removeMutation.mutate()}>
+                {removeMutation.isPending ? 'Removing…' : 'Remove'}
+              </Button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {editing && (
+        <div className="flex items-center gap-2">
+          <Input
+            autoFocus
+            type="password"
+            size="sm"
+            aria-label={`${title} GitHub Personal Access Token`}
+            placeholder="Paste classic Personal Access Token"
+            value={draft}
+            onChange={event => setDraft(event.target.value)}
+            onKeyDown={event => {
+              if (event.key === 'Enter') void save();
+              if (event.key === 'Escape') {
+                setEditing(false);
+                setDraft('');
+              }
+            }}
+          />
+          <Button
+            size="sm"
+            disabled={busy}
+            onClick={() => {
+              setEditing(false);
+              setDraft('');
+            }}
+          >
+            Cancel
+          </Button>
+          <Button variant="primary" size="sm" disabled={busy || !draft.trim()} onClick={() => void save()}>
+            {saveMutation.isPending ? 'Saving…' : 'Save'}
+          </Button>
+        </div>
+      )}
+
+      {error && (
+        <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
+          {error}
+        </Txt>
+      )}
+    </div>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/settings/components/SourceControlSection.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/SourceControlSection.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router';
 
 import { useFactoryQuery, useRemoveFactoryMutation } from '../../../../../shared/hooks/useFactories';
 import { ConnectRepositoriesPanel } from '../../workspaces';
+import { GithubPatBlock } from './GithubPatBlock';
 import { UserGithubConnectionRow } from './UserGithubConnectionRow';
 
 /**
@@ -32,6 +33,8 @@ export function SourceControlSection() {
 
       <ConnectRepositoriesPanel factory={activeFactory} />
       <UserGithubConnectionRow />
+
+      <GithubPatBlock />
 
       <div className="flex items-center justify-between gap-4 border-t border-border1 pt-4">
         <div className="min-w-0 flex flex-col">

--- a/mastracode/web/src/web/ui/domains/workspaces/services/github.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/services/github.ts
@@ -133,6 +133,52 @@ export function connectUserGithub(baseUrl: string): void {
   window.location.assign(`${baseUrl}/auth/github/connect-user?redirectTo=${currentPageRedirectTo()}`);
 }
 
+/** `default` = the worker token every sandbox gets; `reviewer` = optional
+ * token review-board sessions use so PR reviews come from another account. */
+export type GithubPatKind = 'default' | 'reviewer';
+
+export interface GithubPatStatus {
+  configured: boolean;
+  reviewerConfigured: boolean;
+}
+
+/**
+ * Which GitHub Personal Access Tokens the org has configured for `gh` CLI
+ * use in sandboxes. The tokens themselves never reach the browser.
+ */
+export async function fetchGithubPatStatus(baseUrl: string): Promise<GithubPatStatus> {
+  const res = await fetch(`${baseUrl}/web/github/pat`, {
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Failed to load GitHub token status (${res.status})`);
+  return (await res.json()) as GithubPatStatus;
+}
+
+/** Save an org GitHub PAT (used only for `gh` CLI auth in sandboxes). */
+export async function saveGithubPat(baseUrl: string, token: string, kind: GithubPatKind = 'default'): Promise<void> {
+  const res = await fetch(`${baseUrl}/web/github/pat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ token, kind }),
+  });
+  if (!res.ok) {
+    const body = (await res.json().catch(() => undefined)) as { error?: string } | undefined;
+    throw new Error(body?.error ?? `Failed to save GitHub token (${res.status})`);
+  }
+}
+
+/** Remove an org GitHub PAT. */
+export async function deleteGithubPat(baseUrl: string, kind: GithubPatKind = 'default'): Promise<void> {
+  const res = await fetch(`${baseUrl}/web/github/pat?kind=${kind}`, {
+    method: 'DELETE',
+    headers: { Accept: 'application/json' },
+    credentials: 'include',
+  });
+  if (!res.ok) throw new Error(`Failed to remove GitHub token (${res.status})`);
+}
+
 /** List repos across the user's installations, optionally filtered by query. */
 export async function listGithubRepos(baseUrl: string, query?: string): Promise<GithubRepo[]> {
   const url = query ? `${baseUrl}/web/github/repos?q=${encodeURIComponent(query)}` : `${baseUrl}/web/github/repos`;


### PR DESCRIPTION
## Summary

Factory session sandboxes authenticate the `gh` CLI with GitHub App installation tokens today, but `gh` is not designed for them — several endpoints (issues, PR review flows) return 403 "Resource not accessible by integration" even with widened token permissions. This PR adds org-level GitHub personal access token settings so `gh` works fully inside Factory sandboxes:

- **Worker token** — a classic PAT (with `repo` access to the linked repositories) stored per org in the `github` integration settings. When configured, it is injected as `GH_TOKEN` into every Factory session sandbox instead of the minted installation token.
- **Reviewer token (optional)** — a second PAT used only by review-board sessions, so PR reviews come from a distinct account rather than the same identity that authored the work. Falls back to the worker token when unset.
- **Scoped use** — PATs only feed the `gh` CLI (`GH_TOKEN`). Git materialization and all other repository operations keep using installation-scoped tokens.
- **Refresh-aware** — each sandbox remembers which credential kind it was provisioned with; `github_refresh_token` re-injects the same kind (and skips minting entirely for PATs, which don't expire), so a reviewer sandbox is never clobbered with the worker credential.
- **Settings UI** — Settings › Source Control gains a "GitHub CLI tokens" block with add/update/remove for both tokens, classic-token guidance, and per-kind configured status. Tokens are never returned to the browser — status endpoints only report whether one is configured.

## API

- `GET /web/github/pat` → `{ configured, reviewerConfigured }`
- `POST /web/github/pat` `{ pat, kind?: 'default' | 'reviewer' }`
- `DELETE /web/github/pat?kind=…`

## Test plan

- `mastracode/factory`: `vitest run src/workspace.test.ts src/integrations/github/routes.test.ts src/integrations/github/session-subscriptions.test.ts` — 128 passed. Covers: save/status/delete per kind, org scoping, token redaction, unknown-kind 400, worker PAT wins `GH_TOKEN` while git keeps the repo token, review-role sessions get the reviewer PAT, review fallback to worker, non-review sessions never get the reviewer PAT, refresh re-injects the provisioned kind, PAT skips installation-token minting.
- `tsc --noEmit` clean in `mastracode/factory` and `mastracode/web` (including the UI tsconfig).

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This lets each organization securely save GitHub login keys for its factory sandboxes. Regular sessions use the worker key, review sessions can use a separate reviewer key, and the settings page never reveals the keys.

## Summary

- Added organization-scoped GitHub classic PAT storage with worker/reviewer tokens, fallback behavior, status reporting, and safe removal.
- Added authenticated API endpoints for PAT status, creation/update, and deletion with validation and tenant isolation.
- Injected PATs as `GH_TOKEN` while preserving installation tokens for Git operations and handling refreshes correctly.
- Added reviewer-session detection and token selection, including fallback to the worker token.
- Added settings UI and React Query hooks for configuring, updating, removing, and viewing PAT status without exposing values.
- Added coverage for lifecycle, validation, redaction, organization scoping, session roles, refresh behavior, and token usage.
- Passed TypeScript checks for factory and web packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->