### PR TITLE
fix(web): make board card links clickable

### DIFF
--- a/.changeset/board-card-thread-actions.md
+++ b/.changeset/board-card-thread-actions.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Improved Factory board cards with clear thread-opening guidance, top-right action menus, correct workspace links, and impact-free same-column drops.
+Improved Factory board cards with explicit thread actions, top-right action menus, correct workspace links, and impact-free same-column drops.

--- a/.changeset/board-card-thread-actions.md
+++ b/.changeset/board-card-thread-actions.md
@@ -2,4 +2,4 @@
 'mastracode': patch
 ---
 
-Improved Factory board cards with explicit thread actions, top-right action menus, correct workspace links, and impact-free same-column drops.
+Improved Factory board cards with hover-revealed thread actions, top-right action menus, correct workspace links, and impact-free same-column drops.

--- a/.changeset/board-card-thread-actions.md
+++ b/.changeset/board-card-thread-actions.md
@@ -1,0 +1,5 @@
+---
+'mastracode': patch
+---
+
+Improved Factory board cards with clear thread-opening guidance, top-right action menus, correct workspace links, and impact-free same-column drops.

--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -188,7 +188,6 @@ describe('Board card pending states', () => {
 
   it('shows a dedicated thread link while keeping the work item title static', async () => {
     stubBoardEndpoints();
-    const user = userEvent.setup();
     renderWorkBoard();
 
     const titleText = await screen.findByText('Fix login bug');
@@ -200,9 +199,6 @@ describe('Board card pending states', () => {
     );
     const matches = matchRoutes(createAppRoutes(), threadLink.getAttribute('href') ?? '');
     expect(matches?.at(-1)?.route.path).toBe('threads/:threadId');
-
-    await user.hover(threadLink);
-    expect(await screen.findByRole('tooltip')).toHaveTextContent('Open thread — does not start an agent run');
   });
 
   it('ignores a card dropped back into its current column', async () => {

--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -3,10 +3,10 @@
  * card must announce where it is going ("Moving to Planning…") instead of
  * silently waiting, and drop the status once the server answers.
  */
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { http, HttpResponse } from 'msw';
-import { createMemoryRouter, RouterProvider } from 'react-router';
+import { delay, http, HttpResponse } from 'msw';
+import { createMemoryRouter, matchRoutes, RouterProvider } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import { server } from '../../../../e2e/web-ui/msw-server';
@@ -16,6 +16,8 @@ import { createAppRoutes } from '../router';
 const FACTORY_ID = 'fp-1';
 const REPO_ID = 'repo-1';
 const ITEM_ID = 'item-1';
+const SESSION_ID = 'session-1';
+const THREAD_ID = 'thread-1';
 
 const workItem = {
   id: ITEM_ID,
@@ -29,7 +31,14 @@ const workItem = {
   url: null,
   stages: ['triage'],
   stageHistory: [],
-  sessions: {},
+  sessions: {
+    chat: {
+      sessionId: SESSION_ID,
+      branch: 'fix-login',
+      threadId: THREAD_ID,
+      startedBy: 'user-1',
+    },
+  },
   metadata: {},
   revision: 1,
   createdAt: '2026-07-18T00:00:00.000Z',
@@ -44,9 +53,27 @@ function deferred() {
   return { promise, resolve };
 }
 
+function createDataTransfer() {
+  const values = new Map<string, string>();
+  const types: string[] = [];
+  return {
+    types,
+    effectAllowed: 'uninitialized',
+    dropEffect: 'none',
+    setData(type: string, value: string) {
+      values.set(type, value);
+      if (!types.includes(type)) types.push(type);
+    },
+    getData(type: string) {
+      return values.get(type) ?? '';
+    },
+  };
+}
+
 /** Stubs the Work board's data endpoints with one triage item and a gated transition. */
 function stubBoardEndpoints() {
   const transitionGate = deferred();
+  const transitionRequests: string[] = [];
 
   server.use(
     http.get(`${TEST_BASE_URL}/auth/me`, () =>
@@ -80,6 +107,7 @@ function stubBoardEndpoints() {
       HttpResponse.json({ decisions: [] }),
     ),
     http.post(`${TEST_BASE_URL}/web/factory/projects/${FACTORY_ID}/work-items/${ITEM_ID}/transition`, async () => {
+      transitionRequests.push(ITEM_ID);
       await transitionGate.promise;
       return HttpResponse.json({
         result: {
@@ -106,11 +134,30 @@ function stubBoardEndpoints() {
     http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/issues`, () =>
       HttpResponse.json({ issues: [], nextPage: null }),
     ),
-    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () => HttpResponse.json({ sessions: [] })),
+    http.get(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/sessions`, () =>
+      HttpResponse.json({
+        sessions: [
+          {
+            id: 'session-row-1',
+            sessionId: SESSION_ID,
+            projectRepositoryId: REPO_ID,
+            orgId: 'org-1',
+            userId: 'user-1',
+            branch: 'fix-login',
+            baseBranch: 'main',
+            sandboxId: null,
+            sandboxWorkdir: '/repo',
+            materializedAt: '2026-07-18T00:00:00.000Z',
+            createdAt: '2026-07-18T00:00:00.000Z',
+            updatedAt: '2026-07-18T00:00:00.000Z',
+          },
+        ],
+      }),
+    ),
     http.post(`${TEST_BASE_URL}/web/github/projects/${REPO_ID}/ensure`, () => HttpResponse.json({ ok: true })),
   );
 
-  return { transitionGate };
+  return { transitionGate, transitionRequests };
 }
 
 function renderWorkBoard() {
@@ -137,5 +184,37 @@ describe('Board card pending states', () => {
     // Server answered: the status row disappears.
     transitionGate.resolve();
     await waitFor(() => expect(screen.queryByText('Moving to Planning…')).not.toBeInTheDocument());
+  });
+
+  it('links a live-thread title to its workspace route', async () => {
+    stubBoardEndpoints();
+    renderWorkBoard();
+
+    const titleLink = await screen.findByRole('link', { name: /Fix login bug/ });
+    expect(titleLink).toHaveAttribute(
+      'href',
+      `/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`,
+    );
+    const matches = matchRoutes(createAppRoutes(), titleLink.getAttribute('href') ?? '');
+    expect(matches?.at(-1)?.route.path).toBe('threads/:threadId');
+  });
+
+  it('ignores a card dropped back into its current column', async () => {
+    const { transitionRequests } = stubBoardEndpoints();
+    renderWorkBoard();
+
+    const titleLink = await screen.findByRole('link', { name: /Fix login bug/ });
+    const card = titleLink.closest<HTMLElement>('[data-testid="work-item-card"]');
+    if (!card) throw new Error('Expected the title link inside its work item card');
+    const currentColumn = screen.getByTestId('board-column-triage');
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(titleLink, { dataTransfer });
+    fireEvent.dragOver(currentColumn, { dataTransfer });
+    fireEvent.drop(currentColumn, { dataTransfer });
+    await delay(50);
+
+    expect(transitionRequests).toEqual([]);
+    expect(currentColumn).toContainElement(card);
   });
 });

--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -186,8 +186,9 @@ describe('Board card pending states', () => {
     await waitFor(() => expect(screen.queryByText('Moving to Planning…')).not.toBeInTheDocument());
   });
 
-  it('links a live-thread title to its workspace route', async () => {
+  it('links a live-thread title to its workspace route and explains the click outcome', async () => {
     stubBoardEndpoints();
+    const user = userEvent.setup();
     renderWorkBoard();
 
     const titleLink = await screen.findByRole('link', { name: /Fix login bug/ });
@@ -197,6 +198,9 @@ describe('Board card pending states', () => {
     );
     const matches = matchRoutes(createAppRoutes(), titleLink.getAttribute('href') ?? '');
     expect(matches?.at(-1)?.route.path).toBe('threads/:threadId');
+
+    await user.hover(titleLink);
+    expect(await screen.findByRole('tooltip')).toHaveTextContent('Open thread — does not start an agent run');
   });
 
   it('ignores a card dropped back into its current column', async () => {

--- a/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
+++ b/mastracode/web/src/web/ui/__tests__/BoardPagePendingStates.msw.test.tsx
@@ -186,20 +186,22 @@ describe('Board card pending states', () => {
     await waitFor(() => expect(screen.queryByText('Moving to Planning…')).not.toBeInTheDocument());
   });
 
-  it('links a live-thread title to its workspace route and explains the click outcome', async () => {
+  it('shows a dedicated thread link while keeping the work item title static', async () => {
     stubBoardEndpoints();
     const user = userEvent.setup();
     renderWorkBoard();
 
-    const titleLink = await screen.findByRole('link', { name: /Fix login bug/ });
-    expect(titleLink).toHaveAttribute(
+    const titleText = await screen.findByText('Fix login bug');
+    expect(titleText.closest('a, button')).toBeNull();
+    const threadLink = screen.getByRole('link', { name: 'Open thread for Fix login bug' });
+    expect(threadLink).toHaveAttribute(
       'href',
       `/factories/${FACTORY_ID}/workspaces/${SESSION_ID}/threads/${THREAD_ID}`,
     );
-    const matches = matchRoutes(createAppRoutes(), titleLink.getAttribute('href') ?? '');
+    const matches = matchRoutes(createAppRoutes(), threadLink.getAttribute('href') ?? '');
     expect(matches?.at(-1)?.route.path).toBe('threads/:threadId');
 
-    await user.hover(titleLink);
+    await user.hover(threadLink);
     expect(await screen.findByRole('tooltip')).toHaveTextContent('Open thread — does not start an agent run');
   });
 
@@ -207,13 +209,13 @@ describe('Board card pending states', () => {
     const { transitionRequests } = stubBoardEndpoints();
     renderWorkBoard();
 
-    const titleLink = await screen.findByRole('link', { name: /Fix login bug/ });
-    const card = titleLink.closest<HTMLElement>('[data-testid="work-item-card"]');
-    if (!card) throw new Error('Expected the title link inside its work item card');
+    const titleText = await screen.findByText('Fix login bug');
+    const card = titleText.closest<HTMLElement>('[data-testid="work-item-card"]');
+    if (!card) throw new Error('Expected the title inside its work item card');
     const currentColumn = screen.getByTestId('board-column-triage');
     const dataTransfer = createDataTransfer();
 
-    fireEvent.dragStart(titleLink, { dataTransfer });
+    fireEvent.dragStart(titleText, { dataTransfer });
     fireEvent.dragOver(currentColumn, { dataTransfer });
     fireEvent.drop(currentColumn, { dataTransfer });
     await delay(50);

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -1406,7 +1406,7 @@ function WorkItemCard({
         if (!evaluating) setDragPayload(event, { kind: 'work-item', id: item.id, fromStage: columnStage });
       }}
       className={cn(
-        'group relative flex flex-col gap-3 rounded-xl border border-border1 bg-surface1 p-3 outline-none transition-colors hover:bg-surface3',
+        'group relative flex flex-col gap-3 rounded-xl border border-border1 bg-neutral1/5 p-3 outline-none transition-colors hover:bg-surface3',
         evaluating ? 'cursor-wait' : 'cursor-grab active:cursor-grabbing',
         runPending && 'opacity-70',
       )}
@@ -1622,7 +1622,7 @@ function CandidateCard({
           },
         })
       }
-      className="group flex cursor-grab flex-col gap-3 rounded-xl border border-border1 bg-surface1 p-3 outline-none transition-colors hover:bg-surface3 active:cursor-grabbing"
+      className="group flex cursor-grab flex-col gap-3 rounded-xl border border-border1 bg-neutral1/5 p-3 outline-none transition-colors hover:bg-surface3 active:cursor-grabbing"
     >
       <div className="flex min-w-0 flex-col gap-1.5">
         <span className="block truncate text-ui-xs text-icon2">{candidate.meta}</span>

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -1419,7 +1419,7 @@ function WorkItemCard({
             variant="ghost"
             size="xs"
             aria-label={`Open thread for ${item.title}`}
-            tooltip="Open thread — does not start an agent run"
+            className="transition-opacity pointer-fine:pointer-events-none pointer-fine:opacity-0 pointer-fine:group-hover:pointer-events-auto pointer-fine:group-hover:opacity-100 pointer-fine:focus-visible:pointer-events-auto pointer-fine:focus-visible:opacity-100 motion-reduce:transition-none"
           >
             <MessageSquareText aria-hidden />
             Open thread
@@ -1432,7 +1432,7 @@ function WorkItemCard({
             disabled={runDisabled}
             aria-busy={pendingRunRoles.size > 0 || undefined}
             aria-label={`Create thread for ${item.title}`}
-            tooltip="Create thread — does not start an agent run"
+            className="transition-opacity pointer-fine:pointer-events-none pointer-fine:opacity-0 pointer-fine:group-hover:pointer-events-auto pointer-fine:group-hover:opacity-100 pointer-fine:focus-visible:pointer-events-auto pointer-fine:focus-visible:opacity-100 motion-reduce:transition-none"
             onClick={() => onCreateSession(itemSessionSpec(item))}
           >
             <MessageSquareText aria-hidden />

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -12,7 +12,6 @@ import {
   CircleDot,
   CircleX,
   EllipsisVertical,
-  ExternalLink,
   GitCompareArrows,
   GitPullRequest,
   Link2,
@@ -908,7 +907,6 @@ function BoardContent({
                     retryingDecisionId={retryDecision.isPending ? retryDecision.variables : undefined}
                     onRetryDecision={decisionId => retryDecision.mutate(decisionId)}
                     pendingRunRoles={pendingRunRolesByItem.get(item.id) ?? EMPTY_PENDING_RUN_ROLES}
-                    onOpenThread={session => void openThread(session)}
                     onCreateSession={() => void openOrCreateSession(item, stage.id)}
                     onStartRun={(_spec, action) => void openOrStartRun(item, action.role)}
                     onMove={toStage => moveItem(item.id, stage.id, toStage)}
@@ -1352,7 +1350,6 @@ function WorkItemCard({
   retryingDecisionId,
   onRetryDecision,
   pendingRunRoles,
-  onOpenThread,
   onCreateSession,
   onStartRun,
   onMove,
@@ -1371,7 +1368,6 @@ function WorkItemCard({
   retryingDecisionId?: string;
   onRetryDecision: (decisionId: string) => void;
   pendingRunRoles: ReadonlyMap<string, FactoryRunPhase | undefined>;
-  onOpenThread: (session: WorkItemSessionRef) => void;
   /** Title click when the card has no live session: open an empty session (no run). */
   onCreateSession: (spec: { branch: string; threadTitle: string }) => void;
   onStartRun: (spec: ItemRunSpec, action: RunAction) => void;
@@ -1419,23 +1415,19 @@ function WorkItemCard({
         <div className="flex min-w-0 items-center gap-1.5">
           <Icon size={16} className={cn('shrink-0', iconClassName)} aria-hidden />
           {threadSession !== null ? (
-            <a
-              href={`/factories/${factoryId}/threads/${threadSession.threadId}`}
-              onClick={event => {
-                event.preventDefault();
-                onOpenThread(threadSession);
-              }}
-              className="min-w-0 flex-1 truncate text-ui-smd font-semibold text-icon6 no-underline hover:underline"
+            <Link
+              to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
+              className="min-w-0 flex-1 cursor-pointer truncate text-ui-smd font-semibold text-icon6 no-underline hover:underline"
             >
               <SourceTitle source={item.source} title={item.title} />
-            </a>
+            </Link>
           ) : (
             <button
               type="button"
               disabled={runDisabled}
               aria-busy={pendingRunRoles.size > 0 || undefined}
               onClick={() => onCreateSession(itemSessionSpec(item))}
-              className="min-w-0 flex-1 truncate text-left text-ui-smd font-semibold text-icon6 hover:underline disabled:opacity-60"
+              className="min-w-0 flex-1 cursor-pointer truncate text-left text-ui-smd font-semibold text-icon6 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
             >
               <SourceTitle source={item.source} title={item.title} />
             </button>
@@ -1446,9 +1438,9 @@ function WorkItemCard({
               target="_blank"
               rel="noreferrer"
               aria-label={externalLinkLabel(item.source)}
-              className="shrink-0 text-icon3 hover:text-icon5"
+              className="shrink-0 text-icon3 transition-[opacity,translate] hover:text-icon5 focus-visible:translate-x-0 focus-visible:translate-y-0 focus-visible:opacity-100 pointer-fine:-translate-x-1 pointer-fine:translate-y-1 pointer-fine:opacity-0 pointer-fine:group-hover:translate-x-0 pointer-fine:group-hover:translate-y-0 pointer-fine:group-hover:opacity-100 motion-reduce:transition-none"
             >
-              <ExternalLink size={12} aria-hidden />
+              <ArrowUpRight size={12} aria-hidden />
             </a>
           )}
           <DropdownMenu>
@@ -1504,24 +1496,19 @@ function WorkItemCard({
         );
         const relatedSession = itemThreadSession(relatedLiveSessions);
         return (
-          <a
+          <Link
             key={related.id}
-            href={
+            to={
               relatedSession
-                ? `/factories/${factoryId}/threads/${relatedSession.threadId}`
+                ? `/factories/${factoryId}/workspaces/${relatedSession.sessionId}/threads/${relatedSession.threadId}`
                 : relationshipPath(related, factoryId)
             }
-            onClick={event => {
-              if (!relatedSession) return;
-              event.preventDefault();
-              onOpenThread(relatedSession);
-            }}
             className="flex items-center gap-1 text-ui-xs text-icon4 hover:text-icon6 hover:underline"
             aria-label={`Open ${relationText}`}
           >
             <Link2 size={11} aria-hidden />
             <span className="truncate">{relationText}</span>
-          </a>
+          </Link>
         );
       })}
       {otherStages.length > 0 && (

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -5,7 +5,6 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import {
   ArrowUpRight,
@@ -16,6 +15,7 @@ import {
   GitCompareArrows,
   GitPullRequest,
   Link2,
+  MessageSquareText,
   Plus,
   Stethoscope,
   Trash2,
@@ -1411,88 +1411,85 @@ function WorkItemCard({
         runPending && 'opacity-70',
       )}
     >
-      <DropdownMenu>
-        <DropdownMenu.Trigger
-          render={
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              disabled={evaluating}
-              aria-label={`Actions for ${item.title}`}
-              className="absolute top-2 right-2"
-            >
-              <EllipsisVertical size={13} aria-hidden />
-            </Button>
-          }
-        />
-        <DropdownMenu.Content align="end" className="min-w-44">
-          {runSpec !== null &&
-            runActions.map(action => {
-              const starting = pendingRunRoles.has(action.role);
-              return (
-                <DropdownMenu.Item
-                  key={action.label}
-                  disabled={runDisabled || starting}
-                  onClick={() => onStartRun(runSpec, action)}
-                >
-                  {actionIcon(action.label)}
-                  <span>{starting ? 'Starting…' : action.label}</span>
+      <div className="absolute top-2 right-2 flex items-center gap-0.5">
+        {threadSession !== null ? (
+          <Button
+            as={Link}
+            to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
+            variant="ghost"
+            size="xs"
+            aria-label={`Open thread for ${item.title}`}
+            tooltip="Open thread — does not start an agent run"
+          >
+            <MessageSquareText aria-hidden />
+            Open thread
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            variant="ghost"
+            size="xs"
+            disabled={runDisabled}
+            aria-busy={pendingRunRoles.size > 0 || undefined}
+            aria-label={`Create thread for ${item.title}`}
+            tooltip="Create thread — does not start an agent run"
+            onClick={() => onCreateSession(itemSessionSpec(item))}
+          >
+            <MessageSquareText aria-hidden />
+            New thread
+          </Button>
+        )}
+        <DropdownMenu>
+          <DropdownMenu.Trigger
+            render={
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-xs"
+                disabled={evaluating}
+                aria-label={`Actions for ${item.title}`}
+              >
+                <EllipsisVertical size={13} aria-hidden />
+              </Button>
+            }
+          />
+          <DropdownMenu.Content align="end" className="min-w-44">
+            {runSpec !== null &&
+              runActions.map(action => {
+                const starting = pendingRunRoles.has(action.role);
+                return (
+                  <DropdownMenu.Item
+                    key={action.label}
+                    disabled={runDisabled || starting}
+                    onClick={() => onStartRun(runSpec, action)}
+                  >
+                    {actionIcon(action.label)}
+                    <span>{starting ? 'Starting…' : action.label}</span>
+                  </DropdownMenu.Item>
+                );
+              })}
+            {itemStageOptions(item)
+              .filter(stage => stage.id !== columnStage)
+              .map(stage => (
+                <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
+                  <BoardStageIcon stage={stage.id} />
+                  <span>{stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}</span>
                 </DropdownMenu.Item>
-              );
-            })}
-          {itemStageOptions(item)
-            .filter(stage => stage.id !== columnStage)
-            .map(stage => (
-              <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
-                <BoardStageIcon stage={stage.id} />
-                <span>{stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}</span>
-              </DropdownMenu.Item>
-            ))}
-          <DropdownMenu.Item onClick={onRemove}>
-            <Trash2 aria-hidden />
-            <span>Remove</span>
-          </DropdownMenu.Item>
-        </DropdownMenu.Content>
-      </DropdownMenu>
-      <div className="flex min-w-0 flex-col gap-1.5 pr-6">
-        <span className="truncate text-ui-xs text-icon2">{workItemMeta(item)}</span>
+              ))}
+            <DropdownMenu.Item onClick={onRemove}>
+              <Trash2 aria-hidden />
+              <span>Remove</span>
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu>
+      </div>
+      <div className="flex min-w-0 flex-col gap-1.5">
+        <span className="truncate pr-30 text-ui-xs text-icon2">{workItemMeta(item)}</span>
         <div className="flex min-w-0 items-center gap-1.5">
           <Icon size={16} className={cn('shrink-0', iconClassName)} aria-hidden />
-          {threadSession !== null ? (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <Link
-                    to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
-                    aria-label={`Open thread for ${item.title}; does not start an agent run`}
-                    className="min-w-0 flex-1 cursor-pointer truncate text-ui-smd font-semibold text-icon6 no-underline hover:underline"
-                  >
-                    <SourceTitle source={item.source} title={item.title} />
-                  </Link>
-                }
-              />
-              <TooltipContent>Open thread — does not start an agent run</TooltipContent>
-            </Tooltip>
-          ) : (
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    type="button"
-                    disabled={runDisabled}
-                    aria-busy={pendingRunRoles.size > 0 || undefined}
-                    aria-label={`Create thread for ${item.title}; does not start an agent run`}
-                    onClick={() => onCreateSession(itemSessionSpec(item))}
-                    className="min-w-0 flex-1 cursor-pointer truncate text-left text-ui-smd font-semibold text-icon6 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <SourceTitle source={item.source} title={item.title} />
-                  </button>
-                }
-              />
-              <TooltipContent>Create thread — does not start an agent run</TooltipContent>
-            </Tooltip>
-          )}
+          <span className="min-w-0 flex-1 truncate text-ui-smd font-semibold text-icon6">
+            <SourceTitle source={item.source} title={item.title} />
+          </span>
           {item.url !== null && (
             <a
               href={item.url}

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -5,6 +5,7 @@ import { Notice } from '@mastra/playground-ui/components/Notice';
 import { ScrollArea } from '@mastra/playground-ui/components/ScrollArea';
 import { Spinner } from '@mastra/playground-ui/components/Spinner';
 import { Txt } from '@mastra/playground-ui/components/Txt';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@mastra/playground-ui/components/Tooltip';
 import { cn } from '@mastra/playground-ui/utils/cn';
 import {
   ArrowUpRight,
@@ -1405,32 +1406,92 @@ function WorkItemCard({
         if (!evaluating) setDragPayload(event, { kind: 'work-item', id: item.id, fromStage: columnStage });
       }}
       className={cn(
-        'group flex flex-col gap-3 rounded-xl border border-border1 bg-surface1 p-3 outline-none transition-colors hover:bg-surface3',
+        'group relative flex flex-col gap-3 rounded-xl border border-border1 bg-surface1 p-3 outline-none transition-colors hover:bg-surface3',
         evaluating ? 'cursor-wait' : 'cursor-grab active:cursor-grabbing',
         runPending && 'opacity-70',
       )}
     >
-      <div className="flex min-w-0 flex-col gap-1.5">
+      <DropdownMenu>
+        <DropdownMenu.Trigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              disabled={evaluating}
+              aria-label={`Actions for ${item.title}`}
+              className="absolute top-2 right-2"
+            >
+              <EllipsisVertical size={13} aria-hidden />
+            </Button>
+          }
+        />
+        <DropdownMenu.Content align="end" className="min-w-44">
+          {runSpec !== null &&
+            runActions.map(action => {
+              const starting = pendingRunRoles.has(action.role);
+              return (
+                <DropdownMenu.Item
+                  key={action.label}
+                  disabled={runDisabled || starting}
+                  onClick={() => onStartRun(runSpec, action)}
+                >
+                  {actionIcon(action.label)}
+                  <span>{starting ? 'Starting…' : action.label}</span>
+                </DropdownMenu.Item>
+              );
+            })}
+          {itemStageOptions(item)
+            .filter(stage => stage.id !== columnStage)
+            .map(stage => (
+              <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
+                <BoardStageIcon stage={stage.id} />
+                <span>{stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}</span>
+              </DropdownMenu.Item>
+            ))}
+          <DropdownMenu.Item onClick={onRemove}>
+            <Trash2 aria-hidden />
+            <span>Remove</span>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu>
+      <div className="flex min-w-0 flex-col gap-1.5 pr-6">
         <span className="truncate text-ui-xs text-icon2">{workItemMeta(item)}</span>
         <div className="flex min-w-0 items-center gap-1.5">
           <Icon size={16} className={cn('shrink-0', iconClassName)} aria-hidden />
           {threadSession !== null ? (
-            <Link
-              to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
-              className="min-w-0 flex-1 cursor-pointer truncate text-ui-smd font-semibold text-icon6 no-underline hover:underline"
-            >
-              <SourceTitle source={item.source} title={item.title} />
-            </Link>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Link
+                    to={`/factories/${factoryId}/workspaces/${threadSession.sessionId}/threads/${threadSession.threadId}`}
+                    aria-label={`Open thread for ${item.title}; does not start an agent run`}
+                    className="min-w-0 flex-1 cursor-pointer truncate text-ui-smd font-semibold text-icon6 no-underline hover:underline"
+                  >
+                    <SourceTitle source={item.source} title={item.title} />
+                  </Link>
+                }
+              />
+              <TooltipContent>Open thread — does not start an agent run</TooltipContent>
+            </Tooltip>
           ) : (
-            <button
-              type="button"
-              disabled={runDisabled}
-              aria-busy={pendingRunRoles.size > 0 || undefined}
-              onClick={() => onCreateSession(itemSessionSpec(item))}
-              className="min-w-0 flex-1 cursor-pointer truncate text-left text-ui-smd font-semibold text-icon6 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <SourceTitle source={item.source} title={item.title} />
-            </button>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    disabled={runDisabled}
+                    aria-busy={pendingRunRoles.size > 0 || undefined}
+                    aria-label={`Create thread for ${item.title}; does not start an agent run`}
+                    onClick={() => onCreateSession(itemSessionSpec(item))}
+                    className="min-w-0 flex-1 cursor-pointer truncate text-left text-ui-smd font-semibold text-icon6 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    <SourceTitle source={item.source} title={item.title} />
+                  </button>
+                }
+              />
+              <TooltipContent>Create thread — does not start an agent run</TooltipContent>
+            </Tooltip>
           )}
           {item.url !== null && (
             <a
@@ -1443,49 +1504,6 @@ function WorkItemCard({
               <ArrowUpRight size={12} aria-hidden />
             </a>
           )}
-          <DropdownMenu>
-            <DropdownMenu.Trigger
-              render={
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  disabled={evaluating}
-                  aria-label={`Actions for ${item.title}`}
-                >
-                  <EllipsisVertical size={13} aria-hidden />
-                </Button>
-              }
-            />
-            <DropdownMenu.Content align="end" className="min-w-44">
-              {runSpec !== null &&
-                runActions.map(action => {
-                  const starting = pendingRunRoles.has(action.role);
-                  return (
-                    <DropdownMenu.Item
-                      key={action.label}
-                      disabled={runDisabled || starting}
-                      onClick={() => onStartRun(runSpec, action)}
-                    >
-                      {actionIcon(action.label)}
-                      <span>{starting ? 'Starting…' : action.label}</span>
-                    </DropdownMenu.Item>
-                  );
-                })}
-              {itemStageOptions(item)
-                .filter(stage => stage.id !== columnStage)
-                .map(stage => (
-                  <DropdownMenu.Item key={stage.id} onClick={() => onMove(stage.id)}>
-                    <BoardStageIcon stage={stage.id} />
-                    <span>{stage.id === 'done' ? 'Mark done' : `Move to ${stage.label}`}</span>
-                  </DropdownMenu.Item>
-                ))}
-              <DropdownMenu.Item onClick={onRemove}>
-                <Trash2 aria-hidden />
-                <span>Remove</span>
-              </DropdownMenu.Item>
-            </DropdownMenu.Content>
-          </DropdownMenu>
         </div>
       </div>
       <CardLabels labels={labels} />

--- a/mastracode/web/src/web/ui/pages/BoardPage.tsx
+++ b/mastracode/web/src/web/ui/pages/BoardPage.tsx
@@ -1406,7 +1406,7 @@ function WorkItemCard({
         if (!evaluating) setDragPayload(event, { kind: 'work-item', id: item.id, fromStage: columnStage });
       }}
       className={cn(
-        'group relative flex flex-col gap-3 rounded-xl border border-border1 bg-neutral1/5 p-3 outline-none transition-colors hover:bg-surface3',
+        'group relative flex flex-col gap-3 rounded-xl border border-border1/50 bg-neutral6/5 p-3 outline-none transition-colors hover:bg-surface3',
         evaluating ? 'cursor-wait' : 'cursor-grab active:cursor-grabbing',
         runPending && 'opacity-70',
       )}
@@ -1490,17 +1490,6 @@ function WorkItemCard({
           <span className="min-w-0 flex-1 truncate text-ui-smd font-semibold text-icon6">
             <SourceTitle source={item.source} title={item.title} />
           </span>
-          {item.url !== null && (
-            <a
-              href={item.url}
-              target="_blank"
-              rel="noreferrer"
-              aria-label={externalLinkLabel(item.source)}
-              className="shrink-0 text-icon3 transition-[opacity,translate] hover:text-icon5 focus-visible:translate-x-0 focus-visible:translate-y-0 focus-visible:opacity-100 pointer-fine:-translate-x-1 pointer-fine:translate-y-1 pointer-fine:opacity-0 pointer-fine:group-hover:translate-x-0 pointer-fine:group-hover:translate-y-0 pointer-fine:group-hover:opacity-100 motion-reduce:transition-none"
-            >
-              <ArrowUpRight size={12} aria-hidden />
-            </a>
-          )}
         </div>
       </div>
       <CardLabels labels={labels} />
@@ -1622,7 +1611,7 @@ function CandidateCard({
           },
         })
       }
-      className="group flex cursor-grab flex-col gap-3 rounded-xl border border-border1 bg-neutral1/5 p-3 outline-none transition-colors hover:bg-surface3 active:cursor-grabbing"
+      className="group flex cursor-grab flex-col gap-3 rounded-xl border border-border1/50 bg-neutral6/5 p-3 outline-none transition-colors hover:bg-surface3 active:cursor-grabbing"
     >
       <div className="flex min-w-0 flex-col gap-1.5">
         <span className="block truncate text-ui-xs text-icon2">{candidate.meta}</span>


### PR DESCRIPTION
Board cards used thread URLs that skipped the workspace segment, so navigation could land on a missing route. This switches thread and related-session navigation to the workspace-scoped route while preserving drag behavior.

Work item titles are now static. A labeled ghost action beside the overflow menu says `Open thread` for existing sessions or `New thread` when one must be created. On fine pointers it appears only when the card is hovered, while keyboard focus and touch remain supported. The tooltip and separate work item source-link icon were removed.

Work item and candidate cards use `neutral6` at 5% opacity with a 50% softer border. Same-column drops remain no-ops with regression coverage.

Before: `/factories/:factoryId/threads/:threadId`
After: `/factories/:factoryId/workspaces/:sessionId/threads/:threadId`

Includes a patch changeset for `mastracode`. Verified with the UI TypeScript check, focused BoardPage MSW tests, changeset validation, and browser interaction checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## ELI5

Board cards now make it clearer how to open an existing conversation or start a new one, without interfering with dragging cards between columns. The cards also look softer and avoid unnecessary link and tooltip clutter.

## What changed

- Added workspace-scoped routes for existing and new threads.
- Added explicit `Open thread` and `New thread` actions with hover, keyboard-focus, and touch support.
- Kept work item titles static and removed the tooltip and source-link icon.
- Updated work item and candidate card styling with softer borders and a subtle neutral background.
- Prevented same-column drag-and-drop from triggering transitions.
- Added focused MSW regression tests for thread links and same-column drops.
- Added a patch changeset for `mastracode`.

## Verification

- UI TypeScript checks
- Focused BoardPage MSW tests
- Changeset validation
- Browser interaction checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->