### PR TITLE
fix(create-factory): pin Mastra package versions at scaffold time to prevent duplicate installs

### DIFF
--- a/.changeset/plenty-donkeys-invent.md
+++ b/.changeset/plenty-donkeys-invent.md
@@ -1,0 +1,5 @@
+---
+'create-factory': patch
+---
+
+Pin Mastra package versions at scaffold time so generated projects install one consistent set. The template ships floating `latest` specs, and installing with `--prefer-offline` can resolve those tags from stale cached registry metadata around a release — splitting the dependency graph into two Mastra stacks (for example `@mastra/code-sdk@0.1.0` at the root alongside `@mastra/code-sdk@1.0.0` under `@mastra/factory`, each with their own `@mastra/core`, which breaks `instanceof` checks across packages). `create-factory` now resolves dist-tags fresh from the registry before install and applies the exact internal pins of `@mastra/factory` and `@mastra/code-sdk` as the source of truth, writing concrete versions into the generated `package.json`.

--- a/mastracode/mastra-factory/scripts/sync-template.mjs
+++ b/mastracode/mastra-factory/scripts/sync-template.mjs
@@ -14,6 +14,9 @@
  * create-mastra template ships. The Mastra packages ship as a coordinated set
  * on the `latest` dist-tag; pinning here to the same tag keeps the standalone
  * template's install path identical to the rest of the template ecosystem.
+ * At scaffold time `create-factory` resolves these tags to one consistent
+ * exact version set (see src/utils/pin-versions.ts) so installs never mix
+ * releases.
  *
  * Usage:
  *   node scripts/sync-template.mjs [--out <dir>]

--- a/mastracode/mastra-factory/src/create.ts
+++ b/mastracode/mastra-factory/src/create.ts
@@ -20,6 +20,7 @@ import {
   waitForDatabaseReady,
 } from './platform.js';
 import { cloneTemplate, renameProject } from './utils/clone.js';
