### PR TITLE
fix(factory): seed bound session state so agents can propose transitions

### DIFF
--- a/mastracode/factory/src/rules/dispatcher.test.ts
+++ b/mastracode/factory/src/rules/dispatcher.test.ts
@@ -61,6 +61,7 @@ function createSession(accepted?: Promise<unknown>) {
         get: vi.fn(async (name: string) => ({ name, instructions: 'Follow the skill.' })),
       },
     }),
+    state: { set: vi.fn(async () => {}) },
     sendMessage: vi.fn(async () => {}),
     sendSignal: vi.fn((input: { id: string }, _options: { requestContext: { get(key: string): unknown } }) => {
       deliveredSignals.add(input.id);

--- a/mastracode/factory/src/rules/github-service.test.ts
+++ b/mastracode/factory/src/rules/github-service.test.ts
@@ -191,6 +191,7 @@ describe('FactoryGithubEventService', () => {
             return { accepted: Promise.resolve({ accepted: true }) };
           },
         ),
+        state: { set: vi.fn(async () => {}) },
         sendMessage: vi.fn(async () => {}),
         sendNotificationSignal: vi.fn(async () => ({ persisted: Promise.resolve(), accepted: Promise.resolve() })),
       };

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -27,6 +27,7 @@ function makeController(sendMessage = vi.fn(async () => {})) {
       }),
     },
     getWorkspace: vi.fn(() => ({ skills: undefined })),
+    state: { set: vi.fn(async () => {}) },
     sendMessage,
   };
   return {
@@ -203,8 +204,20 @@ describe('FactoryStartCoordinator', () => {
 
     expect(prepared).toMatchObject({ threadId: 'session-1', resourceId: 'session-1', sessionId: 'session-1' });
     expect(controller.createSession).toHaveBeenCalledWith(
-      expect.objectContaining({ id: 'session-1', resourceId: 'session-1', threadId: 'session-1' }),
+      expect.objectContaining({
+        id: 'session-1',
+        resourceId: 'session-1',
+        threadId: 'session-1',
+        tags: { factoryProjectId: PROJECT_ID, projectRepositoryId: 'project-repository-1' },
+      }),
     );
+    // Bound-agent gates (transition tool, factory-phase processor) resolve the
+    // session address from controller state — the coordinator must seed it
+    // server-side, never relying on a browser connecting to set it.
+    expect(session.state.set).toHaveBeenCalledWith({
+      factoryProjectId: PROJECT_ID,
+      projectRepositoryId: 'project-repository-1',
+    });
     expect(session.thread.list).not.toHaveBeenCalled();
     expect(session.thread.switch).not.toHaveBeenCalled();
     expect(session.thread.create).not.toHaveBeenCalled();

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -127,13 +127,25 @@ export class FactoryStartCoordinator {
     if (!request.requestContext) {
       requestContext.set('user', { workosId: request.userId, organizationId: request.orgId });
     }
+    const sessionState = {
+      factoryProjectId: request.factoryProjectId,
+      projectRepositoryId: sourceSession.projectRepositoryId,
+    };
     const session = await this.#controller.createSession({
       id: sourceSession.sessionId,
       ownerId: request.userId,
       resourceId: sourceSession.sessionId,
       threadId: sourceSession.sessionId,
       requestContext,
+      tags: sessionState,
     });
+    // Bound-agent authority gates (the transition tool, the factory-phase
+    // processor, workspace token selection) resolve the session address from
+    // controller state. Seed it server-side — `tags` covers fresh creation,
+    // the explicit setState covers get-or-create returning a session another
+    // caller created without them — so autonomous runs never depend on a
+    // browser connecting to populate the state.
+    await session.state.set(sessionState);
     const threadId = await configureThread(session, request);
     const kickoffMessage = await resolveKickoffMessage(session, request.invocation);
     const prepared = await storage.prepareRunStart({

--- a/mastracode/web/src/shared/hooks/useAgentControllerSessionInit.ts
+++ b/mastracode/web/src/shared/hooks/useAgentControllerSessionInit.ts
@@ -46,9 +46,12 @@ export function useAgentControllerSessionInit({
     queryFn: async () => {
       const activeSession = requireAgentControllerSession(session);
       const created = await activeSession.create({ tags: scope ? { projectPath: scope } : undefined });
-      if (scope) {
+      // Factory sessions have no scope but still need their state seeded —
+      // server-side gates (the transition tool, factory-phase processor)
+      // resolve the session address from `factoryProjectId` in state.
+      if (scope || factorySessionState) {
         try {
-          await activeSession.setState({ projectPath: scope, ...factorySessionState });
+          await activeSession.setState({ ...(scope ? { projectPath: scope } : {}), ...factorySessionState });
         } catch {
           // Continue connecting; session.state() remains the source of truth.
         }


### PR DESCRIPTION
## Summary

Bound Factory agents could not see the `factory_transition_work_item` tool, and the `factory-phase` signal never arrived in their sessions — so autonomous runs finished their work with no way to move the work item forward. Live transcript evidence: the agent's tool call returned `Tool "factory_transition_work_item" not found`.

**Root cause:** the bound-agent authority gates (the transition tool, the `factory-phase` processor, and workspace token selection) resolve the session's Factory address from `factoryProjectId` in the agent-controller session state — but nothing ever set it:

1. `FactoryStartCoordinator.prepare` created bound sessions with no `tags` and no state, so server-started autonomous runs never had it.
2. The browser's `useAgentControllerSessionInit` only calls `setState` when a `scope` is present — and Factory sessions are deliberately scopeless — so even a user opening the thread didn't seed it.

**Fix:**

- `start-coordinator.ts` now passes `tags: { factoryProjectId, projectRepositoryId }` to `createSession` (tags seed the session's initial state) **and** explicitly `session.state.set(...)`s the same keys, covering the get-or-create path where the session was created earlier by another caller without them.
- `useAgentControllerSessionInit.ts` also seeds state when `factorySessionState` is present without a scope, so a browser-first reconnect after a server restart restores the address too.

With the state present, the transition tool registers, the `factory-phase` signal (stage + revision) reaches the bound agent, and workspace credential selection can resolve the session's run-binding role.

## Test plan

- `mastracode/factory`: `vitest run src/rules/` — 131 passed. `start-coordinator.test.ts` now asserts `createSession` receives the tags and that session state is seeded with `factoryProjectId`/`projectRepositoryId`.
- `tsc --noEmit` clean in `mastracode/factory` and `mastracode/web`.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Factory sessions now remember which project and repository they belong to, so they can use transitions, receive phase updates, and choose the right workspace credentials—even after reconnecting in a browser.

## Changes

- Seeded Factory project and repository IDs when creating coordinator sessions.
- Added session tags and explicit state persistence for existing sessions.
- Seeded Factory session state during scopeless browser reconnects.
- Updated coordinator and session mocks/assertions.
- 131 Factory rule tests pass, with clean TypeScript checks for Factory and web.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->