### PR TITLE
Add changeset for the web chat reconnect-loop fix

### DIFF
--- a/.changeset/web-chat-stream-livelock-cli.md
+++ b/.changeset/web-chat-stream-livelock-cli.md
@@ -1,0 +1,5 @@
+---
+'mastra': patch
+---
+
+Fixed web chat sessions getting stuck in a "Connection lost — reconnecting…" loop while the session workspace was still starting up

--- a/.changeset/web-chat-stream-livelock-factory.md
+++ b/.changeset/web-chat-stream-livelock-factory.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed web chat sessions getting stuck in a "Connection lost — reconnecting…" loop while the session workspace was still starting up


### PR DESCRIPTION
## Summary

Adds the missing changeset for #20064 (fix for web chat sessions getting stuck in a "Connection lost — reconnecting…" loop while the session workspace was starting up), which merged before the changeset landed on its branch.

Patch bumps for the packages that ship the web UI:
- `@mastra/factory`
- `mastra` (CLI)

## Test plan

Changeset files only — no code changes.

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>