### PR TITLE
fix(create-factory): show sandboxes in the provisioning success message

### DIFF
--- a/.changeset/shy-coats-listen.md
+++ b/.changeset/shy-coats-listen.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Simplified the create-factory success message: sandboxes now appear as a bullet in the provisioned resources list so users know code agent sessions run inside Mastra platform sandboxes.

--- a/mastracode/mastra-factory/src/create.test.ts
+++ b/mastracode/mastra-factory/src/create.test.ts
@@ -265,7 +265,7 @@ describe('create (platform provisioning)', () => {
     expect(note).toContain('my-factory');
     expect(note).toContain('Acme');
     expect(note).toContain('Postgres database');
-    expect(note).toContain('code agent sessions run inside Mastra platform sandboxes');
+    expect(note).toContain('Sandboxes (code agent sessions run here)');
     expect(note).toContain('Manage your project at');
     expect(note).toContain('https://projects.mastra.ai');
   });

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -203,8 +203,8 @@ export async function create(args: CreateArgs): Promise<void> {
       `${color.green('Provisioned on Mastra platform')} in ${color.cyan(platformResult.orgName)}:`,
       `  - Project ${color.cyan(platformResult.project.name)}`,
       `  - Postgres database (credentials written to ${color.cyan('.env')})`,
+      `  - Sandboxes (code agent sessions run here)`,
       '',
-      'When deployed, code agent sessions run inside Mastra platform sandboxes.',
       `Manage your project at ${color.underline('https://projects.mastra.ai')}`,
     );
   } else if (args.noPlatform) {


### PR DESCRIPTION
## Summary

When `npm create factory` finishes provisioning a project on the Mastra platform, the success note previously ended with a standalone sentence: "When deployed, code agent sessions run inside Mastra platform sandboxes." This read as an afterthought and implied sandboxes were only relevant after deployment.

This PR folds that information into the provisioned resources list, so the note now reads:

```
Provisioned on Mastra platform in <org>:
  - Project <name>
  - Postgres database (credentials written to .env)
  - Sandboxes (code agent sessions run here)

Manage your project at https://projects.mastra.ai
```

Users now see at a glance that code agent sessions in Mastra Factory run inside Mastra platform sandboxes, without extra prose.

## Test plan

- Updated the existing outro assertion in `mastracode/mastra-factory/src/create.test.ts`
- `pnpm vitest run create.test.ts` in `mastracode/mastra-factory` — 18/18 pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

The success message now clearly tells users that code agent sessions run in Mastra platform sandboxes. The related test and changeset were updated to match.

## Changes

- Added “Sandboxes (code agent sessions run here)” to the provisioned resources list.
- Removed the separate deployment-related sentence.
- Updated the expected output assertion and changeset description.
- Tests pass: 18/18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->