### PR TITLE
fix(ai-sdk,react): announce rotated response message ids to clients

### DIFF
--- a/.changeset/chatty-toes-cheer.md
+++ b/.changeset/chatty-toes-cheer.md
@@ -1,0 +1,5 @@
+---
+'@mastra/ai-sdk': patch
+---
+
+Fixed the AI SDK stream announcing a response message id that matches no stored message when a processor rotates the response message id before the model runs (for example observational memory sealing a buffer chunk). The stream's `start` chunk now announces the id the assistant response is actually persisted under, so `useChat` and other AI SDK consumers can reconcile streamed messages with memory. Fixes [#19810](https://github.com/mastra-ai/mastra/issues/19810)

--- a/.changeset/clean-wings-own.md
+++ b/.changeset/clean-wings-own.md
@@ -1,0 +1,5 @@
+---
+'@mastra/react': patch
+---
+
+Fixed streamed assistant messages in `useChat`-style threads being keyed by a stale message id when observational memory rotates the response message id during a run. The accumulator now follows the rotated id carried by `step-start`, so streamed messages always match the ids they are persisted under and no longer disappear or duplicate after a refresh. Part of the fix for [#19810](https://github.com/mastra-ai/mastra/issues/19810)

--- a/client-sdks/ai-sdk/src/__tests__/rotated-response-message-id.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/rotated-response-message-id.test.ts
@@ -162,6 +162,8 @@ describe('rotated response message id announcement', () => {
     // Step 0 did not rotate, step 1 did — the announced id must stay the id
     // the first assistant message persists under.
     expect(stepIds).toHaveLength(2);
+    expect(stepIds[1]).toBeDefined();
+    expect(stepIds[1]).not.toBe(stepIds[0]);
     expect(startChunks).toHaveLength(1);
     expect(startChunks[0].messageId).toBe(stepIds[0]);
   });

--- a/client-sdks/ai-sdk/src/__tests__/rotated-response-message-id.test.ts
+++ b/client-sdks/ai-sdk/src/__tests__/rotated-response-message-id.test.ts
@@ -1,0 +1,215 @@
+/**
+ * When a processor rotates the active response message id during
+ * `processInputStep` (e.g. observational memory sealing a buffer chunk), the
+ * rotated id only reaches the wire via `step-start.payload.messageId`. The
+ * UIMessage stream announces a message id once, in the `start` chunk — so the
+ * transformer must announce the id of the first model step, which is the id
+ * the assistant response is actually persisted under.
+ */
+import type { UIMessage } from '@internal/ai-sdk-v5';
+import { convertArrayToReadableStream, MockLanguageModelV2 } from '@internal/ai-sdk-v5/test';
+import { Agent } from '@mastra/core/agent';
+import { Mastra } from '@mastra/core/mastra';
+import type { ChunkType } from '@mastra/core/stream';
+import { describe, expect, it } from 'vitest';
+
+import { handleChatStream } from '../chat-route';
+import { AgentStreamToAISDKV6Transformer } from '../transformers';
+
+function createTextModel() {
+  return new MockLanguageModelV2({
+    doStream: async () => ({
+      stream: convertArrayToReadableStream([
+        { type: 'stream-start', warnings: [] },
+        { type: 'response-metadata', id: 'resp-1', modelId: 'mock', timestamp: new Date() },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'hello' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish', finishReason: 'stop', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } },
+      ] as any),
+      rawCall: { rawPrompt: [], rawSettings: {} },
+      warnings: [],
+    }),
+  });
+}
+
+async function collect(stream: ReadableStream): Promise<any[]> {
+  const chunks: any[] = [];
+  const reader = stream.getReader();
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+  }
+  return chunks;
+}
+
+const userMessage: UIMessage = {
+  id: 'user-1',
+  role: 'user',
+  parts: [{ type: 'text', text: 'hi' }],
+};
+
+function rawChunk(chunk: object): ChunkType<any> {
+  return { runId: 'run-1', from: 'AGENT', ...chunk } as ChunkType<any>;
+}
+
+describe('rotated response message id announcement', () => {
+  it('announces the rotated id when processInputStep rotates before the first model step', async () => {
+    let rotatedMessageId: string | undefined;
+    const rotatingProcessor = {
+      id: 'rotator',
+      processInputStep: async ({ rotateResponseMessageId }: any) => {
+        rotatedMessageId = rotateResponseMessageId?.();
+        return {};
+      },
+    };
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'helper',
+      model: createTextModel(),
+      inputProcessors: [rotatingProcessor as any],
+    });
+    const mastra = new Mastra({ agents: { 'test-agent': agent } });
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      params: { messages: [userMessage] },
+      version: 'v6',
+    } as any);
+
+    const chunks = await collect(stream);
+    const startChunks = chunks.filter(c => c.type === 'start');
+
+    expect(rotatedMessageId).toBeDefined();
+    expect(startChunks).toHaveLength(1);
+    expect(startChunks[0].messageId).toBe(rotatedMessageId);
+  });
+
+  it('keeps the first step id when rotation happens between later steps', async () => {
+    let callCount = 0;
+    const model = new MockLanguageModelV2({
+      doStream: async () => {
+        callCount++;
+        if (callCount === 1) {
+          return {
+            stream: convertArrayToReadableStream([
+              { type: 'stream-start', warnings: [] },
+              { type: 'response-metadata', id: 'resp-1', modelId: 'mock', timestamp: new Date() },
+              {
+                type: 'tool-call',
+                toolCallType: 'function',
+                toolCallId: 'call-1',
+                toolName: 'clientTool',
+                args: '{}',
+              },
+              {
+                type: 'finish',
+                finishReason: 'tool-calls',
+                usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+              },
+            ] as any),
+            rawCall: { rawPrompt: [], rawSettings: {} },
+            warnings: [],
+          };
+        }
+        return {
+          stream: convertArrayToReadableStream([
+            { type: 'stream-start', warnings: [] },
+            { type: 'response-metadata', id: 'resp-2', modelId: 'mock', timestamp: new Date() },
+            { type: 'text-start', id: 'text-1' },
+            { type: 'text-delta', id: 'text-1', delta: 'done' },
+            { type: 'text-end', id: 'text-1' },
+            { type: 'finish', finishReason: 'stop', usage: { inputTokens: 20, outputTokens: 5, totalTokens: 25 } },
+          ] as any),
+          rawCall: { rawPrompt: [], rawSettings: {} },
+          warnings: [],
+        };
+      },
+    });
+
+    const stepIds: (string | undefined)[] = [];
+    const midRunRotator = {
+      id: 'mid-run-rotator',
+      processInputStep: async ({ stepNumber, messageId, rotateResponseMessageId }: any) => {
+        stepIds.push(stepNumber === 0 ? messageId : rotateResponseMessageId?.());
+        return {};
+      },
+    };
+
+    const agent = new Agent({
+      id: 'test-agent',
+      name: 'Test Agent',
+      instructions: 'helper',
+      model,
+      inputProcessors: [midRunRotator as any],
+    });
+    const mastra = new Mastra({ agents: { 'test-agent': agent } });
+
+    const stream = await handleChatStream({
+      mastra,
+      agentId: 'test-agent',
+      params: { messages: [userMessage] },
+      version: 'v6',
+    } as any);
+
+    const chunks = await collect(stream);
+    const startChunks = chunks.filter(c => c.type === 'start');
+
+    // Step 0 did not rotate, step 1 did — the announced id must stay the id
+    // the first assistant message persists under.
+    expect(stepIds).toHaveLength(2);
+    expect(startChunks).toHaveLength(1);
+    expect(startChunks[0].messageId).toBe(stepIds[0]);
+  });
+
+  it('preserves the order of data-* chunks emitted between start and the first step', async () => {
+    const stream = convertArrayToReadableStream([
+      rawChunk({ type: 'start', payload: { id: 'agent-1', messageId: 'initial-id' } }),
+      rawChunk({ type: 'data-om-status', data: { status: 'buffering' } }),
+      rawChunk({ type: 'step-start', payload: { request: {}, warnings: [], messageId: 'rotated-id' } }),
+      rawChunk({ type: 'text-start', payload: { id: 'text-1' } }),
+      rawChunk({ type: 'text-delta', payload: { id: 'text-1', text: 'hello' } }),
+      rawChunk({ type: 'text-end', payload: { id: 'text-1' } }),
+    ]).pipeThrough(AgentStreamToAISDKV6Transformer({}));
+
+    const chunks = await collect(stream);
+    const types = chunks.map(c => c.type);
+
+    expect(types.indexOf('start')).toBeLessThan(types.indexOf('data-om-status'));
+    expect(types.indexOf('data-om-status')).toBeLessThan(types.indexOf('start-step'));
+    expect(chunks.find(c => c.type === 'start').messageId).toBe('rotated-id');
+  });
+
+  it('leaves streams whose start chunk has no message id untouched (durable streams)', async () => {
+    const stream = convertArrayToReadableStream([
+      rawChunk({ type: 'start', payload: {} }),
+      rawChunk({ type: 'text-start', payload: { id: 'text-1' } }),
+      rawChunk({ type: 'text-delta', payload: { id: 'text-1', text: 'hello' } }),
+      rawChunk({ type: 'text-end', payload: { id: 'text-1' } }),
+    ]).pipeThrough(AgentStreamToAISDKV6Transformer({}));
+
+    const chunks = await collect(stream);
+    const startChunk = chunks.find(c => c.type === 'start');
+
+    expect(startChunk).toBeDefined();
+    expect(startChunk.messageId).toBeUndefined();
+  });
+
+  it('flushes a held start chunk when the stream ends without a model step', async () => {
+    const stream = convertArrayToReadableStream([
+      rawChunk({ type: 'start', payload: { id: 'agent-1', messageId: 'only-id' } }),
+      rawChunk({ type: 'data-om-status', data: { status: 'buffering' } }),
+    ]).pipeThrough(AgentStreamToAISDKV6Transformer({}));
+
+    const chunks = await collect(stream);
+    const startChunk = chunks.find(c => c.type === 'start');
+
+    expect(startChunk).toBeDefined();
+    expect(startChunk.messageId).toBe('only-id');
+    expect(chunks.some(c => c.type === 'data-om-status')).toBe(true);
+  });
+});

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -351,13 +351,10 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
   let bufferedSteps = new Map<string, any>();
   let tripwireOccurred = false;
   let finishEventSent = false;
