### PR TITLE
feat(memory): support additional OM recall instructions

### DIFF
--- a/.changeset/bright-worms-lose.md
+++ b/.changeset/bright-worms-lose.md
@@ -1,0 +1,18 @@
+---
+'@mastra/memory': patch
+'@mastra/core': patch
+---
+
+Added application-specific instructions to Observational Memory recall tools.
+
+```typescript
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      retrieval: {
+        additionalInstructions: 'Check the current thread before browsing other threads.',
+      },
+    },
+  },
+})
+```

--- a/docs/src/content/en/docs/memory/observational-memory.mdx
+++ b/docs/src/content/en/docs/memory/observational-memory.mdx
@@ -475,6 +475,22 @@ const memory = new Memory({
 })
 ```
 
+#### Add recall instructions
+
+Set `additionalInstructions` to append application-specific guidance to the recall tool description. This keeps the built-in description, modes, input schema, and behavior unchanged.
+
+```typescript
+const memory = new Memory({
+  options: {
+    observationalMemory: {
+      retrieval: {
+        additionalInstructions: 'Check the current thread before browsing other threads.',
+      },
+    },
+  },
+})
+```
+
 #### What retrieval enables
 
 With retrieval mode enabled, OM:

--- a/docs/src/content/en/reference/memory/observational-memory.mdx
+++ b/docs/src/content/en/reference/memory/observational-memory.mdx
@@ -98,9 +98,9 @@ OM performs thresholding with fast local token estimation. Text uses `tokenx`, a
   },
   {
     name: 'retrieval',
-    type: "boolean | { vector?: boolean; scope?: 'thread' | 'resource' }",
+    type: "boolean | { vector?: boolean; scope?: 'thread' | 'resource'; additionalInstructions?: string }",
     description:
-      "Enable retrieval-mode observation groups as durable pointers to raw message history. `true` enables cross-thread browsing by default. `{ vector: true }` also enables semantic search using Memory's vector store and embedder. `{ scope: 'thread' }` restricts the recall tool to the current thread only. Default scope is `'resource'`.",
+      "Enable retrieval-mode observation groups as durable pointers to raw message history. `true` enables cross-thread browsing by default. `{ vector: true }` also enables semantic search using Memory's vector store and embedder. `{ scope: 'thread' }` restricts the recall tool to the current thread only. `additionalInstructions` appends application-specific guidance to the recall tool's built-in description. Default scope is `'resource'`.",
     isOptional: true,
     defaultValue: 'false',
   },

--- a/packages/core/src/memory/memory-config.test.ts
+++ b/packages/core/src/memory/memory-config.test.ts
@@ -97,13 +97,16 @@ describe('MastraMemory config serialization', () => {
     });
   });
 
-  it('should serialize retrieval config with vector: true', () => {
+  it('should serialize retrieval config with additional instructions', () => {
     const memory = new MockMemory({
       storage: new InMemoryStore(),
       options: {
         observationalMemory: {
           scope: 'thread',
-          retrieval: { vector: true },
+          retrieval: {
+            vector: true,
+            additionalInstructions: 'Use message browsing before semantic search.',
+          },
           model: 'test-model',
         },
       },
@@ -112,7 +115,10 @@ describe('MastraMemory config serialization', () => {
     const omConfig = memory.getConfig().observationalMemory;
     expect(typeof omConfig).not.toBe('boolean');
     if (typeof omConfig !== 'boolean' && omConfig) {
-      expect(omConfig.retrieval).toEqual({ vector: true });
+      expect(omConfig.retrieval).toEqual({
+        vector: true,
+        additionalInstructions: 'Use message browsing before semantic search.',
+      });
     }
   });
 

--- a/packages/core/src/memory/types.ts
+++ b/packages/core/src/memory/types.ts
@@ -881,13 +881,20 @@ export interface ObservationalMemoryOptions {
    * - `{ vector: true }` — also enables semantic search using Memory-level vector/embedder
    * - `{ scope: 'thread' }` — restricts the recall tool to the current thread only
    * - `{ vector: true, scope: 'thread' }` — current-thread browsing + semantic search
+   * - `{ additionalInstructions: '...' }` — appends application-specific guidance to the recall tool description
    *
    * `scope` defaults to `'resource'` (cross-thread browsing, thread listing, and search).
    * Set to `'thread'` to restrict to the current thread only.
    *
    * @default false
    */
-  retrieval?: boolean | { vector?: boolean; scope?: 'thread' | 'resource' };
+  retrieval?:
+    | boolean
+    | {
+        vector?: boolean;
+        scope?: 'thread' | 'resource';
+        additionalInstructions?: string;
+      };
 }
 
 /**
@@ -1325,7 +1332,13 @@ export type SerializedObservationalMemoryConfig = {
   /**
    * Enable retrieval-mode observation groups as durable pointers to raw message history.
    */
-  retrieval?: boolean | { vector?: boolean; scope?: 'thread' | 'resource' };
+  retrieval?:
+    | boolean
+    | {
+        vector?: boolean;
+        scope?: 'thread' | 'resource';
+        additionalInstructions?: string;
+      };
 
   /** Observation step configuration */
   observation?: SerializedObservationalMemoryObservationConfig;

--- a/packages/memory/src/index.ts
+++ b/packages/memory/src/index.ts
@@ -102,7 +102,13 @@ type RuntimeMemoryConfig = Omit<MemoryConfig, 'observationalMemory'> & {
 };
 
 type NormalizedObservationalMemoryConfig = MemoryObservationalMemoryOptions & {
-  retrieval?: boolean | { vector?: boolean; scope?: 'thread' | 'resource' };
+  retrieval?:
+    | boolean
+    | {
+        vector?: boolean;
+        scope?: 'thread' | 'resource';
+        additionalInstructions?: string;
+      };
 };
 
 /*
@@ -2341,9 +2347,11 @@ Notes:
 
     const omConfig = normalizeObservationalMemoryConfig(mergedConfig.observationalMemory);
     if (omConfig?.retrieval) {
-      const retrievalScope =
-        typeof omConfig.retrieval === 'object' ? (omConfig.retrieval.scope ?? 'resource') : 'resource';
-      tools.recall = recallTool(mergedConfig, { retrievalScope });
+      const retrievalConfig = typeof omConfig.retrieval === 'object' ? omConfig.retrieval : undefined;
+      tools.recall = recallTool(mergedConfig, {
+        retrievalScope: retrievalConfig?.scope ?? 'resource',
+        additionalInstructions: retrievalConfig?.additionalInstructions,
+      });
     }
 
     return tools;

--- a/packages/memory/src/processors/observational-memory/__tests__/constants.test.ts
+++ b/packages/memory/src/processors/observational-memory/__tests__/constants.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+
+import { OBSERVATION_RETRIEVAL_INSTRUCTIONS } from '../constants';
+
+describe('OBSERVATION_RETRIEVAL_INSTRUCTIONS', () => {
+  it('does not treat a missing relevant range as proof that recall is unnecessary', () => {
+    expect(OBSERVATION_RETRIEVAL_INSTRUCTIONS).not.toContain(
+      'There is no relevant range in your observations for the topic',
+    );
+  });
+});

--- a/packages/memory/src/processors/observational-memory/constants.ts
+++ b/packages/memory/src/processors/observational-memory/constants.ts
@@ -116,6 +116,5 @@ Low-detail results may include truncation hints like:
 ### When recall is NOT needed
 - The user is asking for a high-level summary and your observations already cover it
 - The question is about general preferences or facts that don't require source text
-- There is no relevant range in your observations for the topic
 
 Observation groups with range IDs and your recall tool allows you to think back and remember details you're fuzzy on.`;

