### PR TITLE
fix(factory): restore observational memory settings

### DIFF
--- a/.changeset/sharp-chairs-write.md
+++ b/.changeset/sharp-chairs-write.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': minor
+---
+
+Added guided model-provider setup to Factory onboarding with a recommended default model and provider-specific observational-memory defaults.

--- a/.changeset/wacky-cougars-invent.md
+++ b/.changeset/wacky-cougars-invent.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Restored observational-memory settings so Factory users can choose models and preferences before opening a chat session.

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -649,6 +649,7 @@ describe('OM routes with a tenant', () => {
       new ConfigRoutes({
         auth: fakeRouteAuth({ enabled: opts.authEnabled !== false }),
         controller,
+        modelCredentials: seed.credentials,
         ...(opts.withStorage === false ? {} : { memorySettings: seed.memorySettings }),
       }).routes(),
     );
@@ -662,8 +663,55 @@ describe('OM routes with a tenant', () => {
       body: JSON.stringify(body),
     });
 
+  const postJson = (app: Hono, path: string, body: unknown) =>
+    app.request(path, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+
   beforeEach(async () => {
     seed = await createFactoryStorageForTests();
+    await seed.credentials.setCredential({ orgId: 'org1', userId: 'user-a' }, 'anthropic', {
+      type: 'api_key',
+      key: 'sk-anthropic',
+    });
+  });
+
+  it('seeds provider-specific OM defaults without an active session', async () => {
+    const res = await postJson(buildApp(makeOmSession()), '/web/config/om/provider-defaults', {
+      providerId: 'anthropic',
+      factoryModelId: 'anthropic/claude-fable-5',
+    });
+
+    expect(res.status).toBe(200);
+    expect((await res.json()).config).toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-haiku-4-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
+  });
+
+  it('does not overwrite OM models that the user already selected', async () => {
+    await seed.memorySettings.patch({
+      orgId: 'org1',
+      userId: 'user-a',
+      patch: { observerModelId: 'anthropic/claude-fable-5' },
+    });
+
+    const res = await postJson(buildApp(makeOmSession()), '/web/config/om/provider-defaults', {
+      providerId: 'anthropic',
+      factoryModelId: 'anthropic/claude-fable-5',
+    });
+
+    expect(res.status).toBe(200);
+    await expect(seed.memorySettings.get({ orgId: 'org1', userId: 'user-a' })).resolves.toMatchObject({
+      observerModelId: 'anthropic/claude-fable-5',
+      reflectorModelId: 'anthropic/claude-haiku-4-5',
+    });
   });
 
   it('persists a role model switch to the memory-settings domain, snapshotting the other role', async () => {

--- a/mastracode/factory/src/routes/config.test.ts
+++ b/mastracode/factory/src/routes/config.test.ts
@@ -719,6 +719,45 @@ describe('OM routes with a tenant', () => {
     expect(stored?.observeAttachments).toBe(false);
   });
 
+  it('reads and updates persisted settings without an active session', async () => {
+    const app = buildApp(makeOmSession());
+
+    const initial = await app.request('/web/config/om');
+    expect(initial.status).toBe(200);
+    expect((await initial.json()).config).toMatchObject({
+      observerModelId: DEFAULT_OM_MODEL_ID,
+      reflectorModelId: DEFAULT_OM_MODEL_ID,
+      observationThreshold: 30000,
+      reflectionThreshold: 40000,
+      observeAttachments: 'auto',
+    });
+
+    expect(
+      (
+        await putJson(app, '/web/config/om/observer/model', {
+          modelId: 'anthropic/claude-fable-5',
+        })
+      ).status,
+    ).toBe(200);
+    expect(
+      (
+        await putJson(app, '/web/config/om/thresholds', {
+          observationThreshold: 25000,
+          reflectionThreshold: 45000,
+        })
+      ).status,
+    ).toBe(200);
+    expect((await putJson(app, '/web/config/om/observe-attachments', { value: false })).status).toBe(200);
+
+    const persisted = await app.request('/web/config/om');
+    expect((await persisted.json()).config).toMatchObject({
+      observerModelId: 'anthropic/claude-fable-5',
+      observationThreshold: 25000,
+      reflectionThreshold: 45000,
+      observeAttachments: false,
+    });
+  });
+
   it('returns 503 when tenant mode has no memory-settings storage', async () => {
     const res = await putJson(buildApp(makeOmSession(), { withStorage: false }), '/web/config/om/thresholds', {
       resourceId: 'r1',

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -462,11 +462,9 @@ async function applyPackToSession({
 }
 
 // ── Observational memory ────────────────────────────────────────────────────
-// Mirrors the TUI `/om` command. Observer/reflector model + threshold reads come
-// from the session (state, falling back to omConfig defaults); writes go to both
-// the session (state + thread setting, via the same session methods the TUI uses)
-// and GlobalSettings (settings.json), so the choice survives restarts and stays
-// in sync with the terminal.
+// Mirrors the TUI `/om` command. Settings are persisted per organization and
+// user in the Factory app database. Requests with an active session also apply
+// changes immediately to that session's state and thread settings.
 
 /** Default thresholds mirror the TUI `/om` fallbacks. */
 const DEFAULT_OBSERVATION_THRESHOLD = 30_000;
@@ -490,6 +488,16 @@ export function readOMConfig(session: OMSession): OMConfigInfo {
     observationThreshold: session.om.observer.threshold() ?? DEFAULT_OBSERVATION_THRESHOLD,
     reflectionThreshold: session.om.reflector.threshold() ?? DEFAULT_REFLECTION_THRESHOLD,
     observeAttachments: observeAttachments === true || observeAttachments === false ? observeAttachments : 'auto',
+  };
+}
+
+function readStoredOMConfig(record: MemorySettingsRecord | null): OMConfigInfo {
+  return {
+    observerModelId: record?.observerModelId ?? DEFAULT_OM_MODEL_ID,
+    reflectorModelId: record?.reflectorModelId ?? DEFAULT_OM_MODEL_ID,
+    observationThreshold: record?.observationThreshold ?? DEFAULT_OBSERVATION_THRESHOLD,
+    reflectionThreshold: record?.reflectionThreshold ?? DEFAULT_REFLECTION_THRESHOLD,
+    observeAttachments: record?.observeAttachments ?? 'auto',
   };
 }
 
@@ -1001,11 +1009,9 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
       }),
 
       // ── Observational memory ──────────────────────────────────────────────────
-      // Mirrors the TUI's /om command. All five knobs are session-scoped (resolved
-      // from the session, persisted to its state + thread setting) and durably
-      // stored in the per-(org, user) `memory-settings` app table — never
-      // settings.json. GET hydrates the session from the stored row first so the
-      // DB, not the SDK's boot-time seed, is the source of truth.
+      // Mirrors the TUI's /om command. All five knobs are durably stored in the
+      // per-(org, user) `memory-settings` app table — never settings.json. When a
+      // session is supplied, changes are also applied to its state and thread.
 
       registerApiRoute('/web/config/om', {
         method: 'GET',
@@ -1013,7 +1019,6 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
         handler: async c => {
           const resourceId = c.req.query('resourceId');
           const scope = c.req.query('scope') || undefined;
-          if (!resourceId) return c.json({ error: 'Missing required query param: resourceId' }, 400);
           const context = await resolveMemorySettingsContext({
             c: loose(c),
             auth,
@@ -1021,9 +1026,11 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
+            const record = await context.storage.get({ orgId: context.orgId, userId: context.userId });
+            if (!resourceId) return c.json({ config: readStoredOMConfig(record) });
+
             const session = await controller.getSessionByResource?.(resourceId, scope);
             if (!session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
-            const record = await context.storage.get({ orgId: context.orgId, userId: context.userId });
             await hydrateSessionMemorySettings(session, record);
             return c.json({ config: readOMConfig(session) });
           } catch (error) {
@@ -1049,7 +1056,6 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           const resourceId = typeof body.resourceId === 'string' ? body.resourceId : '';
           const scope = typeof body.scope === 'string' && body.scope ? body.scope : undefined;
           const modelId = typeof body.modelId === 'string' ? body.modelId.trim() : '';
-          if (!resourceId) return c.json({ error: 'Missing required field: resourceId' }, 400);
           if (!modelId) return c.json({ error: 'Missing required field: modelId' }, 400);
           const context = await resolveMemorySettingsContext({
             c: loose(c),
@@ -1058,11 +1064,11 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
-            const session = await controller.getSessionByResource?.(resourceId, scope);
-            if (!session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
-            const otherRole = role === 'observer' ? session.om.reflector : session.om.observer;
-            const otherRoleCurrentModelId = otherRole.modelId() ?? null;
-            await session.om[role].switchModel({ modelId });
+            const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
+            if (resourceId && !session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+            const otherRole = session ? (role === 'observer' ? session.om.reflector : session.om.observer) : undefined;
+            const otherRoleCurrentModelId = otherRole?.modelId() ?? null;
+            await session?.om[role].switchModel({ modelId });
             // Pin the other role's current model too, so a later restart
             // doesn't drift it once this role is explicitly overridden. The
             // "only if still unset" check runs inside the storage layer's
@@ -1074,7 +1080,10 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
               { [role === 'observer' ? 'observerModelId' : 'reflectorModelId']: modelId },
               otherRoleCurrentModelId ? { [otherKey]: otherRoleCurrentModelId } : undefined,
             );
-            return c.json({ ok: true, config: readOMConfig(session) });
+            const config = session
+              ? readOMConfig(session)
+              : readStoredOMConfig(await context.storage.get({ orgId: context.orgId, userId: context.userId }));
+            return c.json({ ok: true, config });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }
@@ -1098,7 +1107,6 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           }
           const resourceId = typeof body.resourceId === 'string' ? body.resourceId : '';
           const scope = typeof body.scope === 'string' && body.scope ? body.scope : undefined;
-          if (!resourceId) return c.json({ error: 'Missing required field: resourceId' }, 400);
           const observation =
             typeof body.observationThreshold === 'number' && body.observationThreshold > 0
               ? Math.round(body.observationThreshold)
@@ -1117,13 +1125,13 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
-            const session = await controller.getSessionByResource?.(resourceId, scope);
-            if (!session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
-            if (observation !== undefined) {
+            const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
+            if (resourceId && !session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+            if (observation !== undefined && session) {
               await session.state.set({ observationThreshold: observation });
               await session.thread.setSetting({ key: 'observationThreshold', value: observation });
             }
-            if (reflection !== undefined) {
+            if (reflection !== undefined && session) {
               await session.state.set({ reflectionThreshold: reflection });
               await session.thread.setSetting({ key: 'reflectionThreshold', value: reflection });
             }
@@ -1131,7 +1139,10 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
               ...(observation !== undefined ? { observationThreshold: observation } : {}),
               ...(reflection !== undefined ? { reflectionThreshold: reflection } : {}),
             });
-            return c.json({ ok: true, config: readOMConfig(session) });
+            const config = session
+              ? readOMConfig(session)
+              : readStoredOMConfig(await context.storage.get({ orgId: context.orgId, userId: context.userId }));
+            return c.json({ ok: true, config });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }
@@ -1150,7 +1161,6 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           }
           const resourceId = typeof body.resourceId === 'string' ? body.resourceId : '';
           const scope = typeof body.scope === 'string' && body.scope ? body.scope : undefined;
-          if (!resourceId) return c.json({ error: 'Missing required field: resourceId' }, 400);
           const raw = body.value;
           const value: 'auto' | boolean = raw === 'auto' || raw === true || raw === false ? raw : 'auto';
           if (raw !== 'auto' && raw !== true && raw !== false) {
@@ -1163,12 +1173,17 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
           });
           if ('response' in context) return context.response;
           try {
-            const session = await controller.getSessionByResource?.(resourceId, scope);
-            if (!session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
-            await session.state.set({ observeAttachments: value });
-            await session.thread.setSetting({ key: 'observeAttachments', value });
+            const session = resourceId ? await controller.getSessionByResource?.(resourceId, scope) : undefined;
+            if (resourceId && !session) return c.json({ error: `No session for resourceId "${resourceId}"` }, 404);
+            if (session) {
+              await session.state.set({ observeAttachments: value });
+              await session.thread.setSetting({ key: 'observeAttachments', value });
+            }
             await persistMemorySettings(context, { observeAttachments: value });
-            return c.json({ ok: true, config: readOMConfig(session) });
+            const config = session
+              ? readOMConfig(session)
+              : readStoredOMConfig(await context.storage.get({ orgId: context.orgId, userId: context.userId }));
+            return c.json({ ok: true, config });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }

--- a/mastracode/factory/src/routes/config.ts
+++ b/mastracode/factory/src/routes/config.ts
@@ -479,6 +479,22 @@ export interface OMConfigInfo {
   observeAttachments: 'auto' | boolean;
 }
 
+export interface ProviderOMDefaultsResponse {
+  ok: true;
+  config: OMConfigInfo;
+}
+
+function providerOMModelId(providerId: string, factoryModelId: string): string {
+  switch (providerId) {
+    case 'anthropic':
+      return 'anthropic/claude-haiku-4-5';
+    case 'openai':
+      return 'openai/gpt-5.4-mini';
+    default:
+      return factoryModelId || DEFAULT_OM_MODEL_ID;
+  }
+}
+
 export function readOMConfig(session: OMSession): OMConfigInfo {
   const state = session.state.get() ?? {};
   const observeAttachments = state.observeAttachments;
@@ -1002,6 +1018,54 @@ export class ConfigRoutes extends Route<ConfigRoutesDeps> {
             if (!pack) return c.json({ error: `Unknown pack "${id}"` }, 404);
             await applyPackToSession({ controller, session, pack });
             return c.json({ ok: true, activePackId: pack.id });
+          } catch (error) {
+            return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
+          }
+        },
+      }),
+
+      registerApiRoute('/web/config/om/provider-defaults', {
+        method: 'POST',
+        requiresAuth: false,
+        handler: async c => {
+          let body: { providerId?: unknown; factoryModelId?: unknown };
+          try {
+            body = await c.req.json();
+          } catch {
+            return c.json({ error: 'Invalid JSON body' }, 400);
+          }
+          const providerId = typeof body.providerId === 'string' ? body.providerId.trim() : '';
+          const factoryModelId = typeof body.factoryModelId === 'string' ? body.factoryModelId.trim() : '';
+          if (!providerId) return c.json({ error: 'Missing required field: providerId' }, 400);
+
+          const context = await resolveMemorySettingsContext({
+            c: loose(c),
+            auth,
+            memorySettings: options.memorySettings,
+          });
+          if ('response' in context) return context.response;
+
+          try {
+            const tenantCredentials = await listTenantCredentialsForRequest({
+              c: loose(c),
+              auth,
+              credentials: options.modelCredentials,
+            });
+            const access = await buildProviderAccess({
+              controller,
+              authStorage: tenantCredentials ? undefined : authStorage,
+              tenantCredentials,
+            });
+            if (!access[providerId]) return c.json({ error: `Provider "${providerId}" is not configured` }, 400);
+
+            const modelId = providerOMModelId(providerId, factoryModelId);
+            const record = await context.storage.patch({
+              orgId: context.orgId,
+              userId: context.userId,
+              patch: {},
+              fillIfUnset: { observerModelId: modelId, reflectorModelId: modelId },
+            });
+            return c.json({ ok: true, config: readStoredOMConfig(record) });
           } catch (error) {
             return c.json({ error: error instanceof Error ? error.message : String(error) }, 500);
           }

--- a/mastracode/web/src/shared/api/types.ts
+++ b/mastracode/web/src/shared/api/types.ts
@@ -9,7 +9,13 @@
  * `import type` keeps this module type-only — no server runtime code is pulled
  * into the shared/platform-agnostic bundle.
  */
-import type { CustomProviderInfo, ModelPackInfo, OMConfigInfo, ProviderInfo } from '@mastra/factory/routes/config';
+import type {
+  CustomProviderInfo,
+  ModelPackInfo,
+  OMConfigInfo,
+  ProviderInfo,
+  ProviderOMDefaultsResponse,
+} from '@mastra/factory/routes/config';
 import type {
   ArtifactEntry,
   ArtifactListing,
@@ -20,7 +26,7 @@ import type {
   WorkspaceRenderedListing,
 } from '@mastra/factory/routes/fs';
 
-export type { ProviderInfo, CustomProviderInfo, ModelPackInfo, OMConfigInfo };
+export type { ProviderInfo, CustomProviderInfo, ModelPackInfo, OMConfigInfo, ProviderOMDefaultsResponse };
 export type {
   ArtifactEntry,
   ArtifactListing,

--- a/mastracode/web/src/shared/hooks/__tests__/use-om.msw.test.tsx
+++ b/mastracode/web/src/shared/hooks/__tests__/use-om.msw.test.tsx
@@ -13,18 +13,15 @@ const URL = `${TEST_BASE_URL}/web/config/om`;
 
 describe('useOMQuery', () => {
   describe('when no resourceId is provided', () => {
-    it('stays disabled and never hits the network', async () => {
+    it('loads persisted settings without a session', async () => {
       const onGet = vi.fn(() => HttpResponse.json(omResponse()));
       server.use(http.get(URL, onGet));
 
       const { result } = renderHookWithProviders(() => useOMQuery(undefined));
 
-      // give react-query a tick; the query must not fire
-      await act(async () => {
-        await Promise.resolve();
-      });
-      expect(result.current.fetchStatus).toBe('idle');
-      expect(onGet).not.toHaveBeenCalled();
+      await waitFor(() => expect(result.current.isSuccess).toBe(true));
+      expect(onGet).toHaveBeenCalledOnce();
+      expect(result.current.data).toEqual(omResponse());
     });
   });
 

--- a/mastracode/web/src/shared/hooks/use-om.ts
+++ b/mastracode/web/src/shared/hooks/use-om.ts
@@ -5,14 +5,10 @@ import { queryKeys } from '../api/keys';
 import type { OMResponse, UpdateOMResponse } from '../api/types';
 
 /**
- * Observational Memory config (mirrors the TUI `/om` command). Everything is
- * session-scoped: the GET route requires the active factory's `resourceId`, so
- * the query is gated by `enabled` and stays idle until a project is open. The
- * cache is keyed by `resourceId` so switching projects yields a distinct entry.
- *
- * Web chat sessions are registered under `(resourceId, scope)` — the scope is
- * the project path — so every call forwards `scope` or the server-side session
- * lookup misses.
+ * Observational Memory config (mirrors the TUI `/om` command). Settings are
+ * persisted per user and can be managed without an active chat session. When a
+ * session is available, resourceId and scope let the server apply changes to it
+ * immediately as well.
  *
  * The update mutations return the full refreshed `{ config }`, so they write it
  * straight into the cache via `setQueryData` instead of triggering a refetch —
@@ -23,10 +19,12 @@ export function useOMQuery(resourceId: string | undefined, scope?: string) {
   return useQuery<OMResponse>({
     queryKey: queryKeys.om(resourceId),
     queryFn: () => {
-      const qs = scope ? `&scope=${encodeURIComponent(scope)}` : '';
-      return client.get<OMResponse>(`/web/config/om?resourceId=${encodeURIComponent(resourceId as string)}${qs}`);
+      const params = new URLSearchParams();
+      if (resourceId) params.set('resourceId', resourceId);
+      if (scope) params.set('scope', scope);
+      const query = params.size > 0 ? `?${params.toString()}` : '';
+      return client.get<OMResponse>(`/web/config/om${query}`);
     },
-    enabled: !!resourceId,
   });
 }
 

--- a/mastracode/web/src/shared/hooks/use-om.ts
+++ b/mastracode/web/src/shared/hooks/use-om.ts
@@ -2,7 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useApiConfig } from '../api/config';
 import { queryKeys } from '../api/keys';
-import type { OMResponse, UpdateOMResponse } from '../api/types';
+import type { OMResponse, ProviderOMDefaultsResponse, UpdateOMResponse } from '../api/types';
 
 /**
  * Observational Memory config (mirrors the TUI `/om` command). Settings are
@@ -25,6 +25,19 @@ export function useOMQuery(resourceId: string | undefined, scope?: string) {
       const query = params.size > 0 ? `?${params.toString()}` : '';
       return client.get<OMResponse>(`/web/config/om${query}`);
     },
+  });
+}
+
+export function useApplyProviderOMDefaults() {
+  const { client } = useApiConfig();
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ providerId, factoryModelId }: { providerId: string; factoryModelId: string }) =>
+      client.post<ProviderOMDefaultsResponse>('/web/config/om/provider-defaults', {
+        providerId,
+        factoryModelId,
+      }),
+    onSuccess: response => queryClient.setQueryData<OMResponse>(queryKeys.om(undefined), { config: response.config }),
   });
 }
 

--- a/mastracode/web/src/web/ui/__tests__/FactoryRootRoute.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/FactoryRootRoute.msw.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 import { createMemoryRouter, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
@@ -102,6 +103,37 @@ describe('Factory root route', () => {
     try {
       await screen.findByRole('heading', { name: 'Connect the work behind the code.' });
       expect(router.state.location.pathname).toBe('/onboarding');
+    } finally {
+      clearOnboarding();
+    }
+  });
+
+  it('continues from project management to Factory model setup', async () => {
+    seedOnboarding('project-management', 'fp-1');
+
+    server.use(
+      http.get(`${TEST_BASE_URL}/auth/me`, () =>
+        HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects`, () =>
+        HttpResponse.json({ projects: [{ id: 'fp-1', name: 'Pending Factory' }] }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/factory/projects/fp-1/source-control-connections`, () =>
+        HttpResponse.json({ connections: [] }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/linear/status`, () =>
+        HttpResponse.json({ enabled: true, connected: false, reason: 'not_connected' }),
+      ),
+      http.get(`${TEST_BASE_URL}/web/config/providers`, () => HttpResponse.json({ providers: [] })),
+      http.get(`${TEST_BASE_URL}/web/config/models`, () => HttpResponse.json({ models: [] })),
+    );
+
+    const user = userEvent.setup();
+    renderFactoryRoute('/onboarding');
+
+    try {
+      await user.click(await screen.findByRole('button', { name: 'Skip for now' }));
+      await screen.findByRole('heading', { name: 'Choose your Factory model.' });
     } finally {
       clearOnboarding();
     }

--- a/mastracode/web/src/web/ui/domains/settings/components/OMSection.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/OMSection.tsx
@@ -1,0 +1,219 @@
+import { Badge } from '@mastra/playground-ui/components/Badge';
+import { Button } from '@mastra/playground-ui/components/Button';
+import { ButtonsGroup } from '@mastra/playground-ui/components/ButtonsGroup';
+import { Input } from '@mastra/playground-ui/components/Input';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { useState } from 'react';
+
+import {
+  useOMQuery,
+  useUpdateOMModel,
+  useUpdateOMObserveAttachments,
+  useUpdateOMThresholds,
+} from '../../../../../shared/hooks/use-om';
+import type { AvailableModelOption } from '../../../../../shared/hooks/useAvailableModels';
+import { SkeletonRows } from '../../../ui/SkeletonRows';
+import { ModelCombobox } from './ModelCombobox';
+
+type AttachmentChoice = 'auto' | 'on' | 'off';
+
+function attachmentToChoice(value: 'auto' | boolean): AttachmentChoice {
+  if (value === true) return 'on';
+  if (value === false) return 'off';
+  return 'auto';
+}
+
+function choiceToAttachment(choice: AttachmentChoice): 'auto' | boolean {
+  if (choice === 'on') return true;
+  if (choice === 'off') return false;
+  return 'auto';
+}
+
+function Field({ label, hint, children }: { label: string; hint: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex flex-col">
+        <Txt as="span" variant="ui-sm" className="text-icon5">
+          {label}
+        </Txt>
+        <Txt as="span" variant="ui-xs" className="text-icon3">
+          {hint}
+        </Txt>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function ThresholdInput({
+  value,
+  disabled,
+  onCommit,
+}: {
+  value: number;
+  disabled: boolean;
+  onCommit: (value: number) => void;
+}) {
+  const [draft, setDraft] = useState(String(value));
+
+  const commit = () => {
+    const parsed = Number(draft);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      setDraft(String(value));
+      return;
+    }
+    const rounded = Math.round(parsed);
+    setDraft(String(rounded));
+    if (rounded !== value) onCommit(rounded);
+  };
+
+  return (
+    <Input
+      size="sm"
+      type="number"
+      min={1}
+      step={1000}
+      value={draft}
+      disabled={disabled}
+      onChange={event => setDraft(event.target.value)}
+      onBlur={commit}
+    />
+  );
+}
+
+/** Persisted observational-memory settings, optionally synchronized to an active session. */
+export function OMSection({
+  resourceId,
+  scope,
+  models,
+}: {
+  resourceId?: string;
+  scope?: string;
+  models: AvailableModelOption[];
+}) {
+  const omQuery = useOMQuery(resourceId, scope);
+  const observerMutation = useUpdateOMModel(resourceId, 'observer', scope);
+  const reflectorMutation = useUpdateOMModel(resourceId, 'reflector', scope);
+  const thresholdsMutation = useUpdateOMThresholds(resourceId, scope);
+  const attachmentsMutation = useUpdateOMObserveAttachments(resourceId, scope);
+
+  const config = omQuery.data?.config;
+  const configuredModelIds = new Set(models.map(model => model.id));
+  const observerAvailable = config !== undefined && configuredModelIds.has(config.observerModelId);
+  const reflectorAvailable = config !== undefined && configuredModelIds.has(config.reflectorModelId);
+  const modelsAvailable = observerAvailable && reflectorAvailable;
+  const loading = omQuery.isPending;
+  const busy =
+    observerMutation.isPending ||
+    reflectorMutation.isPending ||
+    thresholdsMutation.isPending ||
+    attachmentsMutation.isPending;
+  const mutationError = [
+    observerMutation.error,
+    reflectorMutation.error,
+    thresholdsMutation.error,
+    attachmentsMutation.error,
+  ].find(error => error instanceof Error);
+  const error = mutationError?.message ?? (omQuery.error instanceof Error ? omQuery.error.message : undefined);
+
+  const switchModel = (role: 'observer' | 'reflector', modelId: string) => {
+    if (!modelId) return;
+    const mutation = role === 'observer' ? observerMutation : reflectorMutation;
+    mutation.mutate({ modelId });
+  };
+
+  if (loading) {
+    return <SkeletonRows label="Loading observational-memory settings" rows={4} rowClassName="h-10 w-full" />;
+  }
+
+  const attachmentChoice = attachmentToChoice(config?.observeAttachments ?? 'auto');
+  const attachmentOptions: { value: AttachmentChoice; label: string }[] = [
+    { value: 'auto', label: 'Auto' },
+    { value: 'on', label: 'On' },
+    { value: 'off', label: 'Off' },
+  ];
+
+  return (
+    <div className="flex flex-col gap-4">
+      {error && (
+        <Txt as="p" variant="ui-sm" className="text-notice-destructive-fg">
+          {error}
+        </Txt>
+      )}
+
+      {config && !modelsAvailable && (
+        <div className="flex items-center gap-2">
+          <Badge size="md" variant="warning">
+            Model credentials required
+          </Badge>
+          <Txt as="p" variant="ui-xs" className="text-icon3">
+            Observational-memory model calls may fail until credentials are configured.
+          </Txt>
+        </div>
+      )}
+
+      <Field label="Observer model" hint="Summarizes the conversation into observations">
+        <ModelCombobox
+          models={models}
+          value={config?.observerModelId ?? ''}
+          placeholder="Select observer model…"
+          disabled={busy}
+          onValueChange={modelId => switchModel('observer', modelId)}
+        />
+      </Field>
+
+      <Field label="Reflector model" hint="Distills observations into longer-term memory">
+        <ModelCombobox
+          models={models}
+          value={config?.reflectorModelId ?? ''}
+          placeholder="Select reflector model…"
+          disabled={busy}
+          onValueChange={modelId => switchModel('reflector', modelId)}
+        />
+      </Field>
+
+      <Field label="Messages before observation" hint="Message tokens processed before the observer runs.">
+        {config && (
+          <ThresholdInput
+            key={config.observationThreshold}
+            value={config.observationThreshold}
+            disabled={busy}
+            onCommit={observationThreshold => {
+              thresholdsMutation.mutate({ observationThreshold });
+            }}
+          />
+        )}
+      </Field>
+
+      <Field label="Observations before reflection" hint="Observation tokens accumulated before the reflector runs.">
+        {config && (
+          <ThresholdInput
+            key={config.reflectionThreshold}
+            value={config.reflectionThreshold}
+            disabled={busy}
+            onCommit={reflectionThreshold => {
+              thresholdsMutation.mutate({ reflectionThreshold });
+            }}
+          />
+        )}
+      </Field>
+
+      <Field label="Observe attachments" hint="Whether attached files are included in observations">
+        <ButtonsGroup spacing="close" role="group" aria-label="Observe attachments">
+          {attachmentOptions.map(option => (
+            <Button
+              key={option.value}
+              variant={attachmentChoice === option.value ? 'primary' : 'outline'}
+              size="sm"
+              aria-pressed={attachmentChoice === option.value}
+              disabled={busy || !config}
+              onClick={() => attachmentsMutation.mutate({ value: choiceToAttachment(option.value) })}
+            >
+              {option.label}
+            </Button>
+          ))}
+        </ButtonsGroup>
+      </Field>
+    </div>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/settings/components/OMSection.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/OMSection.tsx
@@ -58,11 +58,11 @@ function ThresholdInput({
 
   const commit = () => {
     const parsed = Number(draft);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
+    const rounded = Number.isFinite(parsed) ? Math.round(parsed) : NaN;
+    if (!Number.isFinite(rounded) || rounded <= 0) {
       setDraft(String(value));
       return;
     }
-    const rounded = Math.round(parsed);
     setDraft(String(rounded));
     if (rounded !== value) onCommit(rounded);
   };

--- a/mastracode/web/src/web/ui/domains/settings/components/SettingsPanel.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/SettingsPanel.tsx
@@ -21,6 +21,7 @@ import { IntakeSection } from './IntakeSection';
 import { ModelPacksSection } from './ModelPacksSection';
 import { FactorySetupSection } from './FactorySetupSection';
 import { SourceControlSection } from './SourceControlSection';
+import { OMSection } from './OMSection';
 import { ProviderAccessSection } from './ProviderAccessSection';
 import { BehaviorSettings, GeneralSettings, ModelSettings } from './SettingsPanel.parts';
 
@@ -135,6 +136,12 @@ export function SettingsPanel() {
                 description="A pack sets a model for each mode (build / plan / fast)."
               >
                 <ModelPacksSection resourceId={sessionResourceId} scope={sessionScope} models={models} />
+              </SettingsSubsection>
+              <SettingsSubsection
+                title="Observational memory"
+                description="Choose the models and token thresholds used to summarize and retain conversation context."
+              >
+                <OMSection resourceId={sessionResourceId} scope={sessionScope} models={models} />
               </SettingsSubsection>
             </div>
           )}

--- a/mastracode/web/src/web/ui/domains/settings/components/__tests__/OMSection.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/settings/components/__tests__/OMSection.msw.test.tsx
@@ -1,0 +1,152 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { delay, http, HttpResponse } from 'msw';
+import { describe, expect, it } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { TEST_BASE_URL, renderWithProviders } from '../../../../../../../e2e/web-ui/render';
+import type { OMConfigInfo } from '../../../../../../shared/api/types';
+import type { AvailableModelOption } from '../../../../../../shared/hooks/useAvailableModels';
+import { OMSection } from '../OMSection';
+
+const OM_URL = `${TEST_BASE_URL}/web/config/om`;
+
+const models: AvailableModelOption[] = [
+  { id: 'openai/observer-x', provider: 'openai', modelName: 'observer-x', hasApiKey: true },
+  { id: 'openai/reflector-x', provider: 'openai', modelName: 'reflector-x', hasApiKey: true },
+];
+
+async function pickOption(user: ReturnType<typeof userEvent.setup>, trigger: HTMLElement, name: RegExp) {
+  await user.click(trigger);
+  const option = await screen.findByRole('option', { name });
+  fireEvent.pointerDown(option, { pointerType: 'mouse' });
+  fireEvent.click(option, { detail: 1 });
+  await waitFor(() => expect(screen.queryByRole('option', { name })).not.toBeInTheDocument());
+}
+
+const baseConfig: OMConfigInfo = {
+  observerModelId: 'openai/observer-x',
+  reflectorModelId: 'openai/reflector-x',
+  observationThreshold: 1000,
+  reflectionThreshold: 2000,
+  observeAttachments: 'auto',
+};
+
+describe('OMSection', () => {
+  it('loads persisted settings without an active chat session', async () => {
+    let requested = false;
+    server.use(
+      http.get(OM_URL, ({ request }) => {
+        requested = true;
+        expect(new URL(request.url).search).toBe('');
+        return HttpResponse.json({ config: baseConfig });
+      }),
+    );
+
+    renderWithProviders(<OMSection models={models} />);
+
+    expect(await screen.findByDisplayValue('1000')).toBeInTheDocument();
+    expect(screen.queryByText('Model credentials required')).not.toBeInTheDocument();
+    expect(requested).toBe(true);
+  });
+
+  it('keeps OM enabled and warns when a configured model is unavailable', async () => {
+    server.use(
+      http.get(OM_URL, () =>
+        HttpResponse.json({
+          config: { ...baseConfig, reflectorModelId: 'google/gemini-3.5-flash' },
+        }),
+      ),
+    );
+
+    renderWithProviders(<OMSection models={models} />);
+
+    expect(await screen.findByText('Model credentials required')).toBeInTheDocument();
+    expect(screen.getByText(/model calls may fail until credentials are configured/)).toBeInTheDocument();
+    expect(screen.queryByText('Enabled')).not.toBeInTheDocument();
+    const [observerModel, reflectorModel] = screen.getAllByRole('combobox');
+    expect(observerModel).toHaveTextContent('openai/observer-x');
+    expect(reflectorModel).toHaveTextContent('google/gemini-3.5-flash');
+  });
+
+  it('loads the observer, reflector, thresholds, and attachment setting', async () => {
+    server.use(
+      http.get(OM_URL, async () => {
+        await delay(50);
+        return HttpResponse.json({ config: baseConfig });
+      }),
+    );
+
+    renderWithProviders(<OMSection models={models} />);
+
+    expect(await screen.findByRole('status', { name: 'Loading observational-memory settings' })).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('1000')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('2000')).toBeInTheDocument();
+    expect(screen.getByText('Observer model')).toBeInTheDocument();
+    expect(screen.getByText('Reflector model')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Auto' })).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('updates an observation threshold and reflects the server response', async () => {
+    let requestBody: unknown;
+    server.use(
+      http.get(OM_URL, () => HttpResponse.json({ config: baseConfig })),
+      http.put(`${OM_URL}/thresholds`, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json({ ok: true, config: { ...baseConfig, observationThreshold: 5000 } });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OMSection models={models} />);
+
+    const input = await screen.findByDisplayValue<HTMLInputElement>('1000');
+    await user.clear(input);
+    await user.type(input, '5000');
+    await user.tab();
+
+    await waitFor(() => expect(requestBody).toEqual({ observationThreshold: 5000 }));
+    expect(await screen.findByDisplayValue('5000')).toBeInTheDocument();
+  });
+
+  it('updates the observer model', async () => {
+    let requestBody: unknown;
+    server.use(
+      http.get(OM_URL, () => HttpResponse.json({ config: baseConfig })),
+      http.put(`${OM_URL}/observer/model`, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json({ ok: true, config: { ...baseConfig, observerModelId: 'openai/reflector-x' } });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OMSection models={models} />);
+
+    await screen.findByDisplayValue('1000');
+    const [observerTrigger] = screen.getAllByRole('combobox');
+    expect(observerTrigger).toBeDefined();
+    await pickOption(user, observerTrigger, /openai\/reflector-x/);
+
+    await waitFor(() => expect(requestBody).toEqual({ modelId: 'openai/reflector-x' }));
+  });
+
+  it('updates attachment observation', async () => {
+    let requestBody: unknown;
+    server.use(
+      http.get(OM_URL, () => HttpResponse.json({ config: baseConfig })),
+      http.put(`${OM_URL}/observe-attachments`, async ({ request }) => {
+        requestBody = await request.json();
+        return HttpResponse.json({ ok: true, config: { ...baseConfig, observeAttachments: true } });
+      }),
+    );
+
+    const user = userEvent.setup();
+    renderWithProviders(<OMSection models={models} />);
+
+    await screen.findByDisplayValue('1000');
+    await user.click(screen.getByRole('button', { name: 'On' }));
+
+    await waitFor(() => expect(requestBody).toEqual({ value: true }));
+    await waitFor(() => expect(screen.getByRole('button', { name: 'On' })).toHaveAttribute('aria-pressed', 'true'));
+  });
+});

--- a/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/EmptyFactoryState.tsx
@@ -23,6 +23,7 @@ import {
 import { Txt } from '@mastra/playground-ui/components/Txt';
 import { FactoryHalftoneField } from '../../auth/components/FactoryHalftoneField';
 import { InitialFactoryStep } from './InitialFactoryStep';
+import { ModelProviderFactoryStep } from './ModelProviderFactoryStep';
 import { ProjectManagementFactoryStep } from './ProjectManagementFactoryStep';
 import { VcsFactoryStep } from './VcsFactoryStep';
 import { useNavigate } from 'react-router';
@@ -40,6 +41,10 @@ const STEP_META: Record<Step, { title: string; description?: string }> = {
   },
   'project-management': {
     title: 'Connect the work behind the code.',
+  },
+  'model-provider': {
+    title: 'Choose your Factory model.',
+    description: 'Connect a provider and select the default model for Factory runs.',
   },
 };
 
@@ -59,14 +64,13 @@ export function EmptyFactoryState() {
   const [completionError, setCompletionError] = useState<string | null>(null);
   const [connectingRepositoryId, setConnectingRepositoryId] = useState<number | null>(null);
   const [githubRedirecting, setGithubRedirecting] = useState(false);
-  const [finishing, setFinishing] = useState(false);
   const navigate = useNavigate();
 
   useEffect(() => {
     if (persistedFactories.isPending || pendingFactory) return;
     const pendingId = sessionStorage.getItem(FACTORY_KEY);
     if (!pendingId) {
-      if (step === 'project-management') setStep('vcs');
+      if (step !== 'initial' && step !== 'vcs') setStep('vcs');
       return;
     }
     const restored = persistedFactories.data?.find(factory => factory.id === pendingId);
@@ -121,18 +125,17 @@ export function EmptyFactoryState() {
       return;
     }
     setCompletionError(null);
-    setFinishing(true);
     try {
       await queryClient.invalidateQueries({ queryKey: queryKeys.factories() });
       clearOnboardingFlow();
       void navigate(`/factories/${pendingFactory.id}`);
     } catch (error) {
       setCompletionError(errorMessage(error));
-      setFinishing(false);
     }
   };
 
-  const stepIndex = ['initial', 'vcs', 'project-management'].indexOf(step);
+  const steps: Step[] = ['initial', 'vcs', 'project-management', 'model-provider'];
+  const stepIndex = steps.indexOf(step);
 
   return (
     <main className="factory-signin-theme min-h-dvh bg-surface1 font-mona-sans text-neutral6">
@@ -140,7 +143,7 @@ export function EmptyFactoryState() {
         <section className="relative z-3 flex flex-col justify-center px-6 py-12 sm:px-10 lg:px-16 lg:py-17 xl:px-20">
           <div className="w-full max-w-2xl">
             <ol className="mb-9 flex gap-2" aria-label="Factory setup progress">
-              {(['initial', 'vcs', 'project-management'] as const).map((item, index) => (
+              {steps.map((item, index) => (
                 <li
                   key={item}
                   aria-current={step === item ? 'step' : undefined}
@@ -189,13 +192,18 @@ export function EmptyFactoryState() {
               )}
               {step === 'project-management' && (
                 <ProjectManagementFactoryStep
-                  completionError={completionError}
-                  finishing={finishing}
                   onConnect={() => {
                     persistBeforeRedirect('project-management');
                     connectLinear(baseUrl);
                   }}
-                  onFinish={() => void finish()}
+                  onContinue={() => goTo('model-provider')}
+                />
+              )}
+              {step === 'model-provider' && pendingFactory && (
+                <ModelProviderFactoryStep
+                  factoryId={pendingFactory.id}
+                  completionError={completionError ?? undefined}
+                  onComplete={() => void finish()}
                 />
               )}
             </div>

--- a/mastracode/web/src/web/ui/domains/workspaces/components/ModelProviderFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/ModelProviderFactoryStep.tsx
@@ -1,0 +1,273 @@
+import { Button } from '@mastra/playground-ui/components/Button';
+import { Input } from '@mastra/playground-ui/components/Input';
+import { Spinner } from '@mastra/playground-ui/components/Spinner';
+import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Search } from 'lucide-react';
+import { useState } from 'react';
+
+import type { OAuthStartResponse, ProviderInfo } from '../../../../../shared/api/types';
+import { useApplyProviderOMDefaults } from '../../../../../shared/hooks/use-om';
+import {
+  useCancelProviderOAuth,
+  useProvidersQuery,
+  useStartProviderOAuth,
+} from '../../../../../shared/hooks/use-providers';
+import { useFactoryAuth } from '../../../../../shared/hooks/useFactoryAuth';
+import { useSetFactoryDefaultModelMutation } from '../../../../../shared/hooks/useFactoryDefaultModel';
+import { useAvailableModelsQuery } from '../../../../../shared/hooks/useAvailableModels';
+import { SkeletonRows } from '../../../ui/SkeletonRows';
+import { AddApiKeyDialog } from '../../settings/components/AddApiKeyDialog';
+import { ModelCombobox } from '../../settings/components/ModelCombobox';
+import { providerDisplayName } from '../../settings/components/provider-display-name';
+import { ProviderOAuthDialog } from '../../settings/components/ProviderOAuthDialog';
+
+export interface ModelProviderFactoryStepProps {
+  factoryId: string;
+  completionError?: string;
+  onComplete: () => void;
+}
+
+interface ActiveOAuthSession {
+  provider: string;
+  session: OAuthStartResponse;
+}
+
+const RECOMMENDED_PROVIDER_IDS = new Set(['anthropic', 'openai']);
+
+function preferredFactoryModel(providerId: string): string | undefined {
+  switch (providerId) {
+    case 'openai':
+      return 'openai/gpt-5.6-sol';
+    case 'anthropic':
+      return 'anthropic/claude-fable-5';
+    default:
+      return undefined;
+  }
+}
+
+function isConfigured(provider: ProviderInfo): boolean {
+  return provider.source !== 'none';
+}
+
+export function ModelProviderFactoryStep({ factoryId, completionError, onComplete }: ModelProviderFactoryStepProps) {
+  const providersQuery = useProvidersQuery();
+  const modelsQuery = useAvailableModelsQuery();
+  const authQuery = useFactoryAuth();
+  const startOAuthMutation = useStartProviderOAuth();
+  const cancelOAuthMutation = useCancelProviderOAuth();
+  const setDefaultModel = useSetFactoryDefaultModelMutation(factoryId);
+  const applyOMDefaults = useApplyProviderOMDefaults();
+  const [providerId, setProviderId] = useState<string>();
+  const [providerSearch, setProviderSearch] = useState('');
+  const [selectedModelId, setSelectedModelId] = useState('');
+  const [keyDialogProvider, setKeyDialogProvider] = useState<ProviderInfo>();
+  const [activeOAuth, setActiveOAuth] = useState<ActiveOAuthSession>();
+  const [error, setError] = useState<string>();
+
+  const providers = [...(providersQuery.data ?? [])].sort((left, right) => {
+    if (isConfigured(left) !== isConfigured(right)) return isConfigured(left) ? -1 : 1;
+    return providerDisplayName(left.provider).localeCompare(providerDisplayName(right.provider));
+  });
+  const searchQuery = providerSearch.trim().toLowerCase();
+  const primaryProviders = providers.filter(
+    provider =>
+      isConfigured(provider) || provider.oauth?.supported === true || RECOMMENDED_PROVIDER_IDS.has(provider.provider),
+  );
+  const visibleProviders = searchQuery
+    ? providers.filter(provider => {
+        const displayName = providerDisplayName(provider.provider).toLowerCase();
+        return provider.provider.toLowerCase().includes(searchQuery) || displayName.includes(searchQuery);
+      })
+    : primaryProviders;
+  const connectedProviders = visibleProviders.filter(isConfigured);
+  const availableProviders = visibleProviders.filter(provider => !isConfigured(provider));
+  const selectedProvider = providers.find(provider => provider.provider === providerId);
+  const providerConfigured = selectedProvider ? isConfigured(selectedProvider) : false;
+  const providerModels = (modelsQuery.data ?? []).filter(model => model.provider === providerId);
+  const preferredModelId = providerId ? preferredFactoryModel(providerId) : undefined;
+  const modelId =
+    selectedModelId || providerModels.find(model => model.id === preferredModelId)?.id || providerModels[0]?.id || '';
+  const saving = setDefaultModel.isPending || applyOMDefaults.isPending;
+  const pending = saving || startOAuthMutation.isPending;
+  const catalogError = providersQuery.error ?? modelsQuery.error;
+
+  const selectProvider = (nextProviderId: string) => {
+    setProviderId(nextProviderId);
+    setSelectedModelId('');
+    setError(undefined);
+  };
+
+  const startOAuth = async (provider: ProviderInfo) => {
+    setError(undefined);
+    try {
+      const modes = provider.oauth?.modes ?? [];
+      const session = await startOAuthMutation.mutateAsync({
+        provider: provider.provider,
+        mode: modes.length === 1 ? modes[0] : undefined,
+      });
+      setActiveOAuth({ provider: provider.provider, session });
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to start provider sign in');
+    }
+  };
+
+  const closeOAuth = () => {
+    const flow = activeOAuth;
+    setActiveOAuth(undefined);
+    if (flow) cancelOAuthMutation.mutate({ provider: flow.provider, sessionId: flow.session.sessionId });
+  };
+
+  const finish = async () => {
+    if (!providerId || !modelId) return;
+    setError(undefined);
+    try {
+      await Promise.all([
+        setDefaultModel.mutateAsync(modelId),
+        applyOMDefaults.mutateAsync({ providerId, factoryModelId: modelId }),
+      ]);
+      onComplete();
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : 'Failed to configure model defaults');
+    }
+  };
+
+  return (
+    <section aria-label="Model provider setup" className="flex max-w-xl flex-col gap-5">
+      <div className="flex flex-col gap-5 rounded-2xl border border-border1 bg-surface2/80 p-5">
+        {providersQuery.isPending || modelsQuery.isPending ? (
+          <SkeletonRows label="Loading model providers" rows={3} rowClassName="h-9 w-full" />
+        ) : catalogError instanceof Error ? (
+          <Txt as="p" variant="ui-sm" className="m-0 text-notice-destructive-fg" role="alert">
+            {catalogError.message}
+          </Txt>
+        ) : (
+          <div className="flex flex-col gap-3">
+            <div className="relative">
+              <Search size={14} className="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-icon3" />
+              <Input
+                type="search"
+                placeholder="Search all providers…"
+                value={providerSearch}
+                onChange={event => setProviderSearch(event.target.value)}
+                aria-label="Search model providers"
+                className="pl-8"
+              />
+            </div>
+            {connectedProviders.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+                  Connected providers
+                </Txt>
+                <div className="flex flex-wrap gap-2" aria-label="Connected providers">
+                  {connectedProviders.map(provider => (
+                    <Button
+                      key={provider.provider}
+                      variant={providerId === provider.provider ? 'primary' : 'outline'}
+                      aria-label={providerDisplayName(provider.provider)}
+                      disabled={pending}
+                      onClick={() => selectProvider(provider.provider)}
+                    >
+                      {providerDisplayName(provider.provider)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {availableProviders.length > 0 && (
+              <div className="flex flex-col gap-2">
+                <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+                  {searchQuery ? 'Available providers' : 'Recommended providers'}
+                </Txt>
+                <div className="flex flex-wrap gap-2" aria-label="Available providers">
+                  {availableProviders.map(provider => (
+                    <Button
+                      key={provider.provider}
+                      variant={providerId === provider.provider ? 'primary' : 'outline'}
+                      aria-label={providerDisplayName(provider.provider)}
+                      disabled={pending}
+                      onClick={() => selectProvider(provider.provider)}
+                    >
+                      {providerDisplayName(provider.provider)}
+                    </Button>
+                  ))}
+                </div>
+              </div>
+            )}
+            {visibleProviders.length === 0 && (
+              <Txt as="p" variant="ui-sm" className="m-0 text-icon3">
+                {searchQuery ? `No providers match “${providerSearch.trim()}”.` : 'No model providers are available.'}
+              </Txt>
+            )}
+          </div>
+        )}
+
+        {selectedProvider && !providerConfigured && (
+          <div className="flex flex-wrap gap-2">
+            {selectedProvider.oauth?.supported === true && (
+              <Button
+                variant="primary"
+                disabled={startOAuthMutation.isPending}
+                onClick={() => void startOAuth(selectedProvider)}
+              >
+                {startOAuthMutation.isPending ? 'Starting…' : 'Sign in'}
+              </Button>
+            )}
+            <Button
+              variant={selectedProvider.oauth?.supported === true ? 'outline' : 'primary'}
+              onClick={() => setKeyDialogProvider(selectedProvider)}
+            >
+              Use API key
+            </Button>
+          </div>
+        )}
+
+        {selectedProvider && providerConfigured && (
+          <label className="flex flex-col gap-2">
+            <Txt as="span" variant="ui-sm" className="text-icon5">
+              Factory default model
+            </Txt>
+            <ModelCombobox
+              models={providerModels}
+              value={modelId}
+              onValueChange={setSelectedModelId}
+              placeholder="Select a default model…"
+              disabled={saving}
+            />
+          </label>
+        )}
+
+        {(error ?? completionError) && (
+          <Txt as="p" variant="ui-sm" className="m-0 text-notice-destructive-fg" role="alert">
+            {error ?? completionError}
+          </Txt>
+        )}
+
+        {selectedProvider && providerConfigured && (
+          <div>
+            <Button variant="primary" disabled={!modelId || saving} onClick={() => void finish()}>
+              {saving && <Spinner size="sm" aria-label="Saving model defaults" />}
+              Finish setup
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {keyDialogProvider && (
+        <AddApiKeyDialog
+          provider={keyDialogProvider}
+          authEnabled={authQuery.data?.authEnabled === true}
+          onClose={() => setKeyDialogProvider(undefined)}
+        />
+      )}
+
+      {activeOAuth && (
+        <ProviderOAuthDialog
+          provider={activeOAuth.provider}
+          session={activeOAuth.session}
+          onClose={closeOAuth}
+          onComplete={() => setActiveOAuth(undefined)}
+        />
+      )}
+    </section>
+  );
+}

--- a/mastracode/web/src/web/ui/domains/workspaces/components/ProjectManagementFactoryStep.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/ProjectManagementFactoryStep.tsx
@@ -7,20 +7,19 @@ import { useLinearStatusQuery } from '../../../../../shared/hooks/useLinearData'
 import { LinearIcon } from '../../../ui/icons';
 import { SkeletonRows } from '../../../ui/SkeletonRows';
 
-export interface ProjectManagementFactoryStepProps {
-  completionError: string | null;
-  finishing: boolean;
+interface ProjectManagementFactoryStepBaseProps {
   onConnect: () => void;
-  onFinish: () => void;
 }
 
-export function ProjectManagementFactoryStep({
-  completionError,
-  finishing,
-  onConnect,
-  onFinish,
-}: ProjectManagementFactoryStepProps) {
+export type ProjectManagementFactoryStepProps = ProjectManagementFactoryStepBaseProps &
+  ({ onContinue: () => void } | { completionError: string | null; finishing: boolean; onFinish: () => void });
+
+export function ProjectManagementFactoryStep(props: ProjectManagementFactoryStepProps) {
   const linearStatus = useLinearStatusQuery();
+  const continuesOnboarding = 'onContinue' in props;
+  const continuing = continuesOnboarding ? false : props.finishing;
+  const continueLabel = continuesOnboarding ? 'Continue' : 'Finish setup';
+  const continueSetup = continuesOnboarding ? props.onContinue : props.onFinish;
 
   return (
     <section aria-label="Linear connection" className="max-w-xl rounded-2xl border border-border1 bg-surface2/80 p-5">
@@ -31,9 +30,9 @@ export function ProjectManagementFactoryStep({
           <Txt as="p" variant="ui-md" className="m-0 text-icon5">
             Connected to {linearStatus.data.workspace?.name ?? 'Linear'}.
           </Txt>
-          <Button variant="primary" disabled={finishing} onClick={onFinish}>
-            {finishing && <Spinner size="sm" aria-label="Finishing setup" />}
-            Finish setup
+          <Button variant="primary" disabled={continuing} onClick={continueSetup}>
+            {continuing && <Spinner size="sm" aria-label="Finishing setup" />}
+            {continueLabel}
           </Button>
         </div>
       ) : (
@@ -46,22 +45,22 @@ export function ProjectManagementFactoryStep({
             <div className="flex flex-wrap items-center justify-center gap-2">
               {linearStatus.data?.reason !== 'missing_config' &&
                 linearStatus.data?.reason !== 'organization_required' && (
-                  <Button variant="primary" onClick={onConnect}>
+                  <Button variant="primary" onClick={props.onConnect}>
                     <LinearIcon />
                     {linearStatus.data?.reason === 'not_connected' ? 'Connect Linear' : 'Reconnect Linear'}
                   </Button>
                 )}
-              <Button variant="ghost" disabled={finishing} onClick={onFinish}>
-                {finishing && <Spinner size="sm" aria-label="Finishing setup" />}
-                Skip for now
+              <Button variant="ghost" disabled={continuing} onClick={continueSetup}>
+                {continuing && <Spinner size="sm" aria-label="Finishing setup" />}
+                {continuesOnboarding ? 'Skip for now' : continueLabel}
               </Button>
             </div>
           }
         />
       )}
-      {completionError && (
+      {!continuesOnboarding && props.completionError && (
         <p role="alert" className="mt-4 text-ui-sm text-notice-destructive-fg">
-          {completionError}
+          {props.completionError}
         </p>
       )}
     </section>

--- a/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/ModelProviderFactoryStep.msw.test.tsx
+++ b/mastracode/web/src/web/ui/domains/workspaces/components/__tests__/ModelProviderFactoryStep.msw.test.tsx
@@ -1,0 +1,171 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { describe, expect, it, vi } from 'vitest';
+
+import { server } from '../../../../../../../e2e/web-ui/msw-server';
+import { renderWithProviders, TEST_BASE_URL } from '../../../../../../../e2e/web-ui/render';
+import type { ProviderInfo } from '../../../../../../shared/api/types';
+import { ModelProviderFactoryStep } from '../ModelProviderFactoryStep';
+
+function registerAuthHandler() {
+  server.use(
+    http.get(`${TEST_BASE_URL}/auth/me`, () =>
+      HttpResponse.json({ authenticated: true, authEnabled: true, user: { userId: 'user-1' } }),
+    ),
+  );
+}
+
+function registerPersistenceHandlers(onFactoryModel: (body: unknown) => void, onOMDefaults: (body: unknown) => void) {
+  server.use(
+    http.patch(`${TEST_BASE_URL}/web/factory/projects/factory-1`, async ({ request }) => {
+      onFactoryModel(await request.json());
+      return HttpResponse.json({ project: { id: 'factory-1', name: 'Factory', defaultModelId: 'openai/gpt-5.6-sol' } });
+    }),
+    http.post(`${TEST_BASE_URL}/web/config/om/provider-defaults`, async ({ request }) => {
+      onOMDefaults(await request.json());
+      return HttpResponse.json({
+        ok: true,
+        config: {
+          observerModelId: 'openai/gpt-5.4-mini',
+          reflectorModelId: 'openai/gpt-5.4-mini',
+          observationThreshold: 30000,
+          reflectionThreshold: 40000,
+          observeAttachments: 'auto',
+        },
+      });
+    }),
+  );
+}
+
+describe('Model provider onboarding', () => {
+  describe('when the provider catalog cannot be loaded', () => {
+    it('shows the request error instead of an empty provider result', async () => {
+      registerAuthHandler();
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/config/providers`, () =>
+          HttpResponse.json({ error: 'Provider catalog unavailable' }, { status: 503 }),
+        ),
+        http.get(`${TEST_BASE_URL}/web/config/models`, () => HttpResponse.json({ models: [] })),
+      );
+
+      renderWithProviders(<ModelProviderFactoryStep factoryId="factory-1" onComplete={vi.fn()} />);
+
+      expect(await screen.findByRole('alert')).toHaveTextContent('Provider catalog unavailable');
+      expect(screen.queryByText(/No providers match/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when the provider catalog contains recommended and additional providers', () => {
+    it('shows recommended providers first and finds additional providers through search', async () => {
+      const providers: ProviderInfo[] = [
+        { provider: 'anthropic', source: 'none', oauth: { supported: true, modes: [] } },
+        { provider: 'amazon-bedrock', source: 'none' },
+      ];
+      registerAuthHandler();
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/config/providers`, () => HttpResponse.json({ providers })),
+        http.get(`${TEST_BASE_URL}/web/config/models`, () => HttpResponse.json({ models: [] })),
+      );
+      const user = userEvent.setup();
+
+      renderWithProviders(<ModelProviderFactoryStep factoryId="factory-1" onComplete={vi.fn()} />);
+
+      expect(await screen.findByRole('button', { name: 'Anthropic' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Amazon Bedrock' })).not.toBeInTheDocument();
+      await user.type(screen.getByRole('searchbox', { name: 'Search model providers' }), 'bedrock');
+
+      expect(await screen.findByRole('button', { name: 'Amazon Bedrock' })).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Anthropic' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('when OpenAI is already connected', () => {
+    it('persists the suggested Factory model and hidden OM defaults', async () => {
+      const onFactoryModel = vi.fn<(body: unknown) => void>();
+      const onOMDefaults = vi.fn<(body: unknown) => void>();
+      const onComplete = vi.fn<() => void>();
+      const providers: ProviderInfo[] = [
+        { provider: 'openai', source: 'stored' },
+        { provider: 'anthropic', source: 'none' },
+      ];
+      registerAuthHandler();
+      registerPersistenceHandlers(onFactoryModel, onOMDefaults);
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/config/providers`, () => HttpResponse.json({ providers })),
+        http.get(`${TEST_BASE_URL}/web/config/models`, () =>
+          HttpResponse.json({
+            models: [{ id: 'openai/gpt-5.6-sol', provider: 'openai', modelName: 'gpt-5.6-sol', hasApiKey: true }],
+          }),
+        ),
+      );
+      const user = userEvent.setup();
+
+      renderWithProviders(<ModelProviderFactoryStep factoryId="factory-1" onComplete={onComplete} />);
+
+      await user.click(await screen.findByRole('button', { name: 'OpenAI' }));
+      expect(screen.getByText('openai/gpt-5.6-sol')).toBeInTheDocument();
+      await user.click(screen.getByRole('button', { name: 'Finish setup' }));
+
+      await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+      expect(onFactoryModel).toHaveBeenCalledWith({ defaultModelId: 'openai/gpt-5.6-sol' });
+      expect(onOMDefaults).toHaveBeenCalledWith({
+        providerId: 'openai',
+        factoryModelId: 'openai/gpt-5.6-sol',
+      });
+    });
+  });
+
+  describe('when OpenAI needs an API key', () => {
+    it('keeps the provider selected and persists its defaults after connection', async () => {
+      const onFactoryModel = vi.fn<(body: unknown) => void>();
+      const onOMDefaults = vi.fn<(body: unknown) => void>();
+      const onComplete = vi.fn<() => void>();
+      let connected = false;
+      registerAuthHandler();
+      registerPersistenceHandlers(onFactoryModel, onOMDefaults);
+      server.use(
+        http.get(`${TEST_BASE_URL}/web/config/providers`, () =>
+          HttpResponse.json({
+            providers: [
+              {
+                provider: 'openai',
+                source: connected ? 'stored-user' : 'none',
+                envVar: 'OPENAI_API_KEY',
+              },
+            ],
+          }),
+        ),
+        http.get(`${TEST_BASE_URL}/web/config/models`, () =>
+          HttpResponse.json({
+            models: connected
+              ? [{ id: 'openai/gpt-5.6-sol', provider: 'openai', modelName: 'gpt-5.6-sol', hasApiKey: true }]
+              : [],
+          }),
+        ),
+        http.put(`${TEST_BASE_URL}/web/config/providers/openai/key`, async ({ request }) => {
+          expect(await request.json()).toEqual({ key: 'sk-test', envVar: 'OPENAI_API_KEY', scope: 'user' });
+          connected = true;
+          return HttpResponse.json({ ok: true });
+        }),
+      );
+      const user = userEvent.setup();
+
+      renderWithProviders(<ModelProviderFactoryStep factoryId="factory-1" onComplete={onComplete} />);
+
+      await user.click(await screen.findByRole('button', { name: 'OpenAI' }));
+      await user.click(screen.getByRole('button', { name: 'Use API key' }));
+      const dialog = within(screen.getByRole('dialog'));
+      await user.type(dialog.getByLabelText('API key for OpenAI'), 'sk-test');
+      await user.click(dialog.getByRole('button', { name: 'Save' }));
+      await user.click(await screen.findByRole('button', { name: 'Finish setup' }));
+
+      await waitFor(() => expect(onComplete).toHaveBeenCalledOnce());
+      expect(onFactoryModel).toHaveBeenCalledWith({ defaultModelId: 'openai/gpt-5.6-sol' });
+      expect(onOMDefaults).toHaveBeenCalledWith({
+        providerId: 'openai',
+        factoryModelId: 'openai/gpt-5.6-sol',
+      });
+    });
+  });
+});

--- a/mastracode/web/src/web/ui/domains/workspaces/services/onboardingFlow.ts
+++ b/mastracode/web/src/web/ui/domains/workspaces/services/onboardingFlow.ts
@@ -20,7 +20,7 @@ export const ONBOARDING_UPDATED_AT_KEY = 'mastracode.factory-onboarding.updated-
  */
 export const ONBOARDING_RESUME_WINDOW_MS = 30 * 60 * 1000;
 
-export type OnboardingStep = 'initial' | 'vcs' | 'project-management';
+export type OnboardingStep = 'initial' | 'vcs' | 'project-management' | 'model-provider';
 
 /** Persist the current step and refresh the resume window. */
 export function persistOnboardingStep(step: OnboardingStep): void {
@@ -37,7 +37,7 @@ export function persistOnboardingFactory(factoryId: string): void {
 /** Read the persisted step, defaulting to the beginning of the flow. */
 export function readOnboardingStep(): OnboardingStep {
   const value = sessionStorage.getItem(ONBOARDING_STEP_KEY);
-  return value === 'vcs' || value === 'project-management' ? value : 'initial';
+  return value === 'vcs' || value === 'project-management' || value === 'model-provider' ? value : 'initial';
 }
 
 /** Drop every onboarding marker (flow finished or abandoned). */
@@ -55,7 +55,7 @@ export function clearOnboardingFlow(): void {
  * without this check the wizard would be abandoned at the factory home.
  *
  * Three gates, all required:
- * - a mid-flow step is stored (`vcs` / `project-management`),
+ * - a mid-flow step is stored (`vcs` / `project-management` / `model-provider`),
  * - the stored factory id exists in the server-backed list (a deleted
  *   factory never traps the user),
  * - the flow progressed within {@link ONBOARDING_RESUME_WINDOW_MS} (markers
@@ -64,7 +64,7 @@ export function clearOnboardingFlow(): void {
  */
 export function hasResumableFactoryOnboarding(factories: readonly { id: string }[]): boolean {
   const step = sessionStorage.getItem(ONBOARDING_STEP_KEY);
-  if (step !== 'vcs' && step !== 'project-management') return false;
+  if (step !== 'vcs' && step !== 'project-management' && step !== 'model-provider') return false;
 
   const updatedAt = Number(sessionStorage.getItem(ONBOARDING_UPDATED_AT_KEY));
   if (!Number.isFinite(updatedAt) || Date.now() - updatedAt > ONBOARDING_RESUME_WINDOW_MS) return false;


### PR DESCRIPTION
## Summary

This is PR 1 of 2 in the model-onboarding stack. It restores observational-memory controls under Factory model settings and lets users load or update persisted OM preferences without opening a chat session first.

## Scope

- Restore observer and reflector model controls, token thresholds, and attachment observation settings
- Read and persist OM settings per user and organization without requiring a session resource ID
- Keep active sessions synchronized when a resource ID is available
- Warn when configured OM model credentials are unavailable without disabling OM automatically

## Intentionally excluded

- The stacked follow-up adds provider and default-model setup to Factory onboarding
- A separate PR applies Factory model settings to board-started work sessions

## Verification

- 49 focused Factory config tests
- 248 Web UI tests
- Factory and Web UI typechecks
- Prettier and git diff validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

This PR brings back the “observational memory” settings so users can pick how the app should remember and summarize conversations *before* starting a chat. Those choices get saved for them (and their org) and the app can use them later.

## What changed

- **Factory: restored Observational Memory (OM) controls** in the Factory “model” settings area:
  - observer/reflector model selection
  - observation/reflector thresholds
  - attachment observation mode
- **Factory backend API updates**
  - Added `POST /web/config/om/provider-defaults` to persist per-provider OM defaults (and return the stored result).
  - Made `resourceId` optional for OM config:
    - When **no `resourceId`**, `GET/PUT` read/write from the stored `memory-settings` row.
    - When **`resourceId` is present**, the endpoint hydrates live session config and returns updated live values.
    - Session/thread updates occur only when a session is available; persistence always updates `memory-settings`.
- **Credentials behavior**
  - Keeps configured OM models enabled even when model credentials aren’t available, but **shows a warning** instead.
- **Web UI updates**
  - Updated the `useOMQuery` behavior and URL building so OM settings load correctly **without a `resourceId`**.
  - Added an **`OMSection`** settings UI that:
    - loads persisted OM config
    - allows updating OM models, thresholds, and attachment handling
    - shows a credential-warning badge when needed
    - surfaces mutation errors as destructive notices
  - Wired `OMSection` into the existing Factory settings panel.
- **Factory onboarding flow**
  - Added a new **`model-provider`** step.
  - When setup finishes, it applies the Factory default model and **applies OM defaults** (with tests covering key/OAuth scenarios).

## Verification

- Factory configuration route tests (including OM defaults + persisted settings behavior)
- Web UI/RTL + MSW tests for OMSection and onboarding steps
- Factory and Web UI typechecks
- Prettier validation
- Git diff checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->