-  // Processors can rotate the active response message id between the run-level
-  // `start` chunk and the first model step (e.g. observational memory sealing a
-  // buffer chunk). The rotated id only reaches the wire via
-  // `step-start.payload.messageId`, so hold `start` (and any processor `data-*`
-  // chunks emitted before the model runs) until the first `step-start` and
-  // announce that step's id — the id the first assistant message is actually
-  // persisted under. Held chunks are flushed in their original order.
+  // Processors can rotate the response message id before the first model step
+  // (e.g. observational memory). Hold `start` (and any preceding `data-*`
+  // chunks) until the first `step-start` so the announced id matches the id
+  // the response is actually persisted under.
   let heldChunks: ChunkType<OUTPUT>[] | null = null;
   let startIdResolved = false;
 
@@ -460,12 +457,10 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
           const held = heldChunks;
           heldChunks = null;
           if (chunk.type === 'step-start') {
-            // held[0] is always the run-level `start` chunk (the only chunk type that opens the hold).
+            // held[0] is the run-level `start` chunk (the only chunk type that opens the hold).
             const startPayload = (held[0] as { payload?: { messageId?: unknown } } | undefined)?.payload;
             const stepMessageId = (chunk.payload as { messageId?: unknown } | undefined)?.messageId;
-            // Re-announce under the step's id only when the run's `start`
-            // carried an id in the first place (durable streams emit `start`
-            // without a payload and must stay untouched).
+            // Durable streams emit `start` without an id — leave those untouched.
             if (
               held[0] &&
               typeof stepMessageId === 'string' &&

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -351,91 +351,146 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
   let bufferedSteps = new Map<string, any>();
   let tripwireOccurred = false;
   let finishEventSent = false;
+  // Processors can rotate the active response message id between the run-level
+  // `start` chunk and the first model step (e.g. observational memory sealing a
+  // buffer chunk). The rotated id only reaches the wire via
+  // `step-start.payload.messageId`, so hold `start` (and any processor `data-*`
+  // chunks emitted before the model runs) until the first `step-start` and
+  // announce that step's id — the id the first assistant message is actually
+  // persisted under. Held chunks are flushed in their original order.
+  let heldChunks: ChunkType<OUTPUT>[] | null = null;
+  let startIdResolved = false;
+
+  const processChunk = (chunk: ChunkType<OUTPUT>, controller: TransformStreamDefaultController<object>) => {
+    if (chunk.type === 'tripwire') {
+      tripwireOccurred = true;
+    }
+
+    if (chunk.type === 'finish') {
+      finishEventSent = true;
+    }
+
+    if (chunk.type === 'object-result') {
+      controller.enqueue({
+        type: 'data-structured-output',
+        data: {
+          object: chunk.object,
+        },
+      });
+    }
+
+    const part = convertMastraChunkToAISDK({ chunk, mode: 'stream' });
+
+    const enqueueTransformedPart = (p: any) => {
+      const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({
+        part: p as any,
+        sendReasoning,
+        sendSources,
+        messageMetadataValue: p ? messageMetadata?.({ part: p as TextStreamPart<ToolSet> }) : undefined,
+        sendStart,
+        sendFinish,
+        responseMessageId: lastMessageId,
+        onError(error) {
+          return onError ? onError(error) : safeParseErrorObject(error);
+        },
+      });
+
+      if (transformedChunk) {
+        if (transformedChunk.type === 'tool-agent') {
+          const payload = transformedChunk.payload;
+          const agentTransformed = transformAgent<OUTPUT>(payload, bufferedSteps);
+          if (agentTransformed) controller.enqueue(agentTransformed);
+        } else if (transformedChunk.type === 'tool-workflow') {
+          const payload = transformedChunk.payload;
+          const workflowChunk = transformWorkflow(
+            payload,
+            bufferedSteps,
+            true,
+            undefined,
+            undefined,
+            convertMastraChunkToAISDK,
+          );
+          if (workflowChunk) {
+            if (Array.isArray(workflowChunk)) {
+              for (const item of workflowChunk) {
+                controller.enqueue(item);
+              }
+            } else {
+              controller.enqueue(workflowChunk);
+            }
+          }
+        } else if (transformedChunk.type === 'tool-network') {
+          const payload = transformedChunk.payload;
+          const networkChunk = transformNetwork(payload, bufferedSteps, true);
+          if (Array.isArray(networkChunk)) {
+            for (const c of networkChunk) {
+              if (c) controller.enqueue(c);
+            }
+          } else if (networkChunk) {
+            controller.enqueue(networkChunk);
+          }
+        } else {
+          controller.enqueue(transformedChunk as any);
+        }
+      }
+    };
+
+    if (Array.isArray(part)) {
+      for (const p of part) {
+        enqueueTransformedPart(p);
+      }
+    } else {
+      enqueueTransformedPart(part);
+    }
+  };
 
   return new TransformStream<ChunkType<OUTPUT>, object>({
     transform(chunk, controller) {
-      if (chunk.type === 'tripwire') {
-        tripwireOccurred = true;
-      }
-
-      if (chunk.type === 'finish') {
-        finishEventSent = true;
-      }
-
-      if (chunk.type === 'object-result') {
-        controller.enqueue({
-          type: 'data-structured-output',
-          data: {
-            object: chunk.object,
-          },
-        });
-      }
-
-      const part = convertMastraChunkToAISDK({ chunk, mode: 'stream' });
-
-      const enqueueTransformedPart = (p: any) => {
-        const transformedChunk = convertFullStreamChunkToUIMessageStream<any>({
-          part: p as any,
-          sendReasoning,
-          sendSources,
-          messageMetadataValue: p ? messageMetadata?.({ part: p as TextStreamPart<ToolSet> }) : undefined,
-          sendStart,
-          sendFinish,
-          responseMessageId: lastMessageId,
-          onError(error) {
-            return onError ? onError(error) : safeParseErrorObject(error);
-          },
-        });
-
-        if (transformedChunk) {
-          if (transformedChunk.type === 'tool-agent') {
-            const payload = transformedChunk.payload;
-            const agentTransformed = transformAgent<OUTPUT>(payload, bufferedSteps);
-            if (agentTransformed) controller.enqueue(agentTransformed);
-          } else if (transformedChunk.type === 'tool-workflow') {
-            const payload = transformedChunk.payload;
-            const workflowChunk = transformWorkflow(
-              payload,
-              bufferedSteps,
-              true,
-              undefined,
-              undefined,
-              convertMastraChunkToAISDK,
-            );
-            if (workflowChunk) {
-              if (Array.isArray(workflowChunk)) {
-                for (const item of workflowChunk) {
-                  controller.enqueue(item);
-                }
-              } else {
-                controller.enqueue(workflowChunk);
-              }
-            }
-          } else if (transformedChunk.type === 'tool-network') {
-            const payload = transformedChunk.payload;
-            const networkChunk = transformNetwork(payload, bufferedSteps, true);
-            if (Array.isArray(networkChunk)) {
-              for (const c of networkChunk) {
-                if (c) controller.enqueue(c);
-              }
-            } else if (networkChunk) {
-              controller.enqueue(networkChunk);
-            }
-          } else {
-            controller.enqueue(transformedChunk as any);
+      if (!startIdResolved) {
+        if (chunk.type === 'start') {
+          heldChunks = [chunk];
+          return;
+        }
+        if (heldChunks) {
+          if (typeof chunk.type === 'string' && chunk.type.startsWith('data-')) {
+            heldChunks.push(chunk);
+            return;
           }
+          startIdResolved = true;
+          const held = heldChunks;
+          heldChunks = null;
+          if (chunk.type === 'step-start') {
+            // held[0] is always the run-level `start` chunk (the only chunk type that opens the hold).
+            const startPayload = (held[0] as { payload?: { messageId?: unknown } } | undefined)?.payload;
+            const stepMessageId = (chunk.payload as { messageId?: unknown } | undefined)?.messageId;
+            // Re-announce under the step's id only when the run's `start`
+            // carried an id in the first place (durable streams emit `start`
+            // without a payload and must stay untouched).
+            if (
+              held[0] &&
+              typeof stepMessageId === 'string' &&
+              typeof startPayload?.messageId === 'string' &&
+              stepMessageId !== startPayload.messageId
+            ) {
+              held[0] = { ...held[0], payload: { ...startPayload, messageId: stepMessageId } } as ChunkType<OUTPUT>;
+            }
+          }
+          for (const heldChunk of held) {
+            processChunk(heldChunk, controller);
+          }
+        } else {
+          startIdResolved = true;
         }
-      };
-
-      if (Array.isArray(part)) {
-        for (const p of part) {
-          enqueueTransformedPart(p);
-        }
-      } else {
-        enqueueTransformedPart(part);
       }
+      processChunk(chunk, controller);
     },
     flush(controller) {
+      if (heldChunks) {
+        for (const heldChunk of heldChunks) {
+          processChunk(heldChunk, controller);
+        }
+        heldChunks = null;
+      }
       if (tripwireOccurred && !finishEventSent && sendFinish) {
         controller.enqueue({
           type: 'finish',

--- a/client-sdks/ai-sdk/src/transformers.ts
+++ b/client-sdks/ai-sdk/src/transformers.ts
@@ -354,7 +354,8 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
   // Processors can rotate the response message id before the first model step
   // (e.g. observational memory). Hold `start` (and any preceding `data-*`
   // chunks) until the first `step-start` so the announced id matches the id
-  // the response is actually persisted under.
+  // the response is actually persisted under. With `sendStart: false` no
+  // `start` UI chunk is emitted at all, so nothing is held.
   let heldChunks: ChunkType<OUTPUT>[] | null = null;
   let startIdResolved = false;
 
@@ -444,7 +445,7 @@ export function createAgentStreamToAISDKTransformer<OUTPUT>(
   return new TransformStream<ChunkType<OUTPUT>, object>({
     transform(chunk, controller) {
       if (!startIdResolved) {
-        if (chunk.type === 'start') {
+        if (sendStart && chunk.type === 'start') {
           heldChunks = [chunk];
           return;
         }

--- a/client-sdks/react/src/lib/mastra-db/accumulator.test.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.test.ts
@@ -22,8 +22,13 @@ const startChunk = (messageId = 'asst-1'): ChunkType =>
     payload: { messageId },
   }) as unknown as ChunkType;
 
-const stepStartChunk = (): ChunkType =>
-  ({ type: 'step-start', runId: RUN_ID, from: 'AGENT', payload: {} }) as unknown as ChunkType;
+const stepStartChunk = (messageId?: string): ChunkType =>
+  ({
+    type: 'step-start',
+    runId: RUN_ID,
+    from: 'AGENT',
+    payload: { ...(messageId ? { messageId } : {}) },
+  }) as unknown as ChunkType;
 
 const stepFinishChunk = (): ChunkType =>
   ({ type: 'step-finish', runId: RUN_ID, from: 'AGENT', payload: {} }) as unknown as ChunkType;
@@ -443,10 +448,52 @@ describe('accumulateChunk - lifecycle', () => {
     expect(out).toHaveLength(1);
   });
 
-  it('step-start is a no-op', () => {
+  it('step-start without a message id is a no-op', () => {
     const initial = reduce([startChunk()]);
     const out = reduce([stepStartChunk()], streamMeta(), initial);
     expect(out).toEqual(initial);
+  });
+
+  it('step-start with the current message id is a no-op', () => {
+    const initial = reduce([startChunk('asst-1')]);
+    const out = reduce([stepStartChunk('asst-1')], streamMeta(), initial);
+    expect(out).toEqual(initial);
+  });
+
+  it('step-start with a rotated message id re-keys the empty pending assistant message', () => {
+    const out = reduce([startChunk('asst-1'), stepStartChunk('rotated-1')]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ id: 'rotated-1', role: 'assistant', content: { parts: [] } });
+  });
+
+  it('step-start with a rotated message id re-keys a pending message that only holds data-* parts', () => {
+    const out = reduce([
+      startChunk('asst-1'),
+      dataPartChunk('om-status', { status: 'buffering' }),
+      stepStartChunk('rotated-1'),
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0].id).toBe('rotated-1');
+    expect(out[0].content.parts).toMatchObject([{ type: 'data-om-status', data: { status: 'buffering' } }]);
+  });
+
+  it('step-start with a rotated message id splits after content has streamed', () => {
+    const out = reduce([
+      startChunk('asst-1'),
+      stepStartChunk('asst-1'),
+      textStartChunk('t1'),
+      textDeltaChunk('t1', 'hello'),
+      textEndChunk('t1'),
+      stepStartChunk('rotated-1'),
+      textStartChunk('t2'),
+      textDeltaChunk('t2', 'world'),
+      textEndChunk('t2'),
+    ]);
+    expect(out).toHaveLength(2);
+    expect(out[0].id).toBe('asst-1');
+    expect(out[0].content.parts).toMatchObject([{ type: 'text', text: 'hello', state: 'done' }]);
+    expect(out[1].id).toBe('rotated-1');
+    expect(out[1].content.parts).toMatchObject([{ type: 'text', text: 'world' }]);
   });
 
   it('step-finish is a no-op', () => {

--- a/client-sdks/react/src/lib/mastra-db/accumulator.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.ts
@@ -1443,13 +1443,9 @@ export const accumulateChunk = ({ chunk, conversation, metadata }: AccumulateChu
       return [...result, newMessage];
     }
 
-    // Processors can rotate the active response message id mid-run (e.g.
-    // observational memory sealing a buffer chunk); the rotated id is carried
-    // by `step-start.payload.messageId` and is the id the following step's
-    // output is persisted under. Keep the streamed conversation keyed 1:1 with
-    // persistence: re-key the pending assistant message when it has no parts
-    // yet, or split into a new message when content already streamed under the
-    // previous id.
+    // ----- Rotated response message ids (`step-start.payload.messageId` carries
+    // the id the following step's output is persisted under; processors like
+    // observational memory can rotate it mid-run) -----
     case 'step-start': {
       const stepMessageId = typeof chunk.payload?.messageId === 'string' ? chunk.payload.messageId : undefined;
       if (!stepMessageId) return result;
@@ -1458,11 +1454,9 @@ export const accumulateChunk = ({ chunk, conversation, metadata }: AccumulateChu
       if (!lastMessage || lastMessage.role !== 'assistant') return result;
       if (result.some(message => message.id === stepMessageId)) return result;
 
-      // Processor `data-*` parts (e.g. observational memory status updates) can
-      // land on the pending assistant message before the first model step; they
-      // belong to the run, not to a previously persisted row, so they move with
-      // the re-key. Only model content streamed under the previous id forces a
-      // split into a second message.
+      // Re-key the pending message in place while it only holds `data-*` parts
+      // (they belong to the run, not a persisted row); once model content has
+      // streamed under the previous id, split into a new message instead.
       const hasModelContent = lastMessage.content.parts.some(part => !String(part.type).startsWith('data-'));
       if (!hasModelContent) {
         return replaceLast(result, { ...lastMessage, id: stepMessageId });

--- a/client-sdks/react/src/lib/mastra-db/accumulator.ts
+++ b/client-sdks/react/src/lib/mastra-db/accumulator.ts
@@ -1443,8 +1443,35 @@ export const accumulateChunk = ({ chunk, conversation, metadata }: AccumulateChu
       return [...result, newMessage];
     }
 
+    // Processors can rotate the active response message id mid-run (e.g.
+    // observational memory sealing a buffer chunk); the rotated id is carried
+    // by `step-start.payload.messageId` and is the id the following step's
+    // output is persisted under. Keep the streamed conversation keyed 1:1 with
+    // persistence: re-key the pending assistant message when it has no parts
+    // yet, or split into a new message when content already streamed under the
+    // previous id.
+    case 'step-start': {
+      const stepMessageId = typeof chunk.payload?.messageId === 'string' ? chunk.payload.messageId : undefined;
+      if (!stepMessageId) return result;
+
+      const lastMessage = result[result.length - 1];
+      if (!lastMessage || lastMessage.role !== 'assistant') return result;
+      if (result.some(message => message.id === stepMessageId)) return result;
+
+      // Processor `data-*` parts (e.g. observational memory status updates) can
+      // land on the pending assistant message before the first model step; they
+      // belong to the run, not to a previously persisted row, so they move with
+      // the re-key. Only model content streamed under the previous id forces a
+      // split into a second message.
+      const hasModelContent = lastMessage.content.parts.some(part => !String(part.type).startsWith('data-'));
+      if (!hasModelContent) {
+        return replaceLast(result, { ...lastMessage, id: stepMessageId });
+      }
+
+      return appendAssistantMessage(finishStreamingAssistantMessage(result), stepMessageId, [], metadata);
+    }
+
     // ----- Lifecycle / step / framing chunks (not surfaced on DB messages) -----
-    case 'step-start':
     case 'step-finish':
     case 'step-output':
     case 'raw':


### PR DESCRIPTION
## Description

When a processor rotates the active response message id during a run — observational memory does this when it seals a buffer chunk (`onBufferChunkSealed` / `onSyncObservationComplete`) — the rotated id only reaches the wire via `step-start.payload.messageId`. Both first-party stream consumers dropped that field, so clients kept the pre-rotation id announced in the run-level `start` chunk. After a rotation, the id held by the UI exists nowhere in storage: streamed messages duplicate or disappear once the thread re-syncs with persisted memory (`useChat` dedupe and `subscribeToThread` merging both key by message id).

**`@mastra/ai-sdk`** (shared v5/v6 transformer): the transformer now holds the run-level `start` chunk (and any processor `data-*` chunks emitted before the model runs) until the first `step-start`, then announces that step's `messageId` — the id the assistant response is actually persisted under. Streams whose `start` carries no id (durable streams) and streams that end without a model step are flushed unchanged, in their original order.

**`@mastra/react`** (mastra-db accumulator): `step-start` is no longer a no-op. A rotated id re-keys the pending assistant message in place when it holds no model content yet (`data-*` parts such as OM status updates move with the re-key), and splits into a new message keyed by the rotated id when content already streamed under the previous id — keeping the streamed conversation 1:1 with the persisted rows.

Verified end-to-end against a real model with real observational-memory rotation (tiny `observation.messageTokens` to force a buffer seal between the run-level `start` and the first model step): pre-fix, the wire announced an id that matched no stored message; post-fix, the announced id, the `step-start` id, and the persisted assistant row id all agree, and the accumulator keys the streamed message by the persisted id. Unit tests cover step-0 rotation, mid-run rotation, `data-*` ordering, durable streams without ids, and streams that end without a model step.

## Related Issue(s)

Fixes #19810

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Test update

## Checklist

- [ ] I have made corresponding changes to the documentation (if applicable)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have addressed all Coderabbit comments on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## ELI5

Sometimes the system gives a streamed assistant message a *new* ID while it’s still being generated. Before this fix, the AI SDK and React UI could announce/fetch messages using the *wrong* ID, so messages could disappear or duplicate. Now they stay aligned by using the persisted (rotated) ID.

## What changed

- Updated the AI SDK transformer to **hold back the initial response `start` chunk** until the first `step-start`, then **emit `start` with the correct (persisted) `messageId`**.
- Ensured correct chunk behavior and ordering across edge cases:
  - `data-*` chunks keep their relative ordering before the first `step-start`
  - durable/held streams remain unchanged when `start` has no `messageId`
  - runs that never reach a model step still flush the held `start` appropriately
  - added logic for skipping the `start`-chunk hold when `sendStart` is disabled
- Updated the React database accumulator to handle `step-start` with rotated `messageId`:
  - **re-key** a pending/empty trailing assistant message when only transient `data-*` parts exist
  - **split** into a new assistant message when real (non-`data-*`) content already streamed under the old ID
  - treat `step-start` as a no-op when there’s no valid rotated `messageId`
- Added/updated tests covering:
  - rotation in the first step (step-0) vs mid-run
  - `data-*` ordering between `start` and `step-start`
  - durable streams without IDs
  - streams that end without any model step
- Added patch changesets for `@mastra/ai-sdk` and `@mastra/react` referencing the fix for issue `#19810`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->