### PR TITLE
chore(mastracode-web): fix prettier formatting failing lint on main

### DIFF
--- a/mastracode/web/src/shared/hooks/useGithubPat.ts
+++ b/mastracode/web/src/shared/hooks/useGithubPat.ts
@@ -2,11 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import {
-  deleteGithubPat,
-  fetchGithubPatStatus,
-  saveGithubPat,
-} from '../../web/ui/domains/workspaces/services/github';
+import { deleteGithubPat, fetchGithubPatStatus, saveGithubPat } from '../../web/ui/domains/workspaces/services/github';
 import type { GithubPatKind } from '../../web/ui/domains/workspaces/services/github';
 
 /**

--- a/mastracode/web/src/web/ui/__tests__/FactoryRootRoute.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/FactoryRootRoute.msw.test.tsx
@@ -71,9 +71,7 @@ describe('Factory root route', () => {
       http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
         HttpResponse.json({ connections: [] }),
       ),
-      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/work-items`, () =>
-        HttpResponse.json({ workItems: [] }),
-      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/work-items`, () => HttpResponse.json({ workItems: [] })),
     );
 
     const router = renderFactoryRoute('/onboarding');
@@ -154,9 +152,7 @@ describe('Factory root route', () => {
       http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
         HttpResponse.json({ connections: [] }),
       ),
-      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/work-items`, () =>
-        HttpResponse.json({ workItems: [] }),
-      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/work-items`, () => HttpResponse.json({ workItems: [] })),
     );
 
     const router = renderFactoryRoute('/');
@@ -184,9 +180,7 @@ describe('Factory root route', () => {
       http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
         HttpResponse.json({ connections: [] }),
       ),
-      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/work-items`, () =>
-        HttpResponse.json({ workItems: [] }),
-      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/work-items`, () => HttpResponse.json({ workItems: [] })),
     );
 
     const router = renderFactoryRoute('/onboarding');

--- a/mastracode/web/src/web/ui/domains/auth/components/RootGuards.tsx
+++ b/mastracode/web/src/web/ui/domains/auth/components/RootGuards.tsx
@@ -34,12 +34,7 @@ const OnboardingGuard = () => {
 
   if (factoriesPending) return <AuthPendingSkeleton label="Loading factories" />;
   if ((factories?.length ?? 0) === 0 && pathname !== '/onboarding') return <Navigate to="/onboarding" replace />;
-  if (
-    factories &&
-    factories.length > 0 &&
-    pathname === '/onboarding' &&
-    !hasResumableFactoryOnboarding(factories)
-  ) {
+  if (factories && factories.length > 0 && pathname === '/onboarding' && !hasResumableFactoryOnboarding(factories)) {
     return <Navigate to={`/factories/${factories[0].id}`} replace />;
   }
 


### PR DESCRIPTION
## Summary

The repo-wide `prettier --check` in the Lint workflow fails on `main`, which blocks lint on every PR that includes these files — currently the changeset release PR #20043.

Three files under `mastracode/web` merged without formatting:
- `src/shared/hooks/useGithubPat.ts`
- `src/web/ui/__tests__/FactoryRootRoute.msw.test.tsx`
- `src/web/ui/domains/auth/components/RootGuards.tsx`

Formatting-only change (`prettier --write`), no behavior changes, no changeset needed (private package, no source semantics touched).

## Test plan

- `pnpm prettier --check . '!docs/**/*' '!examples/**/*' '!explorations/**/*'` passes locally against latest main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

This PR tidies up three files so the project’s formatting checker passes again. It only changes how the code is written, not what it does.

## Changes

- Reformatted imports in `useGithubPat.ts`.
- Simplified MSW mock formatting in `FactoryRootRoute.msw.test.tsx`.
- Reformatted an onboarding redirect condition in `RootGuards.tsx`.
- No behavior or source semantics changed.
- No changeset required because the package is private.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->