### PR TITLE
fix(factory): auto-link opened PRs to their work item by session branch

### DIFF
--- a/.changeset/pr-auto-link-head-branch.md
+++ b/.changeset/pr-auto-link-head-branch.md
@@ -1,0 +1,6 @@
+---
+'@mastra/factory': patch
+'mastra': patch
+---
+
+Link Factory Review cards to their work item when a PR opens without recorded provenance. GitHub PR-opened ingress now falls back to matching the PR head branch against work item session branches, and Review intake records `headBranch`/`baseBranch` metadata so the board and session views can relate the cards.

--- a/mastracode/factory/src/rules/defaults.test.ts
+++ b/mastracode/factory/src/rules/defaults.test.ts
@@ -346,6 +346,13 @@ describe('defaultFactoryRules', () => {
     });
   });
 
+  it('records the PR head branch on Review intake so the card links back to its work item', async () => {
+    const rules = defaultFactoryRules({ version: 'deployment-7' });
+    expect(await rules.github.pullRequestOpened?.onEvent?.(githubContext('pullRequestOpened'))).toMatchObject({
+      metadata: { headBranch: 'feature', baseBranch: 'main' },
+    });
+  });
+
   it('reminds the linked Work agent after merge without transitioning to Done', async () => {
     const rules = defaultFactoryRules({ version: 'deployment-7' });
     const context = githubContext('pullRequestMerged');

--- a/mastracode/factory/src/rules/defaults.ts
+++ b/mastracode/factory/src/rules/defaults.ts
@@ -145,6 +145,8 @@ function pullRequestOpened(context: FactoryGithubRuleContext) {
       githubRepositoryId: context.repository.id,
       githubPullRequestNumber: context.pullRequest.number,
       factoryAuthored: context.actor.type === 'github' && context.actor.factoryAuthored,
+      headBranch: context.pullRequest.headBranch,
+      baseBranch: context.pullRequest.baseBranch,
     },
   } as const;
 }

--- a/mastracode/factory/src/rules/github-service.test.ts
+++ b/mastracode/factory/src/rules/github-service.test.ts
@@ -451,6 +451,48 @@ describe('FactoryGithubEventService', () => {
     );
   });
 
+  it('links an opened Review card to the work item whose session branch matches the PR head branch', async () => {
+    const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('read');
+    const work = await workItems.upsert({
+      orgId: 'org-1',
+      userId: 'user-1',
+      factoryProjectId: project.id,
+      input: {
+        externalSource: {
+          integrationId: 'github',
+          type: 'issue',
+          externalId: 'github-issue:42',
+          url: 'https://github.com/acme/repo/issues/42',
+        },
+        title: 'Issue 42',
+        stages: ['execute'],
+        sessions: { work: { sessionId: 'session-issue-42', branch: 'feature', threadId: 'session-issue-42' } },
+        metadata: {},
+      },
+    });
+    const service = new FactoryGithubEventService({
+      github,
+      sourceControl,
+      integrationStorage,
+      projects,
+      storage: workItems,
+      rules: builtInFactoryRules(),
+    });
+
+    await service.ingest(pullRequest('opened', 'delivery-branch-link'));
+    const decisions = await workItems.listDeferredDecisions('org-1', project.id);
+    expect(decisions).toEqual([
+      expect.objectContaining({
+        workItemId: work.item.id,
+        decision: expect.objectContaining({
+          type: 'upsertLinkedWorkItem',
+          source: 'github-pr',
+          metadata: expect.objectContaining({ headBranch: 'feature' }),
+        }),
+      }),
+    ]);
+  });
+
   it('evaluates the same delivery independently for every tenant project mapped to the repository', async () => {
     const { github, sourceControl, integrationStorage, workItems, projects, project } = await setup('write');
     const second = await projects.create({

--- a/mastracode/factory/src/rules/github-service.ts
+++ b/mastracode/factory/src/rules/github-service.ts
@@ -179,6 +179,7 @@ export class FactoryGithubEventService {
       repositoryId,
       issueNumber,
       pullRequestNumber,
+      string(object(pullRequest?.head)?.ref),
       provenance,
     );
     const actor = await githubActor(this.options.github, {
@@ -294,6 +295,7 @@ export class FactoryGithubEventService {
     repositoryId: number,
     issueNumber: number | undefined,
     pullRequestNumber: number | undefined,
+    pullRequestHeadBranch: string | undefined,
     provenance: FactoryPullRequestProvenanceData | null,
   ): Promise<WorkItemRow | undefined> {
     const items = await this.options.storage.list({ orgId, factoryProjectId: projectId });
@@ -309,7 +311,19 @@ export class FactoryGithubEventService {
         items.find(item => item.externalSource?.externalId === canonicalSourceKey('pull-request', pullRequestNumber)) ??
         items.find(
           item => item.externalSource?.externalId === legacySourceKey(repositoryId, 'pull-request', pullRequestNumber),
-        )
+        ) ??
+        // Provenance fallback: a PR pushed from a work item's session branch
+        // belongs to that item even when no gh-pr-create provenance was
+        // recorded (session predating state seeding, or the PR was opened
+        // outside the tracked tool call). Session branches are per-item
+        // (`factory/issue-N`), so a head-branch match is unambiguous.
+        (pullRequestHeadBranch
+          ? items.find(
+              item =>
+                item.externalSource?.type !== 'pull-request' &&
+                Object.values(item.sessions).some(session => session.branch === pullRequestHeadBranch),
+            )
+          : undefined)
       );
     }
     return undefined;


### PR DESCRIPTION
## Summary

When a Factory agent opens a PR from a work item's session branch, the Review card created for that PR should be linked to the originating work item. Today that link depends entirely on PR provenance captured from the bound session's `gh pr create` tool result — if provenance was never recorded (session created before state seeding, PR opened outside the tracked tool call), the Review card lands with no parent and neither the board nor the session view can relate the two.

This PR closes the gap two ways:

- **Server:** GitHub PR-opened ingress falls back to matching the PR's head branch against work item session branches when no provenance subscription exists. Session branches are per-item (`factory/issue-N`), so a head-branch match is unambiguous. The matched item becomes the rule context item, which makes the dispatcher set `parentWorkItemId` on the materialized Review card.
- **Metadata:** the default `pullRequestOpened` Review-intake decision now records `headBranch`/`baseBranch`, so the existing client-side `inferredParentWorkItemId` fallback (which matches `metadata.headBranch` to session branches) also works for rule-materialized cards — previously it only worked for cards added manually from the candidates list.

## Test plan

- New test: PR-opened ingress with no provenance links the Review-card decision to the work item whose session branch matches the PR head branch.
- New test: `pullRequestOpened` decision metadata carries `headBranch`/`baseBranch`.
- Full factory rules suite: 12 files, 114 passed. Typecheck clean.