### PR TITLE
Auto-refresh the Factory board's intake feeds and card positions

### DIFF
--- a/.changeset/factory-board-intake-refresh.md
+++ b/.changeset/factory-board-intake-refresh.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'mastra': patch
+---
+
+Factory board now picks up new GitHub/Linear intake automatically (gentle 30s poll) and refreshes work-item positions immediately when the tab regains focus, instead of requiring a manual page reload

--- a/mastracode/web/src/shared/hooks/__tests__/useFactoryData.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/useFactoryData.msw.test.tsx
@@ -12,7 +12,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { server } from '../../../../e2e/web-ui/msw-server';
 import { renderHookWithProviders, TEST_BASE_URL } from '../../../../e2e/web-ui/render';
 import type { GithubIssue, GithubPullRequest } from '../../../web/ui/domains/factory/services/factory';
-import { useProjectIssuesQuery, useProjectPullRequestsQuery } from '../useFactoryData';
+import { INTAKE_POLL_MS, useProjectIssuesQuery, useProjectPullRequestsQuery } from '../useFactoryData';
 
 const PROJECT_ID = 'github-project-1';
 const ISSUES_URL = `${TEST_BASE_URL}/web/github/projects/${PROJECT_ID}/issues`;
@@ -95,6 +95,33 @@ describe('useProjectIssuesQuery', () => {
     await waitFor(() => expect(client.isFetching()).toBe(0));
     expect(result.current.fetchStatus).toBe('idle');
     expect(hit).not.toHaveBeenCalled();
+  });
+
+  it('given new intake arrives after mount, when the poll interval elapses, then the feed refreshes without a reload', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try {
+      let hits = 0;
+      const freshIssue: GithubIssue = { ...issues[0]!, number: 99, title: 'Fresh intake' };
+      server.use(
+        http.get(ISSUES_URL, () => {
+          hits += 1;
+          return hits === 1
+            ? HttpResponse.json({ issues, nextPage: null })
+            : HttpResponse.json({ issues: [...issues, freshIssue], nextPage: null });
+        }),
+      );
+
+      const { result } = renderHookWithProviders(() => useProjectIssuesQuery(PROJECT_ID));
+      await waitFor(() => expect(result.current.data).toBeDefined());
+      expect(result.current.data).toHaveLength(1);
+
+      await vi.advanceTimersByTimeAsync(INTAKE_POLL_MS + 1_000);
+
+      await waitFor(() => expect(result.current.data).toHaveLength(2));
+      expect(result.current.data?.map(issue => issue.number)).toEqual([12, 99]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('given the server fails, when the hook resolves, then it surfaces the server message', async () => {

--- a/mastracode/web/src/shared/hooks/useFactoryData.ts
+++ b/mastracode/web/src/shared/hooks/useFactoryData.ts
@@ -9,6 +9,10 @@ import {
 } from '../../web/ui/domains/factory/services/factory';
 import type { GithubIssue } from '../../web/ui/domains/factory/services/factory';
 
+/** Board intake candidates come from external APIs (GitHub / Linear via the
+ * server) — poll on a gentler cadence than the DB-backed work-items list. */
+export const INTAKE_POLL_MS = 30_000;
+
 /**
  * Open issues for a GitHub project, loaded one page at a time as the list is
  * scrolled; disabled until a github project is active.
@@ -22,6 +26,11 @@ export function useProjectIssuesQuery(projectRepositoryId: string | undefined, l
     getNextPageParam: lastPage => lastPage.nextPage,
     enabled: Boolean(projectRepositoryId),
     select: data => data.pages.flatMap(page => page.issues),
+    // New intake must show up on the board without a reload. The endpoint
+    // proxies the live GitHub API (and a refetch replays every loaded page),
+    // so poll gently and refresh when the user returns to the tab.
+    refetchInterval: INTAKE_POLL_MS,
+    refetchOnWindowFocus: true,
   });
 }
 
@@ -63,5 +72,8 @@ export function useProjectPullRequestsQuery(projectRepositoryId: string | undefi
     getNextPageParam: lastPage => lastPage.nextPage,
     enabled: Boolean(projectRepositoryId),
     select: data => data.pages.flatMap(page => page.pullRequests),
+    // Same intake-freshness contract as the issues feed above.
+    refetchInterval: INTAKE_POLL_MS,
+    refetchOnWindowFocus: true,
   });
 }

--- a/mastracode/web/src/shared/hooks/useLinearData.ts
+++ b/mastracode/web/src/shared/hooks/useLinearData.ts
@@ -3,6 +3,7 @@ import { skipToken, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
 import { fetchLinearStatus, listLinearIssues, listLinearProjects } from '../../web/ui/domains/factory/services/linear';
+import { INTAKE_POLL_MS } from './useFactoryData';
 
 /**
  * Linear feature/connection status through the shared React Query cache. The
@@ -34,6 +35,10 @@ export function useLinearIssuesQuery(githubProjectId: string | undefined) {
     getNextPageParam: lastPage => lastPage.nextCursor,
     enabled: githubProjectId !== undefined,
     select: data => data.pages.flatMap(page => page.issues),
+    // New intake must show up on the board without a reload; the endpoint
+    // proxies the Linear API, so poll on the gentle intake cadence.
+    refetchInterval: INTAKE_POLL_MS,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/mastracode/web/src/shared/hooks/useWorkItems.ts
+++ b/mastracode/web/src/shared/hooks/useWorkItems.ts
@@ -25,6 +25,9 @@ export function useWorkItemsQuery(factoryProjectId: string | undefined) {
     // Relationships can be created by GitHub ingestion or another open tab.
     // Keep thread-page counterpart links current without requiring a reload.
     refetchInterval: 5_000,
+    // Cards move autonomously (rule transitions, agent runs); polling pauses
+    // while the tab is hidden, so refresh immediately on return.
+    refetchOnWindowFocus: true,
   });
 }
 


### PR DESCRIPTION
## Summary

The Factory board required a manual page reload to see new intake, and card positions could look stale after switching browser tabs.

Two gaps:

- **Intake candidate feeds never refreshed.** The GitHub issues/PRs and Linear issues queries behind the intake lane fetched once on mount and never again (no polling, and the app globally disables refetch-on-focus). New intake only appeared after a full reload. They now poll on a gentle 30s cadence — deliberately slower than the 5s work-items poll, since these endpoints proxy live external APIs and an infinite-query refetch replays every loaded page — and refetch when the tab regains focus.
- **Work-item positions lagged after tab switches.** The work-items list already polls every 5s, but polling pauses while the tab is hidden and focus regain didn't trigger a refetch. The query now refetches on window focus so autonomous card moves (rule transitions, agent runs) appear the moment the user returns.

## Test plan

- New MSW test: new intake arriving after mount shows up when the poll interval elapses, without a remount (verified red without the polling change)
- `useFactoryData` / `useLinearData` / `useWorkItems` MSW suites — 18 passed
- `pnpm run check` clean

Includes a changeset (patch: `@mastra/factory`, `mastra`).

Co-Authored-By: Mastra Code (anthropic/claude-fable-5) <noreply@mastra.ai>
