### PR TITLE
fix(cli): print .factory.mastra.cloud URL after deploying a Software Factory project

### DIFF
--- a/.changeset/brown-cooks-rhyme.md
+++ b/.changeset/brown-cooks-rhyme.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed the CLI's deploy success message to print the correct URL for Software Factory projects. Factory deploys now show `https://<slug>.factory.mastra.cloud` and a `Factory:` label, instead of the generic `Server:` label pointing at `.server.mastra.cloud`. Non-factory projects are unchanged.

--- a/packages/cli/src/commands/deploy/index.ts
+++ b/packages/cli/src/commands/deploy/index.ts
@@ -42,14 +42,20 @@ import { assertDeployDir } from './validate-dir.js';
  * Derive the public studio/server URLs from the environment slug.
  * These are the user-facing URLs, not the internal Railway instanceUrl.
  */
-function derivePublicUrls(slug: string): { studioUrl: string; serverUrl: string } {
+function derivePublicUrls(
+  slug: string,
+  projectType?: string,
+): { studioUrl: string; serverUrl: string; serverLabel: string } {
   // Determine if we're targeting staging or production
   const isStaging = MASTRA_PLATFORM_API_URL.includes('staging');
   const baseDomain = isStaging ? 'staging.mastra.cloud' : 'mastra.cloud';
+  const isFactory = projectType === 'factory';
+  const serverSubdomain = isFactory ? 'factory' : 'server';
 
   return {
     studioUrl: `https://${slug}.studio.${baseDomain}`,
-    serverUrl: `https://${slug}.server.${baseDomain}`,
+    serverUrl: `https://${slug}.${serverSubdomain}.${baseDomain}`,
+    serverLabel: isFactory ? 'Factory' : 'Server',
   };
 }
 
@@ -907,9 +913,9 @@ async function runUnifiedDeploy(dir: string | undefined, opts: DeployOptions) {
   const finalStatus = await pollEnvironmentDeploy(token, orgId, projectId, environment.id, deployResult.id);
 
   if (finalStatus.status === 'running') {
-    const { studioUrl, serverUrl } = derivePublicUrls(environment.slug);
+    const { studioUrl, serverUrl, serverLabel } = derivePublicUrls(environment.slug, projectType);
     p.log.info(`  Studio: ${pc.cyan(studioUrl)}`);
-    p.log.info(`  Server: ${pc.cyan(serverUrl)}`);
+    p.log.info(`  ${serverLabel}: ${pc.cyan(serverUrl)}`);
     p.outro(`Deploy succeeded in ${elapsed(performance.now() - tTotal)}!`);
   } else if (finalStatus.status === 'failed') {
     p.log.error(`Deploy failed: ${finalStatus.error}`);


### PR DESCRIPTION
## Summary

The `mastra deploy` success message printed the wrong URL for Software Factory projects. After a factory deploy, users saw:

```
Studio: https://demo-factory-9.studio.mastra.cloud
Server: https://demo-factory-9.server.mastra.cloud   ← wrong host, wrong label
```

even though factories are actually served from `<slug>.factory.mastra.cloud`. The URL is synthesized locally in the CLI (not returned by the platform), and `derivePublicUrls` in `packages/cli/src/commands/deploy/index.ts` hardcoded `.server.` for every project regardless of kind.

## Change

`derivePublicUrls` now takes the already-detected `projectType` (via `analyzeEntryProjectType`, computed a few lines earlier for build-staleness hashing) and, when it's `'factory'`, returns:

- `serverUrl`: `https://<slug>.factory.<domain>`
- `serverLabel`: `Factory`

Non-factory projects continue to render exactly as before (`.server.` / `Server:`), so the change is a no-op for the vast majority of deploys.

After the fix, factory deploys print:

```
Studio:  https://demo-factory-9.studio.mastra.cloud
Factory: https://demo-factory-9.factory.mastra.cloud
```

## Test plan

- `pnpm --filter ./packages/cli typecheck` — clean
- `pnpm build:cli` — succeeds
- `derivePublicUrls` has no other callers and no existing tests referenced it
- Manual verification will happen on the next factory deploy from this branch

## Changeset

`.changeset/brown-cooks-rhyme.md` (`mastra` patch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When deploying a Software Factory project, the CLI now shows the correct Factory web address instead of a Server address. Other project types work exactly as before.

## Changes

- Updated deploy success URLs to use `https://<slug>.factory.<domain>` for factory projects.
- Added dynamic `Factory` or `Server` labels based on project type.
- Added a patch changeset.
- Typecheck and CLI build completed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->