### PR TITLE
fix(factory): initialize board session models

### DIFF
--- a/.changeset/sixty-beans-jog.md
+++ b/.changeset/sixty-beans-jog.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Fixed board-started work sessions to use the Factory's default coding model and persisted observational-memory settings.

--- a/mastracode/factory/src/routes/surface.ts
+++ b/mastracode/factory/src/routes/surface.ts
@@ -343,6 +343,7 @@ export function assembleFactoryApiRoutes(deps: FactoryApiRoutesDeps): ApiRoute[]
         deps.domains.workItems,
         transitionService,
         githubIntegration?.sourceControlStorage,
+        deps.domains.memorySettings,
       )
     : undefined;
   if (transitionService && startCoordinator) {

--- a/mastracode/factory/src/routes/work-items.test.ts
+++ b/mastracode/factory/src/routes/work-items.test.ts
@@ -390,7 +390,12 @@ describe('POST /web/factory/projects/:id/runs/start', () => {
     },
   });
 
-  it('passes authenticated tenant identity to the coordinator and audits the prepared binding', async () => {
+  it('passes authenticated tenant identity and the Factory default model to the coordinator', async () => {
+    await seed.projects.update({
+      orgId: 'org1',
+      id: PROJECT_ID,
+      input: { defaultModelId: 'anthropic/claude-fable-5' },
+    });
     const created = await json('POST', `/web/factory/projects/${PROJECT_ID}/work-items`, createBody());
     const { workItem } = await created.json();
     auditRecorded = [];
@@ -421,6 +426,7 @@ describe('POST /web/factory/projects/:id/runs/start', () => {
         orgId: 'org1',
         userId: 'u1',
         factoryProjectId: PROJECT_ID,
+        defaultModelId: 'anthropic/claude-fable-5',
         requestContext,
       }),
     );

--- a/mastracode/factory/src/routes/work-items.ts
+++ b/mastracode/factory/src/routes/work-items.ts
@@ -380,7 +380,9 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
    */
   async #resolveProject(
     c: Context,
-  ): Promise<{ orgId: string; userId: string; factoryProjectId: string } | { response: Response }> {
+  ): Promise<
+    { orgId: string; userId: string; factoryProjectId: string; defaultModelId: string | null } | { response: Response }
+  > {
     const tenant = await this.#resolveTenant(c);
     if ('response' in tenant) return tenant;
 
@@ -394,7 +396,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
     if (!project) {
       return { response: c.json({ error: 'Project not found' }, 404) };
     }
-    return { ...tenant, factoryProjectId: projectId };
+    return { ...tenant, factoryProjectId: projectId, defaultModelId: project.defaultModelId };
   }
 
   /**
@@ -711,6 +713,7 @@ export class WorkItemRoutes extends Route<WorkItemRoutesDeps> {
           const input = parseStartBody(await readJson(loose(c)), resolved, resolved.factoryProjectId);
           if (!input) return c.json({ error: 'invalid_factory_start' }, 400);
           input.requestContext = loose(c).get('requestContext');
+          input.defaultModelId = resolved.defaultModelId ?? undefined;
           if (
             !input.workItem.id &&
             ((input.workItem.input.stages ?? ['intake']).length !== 1 ||

--- a/mastracode/factory/src/rules/start-coordinator.test.ts
+++ b/mastracode/factory/src/rules/start-coordinator.test.ts
@@ -28,6 +28,11 @@ function makeController(sendMessage = vi.fn(async () => {})) {
     },
     getWorkspace: vi.fn(() => ({ skills: undefined })),
     state: { set: vi.fn(async () => {}) },
+    model: { switch: vi.fn(async () => {}) },
+    om: {
+      observer: { switchModel: vi.fn(async () => {}) },
+      reflector: { switchModel: vi.fn(async () => {}) },
+    },
     sendMessage,
   };
   return {
@@ -86,6 +91,7 @@ function startRequest(
     kickoffKey: string;
     role: string;
     kickoffMessage: string | null;
+    defaultModelId: string;
     id: string;
   }> = {},
 ) {
@@ -102,6 +108,7 @@ function startRequest(
         ? undefined
         : { type: 'prompt' as const, prompt: overrides.kickoffMessage ?? 'Start work' },
     destinationStage: 'intake' as const,
+    defaultModelId: overrides.defaultModelId,
     workItem: {
       id: overrides.id,
       role: overrides.role ?? 'work',
@@ -151,6 +158,76 @@ describe('FactoryStartCoordinator', () => {
       branch: 'factory/issue-1',
       startedBy: 'user-1',
     });
+  });
+
+  it('applies the Factory default model before preparing a board run', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      undefined,
+      makeSourceControl() as never,
+    );
+
+    await coordinator.prepare(startRequest({ defaultModelId: 'anthropic/claude-fable-5' }));
+
+    expect(session.model.switch).toHaveBeenCalledWith({ modelId: 'anthropic/claude-fable-5' });
+  });
+
+  it('applies persisted observational-memory settings before preparing a board run', async () => {
+    const storage = await createFactoryStorageForTests();
+    await storage.memorySettings.patch({
+      orgId: 'org-1',
+      userId: 'user-1',
+      patch: {
+        observerModelId: 'anthropic/claude-haiku-4-5',
+        reflectorModelId: 'anthropic/claude-haiku-4-5',
+        observationThreshold: 12_000,
+        reflectionThreshold: 23_000,
+        observeAttachments: false,
+      },
+    });
+    const { controller, session } = makeController();
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage.workItems,
+      undefined,
+      makeSourceControl() as never,
+      storage.memorySettings,
+    );
+
+    await coordinator.prepare(startRequest());
+
+    expect(session.om.observer.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
+    expect(session.om.reflector.switchModel).toHaveBeenCalledWith({ modelId: 'anthropic/claude-haiku-4-5' });
+    expect(session.state.set).toHaveBeenCalledWith({
+      observationThreshold: 12_000,
+      reflectionThreshold: 23_000,
+      observeAttachments: false,
+    });
+  });
+
+  it('continues preparing a board run when its saved default model is no longer available', async () => {
+    const storage = (await createFactoryStorageForTests()).workItems;
+    const { controller, session } = makeController();
+    session.model.switch.mockRejectedValueOnce(new Error('Unknown model'));
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const coordinator = new FactoryStartCoordinator(
+      controller as never,
+      storage,
+      undefined,
+      makeSourceControl() as never,
+    );
+
+    await expect(
+      coordinator.prepare(startRequest({ defaultModelId: 'anthropic/claude-fable-5' })),
+    ).resolves.toMatchObject({ threadId: 'session-1', kickoffStatus: 'pending' });
+    expect(warn).toHaveBeenCalledWith('[Factory Start] Failed to apply factory default model', {
+      modelId: 'anthropic/claude-fable-5',
+      error: 'Unknown model',
+    });
+    warn.mockRestore();
   });
 
   it('binds before requesting the governed run-stage transition', async () => {

--- a/mastracode/factory/src/rules/start-coordinator.ts
+++ b/mastracode/factory/src/rules/start-coordinator.ts
@@ -3,6 +3,7 @@ import type { AgentController } from '@mastra/core/agent-controller';
 import { RequestContext } from '@mastra/core/request-context';
 import { formatSkillActivation } from '@mastra/core/workspace';
 
+import type { MemorySettingsRecord, MemorySettingsStorage } from '../storage/domains/memory-settings/base.js';
 import type { SourceControlSession, SourceControlStorageHandle } from '../storage/domains/source-control/base.js';
 import type { CreateWorkItemInput, WorkItemsStorage } from '../storage/domains/work-items/base.js';
 import type { FactoryTransitionService } from './transition-service.js';
@@ -18,6 +19,7 @@ export interface FactoryStartRequest {
   kickoffKey: string;
   invocation?: { type: 'prompt'; prompt: string } | { type: 'skill'; skillName: string; arguments: string };
   destinationStage: FactoryRuleStage;
+  defaultModelId?: string;
   workItem: {
     id?: string;
     role: string;
@@ -101,22 +103,37 @@ async function configureThread(session: FactorySession, request: FactoryStartReq
   return threadId;
 }
 
+async function applyMemorySettings(session: FactorySession, record: MemorySettingsRecord | null): Promise<void> {
+  if (record?.observerModelId) await session.om.observer.switchModel({ modelId: record.observerModelId });
+  if (record?.reflectorModelId) await session.om.reflector.switchModel({ modelId: record.reflectorModelId });
+
+  const state = {
+    ...(record?.observationThreshold != null ? { observationThreshold: record.observationThreshold } : {}),
+    ...(record?.reflectionThreshold != null ? { reflectionThreshold: record.reflectionThreshold } : {}),
+    ...(record?.observeAttachments != null ? { observeAttachments: record.observeAttachments } : {}),
+  };
+  if (Object.keys(state).length > 0) await session.state.set(state);
+}
+
 export class FactoryStartCoordinator {
   readonly #controller: FactoryController;
   readonly #storage: WorkItemsStorage;
   readonly #transitionService?: Pick<FactoryTransitionService, 'transition'>;
   readonly #sourceControl?: SourceControlStorageHandle;
+  readonly #memorySettings?: MemorySettingsStorage;
 
   constructor(
     controller: FactoryController,
     storage: WorkItemsStorage,
     transitionService?: Pick<FactoryTransitionService, 'transition'>,
     sourceControl?: SourceControlStorageHandle,
+    memorySettings?: MemorySettingsStorage,
   ) {
     this.#controller = controller;
     this.#storage = storage;
     this.#transitionService = transitionService;
     this.#sourceControl = sourceControl;
+    this.#memorySettings = memorySettings;
   }
 
   async prepare(request: FactoryStartRequest): Promise<FactoryStartPreparedResult> {
@@ -146,6 +163,26 @@ export class FactoryStartCoordinator {
     // caller created without them — so autonomous runs never depend on a
     // browser connecting to populate the state.
     await session.state.set(sessionState);
+    if (this.#memorySettings) {
+      try {
+        const record = await this.#memorySettings.get({ orgId: request.orgId, userId: request.userId });
+        await applyMemorySettings(session, record);
+      } catch (error) {
+        console.warn('[Factory Start] Failed to apply observational-memory settings', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
+    if (request.defaultModelId) {
+      try {
+        await session.model.switch({ modelId: request.defaultModelId });
+      } catch (error) {
+        console.warn('[Factory Start] Failed to apply factory default model', {
+          modelId: request.defaultModelId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    }
     const threadId = await configureThread(session, request);
     const kickoffMessage = await resolveKickoffMessage(session, request.invocation);
     const prepared = await storage.prepareRunStart({


### PR DESCRIPTION
## Summary

Board-started work sessions currently fall back to SDK coding and observational-memory models instead of the Factory's saved configuration. This PR initializes both model paths before the board kickoff begins.

## Scope

- Pass the Factory project's default model into board-session preparation
- Apply the saved coding model before kickoff
- Hydrate persisted observer, reflector, threshold, and attachment settings for the user
- Continue preparing the run if a retired or unavailable saved coding model cannot be selected
- Preserve existing sessions; the fix applies to newly started board work sessions

## Intentionally excluded

- Observational-memory settings UI is handled in #20079
- Provider and default-model onboarding is handled in the stacked follow-up to #20079

## Verification

- 65 focused coordinator and work-item tests
- 979 full Factory tests
- Factory typecheck
- Prettier and git diff validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a new board task starts, it now uses the project’s chosen AI model and remembers the user’s saved memory settings. If that model is unavailable, the task still starts normally.

## What changed

- Passes the Factory project’s default coding model into board-session preparation.
- Applies saved observer, reflector, threshold, and attachment settings before kickoff.
- Continues preparation when a saved model is retired or unavailable, while logging a warning.
- Preserves existing sessions and excludes settings UI and provider onboarding changes.
- Adds focused coverage for model selection, memory settings, and fallback behavior.
- Adds a patch changeset for `@mastra/factory`.

## Verification

- Focused coordinator and work-item tests
- Full Factory test suite
- Factory typechecking
- Prettier and diff validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->