### PR TITLE
feat(factory): emit pnpm-workspace.yaml with allowBuilds in template

### DIFF
--- a/.changeset/happy-things-report.md
+++ b/.changeset/happy-things-report.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+The factory template now ships a pnpm-workspace.yaml with allowBuilds, preventing pnpm v10+ from exiting with ERR_PNPM_IGNORED_BUILDS during install or build. The file mirrors the mastracode/web build-approval policy minus test-only deps stripped by the template.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -98,8 +98,9 @@ const EXCLUDE_TOP_LEVEL = new Set([
   '.mastra',
   'e2e',
   // The web project is its own pnpm workspace root wired to the monorepo via
-  // `link:` deps — none of that applies to the standalone template, and npm
-  // scaffolds must not ship pnpm workspace/lock files (or a stale npm lock).
+  // `link:` deps — none of that applies to the standalone template. A clean
+  // template-specific pnpm-workspace.yaml (allowBuilds only) is written by
+  // writePnpmWorkspace() below.
   'pnpm-lock.yaml',
   'pnpm-workspace.yaml',
   'package-lock.json',
@@ -343,6 +344,38 @@ function writeNpmrc() {
   fs.writeFileSync(path.join(outDir, '.npmrc'), 'legacy-peer-deps=true\n');
 }
 
+/**
+ * Emit `pnpm-workspace.yaml` with `allowBuilds`.
+ *
+ * pnpm v10+ blocks install scripts by default and exits with
+ * ERR_PNPM_IGNORED_BUILDS if any dependency has a build script that isn't
+ * explicitly approved. The deployer also copies this file to `.mastra/output`,
+ * so without it `mastra build` / `mastra start` fail under pnpm.
+ *
+ * Mirrors the mastracode/web allowBuilds policy, minus test-only deps (msw)
+ * stripped by the template. Packages marked `false` don't need their build
+ * script at runtime — listing them prevents the ignored-builds error without
+ * actually running the script.
+ */
+function writePnpmWorkspace() {
+  const content = `# pnpm configuration for the Mastra Factory template.
+# Prevents ERR_PNPM_IGNORED_BUILDS on pnpm v10+ by explicitly approving
+# (or declining) build scripts for dependencies that have them.
+# npm ignores this file entirely; it only affects pnpm installs.
+allowBuilds:
+  '@google/genai': true
+  agent-browser: true
+  bufferutil: true
+  edgedriver: false
+  esbuild: true
+  geckodriver: false
+  onnxruntime-node: true
+  protobufjs: true
+  utf-8-validate: true
+`;
+  fs.writeFileSync(path.join(outDir, 'pnpm-workspace.yaml'), content);
+}
+
 /** Copy the checked-in user-facing README verbatim. */
 function writeReadme() {
   const source = path.join(pkgRoot, 'template', 'README.md');
@@ -376,6 +409,7 @@ stripTestingTypesFromUiTsconfig();
 writeEnvExample();
 writeGitignore();
 writeNpmrc();
+writePnpmWorkspace();
 writeReadme();
 
 console.log(`sync-template: done. Template written to ${outDir}`);


### PR DESCRIPTION
The factory template sync script now writes a clean `pnpm-workspace.yaml` with `allowBuilds` so pnpm v10+ users don't hit `ERR_PNPM_IGNORED_BUILDS` during install or build.

The web project's own `pnpm-workspace.yaml` was already excluded from the template (it's monorepo-coupled), but nothing replaced it — leaving pnpm users with no build approvals. This adds a `writePnpmWorkspace()` function that emits a standalone `pnpm-workspace.yaml` with just the `allowBuilds` field, mirroring the mastracode/web policy minus test-only deps (msw) that the template strips.

The deployer also copies this file to `.mastra/output`, so without it `mastra build` and `mastra start` fail under pnpm.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR gives generated Factory projects the pnpm settings they need to install and run successfully, then carries those settings into the build output for deployment.

## Changes

- Generate `pnpm-workspace.yaml` during Factory template synchronization.
- Add an `allowBuilds` policy matching the web project, excluding test-only dependencies such as `msw`.
- Copy the workspace file into `.mastra/output` so `mastra build` and `mastra start` work with pnpm v10+.
- Add a patch changeset for `create-factory`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->