### PR TITLE
Apply newly saved GitHub PATs to running Factory sessions without a restart

### DIFF
--- a/.changeset/factory-pat-live-injection.md
+++ b/.changeset/factory-pat-live-injection.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'mastra': patch
+---
+
+Fixed GitHub PATs saved in Settings not taking effect for the gh CLI in already-running Factory sessions until the server was restarted

--- a/mastracode/factory/src/workspace.test.ts
+++ b/mastracode/factory/src/workspace.test.ts
@@ -480,6 +480,40 @@ describe('GitHub session workspace preparation', () => {
     expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'later-token');
   });
 
+  it('installs a PAT saved after provisioning into the running sandbox on the next reuse', async () => {
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+    expect(mocks.setEnvironmentVariable).not.toHaveBeenCalled();
+
+    // The org pastes a PAT in Settings while the sandbox is already running —
+    // it must take effect without a server restart.
+    mocks.githubPat = 'ghp_saved_later';
+    await workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: { getWorkspaceById: vi.fn(() => ({ setToolsConfig: vi.fn() })) } as any,
+    });
+
+    expect(mocks.setEnvironmentVariable).toHaveBeenCalledWith('GH_TOKEN', 'ghp_saved_later');
+  });
+
+  it('does not re-inject an unchanged PAT on workspace reuse', async () => {
+    mocks.githubPat = 'ghp_org_pat';
+    const { workspace } = await createLocalFactory();
+    addProject();
+    addSession({ id: 'session-a' });
+    await workspace({ requestContext: createGithubRequestContext('project-1', 'session-a') });
+    mocks.setEnvironmentVariable.mockClear();
+
+    await workspace({
+      requestContext: createGithubRequestContext('project-1', 'session-a'),
+      mastra: { getWorkspaceById: vi.fn(() => ({ setToolsConfig: vi.fn() })) } as any,
+    });
+
+    expect(mocks.setEnvironmentVariable).not.toHaveBeenCalled();
+  });
+
   it('reuses an already registered workspace for the exact GitHub session', async () => {
     const { workspace } = await createLocalFactory();
     addProject();

--- a/mastracode/factory/src/workspace.ts
+++ b/mastracode/factory/src/workspace.ts
@@ -124,7 +124,10 @@ export interface CreateWorkspaceFactoryOptions {
 export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = {}) {
   const { sandbox: sandboxConfig, github, fleet, workItems } = options;
   const isLocalSandbox = sandboxConfig?.machine instanceof LocalSandbox;
-  const githubTokenInjectors = new Map<string, { inject: (token: string) => void; patKind: GithubPatKind }>();
+  const githubTokenInjectors = new Map<
+    string,
+    { inject: (token: string) => void; patKind: GithubPatKind; ghToken: string }
+  >();
 
   return async ({ requestContext, mastra, skillExtension }: DynamicWorkspaceContext) => {
     const effectiveSkillExtension = skillExtension ?? factorySkillExtension;
@@ -189,6 +192,18 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         if (registered) {
           registerGithubTokenInjector(requestContext, registered.inject);
           registerGithubPatKind(requestContext, registered.patKind);
+          // A PAT saved in Settings after this sandbox was provisioned must
+          // reach the running sandbox without a server restart — re-read it
+          // on every reuse and push it into the live sandbox when it changed.
+          // Best-effort: a failed read or inject keeps the installed token.
+          try {
+            const pat = await getGithubPat(() => github.integrationStorage, session.orgId, registered.patKind);
+            if (pat && pat !== registered.ghToken) {
+              registered.inject(pat);
+            }
+          } catch {
+            // Keep the token already installed in the sandbox.
+          }
         }
         return existing;
       }
@@ -247,8 +262,10 @@ export function createWorkspaceFactory(options: CreateWorkspaceFactoryOptions = 
         throw new Error('The active sandbox provider does not support runtime GitHub token refresh.');
       }
       sandbox.setEnvironmentVariable('GH_TOKEN', freshToken);
+      const registered = githubTokenInjectors.get(workspaceId);
+      if (registered) registered.ghToken = freshToken;
     };
-    githubTokenInjectors.set(workspaceId, { inject: injectGithubToken, patKind });
+    githubTokenInjectors.set(workspaceId, { inject: injectGithubToken, patKind, ghToken: ghCliToken });
     registerGithubTokenInjector(requestContext, injectGithubToken);
     registerGithubPatKind(requestContext, patKind);
 


### PR DESCRIPTION
## Summary

Saving a GitHub PAT in Factory Settings (#20054) had no effect on already-running sessions — the gh CLI kept failing until the server was restarted.

**Root cause:** the gh CLI token is resolved once at workspace creation (`getGithubPat` → fallback to the minted installation token) and baked into the sandbox env at provisioning. The workspace is then cached in Mastra, and the reuse path returned it without ever re-reading the PAT — so a PAT saved after the sandbox existed only took effect once a restart rebuilt the workspace.

**Fix:** on workspace reuse, re-read the org PAT (respecting the session's worker/reviewer kind) and push it into the live sandbox via `setEnvironmentVariable` when it changed. A saved PAT now takes effect on the session's next request. Unchanged tokens are not re-injected (tracked per workspace, kept in sync with the runtime token-refresh injector), and read/inject failures fall back to the currently installed token.

## Test plan

- New tests in `workspace.test.ts`:
  - a PAT saved after provisioning is installed into the running sandbox on the next reuse (fails without the fix — verified red)
  - an unchanged PAT is not re-injected on reuse
- `pnpm exec vitest run src/workspace.test.ts` — 21 passed
- `tsc --noEmit` clean in `mastracode/factory`

Includes a changeset (patch: `@mastra/factory`, `mastra`).

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a GitHub password changes, already-open Factory workspaces now get the new one automatically—without restarting the server. If it hasn’t changed, the system avoids doing extra work.

## Changes

- Re-reads organization GitHub PATs whenever an existing workspace is reused.
- Injects updated tokens into running worker or reviewer sandboxes.
- Preserves the existing token if reading or injection fails.
- Avoids reinjecting unchanged tokens.
- Adds tests for live injection and duplicate-injection prevention.
- Adds patch changesets for `@mastra/factory` and `mastra`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->