### PR TITLE
chore(factory): rename log prefix to [Mastra Factory]

### DIFF
--- a/.changeset/pink-snakes-film.md
+++ b/.changeset/pink-snakes-film.md
@@ -1,0 +1,5 @@
+---
+'@mastra/factory': patch
+---
+
+Renamed Mastra Factory server log prefix from "[MastraCode Web]" to "[Mastra Factory]"

--- a/mastracode/factory/src/integrations/github/routes.ts
+++ b/mastracode/factory/src/integrations/github/routes.ts
@@ -639,7 +639,7 @@ export function buildGithubRoutes(options: MountGithubRoutesOptions): ApiRoute[]
             // reflects reality and the UI prompts a reconnect, then keep
             // listing the remaining installations.
             if ((err as { status?: number }).status !== 404) throw err;
-            console.error(`[MastraCode Web] pruning stale GitHub installation ${inst.externalId} (404 from GitHub)`);
+            console.error(`[Mastra Factory] pruning stale GitHub installation ${inst.externalId} (404 from GitHub)`);
             await github.sourceControlStorage.installations.delete({ orgId: resolved.tenant.orgId, id: inst.id });
             continue;
           }

--- a/mastracode/factory/src/integrations/platform/api-client.test.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.test.ts
@@ -95,7 +95,7 @@ describe('PlatformApiClient', () => {
     expect(error).toBeInstanceOf(PlatformApiError);
     expect(error).toMatchObject({ message: 'Rate limited', status: 429, retryAfterSeconds: 17 });
     const logged = String(errorLog.mock.calls[0]?.[0]);
-    expect(logged).toContain('[MastraCode Web] ERROR Platform API request failed');
+    expect(logged).toContain('[Mastra Factory] ERROR Platform API request failed');
     expect(logged).toContain('"method":"GET"');
     expect(logged).toContain('"path":"/v1/test"');
     expect(logged).toContain('"status":429');

--- a/mastracode/factory/src/integrations/platform/api-client.ts
+++ b/mastracode/factory/src/integrations/platform/api-client.ts
@@ -173,7 +173,7 @@ export function logPlatformError(message: string, fields?: Record<string, unknow
 
 function writePlatformLog(level: 'info' | 'warn' | 'error', message: string, fields?: Record<string, unknown>): void {
   const metadata = fields ? ` ${JSON.stringify(stripUndefined(fields))}` : '';
-  process.stderr.write(`[MastraCode Web] ${level.toUpperCase()} ${message}${metadata}\n`);
+  process.stderr.write(`[Mastra Factory] ${level.toUpperCase()} ${message}${metadata}\n`);
 }
 
 function stripUndefined(fields: Record<string, unknown>): Record<string, unknown> {

--- a/mastracode/factory/src/integrations/platform/github/integration.test.ts
+++ b/mastracode/factory/src/integrations/platform/github/integration.test.ts
@@ -788,7 +788,7 @@ describe('PlatformGithubIntegration', () => {
       userGithubUsername: 'ada',
     });
     const logged = warningLog.mock.calls.map(call => String(call[0])).join('\n');
-    expect(logged).toContain('[MastraCode Web] WARN Platform GitHub user connection verification failed');
+    expect(logged).toContain('[Mastra Factory] WARN Platform GitHub user connection verification failed');
     expect(logged).toContain('"userId":"user-1"');
     expect(logged).toContain('"reason":"missing-permissions"');
     warningLog.mockRestore();

--- a/mastracode/factory/src/server-error.ts
+++ b/mastracode/factory/src/server-error.ts
@@ -19,7 +19,7 @@ export function handleServerError(err: Error, c: Context): Response {
   }
 
   const detail = err instanceof Error ? (err.stack ?? err.message) : String(err);
-  console.error(`[MastraCode Web] ${c.req.method} ${c.req.path} failed: ${detail}`);
+  console.error(`[Mastra Factory] ${c.req.method} ${c.req.path} failed: ${detail}`);
 
   return c.json(
     {


### PR DESCRIPTION
## Summary
Mastra Factory server console logs were prefixed with the outdated `[MastraCode Web]` label. This renames the prefix to `[Mastra Factory]` everywhere it appears (error handler, platform API client, and GitHub integration logs), so log output matches the product name.

## Test plan
- `pnpm vitest run src/integrations/platform/api-client.test.ts src/integrations/platform/github/integration.test.ts` in `mastracode/factory` — 25 tests pass
- `grep -rn '[MastraCode Web]'` returns no remaining matches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Updates server log labels from `[MastraCode Web]` to `[Mastra Factory]` so logs clearly identify where they came from. Behavior and APIs remain unchanged.

## Changes

- Updated log prefixes in the server error handler, Platform API client, and GitHub integration.
- Updated related tests and added a patch changeset.
- 25 tests pass, with no remaining `[MastraCode Web]` references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->