### PR TITLE
fix(factory): serve the Factory SPA when the artifact is started from outside the output dir

### DIFF
--- a/.changeset/factory-spa-entry-dir.md
+++ b/.changeset/factory-spa-entry-dir.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed the Factory SPA not being served in deployed runtimes that start the artifact from outside the output directory (e.g. `WORKDIR /app` + `node output/index.mjs`). `resolveUiDistDir` now also checks for `factory/` next to the entry script (`process.argv[1]`), so cwd no longer has to be the output directory for the UI to mount.

--- a/mastracode/factory/src/spa-static.test.ts
+++ b/mastracode/factory/src/spa-static.test.ts
@@ -48,6 +48,21 @@ describe('resolveUiDistDir', () => {
     expect(resolveUiDistDir()).toBe('/custom/factory-ui');
   });
 
+  it('resolves factory assets next to the entry script when cwd differs (deployed layout)', () => {
+    // Railway runtime: WORKDIR /app, CMD ["node", "output/index.mjs"] — cwd is
+    // /app but the artifact (and its factory/ dir) lives under /app/output.
+    const originalArgv1 = process.argv[1];
+    vi.spyOn(process, 'cwd').mockReturnValue('/app');
+    process.argv[1] = 'output/index.mjs';
+    vi.mocked(existsSync).mockImplementation(path => path === '/app/output/factory/index.html');
+
+    try {
+      expect(resolveUiDistDir()).toBe('/app/output/factory');
+    } finally {
+      process.argv[1] = originalArgv1;
+    }
+  });
+
   it('falls back to the source layout under MASTRA_PROJECT_ROOT', () => {
     process.env.MASTRA_PROJECT_ROOT = '/project';
     vi.spyOn(process, 'cwd').mockReturnValue('/runtime');

--- a/mastracode/factory/src/spa-static.ts
+++ b/mastracode/factory/src/spa-static.ts
@@ -47,16 +47,24 @@ const SERVER_PREFIXES = ['/api', '/web', '/auth'];
  *   1. `MASTRACODE_UI_DIST` — explicit override for custom layouts.
  *   2. `factory/` under cwd — both `mastra dev` (cwd is the Mastra public dir)
  *      and `mastra start` (cwd is `.mastra/output`) expose assets this way.
- *   3. `factory/` next to the bundled server module.
- *   4. Source-layout fallbacks under `MASTRA_PROJECT_ROOT` or cwd.
+ *   3. `factory/` next to the entry script (`process.argv[1]`) — deployed
+ *      runtimes start the artifact from outside the output dir (e.g. Railway:
+ *      `WORKDIR /app`, `CMD ["node", "output/index.mjs"]`), so cwd misses but
+ *      the entry's dir is the output dir.
+ *   4. `factory/` next to this module — only effective when the server is
+ *      bundled into a single file; misses when `@mastra/factory` is
+ *      externalized to `node_modules`.
+ *   5. Source-layout fallbacks under `MASTRA_PROJECT_ROOT` or cwd.
  * Returns `undefined` when no build is found (e.g. plain `mastra dev` without
  * a prior vite build), in which case the middleware is simply not mounted.
  */
 export function resolveUiDistDir(): string | undefined {
   const projectRoot = process.env.MASTRA_PROJECT_ROOT?.trim();
+  const entryScript = process.argv[1];
   const candidates = [
     process.env.MASTRACODE_UI_DIST,
     resolve(process.cwd(), 'factory'),
+    entryScript && join(dirname(resolve(entryScript)), 'factory'),
     join(dirname(fileURLToPath(import.meta.url)), 'factory'),
     projectRoot && resolve(projectRoot, 'src/mastra/public/factory'),
     resolve(process.cwd(), 'src/mastra/public/factory'),


### PR DESCRIPTION
## Summary

Deployed Factory projects on the platform render the default "Mastra Server" welcome page instead of the Factory UI, even though the SPA is correctly packaged into the artifact (`output/factory/` + `mastra-project.json`, from #19948).

Cause: the platform's Railway runtime starts artifacts with `WORKDIR /app` and `CMD ["node", "output/index.mjs"]`. `resolveUiDistDir()` in `@mastra/factory` then misses on every candidate:

- `<cwd>/factory` → `/app/factory` (SPA is at `/app/output/factory`)
- `factory/` next to the module → resolves into `node_modules/@mastra/factory/dist/` because the package is externalized, not bundled

With no dist found, the SPA middleware is never mounted.

Fix: add `dirname(process.argv[1])/factory` as a resolution candidate — the entry script's directory *is* the output directory regardless of cwd. Existing candidates and their precedence are unchanged (`MASTRACODE_UI_DIST` still wins).

## Test plan
- [x] New unit test simulating the deployed layout (cwd `/app`, entry `output/index.mjs`) — fails before, passes after
- [x] All 11 `spa-static.test.ts` tests pass
- [ ] Redeploy a factory project on the platform with a CLI containing this fix → UI renders at `https://<slug>.factory.mastra.cloud`

Platform-side counterpart (env-var injection covering already-built artifacts): mastra-ai/platform#1737

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>