### PR TITLE
Stop web chat pages from livelocking in a reconnect loop

### DIFF
--- a/mastracode/web/src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx
@@ -6,6 +6,7 @@ import { useEffect } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { server } from '../../../../e2e/web-ui/msw-server';
+import { queryKeys } from '../../api/keys';
 import { renderHookWithProviders, TEST_BASE_URL } from '../../../../e2e/web-ui/render';
 import {
   deriveConnectionStatus,
@@ -270,6 +271,108 @@ describe('useAgentControllerConnection', () => {
         syncFailureCount: 10,
       }),
     ).toBe('error');
+  });
+
+  it('given the stream is slow to establish, when the reconnect poll refetches state, then the in-flight stream attempt is not cancelled', async () => {
+    const onReadState = vi.fn();
+    const onStream = vi.fn();
+    const onEvent = vi.fn();
+    const observedStatuses: string[] = [];
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
+      ),
+      http.get(sessionUrl, () => {
+        onReadState();
+        return HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'state-thread',
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        });
+      }),
+      http.get(`${sessionUrl}/stream`, async () => {
+        onStream();
+        // Slower than the 1s reconnect poll — the poll fires while this
+        // stream is still connecting.
+        await new Promise(resolve => setTimeout(resolve, 1600));
+        return new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }),
+    );
+
+    const { result } = renderHookWithProviders(() => {
+      const connection = useAgentControllerConnection({ ...hookArgs, onEvent });
+
+      useEffect(() => {
+        observedStatuses.push(connection.status);
+      }, [connection.status]);
+
+      return connection;
+    });
+
+    // The poll refetches state at least once while the stream is connecting…
+    await waitFor(() => expect(onReadState.mock.calls.length).toBeGreaterThanOrEqual(2), { timeout: 2500 });
+    // …and the slow stream still connects instead of being torn down.
+    await waitFor(() => expect(result.current.status).toBe('ready'), { timeout: 3000 });
+
+    expect(onStream).toHaveBeenCalledTimes(1);
+    expect(observedStatuses).not.toContain('reconnecting');
+  });
+
+  it('given an active stream, when the session state is refetched, then the stream is not torn down', async () => {
+    const onStream = vi.fn();
+    const onEvent = vi.fn();
+    const observedStatuses: string[] = [];
+
+    server.use(
+      http.post(`${TEST_BASE_URL}/api/agent-controller/${controllerId}/sessions`, () =>
+        HttpResponse.json({ controllerId, resourceId, threadId: 'created-thread' }),
+      ),
+      http.get(sessionUrl, () =>
+        HttpResponse.json({
+          controllerId,
+          resourceId,
+          modeId: 'build',
+          modelId: 'openai/gpt-4o-mini',
+          threadId: 'state-thread',
+          settings: { yolo: false, thinkingLevel: 'medium', notifications: 'bell', smartEditing: true },
+        }),
+      ),
+      http.get(`${sessionUrl}/stream`, () => {
+        onStream();
+        return new Response(new ReadableStream<Uint8Array>({ start() {}, cancel() {} }), {
+          headers: { 'content-type': 'text/event-stream' },
+        });
+      }),
+    );
+
+    const { client, result } = renderHookWithProviders(() => {
+      const connection = useAgentControllerConnection({ ...hookArgs, onEvent });
+
+      useEffect(() => {
+        observedStatuses.push(connection.status);
+      }, [connection.status]);
+
+      return connection;
+    });
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    // A refetch bumps dataUpdatedAt (the subscription epoch) — e.g. a mutation
+    // invalidating controller state. The established stream must survive it.
+    await client.invalidateQueries({
+      queryKey: queryKeys.agentControllerConnectionState(controllerId, resourceId, undefined),
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 50));
+    expect(onStream).toHaveBeenCalledTimes(1);
+    expect(result.current.status).toBe('ready');
+    expect(observedStatuses).not.toContain('reconnecting');
   });
 
   it('given the stream drops, when the state re-sync succeeds, then the hook resubscribes and returns to ready', async () => {

--- a/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
+++ b/mastracode/web/src/web/ui/domains/chat/hooks/useAgentControllerEvents.ts
@@ -15,6 +15,8 @@ interface UseAgentControllerEventsArgs {
 
 interface SharedSubscription {
   state: SseConnectionState;
+  /** A subscribe attempt is in flight — do not start another. */
+  connecting: boolean;
   eventListeners: Set<(event: AgentControllerEvent) => void>;
   stateListeners: Set<(state: SseConnectionState) => void>;
   unsubscribe?: () => void;
@@ -22,59 +24,75 @@ interface SharedSubscription {
   disposed?: boolean;
 }
 
-const subscriptions = new WeakMap<AgentControllerSession, Map<number, SharedSubscription>>();
+const subscriptions = new WeakMap<AgentControllerSession, SharedSubscription>();
 
-function getSubscription(session: AgentControllerSession, epoch: number) {
-  let sessionSubscriptions = subscriptions.get(session);
-  if (!sessionSubscriptions) {
-    sessionSubscriptions = new Map();
-    subscriptions.set(session, sessionSubscriptions);
-  }
+function setState(subscription: SharedSubscription, state: SseConnectionState) {
+  if (subscription.state === state) return;
+  subscription.state = state;
+  for (const listener of subscription.stateListeners) listener(state);
+}
 
-  let subscription = sessionSubscriptions.get(epoch);
-  if (subscription) {
-    if (subscription.teardown) {
-      clearTimeout(subscription.teardown);
-      subscription.teardown = undefined;
-    }
-    return subscription;
-  }
+/**
+ * Start a stream attempt unless one is already established or in flight.
+ *
+ * Callers re-invoke this on every sync epoch bump; that is what retries a
+ * dropped (or never-established) stream after the state re-sync completes.
+ * A healthy or still-connecting stream must NOT be torn down by an epoch
+ * bump: while the stream is disconnected the session-state query polls
+ * every second (see useAgentControllerSessionSync), so cancelling the
+ * in-flight subscribe on each successful poll livelocks — the stream can
+ * never finish connecting, which keeps the poll alive, which keeps
+ * cancelling the stream.
+ */
+function ensureConnected(session: AgentControllerSession, subscription: SharedSubscription) {
+  if (subscription.connecting || subscription.state === 'connected') return;
 
-  subscription = {
-    state: 'never',
-    eventListeners: new Set(),
-    stateListeners: new Set(),
-  };
-  sessionSubscriptions.set(epoch, subscription);
-
-  const setState = (state: SseConnectionState) => {
-    if (subscription?.state === state) return;
-    subscription!.state = state;
-    for (const listener of subscription!.stateListeners) listener(state);
-  };
+  subscription.unsubscribe?.();
+  subscription.unsubscribe = undefined;
+  subscription.connecting = true;
 
   void session
     .subscribe({
       onEvent: event => {
-        for (const listener of subscription!.eventListeners) listener(event);
+        for (const listener of subscription.eventListeners) listener(event);
       },
       onError: () => {
-        if (subscription?.state === 'connected') setState('dropped');
+        if (subscription.state === 'connected') setState(subscription, 'dropped');
       },
     })
     .then(
       sub => {
-        if (subscription!.disposed) {
+        subscription.connecting = false;
+        if (subscription.disposed) {
           sub.unsubscribe();
           return;
         }
-        subscription!.unsubscribe = sub.unsubscribe;
-        setState('connected');
+        subscription.unsubscribe = sub.unsubscribe;
+        setState(subscription, 'connected');
       },
       () => {
-        if (subscription?.state === 'connected') setState('dropped');
+        subscription.connecting = false;
+        if (subscription.state === 'connected') setState(subscription, 'dropped');
       },
     );
+}
+
+function getSubscription(session: AgentControllerSession) {
+  let subscription = subscriptions.get(session);
+  if (!subscription) {
+    subscription = {
+      state: 'never',
+      connecting: false,
+      eventListeners: new Set(),
+      stateListeners: new Set(),
+    };
+    subscriptions.set(session, subscription);
+  }
+
+  if (subscription.teardown) {
+    clearTimeout(subscription.teardown);
+    subscription.teardown = undefined;
+  }
 
   return subscription;
 }
@@ -96,7 +114,7 @@ export function useAgentControllerEvents({
   useEffect(() => {
     if (!enabled || !session || !epoch) return;
 
-    const subscription = getSubscription(session, epoch);
+    const subscription = getSubscription(session);
     const handleEvent = (event: AgentControllerEvent) => onEventRef.current(event);
     const handleState = (state: SseConnectionState) => {
       onConnectedChangeRef.current(state === 'connected');
@@ -106,6 +124,7 @@ export function useAgentControllerEvents({
     subscription.eventListeners.add(handleEvent);
     subscription.stateListeners.add(handleState);
     handleState(subscription.state);
+    ensureConnected(session, subscription);
 
     return () => {
       subscription.eventListeners.delete(handleEvent);
@@ -116,7 +135,7 @@ export function useAgentControllerEvents({
         if (subscription.eventListeners.size > 0 || subscription.stateListeners.size > 0) return;
         subscription.disposed = true;
         subscription.unsubscribe?.();
-        subscriptions.get(session)?.delete(epoch);
+        subscriptions.delete(session);
       }, 0);
     };
   }, [enabled, session, epoch]);


### PR DESCRIPTION
## Summary

Fixes a client-side livelock on the web chat/session page where the UI flashes "Connection lost — reconnecting…" and hammers `GET /sessions/:id` + `GET /sessions/:id/stream` every second — with every request returning 200 and no server errors.

**Root cause:** the SSE subscription in `useAgentControllerEvents` was keyed on the session-state query's `dataUpdatedAt` ("epoch"). Every successful state refetch tore down the stream and opened a new one. While the stream is disconnected, the state query polls every second (`reconnectRefetchInterval`), so whenever stream establishment took longer than a poll interval — e.g. factory sessions materializing a sandbox workspace on session open — each poll cancelled the in-flight stream, which kept the connection down, which kept the poll alive. The loop only breaks once the stream happens to connect faster than the poll.

The same teardown also caused a "Connection lost" flash on an already-connected stream whenever anything invalidated the connection-state query (e.g. mutations).

**Fix:** subscriptions are now shared per session, and an epoch bump only *retries* a dropped or never-established stream. A healthy or still-connecting stream survives state refetches. The intended recovery path (stream drops → poll re-syncs state → resubscribe → ready) is unchanged and still covered by the existing test.

## Test plan

- New regression tests in `useAgentControllerConnection.msw.test.tsx`:
  - slow-to-establish stream is not cancelled by the reconnect poll (fails on the old code — livelocks, never reaches `ready`; verified red before the fix)
  - state refetch on an active stream does not resubscribe or flash `reconnecting`
- All 11 tests in the file pass: `pnpm exec vitest run --config e2e/web-ui/vitest.config.ts src/shared/hooks/__tests__/useAgentControllerConnection.msw.test.tsx`
- `pnpm run check` clean in `mastracode/web`

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Web chat was repeatedly stopping and restarting its connection while checking session status, so it could get stuck reconnecting. This change keeps healthy connections alive during those checks and only retries streams that actually failed.

## What changed

- Shared SSE subscriptions per session instead of recreating them after each state refetch.
- Preserved recovery for dropped or never-established streams.
- Added regression tests for slow stream establishment and refetches on active connections.
- All 11 targeted tests pass, and `pnpm run check` is clean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->