--- a/packages/memory/src/processors/observational-memory/types.ts
+++ b/packages/memory/src/processors/observational-memory/types.ts
@@ -902,10 +902,18 @@ export interface ObservationalMemoryConfig {
    * Use `{ vector: true }` to also index emitted observation groups into the
    * configured vector store for semantic recall, and `scope` to limit recall
    * browsing to the current thread instead of the whole resource.
+   * Use `additionalInstructions` to append application-specific guidance to
+   * the recall tool's native description.
    *
    * @default false
    */
-  retrieval?: boolean | { vector?: boolean; scope?: 'thread' | 'resource' };
+  retrieval?:
+    | boolean
+    | {
+        vector?: boolean;
+        scope?: 'thread' | 'resource';
+        additionalInstructions?: string;
+      };
 
   /**
    * Optional callback used to index emitted observation groups for semantic retrieval.

--- a/packages/memory/src/tools/om-tools.test.ts
+++ b/packages/memory/src/tools/om-tools.test.ts
@@ -2753,6 +2753,30 @@ describe('om-tools', () => {
     });
   });
 
+  describe('recallTool description', () => {
+    it('should append configured additional instructions after the native description', () => {
+      const nativeDescription = recallTool(undefined, { retrievalScope: 'thread' }).description;
+      const tool = recallTool(undefined, {
+        retrievalScope: 'thread',
+        additionalInstructions: 'Use message browsing before semantic search.',
+      });
+
+      expect(tool.description).toBe(
+        `${nativeDescription}\n\nAdditional instructions:\nUse message browsing before semantic search.`,
+      );
+    });
+
+    it('should leave the native description unchanged for whitespace-only instructions', () => {
+      const nativeDescription = recallTool(undefined, { retrievalScope: 'resource' }).description;
+      const tool = recallTool(undefined, {
+        retrievalScope: 'resource',
+        additionalInstructions: '   \n  ',
+      });
+
+      expect(tool.description).toBe(nativeDescription);
+    });
+  });
+
   describe('Memory.listTools with retrieval config shapes', () => {
     it('should register recall with retrieval: true (boolean)', () => {
       const memory = new Memory({
@@ -2785,6 +2809,25 @@ describe('om-tools', () => {
 
       // recall tool should still be registered
       expect(memory.listTools()).toHaveProperty('recall');
+    });
+
+    it('should pass retrieval additional instructions to the recall tool', () => {
+      const memory = new Memory({
+        storage: new InMemoryStore(),
+        options: {
+          observationalMemory: {
+            model: 'test-model',
+            scope: 'thread',
+            retrieval: {
+              additionalInstructions: 'Use message browsing before semantic search.',
+            },
+          },
+        } as any,
+      });
+
+      expect(memory.listTools().recall?.description).toContain(
+        'Additional instructions:\nUse message browsing before semantic search.',
+      );
     });
   });
 });

--- a/packages/memory/src/tools/om-tools.ts
+++ b/packages/memory/src/tools/om-tools.ts
@@ -1146,14 +1146,18 @@ export async function recallThreadFromStart({
 
 export const recallTool = (
   _memoryConfig?: MemoryConfigInternal,
-  options?: { retrievalScope?: 'thread' | 'resource' },
+  options?: { retrievalScope?: 'thread' | 'resource'; additionalInstructions?: string },
 ) => {
   const retrievalScope = options?.retrievalScope ?? 'thread';
   const isResourceScope = retrievalScope === 'resource';
 
-  const description = isResourceScope
+  const nativeDescription = isResourceScope
     ? 'Browse conversation history. Use mode="threads" to list all threads for the current user. Use mode="messages" (default) to browse messages in the current thread or pass threadId to browse another thread in the active resource. When mode="messages" has no cursor or threadId, it defaults to the current thread and says so at the top of the result. If you pass only a cursor, it must belong to the current thread. Use mode="search" to find messages by content across all threads.'
     : 'Browse conversation history in the current thread. Use mode="messages" (default) to page through messages near a cursor. Use mode="search" to find messages by content in this thread. Use mode="threads" to get the current thread\'s ID and title.';
+  const additionalInstructions = options?.additionalInstructions?.trim();
+  const description = additionalInstructions
+    ? `${nativeDescription}\n\nAdditional instructions:\n${additionalInstructions}`
+    : nativeDescription;
 
   return createTool({
     id: 'recall',


### PR DESCRIPTION
## Summary

- Add `observationalMemory.retrieval.additionalInstructions` for application-specific recall guidance.
- Append non-empty instructions after Mastra's native recall description while preserving the existing modes, schema, scopes, and execution behavior.
- Remove the misleading observation prompt guidance that treated a missing relevant range as proof that recall was unnecessary.
- Update public types, documentation, changeset metadata, and regression tests.

## Scope

Partially addresses #19561.

This change intentionally does not implement scope-aware native routing or change the `threads`, `messages`, or `search` modes. Applications can use `additionalInstructions` to provide their own routing or workflow guidance.

## Testing

- `@mastra/memory` focused tests: 98/98 passed.
- `@mastra/core` memory configuration tests: 8/8 passed with no type errors.
- Core and Memory type checks passed.
- Core build (14/14 tasks) and Memory build (15/15 tasks) passed.
- Prettier, ESLint, and `git diff --check` passed.
- A temporary end-to-end smoke test passed through `Memory -> Agent.generate -> AI SDK tool call -> recall execution -> second model step`, including a live `zhipuai/glm-4.5-flash` run. The smoke test was removed and is not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Apps can now give Mastra’s memory search extra instructions about where and how to look for information, without changing its normal behavior. The recall guidance was also clarified to avoid skipping searches for the wrong reason.

## Summary

- Added `observationalMemory.retrieval.additionalInstructions`.
- Appends non-empty custom guidance to the native recall tool description.
- Preserves existing retrieval modes, schemas, scopes, and execution behavior.
- Removed misleading observation guidance and replaced it with clearer cases where recall is unnecessary.
- Updated public types, documentation, changeset metadata, serialization, and regression tests.
- Added coverage for custom instructions, whitespace-only values, propagation, and updated prompt behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->