+import { pinMastraDependencies } from './utils/pin-versions.js';
 import { detectPackageManager, getInstallArgs } from './utils/pm.js';
 
 export interface CreateArgs {
@@ -115,6 +116,25 @@ export async function create(args: CreateArgs): Promise<void> {
   } catch (err) {
     spinner.stop('Template download failed.');
     throw err;
+  }
+
+  // ── Pin Mastra package versions ──────────────────────────────────────────
+  // Resolve the template's `"latest"` Mastra deps to one consistent exact
+  // set before install. Installing with floating tags + `--prefer-offline`
+  // can resolve tags from stale cached metadata, splitting the graph into
+  // two Mastra stacks (duplicate @mastra/core copies break instanceof
+  // checks). Best-effort: on registry failure we install with tags as before.
+  const pinSpinner = p.spinner();
+  pinSpinner.start('Resolving Mastra package versions...');
+  try {
+    const { pins } = await pinMastraDependencies(projectPath);
+    const count = Object.keys(pins).length;
+    pinSpinner.stop(count > 0 ? `Pinned ${count} Mastra packages.` : 'No Mastra packages to pin.');
+  } catch (err) {
+    pinSpinner.stop('Could not resolve Mastra package versions.');
+    p.log.warn(
+      `Falling back to dist-tag installs (${err instanceof Error ? err.message : String(err)}). If the install produces duplicate @mastra packages, re-run with a working network connection.`,
+    );
   }
 
   // ── Install dependencies ─────────────────────────────────────────────────

--- a/mastracode/mastra-factory/src/utils/pin-versions.test.ts
+++ b/mastracode/mastra-factory/src/utils/pin-versions.test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { pinMastraDependencies } from './pin-versions.js';
+
+let projectDir: string;
+
+function writeManifest(manifest: Record<string, unknown>) {
+  fs.writeFileSync(path.join(projectDir, 'package.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+}
+
+function readManifest() {
+  return JSON.parse(fs.readFileSync(path.join(projectDir, 'package.json'), 'utf8'));
+}
+
+type PackumentFixture = {
+  'dist-tags'?: Record<string, string>;
+  versions?: Record<string, { dependencies?: Record<string, string> }>;
+};
+
+function mockRegistry(packuments: Record<string, PackumentFixture>) {
+  const fetchMock = vi.fn(async (url: string | URL) => {
+    const name = decodeURIComponent(new URL(String(url)).pathname.replace(/^\//, ''));
+    const packument = packuments[name];
+    if (!packument) return { ok: false, status: 404, json: async () => ({}) };
+    return { ok: true, status: 200, json: async () => packument };
+  });
+  vi.stubGlobal('fetch', fetchMock);
+  return fetchMock;
+}
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sf-pin-test-'));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+describe('pinMastraDependencies', () => {
+  it('pins dist-tag deps to exact versions and applies anchor pins for consistency', async () => {
+    writeManifest({
+      name: 'my-factory',
+      dependencies: {
+        '@mastra/factory': 'latest',
+        '@mastra/code-sdk': 'latest',
+        '@mastra/libsql': 'latest',
+        '@mastra/core': 'latest',
+        react: '^19.0.0',
+      },
+      devDependencies: {
+        mastra: 'latest',
+        typescript: '^5.9.2',
+      },
+    });
+
+    // Simulate a mid-release skew: factory's `latest` already points at the
+    // new release (which exact-pins code-sdk 1.0.0), while code-sdk's and
+    // libsql's dist-tags still point at the previous release.
+    mockRegistry({
+      '@mastra/factory': {
+        'dist-tags': { latest: '0.1.0' },
+        versions: {
+          '0.1.0': { dependencies: { '@mastra/code-sdk': '1.0.0', '@mastra/core': '1.52.0', hono: '^4.12.8' } },
+        },
+      },
+      '@mastra/code-sdk': {
+        'dist-tags': { latest: '0.1.0' },
+        versions: {
+          '0.1.0': { dependencies: { '@mastra/libsql': '1.16.0', '@mastra/core': '1.51.0' } },
+          '1.0.0': { dependencies: { '@mastra/libsql': '1.17.0', '@mastra/core': '1.52.0' } },
+        },
+      },
+      '@mastra/libsql': { 'dist-tags': { latest: '1.16.0' } },
+      '@mastra/core': { 'dist-tags': { latest: '1.51.0' } },
+      mastra: { 'dist-tags': { latest: '1.20.0' } },
+    });
+
+    const { pins } = await pinMastraDependencies(projectDir);
+
+    expect(pins).toEqual({
+      '@mastra/factory': '0.1.0',
+      // Anchor consistency: factory's exact pin wins over the stale dist-tag,
+      // and the *pinned* code-sdk version's exact pins win for libsql/core.
+      '@mastra/code-sdk': '1.0.0',
+      '@mastra/libsql': '1.17.0',
+      '@mastra/core': '1.52.0',
+      mastra: '1.20.0',
+    });
+
+    const manifest = readManifest();
+    expect(manifest.dependencies).toEqual({
+      '@mastra/factory': '0.1.0',
+      '@mastra/code-sdk': '1.0.0',
+      '@mastra/libsql': '1.17.0',
+      '@mastra/core': '1.52.0',
+      react: '^19.0.0',
+    });
+    expect(manifest.devDependencies).toEqual({
+      mastra: '1.20.0',
+      typescript: '^5.9.2',
+    });
+  });
+
+  it('is a no-op without Mastra dist-tag deps and never hits the registry', async () => {
+    writeManifest({
+      name: 'my-factory',
+      dependencies: { react: '^19.0.0', '@mastra/core': '1.52.0' },
+    });
+    const fetchMock = mockRegistry({});
+
+    const { pins } = await pinMastraDependencies(projectDir);
+
+    expect(pins).toEqual({});
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(readManifest().dependencies).toEqual({ react: '^19.0.0', '@mastra/core': '1.52.0' });
+  });
+
+  it('throws when the registry has no matching dist-tag', async () => {
+    writeManifest({
+      name: 'my-factory',
+      dependencies: { '@mastra/factory': 'latest' },
+    });
+    mockRegistry({ '@mastra/factory': { 'dist-tags': { alpha: '0.1.0-alpha.9' } } });
+
+    await expect(pinMastraDependencies(projectDir)).rejects.toThrow(/no "latest" dist-tag for @mastra\/factory/);
+  });
+
+  it('throws when the registry request fails', async () => {
+    writeManifest({
+      name: 'my-factory',
+      dependencies: { '@mastra/factory': 'latest' },
+    });
+    mockRegistry({});
+
+    await expect(pinMastraDependencies(projectDir)).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/mastracode/mastra-factory/src/utils/pin-versions.ts
+++ b/mastracode/mastra-factory/src/utils/pin-versions.ts
@@ -1,0 +1,135 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Pin the template's Mastra dist-tag deps (`"latest"`) to exact versions at
+ * scaffold time.
+ *
+ * Why: the Mastra packages ship as a coordinated set where published packages
+ * pin exact internal versions (`@mastra/factory` -> `@mastra/code-sdk` ->
+ * `@mastra/libsql`/`@mastra/core`/...). If the project's own deps stay as
+ * floating `"latest"` specs, each one is resolved independently by the package
+ * manager — and `--prefer-offline` installs resolve tags from *cached*
+ * packument metadata. Around a release that yields a mixed graph: the root
+ * gets yesterday's `latest` while `@mastra/factory` pulls today's exact pins,
+ * duplicating the entire Mastra stack (two `@mastra/core` copies break
+ * `instanceof` checks across packages).
+ *
+ * Fix: resolve every dist-tag fresh from the registry at one moment, then run
+ * a consistency pass — anchor packages' exact pins win over tag resolution
+ * (`@mastra/factory` decides `@mastra/code-sdk`; that `@mastra/code-sdk`
+ * decides `@mastra/libsql`, `@mastra/pg`, `@mastra/core`, `@mastra/memory`,
+ * ...). The generated project then installs one consistent, deduped set and
+ * stays reproducible on later installs.
+ */
+
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org';
+
+/**
+ * Aggregator packages whose exact internal pins define the coordinated
+ * version set. Order matters: `@mastra/factory` pins `@mastra/code-sdk`, so
+ * it must be applied first for the code-sdk anchor to be read at the right
+ * version.
+ */
+const ANCHOR_PACKAGES = ['@mastra/factory', '@mastra/code-sdk'];
+
+const FETCH_TIMEOUT_MS = 30_000;
+
+interface Packument {
+  'dist-tags'?: Record<string, string>;
+  versions?: Record<string, { dependencies?: Record<string, string> }>;
+}
+
+function isMastraPackage(name: string): boolean {
+  return name === 'mastra' || name.startsWith('@mastra/');
+}
+
+/** A bare dist-tag like `latest` or `alpha` (not a semver range or protocol spec). */
+function isDistTagSpec(spec: string): boolean {
+  return /^[a-z][\w.-]*$/i.test(spec) && !/^v?\d/.test(spec);
+}
+
+function registryUrl(): string {
+  const configured = process.env.npm_config_registry?.trim();
+  return (configured || DEFAULT_REGISTRY).replace(/\/+$/, '');
+}
+
+async function fetchPackument(name: string): Promise<Packument> {
+  const res = await fetch(`${registryUrl()}/${name}`, {
+    headers: {
+      // Abbreviated packument: dist-tags + per-version dependencies, much
+      // smaller than the full document.
+      accept: 'application/vnd.npm.install-v1+json',
+    },
+    signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch registry metadata for ${name}: HTTP ${res.status}`);
+  }
+  return (await res.json()) as Packument;
+}
+
+export interface PinResult {
+  /** Package name -> exact version written into package.json. */
+  pins: Record<string, string>;
+}
+
+/**
+ * Rewrite Mastra dist-tag deps in `<projectPath>/package.json` to exact,
+ * mutually consistent versions. No-op when the manifest has no Mastra
+ * dist-tag deps. Throws on registry errors — the caller decides whether to
+ * fall back to installing with tags.
+ */
+export async function pinMastraDependencies(projectPath: string): Promise<PinResult> {
+  const manifestPath = path.join(projectPath, 'package.json');
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+
+  // name -> dist-tag spec, gathered across both dep sections.
+  const targets = new Map<string, string>();
+  for (const section of ['dependencies', 'devDependencies'] as const) {
+    for (const [name, spec] of Object.entries<string>(manifest[section] ?? {})) {
+      if (isMastraPackage(name) && isDistTagSpec(spec)) targets.set(name, spec);
+    }
+  }
+  if (targets.size === 0) return { pins: {} };
+
+  const packuments = new Map<string, Packument>();
+  await Promise.all(
+    [...targets.keys()].map(async name => {
+      packuments.set(name, await fetchPackument(name));
+    }),
+  );
+
+  // First pass: resolve each dist-tag to a concrete version.
+  const pins: Record<string, string> = {};
+  for (const [name, tag] of targets) {
+    const version = packuments.get(name)?.['dist-tags']?.[tag];
+    if (!version) {
+      throw new Error(`Registry has no "${tag}" dist-tag for ${name}`);
+    }
+    pins[name] = version;
+  }
+
+  // Second pass: anchors' exact pins override tag resolution so the set is
+  // internally consistent even if dist-tags are mid-flip during a release.
+  for (const anchor of ANCHOR_PACKAGES) {
+    const anchorVersion = pins[anchor];
+    if (!anchorVersion) continue;
+    const anchorDeps = packuments.get(anchor)?.versions?.[anchorVersion]?.dependencies ?? {};
+    for (const [dep, depSpec] of Object.entries(anchorDeps)) {
+      if (!(dep in pins)) continue;
+      // Only exact version pins participate (ranges already dedupe).
+      if (!/^\d/.test(depSpec)) continue;
+      pins[dep] = depSpec;
+    }
+  }
+
+  for (const section of ['dependencies', 'devDependencies'] as const) {
+    for (const name of Object.keys(manifest[section] ?? {})) {
+      if (pins[name]) manifest[section][name] = pins[name];
+    }
+  }
+  fs.writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+  return { pins };
+}


### PR DESCRIPTION
## Summary

`pnpm create factory@latest` could generate a project whose dependency graph contains **two copies of the entire Mastra stack**, e.g.:

```
@mastra/libsql@1.16.0 (root, via "latest")
@mastra/libsql@1.17.0 (nested, via @mastra/factory@0.1.0 → @mastra/code-sdk@1.0.0)
```

Duplicate `@mastra/core` copies break `instanceof` checks across packages (the same failure class as #20030).

### Root cause
- The template declares all Mastra deps as floating `"latest"` specs.
- `create-factory` installs with `--prefer-offline`, which resolves dist-tags from **cached** registry metadata without staleness checks.
- Published Mastra packages pin **exact** internal versions (`@mastra/factory` → `@mastra/code-sdk@1.0.0` → `@mastra/libsql@1.17.0`).
- Around a release, cached tags resolve to the previous set at the root while `@mastra/factory` pulls the new exact-pinned set — an unmergeable, duplicated graph.

### Fix
Before install, `create-factory` now:
1. Resolves every Mastra dist-tag dep **fresh** from the registry (abbreviated packuments, respects `npm_config_registry`).
2. Runs a consistency pass where anchor packages' exact pins win: `@mastra/factory` decides `@mastra/code-sdk`; that `@mastra/code-sdk` decides `@mastra/libsql`/`@mastra/pg`/`@mastra/core`/`@mastra/memory`/… — so the set is consistent even if dist-tags are mid-flip during a publish.
3. Writes the concrete versions into the generated `package.json`, making later installs reproducible (and keeping `--prefer-offline` safe for speed).

Registry failures fall back to the previous tag-based install with a warning.

## Test plan
- 4 new unit tests for `pinMastraDependencies` (skewed dist-tags + anchor override, no-op, missing tag, registry error); full package suite: 40 passed
- `tsc --noEmit` clean, eslint + prettier clean
- Live verification: ran the pinning against the real template `package.json` + npm registry, then `pnpm install` — `pnpm why @mastra/libsql` reports **1 version** (was 2 versions / 3 instances) and a single `@mastra/core@1.52.0` in the store

## Note for affected users
Existing broken projects can recover with: `rm -rf node_modules pnpm-lock.yaml && pnpm install --prefer-online` (all `latest` tags are consistent again now that the stable release is fully published).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

When a new Mastra project is created, this change makes sure all Mastra packages use matching, exact versions instead of potentially different “latest” versions. If the registry cannot be reached, setup continues using the old behavior with a warning.

## Changes

- Added dependency pinning for Mastra packages during scaffolding.
- Resolves dist-tags from npm and uses anchor packages to maintain a consistent dependency set.
- Updates the generated `package.json` with concrete versions.
- Added tests covering successful pinning, consistency, no-op behavior, missing tags, and registry failures.
- Clarified template synchronization documentation.

## Validation

- Package tests, TypeScript checks, ESLint, and Prettier checks pass.
- Live installation verification confirmed a single version of `@mastra/libsql` and `@mastra/core`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->